### PR TITLE
Surface collection descriptions to metabot in search

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
@@ -1064,7 +1064,8 @@
    [:created_at {:optional true} [:maybe :string]]
    [:collection {:optional true} [:maybe [:map
                                           [:name {:optional true} [:maybe :string]]
-                                          [:authority_level {:optional true} [:maybe :string]]]]]])
+                                          [:authority_level {:optional true} [:maybe :string]]
+                                          [:description {:optional true} [:maybe :string]]]]]])
 
 (mr/def ::search-result
   [:or

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
@@ -30,7 +30,7 @@
   [{:keys [verified moderated_status collection] :as result}]
   (let [model (:model result)
         verified? (or (boolean verified) (= moderated_status "verified"))
-        collection-info (select-keys collection [:name :authority_level])
+        collection-info (select-keys collection [:name :authority_level :description])
         common-fields {:id          (:id result)
                        :type        (search-model->result-type model)
                        :name        (:name result)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
@@ -30,7 +30,7 @@
   [{:keys [verified moderated_status collection] :as result}]
   (let [model (:model result)
         verified? (or (boolean verified) (= moderated_status "verified"))
-        collection-info (select-keys collection [:name :authority_level :description])
+        collection-info (select-keys collection [:id :name :authority_level])
         common-fields {:id          (:id result)
                        :type        (search-model->result-type model)
                        :name        (:name result)
@@ -62,6 +62,22 @@
              {:database_id (:database_id result)
               :verified    verified?
               :collection  collection-info}))))
+
+(defn- enrich-with-collection-descriptions
+  "Fetch and merge collection descriptions for all search results that have collection IDs."
+  [results]
+  (let [collection-ids (->> results
+                            (keep #(get-in % [:collection :id]))
+                            distinct
+                            seq)]
+    (if-not collection-ids
+      results
+      (let [descriptions (t2/select-pk->fn :description :model/Collection :id [:in collection-ids])]
+        (mapv (fn [result]
+                (if-let [coll-id (get-in result [:collection :id])]
+                  (assoc-in result [:collection :description] (get descriptions coll-id))
+                  result))
+              results)))))
 
 (defn- search-result-id
   "Generate a unique identifier for a search result based on its id and model."
@@ -159,4 +175,6 @@
         futures (mapv #(future (search-fn %)) all-queries)
         result-lists (mapv deref futures)
         fused-results (take limit (reciprocal-rank-fusion result-lists))]
-    (map postprocess-search-result fused-results)))
+    (->> fused-results
+         (map postprocess-search-result)
+         enrich-with-collection-descriptions)))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/search_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/search_test.clj
@@ -7,6 +7,7 @@
    [metabase.search.core :as search-core]
    [metabase.search.test-util :as search.tu]
    [metabase.test :as mt]
+   [metabase.util :as u]
    [toucan2.core :as t2]))
 
 (deftest reciprocal-rank-fusion-test
@@ -171,7 +172,7 @@
                   :name "Main Dashboard"
                   :description "Dashboard desc"
                   :verified false
-                  :collection {:name "Finance" :authority_level "official" :description "Finance collection"}
+                  :collection {:id 10 :name "Finance" :authority_level "official"}
                   :updated_at "2024-01-03"
                   :created_at "2024-01-03"}
           expected {:id 3
@@ -179,7 +180,7 @@
                     :name "Main Dashboard"
                     :description "Dashboard desc"
                     :verified false
-                    :collection {:name "Finance" :authority_level "official" :description "Finance collection"}
+                    :collection {:id 10 :name "Finance" :authority_level "official"}
                     :updated_at "2024-01-03"
                     :created_at "2024-01-03"}]
       (is (= expected (#'search/postprocess-search-result result)))))
@@ -190,7 +191,7 @@
                   :name "Q1"
                   :description "Question desc"
                   :moderated_status "verified"
-                  :collection {:name "Analytics" :authority_level nil :description "Analytics collection"}
+                  :collection {:id 11 :name "Analytics" :authority_level nil}
                   :updated_at "2024-01-04"
                   :created_at "2024-01-04"}
           expected {:id 4
@@ -199,7 +200,7 @@
                     :description "Question desc"
                     :database_id nil
                     :verified true
-                    :collection {:name "Analytics" :authority_level nil :description "Analytics collection"}
+                    :collection {:id 11 :name "Analytics" :authority_level nil}
                     :updated_at "2024-01-04"
                     :created_at "2024-01-04"}]
       (is (= expected (#'search/postprocess-search-result result)))))
@@ -362,3 +363,36 @@
                           (filter (fn [{:keys [id type]}] (and (= "dashboard" type) (contains? test-dashboard-ids id))))
                           (map :name)
                           (set)))))))))))
