### PR TITLE
Annotate draft transforms in user_is_viewing context with source type when possible

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/context.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/context.clj
@@ -3,6 +3,7 @@
    [clojure.java.io :as io]
    [medley.core :as m]
    [metabase-enterprise.metabot-v3.table-utils :as table-utils]
+   [metabase-enterprise.transforms.models.transform :as transform]
    [metabase.config.core :as config]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
@@ -130,6 +131,24 @@
       (assoc context :user_is_viewing enhanced-viewing))
     context))
 
+(defn- annotate-transform-source-types
+  "Annotate transforms in context with source types if not already present (e.g. for draft transforms not yet saved)"
+  [context]
+  (if-let [user-viewing (get context :user_is_viewing)]
+    (let [annotated-viewing
+          (mapv (fn [item]
+                  (try
+                    (if (and (= (:type item) "transform")
+                             (not (:source_type item)))
+                      (assoc item :source_type (transform/compute-transform-source-type (:source item)))
+                      item)
+                    (catch Exception e
+                      (log/error e "Error annotating transform source type for metabot context")
+                      item)))
+                user-viewing)]
+      (assoc context :user_is_viewing annotated-viewing))
+    context))
+
 (defn- add-backend-capabilities
   "Add backend capabilities to context, merging with any existing capabilities."
   [context]
@@ -151,5 +170,6 @@
     opts    :- [:maybe [:map-of :keyword :any]]]
    (-> context
        enhance-context-with-schema
+       annotate-transform-source-types
        add-backend-capabilities
        (set-user-time opts))))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/context.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/context.clj
@@ -3,7 +3,7 @@
    [clojure.java.io :as io]
    [medley.core :as m]
    [metabase-enterprise.metabot-v3.table-utils :as table-utils]
-   [metabase-enterprise.transforms.models.transform :as transform]
+   [metabase-enterprise.transforms.util :as transforms.util]
    [metabase.config.core :as config]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
@@ -140,7 +140,7 @@
                   (try
                     (if (and (= (:type item) "transform")
                              (not (:source_type item)))
-                      (assoc item :source_type (transform/compute-transform-source-type (:source item)))
+                      (assoc item :source_type (transforms.util/transform-source-type (:source item)))
                       item)
                     (catch Exception e
                       (log/error e "Error annotating transform source type for metabot context")

--- a/enterprise/backend/src/metabase_enterprise/transforms/models/transform.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/models/transform.clj
@@ -4,6 +4,7 @@
    [medley.core :as m]
    [metabase-enterprise.transforms.interface :as transforms.i]
    [metabase-enterprise.transforms.models.transform-run :as transform-run]
+   [metabase-enterprise.transforms.util :as transforms.util]
    [metabase.events.core :as events]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
@@ -46,31 +47,20 @@
    :target      mi/transform-json
    :run_trigger mi/transform-keyword})
 
-(defn compute-transform-source-type
-  "Compute the top-level source_type field for a transform based on its source."
-  [source]
-  (case (keyword (:type source))
-    :python :python
-    :query  (if (lib/native-only-query? (:query source))
-              :native
-              :mbql)
-    (throw (ex-info (str "Unknown transform source type: " (:type source))
-                    {:source source}))))
-
 (t2/define-before-insert :model/Transform
   [{:keys [source] :as transform}]
-  (assoc transform :source_type (compute-transform-source-type source)))
+  (assoc transform :source_type (transforms.util/transform-source-type source)))
 
 (t2/define-before-update :model/Transform
   [{:keys [source] :as transform}]
   (if source
-    (assoc transform :source_type (compute-transform-source-type source))
+    (assoc transform :source_type (transforms.util/transform-source-type source))
     transform))
 
 (t2/define-after-select :model/Transform
   [{:keys [source] :as transform}]
   (if source
-    (assoc transform :source_type (compute-transform-source-type source))
+    (assoc transform :source_type (transforms.util/transform-source-type source))
     transform))
 
 (methodical/defmethod t2/batched-hydrate [:model/TransformRun :transform]

--- a/enterprise/backend/src/metabase_enterprise/transforms/models/transform.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/models/transform.clj
@@ -46,7 +46,7 @@
    :target      mi/transform-json
    :run_trigger mi/transform-keyword})
 
