### PR TITLE
Toggle dark mode from command palette

### DIFF
--- a/frontend/src/metabase/palette/components/Palette.unit.spec.tsx
+++ b/frontend/src/metabase/palette/components/Palette.unit.spec.tsx
@@ -53,4 +53,20 @@ describe("command palette", () => {
       false,
     );
   });
+
+  it("should toggle dark mode", async () => {
+    setup();
+    await userEvent.keyboard("[ControlLeft>]k");
+    await screen.findByTestId("command-palette");
+    const input = await screen.findByPlaceholderText(/search for anything/i);
+    await userEvent.type(input, "dark mode");
+    await userEvent.click(await screen.findByText("Toggle dark/light mode"));
+
+    const getColorSchemeValue = () =>
+      window.localStorage.getItem("metabase-color-scheme");
+
+    expect(getColorSchemeValue()).toBe("dark");
+    await userEvent.click(await screen.findByText("Toggle dark/light mode"));
+    expect(getColorSchemeValue()).toBe("auto");
+  });
 });

--- a/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
@@ -318,11 +318,6 @@ export const useCommandPaletteBasicActions = ({
   useRegisterShortcut([
     {
       id: "toggle-dark-mode",
-      name: t`Toggle dark/light mode`,
-      section: "basic",
-      keywords:
-        "toggle, toggle dark, toggle light, dark, light, dark mode, light mode, theme, mode, night",
-      icon: "moon",
       perform: () => colorSchemeRef.current.toggleColorScheme(),
     },
     {

--- a/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
@@ -318,6 +318,11 @@ export const useCommandPaletteBasicActions = ({
   useRegisterShortcut([
     {
       id: "toggle-dark-mode",
+      name: t`Toggle dark/light mode`,
+      section: "basic",
+      keywords:
+        "toggle, toggle dark, toggle light, dark, light, dark mode, light mode, theme, mode, night",
+      icon: "moon",
       perform: () => colorSchemeRef.current.toggleColorScheme(),
     },
     {

--- a/frontend/src/metabase/palette/shortcuts/global.ts
+++ b/frontend/src/metabase/palette/shortcuts/global.ts
@@ -145,8 +145,13 @@ export const globalShortcuts = {
 
   "toggle-dark-mode": {
     get name() {
-      return t`Toggle dark mode`;
+      return t`Toggle dark/light mode`;
     },
+
+    section: "basic",
+    keywords:
+      "toggle, toggle dark, toggle light, dark, light, dark mode, light mode, theme, mode, night",
+    icon: "moon",
 
     shortcut: ["$mod+Shift+KeyL"],
     shortcutGroup: "global" as const,


### PR DESCRIPTION
Closes UXW-1913

## Description

Adds dark/light mode toggling to the command palette. Also adds some search aliases to make it easier to find.

<img width="704" height="358" alt="CleanShot 2025-11-03 at 08 08 33" src="https://github.com/user-attachments/assets/067bf9c5-7d10-4bc5-afd1-58957430c6f2" />
