### PR TITLE
And basic recent views info to metabot user context

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1878,7 +1878,8 @@
            metabase-enterprise.metabot-v3.core
            metabase-enterprise.metabot-v3.init
            metabase-enterprise.metabot-v3.tools.api}
-   :uses #{api
+   :uses #{activity-feed
+           api
            app-db
            audit-app
            collections

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/context.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/context.clj
@@ -200,12 +200,9 @@
    (create-context context nil))
   ([context :- ::context
     opts    :- [:maybe [:map-of :keyword :any]]]
-   (def context context)
-   (def res
-     (-> context
-         enhance-context-with-schema
-         annotate-transform-source-types
-         add-backend-capabilities
-         add-recent-views
-         (set-user-time opts)))
-   res))
+   (-> context
+       enhance-context-with-schema
+       annotate-transform-source-types
+       add-backend-capabilities
+       add-recent-views
+       (set-user-time opts))))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/context.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/context.clj
@@ -4,6 +4,8 @@
    [medley.core :as m]
    [metabase-enterprise.metabot-v3.table-utils :as table-utils]
    [metabase-enterprise.transforms.util :as transforms.util]
+   [metabase.activity-feed.core :as activity-feed]
+   [metabase.api.common :as api]
    [metabase.config.core :as config]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
@@ -160,6 +162,30 @@
   [context]
   (update context :capabilities (fnil into #{}) (backend-metabot-capabilities)))
 
+(defn- add-recent-views
+  "Add user's recent views to the context since these have a higher likelihood of being relevant to a user's query.
+  Includes the 5 most recent items across cards, datasets, metrics, dashboards, and tables.
+  (Excludes collections and documents for now, which aren't searchable by Metabot.)"
+  [context]
+  (try
+    (let [recents (:recents (activity-feed/get-recents api/*current-user-id*
+                                                       [:views :selections]
+                                                       {:models [:card :dataset :metric :dashboard :table]}))
+          processed-recents (mapv (fn [item]
+                                    (let [item-type
+                                          (case (:model item)
+                                            :card "question"
+                                            :dataset "model"
+                                            (name (:model item)))]
+                                      (-> item
+                                          (select-keys [:id :name :description])
+                                          (assoc :type item-type))))
+                                  (take 5 recents))]
+      (assoc context :user_recently_viewed processed-recents))
+    (catch Exception e
+      (log/error e "Error adding recent views to metabot context")
+      context)))
+
 (defn- set-user-time
   [context {:keys [date-format] :or {date-format DateTimeFormatter/ISO_INSTANT}}]
   (let [offset-time (or (some-> context :current_time_with_timezone OffsetDateTime/parse)
@@ -174,8 +200,12 @@
    (create-context context nil))
   ([context :- ::context
     opts    :- [:maybe [:map-of :keyword :any]]]
-   (-> context
-       enhance-context-with-schema
-       annotate-transform-source-types
-       add-backend-capabilities
-       (set-user-time opts))))
+   (def context context)
+   (def res
+     (-> context
+         enhance-context-with-schema
+         annotate-transform-source-types
+         add-backend-capabilities
+         add-recent-views
+         (set-user-time opts)))
+   res))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/context_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/context_test.clj
@@ -217,3 +217,6 @@
                                                      :database (mt/id)}}}]}
           result (#'context/annotate-transform-source-types input)]
       (is (= :native (get-in result [:user_is_viewing 0 :source_type]))))))
+
+(deftest recent-views-in-context-test
+  (testing "Adds recent views to context"))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/context_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/context_test.clj
@@ -4,6 +4,7 @@
    [clojure.test :refer :all]
    [metabase-enterprise.metabot-v3.context :as context]
    [metabase-enterprise.metabot-v3.table-utils :as table-utils]
+   [metabase.activity-feed.models.recent-views :as recent-views]
    [metabase.lib.core :as lib]
    [metabase.lib.test-metadata :as meta]
    [metabase.test :as mt]))
@@ -219,4 +220,30 @@
       (is (= :native (get-in result [:user_is_viewing 0 :source_type]))))))
 
 (deftest recent-views-in-context-test
-  (testing "Adds recent views to context"))
+  (testing "Adds recent views to context"
+    (mt/with-test-user :rasta
+      (mt/with-temp [:model/Collection {col-id :id}   {}
+                     :model/Card       {card-id :id}   {:type "question"
+                                                        :name "my question"
+                                                        :description "question description"}
+                     :model/Card       {card-id-2 :id} {:type "question"
+                                                        :name "my question 2"
+                                                        :description "question description 2"}
+                     :model/Card       {model-id :id} {:type "model"
+                                                       :name "my model"
+                                                       :description "model description"}
+                     :model/Dashboard  {dash-id :id}  {:name "my dashboard"
+                                                       :description "dashboard description"}
+                     :model/Table      {table-id :id} {}]
+        (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Card card-id :view)
+        (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Card card-id-2 :view)
+        (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Card model-id :view)
+        (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Table table-id :selection)
+        (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Dashboard dash-id :view)
+        (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Collection col-id :view)
+        (let [recently-viewed (-> (context/create-context {})
+                                  :user_recently_viewed)]
+          (is (= 5 (count recently-viewed)))
+          ;; Assert that collection is excluded even though it was viewed most recently
+          (is (= #{"question" "model" "dashboard" "table"}
+                 (set (map :type recently-viewed)))))))))

--- a/src/metabase/activity_feed/core.clj
+++ b/src/metabase/activity_feed/core.clj
@@ -9,5 +9,6 @@
 (p/import-vars
  [metabase.activity-feed.models.recent-views
   fill-recent-view-info
+  get-recents
   rv-models
   update-users-recent-views!])

--- a/src/metabase/activity_feed/models/recent_views.clj
+++ b/src/metabase/activity_feed/models/recent_views.clj
@@ -26,7 +26,7 @@
   [Metrics] TODO:
   At some point in 2024, there was an attempt to add `metric` to the list of recent-view models. This
   was never completed, and the code has not been hooked up. There is no query for metrics, despite there being a
-  `:metric` model in the `models-of-interest` list. This is a TODO to complete this work."
+  `:metric` model in the `rv-models` list. This is a TODO to complete this work."
   (:require
    [clojure.set :as set]
    [colorize.core :as colorize]
@@ -62,7 +62,7 @@
 
 (def ^:dynamic *recent-views-stored-per-user-per-model*
   "The number of recently viewed items to keep per user per model. This is used to keep the most recent views of each
-  model type in [[models-of-interest]]."
+  model type in [[rv-models]]."
   20)
 
 (defn- duplicate-model-ids
@@ -79,12 +79,11 @@
                        (map :id)))))
 
 (def rv-models
-  "These are models for which we will retrieve recency."
-  (cond->
-   [:card :dataset :metric
-       ;; n.b.: `:card`, `metric` and `:model` are stored in recent_views as "card", and a join with report_card is
-       ;; needed to distinguish between them.
-    :dashboard :table :collection]
+  "Keywords representing entity types that can be returned as recent views."
+  ;; n.b.: `:card`, `metric` and `:dataset` are stored in recent_views as "card", and a join with report_card is
+  ;; needed to distinguish between them. `:dataset` is an alias for `:model/Card` with type "model".
+  (cond-> [:card :dataset :metric
+           :dashboard :table :collection]
     config/ee-available? (conj :document)))
 
 (mu/defn rv-model->model
@@ -164,6 +163,16 @@
     :left-join [[:report_dashboard :d]
                 [:= :recent_views.model_id :d.id]]}))
 
+(def ^:private card-type->rv-model
+  "Mapping from report_card.type to rv-model keyword."
+  {"model"    :dataset
+   "question" :card
+   "metric"   :metric})
+
+(def ^:private rv-model->card-type
+  "Mapping from rv-model keyword to report_card.type string."
+  (set/map-invert card-type->rv-model))
+
 (def Item
   "The shape of a recent view item, returned from `GET /recent_views`."
   (mc/schema
@@ -225,7 +234,7 @@
   exists). In these cases we simply do not include the value in the recent views response."
   {:arglists '([recent-view])}
   (fn [{:keys [model #_model_id #_timestamp card_type]}]
-    (or (get {"model" :dataset "question" :card "metric" :metric} card_type)
+    (or (card-type->rv-model card_type)
         (keyword model))))
 
 (defmethod fill-recent-view-info :default [m] (throw (ex-info "Unknown model" {:model m})))
@@ -481,37 +490,59 @@
   {:views      "view"
    :selections "selection"})
 
-(defn ^:private do-query [user-id context]
+(defn- rv-models->db-models
+  "Convert rv-model keywords to database model strings.
+  Note: :card, :dataset, and :metric all map to \"card\" in the database,
+  distinguished by report_card.type."
+  [models]
+  (when (seq models)
+    (distinct
+     (map (fn [model]
+            (case model
+              (:card :dataset :metric) "card"
+              (name model)))
+          models))))
+
+(defn ^:private do-query [user-id context models]
   (when-not (seq context)
     (throw (ex-info "context must be non-empty" {:context context})))
-  (t2/select :model/RecentViews {:select    [:rv.* [:rc.type :card_type]]
-                                 :from      [[:recent_views :rv]]
-                                 :where     [:and
-                                             [:= :rv.user_id user-id]
-                                             [:in :rv.context (map query-context->recent-context context)]
-                                             ;; include non-collections, or collections without a namespace/type.
-                                             [:or
-                                              [:= :coll.id nil]
-                                              [:and
-                                               ;; trash collection is never returned
-                                               [:or [:= nil :coll.type] [:not= :coll.type collection/trash-collection-type]]
-                                               ;; collections in a different namespace can't interact with collections
-                                               ;; in the normal NULL namespace.
-                                               [:= nil :coll.namespace]
-                                               ;; exclude instance analytics for selects
-                                               (when (contains? (set context) :selections)
-                                                 [:or [:= nil :coll.type] [:not= :coll.type collection/instance-analytics-collection-type]])]]]
-                                 :left-join [[:report_card :rc]
-                                             [:and
-                                              ;; only want to join on card_type if it's a card
-                                              [:= :rv.model "card"]
-                                              [:= :rc.id :rv.model_id]]
+  (let [db-models (rv-models->db-models models)]
+    (t2/select :model/RecentViews {:select    [:rv.* [:rc.type :card_type]]
+                                   :from      [[:recent_views :rv]]
+                                   :where     [:and
+                                               [:= :rv.user_id user-id]
+                                               [:in :rv.context (map query-context->recent-context context)]
+                                               (when (seq db-models)
+                                                 [:in :rv.model db-models])
+                                               ;; Additionally filter by card type to distinguish questions/models/metrics
+                                               (let [card-types (keep rv-model->card-type models)]
+                                                 (when (seq card-types)
+                                                   [:or
+                                                    [:!= :rv.model "card"]
+                                                    [:in :rc.type (map h2x/literal card-types)]]))
+                                               ;; include non-collections, or collections without a namespace/type.
+                                               [:or
+                                                [:= :coll.id nil]
+                                                [:and
+                                                 ;; trash collection is never returned
+                                                 [:or [:= nil :coll.type] [:not= :coll.type collection/trash-collection-type]]
+                                                 ;; collections in a different namespace can't interact with collections
+                                                 ;; in the normal NULL namespace.
+                                                 [:= nil :coll.namespace]
+                                                 ;; exclude instance analytics for selects
+                                                 (when (contains? (set context) :selections)
+                                                   [:or [:= nil :coll.type] [:not= :coll.type collection/instance-analytics-collection-type]])]]]
+                                   :left-join [[:report_card :rc]
+                                               [:and
+                                                ;; only want to join on card_type if it's a card
+                                                [:= :rv.model "card"]
+                                                [:= :rc.id :rv.model_id]]
 
-                                             [:collection :coll]
-                                             [:and
-                                              [:= :rv.model "collection"]
-                                              [:= :coll.id :rv.model_id]]]
-                                 :order-by  [[:rv.timestamp :desc]]}))
+                                               [:collection :coll]
+                                               [:and
+                                                [:= :rv.model "collection"]
+                                                [:= :coll.id :rv.model_id]]]
+                                   :order-by  [[:rv.timestamp :desc]]})))
 
 (mu/defn- model->return-model [model :- :keyword]
   (if (= :question model) :card model))
@@ -557,20 +588,29 @@
                   (me/humanize (mr/explain Item item))))))
 
 (mu/defn get-recents
-  "Gets all recent views for a given user, and context. Returns a list of at most 20 [[Item]]s per [[models-of-interest]], per context.
+  "Gets all recent views for a given user, and context. Returns a list of at most 20 [[Item]]s per [[rv-models]], per context.
 
   Returns: [:map [:recents [:sequential Item]]]
 
   [[do-query]] can return nils, and we remove them here becuase there can be recent views for deleted entities, and we
   don't want to show those in the recent views.
 
+  Options:
+  - `:include-metadata?` - Include result_metadata in the response (default: false)
+  - `:models` - Filter to specific model types from [[rv-models]] (default: all models)
+
   Returns a sequence of [[Item]]s. The reason this isn't a `mu/defn`, is that error-avoider validates each Item in the
   sequence, so there's no need to do it twice."
   ([user-id] (get-recents user-id [:views :selections]))
   ([user-id context :- [:sequential [:enum :views :selections]]]
    (get-recents user-id context {}))
-  ([user-id context :- [:sequential [:enum :views :selections]] options]
-   (let [recent-items (do-query user-id context)
+  ([user-id
+    context :- [:sequential [:enum :views :selections]]
+    options :- [:map
+                [:include-metadata? {:optional true} [:maybe :boolean]]
+                [:models {:optional true} [:maybe [:sequential (into [:enum] rv-models)]]]]]
+   (let [models (:models options)
+         recent-items (do-query user-id context models)
          entity->id->data (get-entity->id->data recent-items)
          view-items (into []
                           (comp


### PR DESCRIPTION
* Adds basic info about the 5 most recently viewed entities to the Metabot context. Currently this is just id, type, name and description — my idea is that this might be enough for Metabot to detect if a recent view is relevant to the user's query, and it can fetch more info via a tool call if needed. I'm not sure if this is the best approach in practice though vs giving more info up front akin to what we provide in the `user_is_viewing` context.
* Allows `get-recents` to be parameterized by model type so that we can exclude models that aren't yet relevant to Metabot
* Adds some unit tests