### PR TITLE
fix broken text wrapping in tables in documents

### DIFF
--- a/e2e/test/scenarios/documents/card-embed-node.cy.spec.ts
+++ b/e2e/test/scenarios/documents/card-embed-node.cy.spec.ts
@@ -1,3 +1,4 @@
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   DOCUMENT_WITH_THREE_CARDS_AND_COLUMNS,
   DOCUMENT_WITH_TWO_CARDS,
@@ -499,6 +500,45 @@ describe("documents card embed node custom logic", () => {
       H.documentContent()
         .find('[data-type="flexContainer"]')
         .should("have.length", 2);
+    });
+  });
+
+  describe("text wrapping in table cards", () => {
+    it("should support text wrapping with proper row heights", () => {
+      H.createQuestion({
+        name: "reviews",
+        type: "model",
+        query: {
+          "source-table": SAMPLE_DATABASE.REVIEWS_ID,
+        },
+        visualization_settings: {
+          "table.column_widths": [246, 195, 69, 116, 134, 83],
+          column_settings: {
+            '["name","BODY"]': {
+              text_wrapping: true,
+            },
+          },
+        },
+      });
+
+      cy.visit("/document/new");
+
+      H.documentContent().click();
+      H.addToDocument("/reviews", false);
+      H.commandSuggestionItem(/reviews/).click();
+
+      H.getDocumentCard("reviews")
+        .should("be.visible")
+        .findByTestId("table-root")
+        .should("exist");
+
+      H.getDocumentCard("reviews").within(() => {
+        H.tableInteractive()
+          .find("[data-index=0]")
+          .should("exist")
+          .invoke("height")
+          .should("be.greaterThan", 60);
+      });
     });
   });
 

--- a/frontend/src/metabase/data-grid/hooks/use-body-cell-measure.tsx
+++ b/frontend/src/metabase/data-grid/hooks/use-body-cell-measure.tsx
@@ -1,6 +1,8 @@
 import type React from "react";
 import { useCallback, useMemo, useRef } from "react";
+import { createPortal } from "react-dom";
 
+import { getPortalRootElement } from "metabase/css/core/overlays/utils";
 import { BodyCell } from "metabase/data-grid/components/BodyCell/BodyCell";
 import { reactNodeToHtmlString } from "metabase/lib/react-to-html";
 import { EmotionCacheProvider } from "metabase/styled-components/components/EmotionCacheProvider";
@@ -99,11 +101,13 @@ export const useBodyCellMeasure = (theme?: DataGridTheme) => {
   } = useCellMeasure(bodyCellToMeasure, "[data-grid-cell-content]");
 
   const measureRoot = useMemo(
-    () => (
-      <EmotionCacheProvider>
-        <ThemeProvider>{measureBodyCellRoot}</ThemeProvider>
-      </EmotionCacheProvider>
-    ),
+    () =>
+      createPortal(
+        <EmotionCacheProvider>
+          <ThemeProvider>{measureBodyCellRoot}</ThemeProvider>
+        </EmotionCacheProvider>,
+        getPortalRootElement(),
+      ),
     [measureBodyCellRoot],
   );
 

--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedNode.module.css
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedNode.module.css
@@ -33,10 +33,6 @@
   -ms-user-select: none;
 }
 
-.cardEmbed div[data-element-id="data-grid-measure-root"] {
-  display: none;
-}
-
 .questionHeader {
   padding: 0.5rem 1rem;
 }


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #64834
### Description

Text wrapping in documents should be working now. Previously it could not calculate row heights as getBoundingClientRect returns zeroed dimensions for an element with display: none.

<img width="1026" height="624" alt="Screenshot 2025-10-30 at 6 29 12 PM" src="https://github.com/user-attachments/assets/6f4c4730-7463-464c-a5e6-ebb35a92762a" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
