### PR TITLE
[util] Explicitly test for BigDecimals in real-number?

### DIFF
--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -440,9 +440,12 @@
 (defn real-number?
   "Is `x` a real number (i.e. not a `NaN` or an `Infinity`)?"
   [x]
-  (and (number? x)
-       (not (NaN? x))
-       (not (infinite? x))))
+  ;; Check for BigDec explicitly. BigDec cannot be nan or infinite, but using those predicates on bigdec with higher
+  ;; precision may allocate.
+  (or #?(:clj (decimal? x) :default false)
+      (and (number? x)
+           (not (NaN? x))
+           (not (infinite? x)))))
 
 (defn remove-diacritical-marks
   "Return a version of `s` with diacritical marks removed."


### PR DESCRIPTION
Discovered this accidentally. When the bigdecimal gets too big, running `NaN?` and `infinite`? against it causes conversion to Double which is just unnecessary work.

According to the docs, BigDecimal can't neither be nan nor infinite, hence being a bigdec is enough to say it is a real number.