### PR TITLE
Separate hybrid and non-hybrid semantic search engines

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
@@ -19,7 +19,7 @@
 (defn- fallback-engine
   "Find the highest priority search engine available for fallback."
   []
-  (u/seek #(not= :search.engine/semantic %) (search.engine/supported-engines)))
+  (u/seek #(not (isa? % :search.engine/semantic)) (search.engine/supported-engines)))
 
 (defn- index-active? [pgvector index-metadata]
   (boolean (semantic.index-metadata/get-active-index-state pgvector index-metadata)))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
@@ -33,19 +33,29 @@
    (some? semantic.db.datasource/db-url)
    (semantic.settings/semantic-search-enabled)))
 
+(defn- hybrid-variant? [{:keys [search-engine]}]
+  (case search-engine
+    :search.engine/semantic        true
+    :search.engine/semantic-hybrid true
+    :search.engine/semantic-only   false
+    (do
+      (log/warn "Unknown semantic search-engine variant:" search-engine)
+      true)))
+
 (defenterprise results
   "Enterprise implementation of semantic search results with improved fallback logic. Falls back to appdb search only
   when semantic search returns too few results and some results were filtered out (e.g. due to permission checks)."
   :feature :semantic-search
   [search-ctx]
   (try
-    (let [{:keys [results raw-count]}
+    (let [hybrid? (hybrid-variant? search-ctx)
+          {:keys [results raw-count]}
           (semantic.pgvector-api/query (semantic.env/get-pgvector-datasource!)
                                        (semantic.env/get-index-metadata)
-                                       search-ctx)
+                                       (assoc search-ctx :semantic-hybrid-mode? hybrid?))
           final-count (count results)
           threshold (semantic.settings/semantic-search-min-results-threshold)]
-      (if (or (>= final-count threshold)
+      (if (or (and (not hybrid?) (>= final-count threshold))
               (and (zero? raw-count)
                    ;; :search-string is nil when using search to populate the list of tables for a given database in
                    ;; the native query editor. Semantic search doesn't support this, so fallback in this case.

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -601,7 +601,8 @@
   ;; The purpose of this query is just to project the coalesced hybrid columns with standard names so the scorers know
   ;; what to call them (e.g. :model rather than [:coalesced :v.model :t.model]). Likewise, the :search_index alias
   ;; allows us to re-use scoring expressions between the appdb and semantic backends without adjusting column names.
-  (let [hybrid-query (hybrid-search-query index embedding search-context)
+  (let [hybrid? (:semantic-hybrid-mode? search-context)
+        hybrid-query (hybrid-search-query index embedding search-context)
         full-query {:with [[:hybrid_results hybrid-query]]
                     :select [:id :model_id :model :content :verified :metadata :semantic_rank :keyword_rank]
                     :from [[:hybrid_results :search_index]]

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -604,7 +604,7 @@
     {:with [[:semantic_results semantic-results]]
      :select (into common-search-columns
                    [[:semantic_rank :semantic_rank]
-                    [[:inline nil] :keyword_rank]])
+                    [[:inline 0] :keyword_rank]])
      :from [[:semantic_results]]
      :limit (semantic-settings/semantic-search-results-limit)}))
 
@@ -616,7 +616,7 @@
   ;; The purpose of this query is just to project the coalesced hybrid columns with standard names so the scorers know
   ;; what to call them (e.g. :model rather than [:coalesced :v.model :t.model]). Likewise, the :search_index alias
   ;; allows us to re-use scoring expressions between the appdb and semantic backends without adjusting column names.
-  (let [hybrid? (:semantic-hybrid-mode? search-context)
+  (let [hybrid? (:semantic-hybrid-mode? search-context true)
         base-query (if hybrid?
                      (hybrid-search-query index embedding search-context)
                      (wrapped-semantic-search-query index embedding search-context))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -600,13 +600,12 @@
   Returns semantic search results with keyword_rank set to NULL so the same
   scorers can be used regardless of search mode."
   [index embedding search-context]
-  (let [semantic-results (semantic-search-query index embedding search-context)]
-    {:with [[:semantic_results semantic-results]]
-     :select (into common-search-columns
-                   [[:semantic_rank :semantic_rank]
-                    [[:inline 0] :keyword_rank]])
-     :from [[:semantic_results]]
-     :limit (semantic-settings/semantic-search-results-limit)}))
+  {:with   [[:semantic_results (semantic-search-query index embedding search-context)]]
+   :select (into common-search-columns
+                 [[:semantic_rank :semantic_rank]
+                  [[:inline 0] :keyword_rank]])
+   :from   [[:semantic_results]]
+   :limit  (semantic-settings/semantic-search-results-limit)})
 
 (defn- scored-search-query
   "Build a search query with additional `scorers`.

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -595,17 +595,34 @@
                     :limit (semantic-settings/semantic-search-results-limit)}]
     full-query))
 
+(defn- wrapped-semantic-search-query
+  "Wraps semantic-only search to match hybrid-search-query's output structure.
+  Returns semantic search results with keyword_rank set to NULL so the same
+  scorers can be used regardless of search mode."
+  [index embedding search-context]
+  (let [semantic-results (semantic-search-query index embedding search-context)]
+    {:with [[:semantic_results semantic-results]]
+     :select (into common-search-columns
+                   [[:semantic_rank :semantic_rank]
+                    [[:inline nil] :keyword_rank]])
+     :from [[:semantic_results]]
+     :limit (semantic-settings/semantic-search-results-limit)}))
+
 (defn- scored-search-query
-  "Build a hybrid search query with additional `scorers`"
+  "Build a search query with additional `scorers`.
+   When hybrid? is true, uses hybrid search (vector + keyword with RRF fusion).
+   When hybrid? is false, uses semantic-only search (vector search only)."
   [index embedding search-context scorers]
   ;; The purpose of this query is just to project the coalesced hybrid columns with standard names so the scorers know
   ;; what to call them (e.g. :model rather than [:coalesced :v.model :t.model]). Likewise, the :search_index alias
   ;; allows us to re-use scoring expressions between the appdb and semantic backends without adjusting column names.
   (let [hybrid? (:semantic-hybrid-mode? search-context)
-        hybrid-query (hybrid-search-query index embedding search-context)
-        full-query {:with [[:hybrid_results hybrid-query]]
+        base-query (if hybrid?
+                     (hybrid-search-query index embedding search-context)
+                     (wrapped-semantic-search-query index embedding search-context))
+        full-query {:with [[:base_results base-query]]
                     :select [:id :model_id :model :content :verified :metadata :semantic_rank :keyword_rank]
-                    :from [[:hybrid_results :search_index]]
+                    :from [[:base_results :search_index]]
                     :limit (semantic-settings/semantic-search-results-limit)}]
     (scoring/with-scores search-context scorers full-query)))
 

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/core_test.clj
@@ -82,7 +82,7 @@
                     (is (not @semantic-called?) "Semantic search should not be called when overridden")
                     (is (not @appdb-called?) "AppDB search should not be called when overridden")))))))))))
 
-;; This is behind a delay as we need the db to be initialized before we can determine the admin user id.
+;; Behind a delay as we need the db to be initialized before we can determine the admin user id.
 (def ^:private search-context-input-delay
   (delay
     {:search-string         "test"
@@ -96,8 +96,7 @@
      :model-ancestors?      false
      :models                nil}))
 
-;; This is behind a delay as there are feature flag checks in this normalization function, and those trigger db
-;; initialization, which we don't want in a top-level form. It's a pity this code mixes concerns like that.
+;; Behind a delay as we need the db to be initialized before we can build the input, and do feature flag validation
 (def ^:private search-context-delay (delay (search.core/search-context @search-context-input-delay)))
 
 (defn- with-search-engine-mocks!

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_embedding_test.clj
@@ -10,7 +10,7 @@
 (def ^:private test-long-model-name "some-really-really-really-really-really-long-model-name-that-will-exceed-the-limit")
 (def ^:private test-vector-dimensions 1024)
 
-;; Postgres truncates indentifier names to 63 bytes (+ 1 byte for a terminating NULL). Ensure that names do not exceed the limit
+;; Postgres truncates identifier names to 63 bytes (+ 1 byte for a terminating NULL). Ensure that names do not exceed the limit
 (deftest ^:parallel index-embedding-name-length-test
   (mt/with-premium-features #{:semantic-search}
     (testing "Truncates if name would be longer than the 63 byte Postgres limit"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -339,7 +339,7 @@
                  (semantic.tu/upsert-index! (semantic.tu/mock-documents))))
           (is (= 2.0 (mt/metric-value system :metabase-search/semantic-index-size))))))))
 
