### PR TITLE
Remote sync analytics

### DIFF
--- a/e2e/test/scenarios/admin/remote-sync.cy.spec.ts
+++ b/e2e/test/scenarios/admin/remote-sync.cy.spec.ts
@@ -196,7 +196,14 @@ H.describeWithSnowplowEE("Remote Sync", () => {
     });
 
     describe("Branching", () => {
+      let branchCount = 0;
+
+      beforeEach(() => {
+        branchCount = 0;
+      });
+
       const createNewBranch = (newBranchName: string) => {
+        branchCount++;
         H.navigationSidebar().findByTestId("branch-picker-button").click();
         H.popover()
           .findByPlaceholderText("Find or create a branch...")
@@ -205,10 +212,13 @@ H.describeWithSnowplowEE("Remote Sync", () => {
           .findByRole("option", { name: /Create branch/ })
           .click();
 
-        H.expectUnstructuredSnowplowEvent({
-          event: "remote_sync_branch_created",
-          triggered_from: "branch-picker",
-        });
+        H.expectUnstructuredSnowplowEvent(
+          {
+            event: "remote_sync_branch_created",
+            triggered_from: "branch-picker",
+          },
+          branchCount,
+        );
 
         H.navigationSidebar()
           .findByTestId("branch-picker-button")

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/analytics.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/analytics.ts
@@ -1,0 +1,65 @@
+import { trackSimpleEvent } from "metabase/lib/analytics";
+
+export const trackBranchSwitched = ({
+  triggeredFrom,
+}: {
+  triggeredFrom: "sidebar" | "admin-settings";
+}) => {
+  trackSimpleEvent({
+    event: "remote_sync_branch_switched",
+    triggered_from: triggeredFrom,
+  });
+};
+
+export const trackBranchCreated = ({
+  triggeredFrom,
+}: {
+  triggeredFrom: "branch-picker" | "conflict-modal";
+}) => {
+  trackSimpleEvent({
+    event: "remote_sync_branch_created",
+    triggered_from: triggeredFrom,
+  });
+};
+
+export const trackPullChanges = ({
+  triggeredFrom,
+  force,
+}: {
+  triggeredFrom: "sidebar" | "admin-settings";
+  force: boolean;
+}) => {
+  trackSimpleEvent({
+    event: "remote_sync_pull_changes",
+    triggered_from: triggeredFrom,
+    ...(force && { event_detail: "force" }),
+  });
+};
+
+export const trackPushChanges = ({
+  triggeredFrom,
+  force,
+}: {
+  triggeredFrom: "sidebar" | "conflict-modal";
+  force: boolean;
+}) => {
+  trackSimpleEvent({
+    event: "remote_sync_push_changes",
+    triggered_from: triggeredFrom,
+    ...(force && { event_detail: "force" }),
+  });
+};
+
+export const trackRemoteSyncSettingsChanged = () => {
+  trackSimpleEvent({
+    event: "remote_sync_settings_changed",
+    triggered_from: "admin-settings",
+  });
+};
+
+export const trackRemoteSyncDeactivated = () => {
+  trackSimpleEvent({
+    event: "remote_sync_deactivated",
+    triggered_from: "admin-settings",
+  });
+};

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/PushChangesModal/PushChangesModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/PushChangesModal/PushChangesModal.tsx
@@ -14,6 +14,7 @@ import {
 import { useExportChangesMutation } from "metabase-enterprise/api";
 import type { Collection } from "metabase-types/api";
 
+import { trackPushChanges } from "../../analytics";
 import { type SyncError, parseSyncError } from "../../utils";
 import { ChangesLists } from "../ChangesLists";
 import { SyncConflictModal } from "../SyncConflictModal";
@@ -57,6 +58,11 @@ export const PushChangesModal = ({
     exportChanges({
       message: commitMessage.trim() || undefined,
       branch: currentBranch,
+    });
+
+    trackPushChanges({
+      triggeredFrom: "sidebar",
+      force: false,
     });
   }, [commitMessage, exportChanges, currentBranch]);
 

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/PullChangesButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/PullChangesButton.tsx
@@ -5,6 +5,8 @@ import { useToast } from "metabase/common/hooks";
 import { Button, Tooltip } from "metabase/ui";
 import { useImportChangesMutation } from "metabase-enterprise/api";
 
+import { trackPullChanges } from "../../analytics";
+
 interface PullChangesButtonProps {
   dirty: boolean; // disambiguation: local form state, not the git-synced collection state
   branch: string;
@@ -20,6 +22,12 @@ export const PullChangesButton = (props: PullChangesButtonProps) => {
   const handlePullChanges = useCallback(async () => {
     try {
       await importChanges({ branch, force: forcePull }).unwrap();
+
+      trackPullChanges({
+        triggeredFrom: "admin-settings",
+        force: forcePull,
+      });
+
       sendToast({
         message: t`Latest changes have been pulled successfully`,
         icon: "check",

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncAdminSettings.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncAdminSettings.tsx
@@ -42,6 +42,11 @@ import type {
 } from "metabase-types/api";
 
 import {
+  trackBranchSwitched,
+  trackRemoteSyncDeactivated,
+  trackRemoteSyncSettingsChanged,
+} from "../../analytics";
+import {
   AUTO_IMPORT_KEY,
   BRANCH_KEY,
   REMOTE_SYNC_KEY,
@@ -82,6 +87,19 @@ export const RemoteSyncAdminSettings = () => {
       const saveSettings = async (values: RemoteSyncConfigurationSettings) => {
         try {
           await updateRemoteSyncSettings(values).unwrap();
+
+          trackRemoteSyncSettingsChanged();
+
+          if (
+            didBranchChange &&
+            settingValues?.[BRANCH_KEY] &&
+            values[BRANCH_KEY]
+          ) {
+            trackBranchSwitched({
+              triggeredFrom: "admin-settings",
+            });
+          }
+
           sendToast({ message: t`Settings saved successfully`, icon: "check" });
         } catch (error) {
           sendToast({
@@ -136,6 +154,7 @@ export const RemoteSyncAdminSettings = () => {
       onConfirm: async () => {
         try {
           await updateRemoteSyncSettings({ [URL_KEY]: "" }).unwrap();
+          trackRemoteSyncDeactivated();
           sendToast({ message: t`Remote Sync disabled`, icon: "check" });
         } catch (error) {
           console.error(error);

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/SyncConflictModal/mutation-wrappers.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/SyncConflictModal/mutation-wrappers.ts
@@ -12,6 +12,8 @@ import {
   parseSyncError,
 } from "metabase-enterprise/remote_sync/utils";
 
+import { trackBranchCreated, trackPushChanges } from "../../analytics";
+
 export const usePushChangesAction = () => {
   const [exportChanges, { isLoading: isPushingChanges }] =
     useExportChangesMutation();
@@ -25,6 +27,12 @@ export const usePushChangesAction = () => {
             branch,
             force,
           }).unwrap();
+
+          trackPushChanges({
+            triggeredFrom: "conflict-modal",
+            force,
+          });
+
           sendToast({
             message: c("{0} is the GitHub branch name")
               .t`Changes pushed to branch ${branch} successfully.`,
@@ -74,6 +82,11 @@ export const useStashToNewBranchAction = (existingBranches: string[]) => {
         try {
           setIsStashing(true);
           await createBranch({ name: newBranchName }).unwrap();
+
+          trackBranchCreated({
+            triggeredFrom: "conflict-modal",
+          });
+
           await exportChanges({
             branch: newBranchName,
           }).unwrap();

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/SyncedCollectionsSidebarSection/BranchPicker.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/SyncedCollectionsSidebarSection/BranchPicker.tsx
@@ -21,6 +21,8 @@ import {
   useGetBranchesQuery,
 } from "metabase-enterprise/api";
 
+import { trackBranchCreated } from "../../analytics";
+
 export interface BranchPickerProps {
   value: string;
   onChange: (branch: string, isNewBranch?: boolean) => void;
@@ -81,6 +83,10 @@ export const BranchPicker = ({
       await createBranch({
         name: branchName,
       }).unwrap();
+
+      trackBranchCreated({
+        triggeredFrom: "branch-picker",
+      });
 
       onChange(branchName, true);
     } catch (error) {

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/SyncedCollectionsSidebarSection/PullFromRemoteButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/SyncedCollectionsSidebarSection/PullFromRemoteButton.tsx
@@ -9,6 +9,7 @@ import {
   parseSyncError,
 } from "metabase-enterprise/remote_sync/utils";
 
+import { trackPullChanges } from "../../analytics";
 import type { SyncConflictVariant } from "../SyncConflictModal";
 
 interface PushChangesButtonProps {
@@ -26,6 +27,12 @@ export const PullFromRemoteButton = (props: PushChangesButtonProps) => {
   const handleClick = async () => {
     try {
       await importChanges({ branch }).unwrap();
+
+      trackPullChanges({
+        triggeredFrom: "sidebar",
+        force: false,
+      });
+
       sendToast({
         message: t`Your branch is now up to date with remote`,
         icon: "check",

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/SyncedCollectionsSidebarSection/SyncedCollectionsSidebarSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/SyncedCollectionsSidebarSection/SyncedCollectionsSidebarSection.tsx
@@ -19,6 +19,7 @@ import {
   useImportChangesMutation,
 } from "metabase-enterprise/api";
 
+import { trackBranchSwitched } from "../../analytics";
 import { BRANCH_KEY, REMOTE_SYNC_KEY } from "../../constants";
 import { useSyncStatus } from "../../hooks/use-sync-status";
 import {
@@ -71,6 +72,11 @@ export const SyncedCollectionsSidebarSection = ({
 
       if (!isNewBranch) {
         await importChanges({ branch });
+
+        // Tracking only when not creating a new branch since it has its own event
+        trackBranchSwitched({
+          triggeredFrom: "sidebar",
+        });
       }
 
       setNextBranch(null);

--- a/frontend/src/metabase-types/analytics/event.ts
+++ b/frontend/src/metabase-types/analytics/event.ts
@@ -452,6 +452,46 @@ export type ClickActionPerformedEvent = ValidateEvent<{
   triggered_from: ClickActionSection;
 }>;
 
+export type RemoteSyncBranchSwitchedEvent = ValidateEvent<{
+  event: "remote_sync_branch_switched";
+  triggered_from: "sidebar" | "admin-settings";
+}>;
+
+export type RemoteSyncBranchCreatedEvent = ValidateEvent<{
+  event: "remote_sync_branch_created";
+  triggered_from: "branch-picker" | "conflict-modal";
+}>;
+
+export type RemoteSyncPullChangesEvent = ValidateEvent<{
+  event: "remote_sync_pull_changes";
+  triggered_from: "sidebar" | "admin-settings";
+  event_detail?: "force";
+}>;
+
+export type RemoteSyncPushChangesEvent = ValidateEvent<{
+  event: "remote_sync_push_changes";
+  triggered_from: "sidebar" | "conflict-modal";
+  event_detail?: "force";
+}>;
+
+export type RemoteSyncSettingsChangedEvent = ValidateEvent<{
+  event: "remote_sync_settings_changed";
+  triggered_from: "admin-settings";
+}>;
+
+export type RemoteSyncDeactivatedEvent = ValidateEvent<{
+  event: "remote_sync_deactivated";
+  triggered_from: "admin-settings";
+}>;
+
+export type RemoteSyncEvent =
+  | RemoteSyncBranchSwitchedEvent
+  | RemoteSyncBranchCreatedEvent
+  | RemoteSyncPullChangesEvent
+  | RemoteSyncPushChangesEvent
+  | RemoteSyncSettingsChangedEvent
+  | RemoteSyncDeactivatedEvent;
+
 export type BookmarkEvent =
   | BookmarkQuestionEvent
   | BookmarkModelEvent
@@ -509,4 +549,5 @@ export type SimpleEvent =
   | LearnAboutDataClickedEvent
   | MetadataEditEvent
   | BookmarkEvent
+  | RemoteSyncEvent
   | ClickActionPerformedEvent;


### PR DESCRIPTION
Closes [UXW-2098: Add event tracking for use of Remote Sync functionality](https://linear.app/metabase/issue/UXW-2098/add-event-tracking-for-use-of-remote-sync-functionality)

## Description

Adds snowplow analytics tracking:

- **remote_sync_branch_switched** - triggered_from: sidebar | admin-settings
- **remote_sync_branch_created** - triggered_from: branch-picker | conflict-modal
- **remote_sync_pull_changes** - triggered_from: sidebar | admin-settings, event_detail?: "force"
- **remote_sync_push_changes** - triggered_from: sidebar | conflict-modal, event_detail?: "force"
- **remote_sync_settings_changed** - triggered_from: admin-settings
- **remote_sync_deactivated** - triggered_from: admin-settings