### PR TITLE
Fix flaky Remote Sync test

### DIFF
--- a/e2e/test/scenarios/admin/remote-sync.cy.spec.ts
+++ b/e2e/test/scenarios/admin/remote-sync.cy.spec.ts
@@ -597,7 +597,7 @@ H.describeWithSnowplowEE("Remote Sync", () => {
 
       cy.visit("/admin/settings/remote-sync");
       cy.findByLabelText("Sync branch").clear().type("test");
-      cy.button("Save changes").click();
+      cy.findByTestId("remote-sync-submit-button").click();
 
       cy.findByTestId("admin-layout-content")
         .findByText("Success")
@@ -609,7 +609,7 @@ H.describeWithSnowplowEE("Remote Sync", () => {
 
       H.waitForTask({ taskName: "import" });
 
-      cy.findByRole("button", { name: "Save changes" }).should("be.disabled");
+      cy.findByTestId("remote-sync-submit-button").should("be.disabled");
 
       cy.visit("/");
 

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncAdminSettings.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncAdminSettings.tsx
@@ -304,6 +304,7 @@ export const RemoteSyncAdminSettings = () => {
                       </Button>
                     )}
                     <FormSubmitButton
+                      data-testid="remote-sync-submit-button"
                       label={
                         isRemoteSyncEnabled
                           ? t`Save changes`


### PR DESCRIPTION
When you click a submit button, our `FormSubmitButton` component automatically changes the text from the original value (here, "Save Changes") to "Success" for 5 seconds.

In this test, we clicked "Save Changes", then waited for the import to complete, then waited up to 4 seconds for the button with "Save Changes" to be visible.

If the import was a little slow, say 2s, then we'd click "Save Changes", import for 2s, then wait another 4s for the button => 6 seconds total, "Save Changes" reappears within that time limit, the test passes.

If the import was fast, say 500ms, then we'd click "Save Changes", import for .5s, then wait another 4s for the button => 4.5s total, "Save Changes" never re-appears within that time limit, and the test fails.