### PR TITLE
Revert "53 fix: Add e2e case to query analysis execution (#65181)"

### DIFF
--- a/src/metabase/query_analysis/core.clj
+++ b/src/metabase/query_analysis/core.clj
@@ -71,9 +71,9 @@
   By default, it is async in production for the backfill."
   []
   (case config/run-mode
-    (:prod :e2e) ::queued
-    :dev         *analyze-execution-in-dev?*
-    :test        *analyze-execution-in-test?*))
+    :prod ::queued
+    :dev  *analyze-execution-in-dev?*
+    :test *analyze-execution-in-test?*))
 
 (defn enabled-type?
   "Is analysis of the given query type enabled?"


### PR DESCRIPTION
This PR reverts commit c571ba94ac0d729fc8136cee0c98571607e044d0.
We decided not to support the custom "e2e" run mode in branches older than v55, so this change is not really needed here.

