### PR TITLE
fix(embed-js): black background is shown on systems with dark mode preferences

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
@@ -465,6 +465,26 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
         H.getSimpleEmbedIframeContent().should("not.contain", "Orders model");
       });
     });
+
+    it("should not define color-scheme meta tag on embeds (metabase#65533)", () => {
+      H.visitCustomHtmlPage(`
+        ${H.getNewEmbedScriptTag()}
+        ${H.getNewEmbedConfigurationScript()}
+        <metabase-question question-id="new" />
+      `);
+
+      H.waitForSimpleEmbedIframesToLoad();
+
+      cy.get("iframe[data-metabase-embed]")
+        .its("0.contentDocument")
+        .within(() => {
+          cy.log("a generic meta tag should exist");
+          cy.get("meta[name='viewport']").should("exist");
+
+          cy.log("the color-scheme tag should not exist on EAJS embeds");
+          cy.get("meta[name='color-scheme']").should("not.exist");
+        });
+    });
   });
 
   describe("sync vs async vs defer script loading", () => {

--- a/resources/frontend_client/index_template.html
+++ b/resources/frontend_client/index_template.html
@@ -16,7 +16,6 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="base-href" content="{{{baseHref}}}" />
     <meta name="uri" content="{{{uri}}}" />
-    <meta name="color-scheme" content="light dark" />
 
     {{{embedCode}}}
 

--- a/resources/frontend_client/index_template.html
+++ b/resources/frontend_client/index_template.html
@@ -16,6 +16,10 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="base-href" content="{{{baseHref}}}" />
     <meta name="uri" content="{{{uri}}}" />
+    
+    {{#hasColorSchemeMetaTag}}
+    <meta name="color-scheme" content="light dark" />
+    {{/hasColorSchemeMetaTag}}
 
     {{{embedCode}}}
 

--- a/src/metabase/server/routes/index.clj
+++ b/src/metabase/server/routes/index.clj
@@ -78,33 +78,35 @@
         (throw (Exception. message e))))))
 
 (defn- template-parameters
-  [embeddable? {:keys [uri params nonce]}]
+  [entrypoint-name embeddable? {:keys [uri params nonce]}]
   (let [{:keys [anon-tracking-enabled google-auth-client-id], :as public-settings} (setting/user-readable-values-map #{:public})
         ;; We disable `locale` parameter on static embeds/public links (metabase#50313)
         should-load-locale-params? (not embeddable?)]
-    {:bootstrapJS          (load-inline-js "index_bootstrap")
-     :bootstrapJSON        (escape-script (json/encode public-settings))
-     :assetOnErrorJS       (load-inline-js "asset_loading_error")
-     :userLocalizationJSON (escape-script (load-localization (when should-load-locale-params? (:locale params))))
-     :siteLocalizationJSON (escape-script (load-localization (system/site-locale)))
-     :nonceJSON            (escape-script (json/encode nonce))
-     :language             (hiccup.util/escape-html (or (i18n/user-locale-string) (system/site-locale)))
-     :favicon              (hiccup.util/escape-html (let [custom-favicon (appearance/application-favicon-url)]
-                                                      (if (and config/is-dev?
-                                                               (= custom-favicon "app/assets/img/favicon.ico"))
-                                                        "app/assets/img/favicon-dev.ico"
-                                                        custom-favicon)))
-     :applicationName      (hiccup.util/escape-html (appearance/application-name))
-     :uri                  (hiccup.util/escape-html uri)
-     :baseHref             (hiccup.util/escape-html (base-href))
-     :embedCode            (when embeddable? (embed/head uri))
-     :enableGoogleAuth     (boolean google-auth-client-id)
-     :enableAnonTracking   (boolean anon-tracking-enabled)}))
+    {:bootstrapJS            (load-inline-js "index_bootstrap")
+     :bootstrapJSON          (escape-script (json/encode public-settings))
+     :assetOnErrorJS         (load-inline-js "asset_loading_error")
+     :userLocalizationJSON   (escape-script (load-localization (when should-load-locale-params? (:locale params))))
+     :siteLocalizationJSON   (escape-script (load-localization (system/site-locale)))
+     :nonceJSON              (escape-script (json/encode nonce))
+     :language               (hiccup.util/escape-html (or (i18n/user-locale-string) (system/site-locale)))
+     :favicon                (hiccup.util/escape-html (let [custom-favicon (appearance/application-favicon-url)]
+                                                        (if (and config/is-dev?
+                                                                 (= custom-favicon "app/assets/img/favicon.ico"))
+                                                          "app/assets/img/favicon-dev.ico"
+                                                          custom-favicon)))
+     :applicationName        (hiccup.util/escape-html (appearance/application-name))
+     :uri                    (hiccup.util/escape-html uri)
+     :baseHref               (hiccup.util/escape-html (base-href))
+     :embedCode              (when embeddable? (embed/head uri))
+     :enableGoogleAuth       (boolean google-auth-client-id)
+     :enableAnonTracking     (boolean anon-tracking-enabled)
+     ;; (metabase#65533) color-scheme meta tag breaks EAJS because it has a transparent background.
+     :hasColorSchemeMetaTag  (not= entrypoint-name "embed-sdk")}))
 
 (defn- load-entrypoint-template [entrypoint-name embeddable? opts]
   (load-template
    (str "frontend_client/" entrypoint-name ".html")
-   (template-parameters embeddable? opts)))
+   (template-parameters entrypoint-name embeddable? opts)))
 
 (defn- load-init-template []
   (load-template

--- a/test/metabase/server/routes/index_test.clj
+++ b/test/metabase/server/routes/index_test.clj
@@ -85,14 +85,3 @@
     ;; but we can override with the user locale
     (binding [i18n/*user-locale* "fr"]
       (is (= "fr" (:language (#'index/template-parameters "index" false {})))))))
-
-(deftest color-scheme-meta-tag-test
-  (mt/with-temp-env-var-value! [mb-premium-embedding-token "test-token"]
-    (testing "color-scheme meta tag should be present for static embedding"
-      (let [embed-html (#'index/load-entrypoint-template "embed" true {})]
-        (is (re-find #"<meta name=\"color-scheme\" content=\"light dark\"" embed-html)
-            "embed entrypoint should have color-scheme meta tag")))
-    (testing "color-scheme meta tag should NOT be present for EAJS"
-      (let [embed-sdk-html (#'index/load-entrypoint-template "embed-sdk" true {})]
-        (is (not (re-find #"<meta name=\"color-scheme\" content=\"light dark\"" embed-sdk-html))
-            "embed-sdk entrypoint should NOT have color-scheme meta tag")))))

--- a/test/metabase/server/routes/index_test.clj
+++ b/test/metabase/server/routes/index_test.clj
@@ -76,12 +76,23 @@
 
 (deftest load-entrypoint-template-contains-user-locale
   (binding [i18n/*user-locale* "es"]
-    (is (= "es" (:language (#'index/template-parameters false {})))))
+    (is (= "es" (:language (#'index/template-parameters "index" false {})))))
   (binding [i18n/*user-locale* "en"]
-    (is (= "en" (:language (#'index/template-parameters false {})))))
+    (is (= "en" (:language (#'index/template-parameters "index" false {})))))
   (mt/with-temporary-setting-values [site-locale "es"]
     ;; site locale is used as the default
-    (is (= "es" (:language (#'index/template-parameters false {}))))
+    (is (= "es" (:language (#'index/template-parameters "index" false {}))))
     ;; but we can override with the user locale
     (binding [i18n/*user-locale* "fr"]
-      (is (= "fr" (:language (#'index/template-parameters false {})))))))
+      (is (= "fr" (:language (#'index/template-parameters "index" false {})))))))
+
+(deftest color-scheme-meta-tag-test
+  (mt/with-temp-env-var-value! [mb-premium-embedding-token "test-token"]
+    (testing "color-scheme meta tag should be present for static embedding"
+      (let [embed-html (#'index/load-entrypoint-template "embed" true {})]
+        (is (re-find #"<meta name=\"color-scheme\" content=\"light dark\"" embed-html)
+            "embed entrypoint should have color-scheme meta tag")))
+    (testing "color-scheme meta tag should NOT be present for EAJS"
+      (let [embed-sdk-html (#'index/load-entrypoint-template "embed-sdk" true {})]
+        (is (not (re-find #"<meta name=\"color-scheme\" content=\"light dark\"" embed-sdk-html))
+            "embed-sdk entrypoint should NOT have color-scheme meta tag")))))


### PR DESCRIPTION
Closes #65533
Closes EMB-966

Conditionally applies the change from #64324 which was causing EAJS to display a black background color:

<img width="600" alt="CleanShot 2568-11-06 at 20 29 49@2x" src="https://github.com/user-attachments/assets/62b2292f-d409-4c17-9ce9-64a455bc249e" />

The reason for this is that EAJS iframes are transparent by default, and the meta tag sets the iframe's background color to follow system preferences (i.e. light or dark). Even if users are on dark mode, that should not set the background to dark by default.

I tried setting `bg="bg-primary"`, but that still causes a flash of dark background while the React components are being loaded.

For now, we simply stop applying `color-scheme` in EAJS.