### PR TITLE
Add multi-tenancy setup guide to embedding hub

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1964,6 +1964,7 @@
            audit-app
            embedding
            premium-features
+           permissions
            enterprise/sso}}
 
   enterprise/gsheets

--- a/e2e/test/scenarios/admin-2/tenants.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/tenants.cy.spec.js
@@ -118,6 +118,13 @@ describe("Tenants - management", () => {
       cy.button("Apply").click();
     });
 
+    cy.log("should show toast hint message about tenant collections");
+    cy.findAllByText(
+      "You can create tenant collections from the main Metabase navigation",
+    )
+      .first()
+      .should("be.visible");
+
     cy.findByRole("link", { name: /External Users/ }).should("exist");
     cy.findByRole("link", { name: /Tenants/ }).click();
 

--- a/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
@@ -296,5 +296,36 @@ describe("scenarios - embedding hub", () => {
       H.main().findByText("Set up tenants").click();
       cy.url().should("include", "/admin/tenants");
     });
+
+    it("should link to user strategy when tenants are disabled", () => {
+      H.restore("setup");
+      cy.signInAsAdmin();
+      H.activateToken("bleeding-edge");
+
+      cy.visit("/admin/embedding/setup-guide");
+
+      H.main()
+        .findByText("Tenants")
+        .scrollIntoView()
+        .should("be.visible")
+        .closest("a")
+        .should("have.attr", "href", "/admin/people/user-strategy");
+    });
+
+    it("should link to tenants page when tenants are enabled", () => {
+      H.restore("setup");
+      cy.signInAsAdmin();
+      H.activateToken("bleeding-edge");
+
+      cy.visit("/admin/embedding/setup-guide");
+      H.updateSetting("use-tenants", true);
+
+      H.main()
+        .findByText("Tenants")
+        .scrollIntoView()
+        .should("be.visible")
+        .closest("a")
+        .should("have.attr", "href", "/admin/tenants");
+    });
   });
 });

--- a/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
@@ -259,5 +259,42 @@ describe("scenarios - embedding hub", () => {
         .findByText("Get started with Embedded Analytics JS")
         .should("not.exist");
     });
+
+    it('"Set up tenants" card should navigate to admin settings', () => {
+      H.restore("setup");
+      cy.signInAsAdmin();
+      H.activateToken("bleeding-edge");
+
+      cy.request("PUT", "/api/setting/embedding-homepage", {
+        value: "visible",
+      });
+
+      cy.visit("/");
+
+      H.main().findByText("Set up tenants").should("be.visible").click();
+
+      H.modal().within(() => {
+        cy.findByText("People settings").should("be.visible");
+
+        cy.log("enable multi-tenancy");
+        cy.findByLabelText("User strategy").should("be.visible").click();
+      });
+
+      H.popover().findByText("Multi tenant").click();
+
+      cy.visit("/");
+
+      cy.log("'Set up tenants' should now be marked as done");
+      H.main()
+        .findByText("Set up tenants")
+        .closest("button")
+        .scrollIntoView()
+        .findByText("Done", { timeout: 10_000 })
+        .should("be.visible");
+
+      cy.log("clicking on tenants should go to tenants page");
+      H.main().findByText("Set up tenants").click();
+      cy.url().should("include", "/admin/tenants");
+    });
   });
 });

--- a/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
@@ -274,13 +274,16 @@ describe("scenarios - embedding hub", () => {
       H.main().findByText("Set up tenants").should("be.visible").click();
 
       H.modal().within(() => {
-        cy.findByText("People settings").should("be.visible");
-
-        cy.log("enable multi-tenancy");
-        cy.findByLabelText("User strategy").should("be.visible").click();
+        cy.findByText("User strategy").should("be.visible");
+        cy.findByText("Multi tenant").click();
+        cy.button("Apply").click();
       });
 
-      H.popover().findByText("Multi tenant").click();
+      cy.log("the internal prefix should show up on the page");
+      H.main()
+        .findAllByText("Internal Users")
+        .should("have.length", 2)
+        .should("be.visible");
 
       cy.visit("/");
 

--- a/e2e/test/scenarios/embedding/modular-embedding-settings.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/modular-embedding-settings.cy.spec.ts
@@ -1,0 +1,32 @@
+const { H } = cy;
+
+describe("scenarios > modular embedding settings", { tags: "@EE" }, () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    H.activateToken("bleeding-edge");
+  });
+
+  it("should link to user strategy when tenants are disabled", () => {
+    cy.visit("/admin/embedding/modular");
+
+    H.main()
+      .findByText("Tenants")
+      .scrollIntoView()
+      .should("be.visible")
+      .closest("a")
+      .should("have.attr", "href", "/admin/people/user-strategy");
+  });
+
+  it("should link to tenants page when tenants are enabled", () => {
+    cy.visit("/admin/embedding/modular");
+    H.updateSetting("use-tenants", true);
+
+    H.main()
+      .findByText("Tenants")
+      .scrollIntoView()
+      .should("be.visible")
+      .closest("a")
+      .should("have.attr", "href", "/admin/tenants");
+  });
+});

