### PR TITLE
Fix SDK v56 can't drills dashboard with entity IDs

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/interactive-dashboard.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-dashboard.cy.spec.tsx
@@ -209,6 +209,46 @@ describe("scenarios > embedding-sdk > interactive-dashboard", () => {
     });
   });
 
+  const idTypes = [
+    { idType: "numeric id", dashboardIdAlias: "@dashboardId" },
+    { idType: "entity id", dashboardIdAlias: "@dashboardEntityId" },
+  ];
+
+  idTypes.forEach(({ idType, dashboardIdAlias }) => {
+    it(`can go to dashcard and go back using a ${idType} dashboard (EMB-773)`, () => {
+      cy.get(dashboardIdAlias).then((dashboardId) => {
+        mountSdkContent(<InteractiveDashboard dashboardId={dashboardId} />);
+      });
+
+      getSdkRoot().within(() => {
+        H.getDashboardCard().findByText("Orders").click();
+
+        cy.findByTestId("interactive-question-result-toolbar").should(
+          "be.visible",
+        );
+
+        cy.findByLabelText("Back to Orders in a dashboard").click();
+        cy.findByText("Orders in a dashboard").should("be.visible");
+        cy.findByText("Back to Orders in a dashboard").should("not.exist");
+      });
+    });
+
+    it(`can drill a question and go back using a ${idType} dashboard (EMB-773)`, () => {
+      cy.get(dashboardIdAlias).then((dashboardId) => {
+        mountSdkContent(<InteractiveDashboard dashboardId={dashboardId} />);
+      });
+
+      getSdkRoot().within(() => {
+        cy.findByText("123").first().click();
+        H.popover().findByText("View this Product's Orders").click();
+
+        cy.findByLabelText("Back to Orders in a dashboard").click();
+        cy.findByText("Orders in a dashboard").should("be.visible");
+        cy.findByText("Back to Orders in a dashboard").should("not.exist");
+      });
+    });
+  });
+
   it("should only call POST /dataset once when parent component re-renders (EMB-288)", () => {
     cy.intercept("POST", "/api/dataset").as("datasetQuery");
 

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/dashboard/use-common-dashboard-params.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/dashboard/use-common-dashboard-params.tsx
@@ -13,6 +13,7 @@ import { navigateBackToDashboard } from "metabase/query_builder/actions";
 import { getMetadata } from "metabase/selectors/metadata";
 import type Question from "metabase-lib/v1/Question";
 import type { DashboardId, QuestionDashboardCard } from "metabase-types/api";
+import type { StoreDashboard } from "metabase-types/store";
 
 export const useCommonDashboardParams = ({
   dashboardId,
@@ -47,7 +48,12 @@ export const useCommonDashboardParams = ({
       const state = store.getState();
       const metadata = getMetadata(state);
       const { dashboards, parameterValues } = state.dashboard;
-      const dashboard = dashboardId && dashboards[dashboardId];
+
+      if (dashboardId === null) {
+        return;
+      }
+
+      const dashboard = findDashboardById(dashboardId, dashboards);
 
       if (dashboard) {
         const url = getNewCardUrl({
@@ -89,4 +95,25 @@ export const useCommonDashboardParams = ({
     onEditQuestion,
     onNavigateToNewCardFromDashboard: handleNavigateToNewCardFromDashboard,
   };
+};
+
+const findDashboardById = (
+  dashboardId: DashboardId,
+  dashboards: Record<DashboardId, StoreDashboard>,
+): StoreDashboard | null => {
+  if (typeof dashboardId === "number") {
+    return dashboards[dashboardId] ?? null;
+  }
+
+  // Lookup via entity ids.
+  // Dashboards are a mapping of numeric id to dashboard.
+  if (typeof dashboardId === "string") {
+    return (
+      Object.values(dashboards).find(
+        (dashboard) => dashboard.entity_id === dashboardId,
+      ) ?? null
+    );
+  }
+
+  return null;
 };

--- a/frontend/src/metabase/dashboard/actions/cards.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/actions/cards.unit.spec.ts
@@ -362,7 +362,7 @@ async function runAddCardToDashboard({
   const nextState = store.getState();
 
   const tempDashCardId =
-    getDashboardById(nextState, dashId).dashcards.find(
+    getDashboardById(nextState, dashId)!.dashcards.find(
       (dashcardId) => dashcardId < 0,
     ) ?? -1;
 

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -8,7 +8,7 @@ import {
   SIDEBAR_NAME,
 } from "metabase/dashboard/constants";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
-import { isNotNull } from "metabase/lib/types";
+import { checkNotNull, isNotNull } from "metabase/lib/types";
 import * as Urls from "metabase/lib/urls";
 import {
   getDashboardQuestions,
@@ -191,7 +191,7 @@ export const getDashboardById = (
 
   const isEntityId = typeof dashboardId === "string";
   if (isEntityId) {
-    return isNotNull(
+    return checkNotNull(
       Object.values(dashboards).find(
         (dashboard) => dashboard.entity_id === dashboardId,
       ),

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -8,7 +8,7 @@ import {
   SIDEBAR_NAME,
 } from "metabase/dashboard/constants";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
-import { checkNotNull, isNotNull } from "metabase/lib/types";
+import { isNotNull } from "metabase/lib/types";
 import * as Urls from "metabase/lib/urls";
 import {
   getDashboardQuestions,
@@ -184,18 +184,13 @@ export function getDashCardBeforeEditing(state: State, dashcardId: DashCardId) {
 export const getLoadingDashCards = (state: State) =>
   state.dashboard.loadingDashCards;
 
-export const getDashboardById = (
-  state: State,
-  dashboardId: DashboardId,
-): StoreDashboard => {
+export const getDashboardById = (state: State, dashboardId: DashboardId) => {
   const dashboards = getDashboards(state);
 
   const isEntityId = isBaseEntityID(dashboardId);
   if (isEntityId) {
-    return checkNotNull(
-      Object.values(dashboards).find(
-        (dashboard) => dashboard.entity_id === dashboardId,
-      ),
+    return Object.values(dashboards).find(
+      (dashboard) => dashboard.entity_id === dashboardId,
     );
   } else {
     // Number and jwt (static embed) IDs

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -183,9 +183,23 @@ export function getDashCardBeforeEditing(state: State, dashcardId: DashCardId) {
 export const getLoadingDashCards = (state: State) =>
   state.dashboard.loadingDashCards;
 
-export const getDashboardById = (state: State, dashboardId: DashboardId) => {
+export const getDashboardById = (
+  state: State,
+  dashboardId: DashboardId,
+): StoreDashboard => {
   const dashboards = getDashboards(state);
-  return dashboards[dashboardId];
+
+  const isEntityId = typeof dashboardId === "string";
+  if (isEntityId) {
+    return isNotNull(
+      Object.values(dashboards).find(
+        (dashboard) => dashboard.entity_id === dashboardId,
+      ),
+    );
+  } else {
+    // Number ID
+    return dashboards[dashboardId];
+  }
 };
 
 export const getDashboardComplete = createSelector(

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -31,15 +31,16 @@ import {
   getValuePopulatedParameters as _getValuePopulatedParameters,
   getParameterValuesBySlug,
 } from "metabase-lib/v1/parameters/utils/parameter-values";
-import type {
-  Card,
-  DashCardId,
-  Dashboard,
-  DashboardCard,
-  DashboardId,
-  DashboardParameterMapping,
-  ParameterId,
-  VirtualCard,
+import {
+  type Card,
+  type DashCardId,
+  type Dashboard,
+  type DashboardCard,
+  type DashboardId,
+  type DashboardParameterMapping,
+  type ParameterId,
+  type VirtualCard,
+  isBaseEntityID,
 } from "metabase-types/api";
 import type {
   ClickBehaviorSidebarState,
@@ -189,7 +190,7 @@ export const getDashboardById = (
 ): StoreDashboard => {
   const dashboards = getDashboards(state);
 
-  const isEntityId = typeof dashboardId === "string";
+  const isEntityId = isBaseEntityID(dashboardId);
   if (isEntityId) {
     return checkNotNull(
       Object.values(dashboards).find(
@@ -197,7 +198,7 @@ export const getDashboardById = (
       ),
     );
   } else {
-    // Number ID
+    // Number and jwt (static embed) IDs
     return dashboards[dashboardId];
   }
 };

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/DashboardBackButton/DashboardBackButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/DashboardBackButton/DashboardBackButton.tsx
@@ -8,6 +8,7 @@ import { navigateBackToDashboard } from "metabase/query_builder/actions";
 import { getDashboard } from "metabase/query_builder/selectors";
 import { ActionIcon, type ActionIconProps, Icon, Tooltip } from "metabase/ui";
 import type { DashboardId } from "metabase-types/api";
+import type { StoreDashboard } from "metabase-types/store";
 
 import DashboardBackButtonS from "./DashboardBackButton.module.css";
 
@@ -27,7 +28,12 @@ export function DashboardBackButton({
   dashboardOverride,
   ...actionIconProps
 }: DashboardBackButtonProps) {
-  const dashboardState = useSelector(getDashboard);
+  /**
+   * The previous signature was actually incorrect, it seems this selector
+   * can return undefined. But at this point, we will already have the dashboard
+   * ready.
+   */
+  const dashboardState = useSelector(getDashboard) as StoreDashboard;
   const dashboard = dashboardOverride ?? dashboardState;
   const dispatch = useDispatch();
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #64884
Closes EMB-910

> [!note]
> This PR targets 56 directly as [this bug doesn't seem to occur on 57.](https://github.com/metabase/metabase/issues/64884#issuecomment-3459911063)

### Description

Fix can't drill dashboards with entity IDs.

The fix is cherry-picked from https://github.com/metabase/metabase/pull/62953, with some conflicts (see inline comments).

Also, the back button not showing when using entity ID is believed to be fixed in https://github.com/metabase/metabase/pull/62519 (and maybe other dependent PRs) which isn't backported to 56. So I made a fix in the dashboard selector instead.

### How to verify
1. Go to the E-Commerce Insights dashboard from Examples
2. Go to the info icon and copy its entityId
3. Embed with SDK using the entityId as dashboardId:
```jsx
    <MetabaseProvider authConfig={authConfig}>
      <InteractiveDashboard dashboardId={'xBLdW9FsgRuB2HGhWiBa_'}></InteractiveDashboard>
    </MetabaseProvider>
```
4. Drills should work, and you should be able to go back to the dashboard


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
