### PR TITLE
Don't use semantic search to keyword terms

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
@@ -7,6 +7,8 @@
    [metabase.api.common :as api]
    [metabase.permissions.core :as perms]
    [metabase.search.core :as search]
+   [metabase.search.engine :as search.engine]
+   [metabase.util :as u]
    [metabase.util.log :as log]
    [toucan2.core :as t2]))
 
@@ -97,42 +99,52 @@
   ([result-lists]
    (reciprocal-rank-fusion result-lists 60))
   ([result-lists k]
-   (let [rrf-results (reduce
-                      (fn [acc-map result-list]
-                        (reduce-kv
-                         (fn [acc rank search-result]
-                           (let [id (search-result-id search-result)
-                                 rrf-score (/ 1.0 (+ k (inc rank)))]
-                             (if (contains? acc id)
-                               (update-in acc [id :rrf] + rrf-score)
-                               (assoc acc id {:search-result search-result
-                                              :rrf rrf-score}))))
-                         acc-map
-                         (vec result-list)))
-                      {}
-                      result-lists)]
-     (->> rrf-results
-          vals
-          (sort-by :rrf >)
-          (map :search-result)))))
+   (if (<= (count result-lists) 1)
+     (first result-lists)
+     (let [rrf-results (reduce
+                        (fn [acc-map result-list]
+                          (reduce-kv
+                           (fn [acc rank search-result]
+                             (let [id        (search-result-id search-result)
+                                   rrf-score (/ 1.0 (+ k (inc rank)))]
+                               (if (contains? acc id)
+                                 (update-in acc [id :rrf] + rrf-score)
+                                 (assoc acc id {:search-result search-result
+                                                :rrf           rrf-score}))))
+                           acc-map
+                           (vec result-list)))
+                        {}
+                        result-lists)]
+       (->> rrf-results
+            vals
+            (sort-by :rrf >)
+            (map :search-result))))))
 
