### PR TITLE
Prevent driver tests

### DIFF
--- a/.github/actions/prepare-backend/action.yml
+++ b/.github/actions/prepare-backend/action.yml
@@ -28,7 +28,7 @@ runs:
     - name: Fetch CI config
       shell: bash
       run: |
-        curl -o ci-test-config.json https://raw.githubusercontent.com/metabase/metabase/refs/heads/master/ci-test-config.json
+        curl -o ci-test-config.json https://raw.githubusercontent.com/metabase/ci-test-config/refs/heads/master/ci-test-config.json
 
     - name: Get M2 cache key
       uses: ./.github/actions/get-cache-keys

--- a/.github/actions/prepare-backend/action.yml
+++ b/.github/actions/prepare-backend/action.yml
@@ -25,11 +25,6 @@ runs:
         curl -O https://download.clojure.org/install/linux-install-${{ inputs.clojure-version }}.sh &&
         sudo bash ./linux-install-${{ inputs.clojure-version }}.sh
 
-    - name: Fetch CI config
-      shell: bash
-      run: |
-        curl -o ci-test-config.json https://raw.githubusercontent.com/metabase/ci-test-config/refs/heads/master/ci-test-config.json
-
     - name: Get M2 cache key
       uses: ./.github/actions/get-cache-keys
       id: get-cache-keys

--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -22,6 +22,13 @@ runs:
       id: check-driver
       shell: bash
       run: |
+        # If DRIVERS env var is not set, proceed with tests
+        if [ -z "$DRIVERS" ]; then
+          echo "No DRIVERS env var set. Proceeding with tests."
+          echo "skip=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
         # Fetch CI config and check if driver should be skipped
         curl -sSf -o ci-test-config.json https://raw.githubusercontent.com/metabase/ci-test-config/refs/heads/master/ci-test-config.json || true
 

--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -13,39 +13,15 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Fetch CI config
-      id: ci-config
-      shell: bash
-      run: |
-        echo "Fetching CI test configuration..."
-        curl -sSf -o ci-test-config.json https://raw.githubusercontent.com/metabase/ci-test-config/refs/heads/master/ci-test-config.json || {
-          echo "Failed to fetch CI config, proceeding with tests"
-          echo "skip=false" >> $GITHUB_OUTPUT
-          exit 0
-        }
-
-        # Show the config for debugging
-        echo "CI Config contents:"
-        cat ci-test-config.json
-
     - name: Check if driver is ignored
       id: check-driver
       shell: bash
       run: |
-        if [ -z "$DRIVERS" ]; then
-          echo "DRIVERS env var not set, proceeding with tests"
-          echo "skip=false" >> $GITHUB_OUTPUT
-          exit 0
-        fi
+        # Fetch CI config and check if driver should be skipped
+        curl -sSf -o ci-test-config.json https://raw.githubusercontent.com/metabase/ci-test-config/refs/heads/main/ci-test-config.json || true
 
-        if [ ! -f ci-test-config.json ]; then
-          echo "CI config not found, proceeding with tests"
-          echo "skip=false" >> $GITHUB_OUTPUT
-          exit 0
-        fi
-
-        # Check if the driver is in the ignored list
-        IS_IGNORED=$(jq --arg driver "$DRIVERS" '.ignored.drivers | contains([$driver])' ci-test-config.json)
+        # Check if the driver is in the ignored list (gracefully handle missing/invalid config)
+        IS_IGNORED=$(jq --arg driver "$DRIVERS" '.ignored.drivers // [] | contains([$driver])' ci-test-config.json 2>/dev/null || echo "false")
 
         if [ "$IS_IGNORED" = "true" ]; then
           echo "⚠️  Driver '$DRIVERS' is in the ignored list. Skipping tests."
@@ -59,15 +35,16 @@ runs:
       if: steps.check-driver.outputs.skip != 'true'
       uses: ./.github/actions/prepare-backend
     - name: Prepare front-end environment
+      if: ${{ steps.check-driver.outputs.skip != 'true' && inputs.build-static-viz == 'true' }}
       uses: ./.github/actions/prepare-frontend
