### PR TITLE
Fix: UXW-2171 Prevents "Edit Query" from clearing name on chart

### DIFF
--- a/e2e/test/scenarios/documents/documents.cy.spec.ts
+++ b/e2e/test/scenarios/documents/documents.cy.spec.ts
@@ -706,6 +706,31 @@ H.describeWithSnowplowEE("documents", () => {
         H.getDocumentCard("Orders").should("exist");
       });
 
+      it("should support renaming cards", () => {
+        cy.log("Add card");
+        H.documentContent().click();
+        H.addToDocument("/", false);
+        H.commandSuggestionItem("Chart").click();
+        H.commandSuggestionDialog()
+          .findByText(PRODUCTS_COUNT_BY_CATEGORY_PIE.name)
+          .click();
+
+        cy.log("Rename card");
+        cy.findByTestId("card-embed-title").realHover();
+        cy.icon("pencil").click();
+        cy.realType("New name{enter}");
+
+        cy.log("Edit query");
+        H.openDocumentCardMenu("New name");
+        H.popover().findByText("Edit Query").click();
+        H.removeSummaryGroupingField({ field: "Category" });
+        H.addSummaryGroupingField({ field: "Price" });
+        H.modal().findByRole("button", { name: "Save and use" }).click();
+
+        cy.log("Assert new name is preserved");
+        H.getDocumentCard("New name").should("exist");
+      });
+
       it("should support resizing cards", () => {
         H.documentContent().click();
         H.addToDocument("/", false);

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedNode.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedNode.tsx
@@ -884,7 +884,6 @@ export const CardEmbedComponent = memo(
                 onSave={(result) => {
                   updateAttributes({
                     id: result.card_id,
-                    name: null,
                   });
                   setIsModifyModalOpen(false);
                 }}
@@ -897,7 +896,6 @@ export const CardEmbedComponent = memo(
                 onSave={(result) => {
                   updateAttributes({
                     id: result.card_id,
-                    name: null,
                   });
                   setIsModifyModalOpen(false);
                 }}

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/CardEmbed/ModifyQuestionModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/CardEmbed/ModifyQuestionModal.tsx
@@ -22,7 +22,7 @@ interface ModifyQuestionModalProps {
   card: Card;
   isOpen: boolean;
   onClose: () => void;
-  onSave: (result: { card_id: number; name: string }) => void;
+  onSave: (result: { card_id: number }) => void;
 }
 
 export const ModifyQuestionModal = ({
@@ -110,7 +110,7 @@ export const ModifyQuestionModal = ({
         }),
       );
 
-      onSave({ card_id: newCardId, name: card.name });
+      onSave({ card_id: newCardId });
       onClose();
     } catch (error) {
       console.error("Failed to save modified question:", error);

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/CardEmbed/NativeQueryModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/CardEmbed/NativeQueryModal.tsx
@@ -33,7 +33,7 @@ interface NativeQueryModalProps {
   card: Card;
   isOpen: boolean;
   onClose: () => void;
-  onSave: (result: { card_id: number; name: string }) => void;
+  onSave: (result: { card_id: number }) => void;
   initialDataset?: Dataset;
 }
 
@@ -231,7 +231,7 @@ export const NativeQueryModal = ({
       }),
     );
 
-    onSave({ card_id: newCardId, name: card.name });
+    onSave({ card_id: newCardId });
     onClose();
   }, [modifiedQuestion, card, dispatch, onSave, onClose]);
 


### PR DESCRIPTION
Closes UXW-2171

### Description

Removes the code that reset a card's title when its query is edited. I'm guessing it made sense at one time, but I can't think of a scenario where we'd want that to happen anymore.

### How to verify

See UXW-2171 for repro steps.

### Demo

https://github.com/user-attachments/assets/06595359-bb67-4abc-926a-7a4afa4a2420

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
