### PR TITLE
docs - links workflow

### DIFF
--- a/.github/workflows/docs-links.yml
+++ b/.github/workflows/docs-links.yml
@@ -2,8 +2,6 @@ name: Check doc links
 
 on:
   pull_request:
-    paths:
-      - "docs/**"
   workflow_dispatch:
 
 jobs:

--- a/.lychee/config.toml
+++ b/.lychee/config.toml
@@ -1,5 +1,8 @@
 accept = ["200..=204", "429"]
-exclude_path = ["docs/embedding/sdk", "docs/embedding/snippets", "docs/util"]
+exclude = ["\\.html(#.*)?$"]
+exclude_path = ["docs/util"]
 no_progress = true
 include_fragments = true
 verbose = "error"
+include_verbatim = false
+cache = false

--- a/.lychee/config.toml
+++ b/.lychee/config.toml
@@ -1,5 +1,5 @@
 accept = ["200..=204", "429"]
-exclude_path = ["docs/embedding/sdk", "docs/utils"]
+exclude_path = ["docs/embedding/sdk", "docs/embedding/snippets", "docs/util"]
 no_progress = true
 include_fragments = true
 verbose = "error"

--- a/.lychee/config.toml
+++ b/.lychee/config.toml
@@ -1,5 +1,5 @@
 accept = ["200..=204", "429"]
-exclude_path = ["docs/embedding/sdk"]
+exclude_path = ["docs/embedding/sdk", "docs/utils"]
 no_progress = true
 include_fragments = true
 verbose = "error"


### PR DESCRIPTION
* Updated `.lychee/config.toml` to exclude all `.html` URLs (with optional fragments) from link checks, and added `docs/util` to the excluded paths. Also disabled verbatim inclusion and caching for link checks.
* Modified `.github/workflows/docs-links.yml` to remove the restriction that the link check workflow only runs on changes in the `docs/**` directory, allowing it to be triggered for all pull requests. This way we should be able to require it.