### PR TITLE
Clean up backend-test matrix

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -48,13 +48,11 @@ jobs:
           - name: Enterprise Tests
             edition: ee
             test-group-name: ee
-            build-static-viz: 'false'
             test-args: >-
               :only '"enterprise/backend/test"'
           - name: EE App DB Tests (Part 1)
             edition: ee
             test-group-name: ee-app-db-1
-            build-static-viz: 'true'
             test-args: >-
               :only '["test" ".clj-kondo/test"]'
               :partition/total 2
@@ -62,7 +60,6 @@ jobs:
           - name: EE App DB Tests (Part 2)
             edition: ee
             test-group-name: ee-app-db-2
-            build-static-viz: 'true'
             test-args: >-
               :only '["test" ".clj-kondo/test"]'
               :partition/total 2
@@ -70,7 +67,6 @@ jobs:
           - name: OSS App DB Tests (Part 1)
             edition: oss
             test-group-name: oss-app-db-1
-            build-static-viz: 'true'
             test-args: >-
               :only '["test" ".clj-kondo/test"]'
               :partition/total 2
@@ -78,7 +74,6 @@ jobs:
           - name: OSS App DB Tests (Part 2)
             edition: oss
             test-group-name: oss-app-db-2
-            build-static-viz: 'true'
             test-args: >-
               :only '["test" ".clj-kondo/test"]'
               :partition/total 2
@@ -103,25 +98,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Prepare front-end environment
-        if: ${{ matrix.job.build-static-viz == 'true' }}
         uses: ./.github/actions/prepare-frontend
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
         with:
           java-version: "${{ matrix.java-version }}"
-      # Depending on which files changed, we might either have to build static-viz
-      # from scratch or download the previously built artifact
       - name: Build static-viz frontend
-        if: ${{ matrix.job.build-static-viz == 'true' && !inputs.skip }}
         run: yarn build-static-viz
         env:
           MB_EDITION: ${{ matrix.job.edition }}
-      - name: Download Static Viz Bundle Artifact
-        if: ${{ matrix.job.build-static-viz == 'true' && !inputs.skip }}
-        uses: actions/download-artifact@v4
-        with:
-          name: static-viz-bundle-${{ github.sha }}
-          path: resources/frontend_client/app/dist
 
       - name: "Test Java ${{ matrix.java-version }} ${{ matrix.job.name }}"
         id: run-java-tests


### PR DESCRIPTION
I don't think these conditions set in a matrix made much sense. They have been working just by pure chance, and they finally stopped working when we removed the "check if static-viz files changed" in https://github.com/metabase/metabase/pull/66138

This is from one of the runs from before #66138.
We were both building and downloading the static-viz in the same step, which doesn't make any sense.
<img width="786" height="84" alt="image" src="https://github.com/user-attachments/assets/8b93cd34-9f4b-4d97-b435-bc94ab2f540d" />

I think this proves that the matrix was wrong.

There have been a lot of changes to how we run tests, and these matrix inputs accidentally remained there because they didn't cause any apparent failures. This doesn't mean they were right.

So, what was happening before #66138?
- Backend tests were waiting for ~2 minutes for the "check whether static viz files changed" ran
- Once the backend-tests started resolving the matrix in order to determine which jobs should run it was building static viz all over again (redundant)
- It was then trying to download it (luckily this took only 1-2s because the files are already there in that same run

tl;dr

Waiting to see whether static viz files changed required the whole build-static viz to be built. If that's the case, we might as well build it always as part of backend tests. in the process, we simplify the matrix that was wrong either way.

