### PR TITLE
Add :order-by to metabase-enterprise.transforms.api/get-transforms

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/transforms/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/api.clj
@@ -89,7 +89,7 @@
   "Get a list of transforms."
   [& {:keys [last_run_start_time last_run_statuses tag_ids]}]
   (api/check-superuser)
-  (let [transforms (t2/select :model/Transform)]
+  (let [transforms (t2/select :model/Transform {:order-by [[:id :asc]]})]
     (into []
           (comp (transforms.util/->date-field-filter-xf [:last_run :start_time] last_run_start_time)
                 (transforms.util/->status-filter-xf [:last_run :status] last_run_statuses)


### PR DESCRIPTION
Closes BOT-481

### Description

Add an `:order-by` to `metabase-enterprise.transforms.api/get-transforms` to ensure transforms are returned in a consistent order to and reduce test flakes.

https://metaboat.slack.com/archives/C5XHN8GLW/p1761753664842279

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
