### PR TITLE
Fix the auto-patch workflow

### DIFF
--- a/.github/workflows/release-patch.yml
+++ b/.github/workflows/release-patch.yml
@@ -50,7 +50,7 @@ jobs:
                 majorVersion,
               });
 
-              const releaseCommit = overrideSha ?? await getLatestGreenCommit({
+              const releaseCommit = overrideSha || await getLatestGreenCommit({
                 github,
                 owner: context.repo.owner,
                 repo: context.repo.repo,


### PR DESCRIPTION
This failure https://github.com/metabase/metabase/actions/runs/19049254832 is most likely caused by the changes in #58260

The error shown is: `Invalid value for input 'commit'`, so it seems that this code resolves to an empty string because `overrideSha`'s default value is an empty string:
```
const releaseCommit = overrideSha ?? await getLatestGreenCommit({
  github,
  owner: context.repo.owner,
  repo: context.repo.repo,
  branch: `release-x.${majorVersion}.x`,
});
```

From the browser console:
<img width="88" height="92" alt="image" src="https://github.com/user-attachments/assets/430cf721-e6ab-4585-bf5f-19661e923b5b" />

