### PR TITLE
Use join tables to track workspace entity mappings 

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/workspaces/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/common.clj
@@ -109,9 +109,8 @@
         (t2/delete! :model/Table :schema schema)
         (let [db        (t2/select-one :model/Database db_id)
               driver    (metabase.driver.util/database->driver db)
-              jdbc-spec ((requiring-resolve 'metabase.driver.sql-jdbc.connection/connection-details->spec)
-                         driver
-                         (:details db))]
+              make-spec (requiring-resolve 'metabase.driver.sql-jdbc.connection/connection-details->spec)
+              jdbc-spec (make-spec driver (:details db))]
           (clojure.java.jdbc/execute! jdbc-spec [(str "DROP SCHEMA \"" schema "\" CASCADE")])))
       (t2/delete! :model/Workspace :id ws-clause)))
 

--- a/enterprise/backend/src/metabase_enterprise/workspaces/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/init.clj
@@ -1,3 +1,4 @@
 (ns metabase-enterprise.workspaces.init
   (:require
-   [metabase-enterprise.workspaces.models.workspace]))
+   [metabase-enterprise.workspaces.models.workspace]
+   [metabase-enterprise.workspaces.models.workspace-mapping]))

--- a/enterprise/backend/src/metabase_enterprise/workspaces/isolation.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/isolation.clj
@@ -8,7 +8,7 @@
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.util :as driver.u]
    [metabase.system.core :as system]
-   [metabase.util :as u]))
+   [toucan2.core :as t2]))
 
 ;;;; Naming
 
@@ -92,6 +92,10 @@
   (assoc graph :outputs (vec
                          (for [upstream-output (:outputs graph)]
                            (let [isolated-table (duplicate-output-table! database workspace upstream-output)]
+                             (t2/insert! :model/WorkspaceMappingTable
+                                         {:upstream_id   (:id upstream-output)
+                                          :downstream_id (:id isolated-table)
+                                          :workspace_id  (:id workspace)})
                              (assoc upstream-output :mapping isolated-table))))))
 
 (defn ensure-database-isolation!

--- a/enterprise/backend/src/metabase_enterprise/workspaces/mirroring.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/mirroring.clj
@@ -38,6 +38,10 @@
                                         :database database-id
                                         :schema   (:schema output-table)
                                         :name     (:name output-table)}}))]
