### PR TITLE
[mage] Use Babashka to run cljfmt on staged files in git pre-commit hook

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -2,7 +2,8 @@
  ;; we put path as bin, and everything is in the ./mage subdirectory,
  ;; so the namespaces are mage.cli, mage.format, etc.
  :paths          ["mage/src" "mage/test" "bin/lint-migrations-file/src"]
- :deps           {org.babashka/json {:mvn/version "0.1.6"}
+ :deps           {dev.weavejester/cljfmt {:mvn/version "0.15.3"}
+                  org.babashka/json {:mvn/version "0.1.6"}
                   metosin/malli     {:mvn/version "0.17.0"}
                   table/table       {:mvn/version "0.5.0"}
                   mvxcvi/puget      {:mvn/version "1.3.4"}}

--- a/deps.edn
+++ b/deps.edn
@@ -691,7 +691,7 @@
   ;;
   ;; ./bin/mage cljfmt-all -h for more info
   :cljfmt
-  {:deps       {io.github.weavejester/cljfmt {:git/sha "7de286008766127128a156275b9add3bf443d7e5"}}
+  {:deps       {io.github.weavejester/cljfmt {:mvn/version "0.15.3"}}
    :ns-default cljfmt.tool
    :exec-fn    cljfmt.tool/fix}
 

--- a/mage/src/mage/format.clj
+++ b/mage/src/mage/format.clj
@@ -1,26 +1,26 @@
 (ns mage.format
   (:require
+   [cljfmt.tool]
    [clojure.string :as str]
    [mage.color :as c]
    [mage.util :as u]))
 
 (set! *warn-on-reflection* true)
 
-(defn- ->mode [force-check?] (if force-check? "check" "fix"))
+(defn- select-cljfmt-function [force-check?]
+  (if force-check? #'cljfmt.tool/check #'cljfmt.tool/fix))
 
 (defn files
   "Formats or checks a list of files."
   [{{force-check? :force-check} :options
     file-paths :arguments}]
-  (let [mode (->mode force-check?)]
+  (let [f (select-cljfmt-function force-check?)]
     (when-not (seq file-paths)
-      (throw (ex-info (str "No files to " mode "."
+      (throw (ex-info (str "No files to " f "."
                            "\nPlease specify file paths as arguments.")
                       {:babashka/exit 0})))
-    (printf (c/green "%sing %s...\n") mode (str/join ", " file-paths)) (flush)
-    (let [cmd (str "clojure -T:cljfmt " mode " '" (pr-str {:paths file-paths}) "'")]
-      (println "Running: " cmd)
-      (try (u/sh cmd) (catch Exception _e nil)))))
+    (printf (c/green "%sing %s...\n") f (str/join ", " file-paths)) (flush)
+    (try (f {:paths file-paths}) (catch Exception _e nil))))
 
 (defn updated
   "Formats or checks all updated clojure files with cljfmt."
@@ -40,7 +40,7 @@
          (u/debug "fp " file-paths)
          (if (seq file-paths)
            (files {:options {:force-check force-check?} :arguments file-paths})
-           (println (str "No staged clj, cljc, or cljs files to " (->mode force-check?) "."))))
+           (println (str "No staged clj, cljc, or cljs files to " (select-cljfmt-function force-check?) "."))))
        (catch Exception e
          (throw (ex-info (str (c/red "Problem formatting staged files. Are they readable?") "\ncause:\n" (ex-message e))
                          {:babashka/exit 1})))))
@@ -48,6 +48,6 @@
 (defn all
   "Formats or checks of the usual clojure files with cljfmt."
   [{{force-check? :force-check} :options}]
-  (let [mode (->mode force-check?)]
-    (println (str mode "ing all clojure files, sit tight: this could take a minute..."))
-    (u/sh (str "clojure -T:cljfmt " mode))))
+  (let [f (select-cljfmt-function force-check?)]
+    (println (format "Running %s on all clojure files, sit tight: this could take a minute..." f))
+    (f {})))


### PR DESCRIPTION
The biggest pre-commit hook overhead comes from running `bb cljfmt-staged` which in turn invokes `mage.format/staged` which in turns shells out to `clojure -T:cljfmt` which takes longer to bootstrap because it is regular Clojure.

As of sometime ago, Cljfmt is compatible with Babashka, which means we can use Babashka to run cljfmt on individual files. Saves ~1 second of waiting per commit which is a pure devexp thing. Especially if you like committing/amending a lot.

This PR provokes a question: why use Babashka only for individual files, but `cljfmt-all` still goes through Clojure? Because Clojure-run cljfmt is faster throughput-wise. Locally on M1, I get ~50 seconds to check all source files with Clojure vs 200-300 sec to do it with Babashka.

The proposed solution is open to a discussion.