### PR TITLE
[v54] Make Trunk analytics always run (#65451)

### DIFF
--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -30,10 +30,9 @@ runs:
       shell: bash
       id: run-test
       # Trunk Quarantine controls the final state of the run in the CI!
-      # Even if this step fails, we let it pass and then `trunk-io/analytics-uploader` determines whether to fail or to
-      # pass the whole job, based on the quarantine list.
-      # We only want to "continue on error" (ignore failures) when the Trunk upload is active - i.e. not on drafts!
-      continue-on-error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.draft == true) }}
+      # Even if this step fails we let it pass, and then `trunk-io/analytics-uploader` determines
+      # whether to fail or to pass the whole job, based on the quarantine list.
+      continue-on-error: true
     - name: Publish Test Report (JUnit)
       uses: dorny/test-reporter@v1
       # As per the documentation: https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#steps-context

--- a/.github/actions/upload-test-results/action.yml
+++ b/.github/actions/upload-test-results/action.yml
@@ -48,10 +48,11 @@ runs:
         aws s3 cp ${OUTPUT_FILE}.zip s3://$BUCKET/$DATE/$GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT/
 
     - name: Upload results to Trunk
-      if: ${{ always() }}
+      if: always() # Important! This step must always run because it controls job's exit code.
       uses: trunk-io/analytics-uploader@main
       with:
         junit-paths: ${{ inputs.input-path }}
         variant: ${{ inputs.variant || inputs.output-name }}
         org-slug: metabase
+        dry-run: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft == true }} # quarantine, but do not upload results
         token: ${{ inputs.trunk-api-token }}

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -151,10 +151,9 @@ jobs:
           :exclude-tags '[:mb/driver-tests ${{ env.__ADDITIONAL_EXCLUDED_TAG__ }}]'
           ${{ matrix.job.test-args }}
         # Trunk Quarantine controls the final state of the run in the CI!
-        # Even if this step fails, we let it pass and then `trunk-io/analytics-uploader` determines whether to fail or to
-        # pass the whole job, based on the quarantine list.
-        # We only want to "continue on error" (ignore failures) when the Trunk upload is active - i.e. not on drafts!
-        continue-on-error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.draft == true) }}
+        # Even if this step fails we let it pass, and then `trunk-io/analytics-uploader` determines
+        # whether to fail or to pass the whole job, based on the quarantine list.
+        continue-on-error: true
 
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -139,10 +139,9 @@ jobs:
             --spec "$SPEC_PATH" \
             --browser ${{ steps.cypress-prep.outputs.chrome-path }}
         # Trunk Quarantine controls the final state of the run in the CI!
-        # Even if this step fails, we let it pass and then `trunk-io/analytics-uploader` determines whether to fail or to
-        # pass the whole job, based on the quarantine list.
-        # We only want to "continue on error" (ignore failures) when the Trunk upload is active - i.e. not on drafts!
-        continue-on-error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.draft == true) }}
+        # Even if this step fails we let it pass, and then `trunk-io/analytics-uploader` determines
+        # whether to fail or to pass the whole job, based on the quarantine list.
+        continue-on-error: true
 
       - name: Run Tagged EE Cypress tests on ${{ inputs.name }}
         if: ${{ inputs.specs }}
@@ -156,10 +155,9 @@ jobs:
           --spec "$SPEC_PATH" \
           --browser ${{ steps.cypress-prep.outputs.chrome-path }}
         # Trunk Quarantine controls the final state of the run in the CI!
-        # Even if this step fails, we let it pass and then `trunk-io/analytics-uploader` determines whether to fail or to
-        # pass the whole job, based on the quarantine list.
-        # We only want to "continue on error" (ignore failures) when the Trunk upload is active - i.e. not on drafts!
-        continue-on-error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.draft == true) }}
+        # Even if this step fails we let it pass, and then `trunk-io/analytics-uploader` determines
+        # whether to fail or to pass the whole job, based on the quarantine list.
+        continue-on-error: true
 
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -74,8 +74,8 @@ jobs:
       - name: Run frontend unit tests
         if: github.ref_name != 'master'
         run: yarn run test-unit --silent
-        # We want Trunk to still receive test reports even if this job fails.
-        # It will filter out the quarantined tests, and will control the job exit code based on the analysis.
+        # Even if this step fails we let it pass, and then `trunk-io/analytics-uploader` determines
+        # whether to fail or to pass the whole job, based on the quarantine list.
         continue-on-error: true
       - name: Upload coverage to codecov.io
         if: github.ref_name == 'master'


### PR DESCRIPTION
Manual backport of https://github.com/metabase/metabase/pull/65451 to 54 release branch.

* Make Trunk analytics always run

This prevents false positives because Trunk analytics actio will now always analyze test results, and compare them with their own test quarantine list. It uses this information to know if it should fail the job or let it pass.

* Introduce dry-run

When a PR is in a draft mode, we don't want to upload results but still have to quarantine tests.
