### PR TITLE
Fix deleted documents were editable

### DIFF
--- a/e2e/test/scenarios/documents/documents.cy.spec.ts
+++ b/e2e/test/scenarios/documents/documents.cy.spec.ts
@@ -145,7 +145,15 @@ H.describeWithSnowplowEE("documents", () => {
 
     // Force the click since this is hidden behind a toast notification
     H.navigationSidebar().findByText("Trash").click({ force: true });
-    H.getUnpinnedSection().findByText("Test Document").should("exist");
+    H.getUnpinnedSection().findByText("Test Document").should("exist").click();
+
+    cy.log("test that trashed documents cannot be edited (metabase#64608)");
+    cy.findByRole("textbox", { name: "Document Title" })
+      .should("be.visible")
+      .and("have.attr", "readonly");
+    H.documentContent()
+      .findByRole("textbox")
+      .should("have.attr", "contenteditable", "false");
   });
 
   it("should handle navigating from /new to /new gracefully", () => {

--- a/e2e/test/scenarios/documents/documents.cy.spec.ts
+++ b/e2e/test/scenarios/documents/documents.cy.spec.ts
@@ -147,7 +147,7 @@ H.describeWithSnowplowEE("documents", () => {
     H.navigationSidebar().findByText("Trash").click({ force: true });
     H.getUnpinnedSection().findByText("Test Document").should("exist").click();
 
-    cy.log("test that trashed documents cannot be edited (metabase#64608)");
+    cy.log("test that deleted documents cannot be edited (metabase#64608)");
     cy.findByRole("textbox", { name: "Document Title" })
       .should("be.visible")
       .and("have.attr", "readonly");

--- a/e2e/test/scenarios/documents/documents.cy.spec.ts
+++ b/e2e/test/scenarios/documents/documents.cy.spec.ts
@@ -147,7 +147,7 @@ H.describeWithSnowplowEE("documents", () => {
     H.navigationSidebar().findByText("Trash").click({ force: true });
     H.getUnpinnedSection().findByText("Test Document").should("exist").click();
 
-    cy.log("test that deleted documents cannot be edited (metabase#64608)");
+    cy.log("test that deleted documents cannot be edited (metabase#63112)");
     cy.findByRole("textbox", { name: "Document Title" })
       .should("be.visible")
       .and("have.attr", "readonly");

--- a/enterprise/backend/src/metabase_enterprise/documents/api/document.clj
+++ b/enterprise/backend/src/metabase_enterprise/documents/api/document.clj
@@ -197,8 +197,7 @@
    _query-params
    {:keys [name document collection_id collection_position cards] :as body} :- DocumentUpdateOptions]
   (let [existing-document (api/check-404 (get-document document-id))]
-    (api/write-check existing-document)
-    (when (not (false? (:archived body)))
+    (when-not (contains? body :archived)
       (api/check-not-archived existing-document))
     (when (api/column-will-change? :collection_id existing-document body)
       (m.document/validate-collection-move-permissions (:collection_id existing-document) collection_id))

--- a/enterprise/backend/src/metabase_enterprise/documents/api/document.clj
+++ b/enterprise/backend/src/metabase_enterprise/documents/api/document.clj
@@ -194,6 +194,7 @@
    {:keys [name document collection_id collection_position cards] :as body} :- DocumentUpdateOptions]
   (let [existing-document (api/check-404 (get-document document-id))]
     (api/write-check existing-document)
+    (api/check-not-archived existing-document)
     (when (api/column-will-change? :collection_id existing-document body)
       (m.document/validate-collection-move-permissions (:collection_id existing-document) collection_id))
 

--- a/enterprise/backend/src/metabase_enterprise/documents/api/document.clj
+++ b/enterprise/backend/src/metabase_enterprise/documents/api/document.clj
@@ -198,7 +198,8 @@
    {:keys [name document collection_id collection_position cards] :as body} :- DocumentUpdateOptions]
   (let [existing-document (api/check-404 (get-document document-id))]
     (api/write-check existing-document)
-    (api/check-not-archived existing-document)
+    (when (not (false? (:archived body)))
+      (api/check-not-archived existing-document))
     (when (api/column-will-change? :collection_id existing-document body)
       (m.document/validate-collection-move-permissions (:collection_id existing-document) collection_id))
 

--- a/enterprise/backend/src/metabase_enterprise/documents/api/document.clj
+++ b/enterprise/backend/src/metabase_enterprise/documents/api/document.clj
@@ -199,6 +199,7 @@
   (let [existing-document (api/check-404 (get-document document-id))]
     (when-not (contains? body :archived)
       (api/check-not-archived existing-document))
+    (api/write-check existing-document)
     (when (api/column-will-change? :collection_id existing-document body)
       (m.document/validate-collection-move-permissions (:collection_id existing-document) collection_id))
 

--- a/enterprise/backend/test/metabase_enterprise/documents/api/document_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/documents/api/document_test.clj
@@ -86,7 +86,7 @@
 (deftest put-document-archived-test
   (testing "PUT /api/ee/document/:id - cannot update archived document"
     (mt/with-temp [:model/Document {doc-id :id} {:name "Test Document"
-                                                 :document (text->prose-mirror-ast "Initial")
+                                                 :document (documents.test-util/text->prose-mirror-ast "Initial")
                                                  :archived true}]
       (testing "editing archived document returns 404"
         (is (= "The object has been archived."

--- a/enterprise/backend/test/metabase_enterprise/documents/api/document_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/documents/api/document_test.clj
@@ -88,6 +88,17 @@
       (mt/user-http-request :rasta :put 403 (str "ee/document/" document-id)
                             {:name "Meow"}))))
 
+(deftest put-document-archived-test
+  (testing "PUT /api/ee/document/:id - cannot update archived document"
+    (mt/with-temp [:model/Document {doc-id :id} {:name "Test Document"
+                                                 :document (text->prose-mirror-ast "Initial")
+                                                 :archived true}]
+      (testing "editing archived document returns 404"
+        (is (= "The object has been archived."
+               (:message (mt/user-http-request :crowberto
+                                               :put 404 (format "ee/document/%s" doc-id)
+                                               {:name "Updated Name"}))))))))
+
 (deftest post-document-with-no-perms-test
   (mt/with-temp [:model/Collection {coll-id :id} {}]
     (mt/with-non-admin-groups-no-collection-perms coll-id

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentPage.tsx
@@ -138,7 +138,8 @@ export const DocumentPage = ({
   const hasComments =
     !!commentsData?.comments && commentsData.comments.length > 0;
 
-  const canWrite = isNewDocument || documentData?.can_write;
+  const canWrite =
+    !documentData?.archived && (isNewDocument || documentData?.can_write);
 
   useEffect(() => {
     if (error) {


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #63112
Closes UXW-1995

### Backport reason
This PR will likely be merged after 57 is cut, so I set it to backport.

### Description

Deleted documents were editable, this PR fixes that. However, I think we should also fix commenting as the UI is still visible and submit-able even though the API would fail. I was trying to work on comment entrypoints, but it would make this PR much bigger, so I think it deserves its own issue.

### How to verify

Create a document and delete it, now try to modify either the document title or the document body.

You shouldn't be able to to those things.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
