### PR TITLE
feat(sdk): skip first /auth/sso request when jwtProviderUri is passed

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/loading-performance.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/loading-performance.cy.spec.tsx
@@ -1,0 +1,80 @@
+import { InteractiveQuestion } from "@metabase/embedding-sdk-react";
+
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
+import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
+import { mountSdkContent } from "e2e/support/helpers/embedding-sdk-component-testing";
+import {
+  AUTH_PROVIDER_URL,
+  METABASE_INSTANCE_URL,
+} from "e2e/support/helpers/embedding-sdk-helpers/constants";
+import {
+  mockAuthProviderAndJwtSignIn,
+  signInAsAdminAndEnableEmbeddingSdk,
+} from "e2e/support/helpers/embedding-sdk-testing";
+
+describe("scenarios > embedding-sdk > loading-performance", () => {
+  beforeEach(() => {
+    signInAsAdminAndEnableEmbeddingSdk();
+    cy.signOut();
+    mockAuthProviderAndJwtSignIn();
+
+    // Intercept SSO discovery request (without jwt parameter)
+    cy.intercept("GET", /\/auth\/sso(\?preferred_method=\w+)?$/).as(
+      "authSsoDiscovery",
+    );
+    // Intercept token exchange request (with jwt parameter)
+    cy.intercept("GET", /\/auth\/sso\?.*jwt=/).as("authSsoTokenExchange");
+    cy.intercept("GET", "/api/user/current").as("getCurrentUser");
+    cy.intercept("GET", "/api/session/properties").as("getSessionProperties");
+  });
+
+  describe("Baseline: when jwtProviderUri is not provided", () => {
+    it("should make SSO discovery request, then token exchange", () => {
+      mountSdkContent(<InteractiveQuestion questionId={ORDERS_QUESTION_ID} />, {
+        sdkProviderProps: {
+          authConfig: {
+            metabaseInstanceUrl: METABASE_INSTANCE_URL,
+          },
+        },
+      });
+
+      // Verify question renders
+      getSdkRoot().within(() => {
+        cy.findByText("Orders").should("exist");
+        cy.findByTestId("visualization-root").should("be.visible");
+      });
+
+      // Baseline: discovery + token exchange
+      cy.get("@authSsoDiscovery.all").should("have.length", 1);
+      cy.get("@authSsoTokenExchange.all").should("have.length", 1);
+      cy.get("@getCurrentUser.all").should("have.length", 1);
+      cy.get("@getSessionProperties.all").should("have.length", 1);
+    });
+  });
+
+  describe("when jwtProviderUri is provided", () => {
+    it("should skip the initial /auth/sso request", () => {
+      mountSdkContent(<InteractiveQuestion questionId={ORDERS_QUESTION_ID} />, {
+        sdkProviderProps: {
+          authConfig: {
+            metabaseInstanceUrl: METABASE_INSTANCE_URL,
+            preferredAuthMethod: "jwt",
+            jwtProviderUri: AUTH_PROVIDER_URL,
+          },
+        },
+      });
+
+      // Verify question renders
+      getSdkRoot().within(() => {
+        cy.findByText("Orders").should("exist");
+        cy.findByTestId("visualization-root").should("be.visible");
+      });
+
+      // Optimized: no discovery, only token exchange
+      cy.get("@authSsoDiscovery.all").should("have.length", 0);
+      cy.get("@authSsoTokenExchange.all").should("have.length", 1);
+      cy.get("@getCurrentUser.all").should("have.length", 1);
+      cy.get("@getSessionProperties.all").should("have.length", 1);
+    });
+  });
+});

--- a/e2e/test-component/scenarios/embedding-sdk/requests.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/requests.cy.spec.tsx
@@ -39,16 +39,9 @@ describe("scenarios > embedding-sdk > requests", () => {
     });
 
     it("properly performs session token refresh request when multiple data requests are triggered at the same time", () => {
-      let datasetCount = 0;
-      cy.intercept("POST", "/api/dataset", (req) => {
-        datasetCount++;
-        // eslint-disable-next-line no-console
-        console.log(
-          `Dataset request #${datasetCount}`,
-          req.headers["x-metabase-session"],
-        );
-        req.continue();
-      }).as("dataset");
+      cy.clock(Date.now());
+
+      cy.intercept("POST", "/api/dataset").as("dataset");
 
       const sessionIds: string[] = [];
 

--- a/e2e/test-component/scenarios/embedding-sdk/requests.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/requests.cy.spec.tsx
@@ -38,14 +38,6 @@ describe("scenarios > embedding-sdk > requests", () => {
       });
     });
 
