### PR TITLE
Add creator to transform content view, and include glossary 

### DIFF
--- a/resources/migrations/057_update_migrations.yaml
+++ b/resources/migrations/057_update_migrations.yaml
@@ -2532,6 +2532,37 @@ databaseChangeLog:
               SET "VALUE" = 'production'
               WHERE "KEY"='remote-sync-type' AND "VALUE"='read-only';
 
+  - changeSet:
+      id: v57.2025-11-18T10:01:00
+      author: bronsa
+      comment: Usage analytics; Add glossary to content, creator_id to transform content
+      changes:
+        - sqlFile:
+            dbms: postgresql
+            path: instance_analytics_views/content/v6/postgres-content.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: mysql,mariadb
+            path: instance_analytics_views/content/v6/mysql-content.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: h2
+            path: instance_analytics_views/content/v6/h2-content.sql
+            relativeToChangelogFile: true
+      rollback:
+        - sqlFile:
+            dbms: postgresql
+            path: instance_analytics_views/content/v5/postgres-content.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: mysql,mariadb
+            path: instance_analytics_views/content/v5/mysql-content.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: h2
+            path: instance_analytics_views/content/v5/h2-content.sql
+            relativeToChangelogFile: true
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/057_update_migrations.yaml
+++ b/resources/migrations/057_update_migrations.yaml
@@ -2533,6 +2533,47 @@ databaseChangeLog:
               WHERE "KEY"='remote-sync-type' AND "VALUE"='read-only';
 
   - changeSet:
+      id: v57.2025-11-18T10:00:00
+      author: bronsa
+      comment: Add creator_id column to glossary table
+      changes:
+        - addColumn:
+            tableName: glossary
+            columns:
+              - column:
+                  name: creator_id
+                  remarks: User who created this glossary entry
+                  type: int
+                  defaultValue: 13371338
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: v57.2025-11-18T10:00:01
+      author: bronsa
+      comment: Add index on glossary.creator_id
+      changes:
+        - createIndex:
+            tableName: glossary
+            indexName: idx_glossary_creator_id
+            columns:
+              - column:
+                  name: creator_id
+
+  - changeSet:
+      id: v57.2025-11-18T10:00:02
+      author: bronsa
+      comment: Add foreign key constraint for glossary.creator_id
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: glossary
+            baseColumnNames: creator_id
+            referencedTableName: core_user
+            referencedColumnNames: id
+            constraintName: fk_glossary_ref_creator_id
+            onDelete: CASCADE
+
+  - changeSet:
       id: v57.2025-11-18T10:01:00
       author: bronsa
       comment: Usage analytics; Add glossary to content, creator_id to transform content

