### PR TITLE
Fix template tag parsing for model references in transforms generated by metabot

### DIFF
--- a/e2e/test/scenarios/metabot/transforms-codegen.cy.spec.ts
+++ b/e2e/test/scenarios/metabot/transforms-codegen.cy.spec.ts
@@ -231,55 +231,55 @@ describe("scenarios > metabot > transforms codegen", () => {
 
       it("should create SQL transform with model reference via metabot and run successfully", () => {
         // Create a model first
-        H.getTableId({ name: SOURCE_TABLE, databaseId: WRITABLE_DB_ID }).then(
-          (tableId) => {
-            H.createQuestion({
-              name: "Test Model",
-              type: "model",
-              query: {
-                "source-table": tableId,
-                limit: 5,
-              },
-            }).then(({ body: model }) => {
-              visitTransformListPage();
-              H.openMetabotViaSearchButton(true);
-
-              cy.log(
-                "Ask metabot for a new transform that references the model",
-              );
-              const modelTagName = `#${model.id}-test-model`;
-              const queryWithModelRef = `SELECT * FROM {{${modelTagName}}}`;
-
-              H.mockMetabotResponse({
-                body: createMockTransformSuggestionResponse(
-                  "I'll create a transform that queries your model.",
-                  createMockNativeTransformJSON(
-                    null,
-                    WRITABLE_DB_ID,
-                    queryWithModelRef,
-                  ),
-                ),
-              });
-              H.sendMetabotMessage(
-                "Create a transform that queries the Test Model",
-              );
-              assertSuggestionInSidebar({ newSourcePartial: "SELECT * FROM" });
-
-              cy.log("Should be able to visit the new transform");
-              viewLastSuggestion();
-              cy.url().should("include", "/admin/transforms/new/native");
-              assertEditorContent("native", "SELECT * FROM");
-
-              cy.log(
-                "Should be able to run the transform successfully (verifies template tags were parsed)",
-              );
-              cy.findByTestId("native-query-editor-container")
-                .icon("play")
-                .click();
-              cy.findByTestId("query-visualization-root").should("be.visible");
-            });
-          },
+        H.getTableId({ name: SOURCE_TABLE, databaseId: WRITABLE_DB_ID }).as(
+          "tableId",
         );
+
+        cy.get("@tableId").then((tableId) => {
+          H.createQuestion({
+            name: "Test Model",
+            type: "model",
+            query: {
+              "source-table": tableId,
+              limit: 5,
+            },
+          }).as("model");
+        });
+
+        cy.get("@model").then(({ body: model }) => {
+          visitTransformListPage();
+          H.openMetabotViaSearchButton(true);
+
+          cy.log("Ask metabot for a new transform that references the model");
+          const modelTagName = `#${model.id}-test-model`;
+          const queryWithModelRef = `SELECT * FROM {{${modelTagName}}}`;
+
+          H.mockMetabotResponse({
+            body: createMockTransformSuggestionResponse(
+              "I'll create a transform that queries your model.",
+              createMockNativeTransformJSON(
+                null,
+                WRITABLE_DB_ID,
+                queryWithModelRef,
+              ),
+            ),
+          });
+          H.sendMetabotMessage(
+            "Create a transform that queries the Test Model",
+          );
+          assertSuggestionInSidebar({ newSourcePartial: "SELECT * FROM" });
+
+          cy.log("Should be able to visit the new transform");
+          viewLastSuggestion();
+          cy.url().should("include", "/admin/transforms/new/native");
+          assertEditorContent("native", "SELECT * FROM");
+
+          cy.log(
+            "Should be able to run the transform successfully (verifies template tags were parsed)",
+          );
+          cy.findByTestId("native-query-editor-container").icon("play").click();
+          cy.findByTestId("query-visualization-root").should("be.visible");
+        });
       });
     });
 

--- a/e2e/test/scenarios/metabot/transforms-codegen.cy.spec.ts
+++ b/e2e/test/scenarios/metabot/transforms-codegen.cy.spec.ts
@@ -75,59 +75,6 @@ describe("scenarios > metabot > transforms codegen", () => {
 
   describe("Native SQL transform tests", () => {
     describe("create new transform", () => {
-      it("should create SQL transform with model reference via metabot and run successfully", () => {
-        // Create a model first
-        H.getTableId({ name: SOURCE_TABLE, databaseId: WRITABLE_DB_ID }).then(
-          (tableId) => {
-            H.createQuestion({
-              name: "Test Model",
-              type: "model",
-              query: {
-                "source-table": tableId,
-                limit: 5,
-              },
-            }).then(({ body: model }) => {
-              visitTransformListPage();
-              H.openMetabotViaSearchButton(true);
-
-              cy.log(
-                "Ask metabot for a new transform that references the model",
-              );
-              const modelTagName = `#${model.id}-test-model`;
-              const queryWithModelRef = `SELECT * FROM {{${modelTagName}}}`;
-
-              H.mockMetabotResponse({
-                body: createMockTransformSuggestionResponse(
-                  "I'll create a transform that queries your model.",
-                  createMockNativeTransformJSON(
-                    null,
-                    WRITABLE_DB_ID,
-                    queryWithModelRef,
-                  ),
-                ),
-              });
-              H.sendMetabotMessage(
-                "Create a transform that queries the Test Model",
-              );
-              assertSuggestionInSidebar({ newSourcePartial: "SELECT * FROM" });
-
-              cy.log("Should be able to visit the new transform");
-              viewLastSuggestion();
-              cy.url().should("include", "/admin/transforms/new/native");
-              assertEditorContent("native", "SELECT * FROM");
-
-              cy.log(
-                "Should be able to run the transform successfully (verifies template tags were parsed)",
-              );
-              cy.findByTestId("native-query-editor-container")
-                .icon("play")
-                .click();
-              cy.findByTestId("query-visualization-root").should("be.visible");
-            });
-          },
-        );
-      });
-
       it("should create SQL transform via metabot", () => {
         visitTransformListPage();
         H.openMetabotViaSearchButton(true);
@@ -280,6 +227,59 @@ describe("scenarios > metabot > transforms codegen", () => {
         rejectSuggestion();
         assertEditorContent("python", "pd.DataFrame({'value': [3]})");
         assertAcceptRejectUI({ visible: false });
+      });
+
+      it("should create SQL transform with model reference via metabot and run successfully", () => {
+        // Create a model first
+        H.getTableId({ name: SOURCE_TABLE, databaseId: WRITABLE_DB_ID }).then(
+          (tableId) => {
+            H.createQuestion({
+              name: "Test Model",
+              type: "model",
+              query: {
+                "source-table": tableId,
+                limit: 5,
+              },
+            }).then(({ body: model }) => {
+              visitTransformListPage();
+              H.openMetabotViaSearchButton(true);
+
+              cy.log(
+                "Ask metabot for a new transform that references the model",
+              );
+              const modelTagName = `#${model.id}-test-model`;
+              const queryWithModelRef = `SELECT * FROM {{${modelTagName}}}`;
+
+              H.mockMetabotResponse({
+                body: createMockTransformSuggestionResponse(
+                  "I'll create a transform that queries your model.",
+                  createMockNativeTransformJSON(
+                    null,
+                    WRITABLE_DB_ID,
+                    queryWithModelRef,
+                  ),
+                ),
+              });
+              H.sendMetabotMessage(
+                "Create a transform that queries the Test Model",
+              );
+              assertSuggestionInSidebar({ newSourcePartial: "SELECT * FROM" });
+
+              cy.log("Should be able to visit the new transform");
+              viewLastSuggestion();
+              cy.url().should("include", "/admin/transforms/new/native");
+              assertEditorContent("native", "SELECT * FROM");
+
+              cy.log(
+                "Should be able to run the transform successfully (verifies template tags were parsed)",
+              );
+              cy.findByTestId("native-query-editor-container")
+                .icon("play")
+                .click();
+              cy.findByTestId("query-visualization-root").should("be.visible");
+            });
+          },
+        );
       });
     });
 

--- a/enterprise/frontend/src/metabase-enterprise/transforms/hooks/use-source-state.ts
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/hooks/use-source-state.ts
@@ -33,6 +33,10 @@ type UseSourceStateResult = {
   rejectProposed: () => void;
 };
 
+/**
+ * Normalizes a transform source by ensuring template tags are properly parsed.
+ * Necessary for model references in a SQL transform to work correctly.
+ */
 function normalizeSource(
   source: DraftTransformSource,
   metadata: Metadata,

--- a/enterprise/frontend/src/metabase-enterprise/transforms/hooks/use-source-state.ts
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/hooks/use-source-state.ts
@@ -45,16 +45,12 @@ function normalizeSource(
   const { isNative } = Lib.queryDisplayInfo(query);
 
   if (isNative) {
-    const nativeQuery = question.legacyNativeQuery();
-    if (nativeQuery) {
-      const queryText = nativeQuery.queryText();
-      // For native queries, ensure template tags are processed
-      const updatedQuery = nativeQuery.setQueryText(queryText);
-      return {
-        type: "query",
-        query: updatedQuery.datasetQuery(),
-      };
-    }
+    const updatedQuery = Lib.withNativeQuery(query, Lib.rawNativeQuery(query));
+    return {
+      type: "query",
+      // question.setQuery ensures template tags get processed
+      query: question.setQuery(updatedQuery).datasetQuery(),
+    };
   }
 
   return source;

--- a/enterprise/frontend/src/metabase-enterprise/transforms/hooks/use-source-state.ts
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/hooks/use-source-state.ts
@@ -8,6 +8,7 @@ import {
 } from "metabase-enterprise/metabot/state";
 import * as Lib from "metabase-lib";
 import Question from "metabase-lib/v1/Question";
+import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type {
   DraftTransformSource,
   SuggestedTransform,
@@ -34,7 +35,7 @@ type UseSourceStateResult = {
 
 function normalizeSource(
   source: DraftTransformSource,
-  metadata: ReturnType<typeof getMetadata>,
+  metadata: Metadata,
 ): DraftTransformSource {
   if (source.type !== "query") {
     return source;


### PR DESCRIPTION
Fixes issue reported here: https://metaboat.slack.com/archives/C07SJT1P0ET/p1761915760586949

For transform edits proposed by Metabot, we need to ensure that template tags like model references get parsed so that the query can run successfully. The easiest way to do that is to ensure that `setQueryText` gets called on the transform source. This PR adds a `normalizeSource` helper function which does this, and ensures that it's called. 

This is very similar to a prior fix (in https://github.com/metabase/metabase/pull/64001) I had applied to the transforms codegen branch which got inadvertently removed in https://github.com/metabase/metabase/pull/65160. I've added an e2e test here to hopefully prevent future breakages. 