### PR TITLE
fix: allow stacktraces to be suppressed in API

### DIFF
--- a/src/metabase/server/middleware/exceptions.clj
+++ b/src/metabase/server/middleware/exceptions.clj
@@ -4,6 +4,8 @@
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
    [metabase.server.middleware.security :as mw.security]
+   [metabase.server.settings :as server.settings]
+   [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log])
   (:import
    (java.sql SQLException)
@@ -35,6 +37,11 @@
                                           ;; ex-data.
                                           (and status-code (:errors other-info))
                                           other-info
+
+                                          ;; allow administrators to configure their instances to suppress stacktraces
+                                          ;; returns 500 with a generic message
+                                          (server.settings/hide-stacktraces)
+                                          {:message (tru "Something went wrong")}
 
                                           ;; Otherwise return the full `Throwable->map` representation with Stacktrace
                                           ;; and ex-data

--- a/src/metabase/server/settings.clj
+++ b/src/metabase/server/settings.clj
@@ -67,3 +67,10 @@ x.com")
   :default    false
   :visibility :admin
   :export?    true)
+
+(defsetting hide-stacktraces
+  (deferred-tru "Prevent the exception middleware from including stacktraces in responses.")
+  :type       :boolean
+  :default    false
+  :visibility :admin
+  :export?    false)

--- a/src/metabase/server/streaming_response.clj
+++ b/src/metabase/server/streaming_response.clj
@@ -5,6 +5,7 @@
    [compojure.response]
    [metabase.api.common.internal]
    [metabase.server.protocols :as server.protocols]
+   [metabase.server.settings :as server.settings]
    [metabase.server.streaming-response.thread-pool :as thread-pool]
    [metabase.util :as u]
    [metabase.util.async :as async.u]
@@ -42,7 +43,8 @@
       500))
 
 (defn- format-exception [e]
-  (assoc (Throwable->map e) :_status (ex-status-code e)))
+  (cond-> (assoc (Throwable->map e) :_status (ex-status-code e))
+    (server.settings/hide-stacktraces) (dissoc :via :trace)))
 
 (defn write-error!
   "Write an error to the output stream, formatting it nicely. Closes output stream afterwards."

--- a/src/metabase/server/streaming_response.clj
+++ b/src/metabase/server/streaming_response.clj
@@ -69,7 +69,8 @@
                              x))
                          obj)
                         obj)
-                      (dissoc :export-format))]
+                      (dissoc :export-format)
+                      (cond-> (server.settings/hide-stacktraces) (dissoc :stacktrace :trace :via)))]
           (with-open [writer (BufferedWriter. (OutputStreamWriter. os StandardCharsets/UTF_8))]
             (json/encode-to obj writer {})))
         (catch EofException _)

