### PR TITLE
Fix having to update table datasource to metabase-transform

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/transforms/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/util.clj
@@ -162,10 +162,13 @@
 (defn activate-table-and-mark-computed!
   "Activate table for `target` in `database` in the app db."
   [database target]
-  (sync-table! database (assoc target
-                               :data_authority :computed
-                               :data_source :metabase-transform)
-               {:create? true}))
+  (when-let [table (sync-table! database (assoc target
+                                                :data_authority :computed
+                                                :data_source :metabase-transform)
+                                {:create? true})]
+    (when-not (:active table)
+      (t2/update! :model/Table (:id table) {:active true}))
+    table))
 
 (defn deactivate-table!
   "Deactivate table for `target` in `database` in the app db."

--- a/enterprise/backend/src/metabase_enterprise/transforms/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/util.clj
@@ -155,7 +155,7 @@
   ([database target {:keys [create?]}]
    (when-let [table (or (target-table (:id database) target)
                         (when create?
-                          (sync/create-table! database (select-keys target [:schema :name :data_source]))))]
+                          (sync/create-table! database (select-keys target [:schema :name :data_source :data_authority]))))]
      (sync/sync-table! table)
      table)))
 

--- a/src/metabase/sync/sync_metadata/tables.clj
+++ b/src/metabase/sync/sync_metadata/tables.clj
@@ -141,7 +141,9 @@
            :display_name            (or (:display_name table)
                                         (humanization/name->human-readable-name (:name table)))
            :name                    (:name table)
-           :is_writable             (:is_writable table)}
+           :is_writable             (:is_writable table)
+           :data_source             (:data_source table)
+           :data_authority          (:data_authority table)}
           (when (:is_sample database)
             {:data_authority :ingested
              :data_source    :ingested}))))

--- a/src/metabase/sync/sync_metadata/tables.clj
+++ b/src/metabase/sync/sync_metadata/tables.clj
@@ -141,9 +141,11 @@
            :display_name            (or (:display_name table)
                                         (humanization/name->human-readable-name (:name table)))
            :name                    (:name table)
-           :is_writable             (:is_writable table)
-           :data_source             (:data_source table)
-           :data_authority          (:data_authority table)}
+           :is_writable             (:is_writable table)}
+          (when (:data_source table)
+            {:data_source (:data_source table)})
+          (when (:data_authority table)
+            {:data_authority (:data_authority table)})
           (when (:is_sample database)
             {:data_authority :ingested
              :data_source    :ingested}))))

--- a/src/metabase/warehouse_schema/models/table.clj
+++ b/src/metabase/warehouse_schema/models/table.clj
@@ -181,10 +181,6 @@
                       {:status-code 400})))
 
     ;; Prevent changing data_source to/from metabase-transform
-    ;; TODO DS 2025-11-13
-    ;;  this is as generic hook, but the policy is not (it only applies to update instructions via API calls)
-    ;;  - the transform target activation needs to set the data_source
-    ;;  - when a table is no longer a target we ought to be able to unset it
     (when (contains? changes :data_source)
       (let [original-data-source (:data_source original-table)
             new-data-source      (:data_source changes)]
@@ -192,8 +188,7 @@
                    (not= new-data-source :metabase-transform))
           (throw (ex-info "Cannot change data_source from metabase-transform"
                           {:status-code 400})))
-        (when (and (some? original-data-source)             ;; DS: this is wrong (See above note)
-                   (not= original-data-source :metabase-transform)
+        (when (and (not= original-data-source :metabase-transform)
                    (= new-data-source :metabase-transform))
           (throw (ex-info "Cannot set data_source to metabase-transform"
                           {:status-code 400})))))


### PR DESCRIPTION
transformed tables can be created with data-source=metabase-transform, it doesn't have to be updated

basically revert https://github.com/metabase/metabase/pull/65372/commits/53fcba55cb77925957b7e07ba10cd7834e658931 + cherry on top