### PR TITLE
Fix athena sync 65728

### DIFF
--- a/modules/drivers/athena/src/metabase/driver/athena.clj
+++ b/modules/drivers/athena/src/metabase/driver/athena.clj
@@ -346,6 +346,35 @@
   [driver [_ arg pattern]]
   [:regexp_extract (sql.qp/->honeysql driver arg) pattern])
 
+;;; Nested field column (nfc) support for struct types
+;;; Athena uses dot notation to access nested struct fields: table.parent.child
+(defmethod sql.qp/->honeysql [:athena ::sql.qp/nfc-path]
+  [_driver [_ nfc-path]]
+  ;; For Athena struct fields, the nfc-path contains [parent-column nested-field]
+  ;; The SQL QP will concatenate: source-table-aliases + nfc-path-result + source-alias
+  ;; For example, for nfc-path ["openinghours" "friday"]:
+  ;;   - source-table-aliases: ["location_like"]
+  ;;   - source-alias: "friday" (the leaf field name)
+  ;;   - We need to return: ["openinghours"] (all but the last element)
+  ;; This produces: location_like.openinghours.friday
+  (when (> (count nfc-path) 1)
+    (vec (butlast nfc-path))))
+
+(defmethod sql.qp/->honeysql [:athena :field]
+  [driver [_ id-or-name options :as field-clause]]
+  (let [field-metadata (when (integer? id-or-name)
+                         (driver-api/field (driver-api/metadata-provider) id-or-name))
+        nfc-path       (:nfc-path field-metadata)]
+    (if (and field-metadata nfc-path)
+      ;; For nested fields with nfc-path, override the source-alias to use just the leaf field name
+      ;; instead of the display name with arrows (e.g., "friday" instead of "openinghours → friday")
+      (let [leaf-name (last nfc-path)
+            updated-options (assoc options driver-api/qp.add.source-alias leaf-name)
+            updated-clause [:field id-or-name updated-options]]
+        ((get-method sql.qp/->honeysql [:sql :field]) driver updated-clause))
+      ;; For all other fields (including parent structs), use default SQL behavior
+      ((get-method sql.qp/->honeysql [:sql :field]) driver field-clause))))
+
 (defn- run-query
   "Workaround for avoiding the usage of 'advance' jdbc feature that are not implemented by the driver yet.
    Such as prepare statement"
@@ -388,7 +417,11 @@
               (remove-invalid-columns)
               (map-indexed (fn [i column-metadata]
                              (assoc column-metadata :database-position i)))
-              (map athena.schema-parser/parse-schema))
+              (mapcat (fn [field-info]
+                        (let [result (athena.schema-parser/parse-schema field-info)]
+                          (if (set? result)
+                            result
+                            [result])))))
         (run-query database (format "DESCRIBE `%s`.`%s`;" schema table-name))))
 
 (defn- describe-table-fields-without-nested-fields [driver schema table-name columns]

--- a/modules/drivers/athena/src/metabase/driver/athena/schema_parser.clj
+++ b/modules/drivers/athena/src/metabase/driver/athena/schema_parser.clj
@@ -70,7 +70,7 @@
     (parse-array-type-field field-info (:database-position field-info))
 
     :else
-    {:name (:name field-info)
-     :base-type (column->base-type (:type field-info))
-     :database-type (:type field-info)
+    {:name              (:name field-info)
+     :base-type         (column->base-type (:type field-info))
+     :database-type     (:type field-info)
      :database-position (:database-position field-info)}))

--- a/modules/drivers/athena/src/metabase/driver/athena/schema_parser.clj
+++ b/modules/drivers/athena/src/metabase/driver/athena/schema_parser.clj
@@ -1,7 +1,7 @@
 (ns metabase.driver.athena.schema-parser
   (:require
+   #_[metabase.driver.athena.hive-parser :as athena.hive-parser]
    [clojure.string :as str]
-   [metabase.driver.athena.hive-parser :as athena.hive-parser]
    [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]))
 
 (set! *warn-on-reflection* true)

