### PR TITLE
Closes EMB-982 embedding stuck on 404 when navigating with postMessage

### DIFF
--- a/e2e/support/helpers/e2e-embedding-iframe-interactive-helpers.ts
+++ b/e2e/support/helpers/e2e-embedding-iframe-interactive-helpers.ts
@@ -6,14 +6,12 @@ import { getIframeBody } from "./e2e-embedding-helpers";
 interface BaseEmbedTestPageOptions {
   dashboardId: number | string;
   iframeSelector?: string;
-  onVisitPage?(win: Cypress.AUTWindow): void;
 }
 
 /**
  * Creates and loads a test fixture for interactive iframe embedding tests
  */
 export function loadInteractiveIframeEmbedTestPage({
-  onVisitPage,
   iframeSelector,
   ...options
 }: BaseEmbedTestPageOptions) {
@@ -26,7 +24,7 @@ export function loadInteractiveIframeEmbedTestPage({
     headers: { "content-type": "text/html" },
   }).as("dynamicPage");
 
-  cy.visit(testPageUrl, { onLoad: onVisitPage });
+  cy.visit(testPageUrl);
   cy.title().should("include", "Metabase Embed Test");
 
   return getIframeBody(iframeSelector);
@@ -92,10 +90,6 @@ function getInteractiveHtml({ dashboardId }: BaseEmbedTestPageOptions) {
       <style>
         body {
           margin: 0;
-        }
-
-        metabase-question, metabase-dashboard {
-          height: 100vh;
         }
       </style>
     </head>

--- a/e2e/support/helpers/e2e-embedding-iframe-interactive-helpers.ts
+++ b/e2e/support/helpers/e2e-embedding-iframe-interactive-helpers.ts
@@ -1,0 +1,111 @@
+import { getIframeBody } from "./e2e-embedding-helpers";
+
+/**
+ * Base interface for interactive embedding test page options
+ */
+interface BaseEmbedTestPageOptions {
+  dashboardId: number | string;
+  iframeSelector?: string;
+  onVisitPage?(win: Cypress.AUTWindow): void;
+}
+
+/**
+ * Creates and loads a test fixture for interactive iframe embedding tests
+ */
+export function loadInteractiveIframeEmbedTestPage({
+  onVisitPage,
+  iframeSelector,
+  ...options
+}: BaseEmbedTestPageOptions) {
+  const testPageSource = getInteractiveHtml(options);
+
+  const testPageUrl = `${origin}/interactive-iframe-test-page`;
+
+  cy.intercept("GET", testPageUrl, {
+    body: testPageSource,
+    headers: { "content-type": "text/html" },
+  }).as("dynamicPage");
+
+  cy.visit(testPageUrl, { onLoad: onVisitPage });
+  cy.title().should("include", "Metabase Embed Test");
+
+  return getIframeBody(iframeSelector);
+}
+
+interface PostMessageOptions {
+  /**
+   * CSS selector for the iframe to post the message to
+   * @example `iframe[src*="localhost:4000/dashboard"]`
+   */
+  iframeSelector: string;
+
+  /**
+   * Something like `{ metabase: { type: "location", location: "/dashboard/9999990" } }` for instance
+   */
+  messageData: any;
+}
+
+export function postMessageToIframe(options: PostMessageOptions) {
+  const { messageData, iframeSelector } = options;
+
+  // this madness is necessary to simulate a real MessageEvent coming from the parent window
+  // because in frontend/src/metabase/lib/embed.js we check e.source === window.parent
+  cy.get(iframeSelector)
+    .should("be.visible")
+    .then(($iframe) => {
+      const iframeEl = $iframe[0] as HTMLIFrameElement;
+      // Get the actual parent window from the iframe's perspective
+      const actualParent = iframeEl.ownerDocument.defaultView;
+      const targetWin = iframeEl.contentWindow;
+
+      if (!actualParent || !targetWin) {
+        throw new Error("Could not access iframe or its parent window");
+      }
+
+      // Create a MessageEvent manually with the correct source
+      const event = new MessageEvent("message", {
+        data: messageData,
+        origin: actualParent.location.origin,
+        source: actualParent,
+      });
+
+      targetWin.dispatchEvent(event);
+    });
+
+  return getIframeBody(iframeSelector);
+}
+
+/**
+ * Base HTML template for embedding test pages
+ */
+function getInteractiveHtml({ dashboardId }: BaseEmbedTestPageOptions) {
+  const MB_BASE_URL = "http://localhost:4000";
+
+  const url = `${MB_BASE_URL}/dashboard/${dashboardId}`;
+
+  return `
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <title>Metabase Embed Test</title>
+
+      <style>
+        body {
+          margin: 0;
+        }
+
+        metabase-question, metabase-dashboard {
+          height: 100vh;
+        }
+      </style>
+    </head>
+    <body>
+      <iframe
+        src="${url}"
+        style="position: absolute; height: 100%; width:99%; border: none; border: 2px solid red"
+        allowtransparency
+      ></iframe>
+    </body>
+    </html>
+  `;
+}

--- a/e2e/support/helpers/index.ts
+++ b/e2e/support/helpers/index.ts
@@ -23,6 +23,7 @@ export * from "./e2e-dragndrop-helpers";
 export * from "./e2e-element-visibility-helpers";
 export * from "./e2e-email-helpers";
 export * from "./e2e-embedding-helpers";
+export * from "./e2e-embedding-iframe-interactive-helpers";
 export * from "./e2e-embedding-iframe-sdk-helpers";
 export * from "./e2e-embedding-sdk-assertion-helpers";
 export * from "./e2e-enterprise-helpers";

--- a/frontend/src/metabase/App.tsx
+++ b/frontend/src/metabase/App.tsx
@@ -2,6 +2,7 @@ import type { Location } from "history";
 import { KBarProvider } from "kbar";
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
+import { memoize } from "underscore";
 
 import { AppBanner } from "metabase/common/components/AppBanner";
 import {
@@ -36,21 +37,23 @@ import { useTokenRefresh } from "./api/utils/use-token-refresh";
 import { NewModals } from "./new/components/NewModals/NewModals";
 import { Palette } from "./palette/components/Palette";
 
-const getErrorComponent = ({ status, data, context }: AppErrorDescriptor) => {
-  if (status === 403 || data?.error_code === "unauthorized") {
-    return <Unauthorized />;
-  }
-  if (status === 404 || data?.error_code === "not-found") {
-    return <NotFound />;
-  }
-  if (data?.error_code === "archived" && context === "dashboard") {
-    return <Archived entityName="dashboard" linkTo="/dashboards/archive" />;
-  }
-  if (data?.error_code === "archived" && context === "query-builder") {
-    return <Archived entityName="question" linkTo="/questions/archive" />;
-  }
-  return <GenericError details={data?.message} />;
-};
+const getErrorComponent = memoize(
+  ({ status, data, context }: AppErrorDescriptor) => {
+    if (status === 403 || data?.error_code === "unauthorized") {
+      return <Unauthorized />;
+    }
+    if (status === 404 || data?.error_code === "not-found") {
+      return <NotFound />;
+    }
+    if (data?.error_code === "archived" && context === "dashboard") {
+      return <Archived entityName="dashboard" linkTo="/dashboards/archive" />;
+    }
+    if (data?.error_code === "archived" && context === "query-builder") {
+      return <Archived entityName="question" linkTo="/questions/archive" />;
+    }
+    return <GenericError details={data?.message} />;
+  },
+);
 
 interface AppStateProps {
   errorPage: AppErrorDescriptor | null;

--- a/frontend/src/metabase/App.tsx
+++ b/frontend/src/metabase/App.tsx
@@ -2,7 +2,6 @@ import type { Location } from "history";
 import { KBarProvider } from "kbar";
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
-import { memoize } from "underscore";
 
 import { AppBanner } from "metabase/common/components/AppBanner";
 import {
@@ -37,23 +36,21 @@ import { useTokenRefresh } from "./api/utils/use-token-refresh";
 import { NewModals } from "./new/components/NewModals/NewModals";
 import { Palette } from "./palette/components/Palette";
 
-const getErrorComponent = memoize(
-  ({ status, data, context }: AppErrorDescriptor) => {
-    if (status === 403 || data?.error_code === "unauthorized") {
-      return <Unauthorized />;
-    }
-    if (status === 404 || data?.error_code === "not-found") {
-      return <NotFound />;
-    }
-    if (data?.error_code === "archived" && context === "dashboard") {
-      return <Archived entityName="dashboard" linkTo="/dashboards/archive" />;
-    }
-    if (data?.error_code === "archived" && context === "query-builder") {
-      return <Archived entityName="question" linkTo="/questions/archive" />;
-    }
-    return <GenericError details={data?.message} />;
-  },
-);
+const getErrorComponent = ({ status, data, context }: AppErrorDescriptor) => {
+  if (status === 403 || data?.error_code === "unauthorized") {
+    return <Unauthorized />;
+  }
+  if (status === 404 || data?.error_code === "not-found") {
+    return <NotFound />;
+  }
+  if (data?.error_code === "archived" && context === "dashboard") {
+    return <Archived entityName="dashboard" linkTo="/dashboards/archive" />;
+  }
+  if (data?.error_code === "archived" && context === "query-builder") {
+    return <Archived entityName="question" linkTo="/questions/archive" />;
+  }
+  return <GenericError details={data?.message} />;
+};
 
 interface AppStateProps {
   errorPage: AppErrorDescriptor | null;

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
@@ -147,6 +147,11 @@ export const DashboardApp = ({
   const { autoScrollToDashcardId, reportAutoScrolledToDashcard } =
     useAutoScrollToDashcard(location);
 
+  const isRouteInSync = window.location.pathname === location.pathname;
+  if (!isRouteInSync) {
+    return null; // Don't render until route syncs (metabase#65500)
+  }
+
   return (
     <ErrorBoundary message={error}>
       <DashboardContextProvider

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
@@ -25,6 +25,7 @@ import { DashboardContextProvider } from "metabase/dashboard/context";
 import { useDashboardUrlQuery } from "metabase/dashboard/hooks";
 import { useAutoScrollToDashcard } from "metabase/dashboard/hooks/use-auto-scroll-to-dashcard";
 import { parseHashOptions, stringifyHashOptions } from "metabase/lib/browser";
+import { isWithinIframe } from "metabase/lib/dom";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { setErrorPage } from "metabase/redux/app";
@@ -148,7 +149,7 @@ export const DashboardApp = ({
     useAutoScrollToDashcard(location);
 
   const isRouteInSync = window.location.pathname === location.pathname;
-  if (!isRouteInSync) {
+  if (isWithinIframe() && !isRouteInSync) {
     return null; // Don't render until route syncs (metabase#65500)
   }
 

--- a/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.styled.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.styled.tsx
@@ -1,3 +1,4 @@
+import isPropValid from "@emotion/is-prop-valid";
 // eslint-disable-next-line no-restricted-imports
 import { css } from "@emotion/react";
 // eslint-disable-next-line no-restricted-imports
@@ -39,6 +40,7 @@ export const SearchInputContainer = styled.div<{
     }
     return css`
       background-color: var(--mb-color-bg-white);
+
       &:hover {
         background-color: var(--mb-color-bg-light);
       }
@@ -116,7 +118,7 @@ export const SearchInput = styled.input<{
 
 const ICON_MARGIN = "10px";
 
-export const SearchIcon = styled(Icon)<{
+export const SearchIcon = styled(Icon, { shouldForwardProp: isPropValid })<{
   isActive: boolean;
 }>`
   flex-basis: 1rem;

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.tsx
@@ -18,6 +18,7 @@ import Bookmark from "metabase/entities/bookmarks";
 import Timelines from "metabase/entities/timelines";
 import title from "metabase/hoc/Title";
 import titleWithLoadingTime from "metabase/hoc/TitleWithLoadingTime";
+import { isWithinIframe } from "metabase/lib/dom";
 import { connect, useSelector } from "metabase/lib/redux";
 import { closeNavbar } from "metabase/redux/app";
 import { getIsNavbarOpen } from "metabase/selectors/app";
@@ -324,6 +325,10 @@ function QueryBuilderInner(props: QueryBuilderInnerProps) {
   const handleSave = useSaveQuestion({ scheduleCallback });
 
   useMount(() => {
+    const isRouteInSync = window.location.pathname === location.pathname;
+    if (isWithinIframe() && !isRouteInSync) {
+      return null; // Don't render until route syncs (metabase#65500)
+    }
     initializeQB(location, params);
   });
 

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.tsx
@@ -327,7 +327,7 @@ function QueryBuilderInner(props: QueryBuilderInnerProps) {
   useMount(() => {
     const isRouteInSync = window.location.pathname === location.pathname;
     if (isWithinIframe() && !isRouteInSync) {
-      return null; // Don't render until route syncs (metabase#65500)
+      return null; // Don't initialize query builder until route syncs (metabase#65500)
     }
     initializeQB(location, params);
   });


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #65500
Closes [EMB-982: Interactive embedding navigation via `postMessage` does not work after a 404](https://linear.app/metabase/issue/EMB-982/interactive-embedding-navigation-via-postmessage-does-not-work-after-a)

### Description

There is a race condition between resetting the errorPage and navigating programmatically that leads to the DashboardApp being re-rendered with a stale dashboardId coming from react-router's param. This only happens in the context of embedding.

### How to verify

1. Open an interactive embedding
2. Get the iframe (`iframe = document.getElementsByTagName('iframe')[0];`)
3. Navigate to an unknown question (`iframe.contentWindow.postMessage({ metabase: {type: 'location', location: '/question/136576876' } }, 'http://localhost:3000')`)
4. Navigate to an existing entity (`iframe.contentWindow.postMessage({ metabase: {type: 'location', location: '/dashboard/1' } }, 'http://localhost:3000')`

-> It should work and not stick to the "We're a little lost" page.


### Checklist

TODO

- [x] Tests have been added/updated to cover changes in this PR
