### PR TITLE
fix(sdk): Fix missing SDK CSS custom properties

### DIFF
--- a/frontend/src/metabase/styled-components/theme/css-variables.ts
+++ b/frontend/src/metabase/styled-components/theme/css-variables.ts
@@ -43,8 +43,8 @@ export function getMetabaseSdkCssVariables(theme: MantineTheme, font: string) {
       --mb-default-font-family: ${font};
       ${createColorVars("light")}
       ${getSdkDesignSystemCssVariables(theme)}
-      ${getThemeSpecificCssVariables(theme)}
       ${getDynamicCssVariables(theme)}
+      ${getThemeSpecificCssVariables(theme)}
     }
   `;
 }

--- a/frontend/src/metabase/styled-components/theme/css-variables.ts
+++ b/frontend/src/metabase/styled-components/theme/css-variables.ts
@@ -42,8 +42,8 @@ export function getMetabaseSdkCssVariables(theme: MantineTheme, font: string) {
     :root {
       --mb-default-font-family: ${font};
       ${getSdkDesignSystemCssVariables(theme)}
-      ${getDynamicCssVariables(theme)}
       ${getThemeSpecificCssVariables(theme)}
+      ${getDynamicCssVariables(theme)}
     }
   `;
 }

--- a/frontend/src/metabase/styled-components/theme/css-variables.ts
+++ b/frontend/src/metabase/styled-components/theme/css-variables.ts
@@ -41,6 +41,7 @@ export function getMetabaseSdkCssVariables(theme: MantineTheme, font: string) {
   return css`
     :root {
       --mb-default-font-family: ${font};
+      ${createColorVars("light")}
       ${getSdkDesignSystemCssVariables(theme)}
       ${getThemeSpecificCssVariables(theme)}
       ${getDynamicCssVariables(theme)}
@@ -53,8 +54,8 @@ export function getMetabaseSdkCssVariables(theme: MantineTheme, font: string) {
  * These CSS variables are part of the core design system colors.
  *
  * Only keep colors that depend on the theme and are not specified anywhere else here.
- * You don't need to add new colors from `colors.module.css` here since they'll already
- * be available globally at :root
+ * You don't need to add new colors from `frontend/src/metabase/lib/colors/colors.ts` here since
+ * they're already included in `getMetabaseSdkCssVariables`
  **/
 function getSdkDesignSystemCssVariables(theme: MantineTheme) {
   const createSdkColorVars = (colorName: ColorName) => {


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #65064
closes EMB-927

### Backport reason
Since we don't backport dark mode, we don't need to backport this PR either.
### Description

After dark mode (https://github.com/metabase/metabase/pull/64016) landed, we didn't include new CSS custom properties to the SDK.

### How to verify

Render any SDK component that renders the modal e.g.
```tsx
<CreateDashboardModal isOpen onCreate={() => {}} />
```


### Demo

#### After
<img width="1319" height="694" alt="image" src="https://github.com/user-attachments/assets/b19a119d-d095-4af9-90e3-30bda05d9b74" />


#### Before
<img width="1338" height="666" alt="image" src="https://github.com/user-attachments/assets/d919dc27-1c32-4ae6-9fe5-d01f4aac9e22" />
