### PR TITLE
[v53 backport] Run e2e tests using staging tokens

### DIFF
--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -126,10 +126,12 @@ jobs:
     env:
       MB_EDITION: ee
       DISPLAY: ""
+      MB_RUN_MODE: "e2e"
+      METASTORE_DEV_SERVER_URL: ${{ secrets.METASTORE_DEV_SERVER_URL }}
       # Any env starting with `CYPRESS_` will be available to all Cypress tests via `Cypress.env()`
       # Example: you can get `CYPRESS_FOO` with `Cypress.env("FOO")`
-      CYPRESS_ALL_FEATURES_TOKEN: ${{ secrets.MB_ALL_FEATURES_TOKEN }}
-      CYPRESS_NO_FEATURES_TOKEN: ${{ secrets.MB_STARTER_CLOUD_TOKEN }}
+      CYPRESS_ALL_FEATURES_TOKEN: ${{ secrets.STAGING_MB_ALL_FEATURES_TOKEN }}
+      CYPRESS_NO_FEATURES_TOKEN: ${{ secrets.STAGING_MB_STARTER_CLOUD_TOKEN }}
       CYPRESS_PULL_REQUEST_ID: ${{ github.event.pull_request.number || '' }}
       COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title || github.event.head_commit.message || github.event.head.sha }}
       TZ: US/Pacific # to make node match the instance tz

--- a/.github/workflows/e2e-component-tests-embedding-sdk.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk.yml
@@ -108,10 +108,12 @@ jobs:
     env:
       MB_EDITION: ee
       DISPLAY: ""
+      MB_RUN_MODE: "e2e"
+      METASTORE_DEV_SERVER_URL: ${{ secrets.METASTORE_DEV_SERVER_URL }}
       # Any env starting with `CYPRESS_` will be available to all Cypress tests via `Cypress.env()`
       # Example: you can get `CYPRESS_FOO` with `Cypress.env("FOO")`
-      CYPRESS_ALL_FEATURES_TOKEN: ${{ secrets.MB_ALL_FEATURES_TOKEN }}
-      CYPRESS_NO_FEATURES_TOKEN: ${{ secrets.MB_STARTER_CLOUD_TOKEN }}
+      CYPRESS_ALL_FEATURES_TOKEN: ${{ secrets.STAGING_MB_ALL_FEATURES_TOKEN }}
+      CYPRESS_NO_FEATURES_TOKEN: ${{ secrets.STAGING_MB_STARTER_CLOUD_TOKEN }}
       CYPRESS_PULL_REQUEST_ID: ${{ github.event.pull_request.number || '' }}
       CYPRESS_IS_EMBEDDING_SDK: true
       COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title || github.event.head_commit.message || github.event.head.sha }}

--- a/.github/workflows/e2e-cross-version.yml
+++ b/.github/workflows/e2e-cross-version.yml
@@ -66,8 +66,10 @@ jobs:
         docker run -d \
         -v $PWD/my-metabase:/metabase.db \
         -p 3000:3000 \
-        -e CYPRESS_ALL_FEATURES_TOKEN=${{ secrets.MB_ALL_FEATURES_TOKEN }} \
-        -e CYPRESS_NO_FEATURES_TOKEN=${{ secrets.MB_STARTER_CLOUD_TOKEN }} \
+        -e MB_RUN_MODE=e2e \
+        -e METASTORE_DEV_SERVER_URL=${{ secrets.METASTORE_DEV_SERVER_URL }} \
+        -e CYPRESS_ALL_FEATURES_TOKEN=${{ secrets.STAGING_MB_ALL_FEATURES_TOKEN }} \
+        -e CYPRESS_NO_FEATURES_TOKEN=${{ secrets.STAGING_MB_STARTER_CLOUD_TOKEN }} \
         --name metabase-${{ matrix.version.source }} \
         ${{ env.DOCKER_SOURCE_IMAGE }}
     - name: Wait for Metabase to start on port 3000
@@ -97,8 +99,10 @@ jobs:
         docker run -d \
           -v $PWD/my-metabase:/metabase.db \
           -p 3001:3000 \
