### PR TITLE
[perf] Add and use m.u.performance/get-in

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -907,6 +907,7 @@
      clojure.core/every?          {:message "Use metabase.util.performance/every?"}
      clojure.core/mapv            {:message "Use metabase.util.performance/mapv"}
      clojure.core/run!            {:message "Use metabase.util.performance/run!"}
+     clojure.core/get-in          {:message "Use metabase.util.performance/get-in"}
      clojure.core/select-keys     {:message "Use metabase.util.performance/select-keys"}
      clojure.core/some            {:message "Use metabase.util.performance/some"}
      clojure.core/update-keys     {:message "Use metabase.util.performance/update-keys"}

--- a/modules/drivers/athena/src/metabase/driver/athena.clj
+++ b/modules/drivers/athena/src/metabase/driver/athena.clj
@@ -1,5 +1,5 @@
 (ns metabase.driver.athena
-  (:refer-clojure :exclude [some select-keys mapv empty? not-empty])
+  (:refer-clojure :exclude [some select-keys mapv empty? not-empty get-in])
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.set :as set]
@@ -19,7 +19,7 @@
    [metabase.util.date-2 :as u.date]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.log :as log]
-   [metabase.util.performance :refer [some select-keys mapv empty? not-empty]])
+   [metabase.util.performance :refer [some select-keys mapv empty? not-empty get-in]])
   (:import
    (java.sql Connection DatabaseMetaData Date ResultSet Time Types)
    (java.time OffsetDateTime ZonedDateTime)

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -1,5 +1,5 @@
 (ns metabase.driver.bigquery-cloud-sdk
-  (:refer-clojure :exclude [mapv some empty? not-empty])
+  (:refer-clojure :exclude [mapv some empty? not-empty get-in])
   (:require
    [clojure.core.async :as a]
    [clojure.set :as set]
@@ -24,7 +24,7 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [mapv some empty? not-empty]]
+   [metabase.util.performance :refer [mapv some empty? not-empty get-in]]
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2])
   (:import

--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse_introspection.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse_introspection.clj
@@ -1,5 +1,5 @@
 (ns metabase.driver.clickhouse-introspection
-  (:refer-clojure :exclude [empty?])
+  (:refer-clojure :exclude [empty? get-in])
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
@@ -10,7 +10,7 @@
    [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
    [metabase.driver.sql-jdbc.sync.describe-table :as sql-jdbc.describe-table]
    [metabase.util :as u]
-   [metabase.util.performance :refer [empty?]])
+   [metabase.util.performance :refer [empty? get-in]])
   (:import
    (java.sql Connection DatabaseMetaData)))
 

--- a/modules/drivers/databricks/src/metabase/driver/databricks.clj
+++ b/modules/drivers/databricks/src/metabase/driver/databricks.clj
@@ -1,5 +1,5 @@
 (ns metabase.driver.databricks
-  (:refer-clojure :exclude [not-empty])
+  (:refer-clojure :exclude [not-empty get-in])
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
@@ -19,7 +19,7 @@
    [metabase.util :as u]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.log :as log]
-   [metabase.util.performance :refer [not-empty]]
+   [metabase.util.performance :refer [not-empty get-in]]
    [ring.util.codec :as codec])
   (:import
    [java.sql

--- a/modules/drivers/druid/src/metabase/driver/druid/client.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/client.clj
@@ -1,4 +1,5 @@
 (ns metabase.driver.druid.client
+  (:refer-clojure :exclude [get-in])
   (:require
    [clj-http.client :as http]
    [clojure.core.async :as a]
@@ -7,7 +8,8 @@
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
-   [metabase.util.log :as log]))
+   [metabase.util.log :as log]
+   [metabase.util.performance :refer [get-in]]))
 
 (set! *warn-on-reflection* true)
 

--- a/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
@@ -1,5 +1,5 @@
 (ns metabase.driver.druid.query-processor
-  (:refer-clojure :exclude [every? mapv some])
+  (:refer-clojure :exclude [every? mapv some get-in])
   (:require
    [clojure.core.match :refer [match]]
    [clojure.string :as str]
@@ -11,7 +11,7 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [every? mapv some]]))
+   [metabase.util.performance :refer [every? mapv some get-in]]))
 
 (set! *warn-on-reflection* true)
 

