### PR TITLE
Increase sync timeout in python execution test

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/transforms_python/transforms_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_python/transforms_api_test.clj
@@ -142,7 +142,7 @@
                                         :target  (assoc target :database (mt/id))}
                     {transform-id :id} (mt/user-http-request :crowberto :post 200 "ee/transform" original)]
                 (transforms.tu/test-run transform-id)
-                (transforms.tu/wait-for-table table-name 5000)
+                (transforms.tu/wait-for-table table-name 10000)
                 (is (true? (driver/table-exists? driver/*driver* (mt/db) target)))
                 (is (= [["Alice" 25] ["Bob" 30]]
                        (transforms.tu/table-rows table-name)))))))))))


### PR DESCRIPTION
Redshift sync of even one table can take a really long time (sometimes over 5 seconds)
