### PR TITLE
Delete superfluous test

### DIFF
--- a/e2e/test/scenarios/admin-2/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/settings.cy.spec.js
@@ -658,55 +658,6 @@ describe("scenarios > admin > license and billing", () => {
         .should("have.prop", "tagName", "A");
     });
 
-    // This test needs to be re-examined and unskipped!
-    // It's mocking features that already exist in the self-hosted token
-    // It is using Promise.resolve that is going against the Cypress best-practices
-    // It has a very convoluted setup when we could probably just edit the current admin user
-    // It hard codes the store managed user which makes it breaking as soon as we udpate the token info
-    // I'm tracking the issue here: https://linear.app/metabase/issue/DEV-1017/fix-and-unskip-e2e-should-show-the-user-store-info-for-an-self-hosted
-    it.skip("should show the user store info for an self-hosted instance managed by the store", () => {
-      H.activateToken("pro-self-hosted");
-      mockBillingTokenFeatures([
-        STORE_MANAGED_FEATURE_KEY,
-        NO_UPSELL_FEATURE_HEY,
-      ]);
-
-      const harborMasterConnectedAccount = {
-        email: "ci-admins@metabase.com",
-        first_name: "CI",
-        last_name: "Admins",
-        password: "test-password-123",
-      };
-
-      // create an admin user who is also connected to our test harbormaster account
-      cy.request("GET", "/api/permissions/group")
-        .then(({ body: groups }) => {
-          const adminGroup = groups.find((g) => g.name === "Administrators");
-          return cy
-            .createUserFromRawData(harborMasterConnectedAccount)
-            .then((user) => Promise.resolve([adminGroup.id, user]));
-        })
-        .then(([adminGroupId, user]) => {
-          const data = { user_id: user.id, group_id: adminGroupId };
-          return cy
-            .request("POST", "/api/permissions/membership", data)
-            .then(() => Promise.resolve(user));
-        })
-        .then((user) => {
-          cy.signOut(); // stop being normal admin user and be store connected admin user
-          return cy.request("POST", "/api/session", {
-            username: user.email,
-            password: harborMasterConnectedAccount.password,
-          });
-        })
-        .then(() => {
-          // core test
-          cy.visit("/admin/settings/license");
-          cy.findByTestId("billing-info-key-plan").should("exist");
-          cy.findByTestId("license-input").should("exist");
-        });
-    });
-
     it("should not show license input for cloud-hosted instances", () => {
       H.activateToken("pro-self-hosted");
       mockBillingTokenFeatures([


### PR DESCRIPTION
This behavior is already tested in https://github.com/metabase/metabase/blob/master/enterprise/frontend/src/metabase-enterprise/license/components/LicenseAndBillingSettings/LicenseAndBillingSettings.unit.spec.tsx#L83-L197. e2e test is an overkill for this, especially since it needs to make a round trip to the Store.

Resolves DEV-1017