### PR TITLE
Fix flaky recently-viewed.cy.spec.js

### DIFF
--- a/e2e/test/scenarios/admin/performance/helpers/e2e-performance-helpers.ts
+++ b/e2e/test/scenarios/admin/performance/helpers/e2e-performance-helpers.ts
@@ -177,6 +177,7 @@ export const millisecondsUntilEndOfHour = () => {
   return nextHour.getTime() - now.getTime();
 };
 
+/** Advances the server clock by a specific amount of milliseconds, then stops advancing automatically */
 export const advanceServerClockBy = (milliseconds: number) => {
   log(`Advancing clock by ${milliseconds}ms`);
   return cy.request("POST", "/api/testing/set-time", {

--- a/e2e/test/scenarios/admin/performance/preemptiveCaching.cy.spec.ts
+++ b/e2e/test/scenarios/admin/performance/preemptiveCaching.cy.spec.ts
@@ -37,6 +37,11 @@ describe(
         });
       });
 
+      after(() => {
+        // Reset the effect of calling `advanceServerClockBy` which pauses the server clock.
+        resetServerTime();
+      });
+
       function runPreemptiveCachingTest(questionId: string) {
         function visitCachedQuestion(questionId: string) {
           cy.log("Visiting the question");


### PR DESCRIPTION
Closes EMB-965
> [!note]
> this PR targets 56 directly, because there are already fixes on master, and 57 [ref1](https://github.com/metabase/metabase/pull/62309), [ref2](https://github.com/metabase/metabase/pull/64728)

### Description

This uses the same fix as in #62309. The reason is that the flaky tests are due to the side effects of other tests calling `/api/testing/set-time`, which pauses the server time, so the recently viewed items are created at the exact same time, causing the order to be incorrect.

### How to verify
The `recently-viewed.cy.spec.js` test (ee group 27) should pass the first time along with `preemptiveCaching.cy.spec.ts` (in our case, the first time the suite 27 failed to run altogether so that doesn't count), because if it reruns itself as seen on the backport PR, it will only run the failed test which won't run the test that causes the server time to be frozen in the first place. For example, this [first run](https://github.com/metabase/metabase/actions/runs/19148423785/job/54732869221?pr=65555) failed, but [the second one](https://github.com/metabase/metabase/actions/runs/19148423785/job/54735687054?pr=65555) that only ran the failed suite passed.

This couldn't be stress tested because it needs to run another test that freezes the server time too.

### Demo

#### Failed screenshot from Cypress
<img width="366" height="366" alt="image" src="https://github.com/user-attachments/assets/566e6dd4-8a0d-4593-aeac-d95c7147ead1" />

#### How it should look
<img width="343" height="303" alt="image" src="https://github.com/user-attachments/assets/a3250124-7c1d-40a4-b5f2-feda5151e721" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
