### PR TITLE
Add AWS IAM Authentication Support for PostgreSQL and MySQL

### DIFF
--- a/.github/workflows/app-db.yml
+++ b/.github/workflows/app-db.yml
@@ -143,7 +143,7 @@ jobs:
             image: mysql:latest
             env:
               enable-ssl-tests: 'true'
-              enable-aws-iam-tests: 'false' #TODO: enable
+              enable-aws-iam-tests: 'true'
         job:
           - name: Enterprise Tests
             build-static-viz: false
@@ -216,8 +216,8 @@ jobs:
       MB_MYSQL_AWS_IAM_TEST: ${{ matrix.version.env.enable-aws-iam-tests }}
       MB_MYSQL_AWS_IAM_TEST_HOST: ${{ secrets.MYSQL_AURORA_IAM_INSTANCE_HOST }}
       MB_MYSQL_AWS_IAM_TEST_PORT: 3306
-      MB_MYSQL_AWS_IAM_TEST_USER: mb_test
-      MB_MYSQL_AWS_IAM_TEST_DBNAME: mb_test
+      MB_MYSQL_AWS_IAM_TEST_USER: my_iam_user
+      MB_MYSQL_AWS_IAM_TEST_DBNAME: test_db
       MB_MYSQL_AWS_IAM_TEST_SSL_CERT: trust
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_AURORA_IAM_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_AURORA_IAM_SECRET_ACCESS_KEY }}
@@ -265,7 +265,7 @@ jobs:
             docker-image: postgres:latest
             env:
               enable-ssl-tests: 'true'
-              enable-aws-iam-tests: 'false' #TODO: enable
+              enable-aws-iam-tests: 'true'
         job:
           - name: Enterprise Tests
             build-static-viz: false
@@ -320,8 +320,8 @@ jobs:
       MB_POSTGRES_AWS_IAM_TEST: ${{ matrix.version.env.enable-aws-iam-tests }}
       MB_POSTGRES_AWS_IAM_TEST_HOST: ${{ secrets.POSTGRES_AURORA_IAM_INSTANCE_HOST }}
       MB_POSTGRES_AWS_IAM_TEST_PORT: 5432
-      MB_POSTGRES_AWS_IAM_TEST_USER: mb_test
-      MB_POSTGRES_AWS_IAM_TEST_DBNAME: mb_test
+      MB_POSTGRES_AWS_IAM_TEST_USER: my_iam_user
+      MB_POSTGRES_AWS_IAM_TEST_DBNAME: test_db
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_AURORA_IAM_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_AURORA_IAM_SECRET_ACCESS_KEY }}
     services:

--- a/.github/workflows/app-db.yml
+++ b/.github/workflows/app-db.yml
@@ -143,7 +143,7 @@ jobs:
             image: mysql:latest
             env:
               enable-ssl-tests: 'true'
-              enable-aws-iam-tests: 'true'
+              enable-aws-iam-tests: 'false' #TODO: enable
         job:
           - name: Enterprise Tests
             build-static-viz: false
@@ -265,7 +265,7 @@ jobs:
             docker-image: postgres:latest
             env:
               enable-ssl-tests: 'true'
-              enable-aws-iam-tests: 'true'
+              enable-aws-iam-tests: 'false' #TODO: enable
         job:
           - name: Enterprise Tests
             build-static-viz: false

--- a/.github/workflows/app-db.yml
+++ b/.github/workflows/app-db.yml
@@ -137,11 +137,13 @@ jobs:
             image: cimg/mysql:8.0
             env:
               enable-ssl-tests: 'false'
+              enable-aws-iam-tests: 'false'
           - name: MySQL Latest
             junit-name: be-tests-mysql-latest-ee
             image: mysql:latest
             env:
               enable-ssl-tests: 'true'
+              enable-aws-iam-tests: 'true'
         job:
           - name: Enterprise Tests
             build-static-viz: false
@@ -211,6 +213,14 @@ jobs:
       MB_MYSQL_SSL_TEST_SSL_CERT: ${{ secrets.MB_MYSQL_SSL_TEST_SSL_CERT }}
       MB_MYSQL_SSL_TEST_USER: metabase
       MB_MYSQL_SSL_TEST_PASSWORD: ${{ secrets.MYSQL_RDS_SSL_INSTANCE_PASSWORD }}
+      MB_MYSQL_AWS_IAM_TEST: ${{ matrix.version.env.enable-aws-iam-tests }}
+      MB_MYSQL_AWS_IAM_TEST_HOST: ${{ secrets.MYSQL_AURORA_IAM_INSTANCE_HOST }}
+      MB_MYSQL_AWS_IAM_TEST_PORT: 3306
+      MB_MYSQL_AWS_IAM_TEST_USER: mb_test
+      MB_MYSQL_AWS_IAM_TEST_DBNAME: mb_test
+      MB_MYSQL_AWS_IAM_TEST_SSL_CERT: trust
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_AURORA_IAM_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_AURORA_IAM_SECRET_ACCESS_KEY }}
     # for historic reasons (I don't want to mess around with required jobs) the job name should be something like
     # "be-tests-mariadb-10-2-ee (0)"
     name: "${{ matrix.version.name }} ${{ matrix.job.name }}"
@@ -249,11 +259,13 @@ jobs:
             docker-image: postgres:12-alpine
             env:
               enable-ssl-tests: 'false'
+              enable-aws-iam-tests: 'false'
           - name: Postgres Latest
             junit-name: postgres-latest-ee
             docker-image: postgres:latest
             env:
               enable-ssl-tests: 'true'
+              enable-aws-iam-tests: 'true'
         job:
           - name: Enterprise Tests
             build-static-viz: false
@@ -305,6 +317,13 @@ jobs:
       MB_POSTGRES_SSL_TEST_SSL: ${{ matrix.version.env.enable-ssl-tests }}
       MB_POSTGRES_SSL_TEST_SSL_MODE: verify-full
       MB_POSTGRES_SSL_TEST_SSL_ROOT_CERT_PATH: 'test-resources/certificates/us-east-2-bundle.pem'
+      MB_POSTGRES_AWS_IAM_TEST: ${{ matrix.version.env.enable-aws-iam-tests }}
+      MB_POSTGRES_AWS_IAM_TEST_HOST: ${{ secrets.POSTGRES_AURORA_IAM_INSTANCE_HOST }}
+      MB_POSTGRES_AWS_IAM_TEST_PORT: 5432
+      MB_POSTGRES_AWS_IAM_TEST_USER: mb_test
+      MB_POSTGRES_AWS_IAM_TEST_DBNAME: mb_test
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_AURORA_IAM_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_AURORA_IAM_SECRET_ACCESS_KEY }}
     services:
       postgres:
         image: ${{ matrix.version.docker-image }}

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -441,7 +441,7 @@ jobs:
             image: mysql:latest
             env:
               enable-ssl-tests: 'true'
-              enable-aws-iam-tests: 'false' #TODO: enable
+              enable-aws-iam-tests: 'true'
         job:
           - name: Driver Tests
             test-args: >-
@@ -503,8 +503,8 @@ jobs:
       MB_MYSQL_AWS_IAM_TEST: ${{ matrix.version.env.enable-aws-iam-tests }}
       MB_MYSQL_AWS_IAM_TEST_HOST: ${{ secrets.MYSQL_AURORA_IAM_INSTANCE_HOST }}
       MB_MYSQL_AWS_IAM_TEST_PORT: 3306
-      MB_MYSQL_AWS_IAM_TEST_USER: mb_test
-      MB_MYSQL_AWS_IAM_TEST_DBNAME: mb_test
+      MB_MYSQL_AWS_IAM_TEST_USER: my_iam_user
+      MB_MYSQL_AWS_IAM_TEST_DBNAME: test_db
       MB_MYSQL_AWS_IAM_TEST_SSL_CERT: trust
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_AURORA_IAM_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_AURORA_IAM_SECRET_ACCESS_KEY }}
@@ -804,7 +804,7 @@ jobs:
             docker-image: postgres:latest
             env:
               enable-ssl-tests: 'true'
-              enable-aws-iam-tests: 'false' #TODO: enable
+              enable-aws-iam-tests: 'true'
         job:
           - name: Driver Tests
             test-args: >-
