### PR TITLE
show a warning message when removing items from the library

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/ChangesLists/AllChangesView.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/ChangesLists/AllChangesView.tsx
@@ -1,8 +1,18 @@
 import { Fragment, useMemo } from "react";
+import { t } from "ttag";
 import _ from "underscore";
 
 import { useListCollectionsTreeQuery } from "metabase/api";
-import { Box, Divider, Group, Icon, Paper, Stack, Title } from "metabase/ui";
+import {
+  Box,
+  Divider,
+  Group,
+  Icon,
+  Paper,
+  Stack,
+  Text,
+  Title,
+} from "metabase/ui";
 import {
   buildCollectionMap,
   getCollectionPathSegments,
@@ -45,6 +55,14 @@ export const AllChangesView = ({
 
     return map;
   }, [collectionTree, collections]);
+
+  const hasRemovals = useMemo(() => {
+    return (
+      entities.findIndex((e) =>
+        ["removed", "delete"].includes(e.sync_status),
+      ) >= 0
+    );
+  }, [entities]);
 
   const groupedData = useMemo(() => {
     const byCollection = _.groupBy(entities, (e) => e.collection_id || 0);
@@ -150,6 +168,14 @@ export const AllChangesView = ({
           ))}
         </Stack>
       </Paper>
+      {hasRemovals && (
+        <Text
+          c="error"
+          fz="sm"
+          lh="sm"
+          mt="sm"
+        >{t`Other instances using this library may have items that depend on the items you're removing.`}</Text>
+      )}
     </Box>
   );
 };

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/ChangesLists/AllChangesView.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/ChangesLists/AllChangesView.unit.spec.tsx
@@ -1,0 +1,61 @@
+import fetchMock from "fetch-mock";
+
+import { renderWithProviders, screen } from "__support__/ui";
+import type { RemoteSyncEntity } from "metabase-types/api";
+import { createMockCollection } from "metabase-types/api/mocks";
+import { createMockRemoteSyncEntity } from "metabase-types/api/mocks/remote-sync";
+
+import { AllChangesView } from "./AllChangesView";
+
+const updatedEntity = createMockRemoteSyncEntity({
+  collection_id: 1,
+});
+const removedEntity = createMockRemoteSyncEntity({
+  id: 2,
+  name: "Removed Question",
+  sync_status: "removed",
+  collection_id: 1,
+});
+const deletedEntity = createMockRemoteSyncEntity({
+  id: 3,
+  name: "Deleted Question",
+  sync_status: "delete",
+  collection_id: 1,
+});
+
+const setup = ({
+  entities = [updatedEntity],
+}: {
+  entities: RemoteSyncEntity[];
+}) => {
+  const collections = [createMockCollection({ name: "Entity Collection" })];
+
+  fetchMock.get("/api/collection/tree", collections);
+  renderWithProviders(
+    <AllChangesView entities={entities} collections={collections} />,
+  );
+};
+
+describe("AllChangesView", () => {
+  describe("warning message", () => {
+    it("should show a warning when removing entities", () => {
+      setup({ entities: [updatedEntity, removedEntity] });
+
+      expect(screen.getByText(/that depend on the items/)).toBeInTheDocument();
+    });
+
+    it("should show a warning when deleting entities", () => {
+      setup({ entities: [updatedEntity, deletedEntity] });
+
+      expect(screen.getByText(/that depend on the items/)).toBeInTheDocument();
+    });
+
+    it("should not show a warning when no items have been removed or deleted", () => {
+      setup({ entities: [updatedEntity] });
+
+      expect(
+        screen.queryByText(/that depend on the items/),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/metabase-types/api/mocks/remote-sync.ts
+++ b/frontend/src/metabase-types/api/mocks/remote-sync.ts
@@ -1,0 +1,14 @@
+import type { RemoteSyncEntity } from "../remote-sync";
+
+export const createMockRemoteSyncEntity = (
+  opts?: Partial<RemoteSyncEntity>,
+): RemoteSyncEntity => ({
+  id: 1,
+  name: "My Question",
+  description: null,
+  created_at: "2015-01-01T20:10:30.200",
+  updated_at: "2015-01-01T20:10:30.200",
+  model: "card",
+  sync_status: "update",
+  ...opts,
+});


### PR DESCRIPTION
### Description
Adds a warning message when removing items from a library

### How to verify

1. Remove some items from your library
2. Click the push button
3. In the modal, you should see a mesage saying that other instances may depend on these items
4. This message should not appear if no entities are being moved out of the library, or moved to the trash

### Demo
<img width="665" height="527" alt="image" src="https://github.com/user-attachments/assets/102c91ff-3800-4288-9e01-5132d75fa483" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
