### PR TITLE
Normalize parameter type category/= to category

### DIFF
--- a/src/metabase/lib/schema/parameter.cljc
+++ b/src/metabase/lib/schema/parameter.cljc
@@ -153,9 +153,10 @@
                                     ;; a lot of broken code in Actions was setting param types to invalid things like
                                     ;; `:type/Text`... fix it
                                     (when-let [param-type (lib.schema.common/normalize-keyword param-type)]
-                                      (if (= (namespace param-type) "type")
-                                        (keyword (u/lower-case-en (name param-type)))
-                                        param-type)))}]
+                                      (cond
+                                        (= (namespace param-type) "type") (keyword (u/lower-case-en (name param-type)))
+                                        (= param-type :category/=)        :category
+                                        :else param-type)))}]
         (keys types)))
 
 (mr/def ::widget-type

--- a/src/metabase/lib/schema/parameter.cljc
+++ b/src/metabase/lib/schema/parameter.cljc
@@ -156,7 +156,7 @@
                                       (cond
                                         (= (namespace param-type) "type") (keyword (u/lower-case-en (name param-type)))
                                         (= param-type :category/=)        :category
-                                        :else param-type)))}]
+                                        :else                             param-type)))}]
         (keys types)))
 
 (mr/def ::widget-type

--- a/test/metabase/lib/schema/parameter_test.cljc
+++ b/test/metabase/lib/schema/parameter_test.cljc
@@ -77,9 +77,14 @@
          (lib/normalize ::lib.schema.parameter/target [:template-tag "x"]))))
 
 (deftest ^:parallel decode-busted-param-type-test
-  (is (= :text
-         (lib/normalize ::lib.schema.parameter/type "type/Text")
-         (lib/normalize ::lib.schema.parameter/type :type/Text))))
+  (testing "type namespace should be removed"
+    (is (= :text
+           (lib/normalize ::lib.schema.parameter/type "type/Text")
+           (lib/normalize ::lib.schema.parameter/type :type/Text))))
+  (testing ":category/= should normalize to :category"
+    (is (= :category
+           (lib/normalize ::lib.schema.parameter/type "category/=")
+           (lib/normalize ::lib.schema.parameter/type :category/=)))))
 
 (deftest ^:parallel default-to-type-text-test
   (is (= {:id "x", :type :text}


### PR DESCRIPTION
Stats had exactly one dashboard with one such parameter and that dashboard was immutable because the before-update hook failed before any update could happen.

### Description

Added special handling for this case, now we have two special cases instead of one.

### How to verify

Run the tests.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