@@ -847,8 +847,8 @@ jobs:
       MB_POSTGRES_AWS_IAM_TEST: ${{ matrix.version.env.enable-aws-iam-tests }}
       MB_POSTGRES_AWS_IAM_TEST_HOST: ${{ secrets.POSTGRES_AURORA_IAM_INSTANCE_HOST }}
       MB_POSTGRES_AWS_IAM_TEST_PORT: 5432
-      MB_POSTGRES_AWS_IAM_TEST_USER: mb_test
-      MB_POSTGRES_AWS_IAM_TEST_DBNAME: mb_test
+      MB_POSTGRES_AWS_IAM_TEST_USER: my_iam_user
+      MB_POSTGRES_AWS_IAM_TEST_DBNAME: test_db
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_AURORA_IAM_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_AURORA_IAM_SECRET_ACCESS_KEY }}
     services:

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -441,7 +441,7 @@ jobs:
             image: mysql:latest
             env:
               enable-ssl-tests: 'true'
-              enable-aws-iam-tests: 'true'
+              enable-aws-iam-tests: 'false' #TODO: enable
         job:
           - name: Driver Tests
             test-args: >-
@@ -804,7 +804,7 @@ jobs:
             docker-image: postgres:latest
             env:
               enable-ssl-tests: 'true'
-              enable-aws-iam-tests: 'true'
+              enable-aws-iam-tests: 'false' #TODO: enable
         job:
           - name: Driver Tests
             test-args: >-

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -423,21 +423,25 @@ jobs:
             image: circleci/mariadb:10.2.23
             env:
               enable-ssl-tests: 'false'
+              enable-aws-iam-tests: 'false'
           - name: MariaDB Latest
             junit-name: be-tests-mariadb-latest-ee
             image: circleci/mariadb:latest
             env:
               enable-ssl-tests: 'false'
+              enable-aws-iam-tests: 'false'
           - name: MySQL 8.0
             junit-name: be-tests-mysql-8-0-ee
             image: mysql:8.0
             env:
               enable-ssl-tests: 'false'
+              enable-aws-iam-tests: 'false'
           - name: MySQL Latest
             junit-name: be-tests-mysql-latest-ee
             image: mysql:latest
             env:
               enable-ssl-tests: 'true'
+              enable-aws-iam-tests: 'true'
         job:
           - name: Driver Tests
             test-args: >-
@@ -496,6 +500,14 @@ jobs:
       MB_MYSQL_SSL_TEST_SSL_CERT: ${{ secrets.MB_MYSQL_SSL_TEST_SSL_CERT }}
       MB_MYSQL_SSL_TEST_USER: metabase
       MB_MYSQL_SSL_TEST_PASSWORD: ${{ secrets.MYSQL_RDS_SSL_INSTANCE_PASSWORD }}
+      MB_MYSQL_AWS_IAM_TEST: ${{ matrix.version.env.enable-aws-iam-tests }}
+      MB_MYSQL_AWS_IAM_TEST_HOST: ${{ secrets.MYSQL_AURORA_IAM_INSTANCE_HOST }}
+      MB_MYSQL_AWS_IAM_TEST_PORT: 3306
+      MB_MYSQL_AWS_IAM_TEST_USER: mb_test
+      MB_MYSQL_AWS_IAM_TEST_DBNAME: mb_test
+      MB_MYSQL_AWS_IAM_TEST_SSL_CERT: trust
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_AURORA_IAM_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_AURORA_IAM_SECRET_ACCESS_KEY }}
     # for historic reasons (I don't want to mess around with required jobs) the job name should be something like
     # "be-tests-mariadb-10-2-ee (0)"
     name: "${{ matrix.version.name }} ${{ matrix.job.name }}"
@@ -786,11 +798,13 @@ jobs:
             docker-image: postgres:12-alpine
             env:
               enable-ssl-tests: 'false'
+              enable-aws-iam-tests: 'false'
           - name: Postgres Latest
             junit-name: postgres-latest-ee
             docker-image: postgres:latest
             env:
               enable-ssl-tests: 'true'
+              enable-aws-iam-tests: 'true'
         job:
           - name: Driver Tests
             test-args: >-
@@ -830,6 +844,13 @@ jobs:
       MB_POSTGRES_SSL_TEST_SSL: ${{ matrix.version.env.enable-ssl-tests }}
       MB_POSTGRES_SSL_TEST_SSL_MODE: verify-full
       MB_POSTGRES_SSL_TEST_SSL_ROOT_CERT_PATH: 'test-resources/certificates/us-east-2-bundle.pem'
+      MB_POSTGRES_AWS_IAM_TEST: ${{ matrix.version.env.enable-aws-iam-tests }}
+      MB_POSTGRES_AWS_IAM_TEST_HOST: ${{ secrets.POSTGRES_AURORA_IAM_INSTANCE_HOST }}
+      MB_POSTGRES_AWS_IAM_TEST_PORT: 5432
+      MB_POSTGRES_AWS_IAM_TEST_USER: mb_test
+      MB_POSTGRES_AWS_IAM_TEST_DBNAME: mb_test
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_AURORA_IAM_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_AURORA_IAM_SECRET_ACCESS_KEY }}
     services:
       postgres:
         image: ${{ matrix.version.docker-image }}

--- a/deps.edn
+++ b/deps.edn
@@ -201,6 +201,7 @@
   slingshot/slingshot                       {:mvn/version "0.12.2"}             ; enhanced throw/catch, used by other deps
   software.amazon.awssdk/s3                 {:mvn/version "2.36.2"}             ; AWS SDK v2 for S3
   software.amazon.awssdk/sts                {:mvn/version "2.36.2"}             ; Required for S3 client to use service account
+  software.amazon.jdbc/aws-advanced-jdbc-wrapper {:mvn/version "2.6.5"}        ; AWS JDBC wrapper for IAM authentication
   stencil/stencil                           {:mvn/version "0.5.0"}              ; Mustache templates for Clojure
   user-agent/user-agent                     {:mvn/version "0.1.1"}              ; User-Agent string parser, for Login History page & elsewhere
   weavejester/dependency                    {:mvn/version "1.0.0"}              ; Dependency graphs and topological sorting

--- a/src/metabase/app_db/data_source.clj
+++ b/src/metabase/app_db/data_source.clj
@@ -143,7 +143,7 @@
                                                                      azure-managed-identity-client-id))
          [s m] (if aws-iam
                  [(str/replace s #"^jdbc:(postgresql|mysql):" "jdbc:aws-wrapper:$1:")
-                  (assoc m :wrapperPlugins "iam")]
+                  (assoc m :wrapperPlugins "iam" :useSSL true)]
                  [s m])]
      (update-h2/update-if-needed! s)
      (->DataSource s (some-> (not-empty m) connection-pool/map->properties)))))

--- a/src/metabase/app_db/data_source.clj
+++ b/src/metabase/app_db/data_source.clj
@@ -143,7 +143,7 @@
                                                                      azure-managed-identity-client-id))
          [s m] (if aws-iam
                  [(str/replace s #"^jdbc:(postgresql|mysql):" "jdbc:aws-wrapper:$1:")
-                  (assoc m :wrapperPlugins "iam" :useSSL true)]
+                  (assoc m :wrapperPlugins "iam")]
                  [s m])]
      (update-h2/update-if-needed! s)
      (->DataSource s (some-> (not-empty m) connection-pool/map->properties)))))

--- a/src/metabase/app_db/env.clj
+++ b/src/metabase/app_db/env.clj
@@ -77,7 +77,7 @@
 (defn- broken-out-details
   "Connection details that can be used when pretending the Metabase DB is itself a `Database` (e.g., to use the Generic
   SQL driver functions on the Metabase DB itself)."
