### PR TITLE
Fix order by custom expression aggregations

### DIFF
--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -1290,6 +1290,9 @@
 (defmethod ->honeysql [:sql :aggregation]
   [driver [_ index]]
   (driver-api/match-one (nth (:aggregation *inner-query*) index)
+    [:aggregation-options ag (options :guard driver-api/qp.add.desired-alias)]
+    (->honeysql driver (h2x/identifier :field-alias (driver-api/qp.add.desired-alias options)))
+
     [:aggregation-options ag (options :guard driver-api/qp.add.source-alias)]
     (->honeysql driver (h2x/identifier :field-alias (driver-api/qp.add.source-alias options)))
 

--- a/test/metabase/driver/sql/query_processor_test.clj
+++ b/test/metabase/driver/sql/query_processor_test.clj
@@ -11,6 +11,7 @@
    [metabase.driver.sql.query-processor.deprecated]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.options :as lib.options]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
    [metabase.lib.test-util.macros :as lib.tu.macros]

--- a/test/metabase/driver/sql/query_processor_test.clj
+++ b/test/metabase/driver/sql/query_processor_test.clj
@@ -1644,7 +1644,7 @@
                                         (m/find-first (comp #{"a b"} :name)
                                                       (lib/orderable-columns $query))))
                     (lib/limit 3))]
-      (is (= [["2016-04-01T00:00:00Z" 1]
-              ["2016-05-01T00:00:00Z" 19]
-              ["2016-06-01T00:00:00Z" 37]]
-             (mt/rows (qp/process-query query)))))))
+      (is (= [1 19 37]
+             (->> (qp/process-query query)
+                  (mt/formatted-rows [identity int])
+                  (map second)))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/65893

### Description

Use the desired column alias instead of the source column alias when generating the sql for a non-top level aggregation field. 

### How to verify

1. See steps in original issue
2. It should work now

### Demo

https://github.com/user-attachments/assets/dfa3f6bc-3167-43e4-880a-04bcaca33b41

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
