### PR TITLE
Release Log Upgrades

### DIFF
--- a/.github/workflows/release-log.yml
+++ b/.github/workflows/release-log.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           script: | # js
             const {
-              getVersionFromReleaseBranch,
+              getMajorVersionFromRef,
               getMajorVersion,
             } = require('${{ github.workspace }}/release/dist/index.cjs');
 
@@ -60,11 +60,10 @@ jobs:
             }
 
             // otherwise, get the version from the release branch name
-            const branch = context.payload.ref;
-            const version = getVersionFromReleaseBranch(branch);
-            const majorVersion = getMajorVersion(version);
+            const ref = context.payload.ref;
+            const majorVersion = getMajorVersionFromRef(ref);
 
-            console.log({ branch, version, majorVersion });
+            console.log({ ref, majorVersion });
             core.exportVariable('VERSION', majorVersion);
 
       - name: generate release Log

--- a/.github/workflows/release-log.yml
+++ b/.github/workflows/release-log.yml
@@ -67,6 +67,8 @@ jobs:
             core.exportVariable('VERSION', majorVersion);
 
       - name: generate release Log
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: cd release && tsx ./src/release-log-run.ts $VERSION > v$VERSION.html
       - name: generate release channel log
         run: cd release && tsx ./src/release-channel-log.ts > channels.html