--- a/modules/drivers/mongo/src/metabase/driver/mongo.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo.clj
@@ -1,6 +1,6 @@
 (ns metabase.driver.mongo
   "MongoDB Driver."
-  (:refer-clojure :exclude [some mapv empty?])
+  (:refer-clojure :exclude [some mapv empty? get-in])
   (:require
    [clojure.set :as set]
    [clojure.string :as str]
@@ -21,7 +21,7 @@
    [metabase.util.date-2 :as u.date]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
-   [metabase.util.performance :refer [some mapv empty?]]
+   [metabase.util.performance :refer [some mapv empty? get-in]]
    [taoensso.nippy :as nippy])
   (:import
    (com.mongodb.client MongoClient MongoDatabase)

--- a/modules/drivers/mongo/src/metabase/driver/mongo/parameters.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/parameters.clj
@@ -1,4 +1,5 @@
 (ns metabase.driver.mongo.parameters
+  (:refer-clojure :exclude [get-in])
   (:require
    [clojure.string :as str]
    [java-time.api :as t]
@@ -15,7 +16,7 @@
    [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :as perf])
+   [metabase.util.performance :as perf :refer [get-in]])
   (:import
    (java.time ZoneOffset)
    (java.time.temporal Temporal)

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -1,6 +1,6 @@
 (ns metabase.driver.snowflake
   "Snowflake Driver."
-  (:refer-clojure :exclude [select-keys not-empty])
+  (:refer-clojure :exclude [select-keys not-empty get-in])
   (:require
    [buddy.core.codecs :as codecs]
    [clojure.java.jdbc :as jdbc]
@@ -32,7 +32,7 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
-   [metabase.util.performance :refer [select-keys not-empty]]
+   [metabase.util.performance :refer [select-keys not-empty get-in]]
    [ring.util.codec :as codec])
   (:import
    (java.io File)

--- a/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
+++ b/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
@@ -1,5 +1,5 @@
 (ns metabase.driver.sparksql
-  (:refer-clojure :exclude [select-keys every? empty? not-empty])
+  (:refer-clojure :exclude [select-keys every? empty? not-empty get-in])
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
@@ -18,7 +18,7 @@
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.driver.sql.util :as sql.u]
    [metabase.util.honey-sql-2 :as h2x]
-   [metabase.util.performance :refer [select-keys every? empty? not-empty]])
+   [metabase.util.performance :refer [select-keys every? empty? not-empty get-in]])
   (:import
    (java.sql Connection ResultSet Types)))
 

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -1,6 +1,6 @@
 (ns metabase.driver.sqlserver
   "Driver for SQLServer databases. Uses the official Microsoft JDBC driver under the hood (pre-0.25.0, used jTDS)."
-  (:refer-clojure :exclude [mapv])
+  (:refer-clojure :exclude [mapv get-in])
   (:require
    [clojure.data.xml :as xml]
    [clojure.java.io :as io]
@@ -29,7 +29,7 @@
    [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :as perf :refer [mapv]])
+   [metabase.util.performance :as perf :refer [mapv get-in]])
   (:import
    (java.sql Connection DatabaseMetaData PreparedStatement ResultSet Time)
    (java.time LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime ZonedDateTime)

--- a/modules/drivers/starburst/src/metabase/driver/starburst.clj
+++ b/modules/drivers/starburst/src/metabase/driver/starburst.clj
@@ -1,6 +1,6 @@
 (ns metabase.driver.starburst
   "starburst driver."
-  (:refer-clojure :exclude [select-keys])
+  (:refer-clojure :exclude [select-keys get-in])
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.set :as set]
@@ -26,7 +26,7 @@
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.i18n :refer [trs]]
    [metabase.util.log :as log]
-   [metabase.util.performance :refer [select-keys]])
+   [metabase.util.performance :refer [select-keys get-in]])
   (:import
    (com.mchange.v2.c3p0 C3P0ProxyConnection)
    (io.trino.jdbc TrinoConnection)

--- a/src/metabase/driver/common.clj
+++ b/src/metabase/driver/common.clj
@@ -1,5 +1,6 @@
 (ns metabase.driver.common
   "Shared definitions and helper functions for use across different drivers."
+  (:refer-clojure :exclude [get-in])
   #_{:clj-kondo/ignore [:metabase/modules]}
   (:require
    [clojure.string :as str]
@@ -9,6 +10,7 @@
    [metabase.util.i18n :refer [deferred-tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [get-in]]
    [metabase.warehouses.core :as warehouses]))
 
 (set! *warn-on-reflection* true)

--- a/src/metabase/driver/common/parameters/dates.clj
+++ b/src/metabase/driver/common/parameters/dates.clj
@@ -8,7 +8,7 @@
   in [[metabase.query-processor.parameters.dates]], we should remove the version here to encourage migration to that
   namespace."
   {:deprecated "0.57.0"}
-  (:refer-clojure :exclude [every? some])
+  (:refer-clojure :exclude [every? some get-in])
   (:require
    [clojure.string :as str]
    [java-time.api :as t]
@@ -19,7 +19,7 @@
    [metabase.query-processor.parameters.dates :as qp.parameters.dates]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [every?]]
+   [metabase.util.performance :refer [every? get-in]]
    [potemkin :as p]))
 
 (set! *warn-on-reflection* true)

--- a/src/metabase/driver/common/parameters/operators.clj
+++ b/src/metabase/driver/common/parameters/operators.clj
@@ -10,6 +10,7 @@
 
   DEPRECATED: use [[metabase.query-processor.parameters.operators]] going forward."
   {:deprecated "0.57.0"}
+  (:refer-clojure :exclude [get-in])
   (:require
    [metabase.legacy-mbql.schema :as mbql.s]
    [metabase.legacy-mbql.util :as mbql.u]
@@ -18,6 +19,7 @@
    [metabase.query-processor.parameters.operators :as qp.params.ops]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [get-in]]
    [potemkin :as p]))
 
 (p/import-vars

--- a/src/metabase/driver/common/parameters/values.clj
+++ b/src/metabase/driver/common/parameters/values.clj
@@ -17,7 +17,7 @@
   unused namespaces. We can't migrate to it if it's gone... please restore it when we start migrating usages of it
   over."
   {:deprecated "0.57.0"}
-  (:refer-clojure :exclude [every? some mapv not-empty])
+  (:refer-clojure :exclude [every? some mapv not-empty get-in])
   (:require
    [clojure.string :as str]
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.driver.common.parameters :as params]
@@ -38,7 +38,7 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [every? mapv some not-empty]])
+   [metabase.util.performance :refer [every? mapv some not-empty get-in]])
   (:import
    (clojure.lang ExceptionInfo)
    (java.util UUID)))

--- a/src/metabase/driver/sql_jdbc/actions.clj
+++ b/src/metabase/driver/sql_jdbc/actions.clj
@@ -1,5 +1,5 @@
 (ns metabase.driver.sql-jdbc.actions
-  (:refer-clojure :exclude [some mapv select-keys empty? not-empty])
+  (:refer-clojure :exclude [some mapv select-keys empty? not-empty get-in])
   #_{:clj-kondo/ignore [:discouraged-namespace]} ;; for using toucan2 in this ns
   (:require
    [clojure.java.jdbc :as jdbc]
@@ -18,7 +18,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :as perf :refer [some mapv select-keys empty? not-empty]]
+   [metabase.util.performance :as perf :refer [some mapv select-keys empty? not-empty get-in]]
    [methodical.core :as methodical]
    [toucan2.core :as t2])
   (:import

--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -4,7 +4,7 @@
   `metabase.driver.sql-jdbc.execute.old-impl`, which will be removed in a future release; implementations of methods
   for JDBC drivers that do not support `java.time` classes can be found in
   `metabase.driver.sql-jdbc.execute.legacy-impl`. "
-  (:refer-clojure :exclude [mapv empty?])
+  (:refer-clojure :exclude [mapv empty? get-in])
   #_{:clj-kondo/ignore [:metabase/modules]}
   (:require
    [clojure.core.async :as a]
@@ -25,7 +25,7 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :as perf :refer [mapv empty?]]
+   [metabase.util.performance :as perf :refer [mapv empty? get-in]]
    [potemkin :as p])
   (:import
    (java.sql

--- a/src/metabase/driver/sql_jdbc/sync/describe_database.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_database.clj
@@ -1,5 +1,6 @@
 (ns metabase.driver.sql-jdbc.sync.describe-database
   "SQL JDBC impl for `describe-database`."
+  (:refer-clojure :exclude [get-in])
   (:require
    [clojure.string :as str]
    [metabase.driver :as driver]
@@ -12,7 +13,8 @@
    [metabase.driver.util :as driver.u]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.log :as log]
-   [metabase.util.malli :as mu])
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [get-in]])
   (:import
    (java.sql Connection DatabaseMetaData ResultSet)))
 

--- a/src/metabase/legacy_mbql/util.cljc
+++ b/src/metabase/legacy_mbql/util.cljc
@@ -3,7 +3,7 @@
 
   DEPRECATED: Use [[metabase.lib.core]] for MBQL manipulation in all new code."
   {:deprecated "0.57.0"}
