### PR TITLE
Show both internal and external tenant users in the people list

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/audit_app/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/index.js
@@ -1,7 +1,6 @@
 import { t } from "ttag";
 
 import { ForwardRefLink } from "metabase/common/components/Link";
-import { isInternalUser } from "metabase/lib/urls";
 import {
   PLUGIN_ADMIN_USER_MENU_ITEMS,
   PLUGIN_ADMIN_USER_MENU_ROUTES,
@@ -20,14 +19,10 @@ import { isAuditDb } from "./utils";
 export function initializePlugin() {
   if (hasPremiumFeature("audit_app")) {
     // Add new menu item function
-    const menuItemFunction = (user) => [
+    const menuItemFunction = (user, routePrefix) => [
       <Menu.Item
         component={ForwardRefLink}
-        to={
-          isInternalUser(user)
-            ? `/admin/people/${user.id}/unsubscribe`
-            : `/admin/tenants/people/${user.id}/unsubscribe`
-        }
+        to={`${routePrefix}/${user.id}/unsubscribe`}
         key="unsubscribe"
       >
         {t`Unsubscribe from all subscriptions / alerts`}

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/index.js
@@ -1,6 +1,7 @@
 import { t } from "ttag";
 
 import { ForwardRefLink } from "metabase/common/components/Link";
+import * as Urls from "metabase/lib/urls";
 import {
   PLUGIN_ADMIN_USER_MENU_ITEMS,
   PLUGIN_ADMIN_USER_MENU_ROUTES,
@@ -19,10 +20,10 @@ import { isAuditDb } from "./utils";
 export function initializePlugin() {
   if (hasPremiumFeature("audit_app")) {
     // Add new menu item function
-    const menuItemFunction = (user, routePrefix) => [
+    const menuItemFunction = (user, isExternal) => [
       <Menu.Item
         component={ForwardRefLink}
-        to={`${routePrefix}/${user.id}/unsubscribe`}
+        to={Urls.unsubscribeUser(user, isExternal)}
         key="unsubscribe"
       >
         {t`Unsubscribe from all subscriptions / alerts`}

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/index.js
@@ -20,10 +20,10 @@ import { isAuditDb } from "./utils";
 export function initializePlugin() {
   if (hasPremiumFeature("audit_app")) {
     // Add new menu item function
-    const menuItemFunction = (user, isExternal) => [
+    const menuItemFunction = (user, isExternalPage) => [
       <Menu.Item
         component={ForwardRefLink}
-        to={Urls.unsubscribeUser(user, isExternal)}
+        to={Urls.unsubscribeUser(user, isExternalPage)}
         key="unsubscribe"
       >
         {t`Unsubscribe from all subscriptions / alerts`}

--- a/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
@@ -66,7 +66,7 @@ export function initializePlugin() {
               <ModalRoute
                 path="edit"
                 // @ts-expect-error - params prop can't be infered
-                modal={(props) => <EditUserModal {...props} external />}
+                modal={(props) => <EditUserModal {...props} />}
                 noWrap
               />
               {/* @ts-expect-error - params prop can't be infered */}

--- a/frontend/src/metabase/admin/people/components/PeopleList.tsx
+++ b/frontend/src/metabase/admin/people/components/PeopleList.tsx
@@ -11,6 +11,7 @@ import {
 } from "metabase/api";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { PaginationControls } from "metabase/common/components/PaginationControls";
+import { useSetting } from "metabase/common/hooks";
 import { useConfirmation } from "metabase/common/hooks/use-confirmation";
 import AdminS from "metabase/css/admin.module.css";
 import CS from "metabase/css/core/index.css";
@@ -76,6 +77,7 @@ export const PeopleList = ({
   const total = data?.total ?? 0;
 
   const dispatch = useDispatch();
+  const isUsingTenants = useSetting("use-tenants");
 
   const [createMembership] = useCreateMembershipMutation();
   const [updateMembership] = useUpdateMembershipMutation();
@@ -169,6 +171,10 @@ export const PeopleList = ({
     return createMembership({ group_id: groupId, user_id: userId }).unwrap();
   };
 
+  const groupsOrTenantHeaderTitle = isUsingTenants
+    ? t`Groups / Tenant`
+    : t`Groups`;
+
   return (
     <LoadingAndErrorWrapper loading={isLoading} error={error} noWrapper>
       <Box component="section">
@@ -183,13 +189,13 @@ export const PeopleList = ({
               <th>{t`Email`}</th>
               {showDeactivated ? (
                 <Fragment>
-                  <th>{t`Groups / Tenant`}</th>
+                  <th>{groupsOrTenantHeaderTitle}</th>
                   <th>{t`Deactivated`}</th>
                   <th />
                 </Fragment>
               ) : (
                 <Fragment>
-                  <th>{t`Groups / Tenant`}</th>
+                  <th>{groupsOrTenantHeaderTitle}</th>
                   <th>{t`Last Login`}</th>
                   <th />
                 </Fragment>

--- a/frontend/src/metabase/admin/people/components/PeopleList.tsx
+++ b/frontend/src/metabase/admin/people/components/PeopleList.tsx
@@ -49,7 +49,7 @@ interface PeopleListProps extends PeopleListQueryProps {
   onNextPage?: () => void;
   onPreviousPage: () => void;
   noResultsMessage: string;
-  routePrefix: string;
+  isExternal: boolean;
 }
 
 export const PeopleList = ({
@@ -60,7 +60,7 @@ export const PeopleList = ({
   onNextPage,
   onPreviousPage,
   noResultsMessage,
-  routePrefix,
+  isExternal,
 }: PeopleListProps) => {
   const { modalContent, show } = useConfirmation();
 
@@ -222,7 +222,7 @@ export const PeopleList = ({
                     membershipData: Partial<Member>,
                   ) => handleChange(groupId, membershipData, user.id)}
                   isConfirmModalOpen={Boolean(modalContent)}
-                  routePrefix={routePrefix}
+                  isExternal={isExternal}
                 />
               ))}
           </tbody>

--- a/frontend/src/metabase/admin/people/components/PeopleList.tsx
+++ b/frontend/src/metabase/admin/people/components/PeopleList.tsx
@@ -47,8 +47,8 @@ interface PeopleListProps extends PeopleListQueryProps {
   isAdmin: boolean;
   onNextPage?: () => void;
   onPreviousPage: () => void;
-  external?: boolean;
   noResultsMessage: string;
+  routePrefix: string;
 }
 
 export const PeopleList = ({
@@ -58,8 +58,8 @@ export const PeopleList = ({
   query,
   onNextPage,
   onPreviousPage,
-  external = false,
   noResultsMessage,
+  routePrefix,
 }: PeopleListProps) => {
   const { modalContent, show } = useConfirmation();
 
@@ -183,13 +183,13 @@ export const PeopleList = ({
               <th>{t`Email`}</th>
               {showDeactivated ? (
                 <Fragment>
-                  {external && <th>{t`Tenant`}</th>}
+                  <th>{t`Groups / Tenant`}</th>
                   <th>{t`Deactivated`}</th>
                   <th />
                 </Fragment>
               ) : (
                 <Fragment>
-                  {external ? <th>{t`Tenant`}</th> : <th>{t`Groups`}</th>}
+                  <th>{t`Groups / Tenant`}</th>
                   <th>{t`Last Login`}</th>
                   <th />
                 </Fragment>
@@ -216,6 +216,7 @@ export const PeopleList = ({
                     membershipData: Partial<Member>,
                   ) => handleChange(groupId, membershipData, user.id)}
                   isConfirmModalOpen={Boolean(modalContent)}
+                  routePrefix={routePrefix}
                 />
               ))}
           </tbody>

--- a/frontend/src/metabase/admin/people/components/PeopleList.tsx
+++ b/frontend/src/metabase/admin/people/components/PeopleList.tsx
@@ -1,5 +1,5 @@
 import cx from "classnames";
-import { Fragment } from "react";
+import { Fragment, useMemo } from "react";
 import { msgid, ngettext, t } from "ttag";
 
 import {
@@ -48,8 +48,8 @@ interface PeopleListProps extends PeopleListQueryProps {
   isAdmin: boolean;
   onNextPage?: () => void;
   onPreviousPage: () => void;
+  isExternalPage?: boolean;
   noResultsMessage: string;
-  isExternal: boolean;
 }
 
 export const PeopleList = ({
@@ -59,8 +59,8 @@ export const PeopleList = ({
   query,
   onNextPage,
   onPreviousPage,
+  isExternalPage = false,
   noResultsMessage,
-  isExternal,
 }: PeopleListProps) => {
   const { modalContent, show } = useConfirmation();
 
@@ -171,9 +171,13 @@ export const PeopleList = ({
     return createMembership({ group_id: groupId, user_id: userId }).unwrap();
   };
 
-  const groupsOrTenantHeaderTitle = isUsingTenants
-    ? t`Groups / Tenant`
-    : t`Groups`;
+  const groupOrTenantHeader = useMemo(() => {
+    if (isExternalPage) {
+      return t`Tenant`;
+    }
+
+    return isUsingTenants ? t`Groups / Tenant` : t`Groups`;
+  }, [isExternalPage, isUsingTenants]);
 
   return (
     <LoadingAndErrorWrapper loading={isLoading} error={error} noWrapper>
@@ -189,13 +193,13 @@ export const PeopleList = ({
               <th>{t`Email`}</th>
               {showDeactivated ? (
                 <Fragment>
-                  <th>{groupsOrTenantHeaderTitle}</th>
+                  {isUsingTenants && <th>{t`Tenant`}</th>}
                   <th>{t`Deactivated`}</th>
                   <th />
                 </Fragment>
               ) : (
                 <Fragment>
-                  <th>{groupsOrTenantHeaderTitle}</th>
+                  <th>{groupOrTenantHeader}</th>
                   <th>{t`Last Login`}</th>
                   <th />
                 </Fragment>
@@ -222,7 +226,7 @@ export const PeopleList = ({
                     membershipData: Partial<Member>,
                   ) => handleChange(groupId, membershipData, user.id)}
                   isConfirmModalOpen={Boolean(modalContent)}
-                  isExternal={isExternal}
+                  isExternalPage={isExternalPage}
                 />
               ))}
           </tbody>

--- a/frontend/src/metabase/admin/people/components/PeopleListRow.tsx
+++ b/frontend/src/metabase/admin/people/components/PeopleListRow.tsx
@@ -4,6 +4,7 @@ import { t } from "ttag";
 
 import { ForwardRefLink } from "metabase/common/components/Link";
 import UserAvatar from "metabase/common/components/UserAvatar";
+import { useSetting } from "metabase/common/hooks";
 import { useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { getFullName } from "metabase/lib/user";
@@ -60,6 +61,7 @@ export const PeopleListRow = ({
   isConfirmModalOpen,
   isExternalPage,
 }: PeopleListRowProps) => {
+  const isUsingTenants = useSetting("use-tenants");
   const isExternalUser = !!user.tenant_id;
   const membershipsByGroupId = useMemo(
     () =>
@@ -95,9 +97,11 @@ export const PeopleListRow = ({
       <td>{user.email}</td>
       {showDeactivated ? (
         <Fragment>
-          {isExternalUser && (
+          {isUsingTenants && (
             <td>
-              <PLUGIN_TENANTS.TenantDisplayName id={user.tenant_id} />
+              {isExternalUser && (
+                <PLUGIN_TENANTS.TenantDisplayName id={user.tenant_id} />
+              )}
             </td>
           )}
           <td>{dayjs(user.updated_at).fromNow()}</td>

--- a/frontend/src/metabase/admin/people/components/PeopleListRow.tsx
+++ b/frontend/src/metabase/admin/people/components/PeopleListRow.tsx
@@ -44,6 +44,7 @@ interface PeopleListRowProps {
   onChange: (groupId: GroupId, membershipData: Partial<Member>) => void;
   onRemove: (groupId: GroupId) => void;
   isConfirmModalOpen: boolean;
+  routePrefix: string;
 }
 
 export const PeopleListRow = ({
@@ -57,6 +58,7 @@ export const PeopleListRow = ({
   onRemove,
   onChange,
   isConfirmModalOpen,
+  routePrefix,
 }: PeopleListRowProps) => {
   const isExternal = !!user.tenant_id;
   const membershipsByGroupId = useMemo(
@@ -140,7 +142,7 @@ export const PeopleListRow = ({
                 <Menu.Dropdown>
                   <Menu.Item
                     component={ForwardRefLink}
-                    to={Urls.editUser(user)}
+                    to={Urls.editUser(user, routePrefix)}
                   >
                     {t`Edit user`}
                   </Menu.Item>
@@ -148,20 +150,20 @@ export const PeopleListRow = ({
                   {isPasswordLoginEnabled && (
                     <Menu.Item
                       component={ForwardRefLink}
-                      to={Urls.resetPassword(user)}
+                      to={Urls.resetPassword(user, routePrefix)}
                     >
                       {t`Reset password`}
                     </Menu.Item>
                   )}
 
                   {PLUGIN_ADMIN_USER_MENU_ITEMS.flatMap((getItems) =>
-                    getItems(user),
+                    getItems(user, routePrefix),
                   )}
 
                   {!isCurrentUser && (
                     <Menu.Item
                       component={ForwardRefLink}
-                      to={Urls.deactivateUser(user)}
+                      to={Urls.deactivateUser(user, routePrefix)}
                       c="danger"
                     >
                       {t`Deactivate user`}

--- a/frontend/src/metabase/admin/people/components/PeopleListRow.tsx
+++ b/frontend/src/metabase/admin/people/components/PeopleListRow.tsx
@@ -44,7 +44,7 @@ interface PeopleListRowProps {
   onChange: (groupId: GroupId, membershipData: Partial<Member>) => void;
   onRemove: (groupId: GroupId) => void;
   isConfirmModalOpen: boolean;
-  isExternal: boolean;
+  isExternalPage: boolean;
 }
 
 export const PeopleListRow = ({
@@ -58,7 +58,7 @@ export const PeopleListRow = ({
   onRemove,
   onChange,
   isConfirmModalOpen,
-  isExternal,
+  isExternalPage,
 }: PeopleListRowProps) => {
   const isExternalUser = !!user.tenant_id;
   const membershipsByGroupId = useMemo(
@@ -142,7 +142,7 @@ export const PeopleListRow = ({
                 <Menu.Dropdown>
                   <Menu.Item
                     component={ForwardRefLink}
-                    to={Urls.editUser(user, isExternal)}
+                    to={Urls.editUser(user, isExternalPage)}
                   >
                     {t`Edit user`}
                   </Menu.Item>
@@ -150,20 +150,20 @@ export const PeopleListRow = ({
                   {isPasswordLoginEnabled && (
                     <Menu.Item
                       component={ForwardRefLink}
-                      to={Urls.resetPassword(user, isExternal)}
+                      to={Urls.resetPassword(user, isExternalPage)}
                     >
                       {t`Reset password`}
                     </Menu.Item>
                   )}
 
                   {PLUGIN_ADMIN_USER_MENU_ITEMS.flatMap((getItems) =>
-                    getItems(user, isExternal),
+                    getItems(user, isExternalPage),
                   )}
 
                   {!isCurrentUser && (
                     <Menu.Item
                       component={ForwardRefLink}
-                      to={Urls.deactivateUser(user, isExternal)}
+                      to={Urls.deactivateUser(user, isExternalPage)}
                       c="danger"
                     >
                       {t`Deactivate user`}

--- a/frontend/src/metabase/admin/people/components/PeopleListRow.tsx
+++ b/frontend/src/metabase/admin/people/components/PeopleListRow.tsx
@@ -44,7 +44,7 @@ interface PeopleListRowProps {
   onChange: (groupId: GroupId, membershipData: Partial<Member>) => void;
   onRemove: (groupId: GroupId) => void;
   isConfirmModalOpen: boolean;
-  routePrefix: string;
+  isExternal: boolean;
 }
 
 export const PeopleListRow = ({
@@ -58,9 +58,9 @@ export const PeopleListRow = ({
   onRemove,
   onChange,
   isConfirmModalOpen,
-  routePrefix,
+  isExternal,
 }: PeopleListRowProps) => {
-  const isExternal = !!user.tenant_id;
+  const isExternalUser = !!user.tenant_id;
   const membershipsByGroupId = useMemo(
     () =>
       userMemberships?.reduce((acc, membership) => {
@@ -95,14 +95,14 @@ export const PeopleListRow = ({
       <td>{user.email}</td>
       {showDeactivated ? (
         <Fragment>
-          {isExternal && (
+          {isExternalUser && (
             <td>
               <PLUGIN_TENANTS.TenantDisplayName id={user.tenant_id} />
             </td>
           )}
           <td>{dayjs(user.updated_at).fromNow()}</td>
           <td>
-            {isExternal ? (
+            {isExternalUser ? (
               <PLUGIN_TENANTS.ReactivateExternalUserButton user={user} />
             ) : (
               <ReactivateUserButton user={user} />
@@ -112,7 +112,7 @@ export const PeopleListRow = ({
       ) : (
         <Fragment>
           <td>
-            {isExternal ? (
+            {isExternalUser ? (
               <PLUGIN_TENANTS.TenantDisplayName id={user.tenant_id} />
             ) : (
               <MembershipSelect
@@ -142,7 +142,7 @@ export const PeopleListRow = ({
                 <Menu.Dropdown>
                   <Menu.Item
                     component={ForwardRefLink}
-                    to={Urls.editUser(user, routePrefix)}
+                    to={Urls.editUser(user, isExternal)}
                   >
                     {t`Edit user`}
                   </Menu.Item>
@@ -150,20 +150,20 @@ export const PeopleListRow = ({
                   {isPasswordLoginEnabled && (
                     <Menu.Item
                       component={ForwardRefLink}
-                      to={Urls.resetPassword(user, routePrefix)}
+                      to={Urls.resetPassword(user, isExternal)}
                     >
                       {t`Reset password`}
                     </Menu.Item>
                   )}
 
                   {PLUGIN_ADMIN_USER_MENU_ITEMS.flatMap((getItems) =>
-                    getItems(user, routePrefix),
+                    getItems(user, isExternal),
                   )}
 
                   {!isCurrentUser && (
                     <Menu.Item
                       component={ForwardRefLink}
-                      to={Urls.deactivateUser(user, routePrefix)}
+                      to={Urls.deactivateUser(user, isExternal)}
                       c="danger"
                     >
                       {t`Deactivate user`}

--- a/frontend/src/metabase/admin/people/containers/EditUserModal/EditUserModal.tsx
+++ b/frontend/src/metabase/admin/people/containers/EditUserModal/EditUserModal.tsx
@@ -26,7 +26,7 @@ export const EditUserModal = ({ onClose, params }: EditUserModalProps) => {
 
   // Always consider users with an associated tenant as external users.
   // This allows editing external users from the "People" page.
-  const isExternal = PLUGIN_TENANTS.isExternalUser(user);
+  const isExternalUser = PLUGIN_TENANTS.isExternalUser(user);
 
   const initialValues = useMemo(
     () => ({
@@ -37,11 +37,11 @@ export const EditUserModal = ({ onClose, params }: EditUserModalProps) => {
       login_attributes: user?.login_attributes || {},
       user_group_memberships: user?.user_group_memberships || [],
 
-      ...(isExternal
+      ...(isExternalUser
         ? { tenant_id: user?.tenant_id }
         : { user_group_memberships: user?.user_group_memberships || [] }),
     }),
-    [user, isExternal],
+    [user, isExternalUser],
   );
 
   const handleSubmit = async (newValues: Partial<User>) => {
@@ -64,7 +64,7 @@ export const EditUserModal = ({ onClose, params }: EditUserModalProps) => {
           onCancel={onClose}
           initialValues={initialValues}
           onSubmit={handleSubmit}
-          external={isExternal}
+          external={isExternalUser}
           userId={userId}
           edit
         />

--- a/frontend/src/metabase/admin/people/containers/PeopleListingApp/PeopleListingApp.tsx
+++ b/frontend/src/metabase/admin/people/containers/PeopleListingApp/PeopleListingApp.tsx
@@ -6,10 +6,7 @@ import {
   SettingsPageWrapper,
   SettingsSection,
 } from "metabase/admin/components/SettingsSection";
-import {
-  useListPermissionsGroupsQuery,
-  useListUsersQuery,
-} from "metabase/api";
+import { useListPermissionsGroupsQuery, useListUsersQuery } from "metabase/api";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
@@ -59,12 +56,12 @@ export function PeopleListingApp({
     updateStatus,
     handleNextPage,
     handlePreviousPage,
-  } = usePeopleQuery(PAGE_SIZE, external ? "external" : "internal");
+  } = usePeopleQuery(PAGE_SIZE, external ? "external" : "all");
 
   const { data: usersData } = useListUsersQuery({
     status: "deactivated",
     limit: 0,
-    ...(external ? { tenancy: "external" } : { tenancy: "internal" }),
+    ...(external ? { tenancy: "external" } : { tenancy: "all" }),
   });
   const hasDeactivatedUsers = usersData && usersData.total > 0;
 
@@ -141,7 +138,6 @@ export function PeopleListingApp({
 
               {currentUser && (
                 <PeopleList
-                  external={external}
                   groups={groups}
                   isAdmin={isAdmin}
                   currentUser={currentUser}
@@ -149,6 +145,9 @@ export function PeopleListingApp({
                   onNextPage={handleNextPage}
                   onPreviousPage={handlePreviousPage}
                   noResultsMessage={noUsersFoundMessage}
+                  routePrefix={
+                    external ? "/admin/tenants/people" : "/admin/people"
+                  }
                 />
               )}
 

--- a/frontend/src/metabase/admin/people/containers/PeopleListingApp/PeopleListingApp.tsx
+++ b/frontend/src/metabase/admin/people/containers/PeopleListingApp/PeopleListingApp.tsx
@@ -145,9 +145,7 @@ export function PeopleListingApp({
                   onNextPage={handleNextPage}
                   onPreviousPage={handlePreviousPage}
                   noResultsMessage={noUsersFoundMessage}
-                  routePrefix={
-                    external ? "/admin/tenants/people" : "/admin/people"
-                  }
+                  isExternal={external}
                 />
               )}
 

--- a/frontend/src/metabase/admin/people/containers/PeopleListingApp/PeopleListingApp.unit.spec.tsx
+++ b/frontend/src/metabase/admin/people/containers/PeopleListingApp/PeopleListingApp.unit.spec.tsx
@@ -26,6 +26,7 @@ const setup = ({
     is_superuser: true,
   }),
   tenants = [],
+  isUsingTenants = false,
 }: {
   external?: boolean;
   showInviteButton?: boolean;
@@ -33,11 +34,13 @@ const setup = ({
   users?: User[];
   currentUser?: User;
   tenants?: Tenant[];
+  isUsingTenants?: boolean;
 } = {}) => {
   const settings = mockSettings({
     "token-features": createMockTokenFeatures({
       tenants: true,
     }),
+    "use-tenants": isUsingTenants,
   });
 
   setupEnterprisePlugins();
@@ -75,12 +78,19 @@ const setup = ({
 
 describe("people table", () => {
   it("should show group association when viewing internal users", async () => {
-    setup();
+    setup({ isUsingTenants: true });
 
     expect(await screen.findByText("Name")).toBeInTheDocument();
     expect(await screen.findByText("Email")).toBeInTheDocument();
     expect(await screen.findByText("Groups / Tenant")).toBeInTheDocument();
     expect(await screen.findByText("Last Login")).toBeInTheDocument();
+  });
+
+  it("should show not show tenants in table header when tenants are disabled", async () => {
+    setup({ isUsingTenants: false });
+
+    expect(await screen.findByText("Groups")).toBeInTheDocument();
+    expect(screen.queryByText("Groups / Tenant")).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/src/metabase/admin/people/containers/PeopleListingApp/PeopleListingApp.unit.spec.tsx
+++ b/frontend/src/metabase/admin/people/containers/PeopleListingApp/PeopleListingApp.unit.spec.tsx
@@ -79,7 +79,7 @@ describe("people table", () => {
 
     expect(await screen.findByText("Name")).toBeInTheDocument();
     expect(await screen.findByText("Email")).toBeInTheDocument();
-    expect(await screen.findByText("Groups")).toBeInTheDocument();
+    expect(await screen.findByText("Groups / Tenant")).toBeInTheDocument();
     expect(await screen.findByText("Last Login")).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/lib/urls/admin.ts
+++ b/frontend/src/metabase/lib/urls/admin.ts
@@ -1,12 +1,14 @@
 import type {
-  DatabaseId,
   BaseUser,
+  DatabaseId,
   SchemaName,
   TableId,
-  UserId,
 } from "metabase-types/api";
 
 export const isInternalUser = (user: BaseUser) => user.tenant_id === null;
+
+const getPeopleRoutePrefix = (user: BaseUser) =>
+  isInternalUser(user) ? "/admin/people" : "/admin/tenants/people";
 
 export function newUser() {
   return `/admin/people/new`;
@@ -15,34 +17,24 @@ export function newTenantUser() {
   return "/admin/tenants/people/new";
 }
 
-export function editUser(user: BaseUser) {
-  return isInternalUser(user)
-    ? `/admin/people/${user.id}/edit`
-    : `/admin/tenants/people/${user.id}/edit`;
+export function editUser(user: BaseUser, routePrefix: string) {
+  return `${routePrefix}/${user.id}/edit`;
 }
 
-export function resetPassword(user: BaseUser) {
-  return isInternalUser(user)
-    ? `/admin/people/${user.id}/reset`
-    : `/admin/tenants/people/${user.id}/reset`;
+export function resetPassword(user: BaseUser, routePrefix: string) {
+  return `${routePrefix}/${user.id}/reset`;
 }
 
 export function newUserSuccess(user: BaseUser) {
-  return isInternalUser(user)
-    ? `/admin/people/${user.id}/success`
-    : `/admin/tenants/people/${user.id}/success`;
+  return `${getPeopleRoutePrefix(user)}/${user.id}/success`;
 }
 
-export function deactivateUser(user: BaseUser) {
-  return isInternalUser(user)
-    ? `/admin/people/${user.id}/deactivate`
-    : `/admin/tenants/people/${user.id}/deactivate`;
+export function deactivateUser(user: BaseUser, routePrefix: string) {
+  return `${routePrefix}/${user.id}/deactivate`;
 }
 
 export function reactivateUser(user: BaseUser) {
-  return isInternalUser(user)
-    ? `/admin/people/${user.id}/reactivate`
-    : `/admin/tenants/people/${user.id}/reactivate`;
+  return `${getPeopleRoutePrefix(user)}/${user.id}/reactivate`;
 }
 
 // TODO: move to EE urls

--- a/frontend/src/metabase/lib/urls/admin.ts
+++ b/frontend/src/metabase/lib/urls/admin.ts
@@ -1,11 +1,10 @@
+import { PLUGIN_TENANTS } from "metabase/plugins";
 import type {
   BaseUser,
   DatabaseId,
   SchemaName,
   TableId,
 } from "metabase-types/api";
-
-export const isInternalUser = (user: BaseUser) => user.tenant_id === null;
 
 const getPeopleRoutePrefix = (isExternal: boolean) =>
   isExternal ? "/admin/tenants/people" : "/admin/people";
@@ -17,30 +16,32 @@ export function newTenantUser() {
   return "/admin/tenants/people/new";
 }
 
-export function editUser(user: BaseUser, isExternal: boolean) {
-  return `${getPeopleRoutePrefix(isExternal)}/${user.id}/edit`;
+export function editUser(user: BaseUser, isExternalPage: boolean) {
+  return `${getPeopleRoutePrefix(isExternalPage)}/${user.id}/edit`;
 }
 
-export function resetPassword(user: BaseUser, isExternal: boolean) {
-  return `${getPeopleRoutePrefix(isExternal)}/${user.id}/reset`;
+export function resetPassword(user: BaseUser, isExternalPage: boolean) {
+  return `${getPeopleRoutePrefix(isExternalPage)}/${user.id}/reset`;
 }
 
 export function newUserSuccess(user: BaseUser) {
-  const isExternal = !isInternalUser(user);
-  return `${getPeopleRoutePrefix(isExternal)}/${user.id}/success`;
+  const isExternalUser = PLUGIN_TENANTS.isExternalUser(user);
+
+  return `${getPeopleRoutePrefix(isExternalUser)}/${user.id}/success`;
 }
 
-export function deactivateUser(user: BaseUser, isExternal: boolean) {
-  return `${getPeopleRoutePrefix(isExternal)}/${user.id}/deactivate`;
+export function deactivateUser(user: BaseUser, isExternalPage: boolean) {
+  return `${getPeopleRoutePrefix(isExternalPage)}/${user.id}/deactivate`;
 }
 
 export function reactivateUser(user: BaseUser) {
-  const isExternal = !isInternalUser(user);
-  return `${getPeopleRoutePrefix(isExternal)}/${user.id}/reactivate`;
+  const isExternalUser = PLUGIN_TENANTS.isExternalUser(user);
+
+  return `${getPeopleRoutePrefix(isExternalUser)}/${user.id}/reactivate`;
 }
 
-export function unsubscribeUser(user: BaseUser, isExternal: boolean) {
-  return `${getPeopleRoutePrefix(isExternal)}/${user.id}/unsubscribe`;
+export function unsubscribeUser(user: BaseUser, isExternalPage: boolean) {
+  return `${getPeopleRoutePrefix(isExternalPage)}/${user.id}/unsubscribe`;
 }
 
 // TODO: move to EE urls

--- a/frontend/src/metabase/lib/urls/admin.ts
+++ b/frontend/src/metabase/lib/urls/admin.ts
@@ -7,9 +7,8 @@ import type {
 
 export const isInternalUser = (user: BaseUser) => user.tenant_id === null;
 
-const getPeopleRoutePrefix = (isExternal: boolean) => {
-  return isExternal ? "/admin/tenants/people" : "/admin/people";
-};
+const getPeopleRoutePrefix = (isExternal: boolean) =>
+  isExternal ? "/admin/tenants/people" : "/admin/people";
 
 export function newUser() {
   return `/admin/people/new`;

--- a/frontend/src/metabase/lib/urls/admin.ts
+++ b/frontend/src/metabase/lib/urls/admin.ts
@@ -7,8 +7,9 @@ import type {
 
 export const isInternalUser = (user: BaseUser) => user.tenant_id === null;
 
-const getPeopleRoutePrefix = (user: BaseUser) =>
-  isInternalUser(user) ? "/admin/people" : "/admin/tenants/people";
+const getPeopleRoutePrefix = (isExternal: boolean) => {
+  return isExternal ? "/admin/tenants/people" : "/admin/people";
+};
 
 export function newUser() {
   return `/admin/people/new`;
@@ -17,24 +18,30 @@ export function newTenantUser() {
   return "/admin/tenants/people/new";
 }
 
-export function editUser(user: BaseUser, routePrefix: string) {
-  return `${routePrefix}/${user.id}/edit`;
+export function editUser(user: BaseUser, isExternal: boolean) {
+  return `${getPeopleRoutePrefix(isExternal)}/${user.id}/edit`;
 }
 
-export function resetPassword(user: BaseUser, routePrefix: string) {
-  return `${routePrefix}/${user.id}/reset`;
+export function resetPassword(user: BaseUser, isExternal: boolean) {
+  return `${getPeopleRoutePrefix(isExternal)}/${user.id}/reset`;
 }
 
 export function newUserSuccess(user: BaseUser) {
-  return `${getPeopleRoutePrefix(user)}/${user.id}/success`;
+  const isExternal = !isInternalUser(user);
+  return `${getPeopleRoutePrefix(isExternal)}/${user.id}/success`;
 }
 
-export function deactivateUser(user: BaseUser, routePrefix: string) {
-  return `${routePrefix}/${user.id}/deactivate`;
+export function deactivateUser(user: BaseUser, isExternal: boolean) {
+  return `${getPeopleRoutePrefix(isExternal)}/${user.id}/deactivate`;
 }
 
 export function reactivateUser(user: BaseUser) {
-  return `${getPeopleRoutePrefix(user)}/${user.id}/reactivate`;
+  const isExternal = !isInternalUser(user);
+  return `${getPeopleRoutePrefix(isExternal)}/${user.id}/reactivate`;
+}
+
+export function unsubscribeUser(user: BaseUser, isExternal: boolean) {
+  return `${getPeopleRoutePrefix(isExternal)}/${user.id}/unsubscribe`;
 }
 
 // TODO: move to EE urls

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -229,7 +229,7 @@ export const PLUGIN_ADMIN_USER_FORM_FIELDS = {
 
 // menu items in people management tab
 export const PLUGIN_ADMIN_USER_MENU_ITEMS = [] as Array<
-  (user: User, routePrefix: string) => React.ReactNode
+  (user: User, isExternal: boolean) => React.ReactNode
 >;
 export const PLUGIN_ADMIN_USER_MENU_ROUTES = [] as (() => ReactNode)[];
 

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -229,7 +229,7 @@ export const PLUGIN_ADMIN_USER_FORM_FIELDS = {
 
 // menu items in people management tab
 export const PLUGIN_ADMIN_USER_MENU_ITEMS = [] as Array<
-  (user: User) => React.ReactNode
+  (user: User, routePrefix: string) => React.ReactNode
 >;
 export const PLUGIN_ADMIN_USER_MENU_ROUTES = [] as (() => ReactNode)[];
 


### PR DESCRIPTION
Closes EMB-1008

### Description

Shows external tenant users in the "People" 

### How to verify

- Use the MB_ALL_FEATURES_TOKEN as this is an in-development feature
- Enable multi-tenancy by going to "People > Settings Icon" and set User Strategy to Multi-tenant
- Create a tenant in the "Tenant" menu
- Create an external user in the "External Users" menu
- Go back to the "People" tab
- You should see that new external user shown up in the "People" tab
- You should be able to "Edit user" on both internal and external users

### Demo

External users are now shown in the "People" tab

<img width="2472" height="1332" alt="CleanShot 2568-11-21 at 01 44 14@2x" src="https://github.com/user-attachments/assets/bc5487b7-0b97-4c62-8cd6-87cae2ef1cdb" />

Editing external users shows the tenant select

<img width="2464" height="1664" alt="CleanShot 2568-11-21 at 01 45 43@2x" src="https://github.com/user-attachments/assets/ca70fa26-530b-4df5-8aae-ad382c125323" />

Editing internal users shows the groups select

<img width="2468" height="1650" alt="CleanShot 2568-11-21 at 01 45 30@2x" src="https://github.com/user-attachments/assets/0bd539e6-8876-43fc-ba51-dbc1e4e057db" />

Setting user strategy back to "Single tenant" should hide all the external users, and the column header should say "Groups" instead of "Groups / Tenant"

<img width="2476" height="1242" alt="CleanShot 2568-11-21 at 01 48 21@2x" src="https://github.com/user-attachments/assets/0b13f8fd-4c3f-40c8-8586-d43b6470478e" />

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
