### PR TITLE
remove hash logic in /auth/sso to speed up auth flow

### DIFF
--- a/e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers.ts
+++ b/e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers.ts
@@ -33,9 +33,16 @@ export const getSignedJwtForUser = async ({
 
 export const mockAuthProviderAndJwtSignIn = (
   user = USERS.admin,
-  { jwt }: { jwt?: string } = {},
+  {
+    jwt,
+    waitForPromise,
+  }: { jwt?: string; waitForPromise?: () => Promise<any> } = {},
 ) => {
   cy.intercept("GET", `${AUTH_PROVIDER_URL}**`, async (req) => {
+    const p = waitForPromise ? waitForPromise() : Promise.resolve();
+
+    await p;
+
     try {
       const url = new URL(req.url);
       const responseParam = url.searchParams.get("response");

--- a/e2e/test-component/scenarios/embedding-sdk/requests.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/requests.cy.spec.tsx
@@ -16,6 +16,7 @@ import {
   signInAsAdminAndEnableEmbeddingSdk,
 } from "e2e/support/helpers/embedding-sdk-testing";
 import { mockAuthProviderAndJwtSignIn } from "e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers";
+import { defer } from "metabase/lib/promise";
 
 describe("scenarios > embedding-sdk > requests", () => {
   describe("cache preflight requests", () => {
@@ -37,14 +38,44 @@ describe("scenarios > embedding-sdk > requests", () => {
       });
     });
 
+    beforeEach(() => {
+      cy.clock(Date.now());
+    });
+
+    afterEach(() => {
+      cy.clock().then((clock) => clock.restore());
+    });
+
     it("properly performs session token refresh request when multiple data requests are triggered at the same time", () => {
-      cy.intercept("POST", "/api/dataset").as("dataset");
+      let datasetCount = 0;
+      cy.intercept("POST", "/api/dataset", (req) => {
+        datasetCount++;
+        // eslint-disable-next-line no-console
+        console.log(
+          `Dataset request #${datasetCount}`,
+          req.headers["x-metabase-session"],
+        );
+        req.continue();
+      }).as("dataset");
+
+      const sessionIds: string[] = [];
+
+      cy.intercept("GET", "/auth/sso?jwt=**", (req) => {
+        req.continue((res) => {
+          sessionIds.push(res.body.id);
+        });
+      }).as("jwtToSession");
 
       const expiredInSeconds = 60;
-      cy.clock(Date.now());
+
+      const deferreds = [defer(), defer()];
+      let index = 0;
 
       cy.then(() => getSignedJwtForUser({ expiredInSeconds })).then((jwt) => {
-        mockAuthProviderAndJwtSignIn(USERS.admin, { jwt });
+        mockAuthProviderAndJwtSignIn(USERS.admin, {
+          jwt,
+          waitForPromise: () => deferreds[index++].promise,
+        });
       });
 
       cy.mount(
@@ -53,8 +84,10 @@ describe("scenarios > embedding-sdk > requests", () => {
         </MetabaseProvider>,
       );
 
+      cy.then(() => deferreds[0].resolve());
+
       getSdkRoot().within(() => {
-        cy.findByText("Orders").should("exist");
+        cy.findByText("Orders", { timeout: 60_000 }).should("exist");
 
         cy.findByText("Group").click();
 
@@ -63,14 +96,24 @@ describe("scenarios > embedding-sdk > requests", () => {
         cy.tick(1000 * (expiredInSeconds + 5));
 
         cy.findByRole("dialog").contains(/^ID$/).click();
+        cy.findByText("Doing science...").should("exist");
         cy.findByRole("dialog").findByTestId("badge-remove-button").click();
 
-        // The requests should be done after we refresh the token, so where we should have 0
         cy.get("@dataset.all").should("have.length", 0);
+
+        cy.then(() => deferreds[1].resolve());
+
+        cy.findByText("Product ID").should("be.visible");
 
         cy.wait("@jwtProvider");
         // We ensure that both `dataset` requests are made after the token refresh request
-        cy.get("@dataset.all").should("have.length", 2);
+        cy.get("@dataset.all", { timeout: 60_000 })
+          .should("have.length", 2)
+          .each((interception: any) => {
+            expect(interception.request.headers["x-metabase-session"]).to.equal(
+              sessionIds[1],
+            );
+          });
       });
     });
   });

--- a/e2e/test-component/scenarios/embedding-sdk/requests.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/requests.cy.spec.tsx
@@ -38,6 +38,8 @@ describe("scenarios > embedding-sdk > requests", () => {
     });
 
     it("properly performs session token refresh request when multiple data requests are triggered at the same time", () => {
+      cy.intercept("POST", "/api/dataset").as("dataset");
+
       const expiredInSeconds = 60;
       cy.clock(Date.now());
 
@@ -63,9 +65,10 @@ describe("scenarios > embedding-sdk > requests", () => {
         cy.findByRole("dialog").contains(/^ID$/).click();
         cy.findByRole("dialog").findByTestId("badge-remove-button").click();
 
-        cy.wait("@jwtProvider");
+        // The requests should be done after we refresh the token, so where we should have 0
+        cy.get("@dataset.all").should("have.length", 0);
 
-        cy.intercept("POST", "/api/dataset").as("dataset");
+        cy.wait("@jwtProvider");
         // We ensure that both `dataset` requests are made after the token refresh request
         cy.get("@dataset.all").should("have.length", 2);
       });

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -5,7 +5,6 @@
    [java-time.api :as t]
    [metabase-enterprise.sso.api.interface :as sso.i]
    [metabase-enterprise.sso.integrations.sso-utils :as sso-utils]
-   [metabase-enterprise.sso.integrations.token-utils :as token-utils]
    [metabase-enterprise.sso.settings :as sso-settings]
    [metabase.auth-identity.core :as auth-identity]
    [metabase.embedding.settings :as embed.settings]
@@ -87,7 +86,7 @@
       (and is-embedded-analytics-js? (not (embed.settings/enable-embedding-simple)))
       (throw-simple-embedding-disabled)
 
-      (and is-modular-embedding? (token-utils/has-token request))
+      (and is-modular-embedding? jwt)
       (generate-response-token (:session result) (:jwt-data result))
 
       ;; JWT provided - use auth-identity/login!
@@ -99,8 +98,8 @@
 
       ;; No JWT - return IdP URL for modular embedding or redirect
       is-modular-embedding?
-      (response/response (token-utils/with-token {:url (sso-settings/jwt-identity-provider-uri)
-                                                  :method "jwt"}))
+      (response/response {:url (sso-settings/jwt-identity-provider-uri)
+                          :method "jwt"})
 
       :else
       (redirect-to-idp (sso-settings/jwt-identity-provider-uri) redirect))))

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/token_utils.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/token_utils.clj
@@ -38,21 +38,3 @@
             (t/< (t/instant) (Instant/ofEpochSecond (Long/parseLong expiration))))
           (catch Exception _
             false)))))
-
-(defn- get-token-from-header
-  "Extract the token from the request headers"
-  [request]
-  (get-in request [:headers "x-metabase-sdk-jwt-hash"] nil))
-
-(defn with-token
-  "Add a newly generated token to a response"
-  [response]
-  (assoc response :hash (generate-token)))
-
-(defn has-token
-  "Check if a request has a valid token"
-  [request]
-  (let [token (get-token-from-header request)]
-    (if token
-      (validate-token token)
-      false)))

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
@@ -671,8 +671,7 @@
                       {:request-options {:headers {"x-metabase-client" "embedding-sdk-react"}}})]
           (is (partial= {:url (sso-settings/jwt-identity-provider-uri)
                          :method "jwt"}
-                        (:body result)))
-          (is (nil? (get-in result [:body :hash]))))))))
+                        (:body result))))))))
 
 (deftest jwt-token-sdk-session-token-test
   (testing "should return a session token when a JWT token and sdk headers are passed"

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
@@ -672,7 +672,7 @@
           (is (partial= {:url (sso-settings/jwt-identity-provider-uri)
                          :method "jwt"}
                         (:body result)))
-          (is (not (nil? (get-in result [:body :hash])))))))))
+          (is (nil? (get-in result [:body :hash]))))))))
 
 (deftest jwt-token-sdk-session-token-test
   (testing "should return a session token when a JWT token and sdk headers are passed"
@@ -689,16 +689,20 @@
                              :iat        jwt-iat-time
                              :exp        jwt-exp-time}
                             default-jwt-secret)
