### PR TITLE
Update error message for remote sync dep checking

### DIFF
--- a/e2e/test/scenarios/admin/remote-sync.cy.spec.ts
+++ b/e2e/test/scenarios/admin/remote-sync.cy.spec.ts
@@ -100,7 +100,7 @@ describe("Remote Sync", () => {
       cy.wait("@updateDashboard").then((req) => {
         expect(req.response?.statusCode).to.eq(400);
         expect(req.response?.body.message).to.contain(
-          "non-remote-synced dependencies",
+          "content that is not remote synced",
         );
       });
 

--- a/enterprise/backend/test/metabase_enterprise/documents/api/document_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/documents/api/document_test.clj
@@ -2031,7 +2031,7 @@
                                                  {:name "Doc with bad reference"
                                                   :collection_id remote-synced-id
                                                   :document (prose-mirror-with-smartlink "Link to card" card-id)})]
-              (is (= "Model has non-remote-synced dependencies" (:message response))
+              (is (= "Uses content that is not remote synced." (:message response))
                   "Should report non-remote-synced dependencies"))))))))
 
 (deftest create-document-in-remote-synced-with-remote-synced-smartlink-test
@@ -2107,7 +2107,7 @@
           (let [response (mt/user-http-request :crowberto
                                                :put 400 (format "ee/document/%s" doc-id)
                                                {:document (prose-mirror-with-smartlink "Bad link" card-id)})]
-            (is (= "Model has non-remote-synced dependencies" (:message response)))))))))
+            (is (= "Uses content that is not remote synced." (:message response)))))))))
 
 (deftest update-document-in-remote-synced-with-remote-synced-smartlink-test
   (testing "PUT /api/ee/document/:id - updating document in remote-synced collection to add remote-synced reference"
@@ -2212,7 +2212,7 @@
           (let [response (mt/user-http-request :crowberto
                                                :put 400 (format "ee/document/%s" doc-id)
                                                {:collection_id remote-synced-id})]
-            (is (= "Model has non-remote-synced dependencies" (:message response)))
+            (is (= "Uses content that is not remote synced." (:message response)))
 
             ;; Verify document was NOT moved
             (is (= regular-id (:collection_id (t2/select-one :model/Document :id doc-id)))
@@ -2242,7 +2242,7 @@
                                                :put 400 (format "ee/document/%s" doc-id)
                                                {:document (prose-mirror-with-smartlink "Bad" regular-card-id)
                                                 :collection_id remote-synced-id})]
-            (is (= "Model has non-remote-synced dependencies" (:message response)))))
+            (is (= "Uses content that is not remote synced." (:message response)))))
 
         (testing "Does not throw when moving to a regular collection"
           (mt/user-http-request :crowberto

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/dashboard_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/dashboard_api_test.clj
@@ -51,8 +51,8 @@
       (let [response (mt/user-http-request :crowberto :put 400 (str "dashboard/" dash-id)
                                            {:collection_id target-id})]
         ;; Verify error response contains dependency information
-        (is (str/includes? (:message response) "non-remote-synced dependencies")
-            "Error message should mention non-remote-synced dependencies"))
+        (is (str/includes? (:message response) "content that is not remote synced")
+            "Error message should mention content that is not remote synced"))
 
       ;; Verify the transaction was rolled back - dashboard should not be moved
       (let [unchanged-dash (t2/select-one :model/Dashboard :id dash-id)]
@@ -150,8 +150,8 @@
       (let [response (mt/user-http-request :crowberto :post 400 (format "dashboard/%d/copy" dash-id)
                                            {:collection_id target-id})]
         ;; Verify error response contains dependency information
-        (is (str/includes? (:message response) "non-remote-synced dependencies")
-            "Error message should mention non-remote-synced dependencies"))
+        (is (str/includes? (:message response) "content that is not remote synced")
+            "Error message should mention content that is not remote synced"))
 
       ;; Verify no dashboard was created
       (is (= 1 (t2/count :model/Dashboard :name "Dashboard to Copy"))

--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -1114,8 +1114,9 @@
   Throws an ex-info object with non-remote-synced-dependencies and a 400 status code if dependencies are found."
   [model]
   (when-let [non-remote-synced-deps (not-empty (non-remote-synced-dependencies model))]
-    (throw (ex-info (str (deferred-tru "Model has non-remote-synced dependencies")) {:non-remote-synced-models non-remote-synced-deps
-                                                                                     :status-code 400})))
+    (throw (ex-info (str (deferred-tru "Uses content that is not remote synced."))
+                    {:non-remote-synced-models non-remote-synced-deps
+                     :status-code 400})))
   model)
 
 (defn check-remote-synced-dependents
@@ -1128,8 +1129,9 @@
   Throws an ex-info object with remote-synced-dependencies and a 400 status code if dependents are found."
   [original-collection-id model]
   (when-let [remote-synced-deps (not-empty (remote-synced-dependents original-collection-id model))]
-    (throw (ex-info (str (deferred-tru "Model has remote-synced dependents")) {:remote-synced-models remote-synced-deps
-                                                                               :status-code 400})))
+    (throw (ex-info (str (deferred-tru "Used by remote synced content."))
+                    {:remote-synced-models remote-synced-deps
+                     :status-code 400})))
   model)
 
 (defn- locations-do-not-share-top-level-parent

--- a/test/metabase/collections/models/collection_test.clj
+++ b/test/metabase/collections/models/collection_test.clj
@@ -2099,7 +2099,7 @@
                       (constantly #{dep-card-id})]
           (is (thrown-with-msg?
                clojure.lang.ExceptionInfo
-               #"Model has non-remote-synced dependencies"
+               #"Uses content that is not remote synced."
                (collection/check-non-remote-synced-dependencies (t2/instance :model/Card {:id card-id})))
               "Should throw exception when dependencies exist"))))
 
