### PR TITLE
remove border from dashboard header where header=false and no tabs

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.module.css
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.module.css
@@ -22,6 +22,10 @@
   z-index: 2;
   transition: var(--transition-theme-change);
 
+  &:not(.noBorder) {
+    border-bottom: 1px solid var(--mb-color-border);
+  }
+
   &:not(.isEmbeddingSdk) {
     background-color: var(--mb-color-background);
   }
@@ -29,10 +33,6 @@
   &.isFullscreen {
     background-color: transparent;
     border-color: transparent;
-  }
-
-  &:not(.noBorder) {
-    border-bottom: 1px solid var(--mb-color-border);
   }
 }
 

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.module.css
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.module.css
@@ -20,7 +20,6 @@
 .DashboardHeaderContainer {
   position: relative;
   z-index: 2;
-  border-bottom: 1px solid var(--mb-color-border);
   transition: var(--transition-theme-change);
 
   &:not(.isEmbeddingSdk) {
@@ -30,6 +29,10 @@
   &.isFullscreen {
     background-color: transparent;
     border-color: transparent;
+  }
+
+  &:not(.noBorder) {
+    border-bottom: 1px solid var(--mb-color-border);
   }
 }
 

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -6,7 +6,9 @@ import { DashboardArchivedEntityBanner } from "metabase/archive/components/Archi
 import DashboardS from "metabase/css/dashboard.module.css";
 import { DashboardHeader } from "metabase/dashboard/components/DashboardHeader";
 import { useDashboardContext } from "metabase/dashboard/context";
+import { getIsHeaderVisible } from "metabase/dashboard/selectors";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
+import { useSelector } from "metabase/lib/redux";
 import { FilterApplyToast } from "metabase/parameters/components/FilterApplyToast";
 import EmbedFrameS from "metabase/public/components/EmbedFrame/EmbedFrame.module.css";
 import { FullWidthContainer } from "metabase/styled-components/layout/FullWidthContainer";
@@ -33,6 +35,8 @@ const DashboardDefaultView = ({ className }: { className?: string }) => {
   const { dashboard, isEditing, isFullscreen, isSharing, selectedTabId } =
     useDashboardContext();
 
+  const isHeaderVisible = useSelector(getIsHeaderVisible);
+
   const currentTabDashcards = useMemo(() => {
     if (!dashboard || !Array.isArray(dashboard.dashcards)) {
       return [];
@@ -58,6 +62,7 @@ const DashboardDefaultView = ({ className }: { className?: string }) => {
   }
 
   const isEmpty = !dashboardHasCards || (dashboardHasCards && !tabHasCards);
+  const hasTabs = dashboard.tabs && dashboard.tabs.length > 1;
 
   // Embedding SDK has parent containers that requires dashboard to be full height to avoid double scrollbars.
   const isFullHeight = isEditing || isSharing || isEmbeddingSdk();
@@ -89,6 +94,7 @@ const DashboardDefaultView = ({ className }: { className?: string }) => {
           {
             [S.isEmbeddingSdk]: isEmbeddingSdk(),
             [S.isFullscreen]: isFullscreen,
+            [S.noBorder]: !hasTabs && !isHeaderVisible,
           },
         )}
         data-element-id="dashboard-header-container"


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/EMB-871/remove-a-grey-line-when-metabase-is-iframed
Closes EMB-871

### Description

This PR hides a border when the header is hidden and there are no tabs, as per the issue.


### How to verify

You will need a[ working interactive embedding setup](https://github.com/metabase/metabase-nodejs-express-interactive-embedding-sample).

Embed a dashboard that has no tabs and pass `?top_nav=false&side_nav=false&header=false` to simulate embedding just the dashboard, you should see that we don't render the border anymore

### Demo

#### Before
Notice the border at the top
<img width="784" height="472" alt="image" src="https://github.com/user-attachments/assets/48b88601-2290-4454-b132-715cc8853ce9" />

#### After

With header=false and no tabs, border not visible:
<img width="777" height="499" alt="image" src="https://github.com/user-attachments/assets/ec014b9c-9c06-496b-a76b-367f26d297b3" />


With tabs, the border is still visible:
<img width="771" height="605" alt="image" src="https://github.com/user-attachments/assets/9f5f67db-25e8-4578-a6f8-dd32e1f31165" />

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR

I did not add tests to this, I tried for more than an hour to write some unit tests that weren't a complex system of mocks to test an if, and I don't think this is worth an e2e.
I think we're better off without tests for this small cosmetic thing
