### PR TITLE
Add published_table_id to report_card and associated hydrations

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_layer/validation.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_layer/validation.clj
@@ -14,4 +14,3 @@
         (throw (ex-info "Content type not allowed in this collection" {:content-type content-type, :allowed-content allowed-content})))))
 
   true)
-

--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -140,7 +140,7 @@ databaseChangeLog:
                     nullable: true
 
   - changeSet:
-      id: v57.2025-11-13T10:00:00
+      id: v58.2025-11-13T10:00:00
       author: qnkhuat
       comment: Backfill data_layer from visibility_type
       changes:

--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -52,6 +52,34 @@ databaseChangeLog:
                   remarks: JSON map of the types of items that can be added to this card
 
   - changeSet:
+      id: v58.2025-11-10T14:39:00
+      author: wotbrew
+      comment: Add published_table_id to report_card
+      changes:
+        - addColumn:
+            tableName: report_card
+            columns:
+              - column:
+                  name: published_table_id
+                  type: int
+                  remarks: The table id that is 'published' by this model
+                  constraints:
+                    nullable: true
+
+  - changeSet:
+      id: v58.2025-11-10T14:39:01
+      author: wotbrew
+      comment: Add foreign key report_card(published_table_id) to metabase_table(id)
+      changes:
+       - addForeignKeyConstraint:
+           baseTableName: report_card
+           baseColumnNames: published_table_id
+           referencedTableName: metabase_table
+           referencedColumnNames: id
+           constraintName: fk_report_card_published_table
+           onDelete: SET NULL
+
+  - changeSet:
       id: v58.2025-11-12T11:57:00
       author: wotbrew
       comment: Add data_source column to metabase_table

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -1218,6 +1218,7 @@
     :document_id            (serdes/fk :model/Document)
     :creator_id             (serdes/fk :model/User)
     :made_public_by_id      (serdes/fk :model/User)
+    :published_table_id     (serdes/fk :model/Table)
     :dataset_query          {:export serdes/export-mbql :import serdes/import-mbql}
     :parameters             {:export serdes/export-parameters :import serdes/import-parameters}
     :parameter_mappings     {:export serdes/export-parameter-mappings :import serdes/import-parameter-mappings}

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -903,7 +903,7 @@
                             (not (:dashboard_id input-card-data)))))
    (let [data-keys                          [:dataset_query :description :display :name :visualization_settings
                                              :parameters :parameter_mappings :collection_id :collection_position
-                                             :cache_ttl :type :dashboard_id :document_id]
+                                             :cache_ttl :type :dashboard_id :document_id :published_table_id]
          position-info                      {:collection_id (:collection_id input-card-data)
                                              :collection_position (:collection_position input-card-data)}
          card-data                          (-> (select-keys input-card-data data-keys)

--- a/src/metabase/warehouse_schema/models/table.clj
+++ b/src/metabase/warehouse_schema/models/table.clj
@@ -334,7 +334,7 @@
                                                      :from_entity_type "table"
                                                      :from_entity_id [:in table-ids]
                                                      :to_entity_type "transform")
-          transform-id->transform  (when-let [transform-ids (vals table-id->transform-id)]
+          transform-id->transform  (when-let [transform-ids (seq (vals table-id->transform-id))]
                                      (t2/select-fn->fn :id identity :model/Transform :id [:in transform-ids]))]
       (update-vals table-id->transform-id transform-id->transform))
    :id

--- a/src/metabase/warehouse_schema/models/table.clj
+++ b/src/metabase/warehouse_schema/models/table.clj
@@ -407,9 +407,25 @@
      (let [table-ids          (sort (set (map :id tables)))
            published-as-model (t2/select-fn-set :published_table_id [:model/Card :published_table_id]
                                                 :published_table_id [:in table-ids]
-                                                :archived false
-                                                :archived_directly false)]
+                                                :type               :model
+                                                :archived           false
+                                                :archived_directly  false)]
        (u/index-by identity #(contains? published-as-model %) table-ids)))
+   :id
+   {:default nil}))
+
+(methodical/defmethod t2/batched-hydrate [:model/Table :published_models]
+  [_model k tables]
+  (mi/instances-with-hydrated-data
+   tables k
+   (fn []
+     (let [table-ids (sort (set (map :id tables)))
+           models    (t2/select :model/Card
+                                :published_table_id [:in table-ids]
+                                :type               :model
+                                :archived           false
+                                :archived_directly  false)]
+       (group-by :published_table_id models)))
    :id
    {:default nil}))
 

