### PR TITLE
Add translation for boolean dash filter value

### DIFF
--- a/e2e/test/scenarios/admin/i18n/content-translation/dashboards.cy.spec.ts
+++ b/e2e/test/scenarios/admin/i18n/content-translation/dashboards.cy.spec.ts
@@ -676,7 +676,6 @@ describe("scenarios > content translation > static embedding > dashboards", () =
           );
           cy.wait("@cardQuery");
 
-          H.filterWidget().contains("vrai");
           cy.findByTestId("table-body").within(() => {
             cy.findAllByText(/vrai/).should("have.length", 2);
             cy.findAllByText(/true/).should("have.length", 0);

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-boolean.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-boolean.cy.spec.ts
@@ -82,10 +82,10 @@ describe(
 
         cy.log("assert click behavior");
         H.getDashboardCard().findAllByText("true").first().click();
-        H.filterWidget().findByText("true").should("be.visible");
+        H.filterWidget().findByText("True").should("be.visible");
         H.getDashboardCard().findByText("1 row").should("be.visible");
         H.getDashboardCard().findAllByText("true").first().click();
-        H.filterWidget().findByText("true").should("not.exist");
+        H.filterWidget().findByText("True").should("not.exist");
         H.getDashboardCard().findByText("200 rows").should("be.visible");
       });
 
@@ -128,7 +128,7 @@ describe(
         cy.log("assert click behavior");
         H.getDashboardCard().findAllByText("true").first().click();
         H.dashboardHeader().findByText(DASHBOARD_NAME).should("be.visible");
-        H.filterWidget().findByText("true").should("be.visible");
+        H.filterWidget().findByText("True").should("be.visible");
       });
 
       it("should allow to use a 'Go to a custom destination - Dashboard' click behavior with a parameter", () => {
@@ -141,7 +141,7 @@ describe(
         H.popover().button("Add filter").click();
         H.getDashboardCard().findAllByText("true").first().click();
         H.dashboardHeader().findByText(DASHBOARD_NAME).should("be.visible");
-        H.filterWidget().findByText("true").should("be.visible");
+        H.filterWidget().findByText("True").should("be.visible");
       });
     });
 
@@ -166,7 +166,7 @@ describe(
         H.getDashboardCard().findByText(QUESTION_NAME).click();
         H.queryBuilderHeader().findByText(QUESTION_NAME).should("be.visible");
         H.assertQueryBuilderRowCount(1);
-        H.filterWidget().findByText("true").should("be.visible");
+        H.filterWidget().findByText("True").should("be.visible");
       });
 
       it("should allow to use a 'Go to a custom destination - Saved question' click behavior", () => {
@@ -195,7 +195,7 @@ describe(
         cy.log("assert click behavior");
         H.getDashboardCard().findAllByText("true").first().click();
         H.assertTableRowsCount(1);
-        H.filterWidget().findByText("true").should("be.visible");
+        H.filterWidget().findByText("True").should("be.visible");
       });
 
       it("should allow to use a 'Go to a custom destination - URL' click behavior", () => {
@@ -227,7 +227,7 @@ describe(
             cy.log("assert click behavior");
             H.getDashboardCard().findAllByText("true").first().click();
             H.assertTableRowsCount(1);
-            H.filterWidget().findByText("true").should("be.visible");
+            H.filterWidget().findByText("True").should("be.visible");
           },
         );
       });