-  (:refer-clojure :exclude [replace some mapv every? not-empty #?(:clj for)])
+  (:refer-clojure :exclude [replace some mapv every? not-empty get-in #?(:clj for)])
   (:require
    #?@(:clj
        [[metabase.legacy-mbql.jvm-util :as mbql.jvm-u]])
@@ -18,7 +18,7 @@
    [metabase.util.i18n :as i18n]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [some mapv every? not-empty #?(:clj for)]]
+   [metabase.util.performance :refer [some mapv every? not-empty get-in #?(:clj for)]]
    [metabase.util.time :as u.time]))
 
 (defn mbql-clause?

--- a/src/metabase/lib/binning.cljc
+++ b/src/metabase/lib/binning.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.binning
-  (:refer-clojure :exclude [mapv select-keys])
+  (:refer-clojure :exclude [mapv select-keys get-in])
   (:require
    [clojure.set :as set]
    [clojure.string :as str]
@@ -15,7 +15,7 @@
    [metabase.util :as u]
    [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [mapv select-keys]]))
+   [metabase.util.performance :refer [mapv select-keys get-in]]))
 
 (defmulti with-binning-method
   "Implementation for [[with-binning]]. Implement this to tell [[with-binning]] how to add binning to a particular MBQL

--- a/src/metabase/lib/computed.cljc
+++ b/src/metabase/lib/computed.cljc
@@ -2,9 +2,11 @@
   "A first cut at smarter, more granular memoization of derived data about queries.
 
   Only a corner of the vision is implemented here so far, it's expanding as needed in response to user perf issues."
+  (:refer-clojure :exclude [get-in])
   (:require
    [metabase.util :as u]
-   [metabase.util.log :as log]))
+   [metabase.util.log :as log]
+   [metabase.util.performance :refer [get-in]]))
 
 (def ^:private weak-map
   "A global weak map using queries as keys. Since CLJ(S) maps are immutable, if the map changes it is a new pointer,

--- a/src/metabase/lib/drill_thru/pivot.cljc
+++ b/src/metabase/lib/drill_thru/pivot.cljc
@@ -41,7 +41,7 @@
   - `pivotTypes` function that return available column types for the drill - \"category\" | \"location\" | \"time\"
 
   - `pivotColumnsForType` returns the list of available columns for the drill and the selected type"
-  (:refer-clojure :exclude [select-keys empty? not-empty #?(:clj for)])
+  (:refer-clojure :exclude [select-keys empty? not-empty get-in #?(:clj for)])
   (:require
    [metabase.lib.aggregation :as lib.aggregation]
    [metabase.lib.breakout :as lib.breakout]
@@ -54,7 +54,7 @@
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.lib.underlying :as lib.underlying]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [select-keys empty? not-empty #?(:clj for)]]))
+   [metabase.util.performance :refer [select-keys empty? not-empty get-in #?(:clj for)]]))
 
 (mu/defn- pivot-drill-pred :- [:sequential ::lib.schema.metadata/column]
   "Implementation for pivoting on various kinds of fields.

--- a/src/metabase/lib/drill_thru/pk.cljc
+++ b/src/metabase/lib/drill_thru/pk.cljc
@@ -33,7 +33,7 @@
   drills ([[metabase.lib.drill-thru.pk]], [[metabase.lib.drill-thru.fk-details]],
   or [[metabase.lib.drill-thru.zoom]]); see [[metabase.lib.drill-thru.object-details]] for the high-level logic that
   calls out to the individual implementations."
-  (:refer-clojure :exclude [select-keys #?(:clj for)])
+  (:refer-clojure :exclude [select-keys get-in #?(:clj for)])
   (:require
    [medley.core :as m]
    [metabase.lib.drill-thru.common :as lib.drill-thru.common]
@@ -43,7 +43,7 @@
    [metabase.lib.schema.drill-thru :as lib.schema.drill-thru]
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [select-keys #?(:clj for)]]))
+   [metabase.util.performance :refer [select-keys get-in #?(:clj for)]]))
 
 (mu/defn pk-drill :- [:maybe ::lib.schema.drill-thru/drill-thru.pk]
   "'View details' drill when you click on a value in a table that has MULTIPLE PKs. There are two subtypes of PK

--- a/src/metabase/lib/equality.cljc
+++ b/src/metabase/lib/equality.cljc
@@ -1,6 +1,6 @@
 (ns metabase.lib.equality
   "Logic for determining whether two pMBQL queries are equal."
-  (:refer-clojure :exclude [= every? some mapv empty? not-empty #?(:clj for)])
+  (:refer-clojure :exclude [= every? some mapv empty? not-empty get-in #?(:clj for)])
   (:require
    [medley.core :as m]
    [metabase.lib.binning :as lib.binning]
@@ -21,7 +21,7 @@
    [metabase.lib.util :as lib.util]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [every? some mapv empty? not-empty #?(:clj for)]]))
+   [metabase.util.performance :refer [every? some mapv empty? not-empty get-in #?(:clj for)]]))
 
 (defmulti =
   "Determine whether two already-normalized pMBQL maps, clauses, or other sorts of expressions are equal. The basic rule

--- a/src/metabase/lib/expression.cljc
+++ b/src/metabase/lib/expression.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.expression
-  (:refer-clojure :exclude [+ - * / case coalesce abs time concat replace float mapv some select-keys not-empty
+  (:refer-clojure :exclude [+ - * / case coalesce abs time concat replace float mapv some select-keys not-empty get-in
                             #?(:clj doseq) #?(:clj for)])
   (:require
    [clojure.string :as str]
@@ -30,7 +30,7 @@
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [metabase.util.number :as u.number]
-   [metabase.util.performance :refer [mapv some select-keys not-empty #?(:clj doseq) #?(:clj for)]]))
+   [metabase.util.performance :refer [mapv some select-keys not-empty get-in #?(:clj doseq) #?(:clj for)]]))
 
 (mu/defn column-metadata->expression-ref :- :mbql.clause/expression
   "Given `:metadata/column` column metadata for an expression, construct an `:expression` reference."

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.field
-  (:refer-clojure :exclude [every? select-keys mapv empty? not-empty #?(:clj for)])
+  (:refer-clojure :exclude [every? select-keys mapv empty? not-empty get-in #?(:clj for)])
   (:require
    [clojure.set :as set]
    [clojure.string :as str]
@@ -34,7 +34,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [every? select-keys mapv empty? not-empty #?(:clj for)]]
+   [metabase.util.performance :refer [every? select-keys mapv empty? not-empty get-in #?(:clj for)]]
    [metabase.util.time :as u.time]))
 
 (defn- column-metadata-effective-type

--- a/src/metabase/lib/field/resolution.cljc
+++ b/src/metabase/lib/field/resolution.cljc
@@ -1,7 +1,7 @@
 (ns metabase.lib.field.resolution
   "Code for resolving field metadata from a field ref. There's a lot of code here, isn't there? This is probably more
   complicated than it needs to be!"
-  (:refer-clojure :exclude [not-empty some select-keys #?(:clj empty?)])
+  (:refer-clojure :exclude [not-empty some select-keys get-in #?(:clj empty?)])
   (:require
    #?@(:clj
        ([metabase.config.core :as config]))
@@ -26,7 +26,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [not-empty some select-keys #?(:clj empty?)]]))
+   [metabase.util.performance :refer [not-empty some select-keys get-in #?(:clj empty?)]]))
 
 (mr/def ::id-or-name
   [:or :string ::lib.schema.id/field])

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -1,6 +1,6 @@
 (ns metabase.lib.join
   "Functions related to manipulating EXPLICIT joins in MBQL."
-  (:refer-clojure :exclude [mapv run! some empty? not-empty #?(:clj for)])
+  (:refer-clojure :exclude [mapv run! some empty? not-empty get-in #?(:clj for)])
   (:require
    [clojure.set :as set]
    [clojure.string :as str]
@@ -36,7 +36,7 @@
    [metabase.util.i18n :as i18n]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [mapv run! some empty? not-empty #?(:clj for)]]))
+   [metabase.util.performance :refer [mapv run! some empty? not-empty get-in #?(:clj for)]]))
 
 (defn- join? [x]
   (= (lib.dispatch/dispatch-value x) :mbql/join))

--- a/src/metabase/lib/metadata.cljc
+++ b/src/metabase/lib/metadata.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.metadata
-  (:refer-clojure :exclude [every? empty? #?(:clj doseq) #?(:clj for)])
+  (:refer-clojure :exclude [every? empty? #?(:clj doseq) get-in #?(:clj for)])
   (:require
    [medley.core :as m]
    [metabase.lib.computed :as lib.computed]
@@ -12,7 +12,7 @@
    [metabase.util :as u]
    [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [every? empty? #?(:clj doseq) #?(:clj for)]]))
+   [metabase.util.performance :refer [every? empty? #?(:clj doseq) get-in #?(:clj for)]]))
 
 ;;; TODO -- deprecate all the schemas below, and just use the versions in [[lib.schema.metadata]] instead.
 

--- a/src/metabase/lib/metadata/cached_provider.cljc
+++ b/src/metabase/lib/metadata/cached_provider.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.metadata.cached-provider
-  (:refer-clojure :exclude [update-keys #?(:clj doseq)])
+  (:refer-clojure :exclude [update-keys get-in #?(:clj doseq)])
   (:require
    #?@(:clj ([metabase.util.json :as json]
              [pretty.core :as pretty]))
@@ -9,7 +9,7 @@
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [update-keys #?(:clj doseq)]]))
+   [metabase.util.performance :refer [update-keys get-in #?(:clj doseq)]]))
 
 #?(:clj (set! *warn-on-reflection* true))
 

--- a/src/metabase/lib/metadata/result_metadata.cljc
+++ b/src/metabase/lib/metadata/result_metadata.cljc
@@ -6,7 +6,7 @@
 
   Traditionally this code lived in the [[metabase.query-processor.middleware.annotate]] namespace, where it is still
   used today."
-  (:refer-clojure :exclude [mapv select-keys some update-keys every? empty? not-empty #?(:clj for)])
+  (:refer-clojure :exclude [mapv select-keys some update-keys every? empty? not-empty get-in #?(:clj for)])
   (:require
    #?@(:clj
        ([metabase.config.core :as config]))
@@ -33,7 +33,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [mapv select-keys some update-keys every? empty? not-empty #?(:clj for)]]))
+   [metabase.util.performance :refer [mapv select-keys some update-keys every? empty? not-empty get-in #?(:clj for)]]))
 
 (mr/def ::col
   ;; TODO (Cam 6/19/25) -- I think we should actually namespace all the keys added here (to make it clear where they

--- a/src/metabase/lib/remove_replace.cljc
+++ b/src/metabase/lib/remove_replace.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.remove-replace
-  (:refer-clojure :exclude [every? mapv run! some empty? not-empty #?(:clj for)])
+  (:refer-clojure :exclude [every? mapv run! some empty? not-empty get-in #?(:clj for)])
   (:require
    [clojure.set :as set]
    [medley.core :as m]
@@ -23,7 +23,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :as perf :refer [every? mapv run! some empty? not-empty #?(:clj for)]]))
+   [metabase.util.performance :as perf :refer [every? mapv run! some empty? not-empty get-in #?(:clj for)]]))
 
 (defn- stage-paths
   [query stage-number]

--- a/src/metabase/lib/schema.cljc
+++ b/src/metabase/lib/schema.cljc
@@ -6,7 +6,7 @@
   Some primitives below are duplicated from [[metabase.util.malli.schema]] since that's not `.cljc`. Other stuff is
   copied from [[metabase.legacy-mbql.schema]] so this can exist completely independently; hopefully at some point in the
   future we can deprecate that namespace and eventually do away with it entirely."
-  (:refer-clojure :exclude [ref every? some select-keys empty?])
+  (:refer-clojure :exclude [ref every? some select-keys empty? get-in])
   (:require
    [medley.core :as m]
    [metabase.lib.schema.actions :as actions]
@@ -34,7 +34,7 @@
    [metabase.lib.schema.util :as lib.schema.util]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [every? select-keys some empty?]]))
+   [metabase.util.performance :refer [every? select-keys some empty? get-in]]))
 
 (comment metabase.lib.schema.expression.arithmetic/keep-me
          metabase.lib.schema.expression.conditional/keep-me

--- a/src/metabase/lib/schema/metadata.cljc
+++ b/src/metabase/lib/schema/metadata.cljc
@@ -1,4 +1,5 @@
 (ns metabase.lib.schema.metadata
+  (:refer-clojure :exclude [get-in])
   (:require
    #?@(:clj
        ([metabase.util.regex :as u.regex]))
@@ -9,7 +10,8 @@
    [metabase.lib.schema.join :as lib.schema.join]
    [metabase.lib.schema.metadata.fingerprint :as lib.schema.metadata.fingerprint]
    [metabase.lib.schema.temporal-bucketing :as lib.schema.temporal-bucketing]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [get-in]]))
 
 ;;; Column vs Field?
 ;;;

--- a/src/metabase/lib/schema/parameter.cljc
+++ b/src/metabase/lib/schema/parameter.cljc
@@ -21,6 +21,7 @@
   currently still allowed for backwards-compatibility purposes -- currently the FE client will just parrot back the
   `:widget-type` in some cases. In these cases, the backend is just supposed to infer the actual type of the parameter
   value."
+  (:refer-clojure :exclude [get-in])
   (:require
    #?@(:clj
        ([flatland.ordered.map :as ordered-map]))
@@ -28,7 +29,8 @@
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.util :as u]
    [metabase.util.malli :as mu]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [get-in]]))
 
 (defn- variadic-opts-first
   "Some clauses, like `:contains`, have optional `options` last in their binary form, and required options first in

--- a/src/metabase/lib/stage.cljc
+++ b/src/metabase/lib/stage.cljc
@@ -1,6 +1,6 @@
 (ns metabase.lib.stage
   "Method implementations for a stage of a query."
-  (:refer-clojure :exclude [mapv some not-empty #?(:clj for)])
+  (:refer-clojure :exclude [mapv some not-empty get-in #?(:clj for)])
   (:require
    [clojure.string :as str]
    [metabase.lib.aggregation :as lib.aggregation]
@@ -26,7 +26,7 @@
    [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]
    [metabase.util.namespaces :as shared.ns]
-   [metabase.util.performance :refer [mapv some not-empty #?(:clj for)]]))
+   [metabase.util.performance :refer [mapv some not-empty get-in #?(:clj for)]]))
 
 (comment metabase.lib.stage.util/keep-me)
 

--- a/src/metabase/lib/swap.cljc
+++ b/src/metabase/lib/swap.cljc
@@ -1,7 +1,7 @@
 (ns metabase.lib.swap
-  #?(:clj (:refer-clojure :exclude [for]))
+  #?(:clj (:refer-clojure :exclude [for get-in]))
   (:require
-   #?(:clj [metabase.util.performance :refer [for]])
+   #?(:clj [metabase.util.performance :refer [for get-in]])
    [metabase.lib.options :as lib.options]
    [metabase.lib.remove-replace :as lib.remove-replace]
    [metabase.lib.util :as lib.util]

--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.util
-  (:refer-clojure :exclude [format every? mapv select-keys update-keys some #?(:clj for)])
+  (:refer-clojure :exclude [format every? mapv select-keys update-keys some get-in #?(:clj for)])
   (:require
    #?@(:clj
        ([potemkin :as p])
@@ -23,7 +23,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [every? mapv select-keys update-keys some #?(:clj for)]]))
+   [metabase.util.performance :refer [every? mapv select-keys update-keys some get-in #?(:clj for)]]))
 
 #?(:clj
    (set! *warn-on-reflection* true))

--- a/src/metabase/lib/util/match/impl.cljc
+++ b/src/metabase/lib/util/match/impl.cljc
@@ -1,8 +1,8 @@
 (ns metabase.lib.util.match.impl
   "Internal implementation of the MBQL `match` and `replace` macros. Don't use these directly."
-  (:refer-clojure :exclude [mapv])
+  (:refer-clojure :exclude [mapv get-in])
   (:require
-   [metabase.util.performance :refer [mapv]]))
+   [metabase.util.performance :refer [mapv get-in]]))
 
 ;; have to do this at runtime because we don't know if a symbol is a class or pred or whatever when we compile the macro
 (defn match-with-pred-or-class

--- a/src/metabase/lib/walk.cljc
+++ b/src/metabase/lib/walk.cljc
@@ -1,6 +1,6 @@
 (ns metabase.lib.walk
   "Tools for walking and transforming a query."
-  (:refer-clojure :exclude [mapv empty?])
+  (:refer-clojure :exclude [mapv empty? get-in])
   (:require
    [medley.core :as m]
    [metabase.lib.dispatch :as lib.dispatch]
@@ -14,7 +14,7 @@
    [metabase.util :as u]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [mapv empty?]]))
+   [metabase.util.performance :refer [mapv empty? get-in]]))
 
 (declare walk-stages*)
 

--- a/src/metabase/lib_be/metadata/jvm.clj
+++ b/src/metabase/lib_be/metadata/jvm.clj
@@ -1,5 +1,6 @@
 (ns metabase.lib-be.metadata.jvm
   "Implementation(s) of [[metabase.lib.metadata.protocols/MetadataProvider]] only for the JVM."
+  (:refer-clojure :exclude [get-in])
   (:require
    [clojure.core.cache :as cache]
    [clojure.core.cache.wrapped :as cache.wrapped]
@@ -17,7 +18,7 @@
    [metabase.util.json :as json]
    [metabase.util.malli :as mu]
    [metabase.util.memoize :as u.memo]
-   [metabase.util.performance :as perf]
+   [metabase.util.performance :as perf :refer [get-in]]
    [metabase.util.snake-hating-map :as u.snake-hating-map]
    [methodical.core :as methodical]
    [potemkin :as p]

--- a/src/metabase/query_processor/api.clj
+++ b/src/metabase/query_processor/api.clj
@@ -1,6 +1,6 @@
 (ns metabase.query-processor.api
   "/api/dataset endpoints."
-  (:refer-clojure :exclude [not-empty])
+  (:refer-clojure :exclude [not-empty get-in])
   (:require
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
@@ -32,7 +32,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.util.malli.schema :as ms]
-   [metabase.util.performance :refer [not-empty]]
+   [metabase.util.performance :refer [not-empty get-in]]
    [steffan-westcott.clj-otel.api.trace.span :as span]
    ^{:clj-kondo/ignore [:discouraged-namespace]} [toucan2.core :as t2]))
 

--- a/src/metabase/query_processor/dashboard.clj
+++ b/src/metabase/query_processor/dashboard.clj
@@ -1,6 +1,6 @@
 (ns metabase.query-processor.dashboard
   "Code for running a query in the context of a specific DashboardCard."
-  (:refer-clojure :exclude [some select-keys not-empty])
+  (:refer-clojure :exclude [some select-keys not-empty get-in])
   (:require
    [clojure.string :as str]
    [medley.core :as m]
@@ -18,7 +18,7 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [select-keys some not-empty]]
+   [metabase.util.performance :refer [select-keys some not-empty get-in]]
    [steffan-westcott.clj-otel.api.trace.span :as span]
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2]))

--- a/src/metabase/query_processor/middleware/add_implicit_joins.clj
+++ b/src/metabase/query_processor/middleware/add_implicit_joins.clj
@@ -1,7 +1,7 @@
 (ns metabase.query-processor.middleware.add-implicit-joins
   "Middleware that creates corresponding `:joins` for Tables referred to by `:field` clauses with `:source-field` info
   in the options and adds `:join-alias` info to those `:field` clauses."
-  (:refer-clojure :exclude [alias mapv some empty? not-empty])
+  (:refer-clojure :exclude [alias mapv some empty? not-empty get-in])
   (:require
    [better-cond.core :as b]
    [clojure.set :as set]
@@ -23,7 +23,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [mapv some empty? not-empty]]))
+   [metabase.util.performance :refer [mapv some empty? not-empty get-in]]))
 
 (defn- implicitly-joined-fields
   "Find fields that come from implicit join in form `x`, presumably a query.

--- a/src/metabase/query_processor/middleware/add_remaps.clj
+++ b/src/metabase/query_processor/middleware/add_remaps.clj
@@ -25,7 +25,7 @@
   `name` is `:remapped_from` `:category_id`.
 
   See also [[metabase.parameters.chain-filter]] for another explanation of remapping."
-  (:refer-clojure :exclude [mapv select-keys some empty? not-empty])
+  (:refer-clojure :exclude [mapv select-keys some empty? not-empty get-in])
   (:require
    [clojure.data :as data]
    [medley.core :as m]
@@ -47,7 +47,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [mapv select-keys some empty? not-empty]]))
+   [metabase.util.performance :refer [mapv select-keys some empty? not-empty get-in]]))
 
 (mr/def ::simplified-ref
   [:tuple

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -1,6 +1,6 @@
 (ns metabase.query-processor.middleware.annotate
   "Middleware for annotating (adding type information to) the results of a query, under the `:cols` column."
-  (:refer-clojure :exclude [every? mapv empty?])
+  (:refer-clojure :exclude [every? mapv empty? get-in])
   (:require
    [metabase.analyze.core :as analyze]
    [metabase.driver.common :as driver.common]
@@ -17,7 +17,7 @@
    [metabase.query-processor.schema :as qp.schema]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [every? mapv empty?]]
+   [metabase.util.performance :refer [every? mapv empty? get-in]]
    [potemkin :as p]))
 
 (comment metabase.query-processor.middleware.annotate.legacy-helper-fns/keep-me)

--- a/src/metabase/query_processor/middleware/auto_bucket_datetimes.clj
+++ b/src/metabase/query_processor/middleware/auto_bucket_datetimes.clj
@@ -2,7 +2,7 @@
   "Middleware for automatically bucketing unbucketed `:type/Temporal` (but not `:type/Time`) Fields with `:day`
   bucketing. Applies to any unbucketed Field in a breakout, or fields in a filter clause being compared against
   `yyyy-MM-dd` format datetime strings."
-  (:refer-clojure :exclude [select-keys every? some not-empty])
+  (:refer-clojure :exclude [select-keys every? some not-empty get-in])
   (:require
    [medley.core :as m]
    [metabase.lib.core :as lib]
@@ -16,7 +16,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [select-keys every? some not-empty]]))
+   [metabase.util.performance :refer [select-keys every? some not-empty get-in]]))
 
 (mr/def ::column-type-info
   [:map

--- a/src/metabase/query_processor/middleware/binning.clj
+++ b/src/metabase/query_processor/middleware/binning.clj
@@ -1,6 +1,7 @@
 (ns metabase.query-processor.middleware.binning
   "Middleware that handles `:binning` strategy in `:field` clauses. This adds extra info to the `:binning` options maps
   that contain the information Query Processors will need in order to perform binning."
+  (:refer-clojure :exclude [get-in])
   (:require
    [metabase.lib.binning.util :as lib.binning.util]
    [metabase.lib.core :as lib]
@@ -14,7 +15,8 @@
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.malli :as mu]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [get-in]]))
 
 (mr/def ::field-id-or-name->filters
   [:map-of [:or ::lib.schema.id/field :string] ::lib.schema/filters])

--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -7,6 +7,7 @@
   The default backend is `db`, which uses the application database; this value can be changed by setting the env var
   `MB_QP_CACHE_BACKEND`. Refer to [[metabase.query-processor.middleware.cache-backend.interface]] for more details
   about how the cache backends themselves."
+  (:refer-clojure :exclude [get-in])
   (:require
    [java-time.api :as t]
    [medley.core :as m]
@@ -21,7 +22,8 @@
    [metabase.query-processor.util :as qp.util]
    [metabase.util :as u]
    [metabase.util.log :as log]
-   [metabase.util.malli :as mu])
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [get-in]])
   (:import
    (org.eclipse.jetty.io EofException)))
 

--- a/src/metabase/query_processor/middleware/catch_exceptions.clj
+++ b/src/metabase/query_processor/middleware/catch_exceptions.clj
@@ -1,6 +1,6 @@
 (ns metabase.query-processor.middleware.catch-exceptions
   "Middleware for catching exceptions thrown by the query processor and returning them in a friendlier format."
-  (:refer-clojure :exclude [some])
+  (:refer-clojure :exclude [some get-in])
   (:require
    [clojure.string :as str]
    [metabase.analytics.core :as analytics]
@@ -14,7 +14,7 @@
    [metabase.util.i18n :refer [trs]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [some]])
+   [metabase.util.performance :refer [some get-in]])
   (:import
    (clojure.lang ExceptionInfo)
    (java.sql SQLException)))

--- a/src/metabase/query_processor/middleware/constraints.clj
+++ b/src/metabase/query_processor/middleware/constraints.clj
@@ -1,8 +1,10 @@
 (ns metabase.query-processor.middleware.constraints
   "Middleware that adds default constraints to limit the maximum number of rows returned to queries that specify the
   `:add-default-userland-constraints?` `:middleware` option."
+  (:refer-clojure :exclude [get-in])
   (:require
-   [metabase.query-processor.settings :as qp.settings]))
+   [metabase.query-processor.settings :as qp.settings]
+   [metabase.util.performance :refer [get-in]]))
 
 ;; The following "defaults" are not applied to the settings themselves - why not? Because the existing behavior is
 ;; that, if you manually update the settings, queries are affected *WHETHER OR NOT* the

--- a/src/metabase/query_processor/middleware/expand_macros.clj
+++ b/src/metabase/query_processor/middleware/expand_macros.clj
@@ -2,7 +2,7 @@
   "Middleware for expanding LEGACY `:segment` 'macros' in *unexpanded* MBQL queries.
 
   (`:segment` forms are expanded into filter clauses.)"
-  (:refer-clojure :exclude [mapv not-empty])
+  (:refer-clojure :exclude [mapv not-empty get-in])
   (:require
    [metabase.lib.core :as lib]
    [metabase.lib.filter :as lib.filter]
@@ -19,7 +19,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [mapv not-empty]]))
+   [metabase.util.performance :refer [mapv not-empty get-in]]))
 
 ;;; "legacy macro" as used below means legacy Segment.
 (mr/def ::legacy-macro

--- a/src/metabase/query_processor/middleware/fetch_source_query.clj
+++ b/src/metabase/query_processor/middleware/fetch_source_query.clj
@@ -1,5 +1,5 @@
 (ns metabase.query-processor.middleware.fetch-source-query
-  (:refer-clojure :exclude [some])
+  (:refer-clojure :exclude [some get-in])
   (:require
    [metabase.driver :as driver]
    [metabase.driver.ddl.interface :as ddl.i]
@@ -20,7 +20,7 @@
    [metabase.util.i18n :refer [trs tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [some]]
+   [metabase.util.performance :refer [some get-in]]
    [weavejester.dependency :as dep]))
 
 ;;; TODO -- consider whether [[normalize-card-query]] should be moved into [[metabase.lib.card]], seems like it would

--- a/src/metabase/query_processor/middleware/fix_bad_field_id_refs.clj
+++ b/src/metabase/query_processor/middleware/fix_bad_field_id_refs.clj
@@ -1,5 +1,6 @@
 (ns metabase.query-processor.middleware.fix-bad-field-id-refs
   "Middleware that adds `:join-alias` info to `:field` clauses where needed."
+  (:refer-clojure :exclude [get-in])
   (:require
    [metabase.lib.core :as lib]
    [metabase.lib.field.resolution :as lib.field.resolution]
@@ -7,7 +8,8 @@
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.lib.walk :as lib.walk]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [get-in]]))
 
 (mu/defn- fix-bad-field-id-refs-in-stage :- [:maybe ::lib.schema/stage]
   [query :- ::lib.schema/query

--- a/src/metabase/query_processor/middleware/limit.clj
+++ b/src/metabase/query_processor/middleware/limit.clj
@@ -1,6 +1,6 @@
 (ns metabase.query-processor.middleware.limit
   "Middleware that handles limiting the maximum number of rows returned by a query."
-  (:refer-clojure :exclude [empty?])
+  (:refer-clojure :exclude [empty? get-in])
   (:require
    [metabase.lib.core :as lib]
    [metabase.lib.schema :as lib.schema]
@@ -9,7 +9,7 @@
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.util :as u]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [empty?]]
+   [metabase.util.performance :refer [empty? get-in]]
    [potemkin :as p]))
 
 ;;; provided as a convenience since this var used to live here. Prefer using directly from `qp.settings` going forward.

--- a/src/metabase/query_processor/middleware/optimize_temporal_filters.clj
+++ b/src/metabase/query_processor/middleware/optimize_temporal_filters.clj
@@ -1,6 +1,7 @@
 (ns metabase.query-processor.middleware.optimize-temporal-filters
   "Middlware that optimizes equality filter clauses against bucketed temporal fields. See docstring for
   `optimize-temporal-filters` for more details."
+  (:refer-clojure :exclude [get-in])
   (:require
    [better-cond.core :as b]
    [metabase.lib.core :as lib]
@@ -15,7 +16,8 @@
    [metabase.util.date-2 :as u.date]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [get-in]]))
 
 (def ^:private optimizable-units
   #{:second :minute :hour :day :week :month :quarter :year})

--- a/src/metabase/query_processor/middleware/pivot_export.clj
+++ b/src/metabase/query_processor/middleware/pivot_export.clj
@@ -1,4 +1,7 @@
-(ns metabase.query-processor.middleware.pivot-export)
+(ns metabase.query-processor.middleware.pivot-export
+  (:refer-clojure :exclude [get-in])
+  (:require
+   [metabase.util.performance :refer [get-in]]))
 
 (defn add-data-for-pivot-export
   "Provide `:pivot-export-options` in the query metadata so that `qp.si/streaming-results-writer` implementations can

--- a/src/metabase/query_processor/middleware/process_userland_query.clj
+++ b/src/metabase/query_processor/middleware/process_userland_query.clj
@@ -5,7 +5,7 @@
 
   ViewLog recording is triggered indirectly by the call to [[events/publish-event!]] with the `:event/card-query`
   event -- see [[metabase.view-log.events.view-log]]."
-  (:refer-clojure :exclude [every? empty?])
+  (:refer-clojure :exclude [every? empty? get-in])
   (:require
    [java-time.api :as t]
    [metabase.analytics.core :as analytics]
@@ -16,7 +16,7 @@
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [every? empty?]]
+   [metabase.util.performance :refer [every? empty? get-in]]
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2]))
 

--- a/src/metabase/query_processor/middleware/results_metadata.clj
+++ b/src/metabase/query_processor/middleware/results_metadata.clj
@@ -2,7 +2,7 @@
   "Middleware that stores metadata about results column types after running a query for a Card,
    and returns that metadata (which can be passed *back* to the backend when saving a Card) as well
    as a checksum in the API response."
-  (:refer-clojure :exclude [mapv select-keys])
+  (:refer-clojure :exclude [mapv select-keys get-in])
   (:require
    [clojure.string :as str]
    [malli.error :as me]
@@ -19,7 +19,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [mapv select-keys]]
+   [metabase.util.performance :refer [mapv select-keys get-in]]
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2]))
 

--- a/src/metabase/query_processor/parameters/dates.clj
+++ b/src/metabase/query_processor/parameters/dates.clj
@@ -3,7 +3,7 @@
 
   TODO -- move this into the `lib-be` module since it's not really QP-specific, it's something that would live in Lib
   if it didn't have dependencies on [[metabase.util.date-2]]."
-  (:refer-clojure :exclude [every? some])
+  (:refer-clojure :exclude [every? some get-in])
   (:require
    [clojure.string :as str]
    [java-time.api :as t]
@@ -19,7 +19,7 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [every? some]]
+   [metabase.util.performance :refer [every? some get-in]]
    [metabase.util.time :as u.time])
   (:import
    (java.time.temporal Temporal)))

--- a/src/metabase/query_processor/parameters/operators.clj
+++ b/src/metabase/query_processor/parameters/operators.clj
@@ -10,6 +10,7 @@
 
   TODO (Cam 8/8/25) -- move this into `lib` since there's nothing particularly QP about it except
   for [[qp.error-type]], which maybe belongs in Lib too!"
+  (:refer-clojure :exclude [get-in])
   (:require
    [metabase.lib.core :as lib]
    [metabase.lib.schema.expression :as lib.schema.expression]
@@ -17,7 +18,8 @@
    [metabase.lib.util.match :as lib.util.match]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.util.i18n :refer [tru]]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [get-in]]))
 
 (mu/defn- operator-arity :- [:maybe [:enum :unary :binary :variadic]]
   [param-type]

--- a/src/metabase/query_processor/pivot.clj
+++ b/src/metabase/query_processor/pivot.clj
@@ -3,7 +3,7 @@
   warehouse and concatenates the result rows together, sort of like the way [[clojure.core/lazy-cat]] works. This is
   dumb, right? It's not just me? Why don't we just generate a big ol' UNION query so we can run one single query
   instead of running like 10 separate queries? -- Cam"
-  (:refer-clojure :exclude [every? mapv some select-keys update-keys empty? not-empty])
+  (:refer-clojure :exclude [every? mapv some select-keys update-keys empty? not-empty get-in])
   (:require
    [medley.core :as m]
    [metabase.lib-be.core :as lib-be]
@@ -31,7 +31,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :as perf :refer [mapv some every? select-keys update-keys empty? not-empty]]))
+   [metabase.util.performance :as perf :refer [mapv some every? select-keys update-keys empty? not-empty get-in]]))
 
 (set! *warn-on-reflection* true)
 

--- a/src/metabase/query_processor/store.clj
+++ b/src/metabase/query_processor/store.clj
@@ -17,6 +17,7 @@
   in new code going forward."
   ;; This whole namespace is in the process of deprecation so ignore deprecated vars in this namespace.
   {:clj-kondo/config '{:linters {:deprecated-var {:level :off}}}, :deprecated "0.57.0"}
+  (:refer-clojure :exclude [get-in])
   (:require
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
@@ -29,7 +30,8 @@
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.malli :as mu]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [get-in]]))
 
 (set! *warn-on-reflection* true)
 

--- a/src/metabase/query_processor/streaming/common.clj
+++ b/src/metabase/query_processor/streaming/common.clj
@@ -1,6 +1,6 @@
 (ns metabase.query-processor.streaming.common
   "Shared util fns for various export (download) streaming formats."
-  (:refer-clojure :exclude [mapv select-keys not-empty])
+  (:refer-clojure :exclude [mapv select-keys not-empty get-in])
   (:require
    [clojure.string :as str]
    [java-time.api :as t]
@@ -11,7 +11,7 @@
    [metabase.query-processor.timezone :as qp.timezone]
    [metabase.util.currency :as currency]
    [metabase.util.date-2 :as u.date]
-   [metabase.util.performance :as perf :refer [mapv select-keys not-empty]])
+   [metabase.util.performance :as perf :refer [mapv select-keys not-empty get-in]])
   (:import
    (clojure.lang ISeq)
    (java.time LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime ZonedDateTime)))

--- a/src/metabase/query_processor/util.clj
+++ b/src/metabase/query_processor/util.clj
@@ -1,6 +1,6 @@
 (ns metabase.query-processor.util
   "Utility functions used by the global query processor and middleware functions."
-  (:refer-clojure :exclude [select-keys])
+  (:refer-clojure :exclude [select-keys get-in])
   (:require
    [buddy.core.codecs :as codecs]
    [clojure.string :as str]
@@ -14,7 +14,7 @@
    [metabase.query-processor.schema :as qp.schema]
    [metabase.util :as u]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [select-keys]]
+   [metabase.util.performance :refer [select-keys get-in]]
    [potemkin :as p]))
 
 (set! *warn-on-reflection* true)

--- a/src/metabase/query_processor/util/add_alias_info.clj
+++ b/src/metabase/query_processor/util/add_alias_info.clj
@@ -40,7 +40,7 @@
 
   If this clause is 'selected' (i.e., appears in `:fields`, `:aggregation`, or `:breakout`), select the clause `AS`
   this alias. This alias is guaranteed to be unique."
-  (:refer-clojure :exclude [mapv ref select-keys some empty? not-empty])
+  (:refer-clojure :exclude [mapv ref select-keys some empty? not-empty get-in])
   (:require
    [medley.core :as m]
    [metabase.config.core :as config]
@@ -61,7 +61,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [mapv select-keys some empty? not-empty]]))
+   [metabase.util.performance :refer [mapv select-keys some empty? not-empty get-in]]))
 
 (mu/defn- ^:dynamic *escape-alias-fn* :- :string
   [driver :- :keyword

--- a/src/metabase/util/performance.cljc
+++ b/src/metabase/util/performance.cljc
@@ -2,7 +2,7 @@
   "Functions and utilities for faster processing. This namespace is compatible with both Clojure and ClojureScript.
   However, some functions are either not only available in CLJS, or offer passthrough non-improved functions."
   (:refer-clojure :exclude [reduce mapv run! some every? concat select-keys update-keys empty? not-empty doseq for
-                            first second update-vals #?(:cljs clj->js)])
+                            first second update-vals get-in #?(:cljs clj->js)])
   #?(:clj (:require
            [net.cgrand.macrovich :as macros])
      :cljs (:require
@@ -375,6 +375,18 @@
                              coll coll)
                   maybe-persistent!
                   (with-meta (meta coll)))))
+
+(defn get-in
+  "Drop-in replacement for `clojure.core/get-in`, but more efficient."
+  ([m ks]
+   (reduce get m ks))
+  ([m ks not-found]
+   (let [sentinel #?(:clj (Object.) :cljs #js{})]
+     (reduce #(let [v (get %1 %2 sentinel)]
+                (if (identical? sentinel v)
+                  (reduced not-found)
+                  v))
+             m ks))))
 
 ;; List comprehension reimplementation.
 

--- a/test/metabase/lib/test_metadata/graph_provider.cljc
+++ b/test/metabase/lib/test_metadata/graph_provider.cljc
@@ -1,11 +1,13 @@
 (ns metabase.lib.test-metadata.graph-provider
+  (:refer-clojure :exclude [get-in])
   (:require
    #?@(:clj
        ([pretty.core :as pretty]))
    [clojure.core.protocols]
    [clojure.test :refer [deftest is]]
    [medley.core :as m]
-   [metabase.lib.metadata.protocols :as lib.metadata.protocols]))
+   [metabase.lib.metadata.protocols :as lib.metadata.protocols]
+   [metabase.util.performance :refer [get-in]]))
 
 (defn- graph-database [metadata-graph]
   (dissoc metadata-graph :tables))

--- a/test/metabase/util/performance_test.cljc
+++ b/test/metabase/util/performance_test.cljc
@@ -184,3 +184,32 @@
 
   (testing "f returns nil keys"
     (is (= {nil 2} (perf/update-keys {:a 1 :b 2} (constantly nil))))))
+
+(deftest ^:parallel get-in-test
+  (testing "basic nested access"
+    (is (= 3 (perf/get-in {:a {:b 3}} [:a :b])))
+    (is (= "value" (perf/get-in {:x {:y {:z "value"}}} [:x :y :z])))
+    (is (= 42 (perf/get-in {:key 42} [:key])))
+    (is (= {:a 1} (perf/get-in {:a 1} [])))
+    (is (nil? (perf/get-in nil [:a :b]))))
+
+  (testing "missing keys return nil"
+    (is (nil? (perf/get-in {:a {:b 3}} [:a :c])))
+    (is (nil? (perf/get-in {:a 1} [:x :y :z]))))
+
+  (testing "with not-found value"
+    (is (= :default (perf/get-in {:a {:b 3}} [:a :c] :default)))
+    (is (nil? (perf/get-in {:a {:b 3}} [:a :c] nil)))
+    (is (nil? (perf/get-in {:a {:b nil}} [:a :b] :something-else))))
+
+  (testing "nil values vs missing keys"
+    (is (nil? (perf/get-in {:a {:b nil}} [:a :b])))
+    (is (= :default (perf/get-in {:a {:b nil}} [:a :c] :default))))
+
+  (testing "works with vectors"
+    (is (= 2 (perf/get-in [[1 2] [3 4]] [0 1])))
+    (is (= 30 (perf/get-in {:items [10 20 30]} [:items 2]))))
+
+  (testing "partial path exists"
+    (is (nil? (perf/get-in {:a 1} [:a :b])))
+    (is (= :fallback (perf/get-in {:a "not-a-map"} [:a :b] :fallback)))))


### PR DESCRIPTION
I really don't like using `get-in` at all, but since it is already widely used, it makes sense to supply a more efficient implementation by default and rewrite individual critical cases by hand.