### PR TITLE
Fix add interval honeysql form

### DIFF
--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -433,7 +433,7 @@
   `amount` is usually an integer, but can be floating-point for units like seconds.
 
   This multimethod can be extended by drivers in their respective namespaces."
-  {:added "0.34.2" :arglists '([db-type hsql-form amount unit])}
+  {:added "0.34.2" :arglists '([driver hsql-form amount unit])}
   driver/dispatch-on-initialized-driver
   :hierarchy #'driver/hierarchy)
 

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -434,8 +434,8 @@
 
   This multimethod can be extended by drivers in their respective namespaces."
   {:added "0.34.2" :arglists '([db-type hsql-form amount unit])}
-  (fn [db-type _hsql-form _amount _unit]
-    (keyword db-type)))
+  driver/dispatch-on-initialized-driver
+  :hierarchy #'driver/hierarchy)
 
 (mu/defn adjust-start-of-week
   "Truncate to the day the week starts on.


### PR DESCRIPTION
### Description

Adds back driver hierarchy to `add-interval-honeysql-form`

### How to verify

Tests should pass


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
