### PR TITLE
Closes UXW-1993 tooltip columns in visualizer

### DIFF
--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.ts
@@ -8,6 +8,7 @@ import {
 } from "metabase/visualizations/shared/settings/cartesian-chart";
 import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
 import * as Lib from "metabase-lib";
+import { getColumnNameFromKey } from "metabase-lib/v1/queries/utils/column-key";
 import type {
   Card,
   Dataset,
@@ -82,10 +83,15 @@ function pickColumns(
   }
 
   if (isCartesianChart(display)) {
+    const tooltipColumns = (settings["graph.tooltip_columns"] || []).map(
+      getColumnNameFromKey,
+    );
+
     return originalColumns.filter((col) => {
       return (
         settings["graph.metrics"]?.includes(col.name) ||
-        settings["graph.dimensions"]?.includes(col.name)
+        settings["graph.dimensions"]?.includes(col.name) ||
+        tooltipColumns.includes(col.name)
       );
     });
   }

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.unit.spec.ts
@@ -102,6 +102,79 @@ describe("getInitialStateForCardDataSource", () => {
     });
   });
 
+  it("should pick columns from graph.tooltip_columns as well (metabase#64721)", () => {
+    const dataset = createMockDataset({
+      data: createMockDatasetData({
+        cols: [
+          createMockColumn({
+            name: "CREATED_AT",
+            base_type: "type/DateTime",
+            effective_type: "type/DateTime",
+            semantic_type: null,
+            unit: "month",
+          }),
+          createMockColumn({
+            name: "SOME_METRIC",
+            database_type: "int8",
+            semantic_type: "type/Quantity",
+            base_type: "type/BigInteger",
+          }),
+          createMockColumn({
+            name: "SOME_OTHER_METRIC",
+            database_type: "int8",
+            semantic_type: "type/Quantity",
+            base_type: "type/BigInteger",
+          }),
+        ],
+      }),
+    });
+
+    const card = createMockCard({
+      display: "line",
+      name: "ChartyMcChartface",
+      description: null,
+      visualization_settings: {
+        "graph.metrics": ["SOME_METRIC"],
+        "graph.dimensions": ["CREATED_AT"],
+        "graph.tooltip_columns": [
+          JSON.stringify(["name", "SOME_OTHER_METRIC"]),
+        ],
+      },
+    });
+
+    const state = getInitialStateForCardDataSource(card, dataset);
+
+    expect(state.columnValuesMapping).toEqual({
+      COLUMN_1: [
+        {
+          name: "COLUMN_1",
+          originalName: "CREATED_AT",
+          sourceId: "card:1",
+        },
+      ],
+      COLUMN_2: [
+        {
+          name: "COLUMN_2",
+          originalName: "SOME_METRIC",
+          sourceId: "card:1",
+        },
+      ],
+      COLUMN_3: [
+        {
+          name: "COLUMN_3",
+          originalName: "SOME_OTHER_METRIC",
+          sourceId: "card:1",
+        },
+      ],
+    });
+
+    expect(state.settings).toEqual({
+      "graph.dimensions": ["COLUMN_1"],
+      "graph.metrics": ["COLUMN_2"],
+      "graph.tooltip_columns": [JSON.stringify(["name", "COLUMN_3"])],
+    });
+  });
+
   it("should ignore superfluous columns when the original card is a combo chart", () => {
     const dataset = createMockDataset({
       data: createMockDatasetData({


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #64721
Closes [UXW-1993: Visualizer Erases Tooltips form Underlying Viz](https://linear.app/metabase/issue/UXW-1993/visualizer-erases-tooltips-form-underlying-viz)

### Description

Tooltip columns not present as metrics or dimensions in cartesian charts would not be present in column refs, despite being needed by tooltips.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
