### PR TITLE
Consistent approach to Metabot field IDs for implicitly-joined tables

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/dummy_tools.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/dummy_tools.clj
@@ -170,9 +170,10 @@
            table-query (when query-needed?
                          (lib/query mp (lib.metadata/table mp id)))
            cols (when with-fields?
-                  (->> (lib/visible-columns table-query)
+                  (->> (lib/visible-columns table-query #_#_-1 {:include-implicitly-joinable? false})
                        field-values-fn
                        (map #(metabot-v3.tools.u/add-table-reference table-query %))))
+           _ (def cols cols)
            field-id-prefix (when with-fields?
                              (metabot-v3.tools.u/table-field-id-prefix id))
            related-tables (when with-related-tables?

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/dummy_tools.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/dummy_tools.clj
@@ -199,7 +199,8 @@
                        (filter :fk-field-id))
         related-table-ids (->> fk-fields
                                (map :table-id)
-                               (into #{}))]
+                               (into #{})
+                               sort)]
     (when (seq related-table-ids)
       (map #(table-details % {:with-fields? with-fields?
                               :field-values-fn field-values-fn

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/dummy_tools.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/dummy_tools.clj
@@ -170,10 +170,9 @@
            table-query (when query-needed?
                          (lib/query mp (lib.metadata/table mp id)))
            cols (when with-fields?
-                  (->> (lib/visible-columns table-query #_#_-1 {:include-implicitly-joinable? false})
+                  (->> (lib/visible-columns table-query -1 {:include-implicitly-joinable? false})
                        field-values-fn
                        (map #(metabot-v3.tools.u/add-table-reference table-query %))))
-           _ (def cols cols)
            field-id-prefix (when with-fields?
                              (metabot-v3.tools.u/table-field-id-prefix id))
            related-tables (when with-related-tables?

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
@@ -180,7 +180,7 @@
     [:field_id :string]
     [:field_granularity {:optional true}
      [:maybe [:enum {:encode/tool-api-request keyword}
-              "day" "week" "month" "quarter" "year"]]]]
+              "minute" "hour" "day" "week" "month" "quarter" "year" "day-of-week"]]]]
    [:map {:encode/tool-api-request #(update-keys % metabot-v3.u/safe->kebab-case-en)}]])
 
 (mr/def ::query-metric-arguments

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/field_stats.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/field_stats.clj
@@ -34,13 +34,11 @@
 (defn- table-field-stats
   [table-id agent-field-id limit]
   (try
-    (let [field-id-prefix (metabot-v3.tools.u/table-field-id-prefix table-id)
-          index (metabot-v3.tools.u/resolve-column-index agent-field-id field-id-prefix)
-          query (metabot-v3.tools.u/table-query table-id)]
+    (let [query (metabot-v3.tools.u/table-query table-id)]
       (if query
-        (if-let [col (nth (lib/visible-columns query) index nil)]
-          {:structured-output (field-statistics col limit)}
-          {:output (str "No field found with ID " agent-field-id)})
+        (let [visible-cols (lib/visible-columns query)
+              col (:column (metabot-v3.tools.u/resolve-column {:field-id agent-field-id} visible-cols))]
+          {:structured-output (field-statistics col limit)})
         {:output (str "No table found with ID " table-id)}))
     (catch Exception ex
       (metabot-v3.tools.u/handle-agent-error ex))))
@@ -48,13 +46,11 @@
 (defn- card-field-stats
   [card-id agent-field-id limit card-type]
   (try
-    (let [field-id-prefix (metabot-v3.tools.u/card-field-id-prefix card-id)
-          index (metabot-v3.tools.u/resolve-column-index agent-field-id field-id-prefix)
-          query (metabot-v3.tools.u/card-query card-id)]
+    (let [query (metabot-v3.tools.u/card-query card-id)]
       (if query
-        (if-let [col (nth (lib/visible-columns query) index nil)]
-          {:structured-output (field-statistics col limit)}
-          {:output (str "No field found with ID " agent-field-id)})
+        (let [visible-cols (lib/visible-columns query)
+              col (:column (metabot-v3.tools.u/resolve-column {:field-id agent-field-id} visible-cols))]
+          {:structured-output (field-statistics col limit)})
         {:output (str "No " card-type " found with ID " card-id)}))
     (catch Exception ex
       (metabot-v3.tools.u/handle-agent-error ex))))
@@ -62,13 +58,11 @@
 (defn- metric-field-stats
   [metric-id agent-field-id limit]
   (try
-    (let [field-id-prefix (metabot-v3.tools.u/card-field-id-prefix metric-id)
-          index (metabot-v3.tools.u/resolve-column-index agent-field-id field-id-prefix)
-          query (metabot-v3.tools.u/metric-query metric-id)]
+    (let [query (metabot-v3.tools.u/metric-query metric-id)]
       (if query
-        (if-let [col (nth (lib/filterable-columns query) index nil)]
-          {:structured-output (field-statistics col limit)}
-          {:output (str "No field found with ID " agent-field-id)})
+        (let [filterable-cols (lib/filterable-columns query)
+              col (:column (metabot-v3.tools.u/resolve-column {:field-id agent-field-id} filterable-cols))]
+          {:structured-output (field-statistics col limit)})
         {:output (str "No metric found with ID " metric-id)}))
     (catch Exception ex
       (metabot-v3.tools.u/handle-agent-error ex))))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
@@ -152,14 +152,13 @@
         base-query (->> (lib/query mp (lib.metadata/card mp metric-id))
                         lib/remove-all-breakouts)
         visible-cols (lib/visible-columns base-query)
-        filter-field-id-prefix (metabot-v3.tools.u/card-field-id-prefix metric-id)
         query (as-> base-query $q
                 (reduce add-filter
                         $q
-                        (map #(metabot-v3.tools.u/resolve-column % filter-field-id-prefix visible-cols) filters))
+                        (map #(metabot-v3.tools.u/resolve-column % visible-cols) filters))
                 (reduce add-breakout
                         $q
-                        (map #(metabot-v3.tools.u/resolve-column % filter-field-id-prefix visible-cols) group-by)))
+                        (map #(metabot-v3.tools.u/resolve-column % visible-cols) group-by)))
         query-id (u/generate-nano-id)
         query-field-id-prefix (metabot-v3.tools.u/query-field-id-prefix query-id)
         returned-cols (lib/returned-columns query)]
@@ -235,8 +234,7 @@
         mp (lib-be/application-database-metadata-provider (:database_id card))
         base-query (lib/query mp (lib.metadata/card mp model-id))
         visible-cols (lib/visible-columns base-query)
-        filter-field-id-prefix (metabot-v3.tools.u/card-field-id-prefix model-id)
-        resolve-visible-column  #(metabot-v3.tools.u/resolve-column % filter-field-id-prefix visible-cols)
+        resolve-visible-column  #(metabot-v3.tools.u/resolve-column % visible-cols)
         resolve-order-by-column (fn [{:keys [field direction]}] {:field (resolve-visible-column field) :direction direction})
         projection (map (comp (juxt filter-bucketed-column (fn [{:keys [column bucket]}]
                                                              (let [column (cond-> column
@@ -294,9 +292,9 @@
 
 (defn- query-datasource*
   [{:keys [fields filters aggregations group-by order-by limit] :as arguments}]
-  (let [[filter-field-id-prefix base-query] (resolve-datasource arguments)
+  (let [[_filter-field-id-prefix base-query] (resolve-datasource arguments)
         visible-cols (lib/visible-columns base-query)
-        resolve-visible-column  #(metabot-v3.tools.u/resolve-column % filter-field-id-prefix visible-cols)
+        resolve-visible-column  #(metabot-v3.tools.u/resolve-column % visible-cols)
         resolve-order-by-column (fn [{:keys [field direction]}] {:field (resolve-visible-column field) :direction direction})
         projection (map (comp (juxt filter-bucketed-column (fn [{:keys [column bucket]}]
                                                              (let [column (cond-> column
@@ -390,9 +388,9 @@
   "Add `filters` to the query referenced by `data-source`"
   [{:keys [data-source filters] :as _arguments}]
   (try
-    (let [[filter-field-id-prefix base] (base-query data-source)
+    (let [[_filter-field-id-prefix base] (base-query data-source)
           returned-cols (lib/returned-columns base)
-          query (reduce add-filter base (map #(metabot-v3.tools.u/resolve-column % filter-field-id-prefix returned-cols) filters))
+          query (reduce add-filter base (map #(metabot-v3.tools.u/resolve-column % returned-cols) filters))
           query-id (u/generate-nano-id)
           query-field-id-prefix (metabot-v3.tools.u/query-field-id-prefix query-id)]
       {:structured-output

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
@@ -413,12 +413,12 @@
             api/*is-superuser?* true]
     (-> (filter-records #_{:data-source {:tabl-id 3}
                            :filters [{:operation "number-greater-than"
-                                      :field-id "t3/6"
+                                      :field-id "t3-6"
                                       :value 50}]}
          {:data-source {:table-id 1}
           :filters [{:operation "greater-than"
                      :bucket "month-of-year"
-                     :field-id "t1/3"
+                     :field-id "t1-3"
                      :value #_"2020-01-01" 1}]})
         :structured-output :query qp/process-query :data :native_form :query))
   -)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/find_outliers.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/find_outliers.clj
@@ -67,7 +67,12 @@
                                      first)
                                 (throw (ex-info "Could not determine result field."
                                                 {:agent-error? true})))
-                            (metabot-v3.tools.u/resolve-column-index result-field-id field-id-prefix))]
+                            ;; Parse field-id and extract the numeric index
+                            (if-let [{:keys [field-index]} (metabot-v3.tools.u/parse-field-id result-field-id)]
+                              field-index
+                              (throw (ex-info (str "Invalid result_field_id format: " result-field-id)
+                                              {:agent-error? true
+                                               :result-field-id result-field-id}))))]
         (when-not (< -1 value-col-idx (-> data :rows first count))
           (throw (ex-info (str "Invalid result_field_id " result-field-id)
                           {:agent-error? true})))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/find_outliers.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/find_outliers.clj
@@ -16,34 +16,27 @@
       :dataset_query))
 
 (defn- find-dataset-query
-  [{:keys [query query-id report-id metric-id] :as data-source}]
-  (letfn [(handle-query [query query-id]
-            (api/read-check :model/Database (:database query))
-            [(if query-id
-               (metabot-v3.tools.u/query-field-id-prefix query-id)
-               metabot-v3.tools.u/any-prefix-pattern)
-             query])]
-    (cond
-      metric-id (if (int? metric-id)
-                  [(metabot-v3.tools.u/card-field-id-prefix metric-id)
-                   (checked-card-dataset-query metric-id)]
-                  (throw (ex-info "Invalid metric_id as data_source" {:agent-error? true
-                                                                      :data-source data-source})))
-      report-id (if (int? report-id)
-                  [(metabot-v3.tools.u/card-field-id-prefix report-id)
-                   (checked-card-dataset-query report-id)]
-                  (throw (ex-info "Invalid report_id as data_source" {:agent-error? true
-                                                                      :data-source data-source})))
-      query     (handle-query query query-id)
-      :else     (throw (ex-info "Invalid data_source" {:agent-error? true
-                                                       :data-source data-source})))))
+  [{:keys [query report-id metric-id] :as data-source}]
+  (cond
+    metric-id (if (int? metric-id)
+                (checked-card-dataset-query metric-id)
+                (throw (ex-info "Invalid metric_id as data_source" {:agent-error? true
+                                                                    :data-source data-source})))
+    report-id (if (int? report-id)
+                (checked-card-dataset-query report-id)
+                (throw (ex-info "Invalid report_id as data_source" {:agent-error? true
+                                                                    :data-source data-source})))
+    query     (do (api/read-check :model/Database (:database query))
+                  query)
+    :else     (throw (ex-info "Invalid data_source" {:agent-error? true
+                                                     :data-source data-source}))))
 
 (defn find-outliers
   "Find outliers in the values provided by `data-source` for a given column."
   [{:keys [data-source]}]
   (let [{:keys [metric-id result-field-id]} data-source]
     (try
-      (let [[field-id-prefix dataset-query] (find-dataset-query data-source)
+      (let [dataset-query (find-dataset-query data-source)
             {:keys [data]} (u/prog1 (-> dataset-query
                                         (qp/userland-query-with-default-constraints {:context :ad-hoc})
                                         qp/process-query)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
@@ -90,7 +90,7 @@
     (parse-field-id \"t154-1\") => {:model-tag \"t\", :model-id 154, :field-index 1}
     (parse-field-id \"qpuL95JSvym3k23W1UUuog-0\") => {:model-tag \"q\", :model-id \"puL95JSvym3k23W1UUuog\", :field-index 0}"
   [field-id]
-  (when-let [[_ model-tag model-id field-index] (re-matches #"^([tcq])([^-]+)-(\d+)$" field-id)]
+  (when-let [[_ model-tag model-id field-index] (re-matches #"^([tcq])(.+)-(\d+)$" field-id)]
     {:model-tag model-tag
      ;; For tables and cards, model-id should be numeric; for queries it's a nano-id string
      :model-id (if (= model-tag "q")

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
@@ -1,6 +1,5 @@
 (ns metabase-enterprise.metabot-v3.tools.util
   (:require
-   [clojure.string :as str]
    [medley.core :as m]
    [metabase.api.common :as api]
    [metabase.audit-app.core :as audit-app]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
@@ -44,21 +44,21 @@
 (defn table-field-id-prefix
   "Return the field ID prefix for `table-id`."
   [table-id]
-  (str "t" table-id "/"))
+  (str "t" table-id "-"))
 
 (defn card-field-id-prefix
   "Return the field ID prefix for a model or a metric with ID `card-id`."
   [card-id]
-  (str "c" card-id "/"))
+  (str "c" card-id "-"))
 
 (defn query-field-id-prefix
   "Return the field ID prefix for `query-id`."
   [query-id]
-  (str "q" query-id "/"))
+  (str "q" query-id "-"))
 
 (def any-prefix-pattern
   "A prefix pattern accepting columns from any entity."
-  #"^.*/(\d+)")
+  #"^.*-(\d+)")
 
 (defn ->result-column
   "Return tool result columns for `column` of `query`. The position of `column` is determined by `index`.
@@ -79,7 +79,7 @@
 (defn parse-field-id
   "Parse a field-id string into its components.
 
-  The field-id format is '<model-tag><model-id>/<field-index>' where:
+  The field-id format is '<model-tag><model-id>-<field-index>' where:
   - model-tag is 't' for tables, 'c' for cards/models/metrics, or 'q' for ad-hoc queries
   - model-id is the numeric ID (for tables/cards) or nano-id (for queries)
   - field-index is the index within that model's visible columns
@@ -87,10 +87,10 @@
   Returns a map with :model-tag, :model-id, and :field-index keys, or nil if the format is invalid.
 
   Examples:
-    (parse-field-id \"t154/1\") => {:model-tag \"t\", :model-id 154, :field-index 1}
-    (parse-field-id \"qpuL95JSvym3k23W1UUuog/0\") => {:model-tag \"q\", :model-id \"puL95JSvym3k23W1UUuog\", :field-index 0}"
+    (parse-field-id \"t154-1\") => {:model-tag \"t\", :model-id 154, :field-index 1}
+    (parse-field-id \"qpuL95JSvym3k23W1UUuog-0\") => {:model-tag \"q\", :model-id \"puL95JSvym3k23W1UUuog\", :field-index 0}"
   [field-id]
-  (when-let [[_ model-tag model-id field-index] (re-matches #"^([tcq])([^/]+)/(\d+)$" field-id)]
+  (when-let [[_ model-tag model-id field-index] (re-matches #"^([tcq])([^-]+)-(\d+)$" field-id)]
     {:model-tag model-tag
      ;; For tables and cards, model-id should be numeric; for queries it's a nano-id string
      :model-id (if (= model-tag "q")
@@ -101,13 +101,13 @@
 (defn resolve-column
   "Resolve the reference `field-id` in filter `item` by finding the column in `columns` specified by `field-id`.
 
-  The field-id format is '<model-tag><model-id>/<field-index>' where:
+  The field-id format is '<model-tag><model-id>-<field-index>' where:
   - model-tag is 't' for tables, 'c' for cards/models/metrics, or 'q' for ad-hoc queries
   - model-id is the numeric ID (for tables/cards) or nano-id (for queries)
   - field-index is the index within that model's visible columns
 
-  For example, 't154/1' refers to the second visible column (index 1) from table 154, and
-  'qpuL95JSvym3k23W1UUuog/0' refers to the first column (index 0) from query with nano-id puL95JSvym3k23W1UUuog."
+  For example, 't154-1' refers to the second visible column (index 1) from table 154, and
+  'qpuL95JSvym3k23W1UUuog-0' refers to the first column (index 0) from query with nano-id puL95JSvym3k23W1UUuog."
   [{:keys [field-id] :as item} columns]
   (if-let [{:keys [model-tag model-id field-index]} (parse-field-id field-id)]
     (let [;; Filter columns to those from the specified model

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
@@ -108,11 +108,11 @@
   [{:keys [field-id] :as item} columns]
   (if-let [{:keys [model-tag model-id field-index]} (parse-field-id field-id)]
     (let [;; Filter columns to those from the specified model
-          ;; For queries ('q'), all columns belong to that query so we don't filter
-          model-columns (case model-tag
-                          "t" (filterv #(= (:table-id %) model-id) columns)
-                          "c" (filterv #(= (:lib/card-id %) model-id) columns)
-                          "q" columns)
+          ;; For fields in tables, we filter by table-id since it may be an implicitly-joined table to another
+          ;; table/card, and we only want to index into the columns from that specific table.
+          model-columns (if (= model-tag "t")
+                          (filterv #(= (:table-id %) model-id) columns)
+                          columns)
           ;; Get the column at the specified index within the filtered set
           column (get model-columns field-index)]
       (if column

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/dummy_tools_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/dummy_tools_test.clj
@@ -3,6 +3,7 @@
    [clojure.test :refer :all]
    [metabase-enterprise.metabot-v3.dummy-tools :as dummy-tools]
    [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]))
 
@@ -133,3 +134,27 @@
             (is (map? (:query output)))
             (is (= (mt/id) (get-in output [:query :database])))
             (is (sequential? (:result-columns output)))))))))
+
+(deftest related-tables-exclude-implicitly-joinable-fields-test
+  (testing "Related tables should only include fields from the table itself, not implicitly joinable fields"
+    (mt/test-driver :h2
+      (mt/with-current-user (mt/user->id :crowberto)
+        (let [orders-id (mt/id :orders)
+              products-id (mt/id :products)
+              ;; Get expected field count for Products table (without implicitly joinable fields)
+              products-query (lib/query (mt/metadata-provider) (mt/mbql-query products))
+              expected-products-field-count (count (lib/visible-columns products-query -1 {:include-implicitly-joinable? false}))
+              ;; Get Orders table details with related tables
+              result (dummy-tools/get-table-details {:table-id orders-id})
+              output (:structured-output result)
+              related-tables (:related_tables output)
+              products-related (first (filter #(= products-id (:id %)) related-tables))]
+
+          (testing "Orders table has Products as a related table"
+            (is (some? products-related)))
+
+          (testing "Related Products table has correct number of fields (excluding implicitly joinable fields)"
+            (is (= expected-products-field-count
+                   (count (:fields products-related)))
+                (str "Products related table should have " expected-products-field-count
+                     " fields (only its own fields, not implicitly joinable fields)"))))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/dummy_tools_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/dummy_tools_test.clj
@@ -3,7 +3,6 @@
    [clojure.test :refer :all]
    [metabase-enterprise.metabot-v3.dummy-tools :as dummy-tools]
    [metabase.lib.core :as lib]
-   [metabase.lib.metadata :as lib.metadata]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]))
 

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
@@ -262,17 +262,17 @@
                                        [:= [:get-day-of-week [:field %created_at {}] :iso] 1 7]
                                        [:= [:get-year [:field %created_at {}]] 2008]]})
                     :result_columns
-                    [{:field_id (str "q" query-id "/0")
+                    [{:field_id (str "q" query-id "-0")
                       :name "CREATED_AT"
                       :display_name "Created At: Week"
                       :type "datetime"
                       :semantic_type "creation_timestamp"}
-                     {:field_id (str "q" query-id "/1")
+                     {:field_id (str "q" query-id "-1")
                       :name "CREATED_AT_2"
                       :display_name "Created At: Day"
                       :type "datetime"
                       :semantic_type "creation_timestamp"}
-                     {:field_id (str "q" query-id "/2")
+                     {:field_id (str "q" query-id "-2")
                       :name "avg"
                       :display_name "Metrica"
                       :type "number"
@@ -653,8 +653,8 @@
                                    :query_id string?
                                    :query map?
                                    :result_columns
-                                   [{:field_id (str "q" generated-id "/0"), :name "CREATED_AT", :display_name "Created At: Week", :type "datetime"}
-                                    {:field_id (str "q" generated-id "/1"), :name "avg", :display_name "Average of Rating", :type "number"}]}
+                                   [{:field_id (str "q" generated-id "-0"), :name "CREATED_AT", :display_name "Created At: Week", :type "datetime"}
+                                    {:field_id (str "q" generated-id "-1"), :name "avg", :display_name "Average of Rating", :type "number"}]}
                :conversation_id conversation-id}
               response))
       ;; Verify the query is normalized (supports both MBQL v4 and v5)
@@ -745,21 +745,6 @@
         ;; Related tables via FK (order matches what related-tables function returns)
         expected-related-tables
         [{:type "table"
-          :id (mt/id :products)
-          :name "PRODUCTS"
-          :display_name "Products"
-          :database_id (mt/id)
-          :database_schema "PUBLIC"
-          :fields
-          [{:name "ID", :display_name "ID", :type "number", :semantic_type "pk"}
-           {:name "EAN", :display_name "Ean", :type "string", :field_values string-sequence?}
-           {:name "TITLE", :display_name "Title", :type "string", :semantic_type "title", :field_values string-sequence?}
-           {:name "CATEGORY", :display_name "Category", :type "string", :semantic_type "category", :field_values string-sequence?}
-           {:name "VENDOR", :display_name "Vendor", :type "string", :semantic_type "company", :field_values string-sequence?}
-           {:name "PRICE", :display_name "Price", :type "number"}
-           {:name "RATING", :display_name "Rating", :type "number", :semantic_type "score"}
-           {:name "CREATED_AT", :display_name "Created At", :type "datetime", :semantic_type "creation_timestamp"}]}
-         {:type "table"
           :id (mt/id :people)
           :name "PEOPLE"
           :display_name "People"
@@ -778,6 +763,21 @@
            {:name "BIRTH_DATE", :display_name "Birth Date", :type "date"}
            {:name "ZIP", :display_name "Zip", :type "string"}
            {:name "LATITUDE", :display_name "Latitude", :type "number", :semantic_type "latitude"}
+           {:name "CREATED_AT", :display_name "Created At", :type "datetime", :semantic_type "creation_timestamp"}]}
+         {:type "table"
+          :id (mt/id :products)
+          :name "PRODUCTS"
+          :display_name "Products"
+          :database_id (mt/id)
+          :database_schema "PUBLIC"
+          :fields
+          [{:name "ID", :display_name "ID", :type "number", :semantic_type "pk"}
+           {:name "EAN", :display_name "Ean", :type "string", :field_values string-sequence?}
+           {:name "TITLE", :display_name "Title", :type "string", :semantic_type "title", :field_values string-sequence?}
+           {:name "CATEGORY", :display_name "Category", :type "string", :semantic_type "category", :field_values string-sequence?}
+           {:name "VENDOR", :display_name "Vendor", :type "string", :semantic_type "company", :field_values string-sequence?}
+           {:name "PRICE", :display_name "Price", :type "number"}
+           {:name "RATING", :display_name "Rating", :type "number", :semantic_type "score"}
            {:name "CREATED_AT", :display_name "Created At", :type "datetime", :semantic_type "creation_timestamp"}]}]]
     {:model-data model-data
      :metric-data metric-data
@@ -1046,40 +1046,7 @@
            {:name "TOTAL", :display_name "Total", :type "number"}
            {:name "DISCOUNT", :display_name "Discount", :type "number", :semantic_type "discount"}
            {:name "CREATED_AT", :display_name "Created At", :type "datetime", :semantic_type "creation_timestamp"}
-           {:name "QUANTITY", :display_name "Quantity", :type "number", :semantic_type "quantity", :field_values int-sequence?}
-           {:name "ID", :display_name "ID", :type "number", :semantic_type "pk", :table_reference "User"}
-           {:name "ADDRESS", :display_name "Address", :type "string", :table_reference "User"}
-           {:name "EMAIL", :display_name "Email", :type "string", :semantic_type "email", :table_reference "User"}
-           {:name "PASSWORD", :display_name "Password", :type "string", :table_reference "User"}
-           {:name "NAME", :display_name "Name", :type "string", :semantic_type "name", :table_reference "User"}
-           {:name "CITY", :display_name "City", :type "string", :semantic_type "city", :table_reference "User"}
-           {:name "LONGITUDE", :display_name "Longitude", :type "number", :semantic_type "longitude", :table_reference "User"}
-           {:name "STATE", :display_name "State", :type "string", :semantic_type "state", :table_reference "User"}
-           {:name "SOURCE", :display_name "Source", :type "string", :semantic_type "source", :table_reference "User"}
-           {:name "BIRTH_DATE", :display_name "Birth Date", :type "date", :table_reference "User"}
-           {:name "ZIP", :display_name "Zip", :type "string", :table_reference "User"}
-           {:name "LATITUDE", :display_name "Latitude", :type "number", :semantic_type "latitude", :table_reference "User"}
-           {:name "CREATED_AT", :display_name "Created At", :type "datetime", :semantic_type "creation_timestamp", :table_reference "User"}
-           {:name "ID", :display_name "ID", :type "number", :semantic_type "pk", :table_reference "Product"}
-           {:name "EAN", :display_name "Ean", :type "string", :field_values string-sequence?, :table_reference "Product"}
-           {:name "TITLE", :display_name "Title"
-            :type "string"
-            :semantic_type "title"
-            :field_values string-sequence?
-            :table_reference "Product"}
-           {:name "CATEGORY", :display_name "Category"
-            :type "string"
-            :semantic_type "category"
-            :field_values string-sequence?
-            :table_reference "Product"}
-           {:name "VENDOR", :display_name "Vendor"
-            :type "string"
-            :semantic_type "company"
-            :field_values string-sequence?
-            :table_reference "Product"}
-           {:name "PRICE", :display_name "Price", :type "number", :table_reference "Product"}
-           {:name "RATING", :display_name "Rating", :type "number", :semantic_type "score", :table_reference "Product"}
-           {:name "CREATED_AT", :display_name "Created At", :type "datetime", :semantic_type "creation_timestamp", :table_reference "Product"}]
+           {:name "QUANTITY", :display_name "Quantity", :type "number", :semantic_type "quantity", :field_values int-sequence?}]
           request (fn [arguments]
                     (mt/user-http-request :rasta :post 200 "ee/metabot-tools/get-table-details"
                                           {:request-options {:headers {"x-metabase-session" ai-token}}}

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
@@ -110,13 +110,13 @@
                                              :query-id query-id
                                              :query {}
                                              :result-columns []}})]
-          (let [filters [{:field_id "q2a/1", :operation "is-not-null"}
-                         {:field_id "q2a/2", :operation "equals", :value "3"}
-                         {:field_id "q2a/3", :operation "equals", :values ["3" "4"]}
-                         {:field_id "q2a/5", :operation "not-equals", :values [3 4]}
-                         {:field_id "q2a/6", :operation "month-equals", :values [4 5 9]}
-                         {:field_id "c2a/6", :bucket "week-of-year" :operation "not-equals", :values [14 15 19]}
-                         {:field_id "q2a/6", :operation "year-equals", :value 2008}]
+          (let [filters [{:field_id "q2a-1", :operation "is-not-null"}
+                         {:field_id "q2a-2", :operation "equals", :value "3"}
+                         {:field_id "q2a-3", :operation "equals", :values ["3" "4"]}
+                         {:field_id "q2a-5", :operation "not-equals", :values [3 4]}
+                         {:field_id "q2a-6", :operation "month-equals", :values [4 5 9]}
+                         {:field_id "c2a-6", :bucket "week-of-year" :operation "not-equals", :values [14 15 19]}
+                         {:field_id "q2a-6", :operation "year-equals", :value 2008}]
                 response (mt/user-http-request :rasta :post 200 "ee/metabot-tools/filter-records"
                                                {:request-options {:headers {"x-metabase-session" ai-token}}}
                                                {:arguments       {:data_source data-source
@@ -132,11 +132,11 @@
                     response))))))))
 
 (deftest find-outliers-test
-  (doseq [data-source [{:query {:database 1}, :query_id "query ID", :result_field_id "q1233/2"}
-                       {:query {:database 1}, :result_field_id "q1233/2"}
+  (doseq [data-source [{:query {:database 1}, :query_id "query ID", :result_field_id "q1233-2"}
+                       {:query {:database 1}, :result_field_id "q1233-2"}
                        {:metric_id 1}
-                       {:report_id 1, :result_field_id "c131/3"}
-                       {:table_id "card__1", :result_field_id "t42/7"}]]
+                       {:report_id 1, :result_field_id "c131-3"}
+                       {:table_id "card__1", :result_field_id "t42-7"}]]
     (mt/with-premium-features #{:metabot-v3}
       (let [tool-requests (atom [])
             conversation-id (str (random-uuid))
@@ -194,15 +194,15 @@
                                            :query-id output
                                            :query {}
                                            :result-columns []}})]
-        (let [filters [{:field_id "c2/7", :operation "number-greater-than", :value 50}
-                       {:field_id "c2/3", :operation "equals", :values ["3" "4"]}
-                       {:field_id "c2/5", :operation "not-equals", :values [3 4]}
-                       {:field_id "c2/6", :operation "month-equals", :values [4 5 9]}
-                       {:field_id "c2/6", :bucket "day-of-month" :operation "not-equals", :values [14 15 19]}
-                       {:field_id "c2/6", :bucket "day-of-week" :operation "equals", :values [1 7]}
-                       {:field_id "c2/6", :operation "year-equals", :value 2008}]
-              breakouts [{:field_id "c2/4", :field_granularity "week"}
-                         {:field_id "c2/6", :field_granularity "day"}]
+        (let [filters [{:field_id "c2-7", :operation "number-greater-than", :value 50}
+                       {:field_id "c2-3", :operation "equals", :values ["3" "4"]}
+                       {:field_id "c2-5", :operation "not-equals", :values [3 4]}
+                       {:field_id "c2-6", :operation "month-equals", :values [4 5 9]}
+                       {:field_id "c2-6", :bucket "day-of-month" :operation "not-equals", :values [14 15 19]}
+                       {:field_id "c2-6", :bucket "day-of-week" :operation "equals", :values [1 7]}
+                       {:field_id "c2-6", :operation "year-equals", :value 2008}]
+              breakouts [{:field_id "c2-4", :field_granularity "week"}
+                         {:field_id "c2-6", :field_granularity "day"}]
               response (mt/user-http-request :rasta :post 200 "ee/metabot-tools/query-metric"
                                              {:request-options {:headers {"x-metabase-session" ai-token}}}
                                              {:arguments       {:metric_id 1

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
@@ -230,7 +230,7 @@
                        :dataset_query (lib/->legacy-MBQL source-query)
                        :type :metric}]
       (mt/with-temp [:model/Card {metric-id :id} metric-data]
-        (let [fid #(format "c%d/%d" metric-id %)
+        (let [fid #(format "c%d-%d" metric-id %)
               filters [{:field_id (fid 0), :operation "number-greater-than", :value 50} ; ID
                        {:field_id (fid 2), :operation "equals", :values ["3" "4"]}      ; Title
                        {:field_id (fid 6), :operation "not-equals", :values [3 4]}      ; Rating
@@ -294,19 +294,19 @@
                                            :query-id output
                                            :query {}
                                            :result-columns []}})]
-        (let [fields [{:field_id "c2/8", :bucket "year-of-era"}
-                      {:field_id "c2/9"}]
-              filters [{:field_id "c2/7", :operation "number-greater-than", :value 50}
-                       {:field_id "c2/3", :operation "equals", :values ["3" "4"]}
-                       {:field_id "c2/5", :operation "not-equals", :values [3 4]}
-                       {:field_id "c2/6", :operation "month-equals", :values [4 5 9]}
-                       {:field_id "c2/6", :bucket "day-of-month" :operation "not-equals", :values [14 15 19]}
-                       {:field_id "c2/6", :bucket "day-of-week" :operation "equals", :values [1 7]}
-                       {:field_id "c2/6", :operation "year-equals", :value 2008}]
-              aggregations [{:field_id "c2/10", :bucket "week", :function "count-distinct"}
-                            {:field_id "c2/11", :function "sum"}]
-              breakouts [{:field_id "c2/4", :field_granularity "week"}
-                         {:field_id "c2/6", :field_granularity "day"}]
+        (let [fields [{:field_id "c2-8", :bucket "year-of-era"}
+                      {:field_id "c2-9"}]
+              filters [{:field_id "c2-7", :operation "number-greater-than", :value 50}
+                       {:field_id "c2-3", :operation "equals", :values ["3" "4"]}
+                       {:field_id "c2-5", :operation "not-equals", :values [3 4]}
+                       {:field_id "c2-6", :operation "month-equals", :values [4 5 9]}
+                       {:field_id "c2-6", :bucket "day-of-month" :operation "not-equals", :values [14 15 19]}
+                       {:field_id "c2-6", :bucket "day-of-week" :operation "equals", :values [1 7]}
+                       {:field_id "c2-6", :operation "year-equals", :value 2008}]
+              aggregations [{:field_id "c2-10", :bucket "week", :function "count-distinct"}
+                            {:field_id "c2-11", :function "sum"}]
+              breakouts [{:field_id "c2-4", :field_granularity "week"}
+                         {:field_id "c2-6", :field_granularity "day"}]
               response (mt/user-http-request :rasta :post 200 "ee/metabot-tools/query-model"
                                              {:request-options {:headers {"x-metabase-session" ai-token}}}
                                              {:arguments       {:model_id     1
@@ -338,7 +338,7 @@
                       (swap! tool-requests conj arguments)
                       {:structured-output output})]
         (let [fields []
-              filters [{:field_id "c2/7", :operation "number-greater-than", :value 50}]
+              filters [{:field_id "c2-7", :operation "number-greater-than", :value 50}]
               response (mt/user-http-request :rasta :post 200 "ee/metabot-tools/query-model"
                                              {:request-options {:headers {"x-metabase-session" ai-token}}}
                                              {:arguments       {:model_id     1
@@ -427,17 +427,17 @@
                                           (assoc :id metric-id
                                                  :type "metric"
                                                  :verified true
-                                                 :default_time_dimension_field_id (format "c%d/%d" metric-id 7)
+                                                 :default_time_dimension_field_id (format "c%d-%d" metric-id 7)
                                                  :queryable_dimensions
-                                                 (map-indexed #(assoc %2 :field_id (format "c%d/%d" metric-id %1))
+                                                 (map-indexed #(assoc %2 :field_id (format "c%d-%d" metric-id %1))
                                                               expected-fields)))
                                       (-> model-metric-data
                                           (select-keys [:name :description])
                                           (assoc :id model-metric-id
                                                  :type "metric"
-                                                 :default_time_dimension_field_id (format "c%d/%d" model-metric-id 7)
+                                                 :default_time_dimension_field_id (format "c%d-%d" model-metric-id 7)
                                                  :queryable_dimensions
-                                                 (map-indexed #(assoc %2 :field_id (format "c%d/%d" model-metric-id %1))
+                                                 (map-indexed #(assoc %2 :field_id (format "c%d-%d" model-metric-id %1))
                                                               expected-fields)))]
                             :models [(-> model-data
                                          (select-keys [:name :description :database_id])
@@ -445,13 +445,13 @@
                                                 :type "model"
                                                 :verified true
                                                 :display_name "Model Model"
-                                                :fields (map-indexed #(assoc %2 :field_id (format "c%d/%d" model-id %1))
+                                                :fields (map-indexed #(assoc %2 :field_id (format "c%d-%d" model-id %1))
                                                                      expected-fields)
                                                 :metrics
                                                 [{:id model-metric-id
                                                   :name "Model metric"
                                                   :description "Model metric desc"
-                                                  :default_time_dimension_field_id (format "c%d/%d" model-metric-id 7)}]))]}
+                                                  :default_time_dimension_field_id (format "c%d-%d" model-metric-id 7)}]))]}
                            :conversation_id conversation-id}
                           response))))
               (testing "Minimal call"
@@ -589,9 +589,9 @@
                                             (assoc :id metric-id
                                                    :type "metric"
                                                    :verified true
-                                                   :default_time_dimension_field_id (format "c%d/%d" metric-id 7)
+                                                   :default_time_dimension_field_id (format "c%d-%d" metric-id 7)
                                                    :queryable_dimensions
-                                                   (map-indexed #(assoc %2 :field_id (format "c%d/%d" metric-id %1))
+                                                   (map-indexed #(assoc %2 :field_id (format "c%d-%d" metric-id %1))
                                                                 expected-fields)))
                      :conversation_id conversation-id}
                     (request {:metric_id metric-id}))))
@@ -601,10 +601,10 @@
                                             (assoc :id metric-id
                                                    :type "metric"
                                                    :verified true
-                                                   :default_time_dimension_field_id (format "c%d/%d" metric-id 7)
+                                                   :default_time_dimension_field_id (format "c%d-%d" metric-id 7)
                                                    :queryable_dimensions
                                                    (map-indexed #(assoc %2
-                                                                        :field_id (format "c%d/%d" metric-id %1)
+                                                                        :field_id (format "c%d-%d" metric-id %1)
                                                                         :field_values missing-value)
                                                                 expected-fields)))
                      :conversation_id conversation-id}
@@ -616,7 +616,7 @@
                                             (assoc :id metric-id
                                                    :type "metric"
                                                    :verified true
-                                                   :default_time_dimension_field_id (format "c%d/%d" metric-id 7)
+                                                   :default_time_dimension_field_id (format "c%d-%d" metric-id 7)
                                                    :queryable_dimensions missing-value))
                      :conversation_id conversation-id}
                     (request {:metric_id                 metric-id
@@ -693,7 +693,7 @@
                                                      :type "question"
                                                      :verified true
                                                      :result_columns
-                                                     (map-indexed #(assoc %2 :field_id (format "c%d/%d" question-id %1))
+                                                     (map-indexed #(assoc %2 :field_id (format "c%d-%d" question-id %1))
                                                                   expected-fields)))
                        :conversation_id conversation-id}
                       (request arguments))))
@@ -704,7 +704,7 @@
                                                      :type "question"
                                                      :result_columns
                                                      (map-indexed #(assoc %2
-                                                                          :field_id (format "c%d/%d" question-id %1)
+                                                                          :field_id (format "c%d-%d" question-id %1)
                                                                           :field_values missing-value)
                                                                   expected-fields)))
                        :conversation_id conversation-id}
@@ -1098,7 +1098,7 @@
                                          :database_schema "PUBLIC"
                                          :id table-id
                                          :type "table"
-                                         :fields (map-indexed #(assoc %2 :field_id (format "t%d/%d" table-id %1))
+                                         :fields (map-indexed #(assoc %2 :field_id (format "t%d-%d" table-id %1))
                                                               expected-fields)
                                          :metrics [(assoc metric-data
                                                           :id metric-id
@@ -1115,7 +1115,7 @@
                                          :id table-id
                                          :type "table"
                                          :fields (map-indexed #(assoc %2
-                                                                      :field_id (format "t%d/%d" table-id %1)
+                                                                      :field_id (format "t%d-%d" table-id %1)
                                                                       :field_values missing-value)
                                                               expected-fields)
                                          :metrics [(assoc metric-data

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
@@ -817,15 +817,15 @@
                                                        :type "model"
                                                        :display_name "Model Model"
                                                        :verified true
-                                                       :fields (add-field-ids (format "c%d/%%d" model-id) expected-core-fields)
+                                                       :fields (add-field-ids (format "c%d-%%d" model-id) expected-core-fields)
                                                        :related_tables
                                                        (map #(update % :fields
-                                                                     (partial add-field-ids (format "t%d/%%d" (:id %))))
+                                                                     (partial add-field-ids (format "t%d-%%d" (:id %))))
                                                             expected-related-tables)
                                                        :metrics [(assoc metric-data
                                                                         :id metric-id
                                                                         :type "metric"
-                                                                        :default_time_dimension_field_id (format "c%d/7" metric-id))]))
+                                                                        :default_time_dimension_field_id (format "c%d-7" metric-id))]))
                          :conversation_id conversation-id}
                         (request arguments)))))))))))
 
@@ -855,18 +855,18 @@
                                                      :display_name "Model Model"
                                                      :verified true
                                                      :fields
-                                                     (add-field-ids (format "c%d/%%d" model-id) expected-core-fields
+                                                     (add-field-ids (format "c%d-%%d" model-id) expected-core-fields
                                                                     #(assoc % :field_values missing-value))
                                                      :related_tables
                                                      (map (fn [table]
                                                             (update table :fields
-                                                                    #(add-field-ids (format "t%d/%%d" (:id table)) %
+                                                                    #(add-field-ids (format "t%d-%%d" (:id table)) %
                                                                                     (fn [f] (assoc f :field_values missing-value)))))
                                                           expected-related-tables)
                                                      :metrics [(assoc metric-data
                                                                       :id metric-id
                                                                       :type "metric"
-                                                                      :default_time_dimension_field_id (format "c%d/7" metric-id))]))
+                                                                      :default_time_dimension_field_id (format "c%d-7" metric-id))]))
                        :conversation_id conversation-id}
                       (request (assoc arguments :with_field_values false)))))))))))
 
@@ -901,7 +901,7 @@
                                                      :metrics [(assoc metric-data
                                                                       :id metric-id
                                                                       :type "metric"
-                                                                      :default_time_dimension_field_id (format "c%d/7" metric-id))]))
+                                                                      :default_time_dimension_field_id (format "c%d-7" metric-id))]))
                        :conversation_id conversation-id}
                       (request (assoc arguments :with_fields false)))))))))))
 
@@ -1103,7 +1103,7 @@
                                          :metrics [(assoc metric-data
                                                           :id metric-id
                                                           :type "metric"
-                                                          :default_time_dimension_field_id (format "c%d/7" metric-id))]}
+                                                          :default_time_dimension_field_id (format "c%d-7" metric-id))]}
                      :conversation_id conversation-id}
                     (request {:table_id arg-id})))))
         (let [arguments {:table_id table-id}]
@@ -1121,7 +1121,7 @@
                                          :metrics [(assoc metric-data
                                                           :id metric-id
                                                           :type "metric"
-                                                          :default_time_dimension_field_id (format "c%d/7" metric-id))]}
+                                                          :default_time_dimension_field_id (format "c%d-7" metric-id))]}
                      :conversation_id conversation-id}
                     (request (assoc arguments :with_field_values false)))))
           (testing "Without fields"
@@ -1135,7 +1135,7 @@
                                          :metrics [(assoc metric-data
                                                           :id metric-id
                                                           :type "metric"
-                                                          :default_time_dimension_field_id (format "c%d/7" metric-id))]}
+                                                          :default_time_dimension_field_id (format "c%d-7" metric-id))]}
                      :conversation_id conversation-id}
                     (request (assoc arguments :with_fields false)))))
           (testing "Without fields and metric default time dimension"

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/field_stats_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/field_stats_test.clj
@@ -43,9 +43,9 @@
         people-query (table-query mp people-id)
         birth-date-id (visible-field-id people-query (metabot-v3.tools.u/table-field-id-prefix people-id) "Birth Date")
         state-id (visible-field-id people-query (metabot-v3.tools.u/table-field-id-prefix people-id) "State")
-        orders-id (mt/id :orders)
-        orders-query (table-query mp orders-id)
-        category-id (visible-field-id orders-query (metabot-v3.tools.u/table-field-id-prefix orders-id) "Category")]
+        products-id (mt/id :products)
+        products-query (table-query mp products-id)
+        category-id (visible-field-id products-query (metabot-v3.tools.u/table-field-id-prefix products-id) "Category")]
     (testing "No read permission results in an error."
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"You don't have permissions to do that."
                             (metabot-v3.tools.field-stats/field-values
@@ -69,7 +69,7 @@
                                                 :percent-state  1.0
                                                 :average-length 2.0}
                                    :values     ["AK" "AL" "AR" "AZ" "CA"]}
