### PR TITLE
Experimental options for improving Metabot Search

### DIFF
--- a/.github/workflows/semantic-search.yml
+++ b/.github/workflows/semantic-search.yml
@@ -27,7 +27,7 @@ jobs:
           - name: Semantic Search Tests
             build-static-viz: false
             test-args: >-
-              :only '"enterprise/backend/test/metabase_enterprise/semantic_search"'
+              :only '["enterprise/backend/test/metabase_enterprise/semantic_search" "metabase-enterprise.metabot-v3.tools.search-test"]'
             exclude-tag: ':mb/driver-tests'
 
     services:
@@ -85,7 +85,7 @@ jobs:
           - name: Semantic Search Tests
             build-static-viz: false
             test-args: >-
-              :only '"enterprise/backend/test/metabase_enterprise/semantic_search"'
+              :only '["enterprise/backend/test/metabase_enterprise/semantic_search" "metabase-enterprise.metabot-v3.tools.search-test"]'
             exclude-tag: ':mb/driver-tests'
 
     services:
@@ -157,7 +157,7 @@ jobs:
           - name: Semantic Search Tests
             build-static-viz: false
             test-args: >-
-              :only '"enterprise/backend/test/metabase_enterprise/semantic_search"'
+              :only '["enterprise/backend/test/metabase_enterprise/semantic_search" "metabase-enterprise.metabot-v3.tools.search-test"]'
             exclude-tag: ':mb/driver-tests'
 
     services:
@@ -229,7 +229,7 @@ jobs:
           - name: Semantic Search Tests
             build-static-viz: false
             test-args: >-
-              :only '"enterprise/backend/test/metabase_enterprise/semantic_search"'
+              :only '["enterprise/backend/test/metabase_enterprise/semantic_search" "metabase-enterprise.metabot-v3.tools.search-test"]'
             exclude-tag: ':mb/driver-tests'
 
     services:

--- a/.github/workflows/semantic-search.yml
+++ b/.github/workflows/semantic-search.yml
@@ -27,7 +27,7 @@ jobs:
           - name: Semantic Search Tests
             build-static-viz: false
             test-args: >-
-              :only '["enterprise/backend/test/metabase_enterprise/semantic_search" "metabase-enterprise.metabot-v3.tools.search-test"]'
+              :only '["enterprise/backend/test/metabase_enterprise/semantic_search" "enterprise/backend/test/metabase_enterprise/metabot_v3/tools/search_test.clj"]'
             exclude-tag: ':mb/driver-tests'
 
     services:
@@ -85,7 +85,7 @@ jobs:
           - name: Semantic Search Tests
             build-static-viz: false
             test-args: >-
-              :only '["enterprise/backend/test/metabase_enterprise/semantic_search" "metabase-enterprise.metabot-v3.tools.search-test"]'
+              :only '["enterprise/backend/test/metabase_enterprise/semantic_search" "enterprise/backend/test/metabase_enterprise/metabot_v3/tools/search_test.clj"]'
             exclude-tag: ':mb/driver-tests'
 
     services:
@@ -157,7 +157,7 @@ jobs:
           - name: Semantic Search Tests
             build-static-viz: false
             test-args: >-
-              :only '["enterprise/backend/test/metabase_enterprise/semantic_search" "metabase-enterprise.metabot-v3.tools.search-test"]'
+              :only '["enterprise/backend/test/metabase_enterprise/semantic_search" "enterprise/backend/test/metabase_enterprise/metabot_v3/tools/search_test.clj"]'
             exclude-tag: ':mb/driver-tests'
 
     services:
@@ -229,7 +229,7 @@ jobs:
           - name: Semantic Search Tests
             build-static-viz: false
             test-args: >-
-              :only '["enterprise/backend/test/metabase_enterprise/semantic_search" "metabase-enterprise.metabot-v3.tools.search-test"]'
+              :only '["enterprise/backend/test/metabase_enterprise/semantic_search" "enterprise/backend/test/metabase_enterprise/metabot_v3/tools/search_test.clj"]'
             exclude-tag: ':mb/driver-tests'
 
     services:

--- a/.github/workflows/semantic-search.yml
+++ b/.github/workflows/semantic-search.yml
@@ -27,7 +27,7 @@ jobs:
           - name: Semantic Search Tests
             build-static-viz: false
             test-args: >-
-              :only '["enterprise/backend/test/metabase_enterprise/semantic_search" "enterprise/backend/test/metabase_enterprise/metabot_v3/tools/search_test.clj"]'
+              :only '["enterprise/backend/test/metabase_enterprise/semantic_search" "enterprise/backend/test/metabase_enterprise/metabot_v3/tools/semantic_search_test.clj"]'
             exclude-tag: ':mb/driver-tests'
 
     services:
@@ -85,7 +85,7 @@ jobs:
           - name: Semantic Search Tests
             build-static-viz: false
             test-args: >-
-              :only '["enterprise/backend/test/metabase_enterprise/semantic_search" "enterprise/backend/test/metabase_enterprise/metabot_v3/tools/search_test.clj"]'
+              :only '["enterprise/backend/test/metabase_enterprise/semantic_search" "enterprise/backend/test/metabase_enterprise/metabot_v3/tools/semantic_search_test.clj"]'
             exclude-tag: ':mb/driver-tests'
 
     services:
@@ -157,7 +157,7 @@ jobs:
           - name: Semantic Search Tests
             build-static-viz: false
             test-args: >-
-              :only '["enterprise/backend/test/metabase_enterprise/semantic_search" "enterprise/backend/test/metabase_enterprise/metabot_v3/tools/search_test.clj"]'
+              :only '["enterprise/backend/test/metabase_enterprise/semantic_search" "enterprise/backend/test/metabase_enterprise/metabot_v3/tools/semantic_search_test.clj"]'
             exclude-tag: ':mb/driver-tests'
 
     services:
@@ -229,7 +229,7 @@ jobs:
           - name: Semantic Search Tests
             build-static-viz: false
             test-args: >-
