### PR TITLE
Gracefully shut down queue worker pools

### DIFF
--- a/src/metabase/search/ingestion.clj
+++ b/src/metabase/search/ingestion.clj
@@ -13,14 +13,9 @@
    [metabase.util.performance :as perf]
    [metabase.util.queue :as queue]
    [toucan2.core :as t2]
-   [toucan2.realize :as t2.realize])
-  (:import
-   (java.util.concurrent DelayQueue)))
+   [toucan2.realize :as t2.realize]))
 
 (set! *warn-on-reflection* true)
-
-;; Currently we use a single queue, even if multiple engines are enabled, but may want to revisit this.
-(defonce ^:private ^DelayQueue queue (queue/delay-queue))
 
 ;; Perhaps this config move up somewhere more visible? Conversely, we may want to specialize it per engine.
 
@@ -288,18 +283,34 @@
       (update! documents to-delete))
     {}))
 
-(defn- track-queue-size! []
-  (analytics/set! :metabase-search/queue-size (.size queue)))
+(defn- track-queue-size! [queue]
+  (analytics/set! :metabase-search/queue-size (queue/queue-size queue)))
 
-(defn- index-worker-exists? []
-  (queue/listener-exists? listener-name))
+;; Currently we use a single queue, even if multiple engines are enabled, but may want to revisit this.
+(defonce ^:private queue
+  (queue/create-delay-queue-listener
+   listener-name
+   bulk-ingest!
+   {:success-handler (fn [ql _result _duration _]
+                       (track-queue-size! queue))
+    :error-handler (fn [queue err _]
+                     (log/error err "Error indexing search entries")
+                     (analytics/inc! :metabase-search/index-error)
+                     (track-queue-size! queue))
+    ;; Note that each message can correspond to multiple documents,
+    ;; for example there would be 1 message for updating all
+    ;; the tables within a given database when it is renamed.
+    ;; Messages can also correspond to zero documents,
+    ;; such as when updating a table that is marked as not visible.
+    :max-batch-messages 50
+    :max-next-ms       100}))
 
 (defn ingest-maybe-async!
   "Update or create any search index entries related to the given updates.
   Will be async if the worker exists, otherwise it will be done synchronously on the calling thread.
   Can also be forced to run synchronously for testing."
   ([updates]
-   (ingest-maybe-async! updates (or *force-sync* (not (index-worker-exists?)))))
+   (ingest-maybe-async! updates *force-sync*))
   ([updates sync?]
    (when-not *disable-updates*
      (if sync?
@@ -308,24 +319,5 @@
          (doseq [update updates]
            (log/trace "Queuing update" update)
            (queue/put-with-delay! queue message-delay-ms update))
-         (track-queue-size!)
+         (track-queue-size! queue)
          true)))))
-
-(defn start-listener!
-  "Starts the ingestion listener on the queue"
-  []
-  (when (seq (search.engine/active-engines))
-    (queue/listen! listener-name queue bulk-ingest!
-                   {:success-handler     (fn [_result _duration _]
-                                           (track-queue-size!))
-                    :err-handler        (fn [err _]
-                                          (log/error err "Error indexing search entries")
-                                          (analytics/inc! :metabase-search/index-error)
-                                          (track-queue-size!))
-                    ;; Note that each message can correspond to multiple documents,
-                    ;; for example there would be 1 message for updating all
-                    ;; the tables within a given database when it is renamed.
-                    ;; Messages can also correspond to zero documents,
-                    ;; such as when updating a table that is marked as not visible.
-                    :max-batch-messages 50
-                    :max-next-ms       100})))

--- a/src/metabase/search/task/search_index.clj
+++ b/src/metabase/search/task/search_index.clj
@@ -60,9 +60,6 @@
                        (simple/repeat-forever))))]
     (task/schedule-task! job trigger)))
 
-(defmethod queue/init-listener! ::SearchIndexUpdate [_]
-  (ingestion/start-listener!))
-
 (comment
   (task/job-exists? reindex-job-key)
   (task/trigger-now! reindex-job-key))

--- a/src/metabase/util/queue.clj
+++ b/src/metabase/util/queue.clj
@@ -237,9 +237,7 @@
     (if (listener-exists? listener-name)
       (do
         (log/warn "Listener exists")
-        (stop-listening! listener-name)
-        (swap! listeners dissoc listener-name)
-        (create-queue-listener args))
+        (get @listeners listener-name))
       (let [inner-ql (map->QueueListener {:queue queue
                                           :pool-size pool-size
                                           :state (atom {:status ::initialized})

--- a/src/metabase/util/queue/protocols.clj
+++ b/src/metabase/util/queue/protocols.clj
@@ -1,0 +1,15 @@
+(ns metabase.util.queue.protocols)
+
+(defprotocol IQueueListener
+  (-start [this])
+  (-stop [this])
+  (-stop! [this])
+  (-closed? [this])
+  (-await-termination [this timeout-ms])
+  (queue-size [this]))
+
+(defprotocol IQueuePutter
+  (put! [this item]))
+
+(defprotocol IDelayQueuePutter
+  (put-with-delay! [this delay-ms item]))


### PR DESCRIPTION
There were a couple issues with the existing implementation of queues in `metabase.util.pool`.

- It immediately launched a future per thread in the pool, that would block and wait for more batches. This is slightly inefficient, because if we have 10 threads listening for batches, and 100 items are publishes simultaneously to the queue, it's probably better to have one thread handle all the items in one batch than for each thread to pick up a subset.

- More problematically, because all threads were constantly running, there was no way to gracefully shut down the threadpool. `(cp/shutdown)` shuts down the pool once running threads have finished, but in our implementation, *all* the threads ran indefinitely, so we needed to immediately use `(cp/shutdown!)`.

I've replaced this with a slightly different model:

- regardless of pool size, we start a single "dispatcher" thread. This loops indefinitely looking for batches. Upon filling a batch, it dispatches it to the executor pool to actually be processed. This way, the threads in the executor pool can run momentarily, then exit.

- the "dispatcher" thread is aware of the state of the listener. When we're shutting down, the dispatcher handles all remaining items in the queue before exiting.

- this way, we can shut down the entire system gracefully:
  - we mark the queue as closed, preventing further work from being added
  - then, we wait for the queue to be emptied by the dispatcher thread
  - once the dispatcher thread has exited, we can gracefully shut down the worker pool, because no additional work can be added *there*

I also did a bit of work to clean up the API for `metabase.util.queue`. Before, you needed to do two things: create a queue, and then create an `init-handler` that actually started processing from the queue.

Now you can simply create the queue and the queue listener with a single function, and by default it will be registered for you for easy startup.