-          orders-id category-id   {:statistics {:distinct-count 4
+          products-id category-id {:statistics {:distinct-count 4
                                                 :percent-null   0.0
                                                 :percent-json   0.0
                                                 :percent-url    0.0

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/util_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/util_test.clj
@@ -192,7 +192,13 @@
       (is (= {:model-tag "q", :model-id "puL95JSvym3k23W1UUuog", :field-index 0}
              (metabot-v3.tools.util/parse-field-id "qpuL95JSvym3k23W1UUuog-0")))
       (is (= {:model-tag "q", :model-id "abc123XYZ", :field-index 5}
-             (metabot-v3.tools.util/parse-field-id "qabc123XYZ-5"))))))
+             (metabot-v3.tools.util/parse-field-id "qabc123XYZ-5"))))
+
+    (testing "query field IDs with nano-id containing dashes"
+      (is (= {:model-tag "q", :model-id "wG9GfYTcE-wKTg3wlZyuc", :field-index 6}
+             (metabot-v3.tools.util/parse-field-id "qwG9GfYTcE-wKTg3wlZyuc-6")))
+      (is (= {:model-tag "q", :model-id "a-b-c", :field-index 0}
+             (metabot-v3.tools.util/parse-field-id "qa-b-c-0"))))))
 
 (deftest resolve-column-test
   (testing "resolve-column resolves field IDs to columns"

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/util_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/util_test.clj
@@ -171,3 +171,81 @@
                       unverified-ids #{(:id unverified-model) (:id unverified-metric)}]
                   (is (every? verified-ids (take 2 ordered-ids)))
                   (is (every? unverified-ids (drop 2 ordered-ids))))))))))))