-(deftest ^:syncronized semantic-search-analytics-test
+(deftest ^:synchronized semantic-search-analytics-test
   (mt/with-premium-features #{:semantic-search}
     (with-open [_ (semantic.tu/open-temp-index!)]
       (semantic.tu/upsert-index! (semantic.tu/mock-documents))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
@@ -33,11 +33,9 @@
       (mt/as-admin
         (semantic.tu/with-test-db! {:mode :mock-indexed}
           (testing "Search for 'breed' - keyword in native query only"
-           ;; "breed" appears in Dog Training Guide's native query ("GROUP BY breed")
-           ;; but gets default embedding [0.01 0.02 0.03 0.04] when searched,
-           ;; which is semantically distant from Dog Training Guide's embedding [0.12 -0.34 0.56 -0.78].
-           ;; The cosine distance exceeds the 0.7 threshold, so vector search filters it out.
-           ;; However, keyword search matches it via the native query text.
+           ;; The term "breed" appears in Dog Training Guide's native query ("GROUP BY breed"), but its embedding
+           ;; exceeds the distance threshold to the corresponding document's vector.
+           ;; Hybrid search, however, matches it via the native query text.
             (let [search-string    "breed"
                   hybrid-results   (semantic.tu/query-index {:search-string         search-string
                                                              :semantic-hybrid-mode? true

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
@@ -18,12 +18,12 @@
         (semantic.tu/with-test-db! {:mode :mock-indexed}
           (semantic.tu/with-only-semantic-weights
             (testing "Dog-related query finds dog content"
-              (let [results (-> (semantic.tu/query-index {:search-string "puppy"})
+              (let [results (-> (semantic.tu/query-index {:search-string "puppy", :semantic-hybrid-mode? false})
                                 semantic.tu/filter-for-mock-embeddings)]
                 (is (= "Dog Training Guide" (-> results first :name)))))
 
             (testing "Bird-related query finds bird content"
-              (let [results (-> (semantic.tu/query-index {:search-string "avian"})
+              (let [results (-> (semantic.tu/query-index {:search-string "avian", :semantic-hybrid-mode? false})
                                 semantic.tu/filter-for-mock-embeddings)]
                 (is (= "Bird Watching Tips" (-> results first :name)))))))))))
 

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
@@ -27,6 +27,33 @@
                                 semantic.tu/filter-for-mock-embeddings)]
                 (is (= "Bird Watching Tips" (-> results first :name)))))))))))
 
+(deftest hybrid-vs-semantic-only-test
+  (testing "Hybrid search includes keyword matches that semantic-only misses"
+    (mt/with-premium-features #{:semantic-search}
+      (mt/as-admin
+        (semantic.tu/with-test-db! {:mode :mock-indexed}
+          (testing "Search for 'breed' - keyword in native query only"
+           ;; "breed" appears in Dog Training Guide's native query ("GROUP BY breed")
+           ;; but gets default embedding [0.01 0.02 0.03 0.04] when searched,
+           ;; which is semantically distant from Dog Training Guide's embedding [0.12 -0.34 0.56 -0.78].
+           ;; The cosine distance exceeds the 0.7 threshold, so vector search filters it out.
+           ;; However, keyword search matches it via the native query text.
+            (let [search-string    "breed"
+                  hybrid-results   (semantic.tu/query-index {:search-string         search-string
+                                                             :semantic-hybrid-mode? true
+                                                             :search-native-query   true})
+                  semantic-results (semantic.tu/query-index {:search-string         search-string
+                                                             :semantic-hybrid-mode? false
+                                                             :search-native-query   true})]
+
+              (testing "Hybrid mode finds result via keyword match in native query"
+                (is (some #(= "Dog Training Guide" (:name %)) hybrid-results)
+                    "Dog Training Guide should be found via keyword match in hybrid mode"))
+
+              (testing "Semantic-only mode misses keyword-only match"
+                (is (not-any? #(= "Dog Training Guide" (:name %)) semantic-results)
+                    "Dog Training Guide should NOT be found in semantic-only mode (vector distance too large)")))))))))
+
 (defn- index-of-name
   "Return the index of the item with :name `name` in `coll`"
   [coll name]

--- a/src/metabase/search/semantic/core.clj
+++ b/src/metabase/search/semantic/core.clj
@@ -53,6 +53,12 @@
 
 ;; Search engine method implementations
 
+;; The default version, which incorporates full-text search results.
+(derive :search.engine/semantic-hybrid :search.engine/semantic)
+
+;; A version that only returns embedding-based semantic search results.
+(derive :search.engine/semantic-only :search.engine/semantic)
+
 (defmethod search.engine/supported-engine? :search.engine/semantic [_]
   (try
     (supported?)


### PR DESCRIPTION
Introduce explicit `semantic-hybrid` and `semantic-only` variants, to control whether it blends in full text results and scoring.

It's a bit of a problem that the latter will ignore native queries when performing native query search. It's also unfortunately that the hybrid version won't be searching comments in those queries semantically.

The original idea here was to avoid including unrelated items, or boosting tenuously related ones. I suspect that currently semantic search is heavily reliant on the hybrid aspect for useful recall and sorting. I was thinking to use `semantic-only` for the `semantic-queries` portion in `tools.search`.

Thus I'm no longer sure that this split is useful in the end, but thought it was at least worth discussing.