### PR TITLE
Unskip working embedding repro e2e test

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -976,7 +976,6 @@ describe("issue 40660", () => {
   });
 });
 
-// Skipped since it does not make sense when CSP is disabled
 describe("issue 49142", { tags: "@skip" }, () => {
   const questionDetails = {
     name: "Products",

--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -976,7 +976,7 @@ describe("issue 40660", () => {
   });
 });
 
-describe("issue 49142", { tags: "@skip" }, () => {
+describe("issue 49142", () => {
   const questionDetails = {
     name: "Products",
     query: { "source-table": PRODUCTS_ID, limit: 2 },


### PR DESCRIPTION
This test is working, it was skipped when CSP was disabled

EDIT: the [stress test failed](https://github.com/metabase/metabase/actions/runs/18925910243/job/54032759818), none of them passed. I need to check what's happening there