### PR TITLE
Replace amalloy/ring-buffer dependency with already included CircularFifoQueue

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -4,10 +4,7 @@
  ;; !!                                   PLEASE KEEP THESE ORGANIZED ALPHABETICALLY                                  !!
  ;; !!                                   AND ADD A COMMENT EXPLAINING THEIR PURPOSE                                  !!
  ;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
- {amalloy/ring-buffer                       {:mvn/version "1.3.1"               ; fixed length queue implementation, used in log buffering
-                                             :exclusions  [org.clojure/clojure
-                                                           org.clojure/clojurescript]}
-  amalloy/ring-gzip-middleware              {:mvn/version "0.1.4"}              ; Ring middleware to GZIP responses if client can handle it
+ {amalloy/ring-gzip-middleware              {:mvn/version "0.1.4"}              ; Ring middleware to GZIP responses if client can handle it
   babashka/fs                               {:mvn/version "0.5.27"}             ; Portable filesystem operations
   bigml/histogram                           {:mvn/version "5.0.0"               ; Histogram data structure
                                              :exclusions  [junit/junit]}


### PR DESCRIPTION
We currently only use ring-buffer library in one place – in logger implementation to keep a sliding buffer of log messages. Since we already have Apache Commons on the classpath and will very unlikely ever get rid of it, it makes sense to use it here and spare an extra dependency.

As an alternative, if you don't like exlicitly depending on Commons, we can use a small custom wrapper around ABQ for the same result.

Another question is whether I should explicitly mention apache-commons in `deps.edn` now.