### PR TITLE
Fix: UXW-2235 Prevents 403s from SmartLinks from hiding the whole document

### DIFF
--- a/e2e/test/scenarios/documents/document-links.cy.spec.ts
+++ b/e2e/test/scenarios/documents/document-links.cy.spec.ts
@@ -1,0 +1,78 @@
+import { PRODUCTS_AVERAGE_BY_CATEGORY } from "e2e/support/test-visualizer-data";
+
+const { H } = cy;
+
+describe("Links in documents", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    H.activateToken("bleeding-edge");
+  });
+
+  describe("smart links", () => {
+    beforeEach(() => {
+      H.createQuestion(PRODUCTS_AVERAGE_BY_CATEGORY, { wrapId: true });
+      cy.get("@questionId").then((questionId) => {
+        H.createDocument({
+          name: "Document with SmartLinks",
+          document: {
+            type: "doc",
+            content: [
+              {
+                type: "paragraph",
+                content: [
+                  { type: "text", text: "See " },
+                  {
+                    type: "smartLink",
+                    attrs: {
+                      entityId: questionId,
+                      model: "card",
+                      label: "cached name",
+                    },
+                  },
+                  { type: "text", text: "." },
+                ],
+              },
+            ],
+          },
+          idAlias: "documentId",
+        });
+      });
+    });
+
+    it("should display the most up-to-date title for the entity it references", () => {
+      H.visitDocument("@documentId");
+
+      H.documentContent().should(
+        "contain.text",
+        `See ${PRODUCTS_AVERAGE_BY_CATEGORY.name}`,
+      );
+
+      H.documentContent()
+        .findByRole("link", {
+          name: new RegExp(PRODUCTS_AVERAGE_BY_CATEGORY.name),
+        })
+        .should("exist");
+
+      H.documentContent()
+        .findByRole("link", { name: /cached name/ })
+        .should("not.exist");
+    });
+
+    it("should display 'No access' if the user doesn't have permission to see the link", () => {
+      cy.get("@questionId").then((questionId) => {
+        cy.intercept("GET", `/api/card/${questionId}`, {
+          statusCode: 403,
+        });
+      });
+      H.visitDocument("@documentId");
+
+      H.documentContent().should("contain.text", "See No access");
+      H.documentContent()
+        .findByText("No access")
+        .should("exist")
+        .icon("eye_crossed_out")
+        .should("exist");
+    });
+  });
+});

--- a/frontend/src/metabase-types/api/collection.ts
+++ b/frontend/src/metabase-types/api/collection.ts
@@ -162,6 +162,7 @@ export interface CollectionListQuery {
 export type getCollectionRequest = {
   id: CollectionId;
   namespace?: "snippets";
+  ignore_error?: boolean;
 };
 
 export type ListCollectionItemsSortColumn =

--- a/frontend/src/metabase/api/collection.ts
+++ b/frontend/src/metabase/api/collection.ts
@@ -70,11 +70,12 @@ export const collectionApi = Api.injectEndpoints({
       ],
     }),
     getCollection: builder.query<Collection, getCollectionRequest>({
-      query: ({ id, ...params }) => {
+      query: ({ id, ignore_error, ...params }) => {
         return {
           method: "GET",
           url: `/api/collection/${id}`,
           params,
+          noEvent: ignore_error,
         };
       },
       providesTags: (collection) =>


### PR DESCRIPTION
Closes UXW-2235

### Description

* Prevents 403s from SmartLinks from redirecting to the "Unauthorized" page
* Makes SmartLinks that receive a 403 error display a "No access" version
* (Tangential fix) Pasting a metric url into a document (e.g. http://localhost:3000/metric/119 ) will convert it to a smart link (similar to other Metabase entities).

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create a document as User A with smart links referencing things User A has access to but not User B
2. Save the document so that both User A and User B have access to it
3. Sign in as User B and navigate to said document
4. Verify document loads and any smart link that references something User B doesn't have access to shows the "No access" version.

### Demo

**Example document with admin-only smart links**
<img width="1158" height="991" alt="access" src="https://github.com/user-attachments/assets/26b170c3-ed79-4274-b2ea-18eaf91649a9" />

**BEFORE**
<img width="1156" height="1017" alt="before" src="https://github.com/user-attachments/assets/bf66efe5-c9a2-48a0-ad72-7770e5f33408" />

**AFTER**
<img width="1156" height="1017" alt="no-access" src="https://github.com/user-attachments/assets/e000e154-8cda-4eea-87f2-df08f5727523" />

TMI regarding user mentions: I don't think that endpoint ever 403s nor do we support user mentions in document bodies (just comments). I forced the endpoint to fail in the screenshot above just to make sure it's handled gracefully.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
