### PR TITLE
Fix #50044 - Updates dashcard loading state so it shows the correct title while it's loading

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartCaption.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartCaption.tsx
@@ -37,7 +37,11 @@ const ChartCaption = ({
   width,
   titleMenuItems,
 }: ChartCaptionProps) => {
-  const title = settings["card.title"] ?? series?.[0].card.name ?? "";
+  const title =
+    settings["card.title"] ??
+    series?.[0].card.visualization_settings["card.title"] ??
+    series?.[0].card.name ??
+    "";
   const description = settings["card.description"];
   const data =
     visualizerRawSeries ?? (series as TransformedSeries)._raw ?? series;

--- a/frontend/src/metabase/visualizations/components/ChartCaption.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartCaption.unit.spec.tsx
@@ -105,4 +105,70 @@ describe("ChartCaption", () => {
 
     expect(queryIcon("info")).not.toBeInTheDocument();
   });
+
+  describe("title sources", () => {
+    it("should use card.title from settings as highest priority", () => {
+      setup({
+        series: getSeries({
+          card: createMockCard({
+            name: "Card Name",
+            visualization_settings: { "card.title": "Viz Settings Title" },
+          }),
+        }),
+        settings: { "card.title": "Settings Title" },
+      });
+
+      expect(screen.getByTestId("legend-caption")).toHaveTextContent(
+        "Settings Title",
+      );
+    });
+
+    it("should use card.title from visualization_settings when no settings title", () => {
+      setup({
+        series: getSeries({
+          card: createMockCard({
+            name: "Card Name",
+            visualization_settings: { "card.title": "Viz Settings Title" },
+          }),
+        }),
+        settings: {},
+      });
+
+      expect(screen.getByTestId("legend-caption")).toHaveTextContent(
+        "Viz Settings Title",
+      );
+    });
+
+    it("should use card.name when no title in settings or visualization_settings", () => {
+      setup({
+        series: getSeries({
+          card: createMockCard({
+            name: "Card Name",
+            visualization_settings: {},
+          }),
+        }),
+        settings: {},
+      });
+
+      expect(screen.getByTestId("legend-caption")).toHaveTextContent(
+        "Card Name",
+      );
+    });
+
+    it("should render empty title when no title sources available", () => {
+      setup({
+        series: getSeries({
+          card: createMockCard({
+            name: undefined,
+            visualization_settings: {},
+          }),
+        }),
+        settings: {},
+      });
+
+      const caption = screen.getByTestId("legend-caption");
+      expect(caption).toBeInTheDocument();
+      expect(caption).not.toHaveTextContent(/\S/); // Should not contain any non-whitespace characters
+    });
+  });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/50044
Closes UXW-105

### Description

Updates dashcard title fallback so it shows the correct title while it's loading.

### How to verify

#50044 has good repro steps but you can also reproduce the issue if you throttle your network.

You can also reproduce the issue by changing the title via "Visualize another way".

### Demo

**BEFORE**

https://github.com/user-attachments/assets/51677df1-f0a1-4fa2-b298-88cf7a1b26b9

**AFTER**

https://github.com/user-attachments/assets/ae8813d0-9a35-4712-8ebb-2eac844be48f

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
