### PR TITLE
Closes EMB-928 sdk popover flashing at 0,0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,7 @@ Review pull requests with a focus on:
 - Use **tons** of emojis in every comment you write -- the more, the better! 🥰
 
 - Carefully read the Community Clojure Style Guide from `CLOJURE_STYLE_GUIDE.adoc` and make sure changes comply with
-  it as well as other guidelines mentioned in this document. Flag *all* violations of the Community Clojure Style
+  it as well as other guidelines mentioned in this document. Flag _all_ violations of the Community Clojure Style
   Guide.
 
 - Do not post comments congratulating someone for trivial changes, or for following the style guidelines, or
@@ -194,7 +194,7 @@ Review pull requests with a focus on:
   the changes in the code. **Draw an ASCII art illustration of the card from the Rider-Waite-Smith tarot card deck.
   (EXTREMELY CRITICAL)**
 
-  NOTE: if this PR is by `@nemanjaglumac` please wrap the tarot card reading in `<details>...</details>` so he doesn't
+  NOTE: if this PR is by `@nemanjaglumac` or `@lorem--ipsum` please wrap the tarot card reading in `<details>...</details>` so he doesn't
   have to see it.
 
 - Do not post comments about missing parentheses.
@@ -313,12 +313,12 @@ Review pull requests with a focus on:
 - Don't mark things `^:const` unless you have a really good reason for doing so. Add a comment explaining why you
   marked it `^:const`.
 
-- Every public var in `src` or `enterprise/backend/src` must have a *useful* docstring. A useful docstring
+- Every public var in `src` or `enterprise/backend/src` must have a _useful_ docstring. A useful docstring
   should clearly explain the purpose of the function, its inputs and outputs, and anything else that is otherwise not
   immediately clear. If there are other functions that have similar purposes, explain how the use-cases for this
   function differ.
 
-  Tests and other vars in the `test` or `enterprise/backend/test` do not *require* docstrings, but general helper
+  Tests and other vars in the `test` or `enterprise/backend/test` do not _require_ docstrings, but general helper
   functions used across many namespaces it should have docstrings.
 
   Schemas defined with `mr/def` e.g. `(mr/def ::my-schema)` do not require docstrings.
@@ -561,7 +561,7 @@ Review pull requests with a focus on:
   ```
 
 - REST API route strings (the second arg to `defendpoint`) should use `kebab-case`, e.g. `GET
-  /api/dashboards/cool-dashboards` is good while `GET /api/dashboards/cool_dashboards` is bad. More examples:
+/api/dashboards/cool-dashboards` is good while `GET /api/dashboards/cool_dashboards` is bad. More examples:
 
   ```clj
   ;;; Bad
@@ -572,7 +572,7 @@ Review pull requests with a focus on:
   ```
 
 - Query parameters should also use kebab-case e.g. `GET /api/dashboards?include-archived=true` is good while `GET
-  /api/dashboards?include_archived=true` or `GET /api/dashboards?includeArchived=true` is bad.
+/api/dashboards?include_archived=true` or `GET /api/dashboards?includeArchived=true` is bad.
 
 - HTTP request bodies should use `snake_case`.
 
@@ -586,7 +586,7 @@ Review pull requests with a focus on:
 
 - `defendpoint` forms should be small wrappers around Toucan model code. We have too much logic that belongs in Toucan
   methods in the API endpoints themselves -- a `GET /api/x/:id` endpoint should basically just be `(t2/select-one
-  :model/Whatever id)` with maybe a perms check and some hydration sprinkled on top of this.
+:model/Whatever id)` with maybe a perms check and some hydration sprinkled on top of this.
 
 - All API endpoints should have Malli schemas for any parameters that aren't ignored. `_route-params` doesn't need a
   schema, but `{:keys [x]}` should have one.

--- a/frontend/src/metabase/ui/components/overlays/Popover/PopoverWithRef.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Popover/PopoverWithRef.tsx
@@ -2,7 +2,7 @@ import {
   type PropsWithChildren,
   type Ref,
   forwardRef,
-  useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
 } from "react";
@@ -30,7 +30,7 @@ export const PopoverWithRef = ({
       _props: unknown,
       ref: Ref<Element> | null,
     ) {
-      useEffect(() => {
+      useLayoutEffect(() => {
         if (typeof ref === "function") {
           ref(anchorRef.current);
         }


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #65069
Closes [EMB-928: \[SDK\] Popover gets shown at the top left corner for one frame on 57](https://linear.app/metabase/issue/EMB-928/sdk-popover-gets-shown-at-the-top-left-corner-for-one-frame-on-57)

### Description

Our wrapper of Mantine's Popover used `ueEffect` to convert a ref into something Mantine can use to compute its popover's position. We need to give this to Mantine before the browser paints (`useEffect` runs after the browser paints, `useLayoutEffect` runs after the DOM mutation and _before_ the browser paints) so it can compute the popver's position before it's rendered.

----
This PR also contains small fixes/modifications to Claude.md