### PR TITLE
[deps] Refresh the result_metadata of downstream cards

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1613,7 +1613,6 @@
            warehouses
            enterprise/advanced-permissions}}
 
-
   xrays
   {:team "Querying"
    :api  #{metabase.xrays.api
@@ -1873,7 +1872,8 @@
    :api  #{metabase-enterprise.dependencies.api
            metabase-enterprise.dependencies.core
            metabase-enterprise.dependencies.init}
-   :uses #{analyze
+   :uses #{analytics
+           analyze
            api
            collections
            config

--- a/enterprise/backend/src/metabase_enterprise/dependencies/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/init.clj
@@ -3,4 +3,5 @@
    [metabase-enterprise.dependencies.events]
    [metabase-enterprise.dependencies.schema]
    [metabase-enterprise.dependencies.settings]
-   [metabase-enterprise.dependencies.task.backfill]))
+   [metabase-enterprise.dependencies.task.backfill]
+   [metabase-enterprise.dependencies.task.result-metadata-refresh]))

--- a/enterprise/backend/src/metabase_enterprise/dependencies/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/settings.clj
@@ -25,3 +25,27 @@
   :default    30
   :setter     :none
   :export?    false)
+
+(defsetting card-metadata-refresh-batch-size
+  "Batch size for the background job that refreshes the saved metadata of cards with upstream changes."
+  :visibility :internal
+  :type       :integer
+  :default    50
+  :setter     :none
+  :export?    false)
+
+(defsetting card-metadata-refresh-delay-ms
+  "Card metadata refresh interval in millliseconds. Note that the delay will always be at least 10x longer than the run time."
+  :visibility :internal
+  :type       :integer
+  :default    10000
+  :setter     :none
+  :export?    false)
+
+(defsetting card-metadata-refresh-variance-ms
+  "Card metadata refresh variance in milliseconds. The refresh delay is adjusted randomly up or down by up to his amount. Prevents rhythmic loads on a cluster."
+  :visibility :internal
+  :type       :integer
+  :default    3000
+  :setter     :none
+  :export?    false)

