### PR TITLE
fix: allow analytics collection perms to be set

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/audit_app/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/permissions_test.clj
@@ -103,7 +103,7 @@
     (mt/with-temp [:model/PermissionsGroup {group-id :id}    {}
                    :model/Database         {database-id :id} {}
                    :model/Table            view-table        {:db_id database-id :name "v_users"}
-                   :model/Collection       collection        {}]
+                   :model/Collection       collection        {:namespace "analytics"}]
       (with-redefs [audit/audit-db-id                 database-id
                     audit/default-audit-collection (constantly collection)]
         (testing "Updating permissions for the audit collection also updates audit DB permissions"

--- a/test/metabase/permissions/models/collection/graph_test.clj
+++ b/test/metabase/permissions/models/collection/graph_test.clj
@@ -95,6 +95,7 @@
                  (replace-collection-ids collection (graph :clear-revisions? true, :collections [collection])))))))))
 
 (deftest cannot-set-readwrite-audit-permissions-for-non-admins-test
+  (clear-graph-revisions!)
   (mt/with-non-admin-groups-no-root-collection-perms
     (mt/with-temp [:model/Collection collection {:namespace "analytics"}]
       (with-redefs [audit/default-audit-collection (constantly collection)]
@@ -107,6 +108,7 @@
                (replace-collection-ids collection (graph :clear-revisions? true, :collections [collection]))))))))
 
 (deftest can-set-read-audit-permissions-for-non-admins-test
+  (clear-graph-revisions!)
   (mt/with-non-admin-groups-no-root-collection-perms
     (mt/with-temp [:model/Collection collection {:namespace "analytics"}]
       (with-redefs [audit/default-audit-collection (constantly collection)]

--- a/test/metabase/permissions/models/collection/graph_test.clj
+++ b/test/metabase/permissions/models/collection/graph_test.clj
@@ -94,29 +94,25 @@
                   :groups {(u/the-id (perms-group/admin)) {:root :write, :COLLECTION :read}}}
                  (replace-collection-ids collection (graph :clear-revisions? true, :collections [collection])))))))))
 
