### PR TITLE
Closes UXW-2112 preserve default colors when renaming breakout values in cartesian charts

### DIFF
--- a/frontend/src/metabase/visualizations/shared/settings/series.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/series.ts
@@ -1,5 +1,4 @@
 import { getIn } from "icepick";
-import _ from "underscore";
 
 import { getColorsForValues } from "metabase/lib/colors/charts";
 import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
@@ -13,11 +12,27 @@ export const getSeriesColors = (
   settings: VisualizationSettings,
   seriesVizSettingsDefaultKeys: string[],
 ) => {
-  const assignments = _.chain(seriesVizSettingsKeys)
-    .map((key) => [key, getIn(settings, [SERIES_SETTING_KEY, key, "color"])])
-    .filter(([_key, color]) => color != null)
-    .object()
-    .value();
+  const assignments: Record<string, string> = {};
+
+  const seriesSettings = getIn(settings, [SERIES_SETTING_KEY]) as
+    | Record<string, { color?: string; title?: string }>
+    | undefined;
+
+  if (seriesSettings) {
+    for (const [key, seriesObject] of Object.entries(seriesSettings)) {
+      if (!seriesObject) {
+        continue;
+      }
+
+      if (seriesObject.color != null) {
+        assignments[key] = seriesObject.color;
+
+        if (seriesObject.title != null) {
+          assignments[seriesObject.title] = seriesObject.color;
+        }
+      }
+    }
+  }
 
   const legacyColors = settings["graph.colors"];
   if (legacyColors) {

--- a/frontend/src/metabase/visualizations/shared/settings/series.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/series.unit.spec.ts
@@ -73,23 +73,6 @@ describe("getSeriesColors", () => {
     expect(result["Custom Title Only"]).toBeUndefined();
   });
 
-  it("should handle series with color but null title", () => {
-    const settings = {
-      series_settings: {
-        "Series A": {
-          color: "#FF0000",
-          title: null,
-        },
-      },
-    };
-
-    const result = getSeriesColors(mockSeriesKeys, settings, mockDefaultKeys);
-
-    expect(result["Series A"]).toBe("#FF0000");
-    // Should not create a mapping for null title
-    expect(result[null as any]).toBeUndefined();
-  });
-
   it("should use legacy colors when available and no series settings conflict", () => {
     const settings = {
       "graph.colors": ["#LEGACY1", "#LEGACY2", "#LEGACY3"],

--- a/frontend/src/metabase/visualizations/shared/settings/series.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/series.unit.spec.ts
@@ -1,0 +1,181 @@
+import { getSeriesColors } from "./series";
+
+describe("getSeriesColors", () => {
+  const mockSeriesKeys = ["Series A", "Series B", "Series C"];
+  const mockDefaultKeys = ["Default A", "Default B"];
+
+  it("should return colors when no series settings are provided", () => {
+    const settings = {};
+    const result = getSeriesColors(mockSeriesKeys, settings, mockDefaultKeys);
+
+    expect(result).toBeDefined();
+    expect(Object.keys(result)).toEqual(mockSeriesKeys);
+  });
+
+  it("should assign custom colors from series settings", () => {
+    const settings = {
+      series_settings: {
+        "Series A": { color: "#FF0000" },
+        "Series B": { color: "#00FF00" },
+      },
+    };
+
+    const result = getSeriesColors(mockSeriesKeys, settings, mockDefaultKeys);
+
+    expect(result["Series A"]).toBe("#FF0000");
+    expect(result["Series B"]).toBe("#00FF00");
+  });
+
+  it("should assign colors to custom titles when series has custom title", () => {
+    // Test with custom titles as part of the series keys
+    const seriesKeysWithCustomTitles = [
+      "Series A",
+      "Custom Title A",
+      "Series B",
+    ];
+    const settings = {
+      series_settings: {
+        "Series A": {
+          color: "#FF0000",
+          title: "Custom Title A",
+        },
+        "Series B": {
+          color: "#00FF00",
+          title: "Custom Title B",
+        },
+      },
+    };
+
+    const result = getSeriesColors(
+      seriesKeysWithCustomTitles,
+      settings,
+      mockDefaultKeys,
+    );
+
+    // Original series key should have the color
+    expect(result["Series A"]).toBe("#FF0000");
+    expect(result["Series B"]).toBe("#00FF00");
+
+    // Custom title should also be assigned the same color when it's in the keys
+    expect(result["Custom Title A"]).toBe("#FF0000");
+  });
+
+  it("should handle series with custom title but no color", () => {
+    const settings = {
+      series_settings: {
+        "Series A": { title: "Custom Title Only" },
+      },
+    };
+
+    const result = getSeriesColors(mockSeriesKeys, settings, mockDefaultKeys);
+
+    // Should not assign any color mapping for custom title when no color is provided
+    expect(result["Custom Title Only"]).toBeUndefined();
+  });
+
+  it("should handle series with color but null title", () => {
+    const settings = {
+      series_settings: {
+        "Series A": {
+          color: "#FF0000",
+          title: null,
+        },
+      },
+    };
+
+    const result = getSeriesColors(mockSeriesKeys, settings, mockDefaultKeys);
+
+    expect(result["Series A"]).toBe("#FF0000");
+    // Should not create a mapping for null title
+    expect(result[null as any]).toBeUndefined();
+  });
+
+  it("should use legacy colors when available and no series settings conflict", () => {
+    const settings = {
+      "graph.colors": ["#LEGACY1", "#LEGACY2", "#LEGACY3"],
+    };
+
+    const result = getSeriesColors(mockSeriesKeys, settings, mockDefaultKeys);
+
+    expect(result["Series A"]).toBe("#LEGACY1");
+    expect(result["Series B"]).toBe("#LEGACY2");
+    expect(result["Series C"]).toBe("#LEGACY3");
+  });
+
+  it("should prioritize series settings over legacy colors", () => {
+    const settings = {
+      series_settings: {
+        "Series A": { color: "#SERIES_COLOR" },
+      },
+      "graph.colors": ["#LEGACY1", "#LEGACY2", "#LEGACY3"],
+    };
+
+    const result = getSeriesColors(mockSeriesKeys, settings, mockDefaultKeys);
+
+    expect(result["Series A"]).toBe("#SERIES_COLOR");
+    expect(result["Series B"]).toBe("#LEGACY2");
+    expect(result["Series C"]).toBe("#LEGACY3");
+  });
+
+  it("should handle complex scenario with mixed custom titles and colors", () => {
+    const seriesKeysWithTitles = [
+      "Series A",
+      "Revenue",
+      "Series B",
+      "Series C",
+    ];
+    const settings = {
+      series_settings: {
+        "Series A": {
+          color: "#RED",
+          title: "Revenue",
+        },
+        "Series B": {
+          color: "#BLUE",
+          title: "Profit",
+        },
+        "Series C": {
+          title: "Cost", // No color, should not create color mapping
+        },
+      },
+      "graph.colors": ["#LEGACY1", "#LEGACY2", "#LEGACY3", "#LEGACY4"],
+    };
+
+    const result = getSeriesColors(
+      seriesKeysWithTitles,
+      settings,
+      mockDefaultKeys,
+    );
+
+    // Series with custom colors should be assigned those colors
+    expect(result["Series A"]).toBe("#RED");
+    expect(result["Revenue"]).toBe("#RED"); // Custom title gets the same color when it's in keys
+    expect(result["Series B"]).toBe("#BLUE");
+
+    // Series with title but no color should use legacy/auto-assigned color
+    expect(result["Series C"]).toBeDefined();
+  });
+
+  it("should create internal assignments for custom titles that can be referenced", () => {
+    // This test verifies the internal logic that creates assignments for custom titles
+    // even when they're not in the output keys
+    const settings = {
+      series_settings: {
+        "Original Key": {
+          color: "#CUSTOM_COLOR",
+          title: "Display Title",
+        },
+      },
+    };
+
+    // When the custom title is later used as a key, it should get the assigned color
+    const seriesKeysWithTitle = ["Display Title", "Other Series"];
+    const result = getSeriesColors(
+      seriesKeysWithTitle,
+      settings,
+      mockDefaultKeys,
+    );
+
+    expect(result["Display Title"]).toBe("#CUSTOM_COLOR");
+  });
+});


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #64963
Closes [UXW-2112: Breakout label renames break custom colors when seeing question from dashboard](https://linear.app/metabase/issue/UXW-2112/breakout-label-renames-break-custom-colors-when-seeing-question-from)

### Description
  - Fixes an issue where custom series colors would break when breakout labels are renamed
  - Updates getSeriesColors to properly handle custom titles by creating color assignments for both the original series key and the custom title
  - Adds comprehensive test coverage for the getSeriesColors function, especially for custom title scenarios


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
