### PR TITLE
Remove superfluous python setup from H2 driver test

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -390,10 +390,6 @@ jobs:
     name: H2
     steps:
     - uses: actions/checkout@v4
-    - name: Setup python-runner
-      uses: ./.github/actions/setup-python-runner
-      with:
-        metabase-automation-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
     - name: Test H2 driver
       id: test-driver
       uses: ./.github/actions/test-driver
@@ -413,12 +409,6 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
-    - name: Cleanup python-runner
-      if: always()
-      uses: ./.github/actions/cleanup-python-runner
-      with:
-        upload-logs: ${{ steps.test-driver.outcome == 'failure' }}
-        logs-artifact-suffix: ${{ matrix.job.name }} ${{ matrix.version.name }}
 
   be-tests-mysql-mariadb:
     if: ${{ !inputs.skip }}


### PR DESCRIPTION
Resolves DEV-1041

H2 doesn't seem to be running any python transforms.
Setting up and cleaning up python runner was left there by accident, most likely.

This PR removes the superfluous setup and speeds up the H2 job by 1+ minute(s).

```
Run ./.github/actions/test-driver
  with:
    junit-name: be-tests-h2
    test-args: :only-tags [:mb/driver-tests] :exclude-tags [:mb/transforms-python-test]  <----------
    build-static-viz: false
```