### PR TITLE
[perf] Improve quadratic lookups in `add-alias-info`

### DIFF
--- a/src/metabase/query_processor/util/add_alias_info.clj
+++ b/src/metabase/query_processor/util/add_alias_info.clj
@@ -49,6 +49,7 @@
    [metabase.lib.equality :as lib.equality]
    [metabase.lib.options :as lib.options]
    [metabase.lib.schema :as lib.schema]
+   [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.join :as lib.schema.join]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.lib.util.match :as lib.util.match]
@@ -273,10 +274,12 @@
     (m/update-existing stage :aggregation update-aggregations)))
 
 (mu/defn- add-desired-aliases-to-refs :- ::lib.schema/stage.mbql
-  [query            :- ::lib.schema/query
-   path             :- ::lib.walk/path
-   returned-columns :- :metabase.lib.metadata.calculation/returned-columns
-   stage            :- ::lib.schema/stage.mbql]
+  [query              :- ::lib.schema/query
+   path               :- ::lib.walk/path
+   by-id              :- [:map-of ::lib.schema.id/field [:sequential ::lib.schema.metadata/column]]
+   by-source-alias    :- [:map-of :string [:sequential ::lib.schema.metadata/column]]
+   by-expression-name :- [:map-of :string ::lib.schema.metadata/column]
+   stage              :- ::lib.schema/stage.mbql]
   (lib.util.match/replace stage
     ;; don't recurse into the metadata or joins -- [[lib.walk]] will take care of that recursion for us.
     (_ :guard (constantly (some (set &parents) [:lib/stage-metadata :joins ::resolved])))
@@ -287,11 +290,13 @@
                        (throw (ex-info "Missing ::resolved -- should have been added by add-source-aliases"
                                        {:field-ref &match
                                         :path      (concat path &parents)})))
-          ;; PERF: This is quadratic: O(refs-in-stage * returned-columns)!
-          ;; There's not a direct way to index this since [[lib.equality/=]] is too fuzzy for that.
-          ;; Even a partial fix like (group-by f returned-columns) so that this is scanning a small plausible set
-          ;; of matches instead of everything would go a long way!
-          col      (m/find-first #(lib.equality/= % resolved) returned-columns)]
+          ;; Sometimes these maps of returned columns by `:id` and `:lib/source-column-alias` are not enough to find a
+          ;; match - but in that case no match can be found in the whole `returned-columns` either! So there's no need
+          ;; to search it, since we won't find a match for our `::resolved` column.
+          col      (or (when (:id resolved)
+                         (m/find-first #(lib.equality/= % resolved) (get by-id (:id resolved))))
+                       (m/find-first #(lib.equality/= % resolved)
+                                     (get by-source-alias (:lib/source-column-alias resolved))))]
       (-> &match
           (lib/update-options (fn [opts]
                                 (-> opts
@@ -299,8 +304,7 @@
                                     (dissoc ::resolved))))))
 
     [:expression _opts expression-name]
-    (let [col (m/find-first #(= (:lib/expression-name %) expression-name)
-                            returned-columns)]
+    (let [col (get by-expression-name expression-name)]
       (lib/update-options &match assoc ::desired-alias (escaped-desired-alias query path (:lib/desired-column-alias col))))
 
     [:aggregation _opts uuid]
@@ -313,10 +317,16 @@
   [query :- ::lib.schema/query
    path  :- ::lib.walk/path
    stage :- ::lib.schema/stage.mbql]
-  (let [returned-columns (returned-columns query path)]
+  (let [returned-columns   (returned-columns query path)
+        by-id              (u/group-by :id some? identity some? conj [] returned-columns)
+        by-source-alias    (u/group-by :lib/source-column-alias some? identity some? conj [] returned-columns)
+        by-expression-name (into {} (keep (fn [col]
+                                            (when-let [expr-name (:lib/expression-name col)]
+                                              [expr-name col])))
+                                 returned-columns)]
     (->> stage
          (add-desired-aliases-to-aggregations query path returned-columns)
-         (add-desired-aliases-to-refs query path returned-columns))))
+         (add-desired-aliases-to-refs query path by-id by-source-alias by-expression-name))))
 
 (mu/defn- add-alias-info-to-stage :- ::lib.schema/stage
   [query      :- ::lib.schema/query

--- a/test/metabase/query_processor/perf_test.clj
+++ b/test/metabase/query_processor/perf_test.clj
@@ -133,10 +133,10 @@
   ;; it's much more significant with nested queries, complex expressions and multiple joins.
   (compile-time mp-small  trivial-query computed-cache-off)
   (compile-time mp-small  trivial-query computed-cache-on)
-  (compile-time mp-medium trivial-query computed-cache-off)
-  (compile-time mp-medium trivial-query computed-cache-on)
-  (compile-time mp-large  trivial-query computed-cache-off)
-  (compile-time mp-large  trivial-query computed-cache-on)
+  (compile-time mp-medium trivial-query computed-cache-off) ; 13.15ms - down 6ms with post-`lib.computed` fixes
+  (compile-time mp-medium trivial-query computed-cache-on)  ; 13.02ms - likewise
+  (compile-time mp-large  trivial-query computed-cache-off) ; 128.2ms - down 120ms
+  (compile-time mp-large  trivial-query computed-cache-on)  ; 135.1ms - likewise
 
   ;; WARN: Don't run this one unless you're going to lunch, it's really slow to run that many times even with the
   ;; lib.computed caching on.
@@ -144,6 +144,7 @@
 
   ;; Instead, here's a single run with mp-huge:
   ;; Takes 11114ms with caching off, and 8825ms with it on for me.
+  ;; Now with the quadratic behavior in add-alias-info fixed, it takes 1440ms!
   (crit/time-body
    (mu/disable-enforcement
      (binding [lib.computed/*computed-cache* (computed-cache-off)]
@@ -152,6 +153,8 @@
 
   ;; Using the "huge query" MetadataProvider, the big user query that came with QUE-2686.
   ;; Starting point: 205ms
+  ;; Removed repeated MBQL 5 -> 4 -> 5 -> 4 conversions in `driver.sql.qp/preprocess`: down to 142ms
+  ;; Fixing add-alias-info quadratic lookups: down to 115ms
   (compile-time (constantly nil)
                 (fn [_mp] (lib.tu.huge/huge-query))
                 computed-cache-off)


### PR DESCRIPTION
Part of #64774.

### Description

Replaces quadratic (refs * columns) search in `add-alias-info` with map lookups
by ID and `:lib/source-column-alias`. They don't always succeed, but I ran the tests with a fallback case
that checked the old quadratic way too - in no case does the new match fail but the old way succeed.

- Speeds up the basic query of wide tables (see `qp.perf-test`) about 7x, from 8825ms to 1435ms.
- Reduces the big user query from #64774 from 205ms to 145ms on my machine.

### How to verify

No visible changes aside from the speed boost.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
