### PR TITLE
Native query parsing understands queries with dependent ctes

### DIFF
--- a/src/metabase/driver/sql/references.clj
+++ b/src/metabase/driver/sql/references.clj
@@ -295,8 +295,10 @@
 
 (defmethod field-references-impl [:sql :macaw.ast/select]
   [driver outside-sources outside-withs expr]
-  (let [local-withs (map (partial field-references-impl driver outside-sources outside-withs)
-                         (:with expr))
+  (let [local-withs (reduce (fn [current-withs with-expr]
+                              (conj current-withs (field-references-impl driver outside-sources current-withs with-expr)))
+                            outside-withs
+                            (:with expr))
         withs (into outside-withs local-withs)]
     {:used-fields (into (find-used-fields driver outside-sources withs expr)
                         (mapcat :used-fields)

--- a/test/metabase/driver/sql/references_test.clj
+++ b/test/metabase/driver/sql/references_test.clj
@@ -784,6 +784,22 @@ SELECT * FROM active_users"))))
          (->references "WITH active_users AS (SELECT id, name FROM users WHERE active = true)
 SELECT * FROM products"))))
 
+(deftest ^:parallel multilevel-cte-test
+  (is (= {:used-fields
+          #{{:column "id",
+             :alias nil,
+             :type :single-column,
+             :source-columns [[{:type :all-columns, :table {:table "orders"}}]]}},
+          :returned-fields
+          [{:column "id",
+            :alias nil,
+            :type :single-column,
+            :source-columns [[{:type :all-columns, :table {:table "orders"}}]]}]}
+         (->references "
+WITH orders_a AS (select * from orders),
+orders_b AS (select * from orders_a)
+SELECT id from orders_b"))))
+
 (deftest ^:parallel shadowed-cte-test
   (is (= {:used-fields
           #{{:column "y",

--- a/test/metabase/driver/sql/references_test.clj
+++ b/test/metabase/driver/sql/references_test.clj
@@ -1449,11 +1449,9 @@ ORDER BY
                 :source-columns
                 [[{:type :all-columns,
                    :table {:table-alias "ah", :schema "dbt_models", :table "account_history"}}]]}
-               {:column "month",
-                :alias nil,
-                :type :single-column,
-                :source-columns
-                [[{:type :all-columns, :table {:table-alias "m", :table "months"}}]]}}}
+               {:alias "month",
+                :type :custom-field,
+                :used-fields #{}}}}
             {:alias "is_active_accounts_starter",
              :type :custom-field,
              :used-fields
@@ -1529,11 +1527,9 @@ ORDER BY
                 :source-columns
                 [[{:type :all-columns,
                    :table {:table-alias "ah", :schema "dbt_models", :table "account_history"}}]]}
-               {:column "month",
-                :alias nil,
-                :type :single-column,
-                :source-columns
-                [[{:type :all-columns, :table {:table-alias "m", :table "months"}}]]}}}
+               {:alias "month",
+                :type :custom-field,
+                :used-fields #{}}}}
             {:alias "is_trialing_accounts_cloud",
              :type :custom-field,
              :used-fields
@@ -1555,11 +1551,9 @@ ORDER BY
                 :source-columns
                 [[{:type :all-columns,
                    :table {:table-alias "ah", :schema "dbt_models", :table "account_history"}}]]}
-               {:column "month",
-                :alias nil,
-                :type :single-column,
-                :source-columns
-                [[{:type :all-columns, :table {:table-alias "m", :table "months"}}]]}}}
+               {:alias "month",
+                :type :custom-field,
+                :used-fields #{}}}}
             {:column "deployment",
              :alias nil,
              :type :single-column,
@@ -1662,11 +1656,9 @@ ORDER BY
                 :source-columns
                 [[{:type :all-columns,
                    :table {:table-alias "ah", :schema "dbt_models", :table "account_history"}}]]}
-               {:column "month",
-                :alias nil,
-                :type :single-column,
-                :source-columns
-                [[{:type :all-columns, :table {:table-alias "m", :table "months"}}]]}}}
+               {:alias "month",
+                :type :custom-field,
+                :used-fields #{}}}}
             {:column "customer_name",
              :alias nil,
              :type :single-column,
@@ -1688,11 +1680,9 @@ ORDER BY
                 :source-columns
                 [[{:type :all-columns,
                    :table {:table-alias "ah", :schema "dbt_models", :table "account_history"}}]]}
-               {:column "month",
-                :alias nil,
-                :type :single-column,
-                :source-columns
-                [[{:type :all-columns, :table {:table-alias "m", :table "months"}}]]}}}
+               {:alias "month",
+                :type :custom-field,
+                :used-fields #{}}}}
             {:column "is_active",
              :alias nil,
              :type :single-column,
@@ -1720,11 +1710,9 @@ ORDER BY
                 :source-columns
                 [[{:type :all-columns,
                    :table {:table-alias "a", :schema "dbt_models", :table "account"}}]]}
-               {:column "month",
-                :alias nil,
-                :type :single-column,
-                :source-columns
-                [[{:type :all-columns, :table {:table-alias "m", :table "months"}}]]}}}
+               {:alias "month",
+                :type :custom-field,
+                :used-fields #{}}}}
             {:alias "is_paid_accounts_cloud",
              :type :custom-field,
              :used-fields
@@ -1746,11 +1734,9 @@ ORDER BY
                 :source-columns
                 [[{:type :all-columns,
                    :table {:table-alias "a", :schema "dbt_models", :table "account"}}]]}
-               {:column "month",
-                :alias nil,
-                :type :single-column,
-                :source-columns
-                [[{:type :all-columns, :table {:table-alias "m", :table "months"}}]]}}}
+               {:alias "month",
+                :type :custom-field,
+                :used-fields #{}}}}
             {:alias "is_paid_accounts_starter",
              :type :custom-field,
              :used-fields
@@ -1778,15 +1764,12 @@ ORDER BY
                 :source-columns
                 [[{:type :all-columns,
                    :table {:table-alias "ah", :schema "dbt_models", :table "account_history"}}]]}
-               {:column "month",
-                :alias nil,
-                :type :single-column,
-                :source-columns
-                [[{:type :all-columns, :table {:table-alias "m", :table "months"}}]]}}}
-            {:column "month",
-             :alias nil,
-             :type :single-column,
-             :source-columns [[{:type :all-columns, :table {:table-alias "m", :table "months"}}]]}
+               {:alias "month",
+                :type :custom-field,
+                :used-fields #{}}}}
+            {:alias "month",
+             :type :custom-field,
+             :used-fields #{}}
             {:column "valid_to",
              :alias nil,
              :type :single-column,
@@ -1874,10 +1857,9 @@ ORDER BY
             :source-columns
             [[{:type :all-columns,
                :table {:table-alias "a", :schema "dbt_models", :table "account"}}]]}
-           {:column "month",
-            :alias nil,
-            :type :single-column,
-            :source-columns [[{:type :all-columns, :table {:table-alias "m", :table "months"}}]]}
+           {:alias "month",
+            :type :custom-field,
+            :used-fields #{}}
            {:alias "is_trialing",
             :type :custom-field,
             :used-fields
@@ -1893,10 +1875,9 @@ ORDER BY
                :source-columns
                [[{:type :all-columns,
                   :table {:table-alias "ah", :schema "dbt_models", :table "account_history"}}]]}
-              {:column "month",
-               :alias nil,
-               :type :single-column,
-               :source-columns [[{:type :all-columns, :table {:table-alias "m", :table "months"}}]]}}}
+              {:alias "month",
+               :type :custom-field,
+               :used-fields #{}}}}
            {:alias "is_trialing_accounts_cloud",
             :type :custom-field,
             :used-fields
@@ -1918,10 +1899,9 @@ ORDER BY
                :source-columns
                [[{:type :all-columns,
                   :table {:table-alias "ah", :schema "dbt_models", :table "account_history"}}]]}
-              {:column "month",
-               :alias nil,
-               :type :single-column,
-               :source-columns [[{:type :all-columns, :table {:table-alias "m", :table "months"}}]]}}}
+              {:alias "month",
+               :type :custom-field,
+               :used-fields #{}}}}
            {:alias "is_active_accounts_cloud",
             :type :custom-field,
             :used-fields
@@ -1958,10 +1938,9 @@ ORDER BY
                :source-columns
                [[{:type :all-columns,
                   :table {:table-alias "a", :schema "dbt_models", :table "account"}}]]}
-              {:column "month",
-               :alias nil,
-               :type :single-column,
-               :source-columns [[{:type :all-columns, :table {:table-alias "m", :table "months"}}]]}}}
+              {:alias "month",
+               :type :custom-field,
+               :used-fields #{}}}}
            {:alias "is_trialing_accounts_self_hosted",
             :type :custom-field,
             :used-fields
@@ -1983,10 +1962,9 @@ ORDER BY
                :source-columns
                [[{:type :all-columns,
                   :table {:table-alias "ah", :schema "dbt_models", :table "account_history"}}]]}
-              {:column "month",
-               :alias nil,
-               :type :single-column,
-               :source-columns [[{:type :all-columns, :table {:table-alias "m", :table "months"}}]]}}}
+              {:alias "month",
+               :type :custom-field,
+               :used-fields #{}}}}
            {:alias "is_active_accounts_self_hosted",
             :type :custom-field,
             :used-fields
@@ -2023,10 +2001,9 @@ ORDER BY
                :source-columns
                [[{:type :all-columns,
                   :table {:table-alias "a", :schema "dbt_models", :table "account"}}]]}
-              {:column "month",
-               :alias nil,
-               :type :single-column,
-               :source-columns [[{:type :all-columns, :table {:table-alias "m", :table "months"}}]]}}}
+              {:alias "month",
+               :type :custom-field,
+               :used-fields #{}}}}
            {:alias "is_active_accounts_enterprise",
             :type :custom-field,
             :used-fields
@@ -2075,10 +2052,9 @@ ORDER BY
                :source-columns
                [[{:type :all-columns,
                   :table {:table-alias "ah", :schema "dbt_models", :table "account_history"}}]]}
-              {:column "month",
-               :alias nil,
-               :type :single-column,
-               :source-columns [[{:type :all-columns, :table {:table-alias "m", :table "months"}}]]}}}
+              {:alias "month",
+               :type :custom-field,
+               :used-fields #{}}}}
            {:alias "is_active_accounts_starter",
             :type :custom-field,
             :used-fields
@@ -2127,10 +2103,9 @@ ORDER BY
                :source-columns
                [[{:type :all-columns,
                   :table {:table-alias "ah", :schema "dbt_models", :table "account_history"}}]]}
-              {:column "month",
-               :alias nil,
-               :type :single-column,
-               :source-columns [[{:type :all-columns, :table {:table-alias "m", :table "months"}}]]}}}
+              {:alias "month",
+               :type :custom-field,
+               :used-fields #{}}}}
            {:alias "is_active_accounts_pro",
             :type :custom-field,
             :used-fields
@@ -2179,11 +2154,9 @@ ORDER BY
                :source-columns
                [[{:type :all-columns,
                   :table {:table-alias "ah", :schema "dbt_models", :table "account_history"}}]]}
-              {:column "month",
-               :alias nil,
-               :type :single-column,
-               :source-columns
-               [[{:type :all-columns, :table {:table-alias "m", :table "months"}}]]}}}]}
+              {:alias "month",
+               :type :custom-field,
+               :used-fields #{}}}}]}
          (->references "with months as (
   select
     generate_series(date_trunc('month', '2024-01-01'::date),

--- a/test/metabase/driver/sql/references_test.clj
+++ b/test/metabase/driver/sql/references_test.clj
@@ -784,7 +784,7 @@ SELECT * FROM active_users"))))
          (->references "WITH active_users AS (SELECT id, name FROM users WHERE active = true)
 SELECT * FROM products"))))
 
-(deftest ^:parallel multilevel-cte-test
+(deftest ^:parallel dependent-cte-test
   (is (= {:used-fields
           #{{:column "id",
              :alias nil,


### PR DESCRIPTION
### Description

If you have a query like "WITH query_a AS (...), query_b AS (select ... from query_a) SELECT ... from query_b", native query parsing understood that query_b in the final query referred to query_b in the WITH, but it didn't realize that query_a in query_b referred to query_a in the WITH.  Now, it should understand these sorts of depedent ctes.

### How to verify

Save a query like the one in the test and then try to edit it.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
