### PR TITLE
Upgrade dayjs on v56

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "csv-stringify": "^6.5.0",
     "d3": "^7.9.0",
     "d3-scale": "^4.0.2",
-    "dayjs": "^1.10.4",
+    "dayjs": "^1.11.18",
     "detect-package-manager": "^3.0.2",
     "diff": "^3.2.0",
     "echarts": "^5.5.1-rc.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8943,12 +8943,7 @@ dateformat@^4.5.1:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-4.6.3.tgz#556fa6497e5217fedb78821424f8a1c22fa3f4b5"
   integrity sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==
 
-dayjs@^1.10.4:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.0.tgz#009bf7ef2e2ea2d5db2e6583d2d39a4b5061e805"
-  integrity sha512-JLC809s6Y948/FuCZPm5IX8rRhQwOiyMb2TfVVQEixG7P8Lm/gt5S7yoQZmC8x1UehI9Pb7sksEt4xx14m+7Ug==
-
-dayjs@^1.11.18:
+dayjs@^1.10.4, dayjs@^1.11.18:
   version "1.11.19"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.19.tgz#15dc98e854bb43917f12021806af897c58ae2938"
   integrity sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -8948,6 +8948,11 @@ dayjs@^1.10.4:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.0.tgz#009bf7ef2e2ea2d5db2e6583d2d39a4b5061e805"
   integrity sha512-JLC809s6Y948/FuCZPm5IX8rRhQwOiyMb2TfVVQEixG7P8Lm/gt5S7yoQZmC8x1UehI9Pb7sksEt4xx14m+7Ug==
 
+dayjs@^1.11.18:
+  version "1.11.19"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.19.tgz#15dc98e854bb43917f12021806af897c58ae2938"
+  integrity sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==
+
 deasync@^0.1.0:
   version "0.1.29"
   resolved "https://registry.yarnpkg.com/deasync/-/deasync-0.1.29.tgz#8bbbf9d0b235c561b36edd440b6272f1de6c572c"


### PR DESCRIPTION
Closes #65568

Our issue is about the corner case when there is a trend chart that has to compare two weeks where the first one is in BST, the second in GMT because of the daylight saving ended and the user's system time zone is west of London. The new dayjs version handles this situation properly.

I haven't added a test for this, because it would need controlling the system (browser(?)) time zone. I can research into that if we think it's important.