### PR TITLE
A way to run BE cloverage job on non master

### DIFF
--- a/.github/workflows/backend-cloverage.yml
+++ b/.github/workflows/backend-cloverage.yml
@@ -4,11 +4,17 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 10 * * 1-5' # every weekday at 5am US eastern time
+  pull_request:
+    types: [labeled, synchronize]
 
 jobs:
   be-linter-cloverage:
     # don't run this workflow on a cron for forks
-    if: ${{ github.event_name != 'schedule' || github.repository == 'metabase/metabase' }}
+    if: |
+      ${{
+        (github.event_name != 'schedule' || github.repository == 'metabase/metabase') &&
+        (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-cloverage'))
+      }}
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
@@ -132,7 +138,11 @@ jobs:
 
   be-linter-cloverage-enterprise:
     # don't run this workflow on a cron for forks
-    if: ${{ github.event_name != 'schedule' || github.repository == 'metabase/metabase' }}
+    if: |
+      ${{
+        (github.event_name != 'schedule' || github.repository == 'metabase/metabase') &&
+        (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-cloverage'))
+      }}
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/backend-cloverage.yml
+++ b/.github/workflows/backend-cloverage.yml
@@ -13,7 +13,7 @@ jobs:
     if: |
       ${{
         (github.event_name != 'schedule' || github.repository == 'metabase/metabase') &&
-        (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-cloverage'))
+        contains(github.event.pull_request.labels.*.name, 'run-cloverage')
       }}
     runs-on: ubuntu-22.04
     timeout-minutes: 30


### PR DESCRIPTION
 Add support for running backend coverage tests on PRs by adding a `run-cloverage` label