### PR TITLE
Use Fixed Postgres Version and Add Persistent Volume to Prevent Data Loss

### DIFF
--- a/docs/installation-and-operation/running-metabase-on-docker.md
+++ b/docs/installation-and-operation/running-metabase-on-docker.md
@@ -144,13 +144,15 @@ services:
       timeout: 5s
       retries: 5
   postgres:
-    image: postgres:latest
+    image: postgres:16
     container_name: postgres
     hostname: postgres
     environment:
       POSTGRES_USER: metabase
       POSTGRES_DB: metabaseappdb
       POSTGRES_PASSWORD: mysecretpassword
+    volumes:
+      - ./pg_data:/var/lib/postgresql/data
     networks:
       - metanet1
 networks:


### PR DESCRIPTION
This update replaces the postgres:latest tag with a fixed major version (postgres:16) and adds a persistent volume to the example configuration. Using latest and having no volume defined caused a full loss of two months of Metabase data after running a standard docker-compose down or server restart.
Including these changes in the documentation helps ensure that users avoid accidental data loss and have a more reliable setup out of the box.