### PR TITLE
Metabot glossary integration

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
@@ -463,7 +463,8 @@
                          [:id :int]
                          [:type [:= :user]]
                          [:name :string]
-                         [:email_address :string]]]]
+                         [:email_address :string]
+                         [:glossary [:maybe [:map-of :string :string]]]]]]
    [:map [:output :string]]])
 (mr/def ::get-dashboard-details-result
   [:or

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
@@ -493,17 +493,19 @@
 
 (deftest ^:parallel get-current-user-test
   (mt/with-premium-features #{:metabot-v3}
-    (let [conversation-id (str (random-uuid))
-          ai-token (ai-session-token)
-          response (mt/user-http-request :rasta :post 200 "ee/metabot-tools/get-current-user"
-                                         {:request-options {:headers {"x-metabase-session" ai-token}}}
-                                         {:conversation_id conversation-id})]
-      (is (=? {:structured_output {:id (mt/user->id :rasta)
-                                   :type "user"
-                                   :name "Rasta Toucan"
-                                   :email_address "rasta@metabase.com"}
-               :conversation_id conversation-id}
-              response)))))
+    (mt/with-temp [:model/Glossary _ {:term "asdf" :definition "Sales Team Performance"}]
+      (let [conversation-id (str (random-uuid))
+            ai-token (ai-session-token)
+            response (mt/user-http-request :rasta :post 200 "ee/metabot-tools/get-current-user"
+                                           {:request-options {:headers {"x-metabase-session" ai-token}}}
+                                           {:conversation_id conversation-id})]
+        (is (=? {:structured_output {:id (mt/user->id :rasta)
+                                     :type "user"
+                                     :name "Rasta Toucan"
+                                     :email_address "rasta@metabase.com"
+                                     :glossary {(keyword "asdf") "Sales Team Performance"}}
+                 :conversation_id conversation-id}
+                response))))))
 
 (deftest get-dashboard-details-test
   (mt/with-premium-features #{:metabot-v3}


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/BOT-486/integrate-metabot-with-glossary

This PR adjusts `metabase-enterprise.metabot-v3.dummy-tools/get-current-user` so glossary is returned as part of `/api/ee/metabot-tools/get-current-user` responses.

Glossary size is anticipated as not greater than 10s of items.