### PR TITLE
Fix getNextSdkVersion helper

### DIFF
--- a/release/src/version-helpers.ts
+++ b/release/src/version-helpers.ts
@@ -413,55 +413,105 @@ export const getNextPatchVersion = async ({
   return nextPatch;
 };
 
-export const getNextSdkVersion = (
-  branch: string,
-  currentVersion: string,
-): {
+type SdkVersionInfo = {
   version: string;
   preReleaseLabel: string;
   majorVersion: string;
-} => {
-  const [currentVersionWithoutSuffix, suffix] = currentVersion.split("-");
-  const versionParts = currentVersionWithoutSuffix.split(".");
-  const [_, majorVersion] = versionParts;
+};
+
+type PreReleaseInfo = {
+  label: string;
+  version: number | null;
+};
+
+const parsePreReleaseSuffix = (suffix: string | undefined): PreReleaseInfo => {
+  if (!suffix) {
+    return { label: "", version: null };
+  }
+
+  const [label, versionStr] = suffix.split(".");
+  const version = versionStr ? parseInt(versionStr, 10) : null;
+
+  return { label: label ?? "", version };
+};
+
+const getNextAlphaVersion = (
+  currentVersionBase: string,
+  preRelease: PreReleaseInfo,
+  majorVersion: string,
+): SdkVersionInfo => {
+  if (preRelease.label !== "alpha") {
+    throw new Error(
+      "Only `alpha` versions can be released from the `master` branch.",
+    );
+  }
+
+  const nextPreReleaseVersion = (preRelease.version ?? -1) + 1;
+
+  return {
+    version: `${currentVersionBase}-${preRelease.label}.${nextPreReleaseVersion}`,
+    preReleaseLabel: preRelease.label,
+    majorVersion,
+  };
+};
+
+const getNextReleaseBranchVersion = (
+  versionParts: string[],
+  preRelease: PreReleaseInfo,
+  majorVersion: string,
+): SdkVersionInfo => {
+  if (preRelease.label && preRelease.label !== "beta") {
+    throw new Error(
+      "Only `beta` versions can be released from the `release` branch.",
+    );
+  }
+
+  const updatedVersionParts = [...versionParts];
+  const lastIndex = updatedVersionParts.length - 1;
+  const patchVersion = updatedVersionParts[lastIndex] ?? "0";
+
+  // Handle .x placeholder versions
+  if (patchVersion === "x") {
+    updatedVersionParts[lastIndex] = "0";
+  } else if (!preRelease.label && preRelease.version === null) {
+    // Increment patch version for stable releases
+    const currentPatch = parseInt(patchVersion, 10) || 0;
+    updatedVersionParts[lastIndex] = String(currentPatch + 1);
+  }
+
+  const newVersionBase = updatedVersionParts.join(".");
+  const nextPreReleaseVersion = (preRelease.version ?? -1) + 1;
+
+  const versionSuffix = preRelease.label
+    ? `-${preRelease.label}.${nextPreReleaseVersion}`
+    : "";
+
+  return {
+    version: `${newVersionBase}${versionSuffix}`,
+    preReleaseLabel: "",
+    majorVersion,
+  };
+};
+
+export const getNextSdkVersion = (
+  branch: string,
+  currentVersion: string,
+): SdkVersionInfo => {
+  const [currentVersionBase, suffix] = currentVersion.split("-");
+  const versionParts = currentVersionBase.split(".");
+  const majorVersion = versionParts[1] ?? "";
 
   if (branch === "master") {
     if (!suffix) {
       throw new Error(
-        "Expected pre-release suffix on master branch, got: " + currentVersion,
+        `Expected pre-release suffix on master branch, got: ${currentVersion}`,
       );
     }
 
-    // When the `currentVersion` is `0.57.0-alpha.1`
-    // The `suffix` is `alpha.1`
-    // The `preReleaseLabel is `alpha`
-    // The `preReleaseVersion` is `1`
-    const suffixParts = suffix ? suffix.split(".") : [];
-
-    const preReleaseLabel = suffixParts[0] ?? "";
-    const preReleaseVersion = suffixParts[1] ? parseInt(suffixParts[1]) : null;
-    const nextPreReleaseVersion =
-      preReleaseVersion !== null ? preReleaseVersion + 1 : 0;
-
-    return {
-      version: `${currentVersionWithoutSuffix}-${preReleaseLabel}.${nextPreReleaseVersion}`,
-      preReleaseLabel,
-      majorVersion,
-    };
+    const preRelease = parsePreReleaseSuffix(suffix);
+    return getNextAlphaVersion(currentVersionBase, preRelease, majorVersion);
   }
 
-  // 0.57.0 => 0.57.1
-  // 0.57.0-alpha -> 0.57.1-alpha
-  const minorVersion = versionParts.at(-1) ?? 0;
-  versionParts[versionParts.length - 1] = String(
-    minorVersion ? parseInt(minorVersion) + 1 : 0,
-  );
-
-  const newVersion = versionParts.join(".");
-
-  return {
-    version: suffix ? `${newVersion}-${suffix}` : newVersion,
-    preReleaseLabel: "",
-    majorVersion,
-  };
+  const preRelease = parsePreReleaseSuffix(suffix);
+  return getNextReleaseBranchVersion(versionParts, preRelease, majorVersion);
 };

--- a/release/src/version-helpers.unit.spec.ts
+++ b/release/src/version-helpers.unit.spec.ts
@@ -682,38 +682,22 @@ describe("version-helpers", () => {
 
   describe("getMajorVersionFromRef", () => {
     it("should get major version from a tag", () => {
-      expect(getMajorVersionFromRef("refs/tags/v0.56.x")).toEqual(
-        "56",
-      );
+      expect(getMajorVersionFromRef("refs/tags/v0.56.x")).toEqual("56");
 
-      expect(getMajorVersionFromRef("refs/tags/v1.56.0")).toEqual(
-        "56",
-      );
+      expect(getMajorVersionFromRef("refs/tags/v1.56.0")).toEqual("56");
 
-      expect(getMajorVersionFromRef("refs/tags/v0.51.2.x")).toEqual(
-        "51",
-      );
+      expect(getMajorVersionFromRef("refs/tags/v0.51.2.x")).toEqual("51");
 
-      expect(getMajorVersionFromRef("refs/tags/v0.51.0-beta")).toEqual(
-        "51",
-      );
+      expect(getMajorVersionFromRef("refs/tags/v0.51.0-beta")).toEqual("51");
 
-      expect(getMajorVersionFromRef("refs/tags/v0.51.2.3")).toEqual(
-        "51",
-      );
+      expect(getMajorVersionFromRef("refs/tags/v0.51.2.3")).toEqual("51");
 
-      expect(getMajorVersionFromRef("refs/tags/v0.51.10")).toEqual(
-        "51",
-      );
+      expect(getMajorVersionFromRef("refs/tags/v0.51.10")).toEqual("51");
     });
 
     it("should get major version from a release branch", () => {
-      expect(
-        getMajorVersionFromRef("refs/heads/release-x.51.x"),
-      ).toEqual("51");
-      expect(
-        getMajorVersionFromRef("release-x.52.x"),
-      ).toEqual("52");
+      expect(getMajorVersionFromRef("refs/heads/release-x.51.x")).toEqual("51");
+      expect(getMajorVersionFromRef("release-x.52.x")).toEqual("52");
     });
   });
 
@@ -874,10 +858,10 @@ describe("version-helpers", () => {
       });
 
       it("should set next pre-release version to .1 if no numeric part in suffix", () => {
-        const result = getNextSdkVersion("master", "0.57.0-beta");
+        const result = getNextSdkVersion("master", "0.57.0-alpha");
         expect(result).toEqual({
-          version: "0.57.0-beta.0",
-          preReleaseLabel: "beta",
+          version: "0.57.0-alpha.0",
+          preReleaseLabel: "alpha",
           majorVersion: "57",
         });
       });
@@ -899,10 +883,37 @@ describe("version-helpers", () => {
         });
       });
 
-      it("should increment patch version but keeps suffix if present", () => {
-        const result = getNextSdkVersion("release-x.57.x", "0.57.0-alpha.1");
+      it("should set proper initial patch version for a next major release", () => {
+        const result = getNextSdkVersion("release-x.57.x", "0.57.x");
         expect(result).toEqual({
-          version: "0.57.1-alpha.1",
+          version: "0.57.0",
+          preReleaseLabel: "",
+          majorVersion: "57",
+        });
+      });
+
+      it("should set initial pre-release version when suffix is preset, but pre-release version is not", () => {
+        const result = getNextSdkVersion("release-x.57.x", "0.57.0-beta");
+        expect(result).toEqual({
+          version: "0.57.0-beta.0",
+          preReleaseLabel: "",
+          majorVersion: "57",
+        });
+      });
+
+      it("should set proper initial patch version when pre-release suffix is preset", () => {
+        const result = getNextSdkVersion("release-x.57.x", "0.57.x-beta");
+        expect(result).toEqual({
+          version: "0.57.0-beta.0",
+          preReleaseLabel: "",
+          majorVersion: "57",
+        });
+      });
+
+      it("should increment pre-release version", () => {
+        const result = getNextSdkVersion("release-x.57.x", "0.57.0-beta.0");
+        expect(result).toEqual({
+          version: "0.57.0-beta.1",
           preReleaseLabel: "",
           majorVersion: "57",
         });


### PR DESCRIPTION
Fix getNextSdkVersion helper by handling additional cases:
- package json value `0.57.x` => will be published as `0.57.0`
- package json value `0.57.x-beta` => will be published as `0.57.0-beta.0`
- package json value `0.57.0-beta`  => will be published as `0.57.0-beta.0`