-    beforeEach(() => {
-      cy.clock(Date.now());
-    });
-
-    afterEach(() => {
-      cy.clock().then((clock) => clock.restore());
-    });
-
     it("properly performs session token refresh request when multiple data requests are triggered at the same time", () => {
       let datasetCount = 0;
       cy.intercept("POST", "/api/dataset", (req) => {

--- a/enterprise/frontend/src/embedding-sdk-ee/auth/auth.ts
+++ b/enterprise/frontend/src/embedding-sdk-ee/auth/auth.ts
@@ -212,7 +212,7 @@ const getRefreshToken = async ({
   jwtProviderUri?: string;
   fetchRequestToken?: MetabaseAuthConfig["fetchRequestToken"];
 }) => {
-  const shouldSkipSsoDiscovery = Boolean(jwtProviderUri);
+  const shouldSkipSsoDiscovery = jwtProviderUri !== undefined;
 
   const urlResponseJson = shouldSkipSsoDiscovery
     ? { method: "jwt", url: jwtProviderUri }

--- a/enterprise/frontend/src/embedding-sdk-ee/auth/auth.ts
+++ b/enterprise/frontend/src/embedding-sdk-ee/auth/auth.ts
@@ -43,14 +43,15 @@ let refreshTokenPromise: ReturnType<
 
 // Side effect happening here.
 PLUGIN_EMBEDDING_SDK_AUTH.initAuth = async (
-  {
-    metabaseInstanceUrl,
-    preferredAuthMethod,
-    apiKey,
-    isLocalHost,
-  }: MetabaseAuthConfig & { isLocalHost?: boolean },
+  authConfig: MetabaseAuthConfig & { isLocalHost?: boolean },
   { dispatch }: { dispatch: SdkDispatch },
 ) => {
+  const { metabaseInstanceUrl, preferredAuthMethod, apiKey, isLocalHost } =
+    authConfig;
+  const jwtProviderUri =
+    preferredAuthMethod === "jwt" && "jwtProviderUri" in authConfig
+      ? authConfig.jwtProviderUri
+      : undefined;
   // remove any stale tokens that might be there from a previous session=
   samlTokenStorage.remove();
 
@@ -72,6 +73,7 @@ PLUGIN_EMBEDDING_SDK_AUTH.initAuth = async (
           getOrRefreshSession({
             metabaseInstanceUrl,
             preferredAuthMethod,
+            jwtProviderUri,
           }),
         ).unwrap();
         if (session?.id) {
@@ -84,6 +86,7 @@ PLUGIN_EMBEDDING_SDK_AUTH.initAuth = async (
         getOrRefreshSession({
           metabaseInstanceUrl,
           preferredAuthMethod,
+          jwtProviderUri,
         }),
       ).unwrap();
     } catch (e) {
@@ -119,7 +122,12 @@ const refreshTokenImpl = async (
   {
     metabaseInstanceUrl,
     preferredAuthMethod,
-  }: Pick<MetabaseAuthConfig, "metabaseInstanceUrl" | "preferredAuthMethod">,
+    jwtProviderUri,
+  }: {
+    metabaseInstanceUrl: string;
+    preferredAuthMethod?: MetabaseAuthConfig["preferredAuthMethod"];
+    jwtProviderUri?: string;
+  },
   { getState }: { getState: () => unknown },
 ): Promise<MetabaseEmbeddingSessionToken | null> => {
   const state = getState() as SdkStoreState;
@@ -133,6 +141,7 @@ const refreshTokenImpl = async (
   const session = await getRefreshToken({
     metabaseInstanceUrl,
     preferredAuthMethod,
+    jwtProviderUri,
     fetchRequestToken: customGetRefreshToken,
   });
   validateSession(session);
@@ -152,10 +161,11 @@ PLUGIN_EMBEDDING_SDK_AUTH.refreshTokenAsync = refreshTokenImpl;
 export const getOrRefreshSession = createAsyncThunk(
   GET_OR_REFRESH_SESSION,
   async (
-    authConfig: Pick<
-      MetabaseAuthConfig,
-      "metabaseInstanceUrl" | "preferredAuthMethod"
-    >,
+    authConfig: {
+      metabaseInstanceUrl: string;
+      preferredAuthMethod?: MetabaseAuthConfig["preferredAuthMethod"];
+      jwtProviderUri?: string;
+    },
     { dispatch, getState },
   ) => {
     // necessary to ensure that we don't use a popup every time the user
@@ -194,14 +204,23 @@ const getRefreshToken = async ({
   metabaseInstanceUrl,
   preferredAuthMethod,
   fetchRequestToken: customGetRequestToken,
-}: Pick<
-  MetabaseAuthConfig,
-  "metabaseInstanceUrl" | "fetchRequestToken" | "preferredAuthMethod"
->) => {
-  const urlResponseJson = await connectToInstanceAuthSso(metabaseInstanceUrl, {
-    preferredAuthMethod,
-    headers: getSdkRequestHeaders(),
-  });
+  jwtProviderUri,
+}: {
+  metabaseInstanceUrl: string;
+  preferredAuthMethod?: MetabaseAuthConfig["preferredAuthMethod"];
+  fetchRequestToken?: MetabaseAuthConfig["fetchRequestToken"];
+  jwtProviderUri?: string;
+}) => {
+  const shouldSkipSsoDiscovery =
+    preferredAuthMethod === "jwt" && Boolean(jwtProviderUri);
+
+  const urlResponseJson = shouldSkipSsoDiscovery
+    ? { method: "jwt", url: jwtProviderUri }
+    : await connectToInstanceAuthSso(metabaseInstanceUrl, {
+        preferredAuthMethod,
+        headers: getSdkRequestHeaders(),
+      });
+
   const { method, url: responseUrl, hash } = urlResponseJson || {};
   if (method === "saml") {
     const token = await openSamlLoginPopup(responseUrl);
@@ -209,13 +228,19 @@ const getRefreshToken = async ({
 
     return token;
   }
-  if (method === "jwt") {
+  if (method === "jwt" && responseUrl) {
     return jwtDefaultRefreshTokenFunction(
       responseUrl,
       metabaseInstanceUrl,
       getSdkRequestHeaders(hash),
       customGetRequestToken,
     );
+  }
+  if (method === "jwt") {
+    throw MetabaseError.CANNOT_CONNECT_TO_INSTANCE({
+      instanceUrl: metabaseInstanceUrl,
+      message: "Missing JWT provider URI",
+    });
   }
   throw MetabaseError.INVALID_AUTH_METHOD({ method });
 };

--- a/enterprise/frontend/src/embedding-sdk-ee/tests/auth-flow/jwt.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk-ee/tests/auth-flow/jwt.unit.spec.tsx
@@ -31,7 +31,7 @@ const setup = ({
   setupMockJwtEndpoints();
 
   const getFirstSsoDiscoveryCall = () => {
-    // This is `/auth/sso`/`auth/sso?preferred_method=...`
+    // This is `/auth/sso` or `auth/sso?preferred_method=...`
     // that returns the method (jwt/saml) and the url of the sso provider
     // `auth/sso?jwt=...` is the second call and should be excluded from this
     return fetchMock.callHistory

--- a/enterprise/frontend/src/embedding-sdk-ee/tests/auth-flow/jwt.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk-ee/tests/auth-flow/jwt.unit.spec.tsx
@@ -29,10 +29,25 @@ const setup = ({
   locale,
 }: Pick<MetabaseProviderProps, "authConfig" | "locale">) => {
   setupMockJwtEndpoints();
+
+  const getFirstSsoDiscoveryCall = () => {
+    // This is `/auth/sso`/`auth/sso?preferred_method=...`
+    // that returns the method (jwt/saml) and the url of the sso provider
+    // `auth/sso?jwt=...` is the second call and should be excluded from this
+    return fetchMock.callHistory
+      .calls()
+      .filter(
+        (call) =>
+          new URL(call.url).pathname === "/auth/sso" &&
+          !new URL(call.url).searchParams.has("jwt"),
+      );
+  };
+
   return {
     ...baseSetup({ authConfig, locale }),
     getLastAuthProviderApiCall: () =>
       fetchMock.callHistory.lastCall(`${MOCK_JWT_PROVIDER_URI}?response=json`),
+    getFirstSsoDiscoveryCall,
   };
 };
 
@@ -46,7 +61,7 @@ describe("Auth Flow - JWT", () => {
       metabaseInstanceUrl: MOCK_INSTANCE_URL,
     });
 
-    const { rerender } = setup({ authConfig });
+    const { rerender, getFirstSsoDiscoveryCall } = setup({ authConfig });
 
     await waitForLoaderToBeRemoved();
     expect(
@@ -64,6 +79,8 @@ describe("Auth Flow - JWT", () => {
     expect(
       fetchMock.callHistory.calls(`${MOCK_JWT_PROVIDER_URI}?response=json`),
     ).toHaveLength(1);
+
+    expect(getFirstSsoDiscoveryCall()).toHaveLength(1);
 
     const loader = screen.queryByTestId("loading-indicator");
     expect(loader).not.toBeInTheDocument();
@@ -104,6 +121,22 @@ describe("Auth Flow - JWT", () => {
     );
   });
 
+  it("should skip the initial /auth/sso request when jwtProviderUri is provided", async () => {
+    const authConfig = defineMetabaseAuthConfig({
+      metabaseInstanceUrl: MOCK_INSTANCE_URL,
+      preferredAuthMethod: "jwt",
+      jwtProviderUri: MOCK_JWT_PROVIDER_URI,
+    });
+
+    const { getLastAuthProviderApiCall, getFirstSsoDiscoveryCall } = setup({
+      authConfig,
+    });
+
+    await waitForRequest(() => getLastAuthProviderApiCall());
+
+    expect(getFirstSsoDiscoveryCall()).toHaveLength(0);
+  });
+
   it("should use `fetchRequestToken` if provided", async () => {
     const customFetchFunction = jest.fn().mockImplementation(() => ({
       jwt: MOCK_VALID_JWT_RESPONSE,
@@ -115,13 +148,19 @@ describe("Auth Flow - JWT", () => {
       fetchRequestToken: customFetchFunction,
     });
 
-    const { getLastCardQueryApiCall, getLastUserApiCall } = setup({
+    const {
+      getLastCardQueryApiCall,
+      getLastUserApiCall,
+      getFirstSsoDiscoveryCall,
+    } = setup({
       authConfig,
     });
 
     await waitForRequest(() => getLastUserApiCall());
 
     expect(customFetchFunction).toHaveBeenCalled();
+
+    expect(getFirstSsoDiscoveryCall()).toHaveLength(1);
 
     expect(getLastUserApiCall()?.options.headers).toHaveProperty(
       "x-metabase-session",

--- a/enterprise/frontend/src/embedding-sdk-ee/tests/auth-flow/jwt.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk-ee/tests/auth-flow/jwt.unit.spec.tsx
@@ -124,7 +124,6 @@ describe("Auth Flow - JWT", () => {
   it("should skip the initial /auth/sso request when jwtProviderUri is provided", async () => {
     const authConfig = defineMetabaseAuthConfig({
       metabaseInstanceUrl: MOCK_INSTANCE_URL,
-      preferredAuthMethod: "jwt",
       jwtProviderUri: MOCK_JWT_PROVIDER_URI,
     });
 

--- a/frontend/src/embedding-sdk-bundle/store/auth/auth.ts
+++ b/frontend/src/embedding-sdk-bundle/store/auth/auth.ts
@@ -21,26 +21,10 @@ export const PLUGIN_EMBEDDING_SDK_AUTH = {
 export const initAuth = createAsyncThunk(
   "sdk/token/INIT_AUTH",
   async (
-    config: MetabaseAuthConfig & { isLocalHost?: boolean },
+    authConfig: MetabaseAuthConfig & { isLocalHost?: boolean },
     { dispatch },
   ) => {
-    const { metabaseInstanceUrl, preferredAuthMethod, apiKey, isLocalHost } =
-      config;
-    const jwtProviderUri =
-      preferredAuthMethod === "jwt" && "jwtProviderUri" in config
-        ? config.jwtProviderUri
-        : undefined;
-
-    return await PLUGIN_EMBEDDING_SDK_AUTH.initAuth(
-      {
-        metabaseInstanceUrl,
-        preferredAuthMethod,
-        apiKey,
-        isLocalHost,
-        jwtProviderUri,
-      },
-      { dispatch },
-    );
+    return await PLUGIN_EMBEDDING_SDK_AUTH.initAuth(authConfig, { dispatch });
   },
 );
 

--- a/frontend/src/embedding-sdk-bundle/store/auth/auth.ts
+++ b/frontend/src/embedding-sdk-bundle/store/auth/auth.ts
@@ -21,20 +21,23 @@ export const PLUGIN_EMBEDDING_SDK_AUTH = {
 export const initAuth = createAsyncThunk(
   "sdk/token/INIT_AUTH",
   async (
-    {
-      metabaseInstanceUrl,
-      preferredAuthMethod,
-      apiKey,
-      isLocalHost,
-    }: MetabaseAuthConfig & { isLocalHost?: boolean },
+    config: MetabaseAuthConfig & { isLocalHost?: boolean },
     { dispatch },
   ) => {
+    const { metabaseInstanceUrl, preferredAuthMethod, apiKey, isLocalHost } =
+      config;
+    const jwtProviderUri =
+      preferredAuthMethod === "jwt" && "jwtProviderUri" in config
+        ? config.jwtProviderUri
+        : undefined;
+
     return await PLUGIN_EMBEDDING_SDK_AUTH.initAuth(
       {
         metabaseInstanceUrl,
         preferredAuthMethod,
         apiKey,
         isLocalHost,
+        jwtProviderUri,
       },
       { dispatch },
     );
@@ -47,13 +50,19 @@ export const refreshTokenAsync = createAsyncThunk(
     {
       metabaseInstanceUrl,
       preferredAuthMethod,
-    }: Pick<MetabaseAuthConfig, "metabaseInstanceUrl" | "preferredAuthMethod">,
+      jwtProviderUri,
+    }: {
+      metabaseInstanceUrl: string;
+      preferredAuthMethod?: MetabaseAuthConfig["preferredAuthMethod"];
+      jwtProviderUri?: string;
+    },
     { getState },
   ): Promise<MetabaseEmbeddingSessionToken | null> => {
     return await PLUGIN_EMBEDDING_SDK_AUTH.refreshTokenAsync(
       {
         metabaseInstanceUrl,
         preferredAuthMethod,
+        jwtProviderUri,
       },
       { getState },
     );

--- a/frontend/src/embedding-sdk-bundle/types/auth-config.ts
+++ b/frontend/src/embedding-sdk-bundle/types/auth-config.ts
@@ -19,6 +19,11 @@ export type MetabaseAuthConfigWithJwt = BaseMetabaseAuthConfig & {
   preferredAuthMethod?: "jwt";
 
   /**
+   * Uri of the jwt provider. If provided the sdk will use jwt and will skip the first `/auth/sso` discovery request.
+   */
+  jwtProviderUri?: string;
+
+  /**
    * Specifies a function to fetch the refresh token.
    * The refresh token should be in the format of {@link UserBackendJwtResponse}
    */


### PR DESCRIPTION
# Description

Closes EMB-1098

This PR makes the auth flow in the sdk skip the first `/auth/sso` request if the host app pass us the jwt provider uri, as after :pull-request: [remove hash logic in /auth/sso to speed up auth flow](https://github.com/metabase/metabase/pull/66076) we don't need the first request for anything else if we're using jwt.


# How to verify
Everything should work as before, by default but if you pass `jwtProviderUri` in the authConfig, then it should skip the first `/auth/sso` request, speeding up the auth flow