### PR TITLE
Documents supporting text - Drag-and-drop

### DIFF
--- a/e2e/support/document-initial-data.ts
+++ b/e2e/support/document-initial-data.ts
@@ -163,3 +163,88 @@ export const DOCUMENT_WITH_THREE_CARDS_AND_COLUMNS = {
   ],
   type: "doc",
 };
+
+export const DOCUMENT_WITH_SUPPORTING_TEXT = {
+  type: "doc",
+  content: [
+    {
+      type: "resizeNode",
+      attrs: {
+        height: 350,
+        minHeight: 280,
+        _id: "1",
+      },
+      content: [
+        {
+          type: "flexContainer",
+          attrs: {
+            _id: "1a",
+            columnWidths: [33.33333333333333, 66.66666666666666],
+          },
+          content: [
+            {
+              type: "supportingText",
+              attrs: { _id: "1b" },
+              content: [
+                {
+                  type: "paragraph",
+                  attrs: { _id: "1c" },
+                  content: [
+                    {
+                      type: "text",
+                      text: "Lorem ipsum",
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: "cardEmbed",
+              attrs: {
+                id: ORDERS_QUESTION_ID,
+                name: null,
+                _id: "2a2",
+              },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      type: "paragraph",
+      content: [
+        {
+          type: "text",
+          text: "Standalone card below",
+        },
+      ],
+      attrs: {
+        _id: "3",
+      },
+    },
+    {
+      type: "resizeNode",
+      attrs: {
+        height: 350,
+        minHeight: 280,
+        _id: "4",
+      },
+      content: [
+        {
+          type: "cardEmbed",
+          attrs: {
+            id: ORDERS_COUNT_QUESTION_ID,
+            name: null,
+            _id: "4a",
+          },
+        },
+      ],
+    },
+    {
+      type: "paragraph",
+      attrs: {
+        _id: "5",
+      },
+    },
+  ],
+};

--- a/e2e/support/helpers/e2e-document-helpers.ts
+++ b/e2e/support/helpers/e2e-document-helpers.ts
@@ -109,33 +109,33 @@ const visitDocumentById = (id: DocumentId) => {
   cy.wait(`@${alias}`);
 };
 
-export function dragAndDropCardOnAnotherCard(
-  sourceCardTitle: string,
-  targetCardTitle: string,
-  {
-    side = "left",
-  }: {
-    side?: "left" | "right";
-  } = {},
-) {
-  // Perform drag and drop: drag sourceCard card onto targetCard
-  getDocumentCard(sourceCardTitle)
+export function documentsDragAndDrop({
+  getSource,
+  getTarget,
+  side = "left",
+}: {
+  getSource: () => Cypress.Chainable;
+  getTarget: () => Cypress.Chainable;
+  side?: "left" | "right";
+}) {
+  // Perform drag and drop: drag source onto target
+  getSource()
     .should("exist")
-    .then(($ordersCard) => {
-      getDocumentCard(targetCardTitle)
+    .then(($source) => {
+      getTarget()
         .should("exist")
-        .then(($ordersCountCard) => {
-          const sourceRect = $ordersCard[0].getBoundingClientRect();
+        .then(($target) => {
+          const sourceRect = $source[0].getBoundingClientRect();
 
-          // Start drag from center of Orders card
-          getDocumentCard(sourceCardTitle).trigger("mousedown", {
+          // Start drag from center of source
+          getSource().trigger("mousedown", {
             x: 10,
             y: 10,
             scrollBehavior: false,
             force: true,
           });
           const dataTransfer = new DataTransfer();
-          getDocumentCard(sourceCardTitle).trigger("dragstart", {
+          getSource().trigger("dragstart", {
             dataTransfer,
             clientX: sourceRect.left + 10,
             clientY: sourceRect.top + 10,
@@ -143,8 +143,8 @@ export function dragAndDropCardOnAnotherCard(
             force: true,
           });
 
-          const targetRect = $ordersCountCard[0].getBoundingClientRect();
-          // Calculate position for target card side drop (20% from left or 20% from right based on 'side' param)
+          const targetRect = $target[0].getBoundingClientRect();
+          // Calculate position for target side drop (20% from left or 20% from right based on 'side' param)
           const sideX =
             targetRect.left + targetRect.width * (side === "left" ? 0.2 : 0.8);
           const centerY = targetRect.top + 10;
@@ -153,29 +153,43 @@ export function dragAndDropCardOnAnotherCard(
             clientY: centerY,
             scrollBehavior: false,
           });
-          getDocumentCard(targetCardTitle).trigger("dragover", {
+          getTarget().trigger("dragover", {
             clientX: sideX,
             clientY: centerY,
             scrollBehavior: false,
             force: true,
           });
 
-          getDocumentCard(sourceCardTitle).realMouseUp({
+          getSource().realMouseUp({
             scrollBehavior: false,
           });
-          getDocumentCard(targetCardTitle).trigger("drop", {
+          getTarget().trigger("drop", {
             dataTransfer,
             clientX: sideX,
             clientY: centerY,
             scrollBehavior: false,
             force: true,
           });
-          getDocumentCard(sourceCardTitle).trigger("dragend", {
+          getSource().trigger("dragend", {
             scrollBehavior: false,
             force: true,
           });
         });
     });
+}
+
+export function dragAndDropCardOnAnotherCard(
+  sourceCardTitle: string,
+  targetCardTitle: string,
+  options: {
+    side?: "left" | "right";
+  } = {},
+) {
+  return documentsDragAndDrop({
+    getSource: () => getDocumentCard(sourceCardTitle),
+    getTarget: () => getDocumentCard(targetCardTitle),
+    ...options,
+  });
 }
 
 export function documentUndo() {

--- a/e2e/test/scenarios/documents/supporting-text.cy.spec.ts
+++ b/e2e/test/scenarios/documents/supporting-text.cy.spec.ts
@@ -1,4 +1,5 @@
 import {
+  DOCUMENT_WITH_SUPPORTING_TEXT,
   DOCUMENT_WITH_THREE_CARDS_AND_COLUMNS,
   DOCUMENT_WITH_TWO_CARDS,
 } from "e2e/support/document-initial-data";
@@ -454,5 +455,54 @@ describe("documents supporting text", () => {
     cy.log("No cards remaining in group, supportingText should not exist");
     H.dragAndDropCardOnAnotherCard("Orders, Count", targetCardTitle);
     H.documentContent().findByText("Lorem ipsum").should("not.exist");
+  });
+
+  describe("drag and drop", () => {
+    beforeEach(() => {
+      H.createDocument({
+        name: "DnD Test Document",
+        document: DOCUMENT_WITH_SUPPORTING_TEXT,
+        collection_id: null,
+        alias: "document",
+        idAlias: "documentId",
+      });
+
+      H.visitDocument("@documentId");
+    });
+
+    const assertTestIdOrder = (testIds: string[]) => {
+      cy.get(
+        testIds.map((testId) => `[data-testid="${testId}"]`).join(","),
+      ).then(($results) => {
+        expect(
+          $results
+            .toArray()
+            .slice(0, testIds.length)
+            .map((el) => el.getAttribute("data-testid")),
+        ).to.deep.eq(testIds);
+      });
+    };
+
+    it("should reorder a supporting text card when dropping onto a card", () => {
+      H.getDocumentCard("Orders").should("exist");
+      assertTestIdOrder([
+        "document-card-supporting-text",
+        "document-card-embed",
+      ]);
+
+      H.documentsDragAndDrop({
+        getSource: () =>
+          H.documentContent()
+            .findByTestId("document-card-supporting-text")
+            .find("[data-drag-handle]"),
+        getTarget: () => H.getDocumentCard("Orders"),
+        side: "right",
+      });
+
+      assertTestIdOrder([
+        "document-card-embed",
+        "document-card-supporting-text",
+      ]);
+    });
   });
 });

--- a/e2e/test/scenarios/documents/supporting-text.cy.spec.ts
+++ b/e2e/test/scenarios/documents/supporting-text.cy.spec.ts
@@ -466,43 +466,102 @@ describe("documents supporting text", () => {
         alias: "document",
         idAlias: "documentId",
       });
-
       H.visitDocument("@documentId");
     });
 
-    const assertTestIdOrder = (testIds: string[]) => {
-      cy.get(
-        testIds.map((testId) => `[data-testid="${testId}"]`).join(","),
-      ).then(($results) => {
-        expect(
-          $results
-            .toArray()
-            .slice(0, testIds.length)
-            .map((el) => el.getAttribute("data-testid")),
-        ).to.deep.eq(testIds);
+    const getSupportingText = (contents: string = "Lorem ipsum") => {
+      const testId = "document-card-supporting-text";
+      return cy
+        .findAllByTestId(testId)
+        .contains(contents)
+        .closest(`[data-testid="${testId}"]`);
+    };
+
+    const assertHorizontalLayout = (
+      c1: Cypress.Chainable<JQuery<HTMLElement>>,
+      c2: Cypress.Chainable<JQuery<HTMLElement>>,
+    ) => {
+      c1.then(($c1) => {
+        c2.then(($c2) => {
+          const rect1 = $c1[0].getBoundingClientRect();
+          const rect2 = $c2[0].getBoundingClientRect();
+          expect(rect2.left).to.gte(rect1.right);
+          expect(rect1.top).to.be.closeTo(rect2.top, 2);
+        });
       });
     };
 
-    it("should reorder a supporting text card when dropping onto a card", () => {
-      H.getDocumentCard("Orders").should("exist");
-      assertTestIdOrder([
-        "document-card-supporting-text",
-        "document-card-embed",
-      ]);
+    const assertVerticalLayout = (
+      c1: Cypress.Chainable<JQuery<HTMLElement>>,
+      c2: Cypress.Chainable<JQuery<HTMLElement>>,
+    ) => {
+      c1.then(($c1) => {
+        c2.then(($c2) => {
+          const rect1 = $c1[0].getBoundingClientRect();
+          const rect2 = $c2[0].getBoundingClientRect();
+          expect(rect2.top).to.gte(rect1.bottom);
+          expect(rect1.left).to.be.closeTo(rect2.left, 2);
+        });
+      });
+    };
 
+    it("should reorder when dropping a supporting text block onto a card", () => {
+      H.getDocumentCard("Orders").should("exist");
       H.documentsDragAndDrop({
-        getSource: () =>
-          H.documentContent()
-            .findByTestId("document-card-supporting-text")
-            .find("[data-drag-handle]"),
+        getSource: () => getSupportingText().find("[data-drag-handle]"),
         getTarget: () => H.getDocumentCard("Orders"),
         side: "right",
       });
 
-      assertTestIdOrder([
-        "document-card-embed",
-        "document-card-supporting-text",
-      ]);
+      assertHorizontalLayout(H.getDocumentCard("Orders"), getSupportingText());
+      assertVerticalLayout(
+        H.getDocumentCard("Orders"),
+        H.getDocumentCard("Orders, Count"),
+      );
+    });
+
+    it("should reorder when dropping a card onto a supporting text block", () => {
+      H.getDocumentCard("Orders").should("exist");
+      H.documentsDragAndDrop({
+        getSource: () => H.getDocumentCard("Orders"),
+        getTarget: () => getSupportingText(),
+        side: "left",
+      });
+
+      assertHorizontalLayout(H.getDocumentCard("Orders"), getSupportingText());
+      assertVerticalLayout(
+        H.getDocumentCard("Orders"),
+        H.getDocumentCard("Orders, Count"),
+      );
+    });
+
+    it("should insert a card when dropped onto a supporting text block", () => {
+      H.getDocumentCard("Orders").should("exist");
+      H.documentsDragAndDrop({
+        getSource: () => H.getDocumentCard("Orders, Count"),
+        getTarget: () => getSupportingText(),
+        side: "left",
+      });
+
+      assertHorizontalLayout(
+        H.getDocumentCard("Orders, Count"),
+        getSupportingText(),
+      );
+      assertHorizontalLayout(getSupportingText(), H.getDocumentCard("Orders"));
+    });
+
+    it("should do nothing if dragging a supporting text block outside of a group", () => {
+      H.getDocumentCard("Orders").should("exist");
+      H.documentsDragAndDrop({
+        getSource: () => getSupportingText().find("[data-drag-handle]"),
+        getTarget: () => H.getDocumentCard("Orders, Count"),
+      });
+
+      assertHorizontalLayout(getSupportingText(), H.getDocumentCard("Orders"));
+      assertVerticalLayout(
+        getSupportingText(),
+        H.getDocumentCard("Orders, Count"),
+      );
     });
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/Editor.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/Editor.tsx
@@ -22,6 +22,7 @@ import { CommandExtension } from "metabase-enterprise/rich_text_editing/tiptap/e
 import { CommandSuggestion } from "metabase-enterprise/rich_text_editing/tiptap/extensions/Command/CommandSuggestion";
 import { CustomStarterKit } from "metabase-enterprise/rich_text_editing/tiptap/extensions/CustomStarterKit/CustomStarterKit";
 import { DisableMetabotSidebar } from "metabase-enterprise/rich_text_editing/tiptap/extensions/DisableMetabotSidebar";
+import DropCursorS from "metabase-enterprise/rich_text_editing/tiptap/extensions/DropCursor/DropCursor.module.css";
 import { FlexContainer } from "metabase-enterprise/rich_text_editing/tiptap/extensions/FlexContainer/FlexContainer";
 import { HandleEditorDrop } from "metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/HandleEditorDrop";
 import { LinkHoverMenu } from "metabase-enterprise/rich_text_editing/tiptap/extensions/LinkHoverMenu/LinkHoverMenu";
@@ -109,6 +110,7 @@ export const Editor: React.FC<EditorProps> = ({
         dropcursor: {
           color: DROP_ZONE_COLOR,
           width: 2,
+          class: DropCursorS.dropCursor,
         },
       }),
       Image.configure({

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/Editor.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/Editor.tsx
@@ -17,10 +17,7 @@ import type { DocumentsStoreState } from "metabase-enterprise/documents/types";
 import { isMetabotBlock } from "metabase-enterprise/documents/utils/editorNodeUtils";
 import { getMentionsCacheKey } from "metabase-enterprise/documents/utils/mentionsUtils";
 import { EditorBubbleMenu } from "metabase-enterprise/rich_text_editing/tiptap/components/EditorBubbleMenu/EditorBubbleMenu";
-import {
-  CardEmbed,
-  DROP_ZONE_COLOR,
-} from "metabase-enterprise/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedNode";
+import { CardEmbed } from "metabase-enterprise/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedNode";
 import { CommandExtension } from "metabase-enterprise/rich_text_editing/tiptap/extensions/Command/CommandExtension";
 import { CommandSuggestion } from "metabase-enterprise/rich_text_editing/tiptap/extensions/Command/CommandSuggestion";
 import { CustomStarterKit } from "metabase-enterprise/rich_text_editing/tiptap/extensions/CustomStarterKit/CustomStarterKit";
@@ -40,6 +37,7 @@ import { PlainLink } from "metabase-enterprise/rich_text_editing/tiptap/extensio
 import { ResizeNode } from "metabase-enterprise/rich_text_editing/tiptap/extensions/ResizeNode/ResizeNode";
 import { SmartLink } from "metabase-enterprise/rich_text_editing/tiptap/extensions/SmartLink/SmartLinkNode";
 import { SupportingText } from "metabase-enterprise/rich_text_editing/tiptap/extensions/SupportingText/SupportingText";
+import { DROP_ZONE_COLOR } from "metabase-enterprise/rich_text_editing/tiptap/extensions/shared/constants";
 import { createSuggestionRenderer } from "metabase-enterprise/rich_text_editing/tiptap/extensions/suggestionRenderer";
 
 import S from "./Editor.module.css";

--- a/enterprise/frontend/src/metabase-enterprise/public/containers/PublicDocument/PublicDocument.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/public/containers/PublicDocument/PublicDocument.tsx
@@ -14,15 +14,13 @@ import { getSetting } from "metabase/selectors/settings";
 import { PublicApi } from "metabase/services";
 import { Box } from "metabase/ui";
 import { PublicDocumentProvider } from "metabase-enterprise/public/contexts/PublicDocumentContext";
-import {
-  CardEmbed,
-  DROP_ZONE_COLOR,
-} from "metabase-enterprise/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedNode";
+import { CardEmbed } from "metabase-enterprise/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedNode";
 import { CustomStarterKit } from "metabase-enterprise/rich_text_editing/tiptap/extensions/CustomStarterKit/CustomStarterKit";
 import { FlexContainer } from "metabase-enterprise/rich_text_editing/tiptap/extensions/FlexContainer/FlexContainer";
 import { ResizeNode } from "metabase-enterprise/rich_text_editing/tiptap/extensions/ResizeNode/ResizeNode";
 import { SmartLink } from "metabase-enterprise/rich_text_editing/tiptap/extensions/SmartLink/SmartLinkNode";
 import { SupportingText } from "metabase-enterprise/rich_text_editing/tiptap/extensions/SupportingText/SupportingText";
+import { DROP_ZONE_COLOR } from "metabase-enterprise/rich_text_editing/tiptap/extensions/shared/constants";
 import type { Document } from "metabase-types/api";
 
 import S from "./PublicDocument.module.css";

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedMenuDropdown.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedMenuDropdown.tsx
@@ -1,0 +1,150 @@
+import { t } from "ttag";
+
+import { ForwardRefLink } from "metabase/common/components/Link";
+import { canDownloadResults } from "metabase/dashboard/components/DashCard/DashCardMenu/utils";
+import { isWithinIframe } from "metabase/lib/dom";
+import { QuestionDownloadWidget } from "metabase/query_builder/components/QuestionDownloadWidget";
+import { Icon, Menu } from "metabase/ui";
+import type Question from "metabase-lib/v1/Question";
+import type { Dataset } from "metabase-types/api";
+
+export interface CardEmbedMenuContext {
+  canWrite: boolean;
+  dataset: Dataset | undefined;
+  question: Question | undefined;
+  isNativeQuestion: boolean | undefined;
+  commentsPath: string;
+  hasUnsavedChanges: boolean;
+  unresolvedCommentsCount: number;
+}
+
+export interface CardEmbedMenuActions {
+  handleDownload: (opts: {
+    type: string;
+    enableFormatting: boolean;
+    enablePivot: boolean;
+  }) => void;
+  handleEditVisualizationSettings: () => void;
+  setIsModifyModalOpen: (open: boolean) => void;
+  handleReplaceQuestion: () => void;
+  handleRemoveNode: () => void;
+  handleAddSupportingText?: () => void;
+}
+
+export interface CardEmbedMenuState {
+  menuView: string | null;
+  setMenuView: (view: string | null) => void;
+  isDownloadingData: boolean;
+}
+
+export type CardEmbedMenuDropdownProps = CardEmbedMenuContext &
+  CardEmbedMenuActions &
+  CardEmbedMenuState;
+export const CardEmbedMenuDropdown = ({
+  // Context
+  canWrite,
+  dataset,
+  question,
+  isNativeQuestion,
+  commentsPath,
+  hasUnsavedChanges,
+  unresolvedCommentsCount,
+  // Actions
+  handleDownload,
+  handleEditVisualizationSettings,
+  setIsModifyModalOpen,
+  handleReplaceQuestion,
+  handleRemoveNode,
+  handleAddSupportingText,
+  // State
+  menuView,
+  setMenuView,
+  isDownloadingData,
+}: CardEmbedMenuDropdownProps) => {
+  if (menuView === "downloads" && question && dataset) {
+    return (
+      <QuestionDownloadWidget
+        question={question}
+        result={dataset}
+        onDownload={(opts) => {
+          setMenuView(null);
+          handleDownload(opts);
+        }}
+      />
+    );
+  }
+
+  return (
+    <>
+      {!isWithinIframe() && canWrite && (
+        <Menu.Item
+          leftSection={<Icon name="add_comment" size={14} />}
+          component={ForwardRefLink}
+          to={
+            unresolvedCommentsCount > 0
+              ? commentsPath
+              : `${commentsPath}?new=true`
+          }
+          onClick={(e) => {
+            if (!commentsPath || hasUnsavedChanges) {
+              e.preventDefault();
+            }
+          }}
+          disabled={!commentsPath || hasUnsavedChanges}
+        >
+          {t`Comment`}
+        </Menu.Item>
+      )}
+      <Menu.Item
+        onClick={handleAddSupportingText}
+        disabled={!canWrite || !handleAddSupportingText}
+        leftSection={<Icon name="add_list" size={14} />}
+      >
+        {t`Add supporting text`}
+      </Menu.Item>
+      <Menu.Item
+        onClick={handleEditVisualizationSettings}
+        leftSection={<Icon name="palette" size={14} />}
+        disabled={!canWrite}
+      >
+        {t`Edit Visualization`}
+      </Menu.Item>
+      <Menu.Item
+        onClick={() => setIsModifyModalOpen(true)}
+        leftSection={
+          <Icon name={isNativeQuestion ? "sql" : "notebook"} size={14} />
+        }
+        disabled={!canWrite}
+      >
+        {t`Edit Query`}
+      </Menu.Item>
+      <Menu.Item
+        onClick={handleReplaceQuestion}
+        leftSection={<Icon name="refresh" size={14} />}
+        disabled={!canWrite}
+      >
+        {t`Replace`}
+      </Menu.Item>
+      {canDownloadResults(dataset) && (
+        <Menu.Item
+          leftSection={<Icon name="download" aria-hidden />}
+          aria-label={isDownloadingData ? t`Downloading…` : t`Download results`}
+          disabled={isDownloadingData}
+          closeMenuOnClick={false}
+          onClick={() => {
+            setMenuView("downloads");
+          }}
+        >
+          {isDownloadingData ? t`Downloading…` : t`Download results`}
+        </Menu.Item>
+      )}
+      <Menu.Item
+        onClick={handleRemoveNode}
+        leftSection={<Icon name="trash" size={14} />}
+        disabled={!canWrite}
+      >
+        {t`Remove Chart`}
+      </Menu.Item>
+    </>
+  );
+};

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/CardEmbed/use-dnd-helpers.ts
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/CardEmbed/use-dnd-helpers.ts
@@ -30,7 +30,8 @@ export const useDndHelpers = ({
       const draggingNode = editor.view.draggingNode;
       if (
         draggingNode &&
-        draggingNode.type.name === "cardEmbed" &&
+        (draggingNode.type.name === "cardEmbed" ||
+          draggingNode.type.name === "supportingText") &&
         cardEmbedRef.current
       ) {
         // Check if this cardEmbed is in a flexContainer that already has 3 children

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/DropCursor/DropCursor.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/DropCursor/DropCursor.module.css
@@ -1,4 +1,4 @@
-.hideDropCursor {
+:global(.dragging-supportingText) {
   .dropCursor {
     display: none;
   }

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/DropCursor/DropCursor.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/DropCursor/DropCursor.module.css
@@ -1,0 +1,5 @@
+.hideDropCursor {
+  .dropCursor {
+    display: none;
+  }
+}

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/FlexContainer/FlexContainer.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/FlexContainer/FlexContainer.module.css
@@ -49,16 +49,16 @@
 }
 
 .flexContent :global(.node-supportingText) {
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
 }
 
 .flexContent :global(.node-supportingText):first-child {
-  padding-left: 0;
+  margin-left: 0;
 }
 
 .flexContent :global(.node-supportingText):last-child {
-  padding-right: 0;
+  margin-right: 0;
 }
 
 /* Resize handles */

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/DropHandlers/cardToCard.ts
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/DropHandlers/cardToCard.ts
@@ -15,7 +15,7 @@ export const handleCardDropOnCard = (
   targetCardEmbed: Node,
 ) => {
   const {
-    cardEmbedNode,
+    draggedNode,
     view,
     event: e,
     originalParent,
@@ -25,16 +25,16 @@ export const handleCardDropOnCard = (
     cameFromFlexContainer,
   } = payload;
 
-  if (targetCardEmbed === cardEmbedNode) {
+  if (targetCardEmbed === draggedNode) {
     return true; // Prevent dropping on itself
   }
 
   const dropSide = getCardEmbedDropSide(e);
-  // Create new FlexContainer when dropping on a standalone CardEmbed
+  // Create new FlexContainer when dropping on a standalone item
   const children =
     dropSide === "left"
-      ? [cardEmbedNode.copy(), targetCardEmbed.copy()]
-      : [targetCardEmbed.copy(), cardEmbedNode.copy()];
+      ? [draggedNode.copy(), targetCardEmbed.copy()]
+      : [targetCardEmbed.copy(), draggedNode.copy()];
 
   const flexContainer = view.state.schema.nodes.flexContainer.create(
     {},
@@ -52,7 +52,7 @@ export const handleCardDropOnCard = (
 
   // Determine what to replace - if target is wrapped in resizeNode, replace the wrapper
   let replacePos = originalPos;
-  let replaceSize = cardEmbedNode.nodeSize;
+  let replaceSize = draggedNode.nodeSize;
   if (dropToParent.type.name === "resizeNode") {
     // Target is wrapped, replace the entire resizeNode
     replacePos = dropToParentPos.before();
@@ -64,7 +64,7 @@ export const handleCardDropOnCard = (
 
   // First, find and remove the dropped node from its original position
   const nodeToRemove =
-    originalParent.type.name === "resizeNode" ? originalParent : cardEmbedNode;
+    originalParent.type.name === "resizeNode" ? originalParent : draggedNode;
   let removalHandled = false;
   let removePos: number | null = null;
   view.state.doc.descendants((node, nodePos) => {

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/DropHandlers/cardToDocument.ts
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/DropHandlers/cardToDocument.ts
@@ -4,7 +4,10 @@ import {
   RESIZE_NODE_DEFAULT_HEIGHT,
   RESIZE_NODE_MIN_HEIGHT,
 } from "../../ResizeNode/ResizeNode";
-import { type DroppedCardEmbedNodeData, extractCardEmbed } from "../utils";
+import {
+  type DroppedCardEmbedNodeData,
+  extractContainerSingleCardNode,
+} from "../utils";
 
 export const handleCardDropOnDocument = (payload: DroppedCardEmbedNodeData) => {
   const {
@@ -54,7 +57,8 @@ export const handleCardDropOnDocument = (payload: DroppedCardEmbedNodeData) => {
       if (newChildren.length === 1) {
         // If only one card left, unwrap it from FlexContainer and wrap in resizeNode
         const remainingChild = newChildren[0];
-        const remainingCardEmbed = extractCardEmbed(remainingChild);
+        const remainingCardEmbed =
+          extractContainerSingleCardNode(remainingChild);
 
         if (remainingCardEmbed?.type.name === "supportingText") {
           // Only a SupportingText is left, remove the entire FlexContainer and its wrapper

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/DropHandlers/cardToDocument.ts
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/DropHandlers/cardToDocument.ts
@@ -56,7 +56,17 @@ export const handleCardDropOnDocument = (payload: DroppedCardEmbedNodeData) => {
         const remainingChild = newChildren[0];
         const remainingCardEmbed = extractCardEmbed(remainingChild);
 
-        if (remainingCardEmbed) {
+        if (remainingCardEmbed?.type.name === "supportingText") {
+          // Only a SupportingText is left, remove the entire FlexContainer and its wrapper
+          const containerResolvedPos = view.state.doc.resolve(flexContainerPos);
+          const containerParent = containerResolvedPos.parent;
+          const wrapperPos = containerResolvedPos.before();
+          replaceWith(
+            wrapperPos,
+            wrapperPos + containerParent.nodeSize,
+            Fragment.empty,
+          );
+        } else if (remainingCardEmbed) {
           const wrappedRemainingCard =
             view.state.schema.nodes.resizeNode.create(
               {
@@ -86,16 +96,6 @@ export const handleCardDropOnDocument = (payload: DroppedCardEmbedNodeData) => {
               wrappedRemainingCard,
             );
           }
-        } else {
-          // Only a SupportingText is left, remove the entire FlexContainer and its wrapper
-          const containerResolvedPos = view.state.doc.resolve(flexContainerPos);
-          const containerParent = containerResolvedPos.parent;
-          const wrapperPos = containerResolvedPos.before();
-          replaceWith(
-            wrapperPos,
-            wrapperPos + containerParent.nodeSize,
-            Fragment.empty,
-          );
         }
       } else if (newChildren.length > 1) {
         // Multiple cards left, keep as FlexContainer

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/DropHandlers/cardToDocument.ts
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/DropHandlers/cardToDocument.ts
@@ -15,7 +15,7 @@ export const handleCardDropOnDocument = (payload: DroppedCardEmbedNodeData) => {
     originalPos,
     view,
     cameFromFlexContainer,
-    cardEmbedNode,
+    draggedNode,
     dropPos,
   } = payload;
   let diffSize = 0;
@@ -141,7 +141,7 @@ export const handleCardDropOnDocument = (payload: DroppedCardEmbedNodeData) => {
           height: RESIZE_NODE_DEFAULT_HEIGHT,
           minHeight: RESIZE_NODE_MIN_HEIGHT,
         },
-        [cardEmbedNode],
+        [draggedNode],
       );
 
       // Calculate adjusted drop position if the FlexContainer operations affected positions
@@ -166,10 +166,10 @@ export const handleCardDropOnDocument = (payload: DroppedCardEmbedNodeData) => {
         height: RESIZE_NODE_DEFAULT_HEIGHT,
         minHeight: RESIZE_NODE_MIN_HEIGHT,
       },
-      [cardEmbedNode],
+      [draggedNode],
     );
 
-    const nodeToRemove = originalParent || cardEmbedNode;
+    const nodeToRemove = originalParent || draggedNode;
 
     // Remove the original node from its position
     // Find the actual node to remove (could be the cardEmbed itself or its resizeNode wrapper)

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/DropHandlers/cardToFlexContainer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/DropHandlers/cardToFlexContainer.ts
@@ -18,32 +18,31 @@ export const handleCardDropToFlexContainer = (
     cameFromFlexContainer,
     originalParent,
     dropToParent,
-    cardEmbedNode,
+    draggedNode,
     view,
     originalPos,
     event: e,
-    dropToParentPos,
   } = payload;
 
   // Handle dropping within the same FlexContainer - columns reordering
   if (cameFromFlexContainer && originalParent === dropToParent) {
-    const targetCardEmbedNode = getTargetCardEmbedNode(e, view);
+    const targetNode = getTargetCardEmbedNode(e, view);
 
-    if (!targetCardEmbedNode) {
+    if (!targetNode) {
       return;
     }
-    if (targetCardEmbedNode === cardEmbedNode) {
+    if (targetNode === draggedNode) {
       return true; // Prevent dropping on itself
     }
 
-    // Moving within the same FlexContainer - reorder cards
+    // Moving within the same FlexContainer - reorder items
     const tr = view.state.tr;
 
     // Find the source index
     const sourceIndex = view.state.doc.resolve(originalPos).index();
 
     // Calculate the intended insertion index based on drop position
-    let targetIndex = dropToParent.content.content.indexOf(targetCardEmbedNode);
+    let targetIndex = dropToParent.content.content.indexOf(targetNode);
     const dropSide = getCardEmbedDropSide(e);
 
     if (dropSide === "left" && targetIndex > 1) {
@@ -57,8 +56,8 @@ export const handleCardDropToFlexContainer = (
     for (let i = 0; i < dropToParent.childCount; i++) {
       if (i !== sourceIndex) {
         const child = dropToParent.child(i);
-        const childCardEmbed = extractCardEmbed(child);
-        allChildren.push(childCardEmbed ? childCardEmbed : child);
+        const extractedChild = extractCardEmbed(child);
+        allChildren.push(extractedChild ? extractedChild : child);
       }
     }
 
@@ -81,7 +80,7 @@ export const handleCardDropToFlexContainer = (
     }
 
     // Insert the dragged element at the correct position
-    allChildren.splice(adjustedTargetIndex, 0, cardEmbedNode);
+    allChildren.splice(adjustedTargetIndex, 0, draggedNode);
 
     // Preserve column widths by reordering them to match the new card positions
     const currentColumnWidths = dropToParent.attrs.columnWidths;
@@ -111,7 +110,18 @@ export const handleCardDropToFlexContainer = (
       allChildren,
     );
 
-    const containerPos = dropToParentPos.before();
+    // Find the actual position of the FlexContainer in the document
+    let containerPos: number | null = null;
+    view.state.doc.descendants((node, nodePos) => {
+      if (node === dropToParent) {
+        containerPos = nodePos;
+        return false;
+      }
+    });
+
+    if (containerPos === null) {
+      return true; // Safety check
+    }
 
     tr.replaceWith(
       containerPos,
@@ -128,18 +138,18 @@ export const handleCardDropToFlexContainer = (
   if (cameFromFlexContainer && originalParent !== dropToParent) {
     const targetFlexContainer = dropToParent;
 
-    // Check if target flexContainer already has 3 or more cards
+    // Check if target flexContainer already has 3 or more items
     if (targetFlexContainer.content.childCount >= 3) {
-      return true; // Don't allow dropping if target already has 3 cards
+      return true; // Don't allow dropping if target already has 3 items
     }
 
-    const targetCardEmbedNode = getTargetCardEmbedNode(e, view);
-    if (!targetCardEmbedNode) {
+    const targetNode = getTargetCardEmbedNode(e, view);
+    if (!targetNode) {
       return;
     }
 
     // Calculate the intended insertion index based on drop position
-    let targetIndex = dropToParent.content.content.indexOf(targetCardEmbedNode);
+    let targetIndex = dropToParent.content.content.indexOf(targetNode);
     const dropSide = getCardEmbedDropSide(e);
 
     if (dropSide === "left" && targetIndex > 1) {
@@ -254,14 +264,14 @@ export const handleCardDropToFlexContainer = (
       }
     }
 
-    // Now add the card to the target flexContainer
+    // Now add the item to the target flexContainer
     const targetChildren: Node[] = [];
     for (let i = 0; i < targetFlexContainer.content.childCount; i++) {
       const child = targetFlexContainer.content.child(i);
       targetChildren.push(child);
     }
 
-    targetChildren.splice(targetIndex, 0, cardEmbedNode.copy());
+    targetChildren.splice(targetIndex, 0, draggedNode.copy());
 
     // Find target flexContainer position
     let targetFlexContainerPos: number | null = null;
@@ -304,21 +314,21 @@ export const handleCardDropToFlexContainer = (
     return true;
   }
 
-  // Handle dropping on a cardEmbed that is already in a flexContainer
+  // Handle dropping on an item that is already in a flexContainer
   if (!cameFromFlexContainer) {
     const flexContainer = dropToParent;
 
     if (flexContainer.content.childCount === 3) {
-      return true; // Don't allow more than 3 cards in flexContainer
+      return true; // Don't allow more than 3 items in flexContainer
     }
 
-    const targetCardEmbedNode = getTargetCardEmbedNode(e, view);
-    if (!targetCardEmbedNode) {
+    const targetNode = getTargetCardEmbedNode(e, view);
+    if (!targetNode) {
       return;
     }
 
     // Calculate the intended insertion index based on drop position
-    let targetIndex = dropToParent.content.content.indexOf(targetCardEmbedNode);
+    let targetIndex = dropToParent.content.content.indexOf(targetNode);
     const dropSide = getCardEmbedDropSide(e);
 
     if (dropSide === "left" && targetIndex > 1) {
@@ -327,14 +337,14 @@ export const handleCardDropToFlexContainer = (
       targetIndex++;
     }
 
-    // Get all current children as cardEmbeds
+    // Get all current children
     const newChildren: Node[] = [];
     for (let i = 0; i < flexContainer.content.childCount; i++) {
       const child = flexContainer.content.child(i);
       newChildren.push(child);
     }
 
-    newChildren.splice(targetIndex, 0, cardEmbedNode.copy());
+    newChildren.splice(targetIndex, 0, draggedNode.copy());
 
     // Find the position of the flexContainer (it should be wrapped in resizeNode)
     let flexContainerPos: number | null = null;
@@ -368,9 +378,7 @@ export const handleCardDropToFlexContainer = (
     // Now remove the dropped node from its original position
     // We need to find it again in the updated document
     const nodeToRemove =
-      originalParent.type.name === "resizeNode"
-        ? originalParent
-        : cardEmbedNode;
+      originalParent.type.name === "resizeNode" ? originalParent : draggedNode;
 
     const updatedDoc = tr.doc;
     let nodeFound = false;

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/DropHandlers/cardToFlexContainer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/DropHandlers/cardToFlexContainer.ts
@@ -6,7 +6,7 @@ import {
 } from "../../ResizeNode/ResizeNode";
 import {
   type DroppedCardEmbedNodeData,
-  extractCardEmbed,
+  extractContainerSingleCardNode,
   getCardEmbedDropSide,
   getTargetCardEmbedNode,
 } from "../utils";
@@ -56,7 +56,7 @@ export const handleCardDropToFlexContainer = (
     for (let i = 0; i < dropToParent.childCount; i++) {
       if (i !== sourceIndex) {
         const child = dropToParent.child(i);
-        const extractedChild = extractCardEmbed(child);
+        const extractedChild = extractContainerSingleCardNode(child);
         allChildren.push(extractedChild ? extractedChild : child);
       }
     }
@@ -190,7 +190,7 @@ export const handleCardDropToFlexContainer = (
     if (sourceNewChildren.length === 1) {
       // Only one card left in source - unwrap it from flexContainer
       const remainingChild = sourceNewChildren[0];
-      const remainingCardEmbed = extractCardEmbed(remainingChild);
+      const remainingCardEmbed = extractContainerSingleCardNode(remainingChild);
 
       if (remainingCardEmbed) {
         const wrappedRemainingCard = view.state.schema.nodes.resizeNode.create(

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/DropHandlers/cardToFlexContainer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/DropHandlers/cardToFlexContainer.ts
@@ -136,6 +136,9 @@ export const handleCardDropToFlexContainer = (
 
   // Handle dropping from one FlexContainer to another FlexContainer
   if (cameFromFlexContainer && originalParent !== dropToParent) {
+    if (draggedNode.type.name === "supportingText") {
+      return true;
+    }
     const targetFlexContainer = dropToParent;
 
     // Check if target flexContainer already has 3 or more items

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/DropHandlers/cardToFlexContainer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/DropHandlers/cardToFlexContainer.ts
@@ -195,7 +195,10 @@ export const handleCardDropToFlexContainer = (
       const remainingChild = sourceNewChildren[0];
       const remainingCardEmbed = extractContainerSingleCardNode(remainingChild);
 
-      if (remainingCardEmbed) {
+      if (
+        remainingCardEmbed &&
+        remainingCardEmbed.type.name !== "supportingText"
+      ) {
         const wrappedRemainingCard = view.state.schema.nodes.resizeNode.create(
           {
             height: RESIZE_NODE_DEFAULT_HEIGHT,

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/HandleEditorDrop.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/HandleEditorDrop.tsx
@@ -13,7 +13,7 @@ import { handleCardDropOnDocument } from "./DropHandlers/cardToDocument";
 import {
   type DroppedCardEmbedNodeData,
   cleanupFlexContainerNodes,
-  extractCardEmbed,
+  extractContainerSingleCardNode,
   getDroppedCardEmbedNodeData,
 } from "./utils";
 
@@ -53,7 +53,8 @@ export const HandleEditorDrop = Extension.create({
                 return handleCardDropToFlexContainer(cardEmbedInitialData);
               }
 
-              const targetCardEmbed = extractCardEmbed(dropToParent);
+              const targetCardEmbed =
+                extractContainerSingleCardNode(dropToParent);
               // Dropping on another cardEmbed
               if (
                 targetCardEmbed &&

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/HandleEditorDrop.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/HandleEditorDrop.tsx
@@ -3,8 +3,6 @@ import { Fragment, type NodeType as PMNodeType, Slice } from "@tiptap/pm/model";
 import { NodeSelection, Plugin, PluginKey } from "@tiptap/pm/state";
 import type { EditorView } from "@tiptap/pm/view";
 
-import DropCursorS from "metabase-enterprise/rich_text_editing/tiptap/extensions/DropCursor/DropCursor.module.css";
-
 import {
   handleCardDropOnCard,
   handleCardDropToFlexContainer,
@@ -25,13 +23,15 @@ export const HandleEditorDrop = Extension.create({
         key: new PluginKey("metabaseTiptapDrop"),
         props: {
           handleDrop: (view, e, slice, moved) => {
-            view.dom.offsetParent?.classList.remove(DropCursorS.hideDropCursor);
-
             const cardEmbedInitialData = getDroppedCardEmbedNodeData(
               view,
               e,
               slice,
               moved,
+            );
+            view.dom.offsetParent?.classList.remove(
+              "dragging",
+              `dragging-${cardEmbedInitialData?.draggedNode.type.name}`,
             );
 
             if (cardEmbedInitialData) {
@@ -146,11 +146,10 @@ export const HandleEditorDrop = Extension.create({
                 const { inside } = maybePos;
                 const node = view.state.doc.nodeAt(inside);
 
-                if (node?.type.name === "supportingText") {
-                  view.dom.offsetParent?.classList.add(
-                    DropCursorS.hideDropCursor,
-                  );
-                }
+                view.dom.offsetParent?.classList.add(
+                  "dragging",
+                  `dragging-${node?.type.name}`,
+                );
 
                 view.draggingNode = node;
                 return false;

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/HandleEditorDrop.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/HandleEditorDrop.tsx
@@ -36,7 +36,17 @@ export const HandleEditorDrop = Extension.create({
             );
 
             if (cardEmbedInitialData) {
-              const { dropToParent } = cardEmbedInitialData;
+              const { dropToParent, draggedNode } = cardEmbedInitialData;
+
+              // SupportingText can only be dropped within a flexContainer
+              // Block drops on standalone nodes or outside flexContainer
+              if (
+                draggedNode.type.name === "supportingText" &&
+                dropToParent.type.name !== "flexContainer" &&
+                dropToParent.type.name !== "supportingText"
+              ) {
+                return true; // Block the drop
+              }
 
               // Dropping inside a flexContainer
               if (dropToParent.type.name === "flexContainer") {

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/HandleEditorDrop.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/HandleEditorDrop.tsx
@@ -80,8 +80,8 @@ export const HandleEditorDrop = Extension.create({
               });
 
               if (maybePos) {
-                const { pos } = maybePos;
-                const node = view.state.doc.nodeAt(pos);
+                const { inside } = maybePos;
+                const node = view.state.doc.nodeAt(inside);
 
                 view.draggingNode = node;
                 return false;

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/HandleEditorDrop.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/HandleEditorDrop.tsx
@@ -25,7 +25,6 @@ export const HandleEditorDrop = Extension.create({
         key: new PluginKey("metabaseTiptapDrop"),
         props: {
           handleDrop: (view, e, slice, moved) => {
-            // FIXME: Call this conditionally based on what was dropped
             view.dom.offsetParent?.classList.remove(DropCursorS.hideDropCursor);
 
             const cardEmbedInitialData = getDroppedCardEmbedNodeData(

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/HandleEditorDrop.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/HandleEditorDrop.tsx
@@ -3,6 +3,8 @@ import { Fragment, type NodeType as PMNodeType, Slice } from "@tiptap/pm/model";
 import { NodeSelection, Plugin, PluginKey } from "@tiptap/pm/state";
 import type { EditorView } from "@tiptap/pm/view";
 
+import DropCursorS from "metabase-enterprise/rich_text_editing/tiptap/extensions/DropCursor/DropCursor.module.css";
+
 import {
   handleCardDropOnCard,
   handleCardDropToFlexContainer,
@@ -23,6 +25,9 @@ export const HandleEditorDrop = Extension.create({
         key: new PluginKey("metabaseTiptapDrop"),
         props: {
           handleDrop: (view, e, slice, moved) => {
+            // FIXME: Call this conditionally based on what was dropped
+            view.dom.offsetParent?.classList.remove(DropCursorS.hideDropCursor);
+
             const cardEmbedInitialData = getDroppedCardEmbedNodeData(
               view,
               e,
@@ -82,6 +87,12 @@ export const HandleEditorDrop = Extension.create({
               if (maybePos) {
                 const { inside } = maybePos;
                 const node = view.state.doc.nodeAt(inside);
+
+                if (node?.type.name === "supportingText") {
+                  view.dom.offsetParent?.classList.add(
+                    DropCursorS.hideDropCursor,
+                  );
+                }
 
                 view.draggingNode = node;
                 return false;

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/utils.ts
@@ -3,12 +3,15 @@ import type { EditorView } from "@tiptap/pm/view";
 
 // Helper function to extract cardEmbed from resizeNode wrapper
 export const extractCardEmbed = (node: Node): Node | null => {
-  if (node.type.name === "cardEmbed") {
+  if (node.type.name === "cardEmbed" || node.type.name === "supportingText") {
     return node;
   }
   if (node.type.name === "resizeNode" && node.content.childCount === 1) {
     const child = node.content.child(0);
-    if (child.type.name === "cardEmbed") {
+    if (
+      child.type.name === "cardEmbed" ||
+      child.type.name === "supportingText"
+    ) {
       return child;
     }
   }

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/utils.ts
@@ -2,7 +2,7 @@ import type { Node, ResolvedPos, Slice } from "@tiptap/pm/model";
 import type { EditorView } from "@tiptap/pm/view";
 
 // Helper function to extract cardEmbed or supportingText from resizeNode wrapper
-export const extractCardEmbed = (node: Node): Node | null => {
+export const extractContainerSingleCardNode = (node: Node): Node | null => {
   if (node.type.name === "cardEmbed" || node.type.name === "supportingText") {
     return node;
   }
@@ -68,7 +68,7 @@ export const getTargetCardEmbedNode = (e: DragEvent, view: EditorView) => {
       // For cardEmbed, nodeAt works as expected
       const targetNode = view.state.doc.nodeAt(pos);
       if (targetNode) {
-        return extractCardEmbed(targetNode);
+        return extractContainerSingleCardNode(targetNode);
       }
     }
   }
@@ -100,7 +100,7 @@ export const getDroppedCardEmbedNodeData = (
   // Check if we're moving a cardEmbed or supportingText node
   if (slice.content.childCount === 1) {
     const droppedNode = slice.content.child(0);
-    const draggedNode = extractCardEmbed(droppedNode);
+    const draggedNode = extractContainerSingleCardNode(droppedNode);
 
     // Dropping a "cardEmbed" or "supportingText" node
     if (draggedNode && moved) {
@@ -161,7 +161,10 @@ export const findNodeParentAndPos = (
       return false;
     }
 
-    if (extractCardEmbed(node) === nodeToFind && node !== nodeToFind) {
+    if (
+      extractContainerSingleCardNode(node) === nodeToFind &&
+      node !== nodeToFind
+    ) {
       parentPos = pos;
       parent = node;
       return false;

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/utils.ts
@@ -78,7 +78,6 @@ export const getTargetCardEmbedNode = (e: DragEvent, view: EditorView) => {
 
 export interface DroppedCardEmbedNodeData {
   draggedNode: Node;
-  cardEmbedNode: Node; // Deprecated: use draggedNode instead
   originalPos: number;
   originalParent: Node;
   cameFromFlexContainer: boolean;
@@ -130,7 +129,6 @@ export const getDroppedCardEmbedNodeData = (
 
         return {
           draggedNode,
-          cardEmbedNode: draggedNode, // Backward compatibility
           originalPos,
           originalParent,
           cameFromFlexContainer,

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/SupportingText/SupportingText.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/SupportingText/SupportingText.module.css
@@ -44,7 +44,7 @@
 }
 
 .handle {
-  cursor: pointer;
+  cursor: grab;
   height: 1rem;
   position: absolute;
   top: 0;
@@ -52,6 +52,10 @@
 
   &:focus-visible {
     outline: none !important;
+  }
+
+  &:active {
+    cursor: grabbing;
   }
 }
 

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/SupportingText/SupportingText.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/SupportingText/SupportingText.module.css
@@ -2,7 +2,6 @@
   height: 100%;
   position: relative;
   border-radius: var(--mantine-radius-md);
-  overflow: hidden;
   background-color: var(--mb-color-background-light);
   border: 1px solid transparent;
   transition:

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/SupportingText/SupportingText.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/SupportingText/SupportingText.module.css
@@ -49,6 +49,7 @@
   position: absolute;
   top: 0;
   width: 100%;
+  user-select: none; /* Needed to make this handle draggable in FF */
 
   &:focus-visible {
     outline: none !important;

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/SupportingText/SupportingText.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/SupportingText/SupportingText.module.css
@@ -42,6 +42,11 @@
   caret-color: auto;
 }
 
+/* Prevent dropCursor from displaying while dragging over SupportingText contents */
+:global(.dragging) .scrollContainer {
+  pointer-events: none;
+}
+
 .handle {
   cursor: grab;
   height: 1rem;

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/SupportingText/SupportingText.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/SupportingText/SupportingText.tsx
@@ -170,7 +170,12 @@ const SupportingTextComponent = ({
         )}
         <NodeViewContent />
       </div>
-      <button
+
+      {/* Would be nice to use a real `button` here, but that prevents ProseMirror plugin dragstart events from firing */}
+      <div
+        role="button"
+        tabIndex={0}
+        data-drag-handle
         contentEditable={false}
         aria-label={t`Supporting text`}
         className={S.handle}
@@ -187,21 +192,6 @@ const SupportingTextComponent = ({
               editor.commands.focus(pos);
             }
           }
-        }}
-        draggable
-        onDragStart={(e) => {
-          const pos = getPos();
-          pos && editor.commands.setNodeSelection(pos);
-          const slice = editor.view.state.selection.content();
-          const customImage =
-            e.currentTarget instanceof Element &&
-            e.currentTarget.closest(`.${S.wrapper}`);
-          if (customImage) {
-            // FIXME: Calculate x, y offset
-            e.dataTransfer.setDragImage(customImage, 0, 0);
-          }
-          editor.view.dragging = { slice, move: true };
-          editor.view.draggingNode = node;
         }}
       />
       {document && !isWithinIframe() && (

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/SupportingText/SupportingText.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/SupportingText/SupportingText.tsx
@@ -69,7 +69,7 @@ export const SupportingText = Node.create<{
     return [
       "div",
       mergeAttributes(HTMLAttributes, {
-        "data-type": "supportingText",
+        "data-type": SupportingText.name,
       }),
       0,
     ];

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/SupportingText/SupportingText.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/SupportingText/SupportingText.tsx
@@ -217,9 +217,6 @@ const SupportingTextComponent = ({
             }
           }
         }}
-        onDragStart={() => {
-          editor.view.draggingNode = node;
-        }}
       />
       {document && !isWithinIframe() && (
         <Box

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/SupportingText/SupportingText.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/SupportingText/SupportingText.tsx
@@ -69,7 +69,7 @@ export const SupportingText = Node.create<{
     return [
       "div",
       mergeAttributes(HTMLAttributes, {
-        "data-type": SupportingText.name,
+        "data-type": this.name,
       }),
       0,
     ];

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/SupportingText/SupportingText.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/SupportingText/SupportingText.tsx
@@ -164,12 +164,21 @@ const SupportingTextComponent = ({
   const { isBeingDragged, dragState, setDragState, handleDragOver, dragElRef } =
     useDndHelpers({ editor, node, getPos });
 
+  // Disallow cut/copy on the drag-handle/comments-button since that'd cut/copy the block itself (cutting/copying supportingText *content* should be allowed though)
+  const onCutOrCopy = (e: ClipboardEvent) => {
+    if (window.document.activeElement !== editor.view.dom) {
+      e.preventDefault();
+    }
+  };
+
   return (
     <NodeViewWrapper
       className={cx(S.wrapper, { [S.selected]: selected })}
       data-testid="document-card-supporting-text"
       onDragOver={handleDragOver}
       onDrop={() => setDragState({ isDraggedOver: false, side: null })}
+      onCut={onCutOrCopy}
+      onCopy={onCutOrCopy}
     >
       {canWrite && (
         <>

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/SupportingText/SupportingText.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/SupportingText/SupportingText.tsx
@@ -188,6 +188,21 @@ const SupportingTextComponent = ({
             }
           }
         }}
+        draggable
+        onDragStart={(e) => {
+          const pos = getPos();
+          pos && editor.commands.setNodeSelection(pos);
+          const slice = editor.view.state.selection.content();
+          const customImage =
+            e.currentTarget instanceof Element &&
+            e.currentTarget.closest(`.${S.wrapper}`);
+          if (customImage) {
+            // FIXME: Calculate x, y offset
+            e.dataTransfer.setDragImage(customImage, 0, 0);
+          }
+          editor.view.dragging = { slice, move: true };
+          editor.view.draggingNode = node;
+        }}
       />
       {document && !isWithinIframe() && (
         <Box

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/shared/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/shared/constants.ts
@@ -16,3 +16,5 @@ export const EMBED_SEARCH_MODELS: SuggestionModel[] = ["card", "dataset"];
 export const LINK_SEARCH_LIMIT = 5;
 
 export const USER_SEARCH_LIMIT = LINK_SEARCH_LIMIT;
+
+export const DROP_ZONE_COLOR = "var(--mb-color-brand)";

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/shared/dnd/DropZone.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/shared/dnd/DropZone.tsx
@@ -1,0 +1,31 @@
+import { Box } from "metabase/ui";
+
+import { DROP_ZONE_COLOR } from "../constants";
+
+export interface DropZoneProps {
+  isOver: boolean;
+  side: "left" | "right";
+  disabled?: boolean;
+}
+
+export const DropZone = ({ isOver, side, disabled }: DropZoneProps) => {
+  if (disabled) {
+    return null;
+  }
+
+  return (
+    <Box
+      style={{
+        position: "absolute",
+        top: 0,
+        bottom: 0,
+        width: "0.25rem",
+        [side]: "-0.625rem",
+        borderRadius: "0.125rem",
+        backgroundColor: isOver ? DROP_ZONE_COLOR : "transparent",
+        zIndex: 10,
+        pointerEvents: "all",
+      }}
+    />
+  );
+};

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/shared/dnd/use-dnd-helpers.ts
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/shared/dnd/use-dnd-helpers.ts
@@ -18,7 +18,7 @@ export const useDndHelpers = ({
     side: "left" | "right" | null;
   }>({ isDraggedOver: false, side: null });
   const draggedOverTimeoutRef = useRef<number | undefined>();
-  const cardEmbedRef = useRef<HTMLDivElement | null>(null);
+  const dragElRef = useRef<HTMLDivElement | null>(null);
   const isMountedRef = useRef(false);
 
   const isBeingDragged = editor.view.draggingNode === node;
@@ -32,7 +32,7 @@ export const useDndHelpers = ({
         draggingNode &&
         (draggingNode.type.name === "cardEmbed" ||
           draggingNode.type.name === "supportingText") &&
-        cardEmbedRef.current
+        dragElRef.current
       ) {
         // Check if this cardEmbed is in a flexContainer that already has 3 children
         const pos = getPos();
@@ -60,7 +60,7 @@ export const useDndHelpers = ({
           }
         }
 
-        const rect = cardEmbedRef.current?.getBoundingClientRect();
+        const rect = dragElRef.current?.getBoundingClientRect();
         const relativeX = e.clientX - rect.left;
         const nodeWidth = rect.width;
 
@@ -99,6 +99,6 @@ export const useDndHelpers = ({
     dragState,
     setDragState,
     handleDragOver,
-    cardEmbedRef,
+    dragElRef,
   };
 };

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/shared/dnd/use-dnd-helpers.ts
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/shared/dnd/use-dnd-helpers.ts
@@ -34,12 +34,25 @@ export const useDndHelpers = ({
           draggingNode.type.name === "supportingText") &&
         dragElRef.current
       ) {
-        // Check if this cardEmbed is in a flexContainer that already has 3 children
         const pos = getPos();
         if (pos) {
           const resolvedPos = editor.state.doc.resolve(pos);
           const { parent } = resolvedPos;
 
+          // For simplicity's sake, don't allow dragging supportingText from one group to another
+          if (draggingNode.type.name === "supportingText") {
+            if (
+              parent.type.name === "flexContainer" ||
+              parent.type.name === "resizeNode"
+            ) {
+              if (!parent.content.content.includes(draggingNode)) {
+                setDragState({ isDraggedOver: false, side: null });
+                return;
+              }
+            }
+          }
+
+          // Check if this cardEmbed is in a flexContainer that already has 3 children
           if (
             parent.type.name === "flexContainer" &&
             parent.content.childCount >= 3


### PR DESCRIPTION
Closes UXW-2243

### Description

Adds support for reordering supporting text blocks via drag-and-drop.

### How to verify

1. Add a chart to a document
2. Add supporting text to it
3. Drag the supporting text over the chart -> should reorder
4. Drag a chart over the supporting text -> should reorder
5. Drag the supporting text out of the group -> should not be allowed

### Demo

https://www.loom.com/share/1d799622203649258edda10a9045e63b

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
