### PR TITLE
Add horizontal padding on embedding hub when shown in homepage

### DIFF
--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubHomePage.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubHomePage.tsx
@@ -25,7 +25,7 @@ export const EmbeddingHubHomePage = (): ReactNode => {
     dispatch(dismissEmbeddingHomepage("dismissed-done"));
 
   return (
-    <Stack mx="auto" py="xl" maw={800}>
+    <Stack mx="auto" p="xl" maw={850}>
       <Group gap="sm" justify="space-between" mb="xl">
         <Group gap="sm">
           <MetabotGreeting />


### PR DESCRIPTION
Adds horizontal padding on smaller screens for the onboarding homepage, for displaying the checklist in smaller viewports.

<img width="300" alt="CleanShot 2568-10-27 at 18 54 10@2x" src="https://github.com/user-attachments/assets/61db8ad3-0860-425e-b73f-5aff2a0e69ea" />

<img width="300" alt="CleanShot 2568-10-27 at 18 53 54@2x" src="https://github.com/user-attachments/assets/d075d9aa-9adc-4638-a159-db4cfa766e9f" />
