### PR TITLE
Embed necessary part of crypto-random dependency and remove it

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -76,7 +76,6 @@
                                                            commons-logging/commons-logging]}
   compojure/compojure                       {:mvn/version "1.7.2"               ; HTTP Routing library built on Ring
                                              :exclusions  [ring/ring-codec]}
-  crypto-random/crypto-random               {:mvn/version "1.2.1"}              ; library for generating cryptographically secure random bytes and strings
   diehard/diehard                           {:mvn/version "0.12.0"}
   dk.ative/docjure                          {:mvn/version "1.22.0"              ; excel export
                                              :exclusions  [org.apache.poi/poi

--- a/enterprise/backend/test/metabase_enterprise/content_translation/routes_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_translation/routes_test.clj
@@ -4,10 +4,10 @@
    [buddy.sign.jwt :as jwt]
    [clojure.data.csv :as csv]
    [clojure.test :refer :all]
-   [crypto.random :as crypto-random]
    [metabase-enterprise.content-translation.utils :as ct-utils]
    [metabase.test :as mt]
    [metabase.test.http-client :as client]
+   [metabase.util.random :as u.random]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -116,7 +116,7 @@
                                         {:request-options {:headers {"content-type" "multipart/form-data"}}}
                                         {:file csv-with-invalid-locale}))))))))
 
-(defn random-embedding-secret-key [] (crypto-random/hex 32))
+(defn random-embedding-secret-key [] (u.random/secure-hex 32))
 
 (defn do-with-new-secret-key! [f]
   (let [secret-key (random-embedding-secret-key)]

--- a/enterprise/backend/test/metabase_enterprise/sso/api/sso_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/api/sso_test.clj
@@ -3,13 +3,13 @@
    [buddy.sign.jwt :as jwt]
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [crypto.random :as crypto-random]
    [metabase.config.core :as config]
    [metabase.request.core :as request]
    [metabase.session.core :as session]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
-   [metabase.test.http-client :as client]))
+   [metabase.test.http-client :as client]
+   [metabase.util.random :as u.random]))
 
 (set! *warn-on-reflection* true)
 
@@ -54,7 +54,7 @@
                               "%2FYw11yAqadb8%3D")
                              (:saml-logout-url response))))))))))))))
 
-(def ^:private default-jwt-secret (crypto-random/hex 32))
+(def ^:private default-jwt-secret (u.random/secure-hex 32))
 
 (defn- with-jwt-settings! [f]
   (mt/with-additional-premium-features #{:sso-jwt}

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
@@ -4,7 +4,6 @@
    [buddy.sign.util :as buddy-util]
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [crypto.random :as crypto-random]
    [metabase-enterprise.sso.integrations.saml-test :as saml-test]
    [metabase-enterprise.sso.integrations.token-utils :as token-utils]
    [metabase-enterprise.sso.settings :as sso-settings]
@@ -16,6 +15,7 @@
    [metabase.test.http-client :as client]
    [metabase.util :as u]
    [metabase.util.malli.schema :as ms]
+   [metabase.util.random :as u.random]
    [toucan2.core :as t2]))
 
 (use-fixtures :once (fixtures/initialize :test-users))
@@ -36,7 +36,7 @@
 
 (def ^:private default-idp-uri "http://test.idp.metabase.com")
 (def ^:private default-redirect-uri "/")