-      if: ${{ inputs.build-static-viz == 'true' }}
     - name: Build static viz frontend
+      if: ${{ steps.check-driver.outputs.skip != 'true' && inputs.build-static-viz == 'true' }}
       run: yarn build-static-viz
       shell: bash
-      if: ${{ inputs.build-static-viz == 'true' }}
       env:
         MB_EDITION: ee
     - name: Test database driver
+      if: steps.check-driver.outputs.skip != 'true'
       run: clojure -X:dev:ci:ee:ee-dev:drivers:drivers-dev:test ${{ inputs.test-args }}
       shell: bash
       id: run-test

--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -72,7 +72,7 @@ runs:
         list-tests: failed
         fail-on-error: false
     - name: Upload Logs on Failure
-      if: ${{ always() && steps.run-test.outcome != 'success' && steps.check-driver.outputs.skip != 'true' }}
+      if: always() && steps.run-test.outcome != 'success' && steps.check-driver.outputs.skip != 'true'
       uses: actions/upload-artifact@v4
       with:
         name: test-logs-${{ github.job }}

--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -30,6 +30,7 @@ runs:
 
         if [ "$IS_IGNORED" = "true" ]; then
           echo "⚠️  Driver '$DRIVERS' is in the ignored list. Skipping tests."
+          echo "View the ignored list here: https://github.com/metabase/ci-test-config/blob/master/ci-test-config.json"
           echo "skip=true" >> $GITHUB_OUTPUT
         else
           echo "Driver '$DRIVERS' is not ignored. Proceeding with tests."

--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -49,15 +49,6 @@ runs:
 
         if [ "$IS_IGNORED" = "true" ]; then
           echo "⚠️  Driver '$DRIVERS' is in the ignored list. Skipping tests."
-
-          # Extract metadata for context
-          REASON=$(jq -r '.metadata.reason // "No reason provided"' ci-test-config.json)
-          UPDATED_BY=$(jq -r '.metadata.updated_by // "unknown"' ci-test-config.json)
-          LAST_UPDATED=$(jq -r '.metadata.last_updated // "unknown"' ci-test-config.json)
-
-          echo "Reason: $REASON"
-          echo "Updated by: $UPDATED_BY"
-          echo "Last updated: $LAST_UPDATED"
           echo "skip=true" >> $GITHUB_OUTPUT
         else
           echo "Driver '$DRIVERS' is not ignored. Proceeding with tests."

--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -57,7 +57,7 @@ runs:
       # As per the documentation: https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#steps-context
       # test.outcome gives us access to the result before `continue-on-error` overrides it and sets it to 'success'.
       # We want test reports even if the test step gets cancelled (e.g. times out), hence we match anything that is not a 'success'.
-      if: steps.run-test.outcome != 'success'
+      if: ${{ steps.run-test.outcome != 'success' && steps.check-driver.outputs.skip != 'true' }}
       with:
         path: "target/junit/**/*_test.xml"
         name: JUnit Test Report ${{ inputs.junit-name }}
@@ -66,7 +66,7 @@ runs:
         list-tests: failed
         fail-on-error: false
     - name: Upload Logs on Failure
-      if: always() && steps.run-test.outcome != 'success'
+      if: ${{ always() && steps.run-test.outcome != 'success' && steps.check-driver.outputs.skip != 'true' }}
       uses: actions/upload-artifact@v4
       with:
         name: test-logs-${{ github.job }}

--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -18,7 +18,7 @@ runs:
       shell: bash
       run: |
         # Fetch CI config and check if driver should be skipped
-        curl -sSf -o ci-test-config.json https://raw.githubusercontent.com/metabase/ci-test-config/refs/heads/main/ci-test-config.json || true
+        curl -sSf -o ci-test-config.json https://raw.githubusercontent.com/metabase/ci-test-config/refs/heads/master/ci-test-config.json || true
 
         # Check if the driver is in the ignored list (gracefully handle missing/invalid config)
         IS_IGNORED=$(jq --arg driver "$DRIVERS" '.ignored.drivers // [] | contains([$driver])' ci-test-config.json 2>/dev/null || echo "false")

