### PR TITLE
Support search weight overrides per request for tool calls

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
@@ -1045,7 +1045,8 @@
     [:created_at          {:optional true} [:maybe ms/NonBlankString]]
     [:last_edited_at      {:optional true} [:maybe ms/NonBlankString]]
     [:search_native_query {:optional true, :default false} [:maybe :boolean]]
-    [:limit               {:optional true, :default 50} [:and :int [:fn #(<= 1 % 100)]]]]
+    [:limit               {:optional true, :default 50} [:and :int [:fn #(<= 1 % 100)]]]
+    [:weights             {:optional true} [:map-of :keyword number?]]]
    [:map {:encode/tool-api-request
           #(update-keys % (comp keyword u/->kebab-case-en))}]])
 

--- a/enterprise/backend/src/metabase_enterprise/search/scoring.clj
+++ b/enterprise/backend/src/metabase_enterprise/search/scoring.clj
@@ -56,7 +56,7 @@
   {:name   (legacy-name k)
    :score  (let [f (get legacy-scorers k)]
              (f result))
-   :weight (search.config/weight :default k)})
+   :weight (search.config/weight {} k)})
 
 (defenterprise score-result
   "Scoring implementation that adds score for items in official collections."

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -790,7 +790,7 @@
             embedding-time-ms (u/since-ms timer)
 
             db-timer (u/start-timer)
-            weights (search.config/weights (:context search-context))
+            weights (search.config/weights search-context)
             scorers (scoring/semantic-scorers (:table-name index) search-context)
             query (scored-search-query index embedding search-context scorers)
             xform (comp (map decode-metadata)

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/scoring.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/scoring.clj
@@ -231,6 +231,6 @@
                          {:id 4 :model "indexed-entity"}
                          {:id 7 :model "card"}])
                        vec))
-  (def weights (search.config/weights (:context search-ctx)))
+  (def weights (search.config/weights search-ctx))
   (def app-db-scorers (appdb-scorers search-ctx))
   (with-appdb-scores search-ctx (appdb-scorers search-ctx) weights search-docs))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/search_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/search_test.clj
@@ -406,7 +406,7 @@
                        :model/Dashboard  {id-1 :id}    {:name "Regular Dash (sh1b0le#h)",    :collection_id coll-id}
                        :model/Dashboard  {id-2 :id}    {:name "Bookmarked Dash (sh1b0le#h)", :collection_id coll-id}
                        :model/DashboardBookmark _      {:dashboard_id id-2, :user_id api/*current-user-id*}]
-          (let [base-query   {:term-queries ["sh1b0l#h"], :entity-types ["dashboard"]}
+          (let [base-query   {:term-queries ["sh1b0le#h"], :entity-types ["dashboard"]}
                 test-entity? (comp #{id-1 id-2} :id)
                 query        (fn [& [weights]]
                                (->> (search/search (assoc base-query :weights weights))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/search_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/search_test.clj
@@ -1,5 +1,6 @@
 (ns metabase-enterprise.metabot-v3.tools.search-test
   (:require
+   [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase-enterprise.metabot-v3.tools.search :as search]
    [metabase.api.common :as api]
@@ -396,3 +397,20 @@
                 (let [no-desc-dash (u/seek #(= dash-3-id (:id %)) test-results)]
                   (is (nil? (get-in no-desc-dash [:collection :description])))
                   (is (= "No Description" (get-in no-desc-dash [:collection :name]))))))))))))
+
+(deftest weight-override-test
+  (testing "weights can be overridden on a per-tool-call basis"
+    (mt/with-test-user :crowberto
+      (search.tu/with-temp-index-table
+        (mt/with-temp [:model/Collection {coll-id :id} {}
+                       :model/Dashboard  {id-1 :id}    {:name "Regular Dash (sh1b0le#h)",    :collection_id coll-id}
+                       :model/Dashboard  {id-2 :id}    {:name "Bookmarked Dash (sh1b0le#h)", :collection_id coll-id}
+                       :model/DashboardBookmark _      {:dashboard_id id-2, :user_id api/*current-user-id*}]
+          (let [base-query   {:term-queries ["sh1b0l#h"], :entity-types ["dashboard"]}
+                test-entity? (comp #{id-1 id-2} :id)
+                query        (fn [& [weights]]
+                               (->> (search/search (assoc base-query :weights weights))
+                                    (filter test-entity?)
+                                    (map (comp first #(str/split % #"\s") :name))))]
+            (is (= ["Bookmarked" "Regular"] (query)))
+            (is (= ["Regular" "Bookmarked"] (query {:bookmarked -1})))))))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/scoring_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/scoring_test.clj
@@ -183,10 +183,10 @@
         [{:model "card"      :id 1 :name "view card"      :view_count 0}
          {:model "dashboard" :id 2 :name "view dashboard" :view_count 0}
          {:model "dataset"   :id 3 :name "view dataset"   :view_count 0}]
-        ;; fix some test flakes where dataset 3 exists and has some sort of recent views
-        (semantic.tu/with-weights (assoc (search.config/weights :default)
-                                         :user-recency 0
-                                         :rrf 0)
+        (semantic.tu/with-weights (search.config/weights {:context :default
+                                                          ;; fix some test flakes where dataset 3 exists and has some
+                                                          ;; sort of recent views
+                                                          :weights {:user-recency 0, :rrf 0}})
           (is (=? [{:model "dashboard", :id 2, :name "view dashboard"}
                    {:model "card",      :id 1, :name "view card"}
                    {:model "dataset",   :id 3, :name "view dataset"}]

--- a/src/metabase/search/api.clj
+++ b/src/metabase/search/api.clj
@@ -114,10 +114,8 @@
 (api.macros/defendpoint :get "/weights"
   "Return the current weights being used to rank the search results"
   [_route-params
-   {:keys [context]} :- [:map
-                         [:context {:default :default} :keyword]
-                         [:search_engine {:optional true} :any]]]
-  (search.config/weights context))
+   {:keys [context]} :- [:map [:context {:default :default} :keyword]]]
+  (search.config/weights {:context context}))
 
 ;; TODO (Cam 10/28/25) -- fix this endpoint so it uses kebab-case for query parameters for consistency with the rest
 ;; of the REST API
@@ -132,7 +130,7 @@
   (let [overrides (-> overrides (dissoc :search_engine :context) (update-vals parse-double))]
     (when (seq overrides)
       (set-weights! context overrides))
-    (search.config/weights context)))
+    (search.config/weights {:context context})))
 
 ;; TODO (Cam 10/28/25) -- fix this endpoint so it uses kebab-case for query parameters for consistency with the rest
 ;; of the REST API

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -252,7 +252,7 @@
    ;; TODO this is optional only for tests, clean those up!
    [:search-engine      {:optional true} keyword?]
    [:search-string      {:optional true} [:maybe ms/NonBlankString]]
-   [:weights                             [:maybe [:map-of :keyword number?]]]
+   [:weights            {:optional true} [:maybe [:map-of :keyword number?]]]
    ;;
    ;; optional
    ;;

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -191,15 +191,15 @@
   ([]
    (weights {}))
   ([{request-overrides :weights, :keys [context]}]
-   (let [context   (or context :default)
-         overrides (search.settings/experimental-search-weight-overrides)]
+   (let [context          (or context :default)
+         system-overrides (search.settings/experimental-search-weight-overrides)]
      (if (= :all context)
-       (merge-with merge static-weights overrides)
+       (merge-with merge static-weights system-overrides)
        (merge (get static-weights :default)
               ;; Not sure which of the next two should have precedence, arguments for both "¯\_(ツ)_/¯"
-              (get overrides :default)
+              (get system-overrides :default)
               (get static-weights context)
-              (get overrides context)
+              (get system-overrides context)
               request-overrides)))))
 
 (defn weight

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -188,27 +188,30 @@
 ;; This gets called *a lot* during a search request, so we'll almost certainly need to optimize it. Maybe just TTL.
 (defn weights
   "Strength of the various scorers. Copied from metabase.search.in-place.scoring, but allowing divergence."
-  [context]
-  (let [context   (or context :default)
-        overrides (search.settings/experimental-search-weight-overrides)]
-    (if (= :all context)
-      (merge-with merge static-weights overrides)
-      (merge (get static-weights :default)
-             ;; Not sure which of the next two should have precedence, arguments for both "¯\_(ツ)_/¯"
-             (get overrides :default)
-             (get static-weights context)
-             (get overrides context)))))
+  ([]
+   (weights {}))
+  ([{request-overrides :weights, :keys [context]}]
+   (let [context   (or context :default)
+         overrides (search.settings/experimental-search-weight-overrides)]
+     (if (= :all context)
+       (merge-with merge static-weights overrides)
+       (merge (get static-weights :default)
+              ;; Not sure which of the next two should have precedence, arguments for both "¯\_(ツ)_/¯"
+              (get overrides :default)
+              (get static-weights context)
+              (get overrides context)
+              request-overrides)))))
 
 (defn weight
   "The relative strength the corresponding score has in influencing the total score."
-  [context scorer-key]
-  (get (weights context) scorer-key (when-not (namespace scorer-key) 0)))
+  [search-ctx scorer-key]
+  (get (weights search-ctx) scorer-key (when-not (namespace scorer-key) 0)))
 
 (defn scorer-param
   "Get a nested parameter scoped to the given scorer"
-  [context scorer-key param-key]
+  [search-ctx scorer-key param-key]
   (let [flat-key (keyword (name scorer-key) (name param-key))]
-    (weight context flat-key)))
+    (weight search-ctx flat-key)))
 
 (defn model->alias
   "Given a model string returns the model alias"
@@ -249,6 +252,7 @@
    ;; TODO this is optional only for tests, clean those up!
    [:search-engine      {:optional true} keyword?]
    [:search-string      {:optional true} [:maybe ms/NonBlankString]]
+   [:weights                             [:maybe [:map-of :keyword number?]]]
    ;;
    ;; optional
    ;;

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -286,7 +286,8 @@
    [:include-metadata?                   {:optional true} [:maybe boolean?]]
    [:non-temporal-dim-ids                {:optional true} [:maybe ms/NonBlankString]]
    [:has-temporal-dim                    {:optional true} [:maybe :boolean]]
-   [:display-type                        {:optional true} [:maybe [:set ms/NonBlankString]]]])
+   [:display-type                        {:optional true} [:maybe [:set ms/NonBlankString]]]
+   [:weights                             {:optional true} [:maybe [:map-of :keyword number?]]]])
 
 (mu/defn search-context :- SearchContext
   "Create a new search context that you can pass to other functions like [[search]]."
@@ -317,7 +318,8 @@
            table-db-id
            verified
            non-temporal-dim-ids
-           has-temporal-dim]} :- ::search-context.input]
+           has-temporal-dim
+           weights]} :- ::search-context.input]
   ;; for prod where Malli is disabled
   {:pre [(pos-int? current-user-id) (set? current-user-perms)]}
   (when (some? verified)
@@ -340,7 +342,8 @@
                         :models                              models
                         :model-ancestors?                    (boolean model-ancestors?)
                         :search-engine                       engine
-                        :search-string                       search-string}
+                        :search-string                       search-string
+                        :weights                             weights}
                  (some? created-at)                          (assoc :created-at created-at)
                  (seq created-by)                            (assoc :created-by created-by)
                  (some? filter-items-in-personal-collection) (assoc :filter-items-in-personal-collection filter-items-in-personal-collection)

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -86,12 +86,12 @@
 
 (defn model-rank-expr
   "Score an item based on its :model type."
-  [{:keys [context]}]
+  [search-ctx]
   (let [search-order search.config/models-search-order
         n            (double (count search-order))
         cases        (map-indexed (fn [i sm]
                                     [[:= :search_index.model sm]
-                                     (or (search.config/scorer-param context :model sm)
+                                     (or (search.config/scorer-param search-ctx :model sm)
                                          [:inline (/ (- n i) n)])])
                                   search-order)]
     (-> (into [:case] cat (concat cases))
@@ -144,22 +144,22 @@
 
 (defn weighted-score
   "Multiply a score by its weight."
-  [context [column-alias expr]]
-  [:* [:inline (search.config/weight context column-alias)] expr])
+  [search-ctx [column-alias expr]]
+  [:* [:inline (search.config/weight search-ctx column-alias)] expr])
 
 (defn select-items
   "Select expressions for each scorer, plus a :total_score that is the weighted sum of the `scorers`."
-  [context scorers]
+  [search-ctx scorers]
   (concat
    (for [[column-alias expr] scorers]
      [expr column-alias])
-   [[(sum-columns (map (partial weighted-score context) scorers))
+   [[(sum-columns (map (partial weighted-score search-ctx) scorers))
      :total_score]]))
 
 (defn with-scores
   "Add a bunch of SELECT columns for the individual and total scores."
   [search-ctx scorers qry]
-  (apply sql.helpers/select qry (select-items (:context search-ctx) scorers)))
+  (apply sql.helpers/select qry (select-items search-ctx scorers)))
 
 (defn all-scores
   "Scoring stats for each `index-row`."

--- a/test/metabase/search/api_test.clj
+++ b/test/metabase/search/api_test.clj
@@ -1690,7 +1690,7 @@
 
 (deftest ^:synchronized weights-test
   (let [base-url         (weights-url)
-        original-weights (search.config/weights :default)]
+        original-weights (search.config/weights)]
     (mt/with-temporary-setting-values [experimental-search-weight-overrides nil]
       (testing "default weights"
         (is (= original-weights (mt/user-http-request :crowberto :get 200 base-url)))
@@ -1706,8 +1706,9 @@
   (mt/with-temporary-setting-values [experimental-search-weight-overrides nil]
     (testing "custom context"
       (let [context          :none-given
+            search-ctx       {:context context}
             context-url      (weights-url context {})
-            original-weights (search.config/weights context)]
+            original-weights (search.config/weights search-ctx)]
         (is (= original-weights (mt/user-http-request :crowberto :get 200 context-url)))
         (mt/user-http-request :rasta :put 403 (weights-url context {:recency 5}))
         (is (= original-weights
@@ -1724,8 +1725,9 @@
     (mt/with-temporary-setting-values [experimental-search-weight-overrides nil]
       (testing "all weights (nested)"
         (let [context     :all
+              search-ctx  {:context context}
               context-url (weights-url context {})
-              all-weights (search.config/weights context)]
+              all-weights (search.config/weights search-ctx)]
           (is (= all-weights (mt/user-http-request :crowberto :get 200 context-url)))
           (is (= (mt/user-http-request :crowberto :get 200 base-url)
                  (:default (mt/user-http-request :crowberto :get 200 context-url))))
@@ -1741,13 +1743,14 @@
 (deftest ^:synchronized weights-test-4
   (mt/with-temporary-setting-values [experimental-search-weight-overrides nil]
     (testing "ranker parameters"
-      (let [context :just-for-fun]
+      (let [context    :just-for-fun
+            search-ctx {:context context}]
         (is (=? {:model/dataset 10.0}
                 (mt/user-http-request :crowberto :put 200 (weights-url context {:model/dataset 10}))))
-        (is (= 10.0 (search.config/scorer-param context :model :dataset)))
+        (is (= 10.0 (search.config/scorer-param search-ctx :model :dataset)))
         (is (=? {:model/dataset 5.0}
                 (mt/user-http-request :crowberto :put 200 (weights-url context {:model/dataset 5}))))
-        (is (= 5.0 (search.config/scorer-param context :model :dataset)))))))
+        (is (= 5.0 (search.config/scorer-param search-ctx :model :dataset)))))))
 
 (deftest ^:synchronized dashboard-questions
   (testing "Dashboard questions get a dashboard_id when searched"

--- a/test/metabase/search/appdb/scoring_test.clj
+++ b/test/metabase/search/appdb/scoring_test.clj
@@ -184,11 +184,12 @@
        {:model "dashboard" :id 2 :name "view dashboard" :view_count 0}
        {:model "dataset"   :id 3 :name "view dataset"   :view_count 0}]
       ;; fix some test flakes where dataset 3 exists and has some sort of recent views
-      (with-weights (assoc (search.config/weights {:search-engine "appdb"}) :user-recency 0)
-        (is (=? [{:model "dashboard", :id 2, :name "view dashboard"}
-                 {:model "card",      :id 1, :name "view card"}
-                 {:model "dataset",   :id 3, :name "view dataset"}]
-                (search-results** "view" {})))))))
+      (let [search-ctx {:search-engine "appdb", :weights {:user-recency 0}}]
+        (with-weights (search.config/weights search-ctx)
+          (is (=? [{:model "dashboard", :id 2, :name "view dashboard"}
+                   {:model "card", :id 1, :name "view card"}
+                   {:model "dataset", :id 3, :name "view dataset"}]
+                  (search-results** "view" {}))))))))
 
 (deftest view-count-edge-case-test
   (testing "view count max out at p99, outlier is not preferred"


### PR DESCRIPTION
This introduces the ability for metabot to override weights on a per request basis.

There are three levels at which we may want to leverage this:

1. Experimentation, to find the optimal passive weights for the bot.
2. To specialize further, based on convesation type (e.g. codegen versus text-to-sql)
3. To specialize even further on completely ad hoc basis (e.g. deliberately looking for something older)

Some background: https://metaboat.slack.com/archives/C09PCE0DPNZ/p1762453298474519
