### PR TITLE
Fix Collection Tree Collapsing

### DIFF
--- a/frontend/src/metabase/common/components/tree/Tree.tsx
+++ b/frontend/src/metabase/common/components/tree/Tree.tsx
@@ -41,7 +41,9 @@ function BaseTree({
   const prevData = usePrevious(data);
 
   useEffect(() => {
-    if (initiallyExpanded && data !== prevData) {
+    const dataHasChanged = !_.isEqual(data, prevData);
+
+    if (initiallyExpanded && dataHasChanged) {
       setExpandedIds(new Set(getAllExpandableIds(data)));
       return;
     }
@@ -52,7 +54,7 @@ function BaseTree({
     const selectedItemChanged =
       previousSelectedId !== selectedId && !expandedIds.has(selectedId);
 
-    if (selectedItemChanged || !_.isEqual(data, prevData)) {
+    if (selectedItemChanged || dataHasChanged) {
       setExpandedIds(
         (prev) =>
           new Set([...prev, ...getInitialExpandedIds(selectedId, data)]),

--- a/frontend/src/metabase/common/components/tree/Tree.tsx
+++ b/frontend/src/metabase/common/components/tree/Tree.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import * as React from "react";
 import { usePrevious } from "react-use";
+import _ from "underscore";
 
 import { TreeNode as DefaultTreeNode } from "./TreeNode";
 import { TreeNodeList } from "./TreeNodeList";
@@ -50,7 +51,8 @@ function BaseTree({
     }
     const selectedItemChanged =
       previousSelectedId !== selectedId && !expandedIds.has(selectedId);
-    if (selectedItemChanged || data !== prevData) {
+
+    if (selectedItemChanged || !_.isEqual(data, prevData)) {
       setExpandedIds(
         (prev) =>
           new Set([...prev, ...getInitialExpandedIds(selectedId, data)]),

--- a/frontend/src/metabase/common/components/tree/Tree.tsx
+++ b/frontend/src/metabase/common/components/tree/Tree.tsx
@@ -6,14 +6,13 @@ import _ from "underscore";
 import { TreeNode as DefaultTreeNode } from "./TreeNode";
 import { TreeNodeList } from "./TreeNodeList";
 import type { ITreeNodeItem } from "./types";
-import { getAllExpandableIds, getInitialExpandedIds } from "./utils";
+import { getInitialExpandedIds } from "./utils";
 
 interface TreeProps {
   data: ITreeNodeItem[];
   selectedId?: ITreeNodeItem["id"];
   role?: string;
   emptyState?: React.ReactNode;
-  initiallyExpanded?: boolean;
   onSelect?: (item: ITreeNodeItem) => void;
   rightSection?: (item: ITreeNodeItem) => React.ReactNode;
   TreeNode?: any; // This was previously set to TreeNodeComponent, but after upgrading to react 18, the type no longer played nice with forward ref compontents, including styled components
@@ -24,15 +23,11 @@ function BaseTree({
   selectedId,
   role = "menu",
   emptyState = null,
-  initiallyExpanded = false,
   onSelect,
   TreeNode = DefaultTreeNode,
   rightSection,
 }: TreeProps) {
   const [expandedIds, setExpandedIds] = useState(() => {
-    if (initiallyExpanded) {
-      return new Set(getAllExpandableIds(data));
-    }
     return new Set(
       selectedId != null ? getInitialExpandedIds(selectedId, data) : [],
     );
@@ -41,16 +36,10 @@ function BaseTree({
   const prevData = usePrevious(data);
 
   useEffect(() => {
-    const dataHasChanged = !_.isEqual(data, prevData);
-
-    if (initiallyExpanded && dataHasChanged) {
-      setExpandedIds(new Set(getAllExpandableIds(data)));
-      return;
-    }
-
     if (!selectedId) {
       return;
     }
+    const dataHasChanged = !_.isEqual(data, prevData);
     const selectedItemChanged =
       previousSelectedId !== selectedId && !expandedIds.has(selectedId);
 
@@ -60,14 +49,7 @@ function BaseTree({
           new Set([...prev, ...getInitialExpandedIds(selectedId, data)]),
       );
     }
-  }, [
-    prevData,
-    data,
-    selectedId,
-    previousSelectedId,
-    expandedIds,
-    initiallyExpanded,
-  ]);
+  }, [prevData, data, selectedId, previousSelectedId, expandedIds]);
 
   const handleToggleExpand = useCallback(
     (itemId: string | number) => {

--- a/frontend/src/metabase/common/components/tree/utils.tsx
+++ b/frontend/src/metabase/common/components/tree/utils.tsx
@@ -18,21 +18,3 @@ export const getInitialExpandedIds = (
       return [];
     })
     .flat();
-
-export const getAllExpandableIds = (
-  nodes: ITreeNodeItem[],
-): ITreeNodeItem["id"][] => {
-  const ids: ITreeNodeItem["id"][] = [];
-
-  const traverse = (items: ITreeNodeItem[]) => {
-    for (const item of items) {
-      if (item.children && item.children.length > 0) {
-        ids.push(item.id);
-        traverse(item.children);
-      }
-    }
-  };
-
-  traverse(nodes);
-  return ids;
-};


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #65610
Closes UXW-2240
Closes UXW-2230

## Description
Checking reference changes was not acting as intended and was causing re-renders in the main app and for tree nodes to be uncloseable in permissions. This moves back to checking deep equality.

<img width="686" height="456" alt="CleanShot 2025-11-07 at 14 45 18" src="https://github.com/user-attachments/assets/34fed5b1-d5f2-4e7f-bd92-2c80df8b1b4a" />


- [x] [stress test](https://github.com/metabase/metabase/actions/runs/19178724300)