-          -e CYPRESS_ALL_FEATURES_TOKEN=${{ secrets.MB_ALL_FEATURES_TOKEN }} \
-          -e CYPRESS_NO_FEATURES_TOKEN=${{ secrets.MB_STARTER_CLOUD_TOKEN }} \
+          -e MB_RUN_MODE=e2e \
+          -e METASTORE_DEV_SERVER_URL=${{ secrets.METASTORE_DEV_SERVER_URL }} \
+          -e CYPRESS_ALL_FEATURES_TOKEN=${{ secrets.STAGING_MB_ALL_FEATURES_TOKEN }} \
+          -e CYPRESS_NO_FEATURES_TOKEN=${{ secrets.STAGING_MB_STARTER_CLOUD_TOKEN }} \
           --name metabase-${{ matrix.version.target }} \
           ${{ env.DOCKER_TARGET_IMAGE }}
     - name: Wait for Metabase to start on port 3001

--- a/.github/workflows/e2e-sample-apps-tests.yml
+++ b/.github/workflows/e2e-sample-apps-tests.yml
@@ -207,10 +207,12 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       HASH: ${{ github.event.pull_request.head.sha || github.sha }}-${{ github.run_attempt }}
+      MB_RUN_MODE: e2e
+      METASTORE_DEV_SERVER_URL: ${{ secrets.METASTORE_DEV_SERVER_URL }}
       # Any env starting with `CYPRESS_` will be available to all Cypress tests via `Cypress.env()`
       # Example: you can get `CYPRESS_FOO` with `Cypress.env("FOO")`
-      CYPRESS_ALL_FEATURES_TOKEN: ${{ secrets.MB_ALL_FEATURES_TOKEN }}
-      CYPRESS_NO_FEATURES_TOKEN: ${{ secrets.MB_CLOUD_STARTER_TOKEN }}
+      CYPRESS_ALL_FEATURES_TOKEN: ${{ secrets.STAGING_MB_ALL_FEATURES_TOKEN }}
+      CYPRESS_NO_FEATURES_TOKEN: ${{ secrets.STAGING_MB_STARTER_CLOUD_TOKEN }}
       CYPRESS_PULL_REQUEST_ID: ${{ github.event.pull_request.number || '' }}
       CYPRESS_IS_EMBEDDING_SDK: true
       COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title || github.event.head_commit.message || github.event.head.sha }}

--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -56,8 +56,10 @@ jobs:
       DISPLAY: ""
       QA_DB_ENABLED: ${{ contains(fromJSON('["sql", "mongo"]'), inputs.qa_db) }}
       CYPRESS_QA_DB_MONGO: ${{ inputs.qa_db == 'mongo' }}
-      CYPRESS_ALL_FEATURES_TOKEN: ${{ secrets.MB_ALL_FEATURES_TOKEN }}
-      CYPRESS_NO_FEATURES_TOKEN: ${{ secrets.MB_STARTER_CLOUD_TOKEN }}
+      MB_RUN_MODE: e2e
+      METASTORE_DEV_SERVER_URL: ${{ secrets.METASTORE_DEV_SERVER_URL }}
+      CYPRESS_ALL_FEATURES_TOKEN: ${{ secrets.STAGING_MB_ALL_FEATURES_TOKEN }}
+      CYPRESS_NO_FEATURES_TOKEN: ${{ secrets.STAGING_MB_STARTER_CLOUD_TOKEN }}
       MB_SNOWPLOW_AVAILABLE: true
       MB_SNOWPLOW_URL: "http://localhost:9090" # Snowplow micro
       MB_EDITION: ${{ inputs.mb_edition }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -42,10 +42,12 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       HASH: ${{ github.event.pull_request.head.sha || github.sha }}-${{ github.run_attempt }}
       JOB_NAME: ${{ inputs.name }}
+      MB_RUN_MODE: "e2e"
+      METASTORE_DEV_SERVER_URL: ${{ secrets.METASTORE_DEV_SERVER_URL }}
       # Any env starting with `CYPRESS_` will be available to all Cypress tests via `Cypress.env()`
       # Example: you can get `CYPRESS_FOO` with `Cypress.env("FOO")`
-      CYPRESS_ALL_FEATURES_TOKEN: ${{ secrets.MB_ALL_FEATURES_TOKEN }}
-      CYPRESS_NO_FEATURES_TOKEN: ${{ secrets.MB_STARTER_CLOUD_TOKEN }}
+      CYPRESS_ALL_FEATURES_TOKEN: ${{ secrets.STAGING_MB_ALL_FEATURES_TOKEN }}
+      CYPRESS_NO_FEATURES_TOKEN: ${{ secrets.STAGING_MB_STARTER_CLOUD_TOKEN }}
       CYPRESS_PULL_REQUEST_ID: ${{ github.event.pull_request.number || '' }}
       COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title || github.event.head_commit.message || github.event.head.sha }}
       MB_EXPERIMENTAL_SEARCH_BLOCK_ON_QUEUE: true

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -103,8 +103,10 @@ jobs:
     env:
       MB_EDITION: ${{ matrix.edition }}
       DISPLAY: ""
