### PR TITLE
feat: set shared tenant collection default perms

### DIFF
--- a/frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx
+++ b/frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx
@@ -300,7 +300,6 @@ export const getCollectionsPermissionEditor = createSelector(
             : Messages.UNABLE_TO_CHANGE_ADMIN_PERMISSIONS;
 
         const disabled =
-          (isTenantCollection && !isTenantGroup) ||
           (!isTenantCollection && isTenantGroup) ||
           isAdmin;
 

--- a/src/metabase/permissions/models/permissions.clj
+++ b/src/metabase/permissions/models/permissions.clj
@@ -281,8 +281,8 @@
   (if (or (= read-or-write :read)
           (remote-sync/collection-editable? (or (:collection instance) (:collection_id instance))))
     (perms-objects-set-for-parent-collection instance read-or-write)
-    ;; We need to return a dummy permissions string that cannot possibly be long to a user in
-    ;; the case where an instance is not syncable due to remote-sync being in ':read-only' mode
+    ;; We need to return a dummy permissions string that cannot possibly belong to a user in
+    ;; the case where an instance is not syncable due to remote-sync being in ':production' mode
     #{"___no-remote-sync-access"}))
 
 (methodical/defmethod t2/batched-hydrate [:perms/use-parent-collection-perms :can_write]

--- a/test/metabase/collections/models/collection_test.clj
+++ b/test/metabase/collections/models/collection_test.clj
@@ -3306,3 +3306,204 @@
         (is (= [false false false] (map :can_delete (collection/can-delete [non-archived-collection
                                                                             non-archived-dash
                                                                             non-archived-card]))))))))
