### PR TITLE
Closes EMB-933 static embed translation for scalar title

### DIFF
--- a/e2e/test/scenarios/admin/i18n/content-translation/dashboards.cy.spec.ts
+++ b/e2e/test/scenarios/admin/i18n/content-translation/dashboards.cy.spec.ts
@@ -168,17 +168,17 @@ describe("scenarios > content translation > static embedding > dashboards", () =
     });
 
     it("should translate static embedding dashboard card titles and descriptions", () => {
-      H.createDashboard({
-        name: "the_dashboard",
-      }).then(({ body: { id: dashboardId } }) => {
-        H.visitDashboard(dashboardId);
-        H.editDashboard();
-        H.openQuestionsSidebar();
-
-        H.sidebar().findByText(PRODUCTS_COUNT_BY_CATEGORY_PIE.name).click();
-        H.sidebar().findByText(SCALAR_CARD.LANDING_PAGE_VIEWS.name).click(); // metabase#65085
-        H.saveDashboard();
-
+      H.createDashboardWithQuestions({
+        dashboardName: "the_dashboard",
+        questions: [
+          {
+            ...PRODUCTS_COUNT_BY_CATEGORY_PIE,
+            description: "A breakdown of products by category",
+          },
+          SCALAR_CARD.LANDING_PAGE_VIEWS,
+        ],
+      }).then(({ dashboard }) => {
+        H.visitDashboard(dashboard.id);
         H.openStaticEmbeddingModal({
           acceptTerms: false,
         });
@@ -186,7 +186,7 @@ describe("scenarios > content translation > static embedding > dashboards", () =
 
         H.visitEmbeddedPage(
           {
-            resource: { dashboard: dashboardId as number },
+            resource: { dashboard: dashboard.id as number },
             params: {},
           },
           {
@@ -197,8 +197,6 @@ describe("scenarios > content translation > static embedding > dashboards", () =
         );
 
         cy.wait("@dashboard");
-        cy.wait("@cardQuery");
-        cy.wait("@cardQuery");
 
         // Check that the titles are translated
         cy.findByText("Produits par catégorie (Camembert)").should("exist");

--- a/e2e/test/scenarios/admin/i18n/content-translation/dashboards.cy.spec.ts
+++ b/e2e/test/scenarios/admin/i18n/content-translation/dashboards.cy.spec.ts
@@ -10,6 +10,7 @@ import type {
 import {
   ORDERS_COUNT_BY_CREATED_AT_AND_PRODUCT_CATEGORY,
   PRODUCTS_COUNT_BY_CATEGORY_PIE,
+  SCALAR_CARD,
 } from "e2e/support/test-visualizer-data";
 import type { DictionaryArray } from "metabase-types/api";
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -132,6 +133,11 @@ describe("scenarios > content translation > static embedding > dashboards", () =
           msgid: "A breakdown of products by category",
           msgstr: "Une répartition des produits par catégorie",
         },
+        {
+          locale: "fr",
+          msgid: "Landing page",
+          msgstr: "La page d'atterrissage (ಠ_ಠ)",
+        },
       ]);
 
       cy.intercept("POST", "/api/card/*/query").as("cardQuery");
@@ -141,6 +147,11 @@ describe("scenarios > content translation > static embedding > dashboards", () =
 
       H.createQuestion(ORDERS_COUNT_BY_CREATED_AT_AND_PRODUCT_CATEGORY, {
         idAlias: "productsCountByCreatedAtQuestionId",
+        wrapId: true,
+      });
+
+      H.createNativeQuestion(SCALAR_CARD.LANDING_PAGE_VIEWS, {
+        idAlias: "landingPageViewsScalarQuestionId",
         wrapId: true,
       });
 
@@ -165,6 +176,7 @@ describe("scenarios > content translation > static embedding > dashboards", () =
         H.openQuestionsSidebar();
 
         H.sidebar().findByText(PRODUCTS_COUNT_BY_CATEGORY_PIE.name).click();
+        H.sidebar().findByText(SCALAR_CARD.LANDING_PAGE_VIEWS.name).click(); // metabase#65085
         H.saveDashboard();
 
         H.openStaticEmbeddingModal({
@@ -186,9 +198,11 @@ describe("scenarios > content translation > static embedding > dashboards", () =
 
         cy.wait("@dashboard");
         cy.wait("@cardQuery");
+        cy.wait("@cardQuery");
 
-        // Check that the title is translated
+        // Check that the titles are translated
         cy.findByText("Produits par catégorie (Camembert)").should("exist");
+        cy.findByText("La page d'atterrissage (ಠ_ಠ)").should("exist");
 
         H.getDashboardCard(0).realHover().icon("info").realHover();
         H.tooltip().within(() => {

--- a/frontend/src/metabase/visualizations/components/ScalarValue/ScalarValue.tsx
+++ b/frontend/src/metabase/visualizations/components/ScalarValue/ScalarValue.tsx
@@ -9,6 +9,7 @@ import { Ellipsified } from "metabase/common/components/Ellipsified";
 import Markdown from "metabase/common/components/Markdown";
 import DashboardS from "metabase/css/dashboard.module.css";
 import QueryBuilderS from "metabase/css/query_builder.module.css";
+import { useTranslateContent } from "metabase/i18n/hooks";
 import EmbedFrameS from "metabase/public/components/EmbedFrame/EmbedFrame.module.css";
 import { Tooltip, useMantineTheme } from "metabase/ui";
 import type { VisualizationGridSize } from "metabase/visualizations/types";
@@ -99,38 +100,44 @@ export const ScalarTitle = ({
   title,
   description,
   onClick,
-}: ScalarTitleProps) => (
-  <ScalarTitleContainer data-testid="scalar-title" lines={lines}>
-    {/*
+}: ScalarTitleProps) => {
+  const tc = useTranslateContent();
+
+  return (
+    <ScalarTitleContainer data-testid="scalar-title" lines={lines}>
+      {/*
       This is a hacky spacer so that the h3 is centered correctly.
       It needs match the width of the tooltip icon on the other side.
      */}
-    {description && description.length > 0 && <ScalarDescriptionPlaceholder />}
-    <ScalarTitleContent
-      className={cx(
-        DashboardS.fullscreenNormalText,
-        DashboardS.fullscreenNightText,
-        EmbedFrameS.fullscreenNightText,
+      {description && description.length > 0 && (
+        <ScalarDescriptionPlaceholder />
       )}
-      onClick={onClick}
-    >
-      <Ellipsified tooltip={title} lines={lines} placement="bottom">
-        {title}
-      </Ellipsified>
-    </ScalarTitleContent>
-    {description && description.length > 0 && (
-      <ScalarDescriptionContainer data-testid="scalar-description">
-        <Tooltip
-          label={
-            <Markdown dark disallowHeading unstyleLinks>
-              {description}
-            </Markdown>
-          }
-          maw="22em"
-        >
-          <ScalarDescriptionIcon name="info_filled" />
-        </Tooltip>
-      </ScalarDescriptionContainer>
-    )}
-  </ScalarTitleContainer>
-);
+      <ScalarTitleContent
+        className={cx(
+          DashboardS.fullscreenNormalText,
+          DashboardS.fullscreenNightText,
+          EmbedFrameS.fullscreenNightText,
+        )}
+        onClick={onClick}
+      >
+        <Ellipsified tooltip={title} lines={lines} placement="bottom">
+          {tc(title)}
+        </Ellipsified>
+      </ScalarTitleContent>
+      {description && description.length > 0 && (
+        <ScalarDescriptionContainer data-testid="scalar-description">
+          <Tooltip
+            label={
+              <Markdown dark disallowHeading unstyleLinks>
+                {description}
+              </Markdown>
+            }
+            maw="22em"
+          >
+            <ScalarDescriptionIcon name="info_filled" />
+          </Tooltip>
+        </ScalarDescriptionContainer>
+      )}
+    </ScalarTitleContainer>
+  );
+};


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #65085
Closes [EMB-933: Static embed translation: not working on visualization of type "Number"](https://linear.app/metabase/issue/EMB-933/static-embed-translation-not-working-on-visualization-of-type-number)

### Description

The Scalar component was missing a call to translate() when rendering the card's title. Since this code no longer exists in v57 and further, this PR only applies to 56.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
