### PR TITLE
Proxy apis for store to get plan and addons

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1647,6 +1647,7 @@
    :uses #{api
            events
            premium-features
+           store-api
            util
            enterprise/harbormaster}}
 
@@ -1904,7 +1905,7 @@
            query-processor
            util}}
 
- enterprise/remote-sync
+  enterprise/remote-sync
   {:team "UX West"
    :api  #{metabase-enterprise.remote-sync.api
            metabase-enterprise.remote-sync.core

--- a/enterprise/backend/src/metabase_enterprise/cloud_add_ons/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/cloud_add_ons/api.clj
@@ -56,8 +56,8 @@
     (:body (http/get (str url "/api/v2" endpoint) {:as :json}))
     (throw (ex-info (tru "Please configure store-api-url") {:status-code 400}))))
 
-(api.macros/defendpoint :get "/plan"
-  "Get plan information from the Metabase Store API."
+(api.macros/defendpoint :get "/plans"
+  "Get plans information from the Metabase Store API."
   []
   (api/check-superuser)
   (cond
@@ -68,7 +68,7 @@
     (try
       {:status 200 :body (make-public-store-request! "/plan")}
       (catch Exception e
-        (log/warn e "Error fetching plan information")
+        (log/warn e "Error fetching plans information")
         (handle-store-api-error e)))))
 
 (api.macros/defendpoint :get "/addons"
@@ -92,10 +92,11 @@
                               [:product-type [:enum "metabase-ai" "python-execution"]]]
    _query-params
    {:keys [terms_of_service]} :- [:map
-                                  [:terms_of_service :boolean]]]
+                                  [:terms_of_service {:optional true} [:maybe :boolean]]]]
   (api/check-superuser)
   (cond
-    (not terms_of_service)
+    (and (= product-type "metabase-ai")
+         (not terms_of_service))
     response-terms-not-accepted
 
     (not (premium-features/is-hosted?))

--- a/enterprise/backend/src/metabase_enterprise/cloud_add_ons/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/cloud_add_ons/api.clj
@@ -95,12 +95,12 @@
                                   [:terms_of_service {:optional true} [:maybe :boolean]]]]
   (api/check-superuser)
   (cond
+    (not (premium-features/is-hosted?))
+    response-not-hosted
+
     (and (= product-type "metabase-ai")
          (not terms_of_service))
     response-terms-not-accepted
-
-    (not (premium-features/is-hosted?))
-    response-not-hosted
 
     (and (= product-type "metabase-ai")
          (not (premium-features/offer-metabase-ai?)))

--- a/enterprise/backend/test/metabase_enterprise/cloud_add_ons/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cloud_add_ons/api_test.clj
@@ -71,16 +71,52 @@
                       (is (= (:id user) user_id))
                       (is (= {:add-on {:product-type "metabase-ai"}} details)))))))))))))
 
