### PR TITLE
fix api docs

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
@@ -602,20 +602,17 @@
                                :with_metric_default_temporal_breakout :with-default-temporal-breakout?})}]])
 
 (mr/def ::table-result
-  [:schema
-   {:registry {::table-result
-               [:map
-                [:id :int]
-                [:type [:enum :model :table]]
-                [:name :string]
-                [:display_name :string]
-                [:database_id :int]
-                [:database_schema {:optional true} [:maybe :string]] ; Schema name, if applicable
-                [:fields ::columns]
-                [:related_tables {:optional true} [:sequential [:ref ::table-result]]]
-                [:description {:optional true} [:maybe :string]]
-                [:metrics {:optional true} [:sequential ::basic-metric]]]}}
-   ::table-result])
+  [:map
+   [:id :int]
+   [:type [:enum :model :table]]
+   [:name :string]
+   [:display_name :string]
+   [:database_id :int]
+   [:database_schema {:optional true} [:maybe :string]] ; Schema name, if applicable
+   [:fields ::columns]
+   [:related_tables {:optional true} [:sequential [:ref ::table-result]]]
+   [:description {:optional true} [:maybe :string]]
+   [:metrics {:optional true} [:sequential ::basic-metric]]])
 
 (mr/def ::get-table-details-result
   [:or


### PR DESCRIPTION
This registry was causing an infinite loop.

The ::table-result schema used :schema with a local :registry, which confused Malli's JSON Schema transformer during OpenAPI generation. The transformer output only a self-reference without the schema body, causing browsers to hang when rendering /api/docs.

This PR removes the unnecessary :schema wrapper - mr/def already registers schemas globally, making the local registry redundant. The recursive [:ref ::table-result] now works correctly.

To verify, build with `yarn dev-ee` and view /api/docs. API docs should load.

That said, I don't know why the table-result originally had a registry. This fix is purely about fixing the API docs, which rely on the malli spec.