### PR TITLE
Fix logs upload for drivers

### DIFF
--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -25,7 +25,7 @@ runs:
       env:
         MB_EDITION: ee
     - name: Test database driver
-      run: timeout -s SIGKILL 3m clojure -X:dev:ci:ee:ee-dev:drivers:drivers-dev:test ${{ inputs.test-args }}
+      run: clojure -X:dev:ci:ee:ee-dev:drivers:drivers-dev:test ${{ inputs.test-args }}
       shell: bash
       id: run-test
       # Trunk Quarantine controls the final state of the run in the CI!

--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -35,7 +35,7 @@ runs:
       continue-on-error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.draft == true) }}
     - name: Publish Test Report (JUnit)
       uses: dorny/test-reporter@v1
-      if: ${{ steps.run-test.outcome == 'failure' }}
+      if: steps.run-test.outcome != 'success'
       with:
         path: "target/junit/**/*_test.xml"
         name: JUnit Test Report ${{ inputs.junit-name }}
@@ -44,7 +44,7 @@ runs:
         list-tests: failed
         fail-on-error: false
     - name: Upload Logs on Failure
-      if: ${{ steps.run-test.outcome == 'failure' }}
+      if: always() && steps.run-test.outcome != 'success'
       uses: actions/upload-artifact@v4
       with:
         name: test-logs-${{ github.job }}

--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -25,7 +25,7 @@ runs:
       env:
         MB_EDITION: ee
     - name: Test database driver
-      run: clojure -X:dev:ci:ee:ee-dev:drivers:drivers-dev:test ${{ inputs.test-args }}
+      run: timeout -s SIGKILL 3m clojure -X:dev:ci:ee:ee-dev:drivers:drivers-dev:test ${{ inputs.test-args }}
       shell: bash
       id: run-test
       # Trunk Quarantine controls the final state of the run in the CI!

--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -35,6 +35,9 @@ runs:
       continue-on-error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.draft == true) }}
     - name: Publish Test Report (JUnit)
       uses: dorny/test-reporter@v1
+      # As per the documentation: https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#steps-context
+      # test.outcome gives us access to the result before `continue-on-error` overrides it and sets it to 'success'.
+      # We want test reports even if the test step gets cancelled (e.g. times out), hence we match anything that is not a 'success'.
       if: steps.run-test.outcome != 'success'
       with:
         path: "target/junit/**/*_test.xml"


### PR DESCRIPTION
Resolves DEV-1039

When we introduced `continue-on-error` to the "test" step, we had to update the conditionals for the test report steps as well. I've introduced a bug by checking for a failure, instead of saying - upload test reports whenever the job is not successful.

Hint: test.outcome means "step status BEFORE continue-on-error overrides the exit code"

## Test

In order to test the fix, I've added a timeout to the step that runs clojure test. The logs were uploaded.

https://github.com/metabase/metabase/actions/runs/18958027001?pr=65257
<img width="2870" height="1434" alt="image" src="https://github.com/user-attachments/assets/a614a3c0-7358-4bd4-b357-8fbe6c2f9404" />

