### PR TITLE
[equality] Comment out debugging statements in lib.quality/=

### DIFF
--- a/src/metabase/lib/equality.cljc
+++ b/src/metabase/lib/equality.cljc
@@ -178,9 +178,12 @@ are known to be the same."
 (defmethod = :metadata/column
   [col-1 col-2]
   (let [not-equal-reason (columns-not-equal-reason col-1 col-2)]
-    (if not-equal-reason
-      (log/debugf "Columns are not equal. Reason: %s" (pr-str not-equal-reason))
-      (log/debug "Columns are equal."))
+    ;; This block is commented out for performance reasons. Even when DEBUG level is not enabled, computing level
+    ;; eligibility on each comparison operation is significantly expensive. If you need to debug this, consider
+    ;; restricting the log to particular columns.
+    #_(if not-equal-reason
+        (log/debugf "Columns are not equal. Reason: %s" (pr-str not-equal-reason))
+        (log/debug "Columns are equal."))
     (not not-equal-reason)))
 
 (mu/defn- resolve-field-id-in-source-card :- ::lib.schema.metadata/column


### PR DESCRIPTION
Having these logging statements has significant impact on allocation rate, even if the requested logging level is disabled. That's because the logging system has to construct the logger object anyway.

I'd argue that having those logging statements always on isn't helpful because enabling debug log in that function would create immense noise because of how often this equality function is being called.