### PR TITLE
Fix and revive the backend cloverage workflow

### DIFF
--- a/.github/workflows/backend-cloverage.yml
+++ b/.github/workflows/backend-cloverage.yml
@@ -1,7 +1,6 @@
 name: Backend-Cloverage
 
 on:
-  push: # only temporary to test it
   workflow_dispatch:
   schedule:
     - cron: '0 10 * * 1-5' # every weekday at 5am US eastern time

--- a/.github/workflows/backend-cloverage.yml
+++ b/.github/workflows/backend-cloverage.yml
@@ -130,3 +130,84 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./target/coverage/codecov.json
           flags: back-end
+
+  be-linter-cloverage-enterprise:
+    # don't run this workflow on a cron for forks
+    if: ${{ github.event_name != 'schedule' || github.repository == 'metabase/metabase' }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        modules:
+          - action-v2
+          - advanced-config
+          - advanced-permissions
+          - ai-entity-analysis
+          - ai-sql-fixer
+          - ai-sql-generation
+          - analytics
+          - api
+          - audit-app
+          - auth-provider
+          - billing
+          - bookmarks
+          - cache
+          - cloud-add-ons
+          - comments
+          - content-translation
+          - content-verification
+          - core
+          - dashboard-subscription-filters
+          - database-replication
+          - database-routing
+          - dependencies
+          - documents
+          - email
+          - embedding-hub
+          - gsheets
+          - harbormaster
+          - impersonation
+          - internal-stats
+          - llm
+          - metabot-v3
+          - permission-debug
+          - premium-features
+          - public-sharing
+          - remote-sync
+          - sandbox
+          - scim
+          - search
+          - semantic-search
+          - serialization
+          - snippet-collections
+          - sso
+          - stale
+          - transforms
+          - transforms-python
+          - upload-management
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare front-end environment
+        uses: ./.github/actions/prepare-frontend
+      - name: Prepare back-end environment
+        uses: ./.github/actions/prepare-backend
+
+      - name: Build static viz frontend
+        run: yarn build-static-viz
+        env:
+          MB_EDITION: ee
+      - name: Collect the test coverage
+        run: |
+          clojure -X:dev:ci:ee:ee-dev:test:cloverage \
+            :ns-regex     '["^metabase-enterprise\\.${{ matrix.modules }}\\..*"]' \
+            :test-ns-path '["enterprise/backend/test/metabase/${{ matrix.modules }}"]'
+        continue-on-error: true
+
+      - name: Upload coverage to codecov.io
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./target/coverage/codecov.json
+          flags: back-end

--- a/.github/workflows/backend-cloverage.yml
+++ b/.github/workflows/backend-cloverage.yml
@@ -24,7 +24,7 @@ jobs:
         env:
           MB_EDITION: ee
       - name: Collect the test coverage
-        run: clojure -X:dev:ci:ee:ee-dev:test:cloverage
+        run: clojure -X:dev:ci:ee:ee-dev:test:cloverage :ns-regex '["^metabase\\.actions\\..*"]'
 
       - name: Upload coverage to codecov.io
         uses: codecov/codecov-action@v5

--- a/.github/workflows/backend-cloverage.yml
+++ b/.github/workflows/backend-cloverage.yml
@@ -24,7 +24,10 @@ jobs:
         env:
           MB_EDITION: ee
       - name: Collect the test coverage
-        run: clojure -X:dev:ci:ee:ee-dev:test:cloverage :ns-regex '["^metabase\\.actions\\..*"]'
+        run: |
+          clojure -X:dev:ci:ee:ee-dev:test:cloverage \
+            :ns-regex     '["^metabase\\.actions\\..*"]' \
+            :test-ns-path '["test/metabase/actions"]'
 
       - name: Upload coverage to codecov.io
         uses: codecov/codecov-action@v5

--- a/.github/workflows/backend-cloverage.yml
+++ b/.github/workflows/backend-cloverage.yml
@@ -12,6 +12,10 @@ jobs:
     if: ${{ github.event_name != 'schedule' || github.repository == 'metabase/metabase' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        modules: [actions, activity-feed]
     steps:
       - uses: actions/checkout@v4
       - name: Prepare front-end environment
@@ -26,10 +30,12 @@ jobs:
       - name: Collect the test coverage
         run: |
           clojure -X:dev:ci:ee:ee-dev:test:cloverage \
-            :ns-regex     '["^metabase\\.actions\\..*"]' \
-            :test-ns-path '["test/metabase/actions"]'
+            :ns-regex     '["^metabase\\.${{ matrix.modules }}\\..*"]' \
+            :test-ns-path '["test/metabase/${{ matrix.modules }}"]'
+        continue-on-error: true
 
       - name: Upload coverage to codecov.io
+        if: always()
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/backend-cloverage.yml
+++ b/.github/workflows/backend-cloverage.yml
@@ -1,6 +1,7 @@
 name: Backend-Cloverage
 
 on:
+  push: # only temporary to test it
   workflow_dispatch:
   schedule:
     - cron: '0 10 * * 1-5' # every weekday at 5am US eastern time
@@ -13,16 +14,20 @@ jobs:
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
+      - name: Prepare front-end environment
+        uses: ./.github/actions/prepare-frontend
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
+
       - name: Build static viz frontend
         run: yarn build-static-viz
         env:
           MB_EDITION: ee
       - name: Collect the test coverage
         run: clojure -X:dev:ci:ee:ee-dev:test:cloverage
+
       - name: Upload coverage to codecov.io
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./target/coverage/codecov.json

--- a/.github/workflows/backend-cloverage.yml
+++ b/.github/workflows/backend-cloverage.yml
@@ -27,6 +27,38 @@ jobs:
           - appearance
           - audit-app
           - auth-provider
+          - batch-processing
+          - bookmarks
+          - bug-reporting
+          - cache
+          - channel
+          - classloader
+          - cloud-migration
+          - cmd
+          - collections
+          - config
+          - connection-pool
+          - content-translation
+          - content-verification
+          - core
+          - dashboards
+          - database-routing
+          - driver
+          - driver-api
+          - eid-translation
+          - embedding
+          - events
+          - formatter
+          - geojson
+          - glossary
+          - graph
+          - indexed-entities
+          - internal-stats
+          - legacy-mbql
+          - lib
+          - lib-be
+          - logger
+          - login-history
     steps:
       - uses: actions/checkout@v4
       - name: Prepare front-end environment

--- a/.github/workflows/backend-cloverage.yml
+++ b/.github/workflows/backend-cloverage.yml
@@ -11,7 +11,7 @@ jobs:
     # don't run this workflow on a cron for forks
     if: ${{ github.event_name != 'schedule' || github.repository == 'metabase/metabase' }}
     runs-on: ubuntu-22.04
-    timeout-minutes: 90
+    timeout-minutes: 180
     steps:
       - uses: actions/checkout@v4
       - name: Prepare front-end environment

--- a/.github/workflows/backend-cloverage.yml
+++ b/.github/workflows/backend-cloverage.yml
@@ -11,11 +11,22 @@ jobs:
     # don't run this workflow on a cron for forks
     if: ${{ github.event_name != 'schedule' || github.repository == 'metabase/metabase' }}
     runs-on: ubuntu-22.04
-    timeout-minutes: 180
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
-        modules: [actions, activity-feed]
+        modules:
+          - actions
+          - activity-feed
+          - analytics
+          - analyze
+          - api
+          - api-keys
+          - api-routes
+          - app-db
+          - appearance
+          - audit-app
+          - auth-provider
     steps:
       - uses: actions/checkout@v4
       - name: Prepare front-end environment

--- a/.github/workflows/backend-cloverage.yml
+++ b/.github/workflows/backend-cloverage.yml
@@ -10,7 +10,7 @@ jobs:
     # don't run this workflow on a cron for forks
     if: ${{ github.event_name != 'schedule' || github.repository == 'metabase/metabase' }}
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -134,7 +134,7 @@ jobs:
     # don't run this workflow on a cron for forks
     if: ${{ github.event_name != 'schedule' || github.repository == 'metabase/metabase' }}
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/backend-cloverage.yml
+++ b/.github/workflows/backend-cloverage.yml
@@ -59,6 +59,52 @@ jobs:
           - lib-be
           - logger
           - login-history
+          - model-persistence
+          - models
+          - native-query-snippets
+          - notification
+          - parameters
+          - permissions
+          - pivot
+          - plugins
+          - premium-features
+          - product-feedback
+          - public-sharing
+          - pulse
+          - queries
+          - query-permissions
+          - query-processor
+          - remote-sync
+          - request
+          - revisions
+          - sample-data
+          - search
+          - secrets
+          - segments
+          - server
+          - session
+          - settings
+          - setup
+          - sso
+          - startup
+          - store-api
+          - sync
+          - system
+          - task
+          - task-history
+          - testing-api
+          - tiles
+          - timeline
+          - types
+          - upload
+          - user-key-value
+          - users
+          - util
+          - version
+          - view-log
+          - warehouse-schema
+          - warehouses
+          - xrays
     steps:
       - uses: actions/checkout@v4
       - name: Prepare front-end environment


### PR DESCRIPTION
Resolves DEV-990

This pull request fixes the backend cloverage workflow in `.github/workflows/backend-cloverage.yml`. This workflow has been broken for 1.5 years! The introduction of babashka tests is what broke it originally (see #65046).

*Even when I fixed that, the workflow needed 2.5 hours to finish with 100 errors! *

Once I introduced the parallelization via `matrix`, the whole workflow now finishes reliably in under five minutes without test errors.

**Workflow parallelization and reliability improvements:**

* Added a matrix strategy to split both the open-source and enterprise backend cloverage jobs by individual module, allowing coverage to run in parallel and improving reliability by setting `fail-fast: false`. (`.github/workflows/backend-cloverage.yml`)
* Reduced the timeout for each job from 90 to 30 minutes to better manage CI resources. (`.github/workflows/backend-cloverage.yml`)

## No need to merge reports

As per CodeCov's documentation, we don't have to do anything to merge individual reports. Any report that comes from the same commit will be merged and appended automatically by CodeCov 🎉 

## Test

I've had a trigger on push to test this workflow in this branch. Here's the result of a successful run which finally re-introduces results for the `back-end` flag.
https://app.codecov.io/github/metabase/metabase/tree/dev-990-fix-be-and-fe-code-coverage-ci-workflows/

### Skipped CI

The last commit has a `[ci skip]` comment in order to save some CI cycles because this workflow can only run once it's already merged to `master`. It would only trigger unrelated tests if I'd let it run.