### PR TITLE
Make sure enough info about transforms is selected

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -192,7 +192,9 @@
    :dashboard [:id :name :description :created_at :creator_id :collection_id]
    :document  [:id :name :created_at :creator_id :collection_id]
    :table     [:id :name :description :display_name :db_id :schema]
-   :transform [:id :name :description]
+   :transform [:id :name :description
+               ;; :source has to be selected otherwise the BE won't know what DB it belongs to
+               :source]
    :snippet   [:id :name :description]
    :sandbox   [:id :table_id]})
 


### PR DESCRIPTION
Fixes QUE-2731

### Description

Select source info for transforms for the backend to have enough information to hydrate their tables.

### How to verify

E2E tests should pass.

### Checklist

- [x] Tests are in place to cover changes in this PR
