### PR TITLE
chore(sdk): remove excessive logs in sdk fixup script

### DIFF
--- a/bin/embedding-sdk/fixup-types-after-compilation.js
+++ b/bin/embedding-sdk/fixup-types-after-compilation.js
@@ -32,13 +32,15 @@ const API_EXTRACTOR_CONFIG_PATH = path.join(
 );
 
 const getLogger = (prefix) => {
+  const verbose = process.env.SDK_FIXUP_VERBOSE_LOGS === "true";
   return {
+    verbose: (message) => verbose && console.log(`[${prefix}] ${message}`),
     log: (message) => console.log(`[${prefix}] ${message}`),
     error: (message) => console.error(`[${prefix}] ${message}`),
   };
 };
 
-const { log } = getLogger("dts fixup");
+const { log, verbose } = getLogger("dts fixup");
 
 const getRelativePath = (fromPath, toPath) => {
   const relativePath = path.relative(path.dirname(fromPath), toPath);
@@ -68,7 +70,7 @@ const replaceAliasedImports = (filePath) => {
   });
 
   fs.writeFileSync(filePath, fileContent, { encoding: "utf-8" });
-  log(`Edited file: ${filePath}`);
+  verbose(`Edited file: ${filePath}`);
 };
 
 const removeUnresolvedReexports = (filePath) => {
@@ -95,7 +97,7 @@ const removeUnresolvedReexports = (filePath) => {
         !fs.existsSync(`${path.resolve(dirPath, target)}.d.ts`);
 
       if (isUnresolved) {
-        log(`Removing unresolved re-export: ${line}`);
+        verbose(`Removing unresolved re-export: ${line}`);
         isModified = true;
       }
 
@@ -118,7 +120,7 @@ const fixupTypesAfterCompilation = ({ isWatchMode }) => {
     removeUnresolvedReexports(filePath);
   });
 
-  log("Done!");
+  console.log("[dts fixup] Done!");
 
   if (!isWatchMode) {
     generateDtsRollup();
@@ -177,7 +179,7 @@ const generateDtsRollup = () => {
     });
   });
 
-  log("Dts rollup done!");
+  console.log("[dts rollup] Dts rollup done!");
 };
 
 const watchFilesAndFixThem = () => {


### PR DESCRIPTION
We don't need those logs unless we're debugging something, and they're very spammy and potentially slowing down the script a bit