### PR TITLE
make HoverCard dropdown default to bg-primary

### DIFF
--- a/frontend/src/metabase/embedding-sdk/theme/embedding-color-palette.ts
+++ b/frontend/src/metabase/embedding-sdk/theme/embedding-color-palette.ts
@@ -51,7 +51,7 @@ export const SDK_TO_MAIN_APP_COLORS_MAPPING: Record<
   "text-primary": ["text-dark", "text-primary"],
   "text-secondary": ["text-medium", "text-secondary"],
   "text-tertiary": ["text-light", "text-tertiary"],
-  background: ["bg-white", "background"],
+  background: ["bg-white", "bg-primary", "background"],
   "background-hover": ["bg-light", "background-hover"],
   "background-secondary": ["bg-medium"],
   "background-disabled": ["background-disabled"],

--- a/frontend/src/metabase/ui/components/overlays/HoverCard/HoverCard.module.css
+++ b/frontend/src/metabase/ui/components/overlays/HoverCard/HoverCard.module.css
@@ -2,4 +2,5 @@
   padding: 0;
   overflow: auto;
   background-color: var(--mb-color-bg-primary);
+  border: 1px solid var(--mb-color-border);
 }

--- a/frontend/src/metabase/ui/components/overlays/HoverCard/HoverCard.module.css
+++ b/frontend/src/metabase/ui/components/overlays/HoverCard/HoverCard.module.css
@@ -1,5 +1,5 @@
 .dropdown {
   padding: 0;
   overflow: auto;
-  background-color: var(--mb-color-bg-medium);
+  background-color: var(--mb-color-bg-primary);
 }


### PR DESCRIPTION
Closes UXW-2137

Makes the `HoverCard` component has a white background color on light mode like before, and dark color on dark mode.

<img width="300" alt="CleanShot 2568-10-27 at 16 07 56@2x" src="https://github.com/user-attachments/assets/e42d9819-404d-46ba-b934-84421238c507" />
