### PR TITLE
Make sure 'Pull changes' button is not truncated on remote sync settings

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/PullChangesButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/PullChangesButton.tsx
@@ -45,7 +45,6 @@ export const PullChangesButton = (props: PullChangesButtonProps) => {
       <Button
         disabled={isImporting || dirty}
         loading={isImporting}
-        maw="7rem"
         onClick={handlePullChanges}
         variant="outline"
       >

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncAdminSettings.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncAdminSettings.tsx
@@ -274,6 +274,7 @@ export const RemoteSyncAdminSettings = () => {
                           <FormTextInput
                             name={BRANCH_KEY}
                             label={t`Sync branch`}
+                            mr={0}
                             placeholder="main"
                             {...getEnvSettingProps(
                               settingDetails?.[BRANCH_KEY],


### PR DESCRIPTION
For some scenarios the button text could be truncated with an ellipsis showing up as below:

<img width="1632" height="540" alt="image" src="https://github.com/user-attachments/assets/6f4817ed-67ae-4f78-9936-33fdee2df23a" />


https://metaboat.slack.com/archives/C09LUUMAU1G/p1763412699584689