--- a/enterprise/backend/src/metabase_enterprise/dependencies/task/result_metadata_refresh.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/task/result_metadata_refresh.clj
@@ -1,0 +1,242 @@
+(ns metabase-enterprise.dependencies.task.result-metadata-refresh
+  "Implements a task that drains an in-memory set of cards etc. whose deps have been updated, and also need an update.
+
+  Event listeners populate that set, and this background task drains it again. If the `:model/Dependency` graph is
+  not populated for this instance (eg. because it's OSS) then this has no effect because no downstream dependencies
+  will be found.
+
+  This is fundamentally best-effort - the queue of updates lives in memory and is lost of power-off, and if the
+  re-analysis of some key fails it still gets removed from the backlog of updates."
+  (:require
+   [better-cond.core :as b]
+   [clojurewerkz.quartzite.jobs :as jobs]
+   [clojurewerkz.quartzite.scheduler :as qs]
+   [clojurewerkz.quartzite.triggers :as triggers]
+   [java-time.api :as t]
+   [medley.core :as m]
+   [metabase-enterprise.dependencies.models.dependency :as deps.graph]
+   [metabase-enterprise.dependencies.settings :as deps.settings]
+   [metabase.analytics.prometheus :as prometheus]
+   [metabase.events.core :as events]
+   [metabase.graph.core :as graph]
+   [metabase.queries.core :as queries]
+   [metabase.task.core :as task]
+   [metabase.util :as u]
+   [metabase.util.log :as log]
+   [methodical.core :as methodical]
+   [toucan2.core :as t2])
+  (:import
+   (org.quartz ObjectAlreadyExistsException)))
+
+(set! *warn-on-reflection* true)
+
+(defn- current-millis
+  "Returns the current epoch millis. Uses java-time so that clock settings can be used in tests."
+  []
+  (t/to-millis-from-epoch (t/instant)))
+
+(def ^:private state
+  "A map `{:card {123 time-of-update}}` for dependencies. The first key is the type as used by `:model/Dependency`,
+  then the ID of the transform, card, etc. The time is used to skip entities which have already been updated since
+  the upstream update."
+  (atom {:refresh-needed {}
+         :running?       false}))
+
+(def ^:private failed-refreshes
+  "A map `{:card {123 Exception}}` of failed card refreshes."
+  (atom {}))
+
+(declare ^:private card-updated!)
+
+(defn- refresh-card!
+  "Given a card ID and the time at which something upstream last changed, refresh that card's `:result_metadata`.
+
+  Does nothing if the card has been updated since the upstream change, eg. by a different branch of downstream updates.
+
+  Returns the `:status` for sending to Prometheus: `:card-missing`, `:already-updated`, `:infer-failed`, `:refreshed`,
+  `:exception` or `:unchanged`."
+  [card-id upstream-changed-at]
+  (if-let [card (t2/select-one :model/Card :id card-id)]
+    (if (>= (t/to-millis-from-epoch (:updated_at card)) upstream-changed-at)
+      :already-updated
+      (try
+        (let [new-metadata (queries/infer-metadata-with-model-overrides (:dataset_query card) card)]
+          ;; The inferred metadata can be nil if there's an error processing the query - don't update in that case.
+          (cond
+            (not new-metadata) (do (log/debugf "Could not infer metadata for Card %d; not updating" card-id)
+                                   :failed)
+
+            (not= new-metadata (:result_metadata card))
+            (do (log/debugf "Metadata of Card %d has changed - updating appDB" card-id)
+                ;; Raw update because `queries.models.card/update-card!` tries to add Revisions etc. and this isn't
+                ;; a real, user-driven update.
+                (t2/update! :model/Card card-id {:result_metadata new-metadata})
+                ;; Manually add this card's downstream deps to the queue; it won't be automatically triggered.
+                (card-updated! card-id)
+                :refreshed)
+
+            :else (do (log/debugf "Metadata unchanged for Card %d; skipping the update" card-id)
+                      :unchanged)))
+        (catch Exception e
+          (swap! failed-refreshes assoc-in [:card card-id] e)
+          :exception)))
+    :card-missing))
+
+(defn- random-target
+  "Randomly chooses a target entity from the [[state]] map, and removes it.
+
+  Returns `[entity-type entity-id upstream-changed-at]` for the removed entry.
+  Returns nil if the map is empty."
+  []
+  (let [target (volatile! nil)]
+    (swap! state
+           (fn [{needed :refresh-needed :as s}]
+             (if (empty? needed)
+               s
+               (let [entity-type (rand-nth (keys needed))
+                     entity-id   (rand-nth (keys (get needed entity-type)))]
+                 (vreset! target [entity-type entity-id (get-in needed [entity-type entity-id])])
+                 (m/dissoc-in s [:refresh-needed entity-type entity-id])))))
+    @target))
+
+(defn- refresh-result-metadata!
+  "Job to refresh a single card's `:result_metadata`.
+
+  Returns the number of things updated in this batch."
+  []
+  (loop [refreshed     0
+         refresh-limit (deps.settings/card-metadata-refresh-batch-size)]
+    (if (zero? refresh-limit)
+      refreshed
+      (if-let [[entity-type entity-id upstream-changed-at] (random-target)]
+        (do (log/debugf "Refreshing metadata for %s %d because something upstream changed" entity-type entity-id)
+            (case entity-type
+              :card (u/prog1 (refresh-card! entity-id upstream-changed-at)
+                      (prometheus/inc! :metabase-card-refresh/result {:status (str <>)}))
+              (log/infof "Unexpected %s %d in the refresh-result-metadata queue" entity-type entity-id))
+            (recur (inc refreshed) (dec refresh-limit)))
+        ;; No target, so the queue if empty.
+        refreshed))))
+
+(defn- non-idle-interval
+  "`delay-ms` plus/minus up to `variance-ms`, but never less than 10x the time it took to execute the previous batch."
+  [last-batch-ms]
+  (let [variance-ms (deps.settings/card-metadata-refresh-variance-ms)
+        adjustment  (- (rand-int (* 2 variance-ms))
+                       variance-ms)
+        base-ms     (deps.settings/card-metadata-refresh-delay-ms)]
+    (max (* 10 last-batch-ms)
+         (+ base-ms adjustment))))
+
+(declare ^:private schedule-next-run!)
+
+(task/defjob
+  ^{:doc "Refreshing :result_metadata for cards that have had something change upstream."
+    ;; It's fine for this to run simultaneously on each instance, since the queue is in memory!
+    org.quartz.DisallowConcurrentExecution false}
+  RefreshResultMetadata [ctx]
+  (log/info "Executing RefreshResultMetadata job...")
+  (swap! state assoc :running? true)
+  (let [start-time    (t/instant)
+        n-refreshed   (refresh-result-metadata!)
+        end-time      (t/instant)
+        elapsed-ms    (t/time-between start-time end-time :millis)
+        delay-ms      (non-idle-interval elapsed-ms)]
+    (log/infof "Refreshed result_metdata for %d cards in %.2f seconds" n-refreshed (double (/ elapsed-ms 1000)))
+    (let [{:keys [refresh-needed]} (swap! state assoc :running? false)]
+      (if (empty? refresh-needed)
+        (log/debug "Not scheduling next run - no work in the queue")
+        (schedule-next-run! delay-ms (.getScheduler ctx))))))
+
+(def ^:private job-key     "metabase.task.card-metadata-refresh.job")
+(def ^:private trigger-key "metabase.task.card-metadata-refresh.trigger")
+
+(defn- schedule-next-run!
+  ([delay-ms] (schedule-next-run! delay-ms nil))
+  ([delay-ms scheduler]
+   (let [start-at (java.util.Date. (long (+ (current-millis) delay-ms)))
+         trigger  (triggers/build
+                   (triggers/with-identity (triggers/key (str trigger-key \. (random-uuid))))
+                   (triggers/for-job job-key)
+                   (triggers/start-at start-at))]
+     (log/debug "Scheduling next run at" start-at)
+     (b/cond
+       ;; first schedule
+       (not scheduler)
+       (let [job (jobs/build (jobs/of-type RefreshResultMetadata) (jobs/with-identity job-key))]
+         (log/debug "Scheduling for the first time")
+         (task/schedule-task! job trigger))
+
+       ;; Already scheduled, just let it run then.
+       :let [triggers (qs/get-triggers-of-job scheduler job-key)]
+       (seq triggers) (log/debugf "Existing schedule, letting it run: %s" (pr-str triggers))
+
+       ;; No next run scheduled, so schedule one.
+       :else          (qs/add-trigger scheduler trigger)))))
+
+(defn- schedule-now! []
+  (schedule-next-run! (rand-int (deps.settings/card-metadata-refresh-variance-ms))))
+
+(add-watch state ::watch
+           (fn [_key _ref old-value new-value]
+             (prometheus/set! :metabase-card-refresh/pending-refreshes
+                              (transduce (map count) + 0
+                                         (vals (:refresh-needed new-value))))
+             (when (and (empty? (:refresh-needed old-value))
+                        (seq (:refresh-needed new-value)))
+               (log/debug "Work added to empty queue - maybe rescheduling")
+               (if (:running? new-value)
+                 (log/debug "Job is running now - don't reschedule yet.")
+                 (try
+                   (log/debug "Job is not running - schedule it!")
+                   (schedule-now!)
+                   (catch ObjectAlreadyExistsException _
+                     (log/debug "Failed to schedule job, a trigger already exists")))))))
+
+(defmethod task/init! ::RefreshResultMetadata [_]
+  (if (pos? (deps.settings/card-metadata-refresh-batch-size))
+    (schedule-now!)
+    (log/info "Not starting card metadata refresh job because the batch size is not positive")))
+
+;; Queueing up things to run.
+(derive :event/sync-metadata-end         ::event.database-synced)
+(derive :event/table-manual-sync-success ::event.table-synced)
+(derive :event/card-update               ::event.card-updated)
+(derive :event/table-manual-sync-success :metabase/event)
+
+(defn- card-deps-of [entity-type entity-id]
+  (let [k          [entity-type entity-id]
+        dependents (-> (deps.graph/graph-dependents)
+                       (graph/children-of [k])
+                       (get k))]
+    (filter (comp #{:card} first) dependents)))
+
+(defn- add-refreshes [needed deps]
+  (let [now (current-millis)]
+    (reduce #(assoc-in %1 %2 now) needed deps)))
+
+(defn- card-updated! [card-id]
+  (when-let [cards (seq (card-deps-of :card card-id))]
+    (log/debugf "Card %d was updated - queueing %d downstream cards for metadata refresh" card-id (count cards))
+    (swap! state update :refresh-needed add-refreshes cards)))
+
+(methodical/defmethod events/publish-event! ::event.card-updated [_topic {card :object}]
+  (card-updated! (:id card)))
+
+(methodical/defmethod events/publish-event! ::event.table-synced [topic {table :object}]
+  (when-let [cards (seq (card-deps-of :table (:id table)))]
+    (log/debugf "Table %d was force-synced - queueing %d downstream cards for metadata refresh %s" (:id table) (count cards)
+                topic)
+    (swap! state update :refresh-needed add-refreshes cards)))
+
+(methodical/defmethod events/publish-event! ::event.database-synced [_topic {db-id :database_id}]
+  (let [tables (mapv #(vector :table %)
+                     (t2/select-pks-set :model/Table :db_id db-id))
+        deps   (graph/children-of (deps.graph/graph-dependents) tables)
+        cards  (into #{} (comp cat
+                               (filter (comp #{:card} first)))
+                     (vals deps))]
+    (when (seq cards)
+      (log/debugf "Database %d was synced, updating %d tables - queueing %d downstream cards for metadata refresh"
+                  db-id (count tables) (count cards))
+      (swap! state update :refresh-needed add-refreshes cards))))

--- a/enterprise/backend/test/metabase_enterprise/dependencies/task/result_metadata_refresh_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/task/result_metadata_refresh_test.clj
@@ -1,0 +1,154 @@
+(ns metabase-enterprise.dependencies.task.result-metadata-refresh-test
+  (:require
+   [clojure.test :refer :all]
+   [clojurewerkz.quartzite.jobs :as jobs]
+   [environ.core :as env]
+   [metabase-enterprise.dependencies.task.result-metadata-refresh :as dependencies.refresh]
+   [metabase-enterprise.dependencies.task.test-util :as dependencies.task.tu]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.queries.models.card :as card]
+   [metabase.task.core :as task]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(use-fixtures :once (fixtures/initialize :db))
+
+(defn- drain-refresh-queue!
+  []
+  (mt/with-premium-features #{:dependencies}
+    (while (pos? (#'dependencies.refresh/refresh-result-metadata!)))))
+
+(defn- refresh-single-batch!
+  []
+  (mt/with-premium-features #{:dependencies}
+    (#'dependencies.refresh/refresh-result-metadata!)))
+
+(defn- current-state []
+  (let [state-var  #'dependencies.refresh/state
+        state-atom @state-var]
+    @state-atom))
+
+(deftest ^:sequential drain-result-metadata-refresh-queue-test
+  (testing "Test that the refresh job correctly updates the result_metadata of cards after upstream changes"
+    (drain-refresh-queue!)
+    (with-redefs [env/env (assoc env/env :mb-card-metadata-refresh-batch-size "2")]
+      (let [mp       (mt/metadata-provider)
+            upstream (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+                         (lib/expression "Tax Rate" (lib// (lib.metadata/field mp (mt/id :orders :tax))
+                                                           (lib.metadata/field mp (mt/id :orders :subtotal)))))]
+        (mt/with-premium-features #{}
+          (mt/with-temp [:model/User user           {:email "me@wherever.com"}
+                         :model/Card {card1-id :id} {:dataset_query upstream}
+                         :model/Card {card2-id :id} {:dataset_query
+                                                     (let [mp (mt/metadata-provider)]
+                                                       (lib/query mp (lib.metadata/card mp card1-id)))}]
+            (dependencies.task.tu/backfill-all-existing-entities!)
+            (mt/with-current-user (:id user)
+              (testing "both upstream and downstream start with the original expression name"
+                (is (=? {:name "Tax Rate"}
+                        (-> (t2/select-one :model/Card :id card1-id)
+                            :result_metadata
+                            last)))
+                (is (=? {:name "Tax Rate"}
+                        (-> (t2/select-one :model/Card :id card2-id)
+                            :result_metadata
+                            last))))
+              (testing "changing upstream card triggers the refresh"
+                (let [refreshes     (atom [])
+                      refresh-card! @#'dependencies.refresh/refresh-card!]
+                  (with-redefs [dependencies.refresh/refresh-card!
+                                (fn [card-id upstream-changed-at]
+                                  (swap! refreshes conj card-id)
+                                  (refresh-card! card-id upstream-changed-at))]
+                    (let [card    (t2/select-one :model/Card :id card1-id)
+                          expr    (first (lib/expressions (:dataset_query card)))
+                          renamed (-> (:dataset_query card)
+                                      (lib/replace-clause expr (lib/with-expression-name expr "Tax Fraction")))]
+                      (card/update-card! {:card-before-update card
+                                          :card-updates       {:dataset_query renamed}
+                                          :actor              user}))
+                    (Thread/sleep 50)
+                    (is (=? [] @refreshes)
+                        "no refreshes before the check")
+                    (is (=? {:refresh-needed {:card {card2-id int?}}
+                             :running?       false}
+                            (current-state))
+                        "And the update is queued")
+                    (refresh-single-batch!)
+                    (is (=? [card2-id] @refreshes)
+                        "downstream card gets refreshed")
+                    (is (=? {:refresh-needed (symbol "nil #_\"key is not present.\"")
+                             :running?       false}
+                            (current-state))
+                        "and nothing is queued after")))))))))))
+
+(deftest ^:sequential refresh-scheduling-test
+  (testing "Test that the refresh job is correctly scheduled on demand"
+    (dependencies.task.tu/backfill-all-existing-entities!)
+    (drain-refresh-queue!)
+    (mt/with-temp-scheduler!
+      (with-redefs [env/env (assoc env/env
+                                   :mb-card-metadata-refresh-batch-size  "1"
+                                   :mb-card-metadata-refresh-delay-ms    "0"
+                                   :mb-card-metadata-refresh-variance-ms "0")]
+        (let [mp       (mt/metadata-provider)
+              upstream (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+                           (lib/expression "Tax Rate" (lib// (lib.metadata/field mp (mt/id :orders :tax))
+                                                             (lib.metadata/field mp (mt/id :orders :subtotal)))))
+              batches  (atom [])
+              refresh! @#'dependencies.refresh/refresh-result-metadata!]
+          (mt/test-helpers-set-global-values!
+            (mt/with-premium-features #{}
+              (mt/with-temp [:model/User user           {:email "me@wherever.com"}
+                             :model/Card {card1-id :id} {:dataset_query upstream}
+                             :model/Card _              {:dataset_query
+                                                         (let [mp (mt/metadata-provider)]
+                                                           (lib/query mp (lib.metadata/card mp card1-id)))}]
+                (dependencies.task.tu/backfill-all-existing-entities!)
+                (task/delete-all-triggers-of-job! (jobs/key @#'dependencies.refresh/job-key))
+                (with-redefs [dependencies.refresh/refresh-result-metadata!
+                              (fn []
+                                (let [n (refresh!)]
+                                  (swap! batches conj n)
+                                  n))]
+                  (mt/with-current-user (:id user)
+                    (is (= {:running? false}
+                           (current-state))
+                        "nothing queued at first")
+                    (is (= [] @batches)
+                        "and no batches have run")
+                    (mt/with-premium-features #{:dependencies}
+                      ;; Initialize the task, which should schedule the first run
+                      (task/init! ::dependencies.refresh/RefreshResultMetadata)
+                      (dependencies.task.tu/wait-for-condition #(= [0] @batches) 10000) ; Wait for first empty run.
+                      (is (= [0] @batches)
+                          "exactly one batch ran and did 0 work")
+                      ;; Wait two seconds to ensure it wasn't rescheduled.
+                      (Thread/sleep 2000)
+                      (is (= [0] @batches)
+                          "still one batch a bit later - the job isn't scheduled")
+
+                      ;; Update the upstream card
+                      (let [card    (t2/select-one :model/Card :id card1-id)
+                            expr    (first (lib/expressions (:dataset_query card)))
+                            renamed (-> (:dataset_query card)
+                                        (lib/replace-clause expr (lib/with-expression-name expr "Tax Fraction")))]
+                        (card/update-card! {:card-before-update card
+                                            :card-updates       {:dataset_query renamed}
+                                            :actor              user}))
+                      (dependencies.task.tu/wait-for-condition #(= [0 1] @batches) 10000) ; Wait for second run.
+                      (is (= [0 1] @batches)
+                          "job was scheduled and run on demand")
+                      (is (=? {:refresh-needed (symbol "nil #_\"key is not present.\"")
+                               :running?       false}
+                              (current-state))
+                          "queue is empty again")
+
+                      ;; Wait again, still not running on a schedule.
+                      (Thread/sleep 2000)
+                      (is (= [0 1] @batches)
+                          "job was not rescheduled since queue was empty"))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/dependencies/task/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/task/test_util.clj
@@ -1,0 +1,33 @@
+(ns metabase-enterprise.dependencies.task.test-util
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.dependencies.task.backfill :as dependencies.backfill]
+   [metabase.test :as mt]))
+
+(set! *warn-on-reflection* true)
+
+(defn backfill-dependencies-single-trigger!
+  "Runs a single batch of the dependencies backfill task."
+  []
+  (mt/with-premium-features #{:dependencies}
+    (#'dependencies.backfill/backfill-dependencies!)))
+
+(defn backfill-all-existing-entities!
+  "Repeatedly runs batches of the dependencies backfill until it runs out of work to do.
+
+  This ensures that any [[mt/with-temp]] entities have their dependencies properly filled in."
+  []
+  (mt/with-premium-features #{:dependencies}
+    (while (backfill-dependencies-single-trigger!))))
+
+(defn wait-for-condition
+  "Given a `predicate` and a timeout in milliseconds, repeatedly sleeps for 100ms and checks `(predicate)`.
+
+  Returns when `(predicate)` is truthy or when the timeout expires."
+  [predicate timeout-ms]
+  (let [limit (+ (System/currentTimeMillis) timeout-ms)]
+    (loop []
+      (Thread/sleep 100)
+      (or (predicate)
+          (when (< (System/currentTimeMillis) limit)
+            (recur))))))

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -431,6 +431,13 @@
    (prometheus/counter :metabase-gsheets/connection-manually-synced
                        {:description "How many times the instance has manually sync'ed their Google Sheets connection."})
 
+   ;; Card result_metadata refresh metrics
+   (prometheus/counter :metabase-card-refresh/result
+                       {:description "Number of cards refreshed by refresh outcome."
+                        :labels [:status]})
+   (prometheus/gauge :metabase-card-refresh/pending-refreshes
+                     {:description "Number of card refreshes queued up for processing."})
+
    ;; transform metrics
    (prometheus/counter :metabase-transforms/job-runs-total
                        {:description "Total number of transform job runs started."

--- a/src/metabase/queries/core.clj
+++ b/src/metabase/queries/core.clj
@@ -35,6 +35,7 @@
    ;; TODO -- not convinced whether this belongs here or in `permissions`
   with-can-run-adhoc-query]
  [metabase.queries.models.card.metadata
+  infer-metadata-with-model-overrides
   refresh-metadata]
  [metabase.queries.models.parameter-card]
  [metabase.queries.models.query


### PR DESCRIPTION
Implements QUE-1560.

### Description

On any event that can impact a card's metadata, schedule an update:
- Database sync updates all its tables
- Manual single-table sync
- Updating a card

This is part of the `dependencies` feature, and so is only enabled when
it is.

The background job is unscheduled when there's nothing in the queue, and
is rescheduled whenever work is added to an empty queue.

The interval between runs and the size of each batch is configurable,
but the interval is always at least 10x the time spent processing the
previous batch, which prevents this job from overwhelming an instance or
its (possibly shared) appdb.

Note that the queue is an `atom` in memory rather than durable; it's
best-effort for now.

Includes some Prometheus metrics so we can monitor that the queues are
draining and error rates are low.

### How to verify

Check out the logs (you might want to raise the log level to `DEBUG`) as this task operates.

Cause some syncs or update some cards on which things depend, and watch it run.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
