### PR TITLE
Exclude databricks from database-schema-filtering-test

### DIFF
--- a/test/metabase/driver/sql_jdbc/sync/describe_database_test.clj
+++ b/test/metabase/driver/sql_jdbc/sync/describe_database_test.clj
@@ -168,9 +168,8 @@
   [_driver _feature _database]
   true)
 
-;;; BigQuery is tested separately in [[metabase.driver.bigquery-cloud-sdk-test/dataset-filtering-test]], because
-;;; otherwise this test takes too long and flakes intermittently Redshift is also tested separately because it flakes.
-(doseq [driver [:bigquery-cloud-sdk :redshift]]
+;;; These drivers are tested separately because they take too long and flake in CI
+(doseq [driver [:bigquery-cloud-sdk :redshift :databricks]]
   (defmethod driver/database-supports? [driver ::database-schema-filtering-test]
     [_driver _feature _database]
     false))


### PR DESCRIPTION
### Description

Excludes databricks from `database-schema-filtering-test` due to [flakes in CI](https://github.com/metabase/metabase/actions/runs/18880142360/job/53887397873)

### How to verify

Test shouldn't flake

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
