### PR TITLE
Suggest external users only when adding tenant group members

### DIFF
--- a/e2e/test/scenarios/admin-2/tenants.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/tenants.cy.spec.js
@@ -774,7 +774,9 @@ describe("tenant users", () => {
     cy.button("Add members").click();
     cy.wait("@listUsers");
 
-    cy.findByPlaceholderText(/Julie McMemberson/).type("gizmo");
+    cy.findByRole("textbox", { name: /search for a user to add/i }).type(
+      "gizmo",
+    );
 
     H.popover().within(() => {
       cy.log("tenant user should be visible");

--- a/e2e/test/scenarios/admin-2/tenants.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/tenants.cy.spec.js
@@ -54,6 +54,8 @@ const SECOND_DOOHICKEY_USER = {
 const TENANTS = [GIZMO_TENANT, DOOHICKEY_TENANT];
 const USERS = [GIZMO_USER, DOOHICKEY_USER, SECOND_DOOHICKEY_USER];
 
+const GIZMO_FULL_NAME = H.getFullName(GIZMO_USER);
+
 describe("Tenants - management OSS", { tags: "@OSS" }, () => {
   beforeEach(() => {
     H.restore();
@@ -578,7 +580,7 @@ describe("tenant users", () => {
     cy.findByTestId("admin-layout-content").findByText("1 person found");
 
     cy.findAllByRole("row")
-      .contains("tr", "gizmo user")
+      .contains("tr", GIZMO_FULL_NAME)
       .findByRole("button", { name: /ellipsis/ })
       .click();
 
@@ -606,7 +608,7 @@ describe("tenant users", () => {
     );
 
     cy.findAllByRole("row")
-      .contains("tr", "gizmo user")
+      .contains("tr", GIZMO_FULL_NAME)
       .findByRole("link", { name: /refresh/ })
       .realHover();
 
@@ -780,20 +782,20 @@ describe("tenant users", () => {
 
     H.popover().within(() => {
       cy.log("tenant user should be visible");
-      cy.findByText("gizmo user").should("be.visible");
+      cy.findByText(GIZMO_FULL_NAME).should("be.visible");
 
       cy.log("internal user should not be visible");
       cy.findByText("Bobby Tables").should("not.exist");
 
       cy.log("select a tenant user to add");
-      cy.findByText("gizmo user").click();
+      cy.findByText(GIZMO_FULL_NAME).click();
     });
 
     cy.button("Add").click();
 
     cy.log("user should be added to the group");
     cy.findByTestId("admin-content-table")
-      .findByText("gizmo user")
+      .findByText(GIZMO_FULL_NAME)
       .should("be.visible");
   });
 });

--- a/e2e/test/scenarios/admin-2/tenants.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/tenants.cy.spec.js
@@ -787,7 +787,7 @@ describe("tenant users", () => {
       cy.findByText("gizmo user").click();
     });
 
-    cy.findByTestId("add-member-button").click();
+    cy.button("Add").click();
 
     cy.log("user should be added to the group");
     cy.findByTestId("admin-content-table")

--- a/frontend/src/metabase/admin/people/components/AddMemberRow.tsx
+++ b/frontend/src/metabase/admin/people/components/AddMemberRow.tsx
@@ -3,28 +3,40 @@ import { t } from "ttag";
 
 import { useListUsersQuery } from "metabase/api";
 import UserAvatar from "metabase/common/components/UserAvatar";
+import { PLUGIN_TENANTS } from "metabase/plugins";
 import { Flex, Pill, Popover, Text, UnstyledButton } from "metabase/ui";
-import type { Member, User } from "metabase-types/api";
+import type { Group, Member, User } from "metabase-types/api";
 
 import { userToColor } from "../colors";
 
 import { AddRow } from "./AddRow";
 
 interface AddMemberRowProps {
+  group: Group;
   members: Member[];
   onCancel: () => void;
   onDone: (userIds: number[]) => void;
 }
 
-export function AddMemberRow({ members, onCancel, onDone }: AddMemberRowProps) {
-  const listUsersReq = useListUsersQuery();
+export function AddMemberRow({
+  group,
+  members,
+  onCancel,
+  onDone,
+}: AddMemberRowProps) {
+  const isTenantGroup = PLUGIN_TENANTS.isTenantGroup(group);
+
+  const listUsersQuery = useListUsersQuery(
+    isTenantGroup ? { tenancy: "external" } : undefined,
+  );
+
   const [text, setText] = useState("");
   const [selectedUsersById, setSelectedUsersById] = useState<Map<number, User>>(
     new Map(),
   );
 
   const availableToSelectUsers = useMemo(() => {
-    const { isLoading, error, data } = listUsersReq;
+    const { isLoading, error, data } = listUsersQuery;
     if (isLoading || error) {
       return [];
     }
@@ -33,7 +45,7 @@ export function AddMemberRow({ members, onCancel, onDone }: AddMemberRowProps) {
     return allUsers.filter(
       ({ id }) => !selectedUsersById.has(id) && !groupMemberIds.has(id),
     );
-  }, [members, selectedUsersById, listUsersReq]);
+  }, [members, selectedUsersById, listUsersQuery]);
 
   const handleRemoveUser = (user: User) => {
     const newSelectedUsersById = new Map(selectedUsersById);

--- a/frontend/src/metabase/admin/people/components/AddMemberRow.tsx
+++ b/frontend/src/metabase/admin/people/components/AddMemberRow.tsx
@@ -89,6 +89,7 @@ export function AddMemberRow({
                 onChange={(e) => setText(e.target.value)}
                 onDone={handleDone}
                 onCancel={onCancel}
+                ariaLabel={t`Search for a user to add`}
               >
                 {Array.from(selectedUsersById.values()).map((user, index) => (
                   <Pill

--- a/frontend/src/metabase/admin/people/components/AddRow.tsx
+++ b/frontend/src/metabase/admin/people/components/AddRow.tsx
@@ -7,6 +7,7 @@ interface AddRowProps {
   value: string;
   isValid: boolean;
   placeholder?: string;
+  ariaLabel?: string;
   onKeyDown?: (event: React.KeyboardEvent) => void;
   onChange: (event: ChangeEvent<HTMLInputElement>) => void;
   onDone: () => void;
@@ -18,6 +19,7 @@ export const AddRow = ({
   value,
   isValid,
   placeholder,
+  ariaLabel,
   onKeyDown,
   onChange,
   onDone,
@@ -41,6 +43,7 @@ export const AddRow = ({
       styles={{ input: { background: "transparent" } }}
       value={value}
       placeholder={placeholder}
+      aria-label={ariaLabel}
       autoFocus
       onKeyDown={onKeyDown}
       onChange={onChange}

--- a/frontend/src/metabase/admin/people/components/AddRow.tsx
+++ b/frontend/src/metabase/admin/people/components/AddRow.tsx
@@ -53,7 +53,6 @@ export const AddRow = ({
       bg={!isValid ? "transparent" : ""}
       disabled={!isValid}
       onClick={onDone}
-      data-testid="add-member-button"
     >
       {t`Add`}
     </Button>

--- a/frontend/src/metabase/admin/people/components/AddRow.tsx
+++ b/frontend/src/metabase/admin/people/components/AddRow.tsx
@@ -53,6 +53,7 @@ export const AddRow = ({
       bg={!isValid ? "transparent" : ""}
       disabled={!isValid}
       onClick={onDone}
+      data-testid="add-member-button"
     >
       {t`Add`}
     </Button>

--- a/frontend/src/metabase/admin/people/components/GroupMembersTable/GroupMembersTable.tsx
+++ b/frontend/src/metabase/admin/people/components/GroupMembersTable/GroupMembersTable.tsx
@@ -61,6 +61,7 @@ export function GroupMembersTable({
       >
         {showAddUser && (
           <AddMemberRow
+            group={group}
             members={members}
             onCancel={onAddUserCancel}
             onDone={onAddUserDone}


### PR DESCRIPTION
Closes EMB-1004

### Description

When adding members to tenant groups, it should only show external users as opposed to internal users.

### How to verify

- Use the MB_ALL_FEATURES_TOKEN as this is an in-development feature
- Enable multi-tenancy by going to "People > Settings Icon" and set User Strategy to Multi-tenant
- Create a tenant in the "Tenant" menu
- Create an external user in the "External Users" menu
- Go to the "Tenant Groups" sidebar menu
- Click on a tenant group.
- Click "Add members"
- You should only see external users there. You shouldn't see any internal users there.

### Demo

<img width="2466" height="994" alt="CleanShot 2568-11-20 at 04 48 28@2x" src="https://github.com/user-attachments/assets/4e613702-b9b8-44c8-8de6-d8fc2619d35c" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
