### PR TITLE
Restore calendar hover styles

### DIFF
--- a/frontend/src/metabase/ui/components/inputs/Calendar/Calendar.module.css
+++ b/frontend/src/metabase/ui/components/inputs/Calendar/Calendar.module.css
@@ -6,8 +6,8 @@
   line-height: 24px;
   border-radius: var(--mantine-radius-xs);
 
-  &:hover {
-    background-color: var(--mb-color-bg-light);
+  [data-mantine-color-scheme] &:hover {
+    background-color: var(--mb-color-background-hover);
   }
 
   &[data-disabled] {

--- a/frontend/src/metabase/ui/components/inputs/Calendar/Calendar.module.css
+++ b/frontend/src/metabase/ui/components/inputs/Calendar/Calendar.module.css
@@ -71,7 +71,7 @@
   height: 2rem;
   border-radius: var(--mantine-radius-xs);
 
-  [data-mantine-color-scheme] &:hover {
+  &:hover {
     color: var(--mb-color-text-hover);
     background-color: var(--mb-color-background-hover);
   }

--- a/frontend/src/metabase/ui/components/inputs/Calendar/Calendar.module.css
+++ b/frontend/src/metabase/ui/components/inputs/Calendar/Calendar.module.css
@@ -71,7 +71,7 @@
   height: 2rem;
   border-radius: var(--mantine-radius-xs);
 
-  &:hover {
+  [data-mantine-color-scheme] &:hover {
     color: var(--mb-color-text-hover);
     background-color: var(--mb-color-background-hover);
   }

--- a/frontend/src/metabase/ui/components/inputs/DatePicker/DatePicker.config.tsx
+++ b/frontend/src/metabase/ui/components/inputs/DatePicker/DatePicker.config.tsx
@@ -16,6 +16,7 @@ export const datePickerOverrides = {
       monthsList: Styles.monthsList,
       monthsListRow: Styles.row,
       monthsListCell: Styles.cell,
+      monthsListControl: Styles.monthsListControl,
       yearsList: Styles.yearsList,
       yearsListRow: Styles.row,
       yearsListCell: Styles.cell,


### PR DESCRIPTION
Closes UXW-1873

# Description

With the addition of color theme, the specificity of mantine's default styles increased over our styles for the calendar day hover state, we just needed to specify that our style applies to all color themes.


https://github.com/user-attachments/assets/d88bc495-440a-4002-80f4-18b622aaa4c9


https://github.com/user-attachments/assets/9cfece4c-f578-4224-9635-471d272eba74

