### PR TITLE
document MB_NOTIFICATION_TEMP_FILE_SIZE_MAX_BYTES

### DIFF
--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -1254,6 +1254,15 @@ The base URL where dashboard notitification links will point to instead of the M
 
 The size of the thread pool used to send system event notifications.
 
+### `MB_NOTIFICATION_TEMP_FILE_SIZE_MAX_BYTES`
+
+- Type: integer
+- Default: `10485760`
+
+The maximum file size that will be created when storing notification query results on disk.
+  Note this is in BYTES. Default value is 10485760 which is `10 * 1024 * 1024`. To disable this size limit set the
+  value to 0.
+
 ### `MB_NOTIFICATION_THREAD_POOL_SIZE`
 
 - Type: integer

--- a/src/metabase/notification/settings.clj
+++ b/src/metabase/notification/settings.clj
@@ -27,4 +27,6 @@
   :default (* 10 1024 1024)
   :export? false
   :setter :none
-  :visibility :internal)
+  :visibility :internal
+  :can-read-from-env? true
+  :doc true)


### PR DESCRIPTION
See https://metaboat.slack.com/archives/C07JBRAQ9PA/p1760130124139389

And https://github.com/metabase/metabase/pull/65090