### PR TITLE
Add copy button to column names in Data Reference panel

### DIFF
--- a/frontend/src/metabase/query_builder/components/dataref/FieldList.tsx
+++ b/frontend/src/metabase/query_builder/components/dataref/FieldList.tsx
@@ -1,5 +1,6 @@
 import { msgid, ngettext } from "ttag";
 
+import { CopyButton } from "metabase/common/components/CopyButton";
 import {
   HoverParent,
   TableColumnInfoIcon,
@@ -55,6 +56,11 @@ export const FieldList = ({ fields, onFieldClick }: FieldListProps) => (
               />
               <NodeListItemName>{field.name}</NodeListItemName>
             </NodeListItemLink>
+            <CopyButton
+              value={field.name}
+              className={S.fieldCopyButton}
+              aria-label={msgid`Copy column name`}
+            />
           </HoverParent>
         );
       })}

--- a/frontend/src/metabase/query_builder/components/dataref/FieldList.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/dataref/FieldList.unit.spec.tsx
@@ -1,5 +1,5 @@
 import { createMockMetadata } from "__support__/metadata";
-import { renderWithProviders, screen } from "__support__/ui";
+import { getIcon, renderWithProviders, screen } from "__support__/ui";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
 
 import { FieldList } from "./FieldList";
@@ -13,11 +13,18 @@ const metadata = createMockMetadata({
 function setup() {
   const fields = [Object.values(metadata.fields)[0]];
   renderWithProviders(<FieldList fields={fields} onFieldClick={jest.fn()} />);
+  return { fields };
 }
 
 describe("FieldList", () => {
   it("should render the info icon", () => {
     setup();
     expect(screen.getByLabelText("More info")).toBeInTheDocument();
+  });
+
+  it("should render a copy button for each column", () => {
+    setup();
+    expect(screen.getByTestId("copy-button")).toBeInTheDocument();
+    expect(getIcon("copy")).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/query_builder/components/dataref/NodeList.module.css
+++ b/frontend/src/metabase/query_builder/components/dataref/NodeList.module.css
@@ -37,11 +37,27 @@
 }
 
 .NodeListItem {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+
   .NodeListItemLink {
     padding-top: 0;
     padding-bottom: 0;
     padding-right: 0;
+    flex: 1;
   }
+}
+
+.fieldCopyButton {
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  margin-right: 0.5rem;
+}
+
+.NodeListItem:hover .fieldCopyButton {
+  opacity: 1;
+  cursor: pointer;
 }
 
 .NodeListItemId {


### PR DESCRIPTION
## Summary
Adds a copy button to each column name in the Data Reference panel, making it easy for users to copy column names without navigating to the column detail view.

## Changes
- Added `CopyButton` component next to each field name in `FieldList.tsx`
- Implemented hover state that reveals the copy button
- Added unit test to verify copy button renders correctly
- Used proper localization for accessibility label

## User Experience
- Users hover over any column name in the Data Reference panel
- A copy icon appears next to the column name
- Clicking the icon copies the column name to clipboard
- A "Copied!" tooltip confirms the action

Closes #65133

🤖 Generated with [Claude Code](https://claude.com/claude-code)