### PR TITLE
test a document creation in personal collection

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/documents/api/document_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/documents/api/document_test.clj
@@ -6,8 +6,10 @@
    [metabase.events.core :as events]
    [metabase.permissions.core :as perms]
    [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
    [toucan2.core :as t2]))
 
+(use-fixtures :once (fixtures/initialize :db :test-users :test-users-personal-collections))
 (use-fixtures :each (fn [f] (mt/with-premium-features #{:documents} (f))))
 
 (defn- text->prose-mirror-ast
@@ -2249,3 +2251,40 @@
                                 :put 200 (format "ee/document/%s" doc-id)
                                 {:document (prose-mirror-with-smartlink "Good" remote-card-id)
                                  :collection_id regular-id}))))))
+
+(deftest post-document-to-personal-collection-test
+  (testing "POST /api/ee/document/ - creating a document in a personal collection"
+    (mt/with-model-cleanup [:model/Document]
+      (let [personal-coll-id (t2/select-one-pk :model/Collection :personal_owner_id (mt/user->id :rasta))]
+        (testing "User can create a document in their own personal collection"
+          (let [result (mt/user-http-request :rasta
+                                             :post 200 "ee/document/"
+                                             {:name "Personal Document"
+                                              :document (text->prose-mirror-ast "My personal notes")
+                                              :collection_id personal-coll-id})]
+            (is (pos? (:id result)))
+            (is (= "Personal Document" (:name result)))
+            (is (= personal-coll-id (:collection_id result)))
+
+            (testing "Document is successfully saved in the database"
+              (let [doc (t2/select-one :model/Document :id (:id result))]
+                (is (some? doc))
+                (is (= personal-coll-id (:collection_id doc)))
+                (is (= "Personal Document" (:name doc)))))))
+
+        (testing "Admin can also create a document in someone else's personal collection"
+          (let [result (mt/user-http-request :crowberto
+                                             :post 200 "ee/document/"
+                                             {:name "Admin Document in Personal Collection"
+                                              :document (text->prose-mirror-ast "Admin's notes")
+                                              :collection_id personal-coll-id})]
+            (is (pos? (:id result)))
+            (is (= personal-coll-id (:collection_id result)))))
+
+        (testing "Other users cannot create documents in someone else's personal collection"
+          (mt/user-http-request :lucky
+                                :post 403 "ee/document/"
+                                {:name "Should Fail"
+                                 :document (text->prose-mirror-ast "Should not be created")
+                                 :collection_id personal-coll-id}))))))
+

--- a/enterprise/backend/test/metabase_enterprise/documents/api/document_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/documents/api/document_test.clj
@@ -2265,13 +2265,11 @@
             (is (pos? (:id result)))
             (is (= "Personal Document" (:name result)))
             (is (= personal-coll-id (:collection_id result)))
-
             (testing "Document is successfully saved in the database"
               (let [doc (t2/select-one :model/Document :id (:id result))]
                 (is (some? doc))
                 (is (= personal-coll-id (:collection_id doc)))
                 (is (= "Personal Document" (:name doc)))))))
-
         (testing "Admin can also create a document in someone else's personal collection"
           (let [result (mt/user-http-request :crowberto
                                              :post 200 "ee/document/"
@@ -2280,11 +2278,9 @@
                                               :collection_id personal-coll-id})]
             (is (pos? (:id result)))
             (is (= personal-coll-id (:collection_id result)))))
-
         (testing "Other users cannot create documents in someone else's personal collection"
           (mt/user-http-request :lucky
                                 :post 403 "ee/document/"
                                 {:name "Should Fail"
                                  :document (text->prose-mirror-ast "Should not be created")
                                  :collection_id personal-coll-id}))))))
-


### PR DESCRIPTION
###Description

Adds a test when attempting to repro an issue showing that documents can be created in a personal collection. 