### PR TITLE
EAJS wizard should derive a lighter dashboard background color

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/dynamic-sdk-color-defaults.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/dynamic-sdk-color-defaults.ts
@@ -15,7 +15,7 @@ export const EMBED_FLOW_DERIVED_COLORS_CONFIG: EmbedFlowDerivedDefaultColorConfi
       dark: { source: "background", lighten: 0.2 },
     },
     "background-secondary": {
-      light: { source: "background", darken: 0.05 },
+      light: { source: "background", darken: 0.02 },
       dark: { source: "background", darken: 0.2 },
     },
     "background-light": {


### PR DESCRIPTION
Closes UXW-2233

Right now the derived dashboard background in EAJS wizard is too grey and looks like Windows 95:

<img width="2082" height="1638" alt="image" src="https://github.com/user-attachments/assets/efbd7b54-52d8-49a0-8765-0adbd92dabce" />

We should adjust this to be a lighter derived color.

### How to verify

1. Go to EAJS wizard. You can use the sharing menu > Embedded Analytics JS
2. Select a dashboard.
3. Make sure you are in the default color. If not, reset it.
4. Background color of dashboards now have a lighter tone that more closely matches Orion 5 in the main app (i.e. `hsla(240, 100%, 99%, 1)`):

<img width="2586" height="1710" alt="image" src="https://github.com/user-attachments/assets/5c6343a2-649e-4efd-ac97-e9d2fc3722a1" />