### PR TITLE
Fix #65501 - Resets search  back to first page when filters change

### DIFF
--- a/e2e/test/scenarios/search/search-pagination.cy.spec.js
+++ b/e2e/test/scenarios/search/search-pagination.cy.spec.js
@@ -25,35 +25,58 @@ describe("scenarios > search", () => {
     H.getSearchBar().type(" ");
   });
 
-  it("should allow users to paginate results", () => {
-    generateQuestions(TOTAL_ITEMS);
+  describe("multiple pages of results", () => {
+    before(() => {
+      cy.signInAsAdmin();
+      H.restore();
+      generateQuestions(TOTAL_ITEMS);
+      H.snapshot("many-questions");
+    });
 
-    cy.visit("/");
-    H.commandPaletteSearch("generated_question");
-    cy.findByLabelText("Previous page").should("be.disabled");
+    beforeEach(() => {
+      H.restore("many-questions");
+    });
 
-    // First page
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText(`1 - ${PAGE_SIZE}`);
-    cy.findByTestId("pagination-total").should("have.text", TOTAL_ITEMS);
-    cy.findAllByTestId("search-result-item").should("have.length", PAGE_SIZE);
+    it("should allow users to paginate results", () => {
+      cy.visit("/");
+      H.commandPaletteSearch("generated_question");
+      cy.findByLabelText("Previous page").should("be.disabled");
 
-    cy.findByLabelText("Next page").click();
+      // First page
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText(`1 - ${PAGE_SIZE}`);
+      cy.findByTestId("pagination-total").should("have.text", TOTAL_ITEMS);
+      cy.findAllByTestId("search-result-item").should("have.length", PAGE_SIZE);
 
-    // Second page
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText(`${PAGE_SIZE + 1} - ${TOTAL_ITEMS}`);
-    cy.findByTestId("pagination-total").should("have.text", TOTAL_ITEMS);
-    cy.findAllByTestId("search-result-item").should("have.length", 1);
-    cy.findByLabelText("Next page").should("be.disabled");
+      cy.findByLabelText("Next page").click();
 
-    cy.findByLabelText("Previous page").click();
+      // Second page
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText(`${PAGE_SIZE + 1} - ${TOTAL_ITEMS}`);
+      cy.findByTestId("pagination-total").should("have.text", TOTAL_ITEMS);
+      cy.findAllByTestId("search-result-item").should("have.length", 1);
+      cy.findByLabelText("Next page").should("be.disabled");
 
-    // First page
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText(`1 - ${PAGE_SIZE}`);
-    cy.findByTestId("pagination-total").should("have.text", TOTAL_ITEMS);
-    cy.findAllByTestId("search-result-item").should("have.length", PAGE_SIZE);
+      cy.findByLabelText("Previous page").click();
+
+      // First page
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText(`1 - ${PAGE_SIZE}`);
+      cy.findByTestId("pagination-total").should("have.text", TOTAL_ITEMS);
+      cy.findAllByTestId("search-result-item").should("have.length", PAGE_SIZE);
+    });
+
+    it("should reset the page when filters change (metabase#65501)", () => {
+      cy.visit("/search?q=");
+      cy.findByLabelText("Next page").click();
+      cy.findByTestId("type-search-filter").click();
+      H.popover().findByText("Table").click();
+      H.popover().findByText("Apply").click();
+      cy.findByTestId("search-app")
+        .findByText("Didn't find anything")
+        .should("not.exist");
+      cy.findAllByTestId("search-result-item").should("exist");
+    });
   });
 });
 

--- a/frontend/src/metabase/search/containers/SearchApp.jsx
+++ b/frontend/src/metabase/search/containers/SearchApp.jsx
@@ -9,7 +9,6 @@ import EmptyState from "metabase/common/components/EmptyState";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { PaginationControls } from "metabase/common/components/PaginationControls";
 import { NoObjectError } from "metabase/common/components/errors/NoObjectError";
-import { usePagination } from "metabase/common/hooks/use-pagination";
 import Search from "metabase/entities/search";
 import { usePageTitle } from "metabase/hooks/use-page-title";
 import { useDispatch } from "metabase/lib/redux";
@@ -32,12 +31,19 @@ import {
 } from "metabase/search/utils";
 import { Box, Group, Paper, Text } from "metabase/ui";
 
+const getPageFromLocation = (location) => {
+  const maybePage = location.query?.page
+    ? parseInt(location.query.page, 10)
+    : 0;
+  return maybePage || 0;
+};
+
 function SearchApp({ location }) {
   const dispatch = useDispatch();
 
   usePageTitle(t`Search`);
 
-  const { handleNextPage, handlePreviousPage, page } = usePagination();
+  const page = getPageFromLocation(location);
 
   const searchText = useMemo(
     () => getSearchTextFromLocation(location),
@@ -74,6 +80,15 @@ function SearchApp({ location }) {
     },
     [onChangeLocation, searchText],
   );
+
+  const advancePage = (howMany = 1) => {
+    dispatch(
+      push({
+        pathname: "search",
+        query: { q: searchText.trim(), ...searchFilters, page: page + howMany },
+      }),
+    );
+  };
 
   const { data, error, isFetching, requestId } = useSearchQuery(query);
   const list = useMemo(() => {
@@ -122,8 +137,8 @@ function SearchApp({ location }) {
                   page={page}
                   itemsLength={list.length}
                   total={data.total}
-                  onNextPage={handleNextPage}
-                  onPreviousPage={handlePreviousPage}
+                  onNextPage={() => advancePage(1)}
+                  onPreviousPage={() => advancePage(-1)}
                 />
               </Group>
             </Box>

--- a/frontend/src/metabase/search/containers/SearchApp.jsx
+++ b/frontend/src/metabase/search/containers/SearchApp.jsx
@@ -82,12 +82,10 @@ function SearchApp({ location }) {
   );
 
   const advancePage = (howMany = 1) => {
-    dispatch(
-      push({
-        pathname: "search",
-        query: { q: searchText.trim(), ...searchFilters, page: page + howMany },
-      }),
-    );
+    onChangeLocation({
+      pathname: "search",
+      query: { q: searchText.trim(), ...searchFilters, page: page + howMany },
+    });
   };
 
   const { data, error, isFetching, requestId } = useSearchQuery(query);


### PR DESCRIPTION
Closes #65501 / [GIT-8490](https://linear.app/metabase/issue/GIT-8490/search-pagination-isnt-reset-when-filters-are-added-leading-to)

### Description

Resets page when filters change. Also works with browser back/forward buttons.

### How to verify

See #65501 for repro steps

### Demo

**BEFORE**

https://github.com/user-attachments/assets/0c54cc32-10a6-47c6-b7c0-3f5bfd1f4ab6

**AFTER**

https://github.com/user-attachments/assets/35010d89-4708-4371-850c-d10987376f38


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