--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -13,7 +13,59 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Fetch CI config
+      id: ci-config
+      shell: bash
+      run: |
+        echo "Fetching CI test configuration..."
+        curl -sSf -o ci-test-config.json https://raw.githubusercontent.com/metabase/ci-test-config/refs/heads/main/ci-test-config.json || {
+          echo "Failed to fetch CI config, proceeding with tests"
+          echo "skip=false" >> $GITHUB_OUTPUT
+          exit 0
+        }
+
+        # Show the config for debugging
+        echo "CI Config contents:"
+        cat ci-test-config.json
+
+    - name: Check if driver is ignored
+      id: check-driver
+      shell: bash
+      run: |
+        if [ -z "$DRIVERS" ]; then
+          echo "DRIVERS env var not set, proceeding with tests"
+          echo "skip=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        if [ ! -f ci-test-config.json ]; then
+          echo "CI config not found, proceeding with tests"
+          echo "skip=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        # Check if the driver is in the ignored list
+        IS_IGNORED=$(jq --arg driver "$DRIVERS" '.ignored.drivers | contains([$driver])' ci-test-config.json)
+
+        if [ "$IS_IGNORED" = "true" ]; then
+          echo "⚠️  Driver '$DRIVERS' is in the ignored list. Skipping tests."
+
+          # Extract metadata for context
+          REASON=$(jq -r '.metadata.reason // "No reason provided"' ci-test-config.json)
+          UPDATED_BY=$(jq -r '.metadata.updated_by // "unknown"' ci-test-config.json)
+          LAST_UPDATED=$(jq -r '.metadata.last_updated // "unknown"' ci-test-config.json)
+
+          echo "Reason: $REASON"
+          echo "Updated by: $UPDATED_BY"
+          echo "Last updated: $LAST_UPDATED"
+          echo "skip=true" >> $GITHUB_OUTPUT
+        else
+          echo "Driver '$DRIVERS' is not ignored. Proceeding with tests."
+          echo "skip=false" >> $GITHUB_OUTPUT
+        fi
+
     - name: Prepare back-end environment
+      if: steps.check-driver.outputs.skip != 'true'
       uses: ./.github/actions/prepare-backend
     - name: Prepare front-end environment
       uses: ./.github/actions/prepare-frontend

--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -18,7 +18,7 @@ runs:
       shell: bash
       run: |
         echo "Fetching CI test configuration..."
-        curl -sSf -o ci-test-config.json https://raw.githubusercontent.com/metabase/ci-test-config/refs/heads/main/ci-test-config.json || {
+        curl -sSf -o ci-test-config.json https://raw.githubusercontent.com/metabase/ci-test-config/refs/heads/master/ci-test-config.json || {
           echo "Failed to fetch CI config, proceeding with tests"
           echo "skip=false" >> $GITHUB_OUTPUT
           exit 0

--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -10,6 +10,11 @@ inputs:
     required: true
     default: false
 
+outputs:
+  quarantine-skipped:
+    description: Whether the driver test was skipped due to quarantine
+    value: ${{ steps.check-driver.outputs.skip }}
+
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -76,7 +76,7 @@ jobs:
           :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
