### PR TITLE
Update screen reader description to match the new menu copy

### DIFF
--- a/frontend/src/metabase/embedding/components/ArchiveButton.tsx
+++ b/frontend/src/metabase/embedding/components/ArchiveButton.tsx
@@ -36,7 +36,7 @@ export function ArchiveButton({ item }: ArchiveButtonProps) {
       <Menu.Target>
         <ActionIcon
           aria-label={c(
-            "button that opens a actions dropdown e.g. Delete this row",
+            "button that opens a actions dropdown e.g. Move this item to trash",
           ).t`Actions`}
           variant="subtle"
           onClick={dropdownActions.open}

--- a/frontend/src/metabase/embedding/components/ArchiveButton.tsx
+++ b/frontend/src/metabase/embedding/components/ArchiveButton.tsx
@@ -36,7 +36,7 @@ export function ArchiveButton({ item }: ArchiveButtonProps) {
       <Menu.Target>
         <ActionIcon
           aria-label={c(
-            "button that opens a actions dropdown e.g. Move this item to trash",
+            "button that opens an actions dropdown e.g. Move this item to trash",
           ).t`Actions`}
           variant="subtle"
           onClick={dropdownActions.open}


### PR DESCRIPTION
Follow up from #65688 via this [comment](https://github.com/metabase/metabase/pull/65688#issuecomment-3521799278)

I'll manually cherry-pick the merged commit to https://github.com/metabase/metabase/pull/65746, so I'm not backporting

### Description

Update screen reader description to match the visible label.

### How to verify

Well... Looking at the code should be enough, otherwise, you can spin the whole thing up, embed `CollectionBrowser` and see the accessibility description for this menu button.

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~ We don't test this description
