### PR TITLE
get Scalar back to working state and drop some of json-schema fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@
 ### JavaScript/TypeScript
 
 - **Lint:** `yarn lint-eslint-pure`
-- **Test:** `yarn test-unit-keep-cljs path/to/file.unit.spec.js` or `yarn test-unit-keep-cljs -t "pattern"`
+- **Test:** `yarn test-unit-keep-cljs 'path/to/file.unit.spec.js'` or `yarn test-unit-keep-cljs -t "pattern"`
 - **Format:** `yarn prettier`
 - **Type Check:** `yarn type-check-pure`
 
@@ -29,8 +29,8 @@
   - Use the linter as a way to know that you are adhering to conventions in place in the codebase
 - **Lint Changes:** `./bin/mage kondo-updated HEAD`
 - **Format:** `./bin/mage cljfmt-files [path]`
-- **Run a test:** `./bin-mage run-tests namespace/test-name`
-- **Run all tests in a namespace:** `./bin-mage run-tests namespace`
+- **Run a test:** `./bin/mage run-tests 'namespace/test-name'`
+- **Run all tests in a namespace:** `./bin/mage run-tests 'namespace'`
 - **Check Code Readability** `./bin/mage -check-readable` with optional line-number
   - Run this after every change to Clojure code, only accept readable code
 - **Evaluating Clojure Code** `./bin/mage -repl '<code>'`

--- a/src/metabase/api/docs.clj
+++ b/src/metabase/api/docs.clj
@@ -19,8 +19,8 @@
      (-> (response/resource-response "openapi/index.html")
          (content-type/content-type-response {:uri "index.html"})
          ;; Better would be to append this to our CSP, but there is no good way right now and it's just a single page.
-         ;; Necessary for Scalar to work, script injects styles in runtime.
-         (assoc-in [:headers "Content-Security-Policy"] "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net"))))
+         ;; Necessary for Scalar to work, script injects styles in runtime, and executes some WebAssembly.
+         (assoc-in [:headers "Content-Security-Policy"] "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net"))))
 
   ([request respond raise]
    (try

--- a/test/metabase/api/macros/defendpoint/open_api_test.clj
+++ b/test/metabase/api/macros/defendpoint/open_api_test.clj
@@ -8,14 +8,6 @@
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]))
 
-(deftest ^:parallel json-schema-conversion
-  (testing ":maybe turns into optionality"
-    (is (= {:type       :object
-            :required   []
-            :properties {"name" {:type :string}}}
-           (#'defendpoint.open-api/fix-json-schema
-            (mjs/transform [:map [:name [:maybe string?]]]))))))
-
 (deftest ^:parallel json-schema-conversion-2
   (testing ":json-schema basically works (see definition of :metabase.lib.schema.common/non-blank-string)"
     (is (=? {:$ref        "#/definitions/metabase.lib.schema.common.non-blank-string"
@@ -51,8 +43,9 @@
   (testing "nested data structures are still fixed up"
     (is (=? {:type  :array
              :items {:type       :object
-                     :properties {"params" {:type :array
-                                            :items {:type :string}}}}}
+                     :properties {"params" {:oneOf [{:type  :array
+                                                     :items {:type :string}}
+                                                    {:type :null}]}}}}
             (#'defendpoint.open-api/fix-json-schema
              (mjs/transform [:sequential [:map
                                           [:params {:optional true} [:maybe [:sequential :string]]]]]))))))

--- a/test/metabase/api/open_api_test.clj
+++ b/test/metabase/api/open_api_test.clj
@@ -118,15 +118,17 @@
   (is (=? {:post
            {:parameters [{:in       :query
                           :name     "collection"
-                          :required false
-                          :schema   {:type :array
-                                     :items
-                                     {:type    :integer
-                                      :minimum 1}}}
+                          :required true
+                          :schema   {:oneOf [{:type :array
+                                              :items
+                                              {:type    :integer
+                                               :minimum 1}}
+                                             {:type :null}]}}
                          {:in       :query
                           :name     "settings"
-                          :required false
-                          :schema   {:type :boolean}}
+                          :required true
+                          :schema   {:oneOf [{:type :boolean}
+                                             {:type :null}]}}
                          {:in       :query
                           :name     "data-model"
                           :required false
@@ -162,17 +164,19 @@
                  {:type     :object
                   :required ["dashcards"]
                   :properties
-                  {"name"      {:$ref "#/components/schemas/metabase.lib.schema.common.non-blank-string"}
+                  {"name"      {:oneOf [{:$ref "#/components/schemas/metabase.lib.schema.common.non-blank-string"}
+                                        {:type :null}]}
                    "dashcards" {:type :array
                                 :description string?
                                 :items       {:type       :object
                                               :required   ["id"]
                                               :properties {"id"     {:type :integer}
-                                                           "params" {:type  :array
-                                                                     :items {:type       :object
-                                                                             :required   ["param_id" "target"]
-                                                                             :properties {"param_id" {}
-                                                                                          "target"   {}}}}}}}}}}}}}}}}
+                                                           "params" {:oneOf [{:type  :array
+                                                                              :items {:type       :object
+                                                                                      :required   ["param_id" "target"]
+                                                                                      :properties {"param_id" {}
+                                                                                                   "target"   {}}}}
+                                                                             {:type :null}]}}}}}}}}}}}}}
           (-> (open-api/open-api-spec (api.macros/ns-handler 'metabase.api.open-api-test) "")
               (get-in [:paths "/complex/{id}"])))))
 


### PR DESCRIPTION
- Scalar apparently uses WebAssembly now and was dying w/o unsafe-eval.
- Our code worked hard to make `[:maybe ...]` more representative in json schema so that RapiDoc will show them adequately, but now Scalar is a bit smarter plus TypeScript generation works better with unmodified results, so let's just drop this code.
