### PR TITLE
fix: handle invalid email address in auth-identity

### DIFF
--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -211,226 +211,6 @@ databaseChangeLog:
             constraintName: fk_auth_identity_core_user_id
 
   - changeSet:
-      id: v58.2025-11-12T00:00:03
-      author: edpaget
-      comment: Migrate password authentication to auth_identity table
-      changes:
-        - sql:
-            dbms: postgresql
-            sql: >-
-              INSERT INTO auth_identity (user_id, provider, provider_id, credentials, metadata, created_at, updated_at)
-              SELECT
-                id,
-                'password',
-                email,
-                json_build_object('password_hash', password, 'password_salt', password_salt)::text,
-                NULL,
-                COALESCE(date_joined, now()),
-                now()
-              FROM core_user
-              WHERE password IS NOT NULL
-              ON CONFLICT (user_id, provider) DO NOTHING;
-        - sql:
-            dbms: mysql,mariadb
-            sql: >-
-              INSERT IGNORE INTO auth_identity (user_id, provider, provider_id, credentials, metadata, created_at, updated_at)
-              SELECT
-                id,
-                'password',
-                email,
-                json_object('password_hash', password, 'password_salt', password_salt),
-                NULL,
-                COALESCE(date_joined, now()),
-                now()
-              FROM core_user
-              WHERE password IS NOT NULL;
-        - sql:
-            dbms: h2
-            sql: >-
-              INSERT INTO auth_identity (user_id, provider, provider_id, credentials, metadata, created_at, updated_at)
-              SELECT
-                id,
-                'password',
-                email,
-                CONCAT('{"password_hash":"', password, '","password_salt":"', password_salt, '"}'),
-                NULL,
-                COALESCE(date_joined, now()),
-                now()
-              FROM core_user
-              WHERE password IS NOT NULL
-                AND NOT EXISTS (
-                  SELECT 1 FROM auth_identity ai
-                  WHERE ai.user_id = core_user.id AND ai.provider = 'password'
-                );
-      rollback:
-        - sql: DELETE FROM auth_identity WHERE provider = 'password';
-
-  - changeSet:
-      id: v58.2025-11-12T00:00:04
-      author: edpaget
-      comment: Migrate LDAP authentication to auth_identity table
-      changes:
-        - sql:
-            dbms: postgresql
-            sql: >-
-              INSERT INTO auth_identity (user_id, provider, provider_id, credentials, metadata, created_at, updated_at)
-              SELECT
-                id,
-                'ldap',
-                email,
-                NULL,
-                json_build_object('login_attributes', login_attributes)::text,
-                COALESCE(date_joined, now()),
-                now()
-              FROM core_user
-              WHERE sso_source = 'ldap'
-              ON CONFLICT (user_id, provider) DO NOTHING;
-        - sql:
-            dbms: mysql,mariadb
-            sql: >-
-              INSERT IGNORE INTO auth_identity (user_id, provider, provider_id, credentials, metadata, created_at, updated_at)
-              SELECT
-                id,
-                'ldap',
-                email,
-                NULL,
-                json_object('login_attributes', login_attributes),
-                COALESCE(date_joined, now()),
-                now()
-              FROM core_user
-              WHERE sso_source = 'ldap';
-        - sql:
-            dbms: h2
-            sql: >-
-              INSERT INTO auth_identity (user_id, provider, provider_id, credentials, metadata, created_at, updated_at)
-              SELECT
-                id,
-                'ldap',
-                email,
-                NULL,
-                CONCAT('{"login_attributes":', COALESCE(login_attributes, 'null'), '}'),
-                COALESCE(date_joined, now()),
-                now()
-              FROM core_user
-              WHERE sso_source = 'ldap'
-                AND NOT EXISTS (
-                  SELECT 1 FROM auth_identity ai
-                  WHERE ai.user_id = core_user.id AND ai.provider = 'ldap'
-                );
-      rollback:
-        - sql: DELETE FROM auth_identity WHERE provider = 'ldap';
-
-  - changeSet:
-      id: v58.2025-11-12T00:00:05
-      author: edpaget
-      comment: Migrate Google SSO authentication to auth_identity table
-      changes:
-        - sql:
-            dbms: postgresql
-            sql: >-
-              INSERT INTO auth_identity (user_id, provider, provider_id, credentials, metadata, created_at, updated_at)
-              SELECT
-                id,
-                'google',
-                email,
-                NULL,
-                json_build_object('sso_source', 'google', 'login_attributes', login_attributes)::text,
-                COALESCE(date_joined, now()),
-                now()
-              FROM core_user
-              WHERE sso_source = 'google'
-              ON CONFLICT (user_id, provider) DO NOTHING;
-        - sql:
-            dbms: mysql,mariadb
-            sql: >-
-              INSERT IGNORE INTO auth_identity (user_id, provider, provider_id, credentials, metadata, created_at, updated_at)
-              SELECT
-                id,
-                'google',
-                email,
-                NULL,
-                json_object('sso_source', 'google', 'login_attributes', login_attributes),
-                COALESCE(date_joined, now()),
-                now()
-              FROM core_user
-              WHERE sso_source = 'google';
-        - sql:
-            dbms: h2
-            sql: >-
-              INSERT INTO auth_identity (user_id, provider, provider_id, credentials, metadata, created_at, updated_at)
-              SELECT
-                id,
-                'google',
-                email,
-                NULL,
-                CONCAT('{"sso_source":"google","login_attributes":', COALESCE(login_attributes, 'null'), '}'),
-                COALESCE(date_joined, now()),
-                now()
-              FROM core_user
-              WHERE sso_source = 'google'
-                AND NOT EXISTS (
-                  SELECT 1 FROM auth_identity ai
-                  WHERE ai.user_id = core_user.id AND ai.provider = 'google'
-                );
-      rollback:
-        - sql: DELETE FROM auth_identity WHERE provider = 'google';
-
-  - changeSet:
-      id: v58.2025-11-12T00:00:06
-      author: edpaget
-      comment: Migrate SAML and JWT authentication to auth_identity table
-      changes:
-        - sql:
-            dbms: postgresql
-            sql: >-
-              INSERT INTO auth_identity (user_id, provider, provider_id, credentials, metadata, created_at, updated_at)
-              SELECT
-                id,
-                sso_source,
-                email,
-                NULL,
-                json_build_object('sso_source', sso_source, 'login_attributes', login_attributes, 'jwt_attributes', jwt_attributes)::text,
-                COALESCE(date_joined, now()),
-                now()
-              FROM core_user
-              WHERE sso_source IN ('saml', 'jwt')
-              ON CONFLICT (user_id, provider) DO NOTHING;
-        - sql:
-            dbms: mysql,mariadb
-            sql: >-
-              INSERT IGNORE INTO auth_identity (user_id, provider, provider_id, credentials, metadata, created_at, updated_at)
-              SELECT
-                id,
-                sso_source,
-                email,
-                NULL,
-                json_object('sso_source', sso_source, 'login_attributes', login_attributes, 'jwt_attributes', jwt_attributes),
-                COALESCE(date_joined, now()),
-                now()
-              FROM core_user
-              WHERE sso_source IN ('saml', 'jwt');
-        - sql:
-            dbms: h2
-            sql: >-
-              INSERT INTO auth_identity (user_id, provider, provider_id, credentials, metadata, created_at, updated_at)
-              SELECT
-                id,
-                sso_source,
-                email,
-                NULL,
-                CONCAT('{"sso_source":"', sso_source, '","login_attributes":', COALESCE(login_attributes, 'null'), ',"jwt_attributes":', COALESCE(jwt_attributes, 'null'), '}'),
-                COALESCE(date_joined, now()),
-                now()
-              FROM core_user
-              WHERE sso_source IN ('saml', 'jwt')
-                AND NOT EXISTS (
-                  SELECT 1 FROM auth_identity ai
-                  WHERE ai.user_id = core_user.id AND ai.provider = core_user.sso_source
-                );
-      rollback:
-        - sql: DELETE FROM auth_identity WHERE provider IN ('saml', 'jwt');
-
-  - changeSet:
       id: v58.2025-11-12T00:00:07
       author: edpaget
       comment: Add auth_identity_id columns to core_session table