-      CYPRESS_ALL_FEATURES_TOKEN: ${{ secrets.MB_ALL_FEATURES_TOKEN }}
-      CYPRESS_NO_FEATURES_TOKEN: ${{ secrets.MB_STARTER_CLOUD_TOKEN }}
+      MB_RUN_MODE: e2e
+      METASTORE_DEV_SERVER_URL: ${{ secrets.METASTORE_DEV_SERVER_URL }}
+      CYPRESS_ALL_FEATURES_TOKEN: ${{ secrets.STAGING_MB_ALL_FEATURES_TOKEN }}
+      CYPRESS_NO_FEATURES_TOKEN: ${{ secrets.STAGING_MB_STARTER_CLOUD_TOKEN }}
       # disabled because of out of memory issues
       # probably related to https://github.com/cypress-io/cypress/issues/27415
       CYPRESS_NO_COMMAND_LOG: 1

--- a/e2e/test/scenarios/admin-2/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/settings.cy.spec.js
@@ -689,55 +689,6 @@ describe("scenarios > admin > license and billing", () => {
         .should("have.prop", "tagName", "A");
     });
 
-    // This test needs to be re-examined and unskipped!
-    // It's mocking features that already exist in the self-hosted token
-    // It is using Promise.resolve that is going against the Cypress best-practices
-    // It has a very convoluted setup when we could probably just edit the current admin user
-    // It hard codes the store managed user which makes it breaking as soon as we udpate the token info
-    // I'm tracking the issue here: https://linear.app/metabase/issue/DEV-1017/fix-and-unskip-e2e-should-show-the-user-store-info-for-an-self-hosted
-    it.skip("should show the user store info for an self-hosted instance managed by the store", () => {
-      H.setTokenFeatures("all");
-      mockBillingTokenFeatures([
-        STORE_MANAGED_FEATURE_KEY,
-        NO_UPSELL_FEATURE_HEY,
-      ]);
-
-      const harborMasterConnectedAccount = {
-        email: "ci-admins@metabase.com",
-        first_name: "CI",
-        last_name: "Admins",
-        password: "test-password-123",
-      };
-
-      // create an admin user who is also connected to our test harbormaster account
-      cy.request("GET", "/api/permissions/group")
-        .then(({ body: groups }) => {
-          const adminGroup = groups.find((g) => g.name === "Administrators");
-          return cy
-            .createUserFromRawData(harborMasterConnectedAccount)
-            .then((user) => Promise.resolve([adminGroup.id, user]));
-        })
-        .then(([adminGroupId, user]) => {
-          const data = { user_id: user.id, group_id: adminGroupId };
-          return cy
-            .request("POST", "/api/permissions/membership", data)
-            .then(() => Promise.resolve(user));
-        })
-        .then((user) => {
-          cy.signOut(); // stop being normal admin user and be store connected admin user
-          return cy.request("POST", "/api/session", {
-            username: user.email,
-            password: harborMasterConnectedAccount.password,
-          });
-        })
-        .then(() => {
-          // core test
-          cy.visit("/admin/settings/license");
-          cy.findByTestId("billing-info-key-plan").should("exist");
-          cy.findByTestId("license-input").should("exist");
-        });
-    });
-
     it("should not show license input for cloud-hosted instances", () => {
       H.setTokenFeatures("all");
       mockBillingTokenFeatures([

--- a/e2e/test/scenarios/admin-2/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/settings.cy.spec.js
@@ -689,7 +689,13 @@ describe("scenarios > admin > license and billing", () => {
         .should("have.prop", "tagName", "A");
     });
 
-    it("should show the user store info for an self-hosted instance managed by the store", () => {
+    // This test needs to be re-examined and unskipped!
+    // It's mocking features that already exist in the self-hosted token
+    // It is using Promise.resolve that is going against the Cypress best-practices
+    // It has a very convoluted setup when we could probably just edit the current admin user
+    // It hard codes the store managed user which makes it breaking as soon as we udpate the token info
+    // I'm tracking the issue here: https://linear.app/metabase/issue/DEV-1017/fix-and-unskip-e2e-should-show-the-user-store-info-for-an-self-hosted
+    it.skip("should show the user store info for an self-hosted instance managed by the store", () => {
       H.setTokenFeatures("all");
       mockBillingTokenFeatures([
         STORE_MANAGED_FEATURE_KEY,

--- a/e2e/test/scenarios/admin-2/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/settings.cy.spec.js
@@ -519,7 +519,6 @@ describe("Cloud settings section", () => {
   });
 
   it("should prompt us to migrate to cloud if we are not hosted", () => {
-    H.setTokenFeatures("all");
     cy.visit("/admin");
     cy.findByTestId("admin-list-settings-items").findByText("Cloud").click();
 

--- a/src/metabase/cloud_migration/settings.clj
+++ b/src/metabase/cloud_migration/settings.clj
@@ -19,7 +19,7 @@
   []
   (if-some [env-var-value (config/config-bool :mb-store-use-staging)]
     env-var-value
-    config/is-dev?))
+    (or config/is-dev? config/is-e2e?)))
 
 ;;; TODO -- DEFAULT VALUES SHOULD NOT THE VALUE OF ANOTHER SETTING! BECAUSE GETTING SETTING VALUES REQUIRES THE APP DB
 ;;; TO BE SET UP!! AND IT IS NOT SET UP IMMEDIATELY ON LAUNCH!!

--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -93,6 +93,9 @@
 (def ^Boolean is-dev?  "Are we running in `dev` mode (i.e. in a REPL or via `clojure -M:run`)?" (= :dev  run-mode))
 (def ^Boolean is-prod? "Are we running in `prod` mode (i.e. from a JAR)?"                       (= :prod run-mode))
 (def ^Boolean is-test? "Are we running in `test` mode (i.e. via `clojure -X:test`)?"            (= :test run-mode))
+;; In E2E mode, we can customize the token check URL (e.g., use staging license tokens) while still ensuring that core app logic is unaffected.
+;; This allows us to run Cypress E2E tests with the production-like behavior.
+(def ^Boolean is-e2e?  "Are we running Cypress E2E tests against the production-ready code?"    (= :e2e run-mode))
 
 ;;; Version stuff
 

--- a/src/metabase/premium_features/token_check.clj
+++ b/src/metabase/premium_features/token_check.clj
@@ -44,8 +44,9 @@
   "Base URL to use for token checks. Hardcoded by default but for development purposes you can use a local server.
   Specify the env var `METASTORE_DEV_SERVER_URL`."
   (or
-   ;; only enable the changing the token check url during dev because we don't want people switching it out in production!
-   (when config/is-dev?
+   ;; only enable changing the token check url during dev because we don't want people switching it out in production!
+   ;; additionally, we want to be able to run e2e tests against a staging server.
+   (when (or config/is-dev? config/is-e2e?)
      (some-> (env :metastore-dev-server-url)
              ;; remove trailing slashes
              (str/replace  #"/$" "")))


### PR DESCRIPTION
Manual backport of https://github.com/metabase/metabase/commit/689d4f0e9ba9de0d9b13c5a59848017fb84ff2e7

This pull request updates the configuration and environment handling for E2E and compatibility tests, mainly to support running tests against a staging license/token server and to improve test reliability. The changes affect GitHub Actions workflows, environment variables, and some test and backend logic.

_Backend Logic for E2E Mode_

Added is-e2e? flag in core.clj to distinguish E2E test runs from dev/prod/test modes, allowing for custom behavior in E2E scenarios. Modified token check logic in token_check.clj to allow E2E tests to use a staging server for license validation. Changed store API settings in settings.clj to use staging endpoints when in dev or E2E mode, ensuring tests interact with the correct backend.