### PR TITLE
UXW-2091 user without collection access to Our Analytics can't save documents

### DIFF
--- a/e2e/test/scenarios/documents/document-permissions.cy.spec.ts
+++ b/e2e/test/scenarios/documents/document-permissions.cy.spec.ts
@@ -1,0 +1,110 @@
+const { H } = cy;
+import { USER_GROUPS } from "e2e/support/cypress_data";
+
+const { ALL_USERS_GROUP } = USER_GROUPS;
+
+H.describeWithSnowplowEE("document permissions", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    H.activateToken("bleeding-edge");
+    H.resetSnowplow();
+    cy.signOut();
+  });
+
+  it("should allow a non-admin user to create a new document and save it", () => {
+    cy.signInAsAdmin();
+
+    cy.updateCollectionGraph({
+      [ALL_USERS_GROUP]: { root: "none" },
+    });
+
+    cy.signOut();
+
+    cy.signIn("none");
+
+    cy.visit("/");
+
+    H.newButton("Document").click();
+    cy.title().should("eq", "New document · Metabase");
+
+    cy.findByRole("textbox", { name: "Document Title" })
+      .should("be.focused")
+      .type("User Document");
+
+    H.documentContent().type("This is a document created by a non-admin user");
+
+    cy.findByRole("button", { name: "Save" }).click();
+
+    cy.findByTestId("item-picker-level-0")
+      .findByText("Our analytics")
+      .should("not.exist");
+    H.entityPickerModalItem(0, "Collections").should("exist");
+
+    H.entityPickerModalItem(0, /Personal Collection/).click();
+    H.entityPickerModal().findByRole("button", { name: "Select" }).click();
+
+    cy.location("pathname").should("match", /^\/document\/\d+/);
+    cy.title().should("eq", "User Document · Metabase");
+
+    H.expectUnstructuredSnowplowEvent({ event: "document_created" });
+
+    H.appBar()
+      .findByRole("link", { name: /Personal Collection/ })
+      .click();
+
+    H.collectionTable()
+      .findByRole("link", { name: "User Document" })
+      .should("exist");
+  });
+
+  it("should allow a non-admin user to edit their own document", () => {
+    cy.signInAsNormalUser();
+
+    H.createDocument({
+      name: "User Document",
+      document: {
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              {
+                type: "text",
+                text: "Original content",
+              },
+            ],
+            attrs: {
+              _id: "1",
+            },
+          },
+        ],
+        type: "doc",
+      },
+      collection_id: null,
+      alias: "document",
+      idAlias: "documentId",
+    });
+
+    H.visitDocument("@documentId");
+
+    H.documentContent().should("contain.text", "Original content");
+
+    H.documentContent()
+      .findByRole("textbox")
+      .should("have.attr", "contenteditable", "true");
+
+    H.documentContent().click();
+    H.addToDocument(" and some new content");
+
+    H.documentSaveButton().click();
+
+    cy.findByTestId("toast-undo")
+      .findByText("Document saved")
+      .should("be.visible");
+
+    H.documentContent().should(
+      "contain.text",
+      "Original content and some new content",
+    );
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentPage.tsx
@@ -455,7 +455,6 @@ export const DocumentPage = ({
           <CollectionPickerModal
             title={t`Where should we save this document?`}
             onClose={() => setCollectionPickerMode(null)}
-            value={{ id: "root", model: "collection" }}
             options={{
               showPersonalCollections: true,
               showRootCollection: true,

--- a/frontend/src/metabase/common/components/Pickers/CollectionPicker/components/CollectionPickerModal.tsx
+++ b/frontend/src/metabase/common/components/Pickers/CollectionPicker/components/CollectionPickerModal.tsx
@@ -29,7 +29,7 @@ export interface CollectionPickerModalProps {
   onChange: (item: CollectionPickerValueItem) => void;
   onClose: () => void;
   options?: CollectionPickerOptions;
-  value: Pick<CollectionPickerValueItem, "id" | "model" | "collection_id">;
+  value?: Pick<CollectionPickerValueItem, "id" | "model" | "collection_id">;
   shouldDisableItem?: (item: CollectionPickerItem) => boolean;
   searchResultFilter?: (searchResults: SearchResult[]) => SearchResult[];
   recentFilter?: (recentItems: RecentItem[]) => RecentItem[];
@@ -38,7 +38,7 @@ export interface CollectionPickerModalProps {
 }
 
 const baseCanSelectItem = (
-  item: Pick<CollectionPickerItem, "can_write" | "model"> | null,
+  item: Pick<CollectionPickerItem, "can_write" | "model"> | null | undefined,
 ): item is CollectionPickerValueItem => {
   return (
     !!item &&
@@ -72,7 +72,10 @@ export const CollectionPickerModal = ({
   );
   const canSelectItem = useCallback(
     (
-      item: Pick<CollectionPickerItem, "id" | "can_write" | "model"> | null,
+      item:
+        | Pick<CollectionPickerItem, "id" | "can_write" | "model">
+        | null
+        | undefined,
     ): item is CollectionPickerValueItem => {
       return baseCanSelectItem(item) && (_canSelectItem?.(item) ?? true);
     },

--- a/frontend/src/metabase/common/components/Pickers/CollectionPicker/components/CollectionPickerModal.tsx
+++ b/frontend/src/metabase/common/components/Pickers/CollectionPicker/components/CollectionPickerModal.tsx
@@ -166,9 +166,9 @@ export const CollectionPickerModal = ({
       displayName: models.some((model) => model !== "collection")
         ? t`Browse`
         : t`Collections`,
-      models,
+      models: models as CollectionPickerModel[],
       folderModels: ["collection" as const],
-      icon: "folder",
+      icon: "folder" as const,
       render: ({ onItemSelect }) => (
         <CollectionPicker
           initialValue={value}

--- a/frontend/src/metabase/common/components/Pickers/CollectionPicker/components/CollectionPickerModal.tsx
+++ b/frontend/src/metabase/common/components/Pickers/CollectionPicker/components/CollectionPickerModal.tsx
@@ -62,10 +62,12 @@ export const CollectionPickerModal = ({
   shouldDisableItem,
   searchResultFilter,
   recentFilter,
-  models = ["collection"],
+  models: modelsProp,
   canSelectItem: _canSelectItem,
 }: CollectionPickerModalProps) => {
   options = { ...defaultOptions, ...options };
+
+  const models = modelsProp || ["collection"];
 
   const [selectedItem, setSelectedItem] = useState<CollectionPickerItem | null>(
     null,
@@ -169,9 +171,9 @@ export const CollectionPickerModal = ({
       displayName: models.some((model) => model !== "collection")
         ? t`Browse`
         : t`Collections`,
-      models: models as CollectionPickerModel[],
-      folderModels: ["collection" as const],
-      icon: "folder" as const,
+      models: models,
+      folderModels: ["collection"],
+      icon: "folder",
       render: ({ onItemSelect }) => (
         <CollectionPicker
           initialValue={value}


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #64935
Closes https://linear.app/metabase/issue/UXW-2091/user-without-collection-access-to-our-analytics-cant-save-documents-to

### Description

Disable root collection to be a hardcoded initial value for collection picked to save a document. This way users that don't have access to the root collection can pick any other collection they have access to.

### Demo

https://github.com/user-attachments/assets/30d60d54-f777-49c6-a064-40e932ea8a8a


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
