### PR TITLE
Additional error handling in appdb reindexing

### DIFF
--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -207,10 +207,8 @@
                   (try
                     (t2/with-connection [safe-conn (mdb/app-db)]
                       (t2/delete! :conn safe-conn :model/SearchIndexMetadata :index_name (name table-name)))
-                    (catch Exception e2
-                      (log/warn e2 "Error clearing out search metadata after failure")))
-                    (catch Exception e
-                      (log/warn e "Error clearing out search metadata after failure")))
+                    (catch Exception del-e
+                      (log/warn del-e "Error clearing out search metadata after failure")))
                   (sync-tracking-atoms!))))
             (let [pending (:pending (sync-tracking-atoms!))]
               (log/infof "New pending index %s" pending)

--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -207,6 +207,8 @@
                   (try
                     (t2/with-connection [safe-conn (mdb/app-db)]
                       (t2/delete! :conn safe-conn :model/SearchIndexMetadata :index_name (name table-name)))
+                    (catch Exception e2
+                      (log/warn e2 "Error clearing out search metadata after failure")))
                     (catch Exception e
                       (log/warn e "Error clearing out search metadata after failure")))
                   (sync-tracking-atoms!))))

--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -204,7 +204,11 @@
                 (create-table! table-name)
                 (catch Exception e
                   (log/error e "Error creating pending index table, cleaning up metadata")
-                  (t2/delete! :model/SearchIndexMetadata :index_name (name table-name))
+                  (try
+                    (t2/with-connection [safe-conn (mdb/app-db)]
+                      (t2/delete! :conn safe-conn :model/SearchIndexMetadata :index_name (name table-name)))
+                    (catch Exception e
+                      (log/warn e "Error clearing out search metadata after failure")))
                   (sync-tracking-atoms!))))
             (let [pending (:pending (sync-tracking-atoms!))]
               (log/infof "New pending index %s" pending)


### PR DESCRIPTION
### Description

Improves error handing from #64897

There have been reports of a closed statement in the delete call, although I have been unable to reproduce it.

https://metaboat.slack.com/archives/C010L1Z4F9S/p1761233102124339

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