--- a/test/metabase/server/middleware/exceptions_test.clj
+++ b/test/metabase/server/middleware/exceptions_test.clj
@@ -1,0 +1,195 @@
+(ns metabase.server.middleware.exceptions-test
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [metabase.server.middleware.exceptions :as mw.exceptions]
+   [metabase.server.settings :as server.settings]
+   [metabase.test :as mt]))
+
+(defn- create-test-exception
+  "Create a test exception with a stacktrace."
+  [message]
+  (try
+    (throw (ex-info message {:custom-data "test-value"}))
+    (catch Exception e
+      e)))
+
+(deftest api-exception-response-includes-error-message-test
+  (testing "When hide-stacktraces is false, exception response includes the error message"
+    (mt/with-temporary-setting-values [server.settings/hide-stacktraces false]
+      (let [exception (create-test-exception "Test error message")
+            response (mw.exceptions/api-exception-response exception)]
+        (is (= 500 (:status response)))
+        (is (= "Test error message" (get-in response [:body :message])))))))
+
+(deftest api-exception-response-includes-stacktrace-test
+  (testing "When hide-stacktraces is false, exception response includes stacktrace information"
+    (mt/with-temporary-setting-values [server.settings/hide-stacktraces false]
+      (let [exception (create-test-exception "Test error message")
+            response (mw.exceptions/api-exception-response exception)]
+        (is (contains? (:body response) :trace)
+            "Response should contain :trace key with stacktrace")
+        (is (vector? (get-in response [:body :trace]))
+            "Stacktrace should be a vector")))))
+
+(deftest api-exception-response-includes-ex-data-test
+  (testing "When hide-stacktraces is false, exception response includes ex-data"
+    (mt/with-temporary-setting-values [server.settings/hide-stacktraces false]
+      (let [exception (create-test-exception "Test error message")
+            response (mw.exceptions/api-exception-response exception)]
+        (is (= "test-value" (get-in response [:body :custom-data]))
+            "Response should include custom data from ex-info")))))
+
+(deftest api-exception-response-includes-exception-chain-test
+  (testing "When hide-stacktraces is false, exception response includes exception chain information"
+    (mt/with-temporary-setting-values [server.settings/hide-stacktraces false]
+      (let [exception (create-test-exception "Test error message")
+            response (mw.exceptions/api-exception-response exception)]
+        (is (contains? (:body response) :via)
+            "Response should contain :via key with exception chain")))))
+
+(deftest api-exception-response-hides-stacktraces-returns-generic-message-test
+  (testing "When hide-stacktraces is true, exception response contains only a generic message"
+    (mt/with-temporary-setting-values [server.settings/hide-stacktraces true]
+      (let [exception (create-test-exception "Test error message with sensitive info")
+            response (mw.exceptions/api-exception-response exception)]
+        (is (= 500 (:status response)))
+        (is (= "Something went wrong" (get-in response [:body :message]))
+            "Should return generic message instead of actual exception message")))))
+
+(deftest api-exception-response-hides-stacktraces-omits-trace-test
+  (testing "When hide-stacktraces is true, exception response does not include stacktrace"
+    (mt/with-temporary-setting-values [server.settings/hide-stacktraces true]
+      (let [exception (create-test-exception "Test error message with sensitive info")
+            response (mw.exceptions/api-exception-response exception)]
+        (is (not (contains? (:body response) :trace))
+            "Response should not contain :trace key")))))
+
+(deftest api-exception-response-hides-stacktraces-omits-ex-data-test
+  (testing "When hide-stacktraces is true, exception response does not include ex-data"
+    (mt/with-temporary-setting-values [server.settings/hide-stacktraces true]
+      (let [exception (create-test-exception "Test error message with sensitive info")
+            response (mw.exceptions/api-exception-response exception)]
+        (is (not (contains? (:body response) :custom-data))
+            "Response should not include custom data from ex-info")))))
+
+(deftest api-exception-response-hides-stacktraces-omits-exception-chain-test
+  (testing "When hide-stacktraces is true, exception response does not include exception chain"
+    (mt/with-temporary-setting-values [server.settings/hide-stacktraces true]
+      (let [exception (create-test-exception "Test error message with sensitive info")
+            response (mw.exceptions/api-exception-response exception)]
+        (is (not (contains? (:body response) :via))
+            "Response should not contain :via key")))))
+
+(deftest api-exception-response-hides-stacktraces-omits-original-message-test
+  (testing "When hide-stacktraces is true, exception response does not reveal the original message"
+    (mt/with-temporary-setting-values [server.settings/hide-stacktraces true]
+      (let [exception (create-test-exception "Test error message with sensitive info")
+            response (mw.exceptions/api-exception-response exception)]
+        (is (not (str/includes? (str (:body response)) "sensitive info"))
+            "Response should not contain any part of the original error message")))))
+
+(deftest api-exception-response-hides-stacktraces-minimal-body-test
+  (testing "When hide-stacktraces is true, exception response body is minimal"
+    (mt/with-temporary-setting-values [server.settings/hide-stacktraces true]
+      (let [exception (create-test-exception "Test error message with sensitive info")
+            response (mw.exceptions/api-exception-response exception)]
+        (is (= {:message "Something went wrong"} (:body response))
+            "Response body should only contain the generic message")))))
+
+(deftest api-exception-response-404-without-extra-data-test
+  (testing "404 errors with status-code and no extra data return plain message"
+    (mt/with-temporary-setting-values [server.settings/hide-stacktraces false]
+      (let [exception (ex-info "Resource not found" {:status-code 404})
+            response (mw.exceptions/api-exception-response exception)]
+        (is (= 404 (:status response)))
+        (is (= "Resource not found" (:body response))
+            "Should return plain message for 404s")))))
+
+(deftest api-exception-response-404-with-extra-data-hides-details-test
+  (testing "404 errors with extra data hide details when hide-stacktraces is enabled"
+    (mt/with-temporary-setting-values [server.settings/hide-stacktraces true]
+      (let [exception (ex-info "Resource not found with details" {:status-code 404 :resource-id 123})
+            response (mw.exceptions/api-exception-response exception)]
+        (is (= 404 (:status response))
+            "Status should remain 404 from exception")
+        (is (= "Something went wrong" (get-in response [:body :message]))
+            "Should return generic message")
+        (is (not (contains? (:body response) :resource-id))
+            "Should not include resource-id from ex-data")))))
+
+(deftest api-exception-response-validation-errors-with-stacktraces-disabled-test
+  (testing "Validation errors with :errors key are returned when hide-stacktraces is false"
+    (mt/with-temporary-setting-values [server.settings/hide-stacktraces false]
+      (let [exception (ex-info "Validation failed"
+                               {:status-code 400
+                                :errors {:email "Invalid email format"
+                                         :password "Password too short"}})
+            response (mw.exceptions/api-exception-response exception)]
+        (is (= 400 (:status response)))
+        (is (= {:email "Invalid email format"
+                :password "Password too short"}
+               (get-in response [:body :errors]))
+            "Should include validation errors")))))
+
+(deftest api-exception-response-validation-errors-with-stacktraces-enabled-test
+  (testing "Validation errors with :errors key are returned even when hide-stacktraces is true"
+    (mt/with-temporary-setting-values [server.settings/hide-stacktraces true]
+      (let [exception (ex-info "Validation failed"
+                               {:status-code 400
+                                :errors {:email "Invalid email format"
+                                         :password "Password too short"}})
+            response (mw.exceptions/api-exception-response exception)]
+        (is (= 400 (:status response)))
+        (is (= {:email "Invalid email format"
+                :password "Password too short"}
+               (get-in response [:body :errors]))
+            "Should still include validation errors even with hide-stacktraces enabled")))))
+
+(deftest catch-api-exceptions-middleware-with-stacktraces-disabled-test
+  (testing "catch-api-exceptions middleware with hide-stacktraces disabled returns full error details"
+    (let [test-exception (create-test-exception "Middleware test error")
+          handler (mw.exceptions/catch-api-exceptions
+                   (fn [_request _respond raise]
+                     (raise test-exception)))]
+      (mt/with-temporary-setting-values [server.settings/hide-stacktraces false]
+        (let [captured-response (atom nil)]
+          (handler
+           {:uri "/api/test"}
+           (fn [response] (reset! captured-response response))
+           (fn [_e] (is false "Should not call raise")))
+          (is (= 500 (:status @captured-response)))
+          (is (contains? (:body @captured-response) :trace)
+              "Response should include stacktrace"))))))
+
+(deftest catch-api-exceptions-middleware-with-stacktraces-enabled-test
+  (testing "catch-api-exceptions middleware with hide-stacktraces enabled returns only generic message"
+    (let [test-exception (create-test-exception "Middleware test error")
+          handler (mw.exceptions/catch-api-exceptions
+                   (fn [_request _respond raise]
+                     (raise test-exception)))]
+      (mt/with-temporary-setting-values [server.settings/hide-stacktraces true]
+        (let [captured-response (atom nil)]
+          (handler
+           {:uri "/api/test"}
+           (fn [response] (reset! captured-response response))
+           (fn [_e] (is false "Should not call raise")))
+          (is (= 500 (:status @captured-response)))
+          (is (= "Something went wrong" (get-in @captured-response [:body :message]))
+              "Response should only include generic message")
+          (is (not (contains? (:body @captured-response) :trace))
+              "Response should not include stacktrace"))))))
+
+(deftest catch-uncaught-exceptions-middleware-test
+  (testing "catch-uncaught-exceptions middleware routes exceptions to raise handler"
+    (let [test-exception (create-test-exception "Uncaught exception test")
+          handler (mw.exceptions/catch-uncaught-exceptions
+                   (fn [_request _respond _raise]
+                     (throw test-exception)))
+          captured-exception (atom nil)]
+      (handler
+       {:uri "/api/test"}
+       (fn [_response] (is false "Should not call respond"))
+       (fn [e] (reset! captured-exception e)))
+      (is (= test-exception @captured-exception)
+          "Exception should be routed to raise handler"))))

