### PR TITLE
fix(sdk-bundle): Fix EditableDashboard sometimes doesn't show the correct tab

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/editable-dashboard.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/editable-dashboard.cy.spec.tsx
@@ -410,6 +410,9 @@ describe("scenarios > embedding-sdk > editable-dashboard", () => {
 
           H.modal().within(() => {
             cy.findByLabelText("Name").clear().type(ADDED_QUESTION_NAME_3);
+            cy.findByLabelText("Where do you want to save this?").should(
+              "not.exist",
+            );
             // Test saving a question to a different tab
             cy.findByLabelText("Which tab should this go on?")
               .should("be.visible")

--- a/enterprise/frontend/src/embedding-sdk-bundle/lib/sdk-question/load-question.ts
+++ b/enterprise/frontend/src/embedding-sdk-bundle/lib/sdk-question/load-question.ts
@@ -26,15 +26,20 @@ export const loadQuestionSdk =
     Required<Pick<SdkQuestionState, "question">> &
       Pick<SdkQuestionState, "originalQuestion" | "parameterValues">
   > => {
-    const questionId = initQuestionId === "new" ? undefined : initQuestionId;
+    const isNewQuestion = initQuestionId === "new";
+    const questionId = isNewQuestion ? undefined : initQuestionId;
 
-    const { card, originalCard } = await resolveCards({
+    const { card: resolvedCard, originalCard } = await resolveCards({
       cardId: questionId ?? undefined,
       options,
       dispatch,
       getState,
       deserializedCard,
     });
+
+    const card = isNewQuestion
+      ? { ...resolvedCard, creationType: "custom_question" }
+      : resolvedCard;
 
     await dispatch(loadMetadataForCard(card));
     const metadata = getMetadata(getState());

--- a/frontend/src/metabase/common/components/SaveQuestionModal/SaveQuestionModal.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/SaveQuestionModal/SaveQuestionModal.unit.spec.tsx
@@ -595,9 +595,11 @@ describe("SaveQuestionModal", () => {
       expect(
         await screen.findByLabelText(/Which tab should this go on/),
       ).toBeInTheDocument();
-      expect(
-        await screen.findByLabelText(/Which tab should this go on/),
-      ).toHaveValue("Foo Tab 1");
+      await waitFor(async () => {
+        expect(
+          await screen.findByLabelText(/Which tab should this go on/),
+        ).toHaveValue("Foo Tab 1");
+      });
     });
 
     it("should now show tab input if selected dashboard has no tabs", async () => {

--- a/frontend/src/metabase/dashboard/components/FormDashboardTabSelect/FormDashboardTabSelect.tsx
+++ b/frontend/src/metabase/dashboard/components/FormDashboardTabSelect/FormDashboardTabSelect.tsx
@@ -25,6 +25,17 @@ export const FormDashboardTabSelect = ({
       const firstTabId = currentData?.tabs?.length
         ? String(currentData.tabs[0].id)
         : undefined;
+      /**
+       * Kelvin 2025-11-13 fixes EMB-1001
+       *
+       * I have no idea why this fixes the problem. `dashboardTabHelpers.setValue` should have
+       * worked and `useField("dashboard_tab_id")` should have picked up the change immediately.
+       *
+       * But this hadn't work reliably. I've also tried logging that the `setValue` calls were also
+       * successful and I couldn't find other places that override the field `dashboard_tab_id` either.
+       *
+       * This is still a mystery to me.
+       */
       setTimeout(() => {
         dashboardTabHelpers.setValue(firstTabId);
       }, 0);

--- a/frontend/src/metabase/dashboard/components/FormDashboardTabSelect/FormDashboardTabSelect.tsx
+++ b/frontend/src/metabase/dashboard/components/FormDashboardTabSelect/FormDashboardTabSelect.tsx
@@ -25,7 +25,9 @@ export const FormDashboardTabSelect = ({
       const firstTabId = currentData?.tabs?.length
         ? String(currentData.tabs[0].id)
         : undefined;
-      dashboardTabHelpers.setValue(firstTabId);
+      setTimeout(() => {
+        dashboardTabHelpers.setValue(firstTabId);
+      }, 0);
     },
     [currentData, dashboardTabHelpers],
   );

--- a/frontend/src/metabase/dashboard/components/FormDashboardTabSelect/FormDashboardTabSelect.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/FormDashboardTabSelect/FormDashboardTabSelect.unit.spec.tsx
@@ -87,6 +87,7 @@ describe("FormDashboardTabSelect", () => {
       initialValue: FOO_TAB_1.id,
     });
 
+    await waitForTabSelector(FOO_TAB_1.name);
     await userEvent.click(screen.getByText("Submit"));
     expect(onSubmit).toHaveBeenCalledWith(
       { dashboard_tab_id: String(FOO_TAB_1.id) },
@@ -130,6 +131,7 @@ describe("FormDashboardTabSelect", () => {
       ).not.toBeInTheDocument();
     });
     rerender(FOO_DASH.id);
+    await waitForTabSelector(FOO_TAB_1.name);
 
     await userEvent.click(screen.getByText("Submit"));
     expect(onSubmit).toHaveBeenCalledWith(
@@ -176,3 +178,11 @@ describe("FormDashboardTabSelect", () => {
     );
   });
 });
+
+async function waitForTabSelector(tabName: string) {
+  await waitFor(async () => {
+    expect(
+      await screen.findByLabelText(/Which tab should this go on/),
+    ).toHaveValue(tabName);
+  });
+}


### PR DESCRIPTION
Closes EMB-1001

### Description

I don't think the test was actually flaky, the feature it was actually not working as intended. I've spent hours trying to find the root cause, and tried like many things, but one thing that works is to defer the form field value setter to the next event loop. The formik's helper functions that we're using should already work reactively, so I'm not totally sure what causes this problem. This doesn't seem to happen on the core app though.

Upgrading formik to v2.4.9 also didn't fix the problem

I also fixed the instance where the collection/dashboard selector shows up unintentionally which was caused by https://github.com/metabase/metabase/pull/63855. Not that the PR did anything wrong, it's more like that PR surfaces the incorrect behavior the SDK question has.

### How to verify

Stress test passes
[master](https://github.com/metabase/metabase/actions/runs/19333772673/job/55303176127): 19/20 ❌ 
[this PR](https://github.com/metabase/metabase/actions/runs/19334467052): 20/20 ✅ 
[this PR 2nd run](https://github.com/metabase/metabase/actions/runs/19334872321/job/55306980972): 40/40 ✅ 

### Demo
#### After
<img width="627" height="476" alt="Screenshot 2025-11-13 at 9 03 55 PM" src="https://github.com/user-attachments/assets/20e9c66c-d39b-4104-9a0b-c8906cc004f9" />

#### Before
1. dashboard/collection picker shouldn't show up
2. tab selector should show the correct value
<img width="649" height="544" alt="Screenshot 2025-11-13 at 9 00 17 PM" src="https://github.com/user-attachments/assets/5d4da6e2-1a67-45c5-bb8e-74bb19d04762" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
