### PR TITLE
qp catches circular queries involving both sql and mbql cards

### DIFF
--- a/src/metabase/query_processor/middleware/resolve_referenced.clj
+++ b/src/metabase/query_processor/middleware/resolve_referenced.clj
@@ -49,7 +49,8 @@
    init-query :- ::lib.schema/query]
   (letfn [(card-subquery-graph [mp graph card-id]
             (let [card-query (fetch-card-query mp card-id)
-                  card-ids (lib/native-query-card-ids card-query)
+                  card-ids (concat (lib/native-query-card-ids card-query)
+                                   (lib/all-source-card-ids card-query))
                   snippet-ids (lib/native-query-snippet-ids card-query)]
               (subquery-graph* mp graph ::card card-id card-ids snippet-ids)))
           (snippet-subquery-graph [mp graph snippet-id]


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/65743

### Description

QP throws an error when trying to compile queries that have a card cycle with both sql and mbql cards.  Previously, we caught cycles like that on save, and the qp would throw an exception when trying to compile a card cycle that was entirely sql or mbql.  However, if you had an old card cycle with both sql and mbql cards already in your db, the qp would happily try to compile it and throw an OOM error.

### How to verify

Manually create a card cycle in your db and try to compile it, or try to compile card 445 using Tony's db dump in [the slack thread](https://metaboat.slack.com/archives/C05MPF0TM3L/p1762940487637729).

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
