### PR TITLE
Fix fe coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,7 @@
 name: Test coverage
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '40 1 * * *' # every day at 1:40
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   fe-test-coverage:
     runs-on: ubuntu-22.04
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - name: Prepare front-end environment
@@ -15,9 +15,13 @@ jobs:
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
       - name: Run frontend unit tests
-        run: yarn run test-unit --silent --coverage
+        run: |
+          yarn run test-unit \
+            --silent \
+            --coverage \
+            --testTimeout=60000
       - name: Upload coverage to codecov.io
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           files: ./coverage/lcov.info
           flags: front-end

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,4 +1,4 @@
-name: Test coverage
+name: Frontend Test Coverage
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Instrumentation adds a lot of overhead. Unfortunately, even 30 seconds timeout wasn't enough for some of our unit tests. We're doubling that value in order to minimize the chances of this workflow halting/failing again.

## Test
Here's a test run based on this branch that proves the fix is working as intended: https://github.com/metabase/metabase/actions/runs/18838120734/job/53743756875