### PR TITLE
Adding collection name to recent documents

### DIFF
--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -44,7 +44,6 @@ describe("command palette", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();
-    H.activateToken("bleeding-edge");
   });
 
   it("should render a searchable command palette", () => {
@@ -67,13 +66,6 @@ describe("command palette", () => {
     cy.request("PUT", `/api/card/${ORDERS_COUNT_QUESTION_ID}`, {
       description: "The best question",
     });
-
-    //Create a document so that it appears in the recents list
-    cy.request(
-      "POST",
-      "/api/ee/document",
-      createMockDocument({ collection_id: ADMIN_PERSONAL_COLLECTION_ID }),
-    );
 
     //Request to have an item in the recents list
     cy.request(`/api/dashboard/${ORDERS_DASHBOARD_ID}`);
@@ -107,12 +99,6 @@ describe("command palette", () => {
       cy.findByRole("option", { name: "Orders in a dashboard" }).should(
         "contain.text",
         "Our analytics",
-      );
-
-      // UXW-1786
-      cy.findByRole("option", { name: "Test Document" }).should(
-        "contain.text",
-        "Bobby Tables's Personal Collection",
       );
 
       cy.log("Should search entities and docs");
@@ -233,6 +219,31 @@ describe("command palette", () => {
           });
       });
     });
+  });
+
+  // Making this a separate test for now because it requires the bleeding edge token, which
+  // Enables a bunch of other stuff and messes up the "Renders a searchable command palette"
+  // test. In the future, this can be integrated into the test above, or moved to a BE test
+  it("should display collection names for documents in recents", () => {
+    H.activateToken("bleeding-edge");
+
+    //Create a document so that it appears in the recents list
+    cy.request(
+      "POST",
+      "/api/ee/document",
+      createMockDocument({ collection_id: ADMIN_PERSONAL_COLLECTION_ID }),
+    );
+
+    cy.visit("/");
+
+    cy.findByRole("button", { name: /search/i }).click();
+    H.commandPalette().should("be.visible");
+
+    // UXW-1786
+    cy.findByRole("option", { name: "Test Document" }).should(
+      "contain.text",
+      "Bobby Tables's Personal Collection",
+    );
   });
 
   describe("admin settings links", () => {

--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -7,7 +7,10 @@ import {
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import { createMockDashboardCard } from "metabase-types/api/mocks";
+import {
+  createMockDashboardCard,
+  createMockDocument,
+} from "metabase-types/api/mocks";
 
 const { admin } = USERS;
 
@@ -41,6 +44,7 @@ describe("command palette", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();
+    H.activateToken("bleeding-edge");
   });
 
   it("should render a searchable command palette", () => {
@@ -64,8 +68,16 @@ describe("command palette", () => {
       description: "The best question",
     });
 
+    //Create a document so that it appears in the recents list
+    cy.request(
+      "POST",
+      "/api/ee/document",
+      createMockDocument({ collection_id: ADMIN_PERSONAL_COLLECTION_ID }),
+    );
+
     //Request to have an item in the recents list
     cy.request(`/api/dashboard/${ORDERS_DASHBOARD_ID}`);
+
     cy.visit("/");
 
     cy.findByRole("button", { name: /search/i }).click();
@@ -95,6 +107,12 @@ describe("command palette", () => {
       cy.findByRole("option", { name: "Orders in a dashboard" }).should(
         "contain.text",
         "Our analytics",
+      );
+
+      // UXW-1786
+      cy.findByRole("option", { name: "Test Document" }).should(
+        "contain.text",
+        "Bobby Tables's Personal Collection",
       );
 
       cy.log("Should search entities and docs");

--- a/enterprise/backend/src/metabase_enterprise/documents/models/document.clj
+++ b/enterprise/backend/src/metabase_enterprise/documents/models/document.clj
@@ -117,9 +117,16 @@
            :last-viewed-at :last_viewed_at
            :pinned [:> [:coalesce :collection_position [:inline 0]] [:inline 0]]}
    :search-terms [:name]
+   :joins {:collection [:model/Collection [:= :collection.id :this.collection_id]]}
    :render-terms {:document-name :name
                   :document-id :id
-                  :collection-position true}})
+                  :collection-authority_level :collection.authority_level
+                  :collection-location        :collection.location
+                  :collection-name            :collection.name
+                  ;; This is used for legacy ranking, in future it will be replaced by :pinned
+                  :collection-position        true
+                  :collection-type            :collection.type
+                  :archived-directly          true}})
 
 ;;; ---------------------------------------------- Serialization --------------------------------------------------
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #64100
### Description
Adds the collection name to document entities in the `/recents` response

### How to verify
1. Go to a document that isn't in `Our Analytics` and open it
2. Now open the command palette
3. You should see the name of the collection in the subtext of the result

### Demo
<img width="723" height="295" alt="image" src="https://github.com/user-attachments/assets/a0efa43a-861d-45ac-af68-faca6b028a8e" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
