### PR TITLE
Suppress liquibase output

### DIFF
--- a/src/metabase/app_db/liquibase.clj
+++ b/src/metabase/app_db/liquibase.clj
@@ -23,7 +23,7 @@
    (java.sql Connection)
    (java.util ArrayList List Map)
    (javax.sql DataSource)
-   (liquibase Contexts LabelExpression Liquibase RuntimeEnvironment Scope Scope$Attr Scope$ScopedRunner)
+   (liquibase Contexts LabelExpression Liquibase RuntimeEnvironment Scope Scope$Attr Scope$ScopedRunner UpdateSummaryOutputEnum)
    (liquibase.change.custom CustomChangeWrapper)
    (liquibase.changelog ChangeLogIterator ChangeSet ChangeSet$ExecType)
    (liquibase.changelog.filter AlreadyRanChangeSetFilter ChangeSetFilter ChangeSetFilterResult DbmsChangeSetFilter IgnoreChangeSetFilter)
@@ -136,6 +136,7 @@
              ;; trigger creation of liquibase's databasechangelog tables if needed, without updating any checksums
              ;; we need to do this until https://github.com/liquibase/liquibase/issues/5537 is fixed
              (.checkLiquibaseTables liquibase false (.getDatabaseChangeLog liquibase) nil nil)
+             (.setShowSummaryOutput liquibase UpdateSummaryOutputEnum/LOG)
              (f liquibase))]
     (binding [t2.conn/*current-connectable* conn-or-data-source]
       (if (instance? Connection conn-or-data-source)


### PR DESCRIPTION
We get a bunch of this useless stuff in CI:

```
Placeholder until other changesets

UPDATE SUMMARY
Run:                        641
Previously run:               0
Filtered out:                69
-------------------------------
Total change sets:          710

FILTERED CHANGE SETS SUMMARY
DBMS mismatch:               69
```

Looking for this in liquibase this is not logged but printed to the console :(.

It goes through this:

```java
    private static void writeMessage(String message, UpdateSummaryOutputEnum showSummaryOutput, OutputStream outputStream) throws LiquibaseException {
        switch (showSummaryOutput) {
            case CONSOLE:
                writeToOutput(outputStream, message);
                break;
            case LOG:
                writeToLog(message);
                break;
            default:
                writeToOutput(outputStream, message);
                writeToLog(message);
        }
    }
```

So we want that enum to be LOG.

```clojure
liquibase=> (clojure.reflect/reflect liquibase.Liquibase)
{:bases #{java.lang.Object java.lang.AutoCloseable},
 :flags #{:public},
 :members #{ ,,,
             #clojure.reflect.Method{:name setShowSummaryOutput,
                                    :return-type void,
                                    :declaring-class liquibase.Liquibase,
                                    :parameter-types [liquibase.UpdateSummaryOutputEnum],
                                    :exception-types [],
                                    :flags #{:public}}
          ,,,}}
```

So easy fix. Set this enum and hopefully it shuts up.

#### Before:
<img width="475" height="720" alt="image" src="https://github.com/user-attachments/assets/e95c41b1-9c63-4956-8086-d8c1eb94d9a0" />

#### After:
<img width="719" height="174" alt="image" src="https://github.com/user-attachments/assets/0bef9788-6e7c-4c97-a9ad-50c2eda8f220" />

