### PR TITLE
chore: removing a stub CLJC file that got included accidentally

### DIFF
--- a/src/metabase/lib/pathom/core.cljc
+++ b/src/metabase/lib/pathom/core.cljc
@@ -1,1 +1,0 @@
-(ns metabase.lib.pathom.core)


### PR DESCRIPTION
Removing a stub file that was accidentally included in another PR.
