### PR TITLE
UXW-1872 Fix some tooltips text color in dark theme

### DIFF
--- a/frontend/src/metabase/admin/databases/components/DatabaseConnectionHealthInfo.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseConnectionHealthInfo.tsx
@@ -27,7 +27,11 @@ export const DatabaseConnectionHealthInfo = ({
         { isUninitialized: true },
         { isFetching: true },
         { isLoading: true },
-        () => ({ message: t`Loading...`, color: "text-light" }) as const,
+        () =>
+          ({
+            message: t`Loading...`,
+            color: "var(--mb-color-tooltip-text)",
+          }) as const,
       )
       .with(
         { currentData: { status: "error" } },
@@ -38,7 +42,7 @@ export const DatabaseConnectionHealthInfo = ({
         () =>
           ({
             message: t`Failed to retrieve database health status.`,
-            color: "text-light",
+            color: "var(--mb-color-tooltip-text)",
           }) as const,
       )
       .exhaustive();

--- a/frontend/src/metabase/common/components/CopyButton/CopyButton.tsx
+++ b/frontend/src/metabase/common/components/CopyButton/CopyButton.tsx
@@ -58,7 +58,7 @@ export const CopyButton = ({
     <CopyToClipboard text={value} onCopy={onCopyValue}>
       <div className={className} style={style} data-testid="copy-button">
         <Tooltip
-          label={<Text fw={700} c="white">{t`Copied!`}</Text>}
+          label={<Text fw={700} c="inherit">{t`Copied!`}</Text>}
           opened={copied}
         >
           <span onKeyDown={copyOnEnter}>{target}</span>

--- a/frontend/src/metabase/common/components/upload/UploadTooltip.tsx
+++ b/frontend/src/metabase/common/components/upload/UploadTooltip.tsx
@@ -19,11 +19,11 @@ export const UploadTooltip = ({
       <Box ta="center">
         <Text
           size="sm"
-          c="var(--mb-color-text-white)"
+          c="var(--mb-color-tooltip-text)"
         >{t`Upload data to ${collection.name}`}</Text>
         <Text
           size="sm"
-          c="var(--mb-color-text-tertiary)"
+          c="var(--mb-color-tooltip-text-secondary)"
         >{t`${UPLOAD_DATA_FILE_TYPES.join(
           ", ",
         )} (${MAX_UPLOAD_STRING} MB max)`}</Text>

--- a/frontend/src/metabase/search/components/InfoText/InfoTextEditedInfo.styled.tsx
+++ b/frontend/src/metabase/search/components/InfoText/InfoTextEditedInfo.styled.tsx
@@ -29,5 +29,5 @@ export const LastEditedInfoText = styled(LastEditInfoLabel)`
 `;
 
 export const LastEditedInfoTooltip = styled(LastEditInfoLabel)`
-  color: var(--mb-color-text-white);
+  color: var(--mb-color-tooltip-text);
 `;

--- a/frontend/src/metabase/setup/components/SettingsPage/SettingsPage.tsx
+++ b/frontend/src/metabase/setup/components/SettingsPage/SettingsPage.tsx
@@ -38,7 +38,7 @@ export const SettingsPage = (): JSX.Element => {
   const TOOLTIP_WIDTH = 220;
 
   const label = (
-    <Text size="sm" c="text-white">
+    <Text size="sm" c="var(--mb-color-tooltip-text)">
       {tooltipText}
     </Text>
   );

--- a/frontend/src/metabase/timelines/collections/components/TimelineEmptyState/TimelineEmptyState.tsx
+++ b/frontend/src/metabase/timelines/collections/components/TimelineEmptyState/TimelineEmptyState.tsx
@@ -27,7 +27,7 @@ const TimelineEmptyState = ({
   const applicationName = useSelector(getApplicationName);
   return (
     <Stack align="center" ta="center" gap="lg">
-      <Tooltip color="text-light" label={t`Launch of v2.0`} offset={-24} opened>
+      <Tooltip label={t`Launch of v2.0`} offset={-24} opened>
         <Box maw="6rem">
           <img src={EmptyEvent} alt={t`Collection event illustration`} />
         </Box>


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-1872/tooltip-text

### Description

Fix some tooltips text color when in dark theme

Before:
<img width="204" height="171" alt="Screenshot 2025-10-29 at 23 29 46" src="https://github.com/user-attachments/assets/a4ce1fe1-c9c0-4715-800c-d42e28499fe8" />
<img width="278" height="134" alt="Screenshot 2025-10-29 at 23 30 08" src="https://github.com/user-attachments/assets/1b2f53f5-2b83-4a39-9e12-624be7376c53" />
<img width="260" height="133" alt="Screenshot 2025-10-29 at 23 30 02" src="https://github.com/user-attachments/assets/24de4d31-41f2-4d2a-832e-d44d87387956" />
<img width="187" height="166" alt="Screenshot 2025-10-29 at 23 29 53" src="https://github.com/user-attachments/assets/601e2788-d613-44e3-a8bf-685697da8baf" />



After:
<img width="188" height="164" alt="Screenshot 2025-10-29 at 23 29 28" src="https://github.com/user-attachments/assets/10444b20-8bf0-4ce5-a47e-d8e2cbc10beb" />
<img width="221" height="178" alt="Screenshot 2025-10-29 at 23 29 22" src="https://github.com/user-attachments/assets/1fc14319-dcb2-4533-ba27-587e2166d9db" />
<img width="283" height="125" alt="Screenshot 2025-10-29 at 23 27 50" src="https://github.com/user-attachments/assets/11ff061f-957a-4d83-9230-4ffd4a6f103a" />
<img width="256" height="130" alt="Screenshot 2025-10-29 at 23 27 44" src="https://github.com/user-attachments/assets/1036636c-7705-4157-9c91-0f3e08d0daea" />



### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