-  [db-type {:keys [mb-db-dbname mb-db-host mb-db-pass mb-db-port mb-db-user mb-db-azure-managed-identity-client-id]
+  [db-type {:keys [mb-db-dbname mb-db-host mb-db-pass mb-db-port mb-db-user mb-db-azure-managed-identity-client-id mb-db-aws-iam]
             :as   env-vars}]
   (if (= db-type :h2)
     (assoc h2-connection-properties
@@ -87,7 +87,8 @@
      :db                               mb-db-dbname
      :user                             mb-db-user
      :password                         mb-db-pass
-     :azure-managed-identity-client-id mb-db-azure-managed-identity-client-id}))
+     :azure-managed-identity-client-id mb-db-azure-managed-identity-client-id
+     :aws-iam                          mb-db-aws-iam}))
 
 (defn- env->DataSource
   [db-type {:keys [mb-db-connection-uri mb-db-user mb-db-pass mb-db-azure-managed-identity-client-id], :as env-vars}]
@@ -131,7 +132,8 @@
     :mb-db-dbname                           (config/config-str :mb-db-dbname)
     :mb-db-user                             (config/config-str :mb-db-user)
     :mb-db-pass                             (config/config-str :mb-db-pass)
-    :mb-db-azure-managed-identity-client-id (config/config-str :mb-db-azure-managed-identity-client-id)}
+    :mb-db-azure-managed-identity-client-id (config/config-str :mb-db-azure-managed-identity-client-id)
+    :mb-db-aws-iam                          (config/config-bool :mb-db-aws-iam)}
    (env-defaults db-type)))
 
 (def env

--- a/src/metabase/app_db/env.clj
+++ b/src/metabase/app_db/env.clj
@@ -93,6 +93,7 @@
 (defn- env->DataSource
   [db-type {:keys [mb-db-connection-uri mb-db-user mb-db-pass mb-db-azure-managed-identity-client-id], :as env-vars}]
   (if mb-db-connection-uri
+    ;; TODO: aws-iam
     (mdb.data-source/raw-connection-string->DataSource
      mb-db-connection-uri mb-db-user mb-db-pass mb-db-azure-managed-identity-client-id)
     (mdb.data-source/broken-out-details->DataSource db-type (broken-out-details db-type env-vars))))

--- a/src/metabase/app_db/env.clj
+++ b/src/metabase/app_db/env.clj
@@ -91,11 +91,10 @@
      :aws-iam                          mb-db-aws-iam}))
 
 (defn- env->DataSource
-  [db-type {:keys [mb-db-connection-uri mb-db-user mb-db-pass mb-db-azure-managed-identity-client-id], :as env-vars}]
+  [db-type {:keys [mb-db-connection-uri mb-db-user mb-db-pass mb-db-azure-managed-identity-client-id aws-iam], :as env-vars}]
   (if mb-db-connection-uri
-    ;; TODO: aws-iam
     (mdb.data-source/raw-connection-string->DataSource
-     mb-db-connection-uri mb-db-user mb-db-pass mb-db-azure-managed-identity-client-id)
+     mb-db-connection-uri mb-db-user mb-db-pass mb-db-azure-managed-identity-client-id aws-iam)
     (mdb.data-source/broken-out-details->DataSource db-type (broken-out-details db-type env-vars))))
 
 ;;;; exports: [[db-type]], [[db-file]], and [[data-source]] created using environment variables.

--- a/src/metabase/app_db/spec.clj
+++ b/src/metabase/app_db/spec.clj
@@ -31,8 +31,7 @@
 (defn- make-aws-iam-spec [subprotocol]
   {:subprotocol (str "aws-wrapper:" subprotocol)
    :classname "software.amazon.jdbc.ds.AwsWrapperDataSource"
-   :wrapperPlugins "iam"
-   :useSSL true})
+   :wrapperPlugins "iam"})
 
 (defmethod spec :postgres
   [_ {:keys [host port db aws-iam]

--- a/src/metabase/app_db/spec.clj
+++ b/src/metabase/app_db/spec.clj
@@ -49,7 +49,7 @@
    (dissoc opts :host :port :db :aws-iam)))
 
 (defmethod spec :mysql
-  [_ {:keys [host port db aws-iam]
+  [_ {:keys [host port db aws-iam ssl-cert]
       :or   {host "localhost", port 3306, db ""}
       :as   opts}]
   (merge
@@ -57,10 +57,19 @@
     :subprotocol "mysql"
     :subname     (make-subname host (or port 3306) db)}
    (when aws-iam
-     (assoc
+     (merge
       (make-aws-iam-spec "mysql")
-      :sslMode "VERIFY_CA"))
-   (dissoc opts :host :port :db :aws-iam)))
+      (cond
+        (= ssl-cert "trust")
+        {:trustServerCertificate true}
+
+        (and ssl-cert (not= ssl-cert "trust"))
+        {:sslMode       "VERIFY_CA"
+         :serverSslCert ssl-cert}
+
+        :else
+        {:sslMode "VERIFY_CA"})))
+   (dissoc opts :host :port :db :aws-iam :ssl-cert)))
 
 ;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ;; !!                                                                                                               !!

--- a/src/metabase/app_db/spec.clj
+++ b/src/metabase/app_db/spec.clj
@@ -31,7 +31,8 @@
 (defn- make-aws-iam-spec [subprotocol]
   {:subprotocol (str "aws-wrapper:" subprotocol)
    :classname "software.amazon.jdbc.ds.AwsWrapperDataSource"
-   :wrapperPlugins "iam"})
+   :wrapperPlugins "iam"
+   :useSSL true})
 
 (defmethod spec :postgres
   [_ {:keys [host port db aws-iam]
@@ -57,7 +58,9 @@
     :subprotocol "mysql"
     :subname     (make-subname host (or port 3306) db)}
    (when aws-iam
-     (make-aws-iam-spec "mysql"))
+     (assoc
+      (make-aws-iam-spec "mysql")
+      :sslMode "VERIFY_CA"))
    (dissoc opts :host :port :db)))
 
 ;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/src/metabase/app_db/spec.clj
+++ b/src/metabase/app_db/spec.clj
@@ -47,7 +47,7 @@
     :ApplicationName               config/mb-version-and-process-identifier}
    (when aws-iam
      (make-aws-iam-spec "postgresql"))
-   (dissoc opts :host :port :db)))
+   (dissoc opts :host :port :db :aws-iam)))
 
 (defmethod spec :mysql
   [_ {:keys [host port db aws-iam]
@@ -61,7 +61,7 @@
      (assoc
       (make-aws-iam-spec "mysql")
       :sslMode "VERIFY_CA"))
-   (dissoc opts :host :port :db)))
+   (dissoc opts :host :port :db :aws-iam)))
 
 ;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ;; !!                                                                                                               !!