+
+(deftest parse-field-id-test
+  (testing "parse-field-id parses valid field IDs correctly"
+    (testing "table field IDs with numeric table ID"
+      (is (= {:model-tag "t", :model-id 154, :field-index 1}
+             (metabot-v3.tools.util/parse-field-id "t154-1")))
+      (is (= {:model-tag "t", :model-id 1, :field-index 0}
+             (metabot-v3.tools.util/parse-field-id "t1-0")))
+      (is (= {:model-tag "t", :model-id 999, :field-index 42}
+             (metabot-v3.tools.util/parse-field-id "t999-42"))))
+
+    (testing "card/model/metric field IDs with numeric card ID"
+      (is (= {:model-tag "c", :model-id 125, :field-index 7}
+             (metabot-v3.tools.util/parse-field-id "c125-7")))
+      (is (= {:model-tag "c", :model-id 2, :field-index 0}
+             (metabot-v3.tools.util/parse-field-id "c2-0"))))
+
+    (testing "query field IDs with nano-id string"
+      (is (= {:model-tag "q", :model-id "puL95JSvym3k23W1UUuog", :field-index 0}
+             (metabot-v3.tools.util/parse-field-id "qpuL95JSvym3k23W1UUuog-0")))
+      (is (= {:model-tag "q", :model-id "abc123XYZ", :field-index 5}
+             (metabot-v3.tools.util/parse-field-id "qabc123XYZ-5"))))))
+
+(deftest resolve-column-test
+  (testing "resolve-column resolves field IDs to columns"
+    (let [columns [{:name "ID" :table-id 1 :type :number}           ; index 0
+                   {:name "NAME" :table-id 1 :type :string}         ; index 1
+                   {:name "EMAIL" :table-id 1 :type :string}        ; index 2
+                   {:name "USER_ID" :table-id 2 :type :number}      ; index 0 for table 2
+                   {:name "TOTAL" :table-id 2 :type :number}]]      ; index 1 for table 2
+      (testing "resolves table field IDs correctly"
+        (let [item {:field-id "t1-0" :operation "equals"}
+              result (metabot-v3.tools.util/resolve-column item columns)]
+          (is (= "ID" (get-in result [:column :name])))
+          (is (= 1 (get-in result [:column :table-id])))
+          (is (= :number (get-in result [:column :type])))))
+
+      (testing "resolves table field IDs with filtering by table-id"
+        (let [item {:field-id "t2-0" :operation "equals"}
+              result (metabot-v3.tools.util/resolve-column item columns)]
+          (is (= "USER_ID" (get-in result [:column :name])))
+          (is (= 2 (get-in result [:column :table-id])))))
+
+      (testing "resolves card field IDs without filtering by table-id"
+        (let [item {:field-id "c125-1" :operation "equals"}
+              result (metabot-v3.tools.util/resolve-column item columns)]
+          (is (= "NAME" (get-in result [:column :name])))
+          (is (= 1 (get-in result [:column :table-id])))))
+
+      (testing "resolves query field IDs"
+        (let [item {:field-id "qabc123-2" :operation "equals"}
+              result (metabot-v3.tools.util/resolve-column item columns)]
+          (is (= "EMAIL" (get-in result [:column :name])))))))
+
+  (testing "resolve-column throws for invalid field IDs"
+    (let [columns [{:name "ID" :table-id 1 :type :number}
+                   {:name "NAME" :table-id 1 :type :string}]]
+      (testing "throws for invalid field ID format"
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"invalid field_id format"
+             (metabot-v3.tools.util/resolve-column {:field-id "invalid"} columns)))
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"invalid field_id format"
+             (metabot-v3.tools.util/resolve-column {:field-id "t154/1"} columns))))
+
+      (testing "throws when field index is out of bounds"
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"field t1-10 not found"
+             (metabot-v3.tools.util/resolve-column {:field-id "t1-10"} columns))))
+
+      (testing "throws when no columns match the table ID"
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"field t999-0 not found"
+             (metabot-v3.tools.util/resolve-column {:field-id "t999-0"} columns)))))))


### PR DESCRIPTION
The field ID format for Metabot had the following syntax:
* `t<table-id>/<field-index>`
* `c<card-id>/<field-index>` for cards, models and metrics
* `q<query-id>/<field-index>` for ad-hoc queries

`resolve-column` had a subtle bug: it took a `field-id-prefix` parameter, which might be passed in as `c<card-id>/` or `q<query-id>/` for a card/query. But the actual field ID could be `t<table-id>/<field-index>` if the field is from an implicitly-joinable table to the original entity. 

This PR refactors this function to instead parse the given field-id without using an expected prefix, and if it's a field from a table, ensure that we only index into fields with a matching table-id.

I've also fixed our `table-details` logic so that it only returns fields for the table itself, not for implicitly-joined tables. These fields should be only included explicitly in the `:related_tables` key.

I've also made a minor change to a Malli schema to address https://linear.app/metabase/issue/BOT-566/fix-issue-where-the-hour-granularity-is-not-available-for-group-by. Rolled it into this PR but I can break it out if anyone objects.

**Furthermore** I've changed the field ID syntax to use `-` instead of `/` for separating the table/card/query ID from the field index per @Somtom's  request.