### PR TITLE
Correct the gold release version for real

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-package/package.template.json
+++ b/enterprise/frontend/src/embedding-sdk-package/package.template.json
@@ -1,6 +1,6 @@
 {
   "name": "@metabase/embedding-sdk-react",
-  "version": "0.57.0",
+  "version": "0.57.x",
   "description": "Metabase Embedding SDK for React",
   "bin": "./dist/cli.js",
   "repository": {


### PR DESCRIPTION
A follow-up PR from #65784 which follows up from #65781, but mistakenly use the wrong version.

Check [this task in the checklist](https://www.notion.so/metabase/Embedding-Checklist-What-to-do-after-cutting-a-new-release-branch-20269354c90180808329eab86e59f20d?source=copy_link#20269354c9018000a3c7cca2e23e9b61). It should match what's specified there.
