### PR TITLE
[kondo] Encourage more m.util.performance functions in perf-sensitive namespaces

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -902,7 +902,9 @@
   performance-sensitive
   {:linters
    {:discouraged-var
-    {clojure.core/every?          {:message "Use metabase.util.performance/every?"}
+    {clojure.core/empty?          {:message "Use metabase.util.performance/empty?"}
+     clojure.core/not-empty       {:message "Use metabase.util.performance/not-empty"}
+     clojure.core/every?          {:message "Use metabase.util.performance/every?"}
      clojure.core/mapv            {:message "Use metabase.util.performance/mapv"}
      clojure.core/run!            {:message "Use metabase.util.performance/run!"}
      clojure.core/select-keys     {:message "Use metabase.util.performance/select-keys"}
@@ -911,7 +913,9 @@
      clojure.walk/keywordize-keys {:message "Use metabase.util.performance/keywordize-keys"}
      clojure.walk/postwalk        {:message "Use metabase.util.performance/postwalk"}
      clojure.walk/prewalk         {:message "Use metabase.util.performance/prewalk"}
-     clojure.walk/walk            {:message "Use metabase.util.performance/walk"}}}}
+     clojure.walk/walk            {:message "Use metabase.util.performance/walk"}
+     clojure.walk/for             {:message "Use metabase.util.performance/for"}
+     clojure.walk/doseq           {:message "Use metabase.util.performance/doseq"}}}}
 
   qp-and-driver-source-namespaces
   {:linters

--- a/modules/drivers/athena/src/metabase/driver/athena.clj
+++ b/modules/drivers/athena/src/metabase/driver/athena.clj
@@ -1,5 +1,5 @@
 (ns metabase.driver.athena
-  (:refer-clojure :exclude [some select-keys mapv])
+  (:refer-clojure :exclude [some select-keys mapv empty? not-empty])
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.set :as set]
@@ -19,7 +19,7 @@
    [metabase.util.date-2 :as u.date]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.log :as log]
-   [metabase.util.performance :refer [some select-keys mapv]])
+   [metabase.util.performance :refer [some select-keys mapv empty? not-empty]])
   (:import
    (java.sql Connection DatabaseMetaData Date ResultSet Time Types)
    (java.time OffsetDateTime ZonedDateTime)

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -1,5 +1,5 @@
 (ns metabase.driver.bigquery-cloud-sdk
-  (:refer-clojure :exclude [mapv some])
+  (:refer-clojure :exclude [mapv some empty? not-empty])
   (:require
    [clojure.core.async :as a]
    [clojure.set :as set]
@@ -24,7 +24,7 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [mapv some]]
+   [metabase.util.performance :refer [mapv some empty? not-empty]]
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2])
   (:import

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
@@ -1,5 +1,5 @@
 (ns metabase.driver.bigquery-cloud-sdk.query-processor
-  (:refer-clojure :exclude [select-keys some])
+  (:refer-clojure :exclude [select-keys some not-empty])
   (:require
    [clojure.string :as str]
    [honey.sql :as sql]
@@ -20,7 +20,7 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [select-keys some]])
+   [metabase.util.performance :refer [select-keys some not-empty]])
   (:import
    (com.google.cloud.bigquery
     Field

--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse_introspection.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse_introspection.clj
@@ -1,4 +1,5 @@
 (ns metabase.driver.clickhouse-introspection
+  (:refer-clojure :exclude [empty?])
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
@@ -8,7 +9,8 @@
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
    [metabase.driver.sql-jdbc.sync.describe-table :as sql-jdbc.describe-table]
-   [metabase.util :as u])
+   [metabase.util :as u]
+   [metabase.util.performance :refer [empty?]])
   (:import
    (java.sql Connection DatabaseMetaData)))
 

--- a/modules/drivers/databricks/src/metabase/driver/databricks.clj
+++ b/modules/drivers/databricks/src/metabase/driver/databricks.clj
@@ -1,4 +1,5 @@
 (ns metabase.driver.databricks
+  (:refer-clojure :exclude [not-empty])
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
@@ -18,6 +19,7 @@
    [metabase.util :as u]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.log :as log]
