### PR TITLE
UXW-2182 fix codemirror editor suggestions styles in light mode

### DIFF
--- a/frontend/src/metabase/common/components/CodeMirror/CodeMirror.module.css
+++ b/frontend/src/metabase/common/components/CodeMirror/CodeMirror.module.css
@@ -81,7 +81,7 @@
     .cm-completionMatchedText {
       text-decoration: none;
       font-weight: bold;
-      color: var(--mb-color-focus);
+      color: var(--mb-color-text-brand);
     }
 
     .cm-completionDetail {
@@ -129,6 +129,7 @@
         &:hover,
         &[aria-selected="true"] {
           background-color: var(--mb-color-bg-hover);
+          color: var(--mb-color-text-dark);
         }
       }
 


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-2182/codemirror-styles-issue-in-native-query-related-to-commit-935fe5a0

### Description

Fixes styles for Codemirror editor suggestions styles in light mode

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New  -> SQL Query -> type `Select I`
2. Check suggestions dropdown

### Demo

**Before:**
<img width="600" alt="image" src="https://github.com/user-attachments/assets/ac252ce5-ea36-4c06-91b2-0ae3b5764b9d" />

**After:**
<img width="600" alt="Screenshot 2025-11-03 at 19 11 49" src="https://github.com/user-attachments/assets/05373708-9117-481a-a574-0e0d834f81de" />
<img width="600" alt="Screenshot 2025-11-03 at 19 11 59" src="https://github.com/user-attachments/assets/adef96e7-daf0-4aa3-89d8-45843da1d4f1" />

Issue was introduced in https://github.com/metabase/metabase/pull/64791 , so here are also screenshots that this PR fixes weren't affected:
<img width="775" height="443" alt="Screenshot 2025-11-03 at 19 12 50" src="https://github.com/user-attachments/assets/1bf2bd37-6c3f-40ee-a671-9bf78f40de03" />
<img width="758" height="437" alt="Screenshot 2025-11-03 at 19 12 42" src="https://github.com/user-attachments/assets/d9ae395c-aada-4235-9f1d-ac3493d190b7" />
<img width="792" height="515" alt="Screenshot 2025-11-03 at 19 12 31" src="https://github.com/user-attachments/assets/e2752ae9-aceb-40ca-843d-e86545432225" />
<img width="765" height="440" alt="Screenshot 2025-11-03 at 19 12 23" src="https://github.com/user-attachments/assets/d2cae66b-73cd-4306-8848-6b88ca9c4d61" />
