### PR TITLE
[WIP] Metabot tool helper `/analyze-query`

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/query_analysis.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/query_analysis.clj
@@ -1,0 +1,50 @@
+(ns metabase-enterprise.metabot-v3.tools.query-analysis
+  (:require
+   [metabase-enterprise.metabot-v3.tools.util :as metabot-v3.tools.u]
+   ^{:clj-kondo/ignore [:metabase/modules]} [metabase.lib-be.models.transforms :as lib-be.transforms]
+   ^{:clj-kondo/ignore [:metabase/modules]} [metabase.lib.walk.util :as lib.walk.util]
+   [metabase.models.interface :as mi]
+   [toucan2.core :as t2]))
+
+(defn- fetch-table-metadata
+  [table-ids]
+  (if (empty? table-ids)
+    []
+    (->> (t2/select [:model/Table :id :name :entity_type] :id [:in table-ids])
+         (filter mi/can-read?)
+         (mapv (fn [table]
+                 {:id (:id table)
+                  :name (:name table)
+                  :type (if (= (:entity_type table) :model) :model :table)})))))
+
+(defn- fetch-card-metadata
+  [card-ids]
+  (->> (t2/select [:model/Card :id :name :type :card_schema :collection_id]
+                  :id [:in card-ids])
+       (filter mi/can-read?)
+       (mapv #(select-keys % [:id :name :type]))))
+
+(defn analyze-query
+  "Analyze an MBQL query and return metadata about referenced tables and cards.
+
+  Takes a map with `:query` key containing an MBQL query map.
+  Returns a map with `:structured_output` containing:
+  - `:source_tables` - tables directly referenced in the query
+  - `:source_cards` - cards (models/metrics) referenced in the query
+  - `:implicitly_joined_tables` - tables joined via field references
+
+  Each item includes only basic metadata (id, name, type) and respects user permissions."
+  [{:keys [query]}]
+  (try
+    (let [normalized-query (lib-be.transforms/normalize-query query)
+          source-table-ids (lib.walk.util/all-source-table-ids normalized-query)
+          source-card-ids (lib.walk.util/all-source-card-ids normalized-query)
+          implicitly-joined-table-ids (lib.walk.util/all-implicitly-joined-table-ids normalized-query)
+          source-tables (fetch-table-metadata source-table-ids)
+          source-cards (fetch-card-metadata source-card-ids)
+          implicitly-joined-tables (fetch-table-metadata implicitly-joined-table-ids)]
+      {:structured_output {:source_tables source-tables
+                           :source_cards source-cards
+                           :implicitly_joined_tables implicitly-joined-tables}})
+    (catch Exception e
+      (metabot-v3.tools.u/handle-agent-error e))))


### PR DESCRIPTION
WIP

> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform). Also, if you're attempting to fix a translation issue, please submit your changes to our [Crowdin project](https://crowdin.com/project/metabase-i18n) instead of opening a PR.

Closes https://github.com/metabase/metabase/issues/[issue_number]

### Description

Describe the overall approach and the problem being solved.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> ...
2. ...

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR



### TEMP STUFF

running adventure works on ai-service main and the v57 pinned backend container

first example from failed result report (full thing attached at the bottom)
```markdown
# Benchmark: Query Metric E2E
## Test case: 30b15449-c1ea-481a-9d67-4b0c69c53188
Input Messages:
{'role': 'user', 'content': 'What is our total revenue?'}

The agent took these steps:
{'type': 'text', 'content': "I'll search for revenue-related dashboards and metrics to find the best source for this information."}
<TRUNCATED>
{'type': 'data', 'data_type': <AISDKDataTypes.NAVIGATE_TO: 'navigate_to'>, 'value': '/question#eyJkYXRhc2V0X3F1ZXJ5IjogeyJkYXRhYmFzZSI6IDEsICJ0eXBlIjogInF1ZXJ5IiwgInF1ZXJ5IjogeyJhZ2dyZWdhdGlvbiI6IFtbIm1ldHJpYyIsIDkyXV0sICJzb3VyY2UtdGFibGUiOiAiY2FyZF9fNzYifX0sICJkaXNwbGF5IjogInNjYWxhciIsICJkaXNwbGF5SXNMb2NrZWQiOiB0cnVlLCAidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6IHt9fQ=='}
{'type': 'tool_result', 'tool_call_id': 'toolu_0138XFh18wMzC4Cn1CgZs4xE', 'result': 'The user now can see the result of the chart with ID d04b1716-83a9-45d2-8523-9264d54c2b9d'}
{'type': 'text', 'content': "There's your total revenue! This is based on the verified [Total Revenue](/metric/92) metric that your business team maintains. If you'd like to break this down by time period, product category, or any other dimension, just let me know."}

Response: <TRUNCATED>

### Metric: QueriesMatchDescription
Reason: The provided MBQL query aggregates the total revenue by summing the 'linetotal' from a subquery, but it does not use metric 92 (Total Revenue) as specified in the expected query description. Additionally, the query contains multiple joins and does not meet the requirement of not applying any additional filters or groupings. Therefore, it does not match the expectation.
```

the base64 decoded query from the `navigate_to` tool result is
```json
{
    "database": 1,
    "type": "query",
    "query": {
        "aggregation": [
            [
                "metric",
                92
            ]
        ],
        "source-table": "card__76"
    }
}
```

the QueriesMatchDescription metric [passes this through](https://github.com/metabase/ai-service/blob/a8910492b147f9a47dc1e19ea3a8d1f30a913cda/benchmarks/end_2_end/metrics.py#L226) `/api/dataset/native` which gives us
```sql
SELECT
  SUM("source"."linetotal") AS "sum"
FROM
  (
    -- Sales Fact Model: Core sales transactions with enriched context
    SELECT
      soh.salesorderid,
      soh.orderdate,
      soh.shipdate,
      soh.duedate,
      soh.status,
      soh.subtotal,
      soh.taxamt,
      soh.freight,
      soh.totaldue,
      c.customerid,
      COALESCE(CONCAT(p.firstname, ' ', p.lastname), s.name) as customer_name,
      st.name as territory_name,
      st.territoryid,
      sod.salesorderdetailid,
      sod.productid,
      prod.name as product_name,
      psc.name as subcategory_name,
      pc.name as category_name,
      sod.orderqty,
      sod.unitprice,
      sod.unitpricediscount,
      sod.linetotal,
      sp.businessentityid as salesperson_id
    FROM
      adventureworks2014.salesorderheader soh
      JOIN adventureworks2014.salesorderdetail sod ON soh.salesorderid = sod.salesorderid
      JOIN adventureworks2014.customer c ON soh.customerid = c.customerid
      LEFT JOIN adventureworks2014.person p ON c.personid = p.businessentityid
      LEFT JOIN adventureworks2014.store s ON c.storeid = s.businessentityid
      LEFT JOIN adventureworks2014.salesterritory st ON soh.territoryid = st.territoryid
      LEFT JOIN adventureworks2014.salesperson sp ON soh.salespersonid = sp.businessentityid
      JOIN adventureworks2014.product prod ON sod.productid = prod.productid
      LEFT JOIN adventureworks2014.productsubcategory psc ON prod.productsubcategoryid = psc.productsubcategoryid
      LEFT JOIN adventureworks2014.productcategory pc ON psc.productcategoryid = pc.productcategoryid
  ) AS "source"
```

the endpoint from this draft PR returns the below for this query
```json
{
    "structured_output": {
        "source_tables": [],
        "source_cards": [
            {
                "id": 92,
                "name": "Total Revenue",
                "type": "metric"
            },
            {
                "id": 76,
                "name": "Sales Fact",
                "type": "model"
            }
        ],
        "implicitly_joined_tables": []
    },
    "conversation_id": "00000000-0000-0000-0000-000000000001"
}
```

full failed result report:
[failed_results_report__internal.txt](https://github.com/user-attachments/files/23493957/failed_results_report__internal.txt)
[agent_benchmark_results__internal.json](https://github.com/user-attachments/files/23493958/agent_benchmark_results__internal.json)
[benchmark_results__internal.csv](https://github.com/user-attachments/files/23493959/benchmark_results__internal.csv)