--- a/release/src/github.ts
+++ b/release/src/github.ts
@@ -289,3 +289,23 @@ export async function hasCommitBeenReleased({
 
   return lastTagSha === ref;
 }
+
+export async function getOpenBackportPrs({
+  github,
+  owner,
+  repo,
+  majorVersion,
+}: GithubProps & { majorVersion: number }) {
+  const backportBranch = `release-x.${majorVersion}.x`;
+  // query PR's targeting backport branch
+  const prs = await github.paginate(github.rest.pulls.list, {
+    owner,
+    repo,
+    state: "open",
+    base: backportBranch,
+    per_page: 100,
+  });
+
+  return prs;
+}
+

--- a/release/src/release-log-run.ts
+++ b/release/src/release-log-run.ts
@@ -1,3 +1,3 @@
 import { generateReleaseLog } from './release-log';
 
-generateReleaseLog();
+console.log(await generateReleaseLog());

--- a/release/src/release-log.ts
+++ b/release/src/release-log.ts
@@ -80,7 +80,7 @@ function buildTable(commits: CommitInfo[]) {
 }
 
 type PullRequest = {
-  url: string,
+  html_url: string,
   number: number,
   title: string,
   assignee: { login: string },
@@ -91,7 +91,7 @@ function createBackportTable(prs: PullRequest[]) {
   const rows = prs.map(pr => {
     const assignee = pr.assignee ? pr.assignee.login : '?';
     return `<tr>
-      <td><a href="${pr.url}" target="_blank">#${pr.number}</a></td>
+      <td><a href="${pr.html_url}" target="_blank">#${pr.number}</a></td>
       <td>${linkifyIssueNumbers(pr.title)}</td>
       <td>@${assignee}</td>
       <td>${new Date(pr.created_at).toLocaleString()}</td>

--- a/release/src/release-log.ts
+++ b/release/src/release-log.ts
@@ -20,7 +20,7 @@ export async function gitLog(majorVersion: number) {
   const { stdout: baseCommit } = await $`git merge-base origin/release-x.${previousMajorVersion}.x origin/master`;
   const { stdout } = await $`git log ${baseCommit.trim()}..origin/release-x.${majorVersion}.x --pretty='format:%(decorate:prefix=,suffix=)||%s||%H||%ah'`;
   const processedCommits = stdout.split('\n').map(processCommit);
-  return buildTable(processedCommits, majorVersion);
+  return buildTable(processedCommits);
 }
 
 export function processCommit(commitLine: string): CommitInfo {
@@ -142,4 +142,3 @@ export async function generateReleaseLog() {
     .replace(/{{major-version}}/g, version.toString())
     .replace(/{{current-time}}/, new Date().toLocaleString());
 }
-

--- a/release/src/release-log.ts
+++ b/release/src/release-log.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 
 import { Octokit } from '@octokit/rest';
-import { number } from 'prop-types';
 import { $ } from 'zx';
 
 import { getOpenBackportPrs } from './github';

--- a/release/src/tablePageTemplate.html
+++ b/release/src/tablePageTemplate.html
@@ -32,6 +32,20 @@
   <body class="p-5 text-gray-200 bg-gray-800">
       <h1>Metabase v{{major-version}} Release Log</h1>
       <p>as of {{current-time}}</p>
+      <h2>
+        Pending Backports
+      </h2>
+      <div>
+        {{backport-table}}
+      </div>
+      <h2>
+        Merged Changes
+      </h2>
+      <div>
+        <a href="https://github.com/metabase/metabase/commits/release-x.{{major-version}}.x/">
+          View on GitHub
+        </a>
+      </div>
       <div>
         {{release-table}}
       </div>

--- a/release/src/version-helpers.ts
+++ b/release/src/version-helpers.ts
@@ -106,6 +106,16 @@ export const getVersionFromReleaseBranch = (branch: string) => {
   return `v0.${majorVersion}.0`;
 };
 
+export const getMajorVersionFromRef = (ref: string) => {
+  if (ref.startsWith("refs/tags/")) {
+    const tagName = ref.replace("refs/tags/", "");
+    const versionParts = getVersionParts(tagName);
+    return versionParts.major;
+  }
+
+  return getMajorVersionNumberFromReleaseBranch(ref.replace("refs/heads/", ""));
+}
+
 const SDK_TAG_REGEXP = /embedding-sdk-(0\.\d+\.\d+(-\w+)?)$/;
 
 export const getSdkVersionFromReleaseTagName = (tagName: string) => {

--- a/release/src/version-helpers.ts
+++ b/release/src/version-helpers.ts
@@ -114,7 +114,7 @@ export const getMajorVersionFromRef = (ref: string) => {
   }
 
   return getMajorVersionNumberFromReleaseBranch(ref.replace("refs/heads/", ""));
-}
+};
 
 const SDK_TAG_REGEXP = /embedding-sdk-(0\.\d+\.\d+(-\w+)?)$/;
 

--- a/release/src/version-helpers.unit.spec.ts
+++ b/release/src/version-helpers.unit.spec.ts
@@ -9,6 +9,7 @@ import {
   getGenericVersion,
   getLastReleaseFromTags,
   getMajorVersion,
+  getMajorVersionFromRef,
   getMajorVersionNumberFromReleaseBranch,
   getMilestoneName,
   getMinorVersion,
@@ -676,6 +677,43 @@ describe("version-helpers", () => {
       expect(() =>
         getMajorVersionNumberFromReleaseBranch("my-local-dev-branch"),
       ).toThrow();
+    });
+  });
+
+  describe("getMajorVersionFromRef", () => {
+    it("should get major version from a tag", () => {
+      expect(getMajorVersionFromRef("refs/tags/v0.56.x")).toEqual(
+        "56",
+      );
+
+      expect(getMajorVersionFromRef("refs/tags/v0.56.x")).toEqual(
+        "56",
+      );
+
+      expect(getMajorVersionFromRef("refs/tags/v0.51.2.x")).toEqual(
+        "51",
+      );
+
+      expect(getMajorVersionFromRef("refs/tags/v0.51.0-beta")).toEqual(
+        "51",
+      );
+
+      expect(getMajorVersionFromRef("refs/tags/v0.51.2.3")).toEqual(
+        "51",
+      );
+
+      expect(getMajorVersionFromRef("refs/tags/v0.51.10")).toEqual(
+        "51",
+      );
+    });
+
+    it("should get major version from a release branch", () => {
+      expect(
+        getMajorVersionFromRef("refs/heads/release-x.51.x"),
+      ).toEqual("51");
+      expect(
+        getMajorVersionFromRef("release-x.52.x"),
+      ).toEqual("52");
     });
   });
 

--- a/release/src/version-helpers.unit.spec.ts
+++ b/release/src/version-helpers.unit.spec.ts
@@ -686,7 +686,7 @@ describe("version-helpers", () => {
         "56",
       );
 
-      expect(getMajorVersionFromRef("refs/tags/v0.56.x")).toEqual(
+      expect(getMajorVersionFromRef("refs/tags/v1.56.0")).toEqual(
         "56",
       );
 


### PR DESCRIPTION

Closes DEV-1035
Closes DEV-338

### Description

- fixes issue where release log wouldn't update on tag push (DEV-338)
- adds open backport PRs to release log to make it clear what is in the pipeline but hasn't merged yet
- adds a link to the github commit list just because

<img width="1412" height="868" alt="CleanShot 2025-10-29 at 14 53 29" src="https://github.com/user-attachments/assets/93951660-7d4e-4059-bc94-e515c0c486df" />

