### PR TITLE
Consolidate caches

### DIFF
--- a/.github/actions/get-cache-keys/action.yml
+++ b/.github/actions/get-cache-keys/action.yml
@@ -13,6 +13,9 @@ outputs:
   eslint-cache-key:
     description: "The cache key for Eslint cache"
     value: ${{ steps.keys-factory.outputs.eslint-cache-key }}
+  cypress-cache-key:
+    description: "The cache key for Cypress cache"
+    value: ${{ steps.keys-factory.outputs.cypress-cache-key }}
 
 runs:
   using: "composite"
@@ -23,10 +26,12 @@ runs:
         M2_CACHE_PREFIX='M2'
         NODE_CACHE_PREFIX='node-modules'
         ESLINT_CACHE_PREFIX='eslint'
+        CYPRESS_CACHE_PREFIX='cypress'
         WEEK_OF_YEAR=$(/bin/date "+%G-%V")
         CACHE_SUFFIX="${{ runner.os }}-$WEEK_OF_YEAR"
 
         echo "m2-cache-key=$M2_CACHE_PREFIX-$CACHE_SUFFIX" >> $GITHUB_OUTPUT
         echo "node-cache-key=$NODE_CACHE_PREFIX-$CACHE_SUFFIX" >> $GITHUB_OUTPUT
         echo "eslint-cache-key=$ESLINT_CACHE_PREFIX-$CACHE_SUFFIX" >> $GITHUB_OUTPUT
+        echo "cypress-cache-key=$CYPRESS_CACHE_PREFIX-$CACHE_SUFFIX" >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/actions/prepare-cypress/action.yml
+++ b/.github/actions/prepare-cypress/action.yml
@@ -22,16 +22,16 @@ runs:
         chrome-version: 1097615
       id: setup-chrome
 
-    - name: Get current week of year
-      id: get-date
-      run: |
-        echo "week-of-year=$(/bin/date "+%G-%V")" >> $GITHUB_OUTPUT
-      shell: bash
+    - name: Get cache keys
+      uses: ./.github/actions/get-cache-keys
+      id: get-cache-keys
+
     - name: Get Cypress cache
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       with:
         path: ~/.cache/Cypress
-        key: ${{ runner.os }}-Cypress-${{ steps.get-date.outputs.week-of-year }}
+        key: ${{ steps.get-cache-keys.outputs.cypress-cache-key }}
+
     - name: Ensure that Cypress executable is ready
       run: |
         yarn cypress install

--- a/.github/workflows/cache-generator.yml
+++ b/.github/workflows/cache-generator.yml
@@ -77,7 +77,7 @@ jobs:
             ~/.m2
             ~/.gitlibs
             ~/.deps.clj
-            bin/bb
+            ${{ github.workspace}}/bin/bb
           key: ${{ env.M2_CACHE_KEY }}
 
   generate-frontend-caches:

--- a/.github/workflows/cache-generator.yml
+++ b/.github/workflows/cache-generator.yml
@@ -108,6 +108,14 @@ jobs:
           echo "Yarn cache directory: $YARN_CACHE_DIR"
           echo "dir=$YARN_CACHE_DIR" >> $GITHUB_OUTPUT
 
+      - name: Ensure that Cypress executable is ready
+        run: |
+          yarn cypress install
+          yarn cypress cache path
+          yarn cypress cache list
+          yarn cypress verify
+        shell: bash
+
       - name: Update node_modules cache
         uses: ./.github/actions/update-cache
         with:

--- a/.github/workflows/cache-generator.yml
+++ b/.github/workflows/cache-generator.yml
@@ -30,8 +30,8 @@ name: Cache Generator
 
 on:
   schedule:
-    - cron: '0 3 * * 1'   # Mondays at 03:00 UTC
-  workflow_dispatch:      # manually update the cache
+    - cron: "0 3 * * 1" # Mondays at 03:00 UTC
+  workflow_dispatch: # manually update the cache
 
 concurrency:
   group: cache-generator
@@ -49,6 +49,7 @@ jobs:
       m2-cache-key: ${{ steps.get-cache-keys.outputs.m2-cache-key }}
       node-cache-key: ${{ steps.get-cache-keys.outputs.node-cache-key }}
       eslint-cache-key: ${{ steps.get-cache-keys.outputs.eslint-cache-key }}
