### PR TITLE
Add more generous default max width and responsive width for larger screens on dashboard subscriptions

### DIFF
--- a/src/metabase/channel/email/_dashsub_alert_header.hbs
+++ b/src/metabase/channel/email/_dashsub_alert_header.hbs
@@ -96,6 +96,7 @@
         }
         .container {
           padding: 10px !important;
+          max-width: 100% !important;
         }
 
         {{!-- Collapse filters to a single column on small screens --}}
@@ -105,5 +106,17 @@
           line-height: 12px !important;
         }
       }
+      
+      .container {
+        max-width: 768px !important;
+      }
+
+      {{!-- Wider emails on larger screens --}}
+      @media screen and (min-width: 1440px) {
+        .container {
+          max-width: 1024px !important;
+        }
+      }
+
     </style>
   </head>

--- a/src/metabase/channel/email/dashboard_subscription.hbs
+++ b/src/metabase/channel/email/dashboard_subscription.hbs
@@ -3,7 +3,7 @@
     <table class="background" width="100%" border="0" cellspacing="0" cellpadding="0" style="background-color: #F9F9F9; padding: 20px; table-layout: fixed;">
       <tr>
         <td>
-          <div class="container" style="background-color: white; max-width: 555px; border-radius: 24px; margin: 0 auto; padding: 30px;">
+          <div class="container" style="background-color: white; border-radius: 24px; margin: 0 auto; padding: 30px;">
             {{#if context.include_branding}}
               <a href="https://www.metabase.com?utm_source=product&utm_medium=export&utm_campaign=exports_branding&utm_content=dashboard_subscription">
                 <div style="text-align: right; height: 28px; margin-bottom: 16px; color: {{payload.style.color_text_dark}};">


### PR DESCRIPTION

Closes https://github.com/metabase/metabase/issues/57357

### Description
The current default max-width for dashboard subscriptions is 555px. This is the same max-width used for comment and notification emails. However, it is far too restrictive for many dashboard containing tables or other wider content, especially on larger screens or wider email clients.

This pull request updates the email dashboard subscription templates to improve responsive layout across different screen sizes by changing the max width of the `.container` class in CSS, ensuring the email content displays optimally on various devices.

Obviously the values I provided may be up for debate, but for the companies I work with, the existing email width is constant gripe for those who depend on the reports. I think it's worth changing this or at least giving the users the option to customize this value if needed (which would take some more work).

### How to verify
1. Send a dashboard subscription to yourself or test via Handlebars using this script
[test-dashboard-email.js](https://github.com/user-attachments/files/23372476/test-dashboard-email.js).


### Checklist
- [X] Tests have been added/updated to cover changes in this PR
