### PR TITLE
Temporarily patch the broken FE unit test that times out

### DIFF
--- a/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceModal.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceModal.unit.spec.tsx
@@ -471,7 +471,7 @@ describe("ValuesSourceModal", () => {
         );
         expect(screen.getByText("do it once in a model")).toBeInTheDocument();
         expect(screen.getByText("do it once in a model").tagName).not.toBe("A");
-      });
+      }, 45000); // The test continues to exceed 30 seconds timeout in ci: https://github.com/metabase/metabase/actions/runs/18809109055/job/53668418124#step:5:786
     });
   });
 


### PR DESCRIPTION
Resolves DEV-1006, but I think we should examine what's going on and solve this without having to increase already insane timeout of 30 seconds.

https://github.com/metabase/metabase/actions/runs/18809109055/job/53668418124#step:5:786

> [!IMPORTANT]
> This test was introduced 15 months ago but only started failing recently. It might be a sign of a performance degradation in the real app, or at least a pointer to something that changed in the source code which is making this test timing out now.