### PR TITLE
Remove redundant static-viz files changed condition

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -36,49 +36,19 @@ jobs:
           list-files: csv
           filters: .github/file-paths.yaml
 
-  static-viz-files-changed:
-    name: Check whether static-viz files changed
-    if: ${{ !contains(github.event.pull_request.labels.*.name,'ci skip') && !contains(github.event.pull_request.labels.*.name,'minimal-tests') }}
-    runs-on: ubuntu-22.04
-    timeout-minutes: 10
-    outputs:
-      static_viz: ${{ steps.static_viz.outputs.static_viz }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Prepare front-end environment
-        uses: ./.github/actions/prepare-frontend
-      - name: Prepare back-end environment
-        uses: ./.github/actions/prepare-backend
-      - name: Build static-viz frontend
-        run: yarn build-static-viz
-        env:
-          MB_EDITION: ee
-      - name: Upload Static Viz Bundle Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: static-viz-bundle-${{ github.sha }}
-          path: resources/frontend_client/app/dist
-
-      - name: Check for static viz changes
-        uses: dorny/paths-filter@v3.0.0
-        id: static_viz
-        with:
-          token: ${{ github.token }}
-          filters: .github/static-viz-sources.yaml
-
   uberjar:
-    needs: [files-changed, static-viz-files-changed]
+    needs: [files-changed]
     if: ${{ !cancelled() && !(needs.files-changed.outputs.documentation == 'true' && needs.files-changed.outputs.backend_all == 'false' && needs.files-changed.outputs.frontend_all == 'false' && needs.files-changed.outputs.e2e_all == 'false') }}
     uses: ./.github/workflows/uberjar.yml
     secrets: inherit
 
   backend-tests:
     if: ${{ !cancelled() && needs.files-changed.result == 'success' }}
-    needs: [files-changed, static-viz-files-changed]
+    needs: [files-changed]
     uses: ./.github/workflows/backend.yml
     secrets: inherit
     with:
-      skip: ${{ needs.files-changed.outputs.backend_all != 'true' && needs.static-viz-files-changed.outputs.static_viz != 'true' }}
+      skip: ${{ needs.files-changed.outputs.backend_all != 'true' }}
 
   semantic-search-tests:
     needs: files-changed


### PR DESCRIPTION
Resolves DEV-1109

tl;dr
Static-viz changes are already covered by `frontend_all` and `backend_all` checks from [file-paths.yml](https://github.com/metabase/metabase/blob/master/.github/file-paths.yaml)

Context: https://metaboat.slack.com/archives/C0669P4AF9N/p1763736955298309

= = = = = = = = = 

### Addendum

The only file for which it wasn't obvious is it covered by `backend_all` or not is `shadow-cljs.edn`. I changed it in [this test PR](https://github.com/metabase/metabase/pull/66132), and it still [triggered the uberjar build](https://github.com/metabase/metabase/actions/runs/19576004075/job/56061612668) (which means we're good).