-(deftest ^:sequential get-plan-test
-  (testing "GET /api/ee/cloud-add-ons/plan"
+(deftest ^:sequential post-python-execution-test
+  (testing "POST /api/ee/cloud-add-ons/python-execution"
     (testing "requires superuser"
       (mt/with-premium-features #{}
         (is (=? "You don't have permissions to do that."
-                (mt/user-http-request :rasta :get 403 "ee/cloud-add-ons/plan")))))
+                (mt/user-http-request :rasta :post 403 "ee/cloud-add-ons/python-execution" {})))))
+    (testing "does not require terms of service"
+      (mt/with-temp [:model/User user {:is_superuser true}]
+        (mt/with-premium-features #{:hosting :transforms-python}
+          (with-redefs [premium-features/token-status (constantly {:store-users [{:email (:email user)}]})
+                        hm.client/call (constantly nil)]
+            (testing "succeeds without terms_of_service"
+              (is (=? {}
+                      (mt/user-http-request user :post 200 "ee/cloud-add-ons/python-execution" {}))))
+            (testing "succeeds with terms_of_service false"
+              (is (=? {}
+                      (mt/user-http-request user :post 200 "ee/cloud-add-ons/python-execution"
+                                            {:terms_of_service false}))))
+            (testing "succeeds with terms_of_service true"
+              (is (=? {}
+                      (mt/user-http-request user :post 200 "ee/cloud-add-ons/python-execution"
+                                            {:terms_of_service true}))))))))
     (testing "requires token feature 'hosting'"
       (mt/with-premium-features #{}
         (is (=? "Can only access Store API for Metabase Cloud instances."
-                (mt/user-http-request :crowberto :get 400 "ee/cloud-add-ons/plan")))))
+                (mt/user-http-request :crowberto :post 400 "ee/cloud-add-ons/python-execution" {})))))
+    (testing "requires token feature 'transforms-python'"
+      (mt/with-premium-features #{:hosting}
+        (is (=? "Can only purchase add-ons for eligible subscriptions."
+                (mt/user-http-request :crowberto :post 400 "ee/cloud-add-ons/python-execution" {})))))
+    (testing "requires current user being a store user"
+      (mt/with-temp [:model/User user {:is_superuser true}]
+        (mt/with-premium-features #{:hosting :transforms-python}
+          (is (=? "Only Metabase Store users can purchase add-ons."
+                  (mt/user-http-request user :post 403 "ee/cloud-add-ons/python-execution" {}))))))))
+
+(deftest ^:sequential get-plans-test
+  (testing "GET /api/ee/cloud-add-ons/plans"
+    (testing "requires superuser"
+      (mt/with-premium-features #{}
+        (is (=? "You don't have permissions to do that."
+                (mt/user-http-request :rasta :get 403 "ee/cloud-add-ons/plans")))))
+    (testing "requires token feature 'hosting'"
+      (mt/with-premium-features #{}
+        (is (=? "Can only access Store API for Metabase Cloud instances."
+                (mt/user-http-request :crowberto :get 400 "ee/cloud-add-ons/plans")))))
     (testing "when conditions are met"
       (mt/with-premium-features #{:hosting}
         (testing "passes through HTTP status from Store API"
@@ -90,16 +126,16 @@
             (testing (format "error status %d" status-code)
               (with-redefs [http/get (fn [& _] (throw (ex-info "TEST" {:status status-code})))]
                 (is (=? error-message
-                        (mt/user-http-request :crowberto :get status-code "ee/cloud-add-ons/plan")))))))
+                        (mt/user-http-request :crowberto :get status-code "ee/cloud-add-ons/plans")))))))
         (testing "responds with HTTP status 500 for other errors"
           (with-redefs [http/get (fn [& _] (throw (ex-info "TEST" {:status 500})))]
             (is (=? "Unexpected error"
-                    (mt/user-http-request :crowberto :get 500 "ee/cloud-add-ons/plan")))))
+                    (mt/user-http-request :crowberto :get 500 "ee/cloud-add-ons/plans")))))
         (testing "succeeds"
           (let [plan-data {:body {:plan-name "Pro" :tier "premium"}}]
             (with-redefs [http/get (fn [& _] plan-data)]
               (is (=? (:body plan-data)
-                      (mt/user-http-request :crowberto :get 200 "ee/cloud-add-ons/plan"))))))))))
+                      (mt/user-http-request :crowberto :get 200 "ee/cloud-add-ons/plans"))))))))))
 
 (deftest ^:sequential get-addons-test
   (testing "GET /api/ee/cloud-add-ons/addons"

--- a/enterprise/backend/test/metabase_enterprise/cloud_add_ons/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cloud_add_ons/api_test.clj
@@ -15,7 +15,7 @@
                 (mt/user-http-request :rasta :post 403 "ee/cloud-add-ons/metabase-ai"
                                       {:terms_of_service true})))))
     (testing "requires accepting terms of service"
-      (mt/with-premium-features #{}
+      (mt/with-premium-features #{:hosting}
         (is (=? {:errors {:terms_of_service "Need to accept terms of service."}}
                 (mt/user-http-request :crowberto :post 400 "ee/cloud-add-ons/metabase-ai"
                                       {:terms_of_service false})))))

--- a/enterprise/backend/test/metabase_enterprise/cloud_add_ons/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cloud_add_ons/api_test.clj
@@ -1,5 +1,6 @@
 (ns metabase-enterprise.cloud-add-ons.api-test
   (:require
+   [clj-http.client :as http]
    [clojure.test :refer :all]
    [metabase-enterprise.harbormaster.client :as hm.client]
    [metabase-enterprise.semantic-search.test-util :as semantic.tu]
@@ -87,17 +88,17 @@
                                                403 "Could not establish a connection to Metabase Cloud."
                                                401 "Could not establish a connection to Metabase Cloud."}]
             (testing (format "error status %d" status-code)
-              (with-redefs [hm.client/call (fn [& _] (throw (ex-info "TEST" {:status status-code})))]
+              (with-redefs [http/get (fn [& _] (throw (ex-info "TEST" {:status status-code})))]
                 (is (=? error-message
                         (mt/user-http-request :crowberto :get status-code "ee/cloud-add-ons/plan")))))))
         (testing "responds with HTTP status 500 for other errors"
-          (with-redefs [hm.client/call (fn [& _] (throw (ex-info "TEST" {:status 500})))]
+          (with-redefs [http/get (fn [& _] (throw (ex-info "TEST" {:status 500})))]
             (is (=? "Unexpected error"
                     (mt/user-http-request :crowberto :get 500 "ee/cloud-add-ons/plan")))))
         (testing "succeeds"
-          (let [plan-data {:plan-name "Pro" :tier "premium"}]
-            (with-redefs [hm.client/call (fn [& _] plan-data)]
-              (is (=? plan-data
+          (let [plan-data {:body {:plan-name "Pro" :tier "premium"}}]
+            (with-redefs [http/get (fn [& _] plan-data)]
+              (is (=? (:body plan-data)
                       (mt/user-http-request :crowberto :get 200 "ee/cloud-add-ons/plan"))))))))))
 
 (deftest ^:sequential get-addons-test
@@ -117,15 +118,15 @@
                                                403 "Could not establish a connection to Metabase Cloud."
                                                401 "Could not establish a connection to Metabase Cloud."}]
             (testing (format "error status %d" status-code)
-              (with-redefs [hm.client/call (fn [& _] (throw (ex-info "TEST" {:status status-code})))]
+              (with-redefs [http/get (fn [& _] (throw (ex-info "TEST" {:status status-code})))]
                 (is (=? error-message
                         (mt/user-http-request :crowberto :get status-code "ee/cloud-add-ons/addons")))))))
         (testing "responds with HTTP status 500 for other errors"
-          (with-redefs [hm.client/call (fn [& _] (throw (ex-info "TEST" {:status 500})))]
+          (with-redefs [http/get (fn [& _] (throw (ex-info "TEST" {:status 500})))]
             (is (=? "Unexpected error"
                     (mt/user-http-request :crowberto :get 500 "ee/cloud-add-ons/addons")))))
         (testing "succeeds"
-          (let [addons-data [{:addon-id "metabase-ai" :status "active"}]]
-            (with-redefs [hm.client/call (fn [& _] addons-data)]
-              (is (=? addons-data
+          (let [addons-data {:body [{:addon-id "metabase-ai" :status "active"}]}]
+            (with-redefs [http/get (fn [& _] addons-data)]
+              (is (=? (:body addons-data)
                       (mt/user-http-request :crowberto :get 200 "ee/cloud-add-ons/addons"))))))))))


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/CLO-4575/prepare-backend-for-the-direct-python-upsell-from-the-core-app

by adding 2 proxy hm apis:
- GET /plan
- GET /addons

And also update the purchase addon api to handle python transform addon.