### PR TITLE
Fix flaky drill tests on backports

### DIFF
--- a/e2e/test/scenarios/dashboard/visualizer/drillthrough.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/drillthrough.cy.spec.ts
@@ -223,7 +223,9 @@ describe("scenarios > dashboard > visualizer > drillthrough", () => {
 
     H.getDashboardCard(3).within(() => {
       cy.findByText(PRODUCTS_COUNT_BY_CREATED_AT.name).should("exist");
-      applyBrush(200, 300);
+      const APPROX_DISTANCE_BETWEEN_BARS_PX = 10.5;
+      // drag until the middle of the 9th bar
+      applyBrush(200, 200 + APPROX_DISTANCE_BETWEEN_BARS_PX * 8.5);
       cy.wait("@dataset");
     });
 


### PR DESCRIPTION
> [!note]
> closing as this wasn't working as intended. See the [error below](https://github.com/metabase/metabase/pull/65405#issuecomment-3483696017)
>
> ```
>   1) scenarios > dashboard > visualizer > drillthrough
>        should allow brush filtering single-series timeseries charts (VIZ-979):
> 
>       AssertionError: Timed out retrying after 10000ms: Unable to find an element by: [data-testid="question-row-count"]
>       + expected - actual
> 
>       -'Showing 8 rows'
>       +'Showing 9 rows'
> ```

### Description

Fix flaky drills tests on backport, I found that this failed on 56, and 55.

I'm not sure why we got the value 100px in the first place.

I looked at the video from [the failed Cypress test](https://github.com/metabase/metabase/actions/runs/19035853927/job/54427161663) and saw that the result drilled question has 10 instead of 9 bars.
<img width="1542" height="970" alt="image" src="https://github.com/user-attachments/assets/4771f466-d105-4637-876a-420e6ee4d2a6" />

I then observed the bar dimension on v57 and v56. Here's how the chart looks like (pardon the potato quality from Cypress video, I already closed my Cypress test, and didn't take any screenshot)
<img width="638" height="445" alt="image" src="https://github.com/user-attachments/assets/dc9149bd-4f99-46fa-8125-a309dd9f85a8" />

<img width="582" height="203" alt="Screenshot 2025-11-04 at 10 33 34 AM" src="https://github.com/user-attachments/assets/956291b7-1731-4e78-bee6-1413fec4cb68" />

<img width="617" height="230" alt="Screenshot 2025-11-04 at 10 24 42 AM" src="https://github.com/user-attachments/assets/c7c5e1d0-bb91-40c1-bd3b-7bc1f385190b" />

The distance between each bar on v57 is 10.446px and 10.5507px on v56. That means for the drilled question to have 9 bars, we should drag the chart from the start of the first bar to the middle of the 9th bar (from x to x + 8.5*bar_distance) to prevent margin of error.

By using 10.5 as an approximate bar distance, the distance of the drag would be around 89.25px. This is quite far from the original test (100px).

### How to verify

Test on the [backport PR passes](https://github.com/metabase/metabase/pull/65346), because I included the exact change.


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
