### PR TITLE
Remove the instruction to indent docstrings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,22 +335,6 @@ Review pull requests with a focus on:
 
 - Make sure to update comments and docstrings when you change the code they describe.
 
-  ```clj
-  ;;; BAD
-  (defn update-transform-tags!
-    "Update the tags associated with a transform using smart diff logic.
-     Only modifies what has changed: deletes removed tags, updates positions for moved tags,
-     and inserts new tags. Duplicate tag IDs are automatically deduplicated."
-    ...)
-
-  ;;; GOOD
-  (defn update-transform-tags!
-    "Update the tags associated with a transform using smart diff logic.
-    Only modifies what has changed: deletes removed tags, updates positions for moved tags,
-    and inserts new tags. Duplicate tag IDs are automatically deduplicated."
-    ...)
-  ```
-
 - `TODO` comments should include the author and date, for example
 
   ```clj

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,8 +335,6 @@ Review pull requests with a focus on:
 
 - Make sure to update comments and docstrings when you change the code they describe.
 
-- Docstrings should be indented two spaces.
-
   ```clj
   ;;; BAD
   (defn update-transform-tags!


### PR DESCRIPTION
This results in a lot of wrong comments on PRs.