### PR TITLE
Rename remote-sync modes

### DIFF
--- a/docs/api.json
+++ b/docs/api.json
@@ -20141,7 +20141,7 @@
                   },
                   "remote-sync-type" : {
                     "type" : "string",
-                    "enum" : [ "production", "development" ]
+                    "enum" : [ "read-only", "read-write" ]
                   },
                   "remote-sync-url" : {
                     "type" : "string"

--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -1329,7 +1329,7 @@ Force all traffic to use HTTPS via a redirect, if the site URL is HTTPS.
 - Default: `false`
 - [Configuration file name](./config-file.md): `remote-sync-auto-import`
 
-Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :production.
+Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :read-only.
 
 ### `MB_REMOTE_SYNC_AUTO_IMPORT_RATE`
 
@@ -1337,7 +1337,7 @@ Whether to automatically import from the remote git repository. Only applies if 
 - Default: `5`
 - [Configuration file name](./config-file.md): `remote-sync-auto-import-rate`
 
-If remote-sync-type is :production and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5.
+If remote-sync-type is :read-only and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5.
 
 ### `MB_REMOTE_SYNC_TASK_TIME_LIMIT_MS`
 

--- a/e2e/support/helpers/e2e-remote-sync-helpers.ts
+++ b/e2e/support/helpers/e2e-remote-sync-helpers.ts
@@ -44,7 +44,7 @@ export const commitToRepo = (
 
 // Setup remote sync via the API
 export function configureGit(
-  syncType: "development" | "production",
+  syncType: "read-write" | "read-only",
   syncUrl = LOCAL_GIT_PATH + "/.git",
 ) {
   cy.request("PUT", "/api/ee/remote-sync/settings", {

--- a/e2e/test/scenarios/admin/remote-sync.cy.spec.ts
+++ b/e2e/test/scenarios/admin/remote-sync.cy.spec.ts
@@ -24,9 +24,9 @@ H.describeWithSnowplowEE("Remote Sync", () => {
     H.expectNoBadSnowplowEvents();
   });
 
-  describe("Development Mode", () => {
+  describe("read-write Mode", () => {
     it("can push and pull changes", () => {
-      H.configureGit("development");
+      H.configureGit("read-write");
       H.wrapSyncedCollection();
       const UPDATED_REMOTE_QUESTION_NAME = "Updated Question Name";
 
@@ -96,7 +96,7 @@ H.describeWithSnowplowEE("Remote Sync", () => {
     });
 
     it("should not allow you to move content to the Synced Collection that references non Synced Collection items", () => {
-      H.configureGit("development");
+      H.configureGit("read-write");
       H.wrapSyncedCollection();
       cy.intercept("PUT", `/api/dashboard/${ORDERS_DASHBOARD_ID}`).as(
         "updateDashboard",
@@ -139,7 +139,7 @@ H.describeWithSnowplowEE("Remote Sync", () => {
       const NEW_BRANCH = `new-branch-${Date.now()}`;
       H.copySyncedCollectionFixture();
       H.commitToRepo();
-      H.configureGit("development");
+      H.configureGit("read-write");
       H.wrapSyncedCollection();
 
       cy.visit("/collection/root");
@@ -250,7 +250,7 @@ H.describeWithSnowplowEE("Remote Sync", () => {
       };
 
       it("should allow you to create new branches and switch between them", () => {
-        H.configureGit("development");
+        H.configureGit("read-write");
         H.wrapSyncedCollection();
 
         const NEW_BRANCH_1 = `new-branch-${Date.now()}`;
@@ -296,7 +296,7 @@ H.describeWithSnowplowEE("Remote Sync", () => {
       });
 
       it("should show a popup when trying to switch branches with unsynced changes", () => {
-        H.configureGit("development");
+        H.configureGit("read-write");
 
         const NEW_BRANCH = `new-branch-${Date.now()}`;
 
@@ -351,7 +351,7 @@ H.describeWithSnowplowEE("Remote Sync", () => {
       beforeEach(() => {
         H.copySyncedCollectionFixture();
         H.commitToRepo();
-        H.configureGit("development");
+        H.configureGit("read-write");
         H.wrapSyncedCollection();
 
         cy.visit("/collection/root");
@@ -448,12 +448,12 @@ H.describeWithSnowplowEE("Remote Sync", () => {
       cy.signInAsAdmin();
     });
 
-    it("can set up development mode", () => {
+    it("can set up read-write mode", () => {
       cy.visit("/admin/settings/remote-sync");
       cy.findByLabelText(/repository url/i)
         .clear()
         .type(LOCAL_GIT_URL);
-      cy.findByTestId("admin-layout-content").findByText("Development").click();
+      cy.findByTestId("admin-layout-content").findByText("Read-write").click();
       cy.button("Set up Remote Sync").click();
 
       H.expectUnstructuredSnowplowEvent({
@@ -480,8 +480,8 @@ H.describeWithSnowplowEE("Remote Sync", () => {
       });
     });
 
-    it("can set up production mode", () => {
-      // Set up a Synced Collection to connect to, otherwise production mode will be empty
+    it("can set up read-only mode", () => {
+      // Set up a Synced Collection to connect to, otherwise read-only mode will be empty
       // Copy some files
       H.copySyncedCollectionFixture();
 
@@ -493,7 +493,7 @@ H.describeWithSnowplowEE("Remote Sync", () => {
         .clear()
         .type(LOCAL_GIT_URL);
 
-      cy.findByTestId("admin-layout-content").findByText("Production").click();
+      cy.findByTestId("admin-layout-content").findByText("Read-only").click();
       cy.button("Set up Remote Sync").click();
       cy.findByTestId("admin-layout-content")
         .findByText("Success")
@@ -534,7 +534,7 @@ H.describeWithSnowplowEE("Remote Sync", () => {
     it("can deactivate remote sync", () => {
       H.copySyncedCollectionFixture();
       H.commitToRepo();
-      H.configureGit("development");
+      H.configureGit("read-write");
 
       cy.visit("/admin/settings/remote-sync");
 
@@ -566,7 +566,7 @@ H.describeWithSnowplowEE("Remote Sync", () => {
     });
   });
 
-  describe("production mode", () => {
+  describe("read-only mode", () => {
     beforeEach(() => {
       H.restore();
       cy.signInAsAdmin();
@@ -579,7 +579,7 @@ H.describeWithSnowplowEE("Remote Sync", () => {
 
       H.copySyncedCollectionFixture();
       H.commitToRepo();
-      H.configureGit("production");
+      H.configureGit("read-only");
 
       cy.visit("/");
 

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/api.clj
@@ -187,7 +187,7 @@
                                                  [:new_branch ms/NonBlankString]
                                                  [:message ms/NonBlankString]]]
   (api/check-superuser)
-  (api/check-400 (= (settings/remote-sync-type) :read-write) "Stash is only allowed when remote-sync-type is set to 'read-write-type'")
+  (api/check-400 (= (settings/remote-sync-type) :read-write) "Stash is only allowed when remote-sync-type is set to 'read-write'")
   (let [source (source/source-from-settings)]
     (api/check-400 source  "Source not configured")
     (try

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/api.clj
@@ -81,7 +81,7 @@
                                        [:force {:optional true} :boolean]]
   (api/check-superuser)
   (api/check-400 (settings/remote-sync-enabled) "Remote sync is not configured.")
-  (api/check-400 (= (settings/remote-sync-type) :development) "Exports are only allowed when remote-sync-type is set to 'development'")
+  (api/check-400 (= (settings/remote-sync-type) :read-write) "Exports are only allowed when remote-sync-type is set to 'read-write'")
   (let [branch-name (or branch (settings/remote-sync-branch))
         {task-id :id :as task} (impl/async-export! branch-name
                                                    (or force false)
@@ -115,11 +115,11 @@
    :- [:map
        [:remote-sync-url {:optional true} [:maybe :string]]
        [:remote-sync-token {:optional true} [:maybe :string]]
-       [:remote-sync-type {:optional true} [:maybe [:enum :production :development]]]
+       [:remote-sync-type {:optional true} [:maybe [:enum :read-only :read-write]]]
        [:remote-sync-branch {:optional true} [:maybe :string]]]]
   (api/check-superuser)
-  (api/check-400 (not (and (remote-sync.object/dirty-global?) (= :production remote-sync-type)))
-                 "There are unsaved changes in the Remote Sync collection which will be overwritten switching to production mode.")
+  (api/check-400 (not (and (remote-sync.object/dirty-global?) (= :read-only remote-sync-type)))
+                 "There are unsaved changes in the Remote Sync collection which will be overwritten switching to read-only mode.")
   (try
     (settings/check-and-update-remote-settings! settings)
     (catch Exception e
@@ -187,7 +187,7 @@
                                                  [:new_branch ms/NonBlankString]
                                                  [:message ms/NonBlankString]]]
   (api/check-superuser)
-  (api/check-400 (= (settings/remote-sync-type) :development) "Stash is only allowed when remote-sync-type is set to 'development'")
+  (api/check-400 (= (settings/remote-sync-type) :read-write) "Stash is only allowed when remote-sync-type is set to 'read-write-type'")
   (let [source (source/source-from-settings)]
     (api/check-400 source  "Source not configured")
     (try

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/core.clj
@@ -21,9 +21,9 @@
 
   Takes a collection to check for editability.
 
-  Returns true if the collection is editable, false otherwise. Returns true when remote-sync-type is :development
+  Returns true if the collection is editable, false otherwise. Returns true when remote-sync-type is :read-write
   or when the collection is not a remote-synced collection. Always returns true on OSS."
   :feature :none
   [collection]
-  (or (= (settings/remote-sync-type) :development)
+  (or (= (settings/remote-sync-type) :read-write)
       (not (collections/remote-synced-collection? collection))))

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
@@ -153,7 +153,7 @@
               (t2/with-transaction [_conn]
                 (remove-unsynced! (all-top-level-remote-synced-collections) imported-entities-by-model)
                 (sync-objects! sync-timestamp imported-entities-by-model)
-                (when (and (nil? (collection/remote-synced-collection)) (= :development (settings/remote-sync-type)))
+                (when (and (nil? (collection/remote-synced-collection)) (= :read-write (settings/remote-sync-type)))
                   (collection/create-remote-synced-collection!)))
               (remote-sync.task/update-progress! task-id 0.95)
               (remote-sync.task/set-version!
@@ -304,7 +304,7 @@
 (defn finish-remote-config!
   "Based on the current configuration, fill in any missing settings and finalize remote sync setup.
 
-  Will attempt, import the remote collection if no remote-collection exists locally or you are in production mode.
+  Will attempt, import the remote collection if no remote-collection exists locally or you are in read-only mode.
 
   Returns the async-task id if an async task was started, otherwise nil."
   []
@@ -312,7 +312,7 @@
     (do
       (when (str/blank? (setting/get :remote-sync-branch))
         (setting/set! :remote-sync-branch (source.p/default-branch (source/source-from-settings))))
-      (when (or (nil? (collection/remote-synced-collection)) (= :production (settings/remote-sync-type)))
+      (when (or (nil? (collection/remote-synced-collection)) (= :read-only (settings/remote-sync-type)))
         (:id (async-import! (settings/remote-sync-branch) true {}))))
     (u/prog1 nil
       (collection/clear-remote-synced-collection!))))

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/settings.clj
@@ -46,15 +46,15 @@
   :can-read-from-env? false)
 
 (defsetting remote-sync-type
-  (deferred-tru "Git synchronization type - :development or :production")
+  (deferred-tru "Git synchronization type - :read-write or :read-only")
   :type :keyword
   :visibility :authenticated
   :export? false
   :encryption :no
-  :default :production
+  :default :read-only
   :setter (fn [new-value]
-            (let [new-value (or new-value :production)
-                  valid-types #{:production :development}
+            (let [new-value (or new-value :read-only)
+                  valid-types #{:read-only :read-write}
                   value (or (valid-types (keyword new-value))
                             (throw (ex-info "Remote-sync-type set to an unsupported value"
                                             {:value new-value
@@ -63,7 +63,7 @@
   :can-read-from-env? false)
 
 (defsetting remote-sync-auto-import
-  (deferred-tru "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :production.")
+  (deferred-tru "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :read-only.")
   :type :boolean
   :visibility :authenticated
   :export? false
@@ -71,7 +71,7 @@
   :default false)
 
 (defsetting remote-sync-auto-import-rate
-  (deferred-tru "If remote-sync-type is :production and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5.")
+  (deferred-tru "If remote-sync-type is :read-only and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5.")
   :type :integer
   :visibility :authenticated
   :export? false
@@ -107,7 +107,7 @@
                      {:url remote-sync-url})))
 
    (let [source (git/git-source remote-sync-url "HEAD" remote-sync-token)]
-     (when (and (= :production remote-sync-type) (not (str/blank? remote-sync-branch)) (not (some #{remote-sync-branch} (git/branches source))))
+     (when (and (= :read-only remote-sync-type) (not (str/blank? remote-sync-branch)) (not (some #{remote-sync-branch} (git/branches source))))
        (throw (ex-info "Invalid branch name" {:url remote-sync-url :branch remote-sync-branch}))))))
 
 (defn check-and-update-remote-settings!

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/task/import.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/task/import.clj
@@ -19,7 +19,7 @@
 (defn- auto-import!
   []
   (when (and (settings/remote-sync-enabled)
-             (= :production (settings/remote-sync-type))
+             (= :read-only (settings/remote-sync-type))
              (settings/remote-sync-auto-import))
     (let [branch (settings/remote-sync-branch)
           source (source/source-from-settings branch)

--- a/enterprise/backend/test/metabase_enterprise/documents/api/document_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/documents/api/document_test.clj
@@ -2313,7 +2313,7 @@
 
 (deftest create-document-in-remote-synced-with-non-remote-synced-smartlink-test
   (testing "POST /api/ee/document/ - creating document in remote-synced collection with smartlink to non-remote-synced item"
-    (mt/with-temporary-setting-values [remote-sync-type :development]
+    (mt/with-temporary-setting-values [remote-sync-type :read-write]
       (mt/with-model-cleanup [:model/Document]
         (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced Collection"
                                                                  :location "/"
@@ -2336,7 +2336,7 @@
 
 (deftest create-document-in-remote-synced-with-remote-synced-smartlink-test
   (testing "POST /api/ee/document/ - creating document in remote-synced collection with smartlink to remote-synced item"
-    (mt/with-temporary-setting-values [remote-sync-type :development]
+    (mt/with-temporary-setting-values [remote-sync-type :read-write]
       (mt/with-model-cleanup [:model/Document]
         (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced Collection"
                                                                  :location "/"
@@ -2356,7 +2356,7 @@
 
 (deftest create-document-in-regular-collection-with-any-smartlink-test
   (testing "POST /api/ee/document/ - creating document in regular collection can reference any item"
-    (mt/with-temporary-setting-values [remote-sync-type :development]
+    (mt/with-temporary-setting-values [remote-sync-type :read-write]
       (mt/with-model-cleanup [:model/Document]
         (mt/with-temp [:model/Collection {regular-id :id} {:name "Regular Collection"
                                                            :location "/"
@@ -2389,7 +2389,7 @@
 
 (deftest update-document-in-remote-synced-with-non-remote-synced-smartlink-test
   (testing "PUT /api/ee/document/:id - updating document in remote-synced collection to add non-remote-synced reference"
-    (mt/with-temporary-setting-values [remote-sync-type :development]
+    (mt/with-temporary-setting-values [remote-sync-type :read-write]
       (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced Collection"
                                                                :location "/"
                                                                :type "remote-synced"}
@@ -2411,7 +2411,7 @@
 
 (deftest update-document-in-remote-synced-with-remote-synced-smartlink-test
   (testing "PUT /api/ee/document/:id - updating document in remote-synced collection to add remote-synced reference"
-    (mt/with-temporary-setting-values [remote-sync-type :development]
+    (mt/with-temporary-setting-values [remote-sync-type :read-write]
       (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced Collection"
                                                                :location "/"
                                                                :type "remote-synced"}
@@ -2431,7 +2431,7 @@
 
 (deftest move-document-with-remote-synced-refs-out-of-remote-synced-collection-test
   (testing "PUT /api/ee/document/:id - moving document with remote-synced references out of remote-synced collection"
-    (mt/with-temporary-setting-values [remote-sync-type :development]
+    (mt/with-temporary-setting-values [remote-sync-type :read-write]
       (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced Collection"
                                                                :location "/"
                                                                :type "remote-synced"}
@@ -2454,7 +2454,7 @@
 
 (deftest move-document-with-remote-synced-refs-to-root-collection-test
   (testing "PUT /api/ee/document/:id - moving document with remote-synced references to root collection"
-    (mt/with-temporary-setting-values [remote-sync-type :development]
+    (mt/with-temporary-setting-values [remote-sync-type :read-write]
       (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced Collection"
                                                                :location "/"
                                                                :type "remote-synced"}
@@ -2474,7 +2474,7 @@
 
 (deftest move-document-without-remote-synced-refs-out-of-remote-synced-collection-test
   (testing "PUT /api/ee/document/:id - moving document without remote-synced references out of remote-synced collection"
-    (mt/with-temporary-setting-values [remote-sync-type :development]
+    (mt/with-temporary-setting-values [remote-sync-type :read-write]
       (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced Collection"
                                                                :location "/"
                                                                :type "remote-synced"}
@@ -2494,7 +2494,7 @@
 
 (deftest move-document-into-remote-synced-collection-with-non-remote-synced-refs-test
   (testing "PUT /api/ee/document/:id - moving document into remote-synced collection when it has non-remote-synced references"
-    (mt/with-temporary-setting-values [remote-sync-type :development]
+    (mt/with-temporary-setting-values [remote-sync-type :read-write]
       (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced Collection"
                                                                :location "/"
                                                                :type "remote-synced"}
@@ -2519,7 +2519,7 @@
                 "Document should remain in regular collection")))))))
 
 (deftest update-and-move-document-simultaneously-test
-  (mt/with-temporary-setting-values [remote-sync-type :development]
+  (mt/with-temporary-setting-values [remote-sync-type :read-write]
     (testing "PUT /api/ee/document/:id - updating content and moving collection simultaneously"
       (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced Collection"
                                                                :location "/"

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/api_test.clj
@@ -162,9 +162,9 @@
 
 ;;; ------------------------------------------------- Export Endpoint -------------------------------------------------
 
-(deftest export-errors-in-production-mode-test
-  (testing "POST /api/ee/remote-sync/export errors when in production sync mode"
-    (mt/with-temporary-setting-values [remote-sync-type :production]
+(deftest export-errors-in-read-only-mode-test
+  (testing "POST /api/ee/remote-sync/export errors when in read-only sync mode"
+    (mt/with-temporary-setting-values [remote-sync-type :read-only]
       (mt/with-temp [:model/RemoteSyncTask _ {:sync_task_type "foo"}]
         (let [mock-source (test-helpers/create-mock-source)]
           (mt/with-temporary-setting-values [remote-sync-url "https://github.com/test/repo.git"
@@ -176,7 +176,7 @@
 
 (deftest export-with-default-settings-test
   (testing "POST /api/ee/remote-sync/export succeeds with default settings"
-    (mt/with-temporary-setting-values [remote-sync-type :development]
+    (mt/with-temporary-setting-values [remote-sync-type :read-write]
       (mt/with-temp [:model/Collection _ {:type "remote-synced" :name "Test Collection" :location "/"}]
         (let [mock-main (test-helpers/create-mock-source)]
           (mt/with-temporary-setting-values [remote-sync-url "https://github.com/test/repo.git"
@@ -191,7 +191,7 @@
 
 (deftest export-with-custom-branch-and-message-test
   (testing "POST /api/ee/remote-sync/export succeeds with custom branch and message"
-    (mt/with-temporary-setting-values [remote-sync-type :development]
+    (mt/with-temporary-setting-values [remote-sync-type :read-write]
       (mt/with-temp [:model/Collection _ {:type "remote-synced" :name "Test Collection" :location "/"}]
         (let [mock-main (test-helpers/create-mock-source)]
           (mt/with-temporary-setting-values [remote-sync-url "https://github.com/test/repo.git"
@@ -207,21 +207,21 @@
 
 (deftest export-requires-superuser-test
   (testing "POST /api/ee/remote-sync/export requires superuser permissions"
-    (mt/with-temporary-setting-values [remote-sync-type :development
+    (mt/with-temporary-setting-values [remote-sync-type :read-write
                                        remote-sync-url "file://repo.git"]
       (is (= "You don't have permissions to do that."
              (mt/user-http-request :rasta :post 403 "ee/remote-sync/export" {}))))))
 
 (deftest export-errors-when-remote-sync-disabled-test
   (testing "POST /api/ee/remote-sync/export errors when remote sync is disabled"
-    (mt/with-temporary-setting-values [remote-sync-type :development
+    (mt/with-temporary-setting-values [remote-sync-type :read-write
                                        remote-sync-url nil]
       (is (= "Remote sync is not configured."
              (mt/user-http-request :crowberto :post 400 "ee/remote-sync/export" {}))))))
 
 (deftest export-handles-write-errors-test
   (testing "POST /api/ee/remote-sync/export handles write errors"
-    (mt/with-temporary-setting-values [remote-sync-type :development]
+    (mt/with-temporary-setting-values [remote-sync-type :read-write]
       (mt/with-temp [:model/Collection _ {:type "remote-synced" :name "Test Collection" :location "/"}]
         (let [mock-main (test-helpers/create-mock-source :fail-mode :write-files-error)]
           (mt/with-temporary-setting-values [remote-sync-url "https://github.com/test/repo.git"
@@ -234,7 +234,7 @@
 
 (deftest export-errors-when-task-already-exists-test
   (testing "POST /api/ee/remote-sync/export errors when task already exists"
-    (mt/with-temporary-setting-values [remote-sync-type :development]
+    (mt/with-temporary-setting-values [remote-sync-type :read-write]
       (mt/with-temp [:model/RemoteSyncTask _ {:sync_task_type "foo"}]
         (let [mock-source (test-helpers/create-mock-source)]
           (mt/with-temporary-setting-values [remote-sync-url "https://github.com/test/repo.git"
@@ -246,7 +246,7 @@
 
 (deftest export-errors-if-external-changes-test
   (testing "POST /api/ee/remote-sync/export errors when remote is ahead of the last sync"
-    (mt/with-temporary-setting-values [remote-sync-type :development]
+    (mt/with-temporary-setting-values [remote-sync-type :read-write]
       (mt/with-temp [:model/RemoteSyncTask _ {:sync_task_type "foo"
                                               :ended_at :%now
                                               :version "other-version"}]
@@ -265,7 +265,7 @@
 
 (deftest export-force-if-external-changes-test
   (testing "POST /api/ee/remote-sync/export can force sync when remote is ahead of the last sync"
-    (mt/with-temporary-setting-values [remote-sync-type :development]
+    (mt/with-temporary-setting-values [remote-sync-type :read-write]
       (mt/with-temp [:model/RemoteSyncTask _ {:sync_task_type "foo"
                                               :ended_at :%now
                                               :version "other-version"}]
@@ -493,7 +493,7 @@
       (with-redefs [settings/check-git-settings! (constantly nil)
                     source/source-from-settings (constantly mock-main)]
         (mt/with-temporary-setting-values [remote-sync-url nil
-                                           remote-sync-type :development]
+                                           remote-sync-type :read-write]
           (let [{:as resp :keys [task_id]} (mt/user-http-request :crowberto :put 200 "ee/remote-sync/settings"
                                                                  {:remote-sync-url "https://github.com/test/repo.git"
                                                                   :remote-sync-branch "main"})
@@ -501,18 +501,18 @@
             (is (=? {:success true} resp))
             (is (remote-sync.task/successful? task))))))))
 
-(deftest settings-update-triggers-import-in-production-test
-  (testing "PUT /api/ee/remote-sync/settings triggers import when type is production"
+(deftest settings-update-triggers-import-in-read-only-test
+  (testing "PUT /api/ee/remote-sync/settings triggers import when type is read-only"
     (let [mock-main (test-helpers/create-mock-source)]
       (with-redefs [settings/check-git-settings! (constantly nil)
                     source/source-from-settings (constantly mock-main)]
-        (mt/with-temporary-setting-values [remote-sync-type :production
+        (mt/with-temporary-setting-values [remote-sync-type :read-only
                                            remote-sync-branch "main"
                                            remote-sync-url "https://github.com/test/repo.git"
                                            remote-sync-token "test-token"]
           (let [response (mt/user-http-request :crowberto :put 200 "ee/remote-sync/settings"
                                                {:remote-sync-url "file://repo.git"
-                                                :remote-sync-type :production})
+                                                :remote-sync-type :read-only})
                 task (wait-for-task-completion (:task_id response))]
             (is (=? {:success true} response))
             (is (remote-sync.task/successful? task))))))))
@@ -535,11 +535,11 @@
       (mt/with-temporary-setting-values [remote-sync-url "https://github.com/test/repo.git"
                                          remote-sync-token "test-token"
                                          remote-sync-branch "main"
-                                         remote-sync-type :development]
-        (testing "cannot change to production mode"
-          (is (= "There are unsaved changes in the Remote Sync collection which will be overwritten switching to production mode."
+                                         remote-sync-type :read-write]
+        (testing "cannot change to read-only mode"
+          (is (= "There are unsaved changes in the Remote Sync collection which will be overwritten switching to read-only mode."
                  (mt/user-http-request :crowberto :put 400 "ee/remote-sync/settings"
-                                       {:remote-sync-type :production
+                                       {:remote-sync-type :read-only
                                         :remote-sync-branch "main"
                                         :remote-sync-url "https://github.com/test/repo.git"
                                         :remote-sync-token "test-token"}))))))))
@@ -550,7 +550,7 @@
     (mt/with-temporary-setting-values [remote-sync-url "https://github.com/test/repo.git"
                                        remote-sync-token "test-token"
                                        remote-sync-branch "main"
-                                       remote-sync-type :development]
+                                       remote-sync-type :read-write]
       (with-redefs [source/source-from-settings (constantly mock-source)]
         (is (= {:status "success"
                 :message "Branch 'feature-branch' created from 'main'"}
@@ -567,7 +567,7 @@
     (mt/with-temporary-setting-values [remote-sync-url "https://github.com/test/repo.git"
                                        remote-sync-token "test-token"
                                        remote-sync-branch "main"
-                                       remote-sync-type :development]
+                                       remote-sync-type :read-write]
       (mt/with-temp [:model/RemoteSyncObject remote-sync {:model_type "Card"
                                                           :model_id 1
                                                           :status "updated"

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/api_test.clj
@@ -171,7 +171,7 @@
                                              remote-sync-token "test-token"
                                              remote-sync-branch "main"]
             (with-redefs [source/source-from-settings (constantly mock-source)]
-              (is (= "Exports are only allowed when remote-sync-type is set to 'development'"
+              (is (= "Exports are only allowed when remote-sync-type is set to 'read-write'"
                      (mt/user-http-request :crowberto :post 400 "ee/remote-sync/export" {}))))))))))
 
 (deftest export-with-default-settings-test

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/collection_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/collection_api_test.clj
@@ -10,7 +10,7 @@
 
 (use-fixtures :each
   (fn [f]
-    (mt/with-temporary-setting-values [settings/remote-sync-type :development]
+    (mt/with-temporary-setting-values [settings/remote-sync-type :read-write]
       (f))))
 
 (deftest create-collection-with-remote-synced-type-test
@@ -84,10 +84,10 @@
           (is (nil? (:type updated)))
           (is (nil? (t2/select-one-fn :type :model/Collection :id (:id collection)))))))))
 
-(deftest update-collection-from-remote-synced-to-nil-in-production-fails-test
+(deftest update-collection-from-remote-synced-to-nil-in-read-only-fails-test
   (testing "PUT /api/collection/:id"
-    (testing "Cannot update a remote-synced collection to nil type in production mode"
-      (mt/with-temporary-setting-values [settings/remote-sync-type :production]
+    (testing "Cannot update a remote-synced collection to nil type in read-only mode"
+      (mt/with-temporary-setting-values [settings/remote-sync-type :read-only]
         (mt/with-model-cleanup [:model/Collection]
           (let [collection (mt/user-http-request :crowberto :post 200 "collection"
                                                  {:name "Remote Synced Collection"

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/collection_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/collection_api_test.clj
@@ -72,9 +72,9 @@
           (is (= "remote-synced" (:type updated)))
           (is (= "remote-synced" (t2/select-one-fn :type :model/Collection :id (:id collection)))))))))
 
-(deftest update-collection-from-remote-synced-to-nil-in-development-test
+(deftest update-collection-from-remote-synced-to-nil-in-read-write-test
   (testing "PUT /api/collection/:id"
-    (testing "Can update a remote-synced collection to nil type in development mode"
+    (testing "Can update a remote-synced collection to nil type in read-write mode"
       (mt/with-model-cleanup [:model/Collection]
         (let [collection (mt/user-http-request :crowberto :post 200 "collection"
                                                {:name "Remote Synced Collection"

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/dashboard_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/dashboard_api_test.clj
@@ -6,7 +6,7 @@
    [toucan2.core :as t2]))
 
 (use-fixtures :each (fn [f]
-                      (mt/with-temporary-setting-values [remote-sync-type :development]
+                      (mt/with-temporary-setting-values [remote-sync-type :read-write]
                         (f))))
 
 (deftest api-update-dashboard-collection-id-remote-synced-dependency-checking-success-test

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
@@ -405,7 +405,7 @@
                     "Should call async-import! in read-only mode")))))))))
 
 (deftest finish-remote-config!-does-nothing-when-collection-exists-in-dev-mode-test
-  (testing "finish-remote-config! does nothing when collection exists in development mode"
+  (testing "finish-remote-config! does nothing when collection exists in read-write mode"
     (mt/with-model-cleanup [:model/Collection]
       (let [mock-source (test-helpers/create-mock-source)
             import-called? (atom false)]

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
@@ -134,7 +134,7 @@
 
 (deftest export!-with-no-source-configured-test
   (testing "export! with no source configured"
-    (mt/with-temporary-setting-values [remote-sync-type :development]
+    (mt/with-temporary-setting-values [remote-sync-type :read-write]
       (let [task-id (t2/insert-returning-pk! :model/RemoteSyncTask {:sync_task_type "export" :initiated_by (mt/user->id :rasta)})
             result (impl/export! nil task-id "Test commit")]
         (is (= :error (:status result)))
@@ -142,7 +142,7 @@
 
 (deftest export!-with-no-remote-synced-collections-test
   (testing "export! errors when there are no remote-synced collections"
-    (mt/with-temporary-setting-values [remote-sync-type :development]
+    (mt/with-temporary-setting-values [remote-sync-type :read-write]
       (let [task-id (t2/insert-returning-pk! :model/RemoteSyncTask {:sync_task_type "export" :initiated_by (mt/user->id :rasta)})]
         ;; Create a regular collection (not remote-synced) to verify it's not included
         (mt/with-temp [:model/Collection {_coll-id :id} {:name "Regular Collection" :type nil :location "/"}]
@@ -153,7 +153,7 @@
 
 (deftest export!-successful-with-default-collections-test
   (testing "export! successful with default collections"
-    (mt/with-temporary-setting-values [remote-sync-type :development]
+    (mt/with-temporary-setting-values [remote-sync-type :read-write]
       (let [task-id (t2/insert-returning-pk! :model/RemoteSyncTask {:sync_task_type "export" :initiated_by (mt/user->id :rasta)})]
         (mt/with-temp [:model/Collection {_coll-id :id} {:name "Test Collection" :type "remote-synced" :entity_id "test-collection-1xxxx" :location "/"}]
           (let [mock-source (test-helpers/create-mock-source)
@@ -162,7 +162,7 @@
 
 (deftest export!-handles-store-failure-test
   (testing "export! handles store failure"
-    (mt/with-temporary-setting-values [remote-sync-type :development]
+    (mt/with-temporary-setting-values [remote-sync-type :read-write]
       (let [task-id (t2/insert-returning-pk! :model/RemoteSyncTask {:sync_task_type "export" :initiated_by (mt/user->id :rasta)})]
         (mt/with-temp [:model/Collection {_coll-id :id} {:name "Test Collection" :type "remote-synced" :entity_id "test-collection-1xxxx" :location "/"}]
           (let [mock-source (test-helpers/create-mock-source :fail-mode :store-error)
@@ -172,7 +172,7 @@
 
 (deftest export!-handles-network-errors-during-write-test
   (testing "export! handles network errors during write"
-    (mt/with-temporary-setting-values [remote-sync-type :development]
+    (mt/with-temporary-setting-values [remote-sync-type :read-write]
       (let [task-id (t2/insert-returning-pk! :model/RemoteSyncTask {:sync_task_type "export" :initiated_by (mt/user->id :rasta)})]
         (mt/with-temp [:model/Collection {_coll-id :id} {:name "Test Collection" :type "remote-synced" :entity_id "test-collection-1xxxx" :location "/"}]
           (let [mock-source (test-helpers/create-mock-source :fail-mode :network-error)
@@ -184,7 +184,7 @@
 
 (deftest complete-import-export-workflow-test
   (testing "complete import-export workflow"
-    (mt/with-temporary-setting-values [remote-sync-type :development]
+    (mt/with-temporary-setting-values [remote-sync-type :read-write]
       (mt/with-temp [:model/Collection {coll-id :id} {:name "Test Collection" :type "remote-synced" :entity_id "test-collection-1xxxx" :location "/"}
                      :model/Card {card-id :id} {:name "Test Card" :collection_id coll-id :entity_id "test-card-1xxxxxxxxxx"}]
         (let [mock-main (test-helpers/create-mock-source :branch "test-branch")
@@ -275,7 +275,7 @@
 (deftest export!-calls-update-progress-with-expected-values-test
   (testing "export! calls update-progress! with expected progress values"
     (mt/dataset test-data
-      (mt/with-temporary-setting-values [remote-sync-type :development]
+      (mt/with-temporary-setting-values [remote-sync-type :read-write]
         (let [task-id (t2/insert-returning-pk! :model/RemoteSyncTask {:sync_task_type "export" :initiated_by (mt/user->id :rasta)})]
           (mt/with-temp [:model/Collection {coll-id :id} {:name "Test Collection" :type "remote-synced" :entity_id "test-collection-1xxxx" :location "/"}
                          :model/Collection _ {:name "Test Collection" :type "remote-synced" :entity_id "test-collection-2xxxx" :location "/"}
@@ -323,7 +323,7 @@
 (deftest export!-updates-all-statuses-to-synced-test
   (testing "export! updates all RemoteSyncObject entries to synced status"
     (mt/with-model-cleanup [:model/RemoteSyncObject]
-      (mt/with-temporary-setting-values [remote-sync-type :development]
+      (mt/with-temporary-setting-values [remote-sync-type :read-write]
         (let [task-id (t2/insert-returning-pk! :model/RemoteSyncTask {:sync_task_type "export" :initiated_by (mt/user->id :rasta)})]
           (mt/with-temp [:model/Collection {coll-id :id} {:name "Test Collection" :type "remote-synced" :entity_id "test-collection-1xxxx" :location "/"}
                          :model/Card {card-id :id} {:name "Test Card" :collection_id coll-id :entity_id "test-card-1xxxxxxxxxx"}
@@ -370,7 +370,7 @@
         (mt/with-temporary-setting-values [remote-sync-enabled true
                                            remote-sync-url "https://github.com/test/repo.git"
                                            remote-sync-branch "main"
-                                           remote-sync-type :development]
+                                           remote-sync-type :read-write]
           (with-redefs [source/source-from-settings (constantly mock-source)
                         impl/async-import! (fn [branch force? args]
                                              (reset! import-called? true)
@@ -386,8 +386,8 @@
                      @import-args)
                   "Should call async-import! with correct arguments"))))))))
 
-(deftest finish-remote-config!-starts-import-in-production-mode-test
-  (testing "finish-remote-config! starts import in production mode even when collection exists"
+(deftest finish-remote-config!-starts-import-in-read-only-mode-test
+  (testing "finish-remote-config! starts import in read-only mode even when collection exists"
     (mt/with-model-cleanup [:model/RemoteSyncTask :model/Collection]
       (let [mock-source (test-helpers/create-mock-source)
             import-called? (atom false)]
@@ -395,14 +395,14 @@
           (mt/with-temporary-setting-values [remote-sync-enabled true
                                              remote-sync-url "https://github.com/test/repo.git"
                                              remote-sync-branch "main"
-                                             remote-sync-type :production]
+                                             remote-sync-type :read-only]
             (with-redefs [source/source-from-settings (constantly mock-source)
                           impl/async-import! (fn [& _args] (reset! import-called? true) {:id 123})]
               (let [task-id (impl/finish-remote-config!)]
                 (is (= 123 task-id)
                     "Should return task ID from async-import!")
                 (is @import-called?
-                    "Should call async-import! in production mode")))))))))
+                    "Should call async-import! in read-only mode")))))))))
 
 (deftest finish-remote-config!-does-nothing-when-collection-exists-in-dev-mode-test
   (testing "finish-remote-config! does nothing when collection exists in development mode"
@@ -413,7 +413,7 @@
           (mt/with-temporary-setting-values [remote-sync-enabled true
                                              remote-sync-url "https://github.com/test/repo.git"
                                              remote-sync-branch "main"
-                                             remote-sync-type :development]
+                                             remote-sync-type :read-write]
             (with-redefs [source/source-from-settings (constantly mock-source)
                           impl/async-import! (fn [& _args] (reset! import-called? true) 123)]
               (let [result (impl/finish-remote-config!)]

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/permissions_test.clj
@@ -15,9 +15,9 @@
                          :text text}]}]})
 
 (deftest remote-synced-permissions-with-remote-sync-type-import-test
-  (testing "can_write should be false for remote-synced collection items when remote-sync-type is production"
+  (testing "can_write should be false for remote-synced collection items when remote-sync-type is read-only"
     (mt/with-current-user (mt/user->id :rasta)
-      (mt/with-temporary-setting-values [settings/remote-sync-type :production]
+      (mt/with-temporary-setting-values [settings/remote-sync-type :read-only]
         (mt/with-temp [:model/Collection {library-coll-id :id} {:name "Library Collection"
                                                                 :type "remote-synced"}]
 
@@ -26,25 +26,25 @@
                                                       :collection_id library-coll-id
                                                       :dataset_query (mt/native-query {:query "SELECT 1"})}]
               (is (false? (mi/can-write? (t2/select-one :model/Card :id card-id)))
-                  "Card in remote-synced collection should not be writable when remote-sync-type is production")))
+                  "Card in remote-synced collection should not be writable when remote-sync-type is read-only")))
 
           (testing "Dashboards in remote-synced collections have can_write=false"
             (mt/with-temp [:model/Dashboard {dashboard-id :id} {:name "Library Dashboard"
                                                                 :collection_id library-coll-id}]
               (is (false? (mi/can-write? (t2/select-one :model/Dashboard :id dashboard-id)))
-                  "Dashboard in remote-synced collection should not be writable when remote-sync-type is production")))
+                  "Dashboard in remote-synced collection should not be writable when remote-sync-type is read-only")))
 
           (testing "Documents in remote-synced collections have can_write=false"
             (mt/with-temp [:model/Document {document-id :id} {:name "Library Document"
                                                               :document (text->prose-mirror-ast "Library content")
                                                               :collection_id library-coll-id}]
               (is (false? (mi/can-write? (t2/select-one :model/Document :id document-id)))
-                  "Document in remote-synced collection should not be writable when remote-sync-type is production"))))))))
+                  "Document in remote-synced collection should not be writable when remote-sync-type is read-only"))))))))
 
 (deftest remote-synced-permissions-with-remote-sync-type-export-test
   (testing "can_write should be true for remote-synced collection items when remote-sync-type is development"
     (mt/with-current-user (mt/user->id :rasta)
-      (mt/with-temporary-setting-values [settings/remote-sync-type :development]
+      (mt/with-temporary-setting-values [settings/remote-sync-type :read-write]
         (mt/with-temp [:model/Collection {library-coll-id :id} {:name "Library Collection"
                                                                 :type "remote-synced"}]
 
@@ -74,7 +74,7 @@
       (mt/with-temp [:model/Collection {regular-coll-id :id} {:name "Regular Collection"
                                                               :type nil}]
 
-        (doseq [remote-sync-setting [:production :development]]
+        (doseq [remote-sync-setting [:read-only :read-write]]
           (testing (str "When remote-sync-type is " remote-sync-setting)
             (mt/with-temporary-setting-values [settings/remote-sync-type remote-sync-setting]
 
@@ -107,31 +107,31 @@
                                                                :location (format "/%d/" parent-library-id)
                                                                :type "remote-synced"}]
 
-        (testing "When remote-sync-type is production"
-          (mt/with-temporary-setting-values [settings/remote-sync-type :production]
+        (testing "When remote-sync-type is read-only"
+          (mt/with-temporary-setting-values [settings/remote-sync-type :read-only]
 
             (testing "Cards in nested remote-synced collections have can_write=false"
               (mt/with-temp [:model/Card {card-id :id} {:name "Nested Library Card"
                                                         :collection_id child-library-id
                                                         :dataset_query (mt/native-query {:query "SELECT 1"})}]
                 (is (false? (mi/can-write? (t2/select-one :model/Card :id card-id)))
-                    "Card in nested remote-synced collection should not be writable when remote-sync-type is production")))
+                    "Card in nested remote-synced collection should not be writable when remote-sync-type is read-only")))
 
             (testing "Dashboards in nested remote-synced collections have can_write=false"
               (mt/with-temp [:model/Dashboard {dashboard-id :id} {:name "Nested Library Dashboard"
                                                                   :collection_id child-library-id}]
                 (is (false? (mi/can-write? (t2/select-one :model/Dashboard :id dashboard-id)))
-                    "Dashboard in nested remote-synced collection should not be writable when remote-sync-type is production")))
+                    "Dashboard in nested remote-synced collection should not be writable when remote-sync-type is read-only")))
 
             (testing "Documents in nested remote-synced collections have can_write=false"
               (mt/with-temp [:model/Document {document-id :id} {:name "Nested Library Document"
                                                                 :document (text->prose-mirror-ast "Nested library content")
                                                                 :collection_id child-library-id}]
                 (is (false? (mi/can-write? (t2/select-one :model/Document :id document-id)))
-                    "Document in nested remote-synced collection should not be writable when remote-sync-type is production")))))
+                    "Document in nested remote-synced collection should not be writable when remote-sync-type is read-only")))))
 
         (testing "When remote-sync-type is development"
-          (mt/with-temporary-setting-values [settings/remote-sync-type :development]
+          (mt/with-temporary-setting-values [settings/remote-sync-type :read-write]
 
             (testing "Cards in nested remote-synced collections have can_write=true"
               (mt/with-temp [:model/Card {card-id :id} {:name "Nested Library Card"
@@ -161,8 +161,8 @@
                      :model/Collection {regular-coll-id :id} {:name "Regular Collection"
                                                               :type nil}]
 
-        (testing "When remote-sync-type is production"
-          (mt/with-temporary-setting-values [settings/remote-sync-type :production]
+        (testing "When remote-sync-type is read-only"
+          (mt/with-temporary-setting-values [settings/remote-sync-type :read-only]
 
             (testing "Library items have can_write=false while regular items have can_write=true"
               (mt/with-temp [:model/Card {library-card-id :id} {:name "Library Card"
@@ -205,8 +205,8 @@
                      :model/Collection {regular-coll-id :id} {:name "Regular Collection"
                                                               :type nil}]
 
-        (testing "When remote-sync-type is production"
-          (mt/with-temporary-setting-values [settings/remote-sync-type :production]
+        (testing "When remote-sync-type is read-only"
+          (mt/with-temporary-setting-values [settings/remote-sync-type :read-only]
 
             (testing "Library items have can_write=false while regular items have can_write=true"
               (mt/with-temp [:model/Card {library-card-id :id} {:name "Library Card"
@@ -244,16 +244,16 @@
 (deftest remote-synced-collection-itself-permissions-test
   (testing "can_write for remote-synced collections themselves should respect remote-sync-type"
 
-    (testing "When remote-sync-type is production"
-      (mt/with-temporary-setting-values [settings/remote-sync-type :production]
+    (testing "When remote-sync-type is read-only"
+      (mt/with-temporary-setting-values [settings/remote-sync-type :read-only]
         (mt/with-temp [:model/Collection {library-coll-id :id} {:name "Library Collection"
                                                                 :type "remote-synced"}]
           (mt/with-current-user (mt/user->id :rasta))
           (is (false? (mi/can-write? (t2/select-one :model/Collection :id library-coll-id)))
-              "Library collection itself should not be writable when remote-sync-type is production"))))
+              "Library collection itself should not be writable when remote-sync-type is read-only"))))
 
     (testing "When remote-sync-type is development"
-      (mt/with-temporary-setting-values [settings/remote-sync-type :development]
+      (mt/with-temporary-setting-values [settings/remote-sync-type :read-write]
         (mt/with-temp [:model/Collection {library-coll-id :id} {:name "Library Collection"
                                                                 :type "remote-synced"}]
           (mt/with-current-user (mt/user->id :rasta)
@@ -261,7 +261,7 @@
                 "Library collection itself should be writable when remote-sync-type is development")))))
 
     (testing "Regular collections are always writable regardless of remote-sync-type"
-      (doseq [remote-sync-setting [:production :development]]
+      (doseq [remote-sync-setting [:read-only :read-write]]
         (mt/with-temporary-setting-values [settings/remote-sync-type remote-sync-setting]
           (mt/with-temp [:model/Collection {regular-coll-id :id} {:name "Regular Collection"
                                                                   :type nil}]

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/permissions_test.clj
@@ -42,7 +42,7 @@
                   "Document in remote-synced collection should not be writable when remote-sync-type is read-only"))))))))
 
 (deftest remote-synced-permissions-with-remote-sync-type-export-test
-  (testing "can_write should be true for remote-synced collection items when remote-sync-type is development"
+  (testing "can_write should be true for remote-synced collection items when remote-sync-type is read-write"
     (mt/with-current-user (mt/user->id :rasta)
       (mt/with-temporary-setting-values [settings/remote-sync-type :read-write]
         (mt/with-temp [:model/Collection {library-coll-id :id} {:name "Library Collection"
@@ -53,20 +53,20 @@
                                                       :collection_id library-coll-id
                                                       :dataset_query (mt/native-query {:query "SELECT 1"})}]
               (is (true? (mi/can-write? (t2/select-one :model/Card :id card-id)))
-                  "Card in remote-synced collection should be writable when remote-sync-type is development")))
+                  "Card in remote-synced collection should be writable when remote-sync-type is read-write")))
 
           (testing "Dashboards in remote-synced collections have can_write=true"
             (mt/with-temp [:model/Dashboard {dashboard-id :id} {:name "Library Dashboard"
                                                                 :collection_id library-coll-id}]
               (is (true? (mi/can-write? (t2/select-one :model/Dashboard :id dashboard-id)))
-                  "Dashboard in remote-synced collection should be writable when remote-sync-type is development")))
+                  "Dashboard in remote-synced collection should be writable when remote-sync-type is read-write")))
 
           (testing "Documents in remote-synced collections have can_write=true"
             (mt/with-temp [:model/Document {document-id :id} {:name "Library Document"
                                                               :document (text->prose-mirror-ast "Library content")
                                                               :collection_id library-coll-id}]
               (is (true? (mi/can-write? (t2/select-one :model/Document :id document-id)))
-                  "Document in remote-synced collection should be writable when remote-sync-type is development"))))))))
+                  "Document in remote-synced collection should be writable when remote-sync-type is read-write"))))))))
 
 (deftest non-remote-synced-permissions-unaffected-by-remote-sync-type-test
   (testing "can_write for non-remote-synced collection items should be unaffected by remote-sync-type setting"
@@ -130,7 +130,7 @@
                 (is (false? (mi/can-write? (t2/select-one :model/Document :id document-id)))
                     "Document in nested remote-synced collection should not be writable when remote-sync-type is read-only")))))
 
-        (testing "When remote-sync-type is development"
+        (testing "When remote-sync-type is read-write"
           (mt/with-temporary-setting-values [settings/remote-sync-type :read-write]
 
             (testing "Cards in nested remote-synced collections have can_write=true"
@@ -138,20 +138,20 @@
                                                         :collection_id child-library-id
                                                         :dataset_query (mt/native-query {:query "SELECT 1"})}]
                 (is (true? (mi/can-write? (t2/select-one :model/Card :id card-id)))
-                    "Card in nested remote-synced collection should be writable when remote-sync-type is development")))
+                    "Card in nested remote-synced collection should be writable when remote-sync-type is read-write")))
 
             (testing "Dashboards in nested remote-synced collections have can_write=true"
               (mt/with-temp [:model/Dashboard {dashboard-id :id} {:name "Nested Library Dashboard"
                                                                   :collection_id child-library-id}]
                 (is (true? (mi/can-write? (t2/select-one :model/Dashboard :id dashboard-id)))
-                    "Dashboard in nested remote-synced collection should be writable when remote-sync-type is development")))
+                    "Dashboard in nested remote-synced collection should be writable when remote-sync-type is read-write")))
 
             (testing "Documents in nested remote-synced collections have can_write=true"
               (mt/with-temp [:model/Document {document-id :id} {:name "Nested Library Document"
                                                                 :document (text->prose-mirror-ast "Nested library content")
                                                                 :collection_id child-library-id}]
                 (is (true? (mi/can-write? (t2/select-one :model/Document :id document-id)))
-                    "Document in nested remote-synced collection should be writable when remote-sync-type is development")))))))))
+                    "Document in nested remote-synced collection should be writable when remote-sync-type is read-write")))))))))
 
 (deftest mixed-collection-types-permissions-test
   (testing "can_write behavior should differ between library and regular collections in same test"
@@ -252,13 +252,13 @@
           (is (false? (mi/can-write? (t2/select-one :model/Collection :id library-coll-id)))
               "Library collection itself should not be writable when remote-sync-type is read-only"))))
 
-    (testing "When remote-sync-type is development"
+    (testing "When remote-sync-type is read-write"
       (mt/with-temporary-setting-values [settings/remote-sync-type :read-write]
         (mt/with-temp [:model/Collection {library-coll-id :id} {:name "Library Collection"
                                                                 :type "remote-synced"}]
           (mt/with-current-user (mt/user->id :rasta)
             (is (true? (mi/can-write? (t2/select-one :model/Collection :id library-coll-id)))
-                "Library collection itself should be writable when remote-sync-type is development")))))
+                "Library collection itself should be writable when remote-sync-type is read-write")))))
 
     (testing "Regular collections are always writable regardless of remote-sync-type"
       (doseq [remote-sync-setting [:read-only :read-write]]

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/settings_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/settings_test.clj
@@ -11,7 +11,7 @@
         obfuscated-token (setting/obfuscate-value full-token)
         default-settings
         {:remote-sync-url     "file://my/url.git"
-         :remote-sync-type    :production
+         :remote-sync-type    :read-only
          :remote-sync-branch  "test-branch"
          :remote-sync-token   nil}]
     (with-redefs [settings/check-git-settings! (fn [{:keys [remote-sync-token]}]
@@ -25,7 +25,7 @@
         (testing "Allows setting with no token"
           (settings/check-and-update-remote-settings! (assoc default-settings :remote-sync-token nil))
           (is (= "file://my/url.git" (settings/remote-sync-url)))
-          (is (= :production (settings/remote-sync-type)))
+          (is (= :read-only (settings/remote-sync-type)))
           (is (= "test-branch" (settings/remote-sync-branch)))
           (is (true? (settings/remote-sync-enabled)))
           (is (= nil (settings/remote-sync-token))))

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncAdminSettings.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncAdminSettings.tsx
@@ -246,28 +246,28 @@ export const RemoteSyncAdminSettings = () => {
                   <FormRadioGroup name={TYPE_KEY} label={t`Remote Sync Mode`}>
                     <Stack mt="sm">
                       <Radio
-                        value="development"
-                        label={t`Development`}
-                        description={t`In development mode, you can make changes to synced collections and pull and push from any git branch`}
+                        value="read-write"
+                        label={t`Read-write`}
+                        description={t`In read-write mode, you can make changes to synced collections and pull and push from any git branch`}
                       />
                       <Tooltip
                         disabled={!hasUnsyncedChanges}
-                        label={t`You can't switch to production as you have unpublished changes.`}
+                        label={t`You can't switch to Read-only as you have unpublished changes.`}
                         position="bottom-start"
                       >
                         <Box>
                           <Radio
-                            description={t`In production mode, synced collections are read-only, and automatically sync with the specified branch`}
+                            description={t`In Read-only mode, synced collections are read-only, and automatically sync with the specified branch`}
                             disabled={hasUnsyncedChanges}
-                            label={t`Production`}
-                            value="production"
+                            label={t`Read-only`}
+                            value="read-only"
                           />
                         </Box>
                       </Tooltip>
                     </Stack>
                   </FormRadioGroup>
 
-                  {values?.[TYPE_KEY] === "production" && (
+                  {values?.[TYPE_KEY] === "read-only" && (
                     <Stack ml="1.875rem">
                       <Flex align="end" gap="md">
                         <Box style={{ flex: 1 }}>

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/constants.ts
@@ -15,7 +15,7 @@ export const REMOTE_SYNC_SCHEMA = Yup.object({
   [TOKEN_KEY]: Yup.string().nullable().default(null),
   [AUTO_IMPORT_KEY]: Yup.boolean().nullable().default(false),
   [TYPE_KEY]: Yup.string()
-    .oneOf(["read-only", "read-only"] as const)
+    .oneOf(["read-only", "read-write"] as const)
     .nullable()
     .default("read-only"),
   [BRANCH_KEY]: Yup.string().nullable().default("main"),

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/constants.ts
@@ -15,9 +15,9 @@ export const REMOTE_SYNC_SCHEMA = Yup.object({
   [TOKEN_KEY]: Yup.string().nullable().default(null),
   [AUTO_IMPORT_KEY]: Yup.boolean().nullable().default(false),
   [TYPE_KEY]: Yup.string()
-    .oneOf(["production", "development"] as const)
+    .oneOf(["read-only", "read-only"] as const)
     .nullable()
-    .default("production"),
+    .default("read-only"),
   [BRANCH_KEY]: Yup.string().nullable().default("main"),
 });
 

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -649,7 +649,7 @@ export interface EnterpriseSettings extends Settings {
   "remote-sync-token"?: string | null;
   "remote-sync-url"?: string | null;
   "remote-sync-branch"?: string | null;
-  "remote-sync-type"?: "production" | "development" | null;
+  "remote-sync-type"?: "read-only" | "read-write" | null;
   "remote-sync-auto-import"?: boolean | null;
   "login-page-illustration"?: IllustrationSettingValue;
   "login-page-illustration-custom"?: string;

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
@@ -80,7 +80,7 @@ export function MainNavbarView({
   );
 
   const isAtHomepageDashboard = useIsAtHomepageDashboard();
-  const showSyncGroup = useSetting("remote-sync-type") === "development";
+  const showSyncGroup = useSetting("remote-sync-type") === "read-write";
 
   const [
     addDataModalOpened,

--- a/locales/ar-SA.po
+++ b/locales/ar-SA.po
@@ -31645,15 +31645,15 @@ msgid "The location of your git repository, e.g. https://github.com/acme-inco/me
 msgstr ""
 
 #: metabase_enterprise/remote_sync/settings.clj:46
-msgid "Git synchronization type - :development or :production"
+msgid "Git synchronization type - :read-write or :read-only"
 msgstr ""
 
 #: metabase_enterprise/remote_sync/settings.clj:62
-msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :production."
+msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :read-only."
 msgstr ""
 
 #: metabase_enterprise/remote_sync/settings.clj:70
-msgid "If remote-sync-type is :production and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
+msgid "If remote-sync-type is :read-only and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
 msgstr ""
 
 #: metabase_enterprise/remote_sync/settings.clj:78

--- a/locales/ar.po
+++ b/locales/ar.po
@@ -31663,16 +31663,16 @@ msgid "The location of your git repository, e.g. https://github.com/acme-inco/me
 msgstr "موقع مستودع git الخاص بك، على سبيل المثال https://github.com/acme-inco/metabase.git"
 
 #: metabase_enterprise/remote_sync/settings.clj:46
-msgid "Git synchronization type - :development or :production"
-msgstr "نوع مزامنة Git - :development أو :production"
+msgid "Git synchronization type - :read-write or :read-only"
+msgstr "نوع مزامنة Git - :read-write أو :read-only"
 
 #: metabase_enterprise/remote_sync/settings.clj:62
-msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :production."
-msgstr "هل سيتم الاستيراد تلقائيًا من مستودع git البعيد؟ ينطبق هذا فقط إذا كان نوع المزامنة عن بُعد هو :production."
+msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :read-only."
+msgstr "هل سيتم الاستيراد تلقائيًا من مستودع git البعيد؟ ينطبق هذا فقط إذا كان نوع المزامنة عن بُعد هو :read-only."
 
 #: metabase_enterprise/remote_sync/settings.clj:70
-msgid "If remote-sync-type is :production and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
-msgstr "إذا كان نوع المزامنة عن بُعد هو :production وقيمة المزامنة عن بُعد التلقائية للاستيراد صحيحة، فهذا هو معدل البحث عن التحديثات للاستيراد (بالدقائق). القيمة الافتراضية هي 5."
+msgid "If remote-sync-type is :read-only and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
+msgstr "إذا كان نوع المزامنة عن بُعد هو :read-only وقيمة المزامنة عن بُعد التلقائية للاستيراد صحيحة، فهذا هو معدل البحث عن التحديثات للاستيراد (بالدقائق). القيمة الافتراضية هي 5."
 
 #: metabase_enterprise/remote_sync/settings.clj:78
 msgid "The maximum amount of time a remote sync task will be given to complete"

--- a/locales/bg.po
+++ b/locales/bg.po
@@ -31186,16 +31186,16 @@ msgid "The location of your git repository, e.g. https://github.com/acme-inco/me
 msgstr "Местоположението на вашето git хранилище, например https://github.com/acme-inco/metabase.git"
 
 #: metabase_enterprise/remote_sync/settings.clj:46
-msgid "Git synchronization type - :development or :production"
-msgstr "Тип синхронизация на Git - :development или :production"
+msgid "Git synchronization type - :read-write or :read-only"
+msgstr "Тип синхронизация на Git - :read-write или :read-only"
 
 #: metabase_enterprise/remote_sync/settings.clj:62
-msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :production."
-msgstr "Дали да се импортира автоматично от отдалеченото git хранилище. Прилага се само ако remote-sync-type е :production."
+msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :read-only."
+msgstr "Дали да се импортира автоматично от отдалеченото git хранилище. Прилага се само ако remote-sync-type е :read-only."
 
 #: metabase_enterprise/remote_sync/settings.clj:70
-msgid "If remote-sync-type is :production and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
-msgstr "Ако remote-sync-type е :production и remote-sync-auto-import е true, честотата (в минути), с която да се проверява за актуализации за импортиране. По подразбиране е 5."
+msgid "If remote-sync-type is :read-only and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
+msgstr "Ако remote-sync-type е :read-only и remote-sync-auto-import е true, честотата (в минути), с която да се проверява за актуализации за импортиране. По подразбиране е 5."
 
 #: metabase_enterprise/remote_sync/settings.clj:78
 msgid "The maximum amount of time a remote sync task will be given to complete"

--- a/locales/ca.po
+++ b/locales/ca.po
@@ -31183,16 +31183,16 @@ msgid "The location of your git repository, e.g. https://github.com/acme-inco/me
 msgstr "La ubicació del vostre repositori de git, per exemple https://github.com/acme-inco/metabase.git"
 
 #: metabase_enterprise/remote_sync/settings.clj:46
-msgid "Git synchronization type - :development or :production"
-msgstr "Tipus de sincronització de Git: :development o :production"
+msgid "Git synchronization type - :read-write or :read-only"
+msgstr "Tipus de sincronització de Git: :read-write o :read-only"
 
 #: metabase_enterprise/remote_sync/settings.clj:62
-msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :production."
-msgstr "Si s'ha d'importar automàticament des del repositori git remot. Només s'aplica si remote-sync-type és :production."
+msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :read-only."
+msgstr "Si s'ha d'importar automàticament des del repositori git remot. Només s'aplica si remote-sync-type és :read-only."
 
 #: metabase_enterprise/remote_sync/settings.clj:70
-msgid "If remote-sync-type is :production and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
-msgstr "Si remote-sync-type és :production i remote-sync-auto-import és true, la velocitat (en minuts) a la qual es comprovaran les actualitzacions per importar. El valor per defecte és 5."
+msgid "If remote-sync-type is :read-only and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
+msgstr "Si remote-sync-type és :read-only i remote-sync-auto-import és true, la velocitat (en minuts) a la qual es comprovaran les actualitzacions per importar. El valor per defecte és 5."
 
 #: metabase_enterprise/remote_sync/settings.clj:78
 msgid "The maximum amount of time a remote sync task will be given to complete"

--- a/locales/cs.po
+++ b/locales/cs.po
@@ -31412,16 +31412,16 @@ msgid "The location of your git repository, e.g. https://github.com/acme-inco/me
 msgstr "Umístění vašeho git repozitáře, např. https://github.com/acme-inco/metabase.git"
 
 #: metabase_enterprise/remote_sync/settings.clj:46
-msgid "Git synchronization type - :development or :production"
-msgstr "Typ synchronizace Gitu - :development nebo :production"
+msgid "Git synchronization type - :read-write or :read-only"
+msgstr "Typ synchronizace Gitu - :read-write nebo :read-only"
 
 #: metabase_enterprise/remote_sync/settings.clj:62
-msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :production."
-msgstr "Zda se má automaticky importovat ze vzdáleného repozitáře Git. Platí pouze v případě, že remote-sync-type je :production."
+msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :read-only."
+msgstr "Zda se má automaticky importovat ze vzdáleného repozitáře Git. Platí pouze v případě, že remote-sync-type je :read-only."
 
 #: metabase_enterprise/remote_sync/settings.clj:70
-msgid "If remote-sync-type is :production and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
-msgstr "Pokud je remote-sync-type nastaveno na :production a remote-sync-auto-import je nastaveno na true, frekvence (v minutách), s jakou se mají kontrolovat aktualizace k importu. Výchozí hodnota je 5."
+msgid "If remote-sync-type is :read-only and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
+msgstr "Pokud je remote-sync-type nastaveno na :read-only a remote-sync-auto-import je nastaveno na true, frekvence (v minutách), s jakou se mají kontrolovat aktualizace k importu. Výchozí hodnota je 5."
 
 #: metabase_enterprise/remote_sync/settings.clj:78
 msgid "The maximum amount of time a remote sync task will be given to complete"

--- a/locales/da.po
+++ b/locales/da.po
@@ -31188,16 +31188,16 @@ msgid "The location of your git repository, e.g. https://github.com/acme-inco/me
 msgstr "Placeringen af dit git-repository, f.eks. https://github.com/acme-inco/metabase.git"
 
 #: metabase_enterprise/remote_sync/settings.clj:46
-msgid "Git synchronization type - :development or :production"
-msgstr "Git-synkroniseringstype - :development eller :production"
+msgid "Git synchronization type - :read-write or :read-only"
+msgstr "Git-synkroniseringstype - :read-write eller :read-only"
 
 #: metabase_enterprise/remote_sync/settings.clj:62
-msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :production."
-msgstr "Om der skal importeres automatisk fra det eksterne git-arkiv. Gælder kun, hvis remote-sync-type er :production."
+msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :read-only."
+msgstr "Om der skal importeres automatisk fra det eksterne git-arkiv. Gælder kun, hvis remote-sync-type er :read-only."
 
 #: metabase_enterprise/remote_sync/settings.clj:70
-msgid "If remote-sync-type is :production and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
-msgstr "Hvis remote-sync-type er :production og remote-sync-auto-import er sand, er det den hastighed (i minutter), hvormed der skal kontrolleres for opdateringer til import. Standardværdien er 5."
+msgid "If remote-sync-type is :read-only and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
+msgstr "Hvis remote-sync-type er :read-only og remote-sync-auto-import er sand, er det den hastighed (i minutter), hvormed der skal kontrolleres for opdateringer til import. Standardværdien er 5."
 
 #: metabase_enterprise/remote_sync/settings.clj:78
 msgid "The maximum amount of time a remote sync task will be given to complete"

--- a/locales/de.po
+++ b/locales/de.po
@@ -31183,16 +31183,16 @@ msgid "The location of your git repository, e.g. https://github.com/acme-inco/me
 msgstr "Der Speicherort Ihres Git-Repositorys, z. B. https://github.com/acme-inco/metabase.git"
 
 #: metabase_enterprise/remote_sync/settings.clj:46
-msgid "Git synchronization type - :development or :production"
+msgid "Git synchronization type - :read-write or :read-only"
 msgstr "Git-Synchronisierungstyp – :Entwicklung oder :Produktion"
 
 #: metabase_enterprise/remote_sync/settings.clj:62
-msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :production."
-msgstr "Ob automatisch aus dem Remote-Git-Repository importiert werden soll. Gilt nur, wenn der Remote-Sync-Typ :production ist."
+msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :read-only."
+msgstr "Ob automatisch aus dem Remote-Git-Repository importiert werden soll. Gilt nur, wenn der Remote-Sync-Typ :read-only ist."
 
 #: metabase_enterprise/remote_sync/settings.clj:70
-msgid "If remote-sync-type is :production and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
-msgstr "Wenn remote-sync-type „:production“ und remote-sync-auto-import „true“ ist, wird die Rate (in Minuten) angegeben, mit der nach zu importierenden Updates gesucht wird. Der Standardwert ist 5."
+msgid "If remote-sync-type is :read-only and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
+msgstr "Wenn remote-sync-type „:read-only“ und remote-sync-auto-import „true“ ist, wird die Rate (in Minuten) angegeben, mit der nach zu importierenden Updates gesucht wird. Der Standardwert ist 5."
 
 #: metabase_enterprise/remote_sync/settings.clj:78
 msgid "The maximum amount of time a remote sync task will be given to complete"

--- a/locales/es.po
+++ b/locales/es.po
@@ -31184,16 +31184,16 @@ msgid "The location of your git repository, e.g. https://github.com/acme-inco/me
 msgstr "La ubicación de su repositorio git, por ejemplo https://github.com/acme-inco/metabase.git"
 
 #: metabase_enterprise/remote_sync/settings.clj:46
-msgid "Git synchronization type - :development or :production"
-msgstr "Tipo de sincronización de Git: :development o :production"
+msgid "Git synchronization type - :read-write or :read-only"
+msgstr "Tipo de sincronización de Git: :read-write o :read-only"
 
 #: metabase_enterprise/remote_sync/settings.clj:62
-msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :production."
-msgstr "Si se debe importar automáticamente desde el repositorio Git remoto. Solo se aplica si el tipo de sincronización remota es :production."
+msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :read-only."
+msgstr "Si se debe importar automáticamente desde el repositorio Git remoto. Solo se aplica si el tipo de sincronización remota es :read-only."
 
 #: metabase_enterprise/remote_sync/settings.clj:70
-msgid "If remote-sync-type is :production and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
-msgstr "Si remote-sync-type es :production y remote-sync-auto-import es true, la frecuencia (en minutos) con la que se buscan actualizaciones para importar. El valor predeterminado es 5."
+msgid "If remote-sync-type is :read-only and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
+msgstr "Si remote-sync-type es :read-only y remote-sync-auto-import es true, la frecuencia (en minutos) con la que se buscan actualizaciones para importar. El valor predeterminado es 5."
 
 #: metabase_enterprise/remote_sync/settings.clj:78
 msgid "The maximum amount of time a remote sync task will be given to complete"

--- a/locales/fa.po
+++ b/locales/fa.po
@@ -31187,16 +31187,16 @@ msgid "The location of your git repository, e.g. https://github.com/acme-inco/me
 msgstr "محل مخزن گیت شما، مثلاً https://github.com/acme-inco/metabase.git"
 
 #: metabase_enterprise/remote_sync/settings.clj:46
-msgid "Git synchronization type - :development or :production"
-msgstr "نوع همگام‌سازی گیت - :development یا :production"
+msgid "Git synchronization type - :read-write or :read-only"
+msgstr "نوع همگام‌سازی گیت - :read-write یا :read-only"
 
 #: metabase_enterprise/remote_sync/settings.clj:62
-msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :production."
-msgstr "اینکه آیا به طور خودکار از مخزن گیت ریموت وارد شود یا خیر. فقط در صورتی اعمال می‌شود که remote-sync-type برابر با :production باشد."
+msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :read-only."
+msgstr "اینکه آیا به طور خودکار از مخزن گیت ریموت وارد شود یا خیر. فقط در صورتی اعمال می‌شود که remote-sync-type برابر با :read-only باشد."
 
 #: metabase_enterprise/remote_sync/settings.clj:70
-msgid "If remote-sync-type is :production and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
-msgstr "اگر remote-sync-type برابر با :production باشد و remote-sync-auto-import برابر با true باشد، نرخ (به دقیقه) برای بررسی به‌روزرسانی‌ها جهت وارد کردن. مقدار پیش‌فرض ۵ است."
+msgid "If remote-sync-type is :read-only and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
+msgstr "اگر remote-sync-type برابر با :read-only باشد و remote-sync-auto-import برابر با true باشد، نرخ (به دقیقه) برای بررسی به‌روزرسانی‌ها جهت وارد کردن. مقدار پیش‌فرض ۵ است."
 
 #: metabase_enterprise/remote_sync/settings.clj:78
 msgid "The maximum amount of time a remote sync task will be given to complete"

--- a/locales/fi.po
+++ b/locales/fi.po
@@ -31190,16 +31190,16 @@ msgid "The location of your git repository, e.g. https://github.com/acme-inco/me
 msgstr "Git-arkistosi sijainti, esim. https://github.com/acme-inco/metabase.git"
 
 #: metabase_enterprise/remote_sync/settings.clj:46
-msgid "Git synchronization type - :development or :production"
-msgstr "Git-synkronointityyppi - :development tai :production"
+msgid "Git synchronization type - :read-write or :read-only"
+msgstr "Git-synkronointityyppi - :read-write tai :read-only"
 
 #: metabase_enterprise/remote_sync/settings.clj:62
-msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :production."
-msgstr "Tuodaanko automaattisesti etä-git-arkistosta. Koskee vain, jos remote-sync-type on :production."
+msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :read-only."
+msgstr "Tuodaanko automaattisesti etä-git-arkistosta. Koskee vain, jos remote-sync-type on :read-only."
 
 #: metabase_enterprise/remote_sync/settings.clj:70
-msgid "If remote-sync-type is :production and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
-msgstr "Jos remote-sync-type on :production ja remote-sync-autoimport on true, tämä on taajuus (minuuteissa), jolla tuotavia päivityksiä tarkistetaan. Oletusarvo on 5."
+msgid "If remote-sync-type is :read-only and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
+msgstr "Jos remote-sync-type on :read-only ja remote-sync-autoimport on true, tämä on taajuus (minuuteissa), jolla tuotavia päivityksiä tarkistetaan. Oletusarvo on 5."
 
 #: metabase_enterprise/remote_sync/settings.clj:78
 msgid "The maximum amount of time a remote sync task will be given to complete"

--- a/locales/fr.po
+++ b/locales/fr.po
@@ -31183,15 +31183,15 @@ msgid "The location of your git repository, e.g. https://github.com/acme-inco/me
 msgstr "L'emplacement de votre dépôt git, par exemple https://github.com/acme-inco/metabase.git"
 
 #: metabase_enterprise/remote_sync/settings.clj:46
-msgid "Git synchronization type - :development or :production"
-msgstr "Type de synchronisation Git - :development ou :production"
+msgid "Git synchronization type - :read-write or :read-only"
+msgstr "Type de synchronisation Git - :read-write ou :read-only"
 
 #: metabase_enterprise/remote_sync/settings.clj:62
-msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :production."
+msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :read-only."
 msgstr "Importer automatiquement depuis le dépôt Git distant. S'applique uniquement si le type de synchronisation distante est : production."
 
 #: metabase_enterprise/remote_sync/settings.clj:70
-msgid "If remote-sync-type is :production and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
+msgid "If remote-sync-type is :read-only and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
 msgstr "Si remote-sync-type est : production et remote-sync-auto-import est vrai, la fréquence (en minutes) de vérification des mises à jour à importer est définie. La valeur par défaut est 5."
 
 #: metabase_enterprise/remote_sync/settings.clj:78

--- a/locales/he.po
+++ b/locales/he.po
@@ -31425,16 +31425,16 @@ msgid "The location of your git repository, e.g. https://github.com/acme-inco/me
 msgstr "מיקום מאגר ה-git שלך, לדוגמה https://github.com/acme-inco/metabase.git"
 
 #: metabase_enterprise/remote_sync/settings.clj:46
-msgid "Git synchronization type - :development or :production"
-msgstr "סוג סנכרון Git - :development או :production"
+msgid "Git synchronization type - :read-write or :read-only"
+msgstr "סוג סנכרון Git - :read-write או :read-only"
 
 #: metabase_enterprise/remote_sync/settings.clj:62
-msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :production."
-msgstr "האם לייבא אוטומטית ממאגר git מרוחק. חל רק אם remote-sync-type הוא :production."
+msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :read-only."
+msgstr "האם לייבא אוטומטית ממאגר git מרוחק. חל רק אם remote-sync-type הוא :read-only."
 
 #: metabase_enterprise/remote_sync/settings.clj:70
-msgid "If remote-sync-type is :production and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
-msgstr "אם remote-sync-type הוא :production ו- remote-sync-auto-import הוא true, זהו הקצב (בדקות) שבו יש לבדוק עדכונים לייבוא. ברירת המחדל היא 5."
+msgid "If remote-sync-type is :read-only and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
+msgstr "אם remote-sync-type הוא :read-only ו- remote-sync-auto-import הוא true, זהו הקצב (בדקות) שבו יש לבדוק עדכונים לייבוא. ברירת המחדל היא 5."
 
 #: metabase_enterprise/remote_sync/settings.clj:78
 msgid "The maximum amount of time a remote sync task will be given to complete"

--- a/locales/hu.po
+++ b/locales/hu.po
@@ -31184,16 +31184,16 @@ msgid "The location of your git repository, e.g. https://github.com/acme-inco/me
 msgstr "A git-tárház helye, pl. https://github.com/acme-inco/metabase.git"
 
 #: metabase_enterprise/remote_sync/settings.clj:46
-msgid "Git synchronization type - :development or :production"
-msgstr "Git szinkronizáció típusa - :development vagy :production"
+msgid "Git synchronization type - :read-write or :read-only"
+msgstr "Git szinkronizáció típusa - :read-write vagy :read-only"
 
 #: metabase_enterprise/remote_sync/settings.clj:62
-msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :production."
-msgstr "Automatikusan importáljon-e a távoli git repositoryból. Csak akkor érvényes, ha a remote-sync-type :production."
+msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :read-only."
+msgstr "Automatikusan importáljon-e a távoli git repositoryból. Csak akkor érvényes, ha a remote-sync-type :read-only."
 
 #: metabase_enterprise/remote_sync/settings.clj:70
-msgid "If remote-sync-type is :production and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
-msgstr "Ha a remote-sync-type :production és a remote-sync-autoimport igaz, akkor az importálandó frissítések ellenőrzésének gyakorisága (percben). Alapértelmezés szerint 5."
+msgid "If remote-sync-type is :read-only and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
+msgstr "Ha a remote-sync-type :read-only és a remote-sync-autoimport igaz, akkor az importálandó frissítések ellenőrzésének gyakorisága (percben). Alapértelmezés szerint 5."
 
 #: metabase_enterprise/remote_sync/settings.clj:78
 msgid "The maximum amount of time a remote sync task will be given to complete"

--- a/locales/id.po
+++ b/locales/id.po
@@ -31072,16 +31072,16 @@ msgid "The location of your git repository, e.g. https://github.com/acme-inco/me
 msgstr "Lokasi repositori git Anda, misalnya https://github.com/acme-inco/metabase.git"
 
 #: metabase_enterprise/remote_sync/settings.clj:46
-msgid "Git synchronization type - :development or :production"
-msgstr "Jenis sinkronisasi Git - :development atau :production"
+msgid "Git synchronization type - :read-write or :read-only"
+msgstr "Jenis sinkronisasi Git - :read-write atau :read-only"
 
 #: metabase_enterprise/remote_sync/settings.clj:62
-msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :production."
-msgstr "Apakah akan mengimpor secara otomatis dari repositori git jarak jauh. Hanya berlaku jika remote-sync-type adalah :production."
+msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :read-only."
+msgstr "Apakah akan mengimpor secara otomatis dari repositori git jarak jauh. Hanya berlaku jika remote-sync-type adalah :read-only."
 
 #: metabase_enterprise/remote_sync/settings.clj:70
-msgid "If remote-sync-type is :production and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
-msgstr "Jika remote-sync-type adalah :production dan remote-sync-auto-import adalah true, kecepatan (dalam menit) untuk memeriksa pembaruan yang akan diimpor. Nilai default adalah 5."
+msgid "If remote-sync-type is :read-only and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
+msgstr "Jika remote-sync-type adalah :read-only dan remote-sync-auto-import adalah true, kecepatan (dalam menit) untuk memeriksa pembaruan yang akan diimpor. Nilai default adalah 5."
 
 #: metabase_enterprise/remote_sync/settings.clj:78
 msgid "The maximum amount of time a remote sync task will be given to complete"

--- a/locales/it.po
+++ b/locales/it.po
@@ -31185,16 +31185,16 @@ msgid "The location of your git repository, e.g. https://github.com/acme-inco/me
 msgstr "La posizione del tuo repository git, ad esempio https://github.com/acme-inco/metabase.git"
 
 #: metabase_enterprise/remote_sync/settings.clj:46
-msgid "Git synchronization type - :development or :production"
+msgid "Git synchronization type - :read-write or :read-only"
 msgstr "Tipo di sincronizzazione Git: :sviluppo o :produzione"
 
 #: metabase_enterprise/remote_sync/settings.clj:62
-msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :production."
-msgstr "Se importare automaticamente dal repository git remoto. Applicabile solo se remote-sync-type è :production."
+msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :read-only."
+msgstr "Se importare automaticamente dal repository git remoto. Applicabile solo se remote-sync-type è :read-only."
 
 #: metabase_enterprise/remote_sync/settings.clj:70
-msgid "If remote-sync-type is :production and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
-msgstr "Se remote-sync-type è :production e remote-sync-auto-import è true, la frequenza (in minuti) con cui verificare la presenza di aggiornamenti da importare. Il valore predefinito è 5."
+msgid "If remote-sync-type is :read-only and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
+msgstr "Se remote-sync-type è :read-only e remote-sync-auto-import è true, la frequenza (in minuti) con cui verificare la presenza di aggiornamenti da importare. Il valore predefinito è 5."
 
 #: metabase_enterprise/remote_sync/settings.clj:78
 msgid "The maximum amount of time a remote sync task will be given to complete"

--- a/locales/ja.po
+++ b/locales/ja.po
@@ -31073,16 +31073,16 @@ msgid "The location of your git repository, e.g. https://github.com/acme-inco/me
 msgstr "Git リポジトリの場所 (例: https://github.com/acme-inco/metabase.git)"
 
 #: metabase_enterprise/remote_sync/settings.clj:46
-msgid "Git synchronization type - :development or :production"
-msgstr "Git 同期タイプ - :development または :production"
+msgid "Git synchronization type - :read-write or :read-only"
+msgstr "Git 同期タイプ - :read-write または :read-only"
 
 #: metabase_enterprise/remote_sync/settings.clj:62
-msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :production."
-msgstr "リモート Git リポジトリから自動的にインポートするかどうか。remote-sync-type が :production の場合にのみ適用されます。"
+msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :read-only."
+msgstr "リモート Git リポジトリから自動的にインポートするかどうか。remote-sync-type が :read-only の場合にのみ適用されます。"
 
 #: metabase_enterprise/remote_sync/settings.clj:70
-msgid "If remote-sync-type is :production and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
-msgstr "remote-sync-type が :production で、remote-sync-auto-import が true の場合、インポートする更新をチェックする間隔（分単位）。デフォルトは 5 です。"
+msgid "If remote-sync-type is :read-only and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
+msgstr "remote-sync-type が :read-only で、remote-sync-auto-import が true の場合、インポートする更新をチェックする間隔（分単位）。デフォルトは 5 です。"
 
 #: metabase_enterprise/remote_sync/settings.clj:78
 msgid "The maximum amount of time a remote sync task will be given to complete"

--- a/locales/ko.po
+++ b/locales/ko.po
@@ -31073,16 +31073,16 @@ msgid "The location of your git repository, e.g. https://github.com/acme-inco/me
 msgstr "Git 저장소의 위치(예: https://github.com/acme-inco/metabase.git)"
 
 #: metabase_enterprise/remote_sync/settings.clj:46
-msgid "Git synchronization type - :development or :production"
-msgstr "Git 동기화 유형 - :development 또는 :production"
+msgid "Git synchronization type - :read-write or :read-only"
+msgstr "Git 동기화 유형 - :read-write 또는 :read-only"
 
 #: metabase_enterprise/remote_sync/settings.clj:62
-msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :production."
-msgstr "원격 git 저장소에서 자동으로 가져올지 여부입니다. remote-sync-type이 :production인 경우에만 적용됩니다."
+msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :read-only."
+msgstr "원격 git 저장소에서 자동으로 가져올지 여부입니다. remote-sync-type이 :read-only인 경우에만 적용됩니다."
 
 #: metabase_enterprise/remote_sync/settings.clj:70
-msgid "If remote-sync-type is :production and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
-msgstr "remote-sync-type이 :production이고 remote-sync-auto-import가 true인 경우, 가져올 업데이트를 확인하는 간격(분)입니다. 기본값은 5입니다."
+msgid "If remote-sync-type is :read-only and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
+msgstr "remote-sync-type이 :read-only이고 remote-sync-auto-import가 true인 경우, 가져올 업데이트를 확인하는 간격(분)입니다. 기본값은 5입니다."
 
 #: metabase_enterprise/remote_sync/settings.clj:78
 msgid "The maximum amount of time a remote sync task will be given to complete"

--- a/locales/lv.po
+++ b/locales/lv.po
@@ -31296,16 +31296,16 @@ msgid "The location of your git repository, e.g. https://github.com/acme-inco/me
 msgstr "Jūsu git repozitorija atrašanās vieta, piemēram, https://github.com/acme-inco/metabase.git"
 
 #: metabase_enterprise/remote_sync/settings.clj:46
-msgid "Git synchronization type - :development or :production"
-msgstr "Git sinhronizācijas veids — :development vai :production"
+msgid "Git synchronization type - :read-write or :read-only"
+msgstr "Git sinhronizācijas veids — :read-write vai :read-only"
 
 #: metabase_enterprise/remote_sync/settings.clj:62
-msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :production."
-msgstr "Vai automātiski importēt no attālā git repozitorija. Attiecas tikai tad, ja remote-sync-type ir :production."
+msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :read-only."
+msgstr "Vai automātiski importēt no attālā git repozitorija. Attiecas tikai tad, ja remote-sync-type ir :read-only."
 
 #: metabase_enterprise/remote_sync/settings.clj:70
-msgid "If remote-sync-type is :production and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
-msgstr "Ja remote-sync-type ir :production un remote-sync-autoimport ir true, ātrums (minūtēs), ar kādu pārbaudīt importējamos atjauninājumus. Noklusējuma vērtība ir 5."
+msgid "If remote-sync-type is :read-only and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
+msgstr "Ja remote-sync-type ir :read-only un remote-sync-autoimport ir true, ātrums (minūtēs), ar kādu pārbaudīt importējamos atjauninājumus. Noklusējuma vērtība ir 5."
 
 #: metabase_enterprise/remote_sync/settings.clj:78
 msgid "The maximum amount of time a remote sync task will be given to complete"

--- a/locales/metabase.po
+++ b/locales/metabase.po
@@ -32760,18 +32760,18 @@ msgid ""
 msgstr ""
 
 #: metabase_enterprise/remote_sync/settings.clj:46
-msgid "Git synchronization type - :development or :production"
+msgid "Git synchronization type - :read-write or :read-only"
 msgstr ""
 
 #: metabase_enterprise/remote_sync/settings.clj:62
 msgid ""
 "Whether to automatically import from the remote git repository. Only applies "
-"if remote-sync-type is :production."
+"if remote-sync-type is :read-only."
 msgstr ""
 
 #: metabase_enterprise/remote_sync/settings.clj:70
 msgid ""
-"If remote-sync-type is :production and remote-sync-auto-import is true, the "
+"If remote-sync-type is :read-only and remote-sync-auto-import is true, the "
 "rate (in minutes) at which to check for updates to import. Defaults to 5."
 msgstr ""
 

--- a/locales/ms.po
+++ b/locales/ms.po
@@ -31110,15 +31110,15 @@ msgid "The location of your git repository, e.g. https://github.com/acme-inco/me
 msgstr "Lokasi repositori git anda, cth https://github.com/acme-inco/metabase.git"
 
 #: metabase_enterprise/remote_sync/settings.clj:46
-msgid "Git synchronization type - :development or :production"
+msgid "Git synchronization type - :read-write or :read-only"
 msgstr "Jenis penyegerakan Git - :pembangunan atau :pengeluaran"
 
 #: metabase_enterprise/remote_sync/settings.clj:62
-msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :production."
-msgstr "Sama ada untuk mengimport secara automatik dari repositori git jauh. Hanya terpakai jika remote-sync-type ialah :production."
+msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :read-only."
+msgstr "Sama ada untuk mengimport secara automatik dari repositori git jauh. Hanya terpakai jika remote-sync-type ialah :read-only."
 
 #: metabase_enterprise/remote_sync/settings.clj:70
-msgid "If remote-sync-type is :production and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
+msgid "If remote-sync-type is :read-only and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
 msgstr "Jika remote-sync-type ialah : production dan remote-sync-auto-import adalah benar, kadar (dalam minit) untuk menyemak kemas kini untuk diimport. Lalai kepada 5."
 
 #: metabase_enterprise/remote_sync/settings.clj:78

--- a/locales/nb.po
+++ b/locales/nb.po
@@ -31182,16 +31182,16 @@ msgid "The location of your git repository, e.g. https://github.com/acme-inco/me
 msgstr "Plasseringen til git-depotet ditt, f.eks. https://github.com/acme-inco/metabase.git"
 
 #: metabase_enterprise/remote_sync/settings.clj:46
-msgid "Git synchronization type - :development or :production"
-msgstr "Git-synkroniseringstype - :development eller :production"
+msgid "Git synchronization type - :read-write or :read-only"
+msgstr "Git-synkroniseringstype - :read-write eller :read-only"
 
 #: metabase_enterprise/remote_sync/settings.clj:62
-msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :production."
-msgstr "Om det skal importeres automatisk fra det eksterne git-depotet. Gjelder bare hvis remote-sync-type er :production."
+msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :read-only."
+msgstr "Om det skal importeres automatisk fra det eksterne git-depotet. Gjelder bare hvis remote-sync-type er :read-only."
 
 #: metabase_enterprise/remote_sync/settings.clj:70
-msgid "If remote-sync-type is :production and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
-msgstr "Hvis remote-sync-type er :production og remote-sync-auto-import er true, hastigheten (i minutter) som skal brukes for å se etter oppdateringer som skal importeres. Standardverdien er 5."
+msgid "If remote-sync-type is :read-only and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
+msgstr "Hvis remote-sync-type er :read-only og remote-sync-auto-import er true, hastigheten (i minutter) som skal brukes for å se etter oppdateringer som skal importeres. Standardverdien er 5."
 
 #: metabase_enterprise/remote_sync/settings.clj:78
 msgid "The maximum amount of time a remote sync task will be given to complete"

--- a/locales/nl.po
+++ b/locales/nl.po
@@ -31186,16 +31186,16 @@ msgid "The location of your git repository, e.g. https://github.com/acme-inco/me
 msgstr "De locatie van uw git-repository, bijvoorbeeld https://github.com/acme-inco/metabase.git"
 
 #: metabase_enterprise/remote_sync/settings.clj:46
-msgid "Git synchronization type - :development or :production"
+msgid "Git synchronization type - :read-write or :read-only"
 msgstr "Git-synchronisatietype - :ontwikkeling of :productie"
 
 #: metabase_enterprise/remote_sync/settings.clj:62
-msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :production."
-msgstr "Of er automatisch geïmporteerd moet worden vanuit de externe Git-repository. Alleen van toepassing als remote-sync-type :production is."
+msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :read-only."
+msgstr "Of er automatisch geïmporteerd moet worden vanuit de externe Git-repository. Alleen van toepassing als remote-sync-type :read-only is."
 
 #: metabase_enterprise/remote_sync/settings.clj:70
-msgid "If remote-sync-type is :production and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
-msgstr "Als remote-sync-type :production is en remote-sync-auto-import true is, is dit de frequentie (in minuten) waarmee wordt gecontroleerd op updates voor import. Standaardwaarde is 5."
+msgid "If remote-sync-type is :read-only and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
+msgstr "Als remote-sync-type :read-only is en remote-sync-auto-import true is, is dit de frequentie (in minuten) waarmee wordt gecontroleerd op updates voor import. Standaardwaarde is 5."
 
 #: metabase_enterprise/remote_sync/settings.clj:78
 msgid "The maximum amount of time a remote sync task will be given to complete"

--- a/locales/pl.po
+++ b/locales/pl.po
@@ -31421,16 +31421,16 @@ msgid "The location of your git repository, e.g. https://github.com/acme-inco/me
 msgstr "Lokalizacja Twojego repozytorium Git, np. https://github.com/acme-inco/metabase.git"
 
 #: metabase_enterprise/remote_sync/settings.clj:46
-msgid "Git synchronization type - :development or :production"
-msgstr "Typ synchronizacji Git - :development lub :production"
+msgid "Git synchronization type - :read-write or :read-only"
+msgstr "Typ synchronizacji Git - :read-write lub :read-only"
 
 #: metabase_enterprise/remote_sync/settings.clj:62
-msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :production."
-msgstr "Czy automatycznie importować ze zdalnego repozytorium Git. Dotyczy tylko sytuacji, gdy remote-sync-type to :production."
+msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :read-only."
+msgstr "Czy automatycznie importować ze zdalnego repozytorium Git. Dotyczy tylko sytuacji, gdy remote-sync-type to :read-only."
 
 #: metabase_enterprise/remote_sync/settings.clj:70
-msgid "If remote-sync-type is :production and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
-msgstr "Jeśli remote-sync-type ma wartość :production, a remote-sync-auto-import ma wartość true, określa częstotliwość (w minutach) sprawdzania dostępności aktualizacji do zaimportowania. Domyślnie 5."
+msgid "If remote-sync-type is :read-only and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
+msgstr "Jeśli remote-sync-type ma wartość :read-only, a remote-sync-auto-import ma wartość true, określa częstotliwość (w minutach) sprawdzania dostępności aktualizacji do zaimportowania. Domyślnie 5."
 
 #: metabase_enterprise/remote_sync/settings.clj:78
 msgid "The maximum amount of time a remote sync task will be given to complete"

--- a/locales/pt-BR.po
+++ b/locales/pt-BR.po
@@ -31173,16 +31173,16 @@ msgid "The location of your git repository, e.g. https://github.com/acme-inco/me
 msgstr "A localização do seu repositório git, por exemplo https://github.com/acme-inco/metabase.git"
 
 #: metabase_enterprise/remote_sync/settings.clj:46
-msgid "Git synchronization type - :development or :production"
-msgstr "Tipo de sincronização do Git - :development ou :production"
+msgid "Git synchronization type - :read-write or :read-only"
+msgstr "Tipo de sincronização do Git - :read-write ou :read-only"
 
 #: metabase_enterprise/remote_sync/settings.clj:62
-msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :production."
-msgstr "Importar automaticamente do repositório git remoto. Aplicável somente se remote-sync-type for :production."
+msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :read-only."
+msgstr "Importar automaticamente do repositório git remoto. Aplicável somente se remote-sync-type for :read-only."
 
 #: metabase_enterprise/remote_sync/settings.clj:70
-msgid "If remote-sync-type is :production and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
-msgstr "Se remote-sync-type for :production e remote-sync-auto-import for true, a taxa (em minutos) de verificação de atualizações para importação. O padrão é 5."
+msgid "If remote-sync-type is :read-only and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
+msgstr "Se remote-sync-type for :read-only e remote-sync-auto-import for true, a taxa (em minutos) de verificação de atualizações para importação. O padrão é 5."
 
 #: metabase_enterprise/remote_sync/settings.clj:78
 msgid "The maximum amount of time a remote sync task will be given to complete"

--- a/locales/ru.po
+++ b/locales/ru.po
@@ -31419,16 +31419,16 @@ msgid "The location of your git repository, e.g. https://github.com/acme-inco/me
 msgstr "Расположение вашего git-репозитория, например https://github.com/acme-inco/metabase.git"
 
 #: metabase_enterprise/remote_sync/settings.clj:46
-msgid "Git synchronization type - :development or :production"
-msgstr "Тип синхронизации Git - :development или :production"
+msgid "Git synchronization type - :read-write or :read-only"
+msgstr "Тип синхронизации Git - :read-write или :read-only"
 
 #: metabase_enterprise/remote_sync/settings.clj:62
-msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :production."
-msgstr "Автоматически импортировать данные из удалённого репозитория Git. Применяется только если remote-sync-type — :production."
+msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :read-only."
+msgstr "Автоматически импортировать данные из удалённого репозитория Git. Применяется только если remote-sync-type — :read-only."
 
 #: metabase_enterprise/remote_sync/settings.clj:70
-msgid "If remote-sync-type is :production and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
-msgstr "Если для remote-sync-type задано значение :production, а для remote-sync-auto-import — значение true, то частота (в минутах) проверки наличия обновлений для импорта. Значение по умолчанию — 5."
+msgid "If remote-sync-type is :read-only and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
+msgstr "Если для remote-sync-type задано значение :read-only, а для remote-sync-auto-import — значение true, то частота (в минутах) проверки наличия обновлений для импорта. Значение по умолчанию — 5."
 
 #: metabase_enterprise/remote_sync/settings.clj:78
 msgid "The maximum amount of time a remote sync task will be given to complete"

--- a/locales/sk.po
+++ b/locales/sk.po
@@ -31422,16 +31422,16 @@ msgid "The location of your git repository, e.g. https://github.com/acme-inco/me
 msgstr "Umiestnenie vášho git repozitára, napr. https://github.com/acme-inco/metabase.git"
 
 #: metabase_enterprise/remote_sync/settings.clj:46
-msgid "Git synchronization type - :development or :production"
-msgstr "Typ synchronizácie Gitu - :development alebo :production"
+msgid "Git synchronization type - :read-write or :read-only"
+msgstr "Typ synchronizácie Gitu - :read-write alebo :read-only"
 
 #: metabase_enterprise/remote_sync/settings.clj:62
-msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :production."
-msgstr "Či sa má automaticky importovať zo vzdialeného repozitára git. Platí iba v prípade, ak je remote-sync-type nastavený na :production."
+msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :read-only."
+msgstr "Či sa má automaticky importovať zo vzdialeného repozitára git. Platí iba v prípade, ak je remote-sync-type nastavený na :read-only."
 
 #: metabase_enterprise/remote_sync/settings.clj:70
-msgid "If remote-sync-type is :production and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
-msgstr "Ak je remote-sync-type nastavený na :production a remote-sync-auto-import je nastavený na true, frekvencia (v minútach), akou sa majú kontrolovať aktualizácie na import. Predvolená hodnota je 5."
+msgid "If remote-sync-type is :read-only and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
+msgstr "Ak je remote-sync-type nastavený na :read-only a remote-sync-auto-import je nastavený na true, frekvencia (v minútach), akou sa majú kontrolovať aktualizácie na import. Predvolená hodnota je 5."
 
 #: metabase_enterprise/remote_sync/settings.clj:78
 msgid "The maximum amount of time a remote sync task will be given to complete"

--- a/locales/sl.po
+++ b/locales/sl.po
@@ -31427,16 +31427,16 @@ msgid "The location of your git repository, e.g. https://github.com/acme-inco/me
 msgstr "Lokacija vašega git repozitorija, npr. https://github.com/acme-inco/metabase.git"
 
 #: metabase_enterprise/remote_sync/settings.clj:46
-msgid "Git synchronization type - :development or :production"
-msgstr "Vrsta sinhronizacije Gita - :development ali :production"
+msgid "Git synchronization type - :read-write or :read-only"
+msgstr "Vrsta sinhronizacije Gita - :read-write ali :read-only"
 
 #: metabase_enterprise/remote_sync/settings.clj:62
-msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :production."
-msgstr "Ali naj se samodejno uvozi iz oddaljenega repozitorija git. Velja samo, če je remote-sync-type :production."
+msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :read-only."
+msgstr "Ali naj se samodejno uvozi iz oddaljenega repozitorija git. Velja samo, če je remote-sync-type :read-only."
 
 #: metabase_enterprise/remote_sync/settings.clj:70
-msgid "If remote-sync-type is :production and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
-msgstr "Če je remote-sync-type nastavljen na :production in je remote-sync-auto-import nastavljen na true, je hitrost (v minutah), s katero se preverjajo posodobitve za uvoz. Privzeta vrednost je 5."
+msgid "If remote-sync-type is :read-only and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
+msgstr "Če je remote-sync-type nastavljen na :read-only in je remote-sync-auto-import nastavljen na true, je hitrost (v minutah), s katero se preverjajo posodobitve za uvoz. Privzeta vrednost je 5."
 
 #: metabase_enterprise/remote_sync/settings.clj:78
 msgid "The maximum amount of time a remote sync task will be given to complete"

--- a/locales/sq.po
+++ b/locales/sq.po
@@ -31191,16 +31191,16 @@ msgid "The location of your git repository, e.g. https://github.com/acme-inco/me
 msgstr "Vendndodhja e depos suaj git, p.sh. https://github.com/acme-inco/metabase.git"
 
 #: metabase_enterprise/remote_sync/settings.clj:46
-msgid "Git synchronization type - :development or :production"
-msgstr "Lloji i sinkronizimit Git - :development ose :production"
+msgid "Git synchronization type - :read-write or :read-only"
+msgstr "Lloji i sinkronizimit Git - :read-write ose :read-only"
 
 #: metabase_enterprise/remote_sync/settings.clj:62
-msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :production."
-msgstr "Nëse do të importohet automatikisht nga depoja e largët git. Vlen vetëm nëse remote-sync-type është :production."
+msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :read-only."
+msgstr "Nëse do të importohet automatikisht nga depoja e largët git. Vlen vetëm nëse remote-sync-type është :read-only."
 
 #: metabase_enterprise/remote_sync/settings.clj:70
-msgid "If remote-sync-type is :production and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
-msgstr "Nëse remote-sync-type është :production dhe remote-sync-auto-import është true, shpejtësia (në minuta) me të cilën duhet të kontrollohet për përditësime për t'u importuar. Vlera parazgjedhur është 5."
+msgid "If remote-sync-type is :read-only and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
+msgstr "Nëse remote-sync-type është :read-only dhe remote-sync-auto-import është true, shpejtësia (në minuta) me të cilën duhet të kontrollohet për përditësime për t'u importuar. Vlera parazgjedhur është 5."
 
 #: metabase_enterprise/remote_sync/settings.clj:78
 msgid "The maximum amount of time a remote sync task will be given to complete"

--- a/locales/sr.po
+++ b/locales/sr.po
@@ -31304,16 +31304,16 @@ msgid "The location of your git repository, e.g. https://github.com/acme-inco/me
 msgstr "Локација вашег гит репозиторијума, нпр. https://github.com/acme-inco/metabase.git"
 
 #: metabase_enterprise/remote_sync/settings.clj:46
-msgid "Git synchronization type - :development or :production"
-msgstr "Тип синхронизације Гита - :development или :production"
+msgid "Git synchronization type - :read-write or :read-only"
+msgstr "Тип синхронизације Гита - :read-write или :read-only"
 
 #: metabase_enterprise/remote_sync/settings.clj:62
-msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :production."
-msgstr "Да ли се аутоматски увози из удаљеног git репозиторијума. Примењује се само ако је remote-sync-type :production."
+msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :read-only."
+msgstr "Да ли се аутоматски увози из удаљеног git репозиторијума. Примењује се само ако је remote-sync-type :read-only."
 
 #: metabase_enterprise/remote_sync/settings.clj:70
-msgid "If remote-sync-type is :production and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
-msgstr "Ако је remote-sync-type :production и remote-sync-auto-import је тачно, брзина (у минутима) којом се проверавају ажурирања за увоз. Подразумевана вредност је 5."
+msgid "If remote-sync-type is :read-only and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
+msgstr "Ако је remote-sync-type :read-only и remote-sync-auto-import је тачно, брзина (у минутима) којом се проверавају ажурирања за увоз. Подразумевана вредност је 5."
 
 #: metabase_enterprise/remote_sync/settings.clj:78
 msgid "The maximum amount of time a remote sync task will be given to complete"

--- a/locales/sv.po
+++ b/locales/sv.po
@@ -31173,16 +31173,16 @@ msgid "The location of your git repository, e.g. https://github.com/acme-inco/me
 msgstr "Platsen för ditt git-arkiv, t.ex. https://github.com/acme-inco/metabase.git"
 
 #: metabase_enterprise/remote_sync/settings.clj:46
-msgid "Git synchronization type - :development or :production"
-msgstr "Git-synkroniseringstyp - :development eller :production"
+msgid "Git synchronization type - :read-write or :read-only"
+msgstr "Git-synkroniseringstyp - :read-write eller :read-only"
 
 #: metabase_enterprise/remote_sync/settings.clj:62
-msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :production."
-msgstr "Huruvida import ska ske automatiskt från det fjärrstyrda git-arkivet. Gäller endast om remote-sync-type är :production."
+msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :read-only."
+msgstr "Huruvida import ska ske automatiskt från det fjärrstyrda git-arkivet. Gäller endast om remote-sync-type är :read-only."
 
 #: metabase_enterprise/remote_sync/settings.clj:70
-msgid "If remote-sync-type is :production and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
-msgstr "Om remote-sync-type är :production och remote-sync-auto-import är sant, anges hastigheten (i minuter) med vilken uppdateringar ska kontrolleras för import. Standardvärdet är 5."
+msgid "If remote-sync-type is :read-only and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
+msgstr "Om remote-sync-type är :read-only och remote-sync-auto-import är sant, anges hastigheten (i minuter) med vilken uppdateringar ska kontrolleras för import. Standardvärdet är 5."
 
 #: metabase_enterprise/remote_sync/settings.clj:78
 msgid "The maximum amount of time a remote sync task will be given to complete"

--- a/locales/tr.po
+++ b/locales/tr.po
@@ -31187,16 +31187,16 @@ msgid "The location of your git repository, e.g. https://github.com/acme-inco/me
 msgstr "Git deponuzun konumu, örneğin https://github.com/acme-inco/metabase.git"
 
 #: metabase_enterprise/remote_sync/settings.clj:46
-msgid "Git synchronization type - :development or :production"
-msgstr "Git senkronizasyon türü - :development veya :production"
+msgid "Git synchronization type - :read-write or :read-only"
+msgstr "Git senkronizasyon türü - :read-write veya :read-only"
 
 #: metabase_enterprise/remote_sync/settings.clj:62
-msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :production."
-msgstr "Uzak git deposundan otomatik olarak içe aktarılıp aktarılmayacağı. Yalnızca uzak-senkronizasyon-türü :production ise geçerlidir."
+msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :read-only."
+msgstr "Uzak git deposundan otomatik olarak içe aktarılıp aktarılmayacağı. Yalnızca uzak-senkronizasyon-türü :read-only ise geçerlidir."
 
 #: metabase_enterprise/remote_sync/settings.clj:70
-msgid "If remote-sync-type is :production and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
-msgstr "Uzaktan eşitleme türü :production ve uzaktan eşitleme otomatik içe aktarma doğruysa, içe aktarma güncellemelerini kontrol etme hızı (dakika cinsinden). Varsayılanı 5'tir."
+msgid "If remote-sync-type is :read-only and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
+msgstr "Uzaktan eşitleme türü :read-only ve uzaktan eşitleme otomatik içe aktarma doğruysa, içe aktarma güncellemelerini kontrol etme hızı (dakika cinsinden). Varsayılanı 5'tir."
 
 #: metabase_enterprise/remote_sync/settings.clj:78
 msgid "The maximum amount of time a remote sync task will be given to complete"

--- a/locales/uk.po
+++ b/locales/uk.po
@@ -31420,16 +31420,16 @@ msgid "The location of your git repository, e.g. https://github.com/acme-inco/me
 msgstr "Розташування вашого git-репозиторію, наприклад https://github.com/acme-inco/metabase.git"
 
 #: metabase_enterprise/remote_sync/settings.clj:46
-msgid "Git synchronization type - :development or :production"
-msgstr "Тип синхронізації Git — :development або :production"
+msgid "Git synchronization type - :read-write or :read-only"
+msgstr "Тип синхронізації Git — :read-write або :read-only"
 
 #: metabase_enterprise/remote_sync/settings.clj:62
-msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :production."
-msgstr "Чи слід автоматично імпортувати з віддаленого репозиторію git. Застосовується лише якщо remote-sync-type має значення :production."
+msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :read-only."
+msgstr "Чи слід автоматично імпортувати з віддаленого репозиторію git. Застосовується лише якщо remote-sync-type має значення :read-only."
 
 #: metabase_enterprise/remote_sync/settings.clj:70
-msgid "If remote-sync-type is :production and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
-msgstr "Якщо remote-sync-type має значення :production, а remote-sync-auto-import має значення true, то це означає частоту (у хвилинах), з якою слід перевіряти наявність оновлень для імпорту. Значення за замовчуванням — 5."
+msgid "If remote-sync-type is :read-only and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
+msgstr "Якщо remote-sync-type має значення :read-only, а remote-sync-auto-import має значення true, то це означає частоту (у хвилинах), з якою слід перевіряти наявність оновлень для імпорту. Значення за замовчуванням — 5."
 
 #: metabase_enterprise/remote_sync/settings.clj:78
 msgid "The maximum amount of time a remote sync task will be given to complete"

--- a/locales/vi.po
+++ b/locales/vi.po
@@ -31069,16 +31069,16 @@ msgid "The location of your git repository, e.g. https://github.com/acme-inco/me
 msgstr "Vị trí kho lưu trữ git của bạn, ví dụ: https://github.com/acme-inco/metabase.git"
 
 #: metabase_enterprise/remote_sync/settings.clj:46
-msgid "Git synchronization type - :development or :production"
-msgstr "Loại đồng bộ hóa Git - :development hoặc :production"
+msgid "Git synchronization type - :read-write or :read-only"
+msgstr "Loại đồng bộ hóa Git - :read-write hoặc :read-only"
 
 #: metabase_enterprise/remote_sync/settings.clj:62
-msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :production."
-msgstr "Có nên tự động nhập từ kho lưu trữ git từ xa hay không. Chỉ áp dụng nếu remote-sync-type là :production."
+msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :read-only."
+msgstr "Có nên tự động nhập từ kho lưu trữ git từ xa hay không. Chỉ áp dụng nếu remote-sync-type là :read-only."
 
 #: metabase_enterprise/remote_sync/settings.clj:70
-msgid "If remote-sync-type is :production and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
-msgstr "Nếu remote-sync-type là :production và remote-sync-auto-import là true, thì tốc độ (tính bằng phút) để kiểm tra các bản cập nhật cần nhập. Mặc định là 5."
+msgid "If remote-sync-type is :read-only and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
+msgstr "Nếu remote-sync-type là :read-only và remote-sync-auto-import là true, thì tốc độ (tính bằng phút) để kiểm tra các bản cập nhật cần nhập. Mặc định là 5."
 
 #: metabase_enterprise/remote_sync/settings.clj:78
 msgid "The maximum amount of time a remote sync task will be given to complete"

--- a/locales/zh-CN.po
+++ b/locales/zh-CN.po
@@ -31072,16 +31072,16 @@ msgid "The location of your git repository, e.g. https://github.com/acme-inco/me
 msgstr "您的 git 存储库的位置，例如 https://github.com/acme-inco/metabase.git"
 
 #: metabase_enterprise/remote_sync/settings.clj:46
-msgid "Git synchronization type - :development or :production"
-msgstr "Git 同步类型 - :development 或 :production"
+msgid "Git synchronization type - :read-write or :read-only"
+msgstr "Git 同步类型 - :read-write 或 :read-only"
 
 #: metabase_enterprise/remote_sync/settings.clj:62
-msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :production."
-msgstr "是否自动从远程 git 仓库导入。仅当 remote-sync-type 为 :production 时有效。"
+msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :read-only."
+msgstr "是否自动从远程 git 仓库导入。仅当 remote-sync-type 为 :read-only 时有效。"
 
 #: metabase_enterprise/remote_sync/settings.clj:70
-msgid "If remote-sync-type is :production and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
-msgstr "如果 remote-sync-type 为 :production 且 remote-sync-auto-import 为 true，则指定检查导入更新的频率（以分钟为单位）。默认为 5。"
+msgid "If remote-sync-type is :read-only and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
+msgstr "如果 remote-sync-type 为 :read-only 且 remote-sync-auto-import 为 true，则指定检查导入更新的频率（以分钟为单位）。默认为 5。"
 
 #: metabase_enterprise/remote_sync/settings.clj:78
 msgid "The maximum amount of time a remote sync task will be given to complete"

--- a/locales/zh-HK.po
+++ b/locales/zh-HK.po
@@ -31065,16 +31065,16 @@ msgid "The location of your git repository, e.g. https://github.com/acme-inco/me
 msgstr "您的 git 倉庫位置，例如 https://github.com/acme-inco/metabase.git"
 
 #: metabase_enterprise/remote_sync/settings.clj:46
-msgid "Git synchronization type - :development or :production"
+msgid "Git synchronization type - :read-write or :read-only"
 msgstr "Git 同步類型 - :開發或 :生產"
 
 #: metabase_enterprise/remote_sync/settings.clj:62
-msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :production."
-msgstr "是否自動從遠端 git 倉庫匯入。僅適用於 remote-sync-type 為 :production 時。"
+msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :read-only."
+msgstr "是否自動從遠端 git 倉庫匯入。僅適用於 remote-sync-type 為 :read-only 時。"
 
 #: metabase_enterprise/remote_sync/settings.clj:70
-msgid "If remote-sync-type is :production and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
-msgstr "如果 remote-sync-type 為 :production，且 remote-sync-auto-import 為 true，則為檢查要匯入更新的速率 (分鐘)。預設為 5。"
+msgid "If remote-sync-type is :read-only and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
+msgstr "如果 remote-sync-type 為 :read-only，且 remote-sync-auto-import 為 true，則為檢查要匯入更新的速率 (分鐘)。預設為 5。"
 
 #: metabase_enterprise/remote_sync/settings.clj:78
 msgid "The maximum amount of time a remote sync task will be given to complete"

--- a/locales/zh-TW.po
+++ b/locales/zh-TW.po
@@ -31059,16 +31059,16 @@ msgid "The location of your git repository, e.g. https://github.com/acme-inco/me
 msgstr "您的 git 儲存庫的位置，例如 https://github.com/acme-inco/metabase.git"
 
 #: metabase_enterprise/remote_sync/settings.clj:46
-msgid "Git synchronization type - :development or :production"
-msgstr "Git 同步型別 - :development 或 :production"
+msgid "Git synchronization type - :read-write or :read-only"
+msgstr "Git 同步型別 - :read-write 或 :read-only"
 
 #: metabase_enterprise/remote_sync/settings.clj:62
-msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :production."
-msgstr "是否自動從遠端 git 倉庫匯入。僅當 remote-sync-type 為 :production 時有效。"
+msgid "Whether to automatically import from the remote git repository. Only applies if remote-sync-type is :read-only."
+msgstr "是否自動從遠端 git 倉庫匯入。僅當 remote-sync-type 為 :read-only 時有效。"
 
 #: metabase_enterprise/remote_sync/settings.clj:70
-msgid "If remote-sync-type is :production and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
-msgstr "如果 remote-sync-type 為 :production 且 remote-sync-auto-import 為 true，則指定檢查導入更新的頻率（以分鐘為單位）。預設為 5。"
+msgid "If remote-sync-type is :read-only and remote-sync-auto-import is true, the rate (in minutes) at which to check for updates to import. Defaults to 5."
+msgstr "如果 remote-sync-type 為 :read-only 且 remote-sync-auto-import 為 true，則指定檢查導入更新的頻率（以分鐘為單位）。預設為 5。"
 
 #: metabase_enterprise/remote_sync/settings.clj:78
 msgid "The maximum amount of time a remote sync task will be given to complete"

--- a/resources/migrations/057_update_migrations.yaml
+++ b/resources/migrations/057_update_migrations.yaml
@@ -2459,6 +2459,28 @@ databaseChangeLog:
             constraintName: fk_transform_ref_creator_id
             onDelete: CASCADE
 
+  - changeSet:
+      id: v57.2025-11-13T22:27:19
+      author: nvoxland
+      comment: Update old remote-sync settings
+      changes:
+        - update:
+            tableName: setting
+            columns:
+              - column:
+                  name: value
+                  value: 'read-write'
+            where: key='remote-sync-type' and value='development'
+        - update:
+            tableName: setting
+            columns:
+              - column:
+                  name: value
+                  value: 'read-only'
+            where: key='remote-sync-type' and value='production'
+
+
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/057_update_migrations.yaml
+++ b/resources/migrations/057_update_migrations.yaml
@@ -2464,22 +2464,73 @@ databaseChangeLog:
       author: nvoxland
       comment: Update old remote-sync settings
       changes:
-        - update:
-            tableName: setting
-            columns:
-              - column:
-                  name: value
-                  value: 'read-write'
-            where: key='remote-sync-type' and value='development'
-        - update:
-            tableName: setting
-            columns:
-              - column:
-                  name: value
-                  value: 'read-only'
-            where: key='remote-sync-type' and value='production'
+        - sql:
+            dbms: mariadb,mysql
+            splitStatements: true
+            sql: |
+                UPDATE setting
+                SET value = 'read-write'
+                WHERE `key`='remote-sync-type' AND value='development';
 
+                UPDATE setting
+                SET value = 'read-only'
+                WHERE `key`='remote-sync-type' AND value='production';
+        - sql:
+            dbms: postgresql
+            splitStatements: true
+            sql: |
+                UPDATE setting
+                SET value = 'read-write'
+                WHERE key='remote-sync-type' AND value='development';
 
+                UPDATE setting
+                SET value = 'read-only'
+                WHERE key='remote-sync-type' AND value='production';
+        - sql:
+            dbms: h2
+            splitStatements: true
+            sql: |
+                UPDATE setting
+                SET "VALUE" = 'read-write'
+                WHERE "KEY"='remote-sync-type' AND "VALUE"='development';
+
+                UPDATE setting
+                SET "VALUE" = 'read-only'
+                WHERE "KEY"='remote-sync-type' AND "VALUE"='production';
+      rollback:
+        - sql:
+            dbms: mariadb,mysql
+            splitStatements: true
+            sql: |
+              UPDATE setting
+              SET value = 'development'
+              WHERE `key`='remote-sync-type' AND value='read-write';
+
+              UPDATE setting
+              SET value = 'production'
+              WHERE `key`='remote-sync-type' AND value='read-only';
+        - sql:
+            dbms: postgresql
+            splitStatements: true
+            sql: |
+              UPDATE setting
+              SET value = 'development'
+              WHERE key='remote-sync-type' AND value='read-write';
+
+              UPDATE setting
+              SET value = 'production'
+              WHERE key='remote-sync-type' AND value='read-only';
+        - sql:
+            dbms: h2
+            splitStatements: true
+            sql: |
+              UPDATE setting
+              SET "VALUE" = 'development'
+              WHERE "KEY"='remote-sync-type' AND "VALUE"='read-write';
+
+              UPDATE setting
+              SET "VALUE" = 'production'
+              WHERE "KEY"='remote-sync-type' AND "VALUE"='read-only';
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/src/metabase/permissions/models/permissions.clj
+++ b/src/metabase/permissions/models/permissions.clj
@@ -282,7 +282,7 @@
           (remote-sync/collection-editable? (or (:collection instance) (:collection_id instance))))
     (perms-objects-set-for-parent-collection instance read-or-write)
     ;; We need to return a dummy permissions string that cannot possibly be long to a user in
-    ;; the case where an instance is not syncable due to remote-sync being in ':production' mode
+    ;; the case where an instance is not syncable due to remote-sync being in ':read-only' mode
     #{"___no-remote-sync-access"}))
 
 (methodical/defmethod t2/batched-hydrate [:perms/use-parent-collection-perms :can_write]


### PR DESCRIPTION
### Description

Instead of "Development" and "Prodution" use "Read-Write" and "Read-Only"

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
