### PR TITLE
GDGT-1235 Fix flaky dashboard parameters test

### DIFF
--- a/e2e/support/helpers/e2e-dashboard-helpers.ts
+++ b/e2e/support/helpers/e2e-dashboard-helpers.ts
@@ -59,19 +59,6 @@ export function showDashboardCardActions(index = 0) {
   return getDashboardCard(index).realHover({ scrollBehavior: "bottom" });
 }
 
-/**
- * Given a dashcard HTML element, will return the element for the action icon
- * with the given label text (e.g. "Click behavior", "Replace", "Duplicate", etc)
- */
-export function findDashCardAction(
-  dashcardElement: Cypress.Chainable<JQuery<HTMLElement>>,
-  labelText: string,
-) {
-  return dashcardElement
-    .realHover({ scrollBehavior: "bottom" })
-    .findByLabelText(labelText);
-}
-
 export function removeDashboardCard(index = 0) {
   getDashboardCard(index)
     .realHover()
@@ -151,9 +138,10 @@ export function setDashCardFilter(
   subType?: string,
   name?: string,
 ) {
-  findDashCardAction(getDashboardCard(dashcardIndex), "Add a filter").click({
-    force: true,
-  });
+  getDashboardCard(dashcardIndex)
+    .realHover({ scrollBehavior: "bottom" })
+    .findByLabelText("Add a filter")
+    .click({ force: true });
   _setFilter(type, subType, name);
 }
 

--- a/e2e/test/scenarios/dashboard-cards/dashcard-replace-question.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashcard-replace-question.cy.spec.js
@@ -133,7 +133,10 @@ H.describeWithSnowplow("scenarios > dashboard cards > replace question", () => {
   it("should replace a dashboard card question (metabase#36984)", () => {
     visitDashboardAndEdit();
 
-    H.findDashCardAction(findHeadingDashcard(), "Replace").should("not.exist");
+    findHeadingDashcard()
+      .realHover({ scrollBehavior: "bottom" })
+      .findByLabelText("Replace")
+      .should("not.exist");
 
     // Ensure can replace with a question
     replaceQuestion(findTargetDashcard(), {
@@ -168,7 +171,7 @@ H.describeWithSnowplow("scenarios > dashboard cards > replace question", () => {
   it("should undo the question replace action", () => {
     visitDashboardAndEdit();
 
-    overwriteDashCardTitle(findTargetDashcard(), "Custom name");
+    overwriteDashCardTitle("Custom name");
     connectDashboardFilter(findTargetDashcard(), {
       filterName: PARAMETER.UNUSED.name,
       columnName: "Discount",
@@ -275,8 +278,11 @@ function assertDashCardTitle(title) {
   cy.findByTestId("legend-caption-title").should("have.text", title);
 }
 
-function overwriteDashCardTitle(dashcardElement, textTitle) {
-  H.findDashCardAction(dashcardElement, "Show visualization options").click();
+function overwriteDashCardTitle(textTitle) {
+  findTargetDashcard()
+    .realHover({ scrollBehavior: "bottom" })
+    .findByLabelText("Show visualization options")
+    .click();
   H.modal().within(() => {
     cy.findByLabelText("Title").type(`{selectall}{del}${textTitle}`).blur();
     cy.button("Done").click();

--- a/e2e/test/scenarios/dashboard-cards/duplicate-dashcards-tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/duplicate-dashcards-tabs.cy.spec.js
@@ -79,7 +79,10 @@ H.describeWithSnowplow("scenarios > dashboard cards > duplicate", () => {
     H.visitDashboard("@dashboardId");
     cy.findByLabelText("Edit dashboard").click();
 
-    H.findDashCardAction(H.getDashboardCard(0), "Duplicate").click();
+    H.getDashboardCard(0)
+      .realHover({ scrollBehavior: "bottom" })
+      .findByLabelText("Duplicate")
+      .click();
     H.expectUnstructuredSnowplowEvent(EVENTS.duplicateDashcard);
 
     // check that the new card loads _before_ saving

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-wiring.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-wiring.cy.spec.js
@@ -430,7 +430,10 @@ describe("dashboard filters auto-wiring", () => {
 
       goToFilterMapping();
 
-      H.findDashCardAction(H.getDashboardCard(1), "Replace").click();
+      H.getDashboardCard(1)
+        .realHover({ scrollBehavior: "bottom" })
+        .findByLabelText("Replace")
+        .click();
 
       H.modal().findByText("Orders, Count").click();
 

--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -2315,7 +2315,10 @@ describe("scenarios > dashboard > parameters", () => {
       H.selectDashboardFilter(H.getDashboardCard(0), "Count");
       H.dashboardParameterSidebar().button("Done").click();
 
-      H.findDashCardAction(H.getDashboardCard(0), "Duplicate").click();
+      H.getDashboardCard(0)
+        .realHover({ scrollBehavior: "bottom" })
+        .findByLabelText("Duplicate")
+        .click();
 
       H.getDashboardCard(1).within(() => {
         cy.findByTestId("chart-container").should("exist");

--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -1234,7 +1234,10 @@ describe("scenarios > dashboard > parameters", () => {
         H.editDashboard();
       });
 
-      H.findDashCardAction(H.getDashboardCard(0), "Duplicate").click();
+      H.getDashboardCard(0)
+        .realHover({ scrollBehavior: "bottom" })
+        .findByLabelText("Duplicate")
+        .click();
 
       H.getDashboardCard(2).within(() => {
         cy.findByDisplayValue("Heading Text").should("exist");

--- a/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
@@ -195,7 +195,10 @@ describe("scenarios > dashboard > visualizer > basics", () => {
 
     H.visitDashboard(ORDERS_DASHBOARD_ID);
     H.editDashboard();
-    H.findDashCardAction(dashCard(), "Visualize another way").click();
+    dashCard()
+      .realHover({ scrollBehavior: "bottom" })
+      .findByLabelText("Visualize another way")
+      .click();
 
     H.modal().within(() => {
       H.assertDataSourceColumnSelected("Orders", "ID");
@@ -213,14 +216,19 @@ describe("scenarios > dashboard > visualizer > basics", () => {
       });
     });
 
-    H.findDashCardAction(dashCard(), "Visualize another way").should(
-      "not.exist",
-    );
-    H.findDashCardAction(dashCard(), "Show visualization options").should(
-      "not.exist",
-    );
+    dashCard()
+      .realHover({ scrollBehavior: "bottom" })
+      .findByLabelText("Visualize another way")
+      .should("not.exist");
+    dashCard()
+      .realHover({ scrollBehavior: "bottom" })
+      .findByLabelText("Show visualization options")
+      .should("not.exist");
+    dashCard()
+      .realHover({ scrollBehavior: "bottom" })
+      .findByLabelText("Edit visualization")
+      .click();
 
-    H.findDashCardAction(dashCard(), "Edit visualization").click();
     H.modal().button("Save").should("be.disabled");
   });
 
@@ -388,10 +396,10 @@ describe("scenarios > dashboard > visualizer > basics", () => {
     });
 
     H.editDashboard();
-    H.findDashCardAction(
-      H.getDashboardCard(0),
-      "Visualize another way",
-    ).click();
+    H.getDashboardCard(0)
+      .realHover({ scrollBehavior: "bottom" })
+      .findByLabelText("Visualize another way")
+      .click();
 
     H.modal().within(() => {
       H.selectVisualization("bar");
@@ -439,10 +447,10 @@ describe("scenarios > dashboard > visualizer > basics", () => {
     H.tooltip().findByText("Original question description").should("exist");
 
     H.editDashboard();
-    H.findDashCardAction(
-      H.getDashboardCard(0),
-      "Visualize another way",
-    ).click();
+    H.getDashboardCard(0)
+      .realHover({ scrollBehavior: "bottom" })
+      .findByLabelText("Visualize another way")
+      .click();
 
     H.modal().within(() => {
       cy.findByDisplayValue("Original Question Title").should("exist");
@@ -825,10 +833,10 @@ describe("scenarios > dashboard > visualizer > basics", () => {
     );
 
     H.editDashboard();
-    H.findDashCardAction(
-      H.getDashboardCard(0),
-      "Visualize another way",
-    ).click();
+    H.getDashboardCard(0)
+      .realHover({ scrollBehavior: "bottom" })
+      .findByLabelText("Visualize another way")
+      .click();
 
     cy.intercept("GET", "/api/card/*/query_metadata").as("queryMetadata");
 
@@ -868,7 +876,10 @@ describe("scenarios > dashboard > visualizer > basics", () => {
       cy.findByText("1").should("exist");
     });
 
-    H.findDashCardAction(H.getDashboardCard(0), "Edit visualization").click();
+    H.getDashboardCard(0)
+      .realHover({ scrollBehavior: "bottom" })
+      .findByLabelText("Edit visualization")
+      .click();
     H.modal().within(() => {
       H.dataImporter().findByText(baseQuestion.name).should("exist");
       H.dataImporter().findByText(invalidQuestion.name).should("exist");

--- a/e2e/test/scenarios/dashboard/visualizer/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/reproductions.cy.spec.ts
@@ -139,10 +139,10 @@ describe("issue 61521", () => {
     });
 
     H.editDashboard();
-    H.findDashCardAction(
-      H.getDashboardCard(0),
-      "Visualize another way",
-    ).click();
+    H.getDashboardCard(0)
+      .realHover({ scrollBehavior: "bottom" })
+      .findByLabelText("Visualize another way")
+      .click();
 
     H.modal().within(() => {
       H.switchToAddMoreData();

--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -4604,7 +4604,10 @@ describe("issue 62627", () => {
 
     cy.log("add an inline card filter");
     H.showDashboardCardActions();
-    H.findDashCardAction(H.getDashboardCard(), "Add a filter").click();
+    H.getDashboardCard()
+      .realHover({ scrollBehavior: "bottom" })
+      .findByLabelText("Add a filter")
+      .click();
     H.popover().findByText("Text or Category").click();
     H.selectDashboardFilter(H.getDashboardCard(), "Category");
     H.setDashboardParameterName("Category");

--- a/e2e/test/scenarios/metrics/metrics-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-dashboard.cy.spec.js
@@ -91,10 +91,10 @@ describe("scenarios > metrics > dashboard", () => {
     );
     H.editDashboard();
 
-    H.findDashCardAction(
-      H.getDashboardCard(0),
-      "Visualize another way",
-    ).click();
+    H.getDashboardCard(0)
+      .realHover({ scrollBehavior: "bottom" })
+      .findByLabelText("Visualize another way")
+      .click();
     H.modal().within(() => {
       H.switchToAddMoreData();
       H.selectDataset(PRODUCTS_SCALAR_METRIC.name);

--- a/e2e/test/scenarios/metrics/reproductions/metrics-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/reproductions/metrics-reproductions.cy.spec.ts
@@ -137,10 +137,10 @@ describe("issue 44171", () => {
     H.sidebar().findByText("Metric 44171-A").click();
 
     H.showDashboardCardActions(0);
-    H.findDashCardAction(
-      H.getDashboardCard(0),
-      "Visualize another way",
-    ).click();
+    H.getDashboardCard(0)
+      .realHover({ scrollBehavior: "bottom" })
+      .findByLabelText("Visualize another way")
+      .click();
     H.modal().within(() => {
       H.switchToAddMoreData();
       H.selectDataset("Metric 44171-B");

--- a/e2e/test/scenarios/sharing/sharing-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/sharing-reproductions.cy.spec.js
@@ -323,10 +323,10 @@ describe("issue 21559", { tags: "@external" }, () => {
   it("should respect dashboard card visualization (metabase#21559)", () => {
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");
 
-    H.findDashCardAction(
-      H.getDashboardCard(0),
-      "Visualize another way",
-    ).click();
+    H.getDashboardCard(0)
+      .realHover({ scrollBehavior: "bottom" })
+      .findByLabelText("Visualize another way")
+      .click();
 
     H.modal().within(() => {
       H.switchToAddMoreData();

--- a/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.js
@@ -645,10 +645,10 @@ describe("issue 21665", () => {
       H.editDashboard();
     });
 
-    H.findDashCardAction(
-      H.getDashboardCard(0),
-      "Visualize another way",
-    ).click();
+    H.getDashboardCard(0)
+      .realHover({ scrollBehavior: "bottom" })
+      .findByLabelText("Visualize another way")
+      .click();
     H.modal().within(() => {
       H.switchToAddMoreData();
       H.selectDataset(Q2.name);

--- a/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
@@ -1276,7 +1276,10 @@ describe("issue 52339", () => {
     });
 
     H.editDashboard();
-    H.findDashCardAction(H.getDashboardCard(0), "Click behavior").click();
+    H.getDashboardCard(0)
+      .realHover({ scrollBehavior: "bottom" })
+      .findByLabelText("Click behavior")
+      .click();
 
     H.sidebar().within(() => {
       cy.findByText("Go to a custom destination").click();


### PR DESCRIPTION
Closes [GDGT-1235](https://linear.app/metabase/issue/GDGT-1235/flaky-test-e2e-tests-parameters-in-question-dashcards-scenarios)

### Description

The way `findDashCardAction` helper was implemented, it always broke Cypress chaining, so there were errors like:

```
failure_message: Timed out retrying after 4050ms: `cy.click()` failed because the page updated while this command was executing. Cypress tried to locate elements based on this query:
```

This PR inlines the `findDashCardAction` helper so that Cypress chaining is respected.

### How to verify

Stress test: https://github.com/metabase/metabase/actions/runs/19424420717