-(def ^:private default-jwt-secret (crypto-random/hex 32))
+(def ^:private default-jwt-secret (u.random/secure-hex 32))
 
 (defn- call-with-default-jwt-config! [f]
   (let [current-features (token-check/*token-features*)]

--- a/src/metabase/api/util.clj
+++ b/src/metabase/api/util.clj
@@ -2,8 +2,8 @@
   "Random utilty endpoints for things that don't belong anywhere else in particular, e.g. endpoints for certain admin
   page tasks."
   (:require
-   [crypto.random :as crypto-random]
-   [metabase.api.macros :as api.macros]))
+   [metabase.api.macros :as api.macros]
+   [metabase.util.random :as u.random]))
 
 (set! *warn-on-reflection* true)
 
@@ -13,4 +13,4 @@
   "Return a cryptographically secure random 32-byte token, encoded as a hexadecimal string.
    Intended for use when creating a value for `embedding-secret-key`."
   []
-  {:token (crypto-random/hex 32)})
+  {:token (u.random/secure-hex 32)})

--- a/src/metabase/api_keys/models/api_key.clj
+++ b/src/metabase/api_keys/models/api_key.clj
@@ -3,7 +3,6 @@
   various Toucan CRUD methods for `:model/ApiKey`... see below."
   (:require
    [clojure.core.memoize :as memoize]
-   [crypto.random :as crypto-random]
    [java-time.api :as t]
    [malli.error :as me]
    [metabase.api-keys.core :as-alias api-keys]
@@ -19,6 +18,7 @@
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [metabase.util.password :as u.password]
+   [metabase.util.random :as u.random]
    [metabase.util.secret :as u.secret]
    [methodical.core :as methodical]
    [toucan2.core :as t2]
@@ -82,7 +82,7 @@
   "Generates a new API key - a random base64 string prefixed with `mb_`"
   []
   (u.secret/secret
-   (str "mb_" (crypto-random/base64 api-keys.schema/generated-bytes-key-length))))
+   (str "mb_" (u.random/secure-base64 api-keys.schema/generated-bytes-key-length))))
 
 (mu/defn mask :- ::api-keys.schema/key.masked
   "Given an API key, returns a string of the same length with all but the prefix masked with `*`s"

--- a/src/metabase/embedding/settings.clj
+++ b/src/metabase/embedding/settings.clj
@@ -2,7 +2,6 @@
   "Settings related to embedding Metabase in other applications."
   (:require
    [clojure.string :as str]
-   [crypto.random :as crypto-random]
    [metabase.analytics.core :as analytics]
    [metabase.config.core :as config]
    [metabase.premium-features.core :as premium-features]
@@ -12,6 +11,7 @@
    [metabase.util.i18n :as i18n :refer [deferred-tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
+   [metabase.util.random :as u.random]
    [toucan2.core :as t2]))
 
 (defsetting embedding-secret-key
@@ -60,7 +60,7 @@
         (when (not= new-value old-value)
           (setting/set-value-of-type! :boolean setting-key new-value)
           (when (and new-value (str/blank? (embedding-secret-key)))
-            (embedding-secret-key! (crypto-random/hex 32)))
+            (embedding-secret-key! (u.random/secure-hex 32)))
           (analytics/track-event! :snowplow/embed_share
                                   {:event                      (keyword (str event-name (if new-value "-enabled" "-disabled")))
                                    :embedding-app-origin-set   (boolean

--- a/src/metabase/util/random.cljc
+++ b/src/metabase/util/random.cljc
@@ -1,7 +1,14 @@
 (ns metabase.util.random
   (:require
    [clojure.string :as str]
-   [metabase.util :as u]))
+   [metabase.util :as u])
+  #?(:clj
+     (:import
+      (java.security SecureRandom)
+      (org.apache.commons.codec.binary Base64 Hex))))
+
+#?(:clj
+   (set! *warn-on-reflection* true))
 
 (defn- random-uppercase-letter []
   (char (+ (int \A) (rand-int 26))))
@@ -25,3 +32,24 @@
   "Generate a random email address."
   []
   (str (u/lower-case-en (random-name)) "@metabase.com"))
+
+;; The following functions provide cryptographically secure random generation, replacing the crypto-random library
+;; dependency with inline implementations.
+
+#?(:clj
+   (defn- secure-random-bytes ^bytes [size]
+     (let [arr (byte-array size)]
+       (.nextBytes (SecureRandom.) arr)
+       arr)))
+
+#?(:clj
+   (defn secure-hex
+     "Return a cryptographically secure random hex string of the specified size in bytes."
+     [size]
+     (Hex/encodeHexString (secure-random-bytes size))))
+
+#?(:clj
+   (defn secure-base64
+     "Return a cryptographically secure random Base64 string of the specified size in bytes."
+     [size]
+     (Base64/encodeBase64String (secure-random-bytes size))))

--- a/test/metabase/embedding/jwt_test.clj
+++ b/test/metabase/embedding/jwt_test.clj
@@ -2,9 +2,9 @@
   (:require
    [buddy.sign.jwt :as jwt]
    [clojure.test :refer :all]
-   [crypto.random :as crypto-random]
    [metabase.embedding.jwt :as embed]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.util.random :as u.random]))
 
 (def ^:private ^String token-with-alg-none
   "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJhZG1pbiI6dHJ1ZX0.3Dbtd6Z0yuSfw62fOzBGHyiL0BJp3pod_PZE-BBdR-I")
@@ -16,7 +16,7 @@
 
 (deftest disallow-unsigned-tokens-test
   (testing "check that we disallow tokens signed with alg = none"
-    (mt/with-temporary-setting-values [embedding-secret-key (crypto-random/hex 32)]
+    (mt/with-temporary-setting-values [embedding-secret-key (u.random/secure-hex 32)]
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo
            #"JWT `alg` cannot be `none`"

--- a/test/metabase/embedding_rest/api/embed_test.clj
+++ b/test/metabase/embedding_rest/api/embed_test.clj
@@ -7,7 +7,6 @@
    [clojure.set :as set]
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [crypto.random :as crypto-random]
    [dk.ative.docjure.spreadsheet :as spreadsheet]
    [java-time.api :as t]
    [metabase.api.common :as api]
@@ -26,13 +25,14 @@
    [metabase.test.http-client :as client]
    [metabase.tiles.api-test :as tiles.api-test]
    [metabase.util :as u]
+   [metabase.util.random :as u.random]
    [toucan2.core :as t2])
   (:import
    (java.io ByteArrayInputStream)))
 
 (set! *warn-on-reflection* true)
 
-(defn random-embedding-secret-key [] (crypto-random/hex 32))
+(defn random-embedding-secret-key [] (u.random/secure-hex 32))
 
 (def ^:dynamic *secret-key* nil)
 

--- a/test/metabase/embedding_rest/api/preview_embed_test.clj
+++ b/test/metabase/embedding_rest/api/preview_embed_test.clj
@@ -2,7 +2,6 @@
   (:require
    [buddy.sign.jwt :as jwt]
    [clojure.test :refer :all]
-   [crypto.random :as crypto-random]
    [metabase.dashboards-rest.api-test :as api.dashboard-test]
    [metabase.embedding-rest.api.embed-test :as embed-test]
    [metabase.embedding-rest.api.preview-embed :as api.preview-embed]
@@ -11,6 +10,7 @@
    [metabase.tiles.api-test :as tiles.api-test]
    [metabase.util :as u]
    [metabase.util.json :as json]
+   [metabase.util.random :as u.random]
    [toucan2.core :as t2]))
 
 ;;; --------------------------------------- GET /api/preview_embed/card/:token ---------------------------------------
@@ -527,7 +527,7 @@
 
 ;;; ------------------------------------------------ Chain filtering -------------------------------------------------
 
-(defn random-embedding-secret-key [] (crypto-random/hex 32))
+(defn random-embedding-secret-key [] (u.random/secure-hex 32))
 
 (def ^:dynamic *secret-key* nil)
 


### PR DESCRIPTION
This is a very small dependency and we only need two slim functions from it, so might as well embed it into `metabase.util.random` namespace which we already have and drop the dependency.