### PR TITLE
Fix static embedding or public embed outside iframe not working with #theme

### DIFF
--- a/e2e/test/scenarios/sharing/public-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-dashboard.cy.spec.js
@@ -306,6 +306,25 @@ describe("scenarios > public > dashboard", () => {
       expect(element.href).to.eq("https://metabase.com/");
     });
   });
+
+  it("should support #theme=dark (metabase#65731)", () => {
+    const dashboardName = "Dashboard Theme Test";
+    H.createDashboardWithQuestions({
+      dashboardName,
+      questions: [],
+    }).then(({ dashboard }) => {
+      H.visitPublicDashboard(dashboard.id, {
+        hash: {
+          theme: "dark",
+        },
+      });
+    });
+
+    cy.log("dark theme should have white text");
+    cy.findByRole("heading", {
+      name: dashboardName,
+    }).should("have.css", "color", "rgba(255, 255, 255, 0.95)");
+  });
 });
 
 describe("scenarios [EE] > public > dashboard", () => {

--- a/e2e/test/scenarios/sharing/public-question.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-question.cy.spec.js
@@ -2,7 +2,7 @@ const { H } = cy;
 
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
-const { PEOPLE } = SAMPLE_DATABASE;
+const { PEOPLE, ORDERS_ID } = SAMPLE_DATABASE;
 
 const questionData = {
   name: "Parameterized Public Question",
@@ -191,6 +191,27 @@ describe("scenarios > public > question", () => {
         });
       });
     });
+  });
+
+  it("should support #theme=dark (metabase#65731)", () => {
+    const questionName = "Orders Theme Test";
+    H.createQuestion({
+      name: questionName,
+      query: {
+        "source-table": ORDERS_ID,
+      },
+    }).then(({ body: { id } }) => {
+      H.visitPublicQuestion(id, {
+        hash: {
+          theme: "dark",
+        },
+      });
+    });
+
+    cy.log("dark theme should have white text");
+    cy.findByRole("heading", {
+      name: questionName,
+    }).should("have.css", "color", "rgba(255, 255, 255, 0.95)");
   });
 });
 

--- a/frontend/src/metabase/app-embed.js
+++ b/frontend/src/metabase/app-embed.js
@@ -3,8 +3,12 @@
  * file 'LICENSE-EMBEDDING.txt', which is part of this source code package.
  */
 
+import { setIsStaticEmbedding } from "metabase/embedding/config";
+
 import { init } from "./app";
 import { publicReducers } from "./reducers-public";
 import { getRoutes } from "./routes-embed";
+
+setIsStaticEmbedding();
 
 init(publicReducers, getRoutes, () => {});

--- a/frontend/src/metabase/app-public.js
+++ b/frontend/src/metabase/app-public.js
@@ -1,9 +1,9 @@
-import { setIsPublicEmbed } from "metabase/embedding/config";
+import { setIsPublicEmbedding } from "metabase/embedding/config";
 
 import { init } from "./app";
 import { publicReducers } from "./reducers-public";
 import { getRoutes } from "./routes-public";
 
-setIsPublicEmbed();
+setIsPublicEmbedding();
 
 init(publicReducers, getRoutes, () => {});

--- a/frontend/src/metabase/app-public.js
+++ b/frontend/src/metabase/app-public.js
@@ -1,5 +1,9 @@
+import { setIsPublicEmbed } from "metabase/embedding/config";
+
 import { init } from "./app";
 import { publicReducers } from "./reducers-public";
 import { getRoutes } from "./routes-public";
+
+setIsPublicEmbed();
 
 init(publicReducers, getRoutes, () => {});

--- a/frontend/src/metabase/embedding/config.ts
+++ b/frontend/src/metabase/embedding/config.ts
@@ -1,23 +1,23 @@
 type InternalEmbeddingConfig = {
-  isPublicEmbed: boolean;
+  isPublicEmbedding: boolean;
   isStaticEmbedding: boolean;
 };
 
 const EMBEDDING_CONFIG: InternalEmbeddingConfig = {
-  isPublicEmbed: false,
+  isPublicEmbedding: false,
   isStaticEmbedding: false,
 };
 