-              result (client/client-real-response :get 200 "/auth/sso"
-                                                  {:request-options {:headers {"x-metabase-client" "embedding-sdk-react"
-                                                                               "x-metabase-sdk-jwt-hash" (token-utils/generate-token)}}}
-                                                  :jwt jwt-payload)]
-          (is
-           (=?
-            {:id  (mt/malli=? ms/UUIDString)
-             :iat jwt-iat-time
-             :exp jwt-exp-time}
-            (:body result))))))))
+              do-request (fn [headers]
+                           (client/client-real-response :get 200 "/auth/sso"
+                                                        {:request-options {:headers headers}}
+                                                        :jwt jwt-payload))
+              expected-body {:id  (mt/malli=? ms/UUIDString)
+                             :iat jwt-iat-time
+                             :exp jwt-exp-time}]
+          (testing "without hash header"
+            (is (=? expected-body
+                    (:body (do-request {"x-metabase-client" "embedding-sdk-react"})))))
+          (testing "with hash header (legacy usage)"
+            (is (=? expected-body
+                    (:body (do-request {"x-metabase-client" "embedding-sdk-react"
+                                        "x-metabase-sdk-jwt-hash" (token-utils/generate-token)}))))))))))
 
 (deftest jwt-token-not-configured-test
   (testing "should not return a session token when jwt is not configured"

--- a/enterprise/frontend/src/embedding-sdk-ee/auth/auth.ts
+++ b/enterprise/frontend/src/embedding-sdk-ee/auth/auth.ts
@@ -169,6 +169,7 @@ export const getOrRefreshSession = createAsyncThunk(
     const shouldRefreshToken =
       !session ||
       (typeof session?.exp === "number" && session.exp * 1000 < Date.now());
+
     if (!shouldRefreshToken) {
       return session;
     }

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -138,9 +138,7 @@ export async function runQuestionQuery(
       datasetQueryWithParameters,
       cancelDeferred
         ? {
-            cancelled: cancelDeferred.promise.then(() => {
-              throw new Error("Query cancelled");
-            }),
+            cancelled: cancelDeferred.promise,
           }
         : {},
     );

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -138,7 +138,9 @@ export async function runQuestionQuery(
       datasetQueryWithParameters,
       cancelDeferred
         ? {
-            cancelled: cancelDeferred.promise,
+            cancelled: cancelDeferred.promise.then(() => {
+              throw new Error("Query cancelled");
+            }),
           }
         : {},
     );


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/EMB-960/investigate-if-the-first-request-to-authsso-is-worth-the-slowdown

### Description

This PR removes the `hash` logic from the `/auth/sso` endpoint used by the SDK and EAJS.

We discussed it on slack [here](https://metaboat.slack.com/archives/CKZEMT1MJ/p1763573395712399) and [here](https://metaboat.slack.com/archives/C063Q3F1HPF/p1763637051102859).
We don't need this logic as it was a _soft_ anti abuse, and since it's adding quite some delay in the endpoints it's slowing down the total load time for the SDK so we want to remove it.


Note: locally these requests are really fast, but from my tests on PR envs they're not that fast and the saving is significant

The backend code was edited by instructing claude code since I'm not familiar with with clojure and our BE code, if you're a BE dev and see something that can be improved feel free to suggest and edit on the PR itself 🙏 

### How to verify

Everything should work as before when using SDK and EAJS with JWT and SAML sso




