### PR TITLE
Fix default tag values for temporal template tags

### DIFF
--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -420,7 +420,7 @@
                               {:type   :number/=,
                                :value  ["0"]})
                             (when (isa? effective-type :type/HasDate)
-                              {:type :date/single
+                              {:type  :date/single
                                :value "2025-01-01"})))
     :temporal-unit {:id     id,
                     :type   :temporal-unit,

--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -7,7 +7,6 @@
    [clojure.string :as str]
    [medley.core :as m]
    [metabase.lib.metadata :as lib.metadata]
-   [metabase.lib.options :as lib.options]
    [metabase.lib.parameters.parse :as lib.params.parse]
    [metabase.lib.parameters.parse.types :as lib.params.parse.types]
    [metabase.lib.parse :as lib.parse]
@@ -388,7 +387,7 @@
   (:engine (lib.metadata/database query)))
 
 (defn- get-parameter-value
-  [query tag-name {:keys [id dimension], param-type :type :as tag}]
+  [query tag-name {:keys [id dimension], param-type :type}]
   ;; note that the actual values chosen are completely arbitrary.  We just need to provide some
   ;; value so that the query will compile.
   (case param-type

--- a/test/metabase/lib/native_test.cljc
+++ b/test/metabase/lib/native_test.cljc
@@ -489,7 +489,6 @@
                                        :id "9ae1ea5e-ac33-4574-bc95-ff595b0ac1a7"
                                        :name "mytag"
                                        :type :number}})
-
              lib/add-parameters-for-template-tags
              :parameters))))
 

--- a/test/metabase/lib/native_test.cljc
+++ b/test/metabase/lib/native_test.cljc
@@ -464,3 +464,130 @@
               :display-name "Price"
               :lib/source   :source/card}]
             (lib/returned-columns query)))))