+      cypress-cache-key: ${{ steps.get-cache-keys.outputs.cypress-cache-key }}
 
   generate-m2-cache:
     runs-on: ubuntu-22.04
@@ -81,6 +82,7 @@ jobs:
     env:
       NODE_CACHE_KEY: ${{ needs.get-cache-keys.outputs.node-cache-key }}
       ESLINT_CACHE_KEY: ${{ needs.get-cache-keys.outputs.eslint-cache-key }}
+      CYPRESS_CACHE_KEY: ${{ needs.get-cache-keys.outputs.cypress-cache-key }}
     steps:
       - uses: actions/checkout@v4
       # `prepare-frontend` action (1) prepares Node.js and (2) fetches the node_modules cache if it exists.
@@ -92,7 +94,7 @@ jobs:
       - name: Install front-end dependencies
         uses: ./.github/actions/prepare-frontend
         with:
-          apply-patches: 'false'
+          apply-patches: "false"
 
       - name: Get yarn cache directory
         id: yarn-cache-dir
@@ -114,3 +116,9 @@ jobs:
         with:
           path: .eslintcache
           key: ${{ env.ESLINT_CACHE_KEY }}
+
+      - name: Update Cypress cache
+        uses: ./.github/actions/update-cache
+        with:
+          path: ~/.cache/Cypress
+          key: ${{ env.CYPRESS_CACHE_KEY }}

--- a/.github/workflows/cache-generator.yml
+++ b/.github/workflows/cache-generator.yml
@@ -77,7 +77,7 @@ jobs:
             ~/.m2
             ~/.gitlibs
             ~/.deps.clj
-            ./bin/bb
+            bin/bb
           key: ${{ env.M2_CACHE_KEY }}
 
   generate-frontend-caches:

--- a/.github/workflows/cache-generator.yml
+++ b/.github/workflows/cache-generator.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Update eslint cache
         uses: ./.github/actions/update-cache
         with:
-          path: .eslintcache
+          path: ${{ github.workspace}}/.eslintcache
           key: ${{ env.ESLINT_CACHE_KEY }}
 
       - name: Update Cypress cache

--- a/.github/workflows/cache-generator.yml
+++ b/.github/workflows/cache-generator.yml
@@ -64,8 +64,11 @@ jobs:
 
       # Add or remove aliases to affect the cache size and its contents.
       # Adjust to taste, then redeploy this workflow.
-      - name: Pre-resolve dependencies
+      - name: Pre-resolve Clojure dependencies
         run: clojure -A:build:dev:ee:ee-dev:drivers:drivers-dev:cljs -P
+
+      - name: Let Mage install babashka and clojure-tools
+        run: ./bin/mage
 
       - name: Update M2 cache
         uses: ./.github/actions/update-cache
@@ -73,6 +76,8 @@ jobs:
           path: |
             ~/.m2
             ~/.gitlibs
+            ~/.deps.clj
+            ~/bin/bb
           key: ${{ env.M2_CACHE_KEY }}
 
   generate-frontend-caches:

--- a/.github/workflows/cache-generator.yml
+++ b/.github/workflows/cache-generator.yml
@@ -77,7 +77,7 @@ jobs:
             ~/.m2
             ~/.gitlibs
             ~/.deps.clj
-            ~/bin/bb
+            ./bin/bb
           key: ${{ env.M2_CACHE_KEY }}
 
   generate-frontend-caches:

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -27,21 +27,6 @@ jobs:
           # Fetch the base branch to ensure its history is available for diffing
           git fetch --depth=1 origin ${{ github.event.pull_request.base.ref }}:${{ github.event.pull_request.base.ref }}
           # Only run this if it's a pull request and the base ref exists
-      - name: Get Date
-        id: get-date
-        shell: bash
-        run: |
-          echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
-      - name: Restore Babashka cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.m2
-            ~/.deps.clj
-          restore-keys: |
-            mage-drivers-
-          key: >-
-            mage-drivers-${{ steps.get-date.outputs.date }}
       - name: Check if driver tests should run
         id: check-branch-and-files-changed
         run: |

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           path: |
             ~/.deps.clj
