### PR TITLE
fix falsey check when removing card embed from document

### DIFF
--- a/e2e/test/scenarios/documents/card-embed-node.cy.spec.ts
+++ b/e2e/test/scenarios/documents/card-embed-node.cy.spec.ts
@@ -430,6 +430,19 @@ describe("documents card embed node custom logic", () => {
   });
 
   describe("deleting a cardEmbed", () => {
+    it("should allow you to remove a card if it is the first item in a docuemnt (UXW-2169)", () => {
+      cy.visit("/document/new");
+
+      H.documentContent().click();
+      H.addToDocument("/ord", false);
+      H.commandSuggestionItem(/Orders, Count$/).click();
+
+      H.openDocumentCardMenu("Orders, Count");
+      H.popover().findByText("Remove Chart").click();
+
+      cy.findAllByTestId("document-card-embed").should("have.length", 0);
+    });
+
     it("should delete a cardEmbed when selected and Backspace is pressed", () => {
       H.createDocument({
         name: "DnD Test Document",

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/utils.ts
@@ -134,7 +134,7 @@ export const findNodeParentAndPos = (
     }
   });
 
-  if (parentPos && parent) {
+  if (parentPos !== null && parent !== null) {
     return { parentPos, parent };
   }
 


### PR DESCRIPTION
### Description
Fixes a check we have in document utils that ensure that a parent position was truthy before returning values. However, position 0 is a valid poisiton, and should be returned. Changed the check to `parentPos !== null`

### How to verify
1. Start a new document, and add a chart as the first item in the document
2. Open the menu, and click "Remove Chart"
3. Chart should be removed without an empty card embed hanging out

### Demo

https://github.com/user-attachments/assets/4fe17ee1-dfd3-4f7a-9255-f8fc8cc1f864

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
