### PR TITLE
Remove custom embedding SDK cors config

### DIFF
--- a/.github/workflows/e2e-component-tests-embedding-sdk.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk.yml
@@ -116,7 +116,6 @@ jobs:
       CYPRESS_MB_STARTER_CLOUD_TOKEN: ${{ secrets.STAGING_MB_STARTER_CLOUD_TOKEN }}
       CYPRESS_MB_PRO_CLOUD_TOKEN: ${{ secrets.STAGING_MB_PRO_CLOUD_TOKEN }}
       CYPRESS_MB_PRO_SELF_HOSTED_TOKEN: ${{ secrets.STAGING_MB_PRO_SELF_HOSTED_TOKEN }}
-      CYPRESS_IS_EMBEDDING_SDK: "true"
       COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title || github.event.head_commit.message || github.event.head.sha }}
       TZ: US/Pacific # to make node match the instance tz
       CYPRESS_CI: true

--- a/.github/workflows/e2e-embedding-sdk-compatibility-tests.yml
+++ b/.github/workflows/e2e-embedding-sdk-compatibility-tests.yml
@@ -216,7 +216,6 @@ jobs:
       MB_RUN_MODE: e2e
       METASTORE_DEV_SERVER_URL: ${{ secrets.METASTORE_DEV_SERVER_URL }}
       CYPRESS_MB_ALL_FEATURES_TOKEN: ${{ secrets.STAGING_MB_ALL_FEATURES_TOKEN }}
-      CYPRESS_IS_EMBEDDING_SDK: "true"
       TZ: US/Pacific # to make node match the instance tz
       CYPRESS_CI: true
       SAMPLE_APP_BRANCH_NAME: ${{ needs.get-sample-apps-data.outputs.branch_name }}
@@ -348,7 +347,6 @@ jobs:
       MB_RUN_MODE: e2e
       METASTORE_DEV_SERVER_URL: ${{ secrets.METASTORE_DEV_SERVER_URL }}
       CYPRESS_MB_ALL_FEATURES_TOKEN: ${{ secrets.STAGING_MB_ALL_FEATURES_TOKEN }}
-      CYPRESS_IS_EMBEDDING_SDK: "true"
       TZ: US/Pacific # to make node match the instance tz
       CYPRESS_CI: true
       HOST_APP_ENVIRONMENT: ${{ matrix.environment }}

--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -148,7 +148,6 @@ jobs:
       - name: Stress-test ${{ github.event.inputs.spec }} ${{ github.event.inputs.burn_in }} times
         env:
           GREP: ${{ github.event.inputs.grep }}
-          CYPRESS_IS_EMBEDDING_SDK: ${{ needs.determine-suite.outputs.suite == 'component' }}
         run: |
           node e2e/runner/run_cypress_ci.js ${{ needs.determine-suite.outputs.suite }} \
           --spec '${{ github.event.inputs.spec }}' \

--- a/e2e/runner/run_cypress_local.ts
+++ b/e2e/runner/run_cypress_local.ts
@@ -35,7 +35,6 @@ const derivedOptions = {
   QA_DB_ENABLED: userOptions.START_CONTAINERS,
   BUILD_JAR: userOptions.BACKEND_PORT === 4000,
   START_BACKEND: userOptions.BACKEND_PORT === 4000,
-  CYPRESS_IS_EMBEDDING_SDK: String(userOptions.TEST_SUITE === "component"),
   MB_SNOWPLOW_AVAILABLE: true,
   MB_SNOWPLOW_URL: "http://localhost:9090",
 };

--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -29,8 +29,6 @@ const snowplowMicroUrl = process.env["MB_SNOWPLOW_URL"];
 
 const isQaDatabase = process.env["QA_DB_ENABLED"] === "true";
 
-const isEmbeddingSdk = process.env.CYPRESS_IS_EMBEDDING_SDK === "true";
-
 // docs say that tsconfig paths should handle aliases, but they don't
 const assetsResolverPlugin = {
   name: "assetsResolver",
@@ -174,14 +172,6 @@ const defaultConfig = {
 
 const mainConfig = {
   ...defaultConfig,
-  ...(isEmbeddingSdk
-    ? {
-        chromeWebSecurity: true,
-        hosts: {
-          "my-site.local": "127.0.0.1",
-        },
-      }
-    : {}),
   numTestsKeptInMemory: process.env["CI"] ? 1 : 50,
   reporter: "cypress-multi-reporters",
   reporterOptions: {


### PR DESCRIPTION
This pull request removes the usage of the `CYPRESS_IS_EMBEDDING_SDK` environment variable from both the GitHub Actions workflow files and the Cypress test configuration. This change simplifies the configuration for embedding SDK-related tests and removes conditional logic that depended on this variable.
