### PR TITLE
54 fix: Add e2e case to query analysis execution

### DIFF
--- a/src/metabase/query_analysis/core.clj
+++ b/src/metabase/query_analysis/core.clj
@@ -76,9 +76,9 @@
   By default, it is async in production for the backfill."
   []
   (case config/run-mode
-    :prod ::queued
-    :dev  *analyze-execution-in-dev?*
-    :test *analyze-execution-in-test?*))
+    (:prod :e2e) ::queued
+    :dev         *analyze-execution-in-dev?*
+    :test        *analyze-execution-in-test?*))
 
 (defn enabled-type?
   "Is analysis of the given query type enabled?"


### PR DESCRIPTION
add new run-mode to execution case

```
❯ ag config/run-mode src
src/metabase/query_analysis/core.clj
84:  (case config/run-mode

❯ ag config/run-mode modules
modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
1297:            run-mode   (name config/run-mode)

modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
63:        run-mode   (name config/run-mode)
```

We had a case statement on it. During e2e tests with this new execution mode not accounted for, it would throw errors when running any query. that is resolved now.