--- a/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
@@ -6,6 +6,7 @@
    [metabase.appearance.core :as appearance]
    [metabase.audit-app.core :as audit]
    [metabase.embedding.settings :as embedding.settings]
+   [metabase.permissions.settings :as permissions.settings]
    [metabase.premium-features.core :as premium-features]
    [toucan2.core :as t2]))
 
@@ -52,6 +53,9 @@
                                                               :where  [:= :is_sample true]}]]
                                     [:is :collection_id nil]]]}))
 
+(defn- has-configured-tenants? []
+  (permissions.settings/use-tenants))
+
 (defn- embedding-hub-checklist []
   {"add-data"                      (has-user-added-database?)
    "create-dashboard"              (has-user-created-dashboard?)
@@ -59,7 +63,8 @@
    "configure-row-column-security" (has-configured-sandboxes?)
    "create-test-embed"             (embedding.settings/embedding-hub-test-embed-snippet-created)
    "embed-production"              (embedding.settings/embedding-hub-production-embed-snippet-created)
-   "secure-embeds"                 (has-configured-sso?)})
+   "secure-embeds"                 (has-configured-sso?)
+   "setup-tenants"                 (has-configured-tenants?)})
 
 (api.macros/defendpoint :get "/checklist"
   "Get the embedding hub checklist status, indicating which setup steps have been completed."

--- a/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
@@ -6,7 +6,7 @@
    [metabase.appearance.core :as appearance]
    [metabase.audit-app.core :as audit]
    [metabase.embedding.settings :as embedding.settings]
-   [metabase.permissions.settings :as permissions.settings]
+   [metabase.permissions.core :as perms]
    [metabase.premium-features.core :as premium-features]
    [toucan2.core :as t2]))
 
@@ -53,9 +53,6 @@
                                                               :where  [:= :is_sample true]}]]
                                     [:is :collection_id nil]]]}))
 
