### PR TITLE
refetch settings after updating remote sync settings

### DIFF
--- a/e2e/test/scenarios/admin/remote-sync.cy.spec.ts
+++ b/e2e/test/scenarios/admin/remote-sync.cy.spec.ts
@@ -242,7 +242,7 @@ describe("Remote Sync", () => {
     });
   });
 
-  describe.skip("remote sync admin settings page", () => {
+  describe("remote sync admin settings page", () => {
     beforeEach(() => {
       H.restore();
       H.activateToken("bleeding-edge");
@@ -262,8 +262,8 @@ describe("Remote Sync", () => {
         .findByText("Success")
         .should("exist");
 
-      //TODO: We should be able to remove this, but for now we need to do a page refresh to see changes
-      cy.visit("/");
+      H.modal().should("not.exist", { timeout: 10000 });
+      cy.findByTestId("exit-admin").click();
 
       H.navigationSidebar().within(() => {
         cy.findByRole("heading", { name: /synced collections/i }).should(
@@ -293,8 +293,8 @@ describe("Remote Sync", () => {
         .findByText("Success")
         .should("exist");
 
-      //TODO: We should be able to remove this, but for now we need to do a page refresh to see changes
-      cy.visit("/");
+      H.modal().should("not.exist", { timeout: 10000 });
+      cy.findByTestId("exit-admin").click();
 
       H.navigationSidebar().within(() => {
         cy.findByRole("heading", { name: /synced collections/i }).should(
@@ -319,7 +319,9 @@ describe("Remote Sync", () => {
         .findByText("Failed")
         .should("exist");
       cy.findByTestId("admin-layout-content")
-        .findByText("Invalid git settings")
+        .findByText(
+          "Unable to connect to git repository with the provided settings",
+        )
         .should("exist");
     });
   });

--- a/enterprise/frontend/src/metabase-enterprise/api/remote-sync.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/remote-sync.ts
@@ -87,6 +87,7 @@ export const remoteSyncApi = EnterpriseApi.injectEndpoints({
         url: `/api/ee/remote-sync/settings`,
         body: settings,
       }),
+      invalidatesTags: () => [tag("session-properties")],
     }),
     getBranches: builder.query<GetBranchesResponse, void>({
       query: () => ({


### PR DESCRIPTION
Closes [UXW-2094: Ensure we're calling current_task on first import, when setting up Remote Sync](https://linear.app/metabase/issue/UXW-2094/ensure-were-calling-current-task-on-first-import-when-setting-up)

When initially set up remote sync the in-progress modal appears and gets stuck so users have to do a full page refresh, this PR fixes it. The root cause is that we did not start current task polling as `remote-sync-enabled` is still `false` and we needed to refetch latest instance settings where `remote-sync-enabled` is `true`