### PR TITLE
Document MB_NOTIFICATION_TEMP_FILE_SIZE_MAX_BYTES

### DIFF
--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -1239,6 +1239,14 @@ By default "Site Url" is used in notification links, but can be overridden.
 The base URL where dashboard notitification links will point to instead of the Metabase base URL.
         Only applicable for users who utilize interactive embedding and subscriptions.
 
+### `MB_NOTIFICATION_TEMP_FILE_SIZE_MAX_BYTES`
+
+- Type: integer
+- Default: `10485760`
+
+Controls the maximum temporary file size used when rendering charts for notifications. Set to 0 for unbounded limits, but this is discouraged as large renders can cause OOM crashes.
+If the file size exceeds the value, the chart will fail to render and be replaced by a text message suggesting that the query size be reduced.
+
 ### `MB_NOTIFICATION_SYSTEM_EVENT_THREAD_POOL_SIZE`
 
 - Type: integer


### PR DESCRIPTION
> but this is discouraged as large renders can cause OOM crashes

TMI?


### Description

Added documentation for MB_NOTIFICATION_TEMP_FILE_SIZE_MAX_BYTES environment variable, including its type, default value, and behavior.

### Context:
https://metaboat.slack.com/archives/C07JBRAQ9PA/p1760130124139389

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
