### PR TITLE
Upload checksums with releases

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -189,14 +189,16 @@ jobs:
     - name: Upload to s3 ${{ inputs.tag_name }} path
       run: | # sh
         aws s3 cp \
-          s3://${{ vars.AWS_S3_DOWNLOADS_BUCKET }}/${{ steps.source_path.outputs.result }}/metabase.jar \
-          s3://${{ vars.AWS_S3_DOWNLOADS_BUCKET }}/${{ steps.upload_path.outputs.result }}/metabase.jar
+          s3://${{ vars.AWS_S3_DOWNLOADS_BUCKET }}/${{ steps.source_path.outputs.result }}/ \
+          s3://${{ vars.AWS_S3_DOWNLOADS_BUCKET }}/${{ steps.upload_path.outputs.result }}/ \
+          --recursive \
+          --include "*"
 
     - name: Create cloudfront invalidation
       run: |
         aws cloudfront create-invalidation \
         --distribution-id ${{ vars.AWS_CLOUDFRONT_DOWNLOADS_ID }} \
-        --paths /${{ steps.upload_path.outputs.result }}/metabase.jar
+        --paths "/${{ steps.upload_path.outputs.result }}/*"
 
     - name: Download the jars
       run: | # sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,13 +211,15 @@ jobs:
           return version_path;
 
     - name: Upload to S3
-      run: aws s3 cp ./metabase.jar s3://${{ vars.AWS_S3_DOWNLOADS_BUCKET }}/${{ steps.version_path.outputs.result }}/metabase.jar
+      run: |
+        aws s3 cp ./metabase.jar s3://${{ vars.AWS_S3_DOWNLOADS_BUCKET }}/${{ steps.version_path.outputs.result }}/metabase.jar
+        aws s3 cp ./SHA256.sum s3://${{ vars.AWS_S3_DOWNLOADS_BUCKET }}/${{ steps.version_path.outputs.result }}/metabase.sha256
 
     - name: Create cloudfront invalidation
       run: |
         aws cloudfront create-invalidation \
         --distribution-id ${{ vars.AWS_CLOUDFRONT_DOWNLOADS_ID }} \
-        --paths /${{ steps.version_path.outputs.result }}/metabase.jar
+        --paths "/${{ steps.version_path.outputs.result }}/*"
 
   verify-s3-download:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #51726
Closes DEV-412

### Description

Uploads a `metabase.sha256` file alongside every `metabase.jar` file.

This is pretty uncontroversial for files like

```
/v0.57.1.1/metabase.jar
/v0.57.1.1/metabase.sha256
```
but a bit more complicated for mutable references like
```
/v0.57.x/metabase.jar
/v0.57.x/metabase.sha256
```
Because the checksum will change every time we do a release, which is almost daily, this could be confusing, if you pull the checksum a day after pulling the jar, it is likely wrong. But, I think most people will pull the checksum with the jar, so for now, let's err on the side of providing more information.
