### PR TITLE
Allow `return` to focus body of Documents

### DIFF
--- a/e2e/test/scenarios/documents/documents.cy.spec.ts
+++ b/e2e/test/scenarios/documents/documents.cy.spec.ts
@@ -156,6 +156,27 @@ H.describeWithSnowplowEE("documents", () => {
       .should("have.attr", "contenteditable", "false");
   });
 
+  it("should focus the start of the document body when pressing Enter on the title input", () => {
+    cy.visit("/document/new");
+
+    cy.log("Type a title");
+    cy.findByRole("textbox", { name: "Document Title" })
+      .should("be.focused")
+      .type("Doc Title{enter}");
+
+    cy.log("Add some content to the document body");
+    H.addToDocument("One{enter}Two");
+
+    cy.log("Click back on the title to focus it and hit Enter");
+    cy.findByRole("textbox", { name: "Document Title" })
+      .click()
+      .type("{enter}");
+
+    cy.log("Focus should be placed at the beginning of the document body");
+    cy.realType("NEW: ");
+    H.documentContent().should("have.text", "NEW: OneTwo");
+  });
+
   it("should handle navigating from /new to /new gracefully", () => {
     cy.visit("/");
     H.newButton("Document").click();

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentHeader.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentHeader.tsx
@@ -45,6 +45,7 @@ interface DocumentHeaderProps {
   showSaveButton: boolean;
   isBookmarked: boolean;
   onTitleChange: (title: string) => void;
+  onTitleSubmit?: () => void;
   onSave: () => void;
   onMove: () => void;
   onToggleBookmark: () => void;
@@ -60,6 +61,7 @@ export const DocumentHeader = ({
   showSaveButton,
   isBookmarked,
   onTitleChange,
+  onTitleSubmit,
   onSave,
   onMove,
   onToggleBookmark,
@@ -106,6 +108,15 @@ export const DocumentHeader = ({
           readOnly={!canWrite}
           maxLength={DOCUMENT_TITLE_MAX_LENGTH}
           classNames={{ input: S.titleInput }}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              event.preventDefault();
+
+              if (canWrite) {
+                onTitleSubmit?.();
+              }
+            }
+          }}
         />
         {document && (
           <Flex gap="md">

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentPage.tsx
@@ -354,7 +354,7 @@ export const DocumentPage = ({
   );
 
   const focusEditorBody = useCallback(() => {
-    editorInstance?.commands.focus("end");
+    editorInstance?.commands.focus("start");
   }, [editorInstance]);
 
   const handleUpdate = async (payload: {

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentPage.tsx
@@ -353,6 +353,10 @@ export const DocumentPage = ({
     ],
   );
 
+  const focusEditorBody = useCallback(() => {
+    editorInstance?.commands.focus("end");
+  }, [editorInstance]);
+
   const handleUpdate = async (payload: {
     collection_id?: CollectionId | null;
     archived?: boolean;
@@ -420,6 +424,7 @@ export const DocumentPage = ({
               showSaveButton={showSaveButton ?? false}
               isBookmarked={isBookmarked}
               onTitleChange={setDocumentTitle}
+              onTitleSubmit={focusEditorBody}
               onSave={() => {
                 if (isNewDocument) {
                   setCollectionPickerMode("save");


### PR DESCRIPTION
When your cursor is in the title of a Document, `return` moves it to the body of the document.