### PR TITLE
Fix docs scalar version

### DIFF
--- a/resources/openapi/index.html
+++ b/resources/openapi/index.html
@@ -14,6 +14,7 @@
   </style>
   <body>
     <script id="api-reference" data-url="openapi.json"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.39.1/dist/browser/standalone.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.39.1/dist/style.min.css">
   </body>
 </html>

--- a/resources/openapi/index_external.html.mustache
+++ b/resources/openapi/index_external.html.mustache
@@ -74,6 +74,7 @@ redirect_from:
   <body>
     <script id="api-reference" data-url="{{json_url}}"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.39.1/dist/browser/standalone.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.39.1/dist/style.min.css">
   </body>
 </html>


### PR DESCRIPTION
fixes https://github.com/metabase/metabase/issues/65551

39.2 of scalar uses webassembly and breaks. pin to 39.1