### PR TITLE
Update the delete button copy for better UX

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/collection-browser.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/collection-browser.cy.spec.tsx
@@ -71,7 +71,7 @@ describe("scenarios > embedding-sdk > collection browser", () => {
       getSdkRoot().findByText("Our analytics").should("exist");
     });
 
-    it("should be able to delete resources (EMB-892)", () => {
+    it("should be able to move resources to trash (EMB-892)", () => {
       mountSdkContent(<CollectionBrowser collectionId="root" />);
 
       const dashboardName = "Orders in a dashboard";

--- a/e2e/test-component/scenarios/embedding-sdk/collection-browser.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/collection-browser.cy.spec.tsx
@@ -80,11 +80,11 @@ describe("scenarios > embedding-sdk > collection browser", () => {
         cy.findByText("Our analytics").should("exist");
         cy.findByText("Orders in a dashboard").should("exist");
 
-        cy.log("delete the dashboard");
+        cy.log("move the dashboard to trash");
         cy.findByText(dashboardName).closest("tr").button("Actions").click();
       });
 
-      H.popover().findByRole("menuitem", { name: "Delete" }).click();
+      H.popover().findByRole("menuitem", { name: "Move to trash" }).click();
 
       cy.log("the deleted dashboard should be gone");
       getSdkRoot().findByText(dashboardName).should("not.exist");

--- a/frontend/src/metabase/embedding/components/ArchiveButton.tsx
+++ b/frontend/src/metabase/embedding/components/ArchiveButton.tsx
@@ -50,7 +50,7 @@ export function ArchiveButton({ item }: ArchiveButtonProps) {
           onClick={handleArchive}
           className={S.archiveMenuItem}
         >
-          {t`Delete`}
+          {t`Move to trash`}
         </Menu.Item>
       </Menu.Dropdown>
     </Menu>


### PR DESCRIPTION
closes EMB-968


### Backport reasons
This is meant to go into 57 to fix the `CollectionBrowser`'s delete button which is also launched in 57.

### Description

Update the CollectionBrowser's delete button copy to prevent heart attacks. This makes it clear that it's by no means a hard delete.

### How to verify

Embed `<CollectionBrowser />` via the SDK. The delete button show have the new copy

### Demo

<img width="1132" height="304" alt="image" src="https://github.com/user-attachments/assets/80a92972-d28c-4c2b-8141-7ce66766f03d" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
