### PR TITLE
UXW-2084 Restrict access to Transforms, Metadata and Python Library

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/index.tsx
@@ -1,6 +1,6 @@
 import { t } from "ttag";
 
-import { AdminNavItem } from "metabase/admin/components/AdminNav";
+import type { BenchNavItem } from "metabase/bench/constants/navigation";
 import { ForwardRefLink } from "metabase/common/components/Link";
 import { Route } from "metabase/hoc/Title";
 import { PLUGIN_TRANSFORMS_PYTHON } from "metabase/plugins";
@@ -25,13 +25,22 @@ if (hasPremiumFeature("transforms-python")) {
     <Route path="library/:path" component={PythonLibraryEditorPage} />
   );
 
-  PLUGIN_TRANSFORMS_PYTHON.getTransformsNavLinks = () => (
-    <AdminNavItem
-      label={t`Python library`}
-      path={getPythonLibraryUrl({ path: SHARED_LIB_IMPORT_PATH })}
-      icon="code_block"
-    />
-  );
+  PLUGIN_TRANSFORMS_PYTHON.getTransformNavItems = (
+    isAdmin: boolean,
+  ): BenchNavItem[] => {
+    if (!isAdmin) {
+      return [];
+    }
+
+    return [
+      {
+        id: "library",
+        url: getPythonLibraryUrl({ path: SHARED_LIB_IMPORT_PATH }),
+        icon: "code_block",
+        getLabel: () => t`Python Library`,
+      },
+    ];
+  };
 
   PLUGIN_TRANSFORMS_PYTHON.getCreateTransformsMenuItems = () => (
     <Menu.Item

--- a/enterprise/frontend/src/metabase-enterprise/transforms/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/index.tsx
@@ -1,10 +1,11 @@
 import { PLUGIN_TRANSFORMS } from "metabase/plugins";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
-import { getTransformRoutes } from "./routes";
+import { getTransformNavItems, getTransformRoutes } from "./routes";
 import { ROOT_URL } from "./urls";
 
 if (hasPremiumFeature("transforms")) {
   PLUGIN_TRANSFORMS.ROOT_URL = ROOT_URL;
   PLUGIN_TRANSFORMS.getTransformRoutes = getTransformRoutes;
+  PLUGIN_TRANSFORMS.getTransformNavItems = getTransformNavItems;
 }

--- a/enterprise/frontend/src/metabase-enterprise/transforms/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/routes.tsx
@@ -1,6 +1,8 @@
 import { IndexRoute } from "react-router";
 import { t } from "ttag";
 
+import { createBenchAdminRouteGuard } from "metabase/bench/components/utils";
+import type { BenchNavItem } from "metabase/bench/constants/navigation";
 import { Route } from "metabase/hoc/Title";
 import { PLUGIN_TRANSFORMS_PYTHON } from "metabase/plugins";
 
@@ -16,9 +18,44 @@ import { TransformQueryPage } from "./pages/TransformQueryPage";
 import { TransformSchedulePage } from "./pages/TransformSchedulePage";
 import { TransformTargetPage } from "./pages/TransformTargetPage";
 
+export const getTransformNavItems = (isAdmin: boolean): BenchNavItem[] => {
+  if (!isAdmin) {
+    return [];
+  }
+
+  return [
+    {
+      id: "transforms",
+      url: "/bench/transforms",
+      icon: "transform",
+      getLabel: () => t`Transforms`,
+    },
+    {
+      id: "jobs",
+      url: "/bench/jobs",
+      icon: "play_outlined",
+      getLabel: () => t`Jobs`,
+      parentId: "transforms",
+      nested: true,
+    },
+    {
+      id: "runs",
+      url: "/bench/runs",
+      icon: "list",
+      getLabel: () => t`Runs`,
+      parentId: "transforms",
+      nested: true,
+    },
+  ];
+};
+
 export const getTransformRoutes = () => (
   <>
-    <Route title={t`Transforms`} path="transforms" component={TransformLayout}>
+    <Route
+      title={t`Transforms`}
+      path="transforms"
+      component={createBenchAdminRouteGuard("transforms", TransformLayout)}
+    >
       <IndexRoute component={TransformEmptyPage} />
       <Route path="new/:type" component={NewTransformPage} />
       <Route path="new/card/:cardId" component={NewTransformPage} />
@@ -26,12 +63,20 @@ export const getTransformRoutes = () => (
       <Route path=":transformId/schedule" component={TransformSchedulePage} />
       <Route path=":transformId/target" component={TransformTargetPage} />
     </Route>
-    <Route title={t`Jobs`} path="jobs" component={JobLayout}>
+    <Route
+      title={t`Jobs`}
+      path="jobs"
+      component={createBenchAdminRouteGuard("transforms", JobLayout)}
+    >
       <IndexRoute component={JobEmptyPage} />
       <Route path="new" component={NewJobPage} />
       <Route path=":jobId" component={JobPage} />
     </Route>
-    <Route title={t`Runs`} path="runs" component={RunListPage} />
+    <Route
+      title={t`Runs`}
+      path="runs"
+      component={createBenchAdminRouteGuard("transforms", RunListPage)}
+    />
     {PLUGIN_TRANSFORMS_PYTHON.getAdminRoutes()}
   </>
 );

--- a/frontend/src/metabase/bench/components/BenchApp.tsx
+++ b/frontend/src/metabase/bench/components/BenchApp.tsx
@@ -1,16 +1,17 @@
 import cx from "classnames";
 import type React from "react";
-import { type Ref, forwardRef, useEffect } from "react";
+import { type Ref, forwardRef, useEffect, useMemo } from "react";
 import type { ResizeHandle as HandleAxis } from "react-resizable";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { replace } from "react-router-redux";
 
 import { BenchLayoutProvider } from "metabase/bench/context/BenchLayoutContext";
-import { useDispatch } from "metabase/lib/redux";
+import { useDispatch, useSelector } from "metabase/lib/redux";
 import { PLUGIN_METABOT } from "metabase/plugins";
+import { getUserIsAdmin } from "metabase/selectors/user";
 import { Box, Flex, Stack } from "metabase/ui";
 
-import { BENCH_NAV_ITEMS, OVERVIEW_ITEM } from "../constants/navigation";
+import { OVERVIEW_ITEM, getBenchNavItems } from "../constants/navigation";
 import { useRememberBenchTab } from "../hooks/useBenchRememberTab";
 
 import S from "./BenchApp.module.css";
@@ -95,13 +96,16 @@ export const BenchApp = ({ children }: { children: React.ReactNode }) => {
 export const BenchIndex = () => {
   const { getTab } = useRememberBenchTab();
   const dispatch = useDispatch();
+  const isAdmin = useSelector(getUserIsAdmin);
+  const navItems = useMemo(() => getBenchNavItems(isAdmin), [isAdmin]);
+
   useEffect(() => {
     const tabId = getTab();
     const navItem =
-      (tabId && BENCH_NAV_ITEMS.find((navItem) => navItem.id === tabId)) ||
+      (tabId && navItems.find((navItem) => navItem.id === tabId)) ||
       OVERVIEW_ITEM;
     dispatch(replace(navItem.url));
-  }, [dispatch, getTab]);
+  }, [dispatch, getTab, navItems]);
   return null;
 };
 

--- a/frontend/src/metabase/bench/components/BenchNavMenu.tsx
+++ b/frontend/src/metabase/bench/components/BenchNavMenu.tsx
@@ -1,12 +1,15 @@
 import type { ReactNode } from "react";
+import { useMemo } from "react";
 import { Link } from "react-router";
 
 import { BenchNavItem } from "metabase/bench/components/nav/BenchNavItem";
 import {
-  BENCH_NAV_SECTIONS,
   OVERVIEW_ITEM,
+  getBenchNavSections,
 } from "metabase/bench/constants/navigation";
 import LogoIcon from "metabase/common/components/LogoIcon";
+import { useSelector } from "metabase/lib/redux";
+import { getUserIsAdmin } from "metabase/selectors/user";
 import { Box, Stack, Text, UnstyledButton } from "metabase/ui";
 
 import S from "./BenchNavMenu.module.css";
@@ -32,6 +35,9 @@ interface BenchNavMenuProps {
 }
 
 export function BenchNavMenu({ onClose }: BenchNavMenuProps) {
+  const isAdmin = useSelector(getUserIsAdmin);
+  const navSections = useMemo(() => getBenchNavSections(isAdmin), [isAdmin]);
+
   return (
     <Box w={320} data-testid="bench-nav-menu">
       <Stack gap={0} p="lg">
@@ -42,7 +48,7 @@ export function BenchNavMenu({ onClose }: BenchNavMenuProps) {
           onClick={onClose}
         />
 
-        {BENCH_NAV_SECTIONS.map((section) => (
+        {navSections.map((section) => (
           <BenchNavSection key={section.id} title={section.getTitle()}>
             {section.items.map((item) => {
               const navItem = (

--- a/frontend/src/metabase/bench/components/utils.ts
+++ b/frontend/src/metabase/bench/components/utils.ts
@@ -1,5 +1,9 @@
 import { useCallback, useLayoutEffect, useState } from "react";
+import { routerActions } from "react-router-redux";
+import { connectedReduxRedirect } from "redux-auth-wrapper/history3/redirect";
 import _ from "underscore";
+
+import { MetabaseReduxContext } from "metabase/lib/redux";
 
 /**
  * react-resizable-panels sizes are in percentages,
@@ -33,4 +37,21 @@ export const useAbsoluteSize = ({ groupId }: { groupId: string }) => {
   const getSizeFn = useCallback((px: number) => (px / width) * 100, [width]);
 
   return getSizeFn;
+};
+
+export const createBenchAdminRouteGuard = (
+  routeKey: string,
+  Component?: Function, // eslint-disable-line @typescript-eslint/ban-types
+) => {
+  const Wrapper = connectedReduxRedirect({
+    wrapperDisplayName: `CanAccess(${routeKey})`,
+    redirectPath: "/bench/unauthorized",
+    allowRedirectBack: false,
+    authenticatedSelector: (state) =>
+      Boolean(state.currentUser && state.currentUser.is_superuser),
+    redirectAction: routerActions.replace,
+    context: MetabaseReduxContext,
+  });
+
+  return Wrapper(Component ?? (({ children }) => children));
 };

--- a/frontend/src/metabase/bench/constants/navigation.ts
+++ b/frontend/src/metabase/bench/constants/navigation.ts
@@ -1,5 +1,6 @@
 import { t } from "ttag";
 
+import { PLUGIN_TRANSFORMS, PLUGIN_TRANSFORMS_PYTHON } from "metabase/plugins";
 import type { IconName } from "metabase/ui";
 
 export interface BenchNavItem {
@@ -24,103 +25,90 @@ const OVERVIEW_ITEM: BenchNavItem = {
   getLabel: () => t`Overview`,
 };
 
-export const BENCH_NAV_SECTIONS: BenchNavSection[] = [
-  {
-    id: "data",
-    getTitle: () => t`Data`,
-    items: [
-      {
-        id: "metadata",
-        url: "/bench/metadata",
-        icon: "database",
-        getLabel: () => t`Metadata`,
-      },
-      {
-        id: "transforms",
-        url: "/bench/transforms",
-        icon: "transform",
-        getLabel: () => t`Transforms`,
-      },
-      {
-        id: "jobs",
-        url: "/bench/jobs",
-        icon: "play_outlined",
-        getLabel: () => t`Jobs`,
-        parentId: "transforms",
-        nested: true,
-      },
-      {
-        id: "runs",
-        url: "/bench/runs",
-        icon: "list",
-        getLabel: () => t`Runs`,
-        parentId: "transforms",
-        nested: true,
-      },
-    ],
-  },
-  {
-    id: "modeling",
-    getTitle: () => t`Modeling`,
-    items: [
-      {
-        id: "metric",
-        url: "/bench/metric",
-        icon: "metric",
-        getLabel: () => t`Metrics`,
-      },
-      {
-        id: "model",
-        url: "/bench/model",
-        icon: "model",
-        getLabel: () => t`Models`,
-      },
-      {
-        id: "segment",
-        url: "/bench/segment",
-        icon: "segment",
-        getLabel: () => t`Segments`,
-      },
-      {
-        id: "glossary",
-        url: "/bench/glossary",
-        icon: "globe",
-        getLabel: () => t`Glossary`,
-      },
-    ],
-  },
-  {
-    id: "tools",
-    getTitle: () => t`Tools`,
-    items: [
-      {
-        id: "dependency-graph",
-        url: "/bench/dependencies",
-        icon: "network",
-        getLabel: () => t`Dependency graph`,
-      },
-      {
-        id: "snippet",
-        url: "/bench/snippet",
-        icon: "snippet",
-        getLabel: () => t`SQL snippets`,
-      },
-      {
-        id: "library",
-        url: "/bench/library/common.py",
-        icon: "code_block",
-        getLabel: () => t`Python Library`,
-      },
-    ],
-  },
-];
+export const getBenchNavSections = (isAdmin: boolean): BenchNavSection[] => {
+  const navSections: BenchNavSection[] = [
+    {
+      id: "data",
+      getTitle: () => t`Data`,
+      items: [
+        ...(isAdmin
+          ? [
+            {
+              id: "metadata",
+              url: "/bench/metadata",
+              icon: "database",
+              getLabel: () => t`Metadata`,
+            },
+          ]
+          : []),
+        ...PLUGIN_TRANSFORMS.getTransformNavItems(isAdmin),
+      ],
+    },
+    {
+      id: "modeling",
+      getTitle: () => t`Modeling`,
+      items: [
+        {
+          id: "metric",
+          url: "/bench/metric",
+          icon: "metric",
+          getLabel: () => t`Metrics`,
+        },
+        {
+          id: "model",
+          url: "/bench/model",
+          icon: "model",
+          getLabel: () => t`Models`,
+        },
+        {
+          id: "segment",
+          url: "/bench/segment",
+          icon: "segment",
+          getLabel: () => t`Segments`,
+        },
+        {
+          id: "glossary",
+          url: "/bench/glossary",
+          icon: "globe",
+          getLabel: () => t`Glossary`,
+        },
+      ],
+    },
+    {
+      id: "tools",
+      getTitle: () => t`Tools`,
+      items: [
+        {
+          id: "dependency-graph",
+          url: "/bench/dependencies",
+          icon: "network",
+          getLabel: () => t`Dependency graph`,
+        },
+        {
+          id: "snippet",
+          url: "/bench/snippet",
+          icon: "snippet",
+          getLabel: () => t`SQL snippets`,
+        },
+        ...PLUGIN_TRANSFORMS_PYTHON.getTransformNavItems(isAdmin),
+      ],
+    },
+  ];
 
-export const BENCH_NAV_ITEMS: BenchNavItem[] = [
-  OVERVIEW_ITEM,
-  ...BENCH_NAV_SECTIONS.flatMap((section) => section.items),
-];
+  return navSections.filter((section) => section.items.length > 0);
+};
 
-export function findNavItemByPath(pathname: string): BenchNavItem | null {
+export const getBenchNavItems = (isAdmin: boolean): BenchNavItem[] => {
+  return [
+    OVERVIEW_ITEM,
+    ...getBenchNavSections(isAdmin).flatMap((section) => section.items),
+  ];
+};
+
+export function findNavItemByPath(
+  pathname: string,
+  isAdmin: boolean,
+): BenchNavItem | null {
   if (!pathname) {
     return null;
   }
@@ -134,7 +122,9 @@ export function findNavItemByPath(pathname: string): BenchNavItem | null {
 
   const pathSegment = pathParts[benchIndex + 1];
 
-  return BENCH_NAV_ITEMS.find((item) => item.id === pathSegment) ?? null;
+  return (
+    getBenchNavItems(isAdmin).find((item) => item.id === pathSegment) ?? null
+  );
 }
 
 export { OVERVIEW_ITEM };

--- a/frontend/src/metabase/bench/hooks/useBenchCurrentTab.ts
+++ b/frontend/src/metabase/bench/hooks/useBenchCurrentTab.ts
@@ -1,17 +1,20 @@
 import { useMemo } from "react";
 
 import {
-  BENCH_NAV_ITEMS,
   type BenchNavItem,
   findNavItemByPath,
+  getBenchNavItems,
 } from "metabase/bench/constants/navigation";
 import { usePath } from "metabase/common/hooks";
+import { useSelector } from "metabase/lib/redux";
+import { getUserIsAdmin } from "metabase/selectors/user";
 
 export function useBenchCurrentTab(): BenchNavItem {
   const pathname = usePath();
+  const isAdmin = useSelector(getUserIsAdmin);
 
   return useMemo(() => {
-    const item = pathname ? findNavItemByPath(pathname) : null;
-    return item ?? BENCH_NAV_ITEMS[0];
-  }, [pathname]);
+    const item = pathname ? findNavItemByPath(pathname, isAdmin) : null;
+    return item ?? getBenchNavItems(isAdmin)[0];
+  }, [isAdmin, pathname]);
 }

--- a/frontend/src/metabase/bench/routes.tsx
+++ b/frontend/src/metabase/bench/routes.tsx
@@ -8,6 +8,8 @@ import {
   UpdateSegmentForm,
 } from "metabase/admin/datamodel/containers/SegmentApp";
 import { MetadataLayout } from "metabase/bench/components/metadata/MetadataLayout";
+import { createBenchAdminRouteGuard } from "metabase/bench/components/utils";
+import { Unauthorized } from "metabase/common/components/ErrorPages";
 import NotFoundFallbackPage from "metabase/common/components/NotFoundFallbackPage";
 import { Route } from "metabase/hoc/Title";
 import { DataModel } from "metabase/metadata/pages/DataModel";
@@ -32,12 +34,12 @@ import {
   SnippetsLayout,
 } from "./components/snippets/SnippetsList";
 
-export const getBenchRoutes = () => (
+export const getBenchRoutes = (store, CanAccessSettings, isAdmin) => (
   <Route path="/bench">
     <IndexRoute component={BenchIndex} />
     <Route title={t`Bench`} component={BenchApp}>
       <Route path="overview" component={() => <OverviewPage />} />
-      {PLUGIN_TRANSFORMS.getTransformRoutes()}
+      {PLUGIN_TRANSFORMS.getTransformRoutes(isAdmin)}
       <Route path="segment" component={SegmentApp}>
         <Route path="new" component={CreateSegmentForm} />
         <Route path=":id" component={UpdateSegmentForm} />
@@ -62,7 +64,10 @@ export const getBenchRoutes = () => (
       </Route>
       <Route path="glossary" component={GlossaryContainer} />
       <Route path="dependencies" component={EmptySailboat} />
-      <Route path="metadata" component={MetadataLayout}>
+      <Route
+        path="metadata"
+        component={createBenchAdminRouteGuard("metadata", MetadataLayout)}
+      >
         <Route title={t`Table Metadata`}>
           <IndexRedirect to="database" />
           <Route path="database" component={DataModel} />
@@ -97,6 +102,7 @@ export const getBenchRoutes = () => (
           />
         </Route>
       </Route>
+      <Route path="unauthorized" component={Unauthorized} />
       <Route path="*" component={NotFoundFallbackPage} />
     </Route>
   </Route>

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -23,6 +23,7 @@ import {
   type EntityId,
   type PermissionSubject,
 } from "metabase/admin/permissions/types";
+import type { BenchNavItem } from "metabase/bench/constants/navigation";
 import type {
   MetricFilterControlsProps,
   MetricFilterSettings,
@@ -867,11 +868,13 @@ export const PLUGIN_SEMANTIC_SEARCH = {
 
 export type TransformsPlugin = {
   getTransformRoutes(): ReactNode;
+  getTransformNavItems(isAdmin: boolean): BenchNavItem[];
   ROOT_URL: string | null;
 };
 
 export const PLUGIN_TRANSFORMS: TransformsPlugin = {
   getTransformRoutes: () => null,
+  getTransformNavItems: () => [],
   ROOT_URL: null,
 };
 
@@ -902,7 +905,7 @@ export type PythonTransformsPlugin = {
     onAcceptProposed?: (query: PythonTransformSource) => void;
   }>;
   getAdminRoutes: () => ReactNode;
-  getTransformsNavLinks: () => ReactNode;
+  getTransformNavItems: (isAdmin: boolean) => BenchNavItem[];
   getCreateTransformsMenuItems: () => ReactNode;
 };
 
@@ -911,7 +914,7 @@ export const PLUGIN_TRANSFORMS_PYTHON: PythonTransformsPlugin = {
   TransformEditor: NotFoundPlaceholder,
   SourceSection: PluginPlaceholder,
   getAdminRoutes: () => null,
-  getTransformsNavLinks: () => null,
+  getTransformNavItems: () => [],
   getCreateTransformsMenuItems: () => null,
 };
 


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-2084/restrict-access-to-transforms-metadata-and-python-library-if-user-does

### Description

Describe the overall approach and the problem being solved.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> ...
2. ...

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
