### PR TITLE
[v57 backport] Fix logs upload for drivers (#65257)

### DIFF
--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -35,7 +35,10 @@ runs:
       continue-on-error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.draft == true) }}
     - name: Publish Test Report (JUnit)
       uses: dorny/test-reporter@v1
-      if: ${{ steps.run-test.outcome == 'failure' }}
+      # As per the documentation: https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#steps-context
+      # test.outcome gives us access to the result before `continue-on-error` overrides it and sets it to 'success'.
+      # We want test reports even if the test step gets cancelled (e.g. times out), hence we match anything that is not a 'success'.
+      if: steps.run-test.outcome != 'success'
       with:
         path: "target/junit/**/*_test.xml"
         name: JUnit Test Report ${{ inputs.junit-name }}
@@ -44,7 +47,7 @@ runs:
         list-tests: failed
         fail-on-error: false
     - name: Upload Logs on Failure
-      if: ${{ steps.run-test.outcome == 'failure' }}
+      if: always() && steps.run-test.outcome != 'success'
       uses: actions/upload-artifact@v4
       with:
         name: test-logs-${{ github.job }}


### PR DESCRIPTION
Manual backport of [9b53db9](https://github.com/metabase/metabase/commit/9b53db936ecfcdb40524526a2daf92d2d3110b15)

* Fix logs upload for drivers

When we introduced `continue-on-error` to the "test" step, we had to update the conditionals for the test report steps as well. I've introduced a bug by checking for a failure, instead of saying - upload test reports whenever the job is not successful.

Hint: test.outcome means "step status BEFORE continue-on-error overrides the exit code"

