### PR TITLE
Remove unneeded tests after #65485

### DIFF
--- a/frontend/src/metabase/collections/components/CollectionMenu/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionMenu/tests/common.unit.spec.tsx
@@ -1,10 +1,9 @@
 import userEvent from "@testing-library/user-event";
-import fetchMock from "fetch-mock";
 
 import { getIcon, queryIcon, screen } from "__support__/ui";
 import { createMockCollection } from "metabase-types/api/mocks";
 
-import { assertIndicatorHidden, assertIndicatorVisible, setup } from "./setup";
+import { setup } from "./setup";
 
 describe("CollectionMenu", () => {
   it("should be able to edit collection permissions with admin access", async () => {
@@ -152,145 +151,6 @@ describe("CollectionMenu", () => {
     expect(
       screen.queryByText("Move questions into their dashboards"),
     ).not.toBeInTheDocument();
-  });
-});
-
-describe("for your consideration", () => {
-  describe("dashboard question candidates", () => {
-    it("should show an indicator if we have never shown you the new menu option before, and dismiss when you open the menu", async () => {
-      setup({
-        collection: createMockCollection({ can_write: true }),
-        dashboardQuestionCandidates: [dqCandidate],
-        isAdmin: true,
-      });
-
-      await assertIndicatorVisible();
-      await userEvent.click(getIcon("ellipsis"));
-
-      expect(
-        fetchMock.callHistory.calls(
-          "http://localhost/api/user-key-value/namespace/indicator-menu/key/collection-menu",
-          { method: "PUT" },
-        ),
-      ).toHaveLength(1);
-
-      expect(
-        await screen.findByRole("menuitem", { name: /Move questions into/ }),
-      ).toHaveTextContent("New");
-
-      await userEvent.click(
-        await screen.findByRole("menuitem", { name: /Move questions into/ }),
-      );
-
-      expect(
-        fetchMock.callHistory.calls(
-          "http://localhost/api/user-key-value/namespace/user_acknowledgement/key/move-to-dashboard",
-          { method: "PUT" },
-        ),
-      ).toHaveLength(1);
-    });
-
-    it("should not show an indicator if there are no dq candidates", async () => {
-      setup({
-        collection: createMockCollection({ can_write: true }),
-        dashboardQuestionCandidates: [],
-        isAdmin: true,
-      });
-
-      await assertIndicatorHidden();
-
-      await userEvent.click(getIcon("ellipsis"));
-
-      expect(
-        fetchMock.callHistory.called(
-          "http://localhost/api/user-key-value/namespace/user_acknowledgement/key/collection-menu",
-          { method: "PUT" },
-        ),
-      ).toBe(false);
-    });
-
-    it("should not show an indicator if it has been previously dismissed", async () => {
-      setup({
-        collection: createMockCollection({ can_write: true }),
-        dashboardQuestionCandidates: [dqCandidate],
-        isAdmin: true,
-      });
-
-      await assertIndicatorHidden();
-
-      await userEvent.click(getIcon("ellipsis"));
-
-      expect(
-        fetchMock.callHistory.called(
-          "http://localhost/api/user-key-value/namespace/user_acknowledgement/key/collection-menu",
-          { method: "PUT" },
-        ),
-      ).toBe(false);
-
-      expect(
-        await screen.findByRole("menuitem", { name: /Move questions into/ }),
-      ).toHaveTextContent("New");
-    });
-
-    it("should not show an indicator if we cannot render move to dashboard option", async () => {
-      setup({
-        collection: createMockCollection({ can_write: true }),
-        dashboardQuestionCandidates: [dqCandidate],
-        isAdmin: false,
-      });
-
-      await assertIndicatorHidden();
-      await userEvent.click(getIcon("ellipsis"));
-
-      expect(
-        fetchMock.callHistory.called(
-          "http://localhost/api/user-key-value/namespace/user_acknowledgement/key/collection-menu",
-          { method: "PUT" },
-        ),
-      ).toBe(false);
-    });
-
-    it("should not show an indicator if move to dashboard has been seen", async () => {
-      setup({
-        collection: createMockCollection({ can_write: true }),
-        dashboardQuestionCandidates: [dqCandidate],
-        isAdmin: false,
-        moveToDashboard: true,
-      });
-
-      await assertIndicatorHidden();
-      await userEvent.click(getIcon("ellipsis"));
-
-      expect(
-        fetchMock.callHistory.called(
-          "http://localhost/api/user-key-value/namespace/user_acknowledgement/key/collection-menu",
-          { method: "PUT" },
-        ),
-      ).toBe(false);
-    });
-
-    it("should not show an new badge if move questions to dashboards has been clicked before", async () => {
-      setup({
-        collection: createMockCollection({ can_write: true }),
-        dashboardQuestionCandidates: [dqCandidate],
-        isAdmin: true,
-        moveToDashboard: true,
-      });
-
-      await assertIndicatorHidden();
-      await userEvent.click(getIcon("ellipsis"));
-
-      expect(
-        fetchMock.callHistory.called(
-          "http://localhost/api/user-key-value/namespace/user_acknowledgement/key/collection-menu",
-          { method: "PUT" },
-        ),
-      ).toBe(false);
-
-      expect(
-        await screen.findByRole("menuitem", { name: /Move questions into/ }),
-      ).not.toHaveTextContent("New");
-    });
   });
 });
 


### PR DESCRIPTION
#65485 removed the feature but did not update the tests. This PR does that and fixes a broken master due to https://github.com/metabase/metabase/actions/runs/19118446067/job/54633298469


> [!IMPORTANT]
> I've explicitly set the no-backport label because I'll cherry pick this change into #65506