### PR TITLE
Close New Modals when pathname is changing

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/common.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/common.cy.spec.ts
@@ -42,4 +42,32 @@ describe("scenarios > embedding > sdk iframe embed setup > common", () => {
     H.modal().should("not.exist");
     cy.findAllByTestId("sdk-setting-card").should("be.visible");
   });
+
+  it("should close wizard when navigating back in browser history", () => {
+    cy.visit("/admin");
+    cy.findAllByTestId("settings-sidebar-link")
+      .contains("General")
+      .should("be.visible");
+
+    cy.visit("/admin/embedding");
+    cy.findAllByTestId("sdk-setting-card").should("be.visible");
+
+    cy.findAllByTestId("sdk-setting-card")
+      .first()
+      .within(() => {
+        cy.findByText("New embed").click();
+      });
+
+    cy.wait("@dashboard");
+    cy.get("[data-iframe-loaded]", { timeout: 20000 }).should("have.length", 1);
+
+    H.modal().should("exist");
+
+    cy.go("back");
+
+    H.modal().should("not.exist");
+    cy.findAllByTestId("settings-sidebar-link")
+      .contains("General")
+      .should("be.visible");
+  });
 });

--- a/frontend/src/metabase/new/components/NewModals/NewModals.tsx
+++ b/frontend/src/metabase/new/components/NewModals/NewModals.tsx
@@ -1,7 +1,8 @@
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import type { WithRouterProps } from "react-router";
 import { withRouter } from "react-router";
 import { push } from "react-router-redux";
+import { useLocation } from "react-use";
 
 import ActionCreator from "metabase/actions/containers/ActionCreator";
 import CreateCollectionModal from "metabase/collections/containers/CreateCollectionModal";
@@ -21,6 +22,7 @@ import { getCurrentOpenModalState } from "metabase/selectors/ui";
 import type { WritebackAction } from "metabase-types/api";
 
 export const NewModals = withRouter((props: WithRouterProps) => {
+  const { pathname } = useLocation();
   const { id: currentNewModalId, props: currentNewModalProps } = useSelector(
     getCurrentOpenModalState<SdkIframeEmbedSetupModalProps>,
   );
@@ -40,6 +42,11 @@ export const NewModals = withRouter((props: WithRouterProps) => {
   const handleModalClose = useCallback(() => {
     dispatch(closeModal());
   }, [dispatch]);
+
+  useEffect(() => {
+    // Hide the modals on location change
+    handleModalClose();
+  }, [handleModalClose, pathname]);
 
   useRegisterShortcut(
     [


### PR DESCRIPTION
Close New Modals when a `pathname` is changing.

We have some `new` modals like `new dashboard`, `new search`, `new embed`.
When a modal is opened and user presses `back` in the browser - the modal stays opened, but it should be closed.