### PR TITLE
Adjust cards-with-filters to work with action cards

### DIFF
--- a/src/metabase/parameters/dashboard.clj
+++ b/src/metabase/parameters/dashboard.clj
@@ -90,16 +90,20 @@
   "Lazy seq of cards from `dashboard` that are mapped to param `param-key` and contain some filters.
   Dashboard is expected to have hydrated `:resolved-params`."
   [dashboard param-key]
-  (for [mapping (get-in dashboard [:resolved-params param-key :mappings])
-        :let [database-id (get-in mapping [:dashcard :card :dataset_query :database])
-              card-id (get-in mapping [:dashcard :card :id])
-              mp (lib-be/application-database-metadata-provider database-id)
-              card (lib.metadata/card mp card-id)
-              query (lib/card->underlying-query mp card)]
-        :when (and (not-empty query)
-                   (m/find-first (partial lib/filters query)
-                                 (range (lib/stage-count query))))]
-    card))
+  (keep (fn [mapping]
+          (let [database-id (get-in mapping [:dashcard :card :dataset_query :database])
+                card-id (get-in mapping [:dashcard :card :id])]
+            (when (and (pos-int? database-id)
+                       (pos-int? card-id))
+              (let [mp (lib-be/application-database-metadata-provider database-id)
+                    card (lib.metadata/card mp card-id)]
+                (when (some? card)
+                  (let [query (lib/card->underlying-query mp card)]
+                    (when (and (not-empty query)
+                               (m/find-first (partial lib/filters query)
+                                             (range (lib/stage-count query))))
+                      card)))))))
+        (get-in dashboard [:resolved-params param-key :mappings])))
 
 (defn- cards-with-filters?
   "Does param-key have any card with filter mapped? Dashboard is expected to have hydrated `:resolved-params`."

--- a/src/metabase/parameters/dashboard.clj
+++ b/src/metabase/parameters/dashboard.clj
@@ -93,8 +93,8 @@
   (keep (fn [mapping]
           (let [database-id (get-in mapping [:dashcard :card :dataset_query :database])
                 card-id (get-in mapping [:dashcard :card :id])]
-            ;; Actions is dashcards are stored under :action key. The following makes this function compatible with
-            ;; dashcards that have no `:card`.
+            ;; The following makes sure with ignore dashcards that have no `:card`.
+            ;; For example, Action dashcards stored under the :action key will be skipped.
             (when (and (pos-int? database-id)
                        (pos-int? card-id))
               (let [mp (lib-be/application-database-metadata-provider database-id)

--- a/src/metabase/parameters/dashboard.clj
+++ b/src/metabase/parameters/dashboard.clj
@@ -93,10 +93,13 @@
   (keep (fn [mapping]
           (let [database-id (get-in mapping [:dashcard :card :dataset_query :database])
                 card-id (get-in mapping [:dashcard :card :id])]
+            ;; Actions is dashcards are stored under :action key. Following makes this function compatible with
+            ;; dashcards that have no `:card`.
             (when (and (pos-int? database-id)
                        (pos-int? card-id))
               (let [mp (lib-be/application-database-metadata-provider database-id)
                     card (lib.metadata/card mp card-id)]
+                ;; Following check is in place because card schema has dataset-query optional.
                 (when (not-empty (:dataset-query card))
                   (let [query (lib/card->underlying-query mp card)]
                     (when (and (not-empty query)

--- a/src/metabase/parameters/dashboard.clj
+++ b/src/metabase/parameters/dashboard.clj
@@ -97,7 +97,7 @@
                        (pos-int? card-id))
               (let [mp (lib-be/application-database-metadata-provider database-id)
                     card (lib.metadata/card mp card-id)]
-                (when (some? card)
+                (when (not-empty (:dataset-query card))
                   (let [query (lib/card->underlying-query mp card)]
                     (when (and (not-empty query)
                                (m/find-first (partial lib/filters query)

--- a/src/metabase/parameters/dashboard.clj
+++ b/src/metabase/parameters/dashboard.clj
@@ -93,13 +93,13 @@
   (keep (fn [mapping]
           (let [database-id (get-in mapping [:dashcard :card :dataset_query :database])
                 card-id (get-in mapping [:dashcard :card :id])]
-            ;; Actions is dashcards are stored under :action key. Following makes this function compatible with
+            ;; Actions is dashcards are stored under :action key. The following makes this function compatible with
             ;; dashcards that have no `:card`.
             (when (and (pos-int? database-id)
                        (pos-int? card-id))
               (let [mp (lib-be/application-database-metadata-provider database-id)
                     card (lib.metadata/card mp card-id)]
-                ;; Following check is in place because card schema has dataset-query optional.
+                ;; The following check is in place because card schema has dataset-query optional.
                 (when (not-empty (:dataset-query card))
                   (let [query (lib/card->underlying-query mp card)]
                     (when (and (not-empty query)

--- a/test/metabase/parameters/dashboard_test.clj
+++ b/test/metabase/parameters/dashboard_test.clj
@@ -302,3 +302,10 @@
             (is (= products-title-field-id
                    (#'parameters.dashboard/find-common-remapping-target [orders-product-id-field-id]))
                 "Should return target for single FK with remapping")))))))
+
+(deftest cards-with-filters-with-aciton-card
+  (testing "cards-with-filters can handle non-standard (e.g. action) dashcards (fixes problem introduced by PR #64318)"
+    (is (empty? (@#'parameters.dashboard/cards-with-filters
+                 {:resolved-params {"xxx" {:mappings #{{:card {:no_dataset_query :present}}
+                                                       {:action :not-even-card}}}}}
+                 "xxx")))))


### PR DESCRIPTION
Follow-up for https://github.com/metabase/metabase/pull/65651.

Action parameter mapping have structure as follows, i.e. no `[:card :dataset_query]` is present:
```
{:parameter_id "b187a5a6",
   :target [:variable [:template-tag "name"]],
   :dashcard
   (toucan2.instance/instance
    :model/DashboardCard
    {:size_x 4,
     :dashboard_tab_id nil,
     :series [],
     :inline_parameters (),
     :action_id 6,
     :collection_authority_level nil,
     :card nil,
     :updated_at #t "2025-11-13T14:05:29.008120Z",
     :col 12,
     :id 100,
     :parameter_mappings [{:parameter_id "b187a5a6", :target [:variable [:template-tag "name"]]}],
     :card_id nil,
     :action
     (toucan2.instance/instance
      :model/Action
      {:description nil,
       :archived false,
       :database_id 2,
       :name "Create",
       :type :implicit,
       :creator_id 1,
       :database_enabled_actions true,
       :updated_at #t "2025-11-13T14:03:25.888638Z",
       :made_public_by_id nil,
       :model_id 115,
       :id 6,
       :kind :row/create,
       :parameter_mappings nil,
       :entity_id "HMlrcyLhF-nO__ugmvU3s",
       :visualization_settings
       {:fields
        {"name"
         {:description nil,
          :placeholder "Name",
          :title "Name",
          :hidden false,
          :id "name",
          :order 0,
          :display_name "Name",
          :inputType :string,
          :required true,
          :base_type :type/Text,
          :fieldType :string}}},
       :parameters
       ({:id "name",
         :display-name "Name",
         :target [:variable [:template-tag "name"]],
         :type :text,
         :required true,
         :is-auto-increment false,
         :metabase.actions.models/field-id 243,
         :metabase.actions.models/pk? false}),
       :created_at #t "2025-11-13T14:03:25.888638Z",
       :public_uuid nil}),
     :entity_id "QIhL-qZ47njRhpeC6wjA3",
     :visualization_settings
     {:actionDisplayType "button",
      :virtual_card {:name nil, :display "action", :visualization_settings {}, :dataset_query {}, :archived false},
      :button.label "Click Me"},
     :size_y 1,
     :dashboard_id 10,
     :created_at #t "2025-11-13T14:05:29.008120Z",
     :row 0})}
```

This PR adjusts `cards-with-filters` function to take that into account.