### PR TITLE
Better human readable table-data-event for audit-log

### DIFF
--- a/src/metabase/audit_app/events/audit_log.clj
+++ b/src/metabase/audit_app/events/audit_log.clj
@@ -325,7 +325,14 @@
 
 (derive ::action-v2-event ::event)
 (derive :event/action-v2-execute ::action-v2-event)
+(derive :event/table-data-edit :event/action-v2-execute)
 
 (methodical/defmethod events/publish-event! ::action-v2-event
-  [topic event]
-  (audit-log/record-event! topic event))
+  [_topic event]
+  (let [table-data-edit-events #{:data-grid.row/create :data-grid.row/update :data-grid.row/delete :data-editing/undo :data-editing/redo}]
+    (when (contains? table-data-edit-events
+                     (when-let [event (get-in event [:details :action])]
+                       (when (or (string? event) (keyword? event))
+                         (keyword event))))
+      (when-let [table-id (get-in event [:details :scope :table_id])]
+        (audit-log/record-event! :event/table-data-edit (merge event {:model :model/Table :model-id table-id}))))))

--- a/test/metabase/audit_app/events/audit_log_test.clj
+++ b/test/metabase/audit_app/events/audit_log_test.clj
@@ -759,3 +759,26 @@
                  :topic :remote-sync-stash
                  :model "RemoteSyncTask"}
                 (mt/latest-audit-log-entry :remote-sync-stash task-id))))))))
+
+(deftest action-v2-events-test
+  (mt/when-ee-evailable
+   (mt/with-current-user (mt/user->id :rasta)
+     (testing :event/action-v2-execute
+       (is (=
+            {:details
+             {:action "data-grid.row/create"
+              :scope {:table_id 123}
+              :input_count 1}}
+            (events/publish-event! :event/action-v2-execute
+                                   {:details
+                                    {:action "data-grid.row/create"
+                                     :scope {:table_id 123}
+                                     :input_count 1}})))
+       (is (= {:user_id (mt/user->id :rasta)
+               :details {:action "data-grid.row/create"
+                         :scope {:table_id 123}
+                         :input_count 1}
+               :topic :table-data-edit
+               :model "Table"
+               :model_id 123}
+              (mt/latest-audit-log-entry :table-data-edit)))))))


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-1242/better-events-for-actionv2-events

Instead of a generic `event/action-v2-execute`, we specialize to a `table-data-edit` event in audit-log