-(defn- has-configured-tenants? []
-  (permissions.settings/use-tenants))
-
 (defn- embedding-hub-checklist []
   {"add-data"                      (has-user-added-database?)
    "create-dashboard"              (has-user-created-dashboard?)
@@ -64,7 +61,7 @@
    "create-test-embed"             (embedding.settings/embedding-hub-test-embed-snippet-created)
    "embed-production"              (embedding.settings/embedding-hub-production-embed-snippet-created)
    "secure-embeds"                 (has-configured-sso?)
-   "setup-tenants"                 (has-configured-tenants?)})
+   "setup-tenants"                 (perms/use-tenants)})
 
 (api.macros/defendpoint :get "/checklist"
   "Get the embedding hub checklist status, indicating which setup steps have been completed."

--- a/enterprise/frontend/src/metabase-enterprise/tenants/EditUserStrategyModal/EditUserStrategyModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/EditUserStrategyModal/EditUserStrategyModal.tsx
@@ -53,7 +53,13 @@ export const EditUserStrategyModal = ({
           : t`Changes saved`,
     });
 
-    dispatch(permissionApi.util.invalidateTags(["permissions-group"]));
+    dispatch(
+      permissionApi.util.invalidateTags([
+        "permissions-group",
+        "embedding-hub-checklist",
+      ]),
+    );
+
     onClose();
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/tenants/EditUserStrategyModal/EditUserStrategyModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/EditUserStrategyModal/EditUserStrategyModal.tsx
@@ -4,6 +4,7 @@ import { t } from "ttag";
 import { permissionApi } from "metabase/api";
 import { useAdminSetting } from "metabase/api/utils";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
+import { useToast } from "metabase/common/hooks";
 import { useDispatch } from "metabase/lib/redux";
 import { Button, Flex, Group, Modal, Radio, Stack, Text } from "metabase/ui";
 
@@ -20,6 +21,8 @@ export const EditUserStrategyModal = ({
 
   const { isLoading, error, value, updateSetting } =
     useAdminSetting("use-tenants");
+
+  const [addToast] = useToast();
 
   const initialStrategy = value ? "multi-tenant" : "single-tenant";
 
@@ -41,6 +44,14 @@ export const EditUserStrategyModal = ({
       setSelectedStrategy(initialStrategy);
       return;
     }
+
+    addToast({
+      message:
+        selectedStrategy === "multi-tenant"
+          ? // eslint-disable-next-line no-literal-metabase-strings -- used in admin
+            t`You can create tenant collections from the main Metabase navigation`
+          : t`Changes saved`,
+    });
 
     dispatch(permissionApi.util.invalidateTags(["permissions-group"]));
     onClose();

--- a/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
@@ -42,6 +42,8 @@ import {
 
 export function initializePlugin() {
   if (hasPremiumFeature("tenants")) {
+    PLUGIN_TENANTS.isEnabled = true;
+
     // Register tenant collection permissions tab and routes
     PLUGIN_ADMIN_PERMISSIONS_TABS.tabs.push({
       name: t`Tenant Collections`,

--- a/frontend/src/metabase/admin/components/RelatedSettingsSection/constants.ts
+++ b/frontend/src/metabase/admin/components/RelatedSettingsSection/constants.ts
@@ -1,5 +1,6 @@
 import { t } from "ttag";
 
+import { PLUGIN_TENANTS } from "metabase/plugins";
 import type { IconName } from "metabase/ui";
 
 export interface RelatedSettingItem {
@@ -8,8 +9,14 @@ export interface RelatedSettingItem {
   to: string;
 }
 
-export const getModularEmbeddingRelatedSettingItems =
-  (): RelatedSettingItem[] => [
+export const getModularEmbeddingRelatedSettingItems = ({
+  isUsingTenants,
+}: {
+  isUsingTenants?: boolean;
+}): RelatedSettingItem[] => {
+  const isTenantsFeatureAvailable = PLUGIN_TENANTS.isEnabled;
+
+  const items: RelatedSettingItem[] = [
     // TODO: enable this once we've added the "Security" tab to Embedding Settings.
     // {
     //   icon: "shield_outline",
@@ -41,7 +48,21 @@ export const getModularEmbeddingRelatedSettingItems =
       name: t`Appearance`,
       to: "/admin/settings/appearance",
     },
+    ...(isTenantsFeatureAvailable
+      ? [
+          {
+            icon: "globe" as const,
+            name: t`Tenants`,
+            to: isUsingTenants
+              ? "/admin/tenants"
+              : "/admin/people/user-strategy",
+          },
+        ]
+      : []),
   ];
+
+  return items;
+};
 
 export const getStaticEmbeddingRelatedSettingItems =
   (): RelatedSettingItem[] => [

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
@@ -53,6 +53,7 @@ export function EmbeddingSdkSettings() {
     (isSimpleEmbedFeatureAvailable && isSimpleEmbedEnabled);
 
   const isHosted = useSetting("is-hosted?");
+  const isUsingTenants = useSetting("use-tenants");
 
   const { url: switchMetabaseBinariesUrl } = useDocsUrl(
     "paid-features/activating-the-enterprise-edition",
@@ -252,7 +253,7 @@ export function EmbeddingSdkSettings() {
       )}
 
       <RelatedSettingsSection
-        items={getModularEmbeddingRelatedSettingItems()}
+        items={getModularEmbeddingRelatedSettingItems({ isUsingTenants })}
       />
 
       <UpsellDevInstances location="embedding-page" />

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/tests/common.unit.spec.tsx
@@ -137,6 +137,17 @@ describe("EmbeddingSdkSettings (OSS)", () => {
     expect(await screen.findByText("Appearance")).toBeInTheDocument();
   });
 
+  it("should not show Tenants in related settings when tenants feature is not available", async () => {
+    await setup({
+      isEmbeddingSdkEnabled: true,
+      showSdkEmbedTerms: false,
+      hasEnterprisePlugins: false,
+      tokenFeatures: { tenants: false },
+    });
+
+    expect(screen.queryByText("Tenants")).not.toBeInTheDocument();
+  });
+
   it("shows the Embedded Analytics JS toggle is Disabled when token features are missing (EMB-801)", () => {
     setup({ tokenFeatures: { embedding_simple: false } });
 

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/tests/enterprise.unit.spec.tsx
@@ -31,4 +31,13 @@ describe("EmbeddingSdkSettings (EE)", () => {
       alertInfo.getByText("implement JWT or SAML SSO"),
     ).toBeInTheDocument();
   });
+
+  it("should show Tenants in related settings when tenants feature is available", async () => {
+    await setup({
+      hasEnterprisePlugins: true,
+      tokenFeatures: { tenants: true },
+    });
+
+    expect(screen.getByText("Tenants")).toBeInTheDocument();
+  });
 });

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/tests/setup.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/tests/setup.tsx
@@ -26,6 +26,7 @@ export interface SetupOpts {
   isHosted?: Settings["is-hosted?"];
   hasEnterprisePlugins?: boolean;
   tokenFeatures?: Partial<TokenFeatures>;
+  isUsingTenants?: Settings["use-tenants"];
 }
 
 export async function setup({
@@ -35,6 +36,7 @@ export async function setup({
   isHosted = false,
   hasEnterprisePlugins = false,
   tokenFeatures = {},
+  isUsingTenants = false,
 }: SetupOpts = {}) {
   const settings = createMockSettings({
     "show-sdk-embed-terms": showSdkEmbedTerms,
@@ -42,6 +44,7 @@ export async function setup({
     "enable-embedding-simple": isEmbeddingSimpleEnabled,
     "is-hosted?": isHosted,
     "token-features": createMockTokenFeatures(tokenFeatures),
+    "use-tenants": isUsingTenants,
   });
 
   const state = createMockState({

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/tests/setup.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/tests/setup.tsx
@@ -26,7 +26,6 @@ export interface SetupOpts {
   isHosted?: Settings["is-hosted?"];
   hasEnterprisePlugins?: boolean;
   tokenFeatures?: Partial<TokenFeatures>;
-  isUsingTenants?: Settings["use-tenants"];
 }
 
 export async function setup({
@@ -36,7 +35,6 @@ export async function setup({
   isHosted = false,
   hasEnterprisePlugins = false,
   tokenFeatures = {},
-  isUsingTenants = false,
 }: SetupOpts = {}) {
   const settings = createMockSettings({
     "show-sdk-embed-terms": showSdkEmbedTerms,
@@ -44,7 +42,6 @@ export async function setup({
     "enable-embedding-simple": isEmbeddingSimpleEnabled,
     "is-hosted?": isHosted,
     "token-features": createMockTokenFeatures(tokenFeatures),
-    "use-tenants": isUsingTenants,
   });
 
   const state = createMockState({

--- a/frontend/src/metabase/api/embedding-hub.ts
+++ b/frontend/src/metabase/api/embedding-hub.ts
@@ -9,7 +9,8 @@ type CheckListApiStep =
   | "configure-row-column-security"
   | "create-test-embed"
   | "embed-production"
-  | "secure-embeds";
+  | "secure-embeds"
+  | "setup-tenants";
 export type EmbeddingHubChecklist = Record<CheckListApiStep, boolean>;
 
 export const embeddingHubApi = Api.injectEndpoints({

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubAdminSettingsPage.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubAdminSettingsPage.tsx
@@ -4,11 +4,14 @@ import {
   RelatedSettingsSection,
   getModularEmbeddingRelatedSettingItems,
 } from "metabase/admin/components/RelatedSettingsSection";
+import { useSetting } from "metabase/common/hooks";
 import { Stack, Text, Title } from "metabase/ui";
 
 import { EmbeddingHub } from "./EmbeddingHub";
 
 export const EmbeddingHubAdminSettingsPage = () => {
+  const isUsingTenants = useSetting("use-tenants");
+
   return (
     <Stack mx="auto" py="xl" gap="xl" maw={800}>
       <Stack gap="xs">
@@ -24,7 +27,7 @@ export const EmbeddingHubAdminSettingsPage = () => {
 
       <Stack ml="2.7rem">
         <RelatedSettingsSection
-          items={getModularEmbeddingRelatedSettingItems()}
+          items={getModularEmbeddingRelatedSettingItems({ isUsingTenants })}
         />
       </Stack>
     </Stack>

--- a/frontend/src/metabase/embedding/embedding-hub/hooks/use-completed-embedding-hub-steps.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/hooks/use-completed-embedding-hub-steps.ts
@@ -26,6 +26,7 @@ export const useCompletedEmbeddingHubSteps = (): {
         "secure-embeds": false,
         "embed-production": false,
         "create-models": false,
+        "setup-tenants": false,
       };
     }
 

--- a/frontend/src/metabase/embedding/embedding-hub/hooks/use-get-embedding-hub-steps.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/hooks/use-get-embedding-hub-steps.ts
@@ -1,14 +1,19 @@
 import { useCallback, useMemo } from "react";
 import { t } from "ttag";
 
+import { useSetting } from "metabase/common/hooks";
 import { useDispatch } from "metabase/lib/redux";
-import type { SdkIframeEmbedSetupModalProps } from "metabase/plugins";
+import {
+  PLUGIN_TENANTS,
+  type SdkIframeEmbedSetupModalProps,
+} from "metabase/plugins";
 import { setOpenModalWithProps } from "metabase/redux/ui";
 
 import type { EmbeddingHubStep } from "../types";
 
 export const useGetEmbeddingHubSteps = (): EmbeddingHubStep[] => {
   const dispatch = useDispatch();
+  const isUsingTenants = useSetting("use-tenants");
 
   const openEmbedModal = useCallback(
     (props: Pick<SdkIframeEmbedSetupModalProps, "initialState">) => {
@@ -23,6 +28,8 @@ export const useGetEmbeddingHubSteps = (): EmbeddingHubStep[] => {
   );
 
   return useMemo(() => {
+    const isTenantsFeatureAvailable = PLUGIN_TENANTS.isEnabled;
+
     const TEST_EMBED: EmbeddingHubStep = {
       id: "create-test-embed",
       title: t`Create embed`,
@@ -38,6 +45,19 @@ export const useGetEmbeddingHubSteps = (): EmbeddingHubStep[] => {
           },
           variant: "outline",
         },
+        ...(isTenantsFeatureAvailable
+          ? [
+              {
+                title: t`Set up tenants`,
+                description: t`Define a multi tenant user strategy to manage access for external users.`,
+                to: isUsingTenants
+                  ? "/admin/tenants"
+                  : "/admin/people/user-strategy",
+                optional: true,
+                stepId: "setup-tenants" as const,
+              },
+            ]
+          : []),
       ],
       image: {
         src: "app/assets/img/embedding_hub_create_embed.png",
@@ -154,5 +174,5 @@ export const useGetEmbeddingHubSteps = (): EmbeddingHubStep[] => {
       SECURE_EMBEDS,
       EMBED_PRODUCTION,
     ];
-  }, [openEmbedModal]);
+  }, [isUsingTenants, openEmbedModal]);
 };

--- a/frontend/src/metabase/embedding/embedding-hub/types/embedding-checklist.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/types/embedding-checklist.ts
@@ -8,7 +8,8 @@ export type EmbeddingHubStepId =
   | "configure-row-column-security"
   | "secure-embeds"
   | "embed-production"
-  | "create-models";
+  | "create-models"
+  | "setup-tenants";
 
 export interface EmbeddingHubStep {
   id: EmbeddingHubStepId;

--- a/frontend/src/metabase/plugins/oss/tenants.ts
+++ b/frontend/src/metabase/plugins/oss/tenants.ts
@@ -6,6 +6,7 @@ import type { Collection, Group, User } from "metabase-types/api";
 import { PluginPlaceholder } from "../components/PluginPlaceholder";
 
 const getDefaultPluginTenants = () => ({
+  isEnabled: false,
   userStrategyRoute: null as React.ReactElement | null,
   tenantsRoutes: null as React.ReactElement | null,
   EditUserStrategySettingsButton: PluginPlaceholder,
@@ -26,6 +27,7 @@ const getDefaultPluginTenants = () => ({
 });
 
 export const PLUGIN_TENANTS: {
+  isEnabled: boolean;
   userStrategyRoute: React.ReactElement | null;
   tenantsRoutes: React.ReactElement | null;
   EditUserStrategySettingsButton: React.ComponentType;


### PR DESCRIPTION
Closes EMB-1007

### Description

- Adds an optional "Set up tenants" step in the setup guide, linking to the tenants screen, or the "People" screen with the tenancy model pre-selected if not yet set up.
- Include a tenants card in related settings, following the same logic as above. 
- When the multi-tenant strategy is selected, shows the toast "You can create tenant collections from the main Metabase navigation" in place of the "Changes saved" toast.

### How to verify

- Use the MB_ALL_FEATURES_TOKEN as this is an in-development feature
- Go to the embedding hub on the homepage.
  - If you're not on a fresh instance, you can go into "Admin settings > Embedding > Setup guide" instead
- You should see the "Set up tenants" card which is optional
- Clicking on it should take you to the tenancy modal, if you don't have multi-tenancy set up yet.
- Set the tenancy to "Multi tenant"
- You should see the toast "You can create tenant collections from the main Metabase navigation" in place of the usual "Changes saved" toast.
- Click on the card again
- It should now take you to the Tenants page, now that you have multi-tenancy enabled
- Go to "Modular Embedding" admin settings page
- You should now see the "Tenants" card, which behaves like the above

### Demo

<img width="2440" height="1722" alt="CleanShot 2568-11-21 at 18 02 47@2x" src="https://github.com/user-attachments/assets/2ad0e6ad-7ef1-465a-94f1-754e30cc2a81" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
