### PR TITLE
Closes EMB-1038 wrong endpoint for embed maps preview

### DIFF
--- a/frontend/src/metabase/visualizations/lib/map.ts
+++ b/frontend/src/metabase/visualizations/lib/map.ts
@@ -20,6 +20,12 @@ interface TileUrlParams {
   uuid?: string;
   token?: string;
   datasetResult?: Dataset;
+  /**
+   * Indicates whether the tile URL is being generated for a preview embed context.
+   * You probably don't need to set this manually as it defaults to `IS_EMBED_PREVIEW` (it's used for tests).
+   * @default IS_EMBED_PREVIEW
+   */
+  isEmbedPreview?: boolean;
 }
 
 export function getTileUrl(params: TileUrlParams): string {
@@ -35,6 +41,7 @@ export function getTileUrl(params: TileUrlParams): string {
     uuid,
     token,
     datasetResult,
+    isEmbedPreview = IS_EMBED_PREVIEW,
   } = params;
 
   const parameters = datasetResult?.json_query?.parameters ?? [];
@@ -80,6 +87,7 @@ export function getTileUrl(params: TileUrlParams): string {
         coord,
         latField,
         lonField,
+        isEmbedPreview,
         parameters,
       );
     }
@@ -118,6 +126,7 @@ export function getTileUrl(params: TileUrlParams): string {
         coord,
         latField,
         lonField,
+        isEmbedPreview,
         parameters,
       );
     }
@@ -236,6 +245,7 @@ function embedCardTileUrl(
   coord: TileCoordinate,
   latField: string,
   lonField: string,
+  isEmbedPreview: boolean,
   parameters?: unknown[],
 ): string {
   const params = new URLSearchParams({
@@ -245,7 +255,10 @@ function embedCardTileUrl(
   if (parameters && parameters.length > 0) {
     params.set("parameters", JSON.stringify(parameters));
   }
-  return `/api/embed/tiles/card/${token}/${zoom}/${coord.x}/${coord.y}?${params.toString()}`;
+
+  const endpoint = isEmbedPreview ? "preview_embed" : "embed";
+
+  return `/api/${endpoint}/tiles/card/${token}/${zoom}/${coord.x}/${coord.y}?${params.toString()}`;
 }
 
 function embedDashboardTileUrl(
@@ -256,6 +269,7 @@ function embedDashboardTileUrl(
   coord: TileCoordinate,
   latField: string,
   lonField: string,
+  isEmbedPreview: boolean,
   parameters?: unknown[],
 ): string {
   const params = new URLSearchParams({
@@ -265,6 +279,6 @@ function embedDashboardTileUrl(
   if (parameters && parameters.length > 0) {
     params.set("parameters", JSON.stringify(parameters));
   }
-  const endpoint = IS_EMBED_PREVIEW ? "preview_embed" : "embed";
+  const endpoint = isEmbedPreview ? "preview_embed" : "embed";
   return `/api/${endpoint}/tiles/dashboard/${token}/dashcard/${dashcardId}/card/${cardId}/${zoom}/${coord.x}/${coord.y}?${params.toString()}`;
 }

--- a/frontend/src/metabase/visualizations/lib/map.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/lib/map.unit.spec.ts
@@ -262,6 +262,38 @@ describe("map", () => {
           `/api/embed/tiles/card/embed-token/${zoom}/${coord.x}/${coord.y}?latField=${encodeURIComponent(latField)}&lonField=${encodeURIComponent(lonField)}&parameters=${encodeURIComponent(expectedParameters)}`,
         );
       });
+
+      it("should generate url for embed question with isEmbedPreview=true", () => {
+        const url = getTileUrl({
+          cardId: 123,
+          zoom,
+          coord,
+          latField,
+          lonField,
+          token: "embed-token",
+          isEmbedPreview: true,
+        });
+
+        expect(url).toBe(
+          `/api/preview_embed/tiles/card/embed-token/${zoom}/${coord.x}/${coord.y}?latField=${encodeURIComponent(latField)}&lonField=${encodeURIComponent(lonField)}`,
+        );
+      });
+
+      it("should generate url for embed question with isEmbedPreview=false", () => {
+        const url = getTileUrl({
+          cardId: 123,
+          zoom,
+          coord,
+          latField,
+          lonField,
+          token: "embed-token",
+          isEmbedPreview: false,
+        });
+
+        expect(url).toBe(
+          `/api/embed/tiles/card/embed-token/${zoom}/${coord.x}/${coord.y}?latField=${encodeURIComponent(latField)}&lonField=${encodeURIComponent(lonField)}`,
+        );
+      });
     });
 
     describe("embed dashboard", () => {
@@ -310,6 +342,42 @@ describe("map", () => {
 
         expect(url).toBe(
           `/api/embed/tiles/dashboard/embed-token/dashcard/20/card/30/${zoom}/${coord.x}/${coord.y}?latField=${encodeURIComponent(latField)}&lonField=${encodeURIComponent(lonField)}&parameters=${encodeURIComponent(expectedParameters)}`,
+        );
+      });
+
+      it("should generate url for embed dashboard with isEmbedPreview=true", () => {
+        const url = getTileUrl({
+          dashboardId: jwt,
+          dashcardId: 20,
+          cardId: 30,
+          zoom,
+          coord,
+          latField,
+          lonField,
+          token: "embed-token",
+          isEmbedPreview: true,
+        });
+
+        expect(url).toBe(
+          `/api/preview_embed/tiles/dashboard/embed-token/dashcard/20/card/30/${zoom}/${coord.x}/${coord.y}?latField=${encodeURIComponent(latField)}&lonField=${encodeURIComponent(lonField)}`,
+        );
+      });
+
+      it("should generate url for embed dashboard with isEmbedPreview=false", () => {
+        const url = getTileUrl({
+          dashboardId: jwt,
+          dashcardId: 20,
+          cardId: 30,
+          zoom,
+          coord,
+          latField,
+          lonField,
+          token: "embed-token",
+          isEmbedPreview: false,
+        });
+
+        expect(url).toBe(
+          `/api/embed/tiles/dashboard/embed-token/dashcard/20/card/30/${zoom}/${coord.x}/${coord.y}?latField=${encodeURIComponent(latField)}&lonField=${encodeURIComponent(lonField)}`,
         );
       });
     });


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #66026
Closes [EMB-1038: Pin map question doesn't show pins in static embedding modal preview](https://linear.app/metabase/issue/EMB-1038/pin-map-question-doesnt-show-pins-in-static-embedding-modal-preview)

### Description

Reaches the proper endpoint for embed maps questions preview

### How to verify

1. New > Question > People > Visualaztion: map > Save
2. Sharing > Embed > Static embedding > Parameters > Preview
3. Make sure the embed isn't published if it was previously published before

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
