### PR TITLE
UXW-2170 cleanup chart brush

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
@@ -253,6 +253,13 @@ export const useChartEvents = (
 
           if (eventData) {
             onChangeCardAndRun?.(eventData);
+
+            // clear selected brush area after calling change handler
+            chartRef.current?.dispatchAction({
+              type: "brush",
+              command: "clear",
+              areas: [],
+            });
           }
         },
       },


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-2170/dragging-on-a-chart-does-not-reset-if-we-decline-navigation

### Description

This cleans selected chart area after brush. We don't need to preserve it after brush ended as we either automatically navigate to updated chart, or display a confirmation modal.

### Demo


https://github.com/user-attachments/assets/015da161-79b2-4622-9d9a-b553552c48b8



### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