+   [metabase.util.performance :refer [not-empty]]
    [ring.util.codec :as codec])
   (:import
    [java.sql

--- a/modules/drivers/mongo/src/metabase/driver/mongo.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo.clj
@@ -1,6 +1,6 @@
 (ns metabase.driver.mongo
   "MongoDB Driver."
-  (:refer-clojure :exclude [some mapv])
+  (:refer-clojure :exclude [some mapv empty?])
   (:require
    [clojure.set :as set]
    [clojure.string :as str]
@@ -21,7 +21,7 @@
    [metabase.util.date-2 :as u.date]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
-   [metabase.util.performance :refer [some mapv]]
+   [metabase.util.performance :refer [some mapv empty?]]
    [taoensso.nippy :as nippy])
   (:import
    (com.mongodb.client MongoClient MongoDatabase)

--- a/modules/drivers/mongo/src/metabase/driver/mongo/connection.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/connection.clj
@@ -1,5 +1,6 @@
 (ns metabase.driver.mongo.connection
   "This namespace contains code responsible for connecting to mongo deployment."
+  (:refer-clojure :exclude [not-empty])
   (:require
    [clojure.string :as str]
    [metabase.driver-api.core :as driver-api]
@@ -9,7 +10,8 @@
    [metabase.driver.sql-jdbc.connection.ssh-tunnel :as ssh]
    [metabase.driver.util :as driver.u]
    [metabase.util :as u]
-   [metabase.util.log :as log])
+   [metabase.util.log :as log]
+   [metabase.util.performance :refer [not-empty]])
   (:import
    (com.mongodb
     ConnectionString

--- a/modules/drivers/mongo/src/metabase/driver/mongo/database.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/database.clj
@@ -1,8 +1,10 @@
 (ns metabase.driver.mongo.database
   "This namespace contains functions for work with mongo specific database and database details."
+  (:refer-clojure :exclude [empty? not-empty])
   (:require
    [metabase.driver-api.core :as driver-api]
-   [metabase.util.i18n :refer [tru]])
+   [metabase.util.i18n :refer [tru]]
+   [metabase.util.performance :refer [empty? not-empty]])
   (:import
    (com.mongodb ConnectionString)))
 

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -1,7 +1,7 @@
 (ns metabase.driver.mongo.query-processor
   "Logic for translating MBQL queries into Mongo Aggregation Pipeline queries. See
   https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline/ for more details."
-  (:refer-clojure :exclude [some mapv select-keys])
+  (:refer-clojure :exclude [some mapv select-keys empty?])
   (:require
    [clojure.set :as set]
    [clojure.string :as str]
@@ -28,7 +28,7 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :as perf :refer [some mapv select-keys]])
+   [metabase.util.performance :as perf :refer [some mapv select-keys empty?]])
   (:import
    (org.bson BsonBinarySubType)
    (org.bson.types Binary ObjectId)))

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -1,6 +1,6 @@
 (ns metabase.driver.snowflake
   "Snowflake Driver."
-  (:refer-clojure :exclude [select-keys])
+  (:refer-clojure :exclude [select-keys not-empty])
   (:require
    [buddy.core.codecs :as codecs]
    [clojure.java.jdbc :as jdbc]
@@ -32,7 +32,7 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
-   [metabase.util.performance :refer [select-keys]]
+   [metabase.util.performance :refer [select-keys not-empty]]
    [ring.util.codec :as codec])
   (:import
    (java.io File)

--- a/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
+++ b/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
@@ -1,5 +1,5 @@
 (ns metabase.driver.sparksql
-  (:refer-clojure :exclude [select-keys every?])
+  (:refer-clojure :exclude [select-keys every? empty? not-empty])
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
@@ -18,7 +18,7 @@
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.driver.sql.util :as sql.u]
    [metabase.util.honey-sql-2 :as h2x]
-   [metabase.util.performance :refer [select-keys every?]])
+   [metabase.util.performance :refer [select-keys every? empty? not-empty]])
   (:import
    (java.sql Connection ResultSet Types)))
 

--- a/src/metabase/driver/common/parameters/values.clj
+++ b/src/metabase/driver/common/parameters/values.clj
@@ -17,7 +17,7 @@
   unused namespaces. We can't migrate to it if it's gone... please restore it when we start migrating usages of it
   over."
   {:deprecated "0.57.0"}
-  (:refer-clojure :exclude [every? some mapv])
+  (:refer-clojure :exclude [every? some mapv not-empty])
   (:require
    [clojure.string :as str]
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.driver.common.parameters :as params]
@@ -38,7 +38,7 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [every? mapv some]])
+   [metabase.util.performance :refer [every? mapv some not-empty]])
   (:import
    (clojure.lang ExceptionInfo)
    (java.util UUID)))

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -1,6 +1,6 @@
 (ns metabase.driver.mysql
   "MySQL driver. Builds off of the SQL-JDBC driver."
-  (:refer-clojure :exclude [some])
+  (:refer-clojure :exclude [some not-empty])
   (:require
    [clojure.java.io :as jio]
    [clojure.java.jdbc :as jdbc]
@@ -28,7 +28,7 @@
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.i18n :refer [deferred-tru]]
    [metabase.util.log :as log]
-   [metabase.util.performance :as perf :refer [some]])
+   [metabase.util.performance :as perf :refer [some not-empty]])
   (:import
    (java.io File)
    (java.sql

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -1,7 +1,7 @@
 (ns metabase.driver.postgres
   "Database driver for PostgreSQL databases. Builds on top of the SQL JDBC driver, which implements most functionality
   for JDBC-based drivers."
-  (:refer-clojure :exclude [some select-keys mapv])
+  (:refer-clojure :exclude [some select-keys mapv not-empty])
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.set :as set]
@@ -34,7 +34,7 @@
    [metabase.util.i18n :refer [trs tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :as perf :refer [some select-keys mapv]])
+   [metabase.util.performance :as perf :refer [some select-keys mapv not-empty]])
   (:import
    (java.io StringReader)
    (java.sql

--- a/src/metabase/driver/sql/parameters/substitute.clj
+++ b/src/metabase/driver/sql/parameters/substitute.clj
@@ -1,4 +1,5 @@
 (ns metabase.driver.sql.parameters.substitute
+  (:refer-clojure :exclude [not-empty])
   (:require
    [clojure.string :as str]
    [metabase.driver :as driver]
@@ -8,7 +9,8 @@
    [metabase.driver.sql.parameters.substitution :as sql.params.substitution]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
-   [metabase.util.log :as log]))
+   [metabase.util.log :as log]
+   [metabase.util.performance :refer [not-empty]]))
 
 (declare #^:private substitute*)
 

--- a/src/metabase/driver/sql/parameters/substitution.clj
+++ b/src/metabase/driver/sql/parameters/substitution.clj
@@ -6,6 +6,7 @@
      :replacement-snippet     \"= ?\"
      ;; ; any prepared statement args (values for `?` placeholders) needed for the replacement snippet
      :prepared-statement-args [#t \"2017-01-01\"]}"
+  (:refer-clojure :exclude [not-empty])
   (:require
    [clojure.string :as str]
    [metabase.driver :as driver]
@@ -17,7 +18,8 @@
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
    [metabase.util.i18n :refer [tru]]
-   [metabase.util.malli :as mu])
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [not-empty]])
   (:import
    (clojure.lang IPersistentVector Keyword)
    (java.time.temporal Temporal)

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -1,6 +1,6 @@
 (ns metabase.driver.sql.query-processor
   "The Query Processor is responsible for translating the Metabase Query Language into HoneySQL SQL forms."
-  (:refer-clojure :exclude [some mapv every? select-keys])
+  (:refer-clojure :exclude [some mapv every? select-keys empty? not-empty])
   (:require
    [clojure.core.match :refer [match]]
    [clojure.string :as str]
@@ -19,7 +19,7 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :as perf :refer [some mapv every? select-keys]]
+   [metabase.util.performance :as perf :refer [some mapv every? select-keys empty? not-empty]]
    [toucan2.pipeline :as t2.pipeline])
   (:import
    (java.time LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime ZonedDateTime)

--- a/src/metabase/driver/sql_jdbc/actions.clj
+++ b/src/metabase/driver/sql_jdbc/actions.clj
@@ -1,5 +1,5 @@
 (ns metabase.driver.sql-jdbc.actions
-  (:refer-clojure :exclude [some mapv select-keys])
+  (:refer-clojure :exclude [some mapv select-keys empty? not-empty])
   #_{:clj-kondo/ignore [:discouraged-namespace]} ;; for using toucan2 in this ns
   (:require
    [clojure.java.jdbc :as jdbc]
@@ -18,7 +18,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :as perf :refer [some mapv select-keys]]
+   [metabase.util.performance :as perf :refer [some mapv select-keys empty? not-empty]]
    [methodical.core :as methodical]
    [toucan2.core :as t2])
   (:import

--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -4,7 +4,7 @@
   `metabase.driver.sql-jdbc.execute.old-impl`, which will be removed in a future release; implementations of methods
   for JDBC drivers that do not support `java.time` classes can be found in
   `metabase.driver.sql-jdbc.execute.legacy-impl`. "
-  (:refer-clojure :exclude [mapv])
+  (:refer-clojure :exclude [mapv empty?])
   #_{:clj-kondo/ignore [:metabase/modules]}
   (:require
    [clojure.core.async :as a]
@@ -25,7 +25,7 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :as perf :refer [mapv]]
+   [metabase.util.performance :as perf :refer [mapv empty?]]
    [potemkin :as p])
   (:import
    (java.sql

--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -1,7 +1,7 @@
 (ns metabase.driver.sql-jdbc.sync.describe-table
   "SQL JDBC impl for `describe-fields`, `describe-table`, `describe-fks`, `describe-table-fks`, and `describe-nested-field-columns`.
   `describe-table-fks` is deprecated and will be replaced by `describe-fks` in the future."
-  (:refer-clojure :exclude [some select-keys every? mapv])
+  (:refer-clojure :exclude [some select-keys every? mapv empty? not-empty])
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.set :as set]
@@ -21,7 +21,7 @@
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.log :as log]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [some select-keys every? mapv]]
+   [metabase.util.performance :refer [some select-keys every? mapv empty? not-empty]]
    [potemkin :as p]
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2])

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -1,6 +1,6 @@
 (ns metabase.driver.util
   "Utility functions for common operations on drivers."
-  (:refer-clojure :exclude [mapv])
+  (:refer-clojure :exclude [mapv empty?])
   (:require
    [clojure.core.memoize :as memoize]
    [clojure.set :as set]
@@ -23,7 +23,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.util.malli.schema :as ms]
-   [metabase.util.performance :as perf :refer [mapv]])
+   [metabase.util.performance :as perf :refer [mapv empty?]])
   (:import
    (java.io ByteArrayInputStream)
    (java.security KeyFactory KeyStore PrivateKey)

--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -10,7 +10,7 @@
   the move to MBQL 5 in the app DB and over the wire -- any new MBQL clauses should only get added to the MBQL 5
   schema in [[metabase.lib.schema]] going forward. We don't want to have to add things to two places for the rest of
   our lives; it's ok if MBQL 4 doesn't support some new features."
-  (:refer-clojure :exclude [every? select-keys #?(:clj doseq) some mapv update-keys])
+  (:refer-clojure :exclude [every? select-keys #?(:clj doseq) some mapv update-keys empty? not-empty])
   (:require
    [clojure.set :as set]
    [clojure.string :as str]
@@ -39,7 +39,7 @@
    [metabase.util :as u]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :as perf :refer [every? select-keys #?(:clj doseq) some mapv update-keys]]
+   [metabase.util.performance :as perf :refer [every? select-keys #?(:clj doseq) some mapv update-keys empty? not-empty]]
    [metabase.util.time :as u.time]))
 
 ;; A NOTE ABOUT METADATA:

--- a/src/metabase/legacy_mbql/schema/helpers.cljc
+++ b/src/metabase/legacy_mbql/schema/helpers.cljc
@@ -1,12 +1,12 @@
 (ns metabase.legacy-mbql.schema.helpers
-  (:refer-clojure :exclude [distinct #?(:clj for)])
+  (:refer-clojure :exclude [distinct not-empty #?(:clj for)])
   (:require
-   #?(:clj [metabase.util.performance :refer [for]])
    [clojure.string :as str]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.util :as lib.util]
    [metabase.types.core]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [not-empty #?(:clj for)]]))
 
 (comment metabase.types.core/keep-me)
 

--- a/src/metabase/legacy_mbql/util.cljc
+++ b/src/metabase/legacy_mbql/util.cljc
@@ -3,7 +3,7 @@
 
   DEPRECATED: Use [[metabase.lib.core]] for MBQL manipulation in all new code."
   {:deprecated "0.57.0"}
-  (:refer-clojure :exclude [replace some mapv every? #?(:clj for)])
+  (:refer-clojure :exclude [replace some mapv every? not-empty #?(:clj for)])
   (:require
    #?@(:clj
        [[metabase.legacy-mbql.jvm-util :as mbql.jvm-u]])
@@ -18,7 +18,7 @@
    [metabase.util.i18n :as i18n]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [some mapv every? #?(:clj for)]]
+   [metabase.util.performance :refer [some mapv every? not-empty #?(:clj for)]]
    [metabase.util.time :as u.time]))
 
 (defn mbql-clause?

--- a/src/metabase/lib/aggregation.cljc
+++ b/src/metabase/lib/aggregation.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.aggregation
-  (:refer-clojure :exclude [count distinct max min var select-keys mapv #?(:clj doseq) #?(:clj for)])
+  (:refer-clojure :exclude [count distinct max min var select-keys mapv empty? not-empty #?(:clj doseq) #?(:clj for)])
   (:require
    [medley.core :as m]
    [metabase.lib.common :as lib.common]
@@ -23,7 +23,7 @@
    [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [select-keys mapv #?(:clj doseq) #?(:clj for)]]))
+   [metabase.util.performance :refer [select-keys mapv empty? not-empty #?(:clj doseq) #?(:clj for)]]))
 
 (mu/defn column-metadata->aggregation-ref :- :mbql.clause/aggregation
   "Given `:metadata/column` column metadata for an aggregation, construct an `:aggregation` reference."

--- a/src/metabase/lib/breakout.cljc
+++ b/src/metabase/lib/breakout.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.breakout
-  (:refer-clojure :exclude [mapv #?(:clj for)])
+  (:refer-clojure :exclude [mapv not-empty #?(:clj for)])
   (:require
    [clojure.string :as str]
    [metabase.lib.binning :as lib.binning]
@@ -16,7 +16,7 @@
    [metabase.lib.util :as lib.util]
    [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [mapv #?(:clj for)]]))
+   [metabase.util.performance :refer [mapv not-empty #?(:clj for)]]))
 
 (defmethod lib.metadata.calculation/describe-top-level-key-method :breakout
   [query stage-number _k]

--- a/src/metabase/lib/card.cljc
+++ b/src/metabase/lib/card.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.card
-  (:refer-clojure :exclude [mapv select-keys])
+  (:refer-clojure :exclude [mapv select-keys empty? not-empty])
   (:require
    [medley.core :as m]
    [metabase.lib.binning :as lib.binning]
@@ -21,7 +21,7 @@
    [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :as perf :refer [mapv select-keys]]))
+   [metabase.util.performance :as perf :refer [mapv select-keys empty? not-empty]]))
 
 (defmethod lib.metadata.calculation/display-name-method :metadata/card
   [_query _stage-number card-metadata _style]

--- a/src/metabase/lib/convert.cljc
+++ b/src/metabase/lib/convert.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.convert
-  (:refer-clojure :exclude [mapv some select-keys #?(:clj doseq) #?(:clj for)])
+  (:refer-clojure :exclude [mapv some select-keys not-empty #?(:clj doseq) #?(:clj for)])
   (:require
    [clojure.data :as data]
    [clojure.set :as set]
@@ -22,7 +22,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :as perf :refer [mapv some select-keys #?(:clj doseq) #?(:clj for)]])
+   [metabase.util.performance :as perf :refer [mapv some select-keys not-empty #?(:clj doseq) #?(:clj for)]])
   #?@(:cljs [(:require-macros [metabase.lib.convert :refer [with-aggregation-list]])]))
 
 (def ^:private ^:dynamic *pMBQL-uuid->legacy-index*

--- a/src/metabase/lib/drill_thru.cljc
+++ b/src/metabase/lib/drill_thru.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.drill-thru
-  (:refer-clojure :exclude [select-keys #?(:clj for)])
+  (:refer-clojure :exclude [select-keys empty? not-empty #?(:clj for)])
   (:require
    [metabase.lib.drill-thru.automatic-insights :as lib.drill-thru.automatic-insights]
    [metabase.lib.drill-thru.column-extract :as lib.drill-thru.column-extract]
@@ -32,7 +32,7 @@
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [select-keys #?(:clj for)]]))
+   [metabase.util.performance :refer [select-keys empty? not-empty #?(:clj for)]]))
 
 (comment
   lib.drill-thru.fk-details/keep-me

--- a/src/metabase/lib/drill_thru/automatic_insights.cljc
+++ b/src/metabase/lib/drill_thru/automatic_insights.cljc
@@ -1,4 +1,5 @@
 (ns metabase.lib.drill-thru.automatic-insights
+  (:refer-clojure :exclude [not-empty])
   (:require
    [metabase.lib.drill-thru.common :as lib.drill-thru.common]
    [metabase.lib.drill-thru.underlying-records :as lib.drill-thru.underlying-records]
@@ -7,7 +8,8 @@
    [metabase.lib.schema.drill-thru :as lib.schema.drill-thru]
    [metabase.lib.underlying :as lib.underlying]
    [metabase.lib.util :as lib.util]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [not-empty]]))
 
 (mu/defn automatic-insights-drill :- [:maybe ::lib.schema.drill-thru/drill-thru]
   "Automatic insights appears:

--- a/src/metabase/lib/drill_thru/column_extract.cljc
+++ b/src/metabase/lib/drill_thru/column_extract.cljc
@@ -13,7 +13,7 @@
 
   - MBQL stages only
   - Database must support `:regex` feature for the URL and Email extractions to work."
-  (:refer-clojure :exclude [select-keys])
+  (:refer-clojure :exclude [select-keys not-empty])
   (:require
    [medley.core :as m]
    [metabase.lib.drill-thru.column-filter :as lib.drill-thru.column-filter]
@@ -26,7 +26,7 @@
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [select-keys]]))
+   [metabase.util.performance :refer [select-keys not-empty]]))
 
 (defn- column-extract-drill-for-column [query column]
   (when-let [extractions (not-empty (lib.extraction/column-extractions query column))]

--- a/src/metabase/lib/drill_thru/common.cljc
+++ b/src/metabase/lib/drill_thru/common.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.drill-thru.common
-  (:refer-clojure :exclude [select-keys])
+  (:refer-clojure :exclude [select-keys not-empty])
   (:require
    [medley.core :as m]
    [metabase.lib.card :as lib.card]
@@ -16,7 +16,7 @@
    [metabase.lib.underlying :as lib.underlying]
    [metabase.lib.util :as lib.util]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [select-keys]]))
+   [metabase.util.performance :refer [select-keys not-empty]]))
 
 (defn mbql-stage?
   "Is this query stage an MBQL stage?"

--- a/src/metabase/lib/drill_thru/pivot.cljc
+++ b/src/metabase/lib/drill_thru/pivot.cljc
@@ -41,7 +41,7 @@
   - `pivotTypes` function that return available column types for the drill - \"category\" | \"location\" | \"time\"
 
   - `pivotColumnsForType` returns the list of available columns for the drill and the selected type"
-  (:refer-clojure :exclude [select-keys #?(:clj for)])
+  (:refer-clojure :exclude [select-keys empty? not-empty #?(:clj for)])
   (:require
    [metabase.lib.aggregation :as lib.aggregation]
    [metabase.lib.breakout :as lib.breakout]
@@ -54,7 +54,7 @@
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.lib.underlying :as lib.underlying]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [select-keys #?(:clj for)]]))
+   [metabase.util.performance :refer [select-keys empty? not-empty #?(:clj for)]]))
 
 (mu/defn- pivot-drill-pred :- [:sequential ::lib.schema.metadata/column]
   "Implementation for pivoting on various kinds of fields.

--- a/src/metabase/lib/drill_thru/underlying_records.cljc
+++ b/src/metabase/lib/drill_thru/underlying_records.cljc
@@ -28,7 +28,7 @@
   Question transformation:
 
   - Set display \"table\""
-  (:refer-clojure :exclude [mapv #?(:clj for)])
+  (:refer-clojure :exclude [mapv empty? not-empty #?(:clj for)])
   (:require
    [medley.core :as m]
    [metabase.lib.aggregation :as lib.aggregation]
@@ -50,7 +50,7 @@
    [metabase.lib.underlying :as lib.underlying]
    [metabase.lib.util :as lib.util]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [mapv #?(:clj for)]]))
+   [metabase.util.performance :refer [mapv empty? not-empty #?(:clj for)]]))
 
 (mu/defn underlying-records-drill :- [:maybe ::lib.schema.drill-thru/drill-thru.underlying-records]
   "When clicking on a particular broken-out group, offer a look at the details of all the rows that went into this

--- a/src/metabase/lib/equality.cljc
+++ b/src/metabase/lib/equality.cljc
@@ -1,6 +1,6 @@
 (ns metabase.lib.equality
   "Logic for determining whether two pMBQL queries are equal."
-  (:refer-clojure :exclude [= every? some mapv #?(:clj for)])
+  (:refer-clojure :exclude [= every? some mapv empty? not-empty #?(:clj for)])
   (:require
    [medley.core :as m]
    [metabase.lib.binning :as lib.binning]
@@ -21,7 +21,7 @@
    [metabase.lib.util :as lib.util]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [every? some mapv #?(:clj for)]]))
+   [metabase.util.performance :refer [every? some mapv empty? not-empty #?(:clj for)]]))
 
 (defmulti =
   "Determine whether two already-normalized pMBQL maps, clauses, or other sorts of expressions are equal. The basic rule

--- a/src/metabase/lib/expression.cljc
+++ b/src/metabase/lib/expression.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.expression
-  (:refer-clojure :exclude [+ - * / case coalesce abs time concat replace float mapv some select-keys
+  (:refer-clojure :exclude [+ - * / case coalesce abs time concat replace float mapv some select-keys not-empty
                             #?(:clj doseq) #?(:clj for)])
   (:require
    [clojure.string :as str]
@@ -29,7 +29,7 @@
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [metabase.util.number :as u.number]
-   [metabase.util.performance :refer [mapv some select-keys #?(:clj doseq) #?(:clj for)]]))
+   [metabase.util.performance :refer [mapv some select-keys not-empty #?(:clj doseq) #?(:clj for)]]))
 
 (mu/defn column-metadata->expression-ref :- :mbql.clause/expression
   "Given `:metadata/column` column metadata for an expression, construct an `:expression` reference."

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.field
-  (:refer-clojure :exclude [every? select-keys mapv #?(:clj for)])
+  (:refer-clojure :exclude [every? select-keys mapv empty? not-empty #?(:clj for)])
   (:require
    [clojure.set :as set]
    [clojure.string :as str]
@@ -32,7 +32,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [every? select-keys mapv #?(:clj for)]]
+   [metabase.util.performance :refer [every? select-keys mapv empty? not-empty #?(:clj for)]]
    [metabase.util.time :as u.time]))
 
 (defn- column-metadata-effective-type

--- a/src/metabase/lib/field/resolution.cljc
+++ b/src/metabase/lib/field/resolution.cljc
@@ -1,7 +1,7 @@
 (ns metabase.lib.field.resolution
   "Code for resolving field metadata from a field ref. There's a lot of code here, isn't there? This is probably more
   complicated than it needs to be!"
-  (:refer-clojure :exclude [not-empty some select-keys])
+  (:refer-clojure :exclude [not-empty some select-keys #?(:clj empty?)])
   (:require
    #?@(:clj
        ([metabase.config.core :as config]))
@@ -26,7 +26,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [not-empty some select-keys]]))
+   [metabase.util.performance :refer [not-empty some select-keys #?(:clj empty?)]]))
 
 (mr/def ::id-or-name
   [:or :string ::lib.schema.id/field])

--- a/src/metabase/lib/filter.cljc
+++ b/src/metabase/lib/filter.cljc
@@ -1,5 +1,6 @@
 (ns metabase.lib.filter
-  (:refer-clojure :exclude [filter and or not = < <= > >= not-empty case every? some mapv #?(:clj doseq) #?(:clj for)])
+  (:refer-clojure :exclude [filter and or not = < <= > >= not-empty case every? some mapv empty? not-empty
+                            #?(:clj doseq) #?(:clj for)])
   (:require
    [inflections.core :as inflections]
    [medley.core :as m]
@@ -25,7 +26,7 @@
    [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]
    [metabase.util.number :as u.number]
-   [metabase.util.performance :refer [every? some mapv #?(:clj doseq) #?(:clj for)]]
+   [metabase.util.performance :as perf :refer [every? some mapv empty? #?(:clj doseq) #?(:clj for)]]
    [metabase.util.time :as u.time]))
 
 (doseq [tag [:and :or]]
@@ -42,7 +43,7 @@
 
 (defmethod lib.metadata.calculation/describe-top-level-key-method :filters
   [query stage-number _key]
-  (when-let [filters (clojure.core/not-empty (:filters (lib.util/query-stage query stage-number)))]
+  (when-let [filters (perf/not-empty (:filters (lib.util/query-stage query stage-number)))]
     (i18n/tru "Filtered by {0}"
               (lib.util/join-strings-with-conjunction
                (i18n/tru "and")
@@ -419,7 +420,7 @@
   ([query :- :metabase.lib.schema/query] (filters query nil))
   ([query :- :metabase.lib.schema/query
     stage-number :- [:maybe :int]]
-   (clojure.core/not-empty (:filters (lib.util/query-stage query (clojure.core/or stage-number -1))))))
+   (perf/not-empty (:filters (lib.util/query-stage query (clojure.core/or stage-number -1))))))
 
 (def ColumnWithOperators
   "Malli schema for ColumnMetadata extended with the list of applicable operators."
@@ -437,7 +438,7 @@
   "Extend the column metadata with the available operators if any."
   [column :- ::lib.schema.metadata/column]
   (let [operators (lib.filter.operator/filter-operators column)]
-    (m/assoc-some column :operators (clojure.core/not-empty operators))))
+    (m/assoc-some column :operators (perf/not-empty operators))))
 
 (defn- leading-ref
   "Returns the first argument of `a-filter` if it is a reference clause, nil otherwise."

--- a/src/metabase/lib/filter/simplify_compound.cljc
+++ b/src/metabase/lib/filter/simplify_compound.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.filter.simplify-compound
-  (:refer-clojure :exclude [some])
+  (:refer-clojure :exclude [some empty?])
   (:require
    [medley.core :as m]
    [metabase.lib.filter :as lib.filter]
@@ -10,7 +10,7 @@
    [metabase.lib.util.match :as lib.util.match]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [some]]))
+   [metabase.util.performance :refer [some empty?]]))
 
 (mr/def ::mbql-clause
   "An MBQL clause that may not be well-formed, e.g. an `:and` clause with only one arg."

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -1,6 +1,6 @@
 (ns metabase.lib.join
   "Functions related to manipulating EXPLICIT joins in MBQL."
-  (:refer-clojure :exclude [mapv run! some #?(:clj for)])
+  (:refer-clojure :exclude [mapv run! some empty? not-empty #?(:clj for)])
   (:require
    [clojure.set :as set]
    [clojure.string :as str]
@@ -36,7 +36,7 @@
    [metabase.util.i18n :as i18n]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [mapv run! some #?(:clj for)]]))
+   [metabase.util.performance :refer [mapv run! some empty? not-empty #?(:clj for)]]))
 
 (defn- join? [x]
   (= (lib.dispatch/dispatch-value x) :mbql/join))

--- a/src/metabase/lib/limit.cljc
+++ b/src/metabase/lib/limit.cljc
@@ -1,4 +1,5 @@
 (ns metabase.lib.limit
+  (:refer-clojure :exclude [empty?])
   (:require
    [metabase.lib.aggregation :as lib.aggregation]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
@@ -8,7 +9,8 @@
    [metabase.lib.util :as lib.util]
    [metabase.util :as u]
    [metabase.util.i18n :as i18n]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [empty?]]))
 
 (defmethod lib.metadata.calculation/describe-top-level-key-method :limit
   [query stage-number _k]

--- a/src/metabase/lib/metadata.cljc
+++ b/src/metabase/lib/metadata.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.metadata
-  (:refer-clojure :exclude [every? #?(:clj doseq) #?(:clj for)])
+  (:refer-clojure :exclude [every? empty? #?(:clj doseq) #?(:clj for)])
   (:require
    [medley.core :as m]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
@@ -11,7 +11,7 @@
    [metabase.util :as u]
    [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [every? #?(:clj doseq) #?(:clj for)]]))
+   [metabase.util.performance :refer [every? empty? #?(:clj doseq) #?(:clj for)]]))
 
 ;;; TODO -- deprecate all the schemas below, and just use the versions in [[lib.schema.metadata]] instead.
 

--- a/src/metabase/lib/metadata/cache.cljc
+++ b/src/metabase/lib/metadata/cache.cljc
@@ -2,6 +2,7 @@
   "Cache arbitrary immutable values on `metadata-providerable` (eg. a query), by using the `CachedMetadataProvider`'s
   general caching facilities. Has helpers for constructing a cache key that includes the query and stage, making it
   easy to cache things like `visible-columns`."
+  (:refer-clojure :exclude [not-empty])
   (:require
    [medley.core :as m]
    [metabase.lib.dispatch :as lib.dispatch]
@@ -11,7 +12,8 @@
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.malli.registry :as mr])
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [not-empty]])
   #?(:cljs (:require-macros [metabase.lib.metadata.cache])))
 
 (mr/def ::cache-key

--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.metadata.calculation
-  (:refer-clojure :exclude [select-keys mapv #?(:clj for)])
+  (:refer-clojure :exclude [select-keys mapv empty? #?(:clj for)])
   (:require
    #?(:clj  [metabase.config.core :as config]
       :cljs [metabase.lib.cache :as lib.cache])
@@ -24,7 +24,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [select-keys mapv #?(:clj for)]]))
+   [metabase.util.performance :refer [select-keys mapv empty? #?(:clj for)]]))
 
 (mr/def ::display-name-style
   "Schema for valid values of `display-name-style` as passed to [[display-name-method]].

--- a/src/metabase/lib/metadata/composed_provider.cljc
+++ b/src/metabase/lib/metadata/composed_provider.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.metadata.composed-provider
-  (:refer-clojure :exclude [some])
+  (:refer-clojure :exclude [some empty? not-empty])
   (:require
    #?(:clj [pretty.core :as pretty])
    [better-cond.core :as b]
@@ -9,7 +9,7 @@
    [medley.core :as m]
    [metabase.lib.metadata.protocols :as metadata.protocols]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [some]]))
+   [metabase.util.performance :refer [some empty? not-empty]]))
 
 (mu/defn- cached-providers :- [:sequential ::metadata.protocols/cached-metadata-provider]
   [providers :- [:maybe [:sequential ::metadata.protocols/metadata-provider]]]

--- a/src/metabase/lib/metadata/result_metadata.cljc
+++ b/src/metabase/lib/metadata/result_metadata.cljc
@@ -6,7 +6,7 @@
 
   Traditionally this code lived in the [[metabase.query-processor.middleware.annotate]] namespace, where it is still
   used today."
-  (:refer-clojure :exclude [mapv select-keys some update-keys every? #?(:clj for)])
+  (:refer-clojure :exclude [mapv select-keys some update-keys every? empty? not-empty #?(:clj for)])
   (:require
    #?@(:clj
        ([metabase.config.core :as config]))
@@ -33,7 +33,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [mapv select-keys some update-keys every? #?(:clj for)]]))
+   [metabase.util.performance :refer [mapv select-keys some update-keys every? empty? not-empty #?(:clj for)]]))
 
 (mr/def ::col
   ;; TODO (Cam 6/19/25) -- I think we should actually namespace all the keys added here (to make it clear where they

--- a/src/metabase/lib/metric.cljc
+++ b/src/metabase/lib/metric.cljc
@@ -1,7 +1,7 @@
 (ns metabase.lib.metric
   "A Metric is a special type of Card that you can do special metric stuff with. (Not sure exactly what said special
   stuff is TBH.)"
-  (:refer-clojure :exclude [select-keys])
+  (:refer-clojure :exclude [select-keys not-empty])
   (:require
    ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.legacy-mbql.normalize :as mbql.normalize]
    [metabase.lib.aggregation :as lib.aggregation]
@@ -19,7 +19,7 @@
    [metabase.lib.util :as lib.util]
    [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [select-keys]]))
+   [metabase.util.performance :refer [select-keys not-empty]]))
 
 (defn- resolve-metric [query card-id]
   (when (pos-int? card-id)

--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -1,6 +1,6 @@
 (ns metabase.lib.native
   "Functions for working with native queries."
-  (:refer-clojure :exclude [some select-keys mapv every?])
+  (:refer-clojure :exclude [some select-keys mapv every? empty? not-empty])
   (:require
    [clojure.core.match :refer [match]]
    [clojure.set :as set]
@@ -24,7 +24,7 @@
    [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [every? mapv select-keys some]]))
+   [metabase.util.performance :refer [every? mapv select-keys some empty? not-empty]]))
 
 ;; Template Tags: Variables
 

--- a/src/metabase/lib/options.cljc
+++ b/src/metabase/lib/options.cljc
@@ -1,10 +1,11 @@
 (ns metabase.lib.options
-  (:refer-clojure :exclude [uuid])
+  (:refer-clojure :exclude [uuid not-empty])
   (:require
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.util :as u]
    [metabase.util.i18n :as i18n]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [not-empty]]))
 
 (defn- mbql-clause? [x]
   (and (vector? x)

--- a/src/metabase/lib/order_by.cljc
+++ b/src/metabase/lib/order_by.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.order-by
-  (:refer-clojure :exclude [some mapv #?(:clj for)])
+  (:refer-clojure :exclude [some mapv empty? not-empty #?(:clj for)])
   (:require
    [metabase.lib.aggregation :as lib.aggregation]
    [metabase.lib.breakout :as lib.breakout]
@@ -17,7 +17,7 @@
    [metabase.lib.util.match :as lib.util.match]
    [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [some mapv #?(:clj for)]]))
+   [metabase.util.performance :refer [some mapv empty? not-empty #?(:clj for)]]))
 
 (lib.hierarchy/derive :asc  ::order-by-clause)
 (lib.hierarchy/derive :desc ::order-by-clause)

--- a/src/metabase/lib/parse.cljc
+++ b/src/metabase/lib/parse.cljc
@@ -1,12 +1,12 @@
 (ns metabase.lib.parse
   "Code for parsing parameters in raw SQL strings."
-  (:refer-clojure :exclude [some #?(:clj for)])
+  (:refer-clojure :exclude [some empty? #?(:clj for)])
   (:require
    [clojure.string :as str]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
-   [metabase.util.performance :refer [some #?(:clj for)]]))
+   [metabase.util.performance :refer [some empty? #?(:clj for)]]))
 
 (defn- combine-adjacent-strings
   "Returns any adjacent strings in coll combined together"

--- a/src/metabase/lib/query.cljc
+++ b/src/metabase/lib/query.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.query
-  (:refer-clojure :exclude [remove some select-keys mapv #?(:clj for)])
+  (:refer-clojure :exclude [remove some select-keys mapv empty? #?(:clj for)])
   (:require
    [medley.core :as m]
    ;; allowed since this is needed to convert legacy queries to MBQL 5
@@ -29,7 +29,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [some select-keys mapv #?(:clj for)]]
+   [metabase.util.performance :refer [some select-keys mapv empty? #?(:clj for)]]
    [weavejester.dependency :as dep]))
 
 (defmethod lib.metadata.calculation/metadata-method :mbql/query

--- a/src/metabase/lib/remove_replace.cljc
+++ b/src/metabase/lib/remove_replace.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.remove-replace
-  (:refer-clojure :exclude [every? mapv run! some #?(:clj for)])
+  (:refer-clojure :exclude [every? mapv run! some empty? not-empty #?(:clj for)])
   (:require
    [clojure.set :as set]
    [medley.core :as m]
@@ -23,7 +23,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :as perf :refer [every? mapv run! some #?(:clj for)]]))
+   [metabase.util.performance :as perf :refer [every? mapv run! some empty? not-empty #?(:clj for)]]))
 
 (defn- stage-paths
   [query stage-number]

--- a/src/metabase/lib/schema.cljc
+++ b/src/metabase/lib/schema.cljc
@@ -6,7 +6,7 @@
   Some primitives below are duplicated from [[metabase.util.malli.schema]] since that's not `.cljc`. Other stuff is
   copied from [[metabase.legacy-mbql.schema]] so this can exist completely independently; hopefully at some point in the
   future we can deprecate that namespace and eventually do away with it entirely."
-  (:refer-clojure :exclude [ref every? some select-keys])
+  (:refer-clojure :exclude [ref every? some select-keys empty?])
   (:require
    [medley.core :as m]
    [metabase.lib.schema.actions :as actions]
@@ -34,7 +34,7 @@
    [metabase.lib.schema.util :as lib.schema.util]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [every? select-keys some]]))
+   [metabase.util.performance :refer [every? select-keys some empty?]]))
 
 (comment metabase.lib.schema.expression.arithmetic/keep-me
          metabase.lib.schema.expression.conditional/keep-me

--- a/src/metabase/lib/schema/expression.cljc
+++ b/src/metabase/lib/schema/expression.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.schema.expression
-  (:refer-clojure :exclude [some #?(:clj for)])
+  (:refer-clojure :exclude [some empty? #?(:clj for)])
   (:require
    [metabase.lib.dispatch :as lib.dispatch]
    [metabase.lib.hierarchy :as lib.hierarchy]
@@ -10,7 +10,7 @@
    [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [some #?(:clj for)]]))
+   [metabase.util.performance :refer [some empty? #?(:clj for)]]))
 
 (defmulti type-of-method
   "Impl for [[type-of]]. Use [[type-of]], but implement [[type-of-method]].

--- a/src/metabase/lib/schema/expression/conditional.cljc
+++ b/src/metabase/lib/schema/expression/conditional.cljc
@@ -1,14 +1,14 @@
 (ns metabase.lib.schema.expression.conditional
   "Conditional expressions like `:case` and `:coalesce`."
-  #?(:clj (:refer-clojure :exclude [doseq]))
+  (:refer-clojure :exclude [not-empty #?(:clj doseq)])
   (:require
-   #?(:clj [metabase.util.performance :refer [doseq]])
    [clojure.set :as set]
    [metabase.lib.schema.expression :as expression]
    [metabase.lib.schema.mbql-clause :as mbql-clause]
    [metabase.types.core :as types]
    [metabase.util.malli :as mu]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [not-empty #?(:clj doseq)]]))
 
 ;;; the logic for calculating the return type of a `:case` or similar statement is not optimal nor perfect. But it
 ;;; should be ok for now and errors on the side of being permissive. See this Slack thread for more info:

--- a/src/metabase/lib/schema/join.cljc
+++ b/src/metabase/lib/schema/join.cljc
@@ -1,6 +1,6 @@
 (ns metabase.lib.schema.join
   "Schemas for things related to joins."
-  (:refer-clojure :exclude [mapv every?])
+  (:refer-clojure :exclude [mapv every? empty? not-empty])
   (:require
    [metabase.lib.schema.common :as common]
    [metabase.lib.schema.expression :as expression]
@@ -8,7 +8,7 @@
    [metabase.util :as u]
    [metabase.util.i18n :as i18n]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [every? mapv]]))
+   [metabase.util.performance :refer [every? mapv empty? not-empty]]))
 
 (mr/def ::fields
   "The Fields to include in the results *if* a top-level `:fields` clause *is not* specified. This can be either

--- a/src/metabase/lib/schema/util.cljc
+++ b/src/metabase/lib/schema/util.cljc
@@ -1,11 +1,11 @@
 (ns metabase.lib.schema.util
-  (:refer-clojure :exclude [ref run! every? mapv])
+  (:refer-clojure :exclude [ref run! every? mapv empty?])
   (:require
    [medley.core :as m]
    [metabase.lib.options :as lib.options]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :as perf :refer [run! every? mapv]]))
+   [metabase.util.performance :as perf :refer [run! every? mapv empty?]]))
 
 (declare collect-uuids*)
 

--- a/src/metabase/lib/segment.cljc
+++ b/src/metabase/lib/segment.cljc
@@ -1,6 +1,6 @@
 (ns metabase.lib.segment
   "A Segment is a saved MBQL query stage snippet with `:filter`. Segments are always boolean expressions."
-  (:refer-clojure :exclude [mapv])
+  (:refer-clojure :exclude [mapv empty?])
   (:require
    [metabase.lib.filter :as lib.filter]
    [metabase.lib.metadata :as lib.metadata]
@@ -13,7 +13,7 @@
    [metabase.lib.util :as lib.util]
    [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [mapv]]))
+   [metabase.util.performance :refer [mapv empty?]]))
 
 (defn- resolve-segment [query segment-id]
   (when (integer? segment-id)

--- a/src/metabase/lib/stage.cljc
+++ b/src/metabase/lib/stage.cljc
@@ -1,6 +1,6 @@
 (ns metabase.lib.stage
   "Method implementations for a stage of a query."
-  (:refer-clojure :exclude [mapv some #?(:clj for)])
+  (:refer-clojure :exclude [mapv some not-empty #?(:clj for)])
   (:require
    [clojure.string :as str]
    [metabase.lib.aggregation :as lib.aggregation]
@@ -25,7 +25,7 @@
    [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]
    [metabase.util.namespaces :as shared.ns]
-   [metabase.util.performance :refer [mapv some #?(:clj for)]]))
+   [metabase.util.performance :refer [mapv some not-empty #?(:clj for)]]))
 
 (comment metabase.lib.stage.util/keep-me)
 

--- a/src/metabase/lib/stage/util.cljc
+++ b/src/metabase/lib/stage/util.cljc
@@ -2,11 +2,13 @@
   "General stage-related utility functions that don't require a any other Lib namespaces except for very general
   high-level ones like `lib.schema` and `lib.util`. This namespace was spun out from [[metabase.lib.stage]] to avoid
   circular dependencies between it and other Lib namespaces."
+  (:refer-clojure :exclude [not-empty])
   (:require
    [medley.core :as m]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.util :as lib.util]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [not-empty]]))
 
 (mu/defn has-clauses? :- :boolean
   "Does given query stage have any clauses?"

--- a/src/metabase/lib/template_tags.cljc
+++ b/src/metabase/lib/template_tags.cljc
@@ -1,8 +1,10 @@
 (ns metabase.lib.template-tags
+  (:refer-clojure :exclude [not-empty])
   (:require
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.template-tag :as lib.schema.template-tag]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [not-empty]]))
 
 (mu/defn template-tags->card-ids :- [:maybe [:set {:min 1} ::lib.schema.id/card]]
   "Returns the card IDs from the template tags map."

--- a/src/metabase/lib/underlying.cljc
+++ b/src/metabase/lib/underlying.cljc
@@ -1,9 +1,8 @@
 (ns metabase.lib.underlying
   "Helpers for getting at \"underlying\" or \"top-level\" queries and columns.
   This logic is shared by a handful of things like drill-thrus."
-  #?(:clj (:refer-clojure :exclude [for]))
+  (:refer-clojure :exclude [empty? #?(:clj for)])
   (:require
-   #?(:clj [metabase.util.performance :refer [for]])
    [clojure.set :as set]
    [metabase.lib.aggregation :as lib.aggregation]
    [metabase.lib.breakout :as lib.breakout]
@@ -16,7 +15,8 @@
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.lib.util :as lib.util]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [empty? #?(:clj for)]]))
 
 (mu/defn- pop-until-aggregation-or-breakout :- [:tuple [:maybe ::lib.schema/query] [:int {:max -1}]]
   "Strips off any trailing stages that do not contain aggregations or breakouts.

--- a/src/metabase/lib/util/match.clj
+++ b/src/metabase/lib/util/match.clj
@@ -1,10 +1,10 @@
 (ns metabase.lib.util.match
   "Internal implementation of the MBQL `match` and `replace` macros. Don't use these directly."
-  (:refer-clojure :exclude [every? run! some mapv replace])
+  (:refer-clojure :exclude [every? run! some mapv replace empty?])
   (:require
    [clojure.core.match]
    [metabase.lib.util.match.impl]
-   [metabase.util.performance :as perf :refer [every? run! some mapv]]
+   [metabase.util.performance :as perf :refer [every? run! some mapv empty?]]
    [net.cgrand.macrovich :as macros]))
 
 (defn- generate-pattern

--- a/src/metabase/lib/validate.cljc
+++ b/src/metabase/lib/validate.cljc
@@ -1,11 +1,13 @@
 (ns metabase.lib.validate
   "Checks and validation for queries."
+  (:refer-clojure :exclude [not-empty])
   (:require
    [metabase.lib.field.resolution :as lib.field.resolution]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.mbql-clause :as lib.schema.mbql-clause]
    [metabase.lib.walk :as lib.walk]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [not-empty]]))
 
 (mu/defn find-bad-refs :- [:maybe [:sequential ::lib.schema.mbql-clause/clause]]
   "Returns a list of bad `:field` refs on this query.

--- a/src/metabase/lib/walk.cljc
+++ b/src/metabase/lib/walk.cljc
@@ -1,6 +1,6 @@
 (ns metabase.lib.walk
   "Tools for walking and transforming a query."
-  (:refer-clojure :exclude [mapv])
+  (:refer-clojure :exclude [mapv empty?])
   (:require
    [medley.core :as m]
    [metabase.lib.dispatch :as lib.dispatch]
@@ -14,7 +14,7 @@
    [metabase.util :as u]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [mapv]]))
+   [metabase.util.performance :refer [mapv empty?]]))
 
 (declare walk-stages*)
 

--- a/src/metabase/lib/walk/util.cljc
+++ b/src/metabase/lib/walk/util.cljc
@@ -1,5 +1,6 @@
 (ns metabase.lib.walk.util
   "Utility functions built on top of [[metabase.lib.walk]]."
+  (:refer-clojure :exclude [not-empty])
   (:require
    [clojure.set :as set]
    [metabase.lib.metadata :as lib.metadata]
@@ -9,7 +10,8 @@
    [metabase.lib.schema.template-tag :as lib.schema.template-tag]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.lib.walk :as lib.walk]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [not-empty]]))
 
 (defn- transduce-stages
   ([rf query]

--- a/src/metabase/lib_be/models/transforms.clj
+++ b/src/metabase/lib_be/models/transforms.clj
@@ -1,5 +1,5 @@
 (ns metabase.lib-be.models.transforms
-  (:refer-clojure :exclude [some])
+  (:refer-clojure :exclude [some empty?])
   (:require
    [metabase.lib-be.metadata.bootstrap :as lib-be.bootstrap]
    [metabase.lib-be.metadata.jvm :as lib.metadata.jvm]
@@ -10,7 +10,7 @@
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [some]]))
+   [metabase.util.performance :refer [some empty?]]))
 
 (set! *warn-on-reflection* true)
 

--- a/src/metabase/query_processor/api.clj
+++ b/src/metabase/query_processor/api.clj
@@ -1,5 +1,6 @@
 (ns metabase.query-processor.api
   "/api/dataset endpoints."
+  (:refer-clojure :exclude [not-empty])
   (:require
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
@@ -31,6 +32,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.util.malli.schema :as ms]
+   [metabase.util.performance :refer [not-empty]]
    [steffan-westcott.clj-otel.api.trace.span :as span]
    ^{:clj-kondo/ignore [:discouraged-namespace]} [toucan2.core :as t2]))
 

--- a/src/metabase/query_processor/card.clj
+++ b/src/metabase/query_processor/card.clj
@@ -1,6 +1,6 @@
 (ns metabase.query-processor.card
   "Code for running a query in the context of a specific Card."
-  (:refer-clojure :exclude [mapv select-keys])
+  (:refer-clojure :exclude [mapv select-keys not-empty])
   (:require
    [clojure.string :as str]
    [medley.core :as m]
@@ -33,7 +33,7 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [mapv select-keys]]
+   [metabase.util.performance :refer [mapv select-keys not-empty]]
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2]))
 

--- a/src/metabase/query_processor/dashboard.clj
+++ b/src/metabase/query_processor/dashboard.clj
@@ -1,6 +1,6 @@
 (ns metabase.query-processor.dashboard
   "Code for running a query in the context of a specific DashboardCard."
-  (:refer-clojure :exclude [some select-keys])
+  (:refer-clojure :exclude [some select-keys not-empty])
   (:require
    [clojure.string :as str]
    [medley.core :as m]
@@ -18,7 +18,7 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [select-keys some]]
+   [metabase.util.performance :refer [select-keys some not-empty]]
    [steffan-westcott.clj-otel.api.trace.span :as span]
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2]))

--- a/src/metabase/query_processor/metadata.clj
+++ b/src/metabase/query_processor/metadata.clj
@@ -3,7 +3,7 @@
   MBQL queries; for native queries we use the driver implementation of
   [[metabase.driver/query-result-metadata]], which hopefully can calculate metadata without running the query. If
   that's not possible, our fallback `:default` implementation adds the equivalent of `LIMIT 1` to query and runs it."
-  (:refer-clojure :exclude [mapv])
+  (:refer-clojure :exclude [mapv not-empty])
   (:require
    [metabase.analyze.core :as analyze]
    [metabase.driver :as driver]
@@ -19,7 +19,7 @@
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :as perf :refer [mapv]]))
+   [metabase.util.performance :as perf :refer [mapv not-empty]]))
 
 (mu/defn- metadata-from-preprocessing :- [:maybe [:sequential :map]]
   "For MBQL queries or native queries with result metadata attached to them already we can infer the columns just by

--- a/src/metabase/query_processor/middleware/add_implicit_clauses.clj
+++ b/src/metabase/query_processor/middleware/add_implicit_clauses.clj
@@ -1,6 +1,6 @@
 (ns metabase.query-processor.middleware.add-implicit-clauses
   "Middlware for adding an implicit `:fields` and `:order-by` clauses to certain queries."
-  (:refer-clojure :exclude [every?])
+  (:refer-clojure :exclude [every? empty? not-empty])
   (:require
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
@@ -10,7 +10,7 @@
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [every?]]))
+   [metabase.util.performance :refer [every? empty? not-empty]]))
 
 (mu/defn- should-add-implicit-fields?
   "Whether we should add implicit Fields to a `stage`. True if all of the following are true:

--- a/src/metabase/query_processor/middleware/add_implicit_joins.clj
+++ b/src/metabase/query_processor/middleware/add_implicit_joins.clj
@@ -1,7 +1,7 @@
 (ns metabase.query-processor.middleware.add-implicit-joins
   "Middleware that creates corresponding `:joins` for Tables referred to by `:field` clauses with `:source-field` info
   in the options and adds `:join-alias` info to those `:field` clauses."
-  (:refer-clojure :exclude [alias mapv some])
+  (:refer-clojure :exclude [alias mapv some empty? not-empty])
   (:require
    [better-cond.core :as b]
    [clojure.set :as set]
@@ -23,7 +23,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [mapv some]]))
+   [metabase.util.performance :refer [mapv some empty? not-empty]]))
 
 (defn- implicitly-joined-fields
   "Find fields that come from implicit join in form `x`, presumably a query.

--- a/src/metabase/query_processor/middleware/add_remaps.clj
+++ b/src/metabase/query_processor/middleware/add_remaps.clj
@@ -25,7 +25,7 @@
   `name` is `:remapped_from` `:category_id`.
 
   See also [[metabase.parameters.chain-filter]] for another explanation of remapping."
-  (:refer-clojure :exclude [mapv select-keys some])
+  (:refer-clojure :exclude [mapv select-keys some empty? not-empty])
   (:require
    [clojure.data :as data]
    [medley.core :as m]
@@ -47,7 +47,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [mapv select-keys some]]))
+   [metabase.util.performance :refer [mapv select-keys some empty? not-empty]]))
 
 (mr/def ::simplified-ref
   [:tuple

--- a/src/metabase/query_processor/middleware/add_rows_truncated.clj
+++ b/src/metabase/query_processor/middleware/add_rows_truncated.clj
@@ -1,12 +1,14 @@
 (ns metabase.query-processor.middleware.add-rows-truncated
   "Adds `:rows_truncated` to the query results if the results were truncated because of the query's constraints."
+  (:refer-clojure :exclude [empty?])
   (:require
    [metabase.lib.core :as lib]
    [metabase.lib.schema :as lib.schema]
    [metabase.query-processor.middleware.limit :as-alias limit]
    [metabase.query-processor.schema :as qp.schema]
    [metabase.query-processor.settings :as qp.settings]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [empty?]]))
 
 (defn- results-limit
   [{{:keys [max-results max-results-bare-rows]} :constraints

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -1,6 +1,6 @@
 (ns metabase.query-processor.middleware.annotate
   "Middleware for annotating (adding type information to) the results of a query, under the `:cols` column."
-  (:refer-clojure :exclude [every? mapv])
+  (:refer-clojure :exclude [every? mapv empty?])
   (:require
    [metabase.analyze.core :as analyze]
    [metabase.driver.common :as driver.common]
@@ -17,7 +17,7 @@
    [metabase.query-processor.schema :as qp.schema]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [every? mapv]]
+   [metabase.util.performance :refer [every? mapv empty?]]
    [potemkin :as p]))
 
 (comment metabase.query-processor.middleware.annotate.legacy-helper-fns/keep-me)

--- a/src/metabase/query_processor/middleware/auto_bucket_datetimes.clj
+++ b/src/metabase/query_processor/middleware/auto_bucket_datetimes.clj
@@ -2,7 +2,7 @@
   "Middleware for automatically bucketing unbucketed `:type/Temporal` (but not `:type/Time`) Fields with `:day`
   bucketing. Applies to any unbucketed Field in a breakout, or fields in a filter clause being compared against
   `yyyy-MM-dd` format datetime strings."
-  (:refer-clojure :exclude [select-keys every? some])
+  (:refer-clojure :exclude [select-keys every? some not-empty])
   (:require
    [medley.core :as m]
    [metabase.lib.core :as lib]
@@ -16,7 +16,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [select-keys every? some]]))
+   [metabase.util.performance :refer [select-keys every? some not-empty]]))
 
 (mr/def ::column-type-info
   [:map

--- a/src/metabase/query_processor/middleware/expand_macros.clj
+++ b/src/metabase/query_processor/middleware/expand_macros.clj
@@ -2,7 +2,7 @@
   "Middleware for expanding LEGACY `:segment` 'macros' in *unexpanded* MBQL queries.
 
   (`:segment` forms are expanded into filter clauses.)"
-  (:refer-clojure :exclude [mapv])
+  (:refer-clojure :exclude [mapv not-empty])
   (:require
    [metabase.lib.core :as lib]
    [metabase.lib.filter :as lib.filter]
@@ -19,7 +19,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [mapv]]))
+   [metabase.util.performance :refer [mapv not-empty]]))
 
 ;;; "legacy macro" as used below means legacy Segment.
 (mr/def ::legacy-macro

--- a/src/metabase/query_processor/middleware/limit.clj
+++ b/src/metabase/query_processor/middleware/limit.clj
@@ -1,5 +1,6 @@
 (ns metabase.query-processor.middleware.limit
   "Middleware that handles limiting the maximum number of rows returned by a query."
+  (:refer-clojure :exclude [empty?])
   (:require
    [metabase.lib.core :as lib]
    [metabase.lib.schema :as lib.schema]
@@ -8,6 +9,7 @@
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.util :as u]
    [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [empty?]]
    [potemkin :as p]))
 
 ;;; provided as a convenience since this var used to live here. Prefer using directly from `qp.settings` going forward.

--- a/src/metabase/query_processor/middleware/metrics.clj
+++ b/src/metabase/query_processor/middleware/metrics.clj
@@ -1,5 +1,5 @@
 (ns metabase.query-processor.middleware.metrics
-  (:refer-clojure :exclude [select-keys some])
+  (:refer-clojure :exclude [select-keys some empty? not-empty])
   (:require
    [medley.core :as m]
    [metabase.analytics.core :as analytics]
@@ -11,7 +11,7 @@
    [metabase.lib.walk :as lib.walk]
    [metabase.util :as u]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :as perf :refer [select-keys some]]))
+   [metabase.util.performance :as perf :refer [select-keys some empty? not-empty]]))
 
 (defn- filters->condition
   [filters]

--- a/src/metabase/query_processor/middleware/process_userland_query.clj
+++ b/src/metabase/query_processor/middleware/process_userland_query.clj
@@ -5,7 +5,7 @@
 
   ViewLog recording is triggered indirectly by the call to [[events/publish-event!]] with the `:event/card-query`
   event -- see [[metabase.view-log.events.view-log]]."
-  (:refer-clojure :exclude [every?])
+  (:refer-clojure :exclude [every? empty?])
   (:require
    [java-time.api :as t]
    [metabase.analytics.core :as analytics]
@@ -16,7 +16,7 @@
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [every?]]
+   [metabase.util.performance :refer [every? empty?]]
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2]))
 

--- a/src/metabase/query_processor/middleware/reconcile_breakout_and_order_by_bucketing.clj
+++ b/src/metabase/query_processor/middleware/reconcile_breakout_and_order_by_bucketing.clj
@@ -33,6 +33,7 @@
   The frontend, on the rare occasion it generates a query that explicitly specifies an `order-by` clause, usually will
   generate one that directly corresponds to the bad example above. This middleware finds these cases and rewrites the
   query to look like the good example."
+  (:refer-clojure :exclude [not-empty])
   (:require
    [medley.core :as m]
    [metabase.lib.core :as lib]
@@ -43,7 +44,8 @@
    [metabase.lib.util :as lib.util]
    [metabase.lib.walk :as lib.walk]
    [metabase.util :as u]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [not-empty]]))
 
 (defn- bucketed-breakouts [query stage-path {breakouts :breakout, :as _stage}]
   (->> breakouts

--- a/src/metabase/query_processor/middleware/remove_inactive_field_refs.clj
+++ b/src/metabase/query_processor/middleware/remove_inactive_field_refs.clj
@@ -6,13 +6,15 @@
 
   We only try to fix queries if we know a column has been removed. We recognize this during the next sync: deleted
   columns are marked active = false."
+  (:refer-clojure :exclude [empty? not-empty])
   (:require
    [metabase.lib.field.resolution :as lib.field.resolution]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.walk :as lib.walk]
    [metabase.util :as u]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [empty? not-empty]]))
 
 (mu/defn remove-inactive-field-refs :- ::lib.schema/query
   "Remove any references to fields that are not active.

--- a/src/metabase/query_processor/middleware/resolve_fields.clj
+++ b/src/metabase/query_processor/middleware/resolve_fields.clj
@@ -1,11 +1,13 @@
 (ns metabase.query-processor.middleware.resolve-fields
   "Middleware that resolves the Fields referenced by a query."
+  (:refer-clojure :exclude [not-empty])
   (:require
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.util :as u]
-   [metabase.util.i18n :refer [tru]]))
+   [metabase.util.i18n :refer [tru]]
+   [metabase.util.performance :refer [not-empty]]))
 
 (defn- resolve-fields-with-ids!
   [metadata-providerable field-ids]

--- a/src/metabase/query_processor/middleware/resolve_joins.clj
+++ b/src/metabase/query_processor/middleware/resolve_joins.clj
@@ -1,7 +1,7 @@
 (ns metabase.query-processor.middleware.resolve-joins
   "Middleware that fetches tables that will need to be joined, referred to by `:field` clauses with `:source-field`
   options, and adds information to the query about what joins should be done and how they should be performed."
-  (:refer-clojure :exclude [alias every? mapv])
+  (:refer-clojure :exclude [alias every? mapv empty?])
   (:require
    [clojure.string :as str]
    [medley.core :as m]
@@ -11,7 +11,7 @@
    [metabase.lib.schema.util :as lib.schema.util]
    [metabase.lib.walk :as lib.walk]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [every? mapv]]))
+   [metabase.util.performance :refer [every? mapv empty?]]))
 
 (mu/defn- merge-defaults :- ::lib.schema.join/join
   [join]

--- a/src/metabase/query_processor/pivot.clj
+++ b/src/metabase/query_processor/pivot.clj
@@ -3,7 +3,7 @@
   warehouse and concatenates the result rows together, sort of like the way [[clojure.core/lazy-cat]] works. This is
   dumb, right? It's not just me? Why don't we just generate a big ol' UNION query so we can run one single query
   instead of running like 10 separate queries? -- Cam"
-  (:refer-clojure :exclude [every? mapv some select-keys update-keys])
+  (:refer-clojure :exclude [every? mapv some select-keys update-keys empty? not-empty])
   (:require
    [medley.core :as m]
    [metabase.lib-be.core :as lib-be]
@@ -31,7 +31,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :as perf :refer [mapv some every? select-keys update-keys]]))
+   [metabase.util.performance :as perf :refer [mapv some every? select-keys update-keys empty? not-empty]]))
 
 (set! *warn-on-reflection* true)
 

--- a/src/metabase/query_processor/pivot/postprocess.clj
+++ b/src/metabase/query_processor/pivot/postprocess.clj
@@ -4,14 +4,14 @@
   The shape returned by the pivot qp is not the same visually as what a pivot table looks like in the app.
   It's all of the same data, but some post-processing logic needs to run on the rows to be able to present them
   visually in the same way as in the app."
-  (:refer-clojure :exclude [mapv])
+  (:refer-clojure :exclude [mapv empty?])
   (:require
    [clojure.set :as set]
    [metabase.models.visualization-settings :as mb.viz]
    [metabase.pivot.core :as pivot]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :as perf :refer [mapv]]))
+   [metabase.util.performance :as perf :refer [mapv empty?]]))
 
 (set! *warn-on-reflection* true)
 

--- a/src/metabase/query_processor/preprocess.clj
+++ b/src/metabase/query_processor/preprocess.clj
@@ -1,4 +1,5 @@
 (ns metabase.query-processor.preprocess
+  (:refer-clojure :exclude [not-empty])
   (:require
    [metabase.config.core :as config]
    [metabase.lib.schema :as lib.schema]
@@ -43,7 +44,8 @@
    [metabase.util :as u]
    [metabase.util.i18n :as i18n]
    [metabase.util.log :as log]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [not-empty]]))
 
 (set! *warn-on-reflection* true)
 

--- a/src/metabase/query_processor/streaming.clj
+++ b/src/metabase/query_processor/streaming.clj
@@ -1,5 +1,5 @@
 (ns metabase.query-processor.streaming
-  (:refer-clojure :exclude [every? some mapv])
+  (:refer-clojure :exclude [every? some mapv not-empty])
   (:require
    [clojure.string :as str]
    [metabase.lib.core :as lib]
@@ -15,7 +15,7 @@
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [every? mapv some]])
+   [metabase.util.performance :refer [every? mapv some not-empty]])
   (:import
    (clojure.core.async.impl.channels ManyToManyChannel)
    (java.io OutputStream)

--- a/src/metabase/query_processor/streaming/common.clj
+++ b/src/metabase/query_processor/streaming/common.clj
@@ -1,6 +1,6 @@
 (ns metabase.query-processor.streaming.common
   "Shared util fns for various export (download) streaming formats."
-  (:refer-clojure :exclude [mapv select-keys])
+  (:refer-clojure :exclude [mapv select-keys not-empty])
   (:require
    [clojure.string :as str]
    [java-time.api :as t]
@@ -11,7 +11,7 @@
    [metabase.query-processor.timezone :as qp.timezone]
    [metabase.util.currency :as currency]
    [metabase.util.date-2 :as u.date]
-   [metabase.util.performance :as perf :refer [mapv select-keys]])
+   [metabase.util.performance :as perf :refer [mapv select-keys not-empty]])
   (:import
    (clojure.lang ISeq)
    (java.time LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime ZonedDateTime)))

--- a/src/metabase/query_processor/streaming/json.clj
+++ b/src/metabase/query_processor/streaming/json.clj
@@ -1,7 +1,7 @@
 (ns metabase.query-processor.streaming.json
   "Impls for JSON-based QP streaming response types. `:json` streams a simple array of maps as opposed to the full
   response with all the metadata for `:api`."
-  (:refer-clojure :exclude [mapv])
+  (:refer-clojure :exclude [mapv empty? not-empty])
   (:require
    [medley.core :as m]
    [metabase.formatter.core :as formatter]
@@ -9,7 +9,7 @@
    [metabase.query-processor.streaming.common :as streaming.common]
    [metabase.query-processor.streaming.interface :as qp.si]
    [metabase.util.json :as json]
-   [metabase.util.performance :refer [mapv]])
+   [metabase.util.performance :refer [mapv empty? not-empty]])
   (:import
    (com.fasterxml.jackson.core JsonGenerator)
    (java.io BufferedWriter OutputStream OutputStreamWriter)

--- a/src/metabase/query_processor/util/add_alias_info.clj
+++ b/src/metabase/query_processor/util/add_alias_info.clj
@@ -40,7 +40,7 @@
 
   If this clause is 'selected' (i.e., appears in `:fields`, `:aggregation`, or `:breakout`), select the clause `AS`
   this alias. This alias is guaranteed to be unique."
-  (:refer-clojure :exclude [mapv ref select-keys some])
+  (:refer-clojure :exclude [mapv ref select-keys some empty? not-empty])
   (:require
    [medley.core :as m]
    [metabase.config.core :as config]
@@ -60,7 +60,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [mapv select-keys some]]))
+   [metabase.util.performance :refer [mapv select-keys some empty? not-empty]]))
 
 (mu/defn- ^:dynamic *escape-alias-fn* :- :string
   [driver :- :keyword

--- a/src/metabase/query_processor/util/transformations/nest_breakouts.clj
+++ b/src/metabase/query_processor/util/transformations/nest_breakouts.clj
@@ -1,7 +1,7 @@
 (ns metabase.query-processor.util.transformations.nest-breakouts
   "TODO (Cam 8/7/25) -- this is a pure-MBQL-5 high-level query transformation, and almost certainly belongs in Lib
   rather than in QP -- we should move it there. (This also applies to [[metabase.query-processor.util.nest-query]])."
-  (:refer-clojure :exclude [mapv select-keys some])
+  (:refer-clojure :exclude [mapv select-keys some not-empty])
   (:require
    [flatland.ordered.set :as ordered-set]
    [medley.core :as m]
@@ -14,7 +14,7 @@
    [metabase.lib.util.match :as lib.util.match]
    [metabase.lib.walk :as lib.walk]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [mapv select-keys some]]))
+   [metabase.util.performance :refer [mapv select-keys some not-empty]]))
 
 (defn- stage-has-window-aggregation? [stage]
   (lib.util.match/match (:aggregation stage)


### PR DESCRIPTION
Suggest using the recent additions to `metabase.util.performance`:
- `empty?`
- `not-empty`
- `for`
- `doseq`