### PR TITLE
fix(sdk-bundle): Temporarily hide the incompatibility banner

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/incompatibility-with-instance-banner.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/incompatibility-with-instance-banner.cy.spec.tsx
@@ -21,7 +21,7 @@ const mockIncompatibleMetabaseVersion = () => {
   });
 };
 
-describe("scenarios > embedding-sdk > incompatibility-with-instance-banner", () => {
+describe.skip("scenarios > embedding-sdk > incompatibility-with-instance-banner", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
       "dashcardQuery",

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/ComponentProvider/ComponentProvider.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/ComponentProvider/ComponentProvider.tsx
@@ -2,7 +2,6 @@ import { Global } from "@emotion/react";
 import { type JSX, memo, useEffect, useId, useRef } from "react";
 
 import { SdkThemeProvider } from "embedding-sdk-bundle/components/private/SdkThemeProvider";
-import { SdkIncompatibilityWithInstanceBanner } from "embedding-sdk-bundle/components/private/SdkVersionCompatibilityHandler/SdkIncompatibilityWithInstanceBanner";
 import { useInitDataInternal } from "embedding-sdk-bundle/hooks/private/use-init-data";
 import { getSdkStore } from "embedding-sdk-bundle/store";
 import {
@@ -110,8 +109,6 @@ export const ComponentProviderInternal = ({
             <>
               <LocaleProvider locale={locale || instanceLocale}>
                 {children}
-
-                <SdkIncompatibilityWithInstanceBanner />
               </LocaleProvider>
 
               {isInstanceToRender && (


### PR DESCRIPTION
Temporarily hide the incompatibility banner.
We've found that the Bundle version is set as vUNKNOWN, so it's displayed incorrectly.