### PR TITLE
Fix append for CSVs with really long column names with shared prefixes

### DIFF
--- a/src/metabase/upload/impl.clj
+++ b/src/metabase/upload/impl.clj
@@ -678,12 +678,10 @@
     - the schema of the CSV file does not match the schema of the table
 
     Note that we do not require the column ordering to be consistent between the header and the table schema."
-  [fields-by-normed-name column-names]
-  ;; Assumes table-cols are unique when normalized
-  (let [normalized-field-names (keys fields-by-normed-name)
-        [extra missing _both]  (data/diff (set column-names) (set normalized-field-names))]
+  [old-column-names new-column-names]
+  (let [[extra missing _both] (data/diff (set new-column-names) (set old-column-names))]
     ;; check for duplicates
-    (when (some #(< 1 %) (vals (frequencies column-names)))
+    (when (some #(< 1 %) (vals (frequencies new-column-names)))
       (throw (ex-info (tru "The CSV file contains duplicate column names.")
                       {:status-code 422})))
     (when-let [error-message (extra-and-missing-error-markdown extra missing)]
@@ -806,7 +804,7 @@
                                   (driver/create-auto-pk-with-append-csv? driver)
                                   (not (contains? name->field auto-pk-column-name)))
               name->field        (cond-> name->field auto-pk? (dissoc auto-pk-column-name))
-              _                  (check-schema name->field column-names)
+              _                  (check-schema (keys name->field) column-names)
               settings           (upload-parsing/get-settings)
               ;; TODO: Add a method for drivers to override types here. See https://github.com/metabase/metabase/pull/55209.
               old-types          (map (comp upload-types/base-type->upload-type :base_type name->field) column-names)

--- a/src/metabase/upload/impl.clj
+++ b/src/metabase/upload/impl.clj
@@ -791,7 +791,7 @@
               ;; uploads, they will be matched incorrectly.
               ;; We accept this edge case (customers can reorder CSV columns to fix) rather than rejecting uploads
               ;; with ambiguous column names even when the order is consistent (see #44926/#issuecomment-3524373073).
-              ;; Future ideal: match on display names for smart re-ordering.
+              ;; Future idea: match on display names for smart re-ordering.
               column-names       (map name (derive-column-names driver header))
               display-names      (for [h header] (normalize-display-name h))
               create-auto-pk?    (and

--- a/src/metabase/upload/impl.clj
+++ b/src/metabase/upload/impl.clj
@@ -788,7 +788,7 @@
               name->field        (m/index-by :name (t2/select :model/Field :table_id (:id table) :active true))
               ;; Gotcha: If there are long names that have the same lossily-escaped-and-truncated representation AND
               ;;         these columns appear in a different order to previous uploads, we will deduplicate the column
-              ;;         names based on their order in the latest files, and with match up incorrectly with the existing
+              ;;         names based on their order in the latest files, and will match up incorrectly with the existing
               ;;         fields. Previously we simply skipped deduplication on upload to avoid the ambiguity, see
               ;;         https://github.com/metabase/metabase/issues/44926#issuecomment-3524373073.
               ;;

--- a/test/metabase/upload/impl_test.clj
+++ b/test/metabase/upload/impl_test.clj
@@ -2571,10 +2571,9 @@
             (let [csv-rows [header appended-row]
                   file     (csv-file-with csv-rows (mt/random-name))]
               (update-csv! :metabase.upload/append {:file file, :table-id (:id table)})
-              (testing "Check the data was not uploaded into the table"
-                (is (= (rows-with-auto-pk (concat (csv/read-csv original-row)
-                                                  (csv/read-csv appended-row)))
-                       (rows-for-table table))))
+              (is (= (rows-with-auto-pk (concat (csv/read-csv original-row)
+                                                (csv/read-csv appended-row)))
+                     (rows-for-table table)))
               (io/delete-file file))))))))
 
 (driver/register! ::short-column-test-driver)

--- a/test/metabase/upload/impl_test.clj
+++ b/test/metabase/upload/impl_test.clj
@@ -2570,12 +2570,10 @@
                     :file (csv-file-with [header original-row]))]
             (let [csv-rows [header appended-row]
                   file     (csv-file-with csv-rows (mt/random-name))]
-             ;; TODO: we should be able to make this work with smarter truncation
-              (is (= {:message "The CSV file contains duplicate column names."
-                      :data    {:status-code 422}}
-                     (catch-ex-info (update-csv! :metabase.upload/append {:file file, :table-id (:id table)}))))
+              (update-csv! :metabase.upload/append {:file file, :table-id (:id table)})
               (testing "Check the data was not uploaded into the table"
-                (is (= (rows-with-auto-pk (csv/read-csv original-row))
+                (is (= (rows-with-auto-pk (concat (csv/read-csv original-row)
+                                                  (csv/read-csv appended-row)))
                        (rows-for-table table))))
               (io/delete-file file))))))))
 


### PR DESCRIPTION
See https://github.com/metabase/metabase/issues/44926#issuecomment-3524373073

This was a "known issue" (see failing test), but the fix appears straight forward.

I'm trying to remember why we have the original behavior, and my best guess is that's it's from paranoia that the column order is inconsistent.

I think it's better to have unexpected behavior (mixing up columns) in an edge-case-within-an-edge-case than to outright not support the more common outer edge case.

If we wanted to be tolerant to reordering, we'd need to do something more complex, like check for display name matches.