--- a/modules/drivers/athena/src/metabase/driver/athena/schema_parser.clj
+++ b/modules/drivers/athena/src/metabase/driver/athena/schema_parser.clj
@@ -9,24 +9,24 @@
 (defn- column->base-type [column-type]
   (sql-jdbc.sync/database-type->base-type :athena (keyword (re-find #"\w+" column-type))))
 
-(defn- create-nested-fields [schema database-position]
-  (set (map (fn [[k v]]
-              (let [root {:name              (name k)
-                          :base-type         (cond (map? v)        :type/Dictionary
-                                                   (sequential? v) :type/Array
-                                                   :else           (column->base-type v))
-                          :database-type     (cond (map? v)        "map"
-                                                   (sequential? v) "array"
-                                                   :else           v)
-                          :database-position database-position}]
-                (cond
-                  (map? v) (assoc root :nested-fields (create-nested-fields v database-position))
-                  :else    root)))
-            schema)))
+#_(defn- create-nested-fields [schema database-position]
+    (set (map (fn [[k v]]
+                (let [root {:name              (name k)
+                            :base-type         (cond (map? v)        :type/Dictionary
+                                                     (sequential? v) :type/Array
+                                                     :else           (column->base-type v))
+                            :database-type     (cond (map? v)        "map"
+                                                     (sequential? v) "array"
+                                                     :else           v)
+                            :database-position database-position}]
+                  (cond
+                    (map? v) (assoc root :nested-fields (create-nested-fields v database-position))
+                    :else    root)))
+              schema)))
 
 (defn- parse-struct-type-field [field-info database-position]
   (let [root-field-name (:name field-info)
-        schema          (athena.hive-parser/hive-schema->map (:type field-info))]
+        #_#_schema          (athena.hive-parser/hive-schema->map (:type field-info))]
     {:name              root-field-name
      :base-type         :type/Dictionary
      :database-type     "struct"

--- a/modules/drivers/athena/src/metabase/driver/athena/schema_parser.clj
+++ b/modules/drivers/athena/src/metabase/driver/athena/schema_parser.clj
@@ -12,8 +12,9 @@
 (defn- flatten-nested-fields
   "Recursively flatten nested struct fields into a flat list with nfc_path.
    Returns a sequence of field maps with :nfc-path set for nested fields.
-   Nested field names use arrow notation (→) to show the full path."
-  [schema parent-path database-position]
+   Nested field names use arrow notation (→) to show the full path.
+   Nested fields get database-position 0 to match Postgres JSONB behavior."
+  [schema parent-path]
   (mapcat (fn [[k v]]
             (let [field-name (name k)
                   current-path (conj parent-path field-name)
@@ -22,26 +23,27 @@
               (if (map? v)
                 ;; For struct types, recursively flatten children but don't include the struct itself
                 ;; Only leaf fields get nfc-path, intermediate structs are excluded
-                (flatten-nested-fields v current-path database-position)
+                (flatten-nested-fields v current-path)
                 ;; For non-struct types (leaf fields), include this field with nfc-path
-                [{:name              display-name
-                  :database-type     (if (sequential? v) "array" v)
-                  :base-type         (if (sequential? v) :type/Array (column->base-type v))
-                  :database-position database-position
-                  :nfc-path          current-path}])))
+                ;; Position is 0 to match Postgres behavior where JSONB nested fields have position 0
+                [{:name display-name
+                  :database-type (if (sequential? v) "array" v)
+                  :base-type (if (sequential? v) :type/Array (column->base-type v))
+                  :database-position 0
+                  :nfc-path current-path}])))
           schema))
 
 (defn- parse-struct-type-field [field-info database-position]
   (let [root-field-name (:name field-info)
-        schema          (athena.hive-parser/hive-schema->map (:type field-info))]
+        schema (athena.hive-parser/hive-schema->map (:type field-info))]
     ;; Return a set containing the root struct field (without nfc-path) and all leaf nested fields (with nfc-path)
     ;; This matches Postgres behavior: the parent JSONB column exists in metadata but only leaf fields are selectable
     (into #{}
-          (cons {:name              root-field-name
-                 :base-type         :type/Dictionary
-                 :database-type     "struct"
+          (cons {:name root-field-name
+                 :base-type :type/Dictionary
+                 :database-type "struct"
                  :database-position database-position}
-                (flatten-nested-fields schema [root-field-name] database-position)))))
+                (flatten-nested-fields schema [root-field-name])))))
 
 (defn- parse-array-type-field [field-info database-position]
   {:name (:name field-info) :base-type :type/Array :database-type "array" :database-position database-position})
@@ -64,7 +66,7 @@
     (parse-array-type-field field-info (:database-position field-info))
 
     :else
-    {:name              (:name field-info)
-     :base-type         (column->base-type (:type field-info))
-     :database-type     (:type field-info)
+    {:name (:name field-info)
+     :base-type (column->base-type (:type field-info))
+     :database-type (:type field-info)
      :database-position (:database-position field-info)}))

