### PR TITLE
Fix flaky 'models.cy.spec.js' test

### DIFF
--- a/e2e/test/scenarios/models/models.cy.spec.js
+++ b/e2e/test/scenarios/models/models.cy.spec.js
@@ -464,7 +464,12 @@ describe("scenarios > models", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Save").click();
 
-      cy.findByTestId("save-question-modal").within((modal) => {
+      cy.findByTestId("save-question-modal").within(() => {
+        const recentDashboardName = "Orders in a dashboard";
+        cy.findByLabelText("Where do you want to save this?").should(
+          "have.text",
+          recentDashboardName,
+        );
         cy.findByText("Save").click();
       });
 


### PR DESCRIPTION
closes EMB-987
### Backport reasons

After skimming what branches this problem affects. I could only find it's affecting master and 57, but backport it to 56 should be relatively safe, so why not 🤷 

### Description

The flaky test came from how the question save modal's destination picker behaves. It calls the recent item and try to extract a dashboard from the result, the problem is that, in our test, we never wait for the whole dependent APIs to finish. This PR fixes that by ensure that the picker has to change to the recent dashboard name before saving the question. Otherwise, Metabase won't redirect to that dashboard we're supposed to save to and failed the test.

### How to verify

[Stress test master](https://github.com/metabase/metabase/actions/runs/19264460076/job/55076787969#step:12:247): 0/20 ❌ ☠️
[Sterss test PR](https://github.com/metabase/metabase/actions/runs/19264499969/job/55076917552#step:12:121): 20/20 ✅

### Demo
On failed cases, we click save when the destination picker hasn't changed to the most recent dashboard.
<img width="1591" height="995" alt="Screenshot 2025-11-11 at 6 08 05 PM" src="https://github.com/user-attachments/assets/86fa03eb-3f05-4179-9a94-002a02a6d88a" />

How it should look
<img width="1286" height="817" alt="Screenshot 2025-11-11 at 6 07 44 PM" src="https://github.com/user-attachments/assets/9d04d9a8-08ce-4a8a-a5bd-de7afc01c552" />



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
