### PR TITLE
Fix databricks tests after driver upgrade

### DIFF
--- a/modules/drivers/databricks/src/metabase/driver/databricks.clj
+++ b/modules/drivers/databricks/src/metabase/driver/databricks.clj
@@ -505,5 +505,9 @@
 
 (defmethod sql-jdbc.execute/read-column-thunk [:databricks Types/ARRAY]
   [_driver ^java.sql.ResultSet rs _rsmeta ^Integer i]
-  (fn []
-    (.getObject rs i)))
+  ;; This differs from the sql-jdbc implementation due to a change in
+  ;; Databricks' JDBC driver from 2.7.3 to 3.0.1. It returns the type
+  ;; of an array column as Types/ARRAY now, but the object is a
+  ;; java.lang.String, so we can't call .getArray on it and instead
+  ;; should return it as is.
+  (fn [] (.getObject rs i)))

--- a/modules/drivers/databricks/src/metabase/driver/databricks.clj
+++ b/modules/drivers/databricks/src/metabase/driver/databricks.clj
@@ -27,7 +27,8 @@
     PreparedStatement
     ResultSet
     ResultSetMetaData
-    Statement]
+    Statement
+    Types]
    [java.time
     LocalDate
     LocalDateTime
@@ -501,3 +502,8 @@
 (defmethod sql-jdbc/impl-table-known-to-not-exist? :databricks
   [_ e]
   (= (sql-jdbc/get-sql-state e) "42P01"))
+
+(defmethod sql-jdbc.execute/read-column-thunk [:databricks Types/ARRAY]
+  [_driver ^java.sql.ResultSet rs _rsmeta ^Integer i]
+  (fn []
+    (.getObject rs i)))

--- a/modules/drivers/databricks/test/metabase/driver/databricks_test.clj
+++ b/modules/drivers/databricks/test/metabase/driver/databricks_test.clj
@@ -265,12 +265,7 @@
       (sql-jdbc.conn/with-connection-spec-for-testing-connection
        [spec [:databricks (:details (mt/db))]]
         (is (= (str "Metabase/" (:tag config/mb-version-info)) (:UserAgentEntry spec)))
-        (is (= [{:a 1}] (jdbc/query spec ["select 1 as a"]))))
-      (with-redefs [config/mb-version-info {:tag "invalid agent"}]
-        (sql-jdbc.conn/with-connection-spec-for-testing-connection
-         [spec [:databricks (:details (mt/db))]]
-          (is (= "Metabase/invalid agent" (:UserAgentEntry spec)))
-          (is (= [{:a 1}] (jdbc/query spec ["select 1 as a"]))))))
+        (is (= [{:a 1}] (jdbc/query spec ["select 1 as a"])))))
     (testing "Additional options are added to :subname key of generated spec"
       (is (re-find #";IgnoreTransactions=0$"
                    (->> {:http-path "p/a/t/h",

--- a/modules/drivers/databricks/test/metabase/driver/databricks_test.clj
+++ b/modules/drivers/databricks/test/metabase/driver/databricks_test.clj
@@ -264,14 +264,12 @@
     (testing "Connections with UserAgentEntry"
       (sql-jdbc.conn/with-connection-spec-for-testing-connection
        [spec [:databricks (:details (mt/db))]]
+        (is (= (str "Metabase/" (:tag config/mb-version-info)) (:UserAgentEntry spec)))
         (is (= [{:a 1}] (jdbc/query spec ["select 1 as a"]))))
       (with-redefs [config/mb-version-info {:tag "invalid agent"}]
         (sql-jdbc.conn/with-connection-spec-for-testing-connection
          [spec [:databricks (:details (mt/db))]]
-          (is (thrown-with-msg?
-               Exception
-               #"Incorrect format for User-Agent entry"
-               (jdbc/query spec ["select 1 as a"]))))))
+          (is (= "Metabase/invalid agent" (:UserAgentEntry spec))))))
     (testing "Additional options are added to :subname key of generated spec"
       (is (re-find #";IgnoreTransactions=0$"
                    (->> {:http-path "p/a/t/h",

--- a/modules/drivers/databricks/test/metabase/driver/databricks_test.clj
+++ b/modules/drivers/databricks/test/metabase/driver/databricks_test.clj
@@ -269,7 +269,8 @@
       (with-redefs [config/mb-version-info {:tag "invalid agent"}]
         (sql-jdbc.conn/with-connection-spec-for-testing-connection
          [spec [:databricks (:details (mt/db))]]
-          (is (= "Metabase/invalid agent" (:UserAgentEntry spec))))))
+          (is (= "Metabase/invalid agent" (:UserAgentEntry spec)))
+          (is (= [{:a 1}] (jdbc/query spec ["select 1 as a"]))))))
     (testing "Additional options are added to :subname key of generated spec"
       (is (re-find #";IgnoreTransactions=0$"
                    (->> {:http-path "p/a/t/h",

--- a/test/metabase/query_processor/api_test.clj
+++ b/test/metabase/query_processor/api_test.clj
@@ -668,7 +668,7 @@
                                                         "asdf;"))]
         (is (= {:error_type "invalid-query"
                 :status "failed"
-                :class "class com.databricks.client.support.exceptions.ErrorException"}
+                :class "class com.databricks.jdbc.exception.DatabricksSQLException"}
                (select-keys res [:error_type :status :class])))
         (is (not (str/includes? (:error res) "\n\tat ")))))))
 


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/QUE-2746/databricks-301-jdbc-changes-breaking-array-handling-and-tests

### Description

Fixes tests that broke after upgrading the JDBC driver. 

### How to verify

All tests should pass

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
