### PR TITLE
Temporal incremental transforms

### DIFF
--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -4,11 +4,13 @@ title: Driver interface changelog
 
 # Driver Interface Changelog
 
+## Metabase 0.58.0
+
+- Added `metabase.driver/compile-insert` to implement incremental transforms.
+
 ## Metabase 0.57.0
 
 - `driver/field-reference-mlv2` is now deprecated, and is no longer used. Please remove your implementations.
-
-- Added `metabase.driver/compile-insert` to implement incremental transforms.
 
 - The key `metabase.driver-api.core/qp.add.nfc-path` is now more consistently populated; other `qp.add.*` keys no
   longer include parent column names for drivers like MongoDB -- use `qp.add.nfc-path` instead to qualify the

--- a/enterprise/backend/src/metabase_enterprise/transforms/execute.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/execute.clj
@@ -6,6 +6,7 @@
    [metabase.driver.util :as driver.u]
    [metabase.events.core :as events]
    [metabase.lib.schema.common :as schema.common]
+   [metabase.query-processor.compile :as qp.compile]
    [metabase.util.log :as log]
    [metabase.util.malli.registry :as mr]
    [toucan2.core :as t2]))
@@ -16,7 +17,7 @@
   [:map
    [:transform-type [:enum {:decode/normalize schema.common/normalize-keyword} :table :table-incremental]]
    [:conn-spec :any]
-   [:query :string]
+   [:query ::qp.compile/compiled]
    [:output-table [:keyword {:decode/normalize schema.common/normalize-keyword}]]])
 
 (mr/def ::transform-opts

--- a/enterprise/backend/src/metabase_enterprise/transforms/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/util.clj
@@ -292,17 +292,19 @@
   "Wrap a compiled native query with checkpoint filtering for native queries without explicit checkpoint tags.
 
   Generates SQL that wraps the original query as a subquery and filters by `checkpoint_filter > (checkpoint_query)`. "
-  [query driver {:keys [source-incremental-strategy] :as source} {checkpoint-query :query :as checkpoint}]
+  [outer-query driver {:keys [source-incremental-strategy] :as source} {checkpoint-query :query :as checkpoint}]
   (let [{:keys [checkpoint-filter]} source-incremental-strategy]
     (if (and (lib.query/native? (:query source))
              (not (get-in (:query source) [:stages 0 :template-tags "checkpoint"]))
              (next-checkpoint-value checkpoint))
-      (let [honeysql-query {:select [:*]
-                            :from [[[:raw (str "(" query ")")] :subquery]]
-                            :where [:> (h2x/identifier :field checkpoint-filter)
-                                    [:raw (str "(" (:query (qp.compile/compile checkpoint-query)) ")")]]}]
-        (first (sql.qp/format-honeysql driver honeysql-query)))
-      query)))
+      (let [wrap-query (fn [query]
+                         (let [honeysql-query {:select [:*]
+                                               :from [[[:raw (str "(" query ")")] :subquery]]
+                                               :where [:> (h2x/identifier :field checkpoint-filter)
+                                                       [:raw (str "(" (:query (qp.compile/compile checkpoint-query)) ")")]]}]
+                           (first (sql.qp/format-honeysql driver honeysql-query))))]
+        (update outer-query :query wrap-query))
+      outer-query)))
 
 (defn compile-source
   "Compile the source query of a transform to SQL, applying incremental filtering if required."
@@ -315,8 +317,7 @@
       (-> query
           (preprocess-incremental-query source-incremental-strategy checkpoint)
           massage-sql-query
-          qp.compile/compile-with-inline-parameters
-          :query
+          qp.compile/compile
           (post-process-incremental-query driver source checkpoint)))))
 
 (defn required-database-features

--- a/enterprise/backend/src/metabase_enterprise/transforms/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/util.clj
@@ -280,7 +280,7 @@
       ;; native query with explicit checkpoint filter
       (if (get-in query [:stages 0 :template-tags "checkpoint"])
         (update query :parameters conj
-                {:type :number
+                {:type :text
                  :target [:variable [:template-tag "checkpoint"]]
                  :value checkpoint-value})
         query)

--- a/enterprise/backend/src/metabase_enterprise/transforms/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/util.clj
@@ -280,7 +280,7 @@
       ;; native query with explicit checkpoint filter
       (if (get-in query [:stages 0 :template-tags "checkpoint"])
         (update query :parameters conj
-                {:type :text
+                {:type (if (number? checkpoint-value) :number :text)
                  :target [:variable [:template-tag "checkpoint"]]
                  :value checkpoint-value})
         query)

--- a/enterprise/frontend/src/metabase-enterprise/transforms/components/IncrementalTransform/IncrementalTransformSettings.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/components/IncrementalTransform/IncrementalTransformSettings.tsx
@@ -242,8 +242,8 @@ function SourceStrategyFields({
             <NativeQueryColumnSelect
               name="checkpointFilter"
               label={t`Source Filter Field`}
-              placeholder={t`e.g. id`}
-              description={t`Numeric column to use in the incremental filter`}
+              placeholder={t`e.g. id, created_at`}
+              description={t`Column to use in the incremental filter`}
               query={query as DatasetQuery}
             />
           )}

--- a/enterprise/frontend/src/metabase-enterprise/transforms/components/IncrementalTransform/KeysetColumnSelect/KeysetColumnSelect.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/components/IncrementalTransform/KeysetColumnSelect/KeysetColumnSelect.tsx
@@ -45,7 +45,10 @@ export function KeysetColumnSelect({
       const numericFilterableColumns = returnedColumns.filter((column) => {
         const info = Lib.displayInfo(query, stageIndex, column);
         const identifier = `${info.table?.name ?? "no-table"}:${info.name}`;
-        return filterableIdentifiers.has(identifier) && Lib.isNumeric(column);
+        return (
+          filterableIdentifiers.has(identifier) &&
+          (Lib.isNumeric(column) || Lib.isTemporal(column))
+        );
       });
 
       // Convert to select options with unique keys

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -867,13 +867,17 @@
 
 (defmethod driver/compile-transform :bigquery-cloud-sdk
   [_driver {:keys [query output-table]}]
-  (let [table-str (get-table-str output-table)]
-    [(format "CREATE OR REPLACE TABLE %s AS %s" table-str query)]))
+  (let [{sql-query :query sql-params :params} query
+        table-str (get-table-str output-table)]
+    [(format "CREATE OR REPLACE TABLE %s AS %s" table-str sql-query)
+     sql-params]))
 
 (defmethod driver/compile-insert :bigquery-cloud-sdk
   [_driver {:keys [query output-table]}]
-  (let [table-str (get-table-str output-table)]
-    [(format "INSERT INTO %s %s" table-str query)]))
+  (let [{sql-query :query sql-params :params} query
+        table-str (get-table-str output-table)]
+    [(format "INSERT INTO %s %s" table-str sql-query)
+     sql-params]))
 
 (defmethod driver/compile-drop-table :bigquery-cloud-sdk
   [_driver table]

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -1351,9 +1351,9 @@
   (mt/test-driver :bigquery-cloud-sdk
     (testing "compile-transform creates CREATE OR REPLACE TABLE"
       (is (= ["CREATE OR REPLACE TABLE `PRODUCTS_COPY` AS SELECT * FROM products"]
-             (driver/compile-transform :bigquery-cloud-sdk {:query "SELECT * FROM products"
+             (driver/compile-transform :bigquery-cloud-sdk {:query {:query "SELECT * FROM products"}
                                                             :output-table :PRODUCTS_COPY}))))
     (testing "compile-insert generates INSERT INTO"
       (is (= ["INSERT INTO `PRODUCTS_COPY` SELECT * FROM products"]
-             (driver/compile-insert :bigquery-cloud-sdk {:query "SELECT * FROM products"
+             (driver/compile-insert :bigquery-cloud-sdk {:query {:query "SELECT * FROM products"}
                                                          :output-table :PRODUCTS_COPY}))))))

--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
@@ -326,7 +326,7 @@
                 ;; i.e. only do this if we don't have a non-nullable field to use as a primary key?
                 (sql.qp/format-honeysql driver {:raw "ORDER BY ()"})
                 ["AS"]
-                [sql-query sql-params]]
+                (cond-> [sql-query] (seq sql-params) (conj sql-params))]
         sql (str/join " " (map first pieces))]
     (into [sql] (mapcat rest) pieces)))
 

--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
@@ -320,18 +320,21 @@
 
 (defmethod driver/compile-transform :clickhouse
   [driver {:keys [query output-table]}]
-  (let [pieces [(sql.qp/format-honeysql driver {:create-table output-table})
+  (let [{sql-query :query sql-params :params} query
+        pieces [(sql.qp/format-honeysql driver {:create-table output-table})
                 ;; TODO(rileythomp, 2025-08-22): Is there a better way to do this?
                 ;; i.e. only do this if we don't have a non-nullable field to use as a primary key?
                 (sql.qp/format-honeysql driver {:raw "ORDER BY ()"})
                 ["AS"]
-                (sql.qp/format-honeysql driver {:raw query})]
-        query (str/join " " (map first pieces))]
-    (into [query] (mapcat rest) pieces)))
+                [sql-query sql-params]]
+        sql (str/join " " (map first pieces))]
+    (into [sql] (mapcat rest) pieces)))
 
 (defmethod driver/compile-insert :clickhouse
   [driver {:keys [query output-table]}]
-  (sql.qp/format-honeysql driver {:insert-into [output-table {:raw query}]}))
+  (let [{sql-query :query sql-params :params} query]
+    [(first (sql.qp/format-honeysql driver {:insert-into [output-table {:raw sql-query}]}))
+     sql-params]))
 
 (defmethod driver/create-schema-if-needed! :clickhouse
   [driver conn-spec schema]

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
@@ -318,11 +318,11 @@
   (mt/test-driver :clickhouse
     (testing "compile-transform for clickhouse with empty primary key column"
       (is (= ["CREATE TABLE `PRODUCTS_COPY` ORDER BY () AS SELECT * FROM products"]
-             (driver/compile-transform :clickhouse {:query "SELECT * FROM products"
+             (driver/compile-transform :clickhouse {:query {:query "SELECT * FROM products"}
                                                     :output-table "PRODUCTS_COPY"}))))
     (testing "compile-insert generates INSERT INTO"
       (is (= ["INSERT INTO `PRODUCTS_COPY` SELECT * FROM products"]
-             (driver/compile-insert :clickhouse {:query "SELECT * FROM products"
+             (driver/compile-insert :clickhouse {:query {:query "SELECT * FROM products"}
                                                  :output-table "PRODUCTS_COPY"}))))))
 
 (deftest ^:parallel clickhouse-db-supports-schemas-test

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -1024,16 +1024,18 @@
 
 (defmethod driver/compile-transform :sqlserver
   [driver {:keys [query output-table]}]
-  (let [^String table-name (first (sql.qp/format-honeysql driver (keyword output-table)))
-        ^Select parsed-query (macaw/parsed-query query)
+  (let [{sql-query :query sql-params :params} query
+        ^String table-name (first (sql.qp/format-honeysql driver (keyword output-table)))
+        ^Select parsed-query (macaw/parsed-query sql-query)
         ^PlainSelect select-body (.getSelectBody parsed-query)]
     (.setIntoTables select-body [(Table. table-name)])
-    [(str parsed-query)]))
+    [(str parsed-query) sql-params]))
 
 (defmethod driver/compile-insert :sqlserver
   [driver {:keys [query output-table]}]
-  (let [^String table-name (first (sql.qp/format-honeysql driver (keyword output-table)))]
-    [(format "INSERT INTO %s %s" table-name query)]))
+  (let [{sql-query :query sql-params :params} query
+        ^String table-name (first (sql.qp/format-honeysql driver (keyword output-table)))]
+    [(format "INSERT INTO %s %s" table-name sql-query) sql-params]))
 
 (defmethod driver/table-exists? :sqlserver
   [driver database {:keys [schema name] :as _table}]

--- a/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
+++ b/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
@@ -776,9 +776,9 @@
   (mt/test-driver :sqlserver
     (testing "compile-transform creates SELECT INTO"
       (is (= ["SELECT * INTO [PRODUCTS_COPY] FROM products"]
-             (driver/compile-transform :sqlserver {:query "SELECT * FROM products"
+             (driver/compile-transform :sqlserver {:query {:query "SELECT * FROM products"}
                                                    :output-table "PRODUCTS_COPY"}))))
     (testing "compile-insert generates INSERT INTO"
       (is (= ["INSERT INTO [PRODUCTS_COPY] SELECT * FROM products"]
-             (driver/compile-insert :sqlserver {:query "SELECT * FROM products"
+             (driver/compile-insert :sqlserver {:query {:query "SELECT * FROM products"}
                                                 :output-table "PRODUCTS_COPY"}))))))

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -1171,7 +1171,7 @@
 
 (defmulti compile-insert
   "Compiles the sql for an insert statement (INSERT INTO ... SELECT), given a compiled inner sql query and a destination."
-  {:added "0.57.0", :arglists '([driver {:keys [query output-table]}])}
+  {:added "0.58.0", :arglists '([driver {:keys [query output-table]}])}
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)
 

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -1164,13 +1164,13 @@
   :hierarchy #'hierarchy)
 
 (defmulti compile-transform
-  "Compiles the sql for a transform statement (CREATE TABLE AS), given an inner sql query and a destination."
+  "Compiles the sql for a transform statement (CREATE TABLE AS), given a compiled inner sql query and a destination."
   {:added "0.57.0", :arglists '([driver {:keys [query output-table]}])}
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)
 
 (defmulti compile-insert
-  "Compiles the sql for an insert statement (INSERT INTO ... SELECT), given an inner sql query and a destination."
+  "Compiles the sql for an insert statement (INSERT INTO ... SELECT), given a compiled inner sql query and a destination."
   {:added "0.57.0", :arglists '([driver {:keys [query output-table]}])}
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -2064,14 +2064,18 @@
 
 (defmethod driver/compile-transform :sql
   [driver {:keys [query output-table]}]
-  (format-honeysql driver
-                   {:create-table-as [(keyword output-table)]
-                    :raw query}))
+  (let [{sql-query :query sql-params :params} query]
+    [(first (format-honeysql driver
+                             {:create-table-as [(keyword output-table)]
+                              :raw sql-query}))
+     sql-params]))
 
 (defmethod driver/compile-insert :sql
   [driver {:keys [query output-table]}]
-  (format-honeysql driver
-                   {:insert-into [(keyword output-table) {:raw query}]}))
+  (let [{sql-query :query sql-params :params} query]
+    [(first (format-honeysql driver
+                             {:insert-into [(keyword output-table) {:raw sql-query}]}))
+     sql-params]))
 
 (defmethod driver/compile-drop-table :sql
   [driver table]

--- a/test/metabase/driver/sql/transforms_test.clj
+++ b/test/metabase/driver/sql/transforms_test.clj
@@ -11,7 +11,7 @@
     (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
       (testing "simple table name"
         (let [result (driver/compile-transform driver/*driver*
-                                               {:query "SELECT * FROM products"
+                                               {:query {:query "SELECT * FROM products"}
                                                 :output-table :my_table
                                                 :primary-key "id"})]
           (testing "returns a vector"
@@ -28,7 +28,7 @@
 
       (testing "schema-qualified table name"
         (let [result (driver/compile-transform driver/*driver*
-                                               {:query "SELECT * FROM products"
+                                               {:query {:query "SELECT * FROM products"}
                                                 :output-table :my_schema/my_table
                                                 :primary-key "id"})]
           (testing "returns a vector"
@@ -82,7 +82,7 @@
   (testing "execute-transform! should pass correct format to execute-raw-queries!"
     (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
       (let [compile-result (driver/compile-transform driver/*driver*
-                                                     {:query "SELECT * FROM products"
+                                                     {:query {:query "SELECT * FROM products"}
                                                       :output-table :my_table
                                                       :primary-key "id"})
             drop-result (driver/compile-drop-table driver/*driver* :my_table)]
@@ -132,7 +132,7 @@
     (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
       (testing "simple table name"
         (let [result (driver/compile-insert driver/*driver*
-                                            {:query "SELECT * FROM products"
+                                            {:query {:query "SELECT * FROM products"}
                                              :output-table :my_table})]
           (testing "returns a vector"
             (is (vector? result)))
@@ -145,7 +145,7 @@
 
       (testing "schema-qualified table"
         (let [result (driver/compile-insert driver/*driver*
-                                            {:query "SELECT * FROM products"
+                                            {:query {:query "SELECT * FROM products"}
                                              :output-table :my_schema/my_table})]
           (testing "returns a vector"
             (is (vector? result)))


### PR DESCRIPTION
This PR moves transform compilation away from using `compile-with-inline-values`, which has truncation issues with timestamps, and into using regular compile. 
That in turn enables us to allow temporal checkpoints, instead of just numeric.

The test suite has been extended to include a matrix of different numeric and temporal checkpoints over the different transform types