### PR TITLE
Simplify Snowplow Cypress helpers

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -115,7 +115,6 @@ module.exports = {
           "And",
           "When",
           "Then",
-          "describeWithSnowplow",
         ],
       },
     ],

--- a/docs/developers-guide/e2e-tests.md
+++ b/docs/developers-guide/e2e-tests.md
@@ -155,17 +155,15 @@ export MB_SNOWPLOW_URL=http://localhost:9090
 
 We have a few helpers for dealing with tests involving snowplow
 
-1. You can use `describeWithSnowplow` (or `describeWithSnowplowEE` for EE edition) method to define tests that only
-   run when a Snowplow instance is running
 1. Use `resetSnowplow()` test helper before each test to clear the queue of processed events.
-1. Use `expectSnowplowEvent({ ...payload }, count=n)` to assert that exactly `count` snowplow events match (partially)
+2. Use `expectSnowplowEvent({ ...payload }, count=n)` to assert that exactly `count` snowplow events match (partially)
    the payload provided (count defaults to 1)
-1. Use `expectUnstructuredSnowplowEvent` to assert that exactly `count` snowplow events are unstructured events that
+3. Use `expectUnstructuredSnowplowEvent` to assert that exactly `count` snowplow events are unstructured events that
    partial-match the payload provided. This is simply a convenience function for comparing
    `event.unstruct_event.data.data` rather than the entire `event`. Most of our events are unstructured events, so this is handy.
-1. Use `assertNoUnstructuredSnowplowEvent({ ...eventData })` is the inverse of `expectUnstructuredSnowplowEvent`, and asserts that
+4. Use `assertNoUnstructuredSnowplowEvent({ ...eventData })` is the inverse of `expectUnstructuredSnowplowEvent`, and asserts that
    _no_ unstructured events match the payload.
-1. Use `expectNoBadSnowplowEvents()` after each test to assert that no invalid events have been sent.
+5. Use `expectNoBadSnowplowEvents()` after each test to assert that no invalid events have been sent.
 
 ### Running tests that require SMTP server
 

--- a/e2e/runner/run_cypress_local.ts
+++ b/e2e/runner/run_cypress_local.ts
@@ -36,7 +36,7 @@ const derivedOptions = {
   BUILD_JAR: userOptions.BACKEND_PORT === 4000,
   START_BACKEND: userOptions.BACKEND_PORT === 4000,
   CYPRESS_IS_EMBEDDING_SDK: String(userOptions.TEST_SUITE === "component"),
-  MB_SNOWPLOW_AVAILABLE: userOptions.START_CONTAINERS,
+  MB_SNOWPLOW_AVAILABLE: true,
   MB_SNOWPLOW_URL: "http://localhost:9090",
 };
 

--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -25,7 +25,6 @@ const cypressSplit = require("cypress-split");
 const isEnterprise = process.env["MB_EDITION"] === "ee";
 const isCI = process.env["CYPRESS_CI"] === "true";
 
-const hasSnowplowMicro = process.env["MB_SNOWPLOW_AVAILABLE"];
 const snowplowMicroUrl = process.env["MB_SNOWPLOW_URL"];
 
 const isQaDatabase = process.env["QA_DB_ENABLED"] === "true";
