### PR TITLE
Semantic Data Picker

### DIFF
--- a/frontend/src/metabase/common/components/EntityPicker/components/NestedItemPicker/NestedItemPicker.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/NestedItemPicker/NestedItemPicker.tsx
@@ -1,4 +1,5 @@
 import type { ComponentType } from "react";
+import { useState } from "react";
 
 import ErrorBoundary from "metabase/ErrorBoundary";
 import { Flex } from "metabase/ui";
@@ -27,6 +28,7 @@ export interface NestedItemPickerProps<
   onItemSelect: (item: Item) => void;
   options: Options;
   path: PickerState<Item, Query>;
+  initialValue: Item | undefined;
   isFolder: IsFolder<Id, Model, Item>;
   listResolver: ComponentType<ListProps<Id, Model, Item, Query, Options>>;
   shouldDisableItem?: (item: Item) => boolean;
@@ -48,6 +50,7 @@ export function NestedItemPicker<
   listResolver: ListResolver,
   shouldDisableItem,
   shouldShowItem,
+  initialValue,
 }: NestedItemPickerProps<Id, Model, Item, Query, Options>) {
   const handleClick = (item: Item) => {
     if (isFolder(item)) {
@@ -56,13 +59,14 @@ export function NestedItemPicker<
       onItemSelect(item);
     }
   };
+  const [hashBuster, setHashBuster] = useState(0);
 
   const lastSelectedItem = findLastSelectedItem(path);
 
   return (
     <AutoScrollBox
       data-testid="nested-item-picker"
-      contentHash={generateKey(path[path.length - 1].query)}
+      contentHash={generateKey(path[path.length - 1].query) + hashBuster}
     >
       <Flex h="100%" w="fit-content">
         {path.map((level, index) => {
@@ -89,6 +93,8 @@ export function NestedItemPicker<
                   shouldDisableItem={shouldDisableItem}
                   shouldShowItem={shouldShowItem}
                   isFolder={isFolder}
+                  refresh={() => setHashBuster((b) => b + 1)}
+                  initialValue={initialValue}
                 />
               </ErrorBoundary>
             </ListBox>

--- a/frontend/src/metabase/common/components/EntityPicker/types.ts
+++ b/frontend/src/metabase/common/components/EntityPicker/types.ts
@@ -80,6 +80,7 @@ export type ListProps<
   shouldDisableItem?: (item: Item) => boolean;
   shouldShowItem?: (item: Item) => boolean;
   entity?: "collection" | "dashboard";
+  refresh?: () => void;
 };
 
 export type FilterItemsInPersonalCollection = "only" | "exclude";

--- a/frontend/src/metabase/common/components/Pickers/CollectionPicker/components/CollectionItemPickerResolver.tsx
+++ b/frontend/src/metabase/common/components/Pickers/CollectionPicker/components/CollectionItemPickerResolver.tsx
@@ -1,3 +1,6 @@
+import _ from "underscore";
+
+import { TablePicker } from "metabase/common/components/Pickers/TablePicker";
 import { PERSONAL_COLLECTIONS } from "metabase/entities/collections";
 
 import type { CollectionItemListProps } from "../types";
@@ -17,6 +20,8 @@ export const CollectionItemPickerResolver = ({
   shouldDisableItem,
   shouldShowItem,
   entity = "collection",
+  refresh,
+  initialValue,
 }: CollectionItemListProps) => {
   if (!query) {
     return (
@@ -57,6 +62,23 @@ export const CollectionItemPickerResolver = ({
         shouldDisableItem={shouldDisableItem}
         shouldShowItem={shouldShowItem}
         options={options}
+      />
+    );
+  }
+
+  if (query?.id === "databases") {
+    return (
+      <TablePicker
+        value={initialValue}
+        onItemSelect={(i) => {
+          if (i.model === "table") {
+            onClick(i);
+          } else {
+            // WARNING: may trigger epilepsy
+            refresh?.();
+          }
+        }}
+        onPathChange={_.noop}
       />
     );
   }

--- a/frontend/src/metabase/common/components/Pickers/CollectionPicker/components/CollectionPicker.tsx
+++ b/frontend/src/metabase/common/components/Pickers/CollectionPicker/components/CollectionPicker.tsx
@@ -29,6 +29,8 @@ import { CollectionItemPickerResolver } from "./CollectionItemPickerResolver";
 const defaultOptions: CollectionPickerOptions = {
   showPersonalCollections: true,
   showRootCollection: true,
+  showLibrary: true,
+  showDatabases: true,
 };
 
 interface CollectionPickerProps {

--- a/frontend/src/metabase/common/components/Pickers/CollectionPicker/types.ts
+++ b/frontend/src/metabase/common/components/Pickers/CollectionPicker/types.ts
@@ -74,6 +74,7 @@ export type CollectionPickerOptions = EntityPickerModalOptions & {
   allowCreateNew?: boolean;
   showPersonalCollections?: boolean;
   showRootCollection?: boolean;
+  showLibrary?: boolean;
 };
 
 export type CollectionItemListProps = ListProps<

--- a/frontend/src/metabase/common/components/Pickers/DataPicker/components/DataPickerModal.tsx
+++ b/frontend/src/metabase/common/components/Pickers/DataPicker/components/DataPickerModal.tsx
@@ -32,7 +32,6 @@ import {
   createQuestionPickerItemSelectHandler,
   createShouldShowItem,
   getRecentItemDatabaseId,
-  isCollectionItem,
   isTableItem,
   isValueItem,
 } from "../utils";
@@ -68,7 +67,9 @@ const options: DataPickerModalOptions = {
   hasConfirmButtons: false,
   showPersonalCollections: true,
   showRootCollection: true,
-  hasRecents: true,
+  showLibrary: true,
+  showDatabases: true,
+  hasRecents: false,
 };
 
 export const DataPickerModal = ({
@@ -210,14 +211,19 @@ export const DataPickerModal = ({
     if (shouldShowCollectionsTab) {
       computedTabs.push({
         id: "questions-tab",
-        displayName: t`Collections`,
-        models: ["card" as const, "dataset" as const, "metric" as const],
-        folderModels: ["collection" as const, "dashboard" as const],
+        displayName: t`Data`,
+        models: [
+          "card" as const,
+          "dataset" as const,
+          "metric" as const,
+          "table" as const,
+        ],
+        folderModels: ["collection", "dashboard", "schema", "database"],
         icon: "folder",
         extraButtons: [filterButton],
         render: ({ onItemSelect }) => (
           <QuestionPicker
-            initialValue={isCollectionItem(value) ? value : undefined}
+            initialValue={value}
             models={QUESTION_PICKER_MODELS}
             options={options}
             path={questionsPath}
@@ -244,7 +250,7 @@ export const DataPickerModal = ({
       recentFilter={recentFilter}
       searchParams={searchParams}
       selectedItem={value ?? null}
-      tabs={tabs}
+      tabs={tabs.slice(1, 2)} // FIXME: for testing
       title={title}
       onClose={onClose}
       onItemSelect={handleItemSelect}

--- a/frontend/src/metabase/common/components/Pickers/DataPicker/types.ts
+++ b/frontend/src/metabase/common/components/Pickers/DataPicker/types.ts
@@ -68,4 +68,6 @@ export type DataPickerValueItem =
 export type DataPickerItem = DataPickerFolderItem | DataPickerValueItem;
 
 export type DataPickerModalOptions = EntityPickerModalOptions &
-  QuestionPickerOptions;
+  QuestionPickerOptions & {
+    showDatabases?: boolean;
+  };

--- a/frontend/src/metabase/common/components/Pickers/QuestionPicker/components/QuestionPicker.tsx
+++ b/frontend/src/metabase/common/components/Pickers/QuestionPicker/components/QuestionPicker.tsx
@@ -173,6 +173,7 @@ export const QuestionPicker = ({
 
   return (
     <NestedItemPicker
+      initialValue={initialValue}
       isFolder={(item: QuestionPickerItem) => isFolder(item, models)}
       options={options}
       onFolderSelect={onFolderSelect}

--- a/frontend/src/metabase/common/components/Pickers/QuestionPicker/types.ts
+++ b/frontend/src/metabase/common/components/Pickers/QuestionPicker/types.ts
@@ -35,6 +35,7 @@ export type QuestionPickerValue = Pick<QuestionPickerItem, "id" | "model">;
 export type QuestionPickerOptions = EntityPickerModalOptions & {
   showPersonalCollections?: boolean;
   showRootCollection?: boolean;
+  showLibrary?: boolean;
 };
 
 export type QuestionItemListProps = ListProps<

--- a/frontend/src/metabase/common/components/Pickers/TablePicker/DatabaseList.tsx
+++ b/frontend/src/metabase/common/components/Pickers/TablePicker/DatabaseList.tsx
@@ -53,17 +53,6 @@ export const DatabaseList = ({
         selectedItem={selectedItem}
         onClick={onClick}
         shouldDisableItem={(item) => shouldDisableItem?.(item) || false}
-        containerProps={{
-          pb: "1rem",
-        }}
-        navLinkProps={(isSelected) => ({
-          px: "1.5rem",
-          py: "1.25rem",
-          rightSection: null,
-          style: {
-            border: isSelected ? undefined : "1px solid var(--mb-color-border)",
-          },
-        })}
       />
     </ListBox>
   );

--- a/frontend/src/metabase/common/components/Pickers/TablePicker/TablePicker.tsx
+++ b/frontend/src/metabase/common/components/Pickers/TablePicker/TablePicker.tsx
@@ -11,8 +11,6 @@ import { isNotNull } from "metabase/lib/types";
 import { Flex } from "metabase/ui";
 import type { DatabaseId, SchemaName, TableId } from "metabase-types/api";
 
-import { AutoScrollBox } from "../../EntityPicker";
-
 import { DatabaseList } from "./DatabaseList";
 import { SchemaList } from "./SchemaList";
 import { TableList } from "./TableList";
@@ -23,14 +21,14 @@ import type {
   TablePickerStatePath,
   TablePickerValue,
 } from "./types";
-import { generateKey, getDbItem, getSchemaItem, getTableItem } from "./utils";
+import { getDbItem, getSchemaItem, getTableItem } from "./utils";
 
 interface Props {
   /**
    * Limit selection to a particular database
    */
   databaseId?: DatabaseId;
-  path: TablePickerStatePath | undefined;
+  path?: TablePickerStatePath | undefined;
   value: TablePickerValue | undefined;
   onItemSelect: (value: TablePickerItem) => void;
   onPathChange: (path: TablePickerStatePath) => void;
@@ -240,54 +238,45 @@ export const TablePicker = ({
   );
 
   return (
-    <AutoScrollBox
-      contentHash={generateKey(
-        selectedDbItem,
-        selectedSchemaItem,
-        selectedTableItem,
+    <Flex h="100%" w="fit-content">
+      {!databaseId && (
+        <DatabaseList
+          databases={databases}
+          error={errorDatabases}
+          isCurrentLevel={
+            schemaName == null || (schemas?.length === 1 && !tableId)
+          }
+          isLoading={isLoadingDatabases}
+          selectedItem={selectedDbItem}
+          onClick={handleFolderSelect}
+          shouldDisableItem={shouldDisableItem}
+        />
       )}
-      data-testid="nested-item-picker"
-    >
-      <Flex h="100%" w="fit-content">
-        {!databaseId && (
-          <DatabaseList
-            databases={databases}
-            error={errorDatabases}
-            isCurrentLevel={
-              schemaName == null || (schemas?.length === 1 && !tableId)
-            }
-            isLoading={isLoadingDatabases}
-            selectedItem={selectedDbItem}
-            onClick={handleFolderSelect}
-            shouldDisableItem={shouldDisableItem}
-          />
-        )}
 
-        {isNotNull(dbId) && (
-          <SchemaList
-            dbId={dbId}
-            dbName={selectedDbItem?.name}
-            error={errorSchemas}
-            isCurrentLevel={!tableId}
-            isLoading={isLoadingSchemas}
-            schemas={isLoadingSchemas ? undefined : schemas}
-            selectedItem={selectedSchemaItem}
-            onClick={handleFolderSelect}
-          />
-        )}
+      {isNotNull(dbId) && (
+        <SchemaList
+          dbId={dbId}
+          dbName={selectedDbItem?.name}
+          error={errorSchemas}
+          isCurrentLevel={!tableId}
+          isLoading={isLoadingSchemas}
+          schemas={isLoadingSchemas ? undefined : schemas}
+          selectedItem={selectedSchemaItem}
+          onClick={handleFolderSelect}
+        />
+      )}
 
-        {isNotNull(schemaName) && (
-          <TableList
-            error={errorTables}
-            isCurrentLevel
-            isLoading={isLoadingTables}
-            selectedItem={selectedTableItem}
-            tables={isLoadingTables ? undefined : tables}
-            onClick={handleTableSelect}
-            shouldDisableItem={shouldDisableItem}
-          />
-        )}
-      </Flex>
-    </AutoScrollBox>
+      {isNotNull(schemaName) && (
+        <TableList
+          error={errorTables}
+          isCurrentLevel
+          isLoading={isLoadingTables}
+          selectedItem={selectedTableItem}
+          tables={isLoadingTables ? undefined : tables}
+          onClick={handleTableSelect}
+          shouldDisableItem={shouldDisableItem}
+        />
+      )}
+    </Flex>
   );
 };

--- a/frontend/src/metabase/common/components/Pickers/hooks.ts
+++ b/frontend/src/metabase/common/components/Pickers/hooks.ts
@@ -5,6 +5,7 @@ import {
   useGetDashboardQuery,
 } from "metabase/api";
 import { isValidCollectionId } from "metabase/collections/utils";
+import { DATABASES_COLLECTION } from "metabase/entities/collections";
 
 import type { CollectionPickerItem } from "./CollectionPicker";
 
@@ -16,6 +17,7 @@ export const useGetInitialContainer = (
     initialValue && ["card", "dataset", "metric"].includes(initialValue.model);
   const isCollection = initialValue?.model === "collection";
   const isDashboard = initialValue?.model === "dashboard";
+  const isTable = initialValue?.model === "table";
 
   // Determine the IDs of the things we care about
   const cardId = isQuestion ? Number(initialValue.id) : undefined;
@@ -25,6 +27,8 @@ export const useGetInitialContainer = (
       ? initialValue.id
       : "root"
     : undefined;
+
+  const databasesCollection = isTable ? DATABASES_COLLECTION : undefined;
 
   // Fetch the initial value's entity
   const {
@@ -81,6 +85,7 @@ export const useGetInitialContainer = (
   return {
     currentQuestion: currentQuestion,
     currentCollection:
+      databasesCollection ??
       currentQuestionCollection ??
       currentDashboardCollection ??
       currentCollection,

--- a/frontend/src/metabase/common/components/Pickers/utils.ts
+++ b/frontend/src/metabase/common/components/Pickers/utils.ts
@@ -16,12 +16,20 @@ import type {
 export const getCollectionIdPath = (
   collection: Pick<
     CollectionPickerItem,
-    "id" | "location" | "is_personal" | "effective_location" | "model"
+    "id" | "location" | "is_personal" | "effective_location" | "model" | "type"
   >,
   userPersonalCollectionId?: CollectionId,
 ): CollectionId[] => {
   if (collection.id === null || collection.id === "root") {
     return ["root"];
+  }
+
+  if (collection.id === "databases") {
+    return ["databases"];
+  }
+
+  if (collection.type === "semantic-layer") {
+    return [collection.id];
   }
 
   if (collection.id === PERSONAL_COLLECTIONS.id) {
@@ -42,9 +50,14 @@ export const getCollectionIdPath = (
     (collection.id === userPersonalCollectionId ||
       pathFromRoot.includes(userPersonalCollectionId));
 
+  const isInSemanticLayerCollection =
+    collection?.type?.includes("semantic-layer");
+
   const id = collection.model === "collection" ? collection.id : -collection.id;
 
   if (isInUserPersonalCollection) {
+    return [...pathFromRoot, id];
+  } else if (isInSemanticLayerCollection) {
     return [...pathFromRoot, id];
   } else if (collection.is_personal) {
     return ["personal", ...pathFromRoot, id];

--- a/frontend/src/metabase/entities/collections/constants.ts
+++ b/frontend/src/metabase/entities/collections/constants.ts
@@ -34,3 +34,12 @@ export const PERSONAL_COLLECTIONS = {
   can_write: false,
   is_personal: true,
 };
+
+export const DATABASES_COLLECTION = {
+  id: "databases" as const,
+  get name() {
+    return t`Databases`;
+  },
+  location: "/",
+  can_write: false,
+};

--- a/frontend/src/metabase/lib/icon.ts
+++ b/frontend/src/metabase/lib/icon.ts
@@ -71,6 +71,10 @@ export const getIconBase = (item: ObjectWithModel): IconData => {
     return { name: "person" };
   }
 
+  if (item.model === "collection" && item.id === "databases") {
+    return { name: "database" };
+  }
+
   switch (PLUGIN_LIBRARY.getLibraryCollectionType(item.type)) {
     case "root":
       return { name: "repository" };


### PR DESCRIPTION
Closes UXW-2262

### Description

1. Moves the library (semantic-layer) collection to the top level
2. Moves table picking into a top-level "collection"
3. No more tabs (except when you search)

https://github.com/user-attachments/assets/a3f373d7-d9bd-4a7b-8d73-a7a95fa02f2f

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
