### PR TITLE
Ensure search indexes are fully created in postgresql

### DIFF
--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -185,7 +185,9 @@
 (defn create-table!
   "Create an index table with the given name. Should fail if it already exists."
   [table-name]
-  (t2/with-transaction [_]
+  ;; Create with a separate transaction so that postgresql will complete the index creations before returning,
+  ;; even when already running in a transaction
+  (t2/with-transaction [_ (mdb/app-db)]
     (-> (sql.helpers/create-table table-name)
         (sql.helpers/with-columns (specialization/table-schema base-schema))
         t2/query)


### PR DESCRIPTION
### Description

The index table + indexes were created in a `with-transaction` block. But, if a transaction was already in progress, the unique index may not be fully created before moving on to the next statements in the transaction which may depend on the index existing.

This change runs create-table in a transaction on a new connection to ensure the index is fully created before continuing with the existing transaction.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
