### PR TITLE
Removing new badge for move questions into their dashboards

### DIFF
--- a/frontend/src/metabase/collections/components/CollectionMenu/CollectionMenu.tsx
+++ b/frontend/src/metabase/collections/components/CollectionMenu/CollectionMenu.tsx
@@ -9,11 +9,10 @@ import {
 } from "metabase/collections/utils";
 import { ForwardRefLink } from "metabase/common/components/Link";
 import { useHasDashboardQuestionCandidates } from "metabase/common/components/MoveQuestionsIntoDashboardsModal/hooks";
-import { UserHasSeen } from "metabase/common/components/UserHasSeen/UserHasSeen";
 import { UserHasSeenAll } from "metabase/common/components/UserHasSeen/UserHasSeenAll";
 import * as Urls from "metabase/lib/urls";
 import { PLUGIN_COLLECTIONS } from "metabase/plugins";
-import { ActionIcon, Badge, Icon, Indicator, Menu, Tooltip } from "metabase/ui";
+import { ActionIcon, Icon, Indicator, Menu, Tooltip } from "metabase/ui";
 import type { Collection } from "metabase-types/api";
 
 export interface CollectionMenuProps {
@@ -96,17 +95,11 @@ export const CollectionMenu = ({
 
   if (hasDqCandidates) {
     cleanupItems.push(
-      <UserHasSeen key="move-to-dashboard" id="move-to-dashboard">
-        {({ hasSeen, ack }) => (
-          <Menu.Item
-            leftSection={<Icon name="add_to_dash" />}
-            component={ForwardRefLink}
-            to={`${url}/move-questions-dashboard`}
-            onClick={ack}
-            rightSection={!hasSeen ? <Badge>{t`New`}</Badge> : null}
-          >{t`Move questions into their dashboards`}</Menu.Item>
-        )}
-      </UserHasSeen>,
+      <Menu.Item
+        leftSection={<Icon name="add_to_dash" />}
+        component={ForwardRefLink}
+        to={`${url}/move-questions-dashboard`}
+      >{t`Move questions into their dashboards`}</Menu.Item>,
     );
   }
 


### PR DESCRIPTION

<img width="500" height="500" alt="image" src="https://github.com/user-attachments/assets/a7147531-4d50-4f56-bccb-0ba772e18f71" />

### Description
Removes the `New` badge for moving questions into dashboards. That party is over folks.

### How to verify
1. Set up a new instance
2. Create a collection with a dashboard, and a question
3. Add the question to the dashboard
4. In the collection, open the menu. You should see an option to move questions into the dashboards, but there should be no new badge

### Demo
<img width="1187" height="625" alt="image" src="https://github.com/user-attachments/assets/60711dd1-1874-4a64-8b57-933dde981a9c" />

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