--- a/src/metabase/app_db/spec.clj
+++ b/src/metabase/app_db/spec.clj
@@ -31,6 +31,7 @@
 (defn- make-aws-iam-spec [subprotocol]
   {:subprotocol (str "aws-wrapper:" subprotocol)
    :classname "software.amazon.jdbc.ds.AwsWrapperDataSource"
+   :useSSL true
    :wrapperPlugins "iam"})
 
 (defmethod spec :postgres
@@ -55,7 +56,6 @@
   (merge
    {:classname   "org.mariadb.jdbc.Driver"
     :subprotocol "mysql"
-    :useSSL true
     :subname     (make-subname host (or port 3306) db)}
    (when aws-iam
      (merge

--- a/src/metabase/app_db/spec.clj
+++ b/src/metabase/app_db/spec.clj
@@ -55,6 +55,7 @@
   (merge
    {:classname   "org.mariadb.jdbc.Driver"
     :subprotocol "mysql"
+    :useSSL true
     :subname     (make-subname host (or port 3306) db)}
    (when aws-iam
      (merge

--- a/src/metabase/app_db/spec.clj
+++ b/src/metabase/app_db/spec.clj
@@ -29,7 +29,7 @@
   (str "//" (when-not (str/blank? host) (str host ":" port)) (if-not (str/blank? db) (str "/" db) "/")))
 
 (defmethod spec :postgres
-  [_ {:keys [host port db]
+  [_ {:keys [host port db aws-iam]
       :or   {host "localhost", port 5432, db ""}
       :as   opts}]
   (merge
@@ -39,6 +39,10 @@
     ;; I think this is done to prevent conflicts with redshift driver registering itself to handle postgres://
     :OpenSourceSubProtocolOverride true
     :ApplicationName               config/mb-version-and-process-identifier}
+   (when aws-iam
+     {:subprotocol "aws-wrapper:postgresql"
+      :classname "software.amazon.jdbc.ds.AwsWrapperDataSource"
+      :wrapperPlugins "iam"})
    (dissoc opts :host :port :db)))
 
 (defmethod spec :mysql

--- a/src/metabase/driver/common.clj
+++ b/src/metabase/driver/common.clj
@@ -252,7 +252,7 @@
 (defn auth-provider-options
   "Options for using an auth provider instead of a literal password.
   When called with no arguments, returns options for all available auth providers.
-  When called with a collection of provider keywords (e.g., [:aws-iam]), returns options
+  When called with a collection of provider keywords (e.g., #{:aws-iam}), returns options
   filtered to only those providers."
   ([]
    (auth-provider-options nil))

--- a/src/metabase/driver/common.clj
+++ b/src/metabase/driver/common.clj
@@ -282,6 +282,24 @@
     :display-name (deferred-tru "Auth token request headers (a JSON map)")
     :visible-if {"auth-provider" "oauth"}}])
 
+(def auth-provider-options-only-aws
+  "Options for using an auth provider instead of a literal password. Only AWS IAM enabled."
+  [{:name "use-auth-provider"
+    :type :checked-section
+    :check (fn []
+             (and
+               ;; Managed Identities only make sense if Metabase is in the same cloud as the DW
+              (not (premium-features/is-hosted?))
+              (premium-features/enable-database-auth-providers?)))
+    :default false}
+   {:name "auth-provider"
+    :display-name (deferred-tru "Auth provider")
+    :type :select
+    :options [{:name (deferred-tru "AWS IAM")
+               :value "aws-iam"}]
+    :default "aws-iam"
+    :visible-if {"use-auth-provider" true}}])
+
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                               Class -> Base Type                                               |
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/src/metabase/driver/common.clj
+++ b/src/metabase/driver/common.clj
@@ -264,6 +264,8 @@
     :type :select
     :options [{:name (deferred-tru "Azure Managed Identity")
                :value "azure-managed-identity"}
+              {:name (deferred-tru "AWS IAM")
+               :value "aws-iam"}
               {:name (deferred-tru "OAuth")
                :value "oauth"}]
     :default "azure-managed-identity"

--- a/src/metabase/driver/common.clj
+++ b/src/metabase/driver/common.clj
@@ -249,56 +249,50 @@
   added to the plugin manifest as connection properties, similar to the keys in the `default-options` map."
   {:cloud-ip-address-info cloud-ip-address-info})
 
-(def auth-provider-options
-  "Options for using an auth provider instead of a literal password."
-  [{:name "use-auth-provider"
-    :type :checked-section
-    :check (fn []
-             (and
-               ;; Managed Identities only make sense if Metabase is in the same cloud as the DW
-              (not (premium-features/is-hosted?))
-              (premium-features/enable-database-auth-providers?)))
-    :default false}
-   {:name "auth-provider"
-    :display-name (deferred-tru "Auth provider")
-    :type :select
-    :options [{:name (deferred-tru "Azure Managed Identity")
-               :value "azure-managed-identity"}
-              {:name (deferred-tru "AWS IAM")
-               :value "aws-iam"}
-              {:name (deferred-tru "OAuth")
-               :value "oauth"}]
-    :default "azure-managed-identity"
-    :visible-if {"use-auth-provider" true}}
-   {:name "azure-managed-identity-client-id"
-    :display-name (deferred-tru "Client ID")
-    :required true
-    :visible-if {"auth-provider" "azure-managed-identity"}}
-   {:name "oauth-token-url"
-    :display-name (deferred-tru "Auth token URL")
-    :required true
-    :visible-if {"auth-provider" "oauth"}}
-   {:name "oauth-token-headers"
-    :display-name (deferred-tru "Auth token request headers (a JSON map)")
-    :visible-if {"auth-provider" "oauth"}}])
-
-(def auth-provider-options-only-aws
-  "Options for using an auth provider instead of a literal password. Only AWS IAM enabled."
-  [{:name "use-auth-provider"
-    :type :checked-section
-    :check (fn []
-             (and
-               ;; Managed Identities only make sense if Metabase is in the same cloud as the DW
-              (not (premium-features/is-hosted?))
-              (premium-features/enable-database-auth-providers?)))
-    :default false}
-   {:name "auth-provider"
-    :display-name (deferred-tru "Auth provider")
-    :type :select
-    :options [{:name (deferred-tru "AWS IAM")
-               :value "aws-iam"}]
-    :default "aws-iam"
-    :visible-if {"use-auth-provider" true}}])
+(defn auth-provider-options
+  "Options for using an auth provider instead of a literal password.
+  When called with no arguments, returns options for all available auth providers.
+  When called with a collection of provider keywords (e.g., [:aws-iam]), returns options
+  filtered to only those providers."
+  ([]
+   (auth-provider-options nil))
+  ([allowed-providers]
+   (let [all-provider-options [{:name (deferred-tru "Azure Managed Identity")
+                                :value "azure-managed-identity"}
+                               {:name (deferred-tru "AWS IAM")
+                                :value "aws-iam"}
+                               {:name (deferred-tru "OAuth")
+                                :value "oauth"}]
+         provider-options (if (seq allowed-providers)
+                            (let [allowed-set (set (map name allowed-providers))]
+                              (filterv #(contains? allowed-set (:value %)) all-provider-options))
+                            all-provider-options)
+         default-provider (:value (first provider-options))]
+     [{:name "use-auth-provider"
+       :type :checked-section
+       :check (fn []
+                (and
+                  ;; Managed Identities only make sense if Metabase is in the same cloud as the DW
+                 (not (premium-features/is-hosted?))
+                 (premium-features/enable-database-auth-providers?)))
+       :default false}
+      {:name "auth-provider"
+       :display-name (deferred-tru "Auth provider")
+       :type :select
+       :options provider-options
+       :default default-provider
+       :visible-if {"use-auth-provider" true}}
+      {:name "azure-managed-identity-client-id"
+       :display-name (deferred-tru "Client ID")
+       :required true
+       :visible-if {"auth-provider" "azure-managed-identity"}}
+      {:name "oauth-token-url"
+       :display-name (deferred-tru "Auth token URL")
+       :required true
+       :visible-if {"auth-provider" "oauth"}}
+      {:name "oauth-token-headers"
+       :display-name (deferred-tru "Auth token request headers (a JSON map)")
+       :visible-if {"auth-provider" "oauth"}}])))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                               Class -> Base Type                                               |

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -666,6 +666,10 @@
       (log/info "You may need to add 'trustServerCertificate=true' to the additional connection options to connect with SSL."))
     (when (and use-iam? (not ssl?))
       (throw (ex-info "You must enable SSL in order to use AWS IAM authentication" {})))
+    (when (and use-iam?
+               (contains? addl-opts-map "sslMode")
+               (not (contains? addl-opts-map "sslMode=VERIFY_CA")))
+      (throw (ex-info "sslMode must be VERIFY_CA in order to use AWS IAM authentication" {})))
     (merge
      default-connection-args
      ;; newer versions of MySQL will complain if you don't specify this when not using SSL

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -227,7 +227,7 @@
     (assoc driver.common/default-port-details :placeholder 3306)
     driver.common/default-dbname-details
     driver.common/default-user-details
-    (driver.common/auth-provider-options [:aws-iam])
+    (driver.common/auth-provider-options #{:aws-iam})
     (assoc driver.common/default-password-details
            :visible-if {"use-auth-provider" false})
     driver.common/default-role-details

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -664,6 +664,8 @@
         ssl-cert?     (and ssl? (some? ssl-cert))]
     (when (and ssl? (not (contains? addl-opts-map "trustServerCertificate")))
       (log/info "You may need to add 'trustServerCertificate=true' to the additional connection options to connect with SSL."))
+    (when (and use-iam? (not ssl?))
+      (log/error "You must enable SSL in order to use AWS IAM authentication"))
     (merge
      default-connection-args
      ;; newer versions of MySQL will complain if you don't specify this when not using SSL

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -665,7 +665,7 @@
     (when (and ssl? (not (contains? addl-opts-map "trustServerCertificate")))
       (log/info "You may need to add 'trustServerCertificate=true' to the additional connection options to connect with SSL."))
     (when (and use-iam? (not ssl?))
-      (log/error "You must enable SSL in order to use AWS IAM authentication"))
+      (throw (ex-info "You must enable SSL in order to use AWS IAM authentication" {})))
     (merge
      default-connection-args
      ;; newer versions of MySQL will complain if you don't specify this when not using SSL

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -676,6 +676,7 @@
                      (->
                       (assoc :subprotocol "aws-wrapper:mysql"
                              :classname "software.amazon.jdbc.ds.AwsWrapperDataSource"
+                             :sslMode "VERIFY_CA"
                              :wrapperPlugins "iam")
                       (dissoc :auth-provider :use-auth-provider))
 

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -227,7 +227,7 @@
     (assoc driver.common/default-port-details :placeholder 3306)
     driver.common/default-dbname-details
     driver.common/default-user-details
-    driver.common/auth-provider-options-only-aws
+    (driver.common/auth-provider-options [:aws-iam])
     (assoc driver.common/default-password-details
            :visible-if {"use-auth-provider" false})
     driver.common/default-role-details

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -950,7 +950,7 @@
                 (driver-api/spec :postgres it)
                 (sql-jdbc.common/handle-additional-options it details-map))]
     (when (and use-iam? (not ssl?))
-      (log/error "You must enable SSL in order to use AWS IAM authentication"))
+      (throw (ex-info "You must enable SSL in order to use AWS IAM authentication" {})))
     props))
 
 (defmethod sql-jdbc.sync/excluded-schemas :postgres [_driver] #{"information_schema" "pg_catalog"})

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -921,7 +921,7 @@
 
 (defmethod sql-jdbc.conn/connection-details->spec :postgres
   [_ {ssl? :ssl, auth-provider :auth-provider, :as details-map}]
-  (let [use-iam? (= auth-provider "aws-iam")
+  (let [use-iam? (= (some-> auth-provider keyword) :aws-iam)
         ;; AWS IAM authentication requires SSL
         ;; TODO: should be reflected in the UI
         ssl? (or ssl? use-iam?)
@@ -944,6 +944,7 @@
         props (if use-iam?
                 (-> props
                     (assoc :subprotocol "aws-wrapper:postgresql"
+                           :classname "software.amazon.jdbc.ds.AwsWrapperDataSource"
                            :wrapperPlugins "iam")
                     (dissoc :auth-provider :use-auth-provider))
                 props)

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -941,17 +941,16 @@
                   ;; internal property values back; only merge in the ones the driver might recognize
                   (merge ssl-prms (select-keys props (keys ssl-prms))))
                 (merge disable-ssl-params props))
-        props (as-> props it
-                (set/rename-keys it {:dbname :db})
-                (driver-api/spec :postgres it)
-                (sql-jdbc.common/handle-additional-options it details-map))
         props (if use-iam?
-                ;; TODO: move to handle-additional-options?
                 (-> props
                     (assoc :subprotocol "aws-wrapper:postgresql"
                            :wrapperPlugins "iam")
                     (dissoc :auth-provider :use-auth-provider))
-                props)]
+                props)
+        props (as-> props it
+                (set/rename-keys it {:dbname :db})
+                (driver-api/spec :postgres it)
+                (sql-jdbc.common/handle-additional-options it details-map))]
     props))
 
 (defmethod sql-jdbc.sync/excluded-schemas :postgres [_driver] #{"information_schema" "pg_catalog"})

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -949,6 +949,8 @@
                 (set/rename-keys it {:dbname :db})
                 (driver-api/spec :postgres it)
                 (sql-jdbc.common/handle-additional-options it details-map))]
+    (when (and use-iam? (not ssl?))
+      (log/error "You must enable SSL in order to use AWS IAM authentication"))
     props))
 
 (defmethod sql-jdbc.sync/excluded-schemas :postgres [_driver] #{"information_schema" "pg_catalog"})

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -158,7 +158,7 @@
     (assoc driver.common/default-port-details :placeholder 5432)
     driver.common/default-dbname-details
     driver.common/default-user-details
-    driver.common/auth-provider-options
+    (driver.common/auth-provider-options)
     (assoc driver.common/default-password-details
            :visible-if {"use-auth-provider" false})
     driver.common/cloud-ip-address-info

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -920,11 +920,8 @@
   {:sslmode "disable"})
 
 (defmethod sql-jdbc.conn/connection-details->spec :postgres
-  [_ {ssl? :ssl, auth-provider :auth-provider, :as details-map}]
+  [_ {ssl? :ssl, :keys [auth-provider], :as details-map}]
   (let [use-iam? (= (some-> auth-provider keyword) :aws-iam)
-        ;; AWS IAM authentication requires SSL
-        ;; TODO: should be reflected in the UI
-        ssl? (or ssl? use-iam?)
         props (-> details-map
                   (update :port (fn [port]
                                   (if (string? port)

--- a/src/metabase/driver/sql_jdbc/common.clj
+++ b/src/metabase/driver/sql_jdbc/common.clj
@@ -43,7 +43,7 @@
                       v)) "" additional-opts)))
 
 (defn handle-additional-options
-  "If `details` contains an `:addtional-options` key, append those options to the connection string in `connection-spec`.
+  "If `details` contains an `:additional-options` key, append those options to the connection string in `connection-spec`.
    (Some drivers like MySQL provide this details field to allow special behavior where needed).
 
    Optionally specify `seperator-style`, which defaults to `:url` (e.g. `?a=1&b=2`). You may instead set it to

--- a/test/metabase/app_db/aws_iam_test.clj
+++ b/test/metabase/app_db/aws_iam_test.clj
@@ -33,18 +33,61 @@
     true))
 
 (deftest ^:mb/once postgres-aws-iam-test
-  (let [host   (config/config-str :mb-postgres-aws-iam-test-host)
-        port   (config/config-int :mb-postgres-aws-iam-test-port)
-        user   (config/config-str :mb-postgres-aws-iam-test-user)
-        dbname (config/config-str :mb-postgres-aws-iam-test-dbname)
-        uri (format "postgres://%s:%d/%s?user=%s" host port dbname user)]
-    (if host
-      (do
+  (if (config/config-bool :mb-postgres-aws-iam-test)
+    (let [host   (config/config-str :mb-postgres-aws-iam-test-host)
+          port   (config/config-int :mb-postgres-aws-iam-test-port)
+          user   (config/config-str :mb-postgres-aws-iam-test-user)
+          dbname (config/config-str :mb-postgres-aws-iam-test-dbname)
+          uri (format "postgres://%s:%d/%s?user=%s" host port dbname user)]
+      (testing "Connection details are configured"
+        (is (string? host))
+        (is (string? user))
+        (is (int? port))
+        (is (string? dbname)))
+
+      (testing "using broken-out details"
+        (testing "Can create DataSource with AWS IAM enabled"
+          (let [details {:host     host
+                         :port     port
+                         :user     user
+                         :db       dbname
+                         :aws-iam  true}
+                datasource (mdb.data-source/broken-out-details->DataSource :postgres details)]
+            (is (instance? javax.sql.DataSource datasource))
+
+            (testing "Can establish connection using AWS IAM"
+              (is (true? (get-connection-and-close! datasource)))))))
+
+      (testing "using uri"
+        (testing "Can create DataSource with AWS IAM enabled"
+          (let [datasource (mdb.data-source/raw-connection-string->DataSource
+                            uri nil nil nil true)]
+            (is (instance? javax.sql.DataSource datasource))
+
+            (testing "Can establish connection using AWS IAM"
+              (is (true? (get-connection-and-close! datasource))))))))
+    (log/info "Skipping test: MB_POSTGRES_AWS_IAM_TEST not set")))
+
+(deftest ^:mb/once mysql-aws-iam-test
+  (testing "MySQL App DB connection with AWS IAM authentication"
+    (if (config/config-bool :mb-mysql-aws-iam-test)
+      (let [host     (config/config-str :mb-mysql-aws-iam-test-host)
+            port     (config/config-int :mb-mysql-aws-iam-test-port)
+            user     (config/config-str :mb-mysql-aws-iam-test-user)
+            dbname   (config/config-str :mb-mysql-aws-iam-test-dbname)
+            ssl-cert (config/config-str :mb-mysql-aws-iam-test-ssl-cert)
+            uri (format "mysql://%s:%d/%s?user=%s&%s" host port dbname user
+                        (if (= ssl-cert "trust")
+                          "trustServerCertificate=true"
+                          (str "?sslMode=VERIFY_CA&serverSslCert=" ssl-cert)))]
         (testing "Connection details are configured"
           (is (string? host))
           (is (string? user))
           (is (int? port))
           (is (string? dbname)))
+
+        (testing "SSL certificate is configured"
+          (is (string? ssl-cert)))
 
         (testing "using broken-out details"
           (testing "Can create DataSource with AWS IAM enabled"
@@ -52,8 +95,9 @@
                            :port     port
                            :user     user
                            :db       dbname
+                           :ssl-cert ssl-cert
                            :aws-iam  true}
-                  datasource (mdb.data-source/broken-out-details->DataSource :postgres details)]
+                  datasource (mdb.data-source/broken-out-details->DataSource :mysql details)]
               (is (instance? javax.sql.DataSource datasource))
 
               (testing "Can establish connection using AWS IAM"
@@ -67,50 +111,4 @@
 
               (testing "Can establish connection using AWS IAM"
                 (is (true? (get-connection-and-close! datasource))))))))
-      (log/info "Skipping test: MB_POSTGRES_AWS_IAM_TEST_HOST not set"))))
-
-(deftest ^:mb/once mysql-aws-iam-test
-  (testing "MySQL App DB connection with AWS IAM authentication"
-    (let [host     (config/config-str :mb-mysql-aws-iam-test-host)
-          port     (config/config-int :mb-mysql-aws-iam-test-port)
-          user     (config/config-str :mb-mysql-aws-iam-test-user)
-          dbname   (config/config-str :mb-mysql-aws-iam-test-dbname)
-          ssl-cert (config/config-str :mb-mysql-aws-iam-test-ssl-cert)
-          uri (format "mysql://%s:%d/%s?user=%s&%s" host port dbname user
-                      (if (= ssl-cert "trust")
-                        "trustServerCertificate=true"
-                        (str "?sslMode=VERIFY_CA&serverSslCert=" ssl-cert)))]
-      (if (and host ssl-cert)
-        (do
-          (testing "Connection details are configured"
-            (is (string? host))
-            (is (string? user))
-            (is (int? port))
-            (is (string? dbname)))
-
-          (testing "SSL certificate is configured"
-            (is (string? ssl-cert)))
-
-          (testing "using broken-out details"
-            (testing "Can create DataSource with AWS IAM enabled"
-              (let [details {:host     host
-                             :port     port
-                             :user     user
-                             :db       dbname
-                             :ssl-cert ssl-cert
-                             :aws-iam  true}
-                    datasource (mdb.data-source/broken-out-details->DataSource :mysql details)]
-                (is (instance? javax.sql.DataSource datasource))
-
-                (testing "Can establish connection using AWS IAM"
-                  (is (true? (get-connection-and-close! datasource)))))))
-
-          (testing "using uri"
-            (testing "Can create DataSource with AWS IAM enabled"
-              (let [datasource (mdb.data-source/raw-connection-string->DataSource
-                                uri nil nil nil true)]
-                (is (instance? javax.sql.DataSource datasource))
-
-                (testing "Can establish connection using AWS IAM"
-                  (is (true? (get-connection-and-close! datasource))))))))
-        (log/info "Skipping test: MB_MYSQL_AWS_IAM_TEST_HOST or MB_MYSQL_AWS_IAM_TEST_SSL_CERT not set")))))
+      (log/info "Skipping test: MB_MYSQL_AWS_IAM_TEST not set"))))