--- a/resources/migrations/instance_analytics_views/content/v6/h2-content.sql
+++ b/resources/migrations/instance_analytics_views/content/v6/h2-content.sql
@@ -1,0 +1,186 @@
+drop view if exists v_content;
+
+create or replace view v_content as
+select
+    action.id as entity_id,
+    'action_' || action.id as entity_qualified_id,
+    'action' as entity_type,
+    created_at,
+    updated_at,
+    creator_id,
+    name,
+    description,
+    cast(null as int) as collection_id,
+    made_public_by_id as made_public_by_user,
+    cast(null as boolean) as is_embedding_enabled,
+    cast(null as boolean) as is_verified,
+    archived,
+    type as action_type,
+    model_id as action_model_id,
+    null as collection_is_official,
+    null as collection_is_personal,
+    null as question_viz_type,
+    null as question_database_id,
+    cast(null as boolean) as question_is_native,
+    cast(null as timestamp) as event_timestamp
+    from action
+union
+select
+    collection.id as entity_id,
+    'collection_' || collection.id as entity_qualified_id,
+    'collection' as entity_type,
+    created_at,
+    null as updated_at,
+    null as creator_id,
+    name,
+    description,
+    null as collection_id,
+    null as made_public_by_user,
+    null as is_embedding_enabled,
+    cast(null as boolean) as is_verified,
+    archived,
+    null as action_type,
+    null as action_model_id,
+    case when authority_level='official' then true else false end as collection_is_official,
+    case when personal_owner_id is not null then true else false end as collection_is_personal,
+    null as question_viz_type,
+    null as question_database_id,
+    null as question_is_native,
+    null as event_timestamp
+    from collection
+union
+select
+    report_card.id as entity_id,
+    'card_' || report_card.id as entity_qualified_id,
+    type AS entity_type,
+    created_at,
+    updated_at,
+    creator_id,
+    name,
+    description,
+    collection_id as collection_id,
+    made_public_by_id as made_public_by_user,
+    enable_embedding as is_embedding_enabled,
+    case when is_verified then true else false end as is_verified,
+    archived,
+    null as action_type,
+    null as action_model_id,
+    null as collection_is_official,
+    null as collection_is_personal,
+    display as question_viz_type,
+   'database_' || database_id as question_database_id,
+    case when query_type='native' then true else false end as question_is_native,
+    null as event_timestamp
+    from report_card
+        left join (
+            select
+                moderated_item_type || '_' || moderated_item_id as entity_qualified_id,
+                case when status = 'verified' then true else false end as is_verified
+            from moderation_review
+            where most_recent
+        ) as moderation on 'card_' || report_card.id = moderation.entity_qualified_id
+
+union
+select
+    report_dashboard.id as entity_id,
+    'dashboard_' || report_dashboard.id as entity_qualified_id,
+    'dashboard' as entity_type,
+    created_at,
+    updated_at,
+    creator_id,
+    name,
+    description,
+    collection_id as collection_id,
+    made_public_by_id as made_public_by_user,
+    enable_embedding as is_embedding_enabled,
+    case when is_verified then true else false end as is_verified,
+    archived,
+    null as action_type,
+    null as action_model_id,
+    null as collection_is_official,
+    null as collection_is_personal,
+    null as question_viz_type,
+    null as question_database_id,
+    null as question_is_native,
+    null as event_timestamp
+    from report_dashboard
+        left join (
+            select
+                moderated_item_type || '_' || moderated_item_id as entity_qualified_id,
+                case when status = 'verified' then true else false end as is_verified
+            from moderation_review
+            where most_recent
+        ) as moderation on 'dashboard_' || report_dashboard.id = moderation.entity_qualified_id
+union
+select
+    document.id as entity_id,
+    'document_' || document.id as entity_qualified_id,
+    'document' as entity_type,
+    created_at,
+    updated_at,
+    creator_id,
+    name,
+    cast(null as varchar) as description,
+    collection_id as collection_id,
+    cast(null as int) as made_public_by_user,
+    cast(null as boolean) as is_embedding_enabled,
+    cast(null as boolean) as is_verified,
+    archived,
+    null as action_type,
+    cast(null as int) as action_model_id,
+    null as collection_is_official,
+    null as collection_is_personal,
+    null as question_viz_type,
+    null as question_database_id,
+    cast(null as boolean) as question_is_native,
+    cast(null as timestamp) as event_timestamp
+    from document
+union
+select
+    event.id as entity_id,
+    'event_' || event.id as entity_qualified_id,
+    'event' as entity_type,
+    event.created_at,
+    event.updated_at,
+    event.creator_id,
+    event.name,
+    event.description,
+    timeline.collection_id,
+    null as made_public_by_user,
+    null as is_embedding_enabled,
+    cast(null as boolean) as is_verified,
+    event.archived,
+    null as action_type,
+    null as action_model_id,
+    null as collection_is_official,
+    null as collection_is_personal,
+    null as question_viz_type,
+    null as question_database_id,
+    null as question_is_native,
+    timestamp as event_timestamp
+    from timeline_event event
+        left join timeline on event.timeline_id = timeline.id
+union
+select
+    transform.id as entity_id,
+    'transform_' || transform.id as entity_qualified_id,
+    'transform' as entity_type,
+    created_at,
+    updated_at,
+    creator_id,
+    name,
+    description,
+    cast(null as int) as collection_id,
+    cast(null as int) as made_public_by_user,
+    cast(null as boolean) as is_embedding_enabled,
+    cast(null as boolean) as is_verified,
+    false as archived,
+    null as action_type,
+    cast(null as int) as action_model_id,
+    null as collection_is_official,
+    null as collection_is_personal,
+    null as question_viz_type,
+    null as question_database_id,
+    cast(null as boolean) as question_is_native,
+    cast(null as timestamp) as event_timestamp
+    from transform

