### PR TITLE
Return false from have-select-privilege? if table does not exist

### DIFF
--- a/modules/drivers/starburst/src/metabase/driver/starburst.clj
+++ b/modules/drivers/starburst/src/metabase/driver/starburst.clj
@@ -454,12 +454,10 @@
       ;; but we can't check the type directly since the relevant io.trino.spi.* classes are not
       ;; included in trino-jdbc. We check the vendor-specific error code instead.
       ;; See HiveMetadata.java and UnknownTableTypeException.java in trinodb/trino
-      (if (= 133001 (.getErrorCode e))
-        (do
-          (log/debugf e "Table %s.%s is not accessible through this catalog (mixed catalog table type)"
-                      table-schema table-name)
-          false)
-        (throw e)))))
+      (when (= 133001 (.getErrorCode e))
+        (log/debugf e "Table %s.%s is not accessible through this catalog (mixed catalog table type)"
+                    table-schema table-name))
+      false)))
 
 (defn- describe-schema
   "Gets a set of maps for all tables in the given `catalog` and `schema`."

--- a/src/metabase/sync/fetch_metadata.clj
+++ b/src/metabase/sync/fetch_metadata.clj
@@ -19,7 +19,7 @@
   `(try
      ~@body
      (catch Throwable e#
-       (log/errorf e# "Error while fetching metdata with '%s'" ~function-name)
+       (log/errorf e# "Error while fetching metadata with '%s'" ~function-name)
        (throw e#))))
 
 (mu/defn db-metadata :- i/DatabaseMetadata


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/64643

### Description

Returns false instead of throwing when checking table permissions if the table does not exist. 

### How to verify

Not exactly sure how to recreate the original issue (how did SHOW TABLES return tables that don't exist?, unless there's some sort of race condition). The test verifies behaviour in the case where we do find ourselves in this situation. 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
