### PR TITLE
Support Arbitrary Date Formats

### DIFF
--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -17,7 +17,6 @@ export interface FormattingSettings {
 
 export interface DateFormattingSettings {
   date_style?: string;
-  date_separator?: string;
   date_abbreviate?: boolean;
   time_style?: string;
 }

--- a/frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.tsx
@@ -11,7 +11,7 @@ import {
   getDateStyleOptionsForUnit,
   getTimeStyleOptions,
 } from "metabase/lib/formatting";
-import { Box, Radio, Select, Stack, Switch, Text } from "metabase/ui";
+import { Autocomplete, Box, Radio, Select, Stack, Switch, Text } from "metabase/ui";
 import type { FormattingSettings } from "metabase-types/api";
 
 import { SetByEnvVar } from "./AdminSettingInput";
@@ -92,7 +92,7 @@ export function FormattingWidget() {
       ) : (
         <>
           <SettingsSection title={t`Dates and times`}>
-            <FormattingInput
+            <Autocomplete
               id="date_style"
               label={t`Date style`}
               value={dateStyle}
@@ -105,8 +105,7 @@ export function FormattingWidget() {
                   },
                 })
               }
-              inputType="select"
-              options={
+              data={
                 dateStyleOptions.map(({ name, value }) => ({
                   label: name,
                   value,

--- a/frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.tsx
@@ -4,14 +4,14 @@ import _ from "underscore";
 
 import { SettingsSection } from "metabase/admin/components/SettingsSection";
 import { useAdminSetting } from "metabase/api/utils";
+import { DateFormatInput } from "metabase/common/components/DateFormatInput";
 import {
   type CurrencyStyle,
   getCurrencyOptions,
   getCurrencyStyleOptions,
-  getDateStyleOptionsForUnit,
   getTimeStyleOptions,
 } from "metabase/lib/formatting";
-import { Autocomplete, Box, Radio, Select, Stack, Switch, Text } from "metabase/ui";
+import { Box, Radio, Select, Stack, Switch, Text } from "metabase/ui";
 import type { FormattingSettings } from "metabase-types/api";
 
 import { SetByEnvVar } from "./AdminSettingInput";
@@ -75,8 +75,6 @@ export function FormattingWidget() {
     return null;
   }
 
-  const dateStyleOptions = getDateStyleOptionsForUnit("default", dateAbreviate);
-
   const handleChange = (newValue: FormattingSettings) => {
     if (_.isEqual(newValue, localValue)) {
       return;
@@ -92,10 +90,8 @@ export function FormattingWidget() {
       ) : (
         <>
           <SettingsSection title={t`Dates and times`}>
-            <Autocomplete
-              id="date_style"
-              label={t`Date style`}
-              value={dateStyle}
+            <DateFormatInput
+              value={dateStyle ?? ""}
               onChange={(newValue) =>
                 handleChange({
                   ...localValue,
@@ -104,12 +100,6 @@ export function FormattingWidget() {
                     date_style: newValue as string,
                   },
                 })
-              }
-              data={
-                dateStyleOptions.map(({ name, value }) => ({
-                  label: name,
-                  value,
-                })) ?? []
               }
             />
             <FormattingInput

--- a/frontend/src/metabase/common/components/DateFormatInput/DateFormatInput.tsx
+++ b/frontend/src/metabase/common/components/DateFormatInput/DateFormatInput.tsx
@@ -5,7 +5,10 @@ import _ from "underscore";
 
 import Markdown from "metabase/common/components/Markdown";
 import { useSetting } from "metabase/common/hooks";
-import { getDateStyleOptionsForUnit } from "metabase/lib/formatting";
+import {
+  dateStyleOption,
+  getDateStyleOptionsForUnit,
+} from "metabase/lib/formatting";
 import { Autocomplete, Stack, Text } from "metabase/ui";
 import type { DatetimeUnit } from "metabase-types/api";
 
@@ -23,12 +26,14 @@ export function DateFormatInput({
   const dateStyleOptionValues = useMemo(() => {
     const dateAbbreviate =
       formattingSettings?.["type/Temporal"]?.date_abbreviate;
+    const dateFormatSetting =
+      formattingSettings?.["type/Temporal"]?.date_style ?? "";
     const dateStyleOptions = getDateStyleOptionsForUnit(unit, dateAbbreviate);
     return _.uniq([
+      dateStyleOption(dateFormatSetting, unit, dateAbbreviate),
       ...dateStyleOptions.map(({ value }) => value),
-      value,
     ]).filter(Boolean);
-  }, [formattingSettings, value, unit]);
+  }, [formattingSettings, unit]);
 
   const debouncedChange = _.debounce(onChange, 500);
 
@@ -40,6 +45,10 @@ export function DateFormatInput({
         id="date_style"
         label={t`Date style`}
         value={localValue}
+        comboboxProps={{
+          withinPortal: false,
+          floatingStrategy: "fixed",
+        }}
         description={
           <Markdown>
             {t`Select one of the preset date formats or provide your own using [custom date format options](https://day.js.org/docs/en/display/format).`}

--- a/frontend/src/metabase/common/components/DateFormatInput/DateFormatInput.tsx
+++ b/frontend/src/metabase/common/components/DateFormatInput/DateFormatInput.tsx
@@ -1,0 +1,78 @@
+import dayjs from "dayjs";
+import { useMemo, useState } from "react";
+import { c, t } from "ttag";
+import _ from "underscore";
+
+import Markdown from "metabase/common/components/Markdown";
+import { useSetting } from "metabase/common/hooks";
+import { getDateStyleOptionsForUnit } from "metabase/lib/formatting";
+import { Autocomplete, Stack, Text } from "metabase/ui";
+import type { DatetimeUnit } from "metabase-types/api";
+
+export function DateFormatInput({
+  value,
+  onChange,
+  unit = "default",
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  unit?: DatetimeUnit;
+}) {
+  const formattingSettings = useSetting("custom-formatting");
+
+  const dateStyleOptionValues = useMemo(() => {
+    const dateAbbreviate =
+      formattingSettings?.["type/Temporal"]?.date_abbreviate;
+    const dateStyleOptions = getDateStyleOptionsForUnit(unit, dateAbbreviate);
+    return _.uniq([
+      ...dateStyleOptions.map(({ value }) => value),
+      value,
+    ]).filter(Boolean);
+  }, [formattingSettings, value, unit]);
+
+  const debouncedChange = _.debounce(onChange, 500);
+
+  const [localValue, setLocalValue] = useState(value);
+
+  return (
+    <Stack gap="xs">
+      <Autocomplete
+        id="date_style"
+        label={t`Date style`}
+        value={localValue}
+        description={
+          <Markdown>
+            {t`Select one of the preset date formats or provide your own using [custom date format options](https://day.js.org/docs/en/display/format).`}
+          </Markdown>
+        }
+        onAuxClickCapture={(e) => e.preventDefault()}
+        onChange={(newValue) => {
+          setLocalValue(newValue);
+          debouncedChange(newValue);
+        }}
+        data={dateStyleOptionValues}
+        renderOption={({ option }) => (
+          <DateFormatOptionDisplay format={option?.value || ""} />
+        )}
+      />
+      <DateFormatPreview format={value ?? ""} />
+    </Stack>
+  );
+}
+const DateFormatOptionDisplay = ({ format }: { format: string }) => {
+  return (
+    <Text p="sm" fz="sm">
+      <Text>{format}</Text>{" "}
+      <Text c="text-medium">({dayjs("2018-01-31").format(format)})</Text>
+    </Text>
+  );
+};
+
+const DateFormatPreview = ({ format }: { format: string }) => {
+  return (
+    <Text>
+      {c("{0} is a preview of a formatted date")
+        .t`Preview: ${dayjs("2018-01-31").format(format)}`}
+    </Text>
+  );
+};

--- a/frontend/src/metabase/common/components/DateFormatInput/index.ts
+++ b/frontend/src/metabase/common/components/DateFormatInput/index.ts
@@ -1,0 +1,1 @@
+export * from "./DateFormatInput";

--- a/frontend/src/metabase/lib/formatting/date.tsx
+++ b/frontend/src/metabase/lib/formatting/date.tsx
@@ -732,12 +732,9 @@ export function getDateFormatFromStyle(
 
   if (DATE_STYLE_TO_FORMAT?.[style]?.[unit]) {
     format = DATE_STYLE_TO_FORMAT[style][unit];
-  } else if (style !== "") {
-    console.warn("Unknown date style", style);
-  }
-
-  if (format == null) {
-    format = DEFAULT_DATE_FORMATS[unit] ? DEFAULT_DATE_FORMATS[unit] : style;
+  } else {
+    // TODO: can we get smarter about inferring other units from custom styles?
+    format = DEFAULT_DATE_FORMATS?.[unit] ?? DEFAULT_DATE_STYLE;
   }
 
   if (includeWeekday && hasDay(unit)) {

--- a/frontend/src/metabase/lib/formatting/date.tsx
+++ b/frontend/src/metabase/lib/formatting/date.tsx
@@ -60,6 +60,24 @@ const DATE_STYLE_TO_FORMAT: DATE_STYLE_TO_FORMAT_TYPE = {
   },
 };
 
+const getDateStyleForUnit = ({
+  style,
+  unit,
+}: {
+  style: string;
+  unit: DatetimeUnit;
+}) => {
+  if (DATE_STYLE_TO_FORMAT?.[style]?.[unit]) {
+    return DATE_STYLE_TO_FORMAT[style][unit];
+  }
+
+  if (unit === "month") {
+    return style.replace(/d+([^a-zA-Z0-9]{0,1})(\s){0,1}/gi, "");
+  }
+
+  return style ?? DEFAULT_DATE_FORMATS[unit] ?? DEFAULT_DATE_STYLE;
+};
+
 const DATE_RANGE_MONTH_PLACEHOLDER = "<MONTH>";
 
 type DateVal = string | number | Dayjs;
@@ -728,14 +746,7 @@ export function getDateFormatFromStyle(
     unit = "default";
   }
 
-  let format = null;
-
-  if (DATE_STYLE_TO_FORMAT?.[style]?.[unit]) {
-    format = DATE_STYLE_TO_FORMAT[style][unit];
-  } else {
-    // TODO: can we get smarter about inferring other units from custom styles?
-    format = DEFAULT_DATE_FORMATS?.[unit] ?? DEFAULT_DATE_STYLE;
-  }
+  let format = getDateStyleForUnit({ style, unit });
 
   if (includeWeekday && hasDay(unit)) {
     format = `ddd, ${format}`;

--- a/frontend/src/metabase/lib/formatting/date.tsx
+++ b/frontend/src/metabase/lib/formatting/date.tsx
@@ -722,30 +722,22 @@ const getMonthFormat = (options: OptionsType) =>
 export function getDateFormatFromStyle(
   style: string,
   unit: DatetimeUnit,
-  separator?: string,
   includeWeekday?: boolean,
 ) {
-  const replaceSeparators = (format: string) =>
-    separator && format ? format.replace(/\//g, separator) : format;
-
   if (!unit) {
     unit = "default";
   }
 
   let format = null;
 
-  if (DATE_STYLE_TO_FORMAT[style]) {
-    if (DATE_STYLE_TO_FORMAT[style][unit]) {
-      format = replaceSeparators(DATE_STYLE_TO_FORMAT[style][unit]);
-    }
+  if (DATE_STYLE_TO_FORMAT?.[style]?.[unit]) {
+    format = DATE_STYLE_TO_FORMAT[style][unit];
   } else if (style !== "") {
     console.warn("Unknown date style", style);
   }
 
   if (format == null) {
-    format = DEFAULT_DATE_FORMATS[unit]
-      ? replaceSeparators(DEFAULT_DATE_FORMATS[unit])
-      : replaceSeparators(style);
+    format = DEFAULT_DATE_FORMATS[unit] ? DEFAULT_DATE_FORMATS[unit] : style;
   }
 
   if (includeWeekday && hasDay(unit)) {
@@ -1138,7 +1130,6 @@ export function formatDateTimeWithUnit(
     dateFormat = getDateFormatFromStyle(
       options.date_style as string,
       unit,
-      options.date_separator as string,
       options.weekday_enabled,
     );
   }
@@ -1159,7 +1150,6 @@ const EXAMPLE_DATE = dayjs("2018-01-31 17:24");
 export function getDateStyleOptionsForUnit(
   unit: DatetimeUnit,
   abbreviate = false,
-  separator?: string,
 ) {
   // hour-of-day shouldn't have any date style. It's handled as a time instead.
   // Other date parts are handled as dates, but hour-of-day needs to use the
@@ -1169,12 +1159,12 @@ export function getDateStyleOptionsForUnit(
   }
 
   const options = [
-    dateStyleOption("MMMM D, YYYY", unit, abbreviate, separator),
-    dateStyleOption("D MMMM, YYYY", unit, abbreviate, separator),
-    dateStyleOption("dddd, MMMM D, YYYY", unit, abbreviate, separator),
-    dateStyleOption("M/D/YYYY", unit, abbreviate, separator),
-    dateStyleOption("D/M/YYYY", unit, abbreviate, separator),
-    dateStyleOption("YYYY/M/D", unit, abbreviate, separator),
+    dateStyleOption("MMMM D, YYYY", unit, abbreviate),
+    dateStyleOption("D MMMM, YYYY", unit, abbreviate),
+    dateStyleOption("dddd, MMMM D, YYYY", unit, abbreviate),
+    dateStyleOption("M/D/YYYY", unit, abbreviate),
+    dateStyleOption("D/M/YYYY", unit, abbreviate),
+    dateStyleOption("YYYY/M/D", unit, abbreviate),
   ];
   const seen = new Set();
   return options.filter((option) => {
@@ -1188,19 +1178,18 @@ export function getDateStyleOptionsForUnit(
   });
 }
 
-function dateStyleOption(
+export function dateStyleOption(
   style: string,
   unit: DatetimeUnit,
   abbreviate = false,
-  separator?: string,
 ) {
-  let format = getDateFormatFromStyle(style, unit, separator);
+  let format = getDateFormatFromStyle(style, unit);
   if (abbreviate) {
     format = format.replace(/MMMM/, "MMM").replace(/dddd/, "ddd");
   }
   return {
     name: EXAMPLE_DATE.format(format),
-    value: style,
+    value: format,
   };
 }
 

--- a/frontend/src/metabase/lib/formatting/date.tsx
+++ b/frontend/src/metabase/lib/formatting/date.tsx
@@ -1185,7 +1185,7 @@ export function dateStyleOption(
 ) {
   let format = getDateFormatFromStyle(style, unit);
   if (abbreviate) {
-    format = format.replace(/MMMM/, "MMM").replace(/dddd/, "ddd");
+    format = format.replace(/MMMM/, "MMM").replace(/dddd/, "ddd"); // FIXME: make this not explode, format is null
   }
   return {
     name: EXAMPLE_DATE.format(format),

--- a/frontend/src/metabase/lib/formatting/types.ts
+++ b/frontend/src/metabase/lib/formatting/types.ts
@@ -13,7 +13,6 @@ export interface OptionsType extends TimeOnlyOptions {
   compact?: boolean;
   date_abbreviate?: boolean;
   date_format?: string;
-  date_separator?: string;
   date_style?: string;
   decimals?: number;
   isExclude?: boolean;

--- a/frontend/src/metabase/static-viz/components/RowChart/stories-data.ts
+++ b/frontend/src/metabase/static-viz/components/RowChart/stories-data.ts
@@ -80,7 +80,6 @@ export const MULTIPLE_SERIES: StaticChartProps = {
             name: "CREATED_AT",
             settings: {
               date_style: "D MMMM, YYYY",
-              date_separator: "-",
             },
             source: "breakout",
             field_ref: [
@@ -149,7 +148,6 @@ export const MULTIPLE_SERIES: StaticChartProps = {
               name: "CREATED_AT",
               settings: {
                 date_style: "D MMMM, YYYY",
-                date_separator: "-",
               },
               field_ref: [
                 "field",
@@ -277,7 +275,6 @@ export const METRIC_COLUMN_WITH_SCALING: StaticChartProps = {
             name: "CREATED_AT",
             settings: {
               date_style: "D MMMM, YYYY",
-              date_separator: "-",
             },
             source: "breakout",
             field_ref: [
@@ -346,7 +343,6 @@ export const METRIC_COLUMN_WITH_SCALING: StaticChartProps = {
               name: "CREATED_AT",
               settings: {
                 date_style: "D MMMM, YYYY",
-                date_separator: "-",
               },
               field_ref: [
                 "field",

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/utils.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/utils.unit.spec.ts
@@ -213,7 +213,6 @@ describe("ObjectDetail utils", () => {
           column: () => ({
             column: dateCol,
             date_abbreviate: false,
-            date_separator: "/",
             date_style: "MMMM D, YYYY",
             time_enabled: false,
             time_style: "h:mm A",

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -11,7 +11,6 @@ import {
   getCurrencyStyleOptions,
   getCurrencySymbol,
   getDateFormatFromStyle,
-  getDateStyleOptionsForUnit,
   getTimeStyleOptions,
   numberFormatterForOptions,
 } from "metabase/lib/formatting";
@@ -144,7 +143,6 @@ export const DATE_COLUMN_SETTINGS = {
       );
     },
     getProps: ({ unit }) => ({ unit }),
-    getHidden: ({ unit }) => getDateStyleOptionsForUnit(unit).length < 2,
   },
   date_abbreviate: {
     get title() {

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -2,7 +2,9 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import { currency } from "cljs/metabase.util.currency";
+import { DateFormatInput } from "metabase/common/components/DateFormatInput";
 import {
+  dateStyleOption,
   displayNameForColumn,
   getCurrency,
   getCurrencyNarrowSymbol,
@@ -133,47 +135,16 @@ function getTimeEnabledOptionsForUnit(unit) {
 export const DATE_COLUMN_SETTINGS = {
   date_style: {
     get title() {
-      return t`Date style`;
+      return null;
     },
-    widget: "select",
+    widget: DateFormatInput,
     getDefault: ({ unit }, settings) => {
-      // Grab the first option's value. If there were no options (for
-      // hour-of-day probably), use an empty format string instead.
-      const [{ value = "" } = {}] = getDateStyleOptionsForUnit(unit);
-      return settings["date_style"];
+      return (
+        dateStyleOption(settings["date_style"], unit) ?? settings["date_style"]
+      );
     },
-    isValid: ({ unit }, settings) => {
-      const options = getDateStyleOptionsForUnit(unit);
-      return settings["date_style"];
-    },
-    getProps: ({ unit }, settings) => ({
-      options: getDateStyleOptionsForUnit(
-        unit,
-        settings["date_abbreviate"],
-        settings["date_separator"],
-      ),
-    }),
+    getProps: ({ unit }) => ({ unit }),
     getHidden: ({ unit }) => getDateStyleOptionsForUnit(unit).length < 2,
-  },
-  date_separator: {
-    get title() {
-      return t`Date separators`;
-    },
-    widget: "radio",
-    default: "/",
-    getProps: (column, settings) => {
-      const style = /\//.test(settings["date_style"])
-        ? settings["date_style"]
-        : "M/D/YYYY";
-      return {
-        options: [
-          { name: style, value: "/" },
-          { name: style.replace(/\//g, "-"), value: "-" },
-          { name: style.replace(/\//g, "."), value: "." },
-        ],
-      };
-    },
-    getHidden: ({ unit }, settings) => !/\//.test(settings["date_style"] || ""),
   },
   date_abbreviate: {
     get title() {

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -136,15 +136,15 @@ export const DATE_COLUMN_SETTINGS = {
       return t`Date style`;
     },
     widget: "select",
-    getDefault: ({ unit }) => {
+    getDefault: ({ unit }, settings) => {
       // Grab the first option's value. If there were no options (for
       // hour-of-day probably), use an empty format string instead.
       const [{ value = "" } = {}] = getDateStyleOptionsForUnit(unit);
-      return value;
+      return settings["date_style"];
     },
     isValid: ({ unit }, settings) => {
       const options = getDateStyleOptionsForUnit(unit);
-      return !!_.findWhere(options, { value: settings["date_style"] });
+      return settings["date_style"];
     },
     getProps: ({ unit }, settings) => ({
       options: getDateStyleOptionsForUnit(


### PR DESCRIPTION

Closes UXW-1771

### Description

Allows defining any arbitrary date format to display dates in metabase. Eliminates date separator setting.

<img width="729" height="556" alt="CleanShot 2025-11-03 at 16 58 01" src="https://github.com/user-attachments/assets/374a663b-4e8f-45f0-9c6b-96f74f9e55e4" />
<img width="583" height="496" alt="CleanShot 2025-11-03 at 16 57 10" src="https://github.com/user-attachments/assets/b7902680-2112-46bf-908a-2d42fbbe1d0b" />


### Todo
- [ ] make sure static viz is happy
- [ ] do we need a migration for date separator?
- [ ] do the defaults still make sense?
- [ ] other places to excise separators?
- [ ] cache last custom setting?

