### PR TITLE
Avoid showing other subscription channels

### DIFF
--- a/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/DashboardSubscriptionsSidebar.jsx
+++ b/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/DashboardSubscriptionsSidebar.jsx
@@ -288,8 +288,12 @@ class DashboardSubscriptionsSidebarInner extends Component {
   editPulse = (pulse, channelType) => {
     this.setPulse(pulse);
     this.setState(({ editingMode, returnMode }) => {
+      const editingModeMap = {
+        [CHANNEL_TYPES.EMAIL]: EDITING_MODES.ADD_EMAIL,
+        [CHANNEL_TYPES.SLACK]: EDITING_MODES.ADD_SLACK,
+      };
       return {
-        editingMode: "add-edit-" + channelType,
+        editingMode: editingModeMap[channelType],
         returnMode: returnMode.concat([
           editingMode || EDITING_MODES.LIST_PULSES,
         ]),

--- a/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/DashboardSubscriptionsSidebar.jsx
+++ b/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/DashboardSubscriptionsSidebar.jsx
@@ -136,7 +136,15 @@ class DashboardSubscriptionsSidebarInner extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { isAdmin } = this.props;
+    const { editingMode } = this.state;
+    const { isAdmin, pulses } = this.props;
+
+    if (editingMode === EDITING_MODES.LIST_PULSES && pulses?.length === 0) {
+      this.setState({
+        editingMode: EDITING_MODES.NEW_PULSE,
+        returnMode: [],
+      });
+    }
 
     if (!isAdmin) {
       this.forwardNonAdmins({ prevProps });
@@ -165,9 +173,7 @@ class DashboardSubscriptionsSidebarInner extends Component {
       return;
     }
 
-    const isEditingModeForwardable =
-      editingMode === EDITING_MODES.NEW_PULSE ||
-      (editingMode === EDITING_MODES.LIST_PULSES && newPulses?.length === 0);
+    const isEditingModeForwardable = editingMode === EDITING_MODES.NEW_PULSE;
 
     if (isEditingModeForwardable) {
       const emailConfigured = formInput?.channels?.email?.configured || false;
@@ -337,7 +343,7 @@ class DashboardSubscriptionsSidebarInner extends Component {
       );
     }
 
-    if (editingMode === EDITING_MODES.LIST_PULSES && pulses.length > 0) {
+    if (editingMode === EDITING_MODES.LIST_PULSES) {
       return (
         <PulsesListSidebar
           pulses={pulses}
@@ -437,7 +443,7 @@ class DashboardSubscriptionsSidebarInner extends Component {
       );
     }
 
-    if (editingMode === EDITING_MODES.NEW_PULSE || pulses.length === 0) {
+    if (editingMode === EDITING_MODES.NEW_PULSE) {
       const emailConfigured = formInput?.channels?.email?.configured || false;
       const slackConfigured = formInput?.channels?.slack?.configured || false;
 

--- a/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/DashboardSubscriptionsSidebar.jsx
+++ b/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/DashboardSubscriptionsSidebar.jsx
@@ -7,6 +7,7 @@ import _ from "underscore";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { Sidebar } from "metabase/dashboard/components/Sidebar";
 import { useDashboardContext } from "metabase/dashboard/context";
+import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import Pulses from "metabase/entities/pulses";
 import {
   NEW_PULSE_TEMPLATE,
@@ -144,6 +145,21 @@ class DashboardSubscriptionsSidebarInner extends Component {
         editingMode: EDITING_MODES.NEW_PULSE,
         returnMode: [],
       });
+    }
+
+    /**
+     * (EMB-976): In SDK/EAJS context we need to avoid showing the NEW_PULSE view (the view that lets users select
+     * between Email and Slack options) because we only allow email subscriptions there.
+     *
+     * And it's guaranteed that email would already be set up in SDK/EAJS context.
+     * Otherwise, we won't show the subscription button to open this sidebar
+     * in the first place.
+     */
+    if (isEmbeddingSdk() && editingMode === EDITING_MODES.NEW_PULSE) {
+      this.setState({
+        editingMode: EDITING_MODES.ADD_EMAIL,
+      });
+      this.setPulseWithChannel(CHANNEL_TYPES.EMAIL);
     }
 
     if (!isAdmin) {

--- a/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/common.unit.spec.ts
+++ b/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/common.unit.spec.ts
@@ -41,6 +41,26 @@ describe("DashboardSubscriptionsSidebar", () => {
     expect(await screen.findByText("Send it to Slack")).toBeInTheDocument();
   });
 
+  describe("Embedding SDK", () => {
+    it("should not show subscription options when Slack is set up", async () => {
+      setup({ isEmbeddingSdk: true, email: true, slack: true });
+
+      expect(
+        await screen.findByText("Email this dashboard"),
+      ).toBeInTheDocument();
+    });
+
+    it("should not show subscription options when Slack is not set up", async () => {
+      setup({ isEmbeddingSdk: true, email: true, slack: false });
+
+      expect(
+        await screen.findByText("Email this dashboard"),
+      ).toBeInTheDocument();
+    });
+
+    // We don't test `email: false` because this sidebar is only accessible when email is already set up
+  });
+
   describe("Slack Subscription sidebar", () => {
     it("should not show advanced filter options in OSS", async () => {
       setup();

--- a/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/setup.tsx
+++ b/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/setup.tsx
@@ -7,6 +7,7 @@ import { setupNotificationChannelsEndpoints } from "__support__/server-mocks/pul
 import { mockSettings } from "__support__/settings";
 import type { Screen } from "__support__/ui";
 import { renderWithProviders } from "__support__/ui";
+import { isEmbeddingSdk as mockIsEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { MockDashboardContext } from "metabase/public/containers/PublicOrEmbeddedDashboard/mock-context";
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
 import type {
@@ -29,11 +30,8 @@ import {
 
 import DashboardSubscriptionsSidebar from "../DashboardSubscriptionsSidebar";
 
-const mockIsEmbeddingSdkObject = {
-  value: false,
-};
 jest.mock("metabase/embedding-sdk/config", () => ({
-  isEmbeddingSdk: jest.fn(() => mockIsEmbeddingSdkObject.value),
+  isEmbeddingSdk: jest.fn(() => false),
 }));
 
 export const dashcard = createMockDashboardCard();
@@ -152,7 +150,7 @@ export function setup(
     };
   }
 
-  mockIsEmbeddingSdkObject.value = isEmbeddingSdk;
+  (mockIsEmbeddingSdk as jest.Mock).mockReturnValue(isEmbeddingSdk);
 
   setupNotificationChannelsEndpoints(channelData.channels);
 

--- a/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/setup.tsx
+++ b/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/setup.tsx
@@ -29,6 +29,13 @@ import {
 
 import DashboardSubscriptionsSidebar from "../DashboardSubscriptionsSidebar";
 
+const mockIsEmbeddingSdkObject = {
+  value: false,
+};
+jest.mock("metabase/embedding-sdk/config", () => ({
+  isEmbeddingSdk: jest.fn(() => mockIsEmbeddingSdkObject.value),
+}));
+
 export const dashcard = createMockDashboardCard();
 
 const actionDashcard = createMockActionDashboardCard({
@@ -74,6 +81,17 @@ function createDashboardState(
   });
 }
 
+type SetupOpts = {
+  email?: boolean;
+  slack?: boolean;
+  tokenFeatures?: Partial<TokenFeatures>;
+  hasEnterprisePlugins?: boolean;
+  isAdmin?: boolean;
+  dashcards?: DashboardCard[];
+  parameters?: UiParameter[];
+  isEmbeddingSdk?: boolean;
+};
+
 export function setup(
   {
     email,
@@ -83,15 +101,8 @@ export function setup(
     isAdmin = false,
     dashcards = defaultDashcards,
     parameters = defaultParameters,
-  }: {
-    email?: boolean;
-    slack?: boolean;
-    tokenFeatures?: Partial<TokenFeatures>;
-    hasEnterprisePlugins?: boolean;
-    isAdmin?: boolean;
-    dashcards?: DashboardCard[];
-    parameters?: UiParameter[];
-  } = {
+    isEmbeddingSdk = false,
+  }: SetupOpts = {
     email: true,
     slack: true,
     tokenFeatures: {},
@@ -140,6 +151,8 @@ export function setup(
       ],
     };
   }
+
+  mockIsEmbeddingSdkObject.value = isEmbeddingSdk;
 
   setupNotificationChannelsEndpoints(channelData.channels);
 


### PR DESCRIPTION
closes EMB-976

### Description

This PR removes the screen on the subscriptions sidebar that lets users select either Email or Slack for subscriptions. As we'll only be allowing email, whenever we want to display this screen, if we're on Embedding SDK (and EAJS in later PR), we should skip this screen and go right into the email setup screen.

### How to verify
1. Run MB
2. Test this in storybook
    ```sh
    yarn storbybook-embedding-sdk
    ```
3. Test all 3 dashboard components `StaticDashboard`, `InteractiveDashboard`, `EditableDashboard`
4. Try to click around the sidebar states, and the screen that allows user to select either an Email or Slack should never appear.
5. If you try to remove the email set up, the subscription button should also disappear.

### Demo

#### This PR: When clicking the subscriptions button
<img width="1137" height="520" alt="image" src="https://github.com/user-attachments/assets/7b0bcc01-1a5d-4a4f-858e-a2e01c25eaac" />


#### Before this PR: When clicking the subscriptions button
<img width="1135" height="519" alt="image" src="https://github.com/user-attachments/assets/7adf1003-b16c-483e-aeb8-ce131ed2c7ba" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
