### PR TITLE
Correct interactive embed query execution count

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
@@ -774,6 +774,15 @@ describe("scenarios > embedding > dashboard appearance", () => {
       cy.findByRole("tab", { name: "Look and Feel" }).click();
       cy.get("@previewEmbedSpy").should("have.callCount", 1);
 
+      cy.log(
+        'Embed preview requests should not have "X-Metabase-Client: embedding-iframe" header (EMB-930)',
+      );
+      cy.get("@previewEmbed").then(({ request }) => {
+        expect(request?.headers?.["x-metabase-client"]).to.not.equal(
+          "embedding-iframe",
+        );
+      });
+
       cy.log("Assert dashboard theme");
       H.getIframeBody()
         .findByTestId("embed-frame")

--- a/frontend/src/metabase/lib/api.js
+++ b/frontend/src/metabase/lib/api.js
@@ -76,7 +76,7 @@ export class Api extends EventEmitter {
       // eslint-disable-next-line no-literal-metabase-strings -- Not a user facing string
       headers["X-Metabase-Embedded"] = "true";
       /**
-       * We counted static embed preview query executions which lead to wrong embedding stats (EMB-930)
+       * We counted static embed preview query executions which led to wrong embedding stats (EMB-930)
        * This header is only used for logging in `view_log` and `query_execution` tables, so it's safe to exclude it.
        */
       if (!IS_EMBED_PREVIEW) {

--- a/frontend/src/metabase/lib/api.js
+++ b/frontend/src/metabase/lib/api.js
@@ -77,7 +77,8 @@ export class Api extends EventEmitter {
       headers["X-Metabase-Embedded"] = "true";
       /**
        * We counted static embed preview query executions which led to wrong embedding stats (EMB-930)
-       * This header is only used for logging in `view_log` and `query_execution` tables, so it's safe to exclude it.
+       * This header is only used for analytics and for checking if we want to disable some features in the
+       * embedding iframe (only for Documents at the time of this comment)
        */
       if (!IS_EMBED_PREVIEW) {
         // eslint-disable-next-line no-literal-metabase-strings -- Not a user facing string

--- a/frontend/src/metabase/lib/api.js
+++ b/frontend/src/metabase/lib/api.js
@@ -5,6 +5,8 @@ import { isTest } from "metabase/env";
 import { isWithinIframe } from "metabase/lib/dom";
 import { delay } from "metabase/lib/promise";
 
+import { IS_EMBED_PREVIEW } from "./embed";
+
 const ONE_SECOND = 1000;
 const MAX_RETRIES = 10;
 
@@ -73,8 +75,14 @@ export class Api extends EventEmitter {
     if (isWithinIframe() && !self.requestClient) {
       // eslint-disable-next-line no-literal-metabase-strings -- Not a user facing string
       headers["X-Metabase-Embedded"] = "true";
-      // eslint-disable-next-line no-literal-metabase-strings -- Not a user facing string
-      headers["X-Metabase-Client"] = "embedding-iframe";
+      /**
+       * We counted static embed preview query executions which lead to wrong embedding stats (EMB-930)
+       * This header is only used for logging in `view_log` and `query_execution` tables, so it's safe to exclude it.
+       */
+      if (!IS_EMBED_PREVIEW) {
+        // eslint-disable-next-line no-literal-metabase-strings -- Not a user facing string
+        headers["X-Metabase-Client"] = "embedding-iframe";
+      }
     }
 
     if (self.requestClient) {

--- a/frontend/src/metabase/lib/api.js
+++ b/frontend/src/metabase/lib/api.js
@@ -70,12 +70,7 @@ export class Api extends EventEmitter {
       headers["X-Metabase-Session"] = self.sessionToken;
     }
 
-    // For simple embedding, we use "embedding-simple" instead of "embedding-iframe"
-    const isSimpleEmbedHeader =
-      typeof self.requestClient === "object" &&
-      self.requestClient.name === "embedding-simple";
-
-    if (isWithinIframe() && !isSimpleEmbedHeader) {
+    if (isWithinIframe() && !self.requestClient) {
       // eslint-disable-next-line no-literal-metabase-strings -- Not a user facing string
       headers["X-Metabase-Embedded"] = "true";
       // eslint-disable-next-line no-literal-metabase-strings -- Not a user facing string


### PR DESCRIPTION
closes EMB-930
### Backport reasons
It should be safe to backport to older versions 55, 56, 57 in this case as the change it simple.

### Description

Correct interactive embed query execution count was incorrectly counting static embed preview. Previously, we also set `X-Metabase-Client` to `embedding-iframe` on the static embed preview requests, which makes the SDK analytics wrong. Actually, `X-Metabase-Client` is only used for 3 purposes currently:
1. Used in `query_execution` and `view_log` table
2. Track SDK response status
    https://github.com/metabase/metabase/blob/8541924f7b1a2f7833b360ac43a591b5eae782b5/src/metabase/analytics/sdk.clj#L45-L51
3. Used to determine if we want to disable some features currently only for Documents.
     https://github.com/metabase/metabase/blob/8541924f7b1a2f7833b360ac43a591b5eae782b5/enterprise/backend/src/metabase_enterprise/comments/api.clj#L102-L104

So not sending `X-Metabase-Client` should be fine for static embed preview, and it'd be counted as :internal instead (which would be more accurate than :interactive_embed)

### How to verify
1. Run Metabase FE and BE. For BE I used `clj -M:dev:ee:dev-start`, but whatever command that also runs repl server. You should see this printed out in the console
  ```
  Starting Metabase cider repl on port 50605
  ```
2. Connects to repl
  ```sh
  clj -Sdeps '{:deps {reply/reply {:mvn/version "0.5.1"}}}' -M -m reply.main --attach 50605
  ```
3. In the repl run these commands
  ```clj
  (require '[metabase.internal-stats.query-executions :as qe])
  (require '[clojure.pprint :as pprint])
  (pprint/pprint (qe/query-executions-all-time-and-last-24h))
  ```
4. Now run Metabase in different environments and repeat the command above. Test these environments:
  4.1 internal
  4.2 static embed
  4.3 interactive embed
  4.4 static embed preview
5. The count for each environment should be correct especially the static embed preview should be counted as `:internal`
### Demo

REPL result
```clj
{:query-executions (toucan2.instance/instance :model/QueryExecution {:row_count 0, :sdk_embed 0, :simple_embed 0, :interactive_embed 55, :static_embed 90, :public_link 0, :internal 122}), :query-executions-24h (toucan2.instance/instance :model/QueryExecution {:row_count 0, :sdk_embed 0, :simple_embed 0, :interactive_embed 55, :static_embed 90, :public_link 0, :internal 120})}
```

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
