### PR TITLE
UX for merging workspaces

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/api/workspace.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/workspace.ts
@@ -6,6 +6,7 @@ import type {
   Workspace,
   WorkspaceContents,
   WorkspaceId,
+  WorkspaceMergeResponse,
 } from "metabase-types/api";
 
 import { EnterpriseApi } from "./api";
@@ -75,6 +76,18 @@ export const workspaceApi = EnterpriseApi.injectEndpoints({
       providesTags: (_, error, id) =>
         invalidateTags(error, [idTag("transform", id)]),
     }),
+    mergeWorkspace: builder.mutation<WorkspaceMergeResponse, WorkspaceId>({
+      query: (id) => ({
+        method: "POST",
+        url: `/api/ee/workspace/${id}/merge`,
+      }),
+      invalidatesTags: (_, error) =>
+        invalidateTags(error, [
+          listTag("workspace"),
+          listTag("transform"),
+          tag("transform"),
+        ]),
+    }),
   }),
 });
 
@@ -85,4 +98,5 @@ export const {
   useGetWorkspaceContentsQuery,
   useGetTransformUpstreamMappingQuery,
   useGetTransformDownstreamMappingQuery,
+  useMergeWorkspaceMutation,
 } = workspaceApi;

--- a/frontend/src/metabase-types/api/workspace.ts
+++ b/frontend/src/metabase-types/api/workspace.ts
@@ -49,3 +49,10 @@ export type DownstreamTransformInfo = {
 export type TransformDownstreamMapping = {
   transforms: DownstreamTransformInfo[];
 };
+
+export type WorkspaceMergeResponse = {
+  promoted: { id: TransformId; name: string }[];
+  errors?: { id: TransformId; name: string; error: string }[];
+  workspace: { id: WorkspaceId; name: string };
+  archived_at: string | null;
+};


### PR DESCRIPTION
Add a merge button, that promotes then deletes the workspace.

Disable the Clone button if you haven't run the original transform yet, as we don't yet support it.