### PR TITLE
Allow content-disposition header in cross-origin requests

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/interactive-dashboard.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-dashboard.cy.spec.tsx
@@ -318,6 +318,23 @@ describe("scenarios > embedding-sdk > interactive-dashboard", () => {
 
       cy.wait("@dashcardDownload").then((interception) => {
         expect(interception.response?.statusCode).to.equal(200);
+
+        cy.log(
+          "content-disposition is allowed in cross-origin requests (metabase#61708)",
+        );
+        expect(
+          interception.response?.headers?.["access-control-expose-headers"],
+        ).to.include("Content-Disposition");
+
+        cy.log(
+          "question name is prefixed in the downloaded file name (metabase#61708)",
+        );
+        expect(
+          interception.response?.headers?.["content-disposition"],
+        ).to.include('filename="orders_');
+        expect(
+          interception.response?.headers?.["content-disposition"],
+        ).not.to.include('filename="query_result_');
       });
     });
   });

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -262,7 +262,7 @@
           "Vary"                        "Origin"})
        {"Access-Control-Allow-Headers"  "*"
         "Access-Control-Allow-Methods"  "*"
-        "Access-Control-Expose-Headers" "X-Metabase-Anti-CSRF-Token, X-Metabase-Version"
+        "Access-Control-Expose-Headers" "Content-Disposition, X-Metabase-Anti-CSRF-Token, X-Metabase-Version"
         ;; Needed for Embedding SDK. Should cache preflight requests for the specified number of seconds.
         "Access-Control-Max-Age"  "60"}))))
 


### PR DESCRIPTION
Closes #61708
Closes EMB-687

We forgot to allow `Content-Disposition` in CORS requests, so downloaded files always have `query_result` prefix:

https://github.com/metabase/metabase/blob/0d15756b23ab33af3a061e092bd507e3c9ea156f/frontend/src/metabase/redux/downloads.ts#L521-L530

### How to verify

1. Render an `<InteractiveDashboard dashboardId={1} withDownloads />` SDK component
2. Download a dashcard by clicking on ellipsis menu > Download results
3. The downloaded file must not be prefixed with `query_result_`. The prefix must be the question name:

<img width="952" height="142" alt="CleanShot 2568-11-17 at 23 11 34@2x" src="https://github.com/user-attachments/assets/77ef7c04-d9c8-4a76-a7af-e91b20cd6587" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
