### PR TITLE
Add archived flag to graph endpoints

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -137,34 +137,34 @@
     (broken-cards-response breakages)))
 
 (def ^:private entity-keys
-  {:table [:name :description :display_name :db_id :db :schema :fields]
-   :card [:name :type :display :database_id :view_count
-          :created_at :creator :creator_id :description
-          :result_metadata :last-edit-info
-          :collection :collection_id :dashboard :dashboard_id
-          :moderation_reviews]
-   :snippet [:name :description]
+  {:table     [:name :description :display_name :db_id :db :schema :fields]
+   :card      [:name :type :display :database_id :view_count
+               :created_at :creator :creator_id :description
+               :result_metadata :last-edit-info
+               :collection :collection_id :dashboard :dashboard_id
+               :moderation_reviews]
+   :snippet   [:name :description]
    :transform [:name :description :table]
    :dashboard [:name :description :view_count
                :created_at :creator :creator_id :last-edit-info
                :collection :collection_id
                :moderation_reviews]
-   :document [:name :description :view_count
-              :created_at :creator
-              :collection :collection_id]
-   :sandbox [:table :table_id]})
+   :document  [:name :description :view_count
+               :created_at :creator
+               :collection :collection_id]
+   :sandbox   [:table :table_id]})
 
 (defn- format-subentity [entity]
   (case (t2/model entity)
     :model/Collection (select-keys entity [:id :name :authority_level :is_personal])
-    :model/Dashboard (select-keys entity [:id :name])
+    :model/Dashboard  (select-keys entity [:id :name])
     entity))
 
 (defn- entity-value [entity-type {:keys [id] :as entity} usages]
-  {:id id
-   :type entity-type
-   :data (->> (select-keys entity (entity-keys entity-type))
-              (m/map-vals format-subentity))
+  {:id               id
+   :type             entity-type
+   :data             (->> (select-keys entity (entity-keys entity-type))
+                          (m/map-vals format-subentity))
    :dependents_count (usages [entity-type id])})
 
 (def ^:private entity-model
@@ -201,69 +201,99 @@
 (defn- visible-entities-filter-clause
   "Returns a HoneySQL WHERE clause for filtering dependency graph entities by user visibility.
 
-  Accepts two arguments:
+  Accepts three arguments:
   - `entity-type-field`: Database column name for entity type (e.g., :to_entity_type)
   - `entity-id-field`: Database column name for entity ID (e.g., :to_entity_id)
+  - `include-archived-items`: How to handle archived items (:exclude, :all, :only). Defaults to :exclude.
+    This applies to both archived collections AND archived entities (cards/dashboards/documents/snippets/tables).
 
   Returns a compound [:or ...] clause checking whether entities at those columns are readable.
 
   Handles different entity types:
   - Superuser-only (:model/Transform, :model/Sandbox): Only if api/*is-superuser?* is true
   - Collection-based (:model/Card, :model/Dashboard, :model/Document, :model/NativeQuerySnippet):
-    Uses collection/visible-collection-filter-clause. Native query snippets have additional
-    restrictions for sandboxed users.
-  - Table: Uses mi/visible-filter-clause with appropriate permissions"
-  [entity-type-field entity-id-field]
-  (into [:or]
-        (keep (fn [[entity-type model]]
-                (let [table-name (t2/table-name model)
-                      id-column (keyword (name table-name) "id")]
-                  (case model
-                    ;; Superuser-only entities
-                    (:model/Transform :model/Sandbox)
-                    (when api/*is-superuser?*
-                      [:and
-                       [:= entity-type-field (name entity-type)]
-                       [:in entity-id-field {:select [:id] :from [table-name]}]])
+    Uses collection/visible-collection-filter-clause for collection filtering and adds archived entity filtering.
+    Native query snippets have additional restrictions for sandboxed users.
+  - Table: Uses mi/visible-filter-clause with appropriate permissions and filters by active/visibility_type.
+    Follows search API conventions: active=true AND visibility_type=nil for non-archived tables.
+    Note: archived_at is not checked separately as archived tables always have active=false."
+  ([entity-type-field entity-id-field]
+   (visible-entities-filter-clause entity-type-field entity-id-field nil))
+  ([entity-type-field entity-id-field {:keys [include-archived-items] :or {include-archived-items :exclude}}]
+   (into [:or]
+         (keep (fn [[entity-type model]]
+                 (let [table-name (t2/table-name model)
+                       id-column (keyword (name table-name) "id")]
+                   (case model
+                     ;; Superuser-only entities
+                     (:model/Transform :model/Sandbox)
+                     (when api/*is-superuser?*
+                       [:and
+                        [:= entity-type-field (name entity-type)]
+                        [:in entity-id-field {:select [:id] :from [table-name]}]])
 
-                    ;; Collection-based entities
-                    (:model/Card :model/Dashboard :model/Document :model/NativeQuerySnippet)
-                    (when-not (and (= model :model/NativeQuerySnippet)
-                                   (or (perms/sandboxed-user?)
-                                       (not (perms/user-has-any-perms-of-type?
-                                             api/*current-user-id* :perms/create-queries))))
-                      [:and
-                       [:= entity-type-field (name entity-type)]
-                       [:in entity-id-field {:select [:id]
-                                             :from [table-name]
-                                             :where (collection/visible-collection-filter-clause
-                                                     (keyword (name table-name) "collection_id")
-                                                     {}
-                                                     {:current-user-id api/*current-user-id*
-                                                      :is-superuser? api/*is-superuser?*})}]])
+                     ;; Collection-based entities with archived field
+                     (:model/Card :model/Dashboard :model/Document :model/NativeQuerySnippet)
+                     (let [archived-column (keyword (name table-name) "archived")]
+                       (when-not (and (= model :model/NativeQuerySnippet)
+                                      (or (perms/sandboxed-user?)
+                                          (not (perms/user-has-any-perms-of-type?
+                                                api/*current-user-id* :perms/create-queries))))
+                         [:and
+                          [:= entity-type-field (name entity-type)]
+                          [:in entity-id-field {:select [:id]
+                                                :from [table-name]
+                                                :where [:and
+                                                        ;; Filter by collection visibility
+                                                        (collection/visible-collection-filter-clause
+                                                         (keyword (name table-name) "collection_id")
+                                                         {:include-archived-items include-archived-items}
+                                                         {:current-user-id api/*current-user-id*
+                                                          :is-superuser?   api/*is-superuser?*})
+                                                        ;; Filter by entity archived status
+                                                        (case include-archived-items
+                                                          :exclude [:= archived-column false]
+                                                          :only    [:= archived-column true]
+                                                          :all     nil)]}]]))
 
-                    ;; Table with visible-filter-clause
-                    :model/Table
-                    [:and
-                     [:= entity-type-field (name entity-type)]
-                     [:in entity-id-field {:select [:id]
-                                           :from [table-name]
-                                           :where (mi/visible-filter-clause
-                                                   model
-                                                   id-column
-                                                   {:user-id api/*current-user-id*
-                                                    :is-superuser? api/*is-superuser?*}
-                                                   {:perms/view-data :unrestricted
-                                                    :perms/create-queries :query-builder})}]]))))
-        entity-model))
+                     ;; Table with visible-filter-clause and active/visibility_type filtering
+                     :model/Table
+                     (let [active-column (keyword (name table-name) "active")
+                           visibility-type-column (keyword (name table-name) "visibility_type")]
+                       [:and
+                        [:= entity-type-field (name entity-type)]
+                        [:in entity-id-field {:select [:id]
+                                              :from [table-name]
+                                              :where [:and
+                                                      (mi/visible-filter-clause
+                                                       model
+                                                       id-column
+                                                       {:user-id       api/*current-user-id*
+                                                        :is-superuser? api/*is-superuser?*}
+                                                       {:perms/view-data      :unrestricted
+                                                        :perms/create-queries :query-builder})
+                                                      (case include-archived-items
+                                                        :exclude     [:and
+                                                                      [:= active-column true]
+                                                                      [:= visibility-type-column nil]]
+                                                        (:only :all) nil)]}]])))))
+         entity-model)))
 
 (defn- readable-graph-dependencies
-  []
-  (dependency/filtered-graph-dependencies visible-entities-filter-clause))
+  ([]
+   (readable-graph-dependencies nil))
+  ([opts]
+   (dependency/filtered-graph-dependencies
+    (fn [entity-type-field entity-id-field]
+      (visible-entities-filter-clause entity-type-field entity-id-field opts)))))
 
 (defn- readable-graph-dependents
-  []
-  (dependency/filtered-graph-dependents visible-entities-filter-clause))
+  ([]
+   (readable-graph-dependents nil))
+  ([opts]
+   (dependency/filtered-graph-dependents
+    (fn [entity-type-field entity-id-field]
+      (visible-entities-filter-clause entity-type-field entity-id-field opts)))))
 
 (defn- calc-usages
   "Calculates the count of direct dependents for all nodes in `nodes`, based on `graph`. "
@@ -311,18 +341,24 @@
 (api.macros/defendpoint :get "/graph"
   "This endpoint takes an :id and a supported entity :type, and returns a graph of all its upstream dependencies.
   The graph is represented by a list of :nodes and a list of :edges. Each node has an :id, :type, :data (which
-  depends on the node type), and a map of :dependent_counts per entity type. Each edge is a :model/Dependency"
+  depends on the node type), and a map of :dependent_counts per entity type. Each edge is a :model/Dependency.
+
+  Optional :archived parameter controls whether entities in archived collections are included:
+  - false (default): Excludes entities in archived collections
+  - true: Includes entities in archived collections"
   [_route-params
-   {:keys [id type]} :- [:map
-                         [:id {:optional true} ms/PositiveInt]
-                         [:type {:optional true} (ms/enum-decode-keyword (vec (keys entity-model)))]]]
+   {:keys [id type archived]} :- [:map
+                                  [:id {:optional true} ms/PositiveInt]
+                                  [:type {:optional true} (ms/enum-decode-keyword (vec (keys entity-model)))]
+                                  [:archived {:optional true} :boolean]]]
   (api/read-check (entity-model type) id)
   (lib-be/with-metadata-provider-cache
-    (let [starting-nodes [[type id]]
-          upstream-graph (readable-graph-dependencies)
+    (let [graph-opts {:include-archived-items (if archived :all :exclude)}
+          starting-nodes [[type id]]
+          upstream-graph (readable-graph-dependencies graph-opts)
           ;; cache the downstream graph specifically, because between calculating transitive children and calculating
           ;; edges, we'll call this multiple times on the same nodes.
-          downstream-graph (graph/cached-graph (readable-graph-dependents))
+          downstream-graph (graph/cached-graph (readable-graph-dependents graph-opts))
           nodes (into (set starting-nodes)
                       (graph/transitive upstream-graph starting-nodes))
           edges (graph/calc-edges-between downstream-graph nodes)]
@@ -335,17 +371,23 @@
    [:type (ms/enum-decode-keyword (vec (keys entity-model)))]
    [:dependent_type (ms/enum-decode-keyword (vec (keys entity-model)))]
    [:dependent_card_type {:optional true} (ms/enum-decode-keyword
-                                           [:question :model :metric])]])
+                                           [:question :model :metric])]
+   [:archived {:optional true} :boolean]])
 
 (api.macros/defendpoint :get "/graph/dependents"
   "This endpoint takes an :id, :type, :dependent_type, and an optional :dependent_card_type, and returns a list of
    all that entity's dependents with :dependent_type. If the :dependent_type is :card, the dependents are further
-   filtered by :dependent_card_type."
+   filtered by :dependent_card_type.
+
+   Optional :archived parameter controls whether entities in archived collections are included:
+   - false (default): Excludes entities in archived collections
+   - true: Includes entities in archived collections"
   [_route-params
-   {:keys [id type dependent_type dependent_card_type]} :- dependents-args]
+   {:keys [id type dependent_type dependent_card_type archived]} :- dependents-args]
   (api/read-check (entity-model type) id)
   (lib-be/with-metadata-provider-cache
-    (let [downstream-graph (graph/cached-graph (readable-graph-dependents))
+    (let [graph-opts {:include-archived-items (if archived :all :exclude)}
+          downstream-graph (graph/cached-graph (readable-graph-dependents graph-opts))
           nodes (-> (graph/children-of downstream-graph [[type id]])
                     (get [type id]))]
       (->> (expanded-nodes downstream-graph nodes)

--- a/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
@@ -316,6 +316,57 @@
                       :type "card"}]
                     response))))))))
 
+(deftest graph-archived-card-test
+  (testing "GET /api/ee/dependencies/graph with archived parameter"
+    (mt/with-premium-features #{:dependencies}
+      (mt/with-model-cleanup [:model/Card :model/Dependency]
+        (mt/with-temp [:model/User user {:email "test@test.com"}]
+          (let [base-card (card/create-card! (basic-card "Archived Base Card") user)
+                dependent-card (card/create-card! (wrap-card base-card) user)]
+            (card/update-card! {:card-before-update base-card
+                                :card-updates {:archived true}})
+            (testing "archived=false (default) excludes archived card from dependencies"
+              (let [response (mt/user-http-request :rasta :get 200 "ee/dependencies/graph"
+                                                   :id (:id dependent-card)
+                                                   :type "card")
+                    node-ids (set (map :id (:nodes response)))]
+                (is (contains? node-ids (:id dependent-card)))
+                (is (not (contains? node-ids (:id base-card))))))
+            (testing "archived=true includes archived card in dependencies"
+              (let [response (mt/user-http-request :rasta :get 200 "ee/dependencies/graph"
+                                                   :id (:id dependent-card)
+                                                   :type "card"
+                                                   :archived true)
+                    node-ids (set (map :id (:nodes response)))]
+                (is (contains? node-ids (:id dependent-card)))
+                (is (contains? node-ids (:id base-card)))
+                (is (contains? node-ids (mt/id :orders)))))))))))
+
+(deftest dependents-archived-card-test
+  (testing "GET /api/ee/dependencies/graph/dependents with archived parameter"
+    (mt/with-premium-features #{:dependencies}
+      (mt/with-model-cleanup [:model/Card :model/Dependency]
+        (mt/with-temp [:model/User user {:email "test@test.com"}]
+          (let [base-card (card/create-card! (basic-card "Base Card") user)
+                dependent-card (card/create-card! (wrap-card base-card) user)]
+            (card/update-card! {:card-before-update dependent-card
+                                :card-updates {:archived true}})
+            (testing "archived=false (default) excludes archived dependent"
+              (let [response (mt/user-http-request :rasta :get 200 "ee/dependencies/graph/dependents"
+                                                   :id (:id base-card)
+                                                   :type "card"
+                                                   :dependent_type "card")]
+                (is (empty? response))))
+            (testing "archived=true includes archived dependent"
+              (let [response (mt/user-http-request :rasta :get 200 "ee/dependencies/graph/dependents"
+                                                   :id (:id base-card)
+                                                   :type "card"
+                                                   :dependent_type "card"
+                                                   :dependent_card_type "question"
+                                                   :archived true)
+                    dependent-ids (set (map :id response))]
+                (is (contains? dependent-ids (:id dependent-card)))))))))))
+
 (deftest check-card-permissions-test
   (testing "POST /api/ee/dependencies/check_card requires read permissions on the input card"
     (mt/with-premium-features #{:dependencies}


### PR DESCRIPTION
Closes QUE-2708

### Description

Add an `archived` query parameter similar to the one used in the search API. Exclude archived and inactive items by default.

### How to verify

See the tests.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
