### PR TITLE
update document title compare to determine dirty state

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentPage.tsx
@@ -198,7 +198,10 @@ export const DocumentPage = ({
   const hasUnsavedChanges = useCallback(() => {
     const currentTitle = documentTitle.trim();
     const originalTitle = documentData?.name || "";
-    const titleChanged = currentTitle !== originalTitle;
+    // We call .trim() on documentTitle to ensure that no one can push the save button
+    // with a document name that is all whitespace, the API will reject it. However,
+    // when comparing saved with current titles, we need to use unmofidied values
+    const titleChanged = documentTitle !== originalTitle;
 
     // Check if there are any draft cards
     const hasDraftCards = Object.keys(draftCards).length > 0;

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentPage.unit.spec.tsx
@@ -1,0 +1,66 @@
+import userEvent from "@testing-library/user-event";
+import { Route } from "react-router";
+
+import {
+  setupBookmarksEndpoints,
+  setupCommentEndpoints,
+  setupDocumentEndpoints,
+} from "__support__/server-mocks";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import { createMockDocument } from "metabase-types/api/mocks";
+
+import { DocumentPage } from "./DocumentPage";
+
+const setup = () => {
+  setupBookmarksEndpoints([]);
+  setupDocumentEndpoints(
+    createMockDocument({
+      name: "Ends with whitepsace ",
+      id: 1,
+      can_write: true,
+    }),
+  );
+  setupCommentEndpoints([], { target_type: "document", target_id: 1 });
+
+  renderWithProviders(
+    <>
+      <Route path="/document/:entityId" component={DocumentPage}></Route>
+    </>,
+    {
+      withRouter: true,
+      initialRoute: "/document/1",
+    },
+  );
+};
+
+const getDocumentTitle = async () =>
+  await screen.findByRole("textbox", { name: /document title/i });
+
+describe("Document Page", () => {
+  it("should show a save button when title changes", async () => {
+    setup();
+    await waitFor(async () =>
+      expect(await getDocumentTitle()).toHaveValue("Ends with whitepsace "),
+    );
+
+    await userEvent.clear(await getDocumentTitle());
+    await userEvent.type(await getDocumentTitle(), "New Title");
+
+    expect(
+      await screen.findByRole("button", { name: "Save" }),
+    ).toBeInTheDocument();
+
+    // Change the title back to the old value, the save button should disappear.
+    // I don't love how this test works, but asserting that something doesn't exist
+    // is a very easy way to get false positives in your test. Asserting that something
+    // doesn't exist *anymore* should be more robust
+    await userEvent.clear(await getDocumentTitle());
+    await userEvent.type(await getDocumentTitle(), "Ends with whitepsace ");
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: "Save" }),
+      ).not.toBeInTheDocument(),
+    );
+  });
+});

--- a/frontend/test/__support__/server-mocks/comment.ts
+++ b/frontend/test/__support__/server-mocks/comment.ts
@@ -1,0 +1,14 @@
+import fetchMock from "fetch-mock";
+
+import type { Comment } from "metabase-types/api";
+
+export const setupCommentEndpoints = (
+  comments: Comment[],
+  { target_type, target_id }: { target_type: "document"; target_id: number },
+) => {
+  const url = new URL("api/ee/comment", "http://localhost");
+  url.searchParams.append("target_type", target_type);
+  url.searchParams.append("target_id", target_id.toString());
+
+  fetchMock.get(`path:${url.pathname}${url.search}`, { comments });
+};

--- a/frontend/test/__support__/server-mocks/index.ts
+++ b/frontend/test/__support__/server-mocks/index.ts
@@ -10,6 +10,7 @@ export * from "./bookmark";
 export * from "./bug-report";
 export * from "./card";
 export * from "./collection";
+export * from "./comment";
 export * from "./constants";
 export * from "./dashboard";
 export * from "./database";


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #64412
### Description
Fixes the `hasTitleChanged` check for documents. We call `.trim()` on the title value in the compare function, which also checks that the title has a length > 0. This is a bit of cheekyness that stops the save button from appearing if your title is all whitespace (the API will reject the document), but it means that we use a modified value when comparing against the original to see if there were changes.

### How to verify
1. Create a document and have some whitespace at the end of it's name. Save it
2. Open the document, and hte `save` button should appear when you expect, and navigating away should not always trigger an "are you sure" modal.

### Demo

https://github.com/user-attachments/assets/b8bc8740-160c-4305-950d-e6f7d98cf312


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
