### PR TITLE
Recreate model index quartz triggers on job initialization when needed

### DIFF
--- a/src/metabase/indexed_entities/task/index_values.clj
+++ b/src/metabase/indexed_entities/task/index_values.clj
@@ -111,9 +111,9 @@
                                              (catch Exception e
                                                (log/warn e "Error fetching existing triggers from Quartz, will recreate all triggers")
                                                #{}))
-          missing-trigger-model-indexes  (if (seq existing-trigger-model-index-ids)
-                                           (t2/select :model/ModelIndex :id [:not-in existing-trigger-model-index-ids])
-                                           (t2/select :model/ModelIndex))]
+          missing-trigger-model-indexes (if (seq existing-trigger-model-index-ids)
+                                          (t2/select :model/ModelIndex :id [:not-in existing-trigger-model-index-ids])
+                                          (t2/select :model/ModelIndex))]
       (when (seq missing-trigger-model-indexes)
         (log/infof "Found %d model index(es) without triggers, recreating..."
                    (count missing-trigger-model-indexes))

--- a/src/metabase/indexed_entities/task/index_values.clj
+++ b/src/metabase/indexed_entities/task/index_values.clj
@@ -18,8 +18,9 @@
 (set! *warn-on-reflection* true)
 
 #_{:clj-kondo/ignore [:unused-private-var]}
-(def ^:private refreshable-states
-  "States of a model index that are refreshable."
+;; Possible values for the :state field on model index records.
+;; Unused, but kept here for reference.
+(def ^:private model-index-states
   #{"indexed" "initial" "error" "overflow"})
 
 (defn- should-deindex?

--- a/test/metabase/indexed_entities/models/model_index_test.clj
+++ b/test/metabase/indexed_entities/models/model_index_test.clj
@@ -17,7 +17,7 @@
    [metabase.util.malli.registry :as mr]
    [toucan2.core :as t2]))
 
-(defmacro ^:private with-scheduler-setup! [& body]
+(defmacro with-scheduler-setup! [& body]
   `(let [scheduler# (#'tu/in-memory-scheduler)]
      ;; need cross thread rebinding from with-redefs not a binding
      (with-redefs [task/scheduler (constantly scheduler#)]

--- a/test/metabase/indexed_entities/task/index_values_test.clj
+++ b/test/metabase/indexed_entities/task/index_values_test.clj
@@ -1,0 +1,47 @@
+(ns metabase.indexed-entities.task.index-values-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.indexed-entities.models.model-index-test :refer [with-scheduler-setup!]]
+   [metabase.indexed-entities.task.index-values :as task.index-values]
+   [metabase.task.impl :as task]
+   [metabase.test :as mt]
+   [metabase.util :as u]))
+
+(deftest recreate-missing-triggers-test
+  (with-scheduler-setup!
+    (mt/dataset test-data
+      (testing "Missing triggers are recreated on job-init"
+        (let [query     (mt/mbql-query products)
+              pk-ref    (mt/$ids $products.id)
+              value-ref (mt/$ids $products.title)
+              by-key    (fn [k xs]
+                          (some (fn [x] (when (= (:key x) k) x)) xs))]
+          (mt/with-temp [:model/Card model (assoc (mt/card-with-source-metadata-for-query query)
+                                                  :type :model
+                                                  :name "model index recreate trigger test")
+                         :model/ModelIndex model-index {:model_id   (u/the-id model)
+                                                        :pk_ref     pk-ref
+                                                        :value_ref  value-ref
+                                                        :creator_id (mt/user->id :rasta)
+                                                        :schedule   "0 0 23 * * ? *"
+                                                        :state      "initial"}]
+            (let [trigger-key (format "metabase.task.IndexValues.trigger.%d" (:id model-index))
+                  get-trigger #(->> (task/scheduler-info)
+                                    :jobs
+                                    (by-key "metabase.task.IndexValues.job")
+                                    :triggers
+                                    (by-key trigger-key))]
+              ;; create trigger by calling add-indexing-job
+              (task.index-values/add-indexing-job model-index)
+              (is (some? (get-trigger)) "Trigger should exist after creating model index")
+              ;; delete the trigger from Quartz
+              (task.index-values/remove-indexing-job model-index)
+              (is (nil? (get-trigger)) "Trigger should be deleted")
+              ;; call job-init! to recreate missing triggers
+              (#'task.index-values/job-init!)
+              (let [recreated-trigger (get-trigger)]
+                (is (some? recreated-trigger) "Trigger should be recreated by job-init!")
+                (is (= (:schedule model-index) (:schedule recreated-trigger))
+                    "Recreated trigger should have correct schedule")
+                (is (= {"model-index-id" (:id model-index)} (:data recreated-trigger))
+                    "Recreated trigger should have correct data")))))))))


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/65378

For some reason, almost all triggers for the `metabase.task.IndexValues.job` quartz job got deleted from the app DB sometime around last February, and there's no self-healing mechanism, so many indexed entities are stale. Debugging thread [here](https://metaboat.slack.com/archives/C05MPF0TM3L/p1762189604222619) for context.

We still don't understand the original cause of this but this PR has a proposed fix, to detect any orphaned `ModelIndex` records without triggers when the job is being initialized and re-create them.