-              :only '["enterprise/backend/test/metabase_enterprise/semantic_search" "enterprise/backend/test/metabase_enterprise/metabot_v3/tools/search_test.clj"]'
+              :only '["enterprise/backend/test/metabase_enterprise/semantic_search" "enterprise/backend/test/metabase_enterprise/metabot_v3/tools/semantic_search_test.clj"]'
             exclude-tag: ':mb/driver-tests'
 
     services:

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
@@ -1,7 +1,6 @@
 (ns metabase-enterprise.metabot-v3.tools.search
   (:require
    [clojure.set :as set]
-   [clojure.string :as str]
    [metabase-enterprise.metabot-v3.config :as metabot-v3.config]
    [metabase-enterprise.metabot-v3.reactions]
    [metabase.api.common :as api]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
@@ -126,7 +126,7 @@
    May return more results than requested limit."
   [search-fn search-engine all-queries]
   (if (<= (count all-queries) 1)
-    (search-fn (first all-queries))
+    (search-fn (first all-queries) search-engine)
     ;; Create futures for parallel execution
     (let [futures      (mapv #(future (search-fn % search-engine)) all-queries)
           result-lists (mapv deref futures)]
@@ -160,7 +160,7 @@
                           (:use_verified_content metabot)
                           false)
         limit           (or limit 50)
-        search-fn       (fn [search-string & [search-engine]]
+        search-fn       (fn [search-string search-engine]
                           (let [search-context (search/search-context
                                                 (cond->
                                                  {:search-string                       search-string
@@ -187,7 +187,7 @@
                                                   weights
                                                   (assoc :weights weights)
                                                   search-engine
-                                                  (assoc :search-engine search-engine)))
+                                                  (assoc :search-engine (name search-engine))))
                                 _              (log/infof "[METABOT-SEARCH] Search context models for query '%s': %s"
                                                           search-string (:models search-context))
                                 search-results (search/search search-context)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
@@ -136,21 +136,21 @@
   "Search for data sources (tables, models, cards, dashboards, metrics, transforms) in Metabase.
   Abstracted from the API endpoint logic."
   [{:keys [term-queries semantic-queries database-id created-at last-edited-at
-           entity-types limit metabot-id search-native-query weights
-           ;; experimental options
-           join-with-or?
-           non-semantic-keywords?]}]
+           entity-types limit metabot-id search-native-query weights]
+    ;; Temporary parameters we're experimenting with
+    {:keys [join-with-or?
+            non-semantic-keywords?]} :experimental-opts}]
   (log/infof "[METABOT-SEARCH] Starting search with params: %s"
-             {:term-queries term-queries
-              :semantic-queries semantic-queries
-              :database-id database-id
-              :created-at created-at
-              :last-edited-at last-edited-at
-              :entity-types entity-types
-              :limit limit
-              :metabot-id metabot-id
+             {:term-queries        term-queries
+              :semantic-queries    semantic-queries
+              :database-id         database-id
+              :created-at          created-at
+              :last-edited-at      last-edited-at
+              :entity-types        entity-types
+              :limit               limit
+              :metabot-id          metabot-id
               :search-native-query search-native-query
-              :weights weights})
+              :weights             weights})
   (let [search-models   (if (seq entity-types)
                           (set (distinct (keep entity-type->search-model entity-types)))
                           metabot-search-models)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
@@ -7,6 +7,8 @@
    [metabase.api.common :as api]
    [metabase.permissions.core :as perms]
    [metabase.search.core :as search]
+   [metabase.search.engine :as search.engine]
+   [metabase.util :as u]
    [metabase.util.log :as log]
    [toucan2.core :as t2]))
 
@@ -97,46 +99,47 @@
   ([result-lists]
    (reciprocal-rank-fusion result-lists 60))
   ([result-lists k]
-   (let [rrf-results (reduce
-                      (fn [acc-map result-list]
-                        (reduce-kv
-                         (fn [acc rank search-result]
-                           (let [id (search-result-id search-result)
-                                 rrf-score (/ 1.0 (+ k (inc rank)))]
-                             (if (contains? acc id)
-                               (update-in acc [id :rrf] + rrf-score)
-                               (assoc acc id {:search-result search-result
-                                              :rrf rrf-score}))))
-                         acc-map
-                         (vec result-list)))
-                      {}
-                      result-lists)]
-     (->> rrf-results
-          vals
-          (sort-by :rrf >)
-          (map :search-result)))))
-
-(defn- join-results-by-or [search-fn all-queries]
-  ;; Collect unique results from all queries
-  (when (seq all-queries)
-    (search-fn (str/join " OR " all-queries))))
+   (if (<= (count result-lists) 1)
+     (first result-lists)
+     (let [rrf-results (reduce
+                        (fn [acc-map result-list]
+                          (reduce-kv
+                           (fn [acc rank search-result]
+                             (let [id        (search-result-id search-result)
+                                   rrf-score (/ 1.0 (+ k (inc rank)))]
+                               (if (contains? acc id)
+                                 (update-in acc [id :rrf] + rrf-score)
+                                 (assoc acc id {:search-result search-result
+                                                :rrf           rrf-score}))))
+                           acc-map
+                           (vec result-list)))
+                        {}
+                        result-lists)]
+       (->> rrf-results
+            vals
+            (sort-by :rrf >)
+            (map :search-result))))))
 
 (defn- join-results-by-rrf
   "Execute multiple search queries in parallel and combine results using Reciprocal Rank Fusion.
-   Items appearing in multiple result lists are boosted in the final ranking."
-  [search-fn all-queries limit]
+   Items appearing in multiple result lists are boosted in the final ranking.
+   May return more results than requested limit."
+  [search-fn search-engine all-queries]
   (if (<= (count all-queries) 1)
     (search-fn (first all-queries))
     ;; Create futures for parallel execution
-    (let [futures      (mapv #(future (search-fn %)) all-queries)
+    (let [futures      (mapv #(future (search-fn % search-engine)) all-queries)
           result-lists (mapv deref futures)]
-      (take limit (reciprocal-rank-fusion result-lists)))))
+      (reciprocal-rank-fusion result-lists))))
 
 (defn search
   "Search for data sources (tables, models, cards, dashboards, metrics, transforms) in Metabase.
   Abstracted from the API endpoint logic."
   [{:keys [term-queries semantic-queries database-id created-at last-edited-at
-           entity-types limit metabot-id search-native-query weights join-with-or?]}]
+           entity-types limit metabot-id search-native-query weights
+           ;; experimental options
+           join-with-or?
+           non-semantic-keywords?]}]
   (log/infof "[METABOT-SEARCH] Starting search with params: %s"
              {:term-queries term-queries
               :semantic-queries semantic-queries
@@ -148,53 +151,67 @@
               :metabot-id metabot-id
               :search-native-query search-native-query
               :weights weights})
