### PR TITLE
chore: ignore e2e embedding host apps from linting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@ frontend/src/cljs
 frontend/src/cljs_release
 e2e/support/cypress_sample_database.js
 e2e/support/cypress_sample_instance_data.js
+e2e/embedding-sdk-host-apps


### PR DESCRIPTION
[context](https://metaboat.slack.com/archives/C505ZNNH4/p1762344467584869) 

ignore folders we generate on fly