### PR TITLE
Close the modal to create shared tenant collection after it is created

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/MainNavSharedCollections/MainNavSharedCollections.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/MainNavSharedCollections/MainNavSharedCollections.tsx
@@ -38,13 +38,14 @@ export const MainNavSharedCollections = () => {
     [tenantCollections],
   );
 
-  const handleCreateTenantTollection = useCallback(
-    (values: CreateCollectionProperties) => {
-      createCollection({
+  const handleCreateTenantCollection = useCallback(
+    async (values: CreateCollectionProperties) => {
+      await createCollection({
         ...values,
         parent_id: null,
         type: "shared-tenant-collection",
       });
+      setModalOpen(false);
     },
     [createCollection],
   );
@@ -78,7 +79,7 @@ export const MainNavSharedCollections = () => {
       >
         <CreateCollectionForm
           showCollectionPicker={false}
-          onSubmit={handleCreateTenantTollection}
+          onSubmit={handleCreateTenantCollection}
         />
       </Modal>
     </>


### PR DESCRIPTION
Closes EMB-1005

### Description

When adding members to tenant groups, it should only show external users as opposed to internal users.

### How to verify

- Use the MB_ALL_FEATURES_TOKEN as this is an in-development feature
- Enable multi-tenancy by going to "People > Settings Icon" and set User Strategy to Multi-tenant
- Create a shared tenant collection using the left sidebar > "TENANT COLLECTIONS" > Plus icon.
- The modal should be closed after the tenant collection is created.

There isn't any unit or e2e test for creating tenant collections yet, I'll add this later.