--- a/resources/migrations/instance_analytics_views/content/v6/h2-content.sql
+++ b/resources/migrations/instance_analytics_views/content/v6/h2-content.sql
@@ -184,3 +184,27 @@ select
     cast(null as boolean) as question_is_native,
     cast(null as timestamp) as event_timestamp
     from transform
+union
+select
+    glossary.id as entity_id,
+    'glossary_' || glossary.id as entity_qualified_id,
+    'glossary' as entity_type,
+    created_at,
+    updated_at,
+    creator_id,
+    term as name,
+    definition as description,
+    cast(null as int) as collection_id,
+    cast(null as int) as made_public_by_user,
+    cast(null as boolean) as is_embedding_enabled,
+    cast(null as boolean) as is_verified,
+    false as archived,
+    null as action_type,
+    cast(null as int) as action_model_id,
+    null as collection_is_official,
+    null as collection_is_personal,
+    null as question_viz_type,
+    null as question_database_id,
+    cast(null as boolean) as question_is_native,
+    cast(null as timestamp) as event_timestamp
+    from glossary

--- a/resources/migrations/instance_analytics_views/content/v6/mysql-content.sql
+++ b/resources/migrations/instance_analytics_views/content/v6/mysql-content.sql
@@ -1,0 +1,187 @@
+drop view if exists v_content;
+
+create or replace
+SQL SECURITY INVOKER
+view v_content as
+select
+    action.id as entity_id,
+    concat('action_', action.id) as entity_qualified_id,
+    'action' as entity_type,
+    created_at,
+    updated_at,
+    creator_id,
+    name,
+    description,
+    null as collection_id,
+    made_public_by_id as made_public_by_user,
+    null as is_embedding_enabled,
+    null as is_verified,
+    archived,
+    type as action_type,
+    model_id as action_model_id,
+    null as collection_is_official,
+    null as collection_is_personal,
+    null as question_viz_type,
+    null as question_database_id,
+    null as question_is_native,
+    null as event_timestamp
+    from action
+union
+select
+    collection.id as entity_id,
+    concat('collection_', collection.id) as entity_qualified_id,
+    'collection' as entity_type,
+    created_at,
+    null as updated_at,
+    null as creator_id,
+    name,
+    description,
+    null as collection_id,
+    null as made_public_by_user,
+    null as is_embedding_enabled,
+    null as is_verified,
+    archived,
+    null as action_type,
+    null as action_model_id,
+    case when authority_level='official' then true else false end as collection_is_official,
+    case when personal_owner_id is not null then true else false end as collection_is_personal,
+    null as question_viz_type,
+    null as question_database_id,
+    null as question_is_native,
+    null as event_timestamp
+    from collection
+union
+select
+    report_card.id as entity_id,
+    concat('card_', report_card.id) as entity_qualified_id,
+    type as entity_type,
+    created_at,
+    updated_at,
+    creator_id,
+    name,
+    description,
+    collection_id as collection_id,
+    made_public_by_id as made_public_by_user,
+    enable_embedding as is_embedding_enabled,
+    case when is_verified then true else false end as is_verified,
+    archived,
+    null as action_type,
+    null as action_model_id,
+    null as collection_is_official,
+    null as collection_is_personal,
+    display as question_viz_type,
+    concat('database_', database_id) as question_database_id,
+    case when query_type='native' then true else false end as question_is_native,
+    null as event_timestamp
+    from report_card
+        left join (
+            select
+                concat(moderated_item_type, '_', moderated_item_id) as entity_qualified_id,
+                case when status = 'verified' then true else false end as is_verified
+            from moderation_review
+            where most_recent
+        ) as moderation on concat('card_', report_card.id) = moderation.entity_qualified_id
+union
+select
+    report_dashboard.id as entity_id,
+    concat('dashboard_', report_dashboard.id) as entity_qualified_id,
+    'dashboard' as entity_type,
+    created_at,
+    updated_at,
+    creator_id,
+    name,
+    description,
+    collection_id as collection_id,
+    made_public_by_id as made_public_by_user,
+    enable_embedding as is_embedding_enabled,
+    case when is_verified then true else false end as is_verified,
+    archived,
+    null as action_type,
+    null as action_model_id,
+    null as collection_is_official,
+    null as collection_is_personal,
+    null as question_viz_type,
+    null as question_database_id,
+    null as question_is_native,
+    null as event_timestamp
+    from report_dashboard
+        left join (
+            select
+                concat(moderated_item_type, '_', moderated_item_id) as entity_qualified_id,
+                case when status = 'verified' then true else false end as is_verified
+            from moderation_review
+            where most_recent
+        ) as moderation on concat('dashboard_', report_dashboard.id) = moderation.entity_qualified_id
+union
+select
+    document.id as entity_id,
+    concat('document_', document.id) as entity_qualified_id,
+    'document' as entity_type,
+    created_at,
+    updated_at,
+    creator_id,
+    name,
+    null as description,
+    collection_id as collection_id,
+    null as made_public_by_user,
+    null as is_embedding_enabled,
+    null as is_verified,
+    archived,
+    null as action_type,
+    null as action_model_id,
+    null as collection_is_official,
+    null as collection_is_personal,
+    null as question_viz_type,
+    null as question_database_id,
+    null as question_is_native,
+    null as event_timestamp
+    from document
+union
+select
+    event.id as entity_id,
+    concat('event_', event.id) as entity_qualified_id,
+    'event' as entity_type,
+    event.created_at,
+    event.updated_at,
+    event.creator_id,
+    event.name,
+    event.description,
+    timeline.collection_id,
+    null as made_public_by_user,
+    null as is_embedding_enabled,
+    null as is_verified,
+    event.archived,
+    null as action_type,
+    null as action_model_id,
+    null as collection_is_official,
+    null as collection_is_personal,
+    null as question_viz_type,
+    null as question_database_id,
+    null as question_is_native,
+    timestamp as event_timestamp
+    from timeline_event event
+        left join timeline on event.timeline_id = timeline.id
+union
+select
+    transform.id as entity_id,
+    concat('transform_', transform.id) as entity_qualified_id,
+    'transform' as entity_type,
+    created_at,
+    updated_at,
+    creator_id,
+    name,
+    description,
+    null as collection_id,
+    null as made_public_by_user,
+    null as is_embedding_enabled,
+    null as is_verified,
+    false as archived,
+    null as action_type,
+    null as action_model_id,
+    null as collection_is_official,
+    null as collection_is_personal,
+    null as question_viz_type,
+    null as question_database_id,
+    null as question_is_native,
+    null as event_timestamp
+    from transform

