### PR TITLE
fix: reset pagination on location change in the Search App (#65501)

### DIFF
--- a/frontend/src/metabase/search/containers/SearchApp.jsx
+++ b/frontend/src/metabase/search/containers/SearchApp.jsx
@@ -37,7 +37,8 @@ function SearchApp({ location }) {
 
   usePageTitle(t`Search`);
 
-  const { handleNextPage, handlePreviousPage, page } = usePagination();
+  const { handleNextPage, handlePreviousPage, page, resetPage } =
+    usePagination();
 
   const searchText = useMemo(
     () => getSearchTextFromLocation(location),
@@ -60,19 +61,22 @@ function SearchApp({ location }) {
     include_dashboard_questions: true,
   };
 
-  const onChangeLocation = useCallback(
-    (nextLocation) => dispatch(push(nextLocation)),
-    [dispatch],
+  const changeLocation = useCallback(
+    (nextLocation) => {
+      resetPage();
+      dispatch(push(nextLocation));
+    },
+    [dispatch, resetPage],
   );
 
-  const onFilterChange = useCallback(
+  const changeFilters = useCallback(
     (newFilters) => {
-      onChangeLocation({
+      changeLocation({
         pathname: "search",
         query: { q: searchText.trim(), ...newFilters },
       });
     },
-    [onChangeLocation, searchText],
+    [changeLocation, searchText],
   );
 
   const { data, error, isFetching, requestId } = useSearchQuery(query);
@@ -87,7 +91,7 @@ function SearchApp({ location }) {
       </Text>
       <SearchBody justify="center">
         <SearchControls pb="lg">
-          <SearchSidebar value={searchFilters} onChange={onFilterChange} />
+          <SearchSidebar value={searchFilters} onChange={changeFilters} />
         </SearchControls>
         <SearchResultContainer>
           {(error || isFetching) && (


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/65501

### Description
Changing the filters on `/search` page didn't reset current page number to zero, so request to the api was made with previous offset value (e.g. 50 if user went to second page before changing the filters) which lead to the wrong results.

### How to verify
1. Do a search in the command palette that returns more than 50 results
2. Click on View and filter <x> results
3. Switch to page 2
4. Add a search filter that narrows the results to N, where N < 50
5. You should see these N results

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
