### PR TITLE
only delay remote sync modal dismiss on success

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/middleware/remote-sync-listener-middleware.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/middleware/remote-sync-listener-middleware.ts
@@ -7,7 +7,6 @@ import { collectionApi } from "metabase/api/collection";
 import { dashboardApi } from "metabase/api/dashboard";
 import { timelineApi } from "metabase/api/timeline";
 import { timelineEventApi } from "metabase/api/timeline-event";
-import { delay } from "metabase/lib/promise";
 import type {
   Card,
   Collection,
@@ -310,16 +309,13 @@ remoteSyncListenerMiddleware.startListening({
       const isTerminalState = terminalTaskStates.includes(task.status);
 
       if (isTerminalState && task.ended_at) {
-        // FIXME: Currently backend doesn't immediately update settings or dirty state
-        // after task finishes, adding a slight delay to ensure the state is updated
-        const hackTimeout = task.sync_task_type === "import" ? 1000 : 2500;
-        await delay(hackTimeout);
-
         const isImportTask = task.sync_task_type === "import";
         const isSuccessful = task.status === "successful";
 
         if (isSuccessful) {
-          dispatch(modalDismissed());
+          setTimeout(() => {
+            dispatch(modalDismissed());
+          }, 500);
 
           if (isImportTask) {
             dispatch(


### PR DESCRIPTION
### Description
Small PR to remove unneeded wait that was introduced in initial feature merge

### How to verify
Imports and export modals should now dismiss 500ms after completion, rather than 1s and 2.5s respectively 