-(deftest cannot-set-readwrite-audit-permissions-for-non-admins-test
+(deftest cannot-set-audit-permissions-for-non-admins-test
   (clear-graph-revisions!)
-  (mt/with-non-admin-groups-no-root-collection-perms
-    (mt/with-temp [:model/Collection collection {:namespace "analytics"}]
-      (with-redefs [audit/default-audit-collection (constantly collection)]
-        (is (thrown-with-msg?
-             clojure.lang.ExceptionInfo
-             #"Unable to make audit collections writable."
-             (graph/update-graph! {:revision 0 :groups {(u/the-id (perms-group/all-users)) {(u/the-id collection) :write}}})))
-        (is (= {:revision 0
-                :groups {(u/the-id (perms-group/admin)) {:root :write, :COLLECTION :read}}}
-               (replace-collection-ids collection (graph :clear-revisions? true, :collections [collection]))))))))
-
-(deftest can-set-read-audit-permissions-for-non-admins-test
-  (clear-graph-revisions!)
-  (mt/with-non-admin-groups-no-root-collection-perms
-    (mt/with-temp [:model/Collection collection {:namespace "analytics"}]
-      (with-redefs [audit/default-audit-collection (constantly collection)]
-        (graph/update-graph! {:revision 0 :groups {(u/the-id (perms-group/all-users)) {(u/the-id collection) :read}}})
-        (is (= {:revision 0
-                :groups {(u/the-id (perms-group/all-users)) {:COLLECTION :read}
-                         (u/the-id (perms-group/admin)) {:root :write, :COLLECTION :read}}}
-               (replace-collection-ids collection (graph :clear-revisions? true, :collections [collection]))))))))
+  (mt/with-premium-features #{}
+    (testing "Cannot set write permissiosn with no feature flag"
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-temp [:model/Collection collection {:namespace "analytics"}]
+          (with-redefs [audit/default-audit-collection (constantly collection)]
+            (graph/update-graph! {:revision 0 :groups {(u/the-id (perms-group/all-users)) {(u/the-id collection) :write}}})
+            (is (= {:revision 0
+                    :groups {(u/the-id (perms-group/admin)) {:root :write, :COLLECTION :read}}}
+                   (replace-collection-ids collection (graph :clear-revisions? true, :collections [collection]))))))))
+    (testing "Cannot set read permissiosn with no feature flag"
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-temp [:model/Collection collection {:namespace "analytics"}]
+          (with-redefs [audit/default-audit-collection (constantly collection)]
+            (graph/update-graph! {:revision 0 :groups {(u/the-id (perms-group/all-users)) {(u/the-id collection) :read}}})
+            (is (= {:revision 0
+                    :groups {(u/the-id (perms-group/admin)) {:root :write, :COLLECTION :read}}}
+                   (replace-collection-ids collection (graph :clear-revisions? true, :collections [collection]))))))))))
 
 (deftest read-perms-test
   (testing "make sure read perms show up correctly"

--- a/test/metabase/permissions/models/collection/graph_test.clj
+++ b/test/metabase/permissions/models/collection/graph_test.clj
@@ -88,11 +88,33 @@
 (deftest audit-collections-graph-test
   (testing "Check that the audit collection has :read for admins (sparse - no :none entries)."
     (mt/with-non-admin-groups-no-root-collection-perms
-      (mt/with-temp [:model/Collection collection {}]
+      (mt/with-temp [:model/Collection collection {:namespace "analytics"}]
         (with-redefs [audit/default-audit-collection (constantly collection)]
           (is (= {:revision 0
                   :groups {(u/the-id (perms-group/admin)) {:root :write, :COLLECTION :read}}}
                  (replace-collection-ids collection (graph :clear-revisions? true, :collections [collection])))))))))
+
+(deftest cannot-set-readwrite-audit-permissions-for-non-admins-test
+  (mt/with-non-admin-groups-no-root-collection-perms
+    (mt/with-temp [:model/Collection collection {:namespace "analytics"}]
+      (with-redefs [audit/default-audit-collection (constantly collection)]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"Unable to make audit collections writable."
+             (graph/update-graph! {:revision 0 :groups {(u/the-id (perms-group/all-users)) {(u/the-id collection) :write}}})))
+        (is (= {:revision 0
+                :groups {(u/the-id (perms-group/admin)) {:root :write, :COLLECTION :read}}}
+               (replace-collection-ids collection (graph :clear-revisions? true, :collections [collection]))))))))
+
+(deftest can-set-read-audit-permissions-for-non-admins-test
+  (mt/with-non-admin-groups-no-root-collection-perms
+    (mt/with-temp [:model/Collection collection {:namespace "analytics"}]
+      (with-redefs [audit/default-audit-collection (constantly collection)]
+        (graph/update-graph! {:revision 0 :groups {(u/the-id (perms-group/all-users)) {(u/the-id collection) :read}}})
+        (is (= {:revision 0
+                :groups {(u/the-id (perms-group/all-users)) {:COLLECTION :read}
+                         (u/the-id (perms-group/admin)) {:root :write, :COLLECTION :read}}}
+               (replace-collection-ids collection (graph :clear-revisions? true, :collections [collection]))))))))
 
 (deftest read-perms-test
   (testing "make sure read perms show up correctly"


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #65867
### Description

In #65098, we did not fully replicate the behavior of the old graph endpoint where collection namespacing rules aren't applied to the "analytics" namespace. Collections in this namespace can be modified as though they are part of the root `nil` namespace. The bug was in removing collections not part of the targetted namespace of the `update-graph!` funciton from the graph to update.

This restores the old behavior by not excluding collection permissions updates for collections in the "analytics" namespace in the `remove-collections-from-other-namespaces` function.

it also updates our tests for the collection graph to make sure mock analytics collections have the right namespace set rather than a `nil` namespace.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