-export function setIsPublicEmbed() {
-  EMBEDDING_CONFIG.isPublicEmbed = true;
+export function setIsPublicEmbedding() {
+  EMBEDDING_CONFIG.isPublicEmbedding = true;
 }
 
 export function setIsStaticEmbedding() {
   EMBEDDING_CONFIG.isStaticEmbedding = true;
 }
 
-export function isPublicEmbed() {
-  return EMBEDDING_CONFIG.isPublicEmbed;
+export function isPublicEmbedding() {
+  return EMBEDDING_CONFIG.isPublicEmbedding;
 }
 
 export function isStaticEmbedding() {

--- a/frontend/src/metabase/embedding/config.ts
+++ b/frontend/src/metabase/embedding/config.ts
@@ -1,0 +1,25 @@
+type InternalEmbeddingConfig = {
+  isPublicEmbed: boolean;
+  isStaticEmbedding: boolean;
+};
+
+const EMBEDDING_CONFIG: InternalEmbeddingConfig = {
+  isPublicEmbed: false,
+  isStaticEmbedding: false,
+};
+
+export function setIsPublicEmbed() {
+  EMBEDDING_CONFIG.isPublicEmbed = true;
+}
+
+export function setIsStaticEmbedding() {
+  EMBEDDING_CONFIG.isStaticEmbedding = true;
+}
+
+export function isPublicEmbed() {
+  return EMBEDDING_CONFIG.isPublicEmbed;
+}
+
+export function isStaticEmbedding() {
+  return EMBEDDING_CONFIG.isStaticEmbedding;
+}

--- a/frontend/src/metabase/ui/components/theme/ThemeProvider/ThemeProvider.tsx
+++ b/frontend/src/metabase/ui/components/theme/ThemeProvider/ThemeProvider.tsx
@@ -11,11 +11,11 @@ import {
   useState,
 } from "react";
 
+import { isPublicEmbed, isStaticEmbedding } from "metabase/embedding/config";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { parseHashOptions } from "metabase/lib/browser";
 import { mutateColors } from "metabase/lib/colors/colors";
 import type { DisplayTheme } from "metabase/public/lib/types";
-import { getIsEmbeddingIframe } from "metabase/selectors/embed";
 
 import { getThemeOverrides } from "../../../theme";
 import { ColorSchemeProvider, useColorScheme } from "../ColorSchemeProvider";
@@ -154,7 +154,7 @@ const useColorSchemeFromHash = ({
 
 export const ThemeProvider = (props: ThemeProviderProps) => {
   const schemeFromHash = useColorSchemeFromHash({
-    enabled: getIsEmbeddingIframe(),
+    enabled: isStaticEmbedding() || isPublicEmbed(),
   });
   const forceColorScheme = props.displayTheme
     ? getColorSchemeFromDisplayTheme(props.displayTheme)

--- a/frontend/src/metabase/ui/components/theme/ThemeProvider/ThemeProvider.tsx
+++ b/frontend/src/metabase/ui/components/theme/ThemeProvider/ThemeProvider.tsx
@@ -11,7 +11,10 @@ import {
   useState,
 } from "react";
 
-import { isPublicEmbed, isStaticEmbedding } from "metabase/embedding/config";
+import {
+  isPublicEmbedding,
+  isStaticEmbedding,
+} from "metabase/embedding/config";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { parseHashOptions } from "metabase/lib/browser";
 import { mutateColors } from "metabase/lib/colors/colors";
@@ -154,7 +157,7 @@ const useColorSchemeFromHash = ({
 
 export const ThemeProvider = (props: ThemeProviderProps) => {
   const schemeFromHash = useColorSchemeFromHash({
-    enabled: isStaticEmbedding() || isPublicEmbed(),
+    enabled: isStaticEmbedding() || isPublicEmbedding(),
   });
   const forceColorScheme = props.displayTheme
     ? getColorSchemeFromDisplayTheme(props.displayTheme)


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #65731
Closes EMB-992

### Backport reason
This is a regression for 57, so there's no need to backport further than that.

### Description

Since we shipped dark mode https://github.com/metabase/metabase/pull/64016, the condition used to check whether the `#theme` should be used, was `isWithinIframe` that means it won't work with public link as it's not in an iframe, but it would work with public embed since it would be in an iframe.

### How to verify

Create a public link, then visit that link while appending `#theme=night`, you should see the dark theme.

### Demo
<img width="1295" height="519" alt="Screenshot 2025-11-12 at 4 55 52 PM" src="https://github.com/user-attachments/assets/447c4ea3-4a4f-4b34-995b-6245a9aa7fd2" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
