### PR TITLE
Closes EMB-967 default to false for `canManageSubscriptions` in OSS

### DIFF
--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -527,7 +527,7 @@ export const PLUGIN_APPLICATION_PERMISSIONS = {
   tabs: [] as any,
   selectors: {
     canAccessSettings: (_state: any) => false,
-    canManageSubscriptions: (_state: any) => true,
+    canManageSubscriptions: (_state: any) => false,
   },
 };
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #65536
Closes [EMB-967: React SDK throws invalid unhandled rejection errors when non-critical requests fail](https://linear.app/metabase/issue/EMB-967/react-sdk-throws-invalid-unhandled-rejection-errors-when-non-critical)

### Description

The original issue is about the SDK mishandling rejected requests. It's hard to address in a general way, and the issue that surfaced this is actually the app querying `/api/pulse/form_input` even if the user doesn't have the right permission, resulting in a 403. This happens because the default for `canManageSubscriptions` (which, client side, gates the call) was `true`.

 ### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create an API key set to a group that doesn't have the `Subscriptions and Alerts` permission
2. Use this API key in any SDK application
3. => the call to `/api/pulse/form_input` should not be made

### Checklist

TODO

- [ ] Tests have been added/updated to cover changes in this PR
