### PR TITLE
Update label placeholder text to Optional for Gauge visualization

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingSegmentsEditor/ChartSettingSegmentsEditor.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingSegmentsEditor/ChartSettingSegmentsEditor.tsx
@@ -61,7 +61,7 @@ export const ChartSettingSegmentsEditor = ({
               <td>
                 <TextInput
                   value={segment.label}
-                  placeholder={t`Label for this range (optional)`}
+                  placeholder={t`Optional`}
                   onChange={(e) =>
                     onChangeProperty(index, "label", e.target.value)
                   }

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingSegmentsEditor/ChartSettingSegmentsEditor.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingSegmentsEditor/ChartSettingSegmentsEditor.unit.spec.tsx
@@ -32,9 +32,7 @@ it("Should render a segment editor", () => {
 
   const firstRow = screen.getAllByRole("row").at(1) as HTMLElement;
 
-  expect(within(firstRow).getByPlaceholderText(/Label for this/)).toHaveValue(
-    "bad",
-  );
+  expect(within(firstRow).getByPlaceholderText(/Optional/)).toHaveValue("bad");
   expect(within(firstRow).getByPlaceholderText(/Min/)).toHaveValue("0");
   expect(within(firstRow).getByPlaceholderText(/Max/)).toHaveValue("100");
 });


### PR DESCRIPTION
Change placeholder for label to fit within the text box, and be more concise:
<img width="2040" height="1043" alt="image" src="https://github.com/user-attachments/assets/9c887e2d-4e67-427f-9cd9-cff5e35cb045" />