+
+(deftest enrich-with-collection-descriptions-test
+  (mt/with-premium-features #{:content-verification}
+    (mt/with-test-user :crowberto
+      (search.tu/with-temp-index-table
+        (mt/with-temp [:model/Collection {finance-coll-id :id} {:name "Finance Team"
+                                                                :description "Finance team collection"}
+                       :model/Collection {analytics-coll-id :id} {:name "Analytics"
+                                                                  :description "Analytics collection"}
+                       :model/Collection {no-desc-coll-id :id} {:name "No Description"}
+                       :model/Dashboard {dash-1-id :id} {:name "Finance Dashboard"
+                                                         :collection_id finance-coll-id}
+                       :model/Dashboard {dash-2-id :id} {:name "Analytics Dashboard"
+                                                         :collection_id analytics-coll-id}
+                       :model/Dashboard {dash-3-id :id} {:name "No Desc Dashboard"
+                                                         :collection_id no-desc-coll-id}]
+          (testing "search results include collection descriptions"
+            (let [results (search/search {:term-queries ["Dashboard"]})
+                  test-dashboard-ids #{dash-1-id dash-2-id dash-3-id}
+                  test-results (->> results
+                                    (filter (fn [{:keys [id type]}]
+                                              (and (= "dashboard" type)
+                                                   (contains? test-dashboard-ids id)))))]
+              (testing "includes collection descriptions when present"
+                (let [finance-dash (u/seek #(= dash-1-id (:id %)) test-results)
+                      analytics-dash (u/seek #(= dash-2-id (:id %)) test-results)]
+                  (is (= "Finance team collection" (get-in finance-dash [:collection :description])))
+                  (is (= "Analytics collection" (get-in analytics-dash [:collection :description])))))
+
+              (testing "handles nil collection descriptions"
+                (let [no-desc-dash (u/seek #(= dash-3-id (:id %)) test-results)]
+                  (is (nil? (get-in no-desc-dash [:collection :description])))
+                  (is (= "No Description" (get-in no-desc-dash [:collection :name]))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/search_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/search_test.clj
@@ -171,7 +171,7 @@
                   :name "Main Dashboard"
                   :description "Dashboard desc"
                   :verified false
-                  :collection {:name "Finance" :authority_level "official"}
+                  :collection {:name "Finance" :authority_level "official" :description "Finance collection"}
                   :updated_at "2024-01-03"
                   :created_at "2024-01-03"}
           expected {:id 3
@@ -179,7 +179,7 @@
                     :name "Main Dashboard"
                     :description "Dashboard desc"
                     :verified false
-                    :collection {:name "Finance" :authority_level "official"}
+                    :collection {:name "Finance" :authority_level "official" :description "Finance collection"}
                     :updated_at "2024-01-03"
                     :created_at "2024-01-03"}]
       (is (= expected (#'search/postprocess-search-result result)))))
@@ -190,7 +190,7 @@
                   :name "Q1"
                   :description "Question desc"
                   :moderated_status "verified"
-                  :collection {:name "Analytics" :authority_level nil}
+                  :collection {:name "Analytics" :authority_level nil :description "Analytics collection"}
                   :updated_at "2024-01-04"
                   :created_at "2024-01-04"}
           expected {:id 4
@@ -199,7 +199,7 @@
                     :description "Question desc"
                     :database_id nil
                     :verified true
-                    :collection {:name "Analytics" :authority_level nil}
+                    :collection {:name "Analytics" :authority_level nil :description "Analytics collection"}
                     :updated_at "2024-01-04"
                     :created_at "2024-01-04"}]
       (is (= expected (#'search/postprocess-search-result result)))))


### PR DESCRIPTION
Small follow-up to https://github.com/metabase/ai-service/pull/447 to surface descriptions when available.