### PR TITLE
fix(sdk, embed-js, static): Fix Static embedding styles

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.module.css
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.module.css
@@ -15,8 +15,18 @@
     "Main";
 }
 
+.ContainerSingleRow {
+  display: grid;
+  grid-template: 1fr / 1fr;
+  grid-template-areas: "Main";
+}
+
 .TopBar {
   grid-area: TopBar;
+}
+
+.TopBar:empty {
+  display: none;
 }
 
 .BackButtonWrapper:empty {

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.module.css
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.module.css
@@ -1,13 +1,10 @@
 .Container {
   display: grid;
-  grid-template: auto auto 1fr / 1fr;
-  grid-template-areas:
-    "TopBar"
-    "MidBar"
-    "Main";
+  grid-template: 1fr / 1fr;
+  grid-template-areas: "Main";
 }
 
-.ContainerTwoRows {
+.Container:has(.TopBar) {
   display: grid;
   grid-template: auto 1fr / 1fr;
   grid-template-areas:
@@ -15,10 +12,13 @@
     "Main";
 }
 
-.ContainerSingleRow {
+.Container:has(.TopBar):has(.MidBar) {
   display: grid;
-  grid-template: 1fr / 1fr;
-  grid-template-areas: "Main";
+  grid-template: auto auto 1fr / 1fr;
+  grid-template-areas:
+    "TopBar"
+    "MidBar"
+    "Main";
 }
 
 .TopBar {

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.module.css
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.module.css
@@ -7,6 +7,14 @@
     "Main";
 }
 
+.ContainerTwoRows {
+  display: grid;
+  grid-template: auto 1fr / 1fr;
+  grid-template-areas:
+    "TopBar"
+    "Main";
+}
+
 .TopBar {
   grid-area: TopBar;
 }

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.module.css
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.module.css
@@ -11,6 +11,10 @@
   grid-area: TopBar;
 }
 
+.BackButtonWrapper:empty {
+  display: none;
+}
+
 .MidBar {
   grid-area: MidBar;
 }

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.tsx
@@ -181,7 +181,7 @@ export const SdkQuestionDefaultView = ({
           data-testid="interactive-question-top-toolbar"
         >
           <Group gap="xs">
-            <Box mr="sm">
+            <Box className={InteractiveQuestionS.BackButtonWrapper} mr="sm">
               <BackButton />
             </Box>
             <DefaultViewTitle

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.tsx
@@ -1,4 +1,3 @@
-import cx from "classnames";
 import type { PropsWithChildren } from "react";
 
 import { FlexibleSizeComponent } from "embedding-sdk-bundle/components/private/FlexibleSizeComponent";
@@ -117,16 +116,17 @@ const StaticQuestionInner = ({
       withDownloads={withDownloads}
     >
       {children ?? (
-        <FlexibleSizeComponent width={width} height={height} style={style}>
+        <FlexibleSizeComponent
+          className={className}
+          width={width}
+          height={height}
+          style={style}
+        >
           <Stack
-            className={cx(
-              hasTopBar
-                ? InteractiveQuestionS.ContainerTwoRows
-                : InteractiveQuestionS.ContainerSingleRow,
-              className,
-            )}
+            className={InteractiveQuestionS.Container}
             w="100%"
             h="100%"
+            gap="xs"
           >
             {hasTopBar && (
               <Stack className={InteractiveQuestionS.TopBar} gap="sm" p="md">
@@ -141,11 +141,7 @@ const StaticQuestionInner = ({
               </Stack>
             )}
 
-            <Box
-              className={cx(InteractiveQuestionS.Main, "sdk-question-main")}
-              w="100%"
-              h="100%"
-            >
+            <Box className={InteractiveQuestionS.Main} w="100%" h="100%">
               <Box className={InteractiveQuestionS.Content}>
                 <SdkQuestion.QuestionVisualization
                   height={height}

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.tsx
@@ -117,7 +117,7 @@ const StaticQuestionInner = ({
       {children ?? (
         <FlexibleSizeComponent width={width} height={height} style={style}>
           <Stack
-            className={cx(InteractiveQuestionS.Container, className)}
+            className={cx(InteractiveQuestionS.ContainerTwoRows, className)}
             gap="sm"
             w="100%"
             h="100%"

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.tsx
@@ -105,6 +105,8 @@ const StaticQuestionInner = ({
     );
   };
 
+  const hasTopBar = Boolean(title || withChartTypeSelector || withDownloads);
+
   return (
     <SdkQuestion
       questionId={questionId}
@@ -117,25 +119,30 @@ const StaticQuestionInner = ({
       {children ?? (
         <FlexibleSizeComponent width={width} height={height} style={style}>
           <Stack
-            className={cx(InteractiveQuestionS.ContainerTwoRows, className)}
-            gap="sm"
+            className={cx(
+              hasTopBar
+                ? InteractiveQuestionS.ContainerTwoRows
+                : InteractiveQuestionS.ContainerSingleRow,
+              className,
+            )}
             w="100%"
             h="100%"
           >
-            <Stack className={InteractiveQuestionS.TopBar} gap="sm" p="md">
-              {title && <DefaultViewTitle title={title} />}
+            {hasTopBar && (
+              <Stack className={InteractiveQuestionS.TopBar} gap="sm" p="md">
+                {title && <DefaultViewTitle title={title} />}
 
-              {(withChartTypeSelector || withDownloads) && (
-                <ResultToolbar>
-                  {withChartTypeSelector && <SdkQuestion.ChartTypeDropdown />}
-                  {withDownloads && <SdkQuestion.DownloadWidgetDropdown />}
-                </ResultToolbar>
-              )}
-            </Stack>
+                {(withChartTypeSelector || withDownloads) && (
+                  <ResultToolbar>
+                    {withChartTypeSelector && <SdkQuestion.ChartTypeDropdown />}
+                    {withDownloads && <SdkQuestion.DownloadWidgetDropdown />}
+                  </ResultToolbar>
+                )}
+              </Stack>
+            )}
 
             <Box
               className={cx(InteractiveQuestionS.Main, "sdk-question-main")}
-              p="sm"
               w="100%"
               h="100%"
             >

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.tsx
@@ -1,3 +1,4 @@
+import cx from "classnames";
 import type { PropsWithChildren } from "react";
 
 import { FlexibleSizeComponent } from "embedding-sdk-bundle/components/private/FlexibleSizeComponent";
@@ -21,12 +22,13 @@ import {
 } from "embedding-sdk-bundle/components/private/SdkQuestion/components";
 import { ResultToolbar } from "embedding-sdk-bundle/components/private/SdkQuestion/components/ResultToolbar/ResultToolbar";
 import { DefaultViewTitle } from "embedding-sdk-bundle/components/private/SdkQuestionDefaultView/DefaultViewTitle";
+import InteractiveQuestionS from "embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.module.css";
 import {
   SdkQuestion,
   type SdkQuestionProps,
 } from "embedding-sdk-bundle/components/public/SdkQuestion/SdkQuestion";
 import { StaticQuestionSdkMode } from "embedding-sdk-bundle/components/public/StaticQuestion/mode";
-import { Stack } from "metabase/ui";
+import { Box, Stack } from "metabase/ui";
 import { getEmbeddingMode } from "metabase/visualizations/click-actions/lib/modes";
 import type { ClickActionModeGetter } from "metabase/visualizations/types";
 import type Question from "metabase-lib/v1/Question";
@@ -113,28 +115,39 @@ const StaticQuestionInner = ({
       withDownloads={withDownloads}
     >
       {children ?? (
-        <FlexibleSizeComponent
-          width={width}
-          height={height}
-          className={className}
-          style={style}
-        >
-          <Stack gap="sm" w="100%" h="100%">
-            {title && <DefaultViewTitle title={title} />}
+        <FlexibleSizeComponent width={width} height={height} style={style}>
+          <Stack
+            className={cx(InteractiveQuestionS.Container, className)}
+            gap="sm"
+            w="100%"
+            h="100%"
+          >
+            <Stack className={InteractiveQuestionS.TopBar} gap="sm" p="md">
+              {title && <DefaultViewTitle title={title} />}
 
-            {(withChartTypeSelector || withDownloads) && (
-              <ResultToolbar>
-                {withChartTypeSelector && <SdkQuestion.ChartTypeDropdown />}
-                {withDownloads && <SdkQuestion.DownloadWidgetDropdown />}
-              </ResultToolbar>
-            )}
+              {(withChartTypeSelector || withDownloads) && (
+                <ResultToolbar>
+                  {withChartTypeSelector && <SdkQuestion.ChartTypeDropdown />}
+                  {withDownloads && <SdkQuestion.DownloadWidgetDropdown />}
+                </ResultToolbar>
+              )}
+            </Stack>
 
-            <SdkQuestion.QuestionVisualization
-              height={height}
-              width={width}
-              className={className}
-              style={style}
-            />
+            <Box
+              className={cx(InteractiveQuestionS.Main, "sdk-question-main")}
+              p="sm"
+              w="100%"
+              h="100%"
+            >
+              <Box className={InteractiveQuestionS.Content}>
+                <SdkQuestion.QuestionVisualization
+                  height={height}
+                  width={width}
+                  className={className}
+                  style={style}
+                />
+              </Box>
+            </Box>
           </Stack>
         </FlexibleSizeComponent>
       )}

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/ParametersSettings.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/ParametersSettings.tsx
@@ -6,6 +6,7 @@ import { t } from "ttag";
 import Select, { Option } from "metabase/common/components/Select";
 import CS from "metabase/css/core/index.css";
 import { ParameterWidget as StaticParameterWidget } from "metabase/parameters/components/ParameterWidget";
+import { getParameterIconName } from "metabase/parameters/utils/ui";
 import type {
   EmbedResourceParameter,
   EmbedResourceType,
@@ -13,7 +14,6 @@ import type {
   EmbeddingParameters,
   EmbeddingParametersValues,
 } from "metabase/public/lib/types";
-import type { IconName } from "metabase/ui";
 import { Box, Divider, Icon, Stack, Text } from "metabase/ui";
 import { getValuePopulatedParameters } from "metabase-lib/v1/parameters/utils/parameter-values";
 
@@ -65,7 +65,7 @@ export const ParametersSettings = ({
 
           {resourceParameters.map((parameter) => (
             <div key={parameter.id} className={cx(CS.flex, CS.alignCenter)}>
-              <Icon name={getIconForParameter(parameter)} className={CS.mr2} />
+              <Icon name={getParameterIconName(parameter)} className={CS.mr2} />
               <h3>
                 {parameter.name}
                 {parameter.required && (
@@ -148,16 +148,4 @@ export const ParametersSettings = ({
       <Divider />
     </>
   );
-};
-
-const getIconForParameter = (parameter: EmbedResourceParameter): IconName => {
-  if (parameter.type === "category") {
-    return "string";
-  }
-
-  if (parameter.type.indexOf("date/") === 0) {
-    return "calendar";
-  }
-
-  return "unknown";
 };


### PR DESCRIPTION
This PR fixes 2 things:
- different visuals of the StaticQuestion compared to other SDK  questions
- missing icons for Parameters in the Legacy Static Embedding Wizard

The Static Question visuals fix video:

https://github.com/user-attachments/assets/34db1c2c-7068-4ac6-9bcd-33337170f995



Parameters:
Before:
![telegram-cloud-photo-size-2-5217585142757526867-x](https://github.com/user-attachments/assets/2b4bf398-c349-418b-becd-be0fbff8f590)

After:
![telegram-cloud-photo-size-2-5217585142757526959-x](https://github.com/user-attachments/assets/9a23a11c-f88c-428e-afdd-fbcbdf89dac8)


How to verify:
- Static Question in EmbedJS wizard: open the EmbedJS wizard and toggle on/off the `drills` checkbox. When drills are off we display the StaticQuesiton, so its visuals should be close to the visuals of InteractiveQuestions (when drills are on)
- Parameters icons: create an sql question with params. Open Legacy Static Embedding wizard and ensure that icons for parameters have the same type as the parameters control (T for `text` parameter type)
