### PR TITLE
Fix `dashboard.backgroundColor: transparent` breaking dashboard PDF export

### DIFF
--- a/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
+++ b/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
@@ -217,11 +217,13 @@ export const saveDashboardPdf = async ({
     headerHeight + parametersHeight + (includeBranding ? brandingHeight : 0);
   const contentHeight = gridNode.offsetHeight + verticalOffset;
 
-  let backgroundColor = Color(
-    getComputedStyle(document.documentElement)
-      .getPropertyValue("--mb-color-bg-dashboard")
-      .trim(),
-  ).hex();
+  const rawBackgroundColor = getComputedStyle(document.documentElement)
+    .getPropertyValue("--mb-color-bg-dashboard")
+    .trim();
+  let backgroundColor =
+    rawBackgroundColor === "transparent"
+      ? "transparent"
+      : Color(rawBackgroundColor).hex();
 
   if (!(await isValidColor(backgroundColor))) {
     backgroundColor = "white"; // Fallback to white if the color is invalid


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #65846
Closes EMB-1022

### Description

This was caused by https://github.com/metabase/metabase/pull/65099.

The reason is that `Color("transparent").hex()` is, you guess it! `#000000` great...

### How to verify

1. Run shoppy that connects to your local metabase e.g. `localhost:3000` you can use prod API and everything else, just make sure you use the same JWT secret as the production one.
2. Go to any dashboard, your local instance won't have the dashboard with the hard-coded entity ID, just change the URL to `/1` e.g. http://localhost:3004/admin/analytics/1
3. Export PDF from all 4 themes.


### Demo

[E-commerce Insights (10).pdf](https://github.com/user-attachments/files/23547565/E-commerce.Insights.10.pdf)


### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~ We don't have a reliable way to test PDF export yet :(