--- a/test/metabase/server/streaming_response_test.clj
+++ b/test/metabase/server/streaming_response_test.clj
@@ -10,7 +10,8 @@
    [metabase.server.streaming-response.thread-pool :as thread-pool]
    [metabase.test :as mt]
    [metabase.test.http-client :as client]
-   [metabase.util :as u])
+   [metabase.util :as u]
+   [metabase.util.json :as json])
   (:import
    (jakarta.servlet AsyncContext ServletOutputStream)
    (jakarta.servlet.http HttpServletResponse)
@@ -175,3 +176,63 @@
              (deref complete-promise 1000 ::timed-out)))
         (is (= "2 cans"
                (String. (.toByteArray os) "UTF-8")))))))
+
+(deftest write-error-includes-stacktrace-when-hide-stacktraces-disabled-test
+  (testing "write-error! includes stacktrace and exception chain when hide-stacktraces is false"
+    (mt/with-temporary-setting-values [hide-stacktraces false]
+      (with-open [os (java.io.ByteArrayOutputStream.)]
+        (let [exception (ex-info "Test error message" {:custom-data "test-value"})]
+          (#'streaming-response/write-error! os exception :api)
+          (let [error-response (json/decode (String. (.toByteArray os) "UTF-8") true)]
+            (is (= "Test error message" (:cause error-response))
+                "Response includes the error message")
+            (is (contains? error-response :trace)
+                "Response should contain :trace key")
+            (is (vector? (:trace error-response))
+                "Stacktrace should be a vector")
+            (is (contains? error-response :via)
+                "Response should contain :via key")
+            (is (= "test-value" (get-in error-response [:data :custom-data]))
+                "Response should include custom data from ex-info")))))))
+
+(deftest write-error-omits-stacktrace-when-hide-stacktraces-enabled-test
+  (testing "write-error! omits stacktrace and exception chain when hide-stacktraces is true"
+    (mt/with-temporary-setting-values [hide-stacktraces true]
+      (with-open [os (java.io.ByteArrayOutputStream.)]
+        (let [exception (ex-info "Test error message with sensitive info" {:custom-data "test-value"})]
+          (#'streaming-response/write-error! os exception :api)
+          (let [error-response (json/decode (String. (.toByteArray os) "UTF-8") true)]
+            (is (= "Test error message with sensitive info" (:cause error-response))
+                "Response includes the error message")
+            (is (not (contains? error-response :trace))
+                "Response should not contain :trace key")
+            (is (not (contains? error-response :via))
+                "Response should not contain :via key")
+            (is (= "test-value" (get-in error-response [:data :custom-data]))
+                "Response should include custom data from ex-info")
+            (is (contains? error-response :_status)
+                "Response should include :_status")))))))
+
+(deftest write-error-nested-exception-with-stacktraces-disabled-test
+  (testing "write-error! includes nested exception details when hide-stacktraces is false"
+    (mt/with-temporary-setting-values [hide-stacktraces false]
+      (with-open [os (java.io.ByteArrayOutputStream.)]
+        (let [inner-exception (ex-info "Inner error" {:inner-data "secret"})
+              outer-exception (ex-info "Outer error" {:outer-data "visible"} inner-exception)]
+          (#'streaming-response/write-error! os outer-exception :api)
+          (let [error-response (json/decode (String. (.toByteArray os) "UTF-8") true)]
+            (is (contains? error-response :via)
+                "Response should contain :via key")
+            (is (> (count (:via error-response)) 1)
+                "Exception chain should include multiple exceptions")))))))
+
+(deftest write-error-nested-exception-with-stacktraces-enabled-test
+  (testing "write-error! omits nested exception details when hide-stacktraces is true"
+    (mt/with-temporary-setting-values [hide-stacktraces true]
+      (with-open [os (java.io.ByteArrayOutputStream.)]
+        (let [inner-exception (ex-info "Inner error" {:inner-data "secret"})
+              outer-exception (ex-info "Outer error" {:outer-data "visible"} inner-exception)]
+          (#'streaming-response/write-error! os outer-exception :api)
+          (let [error-response (json/decode (String. (.toByteArray os) "UTF-8") true)]
+            (is (not (contains? error-response :via))
+                "Response should not contain :via key with nested exception information")))))))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #23083
### Description

Allows administrators to configure their metabase instance using MB_HIDE_STACKTRACES to prevent stacktraces from appearing in API response. For standard responses it replaces unhandled exceptions with a generic message and 500 response. For streaming responses it leaves the error message and strips out the trace/via keys to prevent exception info from leaking.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
