### PR TITLE
test(collections): Add MC/DC coverage for getCrumbs

### DIFF
--- a/frontend/src/metabase/lib/collections.unit.spec.ts
+++ b/frontend/src/metabase/lib/collections.unit.spec.ts
@@ -1,6 +1,13 @@
+import { t } from "ttag"; // Import 't'
+
 import { createMockCollection } from "metabase-types/api/mocks";
 
 import { getCrumbs } from "./collections";
+
+// Mock 'ttag'
+jest.mock("ttag", () => ({
+  t: (strings: TemplateStringsArray) => strings.join(""),
+}));
 
 const collectionsById = {
   root: createMockCollection({ id: "root", name: "Our analytics", path: [] }),
@@ -8,7 +15,9 @@ const collectionsById = {
   2: createMockCollection({ id: 2, name: "child", path: ["root", 1] }),
 };
 
+// O 'describe' começa aqui
 describe("getCrumbs", () => {
+  // Teste existente 1
   it("returns path starting from root", () => {
     const crumbs = getCrumbs(collectionsById[2], collectionsById, jest.fn());
 
@@ -19,6 +28,7 @@ describe("getCrumbs", () => {
     ]);
   });
 
+  // Teste existente 2
   it("makes collection step functions calling the callback with the collection id", () => {
     const callbackMock = jest.fn();
     const crumbs = getCrumbs(collectionsById[2], collectionsById, callbackMock);
@@ -30,5 +40,63 @@ describe("getCrumbs", () => {
     const [_parentName, parentCallback] = crumbs[1];
     (parentCallback as any)();
     expect(callbackMock).toHaveBeenCalledWith(1);
+  });
+
+  // CT2 - D1-L2, D2-V: Coleção sem path, com root
+  it("should return root crumb if collection has no path and root exists", () => {
+    const callbackMock = jest.fn();
+    const collection = createMockCollection({ id: 2, name: "Sub", path: null });
+    const collectionsById = {
+      root: createMockCollection({ id: "root", name: "Raiz", path: [] }),
+    };
+
+    const crumbs = getCrumbs(collection, collectionsById, callbackMock);
+
+    expect(crumbs).toMatchObject([["Raiz", expect.any(Function)], ["Unknown"]]);
+
+    const [_rootName, rootCallback] = crumbs[0];
+    (rootCallback as any)();
+    expect(callbackMock).toHaveBeenCalledWith("root");
+  });
+
+  // CT3 - D1-L2, D2-F: Coleção sem path, sem root
+  it("should return only unknown if no path and no root", () => {
+    const callbackMock = jest.fn();
+    const collection = createMockCollection({ id: 2, name: "Sub", path: null });
+    const collectionsById = {
+      root: null,
+    };
+
+    const crumbs = getCrumbs(collection, collectionsById, callbackMock);
+    expect(crumbs).toEqual([[t`Unknown`]]);
+  });
+
+  // CT4 - D1-L3, D2-V: Coleção nula, com root
+  it("should return root crumb if collection is null and root exists", () => {
+    const callbackMock = jest.fn();
+    const collection = null;
+    const collectionsById = {
+      root: createMockCollection({ id: "root", name: "Raiz", path: [] }),
+    };
+
+    const crumbs = getCrumbs(collection, collectionsById, callbackMock);
+
+    expect(crumbs).toMatchObject([["Raiz", expect.any(Function)], ["Unknown"]]);
+
+    const [_rootName, rootCallback] = crumbs[0];
+    (rootCallback as any)();
+    expect(callbackMock).toHaveBeenCalledWith("root");
+  });
+
+  // CT5 - D1-L3, D2-F: Coleção nula, sem root
+  it("should return only unknown if collection is null and no root", () => {
+    const callbackMock = jest.fn();
+    const collection = null;
+    const collectionsById = {
+      root: null,
+    };
+
+    const crumbs = getCrumbs(collection, collectionsById, callbackMock);
+    expect(crumbs).toEqual([[t`Unknown`]]);
   });
 });


### PR DESCRIPTION
I added 4 new unit tests for the getCrumbs method in the collections.ts file to ensure 100% MC/DC (Modified Condition/Decision Coverage) coverage.

The existing tests only covered the "happy path", and these new tests validate the else paths (when collection or collection.path are null),
increasing branch coverage to 100%.

(This is an activity for my Software Testing course at the University of Brasília - UnB).

As this is an addition to unit tests, verification can be done in two ways:

Verifying that the test suite (CI) continues to pass successfully.
(Locally) Running the coverage report for the modified file and confirming that it has reached 100%:

1. Run the tests (should show 6 tests passing)
yarn test-unit frontend/src/metabase/lib/collections.unit.spec.ts

2. Generate the coverage report (should show 100% for branches/lines)
yarn test-unit --
coverage frontend/src/metabase/lib/collections.unit.spec.ts

- [x] Tests have been added/updated to cover changes in this PR