### PR TITLE
Revert "54 fix: Add e2e case to query analysis execution"

### DIFF
--- a/src/metabase/query_analysis/core.clj
+++ b/src/metabase/query_analysis/core.clj
@@ -76,9 +76,9 @@
   By default, it is async in production for the backfill."
   []
   (case config/run-mode
-    (:prod :e2e) ::queued
-    :dev         *analyze-execution-in-dev?*
-    :test        *analyze-execution-in-test?*))
+    :prod ::queued
+    :dev  *analyze-execution-in-dev?*
+    :test *analyze-execution-in-test?*))
 
 (defn enabled-type?
   "Is analysis of the given query type enabled?"


### PR DESCRIPTION
This reverts commit ecf8abece7c4d44c4e69396ba0873a4ec46d7d89.
We decided not to support the custom "e2e" run mode in branches older than v55, so this change is not really needed here.