-(defn- join-results-by-or [search-fn all-queries]
+(defn- join-results-by-or
+  "Perform a single search, using a logical expression"
+  [search-fn search-engine all-queries]
   ;; Collect unique results from all queries
-  (search-fn (str/join " OR " all-queries)))
+  (search-fn (str/join " OR " (map #(str "(" % ")") all-queries)) search-engine))
 
-(defn- join-results-by-rrf [search-fn all-queries limit]
+(defn- join-results-by-rrf
+  "Perform N independent searches, then combine results using Reciprocal Rank Fusion.
+   May return more results than requested limit."
+  [search-fn search-engine all-queries]
   (if (<= (count all-queries) 1)
     (search-fn (first all-queries))
     ;; Create futures for parallel execution
-    (let [futures      (mapv #(future (search-fn %)) all-queries)
+    (let [futures      (mapv #(future (search-fn % search-engine)) all-queries)
           result-lists (mapv deref futures)]
-      (take limit (reciprocal-rank-fusion result-lists)))))
+      (reciprocal-rank-fusion result-lists))))
 
 (defn search
   "Search for data sources (tables, models, cards, dashboards, metrics, transforms) in Metabase.
   Abstracted from the API endpoint logic."
   [{:keys [term-queries semantic-queries database-id created-at last-edited-at
-           entity-types limit metabot-id search-native-query weights join-with-or?]}]
+           entity-types limit metabot-id search-native-query weights
+           ;; experimental options
+           join-with-or?
+           non-semantic-keywords?]}]
   (log/infof "[METABOT-SEARCH] Starting search with params: %s"
              {:term-queries term-queries
               :semantic-queries semantic-queries
@@ -144,52 +156,67 @@
               :metabot-id metabot-id
               :search-native-query search-native-query
               :weights weights})
-  (let [search-models (if (seq entity-types)
-                        (set (distinct (keep entity-type->search-model entity-types)))
-                        metabot-search-models)
-        _ (log/infof "[METABOT-SEARCH] Converted entity-types %s to search-models %s" entity-types search-models)
-        all-queries   (distinct (concat (or term-queries []) (or semantic-queries [])))
-        metabot (t2/select-one :model/Metabot :entity_id (get-in metabot-v3.config/metabot-config [metabot-id :entity-id] metabot-id))
-        use-verified-content? (if metabot-id
-                                (:use_verified_content metabot)
-                                false)
-        limit (or limit 50)
-        search-fn (fn [query]
-                    (let [search-context (search/search-context
-                                          (cond->
-                                           {:search-string query
-                                            :models search-models
-                                            :table-db-id database-id
-                                            :created-at created-at
-                                            :last-edited-at last-edited-at
-                                            :current-user-id api/*current-user-id*
-                                            :is-impersonated-user? (perms/impersonated-user?)
-                                            :is-sandboxed-user? (perms/sandboxed-user?)
-                                            :is-superuser? api/*is-superuser?*
-                                            :current-user-perms @api/*current-user-permissions-set*
-                                            :filter-items-in-personal-collection  "exclude-others"
-                                            :context :metabot
-                                            :archived false
-                                            :limit limit
-                                            :offset 0}
-                                           ;; Don't include search-native-query key if nil so that we don't
-                                           ;; inadvertently filter out search models that don't support it
-                                            search-native-query
-                                            (assoc :search-native-query (boolean search-native-query))
-                                            use-verified-content?
-                                            (assoc :verified true)
-                                            weights
-                                            (assoc :weights weights)))
-                          _ (log/infof "[METABOT-SEARCH] Search context models for query '%s': %s"
-                                       query (:models search-context))
-                          search-results (search/search search-context)
-                          data (:data search-results)
-                          result-models (frequencies (map :model data))]
-                      (log/infof "[METABOT-SEARCH] Query '%s' returned entity types: %s" query result-models)
-                      data))
-        fused-results (if join-with-or?
-                        (join-results-by-or search-fn all-queries)
-                        (join-results-by-rrf search-fn all-queries limit))]
+  (let [search-models   (if (seq entity-types)
+                          (set (distinct (keep entity-type->search-model entity-types)))
+                          metabot-search-models)
+        _               (log/infof "[METABOT-SEARCH] Converted entity-types %s to search-models %s" entity-types search-models)
+        metabot         (t2/select-one :model/Metabot :entity_id (get-in metabot-v3.config/metabot-config [metabot-id :entity-id] metabot-id))
+        use-verified?   (if metabot-id
+                          (:use_verified_content metabot)
+                          false)
+        limit           (or limit 50)
+        search-fn       (fn [search-string & [search-engine]]
+                          (let [search-context (search/search-context
+                                                (cond->
+                                                 {:search-string                       search-string
+                                                  :models                              search-models
+                                                  :table-db-id                         database-id
+                                                  :created-at                          created-at
+                                                  :last-edited-at                      last-edited-at
+                                                  :current-user-id                     api/*current-user-id*
+                                                  :is-impersonated-user?               (perms/impersonated-user?)
+                                                  :is-sandboxed-user?                  (perms/sandboxed-user?)
+                                                  :is-superuser?                       api/*is-superuser?*
+                                                  :current-user-perms                  @api/*current-user-permissions-set*
+                                                  :filter-items-in-personal-collection "exclude-others"
+                                                  :context                             :metabot
+                                                  :archived                            false
+                                                  :limit                               limit
+                                                  :offset                              0}
+                                                  ;; Don't include search-native-query key if nil so that we don't
+                                                  ;; inadvertently filter out search models that don't support it
+                                                  search-native-query
+                                                  (assoc :search-native-query (boolean search-native-query))
+                                                  use-verified?
+                                                  (assoc :verified true)
+                                                  weights
+                                                  (assoc :weights weights)
+                                                  search-engine
+                                                  (assoc :search-engine search-engine)))
+                                _              (log/infof "[METABOT-SEARCH] Search context models for query '%s': %s"
+                                                          search-string (:models search-context))
+                                search-results (search/search search-context)
+                                data           (:data search-results)
+                                result-models  (frequencies (map :model data))]
+                            (log/infof "[METABOT-SEARCH] Query '%s' returned entity types: %s" search-string result-models)
+                            data))
+        search-fn*      (fn [search-engine queries]
+                          (if join-with-or?
+                            (join-results-by-or search-fn search-engine queries)
+                            (join-results-by-rrf search-fn search-engine queries)))
+        ;; NOTE: if we add more semantic engines, e.g. 3rd party vector dbs, we'll need to make this more maintainable
+        semantic?       #{:search.engine/semantic}
+        semantic-engine (u/seek semantic? (search.engine/active-engines))
+        fallback-engine (when semantic-engine
+                          (u/seek (comp not semantic?) (search.engine/supported-engines)))
+        fused-results   (if (and non-semantic-keywords? semantic-engine)
+                          ;; Perform semantic and non-semantic search respectively, then fuse results.
+                          (reciprocal-rank-fusion
+                           (map #(search-fn* %1 %2) {semantic-engine semantic-queries
+                                                     fallback-engine term-queries}))
+                          ;; Search for all the terms on equal footing, using the default engine.
+                          (search-fn* nil (distinct (concat term-queries semantic-queries))))]
     (->> fused-results
+         (take limit)
          (map postprocess-search-result)
          enrich-with-collection-descriptions)))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
@@ -212,8 +212,9 @@
         fused-results   (if (and non-semantic-keywords? semantic-engine)
                           ;; Perform semantic and non-semantic search respectively, then fuse results.
                           (reciprocal-rank-fusion
-                           (map #(search-fn* %1 %2) {semantic-engine semantic-queries
-                                                     fallback-engine term-queries}))
+                           (map (fn [[engine queries]] (search-fn* engine queries))
+                                {semantic-engine semantic-queries
+                                 fallback-engine term-queries}))
                           ;; Search for all the terms on equal footing, using the default engine.
                           (search-fn* nil (distinct (concat term-queries semantic-queries))))]
     (->> fused-results


### PR DESCRIPTION
Closes BOT-500

The metabot search tool can take two types of queries - semantic and keyword based ones.

Counter intuitively the API makes no distinction between these, and joins them into a single flat search.

This may be negatively impacting our results, by including unwanted matches at the expense of more pertinent results.