+      if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -130,7 +130,7 @@ jobs:
         test-args: ${{ matrix.job.test-args }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
+      if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -201,7 +201,7 @@ jobs:
         test-args: ${{ matrix.job.test-args }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
+      if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -245,7 +245,7 @@ jobs:
           :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
+      if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -283,7 +283,7 @@ jobs:
           :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
+      if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -321,7 +321,7 @@ jobs:
           :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
+      if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -360,7 +360,7 @@ jobs:
           :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
+      if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -389,7 +389,7 @@ jobs:
           :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
+      if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -518,7 +518,7 @@ jobs:
             :exclude-tags '[ ${{ matrix.job.exclude-tag }} ${{ env.__ADDITIONAL_EXCLUDED_TAG__ }}]'
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results
-        if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
+        if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
         with:
           input-path: ./target/junit/
           output-name: ${{ github.job }}
@@ -587,7 +587,7 @@ jobs:
         test-args: ${{ matrix.job.test-args }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
+      if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -659,7 +659,7 @@ jobs:
             :only-tags [:mb/driver-tests]
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results
-        if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
+        if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
         with:
           input-path: ./target/junit/
           output-name: ${{ github.job }}
@@ -694,7 +694,7 @@ jobs:
           :only metabase.driver.mongo.sharded-cluster-test
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
+      if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -768,7 +768,7 @@ jobs:
           :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
+      if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -871,7 +871,7 @@ jobs:
             :exclude-tags '[ ${{ matrix.job.exclude-tag }} ${{ env.__ADDITIONAL_EXCLUDED_TAG__ }}]'
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results
-        if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
+        if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
         with:
           input-path: ./target/junit/
           output-name: ${{ github.job }}
@@ -948,7 +948,7 @@ jobs:
           :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
+      if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -1011,7 +1011,7 @@ jobs:
           ${{ matrix.job.test-args }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: ${{ !matrix.job.skip && !cancelled() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
+      if: !matrix.job.skip && !cancelled() && steps.test-driver.outputs.quarantine-skipped != 'true'
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -1081,7 +1081,7 @@ jobs:
         test-args: ${{ matrix.job.test-args }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
+      if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -1123,7 +1123,7 @@ jobs:
           :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
+      if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -1154,7 +1154,7 @@ jobs:
           :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
+      if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -1219,7 +1219,7 @@ jobs:
         test-args: ${{ matrix.job.test-args }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
+      if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -1335,7 +1335,7 @@ jobs:
           :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
+      if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -67,6 +67,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Test Athena driver
+      id: test-driver
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-athena-ee'
@@ -75,7 +76,7 @@ jobs:
           :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: always()
+      if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -129,7 +130,7 @@ jobs:
         test-args: ${{ matrix.job.test-args }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: always()
+      if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -200,7 +201,7 @@ jobs:
         test-args: ${{ matrix.job.test-args }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: always()
+      if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -235,6 +236,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Test Druid driver
+      id: test-driver
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-druid-ee'
@@ -243,7 +245,7 @@ jobs:
           :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: always()
+      if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -272,6 +274,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Test Druid JDBC driver
+      id: test-driver
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-druid-jdbc-ee'
@@ -280,7 +283,7 @@ jobs:
           :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: always()
+      if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -309,6 +312,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Test Databricks driver
+      id: test-driver
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-databricks-ee'
@@ -317,7 +321,7 @@ jobs:
           :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: always()
+      if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -347,6 +351,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Test Databricks driver with multi-catalog
+      id: test-driver
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-databricks-multi-catalog-ee'
@@ -355,7 +360,7 @@ jobs:
           :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: always()
+      if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -384,7 +389,7 @@ jobs:
           :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: always()
+      if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -513,7 +518,7 @@ jobs:
             :exclude-tags '[ ${{ matrix.job.exclude-tag }} ${{ env.__ADDITIONAL_EXCLUDED_TAG__ }}]'
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results
-        if: always()
+        if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
         with:
           input-path: ./target/junit/
           output-name: ${{ github.job }}
@@ -582,7 +587,7 @@ jobs:
         test-args: ${{ matrix.job.test-args }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: always()
+      if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -645,6 +650,7 @@ jobs:
           curl https://raw.githubusercontent.com/metabase/metabase-qa/master/dbs/mongo/certificates/metaca.crt \
           -o ./test_resources/ssl/mongo/metaca.crt
       - name: Test ${{ matrix.version.name }}
+        id: test-driver
         uses: ./.github/actions/test-driver
         with:
           junit-name: ${{ matrix.version.junit-name }}
@@ -653,7 +659,7 @@ jobs:
             :only-tags [:mb/driver-tests]
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results
-        if: always()
+        if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
         with:
           input-path: ./target/junit/
           output-name: ${{ github.job }}
@@ -680,6 +686,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Test MongoDB driver (Sharded cluster)
+      id: test-driver
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-mongo-sharded-cluster-ee'
@@ -687,7 +694,7 @@ jobs:
           :only metabase.driver.mongo.sharded-cluster-test
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: always()
+      if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -752,6 +759,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Test ${{ matrix.version.name }}
+      id: test-driver
       uses: ./.github/actions/test-driver
       with:
         junit-name: ${{ matrix.version.junit-name }}
@@ -760,7 +768,7 @@ jobs:
           :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: always()
+      if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -863,7 +871,7 @@ jobs:
             :exclude-tags '[ ${{ matrix.job.exclude-tag }} ${{ env.__ADDITIONAL_EXCLUDED_TAG__ }}]'
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results
-        if: always()
+        if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
         with:
           input-path: ./target/junit/
           output-name: ${{ github.job }}
@@ -931,6 +939,7 @@ jobs:
         -file /tmp/presto-ssl-ca.der
         -trustcacerts
     - name: Test Presto JDBC driver
+      id: test-driver
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-presto-jdbc-ee'
@@ -939,7 +948,7 @@ jobs:
           :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: always()
+      if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -1002,7 +1011,7 @@ jobs:
           ${{ matrix.job.test-args }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: ${{ !matrix.job.skip && !cancelled() }}
+      if: ${{ !matrix.job.skip && !cancelled() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -1020,7 +1029,7 @@ jobs:
 
   be-tests-snowflake-ee:
     needs: determine-driver-skips
-    if: ${{ !inputs.skip }}
+    if: ${{ !inputs.skip && !(needs.determine-driver-skips.outputs.skip == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -1072,7 +1081,7 @@ jobs:
         test-args: ${{ matrix.job.test-args }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: always()
+      if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -1105,6 +1114,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Test Spark driver
+      id: test-driver
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-sparksql-ee'
@@ -1113,7 +1123,7 @@ jobs:
           :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: always()
+      if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -1135,6 +1145,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Test SQLite driver
+      id: test-driver
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-sqlite-ee'
@@ -1143,7 +1154,7 @@ jobs:
           :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: always()
+      if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -1208,7 +1219,7 @@ jobs:
         test-args: ${{ matrix.job.test-args }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: always()
+      if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -1315,6 +1326,7 @@ jobs:
     - name: Make plugins directory
       run: mkdir plugins
     - name: Test Vertica driver
+      id: test-driver
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-vertica-ee'
@@ -1323,7 +1335,7 @@ jobs:
           :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: always()
+      if: ${{ always() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -1019,6 +1019,7 @@ jobs:
         logs-artifact-suffix: ${{ matrix.job.name }} ${{ matrix.version.name }}
 
   be-tests-snowflake-ee:
+    needs: determine-driver-skips
     if: ${{ !inputs.skip }}
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -1011,7 +1011,7 @@ jobs:
           ${{ matrix.job.test-args }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: !matrix.job.skip && !cancelled() && steps.test-driver.outputs.quarantine-skipped != 'true'
+      if: ${{ !matrix.job.skip && !cancelled() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}

--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -265,7 +265,7 @@
           (is (= [{:s schema}] (jdbc/query spec ["select CURRENT_SCHEMA() s"])))
           (is (= 1 (count (jdbc/query spec ["select * from \"TABLES\" limit 1"])))))))))
 
-(deftest additional-options-test
+(deftest ^:sequential additional-options-test
   (mt/test-driver
     :snowflake
     (let [existing-details (dissoc (:details (mt/db)) :password)]


### PR DESCRIPTION
turn off driver tests when they are not helpful.

Prevent running driver tests from ci-config

https://github.com/metabase/ci-test-config holds this:

```json
{
  "version": "1.0.0",
  "ignored": {
    "vars": [],
    "drivers": [
      "snowflake"
    ]
  },
  "metadata": {
    "last_updated": "2025-11-21",
    "updated_by": "bryan",
    "reason": "Snowflake is on fire. Thrashing creating and deleting the test-data dataset"
  }
}
```

We fetch this in driver tests and then see if `DRIVERS` var is in the
`ignored.drivers`. If we find the current driver is in this list of
ignored drivers, skip the tests

---

Notice: the snowflake test "passed", and the upload test action didn't run.

<img width="1679" height="518" alt="Screenshot 2025-11-21 at 12 46 29 PM" src="https://github.com/user-attachments/assets/17c664bd-c599-4767-a56e-95fb9b8ece95" />

