### PR TITLE
Turn off db routing for clickhouse and it's trick.

### DIFF
--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
@@ -55,7 +55,7 @@
                               :rename                          true
                               :actions                         false
                               :metadata/key-constraints        false
-                              :database-routing                true
+                              :database-routing                false
                               :transforms/python               true
                               :transforms/table                true
                               ;; JDBC driver always provides "NO" for the IS_GENERATEDCOLUMN JDBC metadata

--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse_introspection.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse_introspection.clj
@@ -158,7 +158,6 @@
                 jdbc/metadata-result))))
        (filter not-inner-mv-table?)
        (tables-set)
-       (map #(assoc % :schema nil))
        (set)))
 
 (defmethod driver/describe-database* :clickhouse

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_introspection_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_introspection_test.clj
@@ -542,26 +542,3 @@
           ;; tables from `information_schema`
           (is (contains? tables tables-table))
           (is (contains? tables columns-table)))))))
-
-(deftest ^:parallel clickhouse-describe-database-enable-multiple-db-schema-test
-  (mt/test-driver :clickhouse
-    (let [tables-with-schema {:tables
-                              #{{:name "users", :schema "test_data", :description nil}
-                                {:name "venues", :schema "test_data", :description nil}
-                                {:name "categories", :schema "test_data", :description nil}
-                                {:name "checkins", :schema "test_data", :description nil}
-                                {:name "orders", :schema "test_data", :description nil}
-                                {:name "people", :schema "test_data", :description nil}
-                                {:name "products", :schema "test_data", :description nil}
-                                {:name "reviews", :schema "test_data", :description nil}}}]
-      (testing "when the enable-multiple-db is true describe-database returns tables with the db/schema"
-        (is (= tables-with-schema
-               (driver/describe-database driver/*driver* (mt/db)))))
-      (testing "when the enable-multiple-db is false describe-database returns tables without the db/schema"
-        (mt/with-temp [:model/Database db {:engine :clickhouse,
-                                           :details (assoc (:details (mt/db))
-                                                           :enable-multiple-db false
-                                                           :db-filters-type nil
-                                                           :db-filters-patterns nil)}]
-          (is (= {:tables (set (map #(assoc % :schema nil) (:tables tables-with-schema)))}
-                 (driver/describe-database driver/*driver* db))))))))


### PR DESCRIPTION
Closes: https://github.com/metabase/metabase/issues/65945
Relevant: https://github.com/metabase/metabase/pull/62090 https://linear.app/metabase/issue/QUE-1634/clickhouse-db-routing-need-multi-catalog

DB routing needs a "degree of freedom" to run the exact same query against a different schema/db/instance whatever. Clickhouse only has database.table. so to db route on the same clickhouse instance you have to omit the database and let it resolve during query time.

`select * from db.table` can't work. Have to do `select * from table` and let the connection dictate db1 or db2.

In 56, tables look like this:

```clojure
{:name "upload_records_10k_20251118164620", :schema "db_eafc4346850f435e"}
```

In 57, now they look like this for single db clickhouse things:

```clojure
{:name "upload_records_10k_20251118164620", :schema nil}
```

There are two critical problems here:
1. When uploading, it's not aware to omit the schema. So a table is created with that schema. During the next sync that table is archived and a new one with a nil'd schema is created. So the model created for the uploaded CSV would break as it points to an inactive table. This has a further compounding issue because now there "appear" to be two schema: the faked nil one and also a new one like `db_eafc...`.
2. But _all_ tables will be archived in the same manner which were initially found in 56 or below. These tables will be marked as inactive and new ones created. Meaning all mbql queries based on clickhouse will fail.

I wanted to revert this change but there's actually a bit more in the PR and some conflicts. It also does more than just enabling db-routing so I think we can perhaps undo the damage in this way more easily.