### PR TITLE
Throw Exception when running app DB queries on launch

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -328,7 +328,7 @@
   ;; includes test code as source paths. Run tests with clojure -X:dev:test
   :test
   {:extra-paths ["test_config"]
-   :exec-fn     metabase.test-runner/find-and-run-tests-cli
+   :exec-fn     metabase.test-runner.bootstrap/find-and-run-tests-cli
    :exec-args   {:exclude-tags [:metabot-v3/e2e]}
    :jvm-opts    ["-Dmb.run.mode=test"
                  "-Dmacaw.run.mode=test"

--- a/src/metabase/settings/models/setting.clj
+++ b/src/metabase/settings/models/setting.clj
@@ -896,6 +896,9 @@
 (defn- default-setter-for-type [setting-type]
   (partial set-value-of-type! (keyword setting-type)))
 
+(derive ::event :metabase/event)
+(derive :event/setting-update ::event)
+
 (defn- audit-setting-change!
   [{:keys [name audit sensitive?]} previous-value new-value]
   (let [maybe-obfuscate #(cond-> % sensitive? obfuscate-value)]

--- a/test/metabase/search/util_test.clj
+++ b/test/metabase/search/util_test.clj
@@ -27,7 +27,7 @@
 
 (def search-expr #'search.util/to-tsquery-expr)
 
-(deftest to-tsquery-expr-test
+(deftest ^:parallel to-tsquery-expr-test
   (is (= "'a' & 'b' & 'c':*"
          (search-expr "a b c")))
 
@@ -83,9 +83,9 @@
     (is (= "'you''re':*"
            (search-expr "you're")))))
 
-(deftest available-tsv-languages-test
+(deftest ^:parallel available-tsv-languages-test
   (when (= :postgres (mdb/db-type))
-    (let [available @#'search.util/available-tsv-languages]
+    (let [available (@#'search.util/available-tsv-languages)]
       (is (= :english (:en available)))
       (is (= :german (:de available)))
       (is (nil? (:ko available))))))

--- a/test/metabase/test/redefs.clj
+++ b/test/metabase/test/redefs.clj
@@ -48,5 +48,5 @@
   ;; this seems to be the best way I could come up with to see if we're currently in the process of loading a namespace
   (when (seq @#'clojure.core/*pending-paths*)
     (throw (ex-info "Do not execute app DB queries as a side effect of loading a namespace (e.g., in a top-level `def`)."
-                    {:query compiled-query})))
+                    {:query compiled-query, :path (first @#'clojure.core/*pending-paths*)})))
   compiled-query)

--- a/test/metabase/test_runner.clj
+++ b/test/metabase/test_runner.clj
@@ -16,6 +16,7 @@
    [metabase.test.data.env :as tx.env]
    [metabase.test.fixtures :as fixtures]
    [metabase.test.initialize :as initialize]
+   [metabase.test.redefs]
    [metabase.util :as u]
    [metabase.util.date-2]
    [metabase.util.i18n.impl]
@@ -23,25 +24,6 @@
    [pjstadig.humane-test-output :as humane-test-output]))
 
 (set! *warn-on-reflection* true)
-
-;;; TODO -- consider whether we should just mode all of this stuff to [[user]] instead of doing it here
-
-(comment
-  metabase.core.bootstrap/keep-me
-  ;; make sure stuff like `=?` and what not are loaded
-  metabase.test-runner.assert-exprs/keep-me
-
-  ;; these are necessary so data_readers.clj functions can function
-  metabase.util.date-2/keep-me
-  metabase.util.i18n.impl/keep-me)
-
-;; Initialize Humane Test Output if it's not already initialized. Don't enable humane-test-output when running tests
-;; from the CLI, it breaks diffs.
-(when-not config/is-test?
-  (humane-test-output/activate!))
-
-;;; Same for https://github.com/camsaul/humane-are
-(humane-are/install!)
 
 ;;; Ignore any directories for drivers that are not in the [[tx.env/test-drivers]] (i.e., not in `DRIVERS`)
 ;;;
@@ -167,8 +149,9 @@
   (initialize-all-fixtures)
   (hawk/find-and-run-tests-repl (build-final-options options)))
 
-(defn find-and-run-tests-cli
-  "Entrypoint for `clojure -X:test`."
+(defn -find-and-run-tests-cli
+  "Implementation of the CLI entrypoint for `clojure -X:test`; called
+  by [[metabase.test-runner.bootstrap/find-and-run-tests-cli]]."
   [options]
   (initialize-all-fixtures)
   (hawk/find-and-run-tests-cli (build-final-options options)))

--- a/test/metabase/test_runner/bootstrap.clj
+++ b/test/metabase/test_runner/bootstrap.clj
@@ -1,0 +1,38 @@
+(ns metabase.test-runner.bootstrap
+  "CLI entrypoint for running tests; this loads some namespaces that NEED to be loaded before everything else (such
+  as [[metabase.test.redefs]], which adds some checks to make sure loading namespaces doesn't trigger app DB
+  queries)."
+  (:require
+   [humane-are.core :as humane-are]
+   [metabase.config.core :as config]
+   [metabase.core.bootstrap]
+   [metabase.test-runner.assert-exprs]
+   [metabase.test.redefs]
+   [metabase.util.date-2]
+   [metabase.util.i18n.impl]
+   [pjstadig.humane-test-output :as humane-test-output]))
+
+;;; TODO -- consider whether we should just mode all of this stuff to [[user]] instead of doing it here
+
+(comment
+  metabase.core.bootstrap/keep-me
+  ;; make sure stuff like `=?` and what not are loaded
+  metabase.test-runner.assert-exprs/keep-me
+  ;; load the wrappers around with-temp and other stuff like that
+  metabase.test.redefs/keep-me
+  ;; these are necessary so data_readers.clj functions can function
+  metabase.util.date-2/keep-me
+  metabase.util.i18n.impl/keep-me)
+
+;; Initialize Humane Test Output if it's not already initialized. Don't enable humane-test-output when running tests
+;; from the CLI, it breaks diffs.
+(when-not config/is-test?
+  (humane-test-output/activate!))
+
+;;; Same for https://github.com/camsaul/humane-are
+(humane-are/install!)
+
+(defn find-and-run-tests-cli
+  "Entrypoint for `clojure -X:test`."
+  [options]
+  ((requiring-resolve 'metabase.test-runner/-find-and-run-tests-cli) options))


### PR DESCRIPTION
```
% clj -X:dev:test:user :only metabase.search.util-test
```

```clj
...
{:clojure.main/message
 "Execution error (ExceptionInfo) at metabase.test.redefs/transduce-execute-with-connection-before-method-default (redefs.clj:50).\nDo not execute app DB queries as a side effect of loading a namespace (e.g., in a top-level `def`).\n",
 :clojure.main/triage
 {:clojure.error/class clojure.lang.ExceptionInfo,
  :clojure.error/line 50,
  :clojure.error/cause
  "Do not execute app DB queries as a side effect of loading a namespace (e.g., in a top-level `def`).",
  :clojure.error/symbol metabase.test.redefs/transduce-execute-with-connection-before-method-default,
  :clojure.error/source "redefs.clj",
  :clojure.error/phase :execution},
 :clojure.main/trace
 {:via
  [{:type clojure.lang.Compiler$CompilerException,
    :message "Syntax error macroexpanding at (util.clj:57:5).",
    :data
    {:clojure.error/phase :execution,
     :clojure.error/line 57,
     :clojure.error/column 5,
     :clojure.error/source "util.clj"},
    :at [clojure.lang.Compiler$InvokeExpr eval "Compiler.java" 4227]}
   {:type clojure.lang.ExceptionInfo,
    :message "Do not execute app DB queries as a side effect of loading a namespace (e.g., in a top-level `def`).",
    :data
    {:query ["SELECT \"cfgname\" FROM \"pg_ts_config\""],
     :path "/metabase/search/util",
     :toucan2/context-trace
     [["resolve connection" {:toucan2.connection/connectable metabase.app_db.connection.ApplicationDB}]
      ["resolve connection" {:toucan2.connection/connectable :default}]
      ["resolve connection" {:toucan2.connection/connectable nil}]
      {:toucan2.pipeline/rf #function[toucan2.pipeline/default-rf-primary-method-toucan-result-type-*/fn--31997]}
      ["with compiled query" {:toucan2.pipeline/compiled-query ["SELECT \"cfgname\" FROM \"pg_ts_config\""]}]
      ["with built query" {:toucan2.pipeline/built-query {:select [:cfgname], :from [:pg_ts_config]}}]
      ["with resolved query" {:toucan2.pipeline/resolved-query {:select [:cfgname], :from [:pg_ts_config]}}]
      ["with parsed args"
       {:toucan2.pipeline/query-type :toucan.result-type/*,
        :toucan2.pipeline/parsed-args {:connectable nil, :queryable {:select [:cfgname], :from [:pg_ts_config]}}}]
      ["with model" {:toucan2.pipeline/model nil}]]},
    :at [metabase.test.redefs$transduce_execute_with_connection_before_method_default invokeStatic "redefs.clj" 50]}],
  :trace
  [[metabase.test.redefs$transduce_execute_with_connection_before_method_default invokeStatic "redefs.clj" 50]
   [metabase.test.redefs$transduce_execute_with_connection_before_method_default invoke "redefs.clj" 45]
   [methodical.impl.combo.threaded$combine_methods_thread_last$fn__25215$combined_method_thread_last__25216
    invoke
    "threaded.clj"
    64]
   [methodical.impl.combo.threaded$combine_methods_thread_last$fn__25215$combined_method_thread_last__25216
    invoke
    "threaded.clj"
    64]
   [methodical.util.FnWithMeta invoke "util.clj" 46]
   [methodical.impl.standard$invoke_multifn invokeStatic "standard.clj" 65]
   [methodical.impl.standard$invoke_multifn invoke "standard.clj" 47]
   [methodical.impl.standard.StandardMultiFn invoke "standard.clj" 216]
   [toucan2.pipeline$transduce_execute$with_connection_STAR___31874 invoke "pipeline.clj" 78]
   [toucan2.connection$bind_current_connectable_fn$fn__31460 invoke "connection.clj" 104]
   [toucan2.connection$bind_current_connectable_fn$fn__31460 invoke "connection.clj" 104]
   [toucan2.connection$bind_current_connectable_fn$fn__31460 invoke "connection.clj" 104]
   [toucan2.jdbc.connection$do_with_connection_primary_method_javax_sql_DataSource invokeStatic "connection.clj" 18]
   [toucan2.jdbc.connection$do_with_connection_primary_method_javax_sql_DataSource invoke "connection.clj" 15]
   ...
   [toucan2.execute$query_STAR_$query_STAR__STAR___37282 invoke "execute.clj" 39]
   [toucan2.execute$query_STAR_$query_STAR__STAR___37282 invoke "execute.clj" 33]
   [toucan2.execute$query_STAR_$query_STAR__STAR___37282 invoke "execute.clj" 28]
   [toucan2.execute$query_STAR_$query_STAR__STAR___37282 invoke "execute.clj" 25]
   [metabase.search.util$fn__118389 invokeStatic "util.clj" 75]
   [metabase.search.util$fn__118389 invoke "util.clj" 57]
   [clojure.lang.AFn applyToHelper "AFn.java" 152]
   [clojure.lang.AFn applyTo "AFn.java" 144]
   [clojure.lang.Compiler$InvokeExpr eval "Compiler.java" 4222]
   [clojure.lang.Compiler$IfExpr eval "Compiler.java" 3243]
   [clojure.lang.Compiler$DefExpr eval "Compiler.java" 464]
   [clojure.lang.Compiler eval "Compiler.java" 7762]
   [clojure.lang.Compiler load "Compiler.java" 8223]
   ...
   [metabase.test_runner.bootstrap$find_and_run_tests_cli invokeStatic "bootstrap.clj" 38]
   [metabase.test_runner.bootstrap$find_and_run_tests_cli invoke "bootstrap.clj" 35]
   [clojure.lang.Var invoke "Var.java" 386]
   [clojure.run.exec$exec invokeStatic "exec.clj" 88]
   [clojure.run.exec$exec invoke "exec.clj" 78]
   [clojure.run.exec$_main$fn__29410 invoke "exec.clj" 227]
   [clojure.run.exec$_main invokeStatic "exec.clj" 223]
   [clojure.run.exec$_main doInvoke "exec.clj" 191]
   [clojure.lang.RestFn applyTo "RestFn.java" 140]
   [clojure.lang.Var applyTo "Var.java" 707]
   [clojure.core$apply invokeStatic "core.clj" 667]
   [clojure.main$main_opt invokeStatic "main.clj" 515]
   [clojure.main$main_opt invoke "main.clj" 511]
   [clojure.main$main invokeStatic "main.clj" 665]
   [clojure.main$main doInvoke "main.clj" 617]
   [clojure.lang.RestFn applyTo "RestFn.java" 140]
   [clojure.lang.Var applyTo "Var.java" 707]
   [clojure.main main "main.java" 40]],
  :cause "Do not execute app DB queries as a side effect of loading a namespace (e.g., in a top-level `def`).",
  :data
  {:query ["SELECT \"cfgname\" FROM \"pg_ts_config\""],
   :path "/metabase/search/util",
   :toucan2/context-trace
   [["resolve connection" {:toucan2.connection/connectable metabase.app_db.connection.ApplicationDB}]
    ["resolve connection" {:toucan2.connection/connectable :default}]
    ["resolve connection" {:toucan2.connection/connectable nil}]
    {:toucan2.pipeline/rf #function[toucan2.pipeline/default-rf-primary-method-toucan-result-type-*/fn--31997]}
    ["with compiled query" {:toucan2.pipeline/compiled-query ["SELECT \"cfgname\" FROM \"pg_ts_config\""]}]
    ["with built query" {:toucan2.pipeline/built-query {:select [:cfgname], :from [:pg_ts_config]}}]
    ["with resolved query" {:toucan2.pipeline/resolved-query {:select [:cfgname], :from [:pg_ts_config]}}]
    ["with parsed args"
     {:toucan2.pipeline/query-type :toucan.result-type/*,
      :toucan2.pipeline/parsed-args {:connectable nil, :queryable {:select [:cfgname], :from [:pg_ts_config]}}}]
    ["with model" {:toucan2.pipeline/model nil}]]},
  :phase :execution}}

Execution error (ExceptionInfo) at metabase.test.redefs/transduce-execute-with-connection-before-method-default (redefs.clj:50).
Do not execute app DB queries as a side effect of loading a namespace (e.g., in a top-level `def`).
```