### PR TITLE
Support multiple transforms (mostly)

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/workspaces/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/common.clj
@@ -9,7 +9,7 @@
 
 ;; TODO (Chris 2025-11-20) Just subsume the rest of this up into ws.dag/path-induced-subgraph
 (defn- build-graph
-  "Placeholder for our actual dag module, handling at most 1 transform, and not returning all the analysis."
+  "Thin wrapper around the dag module, that should probably be absorbed by it."
   [upstream]
   (if (not-any? seq (vals upstream))
     {:db_id      nil
@@ -20,6 +20,7 @@
           db-ids       (when-let [table-ids (seq (keep :id (concat (:inputs graph) (:outputs graph))))]
                          (t2/select-fn-set :db_id :model/Table :id [:in table-ids]))
           _            (assert (= 1 (count db-ids)) "All inputs and outputs must belong to the same database.")]
+      ;; One reason this is here, is that I don't want the DAG module to have the single-DWH assumption.
       (assoc graph :db_id (first db-ids)))))
 
 ;; TODO: Generate new metabase user for the workspace

--- a/enterprise/backend/src/metabase_enterprise/workspaces/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/common.clj
@@ -1,50 +1,26 @@
 (ns metabase-enterprise.workspaces.common
   (:require
+   [metabase-enterprise.workspaces.dag :as ws.dag]
    [metabase-enterprise.workspaces.isolation :as ws.isolation]
    [metabase-enterprise.workspaces.mirroring :as ws.mirroring]
    [metabase.api-keys.core :as api-key]
    [metabase.api.common :as api]
    [toucan2.core :as t2]))
 
-(defn- temp-assert-single-transform!
-  "A temporary restriction, until we have graph analysis merged."
-  [upstream-entities]
-  (assert (and (= 1 (count (keys upstream-entities)))
-               (= 1 (count (:transforms upstream-entities))))
-          "The only contents of the workspace must be a single transform."))
-
+;; TODO (Chris 2025-11-20) Just subsume the rest of this up into ws.dag/path-induced-subgraph
 (defn- build-graph
   "Placeholder for our actual dag module, handling at most 1 transform, and not returning all the analysis."
   [upstream]
   (if (not-any? seq (vals upstream))
     {:db_id      nil
      :transforms []
-     :inputs     []}
-    (do
-      (temp-assert-single-transform! upstream)
-      (let [transform-id (first (get upstream :transforms))
-            ;; NOte: we only support MBQL transforms for now
-            transform    (t2/select-one [:model/Transform :id :name :source :target] :id transform-id)
-            _            (assert (not-empty transform))
-            ;; Note: if there are additional tables being joined, we are not picking them up @_@
-            source-id    (get-in transform [:source :query :stages 0 :source-table])
-            _            (assert (pos-int? source-id))
-            source-table (t2/select-one [:model/Table :id :schema :name] :id source-id)
-            _            (assert (not-empty source-table))
-            output-table (let [{:keys [schema name]} (:target transform)]
-                           ;; TODO (Chris 2025-11-19) Relax downstream assumption that upstream-tx output table exists
-                           {:id     (t2/select-one-pk :model/Table :schema schema :name name)
-                            :schema schema
-                            :name   name})
-            db-ids       (vec (sort (distinct (filter pos-int? [(-> transform :source :query :database) (:db_id source-table)]))))
-            _            (assert (= 1 (count db-ids)) "All inputs and outputs must belong to the same database.")]
-        ;; Graph is based on this.
-        ;; https://metaboat.slack.com/archives/C099RKNLP6U/p1763470366995789?thread_ts=1763462819.139739&cid=C099RKNLP6U
-        ;; "tables" was renamed to "outputs", to perhaps make it clearer that they are not the input tables.
-        {:db_id      (first db-ids)
-         :transforms [(select-keys transform [:id :name])]
-         :inputs     [source-table]
-         :outputs    [output-table]}))))
+     :inputs     []
+     :outputs    []}
+    (let [graph        (ws.dag/path-induced-subgraph upstream)
+          db-ids       (when-let [table-ids (seq (keep :id (concat (:inputs graph) (:outputs graph))))]
+                         (t2/select-fn-set :db_id :model/Table :id [:in table-ids]))
+          _            (assert (= 1 (count db-ids)) "All inputs and outputs must belong to the same database.")]
+      (assoc graph :db_id (first db-ids)))))
 
 ;; TODO: Generate new metabase user for the workspace
 ;; TODO: Should we move this to model as per the diagram?
