### PR TITLE
Fix #64685 - Update brand colors in UI without needing refresh

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/ColorCustomizationSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/ColorCustomizationSection.tsx
@@ -4,12 +4,15 @@ import { t } from "ttag";
 import { ColorPillPicker } from "metabase/common/components/ColorPicker";
 import { useSetting } from "metabase/common/hooks";
 import type { MetabaseColors } from "metabase/embedding-sdk/theme";
-import { colors, staticVizOverrides } from "metabase/lib/colors";
+import { originalColors, staticVizOverrides } from "metabase/lib/colors";
 import { ActionIcon, Group, Icon, Stack, Text, Tooltip } from "metabase/ui";
 
 import { getConfigurableThemeColors } from "../utils/theme-colors";
 
-const defaultMetabaseColorsWithoutAlpha = { ...colors, ...staticVizOverrides };
+const defaultMetabaseColorsWithoutAlpha = {
+  ...originalColors,
+  ...staticVizOverrides,
+};
 
 interface ColorCustomizationSectionProps {
   theme?: { colors?: Partial<MetabaseColors> };

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/BrandColorSettings/BrandColorSettings.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/BrandColorSettings/BrandColorSettings.tsx
@@ -1,3 +1,4 @@
+import Color from "color";
 import { memo, useCallback, useMemo } from "react";
 import { t } from "ttag";
 import _ from "underscore";
@@ -113,7 +114,7 @@ const BrandColorRow = memo(function BrandColorRow({
       <TableBodyCell>
         <ColorPicker
           value={color ?? originalColor}
-          placeholder={originalColor}
+          placeholder={Color(originalColor).hex()}
           onChange={handleChange}
         />
       </TableBodyCell>

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ColorSettings/ColorSettings.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ColorSettings/ColorSettings.unit.spec.tsx
@@ -27,7 +27,7 @@ describe("ColorSettings", () => {
       />,
     );
 
-    const input = screen.getByPlaceholderText(color("summarize"));
+    const input = screen.getByPlaceholderText(Color(color("summarize")).hex());
     await userEvent.clear(input);
     await userEvent.type(input, color("error"));
 

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ColorSettingsWidget/ColorSettingsWidget.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ColorSettingsWidget/ColorSettingsWidget.tsx
@@ -3,6 +3,7 @@ import { useDebouncedCallback } from "@mantine/hooks";
 import { SetByEnvVar } from "metabase/admin/settings/components/widgets/AdminSettingInput";
 import { useAdminSetting } from "metabase/api/utils";
 import { originalColors } from "metabase/lib/colors/palette";
+import { useMantineTheme } from "metabase/ui";
 import type { ColorSettings as ColorSettingsType } from "metabase-types/api";
 
 import { ColorSettings } from "../ColorSettings";
@@ -13,12 +14,14 @@ export const ColorSettingsWidget = () => {
     updateSetting,
     settingDetails,
   } = useAdminSetting("application-colors");
+  const theme = useMantineTheme();
 
-  const handleChange = (newValue: ColorSettingsType) => {
-    updateSetting({
+  const handleChange = async (newValue: ColorSettingsType) => {
+    await updateSetting({
       key: "application-colors",
       value: newValue,
     });
+    theme.other?.updateColorSettings?.(newValue);
   };
 
   const onChangeDebounced = useDebouncedCallback(handleChange, 400);

--- a/frontend/src/metabase/lib/colors/colors.ts
+++ b/frontend/src/metabase/lib/colors/colors.ts
@@ -662,12 +662,11 @@ export const colors = getColors(whitelabelColors);
 export const mutateColors = (settings: ColorSettings) => {
   Object.assign(colorConfig, getColorConfig(settings));
 
-  // Updates or unsets values in global `colors` object
-  const newColors = getColors(settings);
+  // Empty the `colors` object to make sure we don't hold onto previously defined (now undefined) values
   Object.keys(colors).forEach((key) => {
-    const colorName = key as keyof typeof colors;
-    colors[colorName] = newColors[colorName];
+    delete colors[key as keyof typeof colors];
   });
+  Object.assign(colors, getColors(settings));
 };
 
 export const staticVizOverrides = {

--- a/frontend/src/metabase/lib/colors/colors.ts
+++ b/frontend/src/metabase/lib/colors/colors.ts
@@ -6,6 +6,8 @@
 // frontend/src/metabase/styled-components/theme/css-variables.ts
 // NOTE: this file is used in the embedding SDK, so it should not contain anything else except the `colors` constant.
 
+import type { ColorSettings } from "metabase-types/api/settings";
+
 const win = typeof window !== "undefined" ? window : ({} as Window);
 const tokenFeatures = win.MetabaseBootstrap?.["token-features"] ?? {};
 const shouldWhitelabel = !!tokenFeatures["whitelabel"];
@@ -238,7 +240,7 @@ const baseColors = {
   },
 };
 
-export const colorConfig = {
+const getColorConfig = (settings: ColorSettings = {}) => ({
   "accent-gray-dark": {
     light: baseColors.orion[20],
     dark: baseColors.orion[110],
@@ -367,8 +369,8 @@ export const colorConfig = {
     dark: baseColors.brand[90],
   },
   brand: {
-    light: whitelabelColors.brand || baseColors.blue[40],
-    dark: whitelabelColors.brand || baseColors.blue[40],
+    light: settings.brand || baseColors.blue[40],
+    dark: settings.brand || baseColors.blue[40],
   },
   danger: {
     light: baseColors.lobster[50],
@@ -379,8 +381,8 @@ export const colorConfig = {
     dark: baseColors.lobster[50],
   },
   filter: {
-    light: whitelabelColors.filter || baseColors.octopus[50],
-    dark: whitelabelColors.filter || baseColors.octopus[40],
+    light: settings.filter || baseColors.octopus[50],
+    dark: settings.filter || baseColors.octopus[40],
   },
   focus: {
     light: baseColors.blue[20],
@@ -446,8 +448,8 @@ export const colorConfig = {
     dark: baseColors.palm[50],
   },
   summarize: {
-    light: whitelabelColors.summarize || baseColors.palm[50],
-    dark: whitelabelColors.summarize || baseColors.palm[40],
+    light: settings.summarize || baseColors.palm[50],
+    dark: settings.summarize || baseColors.palm[40],
   },
   "switch-off": {
     light: baseColors.orionAlpha[20],
@@ -643,13 +645,29 @@ export const colorConfig = {
     light: baseColors.orionAlpha[10],
     dark: baseColors.orionAlphaInverse[10],
   },
-};
+});
 
-export const colors: Record<keyof typeof colorConfig, string> = {
-  ...Object.fromEntries(
-    Object.entries(colorConfig).map(([k, v]) => [k, v.light]),
-  ),
-  ...whitelabelColors,
+export const colorConfig = getColorConfig(whitelabelColors);
+
+export const getColors = (settings?: ColorSettings) =>
+  ({
+    ...Object.fromEntries(
+      Object.entries(getColorConfig(settings)).map(([k, v]) => [k, v.light]),
+    ),
+    ...settings,
+  }) as Record<keyof typeof colorConfig, string>;
+
+export const colors = getColors(whitelabelColors);
+
+export const mutateColors = (settings: ColorSettings) => {
+  Object.assign(colorConfig, getColorConfig(settings));
+
+  // Updates or unsets values in global `colors` object
+  const newColors = getColors(settings);
+  Object.keys(colors).forEach((key) => {
+    const colorName = key as keyof typeof colors;
+    colors[colorName] = newColors[colorName];
+  });
 };
 
 export const staticVizOverrides = {

--- a/frontend/src/metabase/lib/colors/palette.ts
+++ b/frontend/src/metabase/lib/colors/palette.ts
@@ -2,12 +2,12 @@ import Color from "color";
 
 import type { ColorGetter } from "metabase/visualizations/types";
 
-import { colors } from "./colors";
+import { colors, getColors } from "./colors";
 import type { ColorName, ColorPalette } from "./types";
 
 export const ACCENT_COUNT = 8;
 
-export const originalColors = { ...colors };
+export const originalColors = getColors();
 
 export const aliases: Record<string, (palette: ColorPalette) => string> = {
   dashboard: (palette) => color("brand", palette),

--- a/frontend/src/metabase/ui/components/theme/ThemeProvider/ThemeProvider.tsx
+++ b/frontend/src/metabase/ui/components/theme/ThemeProvider/ThemeProvider.tsx
@@ -13,6 +13,7 @@ import {
 
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { parseHashOptions } from "metabase/lib/browser";
+import { mutateColors } from "metabase/lib/colors/colors";
 import type { DisplayTheme } from "metabase/public/lib/types";
 import { getIsEmbeddingIframe } from "metabase/selectors/embed";
 
@@ -38,6 +39,7 @@ interface ThemeProviderProps {
 
 const ThemeProviderInner = (props: ThemeProviderProps) => {
   const { resolvedColorScheme } = useColorScheme();
+  const [themeCacheBuster, setThemeCacheBuster] = useState(1);
 
   // Merge default theme overrides with user-provided theme overrides
   const theme = useMemo(() => {
@@ -48,6 +50,13 @@ const ThemeProviderInner = (props: ThemeProviderProps) => {
 
     return {
       ...theme,
+      other: {
+        ...theme.other,
+        updateColorSettings: (newValue) => {
+          mutateColors(newValue);
+          setThemeCacheBuster(themeCacheBuster + 1);
+        },
+      },
       fn: {
         themeColor: (
           color: string,
@@ -83,7 +92,7 @@ const ThemeProviderInner = (props: ThemeProviderProps) => {
         },
       },
     } as MantineTheme;
-  }, [props.theme, resolvedColorScheme]);
+  }, [props.theme, resolvedColorScheme, themeCacheBuster]);
 
   const { withCssVariables, withGlobalClasses } =
     useContext(ThemeProviderContext);

--- a/frontend/src/types/mantine.d.ts
+++ b/frontend/src/types/mantine.d.ts
@@ -1,4 +1,5 @@
 import type { EmbeddingThemeOptions } from "metabase/embedding-sdk/theme/private";
+import type { ColorSettings } from "metabase-types/api/settings";
 
 interface _EmotionCompatibilityTheme {
   fn: {
@@ -14,6 +15,7 @@ declare module "@mantine/core" {
    **/
   export interface MantineThemeOther extends EmbeddingThemeOptions {
     colorScheme: "light" | "dark";
+    updateColorSettings: (settings: ColorSettings) => void;
   }
   export interface MantineTheme extends _EmotionCompatibilityTheme {}
 }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/64685
Closes UXW-1991

### Description

When brand colors are changed, the color configs are mutated and the theme is recomputed.

An ideal setup would use something like redux for the brand colors, but that'd be a significant refactor since a lot of our color code works by mutating those global color configs (e.g. `updateColors`, `setGlobalEmbeddingColors`, etc). In lieu of a colossal refactor, this seemed like a low-impact, low-risk way to fix a lot of new and existing issues with the branding color pickers now as opposed to some indefinite time in the future.

### How to verify

See #64685 and demos for repro steps.

### Demo

**BEFORE**

https://github.com/user-attachments/assets/6990c995-d015-424f-adbc-f7754791dd48

**AFTER**

https://github.com/user-attachments/assets/f07b686e-bc64-4333-92bf-31a508f0dc1b

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
