### PR TITLE
[perf] More efficient validator-cache old key eviction

### DIFF
--- a/src/metabase/util/malli/registry/validator_cache.clj
+++ b/src/metabase/util/malli/registry/validator_cache.clj
@@ -16,21 +16,21 @@
 
 (def ^:private max-entries 10)
 
-(defn- oldest-entry [k->nano-time]
-  (transduce
-   identity
-   (fn
-     ([[k _nano-time]]
-      k)
-     ([[_ current-oldest-nano-time :as current-oldest-pair] [_k new-nano-time :as new-pair]]
-      (if (< new-nano-time current-oldest-nano-time)
-        new-pair
-        current-oldest-pair)))
-   [nil Long/MAX_VALUE]
-   k->nano-time))
+(defn- oldest-key
+  "Return the key that was recorded into the cache the earliest. The combination of `reduce-kv` and `volatile!` is used
+  to iterate in an efficient way without allocations."
+  [k->nano-time]
+  (let [oldest-key (volatile! nil)]
+    (reduce-kv (fn [oldest-nano-time k nano-time]
+                 (if (< nano-time oldest-nano-time)
+                   (do (vreset! oldest-key k)
+                       nano-time)
+                   oldest-nano-time))
+               Long/MAX_VALUE k->nano-time)
+    @oldest-key))
 
 (defn- remove-oldest-entry [k->nano-time]
-  (dissoc k->nano-time (oldest-entry k->nano-time)))
+  (dissoc k->nano-time (oldest-key k->nano-time)))
 
 (defn- prune-entries-if-over-max-size [k->nano-time max-entries]
   (if (<= (count k->nano-time) max-entries)


### PR DESCRIPTION
Using `reduce-kv` instead of `transduce` makes the iteration part allocation-free and amounts to -5% of both allocations and execution time in @bshepherdson's `metabase.query-processor.perf-test` bechmark.