@@ -81,7 +57,6 @@
                upstream    :upstream}]
   ;; TODO put this in the malli schema for a request
   (assert (or maybe-db-id (some seq (vals upstream))) "Must provide a database_id unless initial entities are given.")
-  (temp-assert-single-transform! upstream)
   (let [graph          (build-graph upstream)
         inferred-db-id (:db_id graph)
         _              (when (and maybe-db-id inferred-db-id)
@@ -115,12 +90,13 @@
       (t2/delete! :model/Workspace :id ws-clause)))
 
   (def upstream-tx-id (t2/select-one-pk :model/Transform :workspace_id nil {:order-by [:id]}))
-  (def admin-id (t2/select-one-pk :model/User :is_superuser true {:order-by [:id]}))
+  (def upstream-tx-ids (t2/select-pks-vec :model/Transform :workspace_id nil {:order-by [:id]}))
 
   ;; Ensure output table exists
   (#'metabase-enterprise.transforms.execute/run-mbql-transform! (t2/select-one :model/Transform upstream-tx-id))
 
-  (binding [api/*current-user-id* admin-id]
-    (create-workspace! admin-id {:name "Workplace Workspace", :upstream {:transforms [upstream-tx-id]}}))
+  (let [admin-id (t2/select-one-pk :model/User :is_superuser true {:order-by [:id]})]
+    (binding [api/*current-user-id* admin-id]
+      (create-workspace! admin-id {:name "Workplace Workspace", :upstream {:transforms upstream-tx-ids #_[upstream-tx-id]}})))
 
   (clean-up-ws!*))

--- a/enterprise/backend/src/metabase_enterprise/workspaces/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/common.clj
@@ -89,14 +89,14 @@
           (clojure.java.jdbc/execute! jdbc-spec [(str "DROP SCHEMA \"" schema "\" CASCADE")])))
       (t2/delete! :model/Workspace :id ws-clause)))
 
-  (def upstream-tx-id (t2/select-one-pk :model/Transform :workspace_id nil {:order-by [:id]}))
-  (def upstream-tx-ids (t2/select-pks-vec :model/Transform :workspace_id nil {:order-by [:id]}))
+  (def upstream-id (t2/select-one-pk :model/Transform :workspace_id nil {:order-by [:id]}))
+  (def upstream-ids (t2/select-pks-vec :model/Transform :workspace_id nil {:order-by [:id]}))
 
   ;; Ensure output table exists
-  (#'metabase-enterprise.transforms.execute/run-mbql-transform! (t2/select-one :model/Transform upstream-tx-id))
+  (#'metabase-enterprise.transforms.execute/run-mbql-transform! (t2/select-one :model/Transform upstream-id))
 
   (let [admin-id (t2/select-one-pk :model/User :is_superuser true {:order-by [:id]})]
     (binding [api/*current-user-id* admin-id]
-      (create-workspace! admin-id {:name "Workplace Workspace", :upstream {:transforms upstream-tx-ids #_[upstream-tx-id]}})))
+      (create-workspace! admin-id {:name "Workplace Workspace", :upstream {:transforms upstream-ids #_[upstream-id]}})))
 
   (clean-up-ws!*))

--- a/enterprise/backend/src/metabase_enterprise/workspaces/isolation.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/isolation.clj
@@ -58,7 +58,7 @@
 ;;;; Transform table duplication
 
 (defmulti duplicate-output-table!
-  "WIP"
+  "Create an isolated copy of the given output tables, for a workspace transform to write to."
   {:added "0.59.0" :arglists '([database transform])}
   #'dispatch-on-engine
   :hierarchy #'driver/hierarchy)
@@ -107,7 +107,7 @@
                                (assoc hydrated-output :mapping isolated-table)))))))
 
 (defn ensure-database-isolation!
-  "WIP"
+  "Wrapper around the driver method, to make migrations easier in future."
   [workspace database]
   ;; TODO: Make this check the ws existence aka fail closed ~atm
   (init-workspace-database-isolation! database workspace))

--- a/enterprise/backend/src/metabase_enterprise/workspaces/mirroring.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/mirroring.clj
@@ -6,13 +6,11 @@
 
 ;; TODO (Chris 2025-11-18) not sure why this is here - maybe we should check that between this and mirrored keys
 ;;       that we are fully specifying everything on the model - so we catch if something important is added.
-(def t2-transform-not-mirrored-keys
-  "WIP"
+(def ^:private t2-transform-not-mirrored-keys
   #{:id :creator_id :created_at :updated_at :entity_id})
 
 ;; t2 for snake
-(def t2-transform-keys
-  "WIP"
+(def ^:private t2-transform-keys
   #{:description :name :source :target :source_type})
 
 (defn- mirror-transform!
@@ -94,7 +92,7 @@
   )
 
 (defn mirror-entities!
-  "WIP"
+  "Create mirrored transforms and isolated tables, etc"
   [workspace
    database
    graph]

--- a/enterprise/backend/src/metabase_enterprise/workspaces/mirroring.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/mirroring.clj
@@ -1,48 +1,55 @@
 (ns metabase-enterprise.workspaces.mirroring
   (:require
    [metabase-enterprise.workspaces.isolation :as ws.isolation]
+   [metabase.util :as u]
    [toucan2.core :as t2]))
 
-;; Following for reference ~atm
+;; TODO (Chris 2025-11-18) not sure why this is here - maybe we should check that between this and mirrored keys
+;;       that we are fully specifying everying on the model - so we catch if something important is added.
 (def t2-transform-not-mirrored-keys
   "WIP"
-  #{:id :creator_id :created_at :updated_at :entity_id #_!!! :target})
+  #{:id :creator_id :created_at :updated_at :entity_id})
 
 ;; t2 for snake
-(def t2-transform-mirrored-keys
+(def t2-transform-keys
   "WIP"
-  #{:description :name :source :source_type})
+  #{:description :name :source :target :source_type})
 
 (defn- mirror-transform!
-  [workspace database-id graph]
+  "Create the mirroring transform and transform mapping rows for a single transform."
+  [workspace database-id graph transform]
   ;; With addition of e.g. Clickhouse I expect some juggling with how we provide targets,
   ;; but for now doing plain copy-paste schema name here.
   ;; TODO (lbrdnk 2025-11-18) revisit schema, name vs db specific access pattern.
-  (let [#_#_table-mapping (u/for-map [{:keys [name schema mapping]} (:outputs graph)]
-                                     [[name schema] ((juxt :name :schema) mapping)])
-        _             (= 1 (count (:outputs graph)))
-        output-table  (-> graph :outputs first :mapping)
-        _             (= 1 (count (:transforms graph)))
-        transform     (-> graph :transforms first)
+  (let [table-mapping (u/for-map [{:keys [name schema mapping]} (:outputs graph)]
+                        [[name schema] ((juxt :name :schema) mapping)])
+        ;; TODO (Chris 2025-11-19) avoid re-selecting here, by passing what we need from the start
+        mirror        (let [transform (t2/select-one (into [:model/Transform] t2-transform-keys) (:id transform))
+                            target    (:target transform)
+                            old-s+n   ((juxt :schema :name) target)
+                            new-s+n   (table-mapping old-s+n old-s+n)]
+                        (assert (= "table" (:type target)) "We only support mirroring transforms that target tables.")
+                        (assert (= database-id (:database target)) "Unexpected target database for transform.")
+                        (merge transform
+                               ;; TODO (Chris 2025-11-19) shouldn't rename like this - will mess up promotion!
+                               {:name         (str (:name transform) "_DUP")
+                                :workspace_id (:id workspace)
+                                ;; TODO (Chris 2025-11-19) remap source table (when necessary)
+                                #_#_:source {}
+                                :target       {:type     "table"
+                                               :database database-id
+                                               :schema   (first new-s+n)
+                                               :name     (second new-s+n)}}))
+        mirror        (t2/insert-returning-instance! :model/Transform mirror)
+        graph-node    (assoc transform :mapping (select-keys mirror [:id :name]))
+        _             (t2/insert! :model/WorkspaceMappingTransform
+                                  {:upstream_id   (:id transform)
+                                   :downstream_id (:id mirror)
+                                   :workspace_id  (:id workspace)})]
+    (update graph :transforms #(if % (conj % graph-node) [graph-node]))))
 
-        mirror        (t2/insert-returning-instance!
-                       :model/Transform
-                       ;; TODO (Chris 2025-11-19) avoid reselecting transform here, by passing along all the keys from the top
-                       (merge (-> (t2/select-one (into [:model/Transform] t2-transform-mirrored-keys) (:id transform))
-                                  ;; TODO (Chris 2025-11-19) shouldn't rename like this - will mess up promotion!
-                                  ;; this should be happening elsewhere, not on write, for now ok
-                                  (update :name str "_DUP")
-                                  (assoc :workspace_id (:id workspace)))
-                              ;; TODO (Chris 2025-11-19) remap source table (when necessary)
-                              {:target {:type     "table"
-                                        :database database-id
-                                        :schema   (:schema output-table)
-                                        :name     (:name output-table)}}))]
-    (t2/insert! :model/WorkspaceMappingTransform
-                {:upstream_id   (:id transform)
-                 :downstream_id (:id mirror)
-                 :workspace_id  (:id workspace)})
-    (assoc graph :transforms [(assoc transform :mapping (select-keys mirror [:id :name]))])))
+(defn- mirror-transforms! [workspace database-id graph]
+  (reduce #(mirror-transform! workspace database-id %1 %2) graph (:transforms graph)))
 
 (comment
   ;;
@@ -95,7 +102,7 @@
   #_(ws.isolation/ensure-database-isolation! workspace database)
   (->> graph
        (ws.isolation/create-isolated-output-tables! workspace database)
-       (mirror-transform! workspace (:id database))))
+       (mirror-transforms! workspace (:id database))))
 
 #_:clj-kondo/ignore
 (comment

--- a/enterprise/backend/src/metabase_enterprise/workspaces/mirroring.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/mirroring.clj
@@ -46,7 +46,7 @@
                                   {:upstream_id   (:id transform)
                                    :downstream_id (:id mirror)
                                    :workspace_id  (:id workspace)})]
-    (update graph :transforms #(if % (conj % graph-node) [graph-node]))))
+    (update graph :transforms #(conj (or % []) graph-node))))
 
 (defn- mirror-transforms! [workspace database-id graph]
   (reduce #(mirror-transform! workspace database-id %1 %2) graph (:transforms graph)))

--- a/enterprise/backend/src/metabase_enterprise/workspaces/mirroring.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/mirroring.clj
@@ -5,7 +5,7 @@
    [toucan2.core :as t2]))
 
 ;; TODO (Chris 2025-11-18) not sure why this is here - maybe we should check that between this and mirrored keys
-;;       that we are fully specifying everying on the model - so we catch if something important is added.
+;;       that we are fully specifying everything on the model - so we catch if something important is added.
 (def t2-transform-not-mirrored-keys
   "WIP"
   #{:id :creator_id :created_at :updated_at :entity_id})


### PR DESCRIPTION
This is "my" portion of the support as discussed.

The remaining part is replacing the table and field references in the "source" component of the transform.

This will need to support SQL, MBQL, and Python transforms. 