### PR TITLE
Run fewer drivers in CI

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -21,47 +21,37 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Fetch base branch
-        if: github.event_name == 'pull_request' && github.event.pull_request.base.ref != ''
-        run: |
-          # Fetch the base branch to ensure its history is available for diffing
-          git fetch origin ${{ github.event.pull_request.base.ref }}:${{ github.event.pull_request.base.ref }}
-          # Only run this if it's a pull request and the base ref exists
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+        with:
+          files: |
+            src/metabase/lib/**
+            src/metabase/query_processor/**
+            modules/drivers/**
+            src/metabase/driver/**
       - name: Check if tier3 drivers should run
         id: check_team_and_branch
         run: |
           IS_MASTER_OR_RELEASE="${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-') }}"
           HAS_TEAM_LABEL="${{ contains(github.event.pull_request.labels.*.name, '.Team/Drivers') || contains(github.event.pull_request.labels.*.name, '.Team/Querying') || contains(github.event.pull_request.labels.*.name, '.Team/SemanticLayer') || contains(github.event.pull_request.labels.*.name, '.Team/DevEx') }}"
 
-
           echo "Is master or release: ${IS_MASTER_OR_RELEASE}"
           echo "Has '.Team/Drivers' or '.Team/Querying' or '.Team/SemanticLayer' label: ${HAS_TEAM_LABEL}"
+
           if [[ "${IS_MASTER_OR_RELEASE}" == "true" ]]; then
             echo "skip=false" >> $GITHUB_OUTPUT
             echo "Merging into master or a release branch. Tier 3 driver tests will run."
           elif [[ "${HAS_TEAM_LABEL}" == "true" ]]; then
             echo "skip=false" >> $GITHUB_OUTPUT
             echo "A relevant team label is present. Tier 3 driver tests will run."
+          elif [[ "${{ steps.changed-files.outputs.any_changed }}" == "true" ]]; then
+            echo "skip=false" >> $GITHUB_OUTPUT
+            echo "Changes detected in: ${{ steps.changed-files.outputs.all_changed_files }}"
+            echo "Tier 3 driver tests will run."
           else
-            echo "Checking for changes in relevant folders..."
-            CHANGED_FILES=$(git diff --name-only $(git merge-base ${{ github.event.pull_request.base.sha }} ${{ github.sha }}) ${{ github.sha }})
-
-            # Initialize an empty array to store folders with changes
-            CHANGED_FOLDERS=()
-            for folder in "src/metabase/lib" "src/metabase/query_processor" "modules/drivers" "src/metabase/driver"; do
-              if echo "$CHANGED_FILES" | grep -q "$folder"; then
-                CHANGED_FOLDERS+=("$folder")
-              fi
-            done
-
-            if [[ ${#CHANGED_FOLDERS[@]} -gt 0 ]]; then
-              echo "skip=false" >> $GITHUB_OUTPUT
-              echo "Changes detected in the following folders: ${CHANGED_FOLDERS[*]}."
-              echo "Tier 3 driver tests will run."
-            else
-              echo "skip=true" >> $GITHUB_OUTPUT
-              echo "No relevant team label, not merging into master/release, and no changes in relevant folders. Tier 3 driver tests will be skipped."
-            fi
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "No relevant team label, not merging into master/release, and no changes in relevant folders. Tier 3 driver tests will be skipped."
           fi
         shell: bash
   be-tests-athena-ee:
@@ -104,7 +94,7 @@ jobs:
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
 
   be-tests-bigquery-cloud-sdk-ee:
-    if: ${{ !inputs.skip }}
+    if: ${{ !inputs.skip && !(needs.determine-driver-skips.outputs.skip == 'true') }}
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     strategy:
@@ -163,7 +153,7 @@ jobs:
         logs-artifact-suffix: ${{ matrix.job.name }} ${{ matrix.version.name }}
 
   be-tests-clickhouse-ee:
-    if: ${{ !inputs.skip }}
+    if: ${{ !inputs.skip && !(needs.determine-driver-skips.outputs.skip == 'true') }}
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     strategy:
@@ -411,7 +401,7 @@ jobs:
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
 
   be-tests-mysql-mariadb:
-    if: ${{ !inputs.skip }}
+    if: ${{ !inputs.skip && !(needs.determine-driver-skips.outputs.skip == 'true') }}
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     strategy:
@@ -964,7 +954,7 @@ jobs:
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
 
   be-tests-redshift-ee:
-    if: ${{ !inputs.skip }}
+    if: ${{ !inputs.skip && !(needs.determine-driver-skips.outputs.skip == 'true') }}
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     strategy:


### PR DESCRIPTION
we had previous made a "third tier" driver scenario. This changes that to be more lopsided.

Now in CI we only run postgres and h2 driver tests on any given PR. The output of this job before this PR is:

```
Is master or release: false
Has '.Team/Drivers' or '.Team/Querying' or '.Team/SemanticLayer' label: false
Checking for changes in relevant folders...
No relevant team label, not merging into master/release, and no changes in relevant folders. Tier 3 driver tests will be skipped.
```

When a "relevant directory" is hit:

```
Is master or release: false
Has '.Team/Drivers' or '.Team/Querying' or '.Team/SemanticLayer' label: true
A relevant team label is present. Tier 3 driver tests will run.
```

Noticed there also seem to be some bugs with file detection so i've switched over to using a proper action to figure out which files have changed.

In the future, this should be dynamic based on modules. Immediately after this lands, I'm going to propose something like:

```clojure
   :test-on-change #{database-routing
                     driver
                     driver-api
                     lib
                     query-processor
                     sync}
```

To be added to `drivers` module config. And then we can dynamically watch for these to be changed. Right now "all" modules or transitive modules of drivers is the following:

```clojure
graph=> (let [data (->> (slurp "/Users/dan/projects/work/metabase/.clj-kondo/config/modules/config.edn")
                        (edn/read-string)
                        :metabase/modules)
              anys (atom #{})]
          (letfn [(closure [module seen]
                    (let [q (-> data module :uses)]
                      (if (= q :any)
                        (do (swap! anys conj module) #{:any})
                        (into q (comp (remove seen)
                                      (map #(closure % (set/union q seen)))
                                      cat) q))))
                  (path [module destination seen]
                    (loop [q (conj clojure.lang.PersistentQueue/EMPTY [module])
                           seen seen]
                      (let [p (peek q)]
                        (cond (nil? p) nil ;; abandon
                              ;; at goal
                              (= (peek p) destination) p
                              :else
                              (recur (into (pop q)
                                           (for [n (get-in data [(peek p) :uses])
                                                 :when (not (seen n))]
                                             (conj p n)))
                                     (conj seen (peek p)))))))
                  (module->name [module] (-> module name (str/replace \- \_)))
                  (module->files [module]
                    (->> (io/file (if (namespace module)
                                    (format "enterprise/backend/src/metabase_enterprise/%s"
                                            (module->name module))
                                    (format "src/metabase/%s" (module->name module))))
                         (file-seq)
                         (remove java.io.File/.isDirectory)
                         (map str)
                         (cons ['why? :path (path 'driver module #{})])))]
            #_(path 'driver 'warehouse-schema #{})
            (let [closures (closure 'driver-api #{})]
                [closures (count closures) @anys])
                 #_(into []
                       (map (fn [m]
                              (let [files (module->files m)]
                                {;; :files files
                                 :path (first files)
                                 :count (dec (count files))
                                 :module m})))
                       (-> data (get 'driver) :test-on-change))))
[#{batch-processing
   timeline
   pivot
   warehouse-schema
   eid-translation
   driver
   lib-be
   version
   queries
   enterprise/serialization
   query-processor
   parameters
   legacy-mbql
   xrays
   app-db
   upload
   session
   users
   premium-features
   analyze
   database-routing
   enterprise/api
   driver-api
   login-history
   sso
   classloader
   enterprise/sso
   permissions
   request
   view-log
   system
   api
   task-history
   connection-pool
   notification
   model-persistence
   task
   dashboards
   startup
   config
   content-verification
   secrets
   server
   formatter
   events
   util
   settings
   channel
   segments
   search
   sync
   enterprise/impersonation
   actions
   warehouses
   sample-data
   collections
   remote-sync
   types
   enterprise/sandbox
   api-keys
   setup
   enterprise/scim
   audit-app
   analytics
   models
   cache
   public-sharing
   pulse
   query-permissions
   plugins
   logger
   enterprise/advanced-permissions
   embedding
   lib
   revisions
   auth-provider
   core
   tiles
   :any
   appearance
   internal-stats}
 81
 #{enterprise/api core}]
```

So there would be 81 modules and enterprise/api and core have a "uses: any" type relationship. I looked through here for what _matters_.

And of course, you can always slap a label on your PR to get all tests to run.
