### PR TITLE
Fetch uberjar using a proper action

### DIFF
--- a/.github/workflows/embedding-sdk-component-tests.yml
+++ b/.github/workflows/embedding-sdk-component-tests.yml
@@ -35,9 +35,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Retrieve uberjar artifact for ee
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/fetch-artifact
         with:
           name: metabase-ee-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
+          extract-path: "target/uberjar"
+          output-name: "metabase.jar"
 
       - name: Retrieve Embedding SDK dist artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/embedding-sdk-e2e-tests.yml
+++ b/.github/workflows/embedding-sdk-e2e-tests.yml
@@ -135,9 +135,11 @@ jobs:
           echo "sample_app_name=${test_suite%-e2e}" >> "$GITHUB_OUTPUT"
 
       - name: Retrieve uberjar artifact for ee
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/fetch-artifact
         with:
           name: metabase-ee-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
+          extract-path: "target/uberjar"
+          output-name: "metabase.jar"
 
       - name: Retrieve Embedding SDK dist artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Fixes this error
<img width="1139" height="175" alt="image" src="https://github.com/user-attachments/assets/c13f3a0a-0624-41de-89f5-e54a4285bf50" />

This was the cue
https://github.com/actions/toolkit/blob/main/packages/artifact/docs/faq.md#which-versions-of-the-artifacts-packages-are-compatible

E2E tests are fetching the artifact using this composite action, as well as any other job.