--- a/test/metabase/app_db/aws_iam_test.clj
+++ b/test/metabase/app_db/aws_iam_test.clj
@@ -61,11 +61,7 @@
         (testing "using uri"
           (testing "Can create DataSource with AWS IAM enabled"
             (let [datasource (mdb.data-source/raw-connection-string->DataSource
-                              uri
-                              nil
-                              nil  ; no password for IAM auth
-                              nil  ; no Azure managed identity
-                              true)] ; enable AWS IAM
+                              uri nil nil nil true)]
               (is (instance? javax.sql.DataSource datasource))
 
               (testing "Can establish connection using AWS IAM"
@@ -79,7 +75,10 @@
           user     (config/config-str :mb-mysql-aws-iam-test-user)
           dbname   (config/config-str :mb-mysql-aws-iam-test-dbname)
           ssl-cert (config/config-str :mb-mysql-aws-iam-test-ssl-cert)
-          uri (format "mysql://%s:%d/%s?user=%s&trustServerCertificate=%s" host port dbname user ssl-cert)]
+          uri (format "mysql://%s:%d/%s?user=%s&%s" host port dbname user
+                      (if (= ssl-cert "trust")
+                        "trustServerCertificate=true"
+                        (str "?sslMode=VERIFY_CA&serverSslCert=" ssl-cert)))]
       (if (and host ssl-cert)
         (do
           (testing "Connection details are configured"
@@ -107,11 +106,7 @@
           (testing "using uri"
             (testing "Can create DataSource with AWS IAM enabled"
               (let [datasource (mdb.data-source/raw-connection-string->DataSource
-                                uri
-                                nil
-                                nil  ; no password for IAM auth
-                                nil  ; no Azure managed identity
-                                true)] ; enable AWS IAM
+                                uri nil nil nil true)]
                 (is (instance? javax.sql.DataSource datasource))
 
                 (testing "Can establish connection using AWS IAM"

--- a/test/metabase/app_db/aws_iam_test.clj
+++ b/test/metabase/app_db/aws_iam_test.clj
@@ -7,12 +7,12 @@
   Required environment variables:
   - Postgres:
     - MB_POSTGRES_AWS_IAM_TEST_HOST
-    - MB_POSTGRES_AWS_IAM_TEST_PORT (optional, defaults to 5432)
+    - MB_POSTGRES_AWS_IAM_TEST_PORT
     - MB_POSTGRES_AWS_IAM_TEST_USER
     - MB_POSTGRES_AWS_IAM_TEST_DBNAME
   - MySQL:
     - MB_MYSQL_AWS_IAM_TEST_HOST
-    - MB_MYSQL_AWS_IAM_TEST_PORT (optional, defaults to 3306)
+    - MB_MYSQL_AWS_IAM_TEST_PORT
     - MB_MYSQL_AWS_IAM_TEST_USER
     - MB_MYSQL_AWS_IAM_TEST_DBNAME
     - MB_MYSQL_AWS_IAM_TEST_SSL_CERT (required, PEM certificate content/trust)"
@@ -37,18 +37,19 @@
         port   (config/config-int :mb-postgres-aws-iam-test-port)
         user   (config/config-str :mb-postgres-aws-iam-test-user)
         dbname (config/config-str :mb-postgres-aws-iam-test-dbname)
-        uri (format "postgres://%s:%d/%s?user=%s&trustServerCertificate=true" host port dbname user)]
+        uri (format "postgres://%s:%d/%s?user=%s" host port dbname user)]
     (if host
       (do
         (testing "Connection details are configured"
           (is (string? host))
           (is (string? user))
+          (is (int? port))
           (is (string? dbname)))
 
         (testing "using broken-out details"
           (testing "Can create DataSource with AWS IAM enabled"
             (let [details {:host     host
-                           :port     (or port 5432)
+                           :port     port
                            :user     user
                            :db       dbname
                            :aws-iam  true}
@@ -84,6 +85,7 @@
           (testing "Connection details are configured"
             (is (string? host))
             (is (string? user))
+            (is (int? port))
             (is (string? dbname)))
 
           (testing "SSL certificate is configured"
@@ -92,7 +94,7 @@
           (testing "using broken-out details"
             (testing "Can create DataSource with AWS IAM enabled"
               (let [details {:host     host
-                             :port     (or port 5432)
+                             :port     port
                              :user     user
                              :db       dbname
                              :ssl-cert ssl-cert

--- a/test/metabase/app_db/aws_iam_test.clj
+++ b/test/metabase/app_db/aws_iam_test.clj
@@ -1,0 +1,119 @@
+(ns metabase.app-db.aws-iam-test
+  "Integration tests for AWS IAM authentication with application database.
+
+  These tests require actual AWS RDS instances configured for IAM authentication.
+  Tests will be skipped if required environment variables are not set.
+
+  Required environment variables:
+  - Postgres:
+    - MB_POSTGRES_AWS_IAM_TEST_HOST
+    - MB_POSTGRES_AWS_IAM_TEST_PORT (optional, defaults to 5432)
+    - MB_POSTGRES_AWS_IAM_TEST_USER
+    - MB_POSTGRES_AWS_IAM_TEST_DBNAME
+  - MySQL:
+    - MB_MYSQL_AWS_IAM_TEST_HOST
+    - MB_MYSQL_AWS_IAM_TEST_PORT (optional, defaults to 3306)
+    - MB_MYSQL_AWS_IAM_TEST_USER
+    - MB_MYSQL_AWS_IAM_TEST_DBNAME
+    - MB_MYSQL_AWS_IAM_TEST_SSL_CERT (required, PEM certificate content/trust)"
+  (:require
+   [clojure.test :refer :all]
+   [metabase.app-db.data-source :as mdb.data-source]
+   [metabase.config.core :as config]
+   [metabase.util.log :as log]))
+
+(set! *warn-on-reflection* true)
+
+(defn- get-connection-and-close!
+  "Attempt to get a connection from the DataSource and close it immediately.
+  Returns true if successful, throws if connection fails."
+  [^javax.sql.DataSource datasource]
+  (with-open [conn (.getConnection datasource)]
+    (assert conn "Connection should not be nil")
+    true))
+
+(deftest ^:mb/once postgres-aws-iam-test
+  (let [host   (config/config-str :mb-postgres-aws-iam-test-host)
+        port   (config/config-int :mb-postgres-aws-iam-test-port)
+        user   (config/config-str :mb-postgres-aws-iam-test-user)
+        dbname (config/config-str :mb-postgres-aws-iam-test-dbname)
+        uri (format "postgres://%s:%d/%s?user=%s&trustServerCertificate=true" host port dbname user)]
+    (if host
+      (do
+        (testing "Connection details are configured"
+          (is (string? host))
+          (is (string? user))
+          (is (string? dbname)))
+
+        (testing "using broken-out details"
+          (testing "Can create DataSource with AWS IAM enabled"
+            (let [details {:host     host
+                           :port     (or port 5432)
+                           :user     user
+                           :db       dbname
+                           :aws-iam  true}
+                  datasource (mdb.data-source/broken-out-details->DataSource :postgres details)]
+              (is (instance? javax.sql.DataSource datasource))
+
+              (testing "Can establish connection using AWS IAM"
+                (is (true? (get-connection-and-close! datasource)))))))
+
+        (testing "using uri"
+          (testing "Can create DataSource with AWS IAM enabled"
+            (let [datasource (mdb.data-source/raw-connection-string->DataSource
+                              uri
+                              nil
+                              nil  ; no password for IAM auth
+                              nil  ; no Azure managed identity
+                              true)] ; enable AWS IAM
+              (is (instance? javax.sql.DataSource datasource))
+
+              (testing "Can establish connection using AWS IAM"
+                (is (true? (get-connection-and-close! datasource))))))))
+      (log/info "Skipping test: MB_POSTGRES_AWS_IAM_TEST_HOST not set"))))
+
+(deftest ^:mb/once mysql-aws-iam-test
+  (testing "MySQL App DB connection with AWS IAM authentication"
+    (let [host     (config/config-str :mb-mysql-aws-iam-test-host)
+          port     (config/config-int :mb-mysql-aws-iam-test-port)
+          user     (config/config-str :mb-mysql-aws-iam-test-user)
+          dbname   (config/config-str :mb-mysql-aws-iam-test-dbname)
+          ssl-cert (config/config-str :mb-mysql-aws-iam-test-ssl-cert)
+          uri (format "mysql://%s:%d/%s?user=%s&trustServerCertificate=%s" host port dbname user ssl-cert)]
+      (if (and host ssl-cert)
+        (do
+          (testing "Connection details are configured"
+            (is (string? host))
+            (is (string? user))
+            (is (string? dbname)))
+
+          (testing "SSL certificate is configured"
+            (is (string? ssl-cert)))
+
+          (testing "using broken-out details"
+            (testing "Can create DataSource with AWS IAM enabled"
+              (let [details {:host     host
+                             :port     (or port 5432)
+                             :user     user
+                             :db       dbname
+                             :ssl-cert ssl-cert
+                             :aws-iam  true}
+                    datasource (mdb.data-source/broken-out-details->DataSource :mysql details)]
+                (is (instance? javax.sql.DataSource datasource))
+
+                (testing "Can establish connection using AWS IAM"
+                  (is (true? (get-connection-and-close! datasource)))))))
+
+          (testing "using uri"
+            (testing "Can create DataSource with AWS IAM enabled"
+              (let [datasource (mdb.data-source/raw-connection-string->DataSource
+                                uri
+                                nil
+                                nil  ; no password for IAM auth
+                                nil  ; no Azure managed identity
+                                true)] ; enable AWS IAM
+                (is (instance? javax.sql.DataSource datasource))
+
+                (testing "Can establish connection using AWS IAM"
+                  (is (true? (get-connection-and-close! datasource))))))))
+        (log/info "Skipping test: MB_MYSQL_AWS_IAM_TEST_HOST or MB_MYSQL_AWS_IAM_TEST_SSL_CERT not set")))))

--- a/test/metabase/app_db/data_source_test.clj
+++ b/test/metabase/app_db/data_source_test.clj
@@ -113,6 +113,37 @@
                                                                      :aws-iam true
                                                                      :db "metabase"}))))))
 
+(deftest ^:parallel broken-out-details-test-8
+  (testing :aws-iam
+    (testing "MySQL with AWS IAM and ssl-cert=trust"
+      (is (= (->DataSource
+              "jdbc:aws-wrapper:mysql://localhost:3306/metabase"
+              {"user" "root"
+               "wrapperPlugins" "iam"
+               "trustServerCertificate" "true"})
+             (mdb.data-source/broken-out-details->DataSource :mysql {:host "localhost"
+                                                                     :port 3306
+                                                                     :user "root"
+                                                                     :aws-iam true
+                                                                     :ssl-cert "trust"
+                                                                     :db "metabase"}))))))
+
+(deftest ^:parallel broken-out-details-test-9
+  (testing :aws-iam
+    (testing "MySQL with AWS IAM and ssl-cert path"
+      (is (= (->DataSource
+              "jdbc:aws-wrapper:mysql://localhost:3306/metabase"
+              {"user" "root"
+               "wrapperPlugins" "iam"
+               "sslMode" "VERIFY_CA"
+               "serverSslCert" "/path/to/certificate.pem"})
+             (mdb.data-source/broken-out-details->DataSource :mysql {:host "localhost"
+                                                                     :port 3306
+                                                                     :user "root"
+                                                                     :aws-iam true
+                                                                     :ssl-cert "/path/to/certificate.pem"
+                                                                     :db "metabase"}))))))
+
 (deftest ^:parallel connection-string-test
   (let [data-source (mdb.data-source/raw-connection-string->DataSource
                      (format "jdbc:h2:mem:%s" (mt/random-name)))]

--- a/test/metabase/app_db/data_source_test.clj
+++ b/test/metabase/app_db/data_source_test.clj
@@ -92,8 +92,7 @@
               {"ApplicationName" config/mb-version-and-process-identifier
                "OpenSourceSubProtocolOverride" "true"
                "user" "cam"
-               "wrapperPlugins" "iam"
-               "useSSL" "true"})
+               "wrapperPlugins" "iam"})
              (mdb.data-source/broken-out-details->DataSource :postgres {:host "localhost"
                                                                         :port 5432
                                                                         :user "cam"
@@ -107,7 +106,6 @@
               "jdbc:aws-wrapper:mysql://localhost:3306/metabase"
               {"user" "root"
                "wrapperPlugins" "iam"
-               "useSSL" "true"
                "sslMode" "VERIFY_CA"})
              (mdb.data-source/broken-out-details->DataSource :mysql {:host "localhost"
                                                                      :port 3306
@@ -205,8 +203,7 @@
     (is (= (->DataSource
             "jdbc:aws-wrapper:postgresql://metabase"
             {"user" "cam"
-             "wrapperPlugins" "iam"
-             "useSSL" "true"})
+             "wrapperPlugins" "iam"})
            (mdb.data-source/raw-connection-string->DataSource "postgres://metabase" "cam" nil nil true)))))
 
 (deftest ^:parallel raw-connection-string-with-aws-iam-test-2
@@ -214,8 +211,7 @@
     (is (= (->DataSource
             "jdbc:aws-wrapper:mysql://metabase"
             {"user" "cam"
-             "wrapperPlugins" "iam"
-             "useSSL" "true"})
+             "wrapperPlugins" "iam"})
            (mdb.data-source/raw-connection-string->DataSource "mysql://metabase" "cam" nil nil true)))))
 
 (deftest ^:parallel equality-test

--- a/test/metabase/app_db/data_source_test.clj
+++ b/test/metabase/app_db/data_source_test.clj
@@ -106,6 +106,7 @@
               "jdbc:aws-wrapper:mysql://localhost:3306/metabase"
               {"user" "root"
                "wrapperPlugins" "iam"
+               "useSSL" true
                "sslMode" "VERIFY_CA"})
              (mdb.data-source/broken-out-details->DataSource :mysql {:host "localhost"
                                                                      :port 3306
@@ -120,6 +121,7 @@
               "jdbc:aws-wrapper:mysql://localhost:3306/metabase"
               {"user" "root"
                "wrapperPlugins" "iam"
+               "useSSL" true
                "trustServerCertificate" "true"})
              (mdb.data-source/broken-out-details->DataSource :mysql {:host "localhost"
                                                                      :port 3306
@@ -136,6 +138,7 @@
               {"user" "root"
                "wrapperPlugins" "iam"
                "sslMode" "VERIFY_CA"
+               "useSSL" true
                "serverSslCert" "/path/to/certificate.pem"})
              (mdb.data-source/broken-out-details->DataSource :mysql {:host "localhost"
                                                                      :port 3306
@@ -242,6 +245,7 @@
     (is (= (->DataSource
             "jdbc:aws-wrapper:mysql://metabase"
             {"user" "cam"
+             "useSSL" true
              "wrapperPlugins" "iam"})
            (mdb.data-source/raw-connection-string->DataSource "mysql://metabase" "cam" nil nil true)))))
 

--- a/test/metabase/app_db/data_source_test.clj
+++ b/test/metabase/app_db/data_source_test.clj
@@ -238,6 +238,7 @@
     (is (= (->DataSource
             "jdbc:aws-wrapper:postgresql://metabase"
             {"user" "cam"
+             "useSSL" true
              "wrapperPlugins" "iam"})
            (mdb.data-source/raw-connection-string->DataSource "postgres://metabase" "cam" nil nil true)))))
 

--- a/test/metabase/app_db/data_source_test.clj
+++ b/test/metabase/app_db/data_source_test.clj
@@ -84,6 +84,37 @@
         (is (= [{:one 1}]
                (jdbc/query {:connection conn} "SELECT 1 AS one;")))))))
 
