### PR TITLE
Add embedding_type field for card/dashboard

### DIFF
--- a/.github/workflows/e2e-embedding-sdk-compatibility-tests.yml
+++ b/.github/workflows/e2e-embedding-sdk-compatibility-tests.yml
@@ -215,7 +215,7 @@ jobs:
       HASH: ${{ github.event.pull_request.head.sha || github.sha }}-${{ github.run_attempt }}
       MB_RUN_MODE: e2e
       METASTORE_DEV_SERVER_URL: ${{ secrets.METASTORE_DEV_SERVER_URL }}
-      CYPRESS_MB_ALL_FEATURES_TOKEN: ${{ secrets.MB_ALL_FEATURES_TOKEN }}
+      CYPRESS_MB_ALL_FEATURES_TOKEN: ${{ secrets.STAGING_MB_ALL_FEATURES_TOKEN }}
       CYPRESS_IS_EMBEDDING_SDK: "true"
       TZ: US/Pacific # to make node match the instance tz
       CYPRESS_CI: true

--- a/.github/workflows/e2e-embedding-sdk-compatibility-tests.yml
+++ b/.github/workflows/e2e-embedding-sdk-compatibility-tests.yml
@@ -215,7 +215,7 @@ jobs:
       HASH: ${{ github.event.pull_request.head.sha || github.sha }}-${{ github.run_attempt }}
       MB_RUN_MODE: e2e
       METASTORE_DEV_SERVER_URL: ${{ secrets.METASTORE_DEV_SERVER_URL }}
-      CYPRESS_MB_ALL_FEATURES_TOKEN: ${{ secrets.STAGING_MB_ALL_FEATURES_TOKEN }}
+      CYPRESS_MB_ALL_FEATURES_TOKEN: ${{ secrets.MB_ALL_FEATURES_TOKEN }}
       CYPRESS_IS_EMBEDDING_SDK: "true"
       TZ: US/Pacific # to make node match the instance tz
       CYPRESS_CI: true

--- a/e2e/runner/embedding-sdk/sample-apps/helpers/start-containers.ts
+++ b/e2e/runner/embedding-sdk/sample-apps/helpers/start-containers.ts
@@ -6,12 +6,14 @@ export async function startContainers({
   env,
   dockerUpCommand,
   dockerDownCommand,
+  appName,
   healthcheckPorts,
 }: {
   cwd: string;
   env: Record<string, string | number>;
   dockerUpCommand: string;
   dockerDownCommand: string;
+  appName: string;
   healthcheckPorts: number[];
 }) {
   console.log("Starting app in background...");
@@ -29,6 +31,11 @@ export async function startContainers({
 
     await Promise.all(healthcheckPromises);
   } catch {
-    shell(dockerDownCommand, { cwd, env });
+    // docker compose up failed, grab recent logs
+    shell(`docker logs --tail 100 ${appName}-metabase-1`, { cwd, env });
+
+    setTimeout(() => {
+      shell(dockerDownCommand, { cwd, env });
+    }, 5000);
   }
 }

--- a/e2e/runner/embedding-sdk/sample-apps/helpers/start-containers.ts
+++ b/e2e/runner/embedding-sdk/sample-apps/helpers/start-containers.ts
@@ -6,14 +6,12 @@ export async function startContainers({
   env,
   dockerUpCommand,
   dockerDownCommand,
-  appName,
   healthcheckPorts,
 }: {
   cwd: string;
   env: Record<string, string | number>;
   dockerUpCommand: string;
   dockerDownCommand: string;
-  appName: string;
   healthcheckPorts: number[];
 }) {
   console.log("Starting app in background...");
@@ -31,11 +29,6 @@ export async function startContainers({
 
     await Promise.all(healthcheckPromises);
   } catch {
-    // docker compose up failed, grab recent logs
-    shell(`docker logs --tail 100 ${appName}-metabase-1`, { cwd, env });
-
-    setTimeout(() => {
-      shell(dockerDownCommand, { cwd, env });
-    }, 5000);
+    shell(dockerDownCommand, { cwd, env });
   }
 }

--- a/e2e/runner/embedding-sdk/sample-apps/start-sample-app-containers.ts
+++ b/e2e/runner/embedding-sdk/sample-apps/start-sample-app-containers.ts
@@ -73,7 +73,6 @@ export async function startSampleAppContainers(
       env,
       dockerUpCommand,
       dockerDownCommand,
-      appName,
       healthcheckPorts,
     });
 

--- a/e2e/runner/embedding-sdk/sample-apps/start-sample-app-containers.ts
+++ b/e2e/runner/embedding-sdk/sample-apps/start-sample-app-containers.ts
@@ -73,6 +73,7 @@ export async function startSampleAppContainers(
       env,
       dockerUpCommand,
       dockerDownCommand,
+      appName,
       healthcheckPorts,
     });
 

--- a/e2e/support/helpers/e2e-embedding-helpers.js
+++ b/e2e/support/helpers/e2e-embedding-helpers.js
@@ -259,6 +259,21 @@ export function publishChanges(apiPath, callback) {
   });
 }
 
+/**
+ * Unpublish a static dashboard or question
+ * @param {"card" | "dashboard"} apiPath
+ * @param callback
+ */
+export function unpublishChanges(apiPath, callback) {
+  cy.intercept("PUT", `/api/${apiPath}/*`).as("unpublishChanges");
+
+  cy.button("Unpublish").click();
+
+  cy.wait("@unpublishChanges").then((xhr) => {
+    callback?.(xhr);
+  });
+}
+
 export function getParametersContainer() {
   return cy.findByLabelText("Configuring parameters");
 }

