### PR TITLE
fix(modular): fix downloads on dashboards loaded by entityIds

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/interactive-dashboard.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-dashboard.cy.spec.tsx
@@ -291,6 +291,36 @@ describe("scenarios > embedding-sdk > interactive-dashboard", () => {
     cy.wait(500);
     cy.get("@datasetQuery.all").should("have.length", 1);
   });
+
+  idTypes.forEach(({ idType, dashboardIdAlias }) => {
+    it(`should be able to download dashcard results using ${idType}`, () => {
+      cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query/xlsx").as(
+        "dashcardDownload",
+      );
+
+      cy.get(dashboardIdAlias).then((dashboardId) => {
+        mountSdkContent(
+          <InteractiveDashboard dashboardId={dashboardId} withDownloads />,
+        );
+      });
+
+      getSdkRoot().within(() => {
+        cy.findByText("Orders in a dashboard").should("be.visible");
+
+        // Open dashcard menu
+        H.getDashboardCard().realHover();
+        H.getEmbeddedDashboardCardMenu().click();
+
+        H.popover().findByText("Download results").click();
+        H.popover().findByText(".xlsx").click();
+        H.popover().findByText("Download").click();
+      });
+
+      cy.wait("@dashcardDownload").then((interception) => {
+        expect(interception.response?.statusCode).to.equal(200);
+      });
+    });
+  });
 });
 
 describe("scenarios > embedding-sdk > interactive-dashboard > tabs", () => {

--- a/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
@@ -609,4 +609,27 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
       });
     });
   });
+
+  it("downloads should work when using entity IDs", () => {
+    cy.intercept("POST", "/api/card/*/query/xlsx").as("questionDownload");
+
+    cy.get<string>("@questionEntityId").then((questionEntityId) => {
+      mountSdkContent(
+        <InteractiveQuestion questionId={questionEntityId} withDownloads />,
+      );
+    });
+
+    getSdkRoot().within(() => {
+      cy.findByTestId("interactive-question-result-toolbar")
+        .findByTestId("question-download-widget-button")
+        .click();
+
+      cy.findByText(".xlsx").click();
+      cy.findByTestId("download-results-button").click();
+    });
+
+    cy.wait("@questionDownload").then((interception) => {
+      expect(interception.response?.statusCode).to.equal(200);
+    });
+  });
 });

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.tsx
@@ -72,7 +72,8 @@ export const DashCardMenu = ({
   const [{ loading: isDownloadingData }, handleDownload] = useDownloadData({
     question,
     result,
-    dashboardId: checkNotNull(dashboardId),
+    // dashboardId can be an entityId and the download endpoint expects a numeric id
+    dashboardId: checkNotNull(dashboard?.id ?? dashboardId),
     dashcardId,
     uuid,
     token,

--- a/frontend/src/metabase/dashboard/components/DashCard/PublicOrEmbeddedDashCardMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/PublicOrEmbeddedDashCardMenu.tsx
@@ -29,7 +29,7 @@ export const PublicOrEmbeddedDashCardMenu = ({
   const store = useStore();
   const token = getDashcardTokenId(dashcard);
   const uuid = getDashcardUuid(dashcard);
-  const { dashboardId } = useDashboardContext();
+  const { dashboard, dashboardId } = useDashboardContext();
 
   const [menuView, setMenuView] = useState<string | null>(null);
   const [isOpen, { close, toggle }] = useDisclosure(false, {
@@ -48,7 +48,8 @@ export const PublicOrEmbeddedDashCardMenu = ({
   const [{ loading: isDownloadingData }, handleDownload] = useDownloadData({
     question: question,
     result,
-    dashboardId: checkNotNull(dashboardId),
+    // dashboardId can be an entityId and the download endpoint expects a numeric id
+    dashboardId: checkNotNull(dashboard?.id ?? dashboardId),
     dashcardId: dashcard.id,
     uuid,
     token,


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #65602
Closes https://linear.app/metabase/issue/EMB-972/sdk-doesnt-support-download-on-dashbaord-with-entity-ids

## Description
This PR makes sure that we're using the numeric ID even when the dashboard is being loaded by an entity ID. The download endpoint doesn't support entity IDs and I don't think we want to add the support. We can just use the numeric ID from the front end since we already have that information. 

## How to verify:
- Use your preferred way to render an InteractiveDashboard with an entity id and `withDownloads`.
- download the results of a dashcard
- it should be failing before this pr, but it should be using the numeric id, and therefore work, in this pr