### PR TITLE
update color scheme for google button

### DIFF
--- a/frontend/src/metabase/auth/components/GoogleButton/GoogleButton.tsx
+++ b/frontend/src/metabase/auth/components/GoogleButton/GoogleButton.tsx
@@ -71,6 +71,8 @@ export const GoogleButton = ({ redirectUrl, isCard }: GoogleButtonProps) => {
               theme={
                 resolvedColorScheme === "dark" ? "filled_black" : "outline"
               }
+              // This is needed to ensure that no white border shows up around the
+              // login button in dark mode (UXW-2138)
               containerProps={{
                 style: { colorScheme: "light" },
               }}

--- a/frontend/src/metabase/auth/components/GoogleButton/GoogleButton.tsx
+++ b/frontend/src/metabase/auth/components/GoogleButton/GoogleButton.tsx
@@ -71,6 +71,9 @@ export const GoogleButton = ({ redirectUrl, isCard }: GoogleButtonProps) => {
               theme={
                 resolvedColorScheme === "dark" ? "filled_black" : "outline"
               }
+              containerProps={{
+                style: { colorScheme: "light" },
+              }}
             />
           </GoogleOAuthProvider>
           <Checkbox


### PR DESCRIPTION
closes https://github.com/metabase/metabase/issues/65600
Closes uxw-2138

### Description
I can only make guesses why this works, but I'm assuming the iFrame is picking up the color scheme of the parent and inverting colors because of it. 

### How to verify
1. Set up google auth on your instance
2. You may need to adjust `src/metabase/server/middleware/security.clj` to allow "*" in the `:frame-src`
3. Log in through google, then sign out. You should see your google profile photo, and hopefully now white borders.

### Demo

<img width="556" height="460" alt="image" src="https://github.com/user-attachments/assets/f0201803-c69e-42cc-a7e5-36d0c8d0fc18" />
<img width="653" height="489" alt="image" src="https://github.com/user-attachments/assets/c6de6d03-7bc4-40c2-81c8-6712bee0c261" />


### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
