### PR TITLE
Fix model filtering on joined tables enum column

### DIFF
--- a/src/metabase/query_processor/middleware/wrap_value_literals.clj
+++ b/src/metabase/query_processor/middleware/wrap_value_literals.clj
@@ -53,8 +53,9 @@
                                       (:source-metadata %))
                                    (:joins inner-query))
                              (:source-metadata inner-query))
-          [{[_ field-name :as field-ref] :field_ref :as field-metadata}] (filter #(= (:name %) field-name)
-                                                                                 source-metadatas)]
+          [{[_ field-name :as field-ref] :field_ref :as field-metadata}]
+          (filter #(or (= (:lib/desired-column-alias %) field-name) (= (:name %) field-name))
+                  source-metadatas)]
       (-> (if (and field-ref (integer? field-name))
             (type-info field-ref)
             {})


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/64891

### Description

Fixes enum filtering on a joined model by filtering for `:lib/desired-column-alias`

### How to verify

See repro steps in original issue, then see demo.

### Demo

https://www.loom.com/share/29bcacce28cf4c69af43e907c94536d9

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
