### PR TITLE
Remove e2e tests for info popovers in field picker

### DIFF
--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -475,67 +475,6 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     H.visualize();
   });
 
-  it("should show an info popover when hovering over a field picker option for a table", () => {
-    H.startNewQuestion();
-    H.entityPickerModal().within(() => {
-      H.entityPickerModalTab("Tables").click();
-      H.entityPickerModalItem(2, "Orders").click();
-    });
-    cy.findByTestId("fields-picker").click();
-    H.popover()
-      .findByText("Total")
-      .closest("label")
-      .findByLabelText("More info")
-      .trigger("mouseover");
-
-    H.popover()
-      .should("have.length", 2)
-      // the info popover is the second in the document
-      .last()
-      .contains("The total billed amount.");
-  });
-
-  it("should show an info popover when hovering over a field picker option for a saved question", () => {
-    H.createNativeQuestion({
-      name: "question a",
-      native: { query: "select 'foo' as a_column" },
-    });
-    H.startNewQuestion();
-    H.entityPickerModal().within(() => {
-      H.entityPickerModalTab("Collections").click();
-      cy.findByText("question a").click();
-    });
-    cy.findByTestId("fields-picker").click();
-    H.popover()
-      .findByText("A_COLUMN")
-      .closest("label")
-      .findByLabelText("More info")
-      .trigger("mouseover");
-
-    H.popover()
-      .should("have.length", 2)
-      // the info popover is the second in the document
-      .last()
-      .contains("No description");
-  });
-
-  it("should allow to pick a saved question when there are models", () => {
-    H.createNativeQuestion({
-      name: "Orders, Model",
-      type: "model",
-      native: { query: "SELECT * FROM ORDERS" },
-    });
-
-    H.startNewQuestion();
-
-    H.entityPickerModal().within(() => {
-      H.entityPickerModalTab("Collections").click();
-      cy.findByText("Orders, Count").click();
-    });
-
-    H.visualize();
-  });
-
   it('should not show "median" aggregation option for databases that do not support "percentile-aggregations" driver feature', () => {
     H.startNewQuestion();
     H.entityPickerModal().within(() => {


### PR DESCRIPTION
Removed multiple tests related to info popovers for field picker options and saved questions.

This behavior is already covered with a unit test at: `frontend/src/metabase/common/components/MetadataInfo/ColumnInfoIcon/ColumnInfoIcon.unit.spec.tsx`

This should also resolve DEV-1091
