### PR TITLE
Fix mapping of params to later query stages

### DIFF
--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -541,8 +541,8 @@
   ([query stage-number]
    (let [stage (query-stage query stage-number)
          stage-cols (-> stage :lib/stage-metadata :columns)
-         new-stage-cols (vec (remove (comp #{:source/breakouts :source/aggregations} :lib/source)
-                                     stage-cols))]
+         new-stage-cols (into [] (remove (comp #{:source/breakouts :source/aggregations} :lib/source))
+                                     stage-cols)]
      (-> query
          (update-query-stage stage-number dissoc :aggregation :breakout)
          (update-query-stage stage-number u/assoc-dissoc

--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -535,14 +535,15 @@
     nil))
 
 (defn drop-summary-clauses
-  "Remove :aggregation and :breakout from the stage at `stage-number` of a `query`."
+  "Remove :aggregation and :breakout from the stage at `stage-number` of a `query`. Adjust stage metadata accordingly."
   ([query]
    (drop-summary-clauses query -1))
   ([query stage-number]
    (let [stage (query-stage query stage-number)
          stage-cols (-> stage :lib/stage-metadata :columns)
-         new-stage-cols (into [] (remove (comp #{:source/breakouts :source/aggregations} :lib/source))
-                                     stage-cols)]
+         new-stage-cols (into []
+                              (remove (comp #{:source/breakouts :source/aggregations} :lib/source))
+                              stage-cols)]
      (-> query
          (update-query-stage stage-number dissoc :aggregation :breakout)
          (update-query-stage stage-number u/assoc-dissoc

--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -548,4 +548,3 @@
          (update-query-stage stage-number u/assoc-dissoc
                              :lib/stage-metadata (when (seq new-stage-cols)
                                                    {:columns new-stage-cols}))))))
-

--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -539,4 +539,13 @@
   ([query]
    (drop-summary-clauses query -1))
   ([query stage-number]
-   (update-query-stage query stage-number dissoc :aggregation :breakout)))
+   (let [stage (query-stage query stage-number)
+         stage-cols (-> stage :lib/stage-metadata :columns)
+         new-stage-cols (vec (remove (comp #{:source/breakouts :source/aggregations} :lib/source)
+                                     stage-cols))]
+     (-> query
+         (update-query-stage stage-number dissoc :aggregation :breakout)
+         (update-query-stage stage-number u/assoc-dissoc
+                             :lib/stage-metadata (when (seq new-stage-cols)
+                                                   {:columns new-stage-cols}))))))
+

--- a/src/metabase/parameters/custom_values.clj
+++ b/src/metabase/parameters/custom_values.clj
@@ -74,8 +74,8 @@
   (when-some [mp (-> card :dataset_query :lib/metadata)]
     (let [card (lib.metadata/card mp (:id card))
           full-query (lib/card->underlying-query mp card)]
-      (loop [stage-number (lib/canonical-stage-index full-query -1)
-             query full-query]
+      (loop [query full-query
+             stage-number (lib/canonical-stage-index full-query -1)]
         ;; (1) Append stage. The searched column may be part of summaries. Further transformations will add
         ;; filters and breakouts. A new stage ensures those operations are not conflated with existing summaries.
         ;; (2) visible-columns. Visible columns are used because ref may come from implicit join.

--- a/test/metabase/dashboards/api_test.clj
+++ b/test/metabase/dashboards/api_test.clj
@@ -5553,3 +5553,40 @@
           (is (=? {:values [["African"] ["Artisan"] ["Bakery"] ["Krua Siri"] ["Red Medicine"]]}
                   (mt/user-http-request :crowberto :get 200 (format "dashboard/%d/params/%s/values"
                                                                     (:id d) param-key)))))))))
+
+(deftest param-mapped-to-nested-field-of-filtered-card-test
+  (testing "Values for param mapped to nested field of a card are computed correctly (#41684)"
+    (let [mp (mt/metadata-provider)
+          param-key "p"
+          query (-> (lib/query mp (lib.metadata/table mp (mt/id :categories)))
+                    (lib/filter (lib/in (lib.metadata/field mp (mt/id :categories :name))
+                                        "African" "Artisan" "Bakery"))
+                    (lib/append-stage)
+                    (lib/aggregate (lib/count))
+                    (lib/breakout (lib.metadata/field mp (mt/id :categories :id)))
+                    (lib/append-stage)
+                    (lib/aggregate (lib/count)))]
+      (mt/with-temp
+        [:model/Card
+         c1
+         {:dataset_query  query}
+
+         :model/Dashboard
+         d
+         {:parameters [{:id param-key
+                        :name "filtered names filter"
+                        :slug param-key
+                        :type "string/="
+                        :sectionId "string"}]}
+
+         :model/DashboardCard
+         _
+         {:dashboard_id (:id d)
+          :card_id (:id c1)
+          :parameter_mappings [{:card_id (:id c1)
+                                :parameter_id param-key
+                                :target ["dimension" ["field" (mt/id :categories :name) nil]]}]}]
+
+        (is (=? {:values [["African"] ["Artisan"] ["Bakery"]]}
+                (mt/user-http-request :crowberto :get 200 (format "dashboard/%d/params/%s/values"
+                                                                  (:id d) param-key))))))))

--- a/test/metabase/dashboards/api_test.clj
+++ b/test/metabase/dashboards/api_test.clj
@@ -5570,7 +5570,6 @@
         [:model/Card
          c1
          {:dataset_query  query}
-
          :model/Dashboard
          d
          {:parameters [{:id param-key
@@ -5578,7 +5577,6 @@
                         :slug param-key
                         :type "string/="
                         :sectionId "string"}]}
-
          :model/DashboardCard
          _
          {:dashboard_id (:id d)


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/65713

My https://github.com/metabase/metabase/pull/64318 introduced a bug with reversed loop args.

It went unnoticed because I believed that FE (e2e) test (failure of which made me realize that param mapping could be performed not only on latest stage) exercises the problematic state.

However with the most recent changes of linked PR it does not. If the mapping is on penultimate stage and aggregations from the last are removed, that makes the field available, hence no need to recurse.

This PR adds test that requires recurse to the problematic loop expression.