@@ -500,6 +280,226 @@ databaseChangeLog:
         - dropForeignKeyConstraint:
             baseTableName: core_session
             constraintName: fk_session_auth_identity
+
+  - changeSet:
+      id: v58.2025-11-12T00:00:11
+      author: edpaget
+      comment: Migrate password authentication to auth_identity table
+      changes:
+        - sql:
+            dbms: postgresql
+            sql: >-
+              INSERT INTO auth_identity (user_id, provider, provider_id, credentials, metadata, created_at, updated_at)
+              SELECT
+                id,
+                'password',
+                LEFT(email, 255),
+                json_build_object('password_hash', password, 'password_salt', password_salt)::text,
+                NULL,
+                COALESCE(date_joined, now()),
+                now()
+              FROM core_user
+              WHERE password IS NOT NULL
+              ON CONFLICT (user_id, provider) DO NOTHING;
+        - sql:
+            dbms: mysql,mariadb
+            sql: >-
+              INSERT IGNORE INTO auth_identity (user_id, provider, provider_id, credentials, metadata, created_at, updated_at)
+              SELECT
+                id,
+                'password',
+                LEFT(email, 255),
+                json_object('password_hash', password, 'password_salt', password_salt),
+                NULL,
+                COALESCE(date_joined, now()),
+                now()
+              FROM core_user
+              WHERE password IS NOT NULL;
+        - sql:
+            dbms: h2
+            sql: >-
+              INSERT INTO auth_identity (user_id, provider, provider_id, credentials, metadata, created_at, updated_at)
+              SELECT
+                id,
+                'password',
+                LEFT(email, 255),
+                CONCAT('{"password_hash":"', password, '","password_salt":"', password_salt, '"}'),
+                NULL,
+                COALESCE(date_joined, now()),
+                now()
+              FROM core_user
+              WHERE password IS NOT NULL
+                AND NOT EXISTS (
+                  SELECT 1 FROM auth_identity ai
+                  WHERE ai.user_id = core_user.id AND ai.provider = 'password'
+                );
+      rollback:
+        - sql: DELETE FROM auth_identity WHERE provider = 'password';
+
+  - changeSet:
+      id: v58.2025-11-12T00:00:12
+      author: edpaget
+      comment: Migrate LDAP authentication to auth_identity table
+      changes:
+        - sql:
+            dbms: postgresql
+            sql: >-
+              INSERT INTO auth_identity (user_id, provider, provider_id, credentials, metadata, created_at, updated_at)
+              SELECT
+                id,
+                'ldap',
+                LEFT(email, 255),
+                NULL,
+                json_build_object('login_attributes', login_attributes)::text,
+                COALESCE(date_joined, now()),
+                now()
+              FROM core_user
+              WHERE sso_source = 'ldap'
+              ON CONFLICT (user_id, provider) DO NOTHING;
+        - sql:
+            dbms: mysql,mariadb
+            sql: >-
+              INSERT IGNORE INTO auth_identity (user_id, provider, provider_id, credentials, metadata, created_at, updated_at)
+              SELECT
+                id,
+                'ldap',
+                LEFT(email, 255),
+                NULL,
+                json_object('login_attributes', login_attributes),
+                COALESCE(date_joined, now()),
+                now()
+              FROM core_user
+              WHERE sso_source = 'ldap';
+        - sql:
+            dbms: h2
+            sql: >-
+              INSERT INTO auth_identity (user_id, provider, provider_id, credentials, metadata, created_at, updated_at)
+              SELECT
+                id,
+                'ldap',
+                LEFT(email, 255),
+                NULL,
+                CONCAT('{"login_attributes":', COALESCE(login_attributes, 'null'), '}'),
+                COALESCE(date_joined, now()),
+                now()
+              FROM core_user
+              WHERE sso_source = 'ldap'
+                AND NOT EXISTS (
+                  SELECT 1 FROM auth_identity ai
+                  WHERE ai.user_id = core_user.id AND ai.provider = 'ldap'
+                );
+      rollback:
+        - sql: DELETE FROM auth_identity WHERE provider = 'ldap';
+
+  - changeSet:
+      id: v58.2025-11-12T00:00:13
+      author: edpaget
+      comment: Migrate Google SSO authentication to auth_identity table
+      changes:
+        - sql:
+            dbms: postgresql
+            sql: >-
+              INSERT INTO auth_identity (user_id, provider, provider_id, credentials, metadata, created_at, updated_at)
+              SELECT
+                id,
+                'google',
+                LEFT(email, 255),
+                NULL,
+                json_build_object('sso_source', 'google', 'login_attributes', login_attributes)::text,
+                COALESCE(date_joined, now()),
+                now()
+              FROM core_user
+              WHERE sso_source = 'google'
+              ON CONFLICT (user_id, provider) DO NOTHING;
+        - sql:
+            dbms: mysql,mariadb
+            sql: >-
+              INSERT IGNORE INTO auth_identity (user_id, provider, provider_id, credentials, metadata, created_at, updated_at)
+              SELECT
+                id,
+                'google',
+                LEFT(email, 255),
+                NULL,
+                json_object('sso_source', 'google', 'login_attributes', login_attributes),
+                COALESCE(date_joined, now()),
+                now()
+              FROM core_user
+              WHERE sso_source = 'google';
+        - sql:
+            dbms: h2
+            sql: >-
+              INSERT INTO auth_identity (user_id, provider, provider_id, credentials, metadata, created_at, updated_at)
+              SELECT
+                id,
+                'google',
+                LEFT(email, 255),
+                NULL,
+                CONCAT('{"sso_source":"google","login_attributes":', COALESCE(login_attributes, 'null'), '}'),
+                COALESCE(date_joined, now()),
+                now()
+              FROM core_user
+              WHERE sso_source = 'google'
+                AND NOT EXISTS (
+                  SELECT 1 FROM auth_identity ai
+                  WHERE ai.user_id = core_user.id AND ai.provider = 'google'
+                );
+      rollback:
+        - sql: DELETE FROM auth_identity WHERE provider = 'google';
+
+  - changeSet:
+      id: v58.2025-11-12T00:00:14
+      author: edpaget
+      comment: Migrate SAML and JWT authentication to auth_identity table
+      changes:
+        - sql:
+            dbms: postgresql
+            sql: >-
+              INSERT INTO auth_identity (user_id, provider, provider_id, credentials, metadata, created_at, updated_at)
+              SELECT
+                id,
+                sso_source,
+                LEFT(email, 255),
+                NULL,
+                json_build_object('sso_source', sso_source, 'login_attributes', login_attributes, 'jwt_attributes', jwt_attributes)::text,
+                COALESCE(date_joined, now()),
+                now()
+              FROM core_user
+              WHERE sso_source IN ('saml', 'jwt')
+              ON CONFLICT (user_id, provider) DO NOTHING;
+        - sql:
+            dbms: mysql,mariadb
+            sql: >-
+              INSERT IGNORE INTO auth_identity (user_id, provider, provider_id, credentials, metadata, created_at, updated_at)
+              SELECT
+                id,
+                sso_source,
+                LEFT(email, 255),
+                NULL,
+                json_object('sso_source', sso_source, 'login_attributes', login_attributes, 'jwt_attributes', jwt_attributes),
+                COALESCE(date_joined, now()),
+                now()
+              FROM core_user
+              WHERE sso_source IN ('saml', 'jwt');
+        - sql:
+            dbms: h2
+            sql: >-
+              INSERT INTO auth_identity (user_id, provider, provider_id, credentials, metadata, created_at, updated_at)
+              SELECT
+                id,
+                sso_source,
+                LEFT(email, 255),
+                NULL,
+                CONCAT('{"sso_source":"', sso_source, '","login_attributes":', COALESCE(login_attributes, 'null'), ',"jwt_attributes":', COALESCE(jwt_attributes, 'null'), '}'),
+                COALESCE(date_joined, now()),
+                now()
+              FROM core_user
+              WHERE sso_source IN ('saml', 'jwt')
+                AND NOT EXISTS (
+                  SELECT 1 FROM auth_identity ai
+                  WHERE ai.user_id = core_user.id AND ai.provider = core_user.sso_source
+                );
+      rollback:
+        - sql: DELETE FROM auth_identity WHERE provider IN ('saml', 'jwt');
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/test/metabase/app_db/schema_migrations_test.clj
+++ b/test/metabase/app_db/schema_migrations_test.clj
@@ -2764,7 +2764,7 @@
 
 (deftest migrate-password-auth-test
   (testing "Migration v58.2025-11-04T23:10:03: Migrate password authentication to auth_identity table"
-    (impl/test-migrations ["v58.2025-11-04T23:09:49" "v58.2025-11-12T00:00:03"] [migrate!]
+    (impl/test-migrations ["v58.2025-11-04T23:09:49" "v58.2025-11-12T00:00:11"] [migrate!]
       ;; Insert users with password auth before migration
       (t2/query-one {:insert-into :core_user
                      :values      [{:first_name    "Password"
@@ -2792,7 +2792,7 @@
 
 (deftest migrate-ldap-auth-test-2
   (testing "Migration v58.2025-11-04T23:10:04: Migrate LDAP authentication to auth_identity table"
-    (impl/test-migrations ["v58.2025-11-04T23:09:49" "v58.2025-11-12T00:00:04"] [migrate!]
+    (impl/test-migrations ["v58.2025-11-04T23:09:49" "v58.2025-11-12T00:00:12"] [migrate!]
       ;; Insert users with LDAP auth before migration (using sso_source='ldap' from current schema)
       (t2/query-one {:insert-into :core_user
                      :values      [{:first_name    "LDAP"
@@ -2819,7 +2819,7 @@
 
 (deftest migrate-google-sso-auth-test
   (testing "Migration v58.2025-11-04T23:10:05: Migrate Google SSO authentication to auth_identity table"
-    (impl/test-migrations ["v58.2025-11-04T23:09:49" "v58.2025-11-12T00:00:05"] [migrate!]
+    (impl/test-migrations ["v58.2025-11-04T23:09:49" "v58.2025-11-12T00:00:13"] [migrate!]
       ;; Insert users with Google SSO before migration
       (t2/query-one {:insert-into :core_user
                      :values      [{:first_name    "Google"
@@ -2845,7 +2845,7 @@
 
 (deftest migrate-saml-jwt-auth-test
   (testing "Migration v58.2025-11-04T23:10:06: Migrate SAML and JWT authentication to auth_identity table"
-    (impl/test-migrations ["v58.2025-11-04T23:09:49" "v58.2025-11-12T00:00:06"] [migrate!]
+    (impl/test-migrations ["v58.2025-11-04T23:09:49" "v58.2025-11-12T00:00:14"] [migrate!]
       ;; Insert users with SAML and JWT before migration
       (t2/query-one {:insert-into :core_user
                      :values      [{:first_name    "SAML"


### PR DESCRIPTION
### Description

...migrations.

Handles cases where emails were set to longer than the valid length of 254 bytes. Those emails would fail on this migration previously. We're not currently using auth-identity to lookup email addresses so this won't cause any incorrect behavior, but also if any emails like this exist they weren't valid anyway.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
