### PR TITLE
Update mongo test after driver upgrade

### DIFF
--- a/modules/drivers/mongo/test/metabase/driver/mongo/execute_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/execute_test.clj
@@ -89,7 +89,7 @@
                     (a/>!! canceled-chan ::streaming-response/request-canceled))
             (testing "Cancel signal kills the in progress query"
               (is (thrown-with-msg? Throwable
-                                    #"Command failed with error 11601.*operation was interrupted"
+                                    #"Command execution failed on MongoDB server with error 11601 \(Interrupted\)"
                                     (qp/process-query query))))))))))
 
 (deftest ^:synchronized question-base-on-native-model-cache-test

--- a/modules/drivers/mongo/test/metabase/driver/mongo/execute_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/execute_test.clj
@@ -89,7 +89,7 @@
                     (a/>!! canceled-chan ::streaming-response/request-canceled))
             (testing "Cancel signal kills the in progress query"
               (is (thrown-with-msg? Throwable
-                                    #"Command execution failed on MongoDB server with error 11601 \(Interrupted\)"
+                                    #"Command.*failed.*11601"
                                     (qp/process-query query))))))))))
 
 (deftest ^:synchronized question-base-on-native-model-cache-test


### PR DESCRIPTION
### Description

Fixes the tests broke in https://github.com/metabase/metabase/actions/runs/19146548147/job/54730976837 after https://github.com/metabase/metabase/pull/64667/

### How to verify

All tests should pass

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
