### PR TITLE
Fix dependencies backfilling: ignore analysis errors

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/dependencies/events.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/events.clj
@@ -13,8 +13,8 @@
 ;; dependency graph up to date. Transform *runs* are also a trigger, since the transform's output table may be created
 ;; or changed at that point.
 
-(defmacro ignore-permanent-errors
-  "Ignore errors that should not be retried.
+(defmacro ignore-errors
+  "Ignore errors.
 
   In practice, we cannot reliably distinguish permanent and temporary errors, so in principle
   every error should be retried a few times. Unfortunately that doesn't work, because updating the
@@ -40,7 +40,7 @@
   (when (premium-features/has-feature? :dependencies)
     (t2/with-transaction [_conn]
       (models.dependency/replace-dependencies! :card (:id object)
-                                               (ignore-permanent-errors
+                                               (ignore-errors
                                                 (deps.calculation/upstream-deps:card object)))
       (when (not= (:dependency_analysis_version object) models.dependency/current-dependency-analysis-version)
         (t2/update! :model/Card (:id object)
@@ -64,7 +64,7 @@
   (when (premium-features/has-feature? :dependencies)
     (t2/with-transaction [_conn]
       (models.dependency/replace-dependencies! :snippet (:id object)
-                                               (ignore-permanent-errors
+                                               (ignore-errors
                                                 (deps.calculation/upstream-deps:snippet object)))
       (when (not= (:dependency_analysis_version object) models.dependency/current-dependency-analysis-version)
         (t2/update! :model/NativeQuerySnippet (:id object)
@@ -113,7 +113,7 @@
   (when (premium-features/has-feature? :dependencies)
     (t2/with-transaction [_conn]
       (models.dependency/replace-dependencies! :transform (:id object)
-                                               (ignore-permanent-errors
+                                               (ignore-errors
                                                 (deps.calculation/upstream-deps:transform object)))
       (when (not= (:dependency_analysis_version object) models.dependency/current-dependency-analysis-version)
         (t2/update! :model/Transform (:id object) {:dependency_analysis_version models.dependency/current-dependency-analysis-version}))
@@ -161,7 +161,7 @@
                                                 :dashboardcard_id [:in (map :id dashcards)]))
             dashboard (assoc object :dashcards dashcards :series-card-ids series-card-ids)]
         (models.dependency/replace-dependencies! :dashboard dashboard-id
-                                                 (ignore-permanent-errors
+                                                 (ignore-errors
                                                   (deps.calculation/upstream-deps:dashboard dashboard))))
       (when (not= (:dependency_analysis_version object) models.dependency/current-dependency-analysis-version)
         (t2/update! :model/Dashboard (:id object)
@@ -185,7 +185,7 @@
   (when (premium-features/has-feature? :dependencies)
     (t2/with-transaction [_conn]
       (models.dependency/replace-dependencies! :document (:id object)
-                                               (ignore-permanent-errors
+                                               (ignore-errors
                                                 (deps.calculation/upstream-deps:document object)))
       (when (not= (:dependency_analysis_version object) models.dependency/current-dependency-analysis-version)
         (t2/update! :model/Document (:id object)
@@ -208,7 +208,7 @@
   [_ {:keys [object]}]
   (when (premium-features/has-feature? :dependencies)
     (t2/with-transaction [_conn]
-      (models.dependency/replace-dependencies! :sandbox (:id object) (ignore-permanent-errors
+      (models.dependency/replace-dependencies! :sandbox (:id object) (ignore-errors
                                                                       (deps.calculation/upstream-deps:sandbox object)))
       (when (not= (:dependency_analysis_version object) models.dependency/current-dependency-analysis-version)
         (t2/update! :model/Sandbox (:id object)

--- a/enterprise/backend/src/metabase_enterprise/dependencies/events.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/events.clj
@@ -4,6 +4,7 @@
    [metabase-enterprise.dependencies.models.dependency :as models.dependency]
    [metabase.events.core :as events]
    [metabase.premium-features.core :as premium-features]
+   [metabase.util.log :as log]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
@@ -11,6 +12,23 @@
 ;; The below listens for inserts, updates and deletes of cards, snippets and transforms in order to keep the
 ;; dependency graph up to date. Transform *runs* are also a trigger, since the transform's output table may be created
 ;; or changed at that point.
+
+(defmacro ignore-permanent-errors
+  "Ignore errors that should not be retried.
+
+  In practice, we cannot reliably distinguish permanent and temporary errors, so in principle
+  every error should be retried a few times. Unfortunately that doesn't work, because updating the
+  dependency_analysis_version field itself is a trigger for new analysis, so the caller has no
+  way to give up and commit the new version after a few retries. We stop on every error until this
+  becomes a serious enough issue, at which point we will have to redesign version marking and
+  analysis triggering."
+  {:style/indent 0}
+  [& body]
+  `(try
+     ~@body
+     (catch clojure.lang.ExceptionInfo e#
+       (log/error e# "Dependency calculation failed")
+       nil)))
 
 ;; ### Cards
 (derive ::card-deps :metabase/event)
@@ -21,7 +39,9 @@
   [_ {:keys [object]}]
   (when (premium-features/has-feature? :dependencies)
     (t2/with-transaction [_conn]
-      (models.dependency/replace-dependencies! :card (:id object) (deps.calculation/upstream-deps:card object))
+      (models.dependency/replace-dependencies! :card (:id object)
+                                               (ignore-permanent-errors
+                                                (deps.calculation/upstream-deps:card object)))
       (when (not= (:dependency_analysis_version object) models.dependency/current-dependency-analysis-version)
         (t2/update! :model/Card (:id object)
                     {:dependency_analysis_version models.dependency/current-dependency-analysis-version})))))
@@ -43,7 +63,9 @@
   [_ {:keys [object]}]
   (when (premium-features/has-feature? :dependencies)
     (t2/with-transaction [_conn]
-      (models.dependency/replace-dependencies! :snippet (:id object) (deps.calculation/upstream-deps:snippet object))
+      (models.dependency/replace-dependencies! :snippet (:id object)
+                                               (ignore-permanent-errors
+                                                (deps.calculation/upstream-deps:snippet object)))
       (when (not= (:dependency_analysis_version object) models.dependency/current-dependency-analysis-version)
         (t2/update! :model/NativeQuerySnippet (:id object)
                     {:dependency_analysis_version models.dependency/current-dependency-analysis-version})))))
@@ -90,7 +112,9 @@
   [_ {:keys [object]}]
   (when (premium-features/has-feature? :dependencies)
     (t2/with-transaction [_conn]
-      (models.dependency/replace-dependencies! :transform (:id object) (deps.calculation/upstream-deps:transform object))
+      (models.dependency/replace-dependencies! :transform (:id object)
+                                               (ignore-permanent-errors
+                                                (deps.calculation/upstream-deps:transform object)))
       (when (not= (:dependency_analysis_version object) models.dependency/current-dependency-analysis-version)
         (t2/update! :model/Transform (:id object) {:dependency_analysis_version models.dependency/current-dependency-analysis-version}))
       (drop-outdated-target-dep! object))))
@@ -136,7 +160,9 @@
                               (t2/select-fn-set :card_id :model/DashboardCardSeries
                                                 :dashboardcard_id [:in (map :id dashcards)]))
             dashboard (assoc object :dashcards dashcards :series-card-ids series-card-ids)]
-        (models.dependency/replace-dependencies! :dashboard dashboard-id (deps.calculation/upstream-deps:dashboard dashboard)))
+        (models.dependency/replace-dependencies! :dashboard dashboard-id
+                                                 (ignore-permanent-errors
+                                                  (deps.calculation/upstream-deps:dashboard dashboard))))
       (when (not= (:dependency_analysis_version object) models.dependency/current-dependency-analysis-version)
         (t2/update! :model/Dashboard (:id object)
                     {:dependency_analysis_version models.dependency/current-dependency-analysis-version})))))
@@ -158,7 +184,9 @@
   [_ {:keys [object]}]
   (when (premium-features/has-feature? :dependencies)
     (t2/with-transaction [_conn]
-      (models.dependency/replace-dependencies! :document (:id object) (deps.calculation/upstream-deps:document object))
+      (models.dependency/replace-dependencies! :document (:id object)
+                                               (ignore-permanent-errors
+                                                (deps.calculation/upstream-deps:document object)))
       (when (not= (:dependency_analysis_version object) models.dependency/current-dependency-analysis-version)
         (t2/update! :model/Document (:id object)
                     {:dependency_analysis_version models.dependency/current-dependency-analysis-version})))))
@@ -180,7 +208,8 @@
   [_ {:keys [object]}]
   (when (premium-features/has-feature? :dependencies)
     (t2/with-transaction [_conn]
-      (models.dependency/replace-dependencies! :sandbox (:id object) (deps.calculation/upstream-deps:sandbox object))
+      (models.dependency/replace-dependencies! :sandbox (:id object) (ignore-permanent-errors
+                                                                      (deps.calculation/upstream-deps:sandbox object)))
       (when (not= (:dependency_analysis_version object) models.dependency/current-dependency-analysis-version)
         (t2/update! :model/Sandbox (:id object)
                     {:dependency_analysis_version models.dependency/current-dependency-analysis-version})))))

--- a/enterprise/backend/src/metabase_enterprise/dependencies/events.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/events.clj
@@ -26,7 +26,7 @@
   [& body]
   `(try
      ~@body
-     (catch clojure.lang.ExceptionInfo e#
+     (catch Throwable e#
        (log/error e# "Dependency calculation failed")
        nil)))
 

--- a/enterprise/backend/test/metabase_enterprise/dependencies/events_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/events_test.clj
@@ -1,11 +1,14 @@
 (ns metabase-enterprise.dependencies.events-test
   (:require
-   [clojure.test :refer [deftest is]]
+   [clojure.test :refer [deftest is testing]]
+   [metabase-enterprise.dependencies.calculation :as deps.calculation]
+   [metabase-enterprise.dependencies.models.dependency :as models.dependency]
    [metabase.api.common :as api]
    [metabase.events.core :as events]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.test :as mt]
+   [metabase.util.log.capture :as log.capture]
    [toucan2.core :as t2]))
 
 (deftest dashboard-update-sets-correct-dependencies
@@ -17,20 +20,20 @@
           orders (lib.metadata/table mp orders-id)
           category-field (lib.metadata/field mp (mt/id :products :category))]
       (mt/with-premium-features #{:dependencies}
-        (mt/with-temp  [:model/Card {basic-card-id :id} {:dataset_query (lib/query mp products)}
-                        :model/Card {series-card-id :id} {:dataset_query (lib/query mp orders)}
-                        :model/Card {param-source-card-id :id} {:dataset_query (-> (lib/query mp products)
-                                                                                   (lib/aggregate (lib/count))
-                                                                                   (lib/breakout category-field))}
-                        :model/Dashboard {dashboard-id :id :as dashboard} {:parameters [{:id "category-param"
-                                                                                         :type "category"
-                                                                                         :values_source_type "card"
-                                                                                         :values_source_config {:card_id param-source-card-id}}]}
-                        :model/DashboardCard {basic-dashcard-id :id} {:dashboard_id dashboard-id
-                                                                      :card_id basic-card-id}
-                        :model/DashboardCardSeries _ {:dashboardcard_id basic-dashcard-id
-                                                      :card_id series-card-id
-                                                      :position 0}]
+        (mt/with-temp [:model/Card {basic-card-id :id} {:dataset_query (lib/query mp products)}
+                       :model/Card {series-card-id :id} {:dataset_query (lib/query mp orders)}
+                       :model/Card {param-source-card-id :id} {:dataset_query (-> (lib/query mp products)
+                                                                                  (lib/aggregate (lib/count))
+                                                                                  (lib/breakout category-field))}
+                       :model/Dashboard {dashboard-id :id :as dashboard} {:parameters [{:id "category-param"
+                                                                                        :type "category"
+                                                                                        :values_source_type "card"
+                                                                                        :values_source_config {:card_id param-source-card-id}}]}
+                       :model/DashboardCard {basic-dashcard-id :id} {:dashboard_id dashboard-id
+                                                                     :card_id basic-card-id}
+                       :model/DashboardCardSeries _ {:dashboardcard_id basic-dashcard-id
+                                                     :card_id series-card-id
+                                                     :position 0}]
           (events/publish-event! :event/dashboard-create {:object dashboard :user-id api/*current-user-id*})
           (is (=? #{{:from_entity_type :dashboard
                      :from_entity_id dashboard-id
@@ -45,7 +48,7 @@
                      :to_entity_type :card
                      :to_entity_id param-source-card-id}}
                   (into #{} (map #(dissoc % :id)
-                                 (t2/select :model/Dependency :from_entity_id dashboard-id)))))
+                                 (t2/select :model/Dependency :from_entity_id dashboard-id :from_entity_type :dashboard)))))
           (t2/delete! :model/DashboardCard :id basic-dashcard-id)
           (t2/update! :model/Dashboard dashboard-id {:parameters []})
           (mt/with-temp [:model/Card {scalar-card-id :id} {:dataset_query (-> (lib/query mp products)
@@ -121,10 +124,10 @@
                          :to_entity_type :dashboard
                          :to_entity_id column-click-target-dashboard-id}}
                       (into #{} (map #(dissoc % :id)
-                                     (t2/select :model/Dependency :from_entity_id dashboard-id)))))
+                                     (t2/select :model/Dependency :from_entity_id dashboard-id :from_entity_type :dashboard)))))
               (t2/delete! :model/Dashboard dashboard-id)
               (events/publish-event! :event/dashboard-delete {:object updated-dashboard :user-id api/*current-user-id*})
-              (is (empty? (t2/select :model/Dependency :from_entity_id dashboard-id))))))))))
+              (is (empty? (t2/select :model/Dependency :from_entity_id dashboard-id :from_entity_type :dashboard))))))))))
 
 (deftest document-update-sets-correct-dependencies
   (mt/with-test-user :rasta
@@ -132,17 +135,17 @@
           products-id (mt/id :products)
           products (lib.metadata/table mp products-id)]
       (mt/with-premium-features #{:dependencies}
-        (mt/with-temp  [:model/Card {card-id :id} {:dataset_query (lib/query mp products)}
-                        :model/Card {embedded-card-id :id} {:dataset_query (lib/query mp products)}
-                        :model/Dashboard {dashboard-id :id} {}
-                        :model/Document {document-id :id :as document} {:content_type "application/json+vnd.prose-mirror"
-                                                                        :document {:type "doc"
-                                                                                   :content [{:type "paragraph"
-                                                                                              :content [{:type "smartLink"
-                                                                                                         :attrs {:entityId card-id
-                                                                                                                 :model "card"}}]}
-                                                                                             {:type "cardEmbed"
-                                                                                              :attrs {:id embedded-card-id}}]}}]
+        (mt/with-temp [:model/Card {card-id :id} {:dataset_query (lib/query mp products)}
+                       :model/Card {embedded-card-id :id} {:dataset_query (lib/query mp products)}
+                       :model/Dashboard {dashboard-id :id} {}
+                       :model/Document {document-id :id :as document} {:content_type "application/json+vnd.prose-mirror"
+                                                                       :document {:type "doc"
+                                                                                  :content [{:type "paragraph"
+                                                                                             :content [{:type "smartLink"
+                                                                                                        :attrs {:entityId card-id
+                                                                                                                :model "card"}}]}
+                                                                                            {:type "cardEmbed"
+                                                                                             :attrs {:id embedded-card-id}}]}}]
           (events/publish-event! :event/document-create {:object document :user-id api/*current-user-id*})
           (is (=? #{{:from_entity_type :document
                      :from_entity_id document-id
@@ -153,7 +156,7 @@
                      :to_entity_type :card
                      :to_entity_id embedded-card-id}}
                   (into #{} (map #(dissoc % :id)
-                                 (t2/select :model/Dependency :from_entity_id document-id)))))
+                                 (t2/select :model/Dependency :from_entity_id document-id :from_entity_type :document)))))
           (let [updated-doc (assoc document :document {:type "doc"
                                                        :content [{:type "paragraph"
                                                                   :content [{:type "smartLink"
@@ -173,28 +176,28 @@
                        :to_entity_type :table
                        :to_entity_id products-id}}
                     (into #{} (map #(dissoc % :id)
-                                   (t2/select :model/Dependency :from_entity_id document-id)))))
+                                   (t2/select :model/Dependency :from_entity_id document-id :from_entity_type :document)))))
             (t2/delete! :model/Document document-id)
             (events/publish-event! :event/document-delete {:object document :user-id api/*current-user-id*})
-            (is (empty? (t2/select :model/Dependency :from_entity_id document-id)))))))))
+            (is (empty? (t2/select :model/Dependency :from_entity_id document-id :from_entity_type :document)))))))))
 
 (deftest sandbox-update-sets-correct-dependencies
   (mt/with-premium-features #{:sandboxes}
     (mt/with-test-user :rasta
       (mt/with-premium-features #{:dependencies}
-        (mt/with-temp  [:model/PermissionsGroup {group-id :id} {:name "sandbox group"}
-                        :model/Card {card1-id :id} {}
-                        :model/Card {card2-id :id} {}
-                        :model/Sandbox {sandbox-id :id :as sandbox} {:group_id group-id
-                                                                     :table_id (mt/id :products)
-                                                                     :card_id card1-id}]
+        (mt/with-temp [:model/PermissionsGroup {group-id :id} {:name "sandbox group"}
+                       :model/Card {card1-id :id} {}
+                       :model/Card {card2-id :id} {}
+                       :model/Sandbox {sandbox-id :id :as sandbox} {:group_id group-id
+                                                                    :table_id (mt/id :products)
+                                                                    :card_id card1-id}]
           (events/publish-event! :event/sandbox-create {:object sandbox :user-id api/*current-user-id*})
           (is (=? #{{:from_entity_type :sandbox
                      :from_entity_id sandbox-id
                      :to_entity_type :card
                      :to_entity_id card1-id}}
                   (into #{} (map #(dissoc % :id)
-                                 (t2/select :model/Dependency :from_entity_id sandbox-id)))))
+                                 (t2/select :model/Dependency :from_entity_id sandbox-id :from_entity_type :sandbox)))))
           (t2/update! :model/Sandbox sandbox-id (assoc sandbox :card_id card2-id))
           (let [updated-sandbox (t2/select-one :model/Sandbox :id sandbox-id)]
             (events/publish-event! :event/sandbox-update {:object updated-sandbox :user-id api/*current-user-id*})
@@ -203,7 +206,173 @@
                        :to_entity_type :card
                        :to_entity_id card2-id}}
                     (into #{} (map #(dissoc % :id)
-                                   (t2/select :model/Dependency :from_entity_id sandbox-id)))))
+                                   (t2/select :model/Dependency :from_entity_id sandbox-id :from_entity_type :sandbox)))))
             (t2/delete! :model/Sandbox sandbox-id)
             (events/publish-event! :event/sandbox-delete {:object sandbox :user-id api/*current-user-id*})
-            (is (empty? (t2/select :model/Dependency :from_entity_id sandbox-id)))))))))
+            (is (empty? (t2/select :model/Dependency :from_entity_id sandbox-id :from_entity_type :sandbox)))))))))
+
+(deftest card-dependency-calculation-error-handling-test
+  (testing "When dependency calculation throws an error, it should be logged and the version should still be updated"
+    (mt/with-test-user :rasta
+      (let [mp (mt/metadata-provider)
+            products-id (mt/id :products)
+            products (lib.metadata/table mp products-id)]
+        (mt/with-premium-features #{:dependencies}
+          (mt/with-temp [:model/Card {card-id :id :as card} {:dataset_query (lib/query mp products)}]
+            (log.capture/with-log-messages-for-level [messages ["metabase-enterprise.dependencies.events" :error]]
+              (with-redefs [deps.calculation/upstream-deps:card (fn [_]
+                                                                  (throw (ex-info "Dependency calculation failed"
+                                                                                  {:card-id card-id})))]
+                (testing "on create event"
+                  (events/publish-event! :event/card-create {:object card :user-id api/*current-user-id*})
+                  (is (some #(and (= "Dependency calculation failed" (ex-message (:e %)))
+                                  (= :error (:level %)))
+                            (messages)))
+                  (is (= models.dependency/current-dependency-analysis-version
+                         (t2/select-one-fn :dependency_analysis_version :model/Card :id card-id)))
+                  (is (empty? (t2/select :model/Dependency :from_entity_id card-id :from_entity_type :card))))
+                (testing "on update event"
+                  (events/publish-event! :event/card-update {:object card :user-id api/*current-user-id*})
+                  (is (some #(and (= "Dependency calculation failed" (ex-message (:e %)))
+                                  (= :error (:level %)))
+                            (messages)))
+                  (is (= models.dependency/current-dependency-analysis-version
+                         (t2/select-one-fn :dependency_analysis_version :model/Card :id card-id)))
+                  (is (empty? (t2/select :model/Dependency :from_entity_id card-id :from_entity_type :card))))))))))))
+
+(deftest snippet-dependency-calculation-error-handling-test
+  (testing "When snippet dependency calculation throws an error, it should be logged and the version should still be updated"
+    (mt/with-test-user :rasta
+      (mt/with-premium-features #{:dependencies}
+        (mt/with-temp [:model/NativeQuerySnippet {snippet-id :id :as snippet} {:name "test snippet"
+                                                                               :content "SELECT 1"}]
+          (log.capture/with-log-messages-for-level [messages ["metabase-enterprise.dependencies.events" :error]]
+            (with-redefs [deps.calculation/upstream-deps:snippet (fn [_]
+                                                                   (throw (ex-info "Snippet dependency calculation failed"
+                                                                                   {:snippet-id snippet-id})))]
+              (testing "on create event"
+                (events/publish-event! :event/snippet-create {:object snippet :user-id api/*current-user-id*})
+                (is (some #(and (= "Snippet dependency calculation failed" (ex-message (:e %)))
+                                (= :error (:level %)))
+                          (messages)))
+                (is (= models.dependency/current-dependency-analysis-version
+                       (t2/select-one-fn :dependency_analysis_version :model/NativeQuerySnippet :id snippet-id)))
+                (is (empty? (t2/select :model/Dependency :from_entity_id snippet-id :from_entity_type :snippet))))
+              (testing "on update event"
+                (events/publish-event! :event/snippet-update {:object snippet :user-id api/*current-user-id*})
+                (is (some #(and (= "Snippet dependency calculation failed" (ex-message (:e %)))
+                                (= :error (:level %)))
+                          (messages)))
+                (is (= models.dependency/current-dependency-analysis-version
+                       (t2/select-one-fn :dependency_analysis_version :model/NativeQuerySnippet :id snippet-id)))
+                (is (empty? (t2/select :model/Dependency :from_entity_id snippet-id :from_entity_type :snippet)))))))))))
+
+(deftest transform-dependency-calculation-error-handling-test
+  (testing "When transform dependency calculation throws an error, it should be logged and the version should still be updated"
+    (mt/with-test-user :rasta
+      (mt/with-premium-features #{:dependencies}
+        (mt/with-temp [:model/Transform {transform-id :id :as transform} {}]
+          (log.capture/with-log-messages-for-level [messages ["metabase-enterprise.dependencies.events" :error]]
+            (with-redefs [deps.calculation/upstream-deps:transform (fn [_]
+                                                                     (throw (ex-info "Transform dependency calculation failed"
+                                                                                     {:transform-id transform-id})))]
+              (testing "on create event"
+                (events/publish-event! :event/create-transform {:object transform :user-id api/*current-user-id*})
+                (is (some #(and (= "Transform dependency calculation failed" (ex-message (:e %)))
+                                (= :error (:level %)))
+                          (messages)))
+                (is (= models.dependency/current-dependency-analysis-version
+                       (t2/select-one-fn :dependency_analysis_version :model/Transform :id transform-id)))
+                (is (empty? (t2/select :model/Dependency :from_entity_id transform-id :from_entity_type :transform))))
+              (testing "on update event"
+                (events/publish-event! :event/update-transform {:object transform :user-id api/*current-user-id*})
+                (is (some #(and (= "Transform dependency calculation failed" (ex-message (:e %)))
+                                (= :error (:level %)))
+                          (messages)))
+                (is (= models.dependency/current-dependency-analysis-version
+                       (t2/select-one-fn :dependency_analysis_version :model/Transform :id transform-id)))
+                (is (empty? (t2/select :model/Dependency :from_entity_id transform-id :from_entity_type :transform)))))))))))
+
+(deftest dashboard-dependency-calculation-error-handling-test
+  (testing "When dashboard dependency calculation throws an error, it should be logged and the version should still be updated"
+    (mt/with-test-user :rasta
+      (mt/with-premium-features #{:dependencies}
+        (mt/with-temp [:model/Dashboard {dashboard-id :id :as dashboard} {}]
+          (log.capture/with-log-messages-for-level [messages ["metabase-enterprise.dependencies.events" :error]]
+            (with-redefs [deps.calculation/upstream-deps:dashboard (fn [_]
+                                                                     (throw (ex-info "Dashboard dependency calculation failed"
+                                                                                     {:dashboard-id dashboard-id})))]
+              (testing "on create event"
+                (events/publish-event! :event/dashboard-create {:object dashboard :user-id api/*current-user-id*})
+                (is (some #(and (= "Dashboard dependency calculation failed" (ex-message (:e %)))
+                                (= :error (:level %)))
+                          (messages)))
+                (is (= models.dependency/current-dependency-analysis-version
+                       (t2/select-one-fn :dependency_analysis_version :model/Dashboard :id dashboard-id)))
+                (is (empty? (t2/select :model/Dependency :from_entity_id dashboard-id :from_entity_type :dashboard))))
+              (testing "on update event"
+                (events/publish-event! :event/dashboard-update {:object dashboard :user-id api/*current-user-id*})
+                (is (some #(and (= "Dashboard dependency calculation failed" (ex-message (:e %)))
+                                (= :error (:level %)))
+                          (messages)))
+                (is (= models.dependency/current-dependency-analysis-version
+                       (t2/select-one-fn :dependency_analysis_version :model/Dashboard :id dashboard-id)))
+                (is (empty? (t2/select :model/Dependency :from_entity_id dashboard-id :from_entity_type :dashboard)))))))))))
+
+(deftest document-dependency-calculation-error-handling-test
+  (testing "When document dependency calculation throws an error, it should be logged and the version should still be updated"
+    (mt/with-test-user :rasta
+      (mt/with-premium-features #{:dependencies}
+        (mt/with-temp [:model/Document {document-id :id :as document} {:content_type "application/json+vnd.prose-mirror"
+                                                                       :document {:type "doc" :content []}}]
+          (log.capture/with-log-messages-for-level [messages ["metabase-enterprise.dependencies.events" :error]]
+            (with-redefs [deps.calculation/upstream-deps:document (fn [_]
+                                                                    (throw (ex-info "Document dependency calculation failed"
+                                                                                    {:document-id document-id})))]
+              (testing "on create event"
+                (events/publish-event! :event/document-create {:object document :user-id api/*current-user-id*})
+                (is (some #(and (= "Document dependency calculation failed" (ex-message (:e %)))
+                                (= :error (:level %)))
+                          (messages)))
+                (is (= models.dependency/current-dependency-analysis-version
+                       (t2/select-one-fn :dependency_analysis_version :model/Document :id document-id)))
+                (is (empty? (t2/select :model/Dependency :from_entity_id document-id :from_entity_type :document))))
+              (testing "on update event"
+                (events/publish-event! :event/document-update {:object document :user-id api/*current-user-id*})
+                (is (some #(and (= "Document dependency calculation failed" (ex-message (:e %)))
+                                (= :error (:level %)))
+                          (messages)))
+                (is (= models.dependency/current-dependency-analysis-version
+                       (t2/select-one-fn :dependency_analysis_version :model/Document :id document-id)))
+                (is (empty? (t2/select :model/Dependency :from_entity_id document-id :from_entity_type :document)))))))))))
+
+(deftest sandbox-dependency-calculation-error-handling-test
+  (testing "When sandbox dependency calculation throws an error, it should be logged and the version should still be updated"
+    (mt/with-premium-features #{:sandboxes}
+      (mt/with-test-user :rasta
+        (mt/with-premium-features #{:dependencies}
+          (mt/with-temp [:model/PermissionsGroup {group-id :id} {:name "test group"}
+                         :model/Card {card-id :id} {}
+                         :model/Sandbox {sandbox-id :id :as sandbox} {:group_id group-id
+                                                                      :table_id (mt/id :products)
+                                                                      :card_id card-id}]
+            (log.capture/with-log-messages-for-level [messages ["metabase-enterprise.dependencies.events" :error]]
+              (with-redefs [deps.calculation/upstream-deps:sandbox (fn [_]
+                                                                     (throw (ex-info "Sandbox dependency calculation failed"
+                                                                                     {:sandbox-id sandbox-id})))]
+                (testing "on create event"
+                  (events/publish-event! :event/sandbox-create {:object sandbox :user-id api/*current-user-id*})
+                  (is (some #(and (= "Sandbox dependency calculation failed" (ex-message (:e %)))
+                                  (= :error (:level %)))
+                            (messages)))
+                  (is (= models.dependency/current-dependency-analysis-version
+                         (t2/select-one-fn :dependency_analysis_version :model/Sandbox :id sandbox-id)))
+                  (is (empty? (t2/select :model/Dependency :from_entity_id sandbox-id :from_entity_type :sandbox))))
+                (testing "on update event"
+                  (events/publish-event! :event/sandbox-update {:object sandbox :user-id api/*current-user-id*})
+                  (is (some #(and (= "Sandbox dependency calculation failed" (ex-message (:e %)))
+                                  (= :error (:level %)))
+                            (messages)))
+                  (is (= models.dependency/current-dependency-analysis-version
+                         (t2/select-one-fn :dependency_analysis_version :model/Sandbox :id sandbox-id)))
+                  (is (empty? (t2/select :model/Dependency :from_entity_id sandbox-id :from_entity_type :sandbox))))))))))))


### PR DESCRIPTION
Fixes QUE-2714

### Description

Ignore all errors during dependency analysis. If there are errors, mark the entity as up to date and assert no dependencies.

An easy (but not simple) option would be to introduce a dynamic variable to control whether the exception should be ignored or not. That would enable the caller to retry a few times on any exception and give up eventually. I'm not sure if it's worth it. Let me know what you think.

### How to verify

See the tests.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
