### PR TITLE
Minor fixes around semantic search

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
@@ -58,11 +58,12 @@
                       final-count threshold raw-count fallback)
           (analytics/inc! :metabase-search/semantic-fallback-triggered {:fallback-engine fallback})
           (analytics/observe! :metabase-search/semantic-results-before-fallback final-count)
+
           (when (some-> (:offset-int search-ctx) pos?)
             (log/warn "Using an offset with semantic search will produce strange results, e.g. missing expected results, or duplicating them across pages"))
+
           (let [total-limit      (semantic.settings/semantic-search-results-limit)
                 fallback-results (try
-                                   ;; Note: we will get weird behaviour with :offset-in
                                    (cond->> (search.engine/results (assoc search-ctx :search-engine fallback))
                                      ;; The in-place engine returns a reducible (but not seqable) result that needs to
                                      ;; be realized before we concat and dedup with the semantic engine results.

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
@@ -58,7 +58,7 @@
                       final-count threshold raw-count fallback)
           (analytics/inc! :metabase-search/semantic-fallback-triggered {:fallback-engine fallback})
           (analytics/observe! :metabase-search/semantic-results-before-fallback final-count)
-          (when (:offset-int search-ctx)
+          (when (some-> (:offset-int search-ctx) pos?)
             (log/warn "Using an offset with semantic search will produce strange results, e.g. missing expected results, or duplicating them across pages"))
           (let [total-limit      (semantic.settings/semantic-search-results-limit)
                 fallback-results (try

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/scoring.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/scoring.clj
@@ -71,8 +71,8 @@
 
 (defn base-scorers
   "The default constituents of the search ranking scores."
-  [index-table {:keys [search-string limit-int] :as search-ctx}]
-  (if (and limit-int (zero? limit-int))
+  [index-table {:keys [search-string] :as search-ctx}]
+  (if (search.scoring/no-scoring-required? search-ctx)
     {:model [:inline 1]}
     ;; NOTE: we calculate scores even if the weight is zero, so that it's easy to consider how we could affect any
     ;; given set of results. At some point, we should optimize away the irrelevant scores for any given context.
@@ -188,8 +188,8 @@
 
 (defn appdb-scorers
   "The appdb-based scorers for search ranking results. Like `base-scorers`, but for scorers that need to query the appdb."
-  [{:keys [limit-int] :as search-ctx}]
-  (when-not (and limit-int (zero? limit-int))
+  [search-ctx]
+  (when-not (search.scoring/no-scoring-required? search-ctx)
     {:bookmarked search.scoring/bookmark-score-expr
      :user-recency (search.scoring/inverse-duration
                     (search.scoring/user-recency-expr search-ctx) [:now] search.config/stale-time-in-days)}))

--- a/src/metabase/search/appdb/scoring.clj
+++ b/src/metabase/search/appdb/scoring.clj
@@ -41,8 +41,8 @@
 
 (defn base-scorers
   "The default constituents of the search ranking scores."
-  [{:keys [search-string limit-int] :as search-ctx}]
-  (if (and limit-int (zero? limit-int))
+  [{:keys [search-string] :as search-ctx}]
+  (if (search.scoring/no-scoring-required? search-ctx)
     {:model       [:inline 1]}
     ;; NOTE: we calculate scores even if the weight is zero, so that it's easy to consider how we could affect any
     ;; given set of results. At some point, we should optimize away the irrelevant scores for any given context.

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -172,3 +172,8 @@
              :weight       weight
              :contribution (* weight score)}))
         scorers))
+
+(defn no-scoring-required?
+  "Scoring is unnecessary unless we will return more than 1 result."
+  [{:keys [limit-int]}]
+  (and limit-int (<= limit-int 1)))

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -174,6 +174,6 @@
         scorers))
 
 (defn no-scoring-required?
-  "Scoring is unnecessary unless we will return more than 1 result."
+  "Scoring is unnecessary when we are not returning any result, e.g. counting potential results"
   [{:keys [limit-int]}]
-  (and limit-int (<= limit-int 1)))
+  (and limit-int (zero? limit-int)))

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -174,6 +174,6 @@
         scorers))
 
 (defn no-scoring-required?
-  "Scoring is unnecessary when we are not returning any result, e.g. counting potential results"
+  "Scoring is unnecessary when we are not returning any results, e.g. counting potential results"
   [{:keys [limit-int]}]
   (and limit-int (zero? limit-int)))


### PR DESCRIPTION
Fixes some small things:

1. Fix how many results we fetch from legacy search, to account for deduping.
2. Fix counting and checking distinctness of excess results in appdb fallback case.
3. DRY up logic for skipping scoring. At first I thought it was wrong too, but that was follly.
4. Add warning for edge case where fallback results could be "weird".