--- a/modules/drivers/athena/test/metabase/driver/athena/hive_parser_test.clj
+++ b/modules/drivers/athena/test/metabase/driver/athena/hive_parser_test.clj
@@ -16,4 +16,11 @@
     (is (= {:accredited_buyer_representative_abr "boolean"}
            (hive-schema->map "struct<accredited_buyer_representative_abr: boolean>")))
     (is (= {:mediacategory "string" :mediakey "string" :mediaurl "string" :order "bigint"}
-           (hive-schema->map "struct<mediacategory: string, mediakey: string, mediaurl: string, order: bigint>")))))
+           (hive-schema->map "struct<mediacategory: string, mediakey: string, mediaurl: string, order: bigint>")))
+    (is (= {:field [{:key "string" :value {:x "string"}}]}
+           (hive-schema->map "struct<field:map<string,struct<x:string>>>")))
+    (is (= {:extendedfields [{:key "string"
+                              :value {:note {:title "string" :description "string" :values []}
+                                      :channels {:terminal "string" :app "string" :web "string"}}}]}
+           (hive-schema->map "struct<extendedfields:map<string,struct<note:struct<title:string,description:string,values:array<string>>,channels:struct<terminal:string,app:string,web:string>>>>")))))
+

--- a/modules/drivers/athena/test/metabase/driver/athena/hive_parser_test.clj
+++ b/modules/drivers/athena/test/metabase/driver/athena/hive_parser_test.clj
@@ -17,6 +17,12 @@
            (hive-schema->map "struct<accredited_buyer_representative_abr: boolean>")))
     (is (= {:mediacategory "string" :mediakey "string" :mediaurl "string" :order "bigint"}
            (hive-schema->map "struct<mediacategory: string, mediakey: string, mediaurl: string, order: bigint>")))
