### PR TITLE
Fix purchase page for paid Metabase AI add-on for non-store users

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotPurchasePage/MetabotPurchasePage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotPurchasePage/MetabotPurchasePage.tsx
@@ -1,181 +1,27 @@
-import { useDisclosure } from "@mantine/hooks";
-import { type ReactElement, useCallback } from "react";
-import { P, match } from "ts-pattern";
+import type { ReactElement } from "react";
 import { t } from "ttag";
-import * as Yup from "yup";
 
-import {
-  SettingsPageWrapper,
-  SettingsSection,
-} from "metabase/admin/components/SettingsSection";
-import ExternalLink from "metabase/common/components/ExternalLink";
-import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
-import {
-  Form,
-  FormCheckbox,
-  FormProvider,
-  FormSubmitButton,
-} from "metabase/forms";
+import { SettingsPageWrapper } from "metabase/admin/components/SettingsSection";
 import { useSelector } from "metabase/lib/redux";
 import { getStoreUsers } from "metabase/selectors/store-users";
-import { Card, Stack, Text } from "metabase/ui";
-import { usePurchaseCloudAddOnMutation } from "metabase-enterprise/api";
+import { Text } from "metabase/ui";
 
-import { MetabotSettingUpModal } from "../MetabotSettingUpModal";
-import { handleFieldError, isFetchBaseQueryError } from "../utils";
-
-import { MetabotRadios } from "./MetabotRadios";
-import { useAddOnsBilling } from "./hooks";
-import type { IMetabotPurchaseFormFields } from "./types";
+import { MetabotPurchasePageForNonStoreUser } from "./MetabotPurchasePageForNonStoreUser";
+import { MetabotPurchasePageForStoreUser } from "./MetabotPurchasePageForStoreUser";
 
 export function MetabotPurchasePage(): ReactElement {
   const { isStoreUser, anyStoreUserEmailAddress } = useSelector(getStoreUsers);
-
-  const { isLoading, error, billingPeriodMonths, tiers, defaultQuantity } =
-    useAddOnsBilling();
-  const hasData =
-    billingPeriodMonths !== undefined &&
-    defaultQuantity !== undefined &&
-    tiers.length > 0;
-
-  const [settingUpModalOpened, settingUpModalHandlers] = useDisclosure(false);
-  const [purchaseCloudAddOn] = usePurchaseCloudAddOnMutation();
-  const onSubmit = useCallback(
-    async ({ quantity, terms_of_service }: IMetabotPurchaseFormFields) => {
-      settingUpModalHandlers.open();
-      await purchaseCloudAddOn({
-        product_type: "metabase-ai-tiered",
-        quantity: parseInt(quantity, 10),
-        terms_of_service,
-      })
-        .unwrap()
-        .catch((error: unknown) => {
-          settingUpModalHandlers.close();
-          if (isFetchBaseQueryError(error)) {
-            handleFieldError<IMetabotPurchaseFormFields>(
-              error.data,
-              "terms_of_service",
-            );
-          }
-          throw error;
-        });
-    },
-    [purchaseCloudAddOn, settingUpModalHandlers],
-  );
-
-  if (error || !hasData || isLoading) {
-    return (
-      <LoadingAndErrorWrapper
-        loading={isLoading}
-        error={match({
-          isLoading,
-          hasData,
-          error,
-        })
-          .with(
-            { isLoading: false, hasData: P.any, error: P.nonNullable },
-            { isLoading: false, hasData: false, error: P.any },
-            () => t`Error fetching information about available add-ons.`,
-          )
-          .otherwise(() => null)}
-      />
-    );
-  }
-
-  const validationSchema = Yup.object({
-    quantity: Yup.string()
-      .required()
-      .test(
-        "quantity-is-int",
-        t`Quantity must be a positive integer`,
-        (v) => !!v && parseInt(v, 10) > 0,
-      ),
-    terms_of_service: Yup.boolean()
-      .required()
-      .isTrue(t`Terms of Service must be accepted`),
-  });
 
   return (
     <SettingsPageWrapper title={t`Metabot AI`}>
       <Text maw="26rem">{t`Metabot helps you move faster and understand your data better. You can ask it to generate SQL, and build or explain queries.`}</Text>
       {isStoreUser ? (
-        <SettingsSection
-          title={t`Monthly usage limit`}
-          description={
-            <Text
-              maw="35rem"
-              mt="sm"
-            >{t`Usage is measured in Metabot requests. If a chat has multiple questions, they are counted as separate Metabot requests. Usage limit applies to your whole organization.`}</Text>
-          }
-        >
-          <FormProvider
-            initialValues={{
-              quantity: `${defaultQuantity}`,
-              terms_of_service: false,
-            }}
-            onSubmit={onSubmit}
-            validationSchema={validationSchema}
-          >
-            {({ values }) => (
-              <Form>
-                <Stack gap="xl" w="100%">
-                  <MetabotRadios
-                    quantity={values.quantity}
-                    tiers={tiers}
-                    billingPeriodMonths={billingPeriodMonths}
-                  />
-
-                  <Stack gap="md">
-                    {/* eslint-disable-next-line no-literal-metabase-strings -- This string only shows for admins. */}
-                    <Text maw="35rem">{t`Additional amount for the add-on will be added to your next billing period invoice. You can cancel the add-on anytime in Metabase Store.`}</Text>
-
-                    <Card
-                      bg="var(--mb-color-bg-light)"
-                      p={12}
-                      radius="md"
-                      shadow="none"
-                      w="100%"
-                    >
-                      <FormCheckbox
-                        name="terms_of_service"
-                        label={
-                          <Text>
-                            {t`I agree with the Metabot AI add-on`}{" "}
-                            <ExternalLink href="https://www.metabase.com/license/hosting">{t`Terms of Service`}</ExternalLink>
-                          </Text>
-                        }
-                      />
-                    </Card>
-
-                    <FormSubmitButton
-                      disabled={!values.terms_of_service}
-                      label={t`Confirm purchase`}
-                      failedLabel={t`Failed to purchase Metabot AI`}
-                      variant="filled"
-                      w="100%"
-                    />
-                  </Stack>
-                </Stack>
-              </Form>
-            )}
-          </FormProvider>
-        </SettingsSection>
+        <MetabotPurchasePageForStoreUser />
       ) : (
-        <Text fw="bold">
-          {
-            /* eslint-disable-next-line no-literal-metabase-strings -- This string only shows for admins. */
-            t`Please ask a Metabase Store Admin${anyStoreUserEmailAddress && ` (${anyStoreUserEmailAddress})`} of your organization to enable this for you.`
-          }
-        </Text>
+        <MetabotPurchasePageForNonStoreUser
+          anyStoreUserEmailAddress={anyStoreUserEmailAddress}
+        />
       )}
-
-      <MetabotSettingUpModal
-        opened={settingUpModalOpened}
-        onClose={() => {
-          settingUpModalHandlers.close();
-          window.location.reload();
-        }}
-      />
     </SettingsPageWrapper>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotPurchasePage/MetabotPurchasePageForNonStoreUser.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotPurchasePage/MetabotPurchasePageForNonStoreUser.tsx
@@ -1,0 +1,16 @@
+import { t } from "ttag";
+
+import { Text } from "metabase/ui";
+
+import type { IPageForNonStoreUserProps } from "./types";
+
+export const MetabotPurchasePageForNonStoreUser = ({
+  anyStoreUserEmailAddress,
+}: IPageForNonStoreUserProps) => (
+  <Text fw="bold">
+    {
+      /* eslint-disable-next-line no-literal-metabase-strings -- This string only shows for admins. */
+      t`Please ask a Metabase Store Admin${anyStoreUserEmailAddress && ` (${anyStoreUserEmailAddress})`} of your organization to enable this for you.`
+    }
+  </Text>
+);

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotPurchasePage/MetabotPurchasePageForStoreUser.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotPurchasePage/MetabotPurchasePageForStoreUser.tsx
@@ -1,0 +1,164 @@
+import { useDisclosure } from "@mantine/hooks";
+import { useCallback } from "react";
+import { P, match } from "ts-pattern";
+import { t } from "ttag";
+import * as Yup from "yup";
+
+import { SettingsSection } from "metabase/admin/components/SettingsSection";
+import ExternalLink from "metabase/common/components/ExternalLink";
+import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
+import {
+  Form,
+  FormCheckbox,
+  FormProvider,
+  FormSubmitButton,
+} from "metabase/forms";
+import { Card, Stack, Text } from "metabase/ui";
+import { usePurchaseCloudAddOnMutation } from "metabase-enterprise/api";
+
+import { MetabotSettingUpModal } from "../MetabotSettingUpModal";
+import { handleFieldError, isFetchBaseQueryError } from "../utils";
+
+import { MetabotRadios } from "./MetabotRadios";
+import { useAddOnsBilling } from "./hooks";
+import type { IMetabotPurchaseFormFields } from "./types";
+
+export const MetabotPurchasePageForStoreUser = () => {
+  const { isLoading, error, billingPeriodMonths, tiers, defaultQuantity } =
+    useAddOnsBilling();
+  const hasData =
+    billingPeriodMonths !== undefined &&
+    defaultQuantity !== undefined &&
+    tiers.length > 0;
+
+  const [settingUpModalOpened, settingUpModalHandlers] = useDisclosure(false);
+  const [purchaseCloudAddOn] = usePurchaseCloudAddOnMutation();
+  const onSubmit = useCallback(
+    async ({ quantity, terms_of_service }: IMetabotPurchaseFormFields) => {
+      settingUpModalHandlers.open();
+      await purchaseCloudAddOn({
+        product_type: "metabase-ai-tiered",
+        quantity: parseInt(quantity, 10),
+        terms_of_service,
+      })
+        .unwrap()
+        .catch((error: unknown) => {
+          settingUpModalHandlers.close();
+          if (isFetchBaseQueryError(error)) {
+            handleFieldError<IMetabotPurchaseFormFields>(
+              error.data,
+              "terms_of_service",
+            );
+          }
+          throw error;
+        });
+    },
+    [purchaseCloudAddOn, settingUpModalHandlers],
+  );
+
+  if (error || !hasData || isLoading) {
+    return (
+      <LoadingAndErrorWrapper
+        loading={isLoading}
+        error={match({
+          isLoading,
+          hasData,
+          error,
+        })
+          .with(
+            { isLoading: false, hasData: P.any, error: P.nonNullable },
+            { isLoading: false, hasData: false, error: P.any },
+            () => t`Error fetching information about available add-ons.`,
+          )
+          .otherwise(() => null)}
+      />
+    );
+  }
+
+  const validationSchema = Yup.object({
+    quantity: Yup.string()
+      .required()
+      .test(
+        "quantity-is-int",
+        t`Quantity must be a positive integer`,
+        (v) => !!v && parseInt(v, 10) > 0,
+      ),
+    terms_of_service: Yup.boolean()
+      .required()
+      .isTrue(t`Terms of Service must be accepted`),
+  });
+
+  return (
+    <>
+      <SettingsSection
+        title={t`Monthly usage limit`}
+        description={
+          <Text
+            maw="35rem"
+            mt="sm"
+          >{t`Usage is measured in Metabot requests. If a chat has multiple questions, they are counted as separate Metabot requests. Usage limit applies to your whole organization.`}</Text>
+        }
+      >
+        <FormProvider
+          initialValues={{
+            quantity: `${defaultQuantity}`,
+            terms_of_service: false,
+          }}
+          onSubmit={onSubmit}
+          validationSchema={validationSchema}
+        >
+          {({ values }) => (
+            <Form>
+              <Stack gap="xl" w="100%">
+                <MetabotRadios
+                  quantity={values.quantity}
+                  tiers={tiers}
+                  billingPeriodMonths={billingPeriodMonths}
+                />
+
+                <Stack gap="md">
+                  {/* eslint-disable-next-line no-literal-metabase-strings -- This string only shows for admins. */}
+                  <Text maw="35rem">{t`Additional amount for the add-on will be added to your next billing period invoice. You can cancel the add-on anytime in Metabase Store.`}</Text>
+
+                  <Card
+                    bg="var(--mb-color-bg-light)"
+                    p={12}
+                    radius="md"
+                    shadow="none"
+                    w="100%"
+                  >
+                    <FormCheckbox
+                      name="terms_of_service"
+                      label={
+                        <Text>
+                          {t`I agree with the Metabot AI add-on`}{" "}
+                          <ExternalLink href="https://www.metabase.com/license/hosting">{t`Terms of Service`}</ExternalLink>
+                        </Text>
+                      }
+                    />
+                  </Card>
+
+                  <FormSubmitButton
+                    disabled={!values.terms_of_service}
+                    label={t`Confirm purchase`}
+                    failedLabel={t`Failed to purchase Metabot AI`}
+                    variant="filled"
+                    w="100%"
+                  />
+                </Stack>
+              </Stack>
+            </Form>
+          )}
+        </FormProvider>
+      </SettingsSection>
+
+      <MetabotSettingUpModal
+        opened={settingUpModalOpened}
+        onClose={() => {
+          settingUpModalHandlers.close();
+          window.location.reload();
+        }}
+      />
+    </>
+  );
+};

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotPurchasePage/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotPurchasePage/types.ts
@@ -5,6 +5,10 @@ export interface IMetabotPurchaseFormFields {
   terms_of_service: boolean;
 }
 
+export interface IPageForNonStoreUserProps {
+  anyStoreUserEmailAddress?: string;
+}
+
 export interface IMetabotRadioProps {
   selected?: boolean;
   value: string;


### PR DESCRIPTION
### Description

Missing billing information is treated as an error for purposes of displaying the purchase page with prices.  Non-store users cannot retrieve billing information.  Thus, previously, they would always see an error page: "Error fetching information about available add-ons." With this change, they see the "Please ask a Metabase Store Admin" page as intended.

We achieve this by splitting the page content for store users from that of non-store users.  Only the former needs to load data (billing and add-on information), so only that page needs `LoadingAndErrorWrapper`. For store users we show no dynamic content that could fail to load (apart from a store user's email address, which we gracefully omit if it is missing).

### How to verify

1. Ensure you have a token with the `offer-metabase-ai-tiered` feature, but without the `metabot-v3` and `offer-metabase-ai` features.
2. As a Metabase user with an email address that *does not* match any of the token's organization's store user email addresses, navigate to `/admin/metabot` and see "Please ask a Metabase Store Admin".
3. As a Metabase user with an email address that *does* match any of the token's organization's store user email addresses, navigate to `/admin/metabot` and see the purchase page with tier selector.

### Demo

#### Store user with error

<img width="2822" height="932" alt="image" src="https://github.com/user-attachments/assets/a184fdf8-ccec-44db-894b-3cabb5c15149" />

#### Non-store user

<img width="3200" height="742" alt="image" src="https://github.com/user-attachments/assets/f4bd49af-81c3-4026-bb29-e92ed4ae6fb3" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR

Fixes: 2b76c38e1f0a84d9f1b287124485568886ca9bc9
Closes: https://metaboat.slack.com/archives/C07RMUQ0GE5/p1763644357893079