--- a/resources/migrations/instance_analytics_views/content/v6/mysql-content.sql
+++ b/resources/migrations/instance_analytics_views/content/v6/mysql-content.sql
@@ -185,3 +185,27 @@ select
     null as question_is_native,
     null as event_timestamp
     from transform
+union
+select
+    glossary.id as entity_id,
+    concat('glossary_', glossary.id) as entity_qualified_id,
+    'glossary' as entity_type,
+    created_at,
+    updated_at,
+    creator_id,
+    term as name,
+    definition as description,
+    null as collection_id,
+    null as made_public_by_user,
+    null as is_embedding_enabled,
+    null as is_verified,
+    false as archived,
+    null as action_type,
+    null as action_model_id,
+    null as collection_is_official,
+    null as collection_is_personal,
+    null as question_viz_type,
+    null as question_database_id,
+    null as question_is_native,
+    null as event_timestamp
+    from glossary

--- a/resources/migrations/instance_analytics_views/content/v6/postgres-content.sql
+++ b/resources/migrations/instance_analytics_views/content/v6/postgres-content.sql
@@ -1,0 +1,185 @@
+drop view if exists v_content;
+
+create or replace view v_content as
+select
+    action.id as entity_id,
+    'action_' || action.id as entity_qualified_id,
+    'action' as entity_type,
+    created_at,
+    updated_at,
+    creator_id,
+    name,
+    description,
+    cast(null as int) as collection_id,
+    made_public_by_id as made_public_by_user,
+    cast(null as boolean) as is_embedding_enabled,
+    null::bool as is_verified,
+    archived,
+    type as action_type,
+    model_id as action_model_id,
+    null as collection_is_official,
+    null as collection_is_personal,
+    null as question_viz_type,
+    null as question_database_id,
+    cast(null as boolean) as question_is_native,
+    cast(null as timestamp) as event_timestamp
+    from action
+union
+select
+    collection.id as entity_id,
+    'collection_' || collection.id as entity_qualified_id,
+    'collection' as entity_type,
+    created_at,
+    null as updated_at,
+    null as creator_id,
+    name,
+    description,
+    null as collection_id,
+    null as made_public_by_user,
+    null as is_embedding_enabled,
+    null::bool as is_verified,
+    archived,
+    null as action_type,
+    null as action_model_id,
+    case when authority_level='official' then true else false end as collection_is_official,
+    case when personal_owner_id is not null then true else false end as collection_is_personal,
+    null as question_viz_type,
+    null as question_database_id,
+    null as question_is_native,
+    null as event_timestamp
+    from collection
+union
+select
+    report_card.id as entity_id,
+    'card_' || report_card.id as entity_qualified_id,
+    type as entity_type,
+    created_at,
+    updated_at,
+    creator_id,
+    name,
+    description,
+    collection_id as collection_id,
+    made_public_by_id as made_public_by_user,
+    enable_embedding as is_embedding_enabled,
+    case when is_verified then true else false end as is_verified,
+    archived,
+    null as action_type,
+    null as action_model_id,
+    null as collection_is_official,
+    null as collection_is_personal,
+    display as question_viz_type,
+   'database_' || database_id as question_database_id,
+    case when query_type='native' then true else false end as question_is_native,
+    null as event_timestamp
+    from report_card
+        left join (
+            select
+                moderated_item_type || '_' || moderated_item_id as entity_qualified_id,
+                case when status = 'verified' then true else false end as is_verified
+            from moderation_review
+            where most_recent
+        ) as moderation on 'card_' || report_card.id = moderation.entity_qualified_id
+union
+select
+    report_dashboard.id as entity_id,
+    'dashboard_' || report_dashboard.id as entity_qualified_id,
+    'dashboard' as entity_type,
+    created_at,
+    updated_at,
+    creator_id,
+    name,
+    description,
+    collection_id as collection_id,
+    made_public_by_id as made_public_by_user,
+    enable_embedding as is_embedding_enabled,
+    case when is_verified then true else false end as is_verified,
+    archived,
+    null as action_type,
+    null as action_model_id,
+    null as collection_is_official,
+    null as collection_is_personal,
+    null as question_viz_type,
+    null as question_database_id,
+    null as question_is_native,
+    null as event_timestamp
+    from report_dashboard
+        left join (
+            select
+                moderated_item_type || '_' || moderated_item_id as entity_qualified_id,
+                case when status = 'verified' then true else false end as is_verified
+            from moderation_review
+            where most_recent
+        ) as moderation on 'dashboard_' || report_dashboard.id = moderation.entity_qualified_id
+union
+select
+    document.id as entity_id,
+    'document_' || document.id as entity_qualified_id,
+    'document' as entity_type,
+    created_at,
+    updated_at,
+    creator_id,
+    name,
+    cast(null as text) as description,
+    collection_id as collection_id,
+    cast(null as int) as made_public_by_user,
+    cast(null as boolean) as is_embedding_enabled,
+    null::bool as is_verified,
+    archived,
+    null as action_type,
+    cast(null as int) as action_model_id,
+    null as collection_is_official,
+    null as collection_is_personal,
+    null as question_viz_type,
+    null as question_database_id,
+    cast(null as boolean) as question_is_native,
+    cast(null as timestamp) as event_timestamp
+    from document
+union
+select
+    event.id as entity_id,
+    'event_' || event.id as entity_qualified_id,
+    'event' as entity_type,
+    event.created_at,
+    event.updated_at,
+    event.creator_id,
+    event.name,
+    event.description,
+    timeline.collection_id,
+    null as made_public_by_user,
+    null as is_embedding_enabled,
+    null::bool as is_verified,
+    event.archived,
+    null as action_type,
+    null as action_model_id,
+    null as collection_is_official,
+    null as collection_is_personal,
+    null as question_viz_type,
+    null as question_database_id,
+    null as question_is_native,
+    timestamp as event_timestamp
+    from timeline_event event
+        left join timeline on event.timeline_id = timeline.id
+union
+select
+    transform.id as entity_id,
+    'transform_' || transform.id as entity_qualified_id,
+    'transform' as entity_type,
+    created_at,
+    updated_at,
+    creator_id,
+    name,
+    description,
+    cast(null as int) as collection_id,
+    cast(null as int) as made_public_by_user,
+    cast(null as boolean) as is_embedding_enabled,
+    null::bool as is_verified,
+    false as archived,
+    null as action_type,
+    cast(null as int) as action_model_id,
+    null as collection_is_official,
+    null as collection_is_personal,
+    null as question_viz_type,
+    null as question_database_id,
+    cast(null as boolean) as question_is_native,
+    cast(null as timestamp) as event_timestamp
+    from transform

