### PR TITLE
chore(sdk,ci): fix stress tests for sdk tests

### DIFF
--- a/e2e/runner/run_cypress_ci.js
+++ b/e2e/runner/run_cypress_ci.js
@@ -51,10 +51,13 @@ if (command === "snapshot") {
 
 // Metabase component or e2e tests
 if (command === "component") {
-  runTests({
-    configFile: "e2e/support/cypress-embedding-sdk-component-test.config.js",
-    testingType: "component",
-  });
+  runTests(
+    {
+      configFile: "e2e/support/cypress-embedding-sdk-component-test.config.js",
+      testingType: "component",
+    },
+    cliArguments,
+  );
 }
 
 if (command === "e2e") {

--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -204,6 +204,7 @@ const mainConfig = {
 
 const embeddingSdkComponentTestConfig = {
   ...defaultConfig,
+  baseUrl: undefined, // baseUrl should not be set for component tests,
   defaultCommandTimeout: 10000,
   requestTimeout: 10000,
   video: false,


### PR DESCRIPTION
### Description

After https://github.com/metabase/metabase/issues/65881 the cli args are not passed anymore to the sdk test runner, which means that the stress was just running the tests normally, all of them and not n times

### How to verify

Example of stress test on master: https://github.com/metabase/metabase/actions/runs/19531703007/job/55915991307

Example on this branch:
https://github.com/metabase/metabase/actions/runs/19532756842/job/55919442453
