### PR TITLE
UXW-186: Mark Mongo connection URI as a "password"

### DIFF
--- a/bin/build/src/build_drivers/lint_manifest_file.clj
+++ b/bin/build/src/build_drivers/lint_manifest_file.clj
@@ -26,7 +26,7 @@
 (s/def ::contact-info (spell/keys :req-un [::name]
                                   :opt-un [::address]))
 
-(def ^:private property-types #{"string" "text" "textFile" "boolean" "secret" "info" "schema-filters" "section"})
+(def ^:private property-types #{"string" "text" "textFile" "boolean" "secret" "info" "schema-filters" "section" "password"})
 
 (s/def ::display-name string?)
 (s/def ::default any?)

--- a/modules/drivers/mongo/resources/metabase-plugin.yaml
+++ b/modules/drivers/mongo/resources/metabase-plugin.yaml
@@ -11,7 +11,7 @@ driver:
       type: section
       default: false
     - name: conn-uri
-      type: string
+      type: password
       display-name: Paste your connection string
       placeholder: 'mongodb://[username:password@]host1[:port1][,...hostN[:portN]][/[dbname][?options]]'
       required: true


### PR DESCRIPTION
Since it contains a password, it should be treated as one. This way it will be redacted in the UI and API.
