### PR TITLE
Ability to open a Legacy Static Embedding modal via calling the setCurrentModal action

### DIFF
--- a/frontend/src/metabase-types/store/modal.ts
+++ b/frontend/src/metabase-types/store/modal.ts
@@ -1,10 +1,13 @@
+import type { STATIC_LEGACY_EMBEDDING_TYPE } from "metabase/embedding/constants";
+
 export type ModalName =
   | null
   | "collection"
   | "dashboard"
   | "action"
   | "help"
-  | "embed";
+  | "embed"
+  | typeof STATIC_LEGACY_EMBEDDING_TYPE;
 
 export type ModalState<TProps = Record<string, unknown>> = {
   id: ModalName | null;

--- a/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal/DashboardSharingEmbeddingModal.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal/DashboardSharingEmbeddingModal.tsx
@@ -12,12 +12,14 @@ import {
   EmbedModal,
   EmbedModalContent,
 } from "metabase/public/components/EmbedModal";
+import type { EmbedModalStep } from "metabase/public/lib/types";
 import type { Dashboard } from "metabase-types/api";
 
 export type DashboardSharingEmbeddingModalProps = {
   className?: string;
   dashboard: Dashboard;
   isOpen: boolean;
+  initialEmbedType?: EmbedModalStep;
   onClose: () => void;
 };
 
@@ -25,6 +27,7 @@ export const DashboardSharingEmbeddingModal = ({
   className,
   dashboard,
   isOpen,
+  initialEmbedType,
   onClose,
 }: DashboardSharingEmbeddingModalProps) => {
   const parameters = useSelector(getParameters);
@@ -39,7 +42,11 @@ export const DashboardSharingEmbeddingModal = ({
   const getPublicUrl = (publicUuid: string) => Urls.publicDashboard(publicUuid);
 
   return (
-    <EmbedModal isOpen={isOpen} onClose={onClose}>
+    <EmbedModal
+      isOpen={isOpen}
+      initialEmbedType={initialEmbedType}
+      onClose={onClose}
+    >
       {({ embedType, goToNextStep }) => (
         <EmbedModalContent
           embedType={embedType}

--- a/frontend/src/metabase/embedding/components/SharingMenu/DashboardSharingMenu.tsx
+++ b/frontend/src/metabase/embedding/components/SharingMenu/DashboardSharingMenu.tsx
@@ -1,5 +1,3 @@
-import { useState } from "react";
-
 import { isInstanceAnalyticsCollection } from "metabase/collections/utils";
 import { setSharing as setDashboardSubscriptionSidebarOpen } from "metabase/dashboard/actions";
 import { getIsSharing as getIsDashboardSubscriptionSidebarOpen } from "metabase/dashboard/selectors";
@@ -7,6 +5,8 @@ import { useDispatch, useSelector } from "metabase/lib/redux";
 import { DashboardSubscriptionMenuItem } from "metabase/notifications/NotificationsActionsMenu/DashboardSubscriptionMenuItem";
 import { Flex, Menu } from "metabase/ui";
 import type { Dashboard } from "metabase-types/api";
+
+import { useSharingModal } from "../../hooks/use-sharing-modal";
 
 import { EmbedMenuItem } from "./MenuItems/EmbedMenuItem";
 import { ExportPdfMenuItem } from "./MenuItems/ExportPdfMenuItem";
@@ -26,9 +26,8 @@ export function DashboardSharingMenu({ dashboard }: { dashboard: Dashboard }) {
       setDashboardSubscriptionSidebarOpen(!isDashboardSubscriptionSidebarOpen),
     );
 
-  const [modalType, setModalType] = useState<DashboardSharingModalType | null>(
-    null,
-  );
+  const { modalType, setModalType } =
+    useSharingModal<DashboardSharingModalType>();
 
   const hasPublicLink = !!dashboard?.public_uuid;
   const isArchived = dashboard.archived;

--- a/frontend/src/metabase/embedding/components/SharingMenu/QuestionSharingMenu.tsx
+++ b/frontend/src/metabase/embedding/components/SharingMenu/QuestionSharingMenu.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { t } from "ttag";
 
 import { isInstanceAnalyticsCollection } from "metabase/collections/utils";
@@ -13,6 +12,8 @@ import {
 import { Flex } from "metabase/ui";
 import type Question from "metabase-lib/v1/Question";
 
+import { useSharingModal } from "../../hooks/use-sharing-modal";
+
 import { EmbedMenuItem } from "./MenuItems/EmbedMenuItem";
 import { PublicLinkMenuItem } from "./MenuItems/PublicLinkMenuItem";
 import { SharingButton, SharingMenu } from "./SharingMenu";
@@ -21,9 +22,8 @@ import type { QuestionSharingModalType } from "./types";
 
 export function QuestionSharingMenu({ question }: { question: Question }) {
   const dispatch = useDispatch();
-  const [modalType, setModalType] = useState<QuestionSharingModalType | null>(
-    null,
-  );
+  const { modalType, setModalType } =
+    useSharingModal<QuestionSharingModalType>();
   const hasPublicLink = !!question?.publicUUID?.();
   const isModel = question.type() === "model";
   const isArchived = question.isArchived();

--- a/frontend/src/metabase/embedding/components/SharingMenu/SharingModals.tsx
+++ b/frontend/src/metabase/embedding/components/SharingMenu/SharingModals.tsx
@@ -1,6 +1,7 @@
 import { type Ref, forwardRef } from "react";
 
 import { DashboardSharingEmbeddingModal } from "metabase/dashboard/containers/DashboardSharingEmbeddingModal";
+import { STATIC_LEGACY_EMBEDDING_TYPE } from "metabase/embedding/constants";
 import { QuestionEmbedWidget } from "metabase/query_builder/components/QuestionEmbedWidget";
 import { Box } from "metabase/ui";
 import type Question from "metabase-lib/v1/Question";
@@ -67,6 +68,16 @@ export const SharingModals = ({
     return <QuestionEmbedWidget card={question._card} onClose={onClose} />;
   }
 
+  if (modalType === STATIC_LEGACY_EMBEDDING_TYPE && question) {
+    return (
+      <QuestionEmbedWidget
+        card={question._card}
+        initialEmbedType="application"
+        onClose={onClose}
+      />
+    );
+  }
+
   if (modalType === "dashboard-public-link") {
     return (
       <DashboardPublicLinkPopover
@@ -83,6 +94,18 @@ export const SharingModals = ({
       <DashboardSharingEmbeddingModal
         key="dashboard-embed"
         dashboard={dashboard}
+        onClose={onClose}
+        isOpen
+      />
+    );
+  }
+
+  if (modalType === STATIC_LEGACY_EMBEDDING_TYPE && dashboard) {
+    return (
+      <DashboardSharingEmbeddingModal
+        key="dashboard-embed"
+        dashboard={dashboard}
+        initialEmbedType="application"
         onClose={onClose}
         isOpen
       />

--- a/frontend/src/metabase/embedding/components/SharingMenu/SharingModals.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/components/SharingMenu/SharingModals.unit.spec.tsx
@@ -1,0 +1,226 @@
+import { render, screen } from "@testing-library/react";
+
+import { STATIC_LEGACY_EMBEDDING_TYPE } from "metabase/embedding/constants";
+import Question from "metabase-lib/v1/Question";
+import { createMockCard, createMockDashboard } from "metabase-types/api/mocks";
+
+import { SharingModals } from "./SharingModals";
+
+jest.mock("../PublicLinkPopover", () => ({
+  QuestionPublicLinkPopover: jest.fn(({ isOpen }) =>
+    isOpen ? <div data-testid="question-public-link-popover" /> : null,
+  ),
+  DashboardPublicLinkPopover: jest.fn(({ isOpen }) =>
+    isOpen ? <div data-testid="dashboard-public-link-popover" /> : null,
+  ),
+}));
+
+jest.mock("metabase/query_builder/components/QuestionEmbedWidget", () => ({
+  QuestionEmbedWidget: jest.fn(({ initialEmbedType }) => (
+    <div
+      data-testid="question-embed-widget"
+      data-initial-embed-type={initialEmbedType ?? "none"}
+    />
+  )),
+}));
+
+jest.mock(
+  "metabase/dashboard/containers/DashboardSharingEmbeddingModal",
+  () => ({
+    DashboardSharingEmbeddingModal: jest.fn(({ isOpen, initialEmbedType }) =>
+      isOpen ? (
+        <div
+          data-testid="dashboard-sharing-embedding-modal"
+          data-initial-embed-type={initialEmbedType ?? "none"}
+        />
+      ) : null,
+    ),
+  }),
+);
+
+describe("SharingModals", () => {
+  const mockOnClose = jest.fn();
+  const mockQuestion = new Question(createMockCard());
+  const mockDashboard = createMockDashboard();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("with null modalType", () => {
+    it("should render nothing when modalType is null", () => {
+      const { container } = render(
+        <SharingModals modalType={null} onClose={mockOnClose} />,
+      );
+
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it("should render nothing when modalType is null with question", () => {
+      const { container } = render(
+        <SharingModals
+          modalType={null}
+          question={mockQuestion}
+          onClose={mockOnClose}
+        />,
+      );
+
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it("should render nothing when modalType is null with dashboard", () => {
+      const { container } = render(
+        <SharingModals
+          modalType={null}
+          dashboard={mockDashboard}
+          onClose={mockOnClose}
+        />,
+      );
+
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  describe("question modals", () => {
+    it("should render QuestionPublicLinkPopover for question-public-link", () => {
+      render(
+        <SharingModals
+          modalType="question-public-link"
+          question={mockQuestion}
+          onClose={mockOnClose}
+        />,
+      );
+
+      expect(
+        screen.getByTestId("question-public-link-popover"),
+      ).toBeInTheDocument();
+    });
+
+    it("should render QuestionEmbedWidget for question-embed", () => {
+      render(
+        <SharingModals
+          modalType="question-embed"
+          question={mockQuestion}
+          onClose={mockOnClose}
+        />,
+      );
+
+      const widget = screen.getByTestId("question-embed-widget");
+      expect(widget).toBeInTheDocument();
+      expect(widget).toHaveAttribute("data-initial-embed-type", "none");
+    });
+
+    it("should render QuestionEmbedWidget with initialEmbedType for static-legacy", () => {
+      render(
+        <SharingModals
+          modalType={STATIC_LEGACY_EMBEDDING_TYPE}
+          question={mockQuestion}
+          onClose={mockOnClose}
+        />,
+      );
+
+      const widget = screen.getByTestId("question-embed-widget");
+      expect(widget).toBeInTheDocument();
+      expect(widget).toHaveAttribute("data-initial-embed-type", "application");
+    });
+  });
+
+  describe("dashboard modals", () => {
+    it("should render DashboardPublicLinkPopover for dashboard-public-link", () => {
+      render(
+        <SharingModals
+          modalType="dashboard-public-link"
+          dashboard={mockDashboard}
+          onClose={mockOnClose}
+        />,
+      );
+
+      expect(
+        screen.getByTestId("dashboard-public-link-popover"),
+      ).toBeInTheDocument();
+    });
+
+    it("should render DashboardSharingEmbeddingModal for dashboard-embed", () => {
+      render(
+        <SharingModals
+          modalType="dashboard-embed"
+          dashboard={mockDashboard}
+          onClose={mockOnClose}
+        />,
+      );
+
+      const modal = screen.getByTestId("dashboard-sharing-embedding-modal");
+      expect(modal).toBeInTheDocument();
+      expect(modal).toHaveAttribute("data-initial-embed-type", "none");
+    });
+
+    it("should render DashboardSharingEmbeddingModal with initialEmbedType for static-legacy", () => {
+      render(
+        <SharingModals
+          modalType={STATIC_LEGACY_EMBEDDING_TYPE}
+          dashboard={mockDashboard}
+          onClose={mockOnClose}
+        />,
+      );
+
+      const modal = screen.getByTestId("dashboard-sharing-embedding-modal");
+      expect(modal).toBeInTheDocument();
+      expect(modal).toHaveAttribute("data-initial-embed-type", "application");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should prioritize question modal when both question and dashboard are provided with question modalType", () => {
+      render(
+        // @ts-expect-error Testing invalid state
+        <SharingModals
+          modalType="question-embed"
+          question={mockQuestion}
+          dashboard={mockDashboard}
+          onClose={mockOnClose}
+        />,
+      );
+
+      expect(screen.getByTestId("question-embed-widget")).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("dashboard-sharing-embedding-modal"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should prioritize dashboard modal when both question and dashboard are provided with dashboard modalType", () => {
+      render(
+        // @ts-expect-error Testing invalid state
+        <SharingModals
+          modalType="dashboard-embed"
+          question={mockQuestion}
+          dashboard={mockDashboard}
+          onClose={mockOnClose}
+        />,
+      );
+
+      expect(
+        screen.getByTestId("dashboard-sharing-embedding-modal"),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("question-embed-widget"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should render question modal for static-legacy when both question and dashboard are provided", () => {
+      render(
+        // @ts-expect-error Testing invalid state
+        <SharingModals
+          modalType={STATIC_LEGACY_EMBEDDING_TYPE}
+          question={mockQuestion}
+          dashboard={mockDashboard}
+          onClose={mockOnClose}
+        />,
+      );
+
+      expect(screen.getByTestId("question-embed-widget")).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("dashboard-sharing-embedding-modal"),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/metabase/embedding/components/SharingMenu/types.ts
+++ b/frontend/src/metabase/embedding/components/SharingMenu/types.ts
@@ -1,3 +1,5 @@
+import type { STATIC_LEGACY_EMBEDDING_TYPE } from "metabase/embedding/constants";
+
 export type EmbedModalType = "question-embed" | "dashboard-embed";
 export type PublicLinkModalType =
   | "question-public-link"
@@ -5,10 +7,12 @@ export type PublicLinkModalType =
 
 export type QuestionSharingModalType =
   | "question-public-link"
-  | "question-embed";
+  | "question-embed"
+  | typeof STATIC_LEGACY_EMBEDDING_TYPE;
 
 export type DashboardSharingModalType =
   | "dashboard-public-link"
-  | "dashboard-embed";
+  | "dashboard-embed"
+  | typeof STATIC_LEGACY_EMBEDDING_TYPE;
 
 export type SharingModalType = PublicLinkModalType | EmbedModalType;

--- a/frontend/src/metabase/embedding/hooks/use-sharing-modal.ts
+++ b/frontend/src/metabase/embedding/hooks/use-sharing-modal.ts
@@ -1,0 +1,44 @@
+import { useCallback, useEffect, useState } from "react";
+
+import type {
+  DashboardSharingModalType,
+  QuestionSharingModalType,
+} from "metabase/embedding/components/SharingMenu/types";
+import { STATIC_LEGACY_EMBEDDING_TYPE } from "metabase/embedding/constants";
+import { useDispatch, useSelector } from "metabase/lib/redux";
+import { setOpenModal } from "metabase/redux/ui";
+import { getCurrentOpenModal } from "metabase/selectors/ui";
+import type { ModalName } from "metabase-types/store/modal";
+
+export const useSharingModal = <
+  TModalType extends DashboardSharingModalType | QuestionSharingModalType,
+>() => {
+  const dispatch = useDispatch();
+  const currentOpenModal = useSelector(getCurrentOpenModal);
+
+  const [modalType, setModalType] = useState<TModalType | null>(null);
+
+  useEffect(() => {
+    const allowedModalTypes: ModalName[] = [STATIC_LEGACY_EMBEDDING_TYPE];
+
+    const isValidModalType =
+      currentOpenModal && allowedModalTypes.includes(currentOpenModal);
+
+    if (isValidModalType) {
+      setModalType(currentOpenModal as TModalType);
+    }
+  }, [dispatch, currentOpenModal]);
+
+  const handleSetModalType = useCallback(
+    (modalType: TModalType | null) => {
+      if (!modalType) {
+        dispatch(setOpenModal(null));
+      }
+
+      setModalType(modalType);
+    },
+    [dispatch],
+  );
+
+  return { modalType, setModalType: handleSetModalType };
+};

--- a/frontend/src/metabase/embedding/hooks/use-sharing-modal.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/hooks/use-sharing-modal.unit.spec.tsx
@@ -1,0 +1,119 @@
+import { act, renderHook } from "@testing-library/react";
+
+import type { DashboardSharingModalType } from "metabase/embedding/components/SharingMenu/types";
+import { STATIC_LEGACY_EMBEDDING_TYPE } from "metabase/embedding/constants";
+import { setOpenModal } from "metabase/redux/ui";
+
+import { useSharingModal } from "./use-sharing-modal";
+
+const mockDispatch = jest.fn();
+const mockSelector = jest.fn();
+
+jest.mock("metabase/lib/redux", () => ({
+  useDispatch: () => mockDispatch,
+  useSelector: (selector: any) => mockSelector(selector),
+}));
+
+describe("useSharingModal", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSelector.mockReturnValue(null);
+  });
+
+  it("should initialize with null modalType", () => {
+    const { result } = renderHook(() =>
+      useSharingModal<DashboardSharingModalType>(),
+    );
+
+    expect(result.current.modalType).toBeNull();
+  });
+
+  it("should set modalType when valid modal exists in Redux", () => {
+    mockSelector.mockReturnValue(STATIC_LEGACY_EMBEDDING_TYPE);
+
+    const { result } = renderHook(() =>
+      useSharingModal<DashboardSharingModalType>(),
+    );
+
+    expect(result.current.modalType).toBe(STATIC_LEGACY_EMBEDDING_TYPE);
+  });
+
+  it("should not set modalType for invalid modal values", () => {
+    mockSelector.mockReturnValue("invalid-modal");
+
+    const { result } = renderHook(() =>
+      useSharingModal<DashboardSharingModalType>(),
+    );
+
+    expect(result.current.modalType).toBeNull();
+  });
+
+  it("should update modalType when Redux modal changes from null to valid", () => {
+    mockSelector.mockReturnValue(null);
+
+    const { result, rerender } = renderHook(() =>
+      useSharingModal<DashboardSharingModalType>(),
+    );
+
+    expect(result.current.modalType).toBeNull();
+
+    mockSelector.mockReturnValue(STATIC_LEGACY_EMBEDDING_TYPE);
+    rerender();
+
+    expect(result.current.modalType).toBe(STATIC_LEGACY_EMBEDDING_TYPE);
+  });
+
+  it("should persist modalType when Redux modal becomes null", () => {
+    mockSelector.mockReturnValue(STATIC_LEGACY_EMBEDDING_TYPE);
+
+    const { result, rerender } = renderHook(() =>
+      useSharingModal<DashboardSharingModalType>(),
+    );
+
+    expect(result.current.modalType).toBe(STATIC_LEGACY_EMBEDDING_TYPE);
+
+    mockSelector.mockReturnValue(null);
+    rerender();
+
+    expect(result.current.modalType).toBe(STATIC_LEGACY_EMBEDDING_TYPE);
+  });
+
+  it("should allow manually setting modalType", () => {
+    const { result } = renderHook(() =>
+      useSharingModal<DashboardSharingModalType>(),
+    );
+
+    act(() => {
+      result.current.setModalType(STATIC_LEGACY_EMBEDDING_TYPE);
+    });
+
+    expect(result.current.modalType).toBe(STATIC_LEGACY_EMBEDDING_TYPE);
+  });
+
+  it("should dispatch setOpenModal(null) when clearing modalType", () => {
+    mockSelector.mockReturnValue(STATIC_LEGACY_EMBEDDING_TYPE);
+
+    const { result } = renderHook(() =>
+      useSharingModal<DashboardSharingModalType>(),
+    );
+
+    act(() => {
+      result.current.setModalType(null);
+    });
+
+    expect(result.current.modalType).toBeNull();
+    expect(mockDispatch).toHaveBeenCalledWith(setOpenModal(null));
+  });
+
+  it("should not dispatch when manually setting non-null modalType", () => {
+    const { result } = renderHook(() =>
+      useSharingModal<DashboardSharingModalType>(),
+    );
+
+    act(() => {
+      result.current.setModalType(STATIC_LEGACY_EMBEDDING_TYPE);
+    });
+
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/metabase/new/components/NewModals/NewModals.tsx
+++ b/frontend/src/metabase/new/components/NewModals/NewModals.tsx
@@ -7,6 +7,7 @@ import ActionCreator from "metabase/actions/containers/ActionCreator";
 import CreateCollectionModal from "metabase/collections/containers/CreateCollectionModal";
 import Modal from "metabase/common/components/Modal";
 import { CreateDashboardModal } from "metabase/dashboard/containers/CreateDashboardModal";
+import { STATIC_LEGACY_EMBEDDING_TYPE } from "metabase/embedding/constants";
 import Collections from "metabase/entities/collections/collections";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
@@ -91,6 +92,10 @@ export const NewModals = withRouter((props: WithRouterProps) => {
           onClose={handleModalClose}
         />
       );
+    }
+    case STATIC_LEGACY_EMBEDDING_TYPE: {
+      // Do nothing, we trigger the modal from `use-sharing-modal.ts` hook and render it in `SharingMenu/SharingModals.tsx`
+      return null;
     }
     default:
       return (

--- a/frontend/src/metabase/public/components/EmbedModal/EmbedModal.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/EmbedModal.tsx
@@ -14,6 +14,7 @@ import { EmbedModalHeader } from "./EmbedModal.styled";
 
 interface EmbedModalProps {
   isOpen?: boolean;
+  initialEmbedType?: EmbedModalStep;
   onClose: () => void;
   children: ({
     embedType,
@@ -26,11 +27,18 @@ interface EmbedModalProps {
   }) => JSX.Element;
 }
 
-export const EmbedModal = ({ children, isOpen, onClose }: EmbedModalProps) => {
+export const EmbedModal = ({
+  children,
+  initialEmbedType,
+  isOpen,
+  onClose,
+}: EmbedModalProps) => {
   const shouldShowEmbedTerms = useSelector((state) =>
     getSetting(state, "show-static-embed-terms"),
   );
-  const [embedType, setEmbedType] = useState<EmbedModalStep>(null);
+  const [embedType, setEmbedType] = useState<EmbedModalStep>(
+    initialEmbedType ?? null,
+  );
   const applicationName = useSelector(getApplicationName);
 
   const isEmbeddingSetupStage = embedType === null;

--- a/frontend/src/metabase/public/components/EmbedModal/EmbedModal.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/EmbedModal.unit.spec.tsx
@@ -11,12 +11,18 @@ import { EmbedModal } from "./EmbedModal";
 const TestEmbedModal = ({
   onClose,
   isOpen,
+  initialEmbedType,
 }: {
   onClose: () => void;
   isOpen?: boolean;
+  initialEmbedType?: "legalese" | "application";
 }): JSX.Element => {
   return (
-    <EmbedModal isOpen={isOpen} onClose={onClose}>
+    <EmbedModal
+      isOpen={isOpen}
+      onClose={onClose}
+      initialEmbedType={initialEmbedType}
+    >
       {({ embedType, goToNextStep, goBackToEmbedModal }) => (
         <Group data-testid="test-embed-modal-content">
           <Button onClick={goBackToEmbedModal}>Previous</Button>
@@ -30,13 +36,27 @@ const TestEmbedModal = ({
   );
 };
 
-const setup = ({ isOpen = true, showStaticEmbedTerms = true } = {}) => {
+const setup = ({
+  isOpen = true,
+  showStaticEmbedTerms = true,
+  initialEmbedType,
+}: {
+  isOpen?: boolean;
+  showStaticEmbedTerms?: boolean;
+  initialEmbedType?: "legalese" | "application";
+} = {}) => {
   const onClose = jest.fn();
 
   renderWithProviders(
     <Route
       path="*"
-      component={() => <TestEmbedModal isOpen={isOpen} onClose={onClose} />}
+      component={() => (
+        <TestEmbedModal
+          isOpen={isOpen}
+          onClose={onClose}
+          initialEmbedType={initialEmbedType}
+        />
+      )}
     ></Route>,
     {
       storeInitialState: createMockState({
@@ -114,6 +134,76 @@ describe("EmbedModal", () => {
   it("calls onClose when the modal is closed", async () => {
     const { onClose } = setup();
     await userEvent.click(screen.getByLabelText("close icon"));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("should start at the application step when initialEmbedType is 'application'", () => {
+    setup({ initialEmbedType: "application" });
+
+    expect(
+      within(screen.getByTestId("modal-header")).getByText("Static embedding"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("test-embed-step")).toHaveTextContent(
+      "application",
+    );
+  });
+
+  it("should start at the legalese step when initialEmbedType is 'legalese'", () => {
+    setup({ initialEmbedType: "legalese" });
+
+    expect(
+      within(screen.getByTestId("modal-header")).getByText("Static embedding"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("test-embed-step")).toHaveTextContent("legalese");
+  });
+
+  it("should skip the landing page when initialEmbedType is provided", () => {
+    setup({ initialEmbedType: "application" });
+
+    expect(screen.queryByText("Embed Metabase")).not.toBeInTheDocument();
+    expect(screen.getByTestId("test-embed-step")).toHaveTextContent(
+      "application",
+    );
+  });
+
+  it("should allow going back to landing page from initialEmbedType step", async () => {
+    setup({ initialEmbedType: "application" });
+
+    expect(screen.getByTestId("test-embed-step")).toHaveTextContent(
+      "application",
+    );
+
+    await userEvent.click(screen.getByText("Previous"));
+
+    expect(
+      within(screen.getByTestId("modal-header")).getByText("Embed Metabase"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("test-embed-step")).toHaveTextContent(
+      "Embed Landing",
+    );
+  });
+
+  it("should allow navigating forward from initialEmbedType legalese to application", async () => {
+    setup({ initialEmbedType: "legalese" });
+
+    expect(screen.getByTestId("test-embed-step")).toHaveTextContent("legalese");
+
+    await userEvent.click(screen.getByText("Next"));
+
+    expect(screen.getByTestId("test-embed-step")).toHaveTextContent(
+      "application",
+    );
+  });
+
+  it("should reset to null embedType when closing modal with initialEmbedType", async () => {
+    const { onClose } = setup({ initialEmbedType: "application" });
+
+    expect(screen.getByTestId("test-embed-step")).toHaveTextContent(
+      "application",
+    );
+
+    await userEvent.click(screen.getByLabelText("close icon"));
+
     expect(onClose).toHaveBeenCalled();
   });
 });

--- a/frontend/src/metabase/query_builder/components/QuestionEmbedWidget/QuestionEmbedWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionEmbedWidget/QuestionEmbedWidget.tsx
@@ -12,6 +12,7 @@ import {
   EmbedModal,
   EmbedModalContent,
 } from "metabase/public/components/EmbedModal";
+import type { EmbedModalStep } from "metabase/public/lib/types";
 import { getMetadata } from "metabase/selectors/metadata";
 import { getCardUiParameters } from "metabase-lib/v1/parameters/utils/cards";
 import type { Card } from "metabase-types/api";
@@ -19,10 +20,11 @@ import type { Card } from "metabase-types/api";
 type QuestionEmbedWidgetProps = {
   className?: string;
   card: Card;
+  initialEmbedType?: EmbedModalStep;
   onClose: () => void;
 };
 export const QuestionEmbedWidget = (props: QuestionEmbedWidgetProps) => {
-  const { className, card, onClose } = props;
+  const { className, card, initialEmbedType, onClose } = props;
 
   const metadata = useSelector(getMetadata);
 
@@ -37,7 +39,7 @@ export const QuestionEmbedWidget = (props: QuestionEmbedWidgetProps) => {
   ) => publicQuestion({ uuid: publicUuid, type: extension });
 
   return (
-    <EmbedModal onClose={onClose}>
+    <EmbedModal initialEmbedType={initialEmbedType} onClose={onClose}>
       {({ embedType, goToNextStep }) => (
         <EmbedModalContent
           embedType={embedType}


### PR DESCRIPTION
This change is a part of preparation for the upcoming Static Embedding via SDK.

Why do we need it?
- in the upcoming Static Embedding via SDK we need to open the Legacy Static Embedding modal by clicking on a link in the EmbedJS wizard.
- the EmbedJS wizard is displayed on multiple pages, so that link will redirect a user to the page with the corresponding entity (dashboard/question) and open the Legacy Static Embedding wizard.

As part of the preparation, I decided to extract the main logic that handles this Legacy Modal opening by dispatching the `setCurrentModal` action.
Currently, this action is not called with the `static-legacy` modal, this call will be added in follow-ups.

Dev notes:
- this logic is kind of temporal. When we kill the legacy static embedding modal, we should kill this logic as well