@@ -2227,7 +2227,7 @@
                                   :dataset_query (mt/mbql-query nil {:source-table (str "card__" non-remote-synced-card-id)})}]
         ;; This should throw an exception because the dependency (non-remote-synced-card) is not in a remote-synced collection
       (let [ex (is (thrown-with-msg? Exception
-                                     #"Model has non-remote-synced dependencies"
+                                     #"Uses content that is not remote synced."
                                      (collection/move-collection! coll (format "/%d/" parent-id) true))
                    "Should throw exception for non-remote-synced dependencies")
             ex-data (ex-data ex)]
@@ -2558,7 +2558,7 @@
                                                   :database_id (mt/id)
                                                   :dataset_query (mt/mbql-query nil {:source-table (str "card__" base-card-id)})}]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                            #"Model has remote-synced dependents"
+                            #"Used by remote synced content."
                             (collection/check-remote-synced-dependents remote-synced-id (t2/instance :model/Card {:id base-card-id})))
           "Should throw exception when model has remote-synced dependents")
 
@@ -2596,7 +2596,7 @@
                                   :database_id (mt/id)
                                   :dataset_query (mt/mbql-query nil {:source-table (str "card__" base-card-id)})}]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                            #"Model has remote-synced dependents"
+                            #"Used by remote synced content."
                             (collection/check-remote-synced-dependents remote-synced-id (t2/instance :model/Collection {:id source-coll-id})))
           "Should throw exception when collection contains cards with remote-synced dependents"))))
 