-(defn- compute-transform-source-type
+(defn compute-transform-source-type
   "Compute the top-level source_type field for a transform based on its source."
   [source]
   (case (keyword (:type source))

--- a/enterprise/backend/src/metabase_enterprise/transforms/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/util.clj
@@ -49,7 +49,7 @@
   [transform]
   (when (query-transform? transform)
     (let [query (-> transform :source :query)]
-      (lib.query/native? query))))
+      (lib/native-only-query? query))))
 
 (defn python-transform?
   "Check if this is a Python transform."
@@ -62,7 +62,7 @@
   [source]
   (case (keyword (:type source))
     :python :python
-    :query  (if (lib.query/native? (:query source))
+    :query  (if (lib/native-only-query? (:query source))
               :native
               :mbql)
     (throw (ex-info (str "Unknown transform source type: " (:type source))

--- a/enterprise/backend/src/metabase_enterprise/transforms/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/util.clj
@@ -8,6 +8,7 @@
    [metabase-enterprise.transforms.models.transform-run :as transform-run]
    [metabase-enterprise.transforms.settings :as transforms.settings]
    [metabase.driver :as driver]
+   [metabase.lib.core :as lib]
    [metabase.lib.query :as lib.query]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.premium-features.core :as premium-features :refer [defenterprise]]
@@ -61,7 +62,7 @@
   [source]
   (case (keyword (:type source))
     :python :python
-    :query  (if (lib.query/native? (:query source))
+    :query  (if (lib/native-only-query? (:query source))
               :native
               :mbql)
     (throw (ex-info (str "Unknown transform source type: " (:type source))

--- a/enterprise/backend/src/metabase_enterprise/transforms/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/util.clj
@@ -9,7 +9,6 @@
    [metabase-enterprise.transforms.settings :as transforms.settings]
    [metabase.driver :as driver]
    [metabase.lib.core :as lib]
-   [metabase.lib.query :as lib.query]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.premium-features.core :as premium-features :refer [defenterprise]]
    [metabase.query-processor.compile :as qp.compile]

--- a/enterprise/backend/src/metabase_enterprise/transforms/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/util.clj
@@ -55,6 +55,18 @@
   [transform]
   (= :python (-> transform :source :type keyword)))
 
+(defn transform-source-type
+  "Returns the type of a transform's source: :python, :native, or :mbql.
+  Throws if the source type cannot be detected."
+  [source]
+  (case (keyword (:type source))
+    :python :python
+    :query  (if (lib.query/native? (:query source))
+              :native
+              :mbql)
+    (throw (ex-info (str "Unknown transform source type: " (:type source))
+                    {:source source}))))
+
 (defn check-feature-enabled
   "Checking whether we have proper feature flags for using a given transform."
   [transform]

--- a/enterprise/backend/src/metabase_enterprise/transforms/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/util.clj
@@ -62,7 +62,7 @@
   [source]
   (case (keyword (:type source))
     :python :python
-    :query  (if (lib/native-only-query? (:query source))
+    :query  (if (lib.query/native? (:query source))
               :native
               :mbql)
     (throw (ex-info (str "Unknown transform source type: " (:type source))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/context_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/context_test.clj
@@ -5,7 +5,6 @@
    [metabase-enterprise.metabot-v3.context :as context]
    [metabase-enterprise.metabot-v3.table-utils :as table-utils]
    [metabase.lib.core :as lib]
-   [metabase.lib.test-metadata :as meta]
    [metabase.test :as mt]))
 
 (deftest database-tables-for-context-prioritization

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/context_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/context_test.clj
@@ -5,6 +5,7 @@
    [metabase-enterprise.metabot-v3.context :as context]
    [metabase-enterprise.metabot-v3.table-utils :as table-utils]
    [metabase.lib.core :as lib]
+   [metabase.lib.test-metadata :as meta]
    [metabase.test :as mt]))
 
 (deftest database-tables-for-context-prioritization
@@ -196,7 +197,7 @@
   (testing "Annotates draft MBQL transform with source_type :mbql"
     (let [input {:user_is_viewing [{:type "transform"
                                     :source {:type :query
-                                             :query (mt/mbql-query venues)}}]}
+                                             :query (lib/query (mt/metadata-provider) (mt/mbql-query venues))}}]}
           result (#'context/annotate-transform-source-types input)]
       (is (= :mbql (get-in result [:user_is_viewing 0 :source_type]))))))
 

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/context_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/context_test.clj
@@ -3,7 +3,9 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase-enterprise.metabot-v3.context :as context]
-   [metabase-enterprise.metabot-v3.table-utils :as table-utils]))
+   [metabase-enterprise.metabot-v3.table-utils :as table-utils]
+   [metabase.lib.core :as lib]
+   [metabase.test :as mt]))
 
 (deftest database-tables-for-context-prioritization
   (let [used [{:id 1 :name "used1"} {:id 2 :name "used2"}]
@@ -181,3 +183,28 @@
            (count (->> (context/create-context {})
                        :capabilities
                        (filter #(str/starts-with? % "backend:"))))))))
+
+(deftest annotate-transform-source-types-native-transform-test
+  (testing "Annotates draft native transform with source_type :native"
+    (let [input {:user_is_viewing [{:type "transform"
+                                    :source {:type :query
+                                             :query (lib/native-query (mt/metadata-provider) "SELECT * FROM users")}}]}
+          result (#'context/annotate-transform-source-types input)]
+      (is (= :native (get-in result [:user_is_viewing 0 :source_type]))))))
+
+(deftest annotate-transform-source-types-mbql-transform-test
+  (testing "Annotates draft MBQL transform with source_type :mbql"
+    (let [input {:user_is_viewing [{:type "transform"
+                                    :source {:type :query
+                                             :query (mt/mbql-query venues)}}]}
+          result (#'context/annotate-transform-source-types input)]
+      (is (= :mbql (get-in result [:user_is_viewing 0 :source_type]))))))
+
+(deftest annotate-transform-source-types-python-transform-test
+  (testing "Annotates draft Python transform with source_type :python"
+    (let [input {:user_is_viewing [{:type "transform"
+                                    :source {:type :python
+                                             :body "import pandas as pd"
+                                             :source-database (mt/id)}}]}
+          result (#'context/annotate-transform-source-types input)]
+      (is (= :python (get-in result [:user_is_viewing 0 :source_type]))))))

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -20,6 +20,7 @@
    [metabase.collections.models.collection :as collection]
    [metabase.config.core :as config]
    [metabase.content-verification.models.moderation-review :as moderation-review]
+   [metabase.lib.core :as lib]
    [metabase.permissions.core :as perms]
    [metabase.permissions.models.data-permissions.graph :as data-perms.graph]
    [metabase.permissions.test-util :as perms.test-util]
@@ -53,7 +54,12 @@
    (java.util Locale)
    (java.util.concurrent CountDownLatch TimeoutException)
    (org.eclipse.jetty.server Server)
-   (org.quartz CronTrigger JobDetail JobKey Scheduler Trigger)
+   (org.quartz
+    CronTrigger
+    JobDetail
+    JobKey
+    Scheduler
+    Trigger)
    (org.quartz.impl StdSchedulerFactory)))
 
 (set! *warn-on-reflection* true)
@@ -325,10 +331,7 @@
    (fn [_]
      {:name (str "Test Transform " (u/generate-nano-id))
       :source {:type  "query"
-               :query {:database (data/id)
-                       :type     "native"
-                       :native   {:query         "SELECT 1 as num"
-                                  :template-tags {}}}}
+               :query (lib/native-query (data/metadata-provider) "SELECT 1 as num")}
       :target {:type "table"
                :name (str "test_table_" (u/generate-nano-id))}})
 


### PR DESCRIPTION
Fixes https://linear.app/metabase/issue/BOT-494/fix-sql-on-not-yet-saved-transform-fails

In https://github.com/metabase/metabase/pull/64970 I added a `transform.source_type` field which gets auto-detected and set when a transform is saved, and then used in AI service to give Metabot context about the type of a transform. However, an unsaved transform may be sent in the user_is_viewing context which does not have `source_type` set, causing errors. This PR annotates any transforms in the user_is_viewing context with `source_type` if not already set.