### PR TITLE
Enhance onBeforeRequest into onBeforeRequestHandlers for Api class

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-bundle/store/auth/auth.ts
+++ b/enterprise/frontend/src/embedding-sdk-bundle/store/auth/auth.ts
@@ -13,7 +13,7 @@ import type { MetabaseAuthConfig } from "embedding-sdk-bundle/types/auth-config"
 import type { MetabaseEmbeddingSessionToken } from "embedding-sdk-bundle/types/refresh-token";
 import { getBuildInfo } from "embedding-sdk-shared/lib/get-build-info";
 import { EMBEDDING_SDK_IFRAME_EMBEDDING_CONFIG } from "metabase/embedding-sdk/config";
-import api, { setOnBeforeRequestHandler } from "metabase/lib/api";
+import api from "metabase/lib/api";
 import { createAsyncThunk } from "metabase/lib/redux";
 import { refreshSiteSettings } from "metabase/redux/settings";
 import { refreshCurrentUser } from "metabase/redux/user";
@@ -48,7 +48,7 @@ export const initAuth = createAsyncThunk(
       // Use existing user session. Do nothing.
     } else if (isValidInstanceUrl) {
       // SSO setup
-      setOnBeforeRequestHandler({
+      api.setOnBeforeRequestHandler({
         key: "get-or-refresh-session-handler",
         handler: async () => {
           const session = await dispatch(

--- a/enterprise/frontend/src/embedding-sdk-bundle/store/auth/auth.ts
+++ b/enterprise/frontend/src/embedding-sdk-bundle/store/auth/auth.ts
@@ -15,6 +15,7 @@ import { getBuildInfo } from "embedding-sdk-shared/lib/get-build-info";
 import { EMBEDDING_SDK_IFRAME_EMBEDDING_CONFIG } from "metabase/embedding-sdk/config";
 import api from "metabase/lib/api";
 import { createAsyncThunk } from "metabase/lib/redux";
+import { PLUGIN_EMBEDDING_SDK } from "metabase/plugins";
 import { refreshSiteSettings } from "metabase/redux/settings";
 import { refreshCurrentUser } from "metabase/redux/user";
 import { requestSessionTokenFromEmbedJs } from "metabase-enterprise/embedding_iframe_sdk/utils";
@@ -48,9 +49,8 @@ export const initAuth = createAsyncThunk(
       // Use existing user session. Do nothing.
     } else if (isValidInstanceUrl) {
       // SSO setup
-      api.setOnBeforeRequestHandler({
-        key: "get-or-refresh-session-handler",
-        handler: async () => {
+      PLUGIN_EMBEDDING_SDK.onBeforeRequestHandlers.getOrRefreshSessionHandler =
+        async () => {
           const session = await dispatch(
             getOrRefreshSession({
               metabaseInstanceUrl,
@@ -60,8 +60,8 @@ export const initAuth = createAsyncThunk(
           if (session?.id) {
             api.sessionToken = session.id;
           }
-        },
-      });
+        };
+
       try {
         // verify that the session is actually valid before proceeding
         await dispatch(

--- a/frontend/src/metabase/entities/containers/EntityListLoader.unit.spec.js
+++ b/frontend/src/metabase/entities/containers/EntityListLoader.unit.spec.js
@@ -1,5 +1,7 @@
 import "mutationobserver-shim";
 
+import { waitFor } from "@testing-library/react";
+
 import { renderWithProviders } from "__support__/ui";
 import { EntityListLoader } from "metabase/entities/containers/rtk-query";
 import { Api } from "metabase/lib/api";
@@ -9,7 +11,9 @@ describe("EntityListLoader", () => {
 
   beforeEach(() => {
     _makeRequest = Api.prototype._makeRequest;
-    Api.prototype._makeRequest = jest.fn().mockReturnValue(Promise.resolve([]));
+    Api.prototype._makeRequest = jest
+      .fn()
+      .mockReturnValue(Promise.resolve({ data: [] }));
   });
 
   afterEach(() => {
@@ -17,13 +21,19 @@ describe("EntityListLoader", () => {
   });
 
   describe("with entityType of search", () => {
+    const MockComponent = () => <div>Mock Component</div>;
+
     it("should handle object entityQuery", async () => {
       renderWithProviders(
         <EntityListLoader
           entityType="search"
           entityQuery={{ collection: "foo" }}
+          ComposedComponent={MockComponent}
         />,
       );
+      await waitFor(() => {
+        expect(Api.prototype._makeRequest).toHaveBeenCalled();
+      });
       expect(
         Api.prototype._makeRequest.mock.calls.map((c) => c.slice(0, 2)),
       ).toEqual([["GET", "/api/collection/foo/items"]]);
@@ -35,8 +45,12 @@ describe("EntityListLoader", () => {
           entityType="search"
           entityQuery={(state, props) => ({ collection: props.collectionId })}
           collectionId="foo"
+          ComposedComponent={MockComponent}
         />,
       );
+      await waitFor(() => {
+        expect(Api.prototype._makeRequest).toHaveBeenCalled();
+      });
       expect(
         Api.prototype._makeRequest.mock.calls.map((c) => c.slice(0, 2)),
       ).toEqual([["GET", "/api/collection/foo/items"]]);

--- a/frontend/src/metabase/lib/api.js
+++ b/frontend/src/metabase/lib/api.js
@@ -53,9 +53,9 @@ export class Api extends EventEmitter {
    * @typedef {{
    *   key: string;
    *   handler: OnBeforeRequestHandler
-   * }} OnBeforeRequestHandlerDescription
+   * }} OnBeforeRequestHandlerDescriptor
    *
-   * @type {OnBeforeRequestHandlerDescription[]}
+   * @type {OnBeforeRequestHandlerDescriptor[]}
    */
   onBeforeRequestHandlers = [];
   onResponseError;
@@ -422,18 +422,17 @@ export class Api extends EventEmitter {
   }
 
   /**
-   * @param {OnBeforeRequestHandlerDescription} handlerDescription
+   * @param {OnBeforeRequestHandlerDescriptor} handlerDescriptor
    */
-  setOnBeforeRequestHandler(handlerDescription) {
+  setOnBeforeRequestHandler(handlerDescriptor) {
     const existingHandlerKeyIndex = this.onBeforeRequestHandlers.findIndex(
-      ({ key }) => key === handlerDescription.key,
+      ({ key }) => key === handlerDescriptor.key,
     );
 
     if (existingHandlerKeyIndex >= 0) {
-      this.onBeforeRequestHandlers[existingHandlerKeyIndex] =
-        handlerDescription;
+      this.onBeforeRequestHandlers[existingHandlerKeyIndex] = handlerDescriptor;
     } else {
-      this.onBeforeRequestHandlers.push(handlerDescription);
+      this.onBeforeRequestHandlers.push(handlerDescriptor);
     }
   }
 }

--- a/frontend/src/metabase/lib/api.js
+++ b/frontend/src/metabase/lib/api.js
@@ -420,6 +420,22 @@ export class Api extends EventEmitter {
         }
       });
   }
+
+  /**
+   * @param {OnBeforeRequestHandlerDescription} handlerDescription
+   */
+  setOnBeforeRequestHandler(handlerDescription) {
+    const existingHandlerKeyIndex = this.onBeforeRequestHandlers.findIndex(
+      ({ key }) => key === handlerDescription.key,
+    );
+
+    if (existingHandlerKeyIndex >= 0) {
+      this.onBeforeRequestHandlers[existingHandlerKeyIndex] =
+        handlerDescription;
+    } else {
+      this.onBeforeRequestHandlers.push(handlerDescription);
+    }
+  }
 }
 
 const instance = new Api();
@@ -434,20 +450,4 @@ export const setLocaleHeader = (locale) => {
    */
   // eslint-disable-next-line no-literal-metabase-strings -- Header name, not a user facing string
   DEFAULT_OPTIONS.headers["X-Metabase-Locale"] = locale ?? undefined;
-};
-
-/**
- * @param {OnBeforeRequestHandlerDescription} handlerDescription
- */
-export const setOnBeforeRequestHandler = (handlerDescription) => {
-  const existingHandlerKeyIndex = instance.onBeforeRequestHandlers.findIndex(
-    ({ key }) => key === handlerDescription.key,
-  );
-
-  if (existingHandlerKeyIndex >= 0) {
-    instance.onBeforeRequestHandlers[existingHandlerKeyIndex] =
-      handlerDescription;
-  } else {
-    instance.onBeforeRequestHandlers.push(handlerDescription);
-  }
 };

--- a/frontend/src/metabase/lib/api.unit.spec.ts
+++ b/frontend/src/metabase/lib/api.unit.spec.ts
@@ -1,6 +1,6 @@
 import fetchMock from "fetch-mock";
 
-import api, { GET, POST, setOnBeforeRequestHandler } from "./api";
+import api, { GET, POST } from "./api";
 
 describe("api", () => {
   describe("on before request handlers", () => {
@@ -294,7 +294,7 @@ describe("api", () => {
           handler: mockHandler,
         };
 
-        setOnBeforeRequestHandler(handlerDescription);
+        api.setOnBeforeRequestHandler(handlerDescription);
 
         expect(api.onBeforeRequestHandlers).toHaveLength(1);
         expect(api.onBeforeRequestHandlers[0]).toEqual(handlerDescription);
@@ -304,11 +304,11 @@ describe("api", () => {
         const handler1 = jest.fn();
         const handler2 = jest.fn();
 
-        setOnBeforeRequestHandler({ key: "shared-key", handler: handler1 });
+        api.setOnBeforeRequestHandler({ key: "shared-key", handler: handler1 });
         expect(api.onBeforeRequestHandlers).toHaveLength(1);
         expect(api.onBeforeRequestHandlers[0].handler).toBe(handler1);
 
-        setOnBeforeRequestHandler({ key: "shared-key", handler: handler2 });
+        api.setOnBeforeRequestHandler({ key: "shared-key", handler: handler2 });
         expect(api.onBeforeRequestHandlers).toHaveLength(1);
         expect(api.onBeforeRequestHandlers[0].handler).toBe(handler2);
       });
@@ -318,9 +318,9 @@ describe("api", () => {
         const handler2 = jest.fn();
         const handler3 = jest.fn();
 
-        setOnBeforeRequestHandler({ key: "handler1", handler: handler1 });
-        setOnBeforeRequestHandler({ key: "handler2", handler: handler2 });
-        setOnBeforeRequestHandler({ key: "handler3", handler: handler3 });
+        api.setOnBeforeRequestHandler({ key: "handler1", handler: handler1 });
+        api.setOnBeforeRequestHandler({ key: "handler2", handler: handler2 });
+        api.setOnBeforeRequestHandler({ key: "handler3", handler: handler3 });
 
         expect(api.onBeforeRequestHandlers).toHaveLength(3);
         expect(api.onBeforeRequestHandlers[0].key).toBe("handler1");
@@ -334,11 +334,11 @@ describe("api", () => {
         const handler3 = jest.fn();
         const handler2Updated = jest.fn();
 
-        setOnBeforeRequestHandler({ key: "handler1", handler: handler1 });
-        setOnBeforeRequestHandler({ key: "handler2", handler: handler2 });
-        setOnBeforeRequestHandler({ key: "handler3", handler: handler3 });
+        api.setOnBeforeRequestHandler({ key: "handler1", handler: handler1 });
+        api.setOnBeforeRequestHandler({ key: "handler2", handler: handler2 });
+        api.setOnBeforeRequestHandler({ key: "handler3", handler: handler3 });
 
-        setOnBeforeRequestHandler({
+        api.setOnBeforeRequestHandler({
           key: "handler2",
           handler: handler2Updated,
         });

--- a/frontend/src/metabase/lib/api.unit.spec.ts
+++ b/frontend/src/metabase/lib/api.unit.spec.ts
@@ -1,0 +1,354 @@
+import fetchMock from "fetch-mock";
+
+import api, { GET, POST, setOnBeforeRequestHandler } from "./api";
+
+describe("api", () => {
+  describe("on before request handlers", () => {
+    beforeEach(() => {
+      api.basename = "";
+      api.onBeforeRequestHandlers = [];
+    });
+
+    describe("onBeforeRequestHandlers", () => {
+      it("should execute handlers before making a request", async () => {
+        const mockHandler = jest.fn().mockResolvedValue(undefined);
+        api.onBeforeRequestHandlers.push({
+          key: "test-handler",
+          handler: mockHandler,
+        });
+
+        fetchMock.get("path:/api/test", { body: { data: "success" } });
+
+        const testEndpoint = GET("/api/test");
+        await testEndpoint();
+
+        expect(mockHandler).toHaveBeenCalledWith({
+          method: "GET",
+          url: "/api/test",
+          options: expect.objectContaining({
+            headers: expect.any(Object),
+            hasBody: false,
+          }),
+        });
+      });
+
+      it("should execute multiple handlers in order", async () => {
+        const executionOrder: string[] = [];
+
+        const handler1 = jest.fn().mockImplementation(async () => {
+          executionOrder.push("handler1");
+          return undefined;
+        });
+
+        const handler2 = jest.fn().mockImplementation(async () => {
+          executionOrder.push("handler2");
+          return undefined;
+        });
+
+        api.onBeforeRequestHandlers.push(
+          { key: "handler1", handler: handler1 },
+          { key: "handler2", handler: handler2 },
+        );
+
+        fetchMock.get("path:/api/test", { body: { data: "success" } });
+
+        const testEndpoint = GET("/api/test");
+        await testEndpoint();
+
+        expect(executionOrder).toEqual(["handler1", "handler2"]);
+        expect(handler1).toHaveBeenCalled();
+        expect(handler2).toHaveBeenCalled();
+      });
+
+      it("should allow handlers to modify the URL", async () => {
+        const mockHandler = jest.fn().mockResolvedValue({
+          url: "/api/modified",
+        });
+
+        api.onBeforeRequestHandlers.push({
+          key: "url-modifier",
+          handler: mockHandler,
+        });
+
+        fetchMock.get("path:/api/modified", { body: { data: "modified" } });
+
+        const testEndpoint = GET("/api/test");
+        await testEndpoint();
+
+        const calls = fetchMock.callHistory.calls();
+
+        expect(calls[0].url).toContain("/api/modified");
+      });
+
+      it("should allow handlers to modify the method", async () => {
+        const mockHandler = jest.fn().mockResolvedValue({
+          method: "POST",
+        });
+
+        api.onBeforeRequestHandlers.push({
+          key: "method-modifier",
+          handler: mockHandler,
+        });
+
+        fetchMock.post("path:/api/test", { body: { data: "success" } });
+
+        const testEndpoint = GET("/api/test");
+        await testEndpoint();
+
+        const calls = fetchMock.callHistory.calls();
+
+        expect(calls[0].options.method).toBe("POST");
+      });
+
+      it("should allow handlers to modify request options by adding headers", async () => {
+        const mockHandler = jest.fn().mockResolvedValue({
+          options: {
+            headers: {
+              "X-Custom-Header": "custom-value",
+            },
+          },
+        });
+
+        api.onBeforeRequestHandlers.push({
+          key: "options-modifier",
+          handler: mockHandler,
+        });
+
+        fetchMock.get("path:/api/test-with-headers", {
+          body: { data: "success" },
+        });
+
+        const testEndpoint = GET("/api/test-with-headers");
+        await testEndpoint();
+
+        const calls = fetchMock.callHistory.calls();
+        const headers = calls[0].options.headers as Record<string, string>;
+
+        expect(headers).toMatchObject({
+          "x-custom-header": "custom-value",
+        });
+      });
+
+      it("should allow handlers to override options from invocation", async () => {
+        const mockHandler = jest.fn().mockResolvedValue({
+          options: {
+            headers: {
+              "X-Handler-Header": "handler-value",
+            },
+          },
+        });
+
+        api.onBeforeRequestHandlers.push({
+          key: "options-merger",
+          handler: mockHandler,
+        });
+
+        fetchMock.get("path:/api/test-merge-opts", {
+          body: { data: "success" },
+        });
+
+        const testEndpoint = GET("/api/test-merge-opts");
+        await testEndpoint(
+          {},
+          { headers: { "X-Original-Header": "original" } },
+        );
+
+        const calls = fetchMock.callHistory.calls();
+        const headers = calls[0].options.headers as Record<string, string>;
+
+        expect(headers).toMatchObject({
+          "x-handler-header": "handler-value",
+        });
+        // The original header from invocationOptions is overridden
+        expect(headers["x-original-header"]).toBeUndefined();
+      });
+
+      it("should handle handlers that return nothing without modifying the request", async () => {
+        const mockHandler = jest.fn().mockResolvedValue(undefined);
+
+        api.onBeforeRequestHandlers.push({
+          key: "void-handler",
+          handler: mockHandler,
+        });
+
+        fetchMock.get("path:/api/test-no-change", {
+          body: { data: "success" },
+        });
+
+        const testEndpoint = GET("/api/test-no-change");
+        await testEndpoint();
+
+        const calls = fetchMock.callHistory.calls();
+
+        expect(mockHandler).toHaveBeenCalled();
+        expect(calls[0].url).toContain("/api/test-no-change");
+        expect(calls[0].options.method).toBe("GET");
+      });
+
+      it("should handle handlers that return partial modifications", async () => {
+        const mockHandler = jest.fn().mockResolvedValue({
+          url: "/api/new-url-only",
+        });
+
+        api.onBeforeRequestHandlers.push({
+          key: "partial-modifier",
+          handler: mockHandler,
+        });
+
+        fetchMock.get("path:/api/new-url-only", { body: { data: "success" } });
+
+        const testEndpoint = GET("/api/test-original");
+        await testEndpoint();
+
+        const calls = fetchMock.callHistory.calls();
+
+        expect(calls[0].url).toContain("/api/new-url-only");
+        expect(calls[0].options.method).toBe("GET");
+      });
+
+      it("should apply modifications from multiple handlers cumulatively", async () => {
+        const handler1 = jest.fn().mockResolvedValue({
+          url: "/api/step1-url",
+        });
+
+        const handler2 = jest.fn().mockResolvedValue({
+          url: "/api/step2-url",
+        });
+
+        api.onBeforeRequestHandlers.push(
+          { key: "handler1", handler: handler1 },
+          { key: "handler2", handler: handler2 },
+        );
+
+        // handler2's URL should win since it runs after handler1
+        fetchMock.get("path:/api/step2-url", { body: { data: "success" } });
+
+        const testEndpoint = GET("/api/original-url");
+        await testEndpoint();
+
+        const calls = fetchMock.callHistory.calls();
+
+        expect(calls[0].url).toContain("/api/step2-url");
+        expect(handler1).toHaveBeenCalled();
+        expect(handler2).toHaveBeenCalledWith({
+          method: "GET",
+          url: "/api/step1-url",
+          options: expect.any(Object),
+        });
+      });
+
+      it("should work with POST requests and handlers", async () => {
+        const mockHandler = jest.fn().mockResolvedValue(undefined);
+
+        api.onBeforeRequestHandlers.push({
+          key: "post-handler",
+          handler: mockHandler,
+        });
+
+        fetchMock.post("path:/api/test-post", { body: { data: "success" } });
+
+        const testEndpoint = POST("/api/test-post");
+        await testEndpoint({ payload: "data" });
+
+        expect(mockHandler).toHaveBeenCalledWith({
+          method: "POST",
+          url: "/api/test-post",
+          options: expect.objectContaining({
+            hasBody: true,
+          }),
+        });
+      });
+
+      it("should allow handlers to modify URL with path parameters", async () => {
+        const mockHandler = jest.fn().mockResolvedValue({
+          url: "/api/customers/:id/updated",
+        });
+
+        api.onBeforeRequestHandlers.push({
+          key: "path-param-modifier",
+          handler: mockHandler,
+        });
+
+        fetchMock.get("path:/api/customers/456/updated", {
+          body: { data: "success" },
+        });
+
+        const testEndpoint = GET("/api/users/:id");
+        await testEndpoint({ id: 456 });
+
+        const calls = fetchMock.callHistory.calls();
+
+        expect(calls[0].url).toContain("/api/customers/456/updated");
+      });
+    });
+
+    describe("setOnBeforeRequestHandler", () => {
+      beforeEach(() => {
+        api.onBeforeRequestHandlers = [];
+      });
+
+      it("should add a new handler to the instance", () => {
+        const mockHandler = jest.fn();
+        const handlerDescription = {
+          key: "new-handler",
+          handler: mockHandler,
+        };
+
+        setOnBeforeRequestHandler(handlerDescription);
+
+        expect(api.onBeforeRequestHandlers).toHaveLength(1);
+        expect(api.onBeforeRequestHandlers[0]).toEqual(handlerDescription);
+      });
+
+      it("should replace an existing handler with the same key", () => {
+        const handler1 = jest.fn();
+        const handler2 = jest.fn();
+
+        setOnBeforeRequestHandler({ key: "shared-key", handler: handler1 });
+        expect(api.onBeforeRequestHandlers).toHaveLength(1);
+        expect(api.onBeforeRequestHandlers[0].handler).toBe(handler1);
+
+        setOnBeforeRequestHandler({ key: "shared-key", handler: handler2 });
+        expect(api.onBeforeRequestHandlers).toHaveLength(1);
+        expect(api.onBeforeRequestHandlers[0].handler).toBe(handler2);
+      });
+
+      it("should add multiple handlers with different keys", () => {
+        const handler1 = jest.fn();
+        const handler2 = jest.fn();
+        const handler3 = jest.fn();
+
+        setOnBeforeRequestHandler({ key: "handler1", handler: handler1 });
+        setOnBeforeRequestHandler({ key: "handler2", handler: handler2 });
+        setOnBeforeRequestHandler({ key: "handler3", handler: handler3 });
+
+        expect(api.onBeforeRequestHandlers).toHaveLength(3);
+        expect(api.onBeforeRequestHandlers[0].key).toBe("handler1");
+        expect(api.onBeforeRequestHandlers[1].key).toBe("handler2");
+        expect(api.onBeforeRequestHandlers[2].key).toBe("handler3");
+      });
+
+      it("should maintain order when replacing a handler", () => {
+        const handler1 = jest.fn();
+        const handler2 = jest.fn();
+        const handler3 = jest.fn();
+        const handler2Updated = jest.fn();
+
+        setOnBeforeRequestHandler({ key: "handler1", handler: handler1 });
+        setOnBeforeRequestHandler({ key: "handler2", handler: handler2 });
+        setOnBeforeRequestHandler({ key: "handler3", handler: handler3 });
+
+        setOnBeforeRequestHandler({
+          key: "handler2",
+          handler: handler2Updated,
+        });
+
+        expect(api.onBeforeRequestHandlers).toHaveLength(3);
+        expect(api.onBeforeRequestHandlers[0].key).toBe("handler1");
+        expect(api.onBeforeRequestHandlers[1].key).toBe("handler2");
+        expect(api.onBeforeRequestHandlers[1].handler).toBe(handler2Updated);
+        expect(api.onBeforeRequestHandlers[2].key).toBe("handler3");
+      });
+    });
+  });
+});

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -581,6 +581,9 @@ export interface SimpleDataPickerProps {
 
 export const PLUGIN_EMBEDDING_SDK = {
   isEnabled: () => false,
+  onBeforeRequestHandlers: {
+    getOrRefreshSessionHandler: async () => {},
+  },
 };
 
 export const PLUGIN_EMBEDDING_IFRAME_SDK = {


### PR DESCRIPTION
Enhance onBeforeRequest into onBeforeRequestHandlers for Api class.

Current Api implementation supports onBeforeRequest field that allows to set a single onBeforeRequest handler.
But for the StaticEmbedding via SDK we need to set multiple handlers:
- for auth (the existing one)
- for endpoints override to override some endpoints from internal to Static Embedding endpoints

The last case is much easier to solve via onBeforeRequest handlers, so this PR enhances the `onBeforeRequest` into `onBeforeRequestHandlers`.

The existing usage of `onBeforeRequest` was replaced to `onBeforeRequestHandlers`. The Static Embedding-related usage with URL overrides will be added in follow-ups in a corresponding PR.

Partial example from Static Embedding WIP PR:
```
/**
 * Registers a request interceptor that transforms standard API requests
 * into static embedding API requests.
 */
export const overrideRequestsForStaticEmbedding = () => {
  setOnBeforeRequestHandler({
    key: "override-requests-for-static-embedding",
    handler: async ({ method, url, options }) => {
      const transformation = getRequestTransformation({ method, url, options });

      if (!transformation) {
        return { method, url, options };
      }

      if (!options.headers) {
        options.headers = {};
      }

      /**
       * Set header to indicate that this request is for static embedding.
       */
      options.headers["x-metabase-static-embedding"] = "true";

      return {
        method: transformation.method,
        url: replaceWithEmbedBase(transformation.url),
        options: transformation.options,
      };
    },
  });
};

```