--- a/resources/migrations/instance_analytics_views/content/v6/postgres-content.sql
+++ b/resources/migrations/instance_analytics_views/content/v6/postgres-content.sql
@@ -183,3 +183,27 @@ select
     cast(null as boolean) as question_is_native,
     cast(null as timestamp) as event_timestamp
     from transform
+union
+select
+    glossary.id as entity_id,
+    'glossary_' || glossary.id as entity_qualified_id,
+    'glossary' as entity_type,
+    created_at,
+    updated_at,
+    creator_id,
+    term as name,
+    definition as description,
+    cast(null as int) as collection_id,
+    cast(null as int) as made_public_by_user,
+    cast(null as boolean) as is_embedding_enabled,
+    null::bool as is_verified,
+    false as archived,
+    null as action_type,
+    cast(null as int) as action_model_id,
+    null as collection_is_official,
+    null as collection_is_personal,
+    null as question_viz_type,
+    null as question_database_id,
+    cast(null as boolean) as question_is_native,
+    cast(null as timestamp) as event_timestamp
+    from glossary

--- a/src/metabase/glossary/models/glossary.clj
+++ b/src/metabase/glossary/models/glossary.clj
@@ -11,6 +11,17 @@
   (derive :metabase/model)
   (derive :hook/timestamped?))
 