+
+(deftest set-tenant-collection-permissions-root-parent-test
+  (testing "When creating a new Shared Tenant Collection at root level"
+    (testing "should apply default read permissions for all non-admin user groups"
+      (mt/with-premium-features #{:tenants}
+        (mt/with-temporary-setting-values [use-tenants true]
+          (mt/with-temp [:model/PermissionsGroup {group-1-id :id} {:name "Group 1"}
+                         :model/PermissionsGroup {group-2-id :id} {:name "Group 2"}
+                         :model/Collection coll {:name "Tenant Collection"
+                                                 :type "shared-tenant-collection"
+                                                 :location "/"}]
+            (let [group-1-perms (t2/select-one :model/Permissions
+                                               :group_id group-1-id
+                                               :object (perms/collection-read-path coll))
+                  group-2-perms (t2/select-one :model/Permissions
+                                               :group_id group-2-id
+                                               :object (perms/collection-read-path coll))]
+              (is (some? group-1-perms)
+                  "Group 1 should have read permissions")
+              (is (some? group-2-perms)
+                  "Group 2 should have read permissions")
+              (is (not (t2/exists? :model/Permissions
+                                   :group_id group-1-id
+                                   :object (perms/collection-readwrite-path coll)))
+                  "Group 1 should not have write permissions")
+              (is (not (t2/exists? :model/Permissions
+                                   :group_id group-2-id
+                                   :object (perms/collection-readwrite-path coll)))
+                  "Group 2 should not have write permissions"))))))))
+
+(deftest set-tenant-collection-permissions-admin-group-excluded-test
+  (testing "Admin group should not receive auto-granted read permissions"
+    (mt/with-premium-features #{:tenants}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (mt/with-temp [:model/Collection coll {:name "Tenant Collection"
+                                               :type "shared-tenant-collection"
+                                               :location "/"}]
+          (let [admin-group-id (:id (perms/admin-group))]
+            (is (not (t2/exists? :model/Permissions
+                                 :group_id admin-group-id
+                                 :object (perms/collection-read-path coll)))
+                "Admin group should not get explicit read permissions (they have implicit access)")))))))
+
+(deftest set-tenant-collection-permissions-nested-in-tenant-test
+  (testing "When creating a Shared Tenant Collection nested in another Shared Tenant Collection"
+    (testing "should copy parent permissions (standard behavior)"
+      (mt/with-premium-features #{:tenants}
+        (mt/with-temporary-setting-values [use-tenants true]
+          (mt/with-temp [:model/PermissionsGroup {group-id :id} {:name "Test Group"}
+                         :model/Collection parent {:name "Parent Tenant Collection"
+                                                   :type "shared-tenant-collection"
+                                                   :location "/"}]
+            (perms/grant-collection-readwrite-permissions! group-id parent)
+            (mt/with-temp [:model/Collection child {:name "Child Tenant Collection"
+                                                    :type "shared-tenant-collection"
+                                                    :location (collection/children-location parent)}]
+              (is (t2/exists? :model/Permissions
+                              :group_id group-id
+                              :object (perms/collection-readwrite-path child))
+                  "Child should inherit write permissions from parent tenant collection"))))))))
+
+(deftest set-tenant-collection-permissions-nested-in-regular-test
+  (testing "When creating a Shared Tenant Collection nested in a regular collection"
+    (testing "should apply default read permissions (not copy parent)"
+      (mt/with-premium-features #{:tenants}
+        (mt/with-temporary-setting-values [use-tenants true]
+          (mt/with-temp [:model/PermissionsGroup {group-id :id} {:name "Test Group"}
+                         :model/Collection parent {:name "Regular Collection"
+                                                   :location "/"}]
+            (perms/grant-collection-readwrite-permissions! group-id parent)
+            (mt/with-temp [:model/Collection child {:name "Tenant Collection"
+                                                    :type "shared-tenant-collection"
+                                                    :location (collection/children-location parent)}]
+              (is (not (t2/exists? :model/Permissions
+                                   :group_id group-id
+                                   :object (perms/collection-readwrite-path child)))
+                  "Child should not inherit write permissions from regular collection parent")
+              (is (t2/exists? :model/Permissions
+                              :group_id group-id
+                              :object (perms/collection-read-path child))
+                  "Child should have read permissions for non-admin group"))))))))
+
+(deftest set-tenant-collection-permissions-multiple-groups-test
+  (testing "Multiple groups should all receive read permissions"
+    (mt/with-premium-features #{:tenants}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (mt/with-temp [:model/PermissionsGroup {group-1-id :id} {:name "Group 1"}
+                       :model/PermissionsGroup {group-2-id :id} {:name "Group 2"}
+                       :model/PermissionsGroup {group-3-id :id} {:name "Group 3"}
+                       :model/Collection coll {:name "Tenant Collection"
+                                               :type "shared-tenant-collection"
+                                               :location "/"}]
+          (let [groups-with-read-perms (t2/select-fn-set :group_id :model/Permissions
+                                                         :object (perms/collection-read-path coll))
+                admin-group-id (:id (perms/admin-group))]
+            (is (contains? groups-with-read-perms group-1-id)
+                "Group 1 should have read permissions")
+            (is (contains? groups-with-read-perms group-2-id)
+                "Group 2 should have read permissions")
+            (is (contains? groups-with-read-perms group-3-id)
+                "Group 3 should have read permissions")
+            (is (not (contains? groups-with-read-perms admin-group-id))
+                "Admin group should not have explicit read permissions")))))))
+
+(deftest set-tenant-collection-permissions-parent-helper-test
+  (testing "The parent function should correctly identify parent collections"
+    (mt/with-premium-features #{:tenants}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (mt/with-temp [:model/Collection {parent-id :id :as parent} {:name "Parent"
+                                                                     :type "shared-tenant-collection"
+                                                                     :location "/"}
+                       :model/Collection child {:name "Child"
+                                                :type "shared-tenant-collection"
+                                                :location (collection/children-location parent)}]
+          (let [child-parent (#'collection/parent child)]
+            (is (= parent-id (:id child-parent))
+                "Parent function should return the correct parent collection")
+            (is (collection/is-tenant-collection? child-parent)
+                "Parent should be identified as tenant collection")))))))
+
+(deftest set-tenant-collection-permissions-is-tenant-check-test
+  (testing "The is-tenant-collection? predicate"
+    (mt/with-premium-features #{:tenants}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (mt/with-temp [:model/Collection tenant-coll {:type "shared-tenant-collection"}
+                       :model/Collection regular-coll {:type nil}
+                       :model/Collection remote-coll {:type "remote-synced"}]
+          (is (collection/is-tenant-collection? tenant-coll)
+              "Should identify shared-tenant-collection as tenant collection")
+          (is (not (collection/is-tenant-collection? regular-coll))
+              "Should not identify regular collection as tenant collection")
+          (is (not (collection/is-tenant-collection? remote-coll))
+              "Should not identify remote-synced collection as tenant collection"))))))
+
+(deftest after-insert-routes-to-correct-permissions-logic-test
+  (testing "The after-insert hook should route to the correct permissions logic"
+    (mt/with-premium-features #{:tenants}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (testing "for tenant collections"
+          (mt/with-temp [:model/PermissionsGroup {group-id :id} {:name "Test Group"}
+                         :model/Collection coll {:name "Tenant Collection"
+                                                 :type "shared-tenant-collection"
+                                                 :location "/"}]
+            (is (t2/exists? :model/Permissions
+                            :group_id group-id
+                            :object (perms/collection-read-path coll))
+                "Tenant collection should trigger set-tenant-collection-permissions!")))
+        (testing "for regular collections"
+          (mt/with-temp [:model/PermissionsGroup {group-id :id} {:name "Test Group"}
+                         :model/Collection coll {:name "Regular Collection"
+                                                 :location "/"}]
+            (is (not (t2/exists? :model/Permissions
+                                 :group_id group-id
+                                 :object (perms/collection-read-path coll)))
+                "Regular collection should use copy-parent-permissions! (no auto-perms)")))))))
+
+(deftest set-tenant-collection-permissions-deeply-nested-test
+  (testing "Deeply nested tenant collections should handle permissions correctly"
+    (mt/with-premium-features #{:tenants}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (mt/with-temp [:model/PermissionsGroup {group-id :id} {:name "Test Group"}
+                       :model/Collection level-1 {:name "Level 1 Tenant"
+                                                  :type "shared-tenant-collection"
+                                                  :location "/"}
+                       :model/Collection level-2 {:name "Level 2 Tenant"
+                                                  :type "shared-tenant-collection"
+                                                  :location (collection/children-location level-1)}
+                       :model/Collection level-3 {:name "Level 3 Tenant"
+                                                  :type "shared-tenant-collection"
+                                                  :location (collection/children-location level-2)}]
+          (is (t2/exists? :model/Permissions
+                          :group_id group-id
+                          :object (perms/collection-read-path level-1))
+              "Level 1 should have default read permissions")
+          (is (t2/exists? :model/Permissions
+                          :group_id group-id
+                          :object (perms/collection-read-path level-2))
+              "Level 2 should copy read permissions from Level 1")
+          (is (t2/exists? :model/Permissions
+                          :group_id group-id
+                          :object (perms/collection-read-path level-3))
+              "Level 3 should copy read permissions from Level 2"))))))
+
+(deftest set-tenant-collection-permissions-no-permission-escalation-test
+  (testing "Creating a tenant collection should not escalate permissions beyond read"
+    (mt/with-premium-features #{:tenants}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (mt/with-temp [:model/PermissionsGroup {group-id :id} {:name "Test Group"}
+                       :model/Collection coll {:name "Tenant Collection"
+                                               :type "shared-tenant-collection"
+                                               :location "/"}]
+          (let [read-perms (t2/exists? :model/Permissions
+                                       :group_id group-id
+                                       :object (perms/collection-read-path coll))
+                write-perms (t2/exists? :model/Permissions
+                                        :group_id group-id
+                                        :object (perms/collection-readwrite-path coll))]
+            (is read-perms
+                "Should have read permissions")
+            (is (not write-perms)
+                "Should NOT have write permissions (no escalation)")))))))

--- a/test/metabase/collections/models/tenant_collection_permissions_test.clj
+++ b/test/metabase/collections/models/tenant_collection_permissions_test.clj
@@ -1,0 +1,9 @@
+(ns metabase.collections.models.tenant-collection-permissions-test
+  "Tests for the after-insert behavior of Tenant Collections, specifically for set-tenant-collection-permissions!"
+  (:require
+   [clojure.test :refer :all]
+   [metabase.collections.models.collection :as collection]
+   [metabase.permissions.core :as perms]
+   [metabase.permissions.settings :refer [use-tenants]]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))


### PR DESCRIPTION
Closes EMB-1028

### Description

Set these permissions to read-only for all groups if a shared tenant collection is created inside a collection of another type. If a shared tenant collection is created as a child of another shared tenant collection copy that collection's permissions.

Also fix FE bug that prevents changing perms for internal groups on shared tenant collections.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
