### PR TITLE
bump databricks

### DIFF
--- a/modules/drivers/databricks/deps.edn
+++ b/modules/drivers/databricks/deps.edn
@@ -2,4 +2,4 @@
  ["src" "resources"]
 
  :deps
- {com.databricks/databricks-jdbc {:mvn/version "3.0.1"}}}
+ {com.databricks/databricks-jdbc-thin {:mvn/version "3.0.5"}}}

--- a/modules/drivers/databricks/test/metabase/driver/databricks_test.clj
+++ b/modules/drivers/databricks/test/metabase/driver/databricks_test.clj
@@ -258,7 +258,7 @@
               (is (= "2017-04-18T09:53:37.046-07:00"
                      (last (first rows)))))))))))
 
-(deftest additional-options-test
+(deftest ^:synchronized additional-options-test
   (mt/test-driver
     :databricks
     (testing "Connections with UserAgentEntry"


### PR DESCRIPTION
This moves over to a thin jar (or regular jar) which provides jdbc classes and lists its dependencies. We can now bump or pin as we like. The previous versions were uberjars that had their dependencies packaged inside.

```clojure
clj -Sdeps '{:deps {com.databricks/databricks-jdbc-thin {:mvn/version "3.0.5"}}}'
Clojure 1.12.1
user=> (Class/forName "com.databricks.client.jdbc.Driver")
com.databricks.client.jdbc.Driver
```

```clojure
clj -Xdeps tree :extra '{:deps {com.databricks/databricks-jdbc-thin {:mvn/version "3.0.5"}}}'
org.clojure/clojure 1.12.1
  . org.clojure/spec.alpha 0.5.238
  . org.clojure/core.specs.alpha 0.4.74
com.databricks/databricks-jdbc-thin 3.0.5
  . com.databricks/databricks-sdk-java 0.69.0
    X org.slf4j/slf4j-api 2.0.9 :older-version
    . org.apache.commons/commons-configuration2 2.11.0 :newer-version
      X org.apache.commons/commons-lang3 3.14.0 :older-version
      . org.apache.commons/commons-text 1.12.0
        X org.apache.commons/commons-lang3 3.14.0 :older-version
      . commons-logging/commons-logging 1.3.2 :newer-version
    X com.fasterxml.jackson.core/jackson-databind 2.15.2 :older-version
...
```

contrasted with

```clojure
❯ clj -Xdeps tree :extra '{:deps {com.databricks/databricks-jdbc {:mvn/version "3.0.1"}}}'
org.clojure/clojure 1.12.1
  . org.clojure/spec.alpha 0.5.238
  . org.clojure/core.specs.alpha 0.4.74
com.databricks/databricks-jdbc 3.0.1
```