### PR TITLE
Remove edit permissions in ellipsis menu when viewing shared tenant collection

### DIFF
--- a/frontend/src/metabase/collections/components/CollectionMenu/CollectionMenu.tsx
+++ b/frontend/src/metabase/collections/components/CollectionMenu/CollectionMenu.tsx
@@ -11,7 +11,7 @@ import { ForwardRefLink } from "metabase/common/components/Link";
 import { useHasDashboardQuestionCandidates } from "metabase/common/components/MoveQuestionsIntoDashboardsModal/hooks";
 import { UserHasSeenAll } from "metabase/common/components/UserHasSeen/UserHasSeenAll";
 import * as Urls from "metabase/lib/urls";
-import { PLUGIN_COLLECTIONS } from "metabase/plugins";
+import { PLUGIN_COLLECTIONS, PLUGIN_TENANTS } from "metabase/plugins";
 import { ActionIcon, Icon, Indicator, Menu, Tooltip } from "metabase/ui";
 import type { Collection } from "metabase-types/api";
 
@@ -44,6 +44,8 @@ export const CollectionMenu = ({
   const isPersonal = isPersonalCollection(collection);
   const isInstanceAnalyticsCustom =
     isInstanceAnalyticsCustomCollection(collection);
+  const isSharedTenantCollection =
+    PLUGIN_TENANTS.isTenantCollection(collection);
 
   const canWrite = collection.can_write;
   const canMove =
@@ -77,7 +79,7 @@ export const CollectionMenu = ({
     );
   }
 
-  if (isAdmin && !isPersonal) {
+  if (isAdmin && !isPersonal && !isSharedTenantCollection) {
     editItems.push(
       <Menu.Item
         key="collection-edit"

--- a/frontend/src/metabase/collections/components/CollectionMenu/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionMenu/tests/enterprise.unit.spec.tsx
@@ -1,7 +1,10 @@
 import userEvent from "@testing-library/user-event";
 
 import { getIcon, screen } from "__support__/ui";
-import { createMockCollection } from "metabase-types/api/mocks";
+import {
+  createMockCollection,
+  createMockTokenFeatures,
+} from "metabase-types/api/mocks";
 
 import type { SetupOpts } from "./setup";
 import { setup } from "./setup";
@@ -23,5 +26,19 @@ describe("CollectionMenu", () => {
     expect(
       screen.queryByText("Make collection official"),
     ).not.toBeInTheDocument();
+  });
+
+  it("should not be able to edit permissions for shared tenant collections", async () => {
+    setupEnterprise({
+      collection: createMockCollection({
+        can_write: true,
+        type: "shared-tenant-collection",
+      }),
+      isAdmin: true,
+      tokenFeatures: createMockTokenFeatures({ tenants: true }),
+    });
+
+    await userEvent.click(getIcon("ellipsis"));
+    expect(screen.queryByText("Edit permissions")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Closes EMB-1003

### Description

Remove the 'Edit permissions' menu item when viewing shared tenant collections.

### How to verify

- Use the MB_ALL_FEATURES_TOKEN as this is an in-development feature
- Enable multi-tenancy by going to "People > Settings Icon" and set User Strategy to Multi-tenant
- Create a tenant in the "Tenant" menu
- Create a shared tenant collection using the left sidebar > "TENANT COLLECTIONS" > Plus icon.
- Click on the shared tenant collection
- Click on the ellipsis menu on the top right
- You should not see 'Edit permissions' even if you are an admin

### Demo

<img width="2466" height="702" alt="CleanShot 2568-11-20 at 03 57 38@2x" src="https://github.com/user-attachments/assets/3018e425-f0e6-4cc0-9809-1cfc6ed1d7f7" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
