### PR TITLE
Don't count app-db not setup errors in circuit breaker

### DIFF
--- a/src/metabase/premium_features/token_check.clj
+++ b/src/metabase/premium_features/token_check.clj
@@ -287,6 +287,11 @@
         (when *token-check-happening*
           (throw (ex-info "Token check is being called recursively, there is a good chance some `defenterprise` is causing this"
                           {:pass-thru true})))
+        ;; important to not count these errors against the circuit breaker. These are not the types of errors we need
+        ;; to circuit break. (#65294)
+        (when-not ((requiring-resolve 'metabase.app-db.core/db-is-set-up?))
+          (throw (ex-info "Metabase DB is not yet set up"
+                          {:reason :token-check/app-db-not-ready})))
         (locking lock
           (binding [*token-check-happening* true]
             (try (dh/with-circuit-breaker breaker


### PR DESCRIPTION
we want to not hammer the network when things are down. But during startup we don't need to circuit break these errors that we throw before the app-db is read

backport of https://github.com/metabase/metabase/pull/65295
see also https://github.com/metabase/metabase/pull/65300