### PR TITLE
[Metabot] Copy change for suggested prompts setting description

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminPage.tsx
@@ -97,7 +97,7 @@ export function MetabotAdminPage() {
             <MetabotCollectionConfigurationPane metabot={metabot} />
           )}
 
-          <MetabotPromptSuggestionPane metabotId={metabotId} />
+          <MetabotPromptSuggestionPane metabot={metabot} />
         </SettingsSection>
       </ErrorBoundary>
     </AdminSettingsLayout>

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminSuggestedPrompts.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminSuggestedPrompts.tsx
@@ -144,7 +144,7 @@ export const MetabotPromptSuggestionPane = ({
                 key={row.id}
                 row={row as SuggestedMetabotPrompt}
                 onDelete={() => handleDeletePrompt(row.id)}
-                metabotId={metabotId}
+                metabotId={metabot.id}
               />
             )
           }

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminSuggestedPrompts.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminSuggestedPrompts.tsx
@@ -101,7 +101,7 @@ export const MetabotPromptSuggestionPane = ({
       <SettingHeader
         id="prompt-suggestions"
         title={t`Prompt suggestions`}
-        description={t`When users open a new Metabot chat, we’ll randomly show them a few suggested prompts based on the models and metrics in the collection you chose.`}
+        description={t`When users open a new Metabot chat, we’ll randomly show them a few suggested prompts based on popular models and metrics in your instance.`}
       />
       <Flex gap="md" align="center">
         <Button

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminSuggestedPrompts.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminSuggestedPrompts.tsx
@@ -103,8 +103,8 @@ export const MetabotPromptSuggestionPane = ({
         title={t`Prompt suggestions`}
         description={
           metabot.collection_id
-            ? t`When users open a new Metabot chat, we’ll randomly show them a few suggested prompts based on popular models and metrics in the collection you chose.`
-            : t`When users open a new Metabot chat, we’ll randomly show them a few suggested prompts based on popular models and metrics in your instance.`
+            ? t`When users open a new Metabot chat, we’ll show them a few suggested prompts based on popular models and metrics in the collection you chose.`
+            : t`When users open a new Metabot chat, we’ll show them a few suggested prompts based on popular models and metrics in your instance.`
         }
       />
       <Flex gap="md" align="center">

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminSuggestedPrompts.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminSuggestedPrompts.tsx
@@ -34,7 +34,7 @@ export const MetabotPromptSuggestionPane = ({
   metabot,
   pageSize = PAGE_SIZE,
 }: {
-  metabot: MetabotInfo;
+  metabot: Pick<MetabotInfo, "id" | "collection_id">;
   pageSize?: number;
 }) => {
   const [sendToast] = useToast();

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminSuggestedPrompts.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminSuggestedPrompts.tsx
@@ -26,15 +26,15 @@ import {
 } from "metabase-enterprise/api";
 import { FIXED_METABOT_IDS } from "metabase-enterprise/metabot/constants";
 import * as Urls from "metabase-enterprise/urls";
-import type { MetabotId, SuggestedMetabotPrompt } from "metabase-types/api";
+import type { MetabotInfo, SuggestedMetabotPrompt } from "metabase-types/api";
 
 export const PAGE_SIZE = 10;
 
 export const MetabotPromptSuggestionPane = ({
-  metabotId,
+  metabot,
   pageSize = PAGE_SIZE,
 }: {
-  metabotId: MetabotId;
+  metabot: MetabotInfo;
   pageSize?: number;
 }) => {
   const [sendToast] = useToast();
@@ -43,7 +43,7 @@ export const MetabotPromptSuggestionPane = ({
   const offset = page * pageSize;
 
   const { data, isLoading, error } = useGetSuggestedMetabotPromptsQuery({
-    metabot_id: metabotId,
+    metabot_id: metabot.id,
     limit: pageSize,
     offset,
   });
@@ -53,7 +53,7 @@ export const MetabotPromptSuggestionPane = ({
 
   const handleDeletePrompt = async (promptId: SuggestedMetabotPrompt["id"]) => {
     const { error } = await deletePrompt({
-      metabot_id: metabotId,
+      metabot_id: metabot.id,
       prompt_id: promptId,
     });
 
@@ -73,7 +73,7 @@ export const MetabotPromptSuggestionPane = ({
   };
 
   const handleRegeneratePrompts = async () => {
-    const { error } = await regeneratePrompts(metabotId);
+    const { error } = await regeneratePrompts(metabot.id);
     if (error) {
       sendToast({
         message: t`Error regenerate prompts`,
@@ -101,7 +101,11 @@ export const MetabotPromptSuggestionPane = ({
       <SettingHeader
         id="prompt-suggestions"
         title={t`Prompt suggestions`}
-        description={t`When users open a new Metabot chat, we’ll randomly show them a few suggested prompts based on popular models and metrics in your instance.`}
+        description={
+          metabot.collection_id
+            ? t`When users open a new Metabot chat, we’ll randomly show them a few suggested prompts based on popular models and metrics in the collection you chose.`
+            : t`When users open a new Metabot chat, we’ll randomly show them a few suggested prompts based on popular models and metrics in your instance.`
+        }
       />
       <Flex gap="md" align="center">
         <Button

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminSuggestedPrompts.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminSuggestedPrompts.unit.spec.tsx
@@ -33,7 +33,6 @@ const nextPage = async () =>
 
 type SetupOpts = {
   metabotId?: number;
-  metabotCollectionId?: number;
   pageSize?: number;
   mockInitialPage?: boolean;
 };

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminSuggestedPrompts.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminSuggestedPrompts.unit.spec.tsx
@@ -33,6 +33,7 @@ const nextPage = async () =>
 
 type SetupOpts = {
   metabotId?: number;
+  metabotCollectionId?: number;
   pageSize?: number;
   mockInitialPage?: boolean;
 };
@@ -59,7 +60,10 @@ const setup = async (opts?: SetupOpts) => {
     : paginationContext;
 
   const TestComponent = () => (
-    <MetabotPromptSuggestionPane metabotId={metabotId} pageSize={pageSize} />
+    <MetabotPromptSuggestionPane
+      metabot={{ id: metabotId, collection_id: null }}
+      pageSize={pageSize}
+    />
   );
 
   renderWithProviders(<Route path="/" component={TestComponent} />, {


### PR DESCRIPTION
[BOT-470](https://linear.app/metabase/issue/BOT-470/update-metabot-copy)

### Description

Updates copy to reflect we no longer limit to a single collection for non-embedded metabots.

### Demo
(edit: removed "randomly" from copy after screenshots were taken, same idea though)
<img width="2940" height="820" alt="CleanShot 2025-10-29 at 11 54 08@2x" src="https://github.com/user-attachments/assets/22e2b414-ca48-44f5-9f27-e497be922c2b" />
<img width="2944" height="1288" alt="CleanShot 2025-10-29 at 11 54 46@2x" src="https://github.com/user-attachments/assets/3c2bb6b5-0eb8-4baa-99f0-05840c371b19" />
<img width="2964" height="1274" alt="CleanShot 2025-10-29 at 11 55 21@2x" src="https://github.com/user-attachments/assets/7d2fbceb-40ad-4922-9266-9b31ee120143" />


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
low value imo, not testing
