### PR TITLE
GDGT-1244: Fix DB tree virtualization

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/Results.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/Results.module.css
@@ -2,6 +2,8 @@
   --owner-column-width: 140px;
   --rows-column-width: 80px;
   --published-column-width: 80px;
+
+  height: 100%;
 }
 
 .header {
@@ -24,7 +26,7 @@
 .results {
   position: relative;
   overflow: auto;
-  flex: 1;
+  flex: 1 1 auto;
   min-height: 0;
 }
 
@@ -32,7 +34,6 @@
   --item-top-border-color: transparent;
   /* box-shadow is a way to avoid layout shifts and doubled borders in the items */
   box-shadow: inset 0 1px 0 var(--item-top-border-color);
-  /* TODO: probably we can avoid using absolute positioning */
   position: absolute;
   cursor: pointer;
   border-bottom: 1px solid var(--mb-color-border);

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/Results.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/Results.module.css
@@ -11,6 +11,7 @@
   align-items: center;
   padding-left: var(--mantine-spacing-md);
   padding-bottom: var(--mantine-spacing-xs);
+  border-bottom: 1px solid var(--mb-color-border);
   font-size: 0.75rem;
   font-weight: 700;
 }
@@ -32,8 +33,7 @@
 
 .item {
   --item-top-border-color: transparent;
-  /* box-shadow is a way to avoid layout shifts and doubled borders in the items */
-  box-shadow: inset 0 1px 0 var(--item-top-border-color);
+
   position: absolute;
   cursor: pointer;
   border-bottom: 1px solid var(--mb-color-border);
@@ -61,10 +61,6 @@
       opacity: 1;
     }
   }
-
-  &:first-of-type {
-    --item-top-border-color: var(--mb-color-border);
-  }
 }
 
 .icon {
@@ -85,7 +81,8 @@
 .checkbox {
   flex-shrink: 0;
   width: 40px;
-  height: 40px;
+  max-height: 40px;
+  height: 100%;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/Results.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/Results.tsx
@@ -493,6 +493,7 @@ const ResultsItem = ({
       justify="flex-start"
       gap={0}
       w="100%"
+      mih={ITEM_MIN_HEIGHT}
       className={cx(S.item, S[type], {
         [S.active]: isActive,
         [S.selected]: selectedIndex === index,
@@ -527,14 +528,7 @@ const ResultsItem = ({
         />
       </Box>
 
-      <Flex
-        align="center"
-        mih={ITEM_MIN_HEIGHT}
-        py="xs"
-        w="100%"
-        pl={indent}
-        gap="sm"
-      >
+      <Flex align="center" py="xs" w="100%" pl={indent} gap="sm">
         <Flex align="flex-start" gap="xs" className={S.content}>
           <Flex align="center" gap="xs">
             <Box className={S.chevronSlot} w={INDENT_OFFSET}>

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/Results.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/Results.tsx
@@ -18,7 +18,7 @@ import {
 } from "metabase/common/hooks/use-number-formatter";
 import { DataModelContext } from "metabase/metadata/pages/shared/DataModelContext";
 import { getUrl } from "metabase/metadata/pages/shared/utils";
-import { Box, Checkbox, Flex, Icon, Skeleton, rem } from "metabase/ui";
+import { Box, Checkbox, Flex, Icon, Skeleton, Stack, rem } from "metabase/ui";
 import type { UserId } from "metabase-types/api";
 
 import { useSelection } from "../../../pages/DataModel/contexts/SelectionContext";
@@ -162,7 +162,7 @@ export function TablePickerResults({
   };
 
   return (
-    <Box className={S.root}>
+    <Stack className={S.root} gap={0}>
       <Flex className={S.header} gap="sm" justify="flex-end">
         <Box className={cx(S.headerCell, S.ownerColumn)}>{t`Owner`}</Box>
         <Box className={cx(S.headerCell, S.rowsColumn)}>{t`Rows`}</Box>
@@ -170,7 +170,7 @@ export function TablePickerResults({
           className={cx(S.headerCell, S.publishedColumn)}
         >{t`Published`}</Box>
       </Flex>
-      <Box ref={ref} pb="lg" className={S.results}>
+      <Box ref={ref} className={S.results}>
         <Box style={{ height: virtual.getTotalSize() }}>
           {virtualItems.map(({ start, index }) => {
             const item = items[index];
@@ -198,7 +198,7 @@ export function TablePickerResults({
           })}
         </Box>
       </Box>
-    </Box>
+    </Stack>
   );
 }
 
@@ -501,7 +501,7 @@ const ResultsItem = ({
       data-open={isExpanded}
       tabIndex={disabled ? -1 : 0}
       style={{
-        top: start,
+        transform: `translateY(${start}px)`,
         pointerEvents: disabled ? "none" : undefined,
       }}
       to={getUrl(baseUrl, {

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/TablePicker.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/TablePicker.tsx
@@ -144,7 +144,7 @@ export function TablePicker({
         </Popover>
       </Group>
 
-      <Box style={{ overflow: "auto" }}>
+      <Box mih={0} flex="1 1 auto">
         {deferredQuery === "" && filtersCount === 0 ? (
           <Tree
             path={path}


### PR DESCRIPTION
Closes [GDGT-1244](https://linear.app/metabase/issue/GDGT-1244/virtualization-in-the-tree-does-not-work)

### Description

I've noticed that the list of tables wasn't virtualized correctly. It turns out that parent container components didn't have proper height specified. Also, I've updated virtualization offset by changing `top` to `translateY` property, since it has better performance in terms of browser rendering.

### How to verify

1. Open Data Studio, open DevTools inspector.
2. Check the Tree component rerendering and having no more than 20-30 child elements at once.
3. Check that there're no unnecessary scrolls.

### Demo

https://github.com/user-attachments/assets/7a89d395-fa10-480a-84da-2124bdc4e5d9

