### PR TITLE
respect column definition order for transform create-table

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/transforms/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/util.clj
@@ -235,15 +235,15 @@
    database-id :- pos-int?
    table-schema :- ::table-definition]
   (let [{:keys [columns] table-name :name} table-schema
-        column-definitions (into {} (map (fn [{:keys [name type database-type]}]
-                                           (let [db-type (if database-type
-                                                           [[:raw database-type]]
-                                                           (try
-                                                             (driver/type->database-type driver type)
-                                                             (catch IllegalArgumentException _
-                                                               (log/warnf "Couldn't determine database type for type %s, fallback to Text" type)
-                                                               (driver/type->database-type driver :type/Text))))]
-                                             [name db-type])))
+        column-definitions (mapv (fn [{:keys [name type database-type]}]
+                                   (let [db-type (if database-type
+                                                   [[:raw database-type]]
+                                                   (try
+                                                     (driver/type->database-type driver type)
+                                                     (catch IllegalArgumentException _
+                                                       (log/warnf "Couldn't determine database type for type %s, fallback to Text" type)
+                                                       (driver/type->database-type driver :type/Text))))]
+                                     [name db-type]))
                                  columns)
         primary-key-opts (select-keys table-schema [:primary-key])]
     (log/infof "Creating table %s with %d columns" table-name (count columns))


### PR DESCRIPTION
Related to https://github.com/metabase/python-runner-container/pull/53

Closes https://linear.app/metabase/issue/GDGT-1134/respect-column-ordering-set-in-dataframe-when-creating-the-table