--- a/e2e/support/helpers/e2e-embedding-helpers.js
+++ b/e2e/support/helpers/e2e-embedding-helpers.js
@@ -239,7 +239,7 @@ export function closeStaticEmbeddingModal() {
 }
 
 /**
- * Open Static Embedding setup modal
+ * Publish a static dashboard or question
  * @param {"card" | "dashboard"} apiPath
  * @param callback
  */

--- a/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
@@ -301,6 +301,11 @@ describe("#39152 sharing an unsaved question", () => {
         assert.deepEqual(request.body.embedding_type, "static-legacy");
         assert.deepEqual(response.body.embedding_type, "static-legacy");
       });
+
+      H.unpublishChanges(apiPath, ({ request, response }) => {
+        assert.deepEqual(request.body.embedding_type, null);
+        assert.deepEqual(response.body.embedding_type, null);
+      });
     });
   });
 

--- a/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
@@ -261,7 +261,49 @@ describe("#39152 sharing an unsaved question", () => {
   });
 });
 
-["dashboard", "question"].forEach((resource) => {
+[
+  {
+    resource: "dashboard",
+    apiPath: "dashboard",
+  },
+  {
+    resource: "question",
+    apiPath: "card",
+  },
+].forEach(({ resource, apiPath }) => {
+  describe(`static modal behavior for ${resource}`, () => {
+    beforeEach(() => {
+      H.restore();
+      cy.signInAsAdmin();
+      H.enableTracking();
+
+      createResource(resource).then(({ body }) => {
+        cy.wrap(body.id).as("resourceId");
+      });
+    });
+
+    it("should set a proper embedding_type", () => {
+      cy.get("@resourceId").then((id) => {
+        visitResource(resource, id);
+      });
+
+      H.openStaticEmbeddingModal({ activeTab: "parameters" });
+
+      H.publishChanges(apiPath, ({ request, response }) => {
+        assert.deepEqual(request.body.embedding_type, "static-legacy");
+        assert.deepEqual(response.body.embedding_type, "static-legacy");
+      });
+
+      H.modal().button("Price").click();
+      H.popover().findByText("Editable").click();
+
+      H.publishChanges(apiPath, ({ request, response }) => {
+        assert.deepEqual(request.body.embedding_type, "static-legacy");
+        assert.deepEqual(response.body.embedding_type, "static-legacy");
+      });
+    });
+  });
+
   H.describeWithSnowplow(`public ${resource} sharing snowplow events`, () => {
     beforeEach(() => {
       H.restore();

--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -1,4 +1,7 @@
-import type { EmbeddingParameters } from "metabase/public/lib/types";
+import type {
+  EmbeddingParameters,
+  EmbeddingType,
+} from "metabase/public/lib/types";
 import type { IconName } from "metabase/ui";
 import type { PieRow } from "metabase/visualizations/echarts/pie/model/types";
 
@@ -48,6 +51,7 @@ export interface Card<Q extends DatasetQuery = DatasetQuery>
 
   /* Indicates whether static embedding for this card has been published */
   enable_embedding: boolean;
+  embedding_type?: EmbeddingType | null;
   embedding_params: EmbeddingParameters | null;
   can_write: boolean;
   can_restore: boolean;
@@ -411,6 +415,7 @@ export interface UpdateCardRequest {
   visualization_settings?: VisualizationSettings;
   archived?: boolean;
   enable_embedding?: boolean;
+  embedding_type?: EmbeddingType | null;
   embedding_params?: EmbeddingParameters;
   collection_id?: CollectionId | null;
   dashboard_id?: DashboardId | null;

--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -1,4 +1,7 @@
-import type { EmbeddingParameters } from "metabase/public/lib/types";
+import type {
+  EmbeddingParameters,
+  EmbeddingType,
+} from "metabase/public/lib/types";
 import type {
   BaseEntityId,
   CardCreatorInfo,
@@ -86,6 +89,7 @@ export interface Dashboard {
 
   /* Indicates whether static embedding for this dashboard has been published */
   enable_embedding: boolean;
+  embedding_type?: EmbeddingType | null;
 
   /* For x-ray dashboards */
   transient_name?: string;
@@ -307,6 +311,7 @@ export type UpdateDashboardRequest = {
     | "tabs"
     | "show_in_getting_started"
     | "enable_embedding"
+    | "embedding_type"
     | "collection_id"
     | "name"
     | "width"

--- a/frontend/src/metabase/api/card.ts
+++ b/frontend/src/metabase/api/card.ts
@@ -38,7 +38,7 @@ const PERSISTED_MODEL_REFRESH_DELAY = 200;
 
 export const cardApi = Api.injectEndpoints({
   endpoints: (builder) => {
-    const updateCardPropertyMutation = <
+    const updateCardPropertiesMutation = <
       PropertyKey extends keyof UpdateCardRequest,
     >() =>
       builder.mutation<Card, UpdateCardKeyRequest<PropertyKey>>({
@@ -291,10 +291,12 @@ export const cardApi = Api.injectEndpoints({
         invalidatesTags: (_, error) =>
           invalidateTags(error, [listTag("public-card")]),
       }),
-      updateCardEnableEmbedding:
-        updateCardPropertyMutation<"enable_embedding">(),
-      updateCardEmbeddingParams:
-        updateCardPropertyMutation<"embedding_params">(),
+      updateCardEnableEmbedding: updateCardPropertiesMutation<
+        "enable_embedding" | "embedding_type"
+      >(),
+      updateCardEmbeddingParams: updateCardPropertiesMutation<
+        "embedding_params" | "embedding_type"
+      >(),
       getCardDashboards: builder.query<
         { id: DashboardId; name: string }[],
         Pick<Card, "id">

--- a/frontend/src/metabase/api/dashboard.ts
+++ b/frontend/src/metabase/api/dashboard.ts
@@ -40,7 +40,7 @@ import { handleQueryFulfilled } from "./utils/lifecycle";
 
 export const dashboardApi = Api.injectEndpoints({
   endpoints: (builder) => {
-    const updateDashboardPropertyMutation = <
+    const updateDashboardPropertiesMutation = <
       Key extends keyof UpdateDashboardRequest,
     >() =>
       builder.mutation<Dashboard, UpdateDashboardPropertyRequest<Key>>({
@@ -201,10 +201,12 @@ export const dashboardApi = Api.injectEndpoints({
           listTag("embed-dashboard"),
         ],
       }),
-      updateDashboardEnableEmbedding:
-        updateDashboardPropertyMutation<"enable_embedding">(),
-      updateDashboardEmbeddingParams:
-        updateDashboardPropertyMutation<"embedding_params">(),
+      updateDashboardEnableEmbedding: updateDashboardPropertiesMutation<
+        "enable_embedding" | "embedding_type"
+      >(),
+      updateDashboardEmbeddingParams: updateDashboardPropertiesMutation<
+        "embedding_params" | "embedding_type"
+      >(),
       listPublicDashboards: builder.query<GetPublicDashboard[], void>({
         query: (params) => ({
           method: "GET",

--- a/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal/DashboardSharingEmbeddingModal.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal/DashboardSharingEmbeddingModal.tsx
@@ -5,6 +5,7 @@ import {
   useUpdateDashboardEnableEmbeddingMutation,
 } from "metabase/api";
 import { getParameters } from "metabase/dashboard/selectors";
+import { STATIC_LEGACY_EMBEDDING_TYPE } from "metabase/embedding/constants";
 import { useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import {
@@ -57,12 +58,16 @@ export const DashboardSharingEmbeddingModal = ({
             updateDashboardEnableEmbedding({
               id: dashboard.id,
               enable_embedding,
+              embedding_type: enable_embedding
+                ? STATIC_LEGACY_EMBEDDING_TYPE
+                : null,
             })
           }
           onUpdateEmbeddingParams={(embedding_params) =>
             updateDashboardEmbeddingParams({
               id: dashboard.id,
               embedding_params,
+              embedding_type: STATIC_LEGACY_EMBEDDING_TYPE,
             })
           }
           getPublicUrl={getPublicUrl}

--- a/frontend/src/metabase/dashboard/reducers-typed.ts
+++ b/frontend/src/metabase/dashboard/reducers-typed.ts
@@ -345,18 +345,18 @@ export const dashboards = createReducer(
       )
       .addMatcher(
         updateDashboardEmbeddingParams.matchFulfilled,
-        (state, { payload }) =>
-          assocIn(
-            state,
-            [payload.id, "embedding_params"],
-            payload.embedding_params,
-          ),
+        (state, { payload }) => {
+          const dashboard = state[payload.id];
+          dashboard.embedding_params = payload.embedding_params;
+          dashboard.embedding_type = payload.embedding_type;
+        },
       )
       .addMatcher(
         updateDashboardEnableEmbedding.matchFulfilled,
         (state, { payload }) => {
           const dashboard = state[payload.id];
           dashboard.enable_embedding = payload.enable_embedding;
+          dashboard.embedding_type = payload.embedding_type;
           dashboard.initially_published_at = payload.initially_published_at;
         },
       );

--- a/frontend/src/metabase/embedding/constants.ts
+++ b/frontend/src/metabase/embedding/constants.ts
@@ -1,0 +1,3 @@
+import type { EmbeddingType } from "metabase/public/lib/types";
+
+export const STATIC_LEGACY_EMBEDDING_TYPE: EmbeddingType = "static-legacy";

--- a/frontend/src/metabase/public/lib/types.ts
+++ b/frontend/src/metabase/public/lib/types.ts
@@ -29,6 +29,8 @@ export type EmbedResourceDownloadOptions = {
   results?: boolean;
 };
 
+export type EmbeddingType = "static-legacy";
+
 export type EmbeddingParameterVisibility = "disabled" | "enabled" | "locked";
 
 export type EmbeddingParameters = Record<string, EmbeddingParameterVisibility>;

--- a/frontend/src/metabase/query_builder/components/QuestionEmbedWidget/QuestionEmbedWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionEmbedWidget/QuestionEmbedWidget.tsx
@@ -5,6 +5,7 @@ import {
   useUpdateCardEnableEmbeddingMutation,
 } from "metabase/api";
 import type { ExportFormatType } from "metabase/embedding/components/PublicLinkPopover/types";
+import { STATIC_LEGACY_EMBEDDING_TYPE } from "metabase/embedding/constants";
 import { useSelector } from "metabase/lib/redux";
 import { publicQuestion } from "metabase/lib/urls";
 import {
@@ -48,10 +49,20 @@ export const QuestionEmbedWidget = (props: QuestionEmbedWidgetProps) => {
           onCreatePublicLink={() => createPublicQuestionLink({ id: card.id })}
           onDeletePublicLink={() => deletePublicQuestionLink({ id: card.id })}
           onUpdateEnableEmbedding={(enable_embedding) =>
-            updateEnableEmbedding({ id: card.id, enable_embedding })
+            updateEnableEmbedding({
+              id: card.id,
+              enable_embedding,
+              embedding_type: enable_embedding
+                ? STATIC_LEGACY_EMBEDDING_TYPE
+                : null,
+            })
           }
           onUpdateEmbeddingParams={(embedding_params) =>
-            updateEmbeddingParams({ id: card.id, embedding_params })
+            updateEmbeddingParams({
+              id: card.id,
+              embedding_params,
+              embedding_type: STATIC_LEGACY_EMBEDDING_TYPE,
+            })
           }
           getPublicUrl={getPublicQuestionUrl}
           onClose={onClose}

--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -1,0 +1,90 @@
+databaseChangeLog:
+  - objectQuotingStrategy: QUOTE_ALL_OBJECTS
+  - changeSet:
+      id: v58.2025-10-30T09:03:00
+      author: sanex3339
+      comment: Add embedding_type column to report_dashboard table
+      changes:
+        - addColumn:
+            tableName: report_dashboard
+            columns:
+              - column:
+                  name: embedding_type
+                  type: varchar(50)
+                  remarks: The type of embedding for this dashboard
+                  constraints:
+                    nullable: true
+      rollback:
+        - dropColumn:
+            tableName: report_dashboard
+            columnName: embedding_type
+
+  - changeSet:
+      id: v58.2025-10-30T09:03:01
+      author: sanex3339
+      comment: Add embedding_type column to report_card table
+      changes:
+        - addColumn:
+            tableName: report_card
+            columns:
+              - column:
+                  name: embedding_type
+                  type: varchar(50)
+                  remarks: The type of embedding for this card
+                  constraints:
+                    nullable: true
+      rollback:
+        - dropColumn:
+            tableName: report_card
+            columnName: embedding_type
+
+
+# >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
+
+########################################################################################################################
+#
+# ADVICE:
+#
+# 1) Think through some of these points when writing a migration, learn from our past mistakes:
+#    - Do you really need a migration? Could the feature work without it? Prefer not to if possible.
+#      Data in the wild can be vastly different from what you expect, and it's hard to get right.
+#    - Make sure your migration is backward compatible: it might not be possible to add a constraint back
+#      if you drop it in a migration.
+#    - Postgres, MySQL and H2 have their differences. Make sure your migration works for all.
+#    - Database encryption is a major issue:
+#      - Fields like `metabase_database.details` or `setting.value` can be encrypted, so you need to decrypt them in
+#        your migration. See #42617, #44048.
+#      - Database could be partially encrypted, see https://www.notion.so/72575933ef2a446bafd16909e05a7387
+#    - Custom migrations:
+#      - Prefer SQL migrations when possible.
+#      - Never use application code: it can change and *will* break your migration.
+#      - Do not use Toucan models - refer table names directly.
+#      - If it's a big change, consider using Quartz, see #42279
+#      - More in `metabase.app_db.custom_migrations` namespace doc.
+#    - Never delete a migration: users won't be able to downgrade. If you really need to, see #44908
+#    - Migration id (`vXX.<date>`) must match its earliest released version:
+#      - Do not backport `v51....` to version 50, Metabase will try to downgrade it.
+#      - Instead, write a migration with an oldest target you plan to backport to in mind.
+#
+# 2) Migrations should go in the ###_update_migrations.yaml file for the target version.
+#
+# 3) Run mage lint-migrations to run core.spec checks against any changes you make here. Liquibase is pretty
+#    forgiving and won't complain if you accidentally mix up things like deleteCascade and onDelete: CASCADE. CI runs
+#    this check but it's nicer to know now instead of waiting for CI.
+#
+# 3) Migration IDs should follow the format
+#
+#    vMM.TIMESTAMP
+#
+#    Where
+#
+#    M         = major version
+#    TIMESTAMP = the current timestamp with format `yyyy-MM-dd'T'HH:mm:ss`
+#                To get this timestamp, evaluate this in your REPL: `(dev/migration-timestamp)`
+#
+#    E.g: You're adding a new migration for version 49, And it's 10:30:00AM on April 1, 2023 (UTC),
+#    your migration id should be: `v49.2023-04-01T10:30:00`.
+#
+# PLEASE KEEP THIS MESSAGE AT THE BOTTOM OF THIS FILE!!!!! Add new migrations above the message.
+#
+########################################################################################################################

--- a/src/metabase/dashboards/api.clj
+++ b/src/metabase/dashboards/api.clj
@@ -931,9 +931,9 @@
            (when-let [updates (not-empty
                                (u/select-keys-when
                                 dash-updates
-                                :present #{:description :position :width :collection_id :collection_position :cache_ttl :archived_directly}
+                                :present #{:description :position :width :collection_id :collection_position :cache_ttl :archived_directly :embedding_type}
                                 :non-nil #{:name :parameters :caveats :points_of_interest :show_in_getting_started :enable_embedding
-                                           :embedding_type :embedding_params :archived :auto_apply_filters}))]
+                                           :embedding_params :archived :auto_apply_filters}))]
              (when (api/column-will-change? :archived current-dash dash-updates)
                (if (:archived dash-updates)
                  (t2/update! :model/Card

--- a/src/metabase/dashboards/api.clj
+++ b/src/metabase/dashboards/api.clj
@@ -622,10 +622,11 @@
      :models (if (seq cards) ["card"] [])}))
 
 (defn- check-allowed-to-change-embedding
-  "You must be a superuser to change the value of `enable_embedding` or `embedding_params`. Embedding must be
+  "You must be a superuser to change the value of `enable_embedding`, `embedding_type` or `embedding_params`. Embedding must be
   enabled."
   [dash-before-update dash-updates]
   (when (or (api/column-will-change? :enable_embedding dash-before-update dash-updates)
+            (api/column-will-change? :embedding_type dash-before-update dash-updates)
             (api/column-will-change? :embedding_params dash-before-update dash-updates))
     (embedding.validation/check-embedding-enabled)
     (api/check-superuser)))
@@ -932,7 +933,7 @@
                                 dash-updates
                                 :present #{:description :position :width :collection_id :collection_position :cache_ttl :archived_directly}
                                 :non-nil #{:name :parameters :caveats :points_of_interest :show_in_getting_started :enable_embedding
-                                           :embedding_params :archived :auto_apply_filters}))]
+                                           :embedding_type :embedding_params :archived :auto_apply_filters}))]
              (when (api/column-will-change? :archived current-dash dash-updates)
                (if (:archived dash-updates)
                  (t2/update! :model/Card
@@ -1004,6 +1005,7 @@
    [:points_of_interest      {:optional true} [:maybe :string]]
    [:show_in_getting_started {:optional true} [:maybe :boolean]]
    [:enable_embedding        {:optional true} [:maybe :boolean]]
+   [:embedding_type          {:optional true} [:maybe :string]]
    [:embedding_params        {:optional true} [:maybe ms/EmbeddingParams]]
    [:parameters              {:optional true} [:maybe ::parameters.schema/parameters]]
    [:position                {:optional true} [:maybe ms/PositiveInt]]

--- a/src/metabase/dashboards/models/dashboard.clj
+++ b/src/metabase/dashboards/models/dashboard.clj
@@ -394,7 +394,7 @@
 
 (defmethod serdes/make-spec "Dashboard" [_model-name opts]
   {:copy      [:archived :archived_directly :auto_apply_filters :caveats :collection_position
-               :description :embedding_params :enable_embedding :entity_id :name
+               :description :embedding_params :enable_embedding :embedding_type :entity_id :name
                :points_of_interest :position :public_uuid :show_in_getting_started :width]
    :skip      [;; those stats are inherently local state
                :view_count :last_viewed_at

--- a/src/metabase/queries/api/card.clj
+++ b/src/metabase/queries/api/card.clj
@@ -552,10 +552,11 @@
     (query-perms/check-run-permissions-for-query (:dataset_query card-updates))))
 
 (defn- check-allowed-to-change-embedding
-  "You must be a superuser to change the value of `enable_embedding` or `embedding_params`. Embedding must be
+  "You must be a superuser to change the value of `enable_embedding`, `embedding_type` or `embedding_params`. Embedding must be
   enabled."
   [card-before-updates card-updates]
   (when (or (api/column-will-change? :enable_embedding card-before-updates card-updates)
+            (api/column-will-change? :embedding_type card-before-updates card-updates)
             (api/column-will-change? :embedding_params card-before-updates card-updates))
     (embedding.validation/check-embedding-enabled)
     (api/check-superuser)))
@@ -588,6 +589,7 @@
    [:visualization_settings {:optional true} [:maybe ms/Map]]
    [:archived               {:optional true} [:maybe :boolean]]
    [:enable_embedding       {:optional true} [:maybe :boolean]]
+   [:embedding_type         {:optional true} [:maybe :string]]
    [:embedding_params       {:optional true} [:maybe ms/EmbeddingParams]]
    [:collection_id          {:optional true} [:maybe ms/PositiveInt]]
    [:collection_position    {:optional true} [:maybe ms/PositiveInt]]

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -1099,9 +1099,9 @@
                 ;; `collection_id` and `description` can be `nil` (in order to unset them).
                 ;; Other values should only be modified if they're passed in as non-nil
                 (u/select-keys-when card-updates
-                                    :present #{:collection_id :collection_position :description :cache_ttl :archived_directly :dashboard_id :document_id}
+                                    :present #{:collection_id :collection_position :description :cache_ttl :archived_directly :dashboard_id :document_id :embedding_type}
                                     :non-nil #{:dataset_query :display :name :visualization_settings :archived
-                                               :enable_embedding :embedding_type :type :parameters :parameter_mappings :embedding_params
+                                               :enable_embedding :type :parameters :parameter_mappings :embedding_params
                                                :result_metadata :collection_preview :verified-result-metadata?}))
     ;; ok, now update dependent dashcard parameters
     (try

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -1101,7 +1101,7 @@
                 (u/select-keys-when card-updates
                                     :present #{:collection_id :collection_position :description :cache_ttl :archived_directly :dashboard_id :document_id}
                                     :non-nil #{:dataset_query :display :name :visualization_settings :archived
-                                               :enable_embedding :type :parameters :parameter_mappings :embedding_params
+                                               :enable_embedding :embedding_type :type :parameters :parameter_mappings :embedding_params
                                                :result_metadata :collection_preview :verified-result-metadata?}))
     ;; ok, now update dependent dashcard parameters
     (try
@@ -1188,7 +1188,7 @@
 (defmethod serdes/make-spec "Card"
   [_model-name _opts]
   {:copy [:archived :archived_directly :collection_position :collection_preview :description :display
-          :embedding_params :enable_embedding :entity_id :metabase_version :public_uuid :query_type :type :name
+          :embedding_params :enable_embedding :embedding_type :entity_id :metabase_version :public_uuid :query_type :type :name
           :card_schema]
    :skip [;; cache invalidation is instance-specific
           :cache_invalidated_at

--- a/src/metabase/revisions/models/revision/diff.clj
+++ b/src/metabase/revisions/models/revision/diff.clj
@@ -34,6 +34,9 @@
     [:enable_embedding true false]
     (deferred-tru "disabled embedding")
 
+    [:embedding_type _ _]
+    (deferred-tru "changed the embedding type")
+
     [:parameters _ _]
     (deferred-tru "changed the filters")
 

--- a/test/metabase/dashboards/api_test.clj
+++ b/test/metabase/dashboards/api_test.clj
@@ -5415,6 +5415,25 @@
                                           :size_y  4}]})
       (is (not (nil? (t2/select-one :model/PulseCard :card_id new-card-id)))))))
 
+(deftest update-dashboard-embedding-type-to-nil-test
+  (testing "PUT /api/dashboard/:id"
+    (testing "Admin should be able to set embedding_type to nil to clear it"
+      (mt/with-temporary-setting-values [enable-embedding-static true]
+        (mt/with-temp [:model/Dashboard dashboard {:enable_embedding true
+                                                   :embedding_type "static-legacy"}]
+          (with-dashboards-in-writeable-collection! [dashboard]
+            (testing "Verify initial state has embedding_type set"
+              (is (= "static-legacy"
+                     (t2/select-one-fn :embedding_type :model/Dashboard :id (u/the-id dashboard)))))
+            (testing "Setting embedding_type to nil should clear it"
+              (let [response (mt/user-http-request :crowberto :put 200 (str "dashboard/" (u/the-id dashboard))
+                                                   {:embedding_type nil})]
+                (testing "Response should contain nil embedding_type"
+                  (is (= nil (:embedding_type response))))
+                (testing "Database should contain nil embedding_type"
+                  (is (= nil
+                         (t2/select-one-fn :embedding_type :model/Dashboard :id (u/the-id dashboard)))))))))))))
+
 (deftest save-dashboard-test
   (let [response (mt/user-http-request :crowberto :post 200 "dashboard/save" {:auto_apply_filters true,
                                                                               :name               "Test Dashboard",

--- a/test/metabase/queries/api/card_test.clj
+++ b/test/metabase/queries/api/card_test.clj
@@ -1583,6 +1583,24 @@
           (is (= {:abc "enabled"}
                  (t2/select-one-fn :embedding_params :model/Card :id (u/the-id card)))))))))
 
+(deftest update-embedding-type-to-nil-test
+  (testing "PUT /api/card/:id"
+    (testing "Admin should be able to set embedding_type to nil to clear it"
+      (mt/with-temporary-setting-values [enable-embedding-static true]
+        (mt/with-temp [:model/Card card {:enable_embedding true
+                                         :embedding_type "static-legacy"}]
+          (testing "Verify initial state has embedding_type set"
+            (is (= "static-legacy"
+                   (t2/select-one-fn :embedding_type :model/Card :id (u/the-id card)))))
+          (testing "Setting embedding_type to nil should clear it"
+            (let [response (mt/user-http-request :crowberto :put 200 (str "card/" (u/the-id card))
+                                                 {:embedding_type nil})]
+              (testing "Response should contain nil embedding_type"
+                (is (= nil (:embedding_type response))))
+              (testing "Database should contain nil embedding_type"
+                (is (= nil
+                       (t2/select-one-fn :embedding_type :model/Card :id (u/the-id card))))))))))))
+
 (deftest can-we-change-the-collection-position-of-a-card-
   (mt/with-temp [:model/Card card]
     (with-cards-in-writeable-collection! card

--- a/test/metabase/queries/api/card_test.clj
+++ b/test/metabase/queries/api/card_test.clj
@@ -72,6 +72,7 @@
    :description            nil
    :display                "scalar"
    :enable_embedding       false
+   :embedding_type         nil
    :initially_published_at nil
    :entity_id              nil
    :embedding_params       nil
@@ -898,6 +899,21 @@
                                                                        :dataset_query          (mt/mbql-query venues)
                                                                        :visualization_settings {}
                                                                        :enable_embedding       true})))))))))
+
+(deftest create-card-disallow-setting-embedding-type-test
+  (testing "POST /api/card"
+    (testing "Ignore values of `embedding_type` while creating a Card (this must be done via `PUT /api/card/:id` instead)"
+                    ;; should be ignored regardless of the value of the `embedding-type` Setting.
+      (doseq [embedding-type [true false]]
+        (mt/with-temporary-setting-values [enable-embedding-static embedding-type]
+          (mt/with-model-cleanup [:model/Card]
+            (is (=? {:embedding_type nil}
+                    (mt/user-http-request :crowberto :post 200 "card" {:name                   "My Card"
+                                                                       :display                :table
+                                                                       :dataset_query          (mt/mbql-query venues)
+                                                                       :visualization_settings {}
+                                                                       :enable_embedding       true
+                                                                       :embedding_type       "static-legacy"})))))))))
 
 (deftest save-empty-card-test
   (testing "POST /api/card"

--- a/test/metabase/revisions/events_test.clj
+++ b/test/metabase/revisions/events_test.clj
@@ -51,6 +51,7 @@
    :collection_position nil
    :enable_embedding    false
    :embedding_params    nil
+   :embedding_type      nil
    :parameters          []
    :archived_directly   (:archived_directly dashboard)})
 

--- a/test/metabase/revisions/impl/card_test.clj
+++ b/test/metabase/revisions/impl/card_test.clj
@@ -100,6 +100,7 @@
                             (= col :display)           :pie
                             (= col :made_public_by_id) (mt/user->id :crowberto)
                             (= col :embedding_params)  {:category_name "locked"}
+                            (= col :embedding_type)    "static-legacy"
                             (= col :public_uuid)       (str (random-uuid))
                             (= col :table_id)          (mt/id :venues)
                             (= col :source_card_id)    (:id base-card)

--- a/test/metabase/revisions/impl/dashboard_test.clj
+++ b/test/metabase/revisions/impl/dashboard_test.clj
@@ -392,6 +392,7 @@
                 :archived            false
                 :collection_position nil
                 :enable_embedding    false
+                :embedding_type      nil
                 :embedding_params    nil
                 :parameters          []
                 :width               "fixed"}
@@ -431,6 +432,7 @@
                 :archived            false
                 :collection_position nil
                 :enable_embedding    false
+                :embedding_type      nil
                 :embedding_params    nil
                 :parameters          []
                 :width               "fixed"}

--- a/test/metabase/revisions/impl/dashboard_test.clj
+++ b/test/metabase/revisions/impl/dashboard_test.clj
@@ -42,6 +42,7 @@
               :archived            false
               :collection_position nil
               :enable_embedding    false
+              :embedding_type      nil
               :embedding_params    nil
               :parameters          []
               :width               "fixed"}
@@ -247,6 +248,7 @@
                                                                          value)
                                (= col :made_public_by_id)          (mt/user->id :crowberto)
                                (= col :embedding_params)           {:category_name "locked"}
+                               (= col :embedding_type)             "static-legacy"
                                (= col :public_uuid)                (str (random-uuid))
                                (int? value)                        (inc value)
                                (boolean? value)                    (not value)
@@ -361,6 +363,7 @@
                                 :archived            false
                                 :collection_position nil
                                 :enable_embedding    false
+                                :embedding_type      nil
                                 :embedding_params    nil
                                 :parameters          []
                                 :width               "fixed"}

--- a/test_resources/serialization_baseline/collections/JS5JHDitDkWEtTt1-N7zr_qdlkexrocaxgnecmryqu/cards/_DexsxY2EQdmhwMZU4BCs_dependent_card.yaml
+++ b/test_resources/serialization_baseline/collections/JS5JHDitDkWEtTt1-N7zr_qdlkexrocaxgnecmryqu/cards/_DexsxY2EQdmhwMZU4BCs_dependent_card.yaml
@@ -13,6 +13,7 @@ database_id: test-data (h2)
 table_id: null
 enable_embedding: false
 embedding_params: null
+embedding_type: null
 made_public_by_id: null
 public_uuid: null
 parameters: []

--- a/test_resources/serialization_baseline/collections/M-Q4pcV0qkiyJ0kiSWECl_some_collection/cards/OMuZ0wHe2O5Z_59-cLmn4_series_question_a.yaml
+++ b/test_resources/serialization_baseline/collections/M-Q4pcV0qkiyJ0kiSWECl_some_collection/cards/OMuZ0wHe2O5Z_59-cLmn4_series_question_a.yaml
@@ -13,6 +13,7 @@ database_id: test-data (h2)
 table_id: null
 enable_embedding: false
 embedding_params: null
+embedding_type: null
 made_public_by_id: null
 public_uuid: null
 parameters: []

--- a/test_resources/serialization_baseline/collections/M-Q4pcV0qkiyJ0kiSWECl_some_collection/cards/XsxiHuzwlGIFNq245HdZC_series_question_b.yaml
+++ b/test_resources/serialization_baseline/collections/M-Q4pcV0qkiyJ0kiSWECl_some_collection/cards/XsxiHuzwlGIFNq245HdZC_series_question_b.yaml
@@ -13,6 +13,7 @@ database_id: test-data (h2)
 table_id: null
 enable_embedding: false
 embedding_params: null
+embedding_type: null
 made_public_by_id: null
 public_uuid: null
 parameters: []

--- a/test_resources/serialization_baseline/collections/M-Q4pcV0qkiyJ0kiSWECl_some_collection/cards/f1C68pznmrpN1F5xFDj6d_some_question.yaml
+++ b/test_resources/serialization_baseline/collections/M-Q4pcV0qkiyJ0kiSWECl_some_collection/cards/f1C68pznmrpN1F5xFDj6d_some_question.yaml
@@ -13,6 +13,7 @@ database_id: test-data (h2)
 table_id: null
 enable_embedding: false
 embedding_params: null
+embedding_type: null
 made_public_by_id: null
 public_uuid: null
 parameters: []

--- a/test_resources/serialization_baseline/collections/M-Q4pcV0qkiyJ0kiSWECl_some_collection/dashboards/Q_jD-f-9clKLFZ2TfUG2h_shared_dashboard.yaml
+++ b/test_resources/serialization_baseline/collections/M-Q4pcV0qkiyJ0kiSWECl_some_collection/dashboards/Q_jD-f-9clKLFZ2TfUG2h_shared_dashboard.yaml
@@ -10,6 +10,7 @@ collection_position: null
 position: null
 enable_embedding: false
 embedding_params: null
+embedding_type: null
 made_public_by_id: null
 public_uuid: null
 show_in_getting_started: false

--- a/test_resources/serialization_baseline/collections/cards/1z82DAj_YUJAsCZZaacxK_linked_card.yaml
+++ b/test_resources/serialization_baseline/collections/cards/1z82DAj_YUJAsCZZaacxK_linked_card.yaml
@@ -13,6 +13,7 @@ database_id: test-data (h2)
 table_id: null
 enable_embedding: false
 embedding_params: null
+embedding_type: null
 made_public_by_id: null
 public_uuid: null
 parameters: []

--- a/test_resources/serialization_baseline/collections/cards/4ahdpFn43jybRFVQTRjX__ai_model.yaml
+++ b/test_resources/serialization_baseline/collections/cards/4ahdpFn43jybRFVQTRjX__ai_model.yaml
@@ -13,6 +13,7 @@ database_id: test-data (h2)
 table_id: null
 enable_embedding: false
 embedding_params: null
+embedding_type: null
 made_public_by_id: null
 public_uuid: null
 parameters: []

--- a/test_resources/serialization_baseline/collections/cards/RC0EJ8I00lOUnvbnGJJNf_ai_model.yaml
+++ b/test_resources/serialization_baseline/collections/cards/RC0EJ8I00lOUnvbnGJJNf_ai_model.yaml
@@ -13,6 +13,7 @@ database_id: test-data (h2)
 table_id: null
 enable_embedding: false
 embedding_params: null
+embedding_type: null
 made_public_by_id: null
 public_uuid: null
 parameters: []

--- a/test_resources/serialization_baseline/collections/cards/aqpA3mIKUnfzYUlwjuGwT_source_question.yaml
+++ b/test_resources/serialization_baseline/collections/cards/aqpA3mIKUnfzYUlwjuGwT_source_question.yaml
@@ -13,6 +13,7 @@ database_id: My Database
 table_id: null
 enable_embedding: false
 embedding_params: null
+embedding_type: null
 made_public_by_id: null
 public_uuid: null
 parameters: []

--- a/test_resources/serialization_baseline/collections/cards/kDd3G__y2cqdZu7A1SUsU_ai_model.yaml
+++ b/test_resources/serialization_baseline/collections/cards/kDd3G__y2cqdZu7A1SUsU_ai_model.yaml
@@ -13,6 +13,7 @@ database_id: test-data (h2)
 table_id: null
 enable_embedding: false
 embedding_params: null
+embedding_type: null
 made_public_by_id: null
 public_uuid: null
 parameters: []

--- a/test_resources/serialization_baseline/collections/cards/ze7O4-8qRFH1v2Ho2apT1_root_card.yaml
+++ b/test_resources/serialization_baseline/collections/cards/ze7O4-8qRFH1v2Ho2apT1_root_card.yaml
@@ -13,6 +13,7 @@ database_id: test-data (h2)
 table_id: null
 enable_embedding: false
 embedding_params: null
+embedding_type: null
 made_public_by_id: null
 public_uuid: null
 parameters: []

--- a/test_resources/serialization_baseline/collections/dashboards/ziLZTiwSdz6aJaB9VhGiO_smart_linked_dashboard.yaml
+++ b/test_resources/serialization_baseline/collections/dashboards/ziLZTiwSdz6aJaB9VhGiO_smart_linked_dashboard.yaml
@@ -10,6 +10,7 @@ collection_position: null
 position: null
 enable_embedding: false
 embedding_params: null
+embedding_type: null
 made_public_by_id: null
 public_uuid: null
 show_in_getting_started: false

--- a/test_resources/serialization_baseline/collections/gQuHAIM4C-7fToHzHyNNQ_ai_model/cards/Mr5p0TE2FSxGeUFaWd9yu_ai_model.yaml
+++ b/test_resources/serialization_baseline/collections/gQuHAIM4C-7fToHzHyNNQ_ai_model/cards/Mr5p0TE2FSxGeUFaWd9yu_ai_model.yaml
@@ -13,6 +13,7 @@ database_id: test-data (h2)
 table_id: null
 enable_embedding: false
 embedding_params: null
+embedding_type: null
 made_public_by_id: null
 public_uuid: null
 parameters: []

--- a/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/cards/m98z04nYGCF5n7cvOTfbj_grandparent_card.yaml
+++ b/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/cards/m98z04nYGCF5n7cvOTfbj_grandparent_card.yaml
@@ -13,6 +13,7 @@ database_id: test-data (h2)
 table_id: null
 enable_embedding: false
 embedding_params: null
+embedding_type: null
 made_public_by_id: null
 public_uuid: null
 parameters: []

--- a/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/qPZhJMPNGkfd3sq8jWiZS_parent_collection/cards/IBZSKSt2-QOMviIaGcQE6_parent_card.yaml
+++ b/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/qPZhJMPNGkfd3sq8jWiZS_parent_collection/cards/IBZSKSt2-QOMviIaGcQE6_parent_card.yaml
@@ -13,6 +13,7 @@ database_id: test-data (h2)
 table_id: null
 enable_embedding: false
 embedding_params: null
+embedding_type: null
 made_public_by_id: null
 public_uuid: null
 parameters: []

--- a/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/qPZhJMPNGkfd3sq8jWiZS_parent_collection/dashboards/JT3BKJwNCfhUHnd9oqQ_1_parent_dash.yaml
+++ b/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/qPZhJMPNGkfd3sq8jWiZS_parent_collection/dashboards/JT3BKJwNCfhUHnd9oqQ_1_parent_dash.yaml
@@ -10,6 +10,7 @@ collection_position: null
 position: null
 enable_embedding: false
 embedding_params: null
+embedding_type: null
 made_public_by_id: null
 public_uuid: null
 show_in_getting_started: false

--- a/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/qPZhJMPNGkfd3sq8jWiZS_parent_collection/fJVsXIDzzipSZsaro9Pvu_child_collection/cards/Ra0JVOCXKTxH5TPbwZm0x_child_card.yaml
+++ b/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/qPZhJMPNGkfd3sq8jWiZS_parent_collection/fJVsXIDzzipSZsaro9Pvu_child_collection/cards/Ra0JVOCXKTxH5TPbwZm0x_child_card.yaml
@@ -13,6 +13,7 @@ database_id: test-data (h2)
 table_id: null
 enable_embedding: false
 embedding_params: null
+embedding_type: null
 made_public_by_id: null
 public_uuid: null
 parameters: []


### PR DESCRIPTION
Add the `embedding_type` field for card/dashboard.

This field will be set by both the legacy and new static wizard.
In this PR this field is set by the legacy wizard.

Description:
For the Embed JS wizard, when it's opened in the static mode for an entity that is currently published from the Legacy Static Wizard - we need to show an alert.

To understand that an entity was published from the Legacy or EmbedJS Static Wizards, we need to introduce a new field  `embedding_type`. 

This field should accept the null or `static-legacy` value, and later the `static-embed-js` value will be added.
This field is a temporary requirement and when we remove the alert or completely kill the Legacy Static Wizard - we can remove it. That's why it's done as a new field/DB column instead of converting `enable_embedding: boolean` => `enable_embedding: EnableEmbeddingEnum`

We should adjust tests and add a migration to add the new field to `Card`/`Dashboard` tables

How to validate:
- it's covered via e2e and unit tests
- manually you can open a static question/dashboard wizard, publish changes, and be sure that `embedding_type` field is passed to the request, and returned in the response. 
- when unpublishing, it should be passed as `null`