@@ -136,7 +135,6 @@ const defaultConfig = {
     config.env.grepFilterSpecs = true;
 
     config.env.IS_ENTERPRISE = isEnterprise;
-    config.env.HAS_SNOWPLOW_MICRO = hasSnowplowMicro;
     config.env.SNOWPLOW_MICRO_URL = snowplowMicroUrl;
 
     require("@cypress/grep/src/plugin")(config);

--- a/e2e/support/helpers/e2e-snowplow-helpers.js
+++ b/e2e/support/helpers/e2e-snowplow-helpers.js
@@ -1,14 +1,8 @@
 import { updateSetting } from "e2e/support/helpers";
 
-const { IS_ENTERPRISE } = Cypress.env();
-const HAS_SNOWPLOW = Cypress.env("HAS_SNOWPLOW_MICRO");
 const SNOWPLOW_URL = Cypress.env("SNOWPLOW_MICRO_URL");
 const SNOWPLOW_INTERVAL = 100;
 const SNOWPLOW_TIMEOUT = 1000;
-
-export const describeWithSnowplow = HAS_SNOWPLOW ? describe : describe.skip;
-export const describeWithSnowplowEE =
-  HAS_SNOWPLOW && IS_ENTERPRISE ? describe : describe.skip;
 
 export const enableTracking = () => {
   updateSetting("anon-tracking-enabled", true);

--- a/e2e/support/helpers/e2e-snowplow-helpers.js
+++ b/e2e/support/helpers/e2e-snowplow-helpers.js
@@ -102,6 +102,7 @@ export const expectNoBadSnowplowEvents = () => {
 };
 
 const sendSnowplowRequest = (url) => {
+  cy.log("Send a Snowplow micro request");
   return cy.request({
     url: `${SNOWPLOW_URL}/${url}`,
     json: true,

--- a/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
@@ -32,7 +32,7 @@ const MODEL_NAME = "Test Action Model";
         );
       });
 
-      H.describeWithSnowplow("adding and executing actions", () => {
+      describe("adding and executing actions", () => {
         beforeEach(() => {
           H.resetSnowplow();
           H.restore(`${dialect}-writable`);

--- a/e2e/test/scenarios/admin-2/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/settings.cy.spec.js
@@ -10,7 +10,7 @@ import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 const { SMTP_PORT, WEB_PORT } = WEBMAIL_CONFIG;
 
-H.describeWithSnowplow("scenarios > admin > settings", () => {
+describe("scenarios > admin > settings", () => {
   beforeEach(() => {
     H.resetSnowplow();
     H.restore();
@@ -346,7 +346,7 @@ describe("Cloud settings section", () => {
   });
 });
 
-H.describeWithSnowplow("scenarios > admin > settings > email settings", () => {
+describe("scenarios > admin > settings > email settings", () => {
   describe("self-hosted instance", () => {
     beforeEach(() => {
       cy.intercept("PUT", "api/email").as("smtpSaved");

--- a/e2e/test/scenarios/admin/database-connection-strings.cy.spec.ts
+++ b/e2e/test/scenarios/admin/database-connection-strings.cy.spec.ts
@@ -359,7 +359,7 @@ describe("Database connection strings", () => {
   });
 });
 
-H.describeWithSnowplow("Database connection strings events", () => {
+describe("Database connection strings events", () => {
   beforeEach(() => {
     H.resetSnowplow();
     H.restore();

--- a/e2e/test/scenarios/admin/databases.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases.cy.spec.js
@@ -984,7 +984,7 @@ describe("scenarios > admin > databases > sample database", () => {
   });
 });
 
-H.describeWithSnowplow("add database card", () => {
+describe("add database card", () => {
   beforeEach(() => {
     H.resetSnowplow();
     H.restore();

--- a/e2e/test/scenarios/admin/datamodel/segments.cy.spec.ts
+++ b/e2e/test/scenarios/admin/datamodel/segments.cy.spec.ts
@@ -281,7 +281,7 @@ describe("scenarios > admin > datamodel > segments", () => {
     });
   });
 
-  H.describeWithSnowplow("x-ray", () => {
+  describe("x-ray", () => {
     afterEach(() => {
       H.expectNoBadSnowplowEvents();
     });

--- a/e2e/test/scenarios/admin/remote-sync.cy.spec.ts
+++ b/e2e/test/scenarios/admin/remote-sync.cy.spec.ts
@@ -10,7 +10,7 @@ const LOCAL_GIT_URL = "file://" + H.LOCAL_GIT_PATH + "/.git";
 
 const REMOTE_QUESTION_NAME = "Remote Sync Test Question";
 
-H.describeWithSnowplowEE("Remote Sync", () => {
+describe("Remote Sync", () => {
   beforeEach(() => {
     H.restore();
     H.resetSnowplow();

--- a/e2e/test/scenarios/admin/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/admin/transforms.cy.spec.ts
@@ -20,7 +20,7 @@ const TARGET_SCHEMA = "Schema A";
 const TARGET_SCHEMA_2 = "Schema B";
 const CUSTOM_SCHEMA = "custom_schema";
 
-H.describeWithSnowplowEE("scenarios > admin > transforms", () => {
+describe("scenarios > admin > transforms", () => {
   beforeEach(() => {
     H.restore("postgres-writable");
     H.resetTestTable({ type: "postgres", table: "many_schemas" });
@@ -2018,7 +2018,7 @@ describe("scenarios > admin > transforms > jobs", () => {
     });
   });
 
-  H.describeWithSnowplowEE("runs", () => {
+  describe("runs", () => {
     beforeEach(() => {
       H.resetSnowplow();
     });

--- a/e2e/test/scenarios/collections/cleanup.cy.spec.js
+++ b/e2e/test/scenarios/collections/cleanup.cy.spec.js
@@ -141,7 +141,7 @@ describe("scenarios > collections > clean up", () => {
       });
     });
 
-    H.describeWithSnowplowEE("clean up collection modal", () => {
+    describe("clean up collection modal", () => {
       beforeEach(() => {
         H.resetSnowplow();
         cy.signInAsAdmin();

--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -30,7 +30,7 @@ describe("scenarios > collection defaults", () => {
     cy.intercept("GET", "/api/collection/*/items?**").as("getCollectionItems");
   });
 
-  H.describeWithSnowplow("new collection button", () => {
+  describe("new collection button", () => {
     beforeEach(() => {
       H.restore();
       H.resetSnowplow();

--- a/e2e/test/scenarios/collections/trash.cy.spec.js
+++ b/e2e/test/scenarios/collections/trash.cy.spec.js
@@ -100,7 +100,7 @@ describe("scenarios > collections > trash", () => {
     H.sidebar().findByText("Trash").should("not.exist");
   });
 
-  H.describeWithSnowplow("", () => {
+  describe("", () => {
     beforeEach(() => {
       H.resetSnowplow();
     });

--- a/e2e/test/scenarios/collections/trash.cy.spec.js
+++ b/e2e/test/scenarios/collections/trash.cy.spec.js
@@ -100,7 +100,7 @@ describe("scenarios > collections > trash", () => {
     H.sidebar().findByText("Trash").should("not.exist");
   });
 
-  describe("", () => {
+  describe("Snowplow analytics", () => {
     beforeEach(() => {
       H.resetSnowplow();
     });

--- a/e2e/test/scenarios/collections/uploads.cy.spec.js
+++ b/e2e/test/scenarios/collections/uploads.cy.spec.js
@@ -5,277 +5,263 @@ import { FIXTURE_PATH, VALID_CSV_FILES } from "e2e/support/helpers";
 
 const { NOSQL_GROUP, ALL_USERS_GROUP } = USER_GROUPS;
 
-H.describeWithSnowplow(
-  "CSV Uploading",
-  { tags: ["@external", "@actions"] },
-  () => {
-    beforeEach(() => {
-      cy.intercept("POST", "/api/dataset").as("dataset");
-      cy.intercept("POST", "/api/table/*/append-csv").as("appendCSV");
-      cy.intercept("POST", "/api/table/*/replace-csv").as("replaceCSV");
+describe("CSV Uploading", { tags: ["@external", "@actions"] }, () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    cy.intercept("POST", "/api/table/*/append-csv").as("appendCSV");
+    cy.intercept("POST", "/api/table/*/replace-csv").as("replaceCSV");
+  });
+
+  it("Can upload a CSV file to an empty postgres schema", () => {
+    const testFile = VALID_CSV_FILES[0];
+    const EMPTY_SCHEMA_NAME = "empty_uploads";
+
+    cy.intercept("PUT", "/api/setting/*").as("saveSettings");
+    cy.intercept("GET", "/api/database").as("databaseList");
+
+    H.restore("postgres-writable");
+    cy.signInAsAdmin();
+
+    H.queryWritableDB(
+      "DROP SCHEMA IF EXISTS empty_uploads CASCADE;",
+      "postgres",
+    );
+    H.queryWritableDB("CREATE SCHEMA IF NOT EXISTS empty_uploads;", "postgres");
+    // create a table because H.resyncDatabase has a check relying on tables count > 0
+    H.queryWritableDB("CREATE TABLE empty_uploads.empty_table ();", "postgres");
+    // Make sure to resync the db because otherwise "public" schema sometimes is there but sometimes is not
+    H.resyncDatabase({ dbId: WRITABLE_DB_ID });
+
+    cy.request("POST", "/api/collection", {
+      name: "Uploads Collection",
+      parent_id: null,
+    }).then(({ body: { id: collectionId } }) => {
+      cy.wrap(collectionId).as("collectionId");
     });
+    cy.visit("/admin/settings/uploads");
+    cy.findByTestId("loading-indicator").should("not.exist");
 
-    it("Can upload a CSV file to an empty postgres schema", () => {
-      const testFile = VALID_CSV_FILES[0];
-      const EMPTY_SCHEMA_NAME = "empty_uploads";
+    cy.findByLabelText("Upload Settings Form")
+      .findByPlaceholderText("Select a database")
+      .click();
+    H.popover().findByText("Writable Postgres12").click();
+    cy.findByLabelText("Upload Settings Form")
+      .findByPlaceholderText("Select a schema")
+      .click();
 
-      cy.intercept("PUT", "/api/setting/*").as("saveSettings");
-      cy.intercept("GET", "/api/database").as("databaseList");
+    H.popover().findByText(EMPTY_SCHEMA_NAME).click();
 
-      H.restore("postgres-writable");
-      cy.signInAsAdmin();
+    cy.findByLabelText("Upload Settings Form").button("Enable uploads").click();
 
+    cy.wait(["@saveSettings", "@databaseList"]);
+
+    uploadFileToCollection(testFile);
+
+    const tableQuery = `SELECT * FROM information_schema.tables WHERE table_name LIKE '%${testFile.tableName}_%' ORDER BY table_name DESC LIMIT 1;`;
+
+    H.queryWritableDB(tableQuery, "postgres").then((result) => {
+      expect(result.rows.length).to.equal(1);
+      const tableName = result.rows[0].table_name;
       H.queryWritableDB(
-        "DROP SCHEMA IF EXISTS empty_uploads CASCADE;",
+        `SELECT count(*) FROM ${EMPTY_SCHEMA_NAME}.${tableName};`,
         "postgres",
-      );
-      H.queryWritableDB(
-        "CREATE SCHEMA IF NOT EXISTS empty_uploads;",
-        "postgres",
-      );
-      // create a table because H.resyncDatabase has a check relying on tables count > 0
-      H.queryWritableDB(
-        "CREATE TABLE empty_uploads.empty_table ();",
-        "postgres",
-      );
-      // Make sure to resync the db because otherwise "public" schema sometimes is there but sometimes is not
-      H.resyncDatabase({ dbId: WRITABLE_DB_ID });
-
-      cy.request("POST", "/api/collection", {
-        name: "Uploads Collection",
-        parent_id: null,
-      }).then(({ body: { id: collectionId } }) => {
-        cy.wrap(collectionId).as("collectionId");
-      });
-      cy.visit("/admin/settings/uploads");
-      cy.findByTestId("loading-indicator").should("not.exist");
-
-      cy.findByLabelText("Upload Settings Form")
-        .findByPlaceholderText("Select a database")
-        .click();
-      H.popover().findByText("Writable Postgres12").click();
-      cy.findByLabelText("Upload Settings Form")
-        .findByPlaceholderText("Select a schema")
-        .click();
-
-      H.popover().findByText(EMPTY_SCHEMA_NAME).click();
-
-      cy.findByLabelText("Upload Settings Form")
-        .button("Enable uploads")
-        .click();
-
-      cy.wait(["@saveSettings", "@databaseList"]);
-
-      uploadFileToCollection(testFile);
-
-      const tableQuery = `SELECT * FROM information_schema.tables WHERE table_name LIKE '%${testFile.tableName}_%' ORDER BY table_name DESC LIMIT 1;`;
-
-      H.queryWritableDB(tableQuery, "postgres").then((result) => {
-        expect(result.rows.length).to.equal(1);
-        const tableName = result.rows[0].table_name;
-        H.queryWritableDB(
-          `SELECT count(*) FROM ${EMPTY_SCHEMA_NAME}.${tableName};`,
-          "postgres",
-        ).then((result) => {
-          expect(Number(result.rows[0].count)).to.equal(testFile.rowCount);
-        });
-      });
-
-      cy.log(
-        "Ensure that table is visible in admin without refreshing (metabase#38041)",
-      );
-
-      cy.findByTestId("app-bar")
-        .findByRole("button", { name: "Settings" })
-        .click();
-      H.popover().findByText("Admin settings").click();
-
-      cy.findByRole("link", { name: "Table Metadata" }).click();
-
-      H.DataModel.TablePicker.getDatabase("Writable Postgres12").click();
-      H.DataModel.TablePicker.getTables().should("have.length", 2);
-      H.DataModel.TablePicker.getTable("Dog Breeds").should("be.visible");
-    });
-
-    ["postgres", "mysql"].forEach((dialect) => {
-      describe(`CSV Uploading (${dialect})`, () => {
-        beforeEach(() => {
-          H.restore(`${dialect}-writable`);
-          H.resetSnowplow();
-          cy.signInAsAdmin();
-          H.enableTracking();
-
-          cy.request("POST", "/api/collection", {
-            name: "Uploads Collection",
-            parent_id: null,
-          }).then(({ body: { id: collectionId } }) => {
-            cy.wrap(collectionId).as("collectionId");
-          });
-          H.enableUploads(dialect);
-        });
-
-        afterEach(() => {
-          H.expectNoBadSnowplowEvents();
-        });
-
-        VALID_CSV_FILES.forEach((testFile) => {
-          it(`Can upload ${testFile.fileName} to a collection`, () => {
-            uploadFileToCollection(testFile);
-
-            H.expectUnstructuredSnowplowEvent({
-              event: "csv_upload_successful",
-            });
-
-            const tableQuery = `SELECT * FROM information_schema.tables WHERE table_name LIKE '%${testFile.tableName}_%' ORDER BY table_name DESC LIMIT 1;`;
-
-            H.queryWritableDB(tableQuery, dialect).then((result) => {
-              expect(result.rows.length).to.equal(1);
-              const tableName =
-                result.rows[0].table_name ?? result.rows[0].TABLE_NAME;
-              H.queryWritableDB(
-                `SELECT count(*) as count FROM ${tableName};`,
-                dialect,
-              ).then((result) => {
-                expect(Number(result.rows[0].count)).to.equal(
-                  testFile.rowCount,
-                );
-              });
-            });
-          });
-        });
-
-        H.INVALID_CSV_FILES.forEach((testFile) => {
-          it(`Cannot upload ${testFile.fileName} to a collection`, () => {
-            uploadFileToCollection(testFile);
-
-            H.expectUnstructuredSnowplowEvent({
-              event: "csv_upload_failed",
-            });
-
-            const tableQuery = `SELECT * FROM information_schema.tables WHERE table_name LIKE '%${testFile.tableName}_%' ORDER BY table_name DESC LIMIT 1;`;
-
-            H.queryWritableDB(tableQuery, dialect).then((result) => {
-              expect(result.rows.length).to.equal(0);
-            });
-
-            cy.log("metabase#55382");
-            cy.findByRole("dialog", { name: "Upload error details" })
-              .findByRole("button", { name: "Close" })
-              .click();
-
-            H.openCollectionMenu();
-            H.popover().findByText("Move to trash").click();
-            cy.findByRole("dialog", { name: "Upload error details" }).should(
-              "not.exist",
-            );
-          });
-        });
-
-        describe("CSV appends", () => {
-          it("Can append a CSV file to an existing table", () => {
-            uploadFileToCollection(VALID_CSV_FILES[0]);
-            cy.findByTestId("view-footer").findByText(
-              `Showing ${VALID_CSV_FILES[0].rowCount} rows`,
-            );
-
-            uploadToExisting({
-              testFile: VALID_CSV_FILES[0],
-              uploadMode: "append",
-            });
-            cy.findByTestId("view-footer").findByText(
-              `Showing ${VALID_CSV_FILES[0].rowCount * 2} rows`,
-            );
-          });
-
-          it("Cannot append a CSV file to a table with a different schema", () => {
-            uploadFileToCollection(VALID_CSV_FILES[0]);
-            cy.findByTestId("view-footer").findByText(
-              `Showing ${VALID_CSV_FILES[0].rowCount} rows`,
-            );
-
-            uploadToExisting({
-              testFile: VALID_CSV_FILES[1],
-              identicalSchema: false,
-              uploadMode: "append",
-            });
-            cy.findByTestId("view-footer").findByText(
-              `Showing ${VALID_CSV_FILES[0].rowCount} rows`,
-            );
-          });
-        });
-
-        describe("CSV replacement", () => {
-          it("Can replace data in an existing table", () => {
-            uploadFileToCollection(VALID_CSV_FILES[0]);
-            cy.findByTestId("view-footer").findByText(
-              `Showing ${VALID_CSV_FILES[0].rowCount} rows`,
-            );
-
-            uploadToExisting({
-              testFile: VALID_CSV_FILES[0],
-              uploadMode: "replace",
-            });
-            cy.findByTestId("view-footer").findByText(
-              `Showing ${VALID_CSV_FILES[0].rowCount} rows`,
-            );
-          });
-
-          it("Cannot data in a table with a different schema", () => {
-            uploadFileToCollection(VALID_CSV_FILES[0]);
-            cy.findByTestId("view-footer").findByText(
-              `Showing ${VALID_CSV_FILES[0].rowCount} rows`,
-            );
-
-            uploadToExisting({
-              testFile: VALID_CSV_FILES[1],
-              identicalSchema: false,
-              uploadMode: "replace",
-            });
-            cy.findByTestId("view-footer").findByText(
-              `Showing ${VALID_CSV_FILES[0].rowCount} rows`,
-            );
-          });
-        });
+      ).then((result) => {
+        expect(Number(result.rows[0].count)).to.equal(testFile.rowCount);
       });
     });
 
-    it("should allow you to choose a model to append to if there are multiple (metabase#53824)", () => {
-      H.restore("postgres-writable");
-      cy.signInAsAdmin();
-      H.enableTracking();
+    cy.log(
+      "Ensure that table is visible in admin without refreshing (metabase#38041)",
+    );
 
-      H.enableUploads("postgres");
-      H.headlessUpload(FIRST_COLLECTION_ID, VALID_CSV_FILES[0]);
-      H.headlessUpload(FIRST_COLLECTION_ID, VALID_CSV_FILES[1]);
+    cy.findByTestId("app-bar")
+      .findByRole("button", { name: "Settings" })
+      .click();
+    H.popover().findByText("Admin settings").click();
 
-      H.visitCollection(FIRST_COLLECTION_ID);
+    cy.findByRole("link", { name: "Table Metadata" }).click();
 
-      cy.fixture(`${FIXTURE_PATH}/${VALID_CSV_FILES[2].fileName}`).then(
-        (file) => {
-          cy.get("#upload-input").selectFile(
-            {
-              contents: Cypress.Buffer.from(file),
-              fileName: VALID_CSV_FILES[2].fileName,
-              mimeType: "text/csv",
-            },
-            { force: true },
+    H.DataModel.TablePicker.getDatabase("Writable Postgres12").click();
+    H.DataModel.TablePicker.getTables().should("have.length", 2);
+    H.DataModel.TablePicker.getTable("Dog Breeds").should("be.visible");
+  });
+
+  ["postgres", "mysql"].forEach((dialect) => {
+    describe(`CSV Uploading (${dialect})`, () => {
+      beforeEach(() => {
+        H.restore(`${dialect}-writable`);
+        H.resetSnowplow();
+        cy.signInAsAdmin();
+        H.enableTracking();
+
+        cy.request("POST", "/api/collection", {
+          name: "Uploads Collection",
+          parent_id: null,
+        }).then(({ body: { id: collectionId } }) => {
+          cy.wrap(collectionId).as("collectionId");
+        });
+        H.enableUploads(dialect);
+      });
+
+      afterEach(() => {
+        H.expectNoBadSnowplowEvents();
+      });
+
+      VALID_CSV_FILES.forEach((testFile) => {
+        it(`Can upload ${testFile.fileName} to a collection`, () => {
+          uploadFileToCollection(testFile);
+
+          H.expectUnstructuredSnowplowEvent({
+            event: "csv_upload_successful",
+          });
+
+          const tableQuery = `SELECT * FROM information_schema.tables WHERE table_name LIKE '%${testFile.tableName}_%' ORDER BY table_name DESC LIMIT 1;`;
+
+          H.queryWritableDB(tableQuery, dialect).then((result) => {
+            expect(result.rows.length).to.equal(1);
+            const tableName =
+              result.rows[0].table_name ?? result.rows[0].TABLE_NAME;
+            H.queryWritableDB(
+              `SELECT count(*) as count FROM ${tableName};`,
+              dialect,
+            ).then((result) => {
+              expect(Number(result.rows[0].count)).to.equal(testFile.rowCount);
+            });
+          });
+        });
+      });
+
+      H.INVALID_CSV_FILES.forEach((testFile) => {
+        it(`Cannot upload ${testFile.fileName} to a collection`, () => {
+          uploadFileToCollection(testFile);
+
+          H.expectUnstructuredSnowplowEvent({
+            event: "csv_upload_failed",
+          });
+
+          const tableQuery = `SELECT * FROM information_schema.tables WHERE table_name LIKE '%${testFile.tableName}_%' ORDER BY table_name DESC LIMIT 1;`;
+
+          H.queryWritableDB(tableQuery, dialect).then((result) => {
+            expect(result.rows.length).to.equal(0);
+          });
+
+          cy.log("metabase#55382");
+          cy.findByRole("dialog", { name: "Upload error details" })
+            .findByRole("button", { name: "Close" })
+            .click();
+
+          H.openCollectionMenu();
+          H.popover().findByText("Move to trash").click();
+          cy.findByRole("dialog", { name: "Upload error details" }).should(
+            "not.exist",
           );
-        },
-      );
+        });
+      });
 
-      cy.findByRole("radio", { name: /Append to a model/ }).click();
+      describe("CSV appends", () => {
+        it("Can append a CSV file to an existing table", () => {
+          uploadFileToCollection(VALID_CSV_FILES[0]);
+          cy.findByTestId("view-footer").findByText(
+            `Showing ${VALID_CSV_FILES[0].rowCount} rows`,
+          );
 
-      cy.findByRole("textbox", { name: "Select a model" })
-        .should("contain.value", VALID_CSV_FILES[1].humanName)
-        .click();
+          uploadToExisting({
+            testFile: VALID_CSV_FILES[0],
+            uploadMode: "append",
+          });
+          cy.findByTestId("view-footer").findByText(
+            `Showing ${VALID_CSV_FILES[0].rowCount * 2} rows`,
+          );
+        });
 
-      H.popover().findByText(VALID_CSV_FILES[0].humanName).click();
-      cy.findByRole("textbox", { name: "Select a model" })
-        .should("have.value", VALID_CSV_FILES[0].humanName)
-        .click();
+        it("Cannot append a CSV file to a table with a different schema", () => {
+          uploadFileToCollection(VALID_CSV_FILES[0]);
+          cy.findByTestId("view-footer").findByText(
+            `Showing ${VALID_CSV_FILES[0].rowCount} rows`,
+          );
+
+          uploadToExisting({
+            testFile: VALID_CSV_FILES[1],
+            identicalSchema: false,
+            uploadMode: "append",
+          });
+          cy.findByTestId("view-footer").findByText(
+            `Showing ${VALID_CSV_FILES[0].rowCount} rows`,
+          );
+        });
+      });
+
+      describe("CSV replacement", () => {
+        it("Can replace data in an existing table", () => {
+          uploadFileToCollection(VALID_CSV_FILES[0]);
+          cy.findByTestId("view-footer").findByText(
+            `Showing ${VALID_CSV_FILES[0].rowCount} rows`,
+          );
+
+          uploadToExisting({
+            testFile: VALID_CSV_FILES[0],
+            uploadMode: "replace",
+          });
+          cy.findByTestId("view-footer").findByText(
+            `Showing ${VALID_CSV_FILES[0].rowCount} rows`,
+          );
+        });
+
+        it("Cannot data in a table with a different schema", () => {
+          uploadFileToCollection(VALID_CSV_FILES[0]);
+          cy.findByTestId("view-footer").findByText(
+            `Showing ${VALID_CSV_FILES[0].rowCount} rows`,
+          );
+
+          uploadToExisting({
+            testFile: VALID_CSV_FILES[1],
+            identicalSchema: false,
+            uploadMode: "replace",
+          });
+          cy.findByTestId("view-footer").findByText(
+            `Showing ${VALID_CSV_FILES[0].rowCount} rows`,
+          );
+        });
+      });
     });
-  },
-);
+  });
+
+  it("should allow you to choose a model to append to if there are multiple (metabase#53824)", () => {
+    H.restore("postgres-writable");
+    cy.signInAsAdmin();
+    H.enableTracking();
+
+    H.enableUploads("postgres");
+    H.headlessUpload(FIRST_COLLECTION_ID, VALID_CSV_FILES[0]);
+    H.headlessUpload(FIRST_COLLECTION_ID, VALID_CSV_FILES[1]);
+
+    H.visitCollection(FIRST_COLLECTION_ID);
+
+    cy.fixture(`${FIXTURE_PATH}/${VALID_CSV_FILES[2].fileName}`).then(
+      (file) => {
+        cy.get("#upload-input").selectFile(
+          {
+            contents: Cypress.Buffer.from(file),
+            fileName: VALID_CSV_FILES[2].fileName,
+            mimeType: "text/csv",
+          },
+          { force: true },
+        );
+      },
+    );
+
+    cy.findByRole("radio", { name: /Append to a model/ }).click();
+
+    cy.findByRole("textbox", { name: "Select a model" })
+      .should("contain.value", VALID_CSV_FILES[1].humanName)
+      .click();
+
+    H.popover().findByText(VALID_CSV_FILES[0].humanName).click();
+    cy.findByRole("textbox", { name: "Select a model" })
+      .should("have.value", VALID_CSV_FILES[0].humanName)
+      .click();
+  });
+});
 
 describe("permissions", { tags: "@external" }, () => {
   it("should not show you upload buttons if you are a sandboxed user", () => {

--- a/e2e/test/scenarios/custom-column/cc-shortcuts-combine.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-shortcuts-combine.cy.spec.ts
@@ -125,38 +125,35 @@ describe("scenarios > question > custom column > expression shortcuts > combine"
   });
 });
 
-H.describeWithSnowplow(
-  "scenarios > question > custom column > combine shortcuts",
-  () => {
-    beforeEach(() => {
-      H.restore();
-      H.resetSnowplow();
-      cy.signInAsNormalUser();
+describe("scenarios > question > custom column > combine shortcuts", () => {
+  beforeEach(() => {
+    H.restore();
+    H.resetSnowplow();
+    cy.signInAsNormalUser();
+  });
+
+  afterEach(() => {
+    H.expectNoBadSnowplowEvents();
+  });
+
+  it("should send an event for combine columns", () => {
+    H.openOrdersTable({ mode: "notebook" });
+    H.addCustomColumn();
+    selectCombineColumns();
+
+    selectColumn(0, "User", "Email");
+    selectColumn(1, "User", "Email");
+
+    H.expressionEditorWidget().button("Done").click();
+
+    H.expectUnstructuredSnowplowEvent({
+      event: "column_combine_via_shortcut",
+      custom_expressions_used: ["concat"],
+      database_id: SAMPLE_DB_ID,
+      question_id: 0,
     });
-
-    afterEach(() => {
-      H.expectNoBadSnowplowEvents();
-    });
-
-    it("should send an event for combine columns", () => {
-      H.openOrdersTable({ mode: "notebook" });
-      H.addCustomColumn();
-      selectCombineColumns();
-
-      selectColumn(0, "User", "Email");
-      selectColumn(1, "User", "Email");
-
-      H.expressionEditorWidget().button("Done").click();
-
-      H.expectUnstructuredSnowplowEvent({
-        event: "column_combine_via_shortcut",
-        custom_expressions_used: ["concat"],
-        database_id: SAMPLE_DB_ID,
-        question_id: 0,
-      });
-    });
-  },
-);
+  });
+});
 
 function selectCombineColumns() {
   H.popover().findByText("Combine columns").click();

--- a/e2e/test/scenarios/custom-column/cc-shortcuts.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-shortcuts.cy.spec.ts
@@ -188,37 +188,34 @@ describe("scenarios > question > custom column > expression shortcuts > extract"
   });
 });
 
-H.describeWithSnowplow(
-  "scenarios > question > custom column > expression shortcuts > extract",
-  () => {
-    beforeEach(() => {
-      H.restore();
-      H.resetSnowplow();
-      cy.signInAsNormalUser();
+describe("scenarios > question > custom column > expression shortcuts > extract", () => {
+  beforeEach(() => {
+    H.restore();
+    H.resetSnowplow();
+    cy.signInAsNormalUser();
+  });
+
+  afterEach(() => {
+    H.expectNoBadSnowplowEvents();
+  });
+
+  it("should track column extraction via shortcut", () => {
+    H.openTable({ mode: "notebook", limit: 1, table: ORDERS_ID });
+    H.addCustomColumn();
+    selectExtractColumn();
+
+    cy.findAllByTestId("dimension-list-item").contains("Created At").click();
+
+    H.popover().findAllByRole("button").contains("Hour of day").click();
+
+    H.expectUnstructuredSnowplowEvent({
+      event: "column_extract_via_shortcut",
+      custom_expressions_used: ["get-hour"],
+      database_id: SAMPLE_DB_ID,
+      question_id: 0,
     });
-
-    afterEach(() => {
-      H.expectNoBadSnowplowEvents();
-    });
-
-    it("should track column extraction via shortcut", () => {
-      H.openTable({ mode: "notebook", limit: 1, table: ORDERS_ID });
-      H.addCustomColumn();
-      selectExtractColumn();
-
-      cy.findAllByTestId("dimension-list-item").contains("Created At").click();
-
-      H.popover().findAllByRole("button").contains("Hour of day").click();
-
-      H.expectUnstructuredSnowplowEvent({
-        event: "column_extract_via_shortcut",
-        custom_expressions_used: ["get-hour"],
-        database_id: SAMPLE_DB_ID,
-        question_id: 0,
-      });
-    });
-  },
-);
+  });
+});
 
 describe("scenarios > question > custom column > expression shortcuts > combine", () => {
   function addColumn() {
@@ -330,35 +327,32 @@ describe("scenarios > question > custom column > expression shortcuts > combine"
   });
 });
 
-H.describeWithSnowplow(
-  "scenarios > question > custom column > combine shortcuts",
-  () => {
-    beforeEach(() => {
-      H.restore();
-      H.resetSnowplow();
-      cy.signInAsNormalUser();
+describe("scenarios > question > custom column > combine shortcuts", () => {
+  beforeEach(() => {
+    H.restore();
+    H.resetSnowplow();
+    cy.signInAsNormalUser();
+  });
+
+  afterEach(() => {
+    H.expectNoBadSnowplowEvents();
+  });
+
+  it("should send an event for combine columns", () => {
+    H.openOrdersTable({ mode: "notebook" });
+    H.addCustomColumn();
+    selectCombineColumns();
+
+    selectColumn(0, "User", "Email");
+    selectColumn(1, "User", "Email");
+
+    H.expressionEditorWidget().button("Done").click();
+
+    H.expectUnstructuredSnowplowEvent({
+      event: "column_combine_via_shortcut",
+      custom_expressions_used: ["concat"],
+      database_id: SAMPLE_DB_ID,
+      question_id: 0,
     });
-
-    afterEach(() => {
-      H.expectNoBadSnowplowEvents();
-    });
-
-    it("should send an event for combine columns", () => {
-      H.openOrdersTable({ mode: "notebook" });
-      H.addCustomColumn();
-      selectCombineColumns();
-
-      selectColumn(0, "User", "Email");
-      selectColumn(1, "User", "Email");
-
-      H.expressionEditorWidget().button("Done").click();
-
-      H.expectUnstructuredSnowplowEvent({
-        event: "column_combine_via_shortcut",
-        custom_expressions_used: ["concat"],
-        database_id: SAMPLE_DB_ID,
-        question_id: 0,
-      });
-    });
-  },
-);
+  });
+});

--- a/e2e/test/scenarios/dashboard-cards/dashboard-sections.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-sections.cy.spec.js
@@ -11,7 +11,7 @@ const CATEGORY_FILTER = createMockParameter({
   type: "string/=",
 });
 
-H.describeWithSnowplow("scenarios > dashboard cards > sections", () => {
+describe("scenarios > dashboard cards > sections", () => {
   beforeEach(() => {
     H.resetSnowplow();
     H.restore();

--- a/e2e/test/scenarios/dashboard-cards/dashcard-replace-question.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashcard-replace-question.cy.spec.js
@@ -100,7 +100,7 @@ function getDashboardCards(mappedQuestionId) {
   ];
 }
 
-H.describeWithSnowplow("scenarios > dashboard cards > replace question", () => {
+describe("scenarios > dashboard cards > replace question", () => {
   beforeEach(() => {
     H.resetSnowplow();
     H.restore();

--- a/e2e/test/scenarios/dashboard-cards/duplicate-dashcards-tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/duplicate-dashcards-tabs.cy.spec.js
@@ -48,7 +48,7 @@ const EVENTS = {
   saveDashboard: { event: "dashboard_saved" },
 };
 
-H.describeWithSnowplow("scenarios > dashboard cards > duplicate", () => {
+describe("scenarios > dashboard cards > duplicate", () => {
   beforeEach(() => {
     H.restore();
     H.resetSnowplow();

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-apply.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-apply.cy.spec.js
@@ -439,7 +439,7 @@ describe(
   },
 );
 
-H.describeWithSnowplow("scenarios > dashboards > filters > auto apply", () => {
+describe("scenarios > dashboards > filters > auto apply", () => {
   beforeEach(() => {
     H.restore();
     H.resetSnowplow();

--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -2974,7 +2974,7 @@ describe("scenarios > dashboard > parameters", () => {
   });
 });
 
-H.describeWithSnowplow("scenarios > dashboard > parameters", () => {
+describe("scenarios > dashboard > parameters", () => {
   beforeEach(() => {
     H.resetSnowplow();
     H.restore();

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -1359,7 +1359,7 @@ describe("scenarios > dashboard", () => {
   });
 });
 
-H.describeWithSnowplow("scenarios > dashboard", () => {
+describe("scenarios > dashboard", () => {
   beforeEach(() => {
     cy.intercept("GET", "/api/activity/recents?*").as("recentViews");
     H.resetSnowplow();

--- a/e2e/test/scenarios/dashboard/tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/tabs.cy.spec.js
@@ -716,7 +716,7 @@ describe("scenarios > dashboard > tabs", () => {
   });
 });
 
-H.describeWithSnowplow("scenarios > dashboard > tabs", () => {
+describe("scenarios > dashboard > tabs", () => {
   beforeEach(() => {
     H.restore();
     H.resetSnowplow();

--- a/e2e/test/scenarios/dashboard/text-cards.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/text-cards.cy.spec.js
@@ -13,7 +13,7 @@ describe("scenarios > dashboard > text and headings", () => {
     H.enableTracking();
   });
 
-  H.describeWithSnowplow("text", () => {
+  describe("text", () => {
     beforeEach(() => {
       H.visitDashboard(ORDERS_DASHBOARD_ID);
     });
@@ -152,7 +152,7 @@ describe("scenarios > dashboard > text and headings", () => {
     });
   });
 
-  H.describeWithSnowplow("heading", () => {
+  describe("heading", () => {
     beforeEach(() => {
       H.visitDashboard(ORDERS_DASHBOARD_ID);
     });

--- a/e2e/test/scenarios/dashboard/visualizer/snowplow-tracking.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/snowplow-tracking.cy.spec.ts
@@ -9,7 +9,7 @@ import {
 const { H } = cy;
 
 describe("Snowplow tracking", () => {
-  H.describeWithSnowplow("add database card", () => {
+  describe("add database card", () => {
     beforeEach(() => {
       H.resetSnowplow();
       H.restore();

--- a/e2e/test/scenarios/dependencies/dependency-checks.cy.spec.ts
+++ b/e2e/test/scenarios/dependencies/dependency-checks.cy.spec.ts
@@ -6,7 +6,7 @@ import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 
 const { PRODUCTS_ID } = SAMPLE_DATABASE;
 
-H.describeWithSnowplowEE("scenarios > dependencies > dependency checks", () => {
+describe("scenarios > dependencies > dependency checks", () => {
   beforeEach(() => {
     H.restore("postgres-writable");
     H.resetTestTable({ type: "postgres", table: "many_schemas" });

--- a/e2e/test/scenarios/documents/comments.cy.spec.ts
+++ b/e2e/test/scenarios/documents/comments.cy.spec.ts
@@ -24,7 +24,7 @@ const CARD_EMBED_ID = "cce109c3-4cec-caf1-a569-89fa15410ae1";
 const FIRST_REACTION_EMOJI = "😀";
 const SECOND_REACTION_EMOJI = "😃";
 
-H.describeWithSnowplowEE("document comments", () => {
+describe("document comments", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/documents/document-permissions.cy.spec.ts
+++ b/e2e/test/scenarios/documents/document-permissions.cy.spec.ts
@@ -3,7 +3,7 @@ import { USER_GROUPS } from "e2e/support/cypress_data";
 
 const { ALL_USERS_GROUP } = USER_GROUPS;
 
-H.describeWithSnowplowEE("document permissions", () => {
+describe("document permissions", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/documents/documents.cy.spec.ts
+++ b/e2e/test/scenarios/documents/documents.cy.spec.ts
@@ -14,7 +14,7 @@ import type { Document } from "metabase-types/api";
 
 const { H } = cy;
 
-H.describeWithSnowplowEE("documents", () => {
+describe("documents", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/embedding/embed-resource-downloads.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embed-resource-downloads.cy.spec.ts
@@ -13,95 +13,171 @@ import * as DateFilter from "../native-filters/helpers/e2e-date-filter-helpers";
  *  Unless the product changes, these should test the same things as `public-resource-downloads.cy.spec.ts`
  */
 
-H.describeWithSnowplowEE(
-  "Static embed dashboards/questions downloads (results and export as pdf)",
-  () => {
-    beforeEach(() => {
-      H.resetSnowplow();
-      cy.deleteDownloadsFolder();
+describe("Static embed dashboards/questions downloads (results and export as pdf)", () => {
+  beforeEach(() => {
+    H.resetSnowplow();
+    cy.deleteDownloadsFolder();
+  });
+
+  describe("Static embed dashboards", () => {
+    before(() => {
+      H.restore("default");
+      cy.signInAsAdmin();
+
+      cy.request("PUT", `/api/dashboard/${ORDERS_DASHBOARD_ID}`, {
+        enable_embedding: true,
+      });
+
+      H.activateToken("pro-self-hosted");
+
+      cy.signOut();
     });
 
-    describe("Static embed dashboards", () => {
-      before(() => {
-        H.restore("default");
+    afterEach(() => {
+      H.expectNoBadSnowplowEvents();
+    });
+
+    it("#downloads=false should disable both PDF downloads and dashcard results downloads", () => {
+      H.visitEmbeddedPage(
+        {
+          resource: { dashboard: ORDERS_DASHBOARD_ID },
+          params: {},
+        },
+        {
+          pageStyle: {
+            downloads: false,
+          },
+        },
+      );
+      waitLoading();
+
+      cy.findByRole("button", { name: "Download as PDF" }).should("not.exist");
+
+      // we should not have any dashcard action in a static embedded/embed scenario, so the menu should not be there
+      cy.findByRole("button", { name: "Download results" }).should("not.exist");
+    });
+
+    it("should be able to download a static embedded dashboard as PDF", () => {
+      H.visitEmbeddedPage(
+        {
+          resource: { dashboard: ORDERS_DASHBOARD_ID },
+          params: {},
+        },
+        {
+          pageStyle: {
+            downloads: true,
+          },
+        },
+      );
+      waitLoading();
+
+      cy.get("header")
+        .findByRole("button", { name: "Download as PDF" })
+        .click();
+
+      cy.verifyDownload("Orders in a dashboard.pdf");
+
+      H.expectUnstructuredSnowplowEvent({
+        event: "dashboard_pdf_exported",
+        dashboard_id: 0,
+        dashboard_accessed_via: "static-embed",
+      });
+    });
+
+    it("should be able to download a static embedded dashcard as CSV", () => {
+      H.visitEmbeddedPage(
+        {
+          resource: { dashboard: ORDERS_DASHBOARD_ID },
+          params: {},
+        },
+        {
+          pageStyle: {
+            downloads: true,
+          },
+        },
+      );
+
+      waitLoading();
+
+      H.getDashboardCard().realHover();
+      H.getEmbeddedDashboardCardMenu().click();
+      H.exportFromDashcard(".csv");
+      cy.verifyDownload(".csv", { contains: true });
+
+      H.expectUnstructuredSnowplowEvent({
+        event: "download_results_clicked",
+        resource_type: "dashcard",
+        accessed_via: "static-embed",
+        export_type: "csv",
+      });
+    });
+
+    describe("with dashboard parameters", () => {
+      beforeEach(() => {
         cy.signInAsAdmin();
 
-        cy.request("PUT", `/api/dashboard/${ORDERS_DASHBOARD_ID}`, {
-          enable_embedding: true,
-        });
-
         H.activateToken("pro-self-hosted");
+
+        // Test parameter with accentuation (metabase#49118)
+        const CATEGORY_FILTER = createMockParameter({
+          id: "5aefc725",
+          name: "usuário",
+          slug: "usu%C3%A1rio",
+          type: "string/=",
+        });
+        const questionDetails = {
+          name: "Products",
+          query: {
+            "source-table": PRODUCTS_ID,
+          },
+        };
+        H.createDashboardWithQuestions({
+          // Can't figure out the type if I extracted `dashboardDetails` to a variable.
+          dashboardDetails: {
+            name: "Dashboard with a parameter",
+            parameters: [CATEGORY_FILTER],
+            enable_embedding: true,
+            embedding_params: {
+              [CATEGORY_FILTER.slug]: "enabled",
+            },
+          },
+          questions: [questionDetails],
+        }).then(({ dashboard, questions }) => {
+          const dashboardId = dashboard.id;
+          cy.wrap(dashboardId).as("dashboardId");
+          const questionId = questions[0].id;
+          H.addOrUpdateDashboardCard({
+            dashboard_id: dashboardId,
+            card_id: questionId,
+            card: {
+              parameter_mappings: [
+                {
+                  card_id: questionId,
+                  parameter_id: CATEGORY_FILTER.id,
+                  target: ["dimension", ["field", PRODUCTS.CATEGORY, null]],
+                },
+              ],
+            },
+          });
+        });
 
         cy.signOut();
       });
 
-      afterEach(() => {
-        H.expectNoBadSnowplowEvents();
-      });
-
-      it("#downloads=false should disable both PDF downloads and dashcard results downloads", () => {
-        H.visitEmbeddedPage(
-          {
-            resource: { dashboard: ORDERS_DASHBOARD_ID },
-            params: {},
-          },
-          {
-            pageStyle: {
-              downloads: false,
-            },
-          },
-        );
-        waitLoading();
-
-        cy.findByRole("button", { name: "Download as PDF" }).should(
-          "not.exist",
-        );
-
-        // we should not have any dashcard action in a static embedded/embed scenario, so the menu should not be there
-        cy.findByRole("button", { name: "Download results" }).should(
-          "not.exist",
-        );
-      });
-
-      it("should be able to download a static embedded dashboard as PDF", () => {
-        H.visitEmbeddedPage(
-          {
-            resource: { dashboard: ORDERS_DASHBOARD_ID },
-            params: {},
-          },
-          {
-            pageStyle: {
-              downloads: true,
-            },
-          },
-        );
-        waitLoading();
-
-        cy.get("header")
-          .findByRole("button", { name: "Download as PDF" })
-          .click();
-
-        cy.verifyDownload("Orders in a dashboard.pdf");
-
-        H.expectUnstructuredSnowplowEvent({
-          event: "dashboard_pdf_exported",
-          dashboard_id: 0,
-          dashboard_accessed_via: "static-embed",
-        });
-      });
-
       it("should be able to download a static embedded dashcard as CSV", () => {
-        H.visitEmbeddedPage(
-          {
-            resource: { dashboard: ORDERS_DASHBOARD_ID },
-            params: {},
-          },
-          {
-            pageStyle: {
-              downloads: true,
+        cy.get("@dashboardId").then((dashboardId) => {
+          H.visitEmbeddedPage(
+            {
+              resource: { dashboard: Number(dashboardId) },
+              params: {},
             },
-          },
-        );
+            {
+              pageStyle: {
+                downloads: true,
+              },
+            },
+          );
+        });
 
         waitLoading();
 
@@ -117,179 +193,205 @@ H.describeWithSnowplowEE(
           export_type: "csv",
         });
       });
+    });
+  });
 
-      describe("with dashboard parameters", () => {
-        beforeEach(() => {
-          cy.signInAsAdmin();
+  describe("Static embed questions", () => {
+    before(() => {
+      H.restore("default");
+      cy.signInAsAdmin();
 
-          H.activateToken("pro-self-hosted");
+      cy.request("PUT", `/api/card/${ORDERS_BY_YEAR_QUESTION_ID}`, {
+        enable_embedding: true,
+      });
 
-          // Test parameter with accentuation (metabase#49118)
-          const CATEGORY_FILTER = createMockParameter({
-            id: "5aefc725",
-            name: "usuário",
-            slug: "usu%C3%A1rio",
-            type: "string/=",
-          });
-          const questionDetails = {
-            name: "Products",
-            query: {
-              "source-table": PRODUCTS_ID,
-            },
-          };
-          H.createDashboardWithQuestions({
-            // Can't figure out the type if I extracted `dashboardDetails` to a variable.
-            dashboardDetails: {
-              name: "Dashboard with a parameter",
-              parameters: [CATEGORY_FILTER],
-              enable_embedding: true,
-              embedding_params: {
-                [CATEGORY_FILTER.slug]: "enabled",
-              },
-            },
-            questions: [questionDetails],
-          }).then(({ dashboard, questions }) => {
-            const dashboardId = dashboard.id;
-            cy.wrap(dashboardId).as("dashboardId");
-            const questionId = questions[0].id;
-            H.addOrUpdateDashboardCard({
-              dashboard_id: dashboardId,
-              card_id: questionId,
-              card: {
-                parameter_mappings: [
-                  {
-                    card_id: questionId,
-                    parameter_id: CATEGORY_FILTER.id,
-                    target: ["dimension", ["field", PRODUCTS.CATEGORY, null]],
-                  },
-                ],
-              },
-            });
-          });
+      H.activateToken("pro-self-hosted");
 
-          cy.signOut();
-        });
+      cy.signOut();
+    });
 
-        it("should be able to download a static embedded dashcard as CSV", () => {
-          cy.get("@dashboardId").then((dashboardId) => {
-            H.visitEmbeddedPage(
-              {
-                resource: { dashboard: Number(dashboardId) },
-                params: {},
-              },
-              {
-                pageStyle: {
-                  downloads: true,
-                },
-              },
-            );
-          });
+    it("#downloads=false should disable result downloads", () => {
+      H.visitEmbeddedPage(
+        {
+          resource: { question: ORDERS_BY_YEAR_QUESTION_ID },
+          params: {},
+        },
+        {
+          pageStyle: {
+            downloads: false,
+          },
+        },
+      );
 
-          waitLoading();
+      waitLoading();
 
-          H.getDashboardCard().realHover();
-          H.getEmbeddedDashboardCardMenu().click();
-          H.exportFromDashcard(".csv");
-          cy.verifyDownload(".csv", { contains: true });
+      cy.findByRole("button", { name: "Download results" }).should("not.exist");
+    });
 
-          H.expectUnstructuredSnowplowEvent({
-            event: "download_results_clicked",
-            resource_type: "dashcard",
-            accessed_via: "static-embed",
-            export_type: "csv",
-          });
-        });
+    it("should be able to download the question as PNG", () => {
+      H.visitEmbeddedPage(
+        {
+          resource: { question: ORDERS_BY_YEAR_QUESTION_ID },
+          params: {},
+        },
+        {
+          pageStyle: {
+            downloads: true,
+          },
+        },
+      );
+
+      waitLoading();
+
+      cy.findByRole("button", { name: "Download results" }).click();
+      H.popover().within(() => {
+        cy.findByText(".png").click();
+        cy.findByTestId("download-results-button").click();
+      });
+
+      cy.verifyDownload(".png", { contains: true });
+
+      H.expectUnstructuredSnowplowEvent({
+        event: "download_results_clicked",
+        resource_type: "question",
+        accessed_via: "static-embed",
+        export_type: "png",
       });
     });
 
-    describe("Static embed questions", () => {
-      before(() => {
-        H.restore("default");
+    it("should be able to download a static embedded card as CSV", () => {
+      H.visitEmbeddedPage(
+        {
+          resource: { question: ORDERS_BY_YEAR_QUESTION_ID },
+          params: {},
+        },
+        {
+          pageStyle: {
+            downloads: true,
+          },
+        },
+      );
+
+      waitLoading();
+
+      cy.findByRole("button", { name: "Download results" }).click();
+
+      H.popover().within(() => {
+        cy.findByText(".csv").click();
+        cy.findByTestId("download-results-button").click();
+      });
+
+      cy.verifyDownload(".csv", { contains: true });
+
+      H.expectUnstructuredSnowplowEvent({
+        event: "download_results_clicked",
+        resource_type: "question",
+        accessed_via: "static-embed",
+        export_type: "csv",
+      });
+    });
+
+    describe("with native question parameters", () => {
+      beforeEach(() => {
         cy.signInAsAdmin();
 
-        cy.request("PUT", `/api/card/${ORDERS_BY_YEAR_QUESTION_ID}`, {
-          enable_embedding: true,
-        });
-
         H.activateToken("pro-self-hosted");
+      });
 
+      it("should be able to download a static embedded question as CSV with correct parameters when field filters has multiple values (metabase#52430)", () => {
+        const FILTER_VALUES = ["NY", "CA"];
+        const QUESTION_NAME = "Native question with a Field parameter";
+
+        // Can't figure out the type if I extracted `questionDetails` to a variable.
+        H.createNativeQuestion(
+          {
+            name: QUESTION_NAME,
+            native: {
+              "template-tags": {
+                state: {
+                  id: "f7672b4d-1e84-1fa8-bf02-b5e584cd4535",
+                  name: "state",
+                  "display-name": "State",
+                  type: "dimension",
+                  options: {
+                    "case-sensitive": false,
+                  },
+                  dimension: ["field", PEOPLE.STATE, null],
+                  default: null,
+                  "widget-type": "string/contains",
+                },
+              },
+              query:
+                "select id, email, state from people where {{state}} limit 2",
+            },
+            parameters: [
+              {
+                id: "f7672b4d-1e84-1fa8-bf02-b5e584cd4535",
+                type: "string/contains",
+                options: {
+                  "case-sensitive": false,
+                },
+                target: ["dimension", ["template-tag", "state"]],
+                name: "State",
+                slug: "state",
+                default: null,
+              },
+            ],
+            enable_embedding: true,
+            embedding_params: {
+              state: "enabled",
+            },
+          },
+          {
+            idAlias: "questionId",
+            wrapId: true,
+          },
+        );
         cy.signOut();
-      });
 
-      it("#downloads=false should disable result downloads", () => {
-        H.visitEmbeddedPage(
-          {
-            resource: { question: ORDERS_BY_YEAR_QUESTION_ID },
-            params: {},
-          },
-          {
-            pageStyle: {
-              downloads: false,
+        cy.get("@questionId").then((questionId) => {
+          H.visitEmbeddedPage(
+            {
+              resource: { question: Number(questionId) },
+              params: {
+                state: FILTER_VALUES,
+              },
             },
-          },
-        );
+            {
+              pageStyle: {
+                downloads: true,
+              },
+              // should ignore `?locale=xx` search parameter when downloading results from questions without parameters (metabase#53037)
+              qs: {
+                locale: "en",
+              },
+            },
+          );
+        });
 
         waitLoading();
 
-        cy.findByRole("button", { name: "Download results" }).should(
-          "not.exist",
-        );
-      });
+        const FIRST_ROW = [
+          5,
+          "leffler.dominique@hotmail.com",
+          FILTER_VALUES[0],
+        ];
+        const SECOND_ROW = [13, "mustafa.thiel@hotmail.com", FILTER_VALUES[1]];
 
-      it("should be able to download the question as PNG", () => {
-        H.visitEmbeddedPage(
-          {
-            resource: { question: ORDERS_BY_YEAR_QUESTION_ID },
-            params: {},
-          },
-          {
-            pageStyle: {
-              downloads: true,
-            },
-          },
-        );
-
-        waitLoading();
-
-        cy.findByRole("button", { name: "Download results" }).click();
-        H.popover().within(() => {
-          cy.findByText(".png").click();
-          cy.findByTestId("download-results-button").click();
+        H.assertTableData({
+          columns: ["ID", "EMAIL", "STATE"],
+          firstRows: [FIRST_ROW, SECOND_ROW],
         });
 
-        cy.verifyDownload(".png", { contains: true });
-
-        H.expectUnstructuredSnowplowEvent({
-          event: "download_results_clicked",
-          resource_type: "question",
-          accessed_via: "static-embed",
-          export_type: "png",
+        cy.findByRole("heading", { name: QUESTION_NAME }).realHover();
+        H.downloadAndAssert({
+          isDashboard: false,
+          isEmbed: true,
+          enableFormatting: true,
+          fileType: "csv",
+          downloadUrl: "/api/embed/card/*/query/csv*",
+          downloadMethod: "GET",
         });
-      });
-
-      it("should be able to download a static embedded card as CSV", () => {
-        H.visitEmbeddedPage(
-          {
-            resource: { question: ORDERS_BY_YEAR_QUESTION_ID },
-            params: {},
-          },
-          {
-            pageStyle: {
-              downloads: true,
-            },
-          },
-        );
-
-        waitLoading();
-
-        cy.findByRole("button", { name: "Download results" }).click();
-
-        H.popover().within(() => {
-          cy.findByText(".csv").click();
-          cy.findByTestId("download-results-button").click();
-        });
-
-        cy.verifyDownload(".csv", { contains: true });
 
         H.expectUnstructuredSnowplowEvent({
           event: "download_results_clicked",
@@ -299,208 +401,93 @@ H.describeWithSnowplowEE(
         });
       });
 
-      describe("with native question parameters", () => {
-        beforeEach(() => {
-          cy.signInAsAdmin();
+      it("should be able to download a static embedded question as CSV when a filter expects 1 parameter value e.g. date (metabase#58957, 59074)", () => {
+        const FILTER_VALUE = "2025-02-11";
+        const QUESTION_NAME = "Native question with a Date parameter";
 
-          H.activateToken("pro-self-hosted");
-        });
-
-        it("should be able to download a static embedded question as CSV with correct parameters when field filters has multiple values (metabase#52430)", () => {
-          const FILTER_VALUES = ["NY", "CA"];
-          const QUESTION_NAME = "Native question with a Field parameter";
-
-          // Can't figure out the type if I extracted `questionDetails` to a variable.
-          H.createNativeQuestion(
-            {
-              name: QUESTION_NAME,
-              native: {
-                "template-tags": {
-                  state: {
-                    id: "f7672b4d-1e84-1fa8-bf02-b5e584cd4535",
-                    name: "state",
-                    "display-name": "State",
-                    type: "dimension",
-                    options: {
-                      "case-sensitive": false,
-                    },
-                    dimension: ["field", PEOPLE.STATE, null],
-                    default: null,
-                    "widget-type": "string/contains",
-                  },
-                },
-                query:
-                  "select id, email, state from people where {{state}} limit 2",
-              },
-              parameters: [
-                {
-                  id: "f7672b4d-1e84-1fa8-bf02-b5e584cd4535",
-                  type: "string/contains",
-                  options: {
-                    "case-sensitive": false,
-                  },
-                  target: ["dimension", ["template-tag", "state"]],
-                  name: "State",
-                  slug: "state",
-                  default: null,
-                },
-              ],
-              enable_embedding: true,
-              embedding_params: {
-                state: "enabled",
-              },
-            },
-            {
-              idAlias: "questionId",
-              wrapId: true,
-            },
-          );
-          cy.signOut();
-
-          cy.get("@questionId").then((questionId) => {
-            H.visitEmbeddedPage(
-              {
-                resource: { question: Number(questionId) },
-                params: {
-                  state: FILTER_VALUES,
-                },
-              },
-              {
-                pageStyle: {
-                  downloads: true,
-                },
-                // should ignore `?locale=xx` search parameter when downloading results from questions without parameters (metabase#53037)
-                qs: {
-                  locale: "en",
-                },
-              },
-            );
-          });
-
-          waitLoading();
-
-          const FIRST_ROW = [
-            5,
-            "leffler.dominique@hotmail.com",
-            FILTER_VALUES[0],
-          ];
-          const SECOND_ROW = [
-            13,
-            "mustafa.thiel@hotmail.com",
-            FILTER_VALUES[1],
-          ];
-
-          H.assertTableData({
-            columns: ["ID", "EMAIL", "STATE"],
-            firstRows: [FIRST_ROW, SECOND_ROW],
-          });
-
-          cy.findByRole("heading", { name: QUESTION_NAME }).realHover();
-          H.downloadAndAssert({
-            isDashboard: false,
-            isEmbed: true,
-            enableFormatting: true,
-            fileType: "csv",
-            downloadUrl: "/api/embed/card/*/query/csv*",
-            downloadMethod: "GET",
-          });
-
-          H.expectUnstructuredSnowplowEvent({
-            event: "download_results_clicked",
-            resource_type: "question",
-            accessed_via: "static-embed",
-            export_type: "csv",
-          });
-        });
-
-        it("should be able to download a static embedded question as CSV when a filter expects 1 parameter value e.g. date (metabase#58957, 59074)", () => {
-          const FILTER_VALUE = "2025-02-11";
-          const QUESTION_NAME = "Native question with a Date parameter";
-
-          // Can't figure out the type if I extracted `questionDetails` to a variable.
-          H.createNativeQuestion(
-            {
-              name: QUESTION_NAME,
-              native: {
-                "template-tags": {
-                  created_at: {
-                    id: "c9bbcc68-c59b-4ac1-b5e7-50d2123b4150",
-                    name: "created_at",
-                    "display-name": "Created At",
-                    type: "date",
-                  },
-                },
-                query:
-                  "select id, created_at, quantity from orders where created_at >= {{created_at}} limit 1",
-              },
-              parameters: [
-                {
+        // Can't figure out the type if I extracted `questionDetails` to a variable.
+        H.createNativeQuestion(
+          {
+            name: QUESTION_NAME,
+            native: {
+              "template-tags": {
+                created_at: {
                   id: "c9bbcc68-c59b-4ac1-b5e7-50d2123b4150",
-                  type: "date/single",
-                  options: {
-                    "case-sensitive": false,
-                  },
-                  target: ["variable", ["template-tag", "created_at"]],
-                  name: "Created At",
-                  slug: "created_at",
+                  name: "created_at",
+                  "display-name": "Created At",
+                  type: "date",
                 },
-              ],
-              enable_embedding: true,
-              embedding_params: {
-                created_at: "enabled",
               },
+              query:
+                "select id, created_at, quantity from orders where created_at >= {{created_at}} limit 1",
+            },
+            parameters: [
+              {
+                id: "c9bbcc68-c59b-4ac1-b5e7-50d2123b4150",
+                type: "date/single",
+                options: {
+                  "case-sensitive": false,
+                },
+                target: ["variable", ["template-tag", "created_at"]],
+                name: "Created At",
+                slug: "created_at",
+              },
+            ],
+            enable_embedding: true,
+            embedding_params: {
+              created_at: "enabled",
+            },
+          },
+          {
+            idAlias: "questionId",
+            wrapId: true,
+          },
+        );
+        cy.signOut();
+
+        cy.get("@questionId").then((questionId) => {
+          H.visitEmbeddedPage(
+            {
+              resource: { question: Number(questionId) },
+              params: {},
             },
             {
-              idAlias: "questionId",
-              wrapId: true,
+              pageStyle: {
+                downloads: true,
+              },
+              // should ignore `?locale=xx` search parameter when downloading results from questions with visible parameters (metabase#53037)
+              qs: {
+                locale: "en",
+              },
             },
           );
-          cy.signOut();
+        });
 
-          cy.get("@questionId").then((questionId) => {
-            H.visitEmbeddedPage(
-              {
-                resource: { question: Number(questionId) },
-                params: {},
-              },
-              {
-                pageStyle: {
-                  downloads: true,
-                },
-                // should ignore `?locale=xx` search parameter when downloading results from questions with visible parameters (metabase#53037)
-                qs: {
-                  locale: "en",
-                },
-              },
-            );
-          });
+        cy.button("Created At").should("be.visible").click();
+        DateFilter.setSingleDate(FILTER_VALUE);
+        H.popover().findByText("Add filter").click();
 
-          cy.button("Created At").should("be.visible").click();
-          DateFilter.setSingleDate(FILTER_VALUE);
-          H.popover().findByText("Add filter").click();
+        waitLoading();
 
-          waitLoading();
+        const FIRST_ROW = [1, "February 11, 2025, 9:40 PM", 2];
 
-          const FIRST_ROW = [1, "February 11, 2025, 9:40 PM", 2];
+        H.assertTableData({
+          columns: ["ID", "CREATED_AT", "QUANTITY"],
+          firstRows: [FIRST_ROW],
+        });
 
-          H.assertTableData({
-            columns: ["ID", "CREATED_AT", "QUANTITY"],
-            firstRows: [FIRST_ROW],
-          });
-
-          cy.findByRole("heading", { name: QUESTION_NAME }).realHover();
-          H.downloadAndAssert({
-            isDashboard: false,
-            isEmbed: true,
-            enableFormatting: true,
-            fileType: "csv",
-            downloadUrl: "/api/embed/card/*/query/csv*",
-            downloadMethod: "GET",
-          });
+        cy.findByRole("heading", { name: QUESTION_NAME }).realHover();
+        H.downloadAndAssert({
+          isDashboard: false,
+          isEmbed: true,
+          enableFormatting: true,
+          fileType: "csv",
+          downloadUrl: "/api/embed/card/*/query/csv*",
+          downloadMethod: "GET",
         });
       });
     });
-  },
-);
+  });
+});
 
 const waitLoading = () => H.main().findByText("Loading...").should("not.exist");

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/embed-parameters.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/embed-parameters.cy.spec.ts
@@ -14,7 +14,7 @@ const { H } = cy;
 const suiteTitle =
   "scenarios > embedding > sdk iframe embed setup > embed parameters";
 
-H.describeWithSnowplow(suiteTitle, () => {
+describe(suiteTitle, () => {
   beforeEach(() => {
     H.restore();
     H.resetSnowplow();

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
@@ -15,7 +15,7 @@ const QUESTION_NAME = "Orders, Count";
 const suiteTitle =
   "scenarios > embedding > sdk iframe embed setup > get code step";
 
-H.describeWithSnowplow(suiteTitle, () => {
+describe(suiteTitle, () => {
   beforeEach(() => {
     H.restore();
     H.resetSnowplow();

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
@@ -21,7 +21,7 @@ const SECOND_QUESTION_NAME = "Orders, Count, Grouped by Created At (year)";
 const suiteTitle =
   "scenarios > embedding > sdk iframe embed setup > select embed entity";
 
-H.describeWithSnowplow(suiteTitle, () => {
+describe(suiteTitle, () => {
   beforeEach(() => {
     H.restore();
     H.resetSnowplow();

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
@@ -15,7 +15,7 @@ const { H } = cy;
 const suiteTitle =
   "scenarios > embedding > sdk iframe embed setup > select embed experience";
 
-H.describeWithSnowplow(suiteTitle, () => {
+describe(suiteTitle, () => {
   beforeEach(() => {
     H.restore();
     H.resetSnowplow();

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
@@ -14,7 +14,7 @@ const QUESTION_NAME = "Orders, Count";
 const suiteTitle =
   "scenarios > embedding > sdk iframe embed setup > select embed options";
 
-H.describeWithSnowplow(suiteTitle, () => {
+describe(suiteTitle, () => {
   beforeEach(() => {
     H.restore();
     H.resetSnowplow();

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-iframe-embedding.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-iframe-embedding.cy.spec.ts
@@ -310,131 +310,128 @@ describe("scenarios > embedding > sdk iframe embedding", () => {
   });
 });
 
-H.describeWithSnowplowEE(
-  "scenarios > embedding > embedded analytics JS",
-  () => {
-    beforeEach(() => {
-      H.resetSnowplow();
-      H.prepareSdkIframeEmbedTest({
-        enabledAuthMethods: ["jwt"],
-        signOut: false,
-      });
-      H.enableTracking();
+describe("scenarios > embedding > embedded analytics JS", () => {
+  beforeEach(() => {
+    H.resetSnowplow();
+    H.prepareSdkIframeEmbedTest({
+      enabledAuthMethods: ["jwt"],
+      signOut: false,
+    });
+    H.enableTracking();
+  });
+
+  it("should send an Embedded Analytics JS usage event", () => {
+    cy.signOut();
+    cy.visit("http://localhost:4000");
+    const frame = H.loadSdkIframeEmbedTestPage({
+      origin: "http://different-than-metabase-instance.com",
+      elements: [
+        {
+          component: "metabase-dashboard",
+          attributes: {
+            dashboardId: ORDERS_DASHBOARD_ID,
+          },
+        },
+        {
+          component: "metabase-question",
+          attributes: {
+            questionId: ORDERS_QUESTION_ID,
+          },
+        },
+        {
+          component: "metabase-question",
+          attributes: {
+            questionId: "new",
+          },
+        },
+        {
+          component: "metabase-browser",
+          attributes: {},
+        },
+      ],
+      selector: `[dashboard-id="${ORDERS_DASHBOARD_ID}"] > iframe`, // get only the first iframe
     });
 
-    it("should send an Embedded Analytics JS usage event", () => {
-      cy.signOut();
-      cy.visit("http://localhost:4000");
-      const frame = H.loadSdkIframeEmbedTestPage({
-        origin: "http://different-than-metabase-instance.com",
-        elements: [
-          {
-            component: "metabase-dashboard",
-            attributes: {
-              dashboardId: ORDERS_DASHBOARD_ID,
-            },
-          },
-          {
-            component: "metabase-question",
-            attributes: {
-              questionId: ORDERS_QUESTION_ID,
-            },
-          },
-          {
-            component: "metabase-question",
-            attributes: {
-              questionId: "new",
-            },
-          },
-          {
-            component: "metabase-browser",
-            attributes: {},
-          },
-        ],
-        selector: `[dashboard-id="${ORDERS_DASHBOARD_ID}"] > iframe`, // get only the first iframe
-      });
+    frame.within(() => {
+      cy.findByText("Orders in a dashboard").should("be.visible");
+      cy.findByText("Orders").should("be.visible");
+      H.assertTableRowsCount(2000);
+    });
 
-      frame.within(() => {
-        cy.findByText("Orders in a dashboard").should("be.visible");
-        cy.findByText("Orders").should("be.visible");
-        H.assertTableRowsCount(2000);
-      });
+    H.expectUnstructuredSnowplowEvent({
+      event: "setup",
+      global: {
+        auth_method: "sso",
+      },
+      dashboard: {
+        with_title: {
+          false: 0,
+          true: 1,
+        },
+        with_downloads: {
+          false: 1,
+          true: 0,
+        },
+        drills: {
+          false: 0,
+          true: 1,
+        },
+      },
+      question: {
+        drills: {
+          false: 0,
+          true: 1,
+        },
+        with_downloads: {
+          false: 1,
+          true: 0,
+        },
+        with_title: {
+          false: 0,
+          true: 1,
+        },
+        is_save_enabled: {
+          false: 1,
+          true: 0,
+        },
+      },
+      exploration: {
+        is_save_enabled: {
+          false: 1,
+          true: 0,
+        },
+      },
+      browser: {
+        read_only: {
+          false: 0,
+          true: 1,
+        },
+      },
+    });
+  });
 
-      H.expectUnstructuredSnowplowEvent({
+  it("should not send an Embedded Analytics JS usage event in the preview", () => {
+    cy.visit(`/question/${ORDERS_QUESTION_ID}`);
+
+    H.openEmbedJsModal();
+
+    H.waitForSimpleEmbedIframesToLoad();
+    H.getSimpleEmbedIframeContent().within(() => {
+      cy.findByText("Orders").should("be.visible");
+    });
+
+    H.expectUnstructuredSnowplowEvent(
+      {
         event: "setup",
         global: {
-          auth_method: "sso",
+          auth_method: "session",
         },
-        dashboard: {
-          with_title: {
-            false: 0,
-            true: 1,
-          },
-          with_downloads: {
-            false: 1,
-            true: 0,
-          },
-          drills: {
-            false: 0,
-            true: 1,
-          },
-        },
-        question: {
-          drills: {
-            false: 0,
-            true: 1,
-          },
-          with_downloads: {
-            false: 1,
-            true: 0,
-          },
-          with_title: {
-            false: 0,
-            true: 1,
-          },
-          is_save_enabled: {
-            false: 1,
-            true: 0,
-          },
-        },
-        exploration: {
-          is_save_enabled: {
-            false: 1,
-            true: 0,
-          },
-        },
-        browser: {
-          read_only: {
-            false: 0,
-            true: 1,
-          },
-        },
-      });
-    });
-
-    it("should not send an Embedded Analytics JS usage event in the preview", () => {
-      cy.visit(`/question/${ORDERS_QUESTION_ID}`);
-
-      H.openEmbedJsModal();
-
-      H.waitForSimpleEmbedIframesToLoad();
-      H.getSimpleEmbedIframeContent().within(() => {
-        cy.findByText("Orders").should("be.visible");
-      });
-
-      H.expectUnstructuredSnowplowEvent(
-        {
-          event: "setup",
-          global: {
-            auth_method: "session",
-          },
-        },
-        // Expect that the usage event shouldn't be sent
-        0,
-      );
-    });
-  },
-);
+      },
+      // Expect that the usage event shouldn't be sent
+      0,
+    );
+  });
+});
 
 const getIframeWindow = () =>
   cy

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-pdf-downloads.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-pdf-downloads.cy.spec.ts
@@ -2,96 +2,93 @@ const { H } = cy;
 import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 import type { BaseEmbedTestPageOptions } from "e2e/support/helpers";
 
-H.describeWithSnowplowEE(
-  "scenarios > embedding > sdk iframe embedding > pdf downloads",
-  () => {
-    const setup = (options: Partial<BaseEmbedTestPageOptions>) => {
-      const frame = H.loadSdkIframeEmbedTestPage({
+describe("scenarios > embedding > sdk iframe embedding > pdf downloads", () => {
+  const setup = (options: Partial<BaseEmbedTestPageOptions>) => {
+    const frame = H.loadSdkIframeEmbedTestPage({
+      elements: [
+        {
+          component: "metabase-dashboard",
+          attributes: {
+            dashboardId: ORDERS_DASHBOARD_ID,
+            withDownloads: true,
+          },
+        },
+      ],
+      ...options,
+    });
+
+    cy.wait("@getDashCardQuery");
+
+    // Check that the dashboard loaded fine
+    frame.within(() => {
+      cy.findByText("Orders in a dashboard").should("be.visible");
+      cy.findByText("Orders").should("be.visible");
+      H.assertTableRowsCount(2000);
+    });
+
+    return frame;
+  };
+
+  beforeEach(() => {
+    H.resetSnowplow();
+    cy.deleteDownloadsFolder();
+  });
+
+  afterEach(() => {
+    H.expectNoBadSnowplowEvents();
+  });
+
+  describe("Dashboard PDF downloads", () => {
+    beforeEach(() => {
+      H.prepareSdkIframeEmbedTest({ signOut: true });
+    });
+
+    it("should download dashboard as PDF with analytics tracking", () => {
+      const frame = setup({
+        metabaseConfig: {
+          theme: {
+            components: {
+              dashboard: {
+                backgroundColor: "transparent",
+              },
+            },
+          },
+        },
+      });
+
+      frame
+        .should("contain", "Orders in a dashboard")
+        .findByLabelText("Download as PDF")
+        .should("be.visible")
+        .click();
+
+      // Verify PDF file download
+      cy.verifyDownload("Orders in a dashboard.pdf");
+
+      // Verify analytics tracking
+      H.expectUnstructuredSnowplowEvent({
+        dashboard_accessed_via: "sdk-embed",
+        event: "dashboard_pdf_exported",
+      });
+    });
+
+    it("should hide PDF download button when with-downloads is false", () => {
+      const frame = setup({
         elements: [
           {
             component: "metabase-dashboard",
             attributes: {
               dashboardId: ORDERS_DASHBOARD_ID,
-              withDownloads: true,
+              withDownloads: false,
             },
           },
         ],
-        ...options,
       });
 
-      cy.wait("@getDashCardQuery");
-
-      // Check that the dashboard loaded fine
-      frame.within(() => {
-        cy.findByText("Orders in a dashboard").should("be.visible");
-        cy.findByText("Orders").should("be.visible");
-        H.assertTableRowsCount(2000);
-      });
-
-      return frame;
-    };
-
-    beforeEach(() => {
-      H.resetSnowplow();
-      cy.deleteDownloadsFolder();
+      frame
+        .should("contain", "Orders in a dashboard")
+        .findByLabelText("Download as PDF")
+        .should("not.exist");
     });
-
-    afterEach(() => {
-      H.expectNoBadSnowplowEvents();
-    });
-
-    describe("Dashboard PDF downloads", () => {
-      beforeEach(() => {
-        H.prepareSdkIframeEmbedTest({ signOut: true });
-      });
-
-      it("should download dashboard as PDF with analytics tracking", () => {
-        const frame = setup({
-          metabaseConfig: {
-            theme: {
-              components: {
-                dashboard: {
-                  backgroundColor: "transparent",
-                },
-              },
-            },
-          },
-        });
-
-        frame
-          .should("contain", "Orders in a dashboard")
-          .findByLabelText("Download as PDF")
-          .should("be.visible")
-          .click();
-
-        // Verify PDF file download
-        cy.verifyDownload("Orders in a dashboard.pdf");
-
-        // Verify analytics tracking
-        H.expectUnstructuredSnowplowEvent({
-          dashboard_accessed_via: "sdk-embed",
-          event: "dashboard_pdf_exported",
-        });
-      });
-
-      it("should hide PDF download button when with-downloads is false", () => {
-        const frame = setup({
-          elements: [
-            {
-              component: "metabase-dashboard",
-              attributes: {
-                dashboardId: ORDERS_DASHBOARD_ID,
-                withDownloads: false,
-              },
-            },
-          ],
-        });
-
-        frame
-          .should("contain", "Orders in a dashboard")
-          .findByLabelText("Download as PDF")
-          .should("not.exist");
-      });
-    });
-  },
-);
+  });
+});

--- a/e2e/test/scenarios/metabot/metabot.cy.spec.ts
+++ b/e2e/test/scenarios/metabot/metabot.cy.spec.ts
@@ -137,7 +137,7 @@ d:{"finishReason":"stop","usage":{"promptTokens":4916,"completionTokens":8}}`,
     });
   });
 
-  H.describeWithSnowplowEE("metabot events", () => {
+  describe("metabot events", () => {
     beforeEach(() => {
       H.resetSnowplow();
       H.restore();

--- a/e2e/test/scenarios/metabot/transforms-codegen.cy.spec.ts
+++ b/e2e/test/scenarios/metabot/transforms-codegen.cy.spec.ts
@@ -59,7 +59,7 @@ const assertAcceptRejectUI = (opts: { visible: boolean }) => {
   rejectSuggestionBtn().should(should);
 };
 
-H.describeWithSnowplowEE("scenarios > metabot > transforms codegen", () => {
+describe("scenarios > metabot > transforms codegen", () => {
   beforeEach(() => {
     H.restore("postgres-writable");
     H.resetTestTable({ type: "postgres", table: "many_schemas" });

--- a/e2e/test/scenarios/metrics/metrics-question.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-question.cy.spec.js
@@ -214,7 +214,7 @@ describe("scenarios > metrics > question", () => {
   });
 });
 
-H.describeWithSnowplow("metrics", () => {
+describe("metrics", () => {
   beforeEach(() => {
     H.resetSnowplow();
     H.restore();

--- a/e2e/test/scenarios/models/models-revision-history.cy.spec.js
+++ b/e2e/test/scenarios/models/models-revision-history.cy.spec.js
@@ -1,7 +1,7 @@
 const { H } = cy;
 import { ORDERS_BY_YEAR_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
-H.describeWithSnowplow("scenarios > models > revision history", () => {
+describe("scenarios > models > revision history", () => {
   beforeEach(() => {
     H.resetSnowplow();
     H.restore();

--- a/e2e/test/scenarios/native/ai-sql-fixer.cy.spec.ts
+++ b/e2e/test/scenarios/native/ai-sql-fixer.cy.spec.ts
@@ -2,7 +2,7 @@ import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 
 const { H } = cy;
 
-H.describeWithSnowplow("scenarios > native > ai sql fixer", () => {
+describe("scenarios > native > ai sql fixer", () => {
   beforeEach(() => {
     H.resetSnowplow();
     H.restore();

--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -464,7 +464,7 @@ describe("command palette", () => {
   });
 });
 
-H.describeWithSnowplow("shortcuts", { tags: ["@actions"] }, () => {
+describe("shortcuts", { tags: ["@actions"] }, () => {
   beforeEach(() => {
     H.resetSnowplow();
     H.restore();

--- a/e2e/test/scenarios/onboarding/embedding-homepage.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/embedding-homepage.cy.spec.ts
@@ -1,48 +1,45 @@
 const { H } = cy;
 
-H.describeWithSnowplow(
-  "scenarios > embedding-homepage > snowplow events",
-  () => {
-    beforeEach(() => {
-      H.restore("default");
-      H.resetSnowplow();
+describe("scenarios > embedding-homepage > snowplow events", () => {
+  beforeEach(() => {
+    H.restore("default");
+    H.resetSnowplow();
 
-      cy.signInAsAdmin();
-      cy.intercept("GET", "/api/session/properties", (req) => {
-        req.continue((res) => {
-          res.body["embedding-homepage"] = "visible";
-          res.body["example-dashboard-id"] = 1;
-          res.body["setup-license-active-at-setup"] = true;
-          res.send();
-        });
+    cy.signInAsAdmin();
+    cy.intercept("GET", "/api/session/properties", (req) => {
+      req.continue((res) => {
+        res.body["embedding-homepage"] = "visible";
+        res.body["example-dashboard-id"] = 1;
+        res.body["setup-license-active-at-setup"] = true;
+        res.send();
       });
     });
+  });
 
-    afterEach(() => {
-      H.expectNoBadSnowplowEvents();
+  afterEach(() => {
+    H.expectNoBadSnowplowEvents();
+  });
+
+  it("opening the example dashboard from the button should send the 'embedding_homepage_example_dashboard_click' event", () => {
+    cy.visit("/");
+
+    // the example-dashboard-id is mocked, it's normal that we'll get to a permision error page
+    H.main().findByText("Embed an example dashboard").click();
+
+    H.expectUnstructuredSnowplowEvent({
+      event: "embedding_homepage_example_dashboard_click",
     });
+  });
 
-    it("opening the example dashboard from the button should send the 'embedding_homepage_example_dashboard_click' event", () => {
-      cy.visit("/");
+  it("dismissing the homepage should send the 'embedding_homepage_dismissed' event", () => {
+    cy.visit("/");
 
-      // the example-dashboard-id is mocked, it's normal that we'll get to a permision error page
-      H.main().findByText("Embed an example dashboard").click();
+    H.main().findByText("Hide these").click();
+    H.popover().findByText("Embedding done, all good").click();
 
-      H.expectUnstructuredSnowplowEvent({
-        event: "embedding_homepage_example_dashboard_click",
-      });
+    H.expectUnstructuredSnowplowEvent({
+      event: "embedding_homepage_dismissed",
+      dismiss_reason: "dismissed-done",
     });
-
-    it("dismissing the homepage should send the 'embedding_homepage_dismissed' event", () => {
-      cy.visit("/");
-
-      H.main().findByText("Hide these").click();
-      H.popover().findByText("Embedding done, all good").click();
-
-      H.expectUnstructuredSnowplowEvent({
-        event: "embedding_homepage_dismissed",
-        dismiss_reason: "dismissed-done",
-      });
-    });
-  },
-);
+  });
+});

--- a/e2e/test/scenarios/onboarding/home/browse.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/home/browse.cy.spec.ts
@@ -67,7 +67,7 @@ describe("browse > models", () => {
   });
 });
 
-H.describeWithSnowplow("scenarios > browse", () => {
+describe("scenarios > browse", () => {
   beforeEach(() => {
     H.resetSnowplow();
     H.restore();
@@ -210,7 +210,7 @@ H.describeWithSnowplow("scenarios > browse", () => {
   });
 });
 
-H.describeWithSnowplowEE("scenarios > browse (EE)", () => {
+describe("scenarios > browse (EE)", () => {
   beforeEach(() => {
     H.resetSnowplow();
     H.restore();

--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -19,7 +19,7 @@ describe("scenarios > home > homepage", () => {
     cy.intercept("POST", "/api/card/*/query").as("getQuestionQuery");
   });
 
-  H.describeWithSnowplow("after setup", () => {
+  describe("after setup", () => {
     afterEach(() => {
       H.expectNoBadSnowplowEvents();
     });
@@ -630,7 +630,7 @@ describe("scenarios > home > custom homepage", () => {
   });
 });
 
-H.describeWithSnowplow("scenarios > setup", () => {
+describe("scenarios > setup", () => {
   beforeEach(() => {
     H.restore();
     H.resetSnowplow();

--- a/e2e/test/scenarios/onboarding/onboarding-checklist.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/onboarding-checklist.cy.spec.ts
@@ -72,7 +72,7 @@ describe("Inaccessible Onboarding checklist", () => {
   });
 });
 
-H.describeWithSnowplow("Onboarding checklist events", () => {
+describe("Onboarding checklist events", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/onboarding/reference/databases.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/reference/databases.cy.spec.js
@@ -108,7 +108,7 @@ describe("scenarios > reference > databases", () => {
     );
   });
 
-  H.describeWithSnowplow("x-ray", () => {
+  describe("x-ray", () => {
     beforeEach(() => {
       cy.intercept("GET", "/api/automagic-dashboards/**").as(
         "getXrayDashboard",

--- a/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
@@ -593,7 +593,7 @@ describe("scenarios > setup (EE)", () => {
   });
 });
 
-H.describeWithSnowplow("scenarios > setup", () => {
+describe("scenarios > setup", () => {
   beforeEach(() => {
     H.restore("blank");
     H.resetSnowplow();

--- a/e2e/test/scenarios/organization/bookmarks-collection.cy.spec.js
+++ b/e2e/test/scenarios/organization/bookmarks-collection.cy.spec.js
@@ -10,217 +10,214 @@ const adminPersonalCollectionName = adminFullName + "'s Personal Collection";
 
 const { STATIC_ORDERS_ID } = SAMPLE_DB_TABLES;
 
-H.describeWithSnowplow(
-  "scenarios > organization > bookmarks > collection",
-  () => {
-    beforeEach(() => {
-      H.resetSnowplow();
-      H.restore();
-      cy.signInAsAdmin();
-      H.enableTracking();
+describe("scenarios > organization > bookmarks > collection", () => {
+  beforeEach(() => {
+    H.resetSnowplow();
+    H.restore();
+    cy.signInAsAdmin();
+    H.enableTracking();
+  });
+
+  it("cannot add bookmark to root collection", () => {
+    H.visitCollection("root");
+
+    H.getSidebarSectionTitle("Collections");
+    cy.icon("bookmark").should("not.exist");
+  });
+
+  it("can add, update bookmark name when collection name is updated, and remove bookmarks from collection from its page", () => {
+    H.visitCollection(FIRST_COLLECTION_ID);
+
+    // Add bookmark
+    cy.icon("bookmark").click();
+
+    H.expectUnstructuredSnowplowEvent({
+      event: "bookmark_added",
+      event_detail: "collection",
+      triggered_from: "collection_header",
     });
 
-    it("cannot add bookmark to root collection", () => {
+    H.navigationSidebar().within(() => {
+      H.getSidebarSectionTitle(/Bookmarks/);
+      cy.findAllByText("First collection").should("have.length", 2);
+
+      // Once there is a list of bookmarks,
+      // we add a heading to the list of collections below the list of bookmarks
+      H.getSidebarSectionTitle("Collections");
+    });
+
+    // Rename bookmarked collection
+    cy.findByTestId("collection-name-heading").click().type(" 2").blur();
+
+    H.navigationSidebar()
+      .findAllByText("First collection 2")
+      .should("have.length", 2);
+
+    // Remove bookmark
+    cy.findByTestId("collection-menu").icon("bookmark_filled").click();
+
+    H.navigationSidebar()
+      .findAllByText("First collection 2")
+      .should("have.length", 1);
+
+    cy.findByTestId("collection-menu")
+      .icon("bookmark_filled")
+      .should("not.exist");
+    cy.findByTestId("collection-menu").icon("bookmark").should("exist");
+  });
+
+  it("removes items from bookmarks list when they are archived", () => {
+    // A question
+    bookmarkThenArchive("Orders");
+
+    // A dashboard
+    bookmarkThenArchive("Orders in a dashboard");
+  });
+
+  it("can remove bookmark from item in sidebar", () => {
+    H.visitCollection(ADMIN_PERSONAL_COLLECTION_ID);
+
+    // Add bookmark
+    cy.findByTestId("collection-menu").icon("bookmark").click();
+
+    H.navigationSidebar().within(() => {
+      cy.icon("bookmark_filled").click({ force: true });
+    });
+
+    H.getSidebarSectionTitle(/Bookmarks/).should("not.exist");
+  });
+
+  it("can toggle bookmark list visibility", () => {
+    H.visitCollection(ADMIN_PERSONAL_COLLECTION_ID);
+
+    // Add bookmark
+    cy.icon("bookmark").click();
+
+    H.navigationSidebar().within(() => {
+      H.getSidebarSectionTitle(/Bookmarks/).click();
+
+      cy.findByText(adminPersonalCollectionName).should("not.exist");
+
+      H.getSidebarSectionTitle(/Bookmarks/).click();
+
+      cy.findByText(adminPersonalCollectionName);
+    });
+  });
+
+  describe("collection items", () => {
+    it("can add/remove bookmark from unpinned Question in collection", () => {
+      addBookmarkTo("Orders");
+      H.expectUnstructuredSnowplowEvent({
+        event: "bookmark_added",
+        event_detail: "question",
+        triggered_from: "collection_list",
+      });
+      removeBookmarkFrom("Orders");
+      H.expectUnstructuredSnowplowEvent(
+        {
+          event: "bookmark_added",
+          event_detail: "question",
+          triggered_from: "collection_list",
+        },
+        1,
+      );
+    });
+
+    it("can add/remove bookmark from pinned Question in collection", () => {
+      const name = "Orders";
       H.visitCollection("root");
 
-      H.getSidebarSectionTitle("Collections");
-      cy.icon("bookmark").should("not.exist");
-    });
-
-    it("can add, update bookmark name when collection name is updated, and remove bookmarks from collection from its page", () => {
-      H.visitCollection(FIRST_COLLECTION_ID);
-
-      // Add bookmark
-      cy.icon("bookmark").click();
+      pin(name);
+      H.tableHeaderColumn("ID");
+      bookmarkPinnedItem(name);
 
       H.expectUnstructuredSnowplowEvent({
         event: "bookmark_added",
-        event_detail: "collection",
-        triggered_from: "collection_header",
-      });
-
-      H.navigationSidebar().within(() => {
-        H.getSidebarSectionTitle(/Bookmarks/);
-        cy.findAllByText("First collection").should("have.length", 2);
-
-        // Once there is a list of bookmarks,
-        // we add a heading to the list of collections below the list of bookmarks
-        H.getSidebarSectionTitle("Collections");
-      });
-
-      // Rename bookmarked collection
-      cy.findByTestId("collection-name-heading").click().type(" 2").blur();
-
-      H.navigationSidebar()
-        .findAllByText("First collection 2")
-        .should("have.length", 2);
-
-      // Remove bookmark
-      cy.findByTestId("collection-menu").icon("bookmark_filled").click();
-
-      H.navigationSidebar()
-        .findAllByText("First collection 2")
-        .should("have.length", 1);
-
-      cy.findByTestId("collection-menu")
-        .icon("bookmark_filled")
-        .should("not.exist");
-      cy.findByTestId("collection-menu").icon("bookmark").should("exist");
-    });
-
-    it("removes items from bookmarks list when they are archived", () => {
-      // A question
-      bookmarkThenArchive("Orders");
-
-      // A dashboard
-      bookmarkThenArchive("Orders in a dashboard");
-    });
-
-    it("can remove bookmark from item in sidebar", () => {
-      H.visitCollection(ADMIN_PERSONAL_COLLECTION_ID);
-
-      // Add bookmark
-      cy.findByTestId("collection-menu").icon("bookmark").click();
-
-      H.navigationSidebar().within(() => {
-        cy.icon("bookmark_filled").click({ force: true });
-      });
-
-      H.getSidebarSectionTitle(/Bookmarks/).should("not.exist");
-    });
-
-    it("can toggle bookmark list visibility", () => {
-      H.visitCollection(ADMIN_PERSONAL_COLLECTION_ID);
-
-      // Add bookmark
-      cy.icon("bookmark").click();
-
-      H.navigationSidebar().within(() => {
-        H.getSidebarSectionTitle(/Bookmarks/).click();
-
-        cy.findByText(adminPersonalCollectionName).should("not.exist");
-
-        H.getSidebarSectionTitle(/Bookmarks/).click();
-
-        cy.findByText(adminPersonalCollectionName);
+        event_detail: "question",
+        triggered_from: "collection_list",
       });
     });
 
-    describe("collection items", () => {
-      it("can add/remove bookmark from unpinned Question in collection", () => {
-        addBookmarkTo("Orders");
-        H.expectUnstructuredSnowplowEvent({
-          event: "bookmark_added",
-          event_detail: "question",
-          triggered_from: "collection_list",
-        });
-        removeBookmarkFrom("Orders");
-        H.expectUnstructuredSnowplowEvent(
-          {
-            event: "bookmark_added",
-            event_detail: "question",
-            triggered_from: "collection_list",
-          },
-          1,
-        );
+    it("can add/remove bookmark from unpinned Dashboard in collection", () => {
+      addBookmarkTo("Orders in a dashboard");
+      H.expectUnstructuredSnowplowEvent({
+        event: "bookmark_added",
+        event_detail: "dashboard",
+        triggered_from: "collection_list",
       });
-
-      it("can add/remove bookmark from pinned Question in collection", () => {
-        const name = "Orders";
-        H.visitCollection("root");
-
-        pin(name);
-        H.tableHeaderColumn("ID");
-        bookmarkPinnedItem(name);
-
-        H.expectUnstructuredSnowplowEvent({
-          event: "bookmark_added",
-          event_detail: "question",
-          triggered_from: "collection_list",
-        });
-      });
-
-      it("can add/remove bookmark from unpinned Dashboard in collection", () => {
-        addBookmarkTo("Orders in a dashboard");
-        H.expectUnstructuredSnowplowEvent({
+      removeBookmarkFrom("Orders in a dashboard");
+      H.expectUnstructuredSnowplowEvent(
+        {
           event: "bookmark_added",
           event_detail: "dashboard",
           triggered_from: "collection_list",
-        });
-        removeBookmarkFrom("Orders in a dashboard");
-        H.expectUnstructuredSnowplowEvent(
-          {
-            event: "bookmark_added",
-            event_detail: "dashboard",
-            triggered_from: "collection_list",
-          },
-          1,
-        );
+        },
+        1,
+      );
+    });
+
+    it("can add/remove bookmark from pinned Dashboard in collection", () => {
+      const name = "Orders in a dashboard";
+      H.visitCollection("root");
+
+      pin(name);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText("A dashboard");
+      bookmarkPinnedItem(name);
+      H.expectUnstructuredSnowplowEvent({
+        event: "bookmark_added",
+        event_detail: "dashboard",
+        triggered_from: "collection_list",
+      });
+    });
+
+    it("adds and removes bookmarks from Model in collection", () => {
+      H.createQuestion({
+        name: "Orders Model",
+        query: { "source-table": STATIC_ORDERS_ID, aggregation: [["count"]] },
+        type: "model",
       });
 
-      it("can add/remove bookmark from pinned Dashboard in collection", () => {
-        const name = "Orders in a dashboard";
-        H.visitCollection("root");
-
-        pin(name);
-        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-        cy.findByText("A dashboard");
-        bookmarkPinnedItem(name);
-        H.expectUnstructuredSnowplowEvent({
-          event: "bookmark_added",
-          event_detail: "dashboard",
-          triggered_from: "collection_list",
-        });
+      addBookmarkTo("Orders Model");
+      H.expectUnstructuredSnowplowEvent({
+        event: "bookmark_added",
+        event_detail: "model",
+        triggered_from: "collection_list",
       });
 
-      it("adds and removes bookmarks from Model in collection", () => {
-        H.createQuestion({
-          name: "Orders Model",
-          query: { "source-table": STATIC_ORDERS_ID, aggregation: [["count"]] },
-          type: "model",
-        });
-
-        addBookmarkTo("Orders Model");
-        H.expectUnstructuredSnowplowEvent({
+      removeBookmarkFrom("Orders Model");
+      H.expectUnstructuredSnowplowEvent(
+        {
           event: "bookmark_added",
           event_detail: "model",
           triggered_from: "collection_list",
-        });
+        },
+        1,
+      );
+    });
 
-        removeBookmarkFrom("Orders Model");
-        H.expectUnstructuredSnowplowEvent(
-          {
-            event: "bookmark_added",
-            event_detail: "model",
-            triggered_from: "collection_list",
-          },
-          1,
-        );
+    it("can bookmark a collection", () => {
+      const collectionName = "First collection";
+
+      addBookmarkTo(collectionName);
+      H.expectUnstructuredSnowplowEvent({
+        event: "bookmark_added",
+        event_detail: "collection",
+        triggered_from: "collection_list",
       });
 
-      it("can bookmark a collection", () => {
-        const collectionName = "First collection";
-
-        addBookmarkTo(collectionName);
-        H.expectUnstructuredSnowplowEvent({
+      removeBookmarkFrom(collectionName);
+      H.expectUnstructuredSnowplowEvent(
+        {
           event: "bookmark_added",
           event_detail: "collection",
           triggered_from: "collection_list",
-        });
-
-        removeBookmarkFrom(collectionName);
-        H.expectUnstructuredSnowplowEvent(
-          {
-            event: "bookmark_added",
-            event_detail: "collection",
-            triggered_from: "collection_list",
-          },
-          1,
-        );
-      });
+        },
+        1,
+      );
     });
-  },
-);
+  });
+});
 
 function addBookmarkTo(name) {
   H.visitCollection("root");

--- a/e2e/test/scenarios/organization/bookmarks-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/organization/bookmarks-dashboard.cy.spec.js
@@ -1,7 +1,7 @@
 const { H } = cy;
 import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 
-H.describeWithSnowplow("scenarios > dashboard > bookmarks", () => {
+describe("scenarios > dashboard > bookmarks", () => {
   beforeEach(() => {
     H.resetSnowplow();
     H.restore();

--- a/e2e/test/scenarios/organization/bookmarks-question.cy.spec.js
+++ b/e2e/test/scenarios/organization/bookmarks-question.cy.spec.js
@@ -6,7 +6,7 @@ import {
 
 import { toggleQuestionBookmarkStatus } from "./helpers/bookmark-helpers";
 
-H.describeWithSnowplow("scenarios > question > bookmarks", () => {
+describe("scenarios > question > bookmarks", () => {
   beforeEach(() => {
     H.resetSnowplow();
     H.restore();

--- a/e2e/test/scenarios/organization/timelines-collection.cy.spec.js
+++ b/e2e/test/scenarios/organization/timelines-collection.cy.spec.js
@@ -628,7 +628,7 @@ describe("scenarios > organization > timelines > collection", () => {
   });
 });
 
-H.describeWithSnowplow("scenarios > collections > timelines", () => {
+describe("scenarios > collections > timelines", () => {
   beforeEach(() => {
     H.restore();
     H.resetSnowplow();

--- a/e2e/test/scenarios/question/column-compare.cy.spec.ts
+++ b/e2e/test/scenarios/question/column-compare.cy.spec.ts
@@ -184,7 +184,7 @@ const CUSTOM_EXPRESSIONS_USED_MOVING_AVERAGE = [
 
 // TODO: reenable test when we reenable the "Compare to the past" components.
 describe("scenarios > question", { tags: "@skip" }, () => {
-  H.describeWithSnowplow("column compare", () => {
+  describe("column compare", () => {
     beforeEach(() => {
       H.restore();
       H.resetSnowplow();

--- a/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
@@ -444,41 +444,38 @@ describe(
   },
 );
 
-H.describeWithSnowplow(
-  "scenarios > notebook > native query preview sidebar tracking events",
-  () => {
-    beforeEach(() => {
-      H.resetSnowplow();
-      H.restore();
-      cy.signInAsAdmin();
-      H.enableTracking();
+describe("scenarios > notebook > native query preview sidebar tracking events", () => {
+  beforeEach(() => {
+    H.resetSnowplow();
+    H.restore();
+    cy.signInAsAdmin();
+    H.enableTracking();
+  });
+
+  afterEach(() => {
+    H.expectNoBadSnowplowEvents();
+  });
+
+  it("should track `notebook_native_preview_shown|hidden` events", () => {
+    cy.intercept("POST", "/api/dataset/native").as("nativeDataset");
+    H.openReviewsTable({ mode: "notebook", limit: 1 });
+
+    cy.findByLabelText("View SQL").click();
+    cy.wait("@nativeDataset");
+    cy.findByTestId("native-query-preview-sidebar").should("exist");
+
+    H.expectUnstructuredSnowplowEvent({
+      event: "notebook_native_preview_shown",
     });
 
-    afterEach(() => {
-      H.expectNoBadSnowplowEvents();
+    cy.findByLabelText("Hide SQL").click();
+    cy.findByTestId("native-query-preview-sidebar").should("not.exist");
+
+    H.expectUnstructuredSnowplowEvent({
+      event: "notebook_native_preview_hidden",
     });
-
-    it("should track `notebook_native_preview_shown|hidden` events", () => {
-      cy.intercept("POST", "/api/dataset/native").as("nativeDataset");
-      H.openReviewsTable({ mode: "notebook", limit: 1 });
-
-      cy.findByLabelText("View SQL").click();
-      cy.wait("@nativeDataset");
-      cy.findByTestId("native-query-preview-sidebar").should("exist");
-
-      H.expectUnstructuredSnowplowEvent({
-        event: "notebook_native_preview_shown",
-      });
-
-      cy.findByLabelText("Hide SQL").click();
-      cy.findByTestId("native-query-preview-sidebar").should("not.exist");
-
-      H.expectUnstructuredSnowplowEvent({
-        event: "notebook_native_preview_hidden",
-      });
-    });
-  },
-);
+  });
+});
 
 function convertToSql() {
   H.openNotebook();

--- a/e2e/test/scenarios/question/question-analytics.cy.spec.js
+++ b/e2e/test/scenarios/question/question-analytics.cy.spec.js
@@ -1,6 +1,6 @@
 const { H } = cy;
 
-H.describeWithSnowplow("scenarios > question > snowplow", () => {
+describe("scenarios > question > snowplow", () => {
   describe("chart_generated", () => {
     const generateNonTableVisualization = () => {
       cy.visit("/");

--- a/e2e/test/scenarios/question/question-management.cy.spec.js
+++ b/e2e/test/scenarios/question/question-management.cy.spec.js
@@ -481,7 +481,7 @@ describe("question moving", () => {
   });
 });
 
-H.describeWithSnowplow("send snowplow question events", () => {
+describe("send snowplow question events", () => {
   beforeEach(() => {
     H.restore();
     H.resetSnowplow();

--- a/e2e/test/scenarios/search/search-snowplow.cy.spec.js
+++ b/e2e/test/scenarios/search/search-snowplow.cy.spec.js
@@ -4,7 +4,7 @@ const { H } = cy;
 
 import { commandPaletteInput } from "../../../support/helpers/e2e-command-palette-helpers";
 
-H.describeWithSnowplow("scenarios > search > snowplow", () => {
+describe("scenarios > search > snowplow", () => {
   const NEW_SEARCH_QUERY_EVENT_NAME = "search_query";
   const SEARCH_CLICK = "search_click";
 

--- a/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
+++ b/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
@@ -39,7 +39,7 @@ describe("scenarios > question > download", () => {
     cy.signInAsAdmin();
   });
 
-  H.describeWithSnowplow("[snowplow]", () => {
+  describe("[snowplow]", () => {
     beforeEach(() => {
       H.resetSnowplow();
       H.enableTracking();
@@ -492,7 +492,7 @@ describe("scenarios > dashboard > download pdf", () => {
   });
 });
 
-H.describeWithSnowplow("[snowplow] scenarios > dashboard", () => {
+describe("[snowplow] scenarios > dashboard", () => {
   beforeEach(() => {
     H.restore();
     H.resetSnowplow();

--- a/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
@@ -309,7 +309,7 @@ describe("#39152 sharing an unsaved question", () => {
     });
   });
 
-  H.describeWithSnowplow(`public ${resource} sharing snowplow events`, () => {
+  describe(`public ${resource} sharing snowplow events`, () => {
     beforeEach(() => {
       H.restore();
       H.resetSnowplow();

--- a/e2e/test/scenarios/sharing/public-sharing-embed-flow.cy.spec.ts
+++ b/e2e/test/scenarios/sharing/public-sharing-embed-flow.cy.spec.ts
@@ -9,7 +9,7 @@ const { H } = cy;
 
 const suiteTitle = "scenarios > sharing > embed flow pre-selection";
 
-H.describeWithSnowplow(suiteTitle, () => {
+describe(suiteTitle, () => {
   beforeEach(() => {
     H.restore();
     H.resetSnowplow();

--- a/e2e/test/scenarios/stats/instance-stats-snowplow.cy.spec.js
+++ b/e2e/test/scenarios/stats/instance-stats-snowplow.cy.spec.js
@@ -1,6 +1,6 @@
 const { H } = cy;
 
-H.describeWithSnowplow("scenarios > stats > snowplow", () => {
+describe("scenarios > stats > snowplow", () => {
   beforeEach(() => {
     H.restore();
     H.resetSnowplow();

--- a/e2e/test/scenarios/visualizations-tabular/column-shortcuts.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-tabular/column-shortcuts.cy.spec.ts
@@ -81,7 +81,7 @@ const URL_CASES = [
   },
 ];
 
-H.describeWithSnowplow("extract shortcut", () => {
+describe("extract shortcut", () => {
   beforeEach(() => {
     H.restore();
     H.resetSnowplow();
@@ -347,7 +347,7 @@ function extractColumnAndCheck({
   }
 }
 
-H.describeWithSnowplow("scenarios > visualizations > combine shortcut", () => {
+describe("scenarios > visualizations > combine shortcut", () => {
   function combineColumns({
     columns,
     example,

--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/chart_drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/chart_drill.cy.spec.js
@@ -855,7 +855,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     });
   });
 
-  H.describeWithSnowplow("chart click actions analytics", () => {
+  describe("chart click actions analytics", () => {
     beforeEach(() => {
       H.resetSnowplow();
       H.restore();

--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/column_extract_drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/column_extract_drill.cy.spec.js
@@ -92,7 +92,7 @@ const DATE_QUESTION = {
   },
 };
 
-H.describeWithSnowplow("extract action", () => {
+describe("extract action", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();
@@ -395,7 +395,7 @@ function extractColumnAndCheck({
   }
 }
 
-H.describeWithSnowplow("extract action", () => {
+describe("extract action", () => {
   beforeEach(() => {
     H.restore();
     H.resetSnowplow();

--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/combine-column.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/combine-column.cy.spec.ts
@@ -4,122 +4,119 @@ import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { PEOPLE, PEOPLE_ID } = SAMPLE_DATABASE;
 
-H.describeWithSnowplow(
-  "scenarios > visualizations > drillthroughs > table_drills > combine columns",
-  () => {
-    beforeEach(() => {
-      H.restore();
-      H.resetSnowplow();
-      cy.signInAsAdmin();
-    });
+describe("scenarios > visualizations > drillthroughs > table_drills > combine columns", () => {
+  beforeEach(() => {
+    H.restore();
+    H.resetSnowplow();
+    cy.signInAsAdmin();
+  });
 
-    afterEach(() => {
-      H.expectNoBadSnowplowEvents();
-    });
+  afterEach(() => {
+    H.expectNoBadSnowplowEvents();
+  });
 
-    it("should be possible to combine columns from the a table header", () => {
-      H.createQuestion(
-        {
-          query: {
-            "source-table": PEOPLE_ID,
-            fields: [
-              ["field", PEOPLE.ID, { "base-type": "type/Number" }],
-              ["field", PEOPLE.EMAIL, { "base-type": "type/Text" }],
-            ],
-            limit: 3,
-          },
+  it("should be possible to combine columns from the a table header", () => {
+    H.createQuestion(
+      {
+        query: {
+          "source-table": PEOPLE_ID,
+          fields: [
+            ["field", PEOPLE.ID, { "base-type": "type/Number" }],
+            ["field", PEOPLE.EMAIL, { "base-type": "type/Text" }],
+          ],
+          limit: 3,
         },
-        { visitQuestion: true },
+      },
+      { visitQuestion: true },
+    );
+
+    H.tableHeaderClick("Email");
+    H.popover().findByText("Combine columns").click();
+
+    H.popover().within(() => {
+      cy.findByTestId("combine-example").should(
+        "contain",
+        "email@example.com12345",
+      );
+      cy.findByText("ID").click();
+    });
+
+    // eslint-disable-next-line no-unsafe-element-filtering
+    H.popover().last().findByText("Name").click();
+
+    H.popover().within(() => {
+      cy.findByText("Separated by (empty)").click();
+      cy.findByLabelText("Separator").type("__");
+      cy.findByTestId("combine-example").should(
+        "have.text",
+        "email@example.com__text",
       );
 
-      H.tableHeaderClick("Email");
-      H.popover().findByText("Combine columns").click();
-
-      H.popover().within(() => {
-        cy.findByTestId("combine-example").should(
-          "contain",
-          "email@example.com12345",
-        );
-        cy.findByText("ID").click();
-      });
-
-      // eslint-disable-next-line no-unsafe-element-filtering
-      H.popover().last().findByText("Name").click();
-
-      H.popover().within(() => {
-        cy.findByText("Separated by (empty)").click();
-        cy.findByLabelText("Separator").type("__");
-        cy.findByTestId("combine-example").should(
-          "have.text",
-          "email@example.com__text",
-        );
-
-        cy.findByText("Add column").click();
-        cy.findByTestId("combine-example").should(
-          "have.text",
-          "email@example.com__text__12345",
-        );
-
-        // eslint-disable-next-line no-unsafe-element-filtering
-        cy.findAllByRole("textbox").last().clear();
-        cy.findByTestId("combine-example").should(
-          "have.text",
-          "email@example.com__text12345",
-        );
-
-        // eslint-disable-next-line no-unsafe-element-filtering
-        cy.findAllByRole("textbox").last().clear().type("+");
-        cy.findByTestId("combine-example").should(
-          "have.text",
-          "email@example.com__text+12345",
-        );
-
-        cy.findByText("Done").click();
-      });
-
-      // eslint-disable-next-line no-unsafe-element-filtering
-      cy.findAllByTestId("header-cell")
-        .last()
-        .should("have.text", "Combined Email, Name, ID");
-
-      H.expectUnstructuredSnowplowEvent({
-        event: "column_combine_via_column_header",
-        custom_expressions_used: ["concat"],
-        database_id: SAMPLE_DB_ID,
-      });
-    });
-
-    it("should handle duplicate column names", () => {
-      H.createQuestion(
-        {
-          query: {
-            "source-table": PEOPLE_ID,
-            fields: [
-              ["field", PEOPLE.ID, { "base-type": "type/Number" }],
-              ["field", PEOPLE.EMAIL, { "base-type": "type/Text" }],
-            ],
-            limit: 3,
-          },
-        },
-        { visitQuestion: true },
+      cy.findByText("Add column").click();
+      cy.findByTestId("combine-example").should(
+        "have.text",
+        "email@example.com__text__12345",
       );
 
-      // first combine (email + ID)
-      H.tableHeaderClick("Email");
-      H.popover().findByText("Combine columns").click();
-      H.popover().findByText("Done").click();
+      // eslint-disable-next-line no-unsafe-element-filtering
+      cy.findAllByRole("textbox").last().clear();
+      cy.findByTestId("combine-example").should(
+        "have.text",
+        "email@example.com__text12345",
+      );
 
-      // second combine (email + ID)
-      H.tableHeaderClick("Email");
-      H.popover().findByText("Combine columns").click();
-      H.popover().findByText("Done").click();
+      // eslint-disable-next-line no-unsafe-element-filtering
+      cy.findAllByRole("textbox").last().clear().type("+");
+      cy.findByTestId("combine-example").should(
+        "have.text",
+        "email@example.com__text+12345",
+      );
 
-      cy.findAllByTestId("header-cell")
-        .contains("Combined Email, ID")
-        .should("exist");
-      cy.findAllByTestId("header-cell")
-        .contains("Combined Email, ID_2")
-        .should("exist");
+      cy.findByText("Done").click();
     });
-  },
-);
+
+    // eslint-disable-next-line no-unsafe-element-filtering
+    cy.findAllByTestId("header-cell")
+      .last()
+      .should("have.text", "Combined Email, Name, ID");
+
+    H.expectUnstructuredSnowplowEvent({
+      event: "column_combine_via_column_header",
+      custom_expressions_used: ["concat"],
+      database_id: SAMPLE_DB_ID,
+    });
+  });
+
+  it("should handle duplicate column names", () => {
+    H.createQuestion(
+      {
+        query: {
+          "source-table": PEOPLE_ID,
+          fields: [
+            ["field", PEOPLE.ID, { "base-type": "type/Number" }],
+            ["field", PEOPLE.EMAIL, { "base-type": "type/Text" }],
+          ],
+          limit: 3,
+        },
+      },
+      { visitQuestion: true },
+    );
+
+    // first combine (email + ID)
+    H.tableHeaderClick("Email");
+    H.popover().findByText("Combine columns").click();
+    H.popover().findByText("Done").click();
+
+    // second combine (email + ID)
+    H.tableHeaderClick("Email");
+    H.popover().findByText("Combine columns").click();
+    H.popover().findByText("Done").click();
+
+    cy.findAllByTestId("header-cell")
+      .contains("Combined Email, ID")
+      .should("exist");
+    cy.findAllByTestId("header-cell")
+      .contains("Combined Email, ID_2")
+      .should("exist");
+  });
+});


### PR DESCRIPTION
Resolves DEV-1094

We're simplifying things both in tests and in the local test runner by removing the custom construct related to the Snowplow. We were trying to be accommodating in the past by conditionally skipping the default Mocha `describe` based on the existence of a few environment variables.

We are today in a position where Snowplow simply has to run by default.