@@ -2732,7 +2732,7 @@
         (let [ex (is (thrown? Exception
                               (collection/move-collection! child-remote-synced-collection (format "/%d/" regular-parent-id)))
                      "Should throw exception when moving collection with remote-synced dependents")]
-          (is (= "Model has remote-synced dependents" (ex-message ex))
+          (is (= "Used by remote synced content." (ex-message ex))
               "Exception should have correct message")
           (let [ex-data (ex-data ex)]
             (is (= 400 (:status-code ex-data))
@@ -2772,7 +2772,7 @@
         (let [ex (is (thrown? Exception
                               (collection/move-collection! child-remote-synced-collection (format "/%d/" regular-parent-id)))
                      "Should throw exception when moving collection with dashboard dependents")]
-          (is (= "Model has remote-synced dependents" (ex-message ex))
+          (is (= "Used by remote synced content." (ex-message ex))
               "Exception should have correct message")
           (let [ex-data (ex-data ex)]
             (is (= 400 (:status-code ex-data))
@@ -2880,7 +2880,7 @@
         (let [ex (is (thrown? Exception
                               (collection/move-collection! child-remote-synced-collection (format "/%d/" regular-parent-id)))
                      "Should throw exception when moving collection with nested dependents")]
-          (is (= "Model has remote-synced dependents" (ex-message ex))
+          (is (= "Used by remote synced content." (ex-message ex))
               "Exception should have correct message")
           (let [ex-data (ex-data ex)]
             (is (= 400 (:status-code ex-data))
@@ -3143,7 +3143,7 @@
                               (mt/with-current-user (mt/user->id :crowberto)
                                 (collection/archive-collection! child-coll)))
                      "Should throw exception when parent has dependents on child items")]
-          (is (= "Model has remote-synced dependents" (ex-message ex))
+          (is (= "Used by remote synced content." (ex-message ex))
               "Exception should have correct message")
           (let [ex-data (ex-data ex)]
             (is (= 400 (:status-code ex-data))
@@ -3250,7 +3250,7 @@
                               (mt/with-current-user (mt/user->id :crowberto)
                                 (collection/archive-collection! child-coll)))
                      "Should throw exception when parent dashboard depends on child items")]
-          (is (= "Model has remote-synced dependents" (ex-message ex))
+          (is (= "Used by remote synced content." (ex-message ex))
               "Exception should have correct message")))
 
       (testing "Collection is NOT archived when exception is thrown"

--- a/test/metabase/queries/models/card_test.clj
+++ b/test/metabase/queries/models/card_test.clj
@@ -1083,7 +1083,7 @@
       (testing "Card with non-remote-synced source card dependency cannot be created in remote-synced collection"
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
-             #"Model has non-remote-synced dependencies"
+             #"Uses content that is not remote synced."
              (card/create-card!
               {:name "Card with non-remote-synced dependency"
                :display "table"
@@ -1115,7 +1115,7 @@
       (testing "Card with non-remote-synced dependencies cannot be moved to remote-synced collection"
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
-             #"Model has non-remote-synced dependencies"
+             #"Uses content that is not remote synced."
              (card/update-card!
               {:card-before-update card
                :card-updates {:collection_id remote-synced-coll-id}
@@ -1147,7 +1147,7 @@
       (testing "Cannot update remote-synced card to have non-remote-synced dependencies"
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
-             #"Model has non-remote-synced dependencies"
+             #"Uses content that is not remote synced."
              (card/update-card!
               {:card-before-update card
                :card-updates {:dataset_query (mt/mbql-query nil {:source-table (str "card__" non-remote-synced-source-id)})}
@@ -1166,7 +1166,7 @@
       (testing "Cannot move remote-synced card to regular collection when remote-synced dependents exist"
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
-             #"Model has remote-synced dependents"
+             #"Used by remote synced content."
              (card/update-card!
               {:card-before-update remote-synced-card
                :card-updates {:collection_id regular-coll-id}
@@ -1198,7 +1198,7 @@
       (testing "Cannot move remote-synced card when dependents reference it via parameters"
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
-             #"Model has remote-synced dependents"
+             #"Used by remote synced content."
              (card/update-card!
               {:card-before-update remote-synced-card
                :card-updates {:collection_id regular-coll-id}
@@ -1222,7 +1222,7 @@
       (testing "Cannot move remote-synced card when dependents reference it via template tags"
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
-             #"Model has remote-synced dependents"
+             #"Used by remote synced content."
              (card/update-card!
               {:card-before-update remote-synced-card
                :card-updates {:collection_id regular-coll-id}


### PR DESCRIPTION
### Description

Try to make these error messages less jargony because they are presented by the user interface when dependency checking content fails.

Closes UXW-2142 and UXW-1879.