### PR TITLE
Make Trunk analytics always run

### DIFF
--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -29,10 +29,9 @@ runs:
       shell: bash
       id: run-test
       # Trunk Quarantine controls the final state of the run in the CI!
-      # Even if this step fails, we let it pass and then `trunk-io/analytics-uploader` determines whether to fail or to
-      # pass the whole job, based on the quarantine list.
-      # We only want to "continue on error" (ignore failures) when the Trunk upload is active - i.e. not on drafts!
-      continue-on-error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.draft == true) }}
+      # Even if this step fails we let it pass, and then `trunk-io/analytics-uploader` determines
+      # whether to fail or to pass the whole job, based on the quarantine list.
+      continue-on-error: true
     - name: Publish Test Report (JUnit)
       uses: dorny/test-reporter@v1
       # As per the documentation: https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#steps-context

--- a/.github/actions/upload-test-results/action.yml
+++ b/.github/actions/upload-test-results/action.yml
@@ -48,7 +48,7 @@ runs:
         aws s3 cp ${OUTPUT_FILE}.zip s3://$BUCKET/$DATE/$GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT/
 
     - name: Upload results to Trunk
-      if: ${{ always() && !(github.event_name == 'pull_request' && github.event.pull_request.draft == true) }}
+      if: always() # Important! This step must always run because it controls job's exit code.
       uses: trunk-io/analytics-uploader@main
       with:
         junit-paths: ${{ inputs.input-path }}

--- a/.github/actions/upload-test-results/action.yml
+++ b/.github/actions/upload-test-results/action.yml
@@ -54,4 +54,5 @@ runs:
         junit-paths: ${{ inputs.input-path }}
         variant: ${{ inputs.variant || inputs.output-name }}
         org-slug: metabase
+        dry-run: ${{ github.event.pull_request.draft == true }} # quarantine, but do not upload results
         token: ${{ inputs.trunk-api-token }}

--- a/.github/actions/upload-test-results/action.yml
+++ b/.github/actions/upload-test-results/action.yml
@@ -54,5 +54,5 @@ runs:
         junit-paths: ${{ inputs.input-path }}
         variant: ${{ inputs.variant || inputs.output-name }}
         org-slug: metabase
-        dry-run: ${{ github.event.pull_request.draft == true }} # quarantine, but do not upload results
+        dry-run: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft == true }} # quarantine, but do not upload results
         token: ${{ inputs.trunk-api-token }}

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -130,10 +130,9 @@ jobs:
           :exclude-tags '[:mb/driver-tests ${{ env.__ADDITIONAL_EXCLUDED_TAG__ }}]'
           ${{ matrix.job.test-args }}
         # Trunk Quarantine controls the final state of the run in the CI!
-        # Even if this step fails, we let it pass and then `trunk-io/analytics-uploader` determines whether to fail or to
-        # pass the whole job, based on the quarantine list.
-        # We only want to "continue on error" (ignore failures) when the Trunk upload is active - i.e. not on drafts!
-        continue-on-error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.draft == true) }}
+        # Even if this step fails we let it pass, and then `trunk-io/analytics-uploader` determines
+        # whether to fail or to pass the whole job, based on the quarantine list.
+        continue-on-error: true
 
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -146,10 +146,9 @@ jobs:
             --spec "$SPEC_PATH" \
             --browser ${{ steps.cypress-prep.outputs.chrome-path }}
         # Trunk Quarantine controls the final state of the run in the CI!
-        # Even if this step fails, we let it pass and then `trunk-io/analytics-uploader` determines whether to fail or to
-        # pass the whole job, based on the quarantine list.
-        # We only want to "continue on error" (ignore failures) when the Trunk upload is active - i.e. not on drafts!
-        continue-on-error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.draft == true) }}
+        # Even if this step fails we let it pass, and then `trunk-io/analytics-uploader` determines
+        # whether to fail or to pass the whole job, based on the quarantine list.
+        continue-on-error: true
 
       - name: Run Tagged EE Cypress tests on ${{ inputs.name }}
         if: ${{ inputs.specs }}
@@ -163,10 +162,9 @@ jobs:
           --spec "$SPEC_PATH" \
           --browser ${{ steps.cypress-prep.outputs.chrome-path }}
         # Trunk Quarantine controls the final state of the run in the CI!
-        # Even if this step fails, we let it pass and then `trunk-io/analytics-uploader` determines whether to fail or to
-        # pass the whole job, based on the quarantine list.
-        # We only want to "continue on error" (ignore failures) when the Trunk upload is active - i.e. not on drafts!
-        continue-on-error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.draft == true) }}
+        # Even if this step fails we let it pass, and then `trunk-io/analytics-uploader` determines
+        # whether to fail or to pass the whole job, based on the quarantine list.
+        continue-on-error: true
 
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -91,8 +91,9 @@ jobs:
         uses: ./.github/actions/prepare-backend
       - name: Run frontend unit tests
         run: yarn run test-unit --silent --shard=${{ matrix.shard }}/${{ env.SHARDS }}
-        # We want Trunk to still receive test reports even if this job fails.
-        # It will filter out the quarantined tests, and will control the job exit code based on the analysis.
+        # Trunk Quarantine controls the final state of the run in the CI!
+        # Even if this step fails we let it pass, and then `trunk-io/analytics-uploader` determines
+        # whether to fail or to pass the whole job, based on the quarantine list.
         continue-on-error: true
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results


### PR DESCRIPTION
This prevents false positives for draft PRs because Trunk analytics action will now always analyze test results, and compare them with their own test quarantine list. It uses this information to know if it should fail the job or let it pass.

> [!NOTE]
> With https://github.com/trunk-io/analytics-uploader/pull/113 merged, we can safely add the `dry-run` flag in this PR. This allows us to always run Trunk analytics in order to quarantine tests without needing to upload test results for analytics.