+
+(deftest ^:parallel add-parameters-text-tag-test
+  (is (= [{:id     "9ae1ea5e-ac33-4574-bc95-ff595b0ac1a7",
+           :type   :string/=,
+           :value  ["foo"],
+           :target ["variable" ["template-tag" "mytag"]]}]
+         (-> (lib/native-query meta/metadata-provider "select * from venues where {{mytag}}")
+             (lib/with-template-tags {"mytag" {:type :text,
+                                               :name "mytag",
+                                               :id "9ae1ea5e-ac33-4574-bc95-ff595b0ac1a7"
+                                               :display-name "My Tag"}})
+             lib/add-parameters-for-template-tags
+             :parameters))))
+
+(deftest ^:parallel add-parameters-number-tag-test
+  (is (= [{:id     "9ae1ea5e-ac33-4574-bc95-ff595b0ac1a7",
+           :type   :number/=,
+           :value  ["0"],
+           :target ["variable" ["template-tag" "mytag"]]}]
+         (-> (lib/native-query meta/metadata-provider "select * from venues where {{mytag}}")
+             (lib/with-template-tags {"mytag"
+                                      {:display-name "My Tag"
+                                       :id "9ae1ea5e-ac33-4574-bc95-ff595b0ac1a7"
+                                       :name "mytag"
+                                       :type :number}})
+
+             lib/add-parameters-for-template-tags
+             :parameters))))
+
+(deftest ^:parallel add-parameters-date-tag-test
+  (is (= [{:id     "9ae1ea5e-ac33-4574-bc95-ff595b0ac1a7",
+           :type   :date/single,
+           :value  "1970-01-01",
+           :target ["variable" ["template-tag" "mytag"]]}]
+         (-> (lib/native-query meta/metadata-provider "select * from venues where {{mytag}}")
+             (lib/with-template-tags {"mytag"
+                                      {:display-name "My Tag"
+                                       :id "9ae1ea5e-ac33-4574-bc95-ff595b0ac1a7"
+                                       :name "mytag"
+                                       :type :date}})
+             lib/add-parameters-for-template-tags
+             :parameters))))
+
+(deftest ^:parallel add-parameters-boolean-tag-test
+  (is (= [{:id     "9ae1ea5e-ac33-4574-bc95-ff595b0ac1a7",
+           :type   :boolean/=,
+           :value  [false],
+           :target ["variable" ["template-tag" "mytag"]]}]
+         (-> (lib/native-query meta/metadata-provider "select * from venues where {{mytag}}")
+             (lib/with-template-tags {"mytag"
+                                      {:display-name "My Tag"
+                                       :id "9ae1ea5e-ac33-4574-bc95-ff595b0ac1a7"
+                                       :name "mytag"
+                                       :type :boolean}})
+             lib/add-parameters-for-template-tags
+             :parameters))))
+
+(deftest ^:parallel add-parameters-string-dimension-tag-test
+  (is (= [{:id     "9ae1ea5e-ac33-4574-bc95-ff595b0ac1a7",
+           :type   :string/=,
+           :value  ["foo"],
+           :target ["dimension" ["template-tag" "mytag"]]}]
+         (-> (lib/native-query meta/metadata-provider "select * from venues where {{mytag}}")
+             (lib/with-template-tags {"mytag"
+                                      {:dimension [:field
+                                                   {:lib/uuid "a9e2b665-cadd-4d25-b1c1-09ca8f1736cf"}
+                                                   (meta/id :products :category)]
+                                       :display-name "My Tag"
+                                       :id "9ae1ea5e-ac33-4574-bc95-ff595b0ac1a7"
+                                       :name "mytag"
+                                       :type :dimension
+                                       :widget-type :date/range}})
+             lib/add-parameters-for-template-tags
+             :parameters))))
+
+(deftest ^:parallel add-parameters-number-dimension-tag-test
+  (is (= [{:id     "9ae1ea5e-ac33-4574-bc95-ff595b0ac1a7",
+           :type   :number/=,
+           :value  ["0"],
+           :target ["dimension" ["template-tag" "mytag"]]}]
+         (-> (lib/native-query meta/metadata-provider "select * from venues where {{mytag}}")
+             (lib/with-template-tags {"mytag"
+                                      {:dimension [:field
+                                                   {:lib/uuid "a9e2b665-cadd-4d25-b1c1-09ca8f1736cf"}
+                                                   (meta/id :orders :total)]
+                                       :display-name "My Tag"
+                                       :id "9ae1ea5e-ac33-4574-bc95-ff595b0ac1a7"
+                                       :name "mytag"
+                                       :type :dimension
+                                       :widget-type :date/range}})
+             lib/add-parameters-for-template-tags
+             :parameters))))
+
+(deftest ^:parallel add-parameters-date-dimension-tag-test
+  (is (= [{:id     "9ae1ea5e-ac33-4574-bc95-ff595b0ac1a7",
+           :type   :date/single,
+           :value  "2025-01-01",
+           :target ["dimension" ["template-tag" "mytag"]]}]
+         (-> (lib/native-query meta/metadata-provider "select * from venues where {{mytag}}")
+             (lib/with-template-tags {"mytag"
+                                      {:dimension [:field
+                                                   {:lib/uuid "a9e2b665-cadd-4d25-b1c1-09ca8f1736cf"}
+                                                   (meta/id :orders :created-at)]
+                                       :display-name "My Tag"
+                                       :id "9ae1ea5e-ac33-4574-bc95-ff595b0ac1a7"
+                                       :name "mytag"
+                                       :type :dimension
+                                       :widget-type :date/range}})
+             lib/add-parameters-for-template-tags
+             :parameters))))
+
+(deftest ^:parallel add-parameters-temporal-unit-tag-test
+  (is (= [{:id     "9ae1ea5e-ac33-4574-bc95-ff595b0ac1a7",
+           :type   :temporal-unit,
+           :value  "week",
+           :target ["dimension" ["template-tag" "mytag"]]}]
+         (-> (lib/native-query meta/metadata-provider "select * from venues where {{mytag}}")
+             (lib/with-template-tags {"mytag"
+                                      {:dimension [:field
+                                                   {:lib/uuid "a9e2b665-cadd-4d25-b1c1-09ca8f1736cf"}
+                                                   (meta/id :orders :created-at)]
+                                       :display-name "My Tag"
+                                       :id "9ae1ea5e-ac33-4574-bc95-ff595b0ac1a7"
+                                       :name "mytag"
+                                       :type :temporal-unit}})
+             lib/add-parameters-for-template-tags
+             :parameters))))


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/QUE-2719/dependency-checker-throws-many-warn-logs

### Description

The default parameter code wasn't handling datetime field filters appropriately.  Now, it is.

### How to verify

Can create and save a native question with a datetime field filter.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