-  (let [search-models (if (seq entity-types)
-                        (set (distinct (keep entity-type->search-model entity-types)))
-                        metabot-search-models)
-        _ (log/infof "[METABOT-SEARCH] Converted entity-types %s to search-models %s" entity-types search-models)
-        all-queries   (distinct (concat (or term-queries []) (or semantic-queries [])))
-        metabot (t2/select-one :model/Metabot :entity_id (get-in metabot-v3.config/metabot-config [metabot-id :entity-id] metabot-id))
-        use-verified-content? (if metabot-id
-                                (:use_verified_content metabot)
-                                false)
-        limit (or limit 50)
-        search-fn (fn [query]
-                    (let [search-context (search/search-context
-                                          (cond->
-                                           {:search-string query
-                                            :models search-models
-                                            :table-db-id database-id
-                                            :created-at created-at
-                                            :last-edited-at last-edited-at
-                                            :current-user-id api/*current-user-id*
-                                            :is-impersonated-user? (perms/impersonated-user?)
-                                            :is-sandboxed-user? (perms/sandboxed-user?)
-                                            :is-superuser? api/*is-superuser?*
-                                            :current-user-perms @api/*current-user-permissions-set*
-                                            :filter-items-in-personal-collection  "exclude-others"
-                                            :context :metabot
-                                            :archived false
-                                            :limit limit
-                                            :offset 0}
-                                           ;; Don't include search-native-query key if nil so that we don't
-                                           ;; inadvertently filter out search models that don't support it
-                                            search-native-query
-                                            (assoc :search-native-query (boolean search-native-query))
-                                            use-verified-content?
-                                            (assoc :verified true)
-                                            weights
-                                            (assoc :weights weights)))
-                          _ (log/infof "[METABOT-SEARCH] Search context models for query '%s': %s"
-                                       query (:models search-context))
-                          search-results (search/search search-context)
-                          data (:data search-results)
-                          result-models (frequencies (map :model data))]
-                      (log/infof "[METABOT-SEARCH] Query '%s' returned entity types: %s" query result-models)
-                      data))
-        fused-results (if join-with-or?
-                        ;; TODO oh crap, only appdb supports this format - will need to make this a multimethod
-                        (join-results-by-or search-fn all-queries)
-                        (join-results-by-rrf search-fn all-queries limit))]
+  (let [search-models   (if (seq entity-types)
+                          (set (distinct (keep entity-type->search-model entity-types)))
+                          metabot-search-models)
+        _               (log/infof "[METABOT-SEARCH] Converted entity-types %s to search-models %s" entity-types search-models)
+        metabot         (t2/select-one :model/Metabot :entity_id (get-in metabot-v3.config/metabot-config [metabot-id :entity-id] metabot-id))
+        use-verified?   (if metabot-id
+                          (:use_verified_content metabot)
+                          false)
+        limit           (or limit 50)
+        search-fn       (fn [search-string & [search-engine]]
+                          (let [search-context (search/search-context
+                                                (cond->
+                                                 {:search-string                       search-string
+                                                  :models                              search-models
+                                                  :table-db-id                         database-id
+                                                  :created-at                          created-at
+                                                  :last-edited-at                      last-edited-at
+                                                  :current-user-id                     api/*current-user-id*
+                                                  :is-impersonated-user?               (perms/impersonated-user?)
+                                                  :is-sandboxed-user?                  (perms/sandboxed-user?)
+                                                  :is-superuser?                       api/*is-superuser?*
+                                                  :current-user-perms                  @api/*current-user-permissions-set*
+                                                  :filter-items-in-personal-collection "exclude-others"
+                                                  :context                             :metabot
+                                                  :archived                            false
+                                                  :limit                               limit
+                                                  :offset                              0}
+                                                  ;; Don't include search-native-query key if nil so that we don't
+                                                  ;; inadvertently filter out search models that don't support it
+                                                  search-native-query
+                                                  (assoc :search-native-query (boolean search-native-query))
+                                                  use-verified?
+                                                  (assoc :verified true)
+                                                  weights
+                                                  (assoc :weights weights)
+                                                  search-engine
+                                                  (assoc :search-engine search-engine)))
+                                _              (log/infof "[METABOT-SEARCH] Search context models for query '%s': %s"
+                                                          search-string (:models search-context))
+                                search-results (search/search search-context)
+                                data           (:data search-results)
+                                result-models  (frequencies (map :model data))]
+                            (log/infof "[METABOT-SEARCH] Query '%s' returned entity types: %s" search-string result-models)
+                            data))
+        search-fn*      (fn [search-engine queries]
+                          (let [queries (if join-with-or? (search.engine/disjunction search-engine queries) queries)]
+                            (join-results-by-rrf search-fn search-engine queries)))
+        ;; NOTE: if we add more semantic engines, e.g. 3rd party vector dbs, we'll need to make this more maintainable
+        semantic?       #{:search.engine/semantic}
+        semantic-engine (u/seek semantic? (search.engine/active-engines))
+        fallback-engine (when semantic-engine
+                          (u/seek (comp not semantic?) (search.engine/supported-engines)))
+        fused-results   (if (and non-semantic-keywords? semantic-engine)
+                          ;; Perform semantic and non-semantic search respectively, then fuse results.
+                          (reciprocal-rank-fusion
+                           (map (fn [[engine queries]] (search-fn* engine queries))
+                                {semantic-engine semantic-queries
+                                 fallback-engine term-queries}))
+                          ;; Search for all the terms on equal footing, using the default engine.
+                          (search-fn* nil (distinct (concat term-queries semantic-queries))))]
     (->> fused-results
+         (take limit)
          (map postprocess-search-result)
          enrich-with-collection-descriptions)))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
@@ -118,7 +118,8 @@
 
 (defn- join-results-by-or [search-fn all-queries]
   ;; Collect unique results from all queries
-  (search-fn (str/join " OR " all-queries)))
+  (when (seq all-queries)
+    (search-fn (str/join " OR " all-queries))))
 
 (defn- join-results-by-rrf [search-fn all-queries limit]
   (if (<= (count all-queries) 1)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
@@ -178,8 +178,8 @@
                                                          :archived                            false
                                                          :limit                               limit
                                                          :offset                              0}
-                                                   ;; Don't include search-native-query key if nil so that we don't
-                                                   ;; inadvertently filter out search models that don't support it
+                                                  ;; Don't include search-native-query key if nil so that we don't
+                                                  ;; inadvertently filter out search models that don't support it
                                                   search-native-query
                                                   (assoc :search-native-query (boolean search-native-query))
                                                   use-verified?
@@ -214,5 +214,4 @@
     (->> fused-results
          (take limit)
          (map postprocess-search-result)
-         enrich-with-collection-descriptions
-         vec)))
+         enrich-with-collection-descriptions)))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
@@ -126,7 +126,8 @@
    Items appearing in multiple result lists are boosted in the final ranking.
    May return more results than requested limit."
   [search-fn search-engine all-queries]
-  (if (<= (count all-queries) 1)
+  ;; Zero queries case is handled nicely by the >1 branch
+  (if (= 1 (count all-queries))
     (search-fn (first all-queries) search-engine)
     ;; Create futures for parallel execution
     (let [futures      (mapv #(future (search-fn % search-engine)) all-queries)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
@@ -189,6 +189,7 @@
                       (log/infof "[METABOT-SEARCH] Query '%s' returned entity types: %s" query result-models)
                       data))
         fused-results (if join-with-or?
+                        ;; TODO oh crap, only appdb supports this format - will need to make this a multimethod
                         (join-results-by-or search-fn all-queries)
                         (join-results-by-rrf search-fn all-queries limit))]
     (->> fused-results

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
@@ -178,8 +178,8 @@
                                                          :archived                            false
                                                          :limit                               limit
                                                          :offset                              0}
-                                                       ;; Don't include search-native-query key if nil so that we don't
-                                                       ;; inadvertently filter out search models that don't support it
+                                                   ;; Don't include search-native-query key if nil so that we don't
+                                                   ;; inadvertently filter out search models that don't support it
                                                   search-native-query
                                                   (assoc :search-native-query (boolean search-native-query))
                                                   use-verified?
@@ -214,4 +214,5 @@
     (->> fused-results
          (take limit)
          (map postprocess-search-result)
-         enrich-with-collection-descriptions)))
+         enrich-with-collection-descriptions
+         vec)))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
@@ -121,7 +121,10 @@
   (when (seq all-queries)
     (search-fn (str/join " OR " all-queries))))
 
-(defn- join-results-by-rrf [search-fn all-queries limit]
+(defn- join-results-by-rrf
+  "Execute multiple search queries in parallel and combine results using Reciprocal Rank Fusion.
+   Items appearing in multiple result lists are boosted in the final ranking."
+  [search-fn all-queries limit]
   (if (<= (count all-queries) 1)
     (search-fn (first all-queries))
     ;; Create futures for parallel execution

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
@@ -163,24 +163,23 @@
         limit           (or limit 50)
         search-fn       (fn [search-string search-engine]
                           (let [search-context (search/search-context
-                                                (cond->
-                                                 {:search-string                       search-string
-                                                  :models                              search-models
-                                                  :table-db-id                         database-id
-                                                  :created-at                          created-at
-                                                  :last-edited-at                      last-edited-at
-                                                  :current-user-id                     api/*current-user-id*
-                                                  :is-impersonated-user?               (perms/impersonated-user?)
-                                                  :is-sandboxed-user?                  (perms/sandboxed-user?)
-                                                  :is-superuser?                       api/*is-superuser?*
-                                                  :current-user-perms                  @api/*current-user-permissions-set*
-                                                  :filter-items-in-personal-collection "exclude-others"
-                                                  :context                             :metabot
-                                                  :archived                            false
-                                                  :limit                               limit
-                                                  :offset                              0}
-                                                  ;; Don't include search-native-query key if nil so that we don't
-                                                  ;; inadvertently filter out search models that don't support it
+                                                (cond-> {:search-string                       search-string
+                                                         :models                              search-models
+                                                         :table-db-id                         database-id
+                                                         :created-at                          created-at
+                                                         :last-edited-at                      last-edited-at
+                                                         :current-user-id                     api/*current-user-id*
+                                                         :is-impersonated-user?               (perms/impersonated-user?)
+                                                         :is-sandboxed-user?                  (perms/sandboxed-user?)
+                                                         :is-superuser?                       api/*is-superuser?*
+                                                         :current-user-perms                  @api/*current-user-permissions-set*
+                                                         :filter-items-in-personal-collection "exclude-others"
+                                                         :context                             :metabot
+                                                         :archived                            false
+                                                         :limit                               limit
+                                                         :offset                              0}
+                                                       ;; Don't include search-native-query key if nil so that we don't
+                                                       ;; inadvertently filter out search models that don't support it
                                                   search-native-query
                                                   (assoc :search-native-query (boolean search-native-query))
                                                   use-verified?

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/db/datasource.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/db/datasource.clj
@@ -18,7 +18,7 @@
   (env :mb-pgvector-db-url))
 
 ;; See metabase.app-db.connection-pool-setup for more details on these properties
-;; TODO: not sure if we need the MetabaseConnectionCustomizer like in the app DB connection pool seutp
+;; TODO: not sure if we need the MetabaseConnectionCustomizer like in the app DB connection pool setup
 (def ^:private semantic-search-connection-pool-props
   "Connection pool properties for semantic search database using c3p0."
   {"idleConnectionTestPeriod"     60

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/search_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/search_test.clj
@@ -414,4 +414,3 @@
                                     (map (comp first #(str/split % #"\s") :name))))]
             (is (= ["Bookmarked" "Regular"] (query)))
             (is (= ["Regular" "Bookmarked"] (query {:bookmarked -1})))))))))
-

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/search_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/search_test.clj
@@ -3,12 +3,9 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase-enterprise.metabot-v3.tools.search :as search]
-   [metabase-enterprise.semantic-search.test-util :as semantic.tu]
    [metabase.api.common :as api]
    [metabase.permissions.core :as perms]
    [metabase.search.core :as search-core]
-   [metabase.search.engine :as search.engine]
-   [metabase.search.ingestion :as search.ingestion]
    [metabase.search.test-util :as search.tu]
    [metabase.test :as mt]
    [metabase.util :as u]
@@ -418,85 +415,3 @@
             (is (= ["Bookmarked" "Regular"] (query)))
             (is (= ["Regular" "Bookmarked"] (query {:bookmarked -1})))))))))
 
-(defmacro with-semantic-search-if-available! [mock-embeddings & body]
-  `(mt/with-premium-features #{:semantic-search}
-     (when (search.engine/supported-engine? :search.engine/semantic)
-       (semantic.tu/with-mock-embeddings ~mock-embeddings
-         (binding [search.ingestion/*disable-updates* false]
-           ~@body)))))
-
-(defmacro with-and-without-semantic-search! [mock-embeddings & body]
-  `(do ~@body (with-semantic-search-if-available! ~mock-embeddings ~@body)))
-
-;; Mock embeddings: similar vectors for semantic synonym pairs, orthogonal vectors for unrelated terms.
-(def ^:private test-mock-embeddings
-  {"belligerent" [1.0 0.0 0.0 0.0]
-   "combative"   [0.99 0.01 0.0 0.0]
-   "bellicose"   [0.0 1.0 0.0 0.0]
-   "quarrelsome" [0.01 0.99 0.0 0.0]
-   "quixotic"    [0.0 0.0 1.0 0.0]
-   "ancillary"   [0.0 0.0 0.0 0.9]
-   "adjunct"     [0.0 0.0 0.0 1.0]
-   "baseline"    [0.5 0.5 0.0 0.0]})
-
-(deftest split-keywords-only-test
-  (testing "search returns only exact matches for keyword terms when {:split-semantic-terms true}, regardless of whether semantic search is enabled\n"
-    (mt/with-test-user :rasta
-      (semantic.tu/with-test-db! {:mode :mock-initialized}
-        (with-and-without-semantic-search! test-mock-embeddings
-          (search.tu/with-new-search-and-legacy-search
-            (let [semantic-support? (search.engine/supported-engine? :search.engine/semantic)]
-              ;; "belligerent" and "bellicose" are semantically similar to our search terms
-              ;; ("combative", "quarrelsome") but should NOT match since we're only doing keyword search
-              (mt/with-temp [:model/Dashboard {id-1 :id} {:name "belligerent"}
-                             :model/Dashboard {id-2 :id} {:name "bellicose"}
-                             ;; "baseline" will match via keyword/fulltext search
-                             :model/Dashboard {id-3 :id} {:name "baseline"}]
-                (when semantic-support?
-                  (semantic.tu/index-all!))
-                (doseq [unified-disjunct-querying [false true]]
-                  (testing (str "{unified-disjunct-querying " unified-disjunct-querying "}\n")
-                    (let [base-query   {:term-queries     ["combative" "quarrelsome" "baseline"]
-                                        :semantic-queries []}
-                          test-entity? (comp #{id-1 id-2 id-3} :id)
-                          query        (fn [unified-disjunct-querying]
-                                         (->> (search/search (assoc base-query
-                                                                    :experimental-opts
-                                                                    {:unified-disjunct-querying unified-disjunct-querying
-                                                                     :split-semantic-terms      true}))
-                                              (filter test-entity?)
-                                              (map :name)))]
-                      (testing "Semantic results are not returned for keyword terms"
-                        (is (= #{"baseline"}
-                               (set (query unified-disjunct-querying))))))))))))))))
-
-(deftest split-keyword-and-semantic-test
-  (testing "search returns only exact matches for keyword terms when {:split-semantic-terms true}\n"
-    (mt/with-test-user :rasta
-      (semantic.tu/with-test-db! {:mode :mock-initialized}
-        (with-semantic-search-if-available! test-mock-embeddings
-          (search.tu/with-new-search-and-legacy-search
-            ;; "belligerent" and "baseline" will match via keyword search (exact match in term-queries)
-            ;; "ancillary" will match via semantic search
-            ;; "bellicose" and "quixotic" should NOT match (not in search terms)
-            (mt/with-temp [:model/Dashboard {id-1 :id} {:name "belligerent"}
-                           :model/Dashboard {id-2 :id} {:name "bellicose"}
-                           :model/Dashboard {id-4 :id} {:name "ancillary"}
-                           :model/Dashboard {id-3 :id} {:name "adjunct"}
-                           :model/Dashboard {id-5 :id} {:name "baseline"}]
-              (semantic.tu/index-all!)
-              (doseq [unified-disjunct-querying [false true]]
-                (testing (str "{unified-disjunct-querying " unified-disjunct-querying "}\n")
-                  (let [base-query   {:term-queries     ["baseline" "belligerent"]
-                                      :semantic-queries ["ancillary"]}
-                        test-entity? (comp #{id-1 id-2 id-3 id-4 id-5} :id)
-                        query        (fn [unified-disjunct-querying]
-                                       (->> (search/search (assoc base-query
-                                                                  :experimental-opts
-                                                                  {:unified-disjunct-querying unified-disjunct-querying
-                                                                   :split-semantic-terms      true}))
-                                            (filter test-entity?)
-                                            (map :name)))]
-                    (testing "Semantic results are only returned for semantic terms"
-                      (is (= #{"baseline" "belligerent" "ancillary" "adjunct"}
-                             (set (query unified-disjunct-querying)))))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/search_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/search_test.clj
@@ -433,7 +433,7 @@
   `(do ~@body (with-semantic-search-if-available! ~@body)))
 
 (deftest non-semantic-keywords-test
-  (testing "search returns only exact matches for keyword terms when {:non-semantic-keywords? true}\n"
+  (testing "search returns only exact matches for keyword terms when {:split-semantic-terms true}\n"
     (mt/with-test-user :rasta
       (with-and-without-semantic-search!
         (search.tu/with-temp-index-table
@@ -448,8 +448,8 @@
                            :model/Dashboard {id-5 :id} {:name "baseline"}]
               (when semantic-support?
                 (semantic.tu/index-all!))
-              (doseq [join-with-or? [false true]]
-                (testing (str "{join-with-or? " join-with-or? "}\n")
+              (doseq [unified-disjunct-querying [false true]]
+                (testing (str "{unified-disjunct-querying " unified-disjunct-querying "}\n")
                   (let [base-query   {:term-queries     ["combative" "quarrelsome" "baseline"]
                                       :semantic-queries (if semantic-support?
                                                           ;; TODO (Chris 2025-11-14) disabled semantic search for now,
@@ -457,11 +457,11 @@
                                                           #_["unrealistic" "adjunct"] []
                                                           ["quixotic" "ancillary"])}
                         test-entity? (comp #{id-1 id-2 id-3 id-4 id-5} :id)
-                        query        (fn [join-with-or?]
+                        query        (fn [unified-disjunct-querying]
                                        (->> (search/search (assoc base-query
                                                                   :experimental-opts
-                                                                  {:join-with-or?          join-with-or?
-                                                                   :non-semantic-keywords? true}))
+                                                                  {:unified-disjunct-querying unified-disjunct-querying
+                                                                   :split-semantic-terms      true}))
                                             (filter test-entity?)
                                             (map :name)))]
                     (testing (if semantic-support?
@@ -469,4 +469,4 @@
                                "Exact matches are returned for both keyword and semantic terms")
                       ;; See above: temporarily disabling semantic search until we can fix it over-matching.
                       (is (= (if semantic-support? #{"baseline"} #{"quixotic" "ancillary" "baseline"})
-                             (set (query join-with-or?)))))))))))))))
+                             (set (query unified-disjunct-querying)))))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/search_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/search_test.clj
@@ -423,8 +423,7 @@
   `(mt/with-premium-features #{:semantic-search}
      (when (search.engine/supported-engine? :search.engine/semantic)
        (with-open [_# (semantic.tu/open-temp-index!)]
-         (semantic.tu/cleanup-index-metadata! (semantic.env/get-pgvector-datasource!)
-                                              semantic.tu/mock-index-metadata)
+         (semantic.tu/cleanup-index-metadata! (semantic.env/get-pgvector-datasource!) semantic.tu/mock-index-metadata)
          (semantic.tu/with-test-db! {:mode :mock-indexed}
            ;; Ensure the temporary items we create within the test are indexed
            (binding [search.ingestion/*disable-updates* false]
@@ -453,7 +452,9 @@
                 (testing (str "{join-with-or? " join-with-or? "}\n")
                   (let [base-query   {:term-queries     ["combative" "quarrelsome" "baseline"]
                                       :semantic-queries (if semantic-support?
-                                                          ["unrealistic" "adjunct"]
+                                                          ;; TODO (Chris 2025-11-14) disabled semantic search for now,
+                                                          ;;      as currently any search returns *everything* @_@
+                                                          #_["unrealistic" "adjunct"] []
                                                           ["quixotic" "ancillary"])}
                         test-entity? (comp #{id-1 id-2 id-3 id-4 id-5} :id)
                         query        (fn [join-with-or?]
@@ -466,5 +467,6 @@
                     (testing (if semantic-support?
                                "Semantic results are not returned for keyword terms"
                                "Exact matches are returned for both keyword and semantic terms")
-                      (is (= #{"quixotic" "ancillary" "baseline"}
+                      ;; See above: temporarily disabling semantic search until we can fix it over-matching.
+                      (is (= (if semantic-support? #{"baseline"} #{"quixotic" "ancillary" "baseline"})
                              (set (query join-with-or?)))))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/search_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/search_test.clj
@@ -438,10 +438,10 @@
       (with-and-without-semantic-search!
         (search.tu/with-new-search-and-legacy-search
           (let [semantic-support? (search.engine/supported-engine? :search.engine/semantic)]
-          ;; we expect these to fail matching via fulltext search (even though they match semantically)
+            ;; we expect these to fail matching via fulltext search (even though they match semantically)
             (mt/with-temp [:model/Dashboard {id-1 :id} {:name "belligerent"}
                            :model/Dashboard {id-2 :id} {:name "bellicose"}
-                         ;; this will match via fulltext search
+                           ;; this will match via fulltext search
                            :model/Dashboard {id-3 :id} {:name "baseline"}]
               (when semantic-support?
                 (semantic.tu/index-all!))
@@ -473,7 +473,7 @@
                          ;; these we expect to match successfully via semantic search
                            :model/Dashboard {id-3 :id} {:name "quixotic"}
                            :model/Dashboard {id-4 :id} {:name "ancillary"}
-                         ;; these we
+                           ;; this will match via fulltext search
                            :model/Dashboard {id-5 :id} {:name "baseline"}]
               (when semantic-support?
                 (semantic.tu/index-all!))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/search_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/search_test.clj
@@ -461,8 +461,9 @@
                   test-entity? (comp #{id-1 id-2 id-3 id-4} :id)
                   query        (fn [join-with-or?]
                                  (->> (search/search (assoc base-query
-                                                            :join-with-or? join-with-or?
-                                                            :non-semantic-keywords? true))
+                                                            :experimental-opts
+                                                            {:join-with-or?          join-with-or?
+                                                             :non-semantic-keywords? true}))
                                       (filter test-entity?)
                                       (map :name)))]
               (doseq [join-with-or? [false true]]

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/semantic_search_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/semantic_search_test.clj
@@ -1,0 +1,97 @@
+(ns metabase-enterprise.metabot-v3.tools.semantic-search-test
+  "Semantic search tests specific to the Metabot search tool integration."
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.metabot-v3.tools.search :as search]
+   [metabase-enterprise.semantic-search.test-util :as semantic.tu]
+   [metabase.search.engine :as search.engine]
+   [metabase.search.ingestion :as search.ingestion]
+   [metabase.search.test-util :as search.tu]
+   [metabase.test :as mt]))
+
+(use-fixtures :once #'semantic.tu/once-fixture)
+
+(defmacro with-semantic-search-if-available! [mock-embeddings & body]
+  `(mt/with-premium-features #{:semantic-search}
+     (when (search.engine/supported-engine? :search.engine/semantic)
+       (semantic.tu/with-mock-embeddings ~mock-embeddings
+         (binding [search.ingestion/*disable-updates* false
+                   search.ingestion/*force-sync* true]
+           ~@body)))))
+
+(defmacro with-and-without-semantic-search! [mock-embeddings & body]
+  `(do ~@body (with-semantic-search-if-available! ~mock-embeddings ~@body)))
+
+;; Mock embeddings: similar vectors for semantic synonym pairs, orthogonal vectors for unrelated terms.
+(def ^:private test-mock-embeddings
+  {"belligerent" [1.0 0.0 0.0 0.0]
+   "combative"   [0.99 0.01 0.0 0.0]
+   "bellicose"   [0.0 1.0 0.0 0.0]
+   "quarrelsome" [0.01 0.99 0.0 0.0]
+   "quixotic"    [0.0 0.0 1.0 0.0]
+   "ancillary"   [0.0 0.0 0.0 0.9]
+   "adjunct"     [0.0 0.0 0.0 1.0]
+   "baseline"    [0.5 0.5 0.0 0.0]})
+
+(deftest split-keywords-only-test
+  (testing "search returns only exact matches for keyword terms when {:split-semantic-terms true}, regardless of whether semantic search is enabled\n"
+    (mt/with-test-user :rasta
+      (semantic.tu/with-test-db! {:mode :mock-initialized}
+        (with-and-without-semantic-search! test-mock-embeddings
+          (search.tu/with-new-search-and-legacy-search
+            (let [semantic-support? (search.engine/supported-engine? :search.engine/semantic)]
+              ;; "belligerent" and "bellicose" are semantically similar to our search terms
+              ;; ("combative", "quarrelsome") but should NOT match since we're only doing keyword search
+              (mt/with-temp [:model/Dashboard {id-1 :id} {:name "belligerent"}
+                             :model/Dashboard {id-2 :id} {:name "bellicose"}
+                             ;; "baseline" will match via keyword/fulltext search
+                             :model/Dashboard {id-3 :id} {:name "baseline"}]
+                (when semantic-support?
+                  (semantic.tu/index-all!))
+                (doseq [unified-disjunct-querying [false true]]
+                  (testing (str "{unified-disjunct-querying " unified-disjunct-querying "}\n")
+                    (let [base-query   {:term-queries     ["combative" "quarrelsome" "baseline"]
+                                        :semantic-queries []}
+                          test-entity? (comp #{id-1 id-2 id-3} :id)
+                          query        (fn [unified-disjunct-querying]
+                                         (->> (search/search (assoc base-query
+                                                                    :experimental-opts
+                                                                    {:unified-disjunct-querying unified-disjunct-querying
+                                                                     :split-semantic-terms      true}))
+                                              (filter test-entity?)
+                                              (map :name)))]
+                      (testing "Semantic results are not returned for keyword terms"
+                        (is (= #{"baseline"}
+                               (set (query unified-disjunct-querying))))))))))))))))
+
+(deftest split-keyword-and-semantic-test
+  (testing "search returns only exact matches for keyword terms when {:split-semantic-terms true}\n"
+    (mt/with-test-user :rasta
+      (semantic.tu/with-test-db! {:mode :mock-initialized}
+        (with-semantic-search-if-available! test-mock-embeddings
+          (search.tu/with-new-search-and-legacy-search
+            ;; "belligerent" and "baseline" will match via keyword search (exact match in term-queries)
+            ;; "ancillary" and "adjunct" will match via semantic search (similar embeddings)
+            ;; "bellicose" and "quixotic" should NOT match (not in search terms)
+            (mt/with-temp [:model/Dashboard {id-1 :id} {:name "belligerent"}
+                           :model/Dashboard {id-2 :id} {:name "bellicose"}
+                           :model/Dashboard {id-3 :id} {:name "ancillary"}
+                           :model/Dashboard {id-4 :id} {:name "adjunct"}
+                           :model/Dashboard {id-5 :id} {:name "quixotic"}
+                           :model/Dashboard {id-6 :id} {:name "baseline"}]
+              (semantic.tu/index-all!)
+              (doseq [unified-disjunct-querying [false true]]
+                (testing (str "{unified-disjunct-querying " unified-disjunct-querying "}\n")
+                  (let [base-query   {:term-queries     ["baseline" "belligerent"]
+                                      :semantic-queries ["ancillary"]}
+                        test-entity? (comp #{id-1 id-2 id-3 id-4 id-5 id-6} :id)
+                        query        (fn [unified-disjunct-querying]
+                                       (->> (search/search (assoc base-query
+                                                                  :experimental-opts
+                                                                  {:unified-disjunct-querying unified-disjunct-querying
+                                                                   :split-semantic-terms      true}))
+                                            (filter test-entity?)
+                                            (map :name)))]
+                    (testing "Semantic results are only returned for semantic terms"
+                      (is (= #{"baseline" "belligerent" "ancillary" "adjunct"}
+                             (set (query unified-disjunct-querying)))))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -446,7 +446,7 @@
   `(do-with-indexable-documents! (fn [] ~@body)))
 
 (defn index-all!
-  "Run indexer synchonously until we've exhausted polling all documents"
+  "Run indexer synchronously until we've exhausted polling all documents"
   []
   (let [metadata-row   {:indexer_last_poll Instant/EPOCH
                         :indexer_last_seen Instant/EPOCH}

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -228,15 +228,43 @@
                 mock-documents-for-embeddings
                 base-embedding-vectors)))
 
-(defn get-mock-embedding
-  "Lookup the embedding for `text` in [[mock-embeddings]]."
+(def ^:dynamic *extra-mock-embeddings*
+  "Dynamic var for test-specific mock embeddings. Merged with [[mock-embeddings]] in [[get-mock-embedding]]."
+  nil)
+
+(defn- parse-entity-name
+  "Extract the entity name from embeddable text format.
+   E.g., '[dashboard]\\nname: My Dashboard\\n...' -> 'My Dashboard'"
   [text]
-  (get mock-embeddings text [0.01 0.02 0.03 0.04]))
+  (second (re-find #"(?m)^name:\s*(.+)$" text)))
+
+(defn get-mock-embedding
+  "Lookup the embedding for `text` in [[*extra-mock-embeddings*]] first, then [[mock-embeddings]].
+   Lookups try both the raw text and the parsed entity name from embeddable text format."
+  [text]
+  (let [entity-name (parse-entity-name text)]
+    (or (get *extra-mock-embeddings* text)
+        (get *extra-mock-embeddings* entity-name)
+        (get mock-embeddings text)
+        (get mock-embeddings entity-name)
+        [0.01 0.02 0.03 0.04])))
 
 (defn get-mock-embeddings-batch
   "Lookup embeddings for multiple texts in [[mock-embeddings]]."
   [texts]
   (mapv get-mock-embedding texts))
+
+(defmacro with-mock-embeddings
+  "Bind extra mock embeddings for the duration of `body`. The embeddings map should be
+   a map from text strings to 4-dimensional vectors, e.g.:
+
+   (with-mock-embeddings
+     {\"belligerent\" [0.9 0.1 0.0 0.0]
+      \"combative\"   [0.91 0.11 0.01 0.01]}  ; similar vector = semantic match
+     ...)"
+  [embeddings-map & body]
+  `(binding [*extra-mock-embeddings* ~embeddings-map]
+     ~@body))
 
 ;;;; mock provider
 

--- a/enterprise/backend/test/metabase_enterprise/transforms/api/search_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/api/search_test.clj
@@ -10,7 +10,7 @@
 
 (use-fixtures :each (fn [thunk]
                       (binding [search.ingestion/*force-sync* true]
-                        (search.tu/with-new-search-if-available (thunk)))))
+                        (search.tu/with-new-search-if-available-otherwise-legacy (thunk)))))
 
 (deftest basic-search-test
   (testing "Transform can be found with search"

--- a/src/metabase/search/appdb/core.clj
+++ b/src/metabase/search/appdb/core.clj
@@ -50,9 +50,9 @@
            (#{"appdb" "semantic"} (some-> (search.settings/search-engine) name)))
        (supported-db? (mdb/db-type))))
 
-(defmethod search.engine/disjunction :search.engine/in-place [_ terms]
+(defmethod search.engine/disjunction :search.engine/appdb [_ terms]
   (when (seq terms)
-    [(str/join " OR " (map #(str "(" % ")" ) terms))]))
+    [(str/join " OR " (map #(str "(" % ")") terms))]))
 
 (defn- parse-datetime [s]
   (when s (OffsetDateTime/parse s)))

--- a/src/metabase/search/appdb/core.clj
+++ b/src/metabase/search/appdb/core.clj
@@ -1,5 +1,6 @@
 (ns metabase.search.appdb.core
   (:require
+   [clojure.string :as str]
    [environ.core :as env]
    [honey.sql.helpers :as sql.helpers]
    [java-time.api :as t]
@@ -48,6 +49,10 @@
            ;; if the default engine is semantic we want appdb to be available, as we want to mix results
            (#{"appdb" "semantic"} (some-> (search.settings/search-engine) name)))
        (supported-db? (mdb/db-type))))
+
+(defmethod search.engine/disjunction :search.engine/in-place [_ terms]
+  (when (seq terms)
+    [(str/join " OR " (map #(str "(" % ")" ) terms))]))
 
 (defn- parse-datetime [s]
   (when s (OffsetDateTime/parse s)))

--- a/src/metabase/search/core.clj
+++ b/src/metabase/search/core.clj
@@ -70,7 +70,7 @@
 
 (defmethod analytics/initial-value :metabase-search/engine-default
   [_ {:keys [engine]}]
-  (if (= engine (name (search.impl/default-engine))) 1 0))
+  (if (= engine (name (search.engine/default-engine))) 1 0))
 
 (defmethod analytics/initial-value :metabase-search/engine-active
   [_ {:keys [engine]}]

--- a/src/metabase/search/engine.clj
+++ b/src/metabase/search/engine.clj
@@ -28,14 +28,6 @@
   {:arglists '([search-context])}
   :search-engine)
 
-(defmulti disjunction
-  "Given multiple terms to search for, reduce this to a search expression that matches any of them in a single search.
-   If this is not possible, return a list of terms to be searched for separately."
-  {:arglists '([search-engine terms])}
-  (fn [search-engine _terms] search-engine))
-
-(defmethod disjunction :default [_ terms] terms)
-
 (defmulti score "For legacy search: perform the in-memory ranking"
   {:arglists '([search-context result])}
   (fn [{engine :search-engine} _]
@@ -101,3 +93,21 @@
   [engine]
   (let [registered? #(contains? (methods supported-engine?) %)]
     (some registered? (cons engine (ancestors engine)))))
+
+(defmulti disjunction
+  "Given multiple terms to search for, reduce this to a search expression that matches any of them in a single search.
+   If this is not possible, return a list of terms to be searched for separately."
+  {:arglists '([search-engine terms])}
+  (fn [search-engine _terms] search-engine))
+
+(defn default-engine
+  "In the absence of an explicit engine argument in a request, which engine should be used?"
+  []
+  ;; TODO (Chris 2025-11-07) It would be good to have a warning on start up whenever this is *not* what's configured.
+  (first (supported-engines)))
+
+(defmethod disjunction :default [_ terms] terms)
+
+(defmethod disjunction nil [_ terms]
+  (disjunction (default-engine) terms))
+

--- a/src/metabase/search/engine.clj
+++ b/src/metabase/search/engine.clj
@@ -110,4 +110,3 @@
 
 (defmethod disjunction nil [_ terms]
   (disjunction (default-engine) terms))
-

--- a/src/metabase/search/engine.clj
+++ b/src/metabase/search/engine.clj
@@ -28,6 +28,14 @@
   {:arglists '([search-context])}
   :search-engine)
 
+(defmulti disjunction
+  "Given multiple terms to search for, reduce this to a search expression that matches any of them in a single search.
+   If this is not possible, return a list of terms to be searched for separately."
+  {:arglists '([search-engine terms])}
+  (fn [search-engine _terms] search-engine))
+
+(defmethod disjunction :default [_ terms] terms)
+
 (defmulti score "For legacy search: perform the in-memory ranking"
   {:arglists '([search-context result])}
   (fn [{engine :search-engine} _]

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -215,12 +215,6 @@
     (not (zero? v))
     v))
 
-(defn default-engine
-  "In the absence of an explicit engine argument in a request, which engine should be used?"
-  []
-  ;; TODO (Chris 2025-11-07) It would be good to have a warning on start up whenever this is *not* what's configured.
-  (first (search.engine/supported-engines)))
-
 (defn- parse-engine [value]
   (or (when-not (str/blank? value)
         (let [engine (keyword "search.engine" value)]
@@ -233,12 +227,12 @@
 
             :else
             engine)))
-      (default-engine)))
+      (search.engine/default-engine)))
 
 ;; This forwarding is here for tests, we should clean those up.
 
 (defn- apply-default-engine [{:keys [search-engine] :as search-ctx}]
-  (let [default (default-engine)]
+  (let [default (search.engine/default-engine)]
     (when (= default search-engine)
       (throw (ex-info "Missing implementation for default search-engine" {:search-engine search-engine})))
     (log/debugf "Missing implementation for %s so instead using %s" search-engine default)

--- a/src/metabase/search/in_place/legacy.clj
+++ b/src/metabase/search/in_place/legacy.clj
@@ -34,7 +34,7 @@
 (defmethod search.engine/disjunction :search.engine/in-place [_ terms]
   ;; The default composition is disjunction with this engine.
   (when (seq terms)
-    (str/join " " terms)))
+    [(str/join " " terms)]))
 
 (defn search-model->revision-model
   "Return the appropriate revision model given a search model."

--- a/src/metabase/search/in_place/legacy.clj
+++ b/src/metabase/search/in_place/legacy.clj
@@ -33,7 +33,8 @@
 
 (defmethod search.engine/disjunction :search.engine/in-place [_ terms]
   ;; The default composition is disjunction with this engine.
-  (str/join " " terms))
+  (when (seq terms)
+    (str/join " " terms)))
 
 (defn search-model->revision-model
   "Return the appropriate revision model given a search model."

--- a/src/metabase/search/in_place/legacy.clj
+++ b/src/metabase/search/in_place/legacy.clj
@@ -31,6 +31,10 @@
 (defmethod search.engine/supported-engine? :search.engine/in-place [_]
   true)
 
+(defmethod search.engine/disjunction :search.engine/in-place [_ terms]
+  ;; The default composition is disjunction with this engine.
+  (str/join " " terms))
+
 (defn search-model->revision-model
   "Return the appropriate revision model given a search model."
   [model]

--- a/test/metabase/search/api_test.clj
+++ b/test/metabase/search/api_test.clj
@@ -37,7 +37,7 @@
 (def ^:private default-collection {:id false :name nil :authority_level nil :type nil})
 
 (use-fixtures :each (fn [thunk] (binding [search.ingestion/*force-sync* true]
-                                  (search.tu/with-new-search-if-available (thunk)))))
+                                  (search.tu/with-new-search-if-available-otherwise-legacy (thunk)))))
 
 (def ^:private default-search-row
   {:archived                   false

--- a/test/metabase/search/filter_test.clj
+++ b/test/metabase/search/filter_test.clj
@@ -11,7 +11,7 @@
    [metabase.search.test-util :as search.tu]))
 
 (use-fixtures :each (fn [thunk] (binding [search.ingestion/*force-sync* true]
-                                  (search.tu/with-new-search-if-available (thunk)))))
+                                  (search.tu/with-new-search-if-available-otherwise-legacy (thunk)))))
 
 (defn- filter-keys []
   (remove #{:ids} (map :context-key (vals search.config/filters))))

--- a/test/metabase/search/test_util.clj
+++ b/test/metabase/search/test_util.clj
@@ -48,9 +48,10 @@
      ~@body))
 
 (defmacro with-new-search-if-available-without-fallback
-  "Create a temporary index table for the duration of the body."
+  "Create a temporary index table for the duration of the body.
+   Only runs if the appdb search engine is supported."
   [& body]
-  `(when (search/supports-index?)
+  `(when (search.engine/supported-engine? :search.engine/appdb)
      (with-new-search-if-available* ~@body)))
 
 (defmacro with-legacy-search

--- a/test/metabase/search/test_util.clj
+++ b/test/metabase/search/test_util.clj
@@ -54,10 +54,12 @@
      (with-new-search-if-available* ~@body)))
 
 (defmacro with-legacy-search
-  "Ensure legacy search, which doesn't require an index, is used."
+  "Ensure legacy search, which doesn't require an index, is used.
+   When split-semantic-terms is enabled, semantic queries go to :search.engine/semantic
+   and keyword queries fall back to :search.engine/in-place."
   [& body]
   `(mt/with-dynamic-fn-redefs [search.engine/default-engine (constantly :search.engine/in-place)
-                               search.engine/active-engines (constantly [])]
+                               search.engine/supported-engines (constantly [:search.engine/semantic :search.engine/in-place])]
      ~@body))
 
 (defmacro with-new-search-and-legacy-search


### PR DESCRIPTION
Closes BOT-500

Don't include semantic matches for "keyword" search terms, only use the fallback engine. Assume metabot wanted precision here, otherwise it would have passed the term as a semantic query.

Can be enabled by setting the `split_semantic_terms` flag on the API - we should do this in a benchmark run.

Closes BOT-501

When receiving N search terms, the metabot search tool performs N independent search queries, and then collate them.

Not only is the quite expensive, we're possibly getting worse results this way compared to full-text search scores for term coverage (e.g. results that match 4 out of 5 terms, but maybe aren't in the top 10 for any of them individually)

Can be enabled by setting the `unified_disjunct_querying` flag on the API - we should do this in a benchmark run.