### PR TITLE
metabot request cancelation

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
@@ -68,7 +68,7 @@
       :history         history
       :state           state
       :on-complete     (fn [lines]
-                         (store-message! conversation_id profile-id (metabot-v3.u/aisdk->messages "assistant" lines))
+                         (store-message! conversation_id profile-id (metabot-v3.u/aisdk->messages :assistant lines))
                          :store-in-db)})))
 
 (api.macros/defendpoint :post "/agent-streaming"

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/client_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/client_test.clj
@@ -75,7 +75,7 @@
             (is (string? body))
             (is (=? [{:_type :TEXT :content "a1a2a3"}
                      {:_type :FINISH_MESSAGE :finish_reason "stop"}]
-                    (metabot-v3.util/aisdk->messages "assistant" (str/split-lines body))))))))))
+                    (metabot-v3.util/aisdk->messages :assistant (str/split-lines body))))))))))
 
 (deftest example-generation-payload-unknown-field-types-test
   (let [mp (mt/metadata-provider)]

--- a/src/metabase/server/streaming_response.clj
+++ b/src/metabase/server/streaming_response.clj
@@ -19,6 +19,7 @@
    (jakarta.servlet AsyncContext)
    (jakarta.servlet.http HttpServletResponse)
    (java.io BufferedWriter OutputStream OutputStreamWriter)
+   (java.net SocketException)
    (java.nio ByteBuffer)
    (java.nio.channels ClosedChannelException SocketChannel)
    (java.nio.charset StandardCharsets)
@@ -188,6 +189,7 @@
           false)))
     (catch InterruptedException _ false)
     (catch ClosedChannelException _ true)
+    (catch SocketException _ true)
     (catch Throwable e
       (log/error e "Error determining whether HTTP request was canceled")
       false)))

--- a/test/metabase/server/streaming_response_test.clj
+++ b/test/metabase/server/streaming_response_test.clj
@@ -184,11 +184,9 @@
                                    :decompress-body false})]
             (.read ^java.io.InputStream (:body res)) ;; start the handler
             (.close ^java.io.Closeable (:body res))
-            (loop [i 10] ;; poll for request cancellation
-              (when (and (pos? i)
-                         (not @canceled))
-                (Thread/sleep 5)
-                (recur (dec i))))
+            (u/poll {:thunk       #(deref canceled)
+                     :done?       some?
+                     :interval-ms 5})
             ;; it's been 29 when I tested this, if it every becomes flaky maybe decrease the number?
             (is (< 20 @cnt) "Stopped writing when channel closed")
             (testing "canceled-chan is working"


### PR DESCRIPTION
second part of request cancellation, this time it is actually working and tests are synchronized with real-world behavior.