### PR TITLE
Use stableStringify for PublicOrEmbedDashboardView story + add StrictUnion type

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/hooks/use-param-rerender-key.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/hooks/use-param-rerender-key.ts
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { P, match } from "ts-pattern";
 
-import { sortObject } from "metabase-lib/v1/utils";
+import { stableStringify } from "metabase/lib/objects";
 
 import type { SdkIframeEmbedSettings } from "../../embedding_iframe_sdk/types/embed";
 
@@ -25,6 +25,3 @@ export const useParamRerenderKey = (settings: SdkIframeEmbedSettings) =>
         .otherwise(() => null),
     [settings],
   );
-
-// Stringify with sorted keys to ensure stable orders.
-const stableStringify = <T>(obj: T): string => JSON.stringify(sortObject(obj));

--- a/frontend/src/metabase/embedding-sdk/types/utils.ts
+++ b/frontend/src/metabase/embedding-sdk/types/utils.ts
@@ -16,3 +16,15 @@ export type FlattenObjectKeys<
     ? `${Key}.${FlattenObjectKeys<Exclude<T[Key], undefined>>}`
     : `${Key}`
   : never;
+
+type UnionKeys<T> = T extends any ? keyof T : never;
+type StrictUnionHelper<T, TAllKeys extends PropertyKey> = T extends any
+  ? T & Partial<Record<Exclude<TAllKeys, keyof T>, never>>
+  : never;
+
+/**
+ * A type that only allows one of the union types to be used at a time.
+ *
+ * @inline
+ */
+export type StrictUnion<T> = StrictUnionHelper<T, UnionKeys<T>>;

--- a/frontend/src/metabase/lib/objects.ts
+++ b/frontend/src/metabase/lib/objects.ts
@@ -1,3 +1,5 @@
+import { sortObject } from "metabase-lib/v1/utils";
+
 export const getObjectEntries = <K extends string, V>(
   obj: Record<K, V>,
 ): [K, V][] => {
@@ -13,6 +15,10 @@ export const getObjectKeys = <K extends string>(
 export const getObjectValues = <V>(obj: Record<string, V>): V[] => {
   return Object.values(obj) as V[];
 };
+
+// Stringify with sorted keys to ensure stable orders.
+export const stableStringify = <T>(obj: T): string =>
+  JSON.stringify(sortObject(obj));
 
 export function isSerializable(value: unknown): boolean {
   if (value === null || value === undefined) {

--- a/frontend/src/metabase/parameters/actions.ts
+++ b/frontend/src/metabase/parameters/actions.ts
@@ -1,3 +1,4 @@
+import { stableStringify } from "metabase/lib/objects";
 import { CardApi, DashboardApi, ParameterApi } from "metabase/services";
 import { getNonVirtualFields } from "metabase-lib/v1/parameters/utils/parameter-fields";
 import { normalizeParameter } from "metabase-lib/v1/parameters/utils/parameter-values";
@@ -158,7 +159,7 @@ const fetchParameterValuesWithCache = async <T>(
   dispatch: Dispatch,
   getState: GetState,
 ) => {
-  const requestKey = JSON.stringify(request);
+  const requestKey = stableStringify(request);
   const requestCache = getParameterValuesCache(getState());
   const response = requestCache[requestKey]
     ? requestCache[requestKey]

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardView-filters.stories.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardView-filters.stories.tsx
@@ -10,6 +10,7 @@ import { getNextId } from "__support__/utils";
 import { NumberColumn, StringColumn } from "__support__/visualizations";
 import { Api } from "metabase/api";
 import { DASHBOARD_DISPLAY_ACTIONS } from "metabase/dashboard/components/DashboardHeader/DashboardHeaderButtonRow/constants";
+import { stableStringify } from "metabase/lib/objects";
 import { MetabaseReduxProvider } from "metabase/lib/redux/custom-context";
 import {
   MockDashboardContext,
@@ -120,16 +121,21 @@ function ReduxDecorator(Story: StoryFn, context: StoryContext) {
     }),
     parameters: {
       parameterValuesCache: {
-        [`{"paramId":"${CATEGORY_DROPDOWN_FILTER.id}","dashId":${DASHBOARD_ID}}`]:
-          {
-            values: [["Doohickey"], ["Gadget"], ["Gizmo"], ["Widget"]],
-            has_more_values: parameterType === "search" ? true : false,
-          },
-        [`{"paramId":"${CATEGORY_DROPDOWN_FILTER.id}","dashId":${DASHBOARD_ID},"query":"g"}`]:
-          {
-            values: [["Gadget"], ["Gizmo"], ["Widget"]],
-            has_more_values: parameterType === "search" ? true : false,
-          },
+        [stableStringify({
+          paramId: CATEGORY_DROPDOWN_FILTER.id,
+          dashId: DASHBOARD_ID,
+        })]: {
+          values: [["Doohickey"], ["Gadget"], ["Gizmo"], ["Widget"]],
+          has_more_values: parameterType === "search" ? true : false,
+        },
+        [stableStringify({
+          paramId: CATEGORY_DROPDOWN_FILTER.id,
+          dashId: DASHBOARD_ID,
+          query: "g",
+        })]: {
+          values: [["Gadget"], ["Gizmo"], ["Widget"]],
+          has_more_values: parameterType === "search" ? true : false,
+        },
       },
     },
     entities: createMockEntitiesState({


### PR DESCRIPTION
Use stableStringify for PublicOrEmbedDashboardView story.

We should not rely on the order of keys, so we sort them using stableStringify

Also the `StrictUnion` type is added (will be used in follow up PRs):
- it allows the proper typechecking for the external API, for example of a react component,  in the case of multiple different subsets of props:
```
const SomeProps = StrictUnion<{
   mode: 'foo';
   fooSpecificProp1: boolean;
   fooSpecificProp2: boolean;
} | {
   mode: 'bar';
   barSpecificProp1: number;
   barSpecificProp2: number;
}}>
```

How to validate: CI is green