### PR TITLE
Fix timeseries value detection

### DIFF
--- a/frontend/src/metabase/visualizations/lib/date-validation.ts
+++ b/frontend/src/metabase/visualizations/lib/date-validation.ts
@@ -34,7 +34,7 @@ const minutePattern = /(?<minute>[0-5]\d)/;
  * Seconds are always 2 digits.
  * 60 is used to represent leap seconds.
  */
-const secondsPattern = /(?<seconds>([0-5]\d)|60)/;
+const secondsPattern = /(?<seconds>([0-5]\d)|60)?/;
 /**
  * Milliseconds have no defined precision.
  * Allowing for up to 9 since this gets to nanoseconds.
@@ -127,7 +127,8 @@ const spaceSeparatedDateTimePattern =
   hourPattern.source +
   /:/.source +
   minutePattern.source +
-  /:/.source +
+  // seconds and milliseconds are optional
+  /:?/.source +
   secondsPattern.source +
   millisecondsPattern.source +
   /$/.source;

--- a/frontend/src/metabase/visualizations/lib/date-validation.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/lib/date-validation.unit.spec.ts
@@ -11,6 +11,7 @@ describe("isValidIso8601", () => {
     "2016-W06-5",
     "2016-043",
     "2024-06-28 00:00:00",
+    "2025-11-21 05:00",
   ];
 
   VALID_ISO_8601_DATES.forEach((isoDate) => {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/66148

### Description

Before https://github.com/metabase/metabase/commit/bbd050dd9585f3210508f9737b7f0de15e5bda0f date time value without seconds was treated as valid timeseries. New `isValidIso8601` implementation is too strict. 
Added support for date time without seconds - e.g. `2025-11-21 05:00`

### How to verify

Check https://github.com/metabase/metabase/issues/66148

### Demo

<img width="800" alt="Screenshot 2025-11-21 at 23 04 00" src="https://github.com/user-attachments/assets/8d6244e6-3fd9-45c5-ab08-53a9c151689a" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
