### PR TITLE
feat: use boolean flag for remote-sync status

### DIFF
--- a/e2e/support/assets/example_synced_collection/collections/AF_m-cEw4pFjXYd90_tnj_library/AF_m-cEw4pFjXYd90_tnj_library.yaml
+++ b/e2e/support/assets/example_synced_collection/collections/AF_m-cEw4pFjXYd90_tnj_library/AF_m-cEw4pFjXYd90_tnj_library.yaml
@@ -5,7 +5,7 @@ slug: synced_collection
 archive_operation_id: null
 name: Synced Collection
 personal_owner_id: null
-type: remote-synced
+type: null
 is_sample: false
 parent_id: null
 serdes/meta:
@@ -16,3 +16,4 @@ archived_directly: null
 entity_id: AF_m-cEw4pFjXYd90_tnj
 namespace: null
 created_at: '2025-10-23T09:38:19.057632-07:00'
+is_remote_synced: true

--- a/e2e/support/helpers/e2e-remote-sync-helpers.ts
+++ b/e2e/support/helpers/e2e-remote-sync-helpers.ts
@@ -96,7 +96,7 @@ export const wrapSyncedCollection = (alias = "syncedCollection", n = 0) => {
 
   cy.request("/api/collection").then(({ body: collections }) => {
     const syncedCollection = collections.find(
-      (c: Collection) => c.type === "remote-synced" && c.location === "/",
+      (c: Collection) => c.is_remote_synced && c.location === "/",
     );
 
     if (syncedCollection) {

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
@@ -25,7 +25,7 @@
 (defn- all-top-level-remote-synced-collections
   "Returns a vector of primary keys for all top-level remote-synced collections."
   []
-  (t2/select-pks-vec :model/Collection :type "remote-synced"))
+  (t2/select-pks-vec :model/Collection :is_remote_synced true))
 
 (defn- sync-objects!
   "Populates the remote-sync-object table with imported entities. Deletes all existing RemoteSyncObject records and
@@ -182,7 +182,7 @@
   [^SourceSnapshot snapshot task-id message]
   (if snapshot
     (let [sync-timestamp (t/instant)
-          collections (t2/select-fn-set :entity_id :model/Collection :type "remote-synced" :location "/")]
+          collections (t2/select-fn-set :entity_id :model/Collection :is_remote_synced true :location "/")]
       (if (empty? collections)
         {:status :error
          :message "No remote-synced collections available to sync."}

--- a/enterprise/backend/test/metabase_enterprise/documents/api/document_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/documents/api/document_test.clj
@@ -2317,7 +2317,7 @@
       (mt/with-model-cleanup [:model/Document]
         (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced Collection"
                                                                  :location "/"
-                                                                 :type "remote-synced"}
+                                                                 :is_remote_synced true}
                        :model/Collection {regular-id :id} {:name "Regular Collection"
                                                            :location "/"
                                                            :type nil}
@@ -2340,7 +2340,7 @@
       (mt/with-model-cleanup [:model/Document]
         (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced Collection"
                                                                  :location "/"
-                                                                 :type "remote-synced"}
+                                                                 :is_remote_synced true}
                        :model/Card {card-id :id} {:name "Remote-Synced Card"
                                                   :collection_id remote-synced-id
                                                   :dataset_query (mt/mbql-query venues)}]
@@ -2363,7 +2363,7 @@
                                                            :type nil}
                        :model/Collection {remote-synced-id :id} {:name "Remote-Synced Collection"
                                                                  :location "/"
-                                                                 :type "remote-synced"}
+                                                                 :is_remote_synced true}
                        :model/Card {remote-card-id :id} {:name "Remote-Synced Card"
                                                          :collection_id remote-synced-id
                                                          :dataset_query (mt/mbql-query venues)}
@@ -2392,7 +2392,7 @@
     (mt/with-temporary-setting-values [remote-sync-type :read-write]
       (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced Collection"
                                                                :location "/"
-                                                               :type "remote-synced"}
+                                                               :is_remote_synced true}
                      :model/Collection {regular-id :id} {:name "Regular Collection"
                                                          :location "/"
                                                          :type nil}
@@ -2414,7 +2414,7 @@
     (mt/with-temporary-setting-values [remote-sync-type :read-write]
       (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced Collection"
                                                                :location "/"
-                                                               :type "remote-synced"}
+                                                               :is_remote_synced true}
                      :model/Document {doc-id :id} {:name "Test Document"
                                                    :collection_id remote-synced-id
                                                    :document (documents.test-util/text->prose-mirror-ast "Initial")}
@@ -2434,7 +2434,7 @@
     (mt/with-temporary-setting-values [remote-sync-type :read-write]
       (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced Collection"
                                                                :location "/"
-                                                               :type "remote-synced"}
+                                                               :is_remote_synced true}
                      :model/Collection {regular-id :id} {:name "Regular Collection"
                                                          :location "/"
                                                          :type nil}
@@ -2457,7 +2457,7 @@
     (mt/with-temporary-setting-values [remote-sync-type :read-write]
       (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced Collection"
                                                                :location "/"
-                                                               :type "remote-synced"}
+                                                               :is_remote_synced true}
                      :model/Card {card-id :id} {:name "Remote-Synced Card"
                                                 :collection_id remote-synced-id
                                                 :dataset_query (mt/mbql-query venues)}
@@ -2477,7 +2477,7 @@
     (mt/with-temporary-setting-values [remote-sync-type :read-write]
       (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced Collection"
                                                                :location "/"
-                                                               :type "remote-synced"}
+                                                               :is_remote_synced true}
                      :model/Collection {regular-id :id} {:name "Regular Collection"
                                                          :location "/"
                                                          :type nil}
@@ -2497,7 +2497,7 @@
     (mt/with-temporary-setting-values [remote-sync-type :read-write]
       (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced Collection"
                                                                :location "/"
-                                                               :type "remote-synced"}
+                                                               :is_remote_synced true}
                      :model/Collection {regular-id :id} {:name "Regular Collection"
                                                          :location "/"
                                                          :type nil}
@@ -2523,7 +2523,7 @@
     (testing "PUT /api/ee/document/:id - updating content and moving collection simultaneously"
       (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced Collection"
                                                                :location "/"
-                                                               :type "remote-synced"}
+                                                               :is_remote_synced true}
                      :model/Collection {regular-id :id} {:name "Regular Collection"
                                                          :location "/"
                                                          :type nil}

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/api_test.clj
@@ -177,7 +177,7 @@
 (deftest export-with-default-settings-test
   (testing "POST /api/ee/remote-sync/export succeeds with default settings"
     (mt/with-temporary-setting-values [remote-sync-type :read-write]
-      (mt/with-temp [:model/Collection _ {:type "remote-synced" :name "Test Collection" :location "/"}]
+      (mt/with-temp [:model/Collection _ {:is_remote_synced true :name "Test Collection" :location "/"}]
         (let [mock-main (test-helpers/create-mock-source)]
           (mt/with-temporary-setting-values [remote-sync-url "https://github.com/test/repo.git"
                                              remote-sync-token "test-token"
@@ -192,7 +192,7 @@
 (deftest export-with-custom-branch-and-message-test
   (testing "POST /api/ee/remote-sync/export succeeds with custom branch and message"
     (mt/with-temporary-setting-values [remote-sync-type :read-write]
-      (mt/with-temp [:model/Collection _ {:type "remote-synced" :name "Test Collection" :location "/"}]
+      (mt/with-temp [:model/Collection _ {:is_remote_synced true :name "Test Collection" :location "/"}]
         (let [mock-main (test-helpers/create-mock-source)]
           (mt/with-temporary-setting-values [remote-sync-url "https://github.com/test/repo.git"
                                              remote-sync-token "test-token"
@@ -222,7 +222,7 @@
 (deftest export-handles-write-errors-test
   (testing "POST /api/ee/remote-sync/export handles write errors"
     (mt/with-temporary-setting-values [remote-sync-type :read-write]
-      (mt/with-temp [:model/Collection _ {:type "remote-synced" :name "Test Collection" :location "/"}]
+      (mt/with-temp [:model/Collection _ {:is_remote_synced true :name "Test Collection" :location "/"}]
         (let [mock-main (test-helpers/create-mock-source :fail-mode :write-files-error)]
           (mt/with-temporary-setting-values [remote-sync-url "https://github.com/test/repo.git"
                                              remote-sync-token "test-token"
@@ -365,7 +365,7 @@
   (testing "GET /api/ee/remote-sync/is-dirty returns false when no remote-synced collections have changes"
     (test-helpers/with-clean-object
       (mt/with-temp [:model/Collection _ {:name "Remote Collection"
-                                          :type "remote-synced"
+                                          :is_remote_synced true
                                           :entity_id "test-collection-1"
                                           :location "/"}]
         (is (= {:is_dirty false}
@@ -375,7 +375,7 @@
   (testing "GET /api/ee/remote-sync/is-dirty returns true when any remote-synced collection has changes"
     (test-helpers/with-clean-object
       (mt/with-temp [:model/Collection remote-col {:name "Remote Collection"
-                                                   :type "remote-synced"
+                                                   :is_remote_synced true
                                                    :entity_id "test-collection-1"
                                                    :location "/"}
                      :model/Card card {:collection_id (:id remote-col)
@@ -398,7 +398,7 @@
   (testing "GET /api/ee/remote-sync/dirty returns empty list when no dirty models"
     (test-helpers/with-clean-object
       (mt/with-temp [:model/Collection _ {:name "Remote Collection"
-                                          :type "remote-synced"
+                                          :is_remote_synced true
                                           :entity_id "test-collection-1"
                                           :location "/"}]
         (is (= {:dirty []}
@@ -408,11 +408,11 @@
   (testing "GET /api/ee/remote-sync/dirty returns all dirty models across remote-synced collections"
     (test-helpers/with-clean-object
       (mt/with-temp [:model/Collection remote-col1 {:name "Remote Collection 1"
-                                                    :type "remote-synced"
+                                                    :is_remote_synced true
                                                     :entity_id "test-collection-1"
                                                     :location "/"}
                      :model/Collection remote-col2 {:name "Remote Collection 2"
-                                                    :type "remote-synced"
+                                                    :is_remote_synced true
                                                     :entity_id "test-collection-2"
                                                     :location "/"}
                      :model/Card card1 {:collection_id (:id remote-col1)
@@ -445,11 +445,11 @@
   (testing "GET /api/ee/remote-sync/dirty returns dirty models from nested collections"
     (test-helpers/with-clean-object
       (mt/with-temp [:model/Collection remote-col {:name "Remote Collection"
-                                                   :type "remote-synced"
+                                                   :is_remote_synced true
                                                    :entity_id "test-collection-1"
                                                    :location "/"}
                      :model/Collection nested-col {:name "Nested Collection"
-                                                   :type "remote-synced"
+                                                   :is_remote_synced true
                                                    :location (str "/" (:id remote-col) "/")}
                      :model/Card nested-card {:collection_id (:id nested-col)
                                               :name "Nested Card"}
@@ -466,7 +466,7 @@
   (testing "GET /api/ee/remote-sync/dirty deduplicates items"
     (test-helpers/with-clean-object
       (mt/with-temp [:model/Collection remote-col {:name "Remote Collection"
-                                                   :type "remote-synced"
+                                                   :is_remote_synced true
                                                    :entity_id "test-collection-1"
                                                    :location "/"}
                      :model/Card card {:collection_id (:id remote-col)

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/collection_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/collection_api_test.clj
@@ -5,7 +5,6 @@
    [metabase-enterprise.remote-sync.settings :as settings]
    [metabase.collections.models.collection :as collection]
    [metabase.test :as mt]
-   [metabase.util :as u]
    [toucan2.core :as t2]))
 
 (use-fixtures :each
@@ -13,287 +12,87 @@
     (mt/with-temporary-setting-values [settings/remote-sync-type :read-write]
       (f))))
 
-(deftest create-collection-with-remote-synced-type-test
-  (testing "POST /api/collection"
-    (testing "Can create a collection with type 'remote-synced'"
-      (mt/with-model-cleanup [:model/Collection]
-        (let [response (mt/user-http-request :crowberto :post 200 "collection"
-                                             {:name "Remote Synced Collection"
-                                              :type "remote-synced"})]
-          (is (= "remote-synced" (:type response)))
-          (is (= "Remote Synced Collection" (:name response)))
-          ;; Verify it was actually saved with the correct type
-          (is (= "remote-synced" (t2/select-one-fn :type :model/Collection :id (:id response)))))))))
-
-(deftest create-collection-with-nil-type-test
-  (testing "POST /api/collection"
-    (testing "Can create a collection with type nil (normal collection)"
-      (mt/with-model-cleanup [:model/Collection]
-        (let [response (mt/user-http-request :crowberto :post 200 "collection"
-                                             {:name "Normal Collection"
-                                              :type nil})]
-          (is (nil? (:type response)))
-          (is (= "Normal Collection" (:name response)))
-          ;; Verify it was actually saved with nil type
-          (is (nil? (t2/select-one-fn :type :model/Collection :id (:id response)))))))))
-
-(deftest create-collection-without-type-test
-  (testing "POST /api/collection"
-    (testing "Can create a collection without specifying type (defaults to nil)"
-      (mt/with-model-cleanup [:model/Collection]
-        (let [response (mt/user-http-request :crowberto :post 200 "collection"
-                                             {:name "Default Type Collection"})]
-          (is (nil? (:type response)))
-          (is (= "Default Type Collection" (:name response)))
-          ;; Verify it was actually saved with nil type
-          (is (nil? (t2/select-one-fn :type :model/Collection :id (:id response)))))))))
-
 (deftest create-collection-inherits-parent-type-test
   (testing "POST /api/collection"
     (testing "Child collection inherits parent's type"
       (mt/with-model-cleanup [:model/Collection]
-        (let [parent (mt/user-http-request :crowberto :post 200 "collection"
-                                           {:name "Parent"
-                                            :type "remote-synced"})
-              child (mt/user-http-request :crowberto :post 200 "collection"
-                                          {:name "Child"
-                                           :parent_id (:id parent)})]
-          (is (= "remote-synced" (:type child)))
-          (is (= "remote-synced" (t2/select-one-fn :type :model/Collection :id (:id child)))))))))
+        (mt/with-temp [:model/Collection parent {:name "Parent"
+                                                 :is_remote_synced true}]
+          (let [child (mt/user-http-request :crowberto :post 200 "collection"
+                                            {:name "Child"
+                                             :parent_id (:id parent)})]
+            (is (true? (t2/select-one-fn :is_remote_synced :model/Collection :id (:id child))))))))))
 
-(deftest update-collection-to-remote-synced-type-test
-  (testing "PUT /api/collection/:id"
-    (testing "Can update an existing collection to be remote-synced"
-      (mt/with-model-cleanup [:model/Collection]
-        (let [collection (mt/user-http-request :crowberto :post 200 "collection"
-                                               {:name "Normal Collection"})
-              updated (mt/user-http-request :crowberto :put 200 (str "collection/" (:id collection))
-                                            {:type "remote-synced"})]
-          (is (= "remote-synced" (:type updated)))
-          (is (= "remote-synced" (t2/select-one-fn :type :model/Collection :id (:id collection)))))))))
-
-(deftest update-collection-from-remote-synced-to-nil-in-read-write-test
-  (testing "PUT /api/collection/:id"
-    (testing "Can update a remote-synced collection to nil type in read-write mode"
-      (mt/with-model-cleanup [:model/Collection]
-        (let [collection (mt/user-http-request :crowberto :post 200 "collection"
-                                               {:name "Remote Synced Collection"
-                                                :type "remote-synced"})
-              updated (mt/user-http-request :crowberto :put 200 (str "collection/" (:id collection))
-                                            {:type nil})]
-          (is (nil? (:type updated)))
-          (is (nil? (t2/select-one-fn :type :model/Collection :id (:id collection)))))))))
-
-(deftest update-collection-from-remote-synced-to-nil-in-read-only-fails-test
-  (testing "PUT /api/collection/:id"
-    (testing "Cannot update a remote-synced collection to nil type in read-only mode"
-      (mt/with-temporary-setting-values [settings/remote-sync-type :read-only]
-        (mt/with-model-cleanup [:model/Collection]
-          (let [collection (mt/user-http-request :crowberto :post 200 "collection"
-                                                 {:name "Remote Synced Collection"
-                                                  :type "remote-synced"})]
-            (is (= "You don't have permissions to do that."
-                   (mt/user-http-request :crowberto :put 403 (str "collection/" (:id collection))
-                                         {:type nil})))))))))
-
-(deftest update-collection-name-preserves-remote-synced-type-test
-  (testing "PUT /api/collection/:id"
-    (testing "Updating name preserves remote-synced type"
-      (mt/with-model-cleanup [:model/Collection]
-        (let [collection (mt/user-http-request :crowberto :post 200 "collection"
-                                               {:name "Remote Synced"
-                                                :type "remote-synced"})
-              updated (mt/user-http-request :crowberto :put 200 (str "collection/" (:id collection))
-                                            {:name "Updated Name"})]
-          (is (= "remote-synced" (:type updated)))
-          (is (= "remote-synced" (t2/select-one-fn :type :model/Collection :id (:id collection)))))))))
-
-(deftest update-collection-name-preserves-nil-type-test
-  (testing "PUT /api/collection/:id"
-    (testing "Can update other properties without changing nil type"
-      (mt/with-temp [:model/Collection collection {:name "Normal Collection" :type nil}]
-        ;; Update name without specifying type (nil type)
-        (let [response (mt/user-http-request :crowberto :put 200 (str "collection/" (u/the-id collection))
-                                             {:name "Updated Normal"})]
-          (is (= "Updated Normal" (:name response)))
-          (is (nil? (:type response)))
-          ;; Verify type wasn't changed
-          (is (nil? (t2/select-one-fn :type :model/Collection :id (:id collection)))))))))
-
-(deftest update-collection-type-cascades-to-children-test
-  (testing "PUT /api/collection/:id"
-    (testing "Updating parent collection type cascades to children"
-      (mt/with-model-cleanup [:model/Collection]
-        (let [parent (mt/user-http-request :crowberto :post 200 "collection"
-                                           {:name "Parent"})
-              child1 (mt/user-http-request :crowberto :post 200 "collection"
-                                           {:name "Child 1"
-                                            :parent_id (:id parent)})
-              child2 (mt/user-http-request :crowberto :post 200 "collection"
-                                           {:name "Child 2"
-                                            :parent_id (:id parent)})
-              grandchild (mt/user-http-request :crowberto :post 200 "collection"
-                                               {:name "Grandchild"
-                                                :parent_id (:id child1)})]
-          ;; Update parent to remote-synced
-          (mt/user-http-request :crowberto :put 200 (str "collection/" (:id parent))
-                                {:type "remote-synced"})
-          ;; Verify all descendants got the type
-          (is (= "remote-synced" (t2/select-one-fn :type :model/Collection :id (:id parent))))
-          (is (= "remote-synced" (t2/select-one-fn :type :model/Collection :id (:id child1))))
-          (is (= "remote-synced" (t2/select-one-fn :type :model/Collection :id (:id child2))))
-          (is (= "remote-synced" (t2/select-one-fn :type :model/Collection :id (:id grandchild)))))))))
-
-(deftest update-collection-type-to-nil-cascades-test
+(deftest update-collection-is-remote-synced-to-false-cascades-test
   (testing "PUT /api/collection/:id"
     (testing "Updating parent collection type to nil cascades to children"
       (mt/with-model-cleanup [:model/Collection]
-        (let [parent (mt/user-http-request :crowberto :post 200 "collection"
-                                           {:name "Parent"
-                                            :type "remote-synced"})
-              child (mt/user-http-request :crowberto :post 200 "collection"
-                                          {:name "Child"
-                                           :parent_id (:id parent)})]
-          ;; Verify both start as remote-synced
-          (is (= "remote-synced" (t2/select-one-fn :type :model/Collection :id (:id parent))))
-          (is (= "remote-synced" (t2/select-one-fn :type :model/Collection :id (:id child))))
-          ;; Update parent to nil
-          (mt/user-http-request :crowberto :put 200 (str "collection/" (:id parent))
-                                {:type nil})
-          ;; Verify both are now nil
-          (is (nil? (t2/select-one-fn :type :model/Collection :id (:id parent))))
-          (is (nil? (t2/select-one-fn :type :model/Collection :id (:id child)))))))))
-
-(deftest update-collection-type-does-not-affect-unrelated-collections-test
-  (testing "PUT /api/collection/:id"
-    (testing "Updating a collection's type does not affect unrelated collections"
-      (mt/with-model-cleanup [:model/Collection]
-        (let [collection1 (mt/user-http-request :crowberto :post 200 "collection"
-                                                {:name "Collection 1"})
-              collection2 (mt/user-http-request :crowberto :post 200 "collection"
-                                                {:name "Collection 2"})]
-          ;; Update collection1 to remote-synced
-          (mt/user-http-request :crowberto :put 200 (str "collection/" (:id collection1))
-                                {:type "remote-synced"})
-          ;; Verify collection1 was updated
-          (is (= "remote-synced" (t2/select-one-fn :type :model/Collection :id (:id collection1))))
-          ;; Verify collection2 was NOT affected
-          (is (nil? (t2/select-one-fn :type :model/Collection :id (:id collection2)))))))))
-
-(deftest update-collection-type-only-cascades-when-changed-test
-  (testing "PUT /api/collection/:id"
-    (testing "Type cascade only happens when type actually changes"
-      (mt/with-model-cleanup [:model/Collection]
-        (let [parent (mt/user-http-request :crowberto :post 200 "collection"
-                                           {:name "Parent"
-                                            :type "remote-synced"})
-              child (mt/user-http-request :crowberto :post 200 "collection"
-                                          {:name "Child"
-                                           :parent_id (:id parent)})]
-          ;; Update parent with same type (no change)
-          (mt/user-http-request :crowberto :put 200 (str "collection/" (:id parent))
-                                {:type "remote-synced"})
-          ;; Verify both still have remote-synced type
-          (is (= "remote-synced" (t2/select-one-fn :type :model/Collection :id (:id parent))))
-          (is (= "remote-synced" (t2/select-one-fn :type :model/Collection :id (:id child)))))))))
-
-(deftest update-collection-type-cascades-through-multiple-levels-test
-  (testing "PUT /api/collection/:id with type change through deep hierarchy"
-    (testing "Type change cascades through multiple levels"
-      (mt/with-temp [:model/Collection level1 {}
-                     :model/Collection level2 {:location (collection/children-location level1)}
-                     :model/Collection level3 {:location (collection/children-location level2)}
-                     :model/Collection level4 {:location (collection/children-location level3)}]
-        ;; Update level1 type
-        (mt/user-http-request :crowberto :put 200 (str "collection/" (:id level1))
-                              {:type "remote-synced"})
-
-        ;; Verify all levels have the new type
-        (is (= "remote-synced" (:type (t2/select-one :model/Collection :id (:id level1)))))
-        (is (= "remote-synced" (:type (t2/select-one :model/Collection :id (:id level2)))))
-        (is (= "remote-synced" (:type (t2/select-one :model/Collection :id (:id level3)))))
-        (is (= "remote-synced" (:type (t2/select-one :model/Collection :id (:id level4)))))))))
+        (mt/with-temp [:model/Collection {grandparent-id :id} {:is_remote_synced true}
+                       :model/Collection {parent-id :id} {:name "Parent"
+                                                          :location (str "/" grandparent-id "/")
+                                                          :is_remote_synced true}
+                       :model/Collection {child-id :id} {:name "Child"
+                                                         :location (str "/" grandparent-id "/" parent-id "/")
+                                                         :is_remote_synced true}]
+          (mt/user-http-request :crowberto :put 200 (str "collection/" parent-id)
+                                {:parent_id nil})
+          (is (false? (t2/select-one-fn :is_remote_synced :model/Collection :id parent-id)))
+          (is (false? (t2/select-one-fn :is_remote_synced :model/Collection :id child-id))))))))
 
 (deftest api-move-collection-into-remote-synced-dependency-checking-success-test
   (testing "PUT /api/collection/:id - move collection into remote-synced"
     (testing "Moving a collection into remote-synced parent succeeds when no remote-sync violations"
-      (mt/with-model-cleanup [:model/Collection]
-        (let [remote-parent (mt/user-http-request :crowberto :post 200 "collection"
-                                                  {:name "Remote Parent"
-                                                   :type "remote-synced"})
-              regular-collection (mt/user-http-request :crowberto :post 200 "collection"
-                                                       {:name "Regular Collection"})
-              response (mt/user-http-request :crowberto :put 200 (str "collection/" (:id regular-collection))
+      (mt/with-temp [:model/Collection remote-parent {:name "Remote Parent" :is_remote_synced true}
+                     :model/Collection regular-collection {:name "Regular Collection"}]
+        (let [response (mt/user-http-request :crowberto :put 200 (str "collection/" (:id regular-collection))
                                              {:parent_id (:id remote-parent)})]
           (is (= (:id remote-parent) (:parent_id response)))
-          (is (= "remote-synced" (:type response)))
-          (is (= "remote-synced" (t2/select-one-fn :type :model/Collection :id (:id regular-collection)))))))))
+          (is (true? (:is_remote_synced response)))
+          (is (true? (t2/select-one-fn :is_remote_synced :model/Collection :id (:id regular-collection)))))))))
 
 (deftest api-move-collection-into-remote-synced-dependency-checking-failure-test
   (testing "PUT /api/collection/:id - move collection into remote-synced"
     (testing "Moving a collection into remote-synced parent fails when remote-sync violations exist"
-      (mt/with-model-cleanup [:model/Collection :model/Card]
-        (let [remote-parent (mt/user-http-request :crowberto :post 200 "collection"
-                                                  {:name "Remote Parent"
-                                                   :type "remote-synced"})
-              regular-collection (mt/user-http-request :crowberto :post 200 "collection"
-                                                       {:name "Regular Collection"})]
-          (mt/with-temp [:model/Card {up-card-id :id} {:dataset_query (mt/mbql-query venues)}
-                         :model/Card _ {:collection_id (:id regular-collection)
-                                        :dataset_query (mt/mbql-query nil {:source-table (str "card__" up-card-id)})}]
-            ;; Try to move regular-collection into remote-parent - should fail
-            (let [response (mt/user-http-request :crowberto :put 400 (str "collection/" (:id regular-collection))
-                                                 {:parent_id (:id remote-parent)})]
-              (is (str/includes? (str response) "remote-synced"))
-              ;; Verify collection wasn't moved
-              (is (nil? (t2/select-one-fn :parent_id :model/Collection :id (:id regular-collection))))
-              (is (nil? (t2/select-one-fn :type :model/Collection :id (:id regular-collection)))))))))))
+      (mt/with-temp [:model/Collection remote-parent {:name "Remote Parent" :is_remote_synced true}
+                     :model/Collection regular-collection {:name "Regular Collection"}
+                     :model/Card {up-card-id :id} {:dataset_query (mt/mbql-query venues)}
+                     :model/Card _ {:collection_id (:id regular-collection)
+                                    :dataset_query (mt/mbql-query nil {:source-table (str "card__" up-card-id)})}]
+        (let [response (mt/user-http-request :crowberto :put 400 (str "collection/" (:id regular-collection))
+                                             {:parent_id (:id remote-parent)})]
+          (is (str/includes? (str response) "remote-synced"))
+          (is (nil? (t2/select-one-fn :parent_id :model/Collection :id (:id regular-collection))))
+          (is (false? (t2/select-one-fn :is_remote_synced :model/Collection :id (:id regular-collection)))))))))
 
 (deftest api-move-collection-into-remote-synced-dependency-checking-transaction-rollback-test
   (testing "PUT /api/collection/:id - move collection into remote-synced"
     (testing "Transaction rollback on dependency check failure leaves database unchanged"
-      (mt/with-model-cleanup [:model/Collection :model/Card]
-        (let [remote-parent (mt/user-http-request :crowberto :post 200 "collection"
-                                                  {:name "Remote Parent"
-                                                   :type "remote-synced"})
-              regular-collection (mt/user-http-request :crowberto :post 200 "collection"
-                                                       {:name "Regular Collection"})
-              child-collection (mt/user-http-request :crowberto :post 200 "collection"
-                                                     {:name "Child Collection"
-                                                      :parent_id (:id regular-collection)})]
-          (mt/with-temp [:model/Card {up-card-id :id} {:dataset_query (mt/mbql-query venues)}
-                         :model/Card _ {:collection_id (:id child-collection)
-                                        :dataset_query (mt/mbql-query nil {:source-table (str "card__" up-card-id)})}]
-            ;; Try to move regular-collection into remote-parent - should fail
-            (mt/user-http-request :crowberto :put 400 (str "collection/" (:id regular-collection))
-                                  {:parent_id (:id remote-parent)})
-
-            ;; Verify NEITHER regular-collection NOR child-collection types changed
-            (is (nil? (t2/select-one-fn :parent_id :model/Collection :id (:id regular-collection))))
-            (is (nil? (t2/select-one-fn :type :model/Collection :id (:id regular-collection))))
-            (is (nil? (t2/select-one-fn :type :model/Collection :id (:id child-collection))))))))))
+      (mt/with-temp [:model/Collection remote-parent {:name "Remote Parent" :is_remote_synced true}
+                     :model/Collection regular-collection {:name "Regular Collection"}
+                     :model/Collection child-collection {:name "Child Collection"
+                                                         :location (collection/children-location regular-collection)}
+                     :model/Card {up-card-id :id} {:dataset_query (mt/mbql-query venues)}
+                     :model/Card _ {:collection_id (:id child-collection)
+                                    :dataset_query (mt/mbql-query nil {:source-table (str "card__" up-card-id)})}]
+        (mt/user-http-request :crowberto :put 400 (str "collection/" (:id regular-collection))
+                              {:parent_id (:id remote-parent)})
+        (is (nil? (t2/select-one-fn :parent_id :model/Collection :id (:id regular-collection))))
+        (is (false? (t2/select-one-fn :is_remote_synced :model/Collection :id (:id regular-collection))))
+        (is (false? (t2/select-one-fn :is_remote_synced :model/Collection :id (:id child-collection))))))))
 
 (deftest api-move-collection-outside-remote-synced-no-dependency-checking-test
   (testing "PUT /api/collection/:id - move collection out of remote-synced"
     (testing "Moving a collection OUT of remote-synced parent does not check dependencies"
-      (mt/with-model-cleanup [:model/Collection :model/Card]
-        (let [remote-parent (mt/user-http-request :crowberto :post 200 "collection"
-                                                  {:name "Remote Parent"
-                                                   :type "remote-synced"})
-              child-collection (mt/user-http-request :crowberto :post 200 "collection"
-                                                     {:name "Child Collection"
-                                                      :parent_id (:id remote-parent)})]
-          ;; Child inherits remote-synced type
-          (is (= "remote-synced" (t2/select-one-fn :type :model/Collection :id (:id child-collection))))
-
-          ;; Create a card in child without document_id
-          (mt/with-temp [:model/Card _ {:collection_id (:id child-collection)
-                                        :document_id nil}]
-            ;; Move child OUT of remote-parent (to root) - should succeed even with violation
-            (let [response (mt/user-http-request :crowberto :put 200 (str "collection/" (:id child-collection))
-                                                 {:parent_id nil})]
-              (is (nil? (:parent_id response)))
-              (is (nil? (:type response)))
-              ;; Verify collection was actually moved and type changed
-              (is (nil? (t2/select-one-fn :parent_id :model/Collection :id (:id child-collection))))
-              (is (nil? (t2/select-one-fn :type :model/Collection :id (:id child-collection)))))))))))
+      (mt/with-temp [:model/Collection remote-parent {:name "Remote Parent" :is_remote_synced true}
+                     :model/Collection child-collection {:name "Child Collection"
+                                                         :location (collection/children-location remote-parent)
+                                                         :is_remote_synced true}
+                     :model/Card _ {:collection_id (:id child-collection)
+                                    :document_id nil}]
+        (is (true? (t2/select-one-fn :is_remote_synced :model/Collection :id (:id child-collection))))
+        (let [response (mt/user-http-request :crowberto :put 200 (str "collection/" (:id child-collection))
+                                             {:parent_id nil})]
+          (is (nil? (:parent_id response)))
+          (is (false? (:is_remote_synced response)))
+          (is (nil? (t2/select-one-fn :parent_id :model/Collection :id (:id child-collection))))
+          (is (false? (t2/select-one-fn :is_remote_synced :model/Collection :id (:id child-collection)))))))))

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/dashboard_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/dashboard_api_test.clj
@@ -11,8 +11,8 @@
 
 (deftest api-update-dashboard-collection-id-remote-synced-dependency-checking-success-test
   (testing "PUT /api/dashboard/:id with collection_id in remote-synced succeeds when all dependencies are in remote-synced"
-    (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced" :location "/" :type "remote-synced"}
-                   :model/Collection {target-id :id} {:name "Target" :location (format "/%d/" remote-synced-id) :type "remote-synced"}
+    (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced" :location "/" :is_remote_synced true}
+                   :model/Collection {target-id :id} {:name "Target" :location (format "/%d/" remote-synced-id) :is_remote_synced true}
                    :model/Collection {source-id :id} {:name "Source" :location "/" :type nil}
                    :model/Dashboard {dash-id :id} {:name "Dashboard to Move"
                                                    :collection_id source-id}
@@ -34,8 +34,8 @@
 (deftest api-update-dashboard-collection-id-remote-synced-dependency-checking-failure-test
   (testing "PUT /api/dashboard/:id with collection_id in remote-synced throws 400 when dependencies exist outside remote-synced"
     (mt/with-temp [:model/Collection {non-remote-synced-id :id} {:name "Non-Remote-Synced" :location "/" :type nil}
-                   :model/Collection {remote-synced-id :id} {:name "Remote-Synced" :location "/" :type "remote-synced"}
-                   :model/Collection {target-id :id} {:name "Target" :location (format "/%d/" remote-synced-id) :type "remote-synced"}
+                   :model/Collection {remote-synced-id :id} {:name "Remote-Synced" :location "/" :is_remote_synced true}
+                   :model/Collection {target-id :id} {:name "Target" :location (format "/%d/" remote-synced-id) :is_remote_synced true}
                    :model/Collection {source-id :id} {:name "Source" :location "/" :type nil}
                    :model/Dashboard {dash-id :id} {:name "Dashboard to Move"
                                                    :collection_id source-id}
@@ -62,8 +62,8 @@
 (deftest api-update-dashboard-collection-id-remote-synced-dependency-checking-transaction-rollback-test
   (testing "PUT /api/dashboard/:id transaction rollback when dependency check fails"
     (mt/with-temp [:model/Collection {non-remote-synced-id :id} {:name "Non-Remote-Synced" :location "/" :type nil}
-                   :model/Collection {remote-synced-id :id} {:name "Remote-Synced" :location "/" :type "remote-synced"}
-                   :model/Collection {target-id :id} {:name "Target" :location (format "/%d/" remote-synced-id) :type "remote-synced"}
+                   :model/Collection {remote-synced-id :id} {:name "Remote-Synced" :location "/" :is_remote_synced true}
+                   :model/Collection {target-id :id} {:name "Target" :location (format "/%d/" remote-synced-id) :is_remote_synced true}
                    :model/Collection {source-id :id} {:name "Source" :location "/" :type nil}
                    :model/Dashboard {dash-id :id} {:name "Dashboard to Move"
                                                    :collection_id source-id}
@@ -108,8 +108,8 @@
 
 (deftest api-copy-dashboard-into-remote-synced-dependency-checking-success-test
   (testing "POST /api/dashboard/:id/copy into remote-synced succeeds when all dependencies are in remote-synced"
-    (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced" :location "/" :type "remote-synced"}
-                   :model/Collection {target-id :id} {:name "Target" :location (format "/%d/" remote-synced-id) :type "remote-synced"}
+    (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced" :location "/" :is_remote_synced true}
+                   :model/Collection {target-id :id} {:name "Target" :location (format "/%d/" remote-synced-id) :is_remote_synced true}
                    :model/Collection {source-id :id} {:name "Source" :location "/" :type nil}
                    :model/Dashboard {dash-id :id} {:name "Dashboard to Copy"
                                                    :collection_id source-id}
@@ -133,8 +133,8 @@
 (deftest api-copy-dashboard-into-remote-synced-dependency-checking-failure-test
   (testing "POST /api/dashboard/:id/copy into remote-synced throws 400 when dependencies exist outside remote-synced"
     (mt/with-temp [:model/Collection {non-remote-synced-id :id} {:name "Non-Remote-Synced" :location "/" :type nil}
-                   :model/Collection {remote-synced-id :id} {:name "Remote-Synced" :location "/" :type "remote-synced"}
-                   :model/Collection {target-id :id} {:name "Target" :location (format "/%d/" remote-synced-id) :type "remote-synced"}
+                   :model/Collection {remote-synced-id :id} {:name "Remote-Synced" :location "/" :is_remote_synced true}
+                   :model/Collection {target-id :id} {:name "Target" :location (format "/%d/" remote-synced-id) :is_remote_synced true}
                    :model/Collection {source-id :id} {:name "Source" :location "/" :type nil}
                    :model/Dashboard {dash-id :id} {:name "Dashboard to Copy"
                                                    :collection_id source-id}

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/events_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/events_test.clj
@@ -19,7 +19,7 @@
 
 (deftest model-in-remote-synced-collection-returns-true-test
   (testing "model-in-remote-synced-collection? returns true for models in remote-synced collections"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced" :name "Remote-Sync"}]
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true :name "Remote-Sync"}]
       (is (true? (#'lib.events/model-in-remote-synced-collection?
                   {:collection_id (:id remote-sync-collection)}))))))
 
@@ -41,15 +41,13 @@
 
 (deftest card-create-event-creates-entry-test
   (testing "card-create event creates remote sync object entry with create status"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced" :name "Remote-Sync"}
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true :name "Remote-Sync"}
                    :model/Card remote-sync-card {:name "Test Card"
                                                  :dataset_query (mt/mbql-query venues)
                                                  :collection_id (:id remote-sync-collection)}]
       (t2/delete! :model/RemoteSyncObject)
-
       (events/publish-event! :event/card-create
                              {:object remote-sync-card :user-id (mt/user->id :rasta)})
-
       (let [entries (t2/select :model/RemoteSyncObject)]
         (is (= 1 (count entries)))
         (is (=? {:model_type "Card"
@@ -59,15 +57,13 @@
 
 (deftest card-update-event-creates-entry-test
   (testing "card-update event creates or updates remote sync object entry with update status"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced" :name "Remote-Sync"}
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true :name "Remote-Sync"}
                    :model/Card remote-sync-card {:name "Test Card"
                                                  :dataset_query (mt/mbql-query venues)
                                                  :collection_id (:id remote-sync-collection)}]
       (t2/delete! :model/RemoteSyncObject)
-
       (events/publish-event! :event/card-update
                              {:object remote-sync-card :user-id (mt/user->id :rasta)})
-
       (let [entries (t2/select :model/RemoteSyncObject)]
         (is (= 1 (count entries)))
         (is (=? {:model_type "Card"
@@ -77,16 +73,14 @@
 
 (deftest card-update-archived-sets-delete-test
   (testing "card-update event with archived=true sets delete status"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced" :name "Remote-Sync"}
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true :name "Remote-Sync"}
                    :model/Card remote-sync-card {:name "Test Card"
                                                  :dataset_query (mt/mbql-query venues)
                                                  :collection_id (:id remote-sync-collection)}]
       (t2/delete! :model/RemoteSyncObject)
-
       (events/publish-event! :event/card-update
                              {:object (assoc remote-sync-card :archived true)
                               :user-id (mt/user->id :rasta)})
-
       (let [entries (t2/select :model/RemoteSyncObject)]
         (is (= 1 (count entries)))
         (is (=? {:model_type "Card"
@@ -96,15 +90,13 @@
 
 (deftest card-delete-event-creates-entry-test
   (testing "card-delete event creates remote sync object entry with delete status"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced" :name "Remote-Sync"}
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true :name "Remote-Sync"}
                    :model/Card remote-sync-card {:name "Test Card"
                                                  :dataset_query (mt/mbql-query venues)
                                                  :collection_id (:id remote-sync-collection)}]
       (t2/delete! :model/RemoteSyncObject)
-
       (events/publish-event! :event/card-delete
                              {:object remote-sync-card :user-id (mt/user->id :rasta)})
-
       (let [entries (t2/select :model/RemoteSyncObject)]
         (is (= 1 (count entries)))
         (is (=? {:model_type "Card"
@@ -114,37 +106,27 @@
 
 (deftest card-multiple-events-update-same-object-test
   (testing "multiple card events do not update object when status is create"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced" :name "Remote-Sync"}
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true :name "Remote-Sync"}
                    :model/Card remote-sync-card {:name "Test Card"
                                                  :dataset_query (mt/mbql-query venues)
                                                  :collection_id (:id remote-sync-collection)}]
       (t2/delete! :model/RemoteSyncObject)
-
-      ;; Create initial entry at time T1
       (let [clock-t1 (t/mock-clock (t/instant "2024-01-01T10:00:00Z") (t/zone-id "UTC"))]
         (t/with-clock clock-t1
           (events/publish-event! :event/card-create
                                  {:object remote-sync-card :user-id (mt/user->id :rasta)}))
-
         (let [initial-entry (t2/select-one :model/RemoteSyncObject
                                            :model_type "Card"
                                            :model_id (:id remote-sync-card))]
-
-          ;; Update the card at time T2 (1 hour later)
           (let [clock-t2 (t/mock-clock (t/instant "2024-01-01T11:00:00Z") (t/zone-id "UTC"))]
             (t/with-clock clock-t2
               (events/publish-event! :event/card-update
                                      {:object remote-sync-card :user-id (mt/user->id :rasta)})))
-
           (let [entries (t2/select :model/RemoteSyncObject)]
-            ;; Should still be just one entry
             (is (= 1 (count entries)))
             (let [update-entry (first entries)]
-              ;; Should be the same ID
               (is (= (:id initial-entry) (:id update-entry)))
-              ;; Status should remain "create" (not update)
               (is (= "create" (:status update-entry)))
-              ;; Timestamp should not change
               (is (= (:status_changed_at initial-entry) (:status_changed_at update-entry))))))))))
 
 (deftest card-event-in-normal-collection-no-entry-test
@@ -154,23 +136,19 @@
                                             :dataset_query (mt/mbql-query venues)
                                             :collection_id (:id normal-collection)}]
       (t2/delete! :model/RemoteSyncObject)
-
       (events/publish-event! :event/card-create
                              {:object normal-card :user-id (mt/user->id :rasta)})
-
       (let [entries (t2/select :model/RemoteSyncObject)]
         (is (= 0 (count entries)))))))
 
 (deftest dashboard-create-event-creates-entry-test
   (testing "dashboard-create event creates remote sync object entry with create status"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced" :name "Remote-Sync"}
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true :name "Remote-Sync"}
                    :model/Dashboard dashboard {:name "Test Dashboard"
                                                :collection_id (:id remote-sync-collection)}]
       (t2/delete! :model/RemoteSyncObject)
-
       (events/publish-event! :event/dashboard-create
                              {:object dashboard :user-id (mt/user->id :rasta)})
-
       (let [entries (t2/select :model/RemoteSyncObject)]
         (is (= 1 (count entries)))
         (is (=? {:model_type "Dashboard"
@@ -180,14 +158,12 @@
 
 (deftest dashboard-update-event-creates-entry-test
   (testing "dashboard-update event creates or updates remote sync object entry"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced" :name "Remote-Sync"}
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true :name "Remote-Sync"}
                    :model/Dashboard dashboard {:name "Test Dashboard"
                                                :collection_id (:id remote-sync-collection)}]
       (t2/delete! :model/RemoteSyncObject)
-
       (events/publish-event! :event/dashboard-update
                              {:object dashboard :user-id (mt/user->id :rasta)})
-
       (let [entries (t2/select :model/RemoteSyncObject)]
         (is (= 1 (count entries)))
         (is (=? {:model_type "Dashboard"
@@ -197,15 +173,13 @@
 
 (deftest dashboard-update-archived-sets-delete-test
   (testing "dashboard-update event with archived=true sets delete status"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced" :name "Remote-Sync"}
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true :name "Remote-Sync"}
                    :model/Dashboard dashboard {:name "Test Dashboard"
                                                :collection_id (:id remote-sync-collection)}]
       (t2/delete! :model/RemoteSyncObject)
-
       (events/publish-event! :event/dashboard-update
                              {:object (assoc dashboard :archived true)
                               :user-id (mt/user->id :rasta)})
-
       (let [entries (t2/select :model/RemoteSyncObject)]
         (is (= 1 (count entries)))
         (is (=? {:model_type "Dashboard"
@@ -215,14 +189,12 @@
 
 (deftest dashboard-delete-event-creates-entry-test
   (testing "dashboard-delete event creates remote sync object entry with delete status"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced" :name "Remote-Sync"}
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true :name "Remote-Sync"}
                    :model/Dashboard dashboard {:name "Test Dashboard"
                                                :collection_id (:id remote-sync-collection)}]
       (t2/delete! :model/RemoteSyncObject)
-
       (events/publish-event! :event/dashboard-delete
                              {:object dashboard :user-id (mt/user->id :rasta)})
-
       (let [entries (t2/select :model/RemoteSyncObject)]
         (is (= 1 (count entries)))
         (is (=? {:model_type "Dashboard"
@@ -232,13 +204,11 @@
 
 (deftest document-create-event-creates-entry-test
   (testing "document-create event creates remote sync object entry with create status"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced" :name "Remote-Sync"}
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true :name "Remote-Sync"}
                    :model/Document document {:collection_id (u/the-id remote-sync-collection)}]
       (t2/delete! :model/RemoteSyncObject)
-
       (events/publish-event! :event/document-create
                              {:object document :user-id (mt/user->id :rasta)})
-
       (let [entries (t2/select :model/RemoteSyncObject)]
         (is (= 1 (count entries)))
         (is (=? {:model_type "Document"
@@ -248,13 +218,11 @@
 
 (deftest document-update-event-creates-entry-test
   (testing "document-update event creates or updates remote sync object entry with update status"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced" :name "Remote-Sync"}
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true :name "Remote-Sync"}
                    :model/Document document {:collection_id (u/the-id remote-sync-collection)}]
       (t2/delete! :model/RemoteSyncObject)
-
       (events/publish-event! :event/document-update
                              {:object document :user-id (mt/user->id :rasta)})
-
       (let [entries (t2/select :model/RemoteSyncObject)]
         (is (= 1 (count entries)))
         (is (=? {:model_type "Document"
@@ -264,14 +232,12 @@
 
 (deftest document-update-archived-sets-delete-test
   (testing "document-update event with archived=true sets delete status"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced" :name "Remote-Sync"}
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true :name "Remote-Sync"}
                    :model/Document document {:collection_id (u/the-id remote-sync-collection)}]
       (t2/delete! :model/RemoteSyncObject)
-
       (events/publish-event! :event/document-update
                              {:object (assoc document :archived true)
                               :user-id (mt/user->id :rasta)})
-
       (let [entries (t2/select :model/RemoteSyncObject)]
         (is (= 1 (count entries)))
         (is (=? {:model_type "Document"
@@ -281,13 +247,11 @@
 
 (deftest document-delete-event-creates-entry-test
   (testing "document-delete event creates remote sync object entry with delete status"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced" :name "Remote-Sync"}
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true :name "Remote-Sync"}
                    :model/Document document {:collection_id (u/the-id remote-sync-collection)}]
       (t2/delete! :model/RemoteSyncObject)
-
       (events/publish-event! :event/document-delete
                              {:object document :user-id (mt/user->id :rasta)})
-
       (let [entries (t2/select :model/RemoteSyncObject)]
         (is (= 1 (count entries)))
         (is (=? {:model_type "Document"
@@ -297,15 +261,13 @@
 
 (deftest snippet-create-event-creates-entry-test
   (testing "snippet-create event creates remote sync object entry with create status"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced" :name "Remote-Sync" :namespace "snippets"}
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true :name "Remote-Sync" :namespace "snippets"}
                    :model/NativeQuerySnippet snippet {:name "Test Snippet"
                                                       :content "SELECT 1"
                                                       :collection_id (:id remote-sync-collection)}]
       (t2/delete! :model/RemoteSyncObject)
-
       (events/publish-event! :event/snippet-create
                              {:object snippet :user-id (mt/user->id :rasta)})
-
       (let [entries (t2/select :model/RemoteSyncObject)]
         (is (= 1 (count entries)))
         (is (=? {:model_type "NativeQuerySnippet"
@@ -315,15 +277,13 @@
 
 (deftest snippet-update-event-creates-entry-test
   (testing "snippet-update event creates or updates remote sync object entry with update status"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced" :name "Remote-Sync" :namespace "snippets"}
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true :name "Remote-Sync" :namespace "snippets"}
                    :model/NativeQuerySnippet snippet {:name "Test Snippet"
                                                       :content "SELECT 1"
                                                       :collection_id (:id remote-sync-collection)}]
       (t2/delete! :model/RemoteSyncObject)
-
       (events/publish-event! :event/snippet-update
                              {:object snippet :user-id (mt/user->id :rasta)})
-
       (let [entries (t2/select :model/RemoteSyncObject)]
         (is (= 1 (count entries)))
         (is (=? {:model_type "NativeQuerySnippet"
@@ -333,16 +293,14 @@
 
 (deftest snippet-update-archived-sets-delete-test
   (testing "snippet-update event with archived=true sets delete status"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced" :name "Remote-Sync" :namespace "snippets"}
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true :name "Remote-Sync" :namespace "snippets"}
                    :model/NativeQuerySnippet snippet {:name "Test Snippet"
                                                       :content "SELECT 1"
                                                       :collection_id (:id remote-sync-collection)}]
       (t2/delete! :model/RemoteSyncObject)
-
       (events/publish-event! :event/snippet-update
                              {:object (assoc snippet :archived true)
                               :user-id (mt/user->id :rasta)})
-
       (let [entries (t2/select :model/RemoteSyncObject)]
         (is (= 1 (count entries)))
         (is (=? {:model_type "NativeQuerySnippet"
@@ -352,15 +310,13 @@
 
 (deftest snippet-delete-event-creates-entry-test
   (testing "snippet-delete event creates remote sync object entry with delete status"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced" :name "Remote-Sync" :namespace "snippets"}
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true :name "Remote-Sync" :namespace "snippets"}
                    :model/NativeQuerySnippet snippet {:name "Test Snippet"
                                                       :content "SELECT 1"
                                                       :collection_id (:id remote-sync-collection)}]
       (t2/delete! :model/RemoteSyncObject)
-
       (events/publish-event! :event/snippet-delete
                              {:object snippet :user-id (mt/user->id :rasta)})
-
       (let [entries (t2/select :model/RemoteSyncObject)]
         (is (= 1 (count entries)))
         (is (=? {:model_type "NativeQuerySnippet"
@@ -375,16 +331,14 @@
                                                       :content "SELECT 1"
                                                       :collection_id (:id normal-collection)}]
       (t2/delete! :model/RemoteSyncObject)
-
       (events/publish-event! :event/snippet-create
                              {:object snippet :user-id (mt/user->id :rasta)})
-
       (let [entries (t2/select :model/RemoteSyncObject)]
         (is (= 0 (count entries)))))))
 
 (deftest existing-snippet-moved-out-of-remote-synced-collection-test
   (testing "snippet moved out of remote-synced collection is marked as removed"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced" :name "Remote-Sync" :namespace "snippets"}
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true :name "Remote-Sync" :namespace "snippets"}
                    :model/Collection normal-collection {:name "Normal" :namespace "snippets"}
                    :model/NativeQuerySnippet snippet {:name "Test Snippet"
                                                       :content "SELECT 1"
@@ -393,8 +347,6 @@
 
       (let [initial-entry (t2/select-one :model/RemoteSyncObject :model_type "NativeQuerySnippet" :model_id (:id snippet))]
         (is (= "synced" (:status initial-entry)))
-
-        ;; Move snippet to normal collection
         (events/publish-event! :event/snippet-update
                                {:object (assoc snippet :collection_id (:id normal-collection))
                                 :user-id (mt/user->id :rasta)})
@@ -406,48 +358,38 @@
 
 (deftest new-snippet-moved-out-of-remote-synced-collection-test
   (testing "new snippet moved out of remote-synced collection are not tracked"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced" :name "Remote-Sync" :namespace "snippets"}
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true :name "Remote-Sync" :namespace "snippets"}
                    :model/Collection normal-collection {:name "Normal" :namespace "snippets"}
                    :model/NativeQuerySnippet snippet {:name "Test Snippet"
                                                       :content "SELECT 1"
                                                       :collection_id (:id remote-sync-collection)}]
       (t2/delete! :model/RemoteSyncObject)
-
-      ;; Create initial entry for snippet in remote-synced collection
       (events/publish-event! :event/snippet-create
                              {:object snippet :user-id (mt/user->id :rasta)})
-
       (let [initial-entry (t2/select-one :model/RemoteSyncObject :model_type "NativeQuerySnippet" :model_id (:id snippet))]
         (is (= "create" (:status initial-entry)))
-
-        ;; Move snippet to normal collection
         (events/publish-event! :event/snippet-update
                                {:object (assoc snippet :collection_id (:id normal-collection))
                                 :user-id (mt/user->id :rasta)})
-
         (let [update-entry (t2/select-one :model/RemoteSyncObject :model_type "NativeQuerySnippet" :model_id (:id snippet))]
           (is (nil? update-entry)))))))
 
 (deftest snippet-moved-into-remote-synced-collection-test
   (testing "snippet moved into remote-synced collection gets tracked"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced" :name "Remote-Sync" :namespace "snippets"}
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true :name "Remote-Sync" :namespace "snippets"}
                    :model/Collection normal-collection {:name "Normal" :namespace "snippets"}
                    :model/NativeQuerySnippet snippet {:name "Test Snippet"
                                                       :content "SELECT 1"
                                                       :collection_id (:id normal-collection)}]
       (t2/delete! :model/RemoteSyncObject)
-
-      ;; Create snippet in normal collection (no entry should be created)
       (events/publish-event! :event/snippet-create
                              {:object snippet :user-id (mt/user->id :rasta)})
-
       (is (= 0 (count (t2/select :model/RemoteSyncObject))))
 
       ;; Move snippet to remote-synced collection
       (events/publish-event! :event/snippet-update
                              {:object (assoc snippet :collection_id (:id remote-sync-collection))
                               :user-id (mt/user->id :rasta)})
-
       (let [entries (t2/select :model/RemoteSyncObject)]
         (is (= 1 (count entries)))
         (is (=? {:model_type "NativeQuerySnippet"
@@ -457,13 +399,11 @@
 
 (deftest collection-create-event-creates-entry-test
   (testing "collection-create event creates remote sync object entry with create status"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced"
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true
                                                              :name "Remote-Sync"}]
       (t2/delete! :model/RemoteSyncObject)
-
       (events/publish-event! :event/collection-create
                              {:object remote-sync-collection :user-id (mt/user->id :rasta)})
-
       (let [entries (t2/select :model/RemoteSyncObject)]
         (is (= 1 (count entries)))
         (is (=? {:model_type "Collection"
@@ -475,23 +415,19 @@
   (testing "collection-create event doesn't create entry for non-remote-synced collections"
     (mt/with-temp [:model/Collection normal-collection {:name "Normal"}]
       (t2/delete! :model/RemoteSyncObject)
-
       (events/publish-event! :event/collection-create
                              {:object normal-collection :user-id (mt/user->id :rasta)})
-
       (let [entries (t2/select :model/RemoteSyncObject)]
         (is (= 0 (count entries)))))))
 
 (deftest collection-create-event-archived-sets-delete-test
   (testing "collection-create event with archived=true sets delete status"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced"
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true
                                                              :name "Remote-Sync"}]
       (t2/delete! :model/RemoteSyncObject)
-
       (events/publish-event! :event/collection-create
                              {:object (assoc remote-sync-collection :archived true)
                               :user-id (mt/user->id :rasta)})
-
       (let [entries (t2/select :model/RemoteSyncObject)]
         (is (= 1 (count entries)))
         (is (=? {:model_type "Collection"
@@ -501,13 +437,11 @@
 
 (deftest collection-update-event-creates-entry-test
   (testing "collection-update event creates or updates remote sync object entry with update status"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced"
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true
                                                              :name "Remote-Sync"}]
       (t2/delete! :model/RemoteSyncObject)
-
       (events/publish-event! :event/collection-update
                              {:object remote-sync-collection :user-id (mt/user->id :rasta)})
-
       (let [entries (t2/select :model/RemoteSyncObject)]
         (is (= 1 (count entries)))
         (is (=? {:model_type "Collection"
@@ -517,14 +451,12 @@
 
 (deftest collection-update-event-archived-sets-delete-test
   (testing "collection-update event with archived=true sets delete status"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced"
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true
                                                              :name "Remote-Sync"}]
       (t2/delete! :model/RemoteSyncObject)
-
       (events/publish-event! :event/collection-update
                              {:object (assoc remote-sync-collection :archived true)
                               :user-id (mt/user->id :rasta)})
-
       (let [entries (t2/select :model/RemoteSyncObject)]
         (is (= 1 (count entries)))
         (is (=? {:model_type "Collection"
@@ -534,14 +466,12 @@
 
 (deftest collection-update-event-unarchived-sets-update-test
   (testing "collection-update event with archived=false sets update status"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced"
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true
                                                              :name "Remote-Sync"}]
       (t2/delete! :model/RemoteSyncObject)
-
       (events/publish-event! :event/collection-update
                              {:object (assoc remote-sync-collection :archived false)
                               :user-id (mt/user->id :rasta)})
-
       (let [entries (t2/select :model/RemoteSyncObject)]
         (is (= 1 (count entries)))
         (is (=? {:model_type "Collection"
@@ -553,41 +483,30 @@
   (testing "collection-update event doesn't create entry for non-remote-synced collections"
     (mt/with-temp [:model/Collection normal-collection {:name "Normal"}]
       (t2/delete! :model/RemoteSyncObject)
-
       (events/publish-event! :event/collection-update
                              {:object normal-collection :user-id (mt/user->id :rasta)})
-
       (let [entries (t2/select :model/RemoteSyncObject)]
         (is (= 0 (count entries)))))))
 
 (deftest collection-multiple-update-events-update-same-object-test
   (testing "multiple collection-update events update the same remote sync object"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced"
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true
                                                              :name "Remote-Sync"}]
       (t2/delete! :model/RemoteSyncObject)
-
-      ;; First update at time T1
       (let [clock-t1 (t/mock-clock (t/instant "2024-01-01T10:00:00Z") (t/zone-id "UTC"))]
         (t/with-clock clock-t1
           (events/publish-event! :event/collection-update
                                  {:object remote-sync-collection :user-id (mt/user->id :rasta)}))
-
         (let [initial-entry (t2/select-one :model/RemoteSyncObject
                                            :model_type "Collection"
-                                           :model_id (:id remote-sync-collection))]
-
-          ;; Second update at time T2 (1 hour later)
-          (let [clock-t2 (t/mock-clock (t/instant "2024-01-01T11:00:00Z") (t/zone-id "UTC"))]
-            (t/with-clock clock-t2
-              (events/publish-event! :event/collection-update
-                                     {:object remote-sync-collection :user-id (mt/user->id :rasta)})))
-
+                                           :model_id (:id remote-sync-collection))
+              clock-t2 (t/mock-clock (t/instant "2024-01-01T11:00:00Z") (t/zone-id "UTC"))]
+          (t/with-clock clock-t2
+            (events/publish-event! :event/collection-update
+                                   {:object remote-sync-collection :user-id (mt/user->id :rasta)}))
           (let [entries (t2/select :model/RemoteSyncObject :model_id (:id remote-sync-collection))]
-            ;; Should still be just one entry
             (is (= 1 (count entries)))
-            ;; Should be the same ID
             (is (= (:id initial-entry) (:id (first entries))))
-            ;; But with update timestamp
             (is (t/after? (:status_changed_at (first entries))
                           (:status_changed_at initial-entry)))))))))
 
@@ -595,9 +514,7 @@
   (testing "create-remote-sync-object-entry! creates new entry when none exists"
     (mt/with-current-user (mt/user->id :rasta)
       (t2/delete! :model/RemoteSyncObject)
-
       (#'lib.events/create-or-update-remote-sync-object-entry! "Card" 123 "create" 456)
-
       (let [entries (t2/select :model/RemoteSyncObject)]
         (is (= 1 (count entries)))
         (is (=? {:model_type "Card"
@@ -609,66 +526,44 @@
   (testing "create-remote-sync-object-entry! updates existing entry when one exists"
     (mt/with-current-user (mt/user->id :rasta)
       (t2/delete! :model/RemoteSyncObject)
-
-      ;; Create initial entry with "update" status at time T1
       (let [clock-t1 (t/mock-clock (t/instant "2024-01-01T10:00:00Z") (t/zone-id "UTC"))]
         (t/with-clock clock-t1
           (#'lib.events/create-or-update-remote-sync-object-entry! "Dashboard" 789 "update"))
-
         (let [initial-entry (t2/select-one :model/RemoteSyncObject :model_type "Dashboard" :model_id 789)
-              initial-time (:status_changed_at initial-entry)]
-
-          ;; Update to synced status at time T2 (1 hour later)
-          (let [clock-t2 (t/mock-clock (t/instant "2024-01-01T11:00:00Z") (t/zone-id "UTC"))]
-            (t/with-clock clock-t2
-              (#'lib.events/create-or-update-remote-sync-object-entry! "Dashboard" 789 "synced")))
-
+              initial-time (:status_changed_at initial-entry)
+              clock-t2 (t/mock-clock (t/instant "2024-01-01T11:00:00Z") (t/zone-id "UTC"))]
+          (t/with-clock clock-t2
+            (#'lib.events/create-or-update-remote-sync-object-entry! "Dashboard" 789 "synced"))
           (let [entries (t2/select :model/RemoteSyncObject :model_type "Dashboard" :model_id 789)]
-            ;; Should still be just one entry
             (is (= 1 (count entries)))
             (let [update-entry (first entries)]
-              ;; Should be the same ID
               (is (= (:id initial-entry) (:id update-entry)))
-              ;; Should have update status
               (is (= "synced" (:status update-entry)))
-              ;; Should have update timestamp
               (is (t/after? (:status_changed_at update-entry) initial-time)))))))))
 
 (deftest create-remote-sync-object-entry-does-not-update-create-status-test
   (testing "create-remote-sync-object-entry! does not update entry when status is 'create'"
     (mt/with-current-user (mt/user->id :rasta)
       (t2/delete! :model/RemoteSyncObject)
-
-      ;; Create initial entry with "create" status at time T1
       (let [clock-t1 (t/mock-clock (t/instant "2024-01-01T10:00:00Z") (t/zone-id "UTC"))]
         (t/with-clock clock-t1
           (#'lib.events/create-or-update-remote-sync-object-entry! "Dashboard" 789 "create"))
-
-        (let [initial-entry (t2/select-one :model/RemoteSyncObject :model_type "Dashboard" :model_id 789)]
-
-          ;; Try to update to synced status at time T2 (1 hour later)
-          (let [clock-t2 (t/mock-clock (t/instant "2024-01-01T11:00:00Z") (t/zone-id "UTC"))]
-            (t/with-clock clock-t2
-              (#'lib.events/create-or-update-remote-sync-object-entry! "Dashboard" 789 "synced")))
-
+        (let [initial-entry (t2/select-one :model/RemoteSyncObject :model_type "Dashboard" :model_id 789)
+              clock-t2 (t/mock-clock (t/instant "2024-01-01T11:00:00Z") (t/zone-id "UTC"))]
+          (t/with-clock clock-t2
+            (#'lib.events/create-or-update-remote-sync-object-entry! "Dashboard" 789 "synced"))
           (let [entries (t2/select :model/RemoteSyncObject :model_type "Dashboard" :model_id 789)]
-            ;; Should still be just one entry
             (is (= 1 (count entries)))
             (let [update-entry (first entries)]
-              ;; Should be the same ID
               (is (= (:id initial-entry) (:id update-entry)))
-              ;; Status should remain "create" (not update)
               (is (= "create" (:status update-entry)))
-              ;; Timestamp should not change
               (is (= (:status_changed_at initial-entry) (:status_changed_at update-entry))))))))))
 
 (deftest create-remote-sync-object-entry-uses-current-user-test
   (testing "create-remote-sync-object-entry! uses current user when user-id not specified"
     (mt/with-current-user (mt/user->id :rasta)
       (t2/delete! :model/RemoteSyncObject)
-
       (#'lib.events/create-or-update-remote-sync-object-entry! "Collection" 999 "create")
-
       (let [entries (t2/select :model/RemoteSyncObject)]
         (is (= 1 (count entries)))
         (is (=? {:model_type "Collection"
@@ -678,7 +573,7 @@
 
 (deftest existing-card-moved-out-of-remote-synced-collection-test
   (testing "existing card moved out of remote-synced collection is marked as removed"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced" :name "Remote-Sync"}
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true :name "Remote-Sync"}
                    :model/Collection normal-collection {:name "Normal"}
                    :model/Card card {:name "Test Card"
                                      :dataset_query (mt/mbql-query venues)
@@ -687,8 +582,6 @@
 
       (let [initial-entry (t2/select-one :model/RemoteSyncObject :model_type "Card" :model_id (:id card))]
         (is (= "synced" (:status initial-entry)))
-
-        ;; Move card to normal collection
         (events/publish-event! :event/card-update
                                {:object (assoc card :collection_id (:id normal-collection))
                                 :user-id (mt/user->id :rasta)})
@@ -699,31 +592,25 @@
 
 (deftest new-card-moved-out-of-remote-synced-collection-test
   (testing "new card moved out of remote-synced collection is no longer tracked"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced" :name "Remote-Sync"}
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true :name "Remote-Sync"}
                    :model/Collection normal-collection {:name "Normal"}
                    :model/Card card {:name "Test Card"
                                      :dataset_query (mt/mbql-query venues)
                                      :collection_id (:id remote-sync-collection)}]
       (t2/delete! :model/RemoteSyncObject)
-
-      ;; Create initial entry for card in remote-synced collection
       (events/publish-event! :event/card-create
                              {:object card :user-id (mt/user->id :rasta)})
-
       (let [initial-entry (t2/select-one :model/RemoteSyncObject :model_type "Card" :model_id (:id card))]
         (is (= "create" (:status initial-entry)))
-
-        ;; Move card to normal collection
         (events/publish-event! :event/card-update
                                {:object (assoc card :collection_id (:id normal-collection))
                                 :user-id (mt/user->id :rasta)})
-
         (let [update-entry (t2/select-one :model/RemoteSyncObject :model_type "Card" :model_id (:id card))]
           (is (nil? update-entry)))))))
 
 (deftest existing-dashboard-moved-out-of-remote-synced-collection-test
   (testing "existing dashboard moved out of remote-synced collection is marked as removed"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced" :name "Remote-Sync"}
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true :name "Remote-Sync"}
                    :model/Collection normal-collection {:name "Normal"}
                    :model/Dashboard dashboard {:name "Test Dashboard"
                                                :collection_id (:id remote-sync-collection)}]
@@ -731,8 +618,6 @@
 
       (let [initial-entry (t2/select-one :model/RemoteSyncObject :model_type "Dashboard" :model_id (:id dashboard))]
         (is (= "synced" (:status initial-entry)))
-
-        ;; Move dashboard to normal collection
         (events/publish-event! :event/dashboard-update
                                {:object (assoc dashboard :collection_id (:id normal-collection))
                                 :user-id (mt/user->id :rasta)})
@@ -743,38 +628,30 @@
 
 (deftest new-dashboard-moved-out-of-remote-synced-collection-test
   (testing "new dashboard moved out of remote-synced collection is no longer tracked"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced" :name "Remote-Sync"}
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true :name "Remote-Sync"}
                    :model/Collection normal-collection {:name "Normal"}
                    :model/Dashboard dashboard {:name "Test Dashboard"
                                                :collection_id (:id remote-sync-collection)}]
       (t2/delete! :model/RemoteSyncObject)
-
-      ;; Create initial entry for dashboard in remote-synced collection
       (events/publish-event! :event/dashboard-create
                              {:object dashboard :user-id (mt/user->id :rasta)})
-
       (let [initial-entry (t2/select-one :model/RemoteSyncObject :model_type "Dashboard" :model_id (:id dashboard))]
         (is (= "create" (:status initial-entry)))
-
-        ;; Move dashboard to normal collection
         (events/publish-event! :event/dashboard-update
                                {:object (assoc dashboard :collection_id (:id normal-collection))
                                 :user-id (mt/user->id :rasta)})
-
         (let [update-entry (t2/select-one :model/RemoteSyncObject :model_type "Dashboard" :model_id (:id dashboard))]
           (is (nil? update-entry)))))))
 
 (deftest existing-document-moved-out-of-remote-synced-collection-test
   (testing "existing document moved out of remote-synced collection is marked as removed"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced" :name "Remote-Sync"}
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true :name "Remote-Sync"}
                    :model/Collection normal-collection {:name "Normal"}
                    :model/Document document {:collection_id (u/the-id remote-sync-collection)}]
       (#'impl/sync-objects! (t/instant) {"Document" #{(:entity_id document)}})
 
       (let [initial-entry (t2/select-one :model/RemoteSyncObject :model_type "Document" :model_id (:id document))]
         (is (= "synced" (:status initial-entry)))
-
-        ;; Move document to normal collection
         (events/publish-event! :event/document-update
                                {:object (assoc document :collection_id (:id normal-collection))
                                 :user-id (mt/user->id :rasta)})
@@ -785,58 +662,43 @@
 
 (deftest new-document-moved-out-of-remote-synced-collection-test
   (testing "new document moved out of remote-synced collection is no longer tracked"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced" :name "Remote-Sync"}
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true :name "Remote-Sync"}
                    :model/Collection normal-collection {:name "Normal"}
                    :model/Document document {:collection_id (u/the-id remote-sync-collection)}]
       (t2/delete! :model/RemoteSyncObject)
-
-      ;; Create initial entry for document in remote-synced collection
       (events/publish-event! :event/document-create
                              {:object document :user-id (mt/user->id :rasta)})
-
       (let [initial-entry (t2/select-one :model/RemoteSyncObject :model_type "Document" :model_id (:id document))]
         (is (= "create" (:status initial-entry)))
-
-        ;; Move document to normal collection
         (events/publish-event! :event/document-update
                                {:object (assoc document :collection_id (:id normal-collection))
                                 :user-id (mt/user->id :rasta)})
-
         (let [update-entry (t2/select-one :model/RemoteSyncObject :model_type "Document" :model_id (:id document))]
           (is (nil? update-entry)))))))
 
 (deftest existing-collection-type-changed-from-remote-synced-test
   (testing "existing collection type changed from remote-synced is marked as removed"
-    (mt/with-temp [:model/Collection collection {:type "remote-synced" :name "Remote-Sync"}]
+    (mt/with-temp [:model/Collection collection {:is_remote_synced true :name "Remote-Sync"}]
       (#'impl/sync-objects! (t/instant) {"Collection" #{(:entity_id collection)}})
-
       (let [initial-entry (t2/select-one :model/RemoteSyncObject :model_type "Collection" :model_id (:id collection))]
         (is (= "synced" (:status initial-entry)))
-
-        ;; Change collection type to default
         (events/publish-event! :event/collection-update
-                               {:object (assoc collection :type nil)
+                               {:object (assoc collection :is_remote_synced false)
                                 :user-id (mt/user->id :rasta)})
-
         (let [update-entry (t2/select-one :model/RemoteSyncObject :model_type "Collection" :model_id (:id collection))]
           (is (= "removed" (:status update-entry)))
           (is (= (:id initial-entry) (:id update-entry))))))))
 
 (deftest new-collection-type-changed-from-remote-synced-test
   (testing "new collection type changed from remote-synced is marked as removed"
-    (mt/with-temp [:model/Collection collection {:type "remote-synced" :name "Remote-Sync"}]
+    (mt/with-temp [:model/Collection collection {:is_remote_synced true :name "Remote-Sync"}]
       (t2/delete! :model/RemoteSyncObject)
-
-      ;; Create initial entry for remote-synced collection
       (events/publish-event! :event/collection-create
                              {:object collection :user-id (mt/user->id :rasta)})
-
       (let [initial-entry (t2/select-one :model/RemoteSyncObject :model_type "Collection" :model_id (:id collection))]
         (is (= "create" (:status initial-entry)))
-
-        ;; Change collection type to default
         (events/publish-event! :event/collection-update
-                               {:object (assoc collection :type nil)
+                               {:object (assoc collection :is_remote_synced false)
                                 :user-id (mt/user->id :rasta)})
 
         (let [update-entry (t2/select-one :model/RemoteSyncObject :model_type "Collection" :model_id (:id collection))]
@@ -849,12 +711,8 @@
                                      :dataset_query (mt/mbql-query venues)
                                      :collection_id (:id normal-collection)}]
       (t2/delete! :model/RemoteSyncObject)
-
-      ;; Update card while it's in normal collection (no prior entry exists)
       (events/publish-event! :event/card-update
                              {:object card :user-id (mt/user->id :rasta)})
-
-      ;; Should not create any entry
       (let [entries (t2/select :model/RemoteSyncObject :model_type "Card" :model_id (:id card))]
         (is (= 0 (count entries)))))))
 
@@ -894,14 +752,12 @@
 
 (deftest timeline-create-event-creates-entry-test
   (testing "timeline-create event creates remote sync object entry with create status"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced" :name "Remote-Sync"}
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true :name "Remote-Sync"}
                    :model/Timeline timeline {:name "Test Timeline"
                                              :collection_id (:id remote-sync-collection)}]
       (t2/delete! :model/RemoteSyncObject)
-
       (events/publish-event! :event/timeline-create
                              {:object timeline :user-id (mt/user->id :rasta)})
-
       (let [entries (t2/select :model/RemoteSyncObject)]
         (is (= 1 (count entries)))
         (is (=? {:model_type "Timeline"
@@ -911,14 +767,12 @@
 
 (deftest timeline-update-event-creates-entry-test
   (testing "timeline-update event creates remote sync object entry with update status"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced" :name "Remote-Sync"}
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true :name "Remote-Sync"}
                    :model/Timeline timeline {:name "Test Timeline"
                                              :collection_id (:id remote-sync-collection)}]
       (t2/delete! :model/RemoteSyncObject)
-
       (events/publish-event! :event/timeline-update
                              {:object timeline :user-id (mt/user->id :rasta)})
-
       (let [entries (t2/select :model/RemoteSyncObject)]
         (is (= 1 (count entries)))
         (is (=? {:model_type "Timeline"
@@ -928,15 +782,13 @@
 
 (deftest timeline-update-archived-sets-delete-test
   (testing "timeline-update event with archived timeline sets delete status"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced" :name "Remote-Sync"}
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true :name "Remote-Sync"}
                    :model/Timeline timeline {:name "Test Timeline"
                                              :collection_id (:id remote-sync-collection)
                                              :archived true}]
       (t2/delete! :model/RemoteSyncObject)
-
       (events/publish-event! :event/timeline-update
                              {:object timeline :user-id (mt/user->id :rasta)})
-
       (let [entries (t2/select :model/RemoteSyncObject)]
         (is (= 1 (count entries)))
         (is (=? {:model_type "Timeline"
@@ -946,14 +798,12 @@
 
 (deftest timeline-delete-event-creates-entry-test
   (testing "timeline-delete event creates remote sync object entry with delete status"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced" :name "Remote-Sync"}
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true :name "Remote-Sync"}
                    :model/Timeline timeline {:name "Test Timeline"
                                              :collection_id (:id remote-sync-collection)}]
       (t2/delete! :model/RemoteSyncObject)
-
       (events/publish-event! :event/timeline-delete
                              {:object timeline :user-id (mt/user->id :rasta)})
-
       (let [entries (t2/select :model/RemoteSyncObject)]
         (is (= 1 (count entries)))
         (is (=? {:model_type "Timeline"
@@ -967,28 +817,22 @@
                    :model/Timeline timeline {:name "Test Timeline"
                                              :collection_id (:id normal-collection)}]
       (t2/delete! :model/RemoteSyncObject)
-
       (events/publish-event! :event/timeline-create
                              {:object timeline :user-id (mt/user->id :rasta)})
-
       (let [entries (t2/select :model/RemoteSyncObject)]
         (is (= 0 (count entries)))))))
 
 (deftest existing-timeline-moved-out-of-remote-synced-collection-test
   (testing "existing timeline moved out of remote-synced collection gets marked as removed"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced" :name "Remote-Sync"}
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true :name "Remote-Sync"}
                    :model/Collection normal-collection {:name "Normal Collection"}
                    :model/Timeline timeline {:name "Test Timeline"
                                              :collection_id (:id remote-sync-collection)}]
       (#'impl/sync-objects! (t/instant) {"Timeline" #{(:entity_id timeline)}})
-
       (is (= 1 (count (t2/select :model/RemoteSyncObject))))
-
-      ;; Move to normal collection
       (events/publish-event! :event/timeline-update
                              {:object (assoc timeline :collection_id (:id normal-collection))
                               :user-id (mt/user->id :rasta)})
-
       (let [entries (t2/select :model/RemoteSyncObject)]
         (is (= 1 (count entries)))
         (is (=? {:model_type "Timeline"
@@ -998,22 +842,16 @@
 
 (deftest new-timeline-moved-out-of-remote-synced-collection-test
   (testing "new timeline moved out of remote-synced collection is no longer tracked"
-    (mt/with-temp [:model/Collection remote-sync-collection {:type "remote-synced" :name "Remote-Sync"}
+    (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true :name "Remote-Sync"}
                    :model/Collection normal-collection {:name "Normal Collection"}
                    :model/Timeline timeline {:name "Test Timeline"
                                              :collection_id (:id remote-sync-collection)}]
       (t2/delete! :model/RemoteSyncObject)
-
-      ;; Create initial entry
       (events/publish-event! :event/timeline-create
                              {:object timeline :user-id (mt/user->id :rasta)})
-
       (is (= 1 (count (t2/select :model/RemoteSyncObject))))
-
-      ;; Move to normal collection
       (events/publish-event! :event/timeline-update
                              {:object (assoc timeline :collection_id (:id normal-collection))
                               :user-id (mt/user->id :rasta)})
-
       (let [entries (t2/select :model/RemoteSyncObject)]
         (is (= 0 (count entries)))))))

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
@@ -36,7 +36,7 @@
 (deftest import!-successful-without-collections-test
   (testing "import! successful without collections (imports all remote-synced)"
     (let [task-id (t2/insert-returning-pk! :model/RemoteSyncTask {:sync_task_type "import" :initiated_by (mt/user->id :rasta)})]
-      (mt/with-temp [:model/Collection {_coll-id :id} {:name "Test Collection" :type "remote-synced" :entity_id "test-collection-1xxxx" :location "/"}]
+      (mt/with-temp [:model/Collection {_coll-id :id} {:name "Test Collection" :is_remote_synced true :entity_id "test-collection-1xxxx" :location "/"}]
         (let [result (impl/import! (source.p/snapshot (test-helpers/create-mock-source)) task-id)]
           (is (= :success (:status result))))))))
 
@@ -114,7 +114,7 @@
             task-defaults (mt/with-temp-defaults :model/RemoteSyncTask)]
         (t2/insert! :model/Collection (merge coll-defaults
                                              {:name "Test Collection"
-                                              :type "remote-synced"
+                                              :is_remote_synced true
                                               :entity_id "test-collection-1xxxx"
                                               :location "/"}))
         (t2/insert! :model/RemoteSyncTask (merge task-defaults
@@ -155,7 +155,7 @@
   (testing "export! successful with default collections"
     (mt/with-temporary-setting-values [remote-sync-type :read-write]
       (let [task-id (t2/insert-returning-pk! :model/RemoteSyncTask {:sync_task_type "export" :initiated_by (mt/user->id :rasta)})]
-        (mt/with-temp [:model/Collection {_coll-id :id} {:name "Test Collection" :type "remote-synced" :entity_id "test-collection-1xxxx" :location "/"}]
+        (mt/with-temp [:model/Collection {_coll-id :id} {:name "Test Collection" :is_remote_synced true :entity_id "test-collection-1xxxx" :location "/"}]
           (let [mock-source (test-helpers/create-mock-source)
                 result (impl/export! (source.p/snapshot mock-source) task-id "Test commit message")]
             (is (= :success (:status result)))))))))
@@ -164,7 +164,7 @@
   (testing "export! handles store failure"
     (mt/with-temporary-setting-values [remote-sync-type :read-write]
       (let [task-id (t2/insert-returning-pk! :model/RemoteSyncTask {:sync_task_type "export" :initiated_by (mt/user->id :rasta)})]
-        (mt/with-temp [:model/Collection {_coll-id :id} {:name "Test Collection" :type "remote-synced" :entity_id "test-collection-1xxxx" :location "/"}]
+        (mt/with-temp [:model/Collection {_coll-id :id} {:name "Test Collection" :is_remote_synced true :entity_id "test-collection-1xxxx" :location "/"}]
           (let [mock-source (test-helpers/create-mock-source :fail-mode :store-error)
                 result (impl/export! (source.p/snapshot mock-source) task-id "Test commit message")]
             (is (= :error (:status result)))
@@ -174,7 +174,7 @@
   (testing "export! handles network errors during write"
     (mt/with-temporary-setting-values [remote-sync-type :read-write]
       (let [task-id (t2/insert-returning-pk! :model/RemoteSyncTask {:sync_task_type "export" :initiated_by (mt/user->id :rasta)})]
-        (mt/with-temp [:model/Collection {_coll-id :id} {:name "Test Collection" :type "remote-synced" :entity_id "test-collection-1xxxx" :location "/"}]
+        (mt/with-temp [:model/Collection {_coll-id :id} {:name "Test Collection" :is_remote_synced true :entity_id "test-collection-1xxxx" :location "/"}]
           (let [mock-source (test-helpers/create-mock-source :fail-mode :network-error)
                 result (impl/export! (source.p/snapshot mock-source) task-id "Test commit message")]
             (is (= :error (:status result)))
@@ -185,7 +185,7 @@
 (deftest complete-import-export-workflow-test
   (testing "complete import-export workflow"
     (mt/with-temporary-setting-values [remote-sync-type :read-write]
-      (mt/with-temp [:model/Collection {coll-id :id} {:name "Test Collection" :type "remote-synced" :entity_id "test-collection-1xxxx" :location "/"}
+      (mt/with-temp [:model/Collection {coll-id :id} {:name "Test Collection" :is_remote_synced true :entity_id "test-collection-1xxxx" :location "/"}
                      :model/Card {card-id :id} {:name "Test Card" :collection_id coll-id :entity_id "test-card-1xxxxxxxxxx"}]
         (let [mock-main (test-helpers/create-mock-source :branch "test-branch")
               export-task (t2/insert-returning-instance! :model/RemoteSyncTask {:sync_task_type "export" :initiated_by (mt/user->id :rasta)})
@@ -217,7 +217,7 @@
             (let [collection (t2/select-one :model/Collection :id coll-id)
                   card (t2/select-one :model/Card :id card-id)]
               (is (= "Test Collection" (:name collection)))
-              (is (= "remote-synced" (:type collection)))
+              (is (true? (:is_remote_synced collection)))
               (is (= "test-collection-1xxxx" (:entity_id collection)))
               (is (= "Test Card" (:name card)))
               (is (= "test-card-1xxxxxxxxxx" (:entity_id card)))
@@ -226,8 +226,8 @@
 (deftest collection-cleanup-during-import-test
   (testing "collection cleanup during import (tests clean-synced! private function)"
     (let [import-task (t2/insert-returning-instance! :model/RemoteSyncTask {:sync_task_type "import" :initiated_by (mt/user->id :rasta)})]
-      (mt/with-temp [:model/Collection {coll1-id :id} {:name "Collection 1" :type "remote-synced" :entity_id "test-collection-1xxxx" :location "/"}
-                     :model/Collection {coll2-id :id} {:name "Collection 2" :type "remote-synced" :entity_id "test-collection-2xxxx" :location "/"}
+      (mt/with-temp [:model/Collection {coll1-id :id} {:name "Collection 1" :is_remote_synced true :entity_id "test-collection-1xxxx" :location "/"}
+                     :model/Collection {coll2-id :id} {:name "Collection 2" :is_remote_synced true :entity_id "test-collection-2xxxx" :location "/"}
                      :model/Card {card1-id :id} {:name "Card 1" :collection_id coll1-id :entity_id "test-card-1xxxxxxxxxx"}
                      :model/Card {card2-id :id} {:name "Card 2" :collection_id coll2-id :entity_id "test-card-2xxxxxxxxxx"}]
         (let [test-files {"test-branch" {"collections/test-collection-1xxxx-_/test-collection-1xxxx.yaml"
@@ -254,7 +254,7 @@
 (deftest import!-calls-update-progress-with-expected-values-test
   (testing "import! calls update-progress! with expected progress values"
     (let [task-id (t2/insert-returning-pk! :model/RemoteSyncTask {:sync_task_type "import" :initiated_by (mt/user->id :rasta)})]
-      (mt/with-temp [:model/Collection {_coll-id :id} {:name "Test Collection" :type "remote-synced" :entity_id "test-collection-1xxxx" :location "/"}]
+      (mt/with-temp [:model/Collection {_coll-id :id} {:name "Test Collection" :is_remote_synced true :entity_id "test-collection-1xxxx" :location "/"}]
         (let [mock-source (test-helpers/create-mock-source)
               progress-calls (atom [])]
           (with-redefs [remote-sync.task/update-progress!
@@ -277,8 +277,8 @@
     (mt/dataset test-data
       (mt/with-temporary-setting-values [remote-sync-type :read-write]
         (let [task-id (t2/insert-returning-pk! :model/RemoteSyncTask {:sync_task_type "export" :initiated_by (mt/user->id :rasta)})]
-          (mt/with-temp [:model/Collection {coll-id :id} {:name "Test Collection" :type "remote-synced" :entity_id "test-collection-1xxxx" :location "/"}
-                         :model/Collection _ {:name "Test Collection" :type "remote-synced" :entity_id "test-collection-2xxxx" :location "/"}
+          (mt/with-temp [:model/Collection {coll-id :id} {:name "Test Collection" :is_remote_synced true :entity_id "test-collection-1xxxx" :location "/"}
+                         :model/Collection _ {:name "Test Collection" :is_remote_synced true :entity_id "test-collection-2xxxx" :location "/"}
                          :model/Card _ {:collection_id coll-id}]
             (let [mock-source (test-helpers/create-mock-source)
                   progress-calls (atom [])]
@@ -297,7 +297,7 @@
   (testing "import! deletes and recreates RemoteSyncObject table with synced status"
     (mt/with-model-cleanup [:model/RemoteSyncObject]
       (let [task-id (t2/insert-returning-pk! :model/RemoteSyncTask {:sync_task_type "import" :initiated_by (mt/user->id :rasta)})]
-        (mt/with-temp [:model/Collection {coll-id :id} {:name "Test Collection" :type "remote-synced" :entity_id "test-collection-1xxxx" :location "/"}
+        (mt/with-temp [:model/Collection {coll-id :id} {:name "Test Collection" :is_remote_synced true :entity_id "test-collection-1xxxx" :location "/"}
                        :model/Card {card-id :id} {:name "Test Card" :collection_id coll-id :entity_id "test-card-1xxxxxxxxxx"}]
           (t2/insert! :model/RemoteSyncObject
                       [{:model_type "Collection" :model_id coll-id :status "created" :status_changed_at (t/offset-date-time)}
@@ -325,7 +325,7 @@
     (mt/with-model-cleanup [:model/RemoteSyncObject]
       (mt/with-temporary-setting-values [remote-sync-type :read-write]
         (let [task-id (t2/insert-returning-pk! :model/RemoteSyncTask {:sync_task_type "export" :initiated_by (mt/user->id :rasta)})]
-          (mt/with-temp [:model/Collection {coll-id :id} {:name "Test Collection" :type "remote-synced" :entity_id "test-collection-1xxxx" :location "/"}
+          (mt/with-temp [:model/Collection {coll-id :id} {:name "Test Collection" :is_remote_synced true :entity_id "test-collection-1xxxx" :location "/"}
                          :model/Card {card-id :id} {:name "Test Card" :collection_id coll-id :entity_id "test-card-1xxxxxxxxxx"}
                          :model/Dashboard {dash-id :id} {:name "Test Dashboard" :collection_id coll-id :entity_id "test-dashboard-1xxxxx"}]
             (t2/insert! :model/RemoteSyncObject
@@ -391,7 +391,7 @@
     (mt/with-model-cleanup [:model/RemoteSyncTask :model/Collection]
       (let [mock-source (test-helpers/create-mock-source)
             import-called? (atom false)]
-        (mt/with-temp [:model/Collection _ {:name "Remote Collection" :type "remote-synced" :location "/"}]
+        (mt/with-temp [:model/Collection _ {:name "Remote Collection" :is_remote_synced true :location "/"}]
           (mt/with-temporary-setting-values [remote-sync-enabled true
                                              remote-sync-url "https://github.com/test/repo.git"
                                              remote-sync-branch "main"
@@ -409,7 +409,7 @@
     (mt/with-model-cleanup [:model/Collection]
       (let [mock-source (test-helpers/create-mock-source)
             import-called? (atom false)]
-        (mt/with-temp [:model/Collection _ {:name "Remote Collection" :type "remote-synced" :location "/"}]
+        (mt/with-temp [:model/Collection _ {:name "Remote Collection" :is_remote_synced true :location "/"}]
           (mt/with-temporary-setting-values [remote-sync-enabled true
                                              remote-sync-url "https://github.com/test/repo.git"
                                              remote-sync-branch "main"
@@ -426,7 +426,7 @@
   (testing "finish-remote-config! clears remote-synced collection when remote sync is disabled"
     (mt/with-model-cleanup [:model/Collection]
       (let [clear-called? (atom false)]
-        (mt/with-temp [:model/Collection _ {:name "Remote Collection" :type "remote-synced" :location "/"}]
+        (mt/with-temp [:model/Collection _ {:name "Remote Collection" :is_remote_synced true :location "/"}]
           (mt/with-temporary-setting-values [remote-sync-enabled false]
             (with-redefs [collection/clear-remote-synced-collection! (fn [] (reset! clear-called? true))]
               (let [result (impl/finish-remote-config!)]

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/permissions_test.clj
@@ -19,7 +19,7 @@
     (mt/with-current-user (mt/user->id :rasta)
       (mt/with-temporary-setting-values [settings/remote-sync-type :read-only]
         (mt/with-temp [:model/Collection {library-coll-id :id} {:name "Library Collection"
-                                                                :type "remote-synced"}]
+                                                                :is_remote_synced true}]
 
           (testing "Cards in remote-synced collections have can_write=false"
             (mt/with-temp [:model/Card {card-id :id} {:name "Library Card"
@@ -46,7 +46,7 @@
     (mt/with-current-user (mt/user->id :rasta)
       (mt/with-temporary-setting-values [settings/remote-sync-type :read-write]
         (mt/with-temp [:model/Collection {library-coll-id :id} {:name "Library Collection"
-                                                                :type "remote-synced"}]
+                                                                :is_remote_synced true}]
 
           (testing "Cards in remote-synced collections have can_write=true"
             (mt/with-temp [:model/Card {card-id :id} {:name "Library Card"
@@ -102,10 +102,10 @@
   (testing "can_write for items in nested remote-synced collections should respect remote-sync-type"
     (mt/with-current-user (mt/user->id :rasta)
       (mt/with-temp [:model/Collection {parent-library-id :id} {:name "Parent Library Collection"
-                                                                :type "remote-synced"}
+                                                                :is_remote_synced true}
                      :model/Collection {child-library-id :id} {:name "Child Library Collection"
                                                                :location (format "/%d/" parent-library-id)
-                                                               :type "remote-synced"}]
+                                                               :is_remote_synced true}]
 
         (testing "When remote-sync-type is read-only"
           (mt/with-temporary-setting-values [settings/remote-sync-type :read-only]
@@ -157,7 +157,7 @@
   (testing "can_write behavior should differ between library and regular collections in same test"
     (mt/with-current-user (mt/user->id :rasta)
       (mt/with-temp [:model/Collection {library-coll-id :id} {:name "Library Collection"
-                                                              :type "remote-synced"}
+                                                              :is_remote_synced true}
                      :model/Collection {regular-coll-id :id} {:name "Regular Collection"
                                                               :type nil}]
 
@@ -201,7 +201,7 @@
   (testing "can_write behavior should differ between library and regular collections in same test when the user is a super user"
     (mt/with-current-user (mt/user->id :crowberto)
       (mt/with-temp [:model/Collection {library-coll-id :id} {:name "Library Collection"
-                                                              :type "remote-synced"}
+                                                              :is_remote_synced true}
                      :model/Collection {regular-coll-id :id} {:name "Regular Collection"
                                                               :type nil}]
 
@@ -247,7 +247,7 @@
     (testing "When remote-sync-type is read-only"
       (mt/with-temporary-setting-values [settings/remote-sync-type :read-only]
         (mt/with-temp [:model/Collection {library-coll-id :id} {:name "Library Collection"
-                                                                :type "remote-synced"}]
+                                                                :is_remote_synced true}]
           (mt/with-current-user (mt/user->id :rasta))
           (is (false? (mi/can-write? (t2/select-one :model/Collection :id library-coll-id)))
               "Library collection itself should not be writable when remote-sync-type is read-only"))))
@@ -255,7 +255,7 @@
     (testing "When remote-sync-type is read-write"
       (mt/with-temporary-setting-values [settings/remote-sync-type :read-write]
         (mt/with-temp [:model/Collection {library-coll-id :id} {:name "Library Collection"
-                                                                :type "remote-synced"}]
+                                                                :is_remote_synced true}]
           (mt/with-current-user (mt/user->id :rasta)
             (is (true? (mi/can-write? (t2/select-one :model/Collection :id library-coll-id)))
                 "Library collection itself should be writable when remote-sync-type is read-write")))))

--- a/enterprise/frontend/src/metabase-enterprise/collections/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/collections/constants.ts
@@ -14,7 +14,7 @@ export const REGULAR_COLLECTION: CollectionAuthorityLevelConfig = {
 };
 
 export const REMOTE_SYNC_COLLECTION: CollectionInstanceAnaltyicsConfig = {
-  type: "remote-synced",
+  type: null,
   icon: "synced_collection",
 };
 
@@ -53,7 +53,6 @@ export const COLLECTION_TYPES: Record<
   [String(OFFICIAL_COLLECTION.type)]: OFFICIAL_COLLECTION,
   [String(REGULAR_COLLECTION.type)]: REGULAR_COLLECTION,
   [String(INSTANCE_ANALYTICS_COLLECTION.type)]: INSTANCE_ANALYTICS_COLLECTION,
-  [String(REMOTE_SYNC_COLLECTION.type)]: REMOTE_SYNC_COLLECTION,
 };
 
 export const CUSTOM_INSTANCE_ANALYTICS_COLLECTION_ENTITY_ID =

--- a/enterprise/frontend/src/metabase-enterprise/collections/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/collections/utils.ts
@@ -31,15 +31,11 @@ export function isRegularCollection({
 export function getCollectionType({
   authority_level,
   type,
-  location,
 }: Partial<Collection>):
   | CollectionAuthorityLevelConfig
   | CollectionInstanceAnaltyicsConfig {
-  const virtualType =
-    type === "remote-synced" && location !== "/" ? null : type;
   return (
-    COLLECTION_TYPES?.[String(virtualType || authority_level)] ??
-    REGULAR_COLLECTION
+    COLLECTION_TYPES?.[String(type || authority_level)] ?? REGULAR_COLLECTION
   );
 }
 
@@ -52,15 +48,14 @@ export function isInstanceAnalyticsCollection(
 }
 
 export function isSyncedCollection(
-  collection: Pick<Collection, "type">,
+  collection: Pick<Collection, "is_remote_synced">,
 ): boolean {
-  return getCollectionType(collection).type === "remote-synced";
+  return collection.is_remote_synced === true;
 }
 
 export const getIcon = (item: ObjectWithModel): IconData => {
   const collectionType = getCollectionType({
     type: item.type || item.collection_type,
-    location: item.location || item.effective_location,
   }).type;
   if (collectionType === "instance-analytics") {
     return {
@@ -68,7 +63,7 @@ export const getIcon = (item: ObjectWithModel): IconData => {
     };
   }
 
-  if (collectionType === "remote-synced") {
+  if (item.is_remote_synced) {
     return {
       name: REMOTE_SYNC_COLLECTION.icon,
     };

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/middleware/remote-sync-listener-middleware.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/middleware/remote-sync-listener-middleware.ts
@@ -90,10 +90,10 @@ function shouldInvalidateForCollection(
     return false;
   }
 
-  const oldType = oldCollection?.type;
-  const newType = newCollection.type;
+  const oldSynced = oldCollection?.is_remote_synced ?? false;
+  const newSynced = newCollection.is_remote_synced ?? false;
 
-  return oldType === "remote-synced" || newType === "remote-synced";
+  return oldSynced || newSynced;
 }
 
 function getOriginalDocument(originalState: State, id: number) {
@@ -240,7 +240,7 @@ remoteSyncListenerMiddleware.startListening({
   effect: async (action: PayloadAction<Collection>, { dispatch }) => {
     const collection = action.payload;
 
-    if (collection.type === "remote-synced") {
+    if (collection.is_remote_synced) {
       invalidateRemoteSyncTags(dispatch);
     }
   },
@@ -277,7 +277,7 @@ remoteSyncListenerMiddleware.startListening({
         deleteRequest.id,
       );
 
-      if (collection?.type === "remote-synced") {
+      if (collection?.is_remote_synced) {
         invalidateRemoteSyncTags(dispatch);
       }
     }

--- a/frontend/src/embedding-sdk-bundle/types/collection.ts
+++ b/frontend/src/embedding-sdk-bundle/types/collection.ts
@@ -30,11 +30,11 @@ export type MetabaseCollectionItem = {
   type?:
     | "instance-analytics"
     | "trash"
-    | "remote-synced"
     | "model"
     | "question"
     | "metric"
     | null;
+  is_remote_synced?: boolean;
   "last-edit-info"?: {
     email: string;
     first_name: string;

--- a/frontend/src/metabase-types/api/collection.ts
+++ b/frontend/src/metabase-types/api/collection.ts
@@ -30,11 +30,7 @@ export type CollectionContentModel = "card" | "dataset";
 
 export type CollectionAuthorityLevel = "official" | null;
 
-export type CollectionType =
-  | "instance-analytics"
-  | "trash"
-  | "remote-synced"
-  | null;
+export type CollectionType = "instance-analytics" | "trash" | null;
 
 export type LastEditInfo = {
   email: string;
@@ -74,6 +70,7 @@ export interface Collection {
   children?: Collection[];
   authority_level?: CollectionAuthorityLevel;
   type?: CollectionType;
+  is_remote_synced?: boolean;
 
   parent_id?: CollectionId | null;
   personal_owner_id?: UserId;

--- a/frontend/src/metabase/lib/icon.ts
+++ b/frontend/src/metabase/lib/icon.ts
@@ -31,6 +31,7 @@ export type ObjectWithModel = {
   location?: Collection["location"];
   effective_location?: Collection["location"];
   is_personal?: boolean;
+  is_remote_synced?: boolean;
 };
 
 export const modelIconMap: Record<IconModel, IconName> = {

--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -651,6 +651,48 @@ databaseChangeLog:
       rollback:
         - sql: DELETE FROM auth_identity WHERE provider IN ('saml', 'jwt');
 
+  - changeSet:
+      id: v58.2025-11-19T00:00:00
+      author: edpaget
+      comment: Add is_remote_synced boolean column to collection table
+      changes:
+        - addColumn:
+            tableName: collection
+            columns:
+              - column:
+                  name: is_remote_synced
+                  type: ${boolean.type}
+                  remarks: Indicates if this collection is synced from a remote source
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: true
+      rollback:
+        - dropColumn:
+            tableName: collection
+            columnName: is_remote_synced
+
+  - changeSet:
+      id: v58.2025-11-19T00:00:01
+      author: edpaget
+      comment: Migrate existing remote-synced collections to use is_remote_synced column
+      changes:
+        - sql:
+            sql: UPDATE collection SET is_remote_synced = true WHERE type = 'remote-synced'
+      rollback:
+        - sql:
+            sql: UPDATE collection SET is_remote_synced = false WHERE type = 'remote-synced'
+
+  - changeSet:
+      id: v58.2025-11-19T00:00:02
+      author: edpaget
+      comment: Clear remote-synced type value (replaced by is_remote_synced column)
+      changes:
+        - sql:
+            sql: UPDATE collection SET type = NULL WHERE type = 'remote-synced'
+      rollback:
+        - sql:
+            sql: UPDATE collection SET type = 'remote-synced' WHERE is_remote_synced = true
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -64,14 +64,6 @@
   "The value of the `:type` field for the Trash collection that holds archived items."
   "trash")
 
-(def ^:constant remote-synced-collection-type
-  "The value of the `:type` field for remote-synced collections."
-  "remote-synced")
-
-(def ^:constant library-entity-id
-  "The remote-synced collection's entity ID"
-  "librarylibrarylibrary")
-
 (defn- trash-collection* []
   (t2/select-one :model/Collection :type trash-collection-type))
 
@@ -115,17 +107,15 @@
 (defn remote-synced-collection?
   "Is this a remote-synced collection?"
   [collection-or-id]
-  (let [type (:type collection-or-id ::not-found)]
-    (if (identical? type ::not-found)
-      ;; If no :type field, it's probably an ID - fetch from DB
-      (some->> collection-or-id u/the-id (t2/select-one-fn :type :model/Collection :id) (= remote-synced-collection-type))
-      ;; If :type field exists, compare directly
-      (= type remote-synced-collection-type))))
+  (cond
+    (nil? collection-or-id) false ;; the root collection is never remote-synced
+    (map? collection-or-id) (:is_remote_synced collection-or-id)
+    :else (t2/select-one-fn :is_remote_synced :model/Collection :id (u/the-id collection-or-id))))
 
 (defn remote-synced-collection
   "Get the remote-synced collection, if it exists."
   []
-  (t2/select-one :model/Collection :type remote-synced-collection-type :location "/"))
+  (t2/select-one :model/Collection :is_remote_synced true :location "/"))
 
 (defn create-remote-synced-collection!
   "Create the remote-synced-collection"
@@ -133,7 +123,7 @@
   (when-not (nil? (remote-synced-collection))
     (throw (ex-info "Remote-synced collection already exists" {})))
   (t2/insert-returning-instance! :model/Collection {:name     "Synced Collection"
-                                                    :type     remote-synced-collection-type
+                                                    :is_remote_synced true
                                                     :location "/"}))
 
 (defonce ^:dynamic ^:private *clearing-remote-sync* false)
@@ -142,7 +132,7 @@
   "Marks any remote-synced-collection as non-remote-synced"
   []
   (binding [*clearing-remote-sync* true]
-    (t2/update! :model/Collection :type remote-synced-collection-type {:type nil})))
+    (t2/update! :model/Collection :is_remote_synced true {:is_remote_synced false})))
 
 (methodical/defmethod t2/table-name :model/Collection [_model] :collection)
 
@@ -326,14 +316,12 @@
   "Check that if this Collection is remote-synced, its parent is either remote-synced or the root collection.
 
   If a collection's parent is remote-synced, it must also be remote-synced."
-  [{:keys [location type]}]
+  [{:keys [location is_remote_synced]}]
   (when-let [parent-id (and location (location-path->parent-id location))]
-    (let [parent-type (t2/select-one-fn :type :model/Collection :id parent-id)]
-      (when (and (or
-                  (= parent-type remote-synced-collection-type)
-                  (= type remote-synced-collection-type))
-                 (not= parent-type type remote-synced-collection-type))
-        (let [msg (if (= type remote-synced-collection-type)
+    (let [parent-is-remote-synced? (t2/select-one-fn :is_remote_synced :model/Collection :id parent-id)]
+      (when (and (or parent-is-remote-synced? is_remote_synced)
+                 (not= parent-is-remote-synced? is_remote_synced))
+        (let [msg (if is_remote_synced
                     (tru "A remote-synced Collection can only be placed in another remote-synced Collection or the root Collection.")
                     (tru "A Collection placed in a remote-synced Collection must also be remote-synced."))]
           (throw (ex-info msg {:status-code 400, :errors {:location msg}})))))))
@@ -1101,7 +1089,7 @@
                                                                                  [:= :c.id :collection_id]
                                                                                  [:or [:= :c.id root-collection-id]
                                                                                   [:like :c.location (str "/" root-collection-id "/%")]]
-                                                                                 [:= :c.type [:inline remote-synced-collection-type]]]]})))))
+                                                                                 [:= :c.is_remote_synced true]]]})))))
     #{}))
 
 (defn check-non-remote-synced-dependencies
@@ -1155,11 +1143,11 @@
    (and (not (nil? new-collection-id))
         (when-let [new-parent-location (t2/select-one-fn :location :model/Collection
                                                          {:where [:and [:= :id new-collection-id]
-                                                                  [:= :type remote-synced-collection-type]]})]
+                                                                  [:= :is_remote_synced true]]})]
           (or (nil? old-collection-id)
               (if-let [old-parent-location (t2/select-one-fn :location :model/Collection
                                                              {:where [:and [:= :id old-collection-id]
-                                                                      [:= :type remote-synced-collection-type]]})]
+                                                                      [:= :is_remote_synced true]]})]
                 (locations-do-not-share-top-level-parent old-parent-location
                                                          old-collection-id
                                                          new-parent-location
@@ -1182,11 +1170,11 @@
    (and (not (nil? old-collection-id))
         (when-let [old-parent-location (t2/select-one-fn :location [:model/Collection :location]
                                                          {:where [:and [:= :id old-collection-id]
-                                                                  [:= :type remote-synced-collection-type]]})]
+                                                                  [:= :is_remote_synced true]]})]
           (or (nil? new-collection-id)
               (if-let [new-parent-location (t2/select-one-fn :location [:model/Collection :location]
                                                              {:where [:and [:= :id new-collection-id]
-                                                                      [:= :type remote-synced-collection-type]]})]
+                                                                      [:= :is_remote_synced true]]})]
                 (locations-do-not-share-top-level-parent old-parent-location
                                                          old-collection-id
                                                          new-parent-location
@@ -1220,7 +1208,7 @@
   [_model k items]
   (mi/instances-with-hydrated-data items k
                                    #(into {}
-                                          (map (juxt :id (fn [{:keys [type]}] (= type "remote-synced")))
+                                          (map (juxt :id :is_remote_synced)
                                                items))
                                    :id
                                    {:default false}))
@@ -1349,7 +1337,7 @@
                            :archived_directly false}
                     {:archived true})))
     (let [updated-collection (t2/select-one :model/Collection :id (:id collection))]
-      (when (= remote-synced-collection-type (:type updated-collection))
+      (when (:is_remote_synced updated-collection)
         (check-remote-synced-dependents (parent-id* updated-collection) updated-collection)))))
 
 (mu/defn unarchive-collection!
@@ -1370,7 +1358,7 @@
         new-parent              (if new-parent-id
                                   (t2/select-one :model/Collection :id new-parent-id)
                                   root-collection)
-        new-parent-type         (:type new-parent)
+        new-parent-is-remote-synced? (:is_remote_synced new-parent)
         new-location            (children-location new-parent)
         orig-children-location  (children-location collection)
         new-children-location   (children-location (assoc collection :location new-location))
@@ -1384,15 +1372,14 @@
     (t2/with-transaction [_conn]
       (t2/update! :model/Collection (u/the-id collection)
                   {:location             new-location
-                   :type                 (if (= new-parent-type "remote-synced")
-                                           "remote-synced"
-                                           :type)
+                   :is_remote_synced (boolean new-parent-is-remote-synced?)
                    :archive_operation_id nil
                    :archived_directly    nil
                    :archived             false})
       (t2/query-one
        {:update :collection
         :set    {:location             [:replace :location orig-children-location new-children-location]
+                 :is_remote_synced (boolean new-parent-is-remote-synced?)
                  :archive_operation_id nil
                  :archived_directly    nil
                  :archived             false}
@@ -1407,7 +1394,7 @@
         (t2/update! model {:collection_id     [:in affected-collection-ids]
                            :archived_directly false}
                     {:archived false}))
-      (when (= remote-synced-collection-type (:type collection))
+      (when (:is_remote_synced collection)
         (check-non-remote-synced-dependencies collection)))))
 
 (mu/defn archive-or-unarchive-collection!
@@ -1429,7 +1416,7 @@
   (let [orig-children-location (children-location collection)
         new-children-location  (children-location (assoc collection :location new-location))
         will-be-in-trash? (str/starts-with? new-location (trash-path))
-        will-be-in-remote-synced? (= remote-synced-collection-type (t2/select-one-fn :type :model/Collection :id (parent-id* {:location new-location})))]
+        will-be-in-remote-synced? (t2/select-one-fn :is_remote_synced :model/Collection :id (parent-id* {:location new-location}))]
     (when will-be-in-trash?
       (throw (ex-info "Cannot `move-collection!` into the Trash. Call `archive-collection!` instead."
                       {:collection collection
@@ -1440,13 +1427,13 @@
     (events/publish-event! :event/collection-touch {:collection-id (:id collection) :user-id api/*current-user-id*})
     (t2/with-transaction [_conn]
       (t2/update! :model/Collection (u/the-id collection)
-                  (cond-> {:location new-location :type nil}
-                    will-be-in-remote-synced? (assoc :type remote-synced-collection-type)))
+                  {:location new-location
+                   :is_remote_synced (boolean will-be-in-remote-synced?)})
       ;; we need to update all the descendant collections as well...
       (u/prog1 (t2/query-one
                 {:update :collection
-                 :set (cond-> {:location [:replace :location orig-children-location new-children-location] :type nil}
-                        will-be-in-remote-synced? (assoc :type remote-synced-collection-type))
+                 :set {:location [:replace :location orig-children-location new-children-location]
+                       :is_remote_synced (boolean will-be-in-remote-synced?)}
                  :where [:like :location (str orig-children-location "%")]})
         (when into-remote-synced?
           (check-non-remote-synced-dependencies collection))
@@ -1466,12 +1453,19 @@
         (throw (ex-info "Can't create a personal collection for an API key" {:user user-id}))))))
 
 (t2/define-before-insert :model/Collection
-  [{collection-name :name, :as collection}]
+  [{collection-name :name, :keys [location] :as collection}]
   (assert-valid-location collection)
   (assert-not-personal-collection-for-api-key collection)
   (assert-valid-namespace (merge {:namespace nil} collection))
   (assert-valid-remote-synced-parent collection)
-  (assoc collection :slug (slugify collection-name)))
+  ;; Inherit is_remote_synced from parent if not explicitly set
+  (let [parent-is-remote-synced? (when-let [parent-id (and location (location-path->parent-id location))]
+                                   (t2/select-one-fn :is_remote_synced :model/Collection :id parent-id))]
+    (-> collection
+        (assoc :slug (slugify collection-name))
+        (cond-> (and (not (contains? collection :is_remote_synced))
+                     parent-is-remote-synced?)
+          (assoc :is_remote_synced true)))))
 
 (defn- copy-collection-permissions!
   "Grant read permissions to destination Collections for every Group with read permissions for a source Collection,
@@ -1821,6 +1815,7 @@
           :authority_level
           :description
           :entity_id
+          :is_remote_synced
           :is_sample
           :name
           :namespace

--- a/src/metabase/collections_rest/api.clj
+++ b/src/metabase/collections_rest/api.clj
@@ -639,7 +639,9 @@
            [:= :id (collection/trash-collection-id)]]
           [:and [:= :archived false] [:not= :id (collection/trash-collection-id)]])
         (when collection-type
-          [:= :type collection-type])
+          (if (= collection-type "remote-synced")
+            [:= :is_remote_synced true]
+            [:= :type collection-type]))
         (perms/audit-namespace-clause :namespace (u/qualified-name collection-namespace))
         (snippets-collection-filter-clause))
        ;; We get from the effective-children-query a normal set of columns selected:
@@ -654,6 +656,7 @@
                 :location
                 :archived_directly
                 :type
+                [[:case [:= :is_remote_synced nil] [:inline false] :else :is_remote_synced] :is_remote_synced]
                 [(h2x/literal "collection") :model]
                 :authority_level])
       ;; the nil indicates that collections are never pinned.
@@ -733,6 +736,7 @@
         (-> (t2/instance :model/Collection row)
             collection/maybe-localize-trash-name
             (update :archived api/bit->boolean)
+            (update :is_remote_synced api/bit->boolean)
             (t2/hydrate :can_write :effective_location :can_restore :can_delete)
             (dissoc :collection_position :display :moderated_status :icon
                     :collection_preview :dataset_query :table_id :query_type :is_upload)
@@ -812,7 +816,7 @@
    :model :collection_position :authority_level [:personal_owner_id :integer] :location
    :last_edit_email :last_edit_first_name :last_edit_last_name :moderated_status :icon
    [:last_edit_user :integer] [:last_edit_timestamp :timestamp] [:database_id :integer]
-   :type [:archived :boolean] [:last_used_at :timestamp]
+   :type [:archived :boolean] [:last_used_at :timestamp] [:is_remote_synced :boolean]
    ;; for determining whether a model is based on a csv-uploaded table
    [:table_id :integer] [:is_upload :boolean] :query_type])
 
@@ -1151,7 +1155,7 @@
            include_can_run_adhoc_query collection_type
            show_dashboard_questions]} :- [:map
                                           [:models                      {:optional true} [:maybe Models]]
-                                          [:collection_type {:optional true} CollectionType]
+                                          [:collection_type             {:optional true} CollectionType]
                                           [:include_can_run_adhoc_query {:default false} [:maybe ms/BooleanValue]]
                                           [:archived                    {:default false} [:maybe ms/BooleanValue]]
                                           [:namespace                   {:optional true} [:maybe ms/NonBlankString]]
@@ -1192,7 +1196,7 @@
 
 (defn create-collection!
   "Create a new collection."
-  [{:keys [name description parent_id namespace authority_level type] :as params}]
+  [{:keys [name description parent_id namespace authority_level] :as params}]
   ;; To create a new collection, you need write perms for the location you are going to be putting it in...
   (write-check-collection-or-root-collection parent_id namespace)
   (when (some? authority_level)
@@ -1200,26 +1204,22 @@
     (premium-features/assert-has-feature :official-collections (tru "Official Collections"))
     (api/check-superuser))
   ;; Get namespace from parent collection if not provided
-  (let [{parent-type :type
+  (let [{remote-synced? :is_remote_synced
          :as parent-collection} (when parent_id
-                                  (t2/select-one [:model/Collection :location :id :namespace :type] :id parent_id))
+                                  (t2/select-one [:model/Collection :location :id :namespace :is_remote_synced] :id parent_id))
         effective-namespace (cond
                               (contains? params :namespace) namespace
                               parent-collection (:namespace parent-collection)
-                              :else nil)
-        effective-type (cond
-                         (contains? params :type) type
-                         parent-type parent-type
-                         :else nil)]
+                              :else nil)]
      ;; Now create the new Collection :)
     (u/prog1 (t2/insert-returning-instance!
               :model/Collection
               (merge
-               {:name            name
-                :description     description
-                :type            effective-type
-                :authority_level authority_level
-                :namespace       effective-namespace}
+               {:name             name
+                :description      description
+                :is_remote_synced (boolean remote-synced?)
+                :authority_level  authority_level
+                :namespace        effective-namespace}
                (when parent-collection
                  {:location (collection/children-location parent-collection)})))
       (when config/ee-available?
@@ -1235,7 +1235,6 @@
             [:description     {:optional true} [:maybe ms/NonBlankString]]
             [:parent_id       {:optional true} [:maybe ms/PositiveInt]]
             [:namespace       {:optional true} [:maybe ms/NonBlankString]]
-            [:type            {:optional true} [:maybe CollectionType]]
             [:authority_level {:optional true} [:maybe collection/AuthorityLevel]]]]
   (create-collection! body))
 
@@ -1406,16 +1405,7 @@
     ;; that's not actually a property of Collection, and since we handle moving a Collection separately below.
     (let [updates (u/select-keys-when collection-updates :present [:name :description :authority_level :type])]
       (when (seq updates)
-        (t2/with-transaction [_conn]
-          (t2/update! :model/Collection id updates)
-          ;; if type is changing, cascade the type change to all child collections
-          (when (api/column-will-change? :type collection-before-update updates)
-            (let [child-location (collection/children-location collection-before-update)]
-              (t2/query-one {:update :collection
-                             :where [:like :location (str child-location "%")]
-                             :set {:type (:type updates)}}))
-            (when (= (:type updates) "remote-synced")
-              (collection/check-non-remote-synced-dependencies (t2/select-one :model/Collection :id id)))))))
+        (t2/update! :model/Collection id updates)))
     ;; if we're trying to move or archive the Collection, go ahead and do that
     (move-or-archive-collection-if-needed! collection-before-update collection-updates)
     (let [updated-collection (t2/select-one :model/Collection :id id)]

--- a/src/metabase/remote_sync/init.clj
+++ b/src/metabase/remote_sync/init.clj
@@ -11,9 +11,7 @@
   (mi/instances-with-hydrated-data items k
                                    #(into {}
                                           (map (juxt :id (comp api/bit->boolean :is_remote_synced))
-                                               (t2/select [model :id [[:and [:= :c.type [:inline "remote-synced"]]
-                                                                       [:not= :c.type nil]]
-                                                                      :is_remote_synced]]
+                                               (t2/select [model :id [:c.is_remote_synced :is_remote_synced]]
                                                           {:where [:in (keyword (str (name (t2/table-name model)) ".id"))
                                                                    (map :id items)]
                                                            :join [[:collection :c]

--- a/test/metabase/collections/models/collection_test.clj
+++ b/test/metabase/collections/models/collection_test.clj
@@ -1775,7 +1775,7 @@
 
 (deftest non-remote-synced-dependencies-no-dependencies-test
   (testing "when model has no dependencies"
-    (mt/with-temp [:model/Collection {remote-synced-coll-id :id} {:name "Remote-Synced Collection" :type "remote-synced"}
+    (mt/with-temp [:model/Collection {remote-synced-coll-id :id} {:name "Remote-Synced Collection" :is_remote_synced true}
                    :model/Card {card-id :id} {:name "Test Card" :collection_id remote-synced-coll-id}]
        ;; Card with no actual dependencies will return empty
       (let [result (collection/non-remote-synced-dependencies (t2/instance :model/Card {:id card-id}))]
@@ -1784,7 +1784,7 @@
 
 (deftest non-remote-synced-dependencies-all-in-remote-synced-test
   (testing "when model has card dependencies all in remote-synced collection"
-    (mt/with-temp [:model/Collection {remote-synced-coll-id :id} {:name "Remote-Synced Collection" :type "remote-synced"}
+    (mt/with-temp [:model/Collection {remote-synced-coll-id :id} {:name "Remote-Synced Collection" :is_remote_synced true}
                    :model/Card {dep-card-id :id} {:name "Dependency Card"
                                                   :collection_id remote-synced-coll-id}
                    :model/Card {source-card-id :id} {:name "Source Card"
@@ -1828,19 +1828,19 @@
     ;; 2. FLAG dependencies that cross between different remote-synced roots
 
     (testing "Setup: Creating remote-synced collection hierarchies"
-      (mt/with-temp [:model/Collection {root-1 :id} {:name "Remote-Synced Root 1" :type "remote-synced"}
+      (mt/with-temp [:model/Collection {root-1 :id} {:name "Remote-Synced Root 1" :is_remote_synced true}
                      :model/Collection {child-1 :id} {:name "Child of Root 1"
                                                       :location (format "/%d/" root-1)
-                                                      :type "remote-synced"}
-                     :model/Collection {root-2 :id} {:name "Remote-Synced Root 2" :type "remote-synced"}
+                                                      :is_remote_synced true}
+                     :model/Collection {root-2 :id} {:name "Remote-Synced Root 2" :is_remote_synced true}
                      :model/Collection {child-2 :id} {:name "Child of Root 2"
                                                       :location (format "/%d/" root-2)
-                                                      :type "remote-synced"}]
+                                                      :is_remote_synced true}]
 
         ;; Verify the collections are correctly created
-        (is (= "remote-synced" (:type (t2/select-one :model/Collection :id root-1)))
+        (is (true? (:is_remote_synced (t2/select-one :model/Collection :id root-1)))
             "Root 1 should be remote-synced type")
-        (is (= "remote-synced" (:type (t2/select-one :model/Collection :id root-2)))
+        (is (true? (:is_remote_synced (t2/select-one :model/Collection :id root-2)))
             "Root 2 should be remote-synced type")
         (is (= (format "/%d/" root-1) (:location (t2/select-one :model/Collection :id child-1)))
             "Child 1 should be nested under Root 1")
@@ -1877,7 +1877,7 @@
 
 (deftest non-remote-synced-dependencies-mixed-locations-test
   (testing "when model has mixed card dependencies (some in remote-synced, some outside)"
-    (mt/with-temp [:model/Collection {remote-synced-coll-id :id} {:name "Remote-Synced Collection" :type "remote-synced"}
+    (mt/with-temp [:model/Collection {remote-synced-coll-id :id} {:name "Remote-Synced Collection" :is_remote_synced true}
                    :model/Collection {regular-coll-id :id} {:name "Regular Collection"}
                    :model/Card _ {:name "Card in Library"
                                   :collection_id remote-synced-coll-id}
@@ -1908,10 +1908,10 @@
 
 (deftest non-remote-synced-dependencies-with-remote-synced-collection-test
   (testing "when Remote-Synced collection exists and has descendants"
-    (mt/with-temp [:model/Collection {remote-synced-coll-id :id} {:name "Remote-Synced Collection" :type "remote-synced"}
+    (mt/with-temp [:model/Collection {remote-synced-coll-id :id} {:name "Remote-Synced Collection" :is_remote_synced true}
                    :model/Collection {regular-coll-id :id} {:name "Regular Collection"}
                    :model/Collection {remote-synced-child-id :id} {:name "Remote-Synced Child"
-                                                                   :type "remote-synced"
+                                                                   :is_remote_synced true
                                                                    :location (format "/%d/" remote-synced-coll-id)}
                    :model/Card {card-in-remote-synced-child :id} {:name "Card in Remote-Synced Child"
                                                                   :collection_id remote-synced-child-id}
@@ -1944,7 +1944,7 @@
 
 (deftest non-remote-synced-dependencies-with-models-test
   (testing "function behavior with model Cards"
-    (mt/with-temp [:model/Collection {remote-synced-coll-id :id} {:name "Remote-Synced Collection" :type "remote-synced"}
+    (mt/with-temp [:model/Collection {remote-synced-coll-id :id} {:name "Remote-Synced Collection" :is_remote_synced true}
                    :model/Collection {regular-coll-id :id} {:name "Regular Collection"}
                    :model/Card _ {:name "Model in Library"
                                   :collection_id remote-synced-coll-id
@@ -1975,7 +1975,7 @@
   (testing "function returns only Card IDs regardless of dependency types"
     (mt/with-temp [:model/Collection {regular-coll-id :id} {:name "Regular Collection"}
                    :model/Collection {snippet-remote-synced-coll-id :id} {:name "Library Snippets"
-                                                                          :type "remote-synced"
+                                                                          :is_remote_synced true
                                                                           :namespace "snippets"}
                    :model/Collection {snippet-regular-coll-id :id} {:name "Regular Snippets"
                                                                     :namespace "snippets"}
@@ -2007,9 +2007,9 @@
   (testing "comprehensive test - function only returns Card IDs outside remote-synced"
     (mt/with-temp [:model/Collection {regular-coll-id :id} {:name "Regular Collection"}
                    :model/Collection {remote-synced-child-id :id} {:name "Remote-Synced Child"
-                                                                   :type "remote-synced"}
+                                                                   :is_remote_synced true}
                    :model/Collection {snippet-remote-synced-coll-id :id} {:name "Library Snippets"
-                                                                          :type "remote-synced"
+                                                                          :is_remote_synced true
                                                                           :namespace "snippets"}
                    :model/Collection {snippet-regular-coll-id :id} {:name "Regular Snippets"
                                                                     :namespace "snippets"}
@@ -2043,9 +2043,9 @@
 
 (deftest moving-into-remote-synced?-test
   (testing "moving-into-remote-synced? function behavior"
-    (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced" :type "remote-synced"}
+    (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced" :is_remote_synced true}
                    :model/Collection {regular-coll-id :id} {:name "Regular Collection"}
-                   :model/Collection {other-remote-synced-id :id} {:name "Other Library" :type "remote-synced"}]
+                   :model/Collection {other-remote-synced-id :id} {:name "Other Library" :is_remote_synced true}]
 
       (testing "when moving from non-remote-synced to remote-synced collection"
         (is (true? (collection/moving-into-remote-synced? regular-coll-id remote-synced-id))
@@ -2120,7 +2120,7 @@
 
 (deftest move-collection!-into-remote-synced-true-test
   (testing "when parent collection is remote-synced collection and descendants become remote-synced type"
-    (mt/with-temp [:model/Collection {parent-id :id} {:name "Parent" :location "/" :type "remote-synced"}
+    (mt/with-temp [:model/Collection {parent-id :id} {:name "Parent" :location "/" :is_remote_synced true}
                    :model/Collection {coll-id :id :as coll} {:name "Collection to Move"
                                                              :location "/"
                                                              :type nil}
@@ -2135,16 +2135,16 @@
 
         ;; Check that the moved collection became remote-synced type
       (let [moved-coll (t2/select-one :model/Collection :id coll-id)]
-        (is (= "remote-synced" (:type moved-coll))
+        (is (true? (:is_remote_synced moved-coll))
             "Moved collection should have remote-synced type"))
 
         ;; Check that child collections also became remote-synced type
       (let [moved-child (t2/select-one :model/Collection :id child-id)]
-        (is (= "remote-synced" (:type moved-child))
+        (is (true? (:is_remote_synced moved-child))
             "Child collection should have remote-synced type"))
 
       (let [moved-grandchild (t2/select-one :model/Collection :id grandchild-id)]
-        (is (= "remote-synced" (:type moved-grandchild))
+        (is (true? (:is_remote_synced moved-grandchild))
             "Grandchild collection should have remote-synced type")))))
 
 (deftest move-collection!-into-remote-synced-false-test
@@ -2161,11 +2161,11 @@
 
         ;; Check that collection types remain nil
       (let [moved-coll (t2/select-one :model/Collection :id coll-id)]
-        (is (nil? (:type moved-coll))
+        (is (false? (:is_remote_synced moved-coll))
             "Moved collection should not have remote-synced type"))
 
       (let [moved-child (t2/select-one :model/Collection :id child-id)]
-        (is (nil? (:type moved-child))
+        (is (false? (:is_remote_synced moved-child))
             "Child collection should not have remote-synced type")))))
 
 (deftest move-collection!-already-remote-synced-test
@@ -2173,26 +2173,26 @@
     (mt/with-temp [:model/Collection {parent-id :id} {:name "Parent" :location "/"}
                    :model/Collection {coll-id :id :as coll} {:name "Remote-Synced Collection"
                                                              :location "/"
-                                                             :type "remote-synced"}
+                                                             :is_remote_synced true}
                    :model/Collection {child-id :id} {:name "Child Collection"
                                                      :location (format "/%d/" coll-id)
-                                                     :type "remote-synced"}]
+                                                     :is_remote_synced true}]
         ;; Move remote-synced collection with into-remote-synced? true
       (collection/move-collection! coll (format "/%d/" parent-id))
 
         ;; Check that collections remain remote-synced type
       (let [moved-coll (t2/select-one :model/Collection :id coll-id)]
-        (is (nil? (:type moved-coll))
+        (is (false? (:is_remote_synced moved-coll))
             "Library collection should lose remote-synced type"))
 
       (let [moved-child (t2/select-one :model/Collection :id child-id)]
-        (is (nil? (:type moved-child))
+        (is (false? (:is_remote_synced moved-child))
             "Child of remote-synced collection lose remote-synced type")))))
 
 (deftest move-collection!-dependency-checking-success-test
   (testing "move-collection! with into-remote-synced? true succeeds when all dependencies are in remote-synced collection"
-    (mt/with-temp [:model/Collection {parent-id :id} {:name "Parent" :location "/" :type "remote-synced"}
-                   :model/Collection {remote-synced-id :id} {:name "Remote-Synced" :location (str "/" parent-id "/") :type "remote-synced"}
+    (mt/with-temp [:model/Collection {parent-id :id} {:name "Parent" :location "/" :is_remote_synced true}
+                   :model/Collection {remote-synced-id :id} {:name "Remote-Synced" :location (str "/" parent-id "/") :is_remote_synced true}
                    :model/Collection {coll-id :id :as coll} {:name "Collection to Move"
                                                              :location "/"
                                                              :type nil}
@@ -2207,7 +2207,7 @@
 
       ;; Verify the collection was moved and became remote-synced type
       (let [moved-coll (t2/select-one :model/Collection :id coll-id)]
-        (is (= "remote-synced" (:type moved-coll))
+        (is (true? (:is_remote_synced moved-coll))
             "Collection should have remote-synced type")
         (is (= (format "/%d/" parent-id) (:location moved-coll))
             "Collection should be moved to new location")))))
@@ -2215,7 +2215,7 @@
 (deftest move-collection!-dependency-checking-failure-test
   (testing "move-collection! with into-remote-synced? true throws exception when dependencies exist outside remote-synced collection"
     (mt/with-temp [:model/Collection {non-remote-synced-id :id} {:name "Non-Remote-Synced" :location "/" :type nil}
-                   :model/Collection {parent-id :id} {:name "Parent" :location "/" :type "remote-synced"}
+                   :model/Collection {parent-id :id} {:name "Parent" :location "/" :is_remote_synced true}
                    :model/Collection {coll-id :id :as coll} {:name "Collection to Move"
                                                              :location "/"
                                                              :type nil}
@@ -2238,7 +2238,7 @@
 
         ;; Verify the transaction was rolled back - collection should not be moved or changed
       (let [unchanged-coll (t2/select-one :model/Collection :id coll-id)]
-        (is (nil? (:type unchanged-coll))
+        (is (false? (:is_remote_synced unchanged-coll))
             "Collection type should remain unchanged after failed move")
         (is (= "/" (:location unchanged-coll))
             "Collection location should remain unchanged after failed move")))))
@@ -2266,13 +2266,13 @@
 
         ;; Verify the transaction was completely rolled back
       (let [unchanged-coll (t2/select-one :model/Collection :id coll-id)]
-        (is (nil? (:type unchanged-coll))
+        (is (false? (:is_remote_synced unchanged-coll))
             "Collection type should remain unchanged after transaction rollback")
         (is (= "/" (:location unchanged-coll))
             "Collection location should remain unchanged after transaction rollback"))
 
       (let [unchanged-child (t2/select-one :model/Collection :id child-id)]
-        (is (nil? (:type unchanged-child))
+        (is (false? (:is_remote_synced unchanged-child))
             "Child collection type should remain unchanged after transaction rollback")
         (is (= (format "/%d/" coll-id) (:location unchanged-child))
             "Child collection location should remain unchanged after transaction rollback")))))
@@ -2295,16 +2295,16 @@
 
         ;; Verify the collection was moved but did not become remote-synced type
       (let [moved-coll (t2/select-one :model/Collection :id coll-id)]
-        (is (nil? (:type moved-coll))
+        (is (false? (:is_remote_synced moved-coll))
             "Collection should not have remote-synced type")
         (is (= (format "/%d/" parent-id) (:location moved-coll))
             "Collection should be moved to new location")))))
 
 (deftest ^:parallel moving-from-remote-synced?-test
   (testing "moving-from-remote-synced? function behavior"
-    (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced" :type "remote-synced"}
+    (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced" :is_remote_synced true}
                    :model/Collection {regular-coll-id :id} {:name "Regular Collection"}
-                   :model/Collection {other-remote-synced-id :id} {:name "Other Library" :type "remote-synced"}]
+                   :model/Collection {other-remote-synced-id :id} {:name "Other Library" :is_remote_synced true}]
 
       (testing "when moving from remote-synced collection to non-remote-synced collection"
         (is (true? (collection/moving-from-remote-synced? remote-synced-id regular-coll-id))
@@ -2341,7 +2341,7 @@
 
 (deftest ^:parallel remote-synced-dependents-no-dependents-test
   (testing "when there are no dependents"
-    (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced" :location "/" :type "remote-synced"}
+    (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced" :location "/" :is_remote_synced true}
                    :model/Card {card-id :id} {:name "Test Card"
                                               :database_id (mt/id)
                                               :dataset_query (mt/mbql-query venues)}]
@@ -2350,7 +2350,7 @@
 
 (deftest ^:parallel remote-synced-dependents-in-remote-synced-test
   (testing "when card has dependents in remote-synced collection"
-    (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced" :location "/" :type "remote-synced"}
+    (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced" :location "/" :is_remote_synced true}
                    :model/Card {base-card-id :id} {:name "Base Card"
                                                    :database_id (mt/id)
                                                    :dataset_query (mt/mbql-query venues)}
@@ -2366,7 +2366,7 @@
 
 (deftest ^:parallel remote-synced-dependents-outside-remote-synced-test
   (testing "when dependents are outside remote-synced collection"
-    (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced" :type "remote-synced"}
+    (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced" :is_remote_synced true}
                    :model/Collection {regular-id :id} {:name "Regular"}
                    :model/Card {base-card-id :id} {:name "Base Card"
                                                    :database_id (mt/id)
@@ -2380,7 +2380,7 @@
 
 (deftest ^:parallel remote-synced-dependents-archived-test
   (testing "when dependents are archived"
-    (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced" :type "remote-synced"}
+    (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced" :is_remote_synced true}
                    :model/Card {base-card-id :id} {:name "Base Card"
                                                    :collection_id remote-synced-id
                                                    :database_id (mt/id)
@@ -2396,14 +2396,14 @@
 
 (deftest ^:parallel remote-synced-dependents-non-card-models-test
   (testing "for non-card models"
-    (mt/with-temp [:model/Collection {coll-id :id} {:type "remote-synced"}
+    (mt/with-temp [:model/Collection {coll-id :id} {:is_remote_synced true}
                    :model/Dashboard {dash-id :id} {:name "Test Dashboard"}]
       (is (= [] (collection/remote-synced-dependents coll-id (t2/instance :model/Dashboard {:id dash-id})))
           "Should return empty seq for dashboard with no deps"))))
 
 (deftest ^:parallel remote-synced-dependents-with-parameters-test
   (testing "when card has dependents using parameters"
-    (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced" :type "remote-synced"}
+    (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced" :is_remote_synced true}
                    :model/Card {base-card-id :id} {:name "Base Card"
                                                    :database_id (mt/id)
                                                    :dataset_query (mt/mbql-query venues)}
@@ -2425,7 +2425,7 @@
 
 (deftest ^:parallel remote-synced-dependents-with-template-tags-test
   (testing "when card has dependents using template tags"
-    (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced" :type "remote-synced"}
+    (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced" :is_remote_synced true}
                    :model/Card {base-card-id :id} {:name "Base Card"
                                                    :database_id (mt/id)
                                                    :dataset_query (mt/mbql-query venues)}
@@ -2447,7 +2447,7 @@
 ;; Runs into deadlocks on mysql/maria with ^:parallel
 (deftest remote-synced-dependents-with-multiple-types-test
   (testing "when card has multiple types of dependents"
-    (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced" :type "remote-synced"}
+    (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced" :is_remote_synced true}
                    :model/Card {base-card-id :id} {:name "Base Card"
                                                    :database_id (mt/id)
                                                    :dataset_query (mt/mbql-query venues)}
@@ -2478,7 +2478,7 @@
 
 (deftest ^:parallel remote-synced-dependents-with-collection-test
   (testing "when a collection is passed to remote-synced-dependents"
-    (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced" :type "remote-synced"}
+    (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced" :is_remote_synced true}
                    :model/Collection source-coll {:name "Source Collection" :location "/"}
                    :model/Card {base-card-id :id} {:name "Base Card"
                                                    :collection_id (u/the-id source-coll)
@@ -2510,7 +2510,7 @@
 
 (deftest ^:parallel remote-synced-dependents-with-nested-collection-test
   (testing "when a collection with nested subcollections is passed to remote-synced-dependents"
-    (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced" :type "remote-synced"}
+    (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced" :is_remote_synced true}
                    :model/Collection {parent-coll-id :id} {:name "Parent Collection" :location "/"}
                    :model/Collection {child-coll-id :id} {:name "Child Collection"
                                                           :location (format "/%d/" parent-coll-id)}
@@ -2538,7 +2538,7 @@
 
 (deftest ^:parallel remote-synced-dependents-with-other-models-test
   (testing "when other model types are passed to remote-synced-dependents"
-    (mt/with-temp [:model/Collection {coll-id :id} {:type "remote-synced"}
+    (mt/with-temp [:model/Collection {coll-id :id} {:is_remote_synced true}
                    :model/Dashboard {dash-id :id} {:name "Test Dashboard"}
                    :model/Pulse {pulse-id :id} {:name "Test Pulse"}]
       (is (= [] (collection/remote-synced-dependents coll-id (t2/instance :model/Dashboard {:id dash-id})))
@@ -2548,7 +2548,7 @@
 
 (deftest ^:parallel check-remote-synced-dependents-throws-test
   (testing "check-remote-synced-dependents throws when model has remote-synced dependents"
-    (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced" :type "remote-synced"}
+    (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced" :is_remote_synced true}
                    :model/Card {base-card-id :id} {:name "Base Card"
                                                    :collection_id remote-synced-id
                                                    :database_id (mt/id)
@@ -2585,7 +2585,7 @@
 
 (deftest ^:parallel check-remote-synced-dependents-with-collection-test
   (testing "check-remote-synced-dependents with Collection model"
-    (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced" :type "remote-synced"}
+    (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced" :is_remote_synced true}
                    :model/Collection {source-coll-id :id} {:name "Source Collection" :location "/"}
                    :model/Card {base-card-id :id} {:name "Base Card"
                                                    :collection_id source-coll-id
@@ -2602,7 +2602,7 @@
 
 (deftest ^:parallel remote-synced-dependents-with-dashboard-test
   (testing "remote-synced-dependents should return dashboards in remote-synced collections that contain the card"
-    (mt/with-temp [:model/Collection {remote-synced-coll-id :id} {:type "remote-synced"}
+    (mt/with-temp [:model/Collection {remote-synced-coll-id :id} {:is_remote_synced true}
                    :model/Collection {regular-coll-id :id} {}
                    :model/Card {remote-synced-card-id :id} {:collection_id remote-synced-coll-id
                                                             :name "Library card"}
@@ -2628,8 +2628,8 @@
 
 (deftest ^:parallel remote-synced-dependents-with-dashboard-in-nested-remote-synced-test
   (testing "remote-synced-dependents should return dashboards in nested remote-synced collections"
-    (mt/with-temp [:model/Collection {remote-synced-coll-id :id} {:type "remote-synced"}
-                   :model/Collection {nested-remote-synced-coll-id :id} {:type "remote-synced"
+    (mt/with-temp [:model/Collection {remote-synced-coll-id :id} {:is_remote_synced true}
+                   :model/Collection {nested-remote-synced-coll-id :id} {:is_remote_synced true
                                                                          :location (format "/%d/" remote-synced-coll-id)}
                    :model/Card {remote-synced-card-id :id} {:collection_id remote-synced-coll-id
                                                             :name "Library card"}
@@ -2648,7 +2648,7 @@
 
 (deftest ^:parallel remote-synced-dependents-with-archived-dashboard-test
   (testing "remote-synced-dependents should not return archived dashboards"
-    (mt/with-temp [:model/Collection {remote-synced-coll-id :id} {:type "remote-synced"}
+    (mt/with-temp [:model/Collection {remote-synced-coll-id :id} {:is_remote_synced true}
                    :model/Card {remote-synced-card-id :id} {:collection_id remote-synced-coll-id
                                                             :name "Library card"}
                    :model/Dashboard {archived-dashboard-id :id} {:collection_id remote-synced-coll-id
@@ -2666,7 +2666,7 @@
 
 (deftest ^:parallel remote-synced-dependents-with-dashboard-series-test
   (testing "remote-synced-dependents should return dashboards that reference cards through dashboard card series"
-    (mt/with-temp [:model/Collection {remote-synced-coll-id :id} {:type "remote-synced"}
+    (mt/with-temp [:model/Collection {remote-synced-coll-id :id} {:is_remote_synced true}
                    :model/Card {remote-synced-card-id :id} {:collection_id remote-synced-coll-id
                                                             :name "Library card"}
                    :model/Card {other-card-id :id} {:collection_id remote-synced-coll-id
@@ -2689,7 +2689,7 @@
 
 (deftest ^:parallel remote-synced-dependents-mixed-dashboard-and-card-dependencies-test
   (testing "remote-synced-dependents should return both dashboard and card dependencies"
-    (mt/with-temp [:model/Collection {remote-synced-coll-id :id} {:type "remote-synced"}
+    (mt/with-temp [:model/Collection {remote-synced-coll-id :id} {:is_remote_synced true}
                    :model/Card {source-card-id :id} {:collection_id remote-synced-coll-id
                                                      :name "Source card"}
                    :model/Card _ {:collection_id remote-synced-coll-id
@@ -2714,10 +2714,10 @@
   (testing "move-collection! prevents moving a collection from remote-synced collection when it has remote-synced dependents"
     (mt/with-temp [:model/Collection {remote-synced-parent-id :id} {:name "Remote-Synced Parent"
                                                                     :location "/"
-                                                                    :type "remote-synced"}
+                                                                    :is_remote_synced true}
                    :model/Collection {child-remote-synced-id :id :as child-remote-synced-collection} {:name "Child Library Collection"
                                                                                                       :location (format "/%d/" remote-synced-parent-id)
-                                                                                                      :type "remote-synced"}
+                                                                                                      :is_remote_synced true}
                    :model/Collection {regular-parent-id :id} {:name "Regular Parent"
                                                               :location "/"
                                                               :type nil}
@@ -2742,7 +2742,7 @@
 
       (testing "Collection remains unchanged after failed move"
         (let [unchanged-coll (t2/select-one :model/Collection :id child-remote-synced-id)]
-          (is (= "remote-synced" (:type unchanged-coll))
+          (is (true? (:is_remote_synced unchanged-coll))
               "Collection type should remain remote-synced collection after failed move")
           (is (= (format "/%d/" remote-synced-parent-id) (:location unchanged-coll))
               "Collection location should remain unchanged after failed move"))))))
@@ -2751,10 +2751,10 @@
   (testing "move-collection! prevents moving a collection from remote-synced collection when it has dashboard dependents"
     (mt/with-temp [:model/Collection {remote-synced-parent-id :id} {:name "Remote-Synced Parent"
                                                                     :location "/"
-                                                                    :type "remote-synced"}
+                                                                    :is_remote_synced true}
                    :model/Collection {child-remote-synced-id :id :as child-remote-synced-collection} {:name "Child Library Collection"
                                                                                                       :location (format "/%d/" remote-synced-parent-id)
-                                                                                                      :type "remote-synced"}
+                                                                                                      :is_remote_synced true}
                    :model/Collection {regular-parent-id :id} {:name "Regular Parent"
                                                               :location "/"
                                                               :type nil}
@@ -2782,7 +2782,7 @@
 
       (testing "Collection remains unchanged after failed move"
         (let [unchanged-coll (t2/select-one :model/Collection :id child-remote-synced-id)]
-          (is (= "remote-synced" (:type unchanged-coll))
+          (is (true? (:is_remote_synced unchanged-coll))
               "Collection type should remain remote-synced collection after failed move")
           (is (= (format "/%d/" remote-synced-parent-id) (:location unchanged-coll))
               "Collection location should remain unchanged after failed move"))))))
@@ -2791,10 +2791,10 @@
   (testing "move-collection! allows moving a collection from remote-synced collection when it has no remote-synced dependents"
     (mt/with-temp [:model/Collection {remote-synced-parent-id :id} {:name "Remote-Synced Parent"
                                                                     :location "/"
-                                                                    :type "remote-synced"}
+                                                                    :is_remote_synced true}
                    :model/Collection {child-remote-synced-id :id :as child-remote-synced-collection} {:name "Child Library Collection"
                                                                                                       :location (format "/%d/" remote-synced-parent-id)
-                                                                                                      :type "remote-synced"}
+                                                                                                      :is_remote_synced true}
                    :model/Collection {regular-parent-id :id} {:name "Regular Parent"
                                                               :location "/"
                                                               :type nil}
@@ -2806,7 +2806,7 @@
         (collection/move-collection! child-remote-synced-collection (format "/%d/" regular-parent-id))
 
         (let [moved-coll (t2/select-one :model/Collection :id child-remote-synced-id)]
-          (is (nil? (:type moved-coll))
+          (is (false? (:is_remote_synced moved-coll))
               "Collection type should be cleared when moved out of remote-synced collection")
           (is (= (format "/%d/" regular-parent-id) (:location moved-coll))
               "Collection should be moved to new location"))))))
@@ -2815,15 +2815,15 @@
   (testing "move-collection! allows moving a collection from one remote-synced collection to another remote-synced collection when no dependents are left behind"
     (mt/with-temp [:model/Collection {remote-synced-parent1-id :id} {:name "Remote-Synced Parent 1"
                                                                      :location "/"
-                                                                     :type "remote-synced"}
+                                                                     :is_remote_synced true}
                    :model/Collection {remote-synced-parent2-id :id} {:name "Remote-Synced Parent 2"
                                                                      :location "/"
-                                                                     :type "remote-synced"}
+                                                                     :is_remote_synced true}
                    :model/Collection {regular-id :id} {:name "Regular Col"
                                                        :location "/"}
                    :model/Collection {child-remote-synced-id :id :as child-remote-synced-collection} {:name "Child Library Collection"
                                                                                                       :location (format "/%d/" remote-synced-parent1-id)
-                                                                                                      :type "remote-synced"}
+                                                                                                      :is_remote_synced true}
                    :model/Card {remote-synced-card-id :id} {:name "Remote-Synced Card"
                                                             :collection_id child-remote-synced-id
                                                             :dataset_query (mt/native-query {:query "SELECT 1"})}
@@ -2839,13 +2839,13 @@
   (testing "move-collection! disallows moving a collection from one remote-synced collection to another remote-synced collection"
     (mt/with-temp [:model/Collection {remote-synced-parent1-id :id} {:name "Remote-Synced Parent 1"
                                                                      :location "/"
-                                                                     :type "remote-synced"}
+                                                                     :is_remote_synced true}
                    :model/Collection {remote-synced-parent2-id :id} {:name "Remote-Synced Parent 2"
                                                                      :location "/"
-                                                                     :type "remote-synced"}
+                                                                     :is_remote_synced true}
                    :model/Collection {child-remote-synced-id :id :as child-remote-synced-collection} {:name "Child Library Collection"
                                                                                                       :location (format "/%d/" remote-synced-parent1-id)
-                                                                                                      :type "remote-synced"}
+                                                                                                      :is_remote_synced true}
                    :model/Card {remote-synced-card-id :id} {:name "Remote-Synced Card"
                                                             :collection_id child-remote-synced-id
                                                             :dataset_query (mt/native-query {:query "SELECT 1"})}
@@ -2859,13 +2859,13 @@
   (testing "move-collection! prevents moving a collection from remote-synced collection when nested collections have dependents"
     (mt/with-temp [:model/Collection {remote-synced-parent-id :id} {:name "Remote-Synced Parent"
                                                                     :location "/"
-                                                                    :type "remote-synced"}
+                                                                    :is_remote_synced true}
                    :model/Collection {child-remote-synced-id :id :as child-remote-synced-collection} {:name "Child Library Collection"
                                                                                                       :location (format "/%d/" remote-synced-parent-id)
-                                                                                                      :type "remote-synced"}
+                                                                                                      :is_remote_synced true}
                    :model/Collection {grandchild-remote-synced-id :id} {:name "Grandchild Library Collection"
                                                                         :location (format "/%d/%d/" remote-synced-parent-id child-remote-synced-id)
-                                                                        :type "remote-synced"}
+                                                                        :is_remote_synced true}
                    :model/Collection {regular-parent-id :id} {:name "Regular Parent"
                                                               :location "/"
                                                               :type nil}
@@ -2890,13 +2890,13 @@
 
       (testing "Collection and nested collections remain unchanged after failed move"
         (let [unchanged-coll (t2/select-one :model/Collection :id child-remote-synced-id)]
-          (is (= "remote-synced" (:type unchanged-coll))
+          (is (true? (:is_remote_synced unchanged-coll))
               "Collection type should remain remote-synced collection after failed move")
           (is (= (format "/%d/" remote-synced-parent-id) (:location unchanged-coll))
               "Collection location should remain unchanged after failed move"))
 
         (let [unchanged-grandchild (t2/select-one :model/Collection :id grandchild-remote-synced-id)]
-          (is (= "remote-synced" (:type unchanged-grandchild))
+          (is (true? (:is_remote_synced unchanged-grandchild))
               "Grandchild collection type should remain remote-synced collection after failed move")
           (is (= (format "/%d/%d/" remote-synced-parent-id child-remote-synced-id) (:location unchanged-grandchild))
               "Grandchild collection location should remain unchanged after failed move"))))))
@@ -2906,7 +2906,7 @@
     (testing "A regular collection cannot be placed in a remote-synced collection"
       (mt/with-temp [:model/Collection {parent-id :id} {:name "Parent Collection"
                                                         :location "/"
-                                                        :type "remote-synced"}]
+                                                        :is_remote_synced true}]
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
              #"A Collection placed in a remote-synced Collection must also be remote-synced"
@@ -2920,16 +2920,16 @@
       (testing "Creating a remote-synced collection in root is allowed"
         (is (some? (t2/insert! :model/Collection
                                {:name "Remote Synced Collection"
-                                :type "remote-synced"})))))))
+                                :is_remote_synced true})))))))
 
 (deftest remote-synced-parent-validation-creating-inside-remote-synced-test
   (mt/with-model-cleanup [:model/Collection]
     (testing "A remote-synced collection can only be placed in another remote-synced collection or the root collection"
       (testing "Creating a remote-synced collection inside another remote-synced collection is allowed"
-        (mt/with-temp [:model/Collection parent-collection {:type "remote-synced"}]
+        (mt/with-temp [:model/Collection parent-collection {:is_remote_synced true}]
           (is (some? (t2/insert! :model/Collection
                                  {:name "Child Remote Synced Collection"
-                                  :type "remote-synced"
+                                  :is_remote_synced true
                                   :location (format "/%d/" (:id parent-collection))}))))))))
 
 (deftest remote-synced-parent-validation-creating-inside-regular-collection-test
@@ -2942,7 +2942,7 @@
                #"A remote-synced Collection can only be placed in another remote-synced Collection or the root Collection"
                (t2/insert! :model/Collection
                            {:name "Child Remote Synced Collection"
-                            :type "remote-synced"
+                            :is_remote_synced true
                             :location (format "/%d/" (:id parent-collection))}))))))))
 
 (deftest remote-synced-parent-validation-moving-into-regular-collection-test
@@ -2950,7 +2950,7 @@
     (testing "A remote-synced collection can only be placed in another remote-synced collection or the root collection"
       (testing "Moving a remote-synced collection into a regular collection should fail"
         (mt/with-temp [:model/Collection regular-parent {}
-                       :model/Collection remote-synced-collection {:type "remote-synced"}]
+                       :model/Collection remote-synced-collection {:is_remote_synced true}]
           (is (thrown-with-msg?
                clojure.lang.ExceptionInfo
                #"A remote-synced Collection can only be placed in another remote-synced Collection or the root Collection"
@@ -2959,11 +2959,11 @@
 
 (deftest moving-into-remote-synced-enhanced-test
   (testing "Enhanced moving-into-remote-synced? function behavior including new remote-synced root scenarios"
-    (mt/with-temp [:model/Collection {remote-synced-root-a :id} {:name "Remote-Synced Root A" :type "remote-synced"}
-                   :model/Collection {remote-synced-root-b :id} {:name "Remote-Synced Root B" :type "remote-synced"}
+    (mt/with-temp [:model/Collection {remote-synced-root-a :id} {:name "Remote-Synced Root A" :is_remote_synced true}
+                   :model/Collection {remote-synced-root-b :id} {:name "Remote-Synced Root B" :is_remote_synced true}
                    :model/Collection {regular-coll-id :id} {:name "Regular Collection"}
                    :model/Collection {child-of-a :id} {:name "Child of A"
-                                                       :type "remote-synced"
+                                                       :is_remote_synced true
                                                        :location (format "/%d/" remote-synced-root-a)}]
 
       (testing "when moving from non-remote-synced to remote-synced collection"
@@ -2988,11 +2988,11 @@
 
 (deftest moving-from-remote-synced-enhanced-test
   (testing "Enhanced moving-from-remote-synced? function behavior including new remote-synced root scenarios"
-    (mt/with-temp [:model/Collection {remote-synced-root-a :id} {:name "Remote-Synced Root A" :type "remote-synced" :location "/"}
-                   :model/Collection {remote-synced-root-b :id} {:name "Remote-Synced Root B" :type "remote-synced" :location "/"}
+    (mt/with-temp [:model/Collection {remote-synced-root-a :id} {:name "Remote-Synced Root A" :is_remote_synced true :location "/"}
+                   :model/Collection {remote-synced-root-b :id} {:name "Remote-Synced Root B" :is_remote_synced true :location "/"}
                    :model/Collection {regular-coll-id :id} {:name "Regular Collection" :location "/"}
                    :model/Collection {child-of-a :id} {:name "Child of A"
-                                                       :type "remote-synced"
+                                                       :is_remote_synced true
                                                        :location (format "/%d/" remote-synced-root-a)}]
 
       (testing "when moving from remote-synced collection to non-remote-synced collection"
@@ -3127,10 +3127,10 @@
   (testing "archive-collection! prevents archiving when parent collection has items depending on child collection items"
     (mt/with-temp [:model/Collection {remote-synced-parent-id :id} {:name "Remote-Synced Parent"
                                                                     :location "/"
-                                                                    :type "remote-synced"}
+                                                                    :is_remote_synced true}
                    :model/Collection {child-id :id :as child-coll} {:name "Remote-Synced Child"
                                                                     :location (format "/%d/" remote-synced-parent-id)
-                                                                    :type "remote-synced"}
+                                                                    :is_remote_synced true}
                    :model/Card {base-card-id :id} {:name "Base Card in Child"
                                                    :collection_id child-id
                                                    :dataset_query (mt/native-query {:query "SELECT 1"})}
@@ -3160,10 +3160,10 @@
   (testing "archive-collection! allows archiving when parent has no dependents on child collection items"
     (mt/with-temp [:model/Collection {remote-synced-parent-id :id} {:name "Remote-Synced Parent"
                                                                     :location "/"
-                                                                    :type "remote-synced"}
+                                                                    :is_remote_synced true}
                    :model/Collection {child-id :id :as child-coll} {:name "Remote-Synced Child"
                                                                     :location (format "/%d/" remote-synced-parent-id)
-                                                                    :type "remote-synced"}
+                                                                    :is_remote_synced true}
                    :model/Card _ {:name "Independent Card in Child"
                                   :collection_id child-id
                                   :dataset_query (mt/native-query {:query "SELECT 1"})}
@@ -3184,7 +3184,7 @@
   (testing "archive-collection! allows archiving root remote-synced collection when there are no external dependents"
     (mt/with-temp [:model/Collection {remote-synced-id :id :as remote-synced-coll} {:name "Remote-Synced Collection"
                                                                                     :location "/"
-                                                                                    :type "remote-synced"}
+                                                                                    :is_remote_synced true}
                    :model/Card {base-card-id :id} {:name "Base Card"
                                                    :collection_id remote-synced-id
                                                    :dataset_query (mt/native-query {:query "SELECT 1"})}
@@ -3231,10 +3231,10 @@
   (testing "archive-collection! checks dashboard dependencies from parent collection"
     (mt/with-temp [:model/Collection {remote-synced-parent-id :id} {:name "Remote-Synced Parent"
                                                                     :location "/"
-                                                                    :type "remote-synced"}
+                                                                    :is_remote_synced true}
                    :model/Collection {child-id :id :as child-coll} {:name "Remote-Synced Child"
                                                                     :location (format "/%d/" remote-synced-parent-id)
-                                                                    :type "remote-synced"}
+                                                                    :is_remote_synced true}
                    :model/Card {child-card-id :id} {:name "Card in Child"
                                                     :collection_id child-id
                                                     :dataset_query (mt/native-query {:query "SELECT 1"})}
@@ -3262,10 +3262,10 @@
   (testing "archive-collection! allows archiving when parent dependents are archived"
     (mt/with-temp [:model/Collection {remote-synced-parent-id :id} {:name "Remote-Synced Parent"
                                                                     :location "/"
-                                                                    :type "remote-synced"}
+                                                                    :is_remote_synced true}
                    :model/Collection {child-id :id :as child-coll} {:name "Remote-Synced Child"
                                                                     :location (format "/%d/" remote-synced-parent-id)
-                                                                    :type "remote-synced"}
+                                                                    :is_remote_synced true}
                    :model/Card {base-card-id :id} {:name "Base Card in Child"
                                                    :collection_id child-id
                                                    :dataset_query (mt/native-query {:query "SELECT 1"})}

--- a/test/metabase/collections/models/collection_test.clj
+++ b/test/metabase/collections/models/collection_test.clj
@@ -3306,3 +3306,18 @@
         (is (= [false false false] (map :can_delete (collection/can-delete [non-archived-collection
                                                                             non-archived-dash
                                                                             non-archived-card]))))))))
+
+(deftest insert-sets-remote-sync-test
+  (mt/with-model-cleanup [:model/Collection]
+    (let [collection (t2/insert-returning-instance! :model/Collection
+                                                    (merge {:type "remote-synced"}
+                                                           (mt/with-temp-defaults :model/Collection)))]
+      (is (nil? (:type collection)))
+      (is (true? (:is_remote_synced collection))))))
+
+(deftest update-sets-remote-sync-test
+  (mt/with-temp [:model/Collection {id :id} {}]
+    (t2/update! :model/Collection :id id {:type "remote-synced"})
+    (let [collection (t2/select-one :model/Collection id)]
+      (is (nil? (:type collection)))
+      (is (true? (:is_remote_synced collection))))))

--- a/test/metabase/collections_rest/api_test.clj
+++ b/test/metabase/collections_rest/api_test.clj
@@ -73,7 +73,7 @@
                  :name                "Our analytics"
                  :authority_level     nil
                  :is_personal         false
-                 :is_remote_synced    false
+                 :is_remote_synced    nil
                  :id                  "root"
                  :can_restore         false
                  :can_delete          false}
@@ -2266,9 +2266,9 @@
       (testing "collection_type=remote-synced returns only remote-synced collections"
         (mt/with-temp [:model/Collection _ {:name "Normal Collection"}
                        :model/Collection _ {:name "Remote Synced Collection"
-                                            :type "remote-synced"}
+                                            :is_remote_synced true}
                        :model/Collection _ {:name "Another Remote Collection"
-                                            :type "remote-synced"}
+                                            :is_remote_synced true}
                        :model/Collection _ {:name "Second Normal Collection"}]
           (let [response (mt/user-http-request :crowberto :get 200 "collection/root/items"
                                                :collection_type "remote-synced")
@@ -2281,15 +2281,14 @@
             (testing "should not include normal collections"
               (is (not (contains? collection-names "Normal Collection")))
               (is (not (contains? collection-names "Second Normal Collection"))))
-            (testing "should include type field in response"
+            (testing "should include is_remote_synced field in response"
               (doseq [coll collections]
-                (is (= "remote-synced" (:type coll))
-                    (str "Collection " (:name coll) " should have type=remote-synced")))))))
-
+                (is (true? (:is_remote_synced coll))
+                    (str "Collection " (:name coll) " should have is_remote_synced=true")))))))
       (testing "without collection_type parameter, all collections are returned"
         (mt/with-temp [:model/Collection _ {:name "Normal Collection Test"}
                        :model/Collection _ {:name "Remote Synced Collection Test"
-                                            :type "remote-synced"}]
+                                            :is_remote_synced true}]
           (let [response (mt/user-http-request :crowberto :get 200 "collection/root/items")
                 collection-names (->> (:data response)
                                       (filter #(= (:model %) "collection"))

--- a/test/metabase/queries/models/card_test.clj
+++ b/test/metabase/queries/models/card_test.clj
@@ -1076,7 +1076,7 @@
 
 (deftest create-card-remote-synced-collection-non-remote-synced-deps-test
   (testing "create-card! should throw exception when saving to remote-synced collection with non-remote-synced dependencies"
-    (mt/with-temp [:model/Collection {remote-synced-coll-id :id} {:type "remote-synced"}
+    (mt/with-temp [:model/Collection {remote-synced-coll-id :id} {:is_remote_synced true}
                    :model/Collection {regular-coll-id :id} {}
                    :model/Card {source-card-id :id} {:collection_id regular-coll-id
                                                      :name "Non-remote-synced source card"}]
@@ -1105,7 +1105,7 @@
 
 (deftest update-card-remote-synced-collection-non-remote-synced-deps-test
   (testing "update-card! should throw exception when moving to remote-synced collection with non-remote-synced dependencies"
-    (mt/with-temp [:model/Collection {remote-synced-coll-id :id} {:type "remote-synced"}
+    (mt/with-temp [:model/Collection {remote-synced-coll-id :id} {:is_remote_synced true}
                    :model/Collection {regular-coll-id :id} {}
                    :model/Card {source-card-id :id} {:collection_id regular-coll-id
                                                      :name "Non-remote-synced source card"}
@@ -1122,7 +1122,7 @@
                :actor {:id (mt/user->id :rasta)}}))))
 
       (testing "Card with remote-synced dependencies can be moved to remote-synced collection"
-        (mt/with-temp [:model/Collection {another-remote-synced-coll-id :id} {:type "remote-synced" :location (str "/" remote-synced-coll-id "/")}
+        (mt/with-temp [:model/Collection {another-remote-synced-coll-id :id} {:is_remote_synced true :location (str "/" remote-synced-coll-id "/")}
                        :model/Card {remote-synced-source-card-id :id} {:collection_id another-remote-synced-coll-id
                                                                        :name "Remote-Synced source card"}
                        :model/Card movable-card {:collection_id regular-coll-id
@@ -1137,7 +1137,7 @@
 
 (deftest update-card-existing-remote-synced-card-non-remote-synced-deps-test
   (testing "update-card! should throw exception when card in remote-synced collection gains non-remote-synced dependencies"
-    (mt/with-temp [:model/Collection {remote-synced-coll-id :id} {:type "remote-synced"}
+    (mt/with-temp [:model/Collection {remote-synced-coll-id :id} {:is_remote_synced true}
                    :model/Collection {regular-coll-id :id} {}
                    :model/Card {non-remote-synced-source-id :id} {:collection_id regular-coll-id
                                                                   :name "Non-remote-synced source"}
@@ -1155,7 +1155,7 @@
 
 (deftest update-card-remote-synced-dependents-prevents-move-from-remote-synced-test
   (testing "update-card! should prevent moving card out of remote-synced collection when it has remote-synced dependents"
-    (mt/with-temp [:model/Collection {remote-synced-coll-id :id} {:type "remote-synced"}
+    (mt/with-temp [:model/Collection {remote-synced-coll-id :id} {:is_remote_synced true}
                    :model/Collection {regular-coll-id :id} {}
                    :model/Card {remote-synced-card-id :id :as remote-synced-card} {:collection_id remote-synced-coll-id
                                                                                    :dataset_query (mt/mbql-query venues)
@@ -1183,7 +1183,7 @@
 
 (deftest update-card-remote-synced-dependents-with-parameters-test
   (testing "update-card! should prevent moving card out of remote-synced collection when dependents reference it via parameters"
-    (mt/with-temp [:model/Collection {remote-synced-coll-id :id} {:type "remote-synced"}
+    (mt/with-temp [:model/Collection {remote-synced-coll-id :id} {:is_remote_synced true}
                    :model/Collection {regular-coll-id :id} {}
                    :model/Card {remote-synced-card-id :id :as remote-synced-card} {:collection_id remote-synced-coll-id
                                                                                    :name "Remote-Synced card"}
@@ -1206,7 +1206,7 @@
 
 (deftest update-card-remote-synced-dependents-with-template-tags-test
   (testing "update-card! should prevent moving card out of remote-synced collection when dependents reference it via template tags"
-    (mt/with-temp [:model/Collection {remote-synced-coll-id :id} {:type "remote-synced"}
+    (mt/with-temp [:model/Collection {remote-synced-coll-id :id} {:is_remote_synced true}
                    :model/Collection {regular-coll-id :id} {}
                    :model/Card {remote-synced-card-id :id :as remote-synced-card} {:collection_id remote-synced-coll-id
                                                                                    :dataset_query (mt/mbql-query venues)
@@ -1230,8 +1230,8 @@
 
 (deftest update-card-remote-synced-dependents-allows-move-within-remote-synced-test
   (testing "update-card! should allow moving card between remote-synced collections even with remote-synced dependents"
-    (mt/with-temp [:model/Collection {remote-synced-coll-1-id :id} {:type "remote-synced" :location "/"}
-                   :model/Collection {remote-synced-coll-2-id :id} {:type "remote-synced" :location (str "/" remote-synced-coll-1-id "/")}
+    (mt/with-temp [:model/Collection {remote-synced-coll-1-id :id} {:is_remote_synced true :location "/"}
+                   :model/Collection {remote-synced-coll-2-id :id} {:is_remote_synced true :location (str "/" remote-synced-coll-1-id "/")}
                    :model/Card {remote-synced-card-id :id :as remote-synced-card} {:collection_id remote-synced-coll-1-id
                                                                                    :dataset_query (mt/mbql-query venues)
                                                                                    :name "Remote-Synced card"}
@@ -1248,7 +1248,7 @@
 
 (deftest update-card-remote-synced-dependents-allows-non-collection-updates-test
   (testing "update-card! should allow non-collection updates to remote-synced cards with dependents"
-    (mt/with-temp [:model/Collection {remote-synced-coll-id :id} {:type "remote-synced"}
+    (mt/with-temp [:model/Collection {remote-synced-coll-id :id} {:is_remote_synced true}
                    :model/Card {remote-synced-card-id :id :as remote-synced-card} {:collection_id remote-synced-coll-id
                                                                                    :dataset_query (mt/mbql-query venues)
                                                                                    :name "Remote-Synced card"}

--- a/test/metabase/remote_sync/init_test.clj
+++ b/test/metabase/remote_sync/init_test.clj
@@ -12,7 +12,7 @@
 (deftest is-remote-synced-hydration-test
   (testing ":is_remote_synced hydration adds boolean field indicating if item is in remote-synced collection"
     (mt/with-temp [:model/Collection remote-sync-coll {:name "Remote Sync Collection"
-                                                       :type "remote-synced"
+                                                       :is_remote_synced true
                                                        :location "/"}
                    :model/Collection normal-coll {:name "Normal Collection"
                                                   :location "/"}
@@ -34,7 +34,7 @@
 (deftest is-remote-synced-hydration-dashboard-test
   (testing ":is_remote_synced hydration works for dashboards"
     (mt/with-temp [:model/Collection remote-sync-coll {:name "Remote Sync Collection"
-                                                       :type "remote-synced"
+                                                       :is_remote_synced true
                                                        :location "/"}
                    :model/Collection normal-coll {:name "Normal Collection"
                                                   :location "/"}
@@ -52,7 +52,7 @@
 (deftest is-remote-synced-hydration-batched-test
   (testing ":is_remote_synced hydration is efficient with batch hydration"
     (mt/with-temp [:model/Collection remote-sync-coll {:name "Remote Sync Collection"
-                                                       :type "remote-synced"
+                                                       :is_remote_synced true
                                                        :location "/"}
                    :model/Collection normal-coll {:name "Normal Collection"
                                                   :location "/"}

--- a/test_resources/serialization_baseline/collections/JS5JHDitDkWEtTt1-N7zr_qdlkexrocaxgnecmryqu/JS5JHDitDkWEtTt1-N7zr_qdlkexrocaxgnecmryqu.yaml
+++ b/test_resources/serialization_baseline/collections/JS5JHDitDkWEtTt1-N7zr_qdlkexrocaxgnecmryqu/JS5JHDitDkWEtTt1-N7zr_qdlkexrocaxgnecmryqu.yaml
@@ -16,3 +16,4 @@ serdes/meta:
 archive_operation_id: null
 archived_directly: null
 is_sample: false
+is_remote_synced: false

--- a/test_resources/serialization_baseline/collections/M-Q4pcV0qkiyJ0kiSWECl_some_collection/M-Q4pcV0qkiyJ0kiSWECl_some_collection.yaml
+++ b/test_resources/serialization_baseline/collections/M-Q4pcV0qkiyJ0kiSWECl_some_collection/M-Q4pcV0qkiyJ0kiSWECl_some_collection.yaml
@@ -16,3 +16,4 @@ serdes/meta:
 archive_operation_id: null
 archived_directly: null
 is_sample: false
+is_remote_synced: false

--- a/test_resources/serialization_baseline/collections/Y6d4QwJgGKw-X1tRh3ir2_shared_collection/Y6d4QwJgGKw-X1tRh3ir2_shared_collection.yaml
+++ b/test_resources/serialization_baseline/collections/Y6d4QwJgGKw-X1tRh3ir2_shared_collection/Y6d4QwJgGKw-X1tRh3ir2_shared_collection.yaml
@@ -16,3 +16,4 @@ serdes/meta:
 archive_operation_id: null
 archived_directly: null
 is_sample: false
+is_remote_synced: false

--- a/test_resources/serialization_baseline/collections/gQuHAIM4C-7fToHzHyNNQ_ai_model/gQuHAIM4C-7fToHzHyNNQ_ai_model.yaml
+++ b/test_resources/serialization_baseline/collections/gQuHAIM4C-7fToHzHyNNQ_ai_model/gQuHAIM4C-7fToHzHyNNQ_ai_model.yaml
@@ -16,3 +16,4 @@ serdes/meta:
 archive_operation_id: null
 archived_directly: null
 is_sample: false
+is_remote_synced: false

--- a/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/olgKH56lYOjakuobH4zPz_grandparent_collection.yaml
+++ b/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/olgKH56lYOjakuobH4zPz_grandparent_collection.yaml
@@ -16,3 +16,4 @@ serdes/meta:
 archive_operation_id: null
 archived_directly: null
 is_sample: false
+is_remote_synced: false

--- a/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/qPZhJMPNGkfd3sq8jWiZS_parent_collection/fJVsXIDzzipSZsaro9Pvu_child_collection/fJVsXIDzzipSZsaro9Pvu_child_collection.yaml
+++ b/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/qPZhJMPNGkfd3sq8jWiZS_parent_collection/fJVsXIDzzipSZsaro9Pvu_child_collection/fJVsXIDzzipSZsaro9Pvu_child_collection.yaml
@@ -16,3 +16,4 @@ serdes/meta:
 archive_operation_id: null
 archived_directly: null
 is_sample: false
+is_remote_synced: false

--- a/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/qPZhJMPNGkfd3sq8jWiZS_parent_collection/qPZhJMPNGkfd3sq8jWiZS_parent_collection.yaml
+++ b/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/qPZhJMPNGkfd3sq8jWiZS_parent_collection/qPZhJMPNGkfd3sq8jWiZS_parent_collection.yaml
@@ -16,3 +16,4 @@ serdes/meta:
 archive_operation_id: null
 archived_directly: null
 is_sample: false
+is_remote_synced: false

--- a/test_resources/serialization_baseline/collections/p8Zq2ud7JlSoSBXdJWIaW_shared_collection/p8Zq2ud7JlSoSBXdJWIaW_shared_collection.yaml
+++ b/test_resources/serialization_baseline/collections/p8Zq2ud7JlSoSBXdJWIaW_shared_collection/p8Zq2ud7JlSoSBXdJWIaW_shared_collection.yaml
@@ -16,3 +16,4 @@ serdes/meta:
 archive_operation_id: null
 archived_directly: null
 is_sample: false
+is_remote_synced: false


### PR DESCRIPTION
### Description

It turns out type is too overloaded to have a 'remote-synced' collection type. This is behavior that we might want to share around other typed collections, so this migrates us to use a boolean column for this value instead.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