-            ~/bin/bb
+            ./bin/bb
           key: ${{ steps.get-cache-keys.outputs.m2-cache-key }}
 
       - name: Check if driver tests should run

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -27,6 +27,17 @@ jobs:
           # Fetch the base branch to ensure its history is available for diffing
           git fetch --depth=1 origin ${{ github.event.pull_request.base.ref }}:${{ github.event.pull_request.base.ref }}
           # Only run this if it's a pull request and the base ref exists
+      - name: Get cache keys
+        uses: ./.github/actions/get-cache-keys
+        id: get-cache-keys
+      - name: Restore babashka cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/.deps.clj
+            ~/bin/bb
+          key: ${{ steps.get-cache-keys.outputs.m2-cache-key }}
+
       - name: Check if driver tests should run
         id: check-branch-and-files-changed
         run: |

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           path: |
             ~/.deps.clj
-            ./bin/bb
+            bin/bb
           key: ${{ steps.get-cache-keys.outputs.m2-cache-key }}
 
       - name: Check if driver tests should run

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           path: |
             ~/.deps.clj
-            bin/bb
+            ${{ github.workspace}}/bin/bb
           key: ${{ steps.get-cache-keys.outputs.m2-cache-key }}
 
       - name: Check if driver tests should run

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Restore ESLint cache
         uses: actions/cache/restore@v4
         with:
-          path: .eslintcache
+          path: ${{ github.workspace}}/.eslintcache
           key: ${{ steps.get-cache-keys.outputs.eslint-cache-key }}
 
       - name: Compile CLJS


### PR DESCRIPTION
This pull request improves the caching strategy in GitHub Actions workflows by introducing a unified cache key generator and adding Cypress cache management. The changes help standardize cache key handling, optimize cache usage for Cypress, ESLint, and Babashka, and streamline workflow steps for better maintainability.

**Caching improvements and standardization:**

* Added Cypress cache key generation to `get-cache-keys` action and updated its outputs, enabling consistent cache key usage for Cypress across workflows. [[1]](diffhunk://#diff-303038e6708d1c4c9f5c4dad53e6138ad84334eb4484ece1f270601493cd34bbR16-R18) [[2]](diffhunk://#diff-303038e6708d1c4c9f5c4dad53e6138ad84334eb4484ece1f270601493cd34bbR29-R36)
* Updated workflows (`cache-generator.yml`, `drivers.yml`, `frontend.yml`) to use the new `get-cache-keys` action for cache key retrieval, replacing manual date-based key generation for Babashka and Cypress. [[1]](diffhunk://#diff-f3e3b9e6c452274f4132359a8bf636e9207c380c4d4b46201e1d5aeb714c0a32R52) [[2]](diffhunk://#diff-f3e3b9e6c452274f4132359a8bf636e9207c380c4d4b46201e1d5aeb714c0a32R90) [[3]](diffhunk://#diff-f4093d5aa7546f2c43649806f9b55708bccf05f46bebad15c0a2ed20685086f3L30-R40)
* Switched Cypress cache restore to use `actions/cache/restore@v4` and standardized the cache path and key in `prepare-cypress/action.yml`.

**Workflow enhancements and maintenance:**

* Added explicit Cypress installation and verification steps in the frontend cache generation workflow to ensure the executable and cache are ready for use.
* Updated cache paths for ESLint and added new cache update steps for Cypress in the frontend workflow for improved cache accuracy and separation. [[1]](diffhunk://#diff-f3e3b9e6c452274f4132359a8bf636e9207c380c4d4b46201e1d5aeb714c0a32L115-R137) [[2]](diffhunk://#diff-ffe3a297ed15e9a79846161a3731a580511bf13c6b5cc5a9e03ddcbd8515fdeeL45-R45)

**Minor improvements:**

* Improved naming and formatting for workflow steps and cron expressions for consistency and clarity. [[1]](diffhunk://#diff-f3e3b9e6c452274f4132359a8bf636e9207c380c4d4b46201e1d5aeb714c0a32L33-R33) [[2]](diffhunk://#diff-f3e3b9e6c452274f4132359a8bf636e9207c380c4d4b46201e1d5aeb714c0a32L66-R80) [[3]](diffhunk://#diff-f3e3b9e6c452274f4132359a8bf636e9207c380c4d4b46201e1d5aeb714c0a32L95-R102)