### PR TITLE
Fix bug / bad type in SchemaFormSelect

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/transforms/components/SchemaFormSelect/SchemaFormSelect.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/components/SchemaFormSelect/SchemaFormSelect.tsx
@@ -8,15 +8,15 @@ import { SelectItem, Text } from "metabase/ui";
 
 export function SchemaFormSelect(props: FormSelectProps & { data: string[] }) {
   const { data, name, ...rest } = props;
-  const [{ value }] = useField(name);
+  const [{ value }] = useField<string | null>(name);
 
-  const [searchValue, setSearchValue] = useState(value);
+  const [searchValue, setSearchValue] = useState(value ?? "");
   const dataWithNewItem = _.uniq([
     ...data,
     ...(searchValue !== "" ? [searchValue] : []),
   ]);
 
-  const isNewValue = value !== "" && !data.includes(value);
+  const isNewValue = value !== "" && !data.includes(value ?? "");
 
   return (
     <FormField>


### PR DESCRIPTION
`SchemaFormSelect`'s `useField` value was of type `any` not `string | null`, typing this correctly surfaces the issue. When `null` was received the `searchValue !== ""` portion of this code
```typescript
 const dataWithNewItem = _.uniq([
    ...data,
    ...(searchValue !== "" ? [searchValue] : []),
  ]);
``` 
would match on !== resulting in 
```typescript
 const dataWithNewItem = _.uniq([
    ...data,
    ...[null],
  ]);
```
ultimately producing values like `["public", null]`. Once this `null` made it to Mantine's `Select`, the component would error out.