+(deftest ^:parallel broken-out-details-test-6
+  (testing :aws-iam
+    (testing "Postgres with AWS IAM"
+      (is (= (->DataSource
+              "jdbc:aws-wrapper:postgresql://localhost:5432/metabase"
+              {"ApplicationName" config/mb-version-and-process-identifier
+               "OpenSourceSubProtocolOverride" "true"
+               "user" "cam"
+               "wrapperPlugins" "iam"
+               "useSSL" "true"})
+             (mdb.data-source/broken-out-details->DataSource :postgres {:host "localhost"
+                                                                        :port 5432
+                                                                        :user "cam"
+                                                                        :aws-iam true
+                                                                        :db "metabase"}))))))
+
+(deftest ^:parallel broken-out-details-test-7
+  (testing :aws-iam
+    (testing "MySQL with AWS IAM"
+      (is (= (->DataSource
+              "jdbc:aws-wrapper:mysql://localhost:3306/metabase"
+              {"user" "root"
+               "wrapperPlugins" "iam"
+               "useSSL" "true"
+               "sslMode" "VERIFY_CA"})
+             (mdb.data-source/broken-out-details->DataSource :mysql {:host "localhost"
+                                                                     :port 3306
+                                                                     :user "root"
+                                                                     :aws-iam true
+                                                                     :db "metabase"}))))))
+
 (deftest ^:parallel connection-string-test
   (let [data-source (mdb.data-source/raw-connection-string->DataSource
                      (format "jdbc:h2:mem:%s" (mt/random-name)))]
@@ -168,6 +199,24 @@
              (mdb.data-source/raw-connection-string->DataSource "postgres://metabase" nil "1234" nil)
              (mdb.data-source/raw-connection-string->DataSource "postgres://metabase" "" "1234" nil)
              (mdb.data-source/raw-connection-string->DataSource "postgres://metabase" "" "1234" "client ID"))))))
