### PR TITLE
Stabilize and deduplicate eslint cache

### DIFF
--- a/.github/actions/get-cache-keys/action.yml
+++ b/.github/actions/get-cache-keys/action.yml
@@ -29,5 +29,5 @@ runs:
         echo "m2-cache-key=$M2_CACHE_PREFIX-$CACHE_SUFFIX" >> $GITHUB_OUTPUT
         echo "node-cache-key=$NODE_CACHE_PREFIX-$CACHE_SUFFIX" >> $GITHUB_OUTPUT
         # eslintrc is stable enough that we don't have to change it weekly
-        echo "eslint-cache-key="$ESLINT_CACHE_PREFIX-${{ hashFiles('.eslintrc.js') }}
+        echo "eslint-cache-key=$ESLINT_CACHE_PREFIX-${{ hashFiles('.eslintrc.js') }}" >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/actions/get-cache-keys/action.yml
+++ b/.github/actions/get-cache-keys/action.yml
@@ -10,6 +10,9 @@ outputs:
   node-cache-key:
     description: "The cache key for the Node.js cache."
     value: ${{ steps.keys-factory.outputs.node-cache-key }}
+  eslint-cache-key:
+    description: "The cache key for Eslint cache"
+    value: ${{ steps.keys-factory.outputs.eslint-cache-key }}
 
 runs:
   using: "composite"
@@ -19,9 +22,12 @@ runs:
       run: |
         M2_CACHE_PREFIX='M2'
         NODE_CACHE_PREFIX='node-modules'
+        ESLINT_CACHE_PREFIX='eslint'
         WEEK_OF_YEAR=$(/bin/date "+%G-%V")
         CACHE_SUFFIX="${{ runner.os }}-$WEEK_OF_YEAR"
 
         echo "m2-cache-key=$M2_CACHE_PREFIX-$CACHE_SUFFIX" >> $GITHUB_OUTPUT
         echo "node-cache-key=$NODE_CACHE_PREFIX-$CACHE_SUFFIX" >> $GITHUB_OUTPUT
+        # eslintrc is stable enough that we don't have to change it weekly
+        echo "eslint-cache-key="$ESLINT_CACHE_PREFIX-${{ hashFiles('.eslintrc.js') }}
       shell: bash

--- a/.github/actions/get-cache-keys/action.yml
+++ b/.github/actions/get-cache-keys/action.yml
@@ -28,6 +28,5 @@ runs:
 
         echo "m2-cache-key=$M2_CACHE_PREFIX-$CACHE_SUFFIX" >> $GITHUB_OUTPUT
         echo "node-cache-key=$NODE_CACHE_PREFIX-$CACHE_SUFFIX" >> $GITHUB_OUTPUT
-        # eslintrc is stable enough that we don't have to change it weekly
-        echo "eslint-cache-key=$ESLINT_CACHE_PREFIX-${{ hashFiles('.eslintrc.js') }}" >> $GITHUB_OUTPUT
+        echo "eslint-cache-key=$ESLINT_CACHE_PREFIX-$CACHE_SUFFIX" >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/workflows/cache-generator.yml
+++ b/.github/workflows/cache-generator.yml
@@ -48,6 +48,7 @@ jobs:
     outputs:
       m2-cache-key: ${{ steps.get-cache-keys.outputs.m2-cache-key }}
       node-cache-key: ${{ steps.get-cache-keys.outputs.node-cache-key }}
+      eslint-cache-key: ${{ steps.get-cache-keys.outputs.eslint-cache-key }}
 
   generate-m2-cache:
     runs-on: ubuntu-22.04
@@ -73,12 +74,13 @@ jobs:
             ~/.gitlibs
           key: ${{ env.M2_CACHE_KEY }}
 
-  generate-node-modules-cache:
+  generate-frontend-caches:
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     needs: get-cache-keys
     env:
       NODE_CACHE_KEY: ${{ needs.get-cache-keys.outputs.node-cache-key }}
+      ESLINT_CACHE_KEY: ${{ needs.get-cache-keys.outputs.eslint-cache-key }}
     steps:
       - uses: actions/checkout@v4
       # `prepare-frontend` action (1) prepares Node.js and (2) fetches the node_modules cache if it exists.
@@ -97,3 +99,9 @@ jobs:
         with:
           path: node_modules
           key: ${{ env.NODE_CACHE_KEY }}
+
+      - name: Update eslint cache
+        uses: ./.github/actions/update-cache
+        with:
+          path: .eslintcache
+          key: ${{ env.ESLINT_CACHE_KEY }}

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -35,13 +35,16 @@ jobs:
         uses: ./.github/actions/prepare-frontend
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
+
+      - name: Get Eslint cache key
+        uses: ./.github/actions/get-cache-keys
+        id: get-cache-keys
       - name: Restore ESLint cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: .eslintcache
-          key: eslintcache-${{ hashFiles('yarn.lock', '.eslintrc.js') }}
-          restore-keys: |
-            eslintcache-
+          key: ${{ steps.get-cache-keys.outputs.eslint-cache-key }}
+
       - name: Compile CLJS
         run: yarn build-pure:cljs
       - name: Find CSS variables that are used but never defined


### PR DESCRIPTION
Avoid this
<img width="2528" height="964" alt="image" src="https://github.com/user-attachments/assets/b4cbb314-3576-494e-afb8-45f1d2986ae8" />

by having a single source of truth for eslint cache. It gets generated once, and then the `frontend` workflow only consumes it.