### PR TITLE
Fix `batch-upsert!` method for heterogeneous entries

### DIFF
--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -1,5 +1,6 @@
 (ns metabase.search.appdb.index
   (:require
+   [clojure.set :as set]
    [clojure.string :as str]
    [honey.sql :as sql]
    [honey.sql.helpers :as sql.helpers]
@@ -247,17 +248,14 @@
 
 (defn- document->entry [entity]
   (-> entity
-      (select-keys
-       ;; remove attrs that get explicitly aliased below
-       (remove #{:id :created_at :updated_at :native_query}
-               (conj search.spec/attr-columns :model :display_data :legacy_input)))
+      (select-keys (conj search.spec/attr-columns :model :display_data :legacy_input))
+      (set/rename-keys {:id :model_id
+                        :created_at :model_created_at
+                        :updated_at :model_updated_at})
+      (assoc :updated_at :%now)
       (update :display_data json/encode)
       (update :legacy_input json/encode)
-      (assoc
-       :updated_at       :%now
-       :model_id         (:id entity)
-       :model_created_at (:created_at entity)
-       :model_updated_at (:updated_at entity))
+      (dissoc :native_query)
       (merge (specialization/extra-entry-fields entity))))
 
 (defn- table-not-found-exception? [e]

--- a/src/metabase/search/appdb/specialization/postgres.clj
+++ b/src/metabase/search/appdb/specialization/postgres.clj
@@ -26,8 +26,10 @@
 (defmethod specialization/batch-upsert! :postgres [table entries]
   (when (seq entries)
     (t2/query
-     ;; The cost of dynamically calculating these keys should be small compared to the IO cost, so unoptimized.
-     (let [update-keys (vec (disj (set (keys (first entries))) :id :model :model_id))
+     ;; The cost of dynamically calculating these keys should be small compared to the IO cost, so unoptimized. Note
+     ;; that the entries are not guaranteed to be homogeneous - some may be missing nullable columns. So we need to
+     ;; get the keys from *all* the entries.
+     (let [update-keys (vec (disj (set (mapcat keys entries)) :id :model :model_id))
            excluded-kw (fn [column] (keyword (str "excluded." (name column))))]
        {:insert-into   table
         :values        entries

--- a/test/metabase/search/appdb/specializations/postgres_test.clj
+++ b/test/metabase/search/appdb/specializations/postgres_test.clj
@@ -1,3 +1,18 @@
 (ns metabase.search.appdb.specializations.postgres-test
   (:require
-   [clojure.test :refer :all]))
+   [clojure.test :refer :all]
+   [metabase.app-db.core :as mdb]
+   [metabase.search.appdb.specialization.api :as specialization]
+   [toucan2.core :as t2]))
+
+(use-fixtures :each (fn [t]
+                      (when (= :postgres (mdb/db-type))
+                        (t))))
+
+(deftest batch-upsert-test
+  (with-redefs [t2/query identity]
+    (let [query (specialization/batch-upsert! :some-table
+                                              [{:a :b}
+                                               {:b :c}])]
+      (is (= [{:a :b} {:b :c}] (:values query)))
+      (is (= {:a :excluded.a :b :excluded.b} (:do-update-set query))))))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #64862

The upsert keys were calculated by looking at the first entry we were
inserting and removing `:id`, `:model`, and `:model_id`.

But the entries are not necessarily homogeneous. In this case, the first
entry is a dashboard (has no `:dashboard_id`) and the second entry is a
card (yes `:dashboard_id`).

This meant we never actually updated the dashboard_id when updating a card.

I attempted to add a test for this:

```
(deftest updates-work-properly
  (mt/with-test-user :rasta
    (mt/with-temp [:model/Dashboard {dash-id :id} {}]
      (let [card-name (str (random-uuid))
            card-id-1 (:id (mt/user-http-request :rasta :post 200 "card/" {:name card-name
                                                                           :collection_id nil
                                                                           :database_id 1
                                                                           :display "table"
                                                                           :creator_id (mt/user->id :rasta)
                                                                           :visualization_settings {}
                                                                           :dataset_query {:type "native" :native {:query "select 123"}
                                                                                           :database 1}}))
            card-id-2 (:id (mt/user-http-request :rasta :post 200 "card/" {:name card-name
                                                                           :collection_id nil
                                                                           :database_id 1
                                                                           :display "table"
                                                                           :creator_id (mt/user->id :rasta)
                                                                           :visualization_settings {}
                                                                           :dataset_query {:type "native" :native {:query "select 123"}
                                                                                           :database 1}}))]
        (mt/user-http-request :rasta :put 200 (str "card/" card-id-1) {:dashboard_id dash-id})
        (is (= [card-name]
               (map :name (:data (mt/user-http-request :rasta :get 200 "search" :q card-name)))))))))
```

The good news is that this test passes after my change. The bad news is
that it also passes without my change. I think what's going on is that
the behavior is different with `*force-sync*` on/off: in async mode, we
get the full batch that contains the updates for `[dashboard, card]`.
In synchronous mode, we get separate batches for `[dashboard]` and then
`[card]`.

I think we might want to rework tests somehow - it would be quite nice
to be able to still run things asynchronously but drain the queue before
making assertions, so the behavior wouldn't be different between
tests/prod.
