### PR TITLE
fix(docs): fix sdk docs not being generated correctly

### DIFF
--- a/bin/embedding-sdk/fixup-types-after-compilation.js
+++ b/bin/embedding-sdk/fixup-types-after-compilation.js
@@ -20,8 +20,9 @@ const REPLACES_MAP = {
   "metabase-types": "frontend/src/metabase-types",
   metabase: "frontend/src/metabase",
   "embedding-sdk-package": "enterprise/frontend/src/embedding-sdk-package",
-  "embedding-sdk-bundle": "enterprise/frontend/src/embedding-sdk-bundle",
-  "embedding-sdk-shared": "enterprise/frontend/src/embedding-sdk-shared",
+  "embedding-sdk-bundle": "frontend/src/embedding-sdk-bundle",
+  "embedding-sdk-shared": "frontend/src/embedding-sdk-shared",
+  "embedding-sdk-ee": "enterprise/frontend/src/embedding-sdk-ee",
   cljs: "target/cljs_release",
 };
 


### PR DESCRIPTION
Context: https://metaboat.slack.com/archives/C063Q3F1HPF/p1763567831165189

###
Apparently i completly broke the generated dts files with  https://github.com/metabase/metabase/pull/65753 because I didn't update the path references in the fixup script

## How to verify:

Run `yarn embedding-sdk:docs:generate`

before this `docs/embedding/sdk/api/snippets` was not getting all the files that it should have had, after this, it does.