### PR TITLE
Don't use entities for Icons

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/clean_up/CleanupCollectionModal/CleanupCollectionTable.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/clean_up/CleanupCollectionModal/CleanupCollectionTable.tsx
@@ -12,6 +12,7 @@ import {
   TableColumn,
 } from "metabase/common/components/ItemsTable/BaseItemsTable.styled";
 import { Columns } from "metabase/common/components/ItemsTable/Columns";
+import { getIcon } from "metabase/lib/icon";
 import { FixedSizeIcon, Flex, Tooltip } from "metabase/ui";
 import type { SortingOptions } from "metabase-types/api/sorting";
 
@@ -97,7 +98,7 @@ export const CleanupCollectionTable = ({
             {/* Select */}
             <Columns.Select.Cell
               testIdPrefix="clean-up-table"
-              icon={item.getIcon()}
+              icon={getIcon(item)}
               isPinned={false}
               isSelected={getIsSelected(item)}
               handleSelectionToggled={() => onToggleSelected(item)}
@@ -106,7 +107,7 @@ export const CleanupCollectionTable = ({
             <ItemCell data-testid="clean-up-table-collection">
               <Flex align="center" gap="sm">
                 <FixedSizeIcon
-                  name={item.getIcon().name}
+                  name={getIcon(item).name}
                   color="var(--mb-color-brand)"
                 />
                 <Ellipsified>{item.name}</Ellipsified>

--- a/enterprise/frontend/src/metabase-enterprise/collections/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/collections/utils.ts
@@ -81,6 +81,10 @@ export const getIcon = (item: ObjectWithModel): IconData => {
     };
   }
 
+  if (item.model === "dataset" && item.moderated_status === "verified") {
+    return { name: "model_with_badge" };
+  }
+
   return getIconBase(item);
 };
 

--- a/enterprise/frontend/src/metabase-enterprise/collections/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/collections/utils.ts
@@ -7,6 +7,7 @@ import type {
   CollectionAuthorityLevelConfig,
   CollectionId,
   CollectionInstanceAnaltyicsConfig,
+  CollectionType,
 } from "metabase-types/api";
 
 import {
@@ -55,7 +56,7 @@ export function isSyncedCollection(
 
 export const getIcon = (item: ObjectWithModel): IconData => {
   const collectionType = getCollectionType({
-    type: item.type || item.collection_type,
+    type: (item.type as CollectionType) || item.collection_type,
   }).type;
   if (collectionType === "instance-analytics") {
     return {

--- a/enterprise/frontend/src/metabase-enterprise/collections/utils.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/collections/utils.unit.spec.tsx
@@ -103,7 +103,7 @@ describe("Collections plugin utils", () => {
       it("should return the correct icon for an official model", () => {
         expect(
           getIcon({ model: "dataset", moderated_status: "verified" }),
-        ).toEqual({ name: "model" });
+        ).toEqual({ name: "model_with_badge" });
       });
     });
   });

--- a/enterprise/frontend/src/metabase-enterprise/entities/documents.ts
+++ b/enterprise/frontend/src/metabase-enterprise/entities/documents.ts
@@ -126,7 +126,6 @@ const Documents = createEntity({
   objectSelectors: {
     getName: (document: Document) => document && document.name,
     getUrl: (document: Document) => document && Urls.document(document),
-    getIcon: () => ({ name: "document" }),
     getColor: () => color("brand"),
   },
 });

--- a/enterprise/frontend/src/metabase-enterprise/entities/transforms.ts
+++ b/enterprise/frontend/src/metabase-enterprise/entities/transforms.ts
@@ -17,7 +17,6 @@ export const Transforms = createEntity({
   objectSelectors: {
     getName: (transform: Transform) => transform && transform.name,
     getUrl: (transform: Transform) => transform && Urls.transform(transform.id),
-    getIcon: () => ({ name: "transform" }),
     getColor: () => color("brand"),
   },
 });

--- a/frontend/src/metabase-types/api/bookmark.ts
+++ b/frontend/src/metabase-types/api/bookmark.ts
@@ -2,6 +2,7 @@ import type { CardId, CardType } from "./card";
 import type { CollectionId } from "./collection";
 import type { DashboardId } from "./dashboard";
 import type { DocumentId } from "./document";
+import type { CardDisplayType } from "./visualization";
 
 export const BOOKMARK_TYPES = [
   "card",
@@ -17,7 +18,7 @@ export type BookmarkId = string;
 export interface Bookmark {
   authority_level?: string;
   card_id?: string;
-  display?: string;
+  display?: CardDisplayType;
   id: BookmarkId;
   item_id: number;
   name: string;

--- a/frontend/src/metabase-types/entities/common.ts
+++ b/frontend/src/metabase-types/entities/common.ts
@@ -1,9 +1,7 @@
-import type { IconProps } from "metabase/ui";
 import type { Collection } from "metabase-types/api";
 
 export type WrappedEntity<Entity> = {
   getName: () => string;
-  getIcon: () => IconProps;
   getColor: () => string;
   getCollection: () => Collection;
   getUrl: () => string;

--- a/frontend/src/metabase/browse/models/ModelsTable.tsx
+++ b/frontend/src/metabase/browse/models/ModelsTable.tsx
@@ -17,6 +17,7 @@ import {
 import { Columns } from "metabase/common/components/ItemsTable/Columns";
 import type { ResponsiveProps } from "metabase/common/components/ItemsTable/utils";
 import { MarkdownPreview } from "metabase/common/components/MarkdownPreview";
+import { getIcon } from "metabase/lib/icon";
 import { useDispatch } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { FixedSizeIcon, Flex, Icon, Repeat, Skeleton } from "metabase/ui";
@@ -32,7 +33,7 @@ import {
 
 import { trackModelClick } from "./analytics";
 import type { ModelResult, SortColumn } from "./types";
-import { getIcon, getModelDescription, sortModels } from "./utils";
+import { getModelDescription, sortModels } from "./utils";
 
 export interface ModelsTableProps {
   models?: ModelResult[];
@@ -202,7 +203,7 @@ const ModelRow = ({ model }: { model?: ModelResult }) => {
 
 function NameCell({ model }: { model?: ModelResult }) {
   const headingId = `model-${model?.id || "dummy"}-heading`;
-  const icon = getIcon(model);
+  const icon = getIcon(model ?? { model: "dataset" }) ?? { name: "folder" };
   return (
     <ItemNameCell data-testid="model-name" aria-labelledby={headingId}>
       <MaybeItemLink

--- a/frontend/src/metabase/browse/models/utils.ts
+++ b/frontend/src/metabase/browse/models/utils.ts
@@ -1,8 +1,6 @@
 import { t } from "ttag";
 
 import { getCollectionPathAsString } from "metabase/collections/utils";
-import { entityForObject } from "metabase/lib/schema";
-import type { IconName } from "metabase/ui";
 import type { RecentItem, SearchResult } from "metabase-types/api";
 import { SortDirection, type SortingOptions } from "metabase-types/api/sorting";
 
@@ -74,9 +72,4 @@ export const getMaxRecentModelCount = (
     return 4;
   }
   return 0;
-};
-
-export const getIcon = (item: unknown): { name: IconName; color: string } => {
-  const entity = entityForObject(item);
-  return entity?.objectSelectors?.getIcon?.(item) || { name: "folder" };
 };

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.unit.spec.tsx
@@ -1,7 +1,12 @@
 import userEvent from "@testing-library/user-event";
 import { Route } from "react-router";
 
-import { getIcon, renderWithProviders, screen } from "__support__/ui";
+import {
+  renderWithProviders,
+  screen,
+  getIcon as testGetIcon,
+} from "__support__/ui";
+import { getIcon } from "metabase/lib/icon";
 import type { IconName } from "metabase/ui";
 import type { CollectionItem, CollectionItemModel } from "metabase-types/api";
 import {
@@ -101,7 +106,7 @@ function setup({ item = defaultItem, collection = defaultCollection } = {}) {
 describe("PinnedItemCard", () => {
   it("should show the item's icon", () => {
     setup();
-    expect(getIcon(defaultItem.getIcon().name)).toBeInTheDocument();
+    expect(testGetIcon(getIcon(defaultItem).name)).toBeInTheDocument();
   });
 
   it("should show the item's name", () => {
@@ -121,7 +126,7 @@ describe("PinnedItemCard", () => {
 
   it("should show an action menu when user clicks on the menu icon in the card", async () => {
     setup();
-    await userEvent.click(getIcon("ellipsis"));
+    await userEvent.click(testGetIcon("ellipsis"));
     expect(await screen.findByText("Unpin")).toBeInTheDocument();
   });
 

--- a/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionCard.tsx
+++ b/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionCard.tsx
@@ -12,8 +12,9 @@ import {
 } from "metabase/collections/utils";
 import EventSandbox from "metabase/common/components/EventSandbox";
 import CS from "metabase/css/core/index.css";
+import { getIcon } from "metabase/lib/icon";
 import { PLUGIN_MODERATION } from "metabase/plugins";
-import { Box, Flex, Group, Icon, type IconName, Text } from "metabase/ui";
+import { Box, Flex, Group, Icon, Text } from "metabase/ui";
 import Visualization from "metabase/visualizations/components/Visualization";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type { Bookmark, Collection, CollectionItem } from "metabase-types/api";
@@ -137,7 +138,7 @@ const PinnedQuestionCard = ({
               description={
                 item.description || DEFAULT_DESCRIPTION[item.model] || ""
               }
-              icon={item.getIcon() as unknown as { name: IconName }}
+              icon={getIcon(item)}
               tooltip={getSkeletonTooltip(item)}
             />
           )}

--- a/frontend/src/metabase/common/components/EntityItem/EntityItem.tsx
+++ b/frontend/src/metabase/common/components/EntityItem/EntityItem.tsx
@@ -81,7 +81,7 @@ const EntityIconCheckBox = ({
           defaultElement={
             <Icon
               name={icon.name}
-              color={icon.color ?? "inherit"}
+              c={icon.color ?? "inherit"}
               size={iconSize}
             />
           }
@@ -89,11 +89,7 @@ const EntityIconCheckBox = ({
           isSwapped={selected || showCheckbox}
         />
       ) : (
-        <Icon
-          name={icon.name}
-          color={icon.color ?? "inherit"}
-          size={iconSize}
-        />
+        <Icon name={icon.name} c={icon.color ?? "inherit"} size={iconSize} />
       )}
     </EntityIconWrapper>
   );

--- a/frontend/src/metabase/common/components/EntityPicker/components/ResultItem/ResultItem.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/ResultItem/ResultItem.unit.spec.tsx
@@ -218,7 +218,7 @@ describe("EntityPicker > ResultItem", () => {
     });
     expect(screen.getByText("My Verified Model")).toBeInTheDocument();
 
-    expect(getIcon("model")).toBeInTheDocument();
+    expect(getIcon("model_with_badge")).toBeInTheDocument();
     expect(getIcon("verified_filled")).toBeInTheDocument();
     expect(screen.getByText("in My parent collection")).toBeInTheDocument();
   });

--- a/frontend/src/metabase/common/components/ItemsTable/Columns.tsx
+++ b/frontend/src/metabase/common/components/ItemsTable/Columns.tsx
@@ -10,10 +10,12 @@ import EntityItem from "metabase/common/components/EntityItem";
 import Markdown from "metabase/common/components/Markdown";
 import { ArchiveButton } from "metabase/embedding/components/ArchiveButton";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
+import { modelToUrl } from "metabase/lib/urls";
 import { getUserName } from "metabase/lib/user";
 import { PLUGIN_MODERATION } from "metabase/plugins";
 import type { IconProps } from "metabase/ui";
 import { Tooltip } from "metabase/ui";
+import { getUrl } from "metabase-lib/v1/urls";
 import type {
   CollectionItem,
   ListCollectionItemsSortColumn,
@@ -52,7 +54,7 @@ const ItemLinkComponent = ({
     return <ItemButton onClick={() => onClick?.(item)}>{children}</ItemButton>;
   }
   return (
-    <ItemLink to={item.getUrl()} onClick={() => onClick?.(item)}>
+    <ItemLink to={modelToUrl(item)} onClick={() => onClick?.(item)}>
       {children}
     </ItemLink>
   );

--- a/frontend/src/metabase/common/components/ItemsTable/Columns.tsx
+++ b/frontend/src/metabase/common/components/ItemsTable/Columns.tsx
@@ -10,12 +10,10 @@ import EntityItem from "metabase/common/components/EntityItem";
 import Markdown from "metabase/common/components/Markdown";
 import { ArchiveButton } from "metabase/embedding/components/ArchiveButton";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
-import { modelToUrl } from "metabase/lib/urls";
 import { getUserName } from "metabase/lib/user";
 import { PLUGIN_MODERATION } from "metabase/plugins";
 import type { IconProps } from "metabase/ui";
 import { Tooltip } from "metabase/ui";
-import { getUrl } from "metabase-lib/v1/urls";
 import type {
   CollectionItem,
   ListCollectionItemsSortColumn,
@@ -54,7 +52,7 @@ const ItemLinkComponent = ({
     return <ItemButton onClick={() => onClick?.(item)}>{children}</ItemButton>;
   }
   return (
-    <ItemLink to={modelToUrl(item)} onClick={() => onClick?.(item)}>
+    <ItemLink to={item.getUrl()} onClick={() => onClick?.(item)}>
       {children}
     </ItemLink>
   );

--- a/frontend/src/metabase/common/components/ItemsTable/DefaultItemRenderer.tsx
+++ b/frontend/src/metabase/common/components/ItemsTable/DefaultItemRenderer.tsx
@@ -5,6 +5,7 @@ import type { OnToggleSelectedWithItem } from "metabase/collections/types";
 import { isRootTrashCollection } from "metabase/collections/utils";
 import type { BaseItemsTableProps } from "metabase/common/components/ItemsTable/BaseItemsTable";
 import { Columns } from "metabase/common/components/ItemsTable/Columns";
+import { getIcon } from "metabase/lib/icon";
 import { color } from "metabase/ui/utils/colors";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type { Bookmark, Collection, CollectionItem } from "metabase-types/api";
@@ -42,7 +43,7 @@ export const DefaultItemRenderer = ({
     (collection?.can_write || isRootTrashCollection(collection)) &&
     typeof onToggleSelected === "function";
 
-  const icon = item.getIcon();
+  const icon = getIcon(item);
   if (item.model === "card" || item.archived) {
     icon.color = color("text-light");
   }

--- a/frontend/src/metabase/common/components/ItemsTable/DefaultItemRenderer.tsx
+++ b/frontend/src/metabase/common/components/ItemsTable/DefaultItemRenderer.tsx
@@ -6,7 +6,6 @@ import { isRootTrashCollection } from "metabase/collections/utils";
 import type { BaseItemsTableProps } from "metabase/common/components/ItemsTable/BaseItemsTable";
 import { Columns } from "metabase/common/components/ItemsTable/Columns";
 import { getIcon } from "metabase/lib/icon";
-import { color } from "metabase/ui/utils/colors";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type { Bookmark, Collection, CollectionItem } from "metabase-types/api";
 
@@ -45,7 +44,7 @@ export const DefaultItemRenderer = ({
 
   const icon = getIcon(item);
   if (item.model === "card" || item.archived) {
-    icon.color = color("text-light");
+    icon.color = "text-light";
   }
 
   const handleSelectionToggled = useCallback(() => {

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionList.tsx
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionList.tsx
@@ -19,6 +19,7 @@ import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import Search from "metabase/entities/search";
 import { trackSimpleEvent } from "metabase/lib/analytics";
 import { DEFAULT_SEARCH_LIMIT } from "metabase/lib/constants";
+import { getIcon } from "metabase/lib/icon";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { PLUGIN_MODERATION } from "metabase/plugins";
 import { ActionIcon, Box, Flex, Icon, Tooltip } from "metabase/ui";
@@ -145,7 +146,7 @@ export function QuestionList({
               className={S.QuestionListItem}
               name={item.getName()}
               icon={{
-                name: item.getIcon().name,
+                name: getIcon(item).name,
                 size: item.model === "dataset" ? 18 : 16,
                 className: S.QuestionListItemIcon,
               }}

--- a/frontend/src/metabase/entities/actions/actions.ts
+++ b/frontend/src/metabase/entities/actions/actions.ts
@@ -229,7 +229,6 @@ const Actions = createEntity({
   objectSelectors: {
     getUrl: (action: WritebackAction) =>
       Urls.action({ id: action.model_id }, action.id),
-    getIcon: () => ({ name: "bolt" }),
   },
 });
 

--- a/frontend/src/metabase/entities/bookmarks.js
+++ b/frontend/src/metabase/entities/bookmarks.js
@@ -8,7 +8,6 @@ import Collections from "metabase/entities/collections";
 import Dashboards from "metabase/entities/dashboards";
 import Questions from "metabase/entities/questions";
 import { createEntity, entityCompatibleQuery } from "metabase/lib/entities";
-import { PLUGIN_ENTITIES } from "metabase/plugins";
 import { addUndo } from "metabase/redux/undo";
 import { BookmarkSchema } from "metabase/schema";
 
@@ -77,9 +76,6 @@ const Bookmarks = createEntity({
       }
     },
   },
-  objectSelectors: {
-    getIcon,
-  },
 
   reducer: (state = {}, { type, payload, error }) => {
     if (type === Questions.actionTypes.UPDATE && payload?.object) {
@@ -144,36 +140,6 @@ const Bookmarks = createEntity({
     return state;
   },
 });
-
-function getEntityFor(type) {
-  const entities = {
-    card: Questions,
-    collection: Collections,
-    dashboard: Dashboards,
-    document: PLUGIN_ENTITIES.entities["documents"],
-    transform: PLUGIN_ENTITIES.entities["transforms"],
-  };
-
-  return entities[type];
-}
-
-function getIcon(bookmark) {
-  const bookmarkEntity = getEntityFor(bookmark.type);
-
-  if (bookmarkEntity.name === "questions") {
-    return bookmarkEntity.objectSelectors.getIcon({
-      ...bookmark,
-      /**
-       * Questions.objectSelectors.getIcon works with Card instances.
-       * In order to reuse it we need to map Bookmark["card_type"] to Card["type"]
-       * because Bookmark["type"] is something else.
-       */
-      type: bookmark.type === "card" ? bookmark.card_type : bookmark.type,
-    });
-  }
-
-  return bookmarkEntity.objectSelectors.getIcon(bookmark);
-}
 
 export function isModelBookmark(bookmark) {
   return bookmark.type === "card" && bookmark.card_type === "model";

--- a/frontend/src/metabase/entities/bookmarks.js
+++ b/frontend/src/metabase/entities/bookmarks.js
@@ -141,10 +141,6 @@ const Bookmarks = createEntity({
   },
 });
 
-export function isModelBookmark(bookmark) {
-  return bookmark.type === "card" && bookmark.card_type === "model";
-}
-
 export const getOrderedBookmarks = createSelector(
   [Bookmarks.selectors.getList],
   (bookmarks) => _.sortBy(bookmarks, (bookmark) => bookmark.index),

--- a/frontend/src/metabase/entities/collections/collections.ts
+++ b/frontend/src/metabase/entities/collections/collections.ts
@@ -33,7 +33,7 @@ import type { Dispatch, GetState, ReduxAction } from "metabase-types/store";
 
 import getExpandedCollectionsById from "./getExpandedCollectionsById";
 import getInitialCollectionId from "./getInitialCollectionId";
-import { getCollectionIcon, getCollectionType } from "./utils";
+import { getCollectionType } from "./utils";
 
 const listCollectionsTree = (
   entityQuery: ListCollectionsTreeRequest,
@@ -54,10 +54,6 @@ const listCollections = (
     dispatch,
     collectionApi.endpoints.listCollections,
   );
-
-type EntityInCollection = {
-  collection?: Collection;
-};
 
 type ListParams = {
   tree?: boolean;
@@ -146,14 +142,6 @@ const Collections = createEntity({
   objectSelectors: {
     getName: (collection?: Collection) => collection?.name,
     getUrl: (collection?: Collection) => Urls.collection(collection),
-    getIcon: (
-      item: Collection | EntityInCollection,
-      opts: { tooltip?: string },
-    ) => {
-      const collection =
-        (item as EntityInCollection).collection || (item as Collection);
-      return getCollectionIcon(collection, opts);
-    },
   },
 
   selectors: {

--- a/frontend/src/metabase/entities/containers/rtk-query/types/entities.ts
+++ b/frontend/src/metabase/entities/containers/rtk-query/types/entities.ts
@@ -1,7 +1,6 @@
 import type { BaseQueryFn, QueryDefinition } from "@reduxjs/toolkit/query";
 
 import type { TagType } from "metabase/api/tags";
-import type { IconName } from "metabase/ui";
 import type { Collection } from "metabase-types/api";
 import type { Dispatch, State } from "metabase-types/store";
 
@@ -95,7 +94,6 @@ export interface EntityDefinition<Entity, EntityWrapper> {
   normalizeList: (list: unknown) => { list: unknown };
   objectSelectors: {
     getName: (entity: Entity | EntityWrapper) => string;
-    getIcon: (entity: Entity | EntityWrapper) => { name: IconName };
     getColor: (entity: Entity | EntityWrapper) => string | undefined;
     getCollection: (entity: Entity | EntityWrapper) => Collection | undefined;
   };

--- a/frontend/src/metabase/entities/dashboards.js
+++ b/frontend/src/metabase/entities/dashboards.js
@@ -178,7 +178,6 @@ const Dashboards = createEntity({
     getUrl: (dashboard) => dashboard && Urls.dashboard(dashboard),
     getCollection: (dashboard) =>
       dashboard && normalizedCollection(dashboard.collection),
-    getIcon: () => ({ name: "dashboard" }),
     getColor: () => color("dashboard"),
   },
 

--- a/frontend/src/metabase/entities/databases.js
+++ b/frontend/src/metabase/entities/databases.js
@@ -111,7 +111,6 @@ const Databases = createEntity({
   objectSelectors: {
     getName: (db) => db && db.name,
     getUrl: (db) => db && Urls.browseDatabase(db),
-    getIcon: (db) => ({ name: "database" }),
     getColor: (db) => color("database"),
   },
 

--- a/frontend/src/metabase/entities/indexed-entities/indexed-entities.ts
+++ b/frontend/src/metabase/entities/indexed-entities/indexed-entities.ts
@@ -17,6 +17,5 @@ export const IndexedEntities = createEntity({
   schema: IndexedEntitySchema,
   objectSelectors: {
     getUrl: indexedEntityUrl,
-    getIcon: () => ({ name: "index" }),
   },
 });

--- a/frontend/src/metabase/entities/pulses.js
+++ b/frontend/src/metabase/entities/pulses.js
@@ -92,7 +92,6 @@ const Pulses = createEntity({
   objectSelectors: {
     getName: (pulse) => pulse && pulse.name,
     getUrl: (pulse) => pulse && Urls.pulse(pulse.id),
-    getIcon: (pulse) => ({ name: "pulse" }),
     getColor: (pulse) => color("pulse"),
   },
 

--- a/frontend/src/metabase/entities/questions.js
+++ b/frontend/src/metabase/entities/questions.js
@@ -17,7 +17,6 @@ import {
   undo,
 } from "metabase/lib/entities";
 import * as Urls from "metabase/lib/urls/questions";
-import { PLUGIN_MODERATION } from "metabase/plugins";
 import {
   API_UPDATE_QUESTION,
   SOFT_RELOAD_CARD,
@@ -168,7 +167,6 @@ const Questions = createEntity({
     getUrl: (card, opts) => card && Urls.question(card, opts),
     getColor: () => color("text-medium"),
     getCollection: (card) => card && normalizedCollection(card.collection),
-    getIcon,
   },
 
   reducer: (state = {}, { type, payload, error }) => {
@@ -233,33 +231,6 @@ function getLabel(card) {
   }
 
   return t`question`;
-}
-
-export function getIcon(card) {
-  const type = PLUGIN_MODERATION.getQuestionIcon(card);
-
-  if (type) {
-    return {
-      name: type.icon,
-      color: type.color ? color(type.color) : undefined,
-      tooltip: type.tooltip,
-    };
-  }
-
-  if (card.type === "model" || card.model === "dataset") {
-    return { name: "model" };
-  }
-
-  if (card.type === "metric" || card.model === "metric") {
-    return { name: "metric" };
-  }
-
-  const visualization = require("metabase/visualizations").default.get(
-    card.display,
-  );
-  return {
-    name: visualization?.iconName ?? "beaker",
-  };
 }
 
 export default Questions;

--- a/frontend/src/metabase/entities/schemas.js
+++ b/frontend/src/metabase/entities/schemas.js
@@ -97,10 +97,6 @@ export default createEntity({
     getObject: (state, { entityId }) => getMetadata(state).schema(entityId),
   },
 
-  objectSelectors: {
-    getIcon: () => ({ name: "folder" }),
-  },
-
   reducer: (state = {}, { type, payload, error }) => {
     if (type === Questions.actionTypes.CREATE && !error) {
       const { question, status, data } = payload;

--- a/frontend/src/metabase/entities/search.js
+++ b/frontend/src/metabase/entities/search.js
@@ -165,13 +165,6 @@ export default createEntity({
         ? (entity?.objectSelectors?.getColor?.(object) ?? null)
         : warnEntityAndReturnObject(object);
     },
-
-    getIcon: (object) => {
-      const entity = entityForObject(object);
-      return entity
-        ? (entity?.objectSelectors?.getIcon?.(object) ?? null)
-        : warnEntityAndReturnObject(object);
-    },
   },
   // delegate to each entity's actionShouldInvalidateLists
   actionShouldInvalidateLists(action) {

--- a/frontend/src/metabase/entities/segments.js
+++ b/frontend/src/metabase/entities/segments.js
@@ -79,7 +79,6 @@ const Segments = createEntity({
         segment.id,
       ),
     getColor: (segment) => color("filter"),
-    getIcon: (segment) => ({ name: "segment" }),
   },
 });
 

--- a/frontend/src/metabase/entities/snippet-collections.js
+++ b/frontend/src/metabase/entities/snippet-collections.js
@@ -67,10 +67,6 @@ const SnippetCollections = createEntity({
       getFetched(state, props) || getObject(state, props),
   }),
 
-  objectSelectors: {
-    getIcon: () => ({ name: "folder" }),
-  },
-
   getAnalyticsMetadata() {
     return undefined; // not tracking
   },

--- a/frontend/src/metabase/entities/tables.js
+++ b/frontend/src/metabase/entities/tables.js
@@ -353,9 +353,6 @@ const Tables = createEntity({
   objectSelectors: {
     getUrl: (table) =>
       Urls.tableRowsQuery(table.database_id, table.table_id, null),
-    getIcon: (table, { variant = "primary" } = {}) => ({
-      name: variant === "primary" ? "table" : "database",
-    }),
     getColor: (table) => color("accent2"),
   },
 

--- a/frontend/src/metabase/lib/icon.ts
+++ b/frontend/src/metabase/lib/icon.ts
@@ -3,10 +3,12 @@ import { PLUGIN_COLLECTIONS, PLUGIN_DATA_STUDIO } from "metabase/plugins";
 import type { IconName } from "metabase/ui";
 import { getIconForVisualizationType } from "metabase/visualizations";
 import type {
-  CardDisplayType,
+  CardType,
   Collection,
   CollectionItemModel,
+  CollectionType,
   SearchModel,
+  VisualizationDisplay,
 } from "metabase-types/api";
 
 import type { ColorName } from "./colors/types";
@@ -25,9 +27,9 @@ export type ObjectWithModel = {
   authority_level?: "official" | string | null;
   collection_authority_level?: "official" | string | null;
   moderated_status?: "verified" | string | null;
-  display?: CardDisplayType | null;
-  type?: Collection["type"];
-  collection_type?: Collection["type"];
+  display?: VisualizationDisplay | null;
+  type?: CollectionType | CardType;
+  collection_type?: CollectionType;
   location?: Collection["location"];
   effective_location?: Collection["location"];
   is_personal?: boolean;
@@ -87,8 +89,11 @@ export const getIconBase = (item: ObjectWithModel): IconData => {
 
   return { name: modelIconMap?.[item.model] ?? "unknown" };
 };
-
-export const getIcon = (item: ObjectWithModel) => {
+/**
+ * relies mainly on the `model` property to determine the icon to return
+ * also handle special collection icons and visualization types for cards
+ */
+export const getIcon = (item: ObjectWithModel): IconData => {
   if (PLUGIN_COLLECTIONS) {
     return PLUGIN_COLLECTIONS.getIcon(item);
   }

--- a/frontend/src/metabase/lib/icon.ts
+++ b/frontend/src/metabase/lib/icon.ts
@@ -78,13 +78,17 @@ export const getIconBase = (item: ObjectWithModel): IconData => {
     return { name: "database" };
   }
 
-  switch (PLUGIN_DATA_STUDIO.getLibraryCollectionType(item.type)) {
-    case "root":
-      return { name: "repository" };
-    case "models":
-      return { name: "model" };
-    case "metrics":
-      return { name: "metric" };
+  if (item.model === "collection") {
+    switch (
+      PLUGIN_DATA_STUDIO.getLibraryCollectionType(item.type as CollectionType)
+    ) {
+      case "root":
+        return { name: "repository" };
+      case "models":
+        return { name: "model" };
+      case "metrics":
+        return { name: "metric" };
+    }
   }
 
   return { name: modelIconMap?.[item.model] ?? "unknown" };

--- a/frontend/src/metabase/lib/urls/modelToUrl.ts
+++ b/frontend/src/metabase/lib/urls/modelToUrl.ts
@@ -19,7 +19,9 @@ export type UrlableModel = {
   collection_id?: CollectionId | null;
 };
 
-export function modelToUrl(item: UrlableModel) {
+const NOT_FOUND_URL = "/404";
+
+export function modelToUrl(item: UrlableModel): string {
   switch (item.model) {
     case "card":
       return question({
@@ -38,7 +40,7 @@ export function modelToUrl(item: UrlableModel) {
       if (item?.database?.id) {
         return tableRowsQuery(item.database.id, item.id);
       }
-      return null;
+      return NOT_FOUND_URL;
     case "collection":
       return collection(item);
     case "document":
@@ -46,10 +48,10 @@ export function modelToUrl(item: UrlableModel) {
     case "timeline":
       return timeline(item);
     case "user":
-      return null;
+      return NOT_FOUND_URL;
     case "transform":
       return transform(item.id);
     default:
-      return null;
+      return NOT_FOUND_URL;
   }
 }

--- a/frontend/src/metabase/lib/urls/modelToUrl.ts
+++ b/frontend/src/metabase/lib/urls/modelToUrl.ts
@@ -19,9 +19,7 @@ export type UrlableModel = {
   collection_id?: CollectionId | null;
 };
 
-const NOT_FOUND_URL = "/404";
-
-export function modelToUrl(item: UrlableModel): string {
+export function modelToUrl(item: UrlableModel) {
   switch (item.model) {
     case "card":
       return question({
@@ -40,7 +38,7 @@ export function modelToUrl(item: UrlableModel): string {
       if (item?.database?.id) {
         return tableRowsQuery(item.database.id, item.id);
       }
-      return NOT_FOUND_URL;
+      return null;
     case "collection":
       return collection(item);
     case "document":
@@ -48,10 +46,10 @@ export function modelToUrl(item: UrlableModel): string {
     case "timeline":
       return timeline(item);
     case "user":
-      return NOT_FOUND_URL;
+      return null;
     case "transform":
       return transform(item.id);
     default:
-      return NOT_FOUND_URL;
+      return null;
   }
 }

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BookmarkList/BookmarkList.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BookmarkList/BookmarkList.tsx
@@ -15,6 +15,7 @@ import CollapseSection from "metabase/common/components/CollapseSection";
 import { Sortable } from "metabase/common/components/Sortable";
 import GrabberS from "metabase/css/components/grabber.module.css";
 import Bookmarks from "metabase/entities/bookmarks";
+import { getIcon } from "metabase/lib/icon";
 import { connect } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { PLUGIN_COLLECTIONS } from "metabase/plugins";
@@ -76,7 +77,7 @@ const BookmarkItem = ({
 }: BookmarkItemProps) => {
   const isSelected = isBookmarkSelected(bookmark, selectedItem);
   const url = Urls.bookmark(bookmark);
-  const icon = Bookmarks.objectSelectors.getIcon(bookmark);
+  const icon = getIcon({ model: bookmark.type, display: bookmark.display });
   const onRemove = () => onDeleteBookmark(bookmark);
 
   const isIrregularCollection =

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BookmarkList/BookmarkList.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BookmarkList/BookmarkList.tsx
@@ -67,6 +67,11 @@ function isBookmarkSelected(bookmark: Bookmark, selectedItem?: SelectedItem) {
   );
 }
 
+function getBookmarkModel(bookmark: Bookmark) {
+  // we should reall fix this on the backend
+  return bookmark.card_type === "model" ? "dataset" : bookmark.type;
+}
+
 const BookmarkItem = ({
   bookmark,
   isDraggable,
@@ -77,7 +82,11 @@ const BookmarkItem = ({
 }: BookmarkItemProps) => {
   const isSelected = isBookmarkSelected(bookmark, selectedItem);
   const url = Urls.bookmark(bookmark);
-  const icon = getIcon({ model: bookmark.type, display: bookmark.display });
+
+  const icon = getIcon({
+    model: getBookmarkModel(bookmark),
+    display: bookmark.display,
+  });
   const onRemove = () => onDeleteBookmark(bookmark);
 
   const isIrregularCollection =

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/components/ModelUsageDetails.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/components/ModelUsageDetails.tsx
@@ -3,7 +3,7 @@ import { t } from "ttag";
 import { useListCardsQuery } from "metabase/api";
 import Link from "metabase/common/components/Link";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
-import { getIcon } from "metabase/entities/questions";
+import { getIcon } from "metabase/lib/icon";
 import * as Urls from "metabase/lib/urls";
 import type { IconName } from "metabase/ui";
 import { Group, Icon, Repeat, Skeleton, Stack, Text } from "metabase/ui";
@@ -60,7 +60,10 @@ export function ModelUsageDetails({ model }: ModelUsageDetailsProps) {
             key={card.id}
           >
             <Group gap="sm">
-              <Icon c="text-dark" name={getIcon(card).name as IconName} />
+              <Icon
+                c="text-dark"
+                name={getIcon({ model: "card", ...card }).name as IconName}
+              />
               <Text lh="1.25rem" color="inherit">
                 {card.name}
               </Text>

--- a/frontend/src/metabase/questions/components/CollectionBadge.tsx
+++ b/frontend/src/metabase/questions/components/CollectionBadge.tsx
@@ -2,6 +2,7 @@ import type { ComponentType, PropsWithChildren } from "react";
 
 import { Badge } from "metabase/common/components/Badge";
 import Collections from "metabase/entities/collections";
+import { getIcon } from "metabase/lib/icon";
 import { PLUGIN_COLLECTIONS } from "metabase/plugins";
 import type {
   CollectionId,
@@ -38,7 +39,7 @@ const CollectionBadgeInner = ({
 
   const isRegular = PLUGIN_COLLECTIONS.isRegularCollection(collection);
   const icon = {
-    ...collection.getIcon(),
+    ...getIcon({ ...collection, model: "collection" }),
     ...(isRegular ? { size: 16 } : IRREGULAR_ICON_PROPS),
   };
 

--- a/frontend/src/metabase/search/components/InfoText/InfoText.unit.spec.tsx
+++ b/frontend/src/metabase/search/components/InfoText/InfoText.unit.spec.tsx
@@ -9,7 +9,6 @@ import {
 } from "__support__/server-mocks";
 import { renderWithProviders, screen, waitFor } from "__support__/ui";
 import type { WrappedResult } from "metabase/search/types";
-import type { IconName } from "metabase/ui";
 import type { SearchModel, SearchResult } from "metabase-types/api";
 import {
   createMockCollection,
@@ -81,18 +80,11 @@ async function setup({
   const result = createSearchResult({ model, ...resultProps });
 
   const getUrl = jest.fn(() => "a/b/c");
-  const getIcon = jest.fn(() => ({
-    name: "eye" as IconName,
-    size: 14,
-    width: 14,
-    height: 14,
-  }));
   const getCollection = jest.fn(() => result.collection);
 
   const wrappedResult: WrappedResult = {
     ...result,
     getUrl,
-    getIcon,
     getCollection,
   };
 
@@ -111,7 +103,6 @@ async function setup({
 
   return {
     getUrl,
-    getIcon,
     getCollection,
   };
 }

--- a/frontend/src/metabase/search/components/SearchResult/components/DefaultIcon.tsx
+++ b/frontend/src/metabase/search/components/SearchResult/components/DefaultIcon.tsx
@@ -1,16 +1,11 @@
 import { getIcon } from "metabase/lib/icon";
-import type { WrappedResult } from "metabase/search/types";
 import { Icon } from "metabase/ui";
 
 import type { IconComponentProps } from "./ItemIcon";
 import { DEFAULT_ICON_SIZE } from "./constants";
 
-const isWrappedResult = (
-  item: IconComponentProps["item"],
-): item is WrappedResult => item && "getIcon" in item;
-
 export function DefaultIcon({ item }: { item: IconComponentProps["item"] }) {
-  const iconData = isWrappedResult(item) ? item?.getIcon?.() : getIcon(item);
+  const iconData = getIcon(item);
 
   return <Icon {...iconData} size={DEFAULT_ICON_SIZE} />;
 }

--- a/frontend/src/metabase/search/components/SearchResult/tests/SearchResult-Collections.unit.spec.tsx
+++ b/frontend/src/metabase/search/components/SearchResult/tests/SearchResult-Collections.unit.spec.tsx
@@ -115,7 +115,6 @@ describe("SearchResult > Collections", () => {
   describe("EE", () => {
     const resultInOfficalCollectionEE: WrappedResult = {
       ...resultInOfficalCollection,
-      getIcon: () => ({ name: "table" }),
     };
 
     it("renders regular collection correctly", async () => {

--- a/frontend/src/metabase/search/components/SearchResult/tests/SearchResult-Collections.unit.spec.tsx
+++ b/frontend/src/metabase/search/components/SearchResult/tests/SearchResult-Collections.unit.spec.tsx
@@ -9,8 +9,8 @@ import {
   queryIcon,
   renderWithProviders,
   screen,
-  waitFor,
 } from "__support__/ui";
+import { reinitialize } from "metabase/plugins";
 import { SearchResult } from "metabase/search/components/SearchResult";
 import type { WrappedResult } from "metabase/search/types";
 import type { TokenFeatures } from "metabase-types/api";
@@ -35,16 +35,17 @@ const TEST_OFFICIAL_COLLECTION = createMockCollection({
   authority_level: "official",
 });
 
-const resultInRegularCollection = createWrappedSearchResult({
-  name: "My Regular Item",
-  collection_authority_level: null,
+const regularCollectionResult = createWrappedSearchResult({
+  name: "My Vanilla Collection",
+  model: "collection",
   collection: TEST_REGULAR_COLLECTION,
 });
 
-const resultInOfficalCollection = createWrappedSearchResult({
-  name: "My Official Item",
+const officialCollectionResult = createWrappedSearchResult({
+  name: "My Official Collection",
+  model: "collection",
   collection_authority_level: "official",
-  collection: TEST_OFFICIAL_COLLECTION,
+  collection: TEST_REGULAR_COLLECTION,
 });
 
 interface SetupOpts {
@@ -69,6 +70,7 @@ const setup = ({
       "token-features": createMockTokenFeatures(tokenFeatures),
     }),
   });
+  reinitialize();
 
   if (hasEnterprisePlugins) {
     setupEnterprisePlugins();
@@ -80,79 +82,55 @@ const setup = ({
 };
 
 describe("SearchResult > Collections", () => {
-  describe("OSS", () => {
-    it("renders regular collection correctly", async () => {
-      setup({ result: resultInRegularCollection });
-      expect(
-        screen.getByText(resultInRegularCollection.name),
-      ).toBeInTheDocument();
-      await waitFor(() => {
-        expect(
-          screen.queryByTestId("info-text-collection-loading-text"),
-        ).not.toBeInTheDocument();
-      });
-      expect(screen.getByText("Regular Collection")).toBeInTheDocument();
-      expect(getIcon("folder")).toBeInTheDocument();
-      expect(queryIcon("official_collection")).not.toBeInTheDocument();
-    });
-
-    it("renders official collections as regular", async () => {
-      setup({ result: resultInOfficalCollection });
-      expect(
-        screen.getByText(resultInOfficalCollection.name),
-      ).toBeInTheDocument();
-      await waitFor(() => {
-        expect(
-          screen.queryByTestId("info-text-collection-loading-text"),
-        ).not.toBeInTheDocument();
-      });
-      expect(screen.getByText("Official Collection")).toBeInTheDocument();
-      expect(getIcon("folder")).toBeInTheDocument();
-      expect(queryIcon("official_collection")).not.toBeInTheDocument();
-    });
-  });
-
   describe("EE", () => {
-    const resultInOfficalCollectionEE: WrappedResult = {
-      ...resultInOfficalCollection,
-    };
-
     it("renders regular collection correctly", async () => {
-      setup({ result: resultInRegularCollection });
-      expect(
-        screen.getByText(resultInRegularCollection.name),
-      ).toBeInTheDocument();
-
-      await waitFor(() => {
-        expect(
-          screen.queryByTestId("info-text-collection-loading-text"),
-        ).not.toBeInTheDocument();
+      setup({
+        result: regularCollectionResult,
+        hasEnterprisePlugins: true,
+        tokenFeatures: { official_collections: true },
       });
-
-      expect(screen.getByText("Regular Collection")).toBeInTheDocument();
+      expect(
+        await screen.findByText(regularCollectionResult.name),
+      ).toBeInTheDocument();
       expect(getIcon("folder")).toBeInTheDocument();
       expect(queryIcon("official_collection")).not.toBeInTheDocument();
     });
 
     it("renders official collections correctly", async () => {
       setup({
-        result: resultInOfficalCollectionEE,
+        result: officialCollectionResult,
         hasEnterprisePlugins: true,
         tokenFeatures: { official_collections: true },
       });
+
       expect(
-        screen.getByText(resultInOfficalCollectionEE.name),
+        await screen.findByText(officialCollectionResult.name),
       ).toBeInTheDocument();
 
-      await waitFor(() => {
-        expect(
-          screen.queryByTestId("info-text-collection-loading-text"),
-        ).not.toBeInTheDocument();
-      });
-
-      expect(screen.getByText("Official Collection")).toBeInTheDocument();
       expect(getIcon("official_collection")).toBeInTheDocument();
       expect(queryIcon("folder")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("OSS", () => {
+    it("renders regular collection correctly", async () => {
+      setup({ result: regularCollectionResult });
+      expect(
+        await screen.findByText(regularCollectionResult.name),
+      ).toBeInTheDocument();
+
+      expect(getIcon("folder")).toBeInTheDocument();
+      expect(queryIcon("official_collection")).not.toBeInTheDocument();
+    });
+
+    it("renders official collections as regular", async () => {
+      setup({ result: officialCollectionResult });
+      expect(
+        await screen.findByText(officialCollectionResult.name),
+      ).toBeInTheDocument();
+
+      expect(getIcon("folder")).toBeInTheDocument();
+      expect(queryIcon("official_collection")).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/metabase/search/components/SearchResult/tests/SearchResult-Tables.unit.spec.tsx
+++ b/frontend/src/metabase/search/components/SearchResult/tests/SearchResult-Tables.unit.spec.tsx
@@ -35,7 +35,6 @@ const setup = (setupOpts: SetupOpts) => {
     table_id: TEST_TABLE.id,
     database_id: TEST_DATABASE.id,
     getUrl: () => `/table/${TEST_TABLE.id}`,
-    getIcon: () => ({ name: "table" }),
     ...setupOpts,
   });
 

--- a/frontend/src/metabase/search/components/SearchResult/tests/SearchResult.unit.spec.tsx
+++ b/frontend/src/metabase/search/components/SearchResult/tests/SearchResult.unit.spec.tsx
@@ -22,7 +22,6 @@ const TEST_RESULT_QUESTION = createWrappedSearchResult({
   name: "My Item",
   model: "card",
   description: "My Item Description",
-  getIcon: () => ({ name: "table" }),
 });
 
 const TEST_RESULT_COLLECTION = createWrappedSearchResult({

--- a/frontend/src/metabase/search/components/SearchResult/tests/util.ts
+++ b/frontend/src/metabase/search/components/SearchResult/tests/util.ts
@@ -9,7 +9,6 @@ export const createWrappedSearchResult = (
   return {
     ...result,
     getUrl: options.getUrl ?? (() => "/collection/root"),
-    getIcon: options.getIcon ?? (() => ({ name: "folder" })),
     getCollection: options.getCollection ?? (() => result.collection),
   };
 };

--- a/frontend/src/metabase/search/types.ts
+++ b/frontend/src/metabase/search/types.ts
@@ -11,12 +11,6 @@ import type {
 
 export interface WrappedResult extends SearchResult {
   getUrl: () => string;
-  getIcon: () => {
-    name: IconName;
-    size?: number;
-    width?: number;
-    height?: number;
-  };
   getCollection: () => SearchResult["collection"];
 }
 

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/EntityDisplay.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/EntityDisplay.tsx
@@ -1,6 +1,7 @@
 import { t } from "ttag";
 
 import Markdown from "metabase/common/components/Markdown";
+import { getIcon } from "metabase/lib/icon";
 import { isEmpty } from "metabase/lib/validate";
 import { Icon } from "metabase/ui";
 
@@ -65,7 +66,7 @@ export const UrlLinkDisplay = ({ url }: { url?: string }) => {
 };
 
 function getSearchIconName(entity: WrappedUnrestrictedLinkEntity) {
-  const entityIcon = entity.getIcon?.() ?? { name: "link" };
+  const entityIcon = getIcon(entity) ?? { name: "link" };
 
   // we need to change this icon to make it match the icon in the search results
   if (entity.model === "table") {


### PR DESCRIPTION
Closes UXW-2373

What if instead of defining tons of functions for getting icons we just used the one existing `getIcon()` function that "just works" for everything already!