@@ -253,7 +253,7 @@ describe(
         H.getDashboardCard().findByText(QUESTION_NAME).click();
         H.queryBuilderHeader().findByText(QUESTION_NAME).should("be.visible");
         H.assertQueryBuilderRowCount(53);
-        H.filterWidget().findByText("true").should("be.visible");
+        H.filterWidget().findByText("True").should("be.visible");
       });
 
       it("should allow to use boolean parameters mapped to SQL query parameters in a public dashboard", () => {

--- a/frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx
+++ b/frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx
@@ -1,3 +1,5 @@
+import { t } from "ttag";
+
 import { Ellipsified } from "metabase/common/components/Ellipsified";
 import { ParameterFieldWidgetValue } from "metabase/parameters/components/widgets/ParameterFieldWidget/ParameterFieldWidgetValue/ParameterFieldWidgetValue";
 import { formatParameterValue } from "metabase/parameters/utils/formatting";
@@ -8,6 +10,7 @@ import {
   isFieldFilterUiParameter,
 } from "metabase-lib/v1/parameters/utils/parameter-fields";
 import {
+  isBooleanParameter,
   isDateParameter,
   isStringParameter,
   isTemporalUnitParameter,
@@ -22,7 +25,7 @@ import type {
 
 export type FormattedParameterValueProps = {
   parameter: UiParameter;
-  value: string | number | number[];
+  value: boolean | string | number | number[];
   cardId?: CardId;
   dashboardId?: DashboardId;
   placeholder?: string;
@@ -47,7 +50,9 @@ function FormattedParameterValue({
     (value) => getValue(value)?.toString() === first?.toString(),
   );
 
-  const label = getLabel(displayValue);
+  const label = !isBooleanParameter(parameter)
+    ? getLabel(displayValue)
+    : getBooleanLabel(first as boolean);
 
   const renderContent = () => {
     if (
@@ -92,7 +97,7 @@ function FormattedParameterValue({
 }
 
 function getValue(
-  value: string | number | number[] | ParameterValue | undefined,
+  value: boolean | string | number | number[] | ParameterValue | undefined,
 ): RowValue | undefined {
   if (Array.isArray(value)) {
     return value[0];
@@ -101,12 +106,16 @@ function getValue(
 }
 
 function getLabel(
-  value: string | ParameterValue | undefined,
+  value: boolean | string | ParameterValue | undefined,
 ): string | undefined {
   if (Array.isArray(value)) {
     return value[1];
   }
   return value?.toString();
+}
+
+function getBooleanLabel(value: boolean) {
+  return value ? t`True` : t`False`;
 }
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage

--- a/frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx
+++ b/frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx
@@ -25,7 +25,7 @@ import type {
 
 export type FormattedParameterValueProps = {
   parameter: UiParameter;
-  value: boolean | string | number | number[];
+  value: string | number | number[] | ParameterValue;
   cardId?: CardId;
   dashboardId?: DashboardId;
   placeholder?: string;
@@ -97,7 +97,7 @@ function FormattedParameterValue({
 }
 
 function getValue(
-  value: boolean | string | number | number[] | ParameterValue | undefined,
+  value: string | number | number[] | ParameterValue | undefined,
 ): RowValue | undefined {
   if (Array.isArray(value)) {
     return value[0];

--- a/frontend/src/metabase/parameters/utils/formatting.ts
+++ b/frontend/src/metabase/parameters/utils/formatting.ts
@@ -38,7 +38,7 @@ function formatWithInferredType(value: any, parameter: UiParameter) {
 }
 
 export function formatParameterValue(
-  value: string | number | number[],
+  value: boolean | string | number | number[],
   parameter: UiParameter,
 ) {
   if (Array.isArray(value) && value.length > 1) {

--- a/frontend/src/metabase/parameters/utils/formatting.ts
+++ b/frontend/src/metabase/parameters/utils/formatting.ts
@@ -14,6 +14,7 @@ import {
   isFieldFilterParameter,
   isTemporalUnitParameter,
 } from "metabase-lib/v1/parameters/utils/parameter-type";
+import type { ParameterValue, RowValue } from "metabase-types/api";
 
 import { formatDateValue } from "./date-formatting";
 
@@ -38,14 +39,14 @@ function formatWithInferredType(value: any, parameter: UiParameter) {
 }
 
 export function formatParameterValue(
-  value: boolean | string | number | number[],
+  rawValue: string | number | number[] | ParameterValue,
   parameter: UiParameter,
 ) {
-  if (Array.isArray(value) && value.length > 1) {
-    return renderNumberOfSelections(value.length);
+  if (Array.isArray(rawValue) && rawValue.length > 1) {
+    return renderNumberOfSelections(rawValue.length);
   }
 
-  value = Array.isArray(value) ? value[0] : value;
+  const value: RowValue = Array.isArray(rawValue) ? rawValue[0] : rawValue;
 
   if (isDateParameter(parameter)) {
     return formatDateValue(parameter, String(value));


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/64982 / UXW-2134

### Description

Fix issue with missing translation for a boolean dashboard filter with a selected value.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> Accounts, then save it to a Dashboard
2. Edit this dashboard and create a boolean filter and connect it to a boolean column (e.g. Active Subscription). Save dashboard
3. When you select a value for boolean filter, selected value should have translation.

### Demo

<img width="692" height="318" alt="Screenshot 2025-11-20 at 01 32 56" src="https://github.com/user-attachments/assets/460e400f-fbca-41a5-8da6-85e382c73e1c" />

NOTE:
Original issue raises a problem with translations for a Text filter that is connected to a boolean column. This way the filter takes values from a database, and values basically work as categories. We still don't this in scope of this PR, and I don't think it is expected behavior as we just show database values.

<img width="671" height="387" alt="Screenshot 2025-11-20 at 01 33 06" src="https://github.com/user-attachments/assets/cb95f228-bccc-4815-8ae2-4132a2277131" />



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
