### PR TITLE
fix(sdk): Avoid portal root taking space under flex parents

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-bundle/components/private/PublicComponentStylesWrapper.style.css
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/private/PublicComponentStylesWrapper.style.css
@@ -1,4 +1,5 @@
 .publicComponentWrapper {
+  /* Try to reset as much as possible to avoid css leaking from host app to our components */
   all: initial;
   text-decoration: none;
   font-style: normal;

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/private/PublicComponentStylesWrapper.style.css
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/private/PublicComponentStylesWrapper.style.css
@@ -1,0 +1,13 @@
+.publicComponentWrapper {
+  all: initial;
+  text-decoration: none;
+  font-style: normal;
+  width: 100%;
+  height: 100%;
+  font-weight: 400;
+  color: var(--mb-color-text-dark);
+  font-family: var(--mb-default-font-family);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  transition: var(--transition-theme-change);
+}

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/private/PublicComponentStylesWrapper.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/private/PublicComponentStylesWrapper.tsx
@@ -1,9 +1,12 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
+import cx from "classnames";
 import type React from "react";
 import { forwardRef } from "react";
 
 import { saveDomImageStyles } from "metabase/visualizations/lib/image-exports";
+
+import S from "./PublicComponentStylesWrapper.style.css";
 
 /**
  * Injects CSS variables and styles to the SDK components underneath them.
@@ -11,26 +14,7 @@ import { saveDomImageStyles } from "metabase/visualizations/lib/image-exports";
  * even when rendered under a React portal.
  */
 const PublicComponentStylesWrapperInner = styled.div`
-  // Try to reset as much as possible to avoid css leaking from host app to our components
-  all: initial;
-  text-decoration: none;
-
-  font-style: normal;
-
-  width: 100%;
-  height: 100%;
-
   font-size: ${({ theme }) => theme.other.fontSize};
-
-  font-weight: 400;
-  color: var(--mb-color-text-dark);
-  font-family: var(--mb-default-font-family);
-
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-
-  transition: var(--transition-theme-change);
-
   ${saveDomImageStyles}
 `;
 
@@ -44,7 +28,7 @@ export const PublicComponentStylesWrapper = forwardRef<
       ref={ref}
       dir="ltr"
       // eslint-disable-next-line react/prop-types -- className is in div props :shrugs:
-      className={`mb-wrapper ${props.className}`}
+      className={cx("mb-wrapper", S.publicComponentWrapper, props.className)}
       // Mantine's cssVariablesSelector expects data-mantine-color-scheme to be set on the target element
       data-mantine-color-scheme="light"
     />

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkPortalContainer.style.css
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkPortalContainer.style.css
@@ -1,0 +1,4 @@
+.portalWrapper {
+  /* Avoid taking space inside a container e.g. flex */
+  display: contents;
+}

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkPortalContainer.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkPortalContainer.tsx
@@ -3,14 +3,16 @@ import { EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID } from "metabase/embedding-sdk/con
 import { Box } from "metabase/ui";
 
 import { PublicComponentStylesWrapper } from "./PublicComponentStylesWrapper";
+import S from "./SdkPortalContainer.style.css";
 
 /**
  * This is the portal container used by popovers modals etc, it is wrapped with PublicComponentStylesWrapper
  * so that it has our styles applied.
  * Mantine components needs to have the defaultProps set to use `EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID` as target for the portal
  */
+
 export const PortalContainer = () => (
-  <PublicComponentStylesWrapper>
+  <PublicComponentStylesWrapper className={S.portalWrapper}>
     <Box
       id={EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID}
       className={ZIndex.Overlay}

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkPortalContainer.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkPortalContainer.tsx
@@ -10,7 +10,6 @@ import S from "./SdkPortalContainer.style.css";
  * so that it has our styles applied.
  * Mantine components needs to have the defaultProps set to use `EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID` as target for the portal
  */
-
 export const PortalContainer = () => (
   <PublicComponentStylesWrapper className={S.portalWrapper}>
     <Box


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #64578
Closes EMB-898

### Backport reasons
This is going directly to 57, so we should not backport this.

### Description
The problem was that after introducing hosted-bundle, we render necessary roots e.g. portal roots, popover roots within a certain Metabase component, from my testing it's the last element.

When such element is wrapped under `display: flex` parent, the portal root in particular will start to take space, so I remove it from the box model with `display: contents`

### How to verify
Render this snippet
```tsx
<div style={{ display: 'flex' }}>
  <EditableDashboard dashboardId={1} />
</div>
```

### Demo
#### After
<img width="2177" height="1267" alt="Screenshot 2025-10-28 at 5 17 41 PM" src="https://github.com/user-attachments/assets/981d9af5-a28c-4760-a5d1-d8301a014d6d" />


#### Before
<img width="2172" height="1271" alt="Screenshot 2025-10-28 at 5 19 45 PM" src="https://github.com/user-attachments/assets/6ae57a7d-2d39-4e4a-a96d-82f7f3952e1a" />


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
