### PR TITLE
Preserve document cards width on reorder

### DIFF
--- a/e2e/test/scenarios/documents/card-embed-node.cy.spec.ts
+++ b/e2e/test/scenarios/documents/card-embed-node.cy.spec.ts
@@ -377,6 +377,80 @@ describe("documents card embed node custom logic", () => {
         });
     });
 
+    it("should preserve card widths when swapping cards within the same flexContainer", () => {
+      // Wait for all cards to load
+      H.getDocumentCard("Orders")
+        .should("be.visible")
+        .findByTestId("table-root")
+        .should("exist");
+      H.getDocumentCard("Orders, Count")
+        .should("be.visible")
+        .findByTestId("table-root")
+        .should("exist");
+
+      // Verify initial order: Orders | Orders, Count
+      H.documentContent()
+        .find('[data-type="flexContainer"]')
+        .should("exist")
+        .within(() => {
+          assertFlexContainerCardsOrder(["Orders", "Orders, Count"]);
+        });
+
+      // Verify both cards start with equal widths
+      getCardWidths(["Orders", "Orders, Count"], (first, second) => {
+        expect(first).to.be.closeTo(second, 3);
+      });
+
+      // Resize the columns to have different widths
+      const flexContainer = H.getFlexContainerForCard("Orders");
+      const handles = H.getResizeHandlesForFlexContianer(flexContainer);
+      H.documentDoDrag(handles.eq(0), { x: 150 });
+
+      // Store the widths after resizing
+      getCardWidths(
+        ["Orders", "Orders, Count"],
+        (ordersWidth, ordersCountWidth) => {
+          cy.wrap(ordersWidth).as("ordersWidth");
+          cy.wrap(ordersCountWidth).as("ordersCountWidth");
+          // Verify the widths are now different
+          expect(ordersWidth).to.be.greaterThan(ordersCountWidth);
+        },
+      );
+
+      // Swap the cards by dragging Orders to the right side of Orders, Count
+      H.dragAndDropCardOnAnotherCard("Orders", "Orders, Count", {
+        side: "right",
+      });
+
+      // Verify new order: Orders, Count | Orders
+      H.documentContent()
+        .find('[data-type="flexContainer"]')
+        .should("exist")
+        .within(() => {
+          assertFlexContainerCardsOrder(["Orders, Count", "Orders"]);
+        });
+
+      // Verify that each card preserved its width after swapping
+      getCardWidths(
+        ["Orders, Count", "Orders"],
+        (ordersCountNewWidth, ordersNewWidth) => {
+          cy.get<number>("@ordersWidth").then((originalOrdersWidth) => {
+            cy.get<number>("@ordersCountWidth").then(
+              (originalOrdersCountWidth) => {
+                // Orders should still have its original width (now on the right)
+                expect(ordersNewWidth).to.be.closeTo(originalOrdersWidth, 3);
+                // Orders, Count should still have its original width (now on the left)
+                expect(ordersCountNewWidth).to.be.closeTo(
+                  originalOrdersCountWidth,
+                  3,
+                );
+              },
+            );
+          });
+        },
+      );
+    });
+
     it("should handle moving cards between different flexContainers", () => {
       // First create another flexContainer by dragging the standalone card onto a new location
       // Add another standalone card first

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/DropHandlers/cardToFlexContainer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/DropHandlers/cardToFlexContainer.ts
@@ -83,8 +83,31 @@ export const handleCardDropToFlexContainer = (
     // Insert the dragged element at the correct position
     allChildren.splice(adjustedTargetIndex, 0, cardEmbedNode);
 
+    // Preserve column widths by reordering them to match the new card positions
+    const currentColumnWidths = dropToParent.attrs.columnWidths;
+    let newColumnWidths = currentColumnWidths;
+    if (
+      currentColumnWidths &&
+      currentColumnWidths.length === dropToParent.childCount
+    ) {
+      // Create array of widths excluding the source column width
+      const allWidths = [];
+      for (let i = 0; i < currentColumnWidths.length; i++) {
+        if (i !== sourceIndex) {
+          allWidths.push(currentColumnWidths[i]);
+        }
+      }
+      // Insert the source column width at the new position
+      allWidths.splice(
+        adjustedTargetIndex,
+        0,
+        currentColumnWidths[sourceIndex],
+      );
+      newColumnWidths = allWidths;
+    }
+
     const newContainer = view.state.schema.nodes.flexContainer.create(
-      dropToParent.attrs,
+      { ...dropToParent.attrs, columnWidths: newColumnWidths },
       allChildren,
     );
 


### PR DESCRIPTION
Needed for https://linear.app/metabase/issue/UXW-2243/make-supporting-text-blocks-reorderable

### Description

Preserve document cards width after reordering them within a group using drag'n'drop

### Demo

https://github.com/user-attachments/assets/5ca76219-0082-47bc-84fa-a98b512a2333

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