+(methodical/defmethod t2/batched-hydrate [:model/Glossary :creator]
+  "Add creator (user) to a glossary entry"
+  [_model _k glossary-entries]
+  (if-not (seq glossary-entries)
+    glossary-entries
+    (let [creator-ids (into #{} (map :creator_id) glossary-entries)
+          id->creator (t2/select-pk->fn identity [:model/User :id :email :first_name :last_name]
+                                        :id [:in creator-ids])]
+      (for [entry glossary-entries]
+        (assoc entry :creator (get id->creator (:creator_id entry)))))))
+
 (def GlossaryEntry
   "Schema for a glossary entry."
   [:map {:closed true}
@@ -34,7 +45,8 @@
 (defmethod serdes/make-spec "Glossary" [_model-name _opts]
   {:copy      [:term :definition]
    :transform {:created_at (serdes/date)
-               :updated_at (serdes/date)}})
+               :updated_at (serdes/date)
+               :creator_id (serdes/fk :model/User)}})
 
 (defmethod serdes/storage-path "Glossary" [item _]
   ["glossary" (:term item)])

--- a/test/metabase/glossary/models/glossary_test.clj
+++ b/test/metabase/glossary/models/glossary_test.clj
@@ -1,0 +1,47 @@
+(ns metabase.glossary.models.glossary-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.config.core :as config]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
+
+(deftest creator-hydration-test
+  (testing "Glossary creator hydration returns user details"
+    (let [user1-data {:first_name "Test"
+                      :last_name  "Creator"
+                      :email      "test.creator@example.com"}
+          user2-data {:first_name "Second"
+                      :last_name  "User"
+                      :email      "second.user@example.com"}]
+      (mt/with-temp [:model/User {user1-id :id} user1-data
+                     :model/Glossary glossary1 {:term       "API"
+                                                :definition "Application Programming Interface"
+                                                :creator_id user1-id}
+                     :model/User {user2-id :id} user2-data
+                     :model/Glossary glossary2 {:term       "REST"
+                                                :definition "Representational State Transfer"
+                                                :creator_id user2-id}]
+        (testing "Single glossary entry hydration"
+          (let [hydrated (t2/hydrate (t2/select-one :model/Glossary :id (:id glossary1)) :creator)]
+            (is (some? (:creator hydrated)))
+            (is (= user1-id (get-in hydrated [:creator :id])))
+            (is (= "Test" (get-in hydrated [:creator :first_name])))
+            (is (= "Creator" (get-in hydrated [:creator :last_name])))
+            (is (= "test.creator@example.com" (get-in hydrated [:creator :email])))))
+
+        (testing "Batch glossary entry hydration"
+          (let [glossary-entries (t2/select :model/Glossary :id [:in [(:id glossary1) (:id glossary2)]])
+                hydrated (t2/hydrate glossary-entries :creator)]
+            (is (= 2 (count hydrated)))
+            (is (every? #(some? (:creator %)) hydrated))
+            (let [creators-by-id (into {} (map (juxt :id :creator) hydrated))]
+              (is (= user1-id (get-in creators-by-id [(:id glossary1) :id])))
+              (is (= user2-id (get-in creators-by-id [(:id glossary2) :id])))
+              (is (= "Test" (get-in creators-by-id [(:id glossary1) :first_name])))
+              (is (= "Second" (get-in creators-by-id [(:id glossary2) :first_name]))))))
+
+        (testing "Glossary created without creator_id defaults to internal user"
+          (let [glossary-no-creator (t2/insert-returning-instance! :model/Glossary
+                                                                   {:term       "SQL"
+                                                                    :definition "Structured Query Language"})]
+            (is (= config/internal-mb-user-id (:creator_id glossary-no-creator)))))))))

--- a/test_resources/serialization_baseline/glossary/foobar.yaml
+++ b/test_resources/serialization_baseline/glossary/foobar.yaml
@@ -1,6 +1,7 @@
 created_at: '2025-09-18T13:38:26.721389Z'
 definition: It's foobar2000 actually
 term: foobar
+creator_id: 'internal@metabase.com'
 updated_at: '2025-09-18T13:38:26.721389Z'
 serdes/meta:
 - id: foobar


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-1246/populate-creator-for-transforms
Closes https://linear.app/metabase/issue/GDGT-1247/add-glossary-to-content
Closes https://linear.app/metabase/issue/GDGT-1248/add-creator-to-glossary-model

- add creator_id for transforms in v_content
- add glossary in v_content
- add creator_id for glossary 