### PR TITLE
Productionize bulk sync table apis

### DIFF
--- a/frontend/src/metabase/api/table.ts
+++ b/frontend/src/metabase/api/table.ts
@@ -169,7 +169,7 @@ export const tableApi = Api.injectEndpoints({
     syncTablesSchemas: builder.mutation<void, SyncTablesSchemasRequest>({
       query: (body) => ({
         method: "POST",
-        url: `/api/table/sync_schema`,
+        url: `/api/table/sync-schema`,
         body,
       }),
       invalidatesTags: (_, error) =>

--- a/frontend/src/metabase/api/table.ts
+++ b/frontend/src/metabase/api/table.ts
@@ -243,7 +243,7 @@ export const {
   useRescanTableFieldValuesMutation,
   useRescanTablesFieldValuesMutation,
   useSyncTableSchemaMutation,
-  eseSyncTablesSchemasMutation,
+  useSyncTablesSchemasMutation,
   useDiscardTableFieldValuesMutation,
   useDiscardTablesFieldValuesMutation,
   usePublishModelsMutation,

--- a/frontend/src/metabase/api/table.ts
+++ b/frontend/src/metabase/api/table.ts
@@ -146,7 +146,7 @@ export const tableApi = Api.injectEndpoints({
     rescanTablesFieldValues: builder.mutation<void, RescanTablesValuesRequest>({
       query: (body) => ({
         method: "POST",
-        url: `/api/table/rescan_values`,
+        url: `/api/table/rescan-values`,
         body,
       }),
       invalidatesTags: (_, error) =>
@@ -195,7 +195,7 @@ export const tableApi = Api.injectEndpoints({
     >({
       query: (body) => ({
         method: "POST",
-        url: `/api/table/discard_values`,
+        url: `/api/table/discard-values`,
         body,
       }),
       invalidatesTags: (_, error) =>
@@ -243,7 +243,7 @@ export const {
   useRescanTableFieldValuesMutation,
   useRescanTablesFieldValuesMutation,
   useSyncTableSchemaMutation,
-  useSyncTablesSchemasMutation,
+  eseSyncTablesSchemasMutation,
   useDiscardTableFieldValuesMutation,
   useDiscardTablesFieldValuesMutation,
   usePublishModelsMutation,

--- a/src/metabase/warehouse_schema/api/table.clj
+++ b/src/metabase/warehouse_schema/api/table.clj
@@ -504,6 +504,11 @@
                 :file     (get-in multipart-params ["file" :tempfile])
                 :action   :metabase.upload/replace}))
 
+(defn- sync-schema-async!
+  [table user-id]
+  (events/publish-event! :event/table-manual-sync {:object table :user-id user-id})
+  (quick-task/submit-task! #(database-routing/with-database-routing-off (sync/sync-table! table))))
+
 ;; TODO (Cam 10/28/25) -- fix this endpoint route to use kebab-case for consistency with the rest of our REST API
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-route-uses-kebab-case]}
 (api.macros/defendpoint :post "/:id/sync_schema"
@@ -512,7 +517,6 @@
                     [:id ms/PositiveInt]]]
   (let [table (api/write-check (t2/select-one :model/Table :id id))
         database (api/write-check (warehouses/get-database (:db_id table) {:exclude-uneditable-details? true}))]
-    (events/publish-event! :event/table-manual-sync {:object table :user-id api/*current-user-id*})
     ;; it's okay to allow testing H2 connections during sync. We only want to disallow you from testing them for the
     ;; purposes of creating a new H2 database.
     (if-let [ex (try
@@ -525,10 +529,10 @@
                     e))]
       (throw (ex-info (ex-message ex) {:status-code 422}))
       (do
-        (quick-task/submit-task! #(database-routing/with-database-routing-off (sync/sync-table! table)))
+        (sync-schema-async! table api/*current-user-id*)
         {:status :ok}))))
 
-(api.macros/defendpoint :post "/sync_schema"
+(api.macros/defendpoint :post "/sync-schema"
   "Batch version of /table/:id/sync_schema. Takes an abstract table selection as /table/edit does.
   - Currently checks policy before returning (so you might receive a 4xx on e.g. AuthZ policy failure)
   - The sync itself is however, asyncronous. This call may return before all tables synced."
@@ -541,17 +545,10 @@
   ;; idea: flag dirty / ready for sync
   ;;       job comes along and actually performs sync
   ;;       promise is nothing is done apart from the dirty/queueing with the call (incl authz/event until batchy batchy)
+  (api/check-superuser)
   (let [tables (t2/select :model/Table {:where (table-selectors->filter body), :order-by [[:id]]})
-        ;; join in clojure, nice, not sure why get-database is important yet, copied from single table sync api
-        db-ids (sort (set (map :db_id tables)))
-        databases (mapv #(warehouses/get-database % {:exclude-uneditable-details? true}) db-ids)
-        db-id->database (u/index-by :id databases)]
-    (doseq [table tables]
-      (api/write-check table)
-      (api/write-check (db-id->database (:db_id table))))
-    (doseq [table tables]
-      (events/publish-event! :event/table-manual-sync {:object table :user-id api/*current-user-id*}))
-    (doseq [database databases]
+        db-ids (sort (set (map :db_id tables)))]
+    (doseq [database (t2/select :model/Database :id [:in db-ids])]
       (try
         (binding [driver.settings/*allow-testing-h2-connections* true]
           (driver.u/can-connect-with-details? (:engine database) (:details database) :throw-exceptions))
@@ -560,7 +557,7 @@
           (log/warn (u/format-color :red "Cannot connect to database '%s' in order to sync tables" (:name database)))
           (throw (ex-info (ex-message e) {:status-code 422})))))
     (doseq [table tables]
-      (quick-task/submit-task! #(database-routing/with-database-routing-off (sync/sync-table! table))))
+      (sync-schema-async! table api/*current-user-id*))
     {:status :ok}))
 
 (api.macros/defendpoint :post "/rescan_values"

--- a/test/metabase/warehouse_schema/api/table_test.clj
+++ b/test/metabase/warehouse_schema/api/table_test.clj
@@ -1397,7 +1397,7 @@
 (deftest ^:parallel non-admins-cant-trigger-bulk-sync-test
   (testing "Non-admins should not be allowed to trigger sync"
     (is (= "You don't have permissions to do that."
-           (mt/user-http-request :rasta :post 403 "table/sync_schema" {:database_ids [(mt/id)]})))))
+           (mt/user-http-request :rasta :post 403 "table/sync-schema" {:database_ids [(mt/id)]})))))
 
 (deftest trigger-bulk-metadata-sync-for-table-test
   ;; lot more to test here but will wait for firmer ground
@@ -1415,7 +1415,7 @@
                                          (swap! tables conj table)
                                          (.countDown latch)
                                          nil)]
-          (mt/user-http-request :crowberto :post 200 "table/sync_schema" {:database_ids [d1],
+          (mt/user-http-request :crowberto :post 200 "table/sync-schema" {:database_ids [d1],
                                                                           :schema_ids   [(format "%d:FOO" d2)]
                                                                           :table_ids    [t4]}))
         (testing "sync called?"

--- a/test/metabase/warehouse_schema/api/table_test.clj
+++ b/test/metabase/warehouse_schema/api/table_test.clj
@@ -1422,6 +1422,11 @@
           (is (true? (.await latch 4 TimeUnit/SECONDS)))
           (is (= [t1 t2 t4 t5] (map :id @tables))))))))
 
+(deftest ^:parallel non-admins-cant-trigger-bulk-rescan-values-test
+  (testing "Non-admins should not be allowed to trigger rescan values"
+    (is (= "You don't have permissions to do that."
+           (mt/user-http-request :rasta :post 403 "table/rescan-values" {:database_ids [(mt/id)]})))))
+
 (deftest trigger-rescan-values-for-tables-test
   ;; lot more to test here but will wait for firmer ground
   (testing "Can we trigger a field values sync for a filtered set of tables"
@@ -1438,12 +1443,17 @@
                                                             (swap! tables conj table)
                                                             (.countDown latch)
                                                             nil)]
-          (mt/user-http-request :crowberto :post 200 "table/rescan_values" {:database_ids [d1],
+          (mt/user-http-request :crowberto :post 200 "table/rescan-values" {:database_ids [d1],
                                                                             :schema_ids   [(format "%d:FOO" d2)]
                                                                             :table_ids    [t4]}))
         (testing "rescanned?"
           (is (true? (.await latch 4 TimeUnit/SECONDS)))
           (is (= [t1 t2 t4 t5] (map :id @tables))))))))
+
+(deftest ^:parallel non-admins-cant-trigger-bulk-discard-values-test
+  (testing "Non-admins should not be allowed to trigger discard values"
+    (is (= "You don't have permissions to do that."
+           (mt/user-http-request :rasta :post 403 "table/discard-values" {:database_ids [(mt/id)]})))))
 
 (deftest ^:parallel bulk-discard-values-test
   (testing "POST /api/table/:id/discard_values"


### PR DESCRIPTION
- Simplified permission check to just allow superuser
- only publish manual sync event once the permissions check are done.

closes https://linear.app/metabase/issue/GDGT-1226/production-read-post-apitablesync-values and https://linear.app/metabase/issue/GDGT-1225/production-read-post-apitablesync-schema