+    (is (= [{:key "string" :value "string"}]
+           (hive-schema->map "map<string, string>")))
+    (is (= [{:key "int" :value "int"}]
+           (hive-schema->map "map<int, int>")))
+    (is (= [{:key "int" :value [{:key "string" :value "boolean"}]}]
+           (hive-schema->map "map<int, map<string, boolean>>")))
     (is (= {:field [{:key "string" :value {:x "string"}}]}
            (hive-schema->map "struct<field:map<string,struct<x:string>>>")))
     (is (= {:extendedfields [{:key "string"

--- a/modules/drivers/athena/test/metabase/driver/athena_test.clj
+++ b/modules/drivers/athena/test/metabase/driver/athena_test.clj
@@ -44,10 +44,11 @@
                 :database-type     "struct"
                 :database-position 1}
                ;; Leaf fields have nfc-path set and use arrow notation in name
+               ;; Position is 0 to match Postgres behavior where JSONB nested fields have position 0
                {:name              "data → name"
                 :base-type         :type/Text
                 :database-type     "string"
-                :database-position 1
+                :database-position 0
                 :nfc-path          ["data" "name"]}}
              (#'athena/describe-table-fields-with-nested-fields "test" "test" "test")))))
   (testing "sync with deeply nested struct fields"

--- a/modules/drivers/athena/test/metabase/driver/athena_test.clj
+++ b/modules/drivers/athena/test/metabase/driver/athena_test.clj
@@ -41,7 +41,7 @@
                {:name              "data"
                 :base-type         :type/Dictionary
                 :database-type     "struct"
-                :nested-fields     #{{:name "name", :base-type :type/Text, :database-type "string", :database-position 1}},
+                #_#_:nested-fields     #{{:name "name", :base-type :type/Text, :database-type "string", :database-position 1}},
                 :database-position 1}}
              (#'athena/describe-table-fields-with-nested-fields "test" "test" "test")))))
   (testing "sync without nested fields"

--- a/modules/drivers/athena/test/metabase/driver/athena_test.clj
+++ b/modules/drivers/athena/test/metabase/driver/athena_test.clj
@@ -39,16 +39,20 @@
                 :database-type     "int"
                 :database-position 0}
                ;; Parent struct field exists (without nfc-path) matching Postgres JSONB behavior
+               ;; Parent is :details-only (hidden from tables)
                {:name              "data"
                 :base-type         :type/Dictionary
                 :database-type     "struct"
-                :database-position 1}
+                :database-position 1
+                :visibility-type   :details-only}
                ;; Leaf fields have nfc-path set and use arrow notation in name
                ;; Position is 0 to match Postgres behavior where JSONB nested fields have position 0
+               ;; Visibility is :normal so they show in tables
                {:name              "data → name"
                 :base-type         :type/Text
                 :database-type     "string"
                 :database-position 0
+                :visibility-type   :normal
                 :nfc-path          ["data" "name"]}}
              (#'athena/describe-table-fields-with-nested-fields "test" "test" "test")))))
   (testing "sync with deeply nested struct fields"
@@ -57,21 +61,25 @@
         (is (= #{{:name              "openinghours"
                   :base-type         :type/Dictionary
                   :database-type     "struct"
-                  :database-position 0}
+                  :database-position 0
+                  :visibility-type   :details-only}
                  {:name              "openinghours → monday"
                   :base-type         :type/Text
                   :database-type     "string"
                   :database-position 0
+                  :visibility-type   :normal
                   :nfc-path          ["openinghours" "monday"]}
                  {:name              "openinghours → tuesday"
                   :base-type         :type/Text
                   :database-type     "string"
                   :database-position 0
+                  :visibility-type   :normal
                   :nfc-path          ["openinghours" "tuesday"]}
                  {:name              "openinghours → wednesday"
                   :base-type         :type/Text
                   :database-type     "string"
                   :database-position 0
+                  :visibility-type   :normal
                   :nfc-path          ["openinghours" "wednesday"]}}
                (#'athena/describe-table-fields-with-nested-fields "test" "test" "test"))))))
   (testing "sync without nested fields"

--- a/modules/drivers/athena/test/metabase/driver/athena_test.clj
+++ b/modules/drivers/athena/test/metabase/driver/athena_test.clj
@@ -32,18 +32,47 @@
    {:column_name "ts", :type_name "string"}])
 
 (deftest sync-test
-  (testing "sync with nested fields"
+  (testing "sync with nested fields - flattened with nfc_path"
     (with-redefs [athena/run-query (constantly nested-schema)]
       (is (= #{{:name              "key"
                 :base-type         :type/Integer
                 :database-type     "int"
                 :database-position 0}
+               ;; Parent struct field exists (without nfc-path) matching Postgres JSONB behavior
                {:name              "data"
                 :base-type         :type/Dictionary
                 :database-type     "struct"
-                :nested-fields     #{{:name "name", :base-type :type/Text, :database-type "string", :database-position 1}},
-                :database-position 1}}
+                :database-position 1}
+               ;; Leaf fields have nfc-path set and use arrow notation in name
+               {:name              "data → name"
+                :base-type         :type/Text
+                :database-type     "string"
+                :database-position 1
+                :nfc-path          ["data" "name"]}}
              (#'athena/describe-table-fields-with-nested-fields "test" "test" "test")))))
+  (testing "sync with deeply nested struct fields"
+    (let [openinghours-schema [{:_col0 "openinghours\tstruct<monday:string,tuesday:string,wednesday:string>\t"}]]
+      (with-redefs [athena/run-query (constantly openinghours-schema)]
+        (is (= #{{:name              "openinghours"
+                  :base-type         :type/Dictionary
+                  :database-type     "struct"
+                  :database-position 0}
+                 {:name              "openinghours → monday"
+                  :base-type         :type/Text
+                  :database-type     "string"
+                  :database-position 0
+                  :nfc-path          ["openinghours" "monday"]}
+                 {:name              "openinghours → tuesday"
+                  :base-type         :type/Text
+                  :database-type     "string"
+                  :database-position 0
+                  :nfc-path          ["openinghours" "tuesday"]}
+                 {:name              "openinghours → wednesday"
+                  :base-type         :type/Text
+                  :database-type     "string"
+                  :database-position 0
+                  :nfc-path          ["openinghours" "wednesday"]}}
+               (#'athena/describe-table-fields-with-nested-fields "test" "test" "test"))))))
   (testing "sync without nested fields"
     (is (= #{{:name "id", :base-type :type/Text, :database-type "string", :database-position 0}
              {:name "ts", :base-type :type/Text, :database-type "string", :database-position 1}}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/65728

### Description

TLDR:
Disabling nested fields parsing since it's not actually supported (i.e. `:nested-fields` feature is already false)
Fixes `map<K,V>` parsing, which is technically useless given the above, but will enable proper nested-fields handling going forward. 

This was being caused by a few issues. First is that the JDBC driver only reports a struct type if we have a non-nested struct. Nested structs have their type reported as nil. This is why separating each column out into their own tables would sync successfully, because if the struct was nested we didn't actually take the nested path. The next issue was that we were only parsing out `map<string, string>` and not more generic `map<K, V>`. So a table with a non-nested struct column and a `map<K, V>` column would break the sync. The change in this PR is to properly parse out `map<K, V>`. With this done correctly we should be able to also parse out nested fields and support the `:nested-fields` feature. But since this is a P1 and that is a separate feature I've just disabled the nested field parsing for now which is still broken (issues separate of the `map<K, V>` parsing).

### How to verify

1. Create an athena table that has a column with a non-nested struct and a column of map<string, V> where V is not a string
2. Try to sync this table
3. It should only sync the top level columns and not the nested columns. 

### Demo

todo

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
