### PR TITLE
fix: use new is_shared_tenant_collection column

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/stale/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/stale/impl.clj
@@ -47,7 +47,7 @@
            [:= :report_card.archived false]
            [:<= :report_card.last_used_at (-> args :cutoff-date)]
            ;; find things only in regular collections, not the `instance-analytics` collection.
-           [:or [:= :collection.type nil] [:= :collection.type "shared-tenant-collection"]]
+           [:or [:= :collection.type nil] [:= :collection.is_shared_tenant_collection true]]
            (when (embed.settings/some-embedding-enabled?)
              [:= :report_card.enable_embedding false])
            (when (setting/get :enable-public-sharing)
@@ -79,7 +79,7 @@
            [:= :report_dashboard.archived false]
            [:<= :report_dashboard.last_viewed_at (-> args :cutoff-date)]
            ;; find things only in regular collections, not the `instance-analytics` collection.
-           [:or [:= :collection.type nil] [:= :collection.type "shared-tenant-collection"]]
+           [:or [:= :collection.type nil] [:= :collection.is_shared_tenant_collection true]]
            (when (embed.settings/some-embedding-enabled?)
              [:= :report_dashboard.enable_embedding false])
            (when (setting/get :enable-public-sharing)

--- a/enterprise/frontend/src/metabase-enterprise/api/tags.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/tags.ts
@@ -1,5 +1,6 @@
 import type { TagDescription } from "@reduxjs/toolkit/query";
 
+import type { TagType } from "metabase/api/tags";
 import {
   TAG_TYPES,
   provideCollectionTags,
@@ -26,7 +27,6 @@ import type {
   TransformTag,
 } from "metabase-types/api";
 
-import type { TagType } from "metabase/api/tags";
 
 export const ENTERPRISE_TAG_TYPES = [
   ...TAG_TYPES,

--- a/enterprise/frontend/src/metabase-enterprise/api/tenants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/tenants.ts
@@ -1,3 +1,4 @@
+import { provideCollectionItemListTags } from "metabase/api/tags";
 import type {
   CreateTenantInput,
   ListCollectionItemsRequest,
@@ -8,7 +9,6 @@ import type {
 
 import { EnterpriseApi } from "./api";
 import { idTag, invalidateTags, listTag } from "./tags";
-import { provideCollectionItemListTags } from "metabase/api/tags";
 
 export const tenantsApi = EnterpriseApi.injectEndpoints({
   endpoints: (builder) => ({

--- a/enterprise/frontend/src/metabase-enterprise/plugins.js
+++ b/enterprise/frontend/src/metabase-enterprise/plugins.js
@@ -41,13 +41,13 @@ import { initializePlugin as initializeSharing } from "./sharing";
 import { initializePlugin as initializeSmtpOverride } from "./smtp-override";
 import { initializePlugin as initializeSnippets } from "./snippets";
 import { initializePlugin as initializeTableEditing } from "./table-editing";
+import { initializePlugin as initializeTenants } from "./tenants";
 import { initializePlugin as initializeTools } from "./tools";
 import { initializePlugin as initializeTransforms } from "./transforms";
 import { initializePlugin as initializeTransformsPython } from "./transforms-python";
 import { initializePlugin as initializeUploadManagement } from "./upload_management";
 import { initializePlugin as initializeUserProvisioning } from "./user_provisioning";
 import { initializePlugin as initializeWhitelabel } from "./whitelabel";
-import { initializePlugin as initializeTenants } from "./tenants";
 
 /**
  * Initialize all enterprise plugins that use hasPremiumFeature.

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/MainNavSharedCollections/MainNavSharedCollections.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/MainNavSharedCollections/MainNavSharedCollections.tsx
@@ -43,7 +43,7 @@ export const MainNavSharedCollections = () => {
       createCollection({
         ...values,
         parent_id: null,
-        type: "shared-tenant-collection",
+        is_shared_tenant_collection: true,
       });
     },
     [createCollection],

--- a/enterprise/frontend/src/metabase-enterprise/tenants/utils/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/utils/utils.ts
@@ -15,4 +15,4 @@ export const isExternalUser = (user?: Pick<User, "tenant_id">) => {
 };
 
 export const isTenantCollection = (collection: Collection) =>
-  collection.type === "shared-tenant-collection";
+  !!collection.is_shared_tenant_collection;

--- a/frontend/src/metabase-types/api/collection.ts
+++ b/frontend/src/metabase-types/api/collection.ts
@@ -76,6 +76,7 @@ export interface Collection {
   children?: Collection[];
   authority_level?: CollectionAuthorityLevel;
   type?: CollectionType;
+  is_shared_tenant_collection?: boolean;
 
   parent_id?: CollectionId | null;
   personal_owner_id?: UserId;
@@ -206,7 +207,7 @@ export interface CreateCollectionRequest {
   parent_id?: CollectionId | null;
   namespace?: string;
   authority_level?: CollectionAuthorityLevel;
-  type?: "shared-tenant-collection";
+  is_shared_tenant_collection?: boolean;
 }
 
 export interface ListCollectionsRequest {

--- a/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/setup.tsx
+++ b/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/setup.tsx
@@ -59,21 +59,21 @@ const collectionTwo = createMockCollection({
 const sharedTenantSubCollectionOne = createMockCollection({
   id: 5,
   name: "Shared Tenant Sub Collection One",
-  type: "shared-tenant-collection",
+  is_shared_tenant_collection: true,
   children: [],
 });
 
 const sharedTenantSubCollectionTwo = createMockCollection({
   id: 6,
   name: "Shared Tenant Sub Collection Two",
-  type: "shared-tenant-collection",
+  is_shared_tenant_collection: true,
   children: [],
 });
 
 const sharedTenantCollection = createMockCollection({
   id: 7,
   name: "Shared Tenant Collection",
-  type: "shared-tenant-collection",
+  is_shared_tenant_collection: true,
   children: [sharedTenantSubCollectionOne, sharedTenantSubCollectionTwo],
 });
 

--- a/frontend/src/metabase/admin/routes.jsx
+++ b/frontend/src/metabase/admin/routes.jsx
@@ -50,8 +50,8 @@ import {
   PLUGIN_DB_ROUTING,
   PLUGIN_DEPENDENCIES,
   PLUGIN_METABOT,
-  PLUGIN_TRANSFORMS,
   PLUGIN_TENANTS,
+  PLUGIN_TRANSFORMS,
 } from "metabase/plugins";
 
 import { ModelPersistenceConfiguration } from "./performance/components/ModelPersistenceConfiguration";

--- a/frontend/src/metabase/common/components/Pickers/CollectionPicker/components/CollectionPicker/tests/setup.tsx
+++ b/frontend/src/metabase/common/components/Pickers/CollectionPicker/components/CollectionPicker/tests/setup.tsx
@@ -214,7 +214,7 @@ export const setup = ({
     allTenantCollections.forEach((collection) => {
       fetchMock.get(`path:/api/collection/${collection.id}`, {
         ...collection,
-        type: "shared-tenant-collection",
+        is_shared_tenant_collection: true,
       });
     });
   }

--- a/frontend/src/metabase/common/components/Pickers/DashboardPicker/components/DashboardPicker/tests/setup.tsx
+++ b/frontend/src/metabase/common/components/Pickers/DashboardPicker/components/DashboardPicker/tests/setup.tsx
@@ -250,7 +250,7 @@ const commonSetup = ({ ee = false }: { ee?: boolean } = {}) => {
       } else {
         fetchMock.get(`path:/api/collection/${item.id}`, {
           ...item,
-          type: "shared-tenant-collection",
+          is_shared_tenant_collection: true,
         });
       }
     });

--- a/frontend/src/metabase/common/components/Pickers/QuestionPicker/components/QuestionPicker/QuestionPicker.tsx
+++ b/frontend/src/metabase/common/components/Pickers/QuestionPicker/components/QuestionPicker/QuestionPicker.tsx
@@ -104,7 +104,7 @@ export const QuestionPicker = ({
             model: "dashboard",
             location,
             is_tenant_dashboard:
-              currentDashboard?.collection?.type === "shared-tenant-collection",
+              !!currentDashboard?.collection?.is_shared_tenant_collection,
           },
           userPersonalCollectionId,
         );

--- a/frontend/src/metabase/common/components/Pickers/QuestionPicker/components/QuestionPicker/tests/setup.tsx
+++ b/frontend/src/metabase/common/components/Pickers/QuestionPicker/components/QuestionPicker/tests/setup.tsx
@@ -109,7 +109,7 @@ const tenantDashboard = createMockCollectionItem({
     collection: createMockCollection({
       id: 7,
       location: "/6/7/",
-      type: "shared-tenant-collection",
+      is_shared_tenant_collection: true,
     }),
   }),
   location: "/6/7/",
@@ -352,7 +352,7 @@ const commonSetup = ({ isEE = false }: { isEE?: boolean } = {}) => {
       if (item.model === "collection") {
         fetchMock.get(`path:/api/collection/${item.id}`, {
           ...item,
-          type: "shared-tenant-collection",
+          is_shared_tenant_collection: true,
         });
       } else if (item.model === "dashboard") {
         fetchMock.get(`path:/api/dashboard/${item.id}`, item);

--- a/frontend/src/metabase/common/components/Pickers/utils.ts
+++ b/frontend/src/metabase/common/components/Pickers/utils.ts
@@ -63,8 +63,7 @@ export const getCollectionIdPath = (
     return ["personal", ...pathFromRoot, id];
   } else if (
     collection.is_tenant_collection ||
-    collection.is_tenant_dashboard ||
-    collection.type === "shared-tenant-collection"
+    collection.is_tenant_dashboard
   ) {
     return ["tenant", ...pathFromRoot, id];
   } else {

--- a/frontend/src/metabase/common/components/Pickers/utils.unit.spec.ts
+++ b/frontend/src/metabase/common/components/Pickers/utils.unit.spec.ts
@@ -153,7 +153,7 @@ describe("getCollectionIdPath", () => {
         location: "/4/5/6/7/8/",
         effective_location: "/6/7/8/",
         model: "collection",
-        type: "shared-tenant-collection",
+        is_shared_tenant_collection: true,
       },
       1337,
     );

--- a/frontend/src/metabase/lib/urls/admin.ts
+++ b/frontend/src/metabase/lib/urls/admin.ts
@@ -1,6 +1,6 @@
 import type {
-  DatabaseId,
   BaseUser,
+  DatabaseId,
   SchemaName,
   TableId,
   UserId,

--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -636,6 +636,25 @@ databaseChangeLog:
               VALUES
               ('All External Users', 'all-external-users', true);
 
+  - changeSet:
+      id: v58.2025-11-18T13:00:00
+      author: edpaget
+      comment: Add is_shared_tenant_collection to collection table
+      changes:
+        - addColumn:
+            tableName: collection
+            columns:
+              - column:
+                  name: is_shared_tenant_collection
+                  type: ${boolean.type}
+                  remarks: Flag to control whether this collection is treated as a shared-tenant-collection
+                  constraints:
+                    nullable: true
+      rollback:
+        - dropColumn:
+            tableName: collection
+            columnName: is_shared_tenant_collection
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/test/metabase/collections/models/collection_test.clj
+++ b/test/metabase/collections/models/collection_test.clj
@@ -3315,7 +3315,7 @@
           (mt/with-temp [:model/PermissionsGroup {group-1-id :id} {:name "Group 1"}
                          :model/PermissionsGroup {group-2-id :id} {:name "Group 2"}
                          :model/Collection coll {:name "Tenant Collection"
-                                                 :type "shared-tenant-collection"
+                                                 :is_shared_tenant_collection true
                                                  :location "/"}]
             (let [group-1-perms (t2/select-one :model/Permissions
                                                :group_id group-1-id
@@ -3341,7 +3341,7 @@
     (mt/with-premium-features #{:tenants}
       (mt/with-temporary-setting-values [use-tenants true]
         (mt/with-temp [:model/Collection coll {:name "Tenant Collection"
-                                               :type "shared-tenant-collection"
+                                               :is_shared_tenant_collection true
                                                :location "/"}]
           (let [admin-group-id (:id (perms/admin-group))]
             (is (not (t2/exists? :model/Permissions
@@ -3356,11 +3356,11 @@
         (mt/with-temporary-setting-values [use-tenants true]
           (mt/with-temp [:model/PermissionsGroup {group-id :id} {:name "Test Group"}
                          :model/Collection parent {:name "Parent Tenant Collection"
-                                                   :type "shared-tenant-collection"
+                                                   :is_shared_tenant_collection true
                                                    :location "/"}]
             (perms/grant-collection-readwrite-permissions! group-id parent)
             (mt/with-temp [:model/Collection child {:name "Child Tenant Collection"
-                                                    :type "shared-tenant-collection"
+                                                    :is_shared_tenant_collection true
                                                     :location (collection/children-location parent)}]
               (is (t2/exists? :model/Permissions
                               :group_id group-id
@@ -3377,7 +3377,7 @@
                                                    :location "/"}]
             (perms/grant-collection-readwrite-permissions! group-id parent)
             (mt/with-temp [:model/Collection child {:name "Tenant Collection"
-                                                    :type "shared-tenant-collection"
+                                                    :is_shared_tenant_collection true
                                                     :location (collection/children-location parent)}]
               (is (not (t2/exists? :model/Permissions
                                    :group_id group-id
@@ -3396,7 +3396,7 @@
                        :model/PermissionsGroup {group-2-id :id} {:name "Group 2"}
                        :model/PermissionsGroup {group-3-id :id} {:name "Group 3"}
                        :model/Collection coll {:name "Tenant Collection"
-                                               :type "shared-tenant-collection"
+                                               :is_shared_tenant_collection true
                                                :location "/"}]
           (let [groups-with-read-perms (t2/select-fn-set :group_id :model/Permissions
                                                          :object (perms/collection-read-path coll))
@@ -3415,10 +3415,10 @@
     (mt/with-premium-features #{:tenants}
       (mt/with-temporary-setting-values [use-tenants true]
         (mt/with-temp [:model/Collection {parent-id :id :as parent} {:name "Parent"
-                                                                     :type "shared-tenant-collection"
+                                                                     :is_shared_tenant_collection true
                                                                      :location "/"}
                        :model/Collection child {:name "Child"
-                                                :type "shared-tenant-collection"
+                                                :is_shared_tenant_collection true
                                                 :location (collection/children-location parent)}]
           (let [child-parent (#'collection/parent child)]
             (is (= parent-id (:id child-parent))
@@ -3430,7 +3430,7 @@
   (testing "The is-tenant-collection? predicate"
     (mt/with-premium-features #{:tenants}
       (mt/with-temporary-setting-values [use-tenants true]
-        (mt/with-temp [:model/Collection tenant-coll {:type "shared-tenant-collection"}
+        (mt/with-temp [:model/Collection tenant-coll {:is_shared_tenant_collection true}
                        :model/Collection regular-coll {:type nil}
                        :model/Collection remote-coll {:type "remote-synced"}]
           (is (collection/is-tenant-collection? tenant-coll)
@@ -3447,7 +3447,7 @@
         (testing "for tenant collections"
           (mt/with-temp [:model/PermissionsGroup {group-id :id} {:name "Test Group"}
                          :model/Collection coll {:name "Tenant Collection"
-                                                 :type "shared-tenant-collection"
+                                                 :is_shared_tenant_collection true
                                                  :location "/"}]
             (is (t2/exists? :model/Permissions
                             :group_id group-id
@@ -3468,13 +3468,13 @@
       (mt/with-temporary-setting-values [use-tenants true]
         (mt/with-temp [:model/PermissionsGroup {group-id :id} {:name "Test Group"}
                        :model/Collection level-1 {:name "Level 1 Tenant"
-                                                  :type "shared-tenant-collection"
+                                                  :is_shared_tenant_collection true
                                                   :location "/"}
                        :model/Collection level-2 {:name "Level 2 Tenant"
-                                                  :type "shared-tenant-collection"
+                                                  :is_shared_tenant_collection true
                                                   :location (collection/children-location level-1)}
                        :model/Collection level-3 {:name "Level 3 Tenant"
-                                                  :type "shared-tenant-collection"
+                                                  :is_shared_tenant_collection true
                                                   :location (collection/children-location level-2)}]
           (is (t2/exists? :model/Permissions
                           :group_id group-id
@@ -3495,7 +3495,7 @@
       (mt/with-temporary-setting-values [use-tenants true]
         (mt/with-temp [:model/PermissionsGroup {group-id :id} {:name "Test Group"}
                        :model/Collection coll {:name "Tenant Collection"
-                                               :type "shared-tenant-collection"
+                                               :is_shared_tenant_collection true
                                                :location "/"}]
           (let [read-perms (t2/exists? :model/Permissions
                                        :group_id group-id

--- a/test_resources/serialization_baseline/collections/JS5JHDitDkWEtTt1-N7zr_qdlkexrocaxgnecmryqu/JS5JHDitDkWEtTt1-N7zr_qdlkexrocaxgnecmryqu.yaml
+++ b/test_resources/serialization_baseline/collections/JS5JHDitDkWEtTt1-N7zr_qdlkexrocaxgnecmryqu/JS5JHDitDkWEtTt1-N7zr_qdlkexrocaxgnecmryqu.yaml
@@ -16,3 +16,4 @@ serdes/meta:
 archive_operation_id: null
 archived_directly: null
 is_sample: false
+is_shared_tenant_collection: null

--- a/test_resources/serialization_baseline/collections/M-Q4pcV0qkiyJ0kiSWECl_some_collection/M-Q4pcV0qkiyJ0kiSWECl_some_collection.yaml
+++ b/test_resources/serialization_baseline/collections/M-Q4pcV0qkiyJ0kiSWECl_some_collection/M-Q4pcV0qkiyJ0kiSWECl_some_collection.yaml
@@ -16,3 +16,4 @@ serdes/meta:
 archive_operation_id: null
 archived_directly: null
 is_sample: false
+is_shared_tenant_collection: null

--- a/test_resources/serialization_baseline/collections/Y6d4QwJgGKw-X1tRh3ir2_shared_collection/Y6d4QwJgGKw-X1tRh3ir2_shared_collection.yaml
+++ b/test_resources/serialization_baseline/collections/Y6d4QwJgGKw-X1tRh3ir2_shared_collection/Y6d4QwJgGKw-X1tRh3ir2_shared_collection.yaml
@@ -16,3 +16,4 @@ serdes/meta:
 archive_operation_id: null
 archived_directly: null
 is_sample: false
+is_shared_tenant_collection: null

--- a/test_resources/serialization_baseline/collections/gQuHAIM4C-7fToHzHyNNQ_ai_model/gQuHAIM4C-7fToHzHyNNQ_ai_model.yaml
+++ b/test_resources/serialization_baseline/collections/gQuHAIM4C-7fToHzHyNNQ_ai_model/gQuHAIM4C-7fToHzHyNNQ_ai_model.yaml
@@ -16,3 +16,4 @@ serdes/meta:
 archive_operation_id: null
 archived_directly: null
 is_sample: false
+is_shared_tenant_collection: null

--- a/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/olgKH56lYOjakuobH4zPz_grandparent_collection.yaml
+++ b/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/olgKH56lYOjakuobH4zPz_grandparent_collection.yaml
@@ -16,3 +16,4 @@ serdes/meta:
 archive_operation_id: null
 archived_directly: null
 is_sample: false
+is_shared_tenant_collection: null

--- a/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/qPZhJMPNGkfd3sq8jWiZS_parent_collection/fJVsXIDzzipSZsaro9Pvu_child_collection/fJVsXIDzzipSZsaro9Pvu_child_collection.yaml
+++ b/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/qPZhJMPNGkfd3sq8jWiZS_parent_collection/fJVsXIDzzipSZsaro9Pvu_child_collection/fJVsXIDzzipSZsaro9Pvu_child_collection.yaml
@@ -16,3 +16,4 @@ serdes/meta:
 archive_operation_id: null
 archived_directly: null
 is_sample: false
+is_shared_tenant_collection: null

--- a/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/qPZhJMPNGkfd3sq8jWiZS_parent_collection/qPZhJMPNGkfd3sq8jWiZS_parent_collection.yaml
+++ b/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/qPZhJMPNGkfd3sq8jWiZS_parent_collection/qPZhJMPNGkfd3sq8jWiZS_parent_collection.yaml
@@ -16,3 +16,4 @@ serdes/meta:
 archive_operation_id: null
 archived_directly: null
 is_sample: false
+is_shared_tenant_collection: null

--- a/test_resources/serialization_baseline/collections/p8Zq2ud7JlSoSBXdJWIaW_shared_collection/p8Zq2ud7JlSoSBXdJWIaW_shared_collection.yaml
+++ b/test_resources/serialization_baseline/collections/p8Zq2ud7JlSoSBXdJWIaW_shared_collection/p8Zq2ud7JlSoSBXdJWIaW_shared_collection.yaml
@@ -16,3 +16,4 @@ serdes/meta:
 archive_operation_id: null
 archived_directly: null
 is_sample: false
+is_shared_tenant_collection: null


### PR DESCRIPTION
### Description

the collection `type` column is too overloaded. Some collections may want to opt into multiple behaviors governed currently by type so we're going to make them (starting with shared-tenant collections) into boolean flags.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
