### PR TITLE
Closes EMB-1037 preview_embed endpoint for filter search

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
@@ -391,6 +391,45 @@ describe("scenarios > embedding > dashboard parameters", () => {
     });
   });
 
+  it("should allow searching dashboard parameters in preview embed modal", () => {
+    H.visitDashboard("@dashboardId");
+
+    H.openStaticEmbeddingModal({
+      activeTab: "parameters",
+      previewMode: "preview",
+    });
+
+    H.modal().within(() => {
+      // Set the Name parameter to enabled so we can test searching
+      cy.findByText("Name")
+        .parent()
+        .within(() => {
+          cy.findByText("Disabled").click();
+        });
+    });
+
+    H.popover().findByText("Editable").click();
+
+    // Test the preview iframe parameter search functionality
+    H.getIframeBody().within(() => {
+      // Open the Name filter dropdown
+      cy.findByTestId("dashboard-parameters-widget-container")
+        .findByText("Name")
+        .click();
+
+      // Test searching for names containing specific text
+      cy.findByPlaceholderText("Search by Name").type("Af");
+
+      // Verify that search results are filtered
+      H.popover().within(() => {
+        // Should show names containing "Af"
+        cy.findByText("Afton Lesch").should("be.visible");
+        // Should not show names that don't match the search
+        cy.findByText("Lina Heaney").should("not.exist");
+      });
+    });
+  });
+
   it("should render error message when `params` is not an object (metabase#14474)", () => {
     cy.get("@dashboardId").then((dashboardId) => {
       cy.request("PUT", `/api/dashboard/${dashboardId}`, {

--- a/src/metabase/embedding_rest/api/preview_embed.clj
+++ b/src/metabase/embedding_rest/api/preview_embed.clj
@@ -86,6 +86,16 @@
                                            (api.embed.common/parse-query-params query-params)
                                            {:preview true}))
 
+(api.macros/defendpoint :get "/dashboard/:token/params/:param-key/search/:prefix"
+  "Embedded version of chain filter search endpoint."
+  [{:keys [token param-key prefix]}
+   query-params]
+  (api.embed.common/dashboard-param-values token
+                                           param-key
+                                           prefix
+                                           (api.embed.common/parse-query-params query-params)
+                                           {:preview true}))
+
 (api.macros/defendpoint :get "/dashboard/:token/params/:param-key/remapping"
   "Embedded version of the remapped dashboard param value endpoint."
   [{:keys [token param-key]}

--- a/test/metabase/embedding_rest/api/preview_embed_test.clj
+++ b/test/metabase/embedding_rest/api/preview_embed_test.clj
@@ -567,6 +567,19 @@
                       :has_more_values false}
                      (mt/user-http-request :rasta :get 200 url))))))))))
 
+(deftest dashboard-params-search-test
+  (testing "GET /api/preview_embed/dashboard/:token/params/:param-key/search/:prefix"
+    (with-embedding-enabled-and-new-secret-key!
+      (api.dashboard-test/with-chain-filter-fixtures [{:keys [dashboard]}]
+        (t2/update! :model/Dashboard (u/the-id dashboard) {:enable_embedding false ;; works without enabling embedding on the dashboard (#44962)
+                                                           :embedding_params {"static_category_label" "enabled"}})
+        (let [signed-token (dash-token dashboard)
+              search-url   (format "preview_embed/dashboard/%s/params/%s/search/%s" signed-token "_STATIC_CATEGORY_LABEL_" "AF")]
+          (testing "Should work if the param we're fetching values for is enabled"
+            (is (= {:values          [["African" "Af"]]
+                    :has_more_values false}
+                   (mt/user-http-request :crowberto :get 200 search-url)))))))))
+
 (deftest boolean-parameter-values-test
   (testing "embedding endpoint supports boolean parameter values (#27643)"
     (embed-test/with-embedding-enabled-and-new-secret-key!


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #65996
Closes [EMB-1037: Cannot search parameter values in search box on static embedding preview](https://linear.app/metabase/issue/EMB-1037/cannot-search-parameter-values-in-search-box-on-static-embedding)

### Description

Adds missing parameter search endpoint for preview embedding. Previously, the regular embed API supported parameter search
  (`/api/embed/dashboard/:token/params/:param-key/search/:prefix`) but the preview embed API was missing the equivalent endpoint
  (`/api/preview_embed/dashboard/:token/params/:param-key/search/:prefix`), causing parameter filtering to fail in the preview embed modal.

  This PR implements the missing endpoint in `preview_embed.clj` with identical functionality to the regular embed version, ensuring consistent parameter search behavior across both
  embedding modes.

### How to verify

  1. Go to a dashboard with parameters (e.g., text/category parameters)
  2. Click "Share" → "Embed" → "Parameters" tab
  3. Set a parameter to "Editable"
  4. Switch to Preview mode
  5. In the preview iframe, click on the parameter dropdown
  6. Type text in the search box - filtering should now work correctly
  7. Verify network requests show successful calls to `/api/preview_embed/dashboard/.../params/.../search/...`

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