+
+(deftest ^:parallel raw-connection-string-with-aws-iam-test
+  (testing "Raw connection string with AWS IAM enabled for Postgres"
+    (is (= (->DataSource
+            "jdbc:aws-wrapper:postgresql://metabase"
+            {"user" "cam"
+             "wrapperPlugins" "iam"
+             "useSSL" "true"})
+           (mdb.data-source/raw-connection-string->DataSource "postgres://metabase" "cam" nil nil true)))))
+
+(deftest ^:parallel raw-connection-string-with-aws-iam-test-2
+  (testing "Raw connection string with AWS IAM enabled for MySQL"
+    (is (= (->DataSource
+            "jdbc:aws-wrapper:mysql://metabase"
+            {"user" "cam"
+             "wrapperPlugins" "iam"
+             "useSSL" "true"})
+           (mdb.data-source/raw-connection-string->DataSource "mysql://metabase" "cam" nil nil true)))))
 
 (deftest ^:parallel equality-test
   (testing "Two DataSources with the same URL should be equal"

--- a/test/metabase/app_db/data_source_test.clj
+++ b/test/metabase/app_db/data_source_test.clj
@@ -92,6 +92,7 @@
               {"ApplicationName" config/mb-version-and-process-identifier
                "OpenSourceSubProtocolOverride" "true"
                "user" "cam"
+               "useSSL" true
                "wrapperPlugins" "iam"})
              (mdb.data-source/broken-out-details->DataSource :postgres {:host "localhost"
                                                                         :port 5432


### PR DESCRIPTION
## Summary

This PR adds support for AWS IAM authentication for both PostgreSQL and MySQL databases in Metabase, enabling passwordless authentication using AWS credentials. This feature is available for both data warehouse (DWH) connections and application database (AppDB) configurations.
### DWH Authentication

**PostgreSQL:**
- Select "AWS IAM" from the auth providers dropdown
- SSL must be enabled

**MySQL:**
- Select "AWS IAM" from the auth providers dropdown 
- SSL must be enabled
- After enabling SSL, you must provide either:
  - An SSL certificate in the SSL certificate field, OR
  - Add `trustServerCertificate=true` to the "Additional JDBC connection options"
- The driver automatically configures `sslMode=VERIFY_CA` when using a certificate

### ­AppDB Authentication

**PostgreSQL:**
- Just set `MB_DB_AWS_IAM=true` and omit password (works with both broken-out environment variables and connection URI)

**MySQL:**
Using broken-out environment variables:
- Set `MB_DB_AWS_IAM=true`
- Additionally set `MB_DB_SSL_CERT` to either:
  - `trust` - Maps to `trustServerCertificate=true` (trusts server certificate)
  - `/path/to/cert.pem` - Maps to `serverSslCert=/path/to/cert.pem` (validates against specific certificate)

Using connection URI:
- Set `MB_DB_AWS_IAM=true`
- Add SSL parameters to the connection URI:
  - Option 1: `MB_DB_CONNECTION_URI=mysql://..?trustServerCertificate=true`
  - Option 2: `MB_DB_CONNECTION_URI=mysql://..?sslMode=VERIFY_CA&serverSslCert=/path/to/certificate.pem`
