### PR TITLE
Prepare dependencies for v57

### DIFF
--- a/e2e/test/scenarios/dependencies/dependency-graph.cy.spec.ts
+++ b/e2e/test/scenarios/dependencies/dependency-graph.cy.spec.ts
@@ -46,7 +46,8 @@ const SNIPPET_BASED_MODEL_NAME = "Snippet-based model";
 const SNIPPET_BASED_TRANSFORM_NAME = "Snippet-based transform";
 const SNIPPET_BASED_SNIPPET_NAME = "Snippet-based snippet";
 
-describe("scenarios > dependencies > dependency graph", () => {
+// TODO skipped until v57 is released
+describe.skip("scenarios > dependencies > dependency graph", () => {
   beforeEach(() => {
     H.restore("postgres-writable");
     H.resetTestTable({ type: "postgres", table: TABLE_NAME });

--- a/enterprise/backend/src/metabase_enterprise/dependencies/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/settings.clj
@@ -6,7 +6,7 @@
   "Batch size."
   :visibility :internal
   :type       :integer
-  :default    20
+  :default    500
   :setter     :none
   :export?    false)
 
@@ -22,6 +22,6 @@
   "Backfill variance (?) whatever that means."
   :visibility :internal
   :type       :integer
-  :default    10
+  :default    30
   :setter     :none
   :export?    false)

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -40,7 +40,6 @@ import NewModelOptions from "metabase/models/containers/NewModelOptions";
 import { getRoutes as getModelRoutes } from "metabase/models/routes";
 import {
   PLUGIN_COLLECTIONS,
-  PLUGIN_DEPENDENCIES,
   PLUGIN_DOCUMENTS,
   PLUGIN_EMBEDDING_IFRAME_SDK_SETUP,
   PLUGIN_LANDING_PAGE,
@@ -154,16 +153,6 @@ export const getRoutes = (store) => {
           >
             <IndexRoute component={Onboarding} />
           </Route>
-
-          {PLUGIN_DEPENDENCIES.isEnabled && (
-            <Route title={t`Dependencies`} path="dependencies">
-              <IndexRoute component={PLUGIN_DEPENDENCIES.DependencyGraphPage} />
-              <Route
-                path=":type/:id"
-                component={PLUGIN_DEPENDENCIES.DependencyGraphPage}
-              />
-            </Route>
-          )}
 
           <Route path="search" title={t`Search`} component={SearchApp} />
           {/* Send historical /archive route to trash - can remove in v52 */}


### PR DESCRIPTION
- Change defaults for the backfill job
- Remove the `/dependencies/` URL
- Skip E2E tests for the dependencies graph