--- a/src/metabase/warehouse_schema/models/table.clj
+++ b/src/metabase/warehouse_schema/models/table.clj
@@ -404,23 +404,12 @@
   (cond
     (empty? tables)                                     tables
     (not-every? :id tables)                             tables
-    (not (premium-features/has-feature? :dependencies)) tables
     :else
     (let [table-ids          (sort (set (map :id tables)))
-          ;; todo temporary: this logic is not well defined, seek clarity on what it means to be a model
-          ;; tested at api level but unsure about that or hydration as implementation
-          ;; archived? collection archived? permission / visibility
-          ;; open question on how best to achieve delivery of this data to client, work in progress
-          published-as-model (t2/select-fn-set :to_entity_id
-                                               [:model/Dependency :to_entity_id]
-                                               :to_entity_type "table"
-                                               :to_entity_id [:in table-ids]
-                                               :from_entity_type "card"
-                                               {:join [[:report_card :card]
-                                                       [:and
-                                                        [:= :dependency.from_entity_id :card.id]
-                                                        [:= :dependency.to_entity_id :card.table_id]]]
-                                                :where [:= "model" :card.type]})]
+          published-as-model (t2/select-fn-set :published_table_id [:model/Card :published_table_id]
+                                               :published_table_id [:in table-ids]
+                                               :archived false
+                                               :archived_directly false)]
       (map #(assoc % :published_as_model (contains? published-as-model (:id %))) tables))))
 
 ;;; ------------------------------------------------ Convenience Fns -------------------------------------------------

--- a/src/metabase/warehouse_schema/table.clj
+++ b/src/metabase/warehouse_schema/table.clj
@@ -33,7 +33,8 @@
     (api/write-check table)
     (api/read-check table))
   (let [hydration-keys (cond-> [:db [:fields [:target :has_field_values] :has_field_values :dimensions :name_field] :segments :metrics]
-                         (premium-features/has-feature? :transforms) (conj :transform))]
+                         (premium-features/has-feature? :transforms) (conj :transform)
+                         api/*is-superuser?*                         (conj :published_models))]
     (-> table
         (#(apply t2/hydrate % hydration-keys))
         (m/dissoc-in [:db :details])

--- a/src/metabase/warehouses/api.clj
+++ b/src/metabase/warehouses/api.clj
@@ -1269,8 +1269,7 @@
                               (f candidate-tables)
                               candidate-tables)
                             (filter mi/can-read? candidate-tables))
-         hydration-keys   (cond-> []
-                            (premium-features/has-feature? :dependencies) (conj :published_as_model)
+         hydration-keys   (cond-> [:published_as_model]
                             (premium-features/has-feature? :transforms)   (conj :transform))]
      (if (seq hydration-keys)
        (apply t2/hydrate filtered-tables hydration-keys)

--- a/test/metabase/warehouse_schema/api/table_test.clj
+++ b/test/metabase/warehouse_schema/api/table_test.clj
@@ -1286,9 +1286,9 @@
               [model] models
               venues-schema              (t2/select-one-fn :schema [:model/Table :schema] (mt/id :venues))
               schema-url                 (format "database/%d/schema/%s" (mt/id) venues-schema)
-              list-tables-via-table-api  #(mt/user-http-request :crowberto :get 200 "table" :db_id (mt/id))
+              list-tables-via-table-api  (fn [] (->> (mt/user-http-request :crowberto :get 200 "table" :db-id (mt/id))
+                                                     (filter #(= (mt/id) (:db_id %)))))
               list-tables-via-schema-api #(mt/user-http-request :crowberto :get 200 schema-url)]
-
           (testing "list tables"
             (let [list-response      (list-tables-via-table-api)
                   published-as-model (u/index-by :id :published_as_model list-response)]
@@ -1301,7 +1301,7 @@
               (is (false? (published-as-model (mt/id :users))))))
           (testing "archived tables are not returned"
             (t2/update! :model/Card (:id model) {:archived true, :archived_directly false})
-            (is (not-any? :published_as_model (list-tables-via-table-api)))))))))
+            (is (not-any? :published_as_model  (list-tables-via-table-api)))))))))
 
 (deftest ^:parallel bulk-edit-visibility-sync-test
   (testing "POST /api/table/edit visibility field synchronization"

--- a/test/metabase/warehouse_schema/api/table_test.clj
+++ b/test/metabase/warehouse_schema/api/table_test.clj
@@ -1279,29 +1279,51 @@
 (deftest published-as-model-test
   (mt/with-model-cleanup [:model/Card]
     (mt/with-temp [:model/Collection {collection-id :id} {}]
-      (mt/with-premium-features #{:dependencies}
-        (let [{:keys [models]} (mt/user-http-request :crowberto :post 200 "table/publish-model"
-                                                     {:table_ids            [(mt/id :venues)]
-                                                      :target_collection_id collection-id})
-              [model] models
-              venues-schema              (t2/select-one-fn :schema [:model/Table :schema] (mt/id :venues))
-              schema-url                 (format "database/%d/schema/%s" (mt/id) venues-schema)
-              list-tables-via-table-api  (fn [] (->> (mt/user-http-request :crowberto :get 200 "table" :db-id (mt/id))
-                                                     (filter #(= (mt/id) (:db_id %)))))
-              list-tables-via-schema-api #(mt/user-http-request :crowberto :get 200 schema-url)]
-          (testing "list tables"
-            (let [list-response      (list-tables-via-table-api)
-                  published-as-model (u/index-by :id :published_as_model list-response)]
-              (is (true? (published-as-model (mt/id :venues))))
-              (is (false? (published-as-model (mt/id :users))))))
-          (testing "list tables via schema"
-            (let [list-response      (list-tables-via-schema-api)
-                  published-as-model (u/index-by :id :published_as_model list-response)]
-              (is (true? (published-as-model (mt/id :venues))))
-              (is (false? (published-as-model (mt/id :users))))))
-          (testing "archived tables are not returned"
-            (t2/update! :model/Card (:id model) {:archived true, :archived_directly false})
-            (is (not-any? :published_as_model  (list-tables-via-table-api)))))))))
+      (let [{:keys [models]} (mt/user-http-request :crowberto :post 200 "table/publish-model"
+                                                   {:table_ids            [(mt/id :venues)]
+                                                    :target_collection_id collection-id})
+            [model] models
+            venues-schema              (t2/select-one-fn :schema [:model/Table :schema] (mt/id :venues))
+            schema-url                 (format "database/%d/schema/%s" (mt/id) venues-schema)
+            list-tables-via-table-api  (fn [] (->> (mt/user-http-request :crowberto :get 200 "table" :db-id (mt/id))
+                                                   (filter #(= (mt/id) (:db_id %)))))
+            list-tables-via-schema-api #(mt/user-http-request :crowberto :get 200 schema-url)]
+        (testing "list tables"
+          (let [list-response      (list-tables-via-table-api)
+                published-as-model (u/index-by :id :published_as_model list-response)]
+            (is (true? (published-as-model (mt/id :venues))))
+            (is (false? (published-as-model (mt/id :users))))))
+        (testing "list tables via schema"
+          (let [list-response      (list-tables-via-schema-api)
+                published-as-model (u/index-by :id :published_as_model list-response)]
+            (is (true? (published-as-model (mt/id :venues))))
+            (is (false? (published-as-model (mt/id :users))))))
+        (testing "archived tables are not returned"
+          (t2/update! :model/Card (:id model) {:archived true, :archived_directly false})
+          (is (not-any? :published_as_model (list-tables-via-table-api))))))))
+
+(deftest published-models-perm-test
+  ;; what I think would be reasonable permissions behaviour:
+  ;;  > if no permissions on model or its collection, model is filtered out
+  ;; what I have done:
+  ;;  > if not super-user we never give you the published models
+  (mt/with-model-cleanup [:model/Card]
+    (mt/with-temp [:model/Collection {collection1 :id} {}
+                   :model/Collection {collection2 :id} {}]
+      (let [publish-venues        #(mt/user-http-request :crowberto :post 200 "table/publish-model"
+                                                         {:table_ids            [(mt/id :venues)]
+                                                          :target_collection_id %})
+            {[{model1 :id}] :models} (publish-venues collection1)
+            {[{model2 :id}] :models} (publish-venues collection2)
+            query-meta-url        #(format "table/%d/query_metadata" %)
+            list-published-models #(:published_models (mt/user-http-request %1 :get 200 (query-meta-url %2)))]
+        (testing "admin sees both models"
+          (is (= [model1 model2] (map :id (list-published-models :crowberto (mt/id :venues))))))
+        (testing "no published models"
+          (is (nil? (list-published-models :crowberto (mt/id :users)))))
+        (testing "non admin does not see published models"
+          (is (nil? (list-published-models :rasta (mt/id :venues))))
+          (is (nil? (list-published-models :rasta (mt/id :users)))))))))
 
 (deftest ^:parallel bulk-edit-visibility-sync-test
   (testing "POST /api/table/edit visibility field synchronization"

--- a/test/metabase/warehouse_schema/models/table_test.clj
+++ b/test/metabase/warehouse_schema/models/table_test.clj
@@ -370,11 +370,11 @@
   (testing "hydrating :published_as_model"
     (mt/with-temp [:model/Table {t1 :id :as table1} {}
                    :model/Table {t2 :id :as table2} {}
-                   :model/Card {c1 :id} {:type :model :published_table_id t1}
-                   :model/Card {c2 :id} {:type :model :published_table_id t1 :archived true}
-                   :model/Card {c3 :id} {:type :model :published_table_id t1}
-                   :model/Card {c4 :id} {:type :model :published_table_id t2 :archived_directly true}
-                   :model/Card {c5 :id} {:type :metric :published_table_id t2}]
+                   :model/Card  {_c1 :id} {:type :model :published_table_id t1}
+                   :model/Card  {_c2 :id} {:type :model :published_table_id t1 :archived true}
+                   :model/Card  {_c3 :id} {:type :model :published_table_id t1}
+                   :model/Card  {_c4 :id} {:type :model :published_table_id t2 :archived_directly true}
+                   :model/Card  {_c5 :id} {:type :metric :published_table_id t2}]
       (is (= {t1 true, t2 false}
              (->> (t2/hydrate [table1 table2] :published_as_model)
                   (u/index-by :id :published_as_model)))))))
@@ -383,11 +383,11 @@
   (testing "hydrating :published_models"
     (mt/with-temp [:model/Table {t1 :id :as table1} {}
                    :model/Table {t2 :id :as table2} {}
-                   :model/Card {c1 :id} {:type :model :published_table_id t1}
-                   :model/Card {c2 :id} {:type :model :published_table_id t1 :archived true}
-                   :model/Card {c3 :id} {:type :model :published_table_id t1}
-                   :model/Card {c4 :id} {:type :model :published_table_id t2 :archived_directly true}
-                   :model/Card {c5 :id} {:type :metric :published_table_id t2}]
+                   :model/Card  {c1 :id} {:type :model :published_table_id t1}
+                   :model/Card  {c2 :id} {:type :model :published_table_id t1 :archived true}
+                   :model/Card  {c3 :id} {:type :model :published_table_id t1}
+                   :model/Card  {c4 :id} {:type :model :published_table_id t2 :archived_directly true}
+                   :model/Card  {c5 :id} {:type :metric :published_table_id t2}]
       (is (= {t1 [c1 c3], t2 []}
              (->> (t2/hydrate [table1 table2] :published_models)
                   (u/index-by :id (comp (partial mapv :id) :published_models))))))))

--- a/test/metabase/warehouse_schema/models/table_test.clj
+++ b/test/metabase/warehouse_schema/models/table_test.clj
@@ -365,3 +365,29 @@
             (is (= #{table-id-1 table-id-2 table-id-3}
                    (fetch-visible-ids user-info permission-map :id))
                 "Clause should filter correctly when requiring :blocked level")))))))
+
+(deftest published-as-model-test
+  (testing "hydrating :published_as_model"
+    (mt/with-temp [:model/Table {t1 :id :as table1} {}
+                   :model/Table {t2 :id :as table2} {}
+                   :model/Card {c1 :id} {:type :model :published_table_id t1}
+                   :model/Card {c2 :id} {:type :model :published_table_id t1 :archived true}
+                   :model/Card {c3 :id} {:type :model :published_table_id t1}
+                   :model/Card {c4 :id} {:type :model :published_table_id t2 :archived_directly true}
+                   :model/Card {c5 :id} {:type :metric :published_table_id t2}]
+      (is (= {t1 true, t2 false}
+             (->> (t2/hydrate [table1 table2] :published_as_model)
+                  (u/index-by :id :published_as_model)))))))
+
+(deftest published-models-test
+  (testing "hydrating :published_models"
+    (mt/with-temp [:model/Table {t1 :id :as table1} {}
+                   :model/Table {t2 :id :as table2} {}
+                   :model/Card {c1 :id} {:type :model :published_table_id t1}
+                   :model/Card {c2 :id} {:type :model :published_table_id t1 :archived true}
+                   :model/Card {c3 :id} {:type :model :published_table_id t1}
+                   :model/Card {c4 :id} {:type :model :published_table_id t2 :archived_directly true}
+                   :model/Card {c5 :id} {:type :metric :published_table_id t2}]
+      (is (= {t1 [c1 c3], t2 []}
+             (->> (t2/hydrate [table1 table2] :published_models)
+                  (u/index-by :id (comp (partial mapv :id) :published_models))))))))


### PR DESCRIPTION
Hydrate calls added to `GET /table` and `GET /table/:id/query_metadata`

New table hydrations
 - `:published_as_model` (true/false) whether or not a table has been published and has at least one model associated with it
 - `:published_models` a collection (unbounded) of `:model/Card` instances associated with the table via a publish relationship. 
 
Publishing a table establishes the relationship to its model via a new column `report_card.published_table_id` and currently:

- at no point is this relationship deleted (discussed on slack).
- archived models are not included in the hydrations