+    (t2/insert! :model/WorkspaceMappingTransform
+                {:upstream_id   (:id transform)
+                 :downstream_id (:id mirror)
+                 :workspace_id  (:id workspace)})
     (assoc graph :transforms [(assoc transform :mapping (select-keys mirror [:id :name]))])))
 
 (comment

--- a/enterprise/backend/src/metabase_enterprise/workspaces/models/workspace_mapping.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/models/workspace_mapping.clj
@@ -1,0 +1,14 @@
+(ns metabase-enterprise.workspaces.models.workspace-mapping
+  (:require
+   [methodical.core :as methodical]
+   [toucan2.core :as t2]))
+
+(methodical/defmethod t2/table-name :model/WorkspaceMappingTable [_model] :workspace_mapping_table)
+
+(doto :model/WorkspaceMappingTable
+  (derive :metabase/model))
+
+(methodical/defmethod t2/table-name :model/WorkspaceMappingTransform [_model] :workspace_mapping_transform)
+
+(doto :model/WorkspaceMappingTransform
+  (derive :metabase/model))

--- a/enterprise/backend/src/metabase_enterprise/workspaces/sync.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/sync.clj
@@ -1,11 +1,11 @@
 (ns metabase-enterprise.workspaces.sync
+  ;; TODO (Chris 2025-11-20) -- Decide whether to mirror metadata manually, and drop sync dependency
   (:require
-   ;; TODO (Chris 2025-11-20) -- Decide whether to mirror metadata manually, and drop sync dependency
-   #_{:clj-kondo/ignore [:metabase/modules]}
-   #_{:clj-kondo/ignore [:metabase/modules]}
    [metabase.driver :as driver]
    [metabase.driver.util :as driver.u]
+   ^{:clj-kondo/ignore [:metabase/modules]}
    [metabase.sync.core :as sync]
+   ^{:clj-kondo/ignore [:metabase/modules]}
    [metabase.sync.sync-metadata.tables :as sync-tables]))
 
 ;; this ns will be probably moved

--- a/enterprise/backend/src/metabase_enterprise/workspaces/sync.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/sync.clj
@@ -1,5 +1,8 @@
 (ns metabase-enterprise.workspaces.sync
   (:require
+   ;; TODO (Chris 2025-11-20) -- Decide whether to mirror metadata manually, and drop sync dependency
+   #_{:clj-kondo/ignore [:metabase/modules]}
+   #_{:clj-kondo/ignore [:metabase/modules]}
    [metabase.driver :as driver]
    [metabase.driver.util :as driver.u]
    [metabase.sync.core :as sync]

--- a/enterprise/backend/test/metabase_enterprise/workspaces/dag.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/dag.clj
@@ -1,19 +1,14 @@
 (ns metabase-enterprise.workspaces.dag
-  (:require [clojure.set :as set]
-            [flatland.ordered.map :as ordered-map]
-            [metabase.util :as u]))
+  (:require
+   [clojure.set :as set]
+   [flatland.ordered.map :as ordered-map]
+   [metabase.util :as u]))
 
 ;; TODO handle shadowing / execution of transforms that depend on checkout out models
-
-(defn- example-type [id]
-  (-> id name first {\t :table
-                     \x :transform
-                     \m :model}))
 
 (defn- related [t id]
   (keyword (str (name t) (subs (name id) 1))))
 
-(def ^:private t->x (partial related :x))
 (def ^:private x->t (partial related :t))
 
 (defn- is? [t id] (= (name t) (str (first (name id)))))
@@ -159,7 +154,7 @@
                    next-up)))))))
 
 (comment
-  #p (path-induced-subgraph example))
+  (path-induced-subgraph example))
 
 ;; (path-induced-subgraph example) =>
 {:check-outs   '(:x3 :m6 :m10 :m12),

--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -801,6 +801,294 @@ databaseChangeLog:
             baseTableName: transform
             constraintName: fk_transform_workspace_id
 
+  - changeSet:
+      id: v58.2025-11-20T08:34:41
+      author: christruter
+      comment: Create workspace_mapping_table for mirroring tables in workspaces
+      changes:
+        - createTable:
+            tableName: workspace_mapping_table
+            remarks: Maps upstream tables to downstream tables within a workspace
+            columns:
+              - column:
+                  name: upstream_id
+                  type: int
+                  remarks: ID of the source table outside the workspace
+                  constraints:
+                    nullable: false
+              - column:
+                  name: downstream_id
+                  type: int
+                  remarks: ID of the mirrored table inside the workspace
+                  constraints:
+                    nullable: false
+              - column:
+                  name: workspace_id
+                  type: int
+                  remarks: ID of the workspace containing the mapping
+                  constraints:
+                    nullable: false
+      rollback:
+        - dropTable:
+            tableName: workspace_mapping_table
+
+  - changeSet:
+      id: v58.2025-11-20T08:34:42
+      author: christruter
+      comment: Add primary key constraint to workspace_mapping_table
+      changes:
+        - addPrimaryKey:
+            tableName: workspace_mapping_table
+            columnNames: upstream_id, downstream_id
+            constraintName: pk_workspace_mapping_table
+      rollback:
+        - dropPrimaryKey:
+            tableName: workspace_mapping_table
+            constraintName: pk_workspace_mapping_table
+
+  - changeSet:
+      id: v58.2025-11-20T08:34:44
+      author: christruter
+      comment: Add index on upstream_id for workspace_mapping_table
+      changes:
+        - createIndex:
+            tableName: workspace_mapping_table
+            indexName: idx_workspace_mapping_table_upstream_id
+            columns:
+              - column:
+                  name: upstream_id
+      rollback:
+        - dropIndex:
+            tableName: workspace_mapping_table
+            indexName: idx_workspace_mapping_table_upstream_id
+
+  - changeSet:
+      id: v58.2025-11-20T08:34:45
+      author: christruter
+      comment: Add index on downstream_id for workspace_mapping_table
+      changes:
+        - createIndex:
+            tableName: workspace_mapping_table
+            indexName: idx_workspace_mapping_table_downstream_id
+            columns:
+              - column:
+                  name: downstream_id
+      rollback:
+        - dropIndex:
+            tableName: workspace_mapping_table
+            indexName: idx_workspace_mapping_table_downstream_id
+
+  - changeSet:
+      id: v58.2025-11-20T08:34:46
+      author: christruter
+      comment: Add index on workspace_id for workspace_mapping_table
+      changes:
+        - createIndex:
+            tableName: workspace_mapping_table
+            indexName: idx_workspace_mapping_table_workspace_id
+            columns:
+              - column:
+                  name: workspace_id
+      rollback:
+        - dropIndex:
+            tableName: workspace_mapping_table
+            indexName: idx_workspace_mapping_table_workspace_id
+
+  - changeSet:
+      id: v58.2025-11-20T08:34:47
+      author: christruter
+      comment: Add foreign key constraint from workspace_mapping_table.upstream_id to metabase_table
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: workspace_mapping_table
+            baseColumnNames: upstream_id
+            constraintName: fk_workspace_mapping_table_upstream_id
+            referencedTableName: metabase_table
+            referencedColumnNames: id
+            onDelete: CASCADE
+      rollback:
+        - dropForeignKeyConstraint:
+            baseTableName: workspace_mapping_table
+            constraintName: fk_workspace_mapping_table_upstream_id
+
+  - changeSet:
+      id: v58.2025-11-20T08:34:48
+      author: christruter
+      comment: Add foreign key constraint from workspace_mapping_table.downstream_id to metabase_table
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: workspace_mapping_table
+            baseColumnNames: downstream_id
+            constraintName: fk_workspace_mapping_table_downstream_id
+            referencedTableName: metabase_table
+            referencedColumnNames: id
+            onDelete: CASCADE
+      rollback:
+        - dropForeignKeyConstraint:
+            baseTableName: workspace_mapping_table
+            constraintName: fk_workspace_mapping_table_downstream_id
+
+  - changeSet:
+      id: v58.2025-11-20T08:34:49
+      author: christruter
+      comment: Add foreign key constraint from workspace_mapping_table.workspace_id to workspace
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: workspace_mapping_table
+            baseColumnNames: workspace_id
+            constraintName: fk_workspace_mapping_table_workspace_id
+            referencedTableName: workspace
+            referencedColumnNames: id
+            onDelete: CASCADE
+      rollback:
+        - dropForeignKeyConstraint:
+            baseTableName: workspace_mapping_table
+            constraintName: fk_workspace_mapping_table_workspace_id
+
+  - changeSet:
+      id: v58.2025-11-20T08:34:50
+      author: christruter
+      comment: Create workspace_mapping_transform for mirroring transforms in workspaces
+      changes:
+        - createTable:
+            tableName: workspace_mapping_transform
+            remarks: Maps upstream transforms to downstream transforms within a workspace
+            columns:
+              - column:
+                  name: upstream_id
+                  type: int
+                  remarks: ID of the source transform outside the workspace
+                  constraints:
+                    nullable: false
+              - column:
+                  name: downstream_id
+                  type: int
+                  remarks: ID of the mirrored transform inside the workspace
+                  constraints:
+                    nullable: false
+              - column:
+                  name: workspace_id
+                  type: int
+                  remarks: ID of the workspace containing the mapping
+                  constraints:
+                    nullable: false
+      rollback:
+        - dropTable:
+            tableName: workspace_mapping_transform
+
+  - changeSet:
+      id: v58.2025-11-20T08:34:51
+      author: christruter
+      comment: Add primary key constraint to workspace_mapping_transform
+      changes:
+        - addPrimaryKey:
+            tableName: workspace_mapping_transform
+            columnNames: upstream_id, downstream_id
+            constraintName: pk_workspace_mapping_transform
+      rollback:
+        - dropPrimaryKey:
+            tableName: workspace_mapping_transform
+            constraintName: pk_workspace_mapping_transform
+
+  - changeSet:
+      id: v58.2025-11-20T08:34:53
+      author: christruter
+      comment: Add index on upstream_id for workspace_mapping_transform
+      changes:
+        - createIndex:
+            tableName: workspace_mapping_transform
+            indexName: idx_workspace_mapping_transform_upstream_id
+            columns:
+              - column:
+                  name: upstream_id
+      rollback:
+        - dropIndex:
+            tableName: workspace_mapping_transform
+            indexName: idx_workspace_mapping_transform_upstream_id
+
+  - changeSet:
+      id: v58.2025-11-20T08:34:54
+      author: christruter
+      comment: Add index on downstream_id for workspace_mapping_transform
+      changes:
+        - createIndex:
+            tableName: workspace_mapping_transform
+            indexName: idx_workspace_mapping_transform_downstream_id
+            columns:
+              - column:
+                  name: downstream_id
+      rollback:
+        - dropIndex:
+            tableName: workspace_mapping_transform
+            indexName: idx_workspace_mapping_transform_downstream_id
+
+  - changeSet:
+      id: v58.2025-11-20T08:34:55
+      author: christruter
+      comment: Add index on workspace_id for workspace_mapping_transform
+      changes:
+        - createIndex:
+            tableName: workspace_mapping_transform
+            indexName: idx_workspace_mapping_transform_workspace_id
+            columns:
+              - column:
+                  name: workspace_id
+      rollback:
+        - dropIndex:
+            tableName: workspace_mapping_transform
+            indexName: idx_workspace_mapping_transform_workspace_id
+
+  - changeSet:
+      id: v58.2025-11-20T08:34:56
+      author: christruter
+      comment: Add foreign key constraint from workspace_mapping_transform.upstream_id to transform
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: workspace_mapping_transform
+            baseColumnNames: upstream_id
+            constraintName: fk_workspace_mapping_transform_upstream_id
+            referencedTableName: transform
+            referencedColumnNames: id
+            onDelete: CASCADE
+      rollback:
+        - dropForeignKeyConstraint:
+            baseTableName: workspace_mapping_transform
+            constraintName: fk_workspace_mapping_transform_upstream_id
+
+  - changeSet:
+      id: v58.2025-11-20T08:34:57
+      author: christruter
+      comment: Add foreign key constraint from workspace_mapping_transform.downstream_id to transform
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: workspace_mapping_transform
+            baseColumnNames: downstream_id
+            constraintName: fk_workspace_mapping_transform_downstream_id
+            referencedTableName: transform
+            referencedColumnNames: id
+            onDelete: CASCADE
+      rollback:
+        - dropForeignKeyConstraint:
+            baseTableName: workspace_mapping_transform
+            constraintName: fk_workspace_mapping_transform_downstream_id
+
+  - changeSet:
+      id: v58.2025-11-20T08:34:58
+      author: christruter
+      comment: Add foreign key constraint from workspace_mapping_transform.workspace_id to workspace
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: workspace_mapping_transform
+            baseColumnNames: workspace_id
+            constraintName: fk_workspace_mapping_transform_workspace_id
+            referencedTableName: workspace
+            referencedColumnNames: id
+            onDelete: CASCADE
+      rollback:
+        - dropForeignKeyConstraint:
+            baseTableName: workspace_mapping_transform
+            constraintName: fk_workspace_mapping_transform_workspace_id
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/models/resolution.clj
+++ b/src/metabase/models/resolution.clj
@@ -108,7 +108,9 @@
     :model/UserKeyValue                      metabase.user-key-value.models.user-key-value
     :model/UserParameterValue                metabase.users.models.user-parameter-value
     :model/ViewLog                           metabase.view-log.models.view-log
-    :model/Workspace                         metabase-enterprise.workspaces.models.workspace})
+    :model/Workspace                         metabase-enterprise.workspaces.models.workspace
+    :model/WorkspaceMappingTable             metabase-enterprise.workspaces.models.workspace-mapping
+    :model/WorkspaceMappingTransform         metabase-enterprise.workspaces.models.workspace-mapping})
 
 ;;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ;;; !!                                                                                                !!


### PR DESCRIPTION
First class joins are kinda nice:

1.  Detection of relationships and navigation back-and-forth in the FE becomes easy. 
2. Database constraints might catch bugs.
3. Clean-up of obsolete mappings is trivial.
4. Debugging and testing is potentially more convenient too.

Maintenance on them will be low, we just need to handle creating them, and 

I haven't covered `metabase_field` _yet_, as that would be more complex. Waiting to confirm they're really necessary, and if so, whether having their mapping in JSON is sufficient.