### PR TITLE
Table Symlinks POC [WIP]

### DIFF
--- a/.clj-kondo/README.md
+++ b/.clj-kondo/README.md
@@ -1,5 +1,5 @@
 Update `clj-kondo` configs for libraries using
 
 ```sh
-clj-kondo --copy-configs --dependencies --lint "$(clojure -Spath -A:dev)"
+clojure -M:kondo --copy-configs --dependencies --lint "$(clojure -Spath -A:dev)"
 ```

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1554,6 +1554,7 @@
            lib
            models
            parameters
+           query-permissions
            query-processor
            request
            sync

--- a/enterprise/backend/src/metabase_enterprise/api_routes/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/api_routes/routes.clj
@@ -96,45 +96,46 @@
   "/api/ee routes. The following routes are NICE and do follow the `/ee/<feature>/` naming convention. Please add new
   routes here and follow the convention."
   ;; Postponing a granular flag for :actions until it's used more widely.
-  {"/action-v2"                    (premium-handler metabase-enterprise.action-v2.api/routes :table-data-editing)
-   "/advanced-permissions"         (premium-handler metabase-enterprise.advanced-permissions.api.routes/routes :advanced-permissions)
-   "/ai-entity-analysis"           (premium-handler metabase-enterprise.ai-entity-analysis.api/routes :ai-entity-analysis)
-   "/ai-sql-fixer"                 (premium-handler metabase-enterprise.ai-sql-fixer.api/routes :ai-sql-fixer)
-   "/ai-sql-generation"            (premium-handler metabase-enterprise.ai-sql-generation.api/routes :ai-sql-generation)
-   "/audit-app"                    (premium-handler metabase-enterprise.audit-app.api.routes/routes :audit-app)
-   "/autodescribe"                 (premium-handler 'metabase-enterprise.llm.api :llm-autodescription)
-   "/billing"                      metabase-enterprise.billing.api.routes/routes
-   "/content-translation"          (premium-handler metabase-enterprise.content-translation.routes/routes :content-translation)
-   "/cloud-add-ons"                metabase-enterprise.cloud-add-ons.api/routes
-   "/comment"                      (premium-handler metabase-enterprise.comments.api/routes :documents)
-   "/database-replication"         (-> database-replication.api/routes ;; database-replication requires all these features.
-                                       (premium-handler :attached-dwh)
-                                       (premium-handler :etl-connections)
-                                       (premium-handler :etl-connections-pg))
-   "/database-routing"             (premium-handler metabase-enterprise.database-routing.api/routes :database-routing)
-   "/dependencies"                 (premium-handler metabase-enterprise.dependencies.api/routes :dependencies)
-   "/document"                     (premium-handler metabase-enterprise.documents.api/routes :documents)
-   "/email"                        (premium-handler metabase-enterprise.email.api/routes :cloud-custom-smtp)
-   "/remote-sync"                  (premium-handler metabase-enterprise.remote-sync.api/routes :remote-sync)
-   "/embedding-hub"                (premium-handler metabase-enterprise.embedding-hub.api/routes :embedding)
-   "/gsheets"                      (-> gsheets.api/routes ;; gsheets requires both features.
-                                       (premium-handler :attached-dwh)
-                                       (premium-handler :etl-connections))
-   "/logs"                         (premium-handler 'metabase-enterprise.advanced-config.api.logs :audit-app)
-   "/metabot-tools"                metabase-enterprise.metabot-v3.tools.api/routes
-   "/metabot-v3"                   (premium-handler metabase-enterprise.metabot-v3.api/routes :metabot-v3)
-   "/permission_debug"             (premium-handler metabase-enterprise.permission-debug.api/routes :advanced-permissions)
-   "/public"                       (api.routes.common/+public-exceptions metabase-enterprise.public-sharing.api/routes)
-   "/transforms-python"            (premium-handler metabase-enterprise.transforms-python.api/routes :transforms-python)
-   "/scim"                         (premium-handler metabase-enterprise.scim.routes/routes :scim)
-   "/semantic-search"              (premium-handler metabase-enterprise.semantic-search.api/routes :semantic-search)
-   "/serialization"                (premium-handler metabase-enterprise.serialization.api/routes :serialization)
-   "/stale"                        (premium-handler metabase-enterprise.stale.api/routes :collection-cleanup)
+  {"/action-v2"            (premium-handler metabase-enterprise.action-v2.api/routes :table-data-editing)
+   "/advanced-permissions" (premium-handler metabase-enterprise.advanced-permissions.api.routes/routes :advanced-permissions)
+   "/ai-entity-analysis"   (premium-handler metabase-enterprise.ai-entity-analysis.api/routes :ai-entity-analysis)
+   "/ai-sql-fixer"         (premium-handler metabase-enterprise.ai-sql-fixer.api/routes :ai-sql-fixer)
+   "/ai-sql-generation"    (premium-handler metabase-enterprise.ai-sql-generation.api/routes :ai-sql-generation)
+   "/audit-app"            (premium-handler metabase-enterprise.audit-app.api.routes/routes :audit-app)
+   "/autodescribe"         (premium-handler 'metabase-enterprise.llm.api :llm-autodescription)
+   "/billing"              metabase-enterprise.billing.api.routes/routes
+   "/cloud-add-ons"        metabase-enterprise.cloud-add-ons.api/routes
+   "/comment"              (premium-handler metabase-enterprise.comments.api/routes :documents)
+   "/content-translation"  (premium-handler metabase-enterprise.content-translation.routes/routes :content-translation)
+   "/database-replication" (-> database-replication.api/routes ;; database-replication requires all these features.
+                               (premium-handler :attached-dwh)
+                               (premium-handler :etl-connections)
+                               (premium-handler :etl-connections-pg))
+   "/database-routing"     (premium-handler metabase-enterprise.database-routing.api/routes :database-routing)
+   "/dependencies"         (premium-handler metabase-enterprise.dependencies.api/routes :dependencies)
+   "/document"             (premium-handler metabase-enterprise.documents.api/routes :documents)
+   "/email"                (premium-handler metabase-enterprise.email.api/routes :cloud-custom-smtp)
+   "/embedding-hub"        (premium-handler metabase-enterprise.embedding-hub.api/routes :embedding)
+   "/gsheets"              (-> gsheets.api/routes ;; gsheets requires both features.
+                               (premium-handler :attached-dwh)
+                               (premium-handler :etl-connections))
+   "/logs"                 (premium-handler 'metabase-enterprise.advanced-config.api.logs :audit-app)
+   "/metabot-tools"        metabase-enterprise.metabot-v3.tools.api/routes
+   "/metabot-v3"           (premium-handler metabase-enterprise.metabot-v3.api/routes :metabot-v3)
+   ;; TODO (Cam 2025-11-21) update this to use a `kebab-case` route like the rest of our API
+   "/permission_debug"     (premium-handler metabase-enterprise.permission-debug.api/routes :advanced-permissions)
+   "/public"               (api.routes.common/+public-exceptions metabase-enterprise.public-sharing.api/routes)
+   "/remote-sync"          (premium-handler metabase-enterprise.remote-sync.api/routes :remote-sync)
+   "/scim"                 (premium-handler metabase-enterprise.scim.routes/routes :scim)
+   "/semantic-search"      (premium-handler metabase-enterprise.semantic-search.api/routes :semantic-search)
+   "/serialization"        (premium-handler metabase-enterprise.serialization.api/routes :serialization)
+   "/stale"                (premium-handler metabase-enterprise.stale.api/routes :collection-cleanup)
    "/support-access-grant" (premium-handler metabase-enterprise.support-access-grants.api/routes :support-users)
-   "/transform"                    (premium-handler metabase-enterprise.transforms.api/routes :transforms)
-   "/transform-job"                (premium-handler metabase-enterprise.transforms.api/transform-job-routes :transforms)
-   "/transform-tag"                (premium-handler metabase-enterprise.transforms.api/transform-tag-routes :transforms)
-   "/upload-management"            (premium-handler metabase-enterprise.upload-management.api/routes :upload-management)})
+   "/transform"            (premium-handler metabase-enterprise.transforms.api/routes :transforms)
+   "/transform-job"        (premium-handler metabase-enterprise.transforms.api/transform-job-routes :transforms)
+   "/transform-tag"        (premium-handler metabase-enterprise.transforms.api/transform-tag-routes :transforms)
+   "/transforms-python"    (premium-handler metabase-enterprise.transforms-python.api/routes :transforms-python)
+   "/upload-management"    (premium-handler metabase-enterprise.upload-management.api/routes :upload-management)})
 ;;; ↑↑↑ KEEP THIS SORTED OR ELSE ↑↑↑
 
 (def ^:private routes-map

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
@@ -450,7 +450,7 @@
                                                                                        :alias        "v"
                                                                                        :strategy     :left-join
                                                                                        :condition    [:= $venue_id &v.venues.id]}]})}]
-        (data-perms/set-table-permissions! (perms-group/all-users) :perms/view-data {(mt/id 'venues) :blocked})
+        (data-perms/set-table-permissions! (perms-group/all-users) :perms/view-data {(mt/id :venues) :blocked})
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
              #"You do not have permissions to run this query"

--- a/enterprise/backend/test/metabase_enterprise/api_routes/routes_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/api_routes/routes_test.clj
@@ -1,0 +1,10 @@
+(ns metabase-enterprise.api-routes.routes-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.api-routes.routes-test]))
+
+(deftest ^:parallel check-route-map-test
+  (metabase.api-routes.routes-test/check-routes-map
+   {:filename                  "enterprise/backend/src/metabase_enterprise/api_routes/routes.clj"
+    :map-def-name              'ee-routes-map
+    :legacy-snake-cased-routes #{"/permission_debug"}}))

--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -651,6 +651,94 @@ databaseChangeLog:
       rollback:
         - sql: DELETE FROM auth_identity WHERE provider IN ('saml', 'jwt');
 
+  - changeSet:
+      id: v58.2025-11-21.00:00:00
+      author: camsaul
+      comment: Add Table Symlink (Table => Collection) 1tM table
+      changes:
+        - createTable:
+            tableName: table_symlink
+            comment: Adds a Table to a Collection; 1tM table
+            columns:
+              # composite PK of table_id + collection_id; no surrogate key (id)
+              - column:
+                  name: table_id
+                  type: int
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: pk_table_symlink
+              - column:
+                  name: collection_id
+                  type: int
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: pk_table_symlink
+              - column:
+                  name: creator_id
+                  type: int
+                  remarks: ID of the User who created this Symlink, for audit purposes. Set to NULL if the User is deleted.
+                  constraints:
+                    nullable: true
+              - column:
+                  name: created_at
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: v58.2025-11-21.00:00:01
+      author: camsaul
+      comment: Add FK constraint for table_symlink.table_id
+      changes:
+        - addForeignKeyConstraint:
+            constraintName: fk_table_symlink_table_id
+            baseTableName: table_symlink
+            baseColumnNames: table_id
+            referencedTableName: metabase_table
+            referencedColumnNames: id
+            onDelete: CASCADE
+
+  - changeSet:
+      id: v58.2025-11-21.00:00:02
+      author: camsaul
+      comment: Add FK constraint for table_symlink.collection_id
+      changes:
+        - addForeignKeyConstraint:
+            constraintName: fk_table_symlink_collection_id
+            baseTableName: table_symlink
+            baseColumnNames: collection_id
+            referencedTableName: collection
+            referencedColumnNames: id
+            onDelete: CASCADE
+
+  - changeSet:
+      id: v58.2025-11-21.00:00:03
+      author: camsaul
+      comment: Add FK constraint for table_symlink.creator_id
+      changes:
+        - addForeignKeyConstraint:
+            constraintName: fk_table_symlink_creator_id
+            baseTableName: table_symlink
+            baseColumnNames: creator_id
+            referencedTableName: core_user
+            referencedColumnNames: id
+            onDelete: SET NULL
+
+  - changeSet:
+      id: v58.2025-11-21.00:00:04
+      author: camsaul
+      comment: Add index on table_symlink.collection_id
+      changes:
+        - createIndex:
+            tableName: table_symlink
+            columns:
+              - column:
+                  name: collection_id
+            indexName: idx_table_symlink_collection_id
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/api_routes/routes.clj
+++ b/src/metabase/api_routes/routes.clj
@@ -175,6 +175,7 @@
    "/setup"                'metabase.setup-rest.api
    "/slack"                (+auth metabase.channel.api/slack-routes)
    "/table"                (+auth metabase.warehouse-schema-rest.api/table-routes)
+   "/table-symlink"        (+auth metabase.warehouse-schema-rest.api/table-symlink-routes)
    "/task"                 (+auth 'metabase.task-history.api)
    "/testing"              (if metabase.testing-api.core/enable-testing-routes? 'metabase.testing-api.api pass-thru-handler)
    "/tiles"                (+auth 'metabase.tiles.api)

--- a/src/metabase/models/resolution.clj
+++ b/src/metabase/models/resolution.clj
@@ -91,8 +91,9 @@
     :model/SemanticSearchTokenTracking       metabase-enterprise.semantic-search.models.token-tracking
     :model/Session                           metabase.session.models.session
     :model/Setting                           metabase.settings.models.setting
-    :model/SupportAccessGrantLog metabase-enterprise.support-access-grants.models.support-access-grant-log
+    :model/SupportAccessGrantLog             metabase-enterprise.support-access-grants.models.support-access-grant-log
     :model/Table                             metabase.warehouse-schema.models.table
+    :model/TableSymlink                      metabase.warehouse-schema.models.table-symlink
     :model/TaskHistory                       metabase.task-history.models.task-history
     :model/Timeline                          metabase.timeline.models.timeline
     :model/TimelineEvent                     metabase.timeline.models.timeline-event

--- a/src/metabase/query_permissions/impl.clj
+++ b/src/metabase/query_permissions/impl.clj
@@ -397,12 +397,10 @@
       (let [paths-excluding-gtap-paths (set/difference paths (:paths gtap-perms))]
         (or (perms/set-has-full-permissions-for-set? @api/*current-user-permissions-set* paths-excluding-gtap-paths)
             (throw (perms-exception paths)))))
-
     ;; Check view-data and create-queries permissions, for individual tables or the entire DB:
     (when (or (not (has-perm-for-query? query :perms/view-data required-perms))
               (not (has-perm-for-query? query :perms/create-queries required-perms)))
       (throw (perms-exception required-perms)))
-
     true
     (catch clojure.lang.ExceptionInfo e
       (if throw-exceptions?
@@ -415,11 +413,9 @@
   (try
     (let [required-perms (required-perms-for-query query)]
       (check-data-perms query required-perms)
-
       ;; Check card read permissions for any cards referenced in subqueries!
       (doseq [card-id (:card-ids required-perms)]
         (check-card-read-perms database-id card-id))
-
       true)
     (catch clojure.lang.ExceptionInfo _e
       false)))

--- a/src/metabase/warehouse_schema/models/table_symlink.clj
+++ b/src/metabase/warehouse_schema/models/table_symlink.clj
@@ -1,0 +1,10 @@
+(ns metabase.warehouse-schema.models.table-symlink
+  (:require
+   [methodical.core :as methodical]
+   [toucan2.core :as t2]))
+
+(derive :model/TableSymlink :metadata/model)
+
+(methodical/defmethod t2/table-name :model/TableSymlink [_model] :table_symlink)
+
+(methodical/defmethod t2/primary-keys :model/TableSymlink [_model] [:table_id :collection_id])

--- a/src/metabase/warehouse_schema_rest/api.clj
+++ b/src/metabase/warehouse_schema_rest/api.clj
@@ -2,10 +2,12 @@
   (:require
    [metabase.api.macros :as api.macros]
    [metabase.warehouse-schema-rest.api.field]
-   [metabase.warehouse-schema-rest.api.table]))
+   [metabase.warehouse-schema-rest.api.table]
+   [metabase.warehouse-schema-rest.api.table-symlink]))
 
 (comment metabase.warehouse-schema-rest.api.field/keep-me
-         metabase.warehouse-schema-rest.api.table/keep-me)
+         metabase.warehouse-schema-rest.api.table/keep-me
+         metabase.warehouse-schema-rest.api.table-symlink/keep-me)
 
 (def ^{:arglists '([request respond raise])} field-routes
   "`/api/field` routes."
@@ -14,3 +16,7 @@
 (def ^{:arglists '([request respond raise])} table-routes
   "`/api/table` routes."
   (api.macros/ns-handler 'metabase.warehouse-schema-rest.api.table))
+
+(def ^{:arglists '([request respond raise])} table-symlink-routes
+  "`/api/table-symlink` routes."
+  (api.macros/ns-handler 'metabase.warehouse-schema-rest.api.table-symlink))

--- a/src/metabase/warehouse_schema_rest/api/table_symlink.clj
+++ b/src/metabase/warehouse_schema_rest/api/table_symlink.clj
@@ -1,0 +1,90 @@
+(ns metabase.warehouse-schema-rest.api.table-symlink
+  "/api/table-symlink endpoints"
+  (:require
+   [metabase.api.common :as api]
+   [metabase.api.macros :as api.macros]
+   [metabase.lib.schema.id :as lib.schema.id]
+   [metabase.lib.schema.literal :as lib.schema.literal]
+   [metabase.query-permissions.core :as query-perms]
+   [metabase.util.i18n :as i18n]
+   [metabase.util.malli.registry :as mr]
+   [toucan2.core :as t2]))
+
+(mr/def ::table-symlink
+  [:map
+   [:collection_id ::lib.schema.id/collection]
+   [:table_id      ::lib.schema.id/collection]
+   [:creator_id    ::lib.schema.id/user]
+   [:created_at    ::lib.schema.literal/string.datetime]])
+
+(defn- check-table-query-permissions [table-id]
+  (let [database-id (api/check-404 (t2/select-one-fn :database_id :model/Table :id table-id))]
+    (when-not (query-perms/can-query-table? database-id table-id)
+      (throw (ex-info (i18n/tru "You must have data permissions to create a symlink for Table {0}."
+                                (pr-str (t2/select-one-fn :name :model/Table :id table-id)))
+                      {:status-code        403
+                       :database-id        database-id
+                       :table-id           table-id
+                       :actual-permissions @api/*current-user-permissions-set*})))))
+
+(api.macros/defendpoint :post "/" :- ::table-symlink
+  "Create a new Table Symlink (add a Table to a Collection). Only one symlink per Table + Collection is allowed.
+
+  To create a Table Symlink you must have Collection curate permissions for the Collection in question as well as
+  full Table data permissions (full query permissions) for the Table in question."
+  [_route-params
+   _query-params
+   {collection-id :collection_id, table-id :table_id, :as _body-params} :- [:map
+                                                                            [:collection_id ::lib.schema.id/collection]
+                                                                            [:table_id      ::lib.schema.id/table]]]
+  (api/write-check :model/Collection collection-id)
+  (check-table-query-permissions table-id)
+  (t2/insert-returning-instance! :model/TableSymlink {:collection_id collection-id
+                                                      :table_id      table-id
+                                                      :creator_id    api/*current-user-id*}))
+
+;;; I'm putting the the params here in the body in the endpoints rather than the route for uniformity with the POST
+;;; endpoint above -- Cam
+
+(api.macros/defendpoint :delete "/"
+  "Delete a Table Symlink.
+
+  To delete a Table Symlink you must have Collection curate permissions."
+  [_route-params
+   _query-params
+   {collection-id :collection_id, table-id :table_id, :as _body-params} :- [:map
+                                                                            [:collection_id ::lib.schema.id/collection]
+                                                                            [:table_id      ::lib.schema.id/table]]]
+  (api/write-check :model/Collection collection-id)
+  (t2/delete! :model/TableSymlink {:collection_id collection-id
+                                   :table_id      table-id})
+  api/generic-204-no-content)
+
+(api.macros/defendpoint :post "/move" :- ::table-symlink
+  "Move a Table Symlink from one Collection to another.
+
+  To move a Table Symlink you must have Collection curate permissions for both Collections as well as full Table data
+  permissions for the Table."
+  [_route-params
+   _query-params
+   {old-collection-id :old_collection_id
+    new-collection-id :new_collection_id
+    table-id          :table_id
+    :as               _body-params} :- [:and
+                                        [:map
+                                         [:old_collection_id ::lib.schema.id/collection]
+                                         [:new_collection_id ::lib.schema.id/collection]
+                                         [:table_id          ::lib.schema.id/table]]
+                                        [:fn
+                                         {:description   "old_collection_id and new_collection_id must be different"
+                                          :error/message "old_collection_id and new_collection_id must be different"}
+                                         #(not= (:old_collection_id %) (:new-collection_id %))]]]
+  (api/write-check :model/Collection old-collection-id)
+  (api/write-check :model/Collection new-collection-id)
+  (check-table-query-permissions table-id)
+  (t2/with-transaction [_]
+    (t2/delete! :model/TableSymlink {:collection_id old-collection-id
+                                     :table_id      table-id})
+    (t2/insert-returning-instance! :model/TableSymlink {:collection_id new-collection-id
+                                                        :table_id      table-id
+                                                        :creator_id    api/*current-user-id*})))

--- a/test/metabase/api_routes/routes_test.clj
+++ b/test/metabase/api_routes/routes_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.api-routes.routes-test
   (:require
+   [clojure.string :as str]
    [clojure.test :refer :all]
    [rewrite-clj.parser]
    [rewrite-clj.zip :as z]))
@@ -14,29 +15,41 @@
         (recur (conj ks (z/sexpr zloc))
                (-> zloc z/right z/right))))))
 
-(defn- find-route-map-def [file]
-  (-> file
+(defn- find-route-map-def [file-zloc map-def-name]
+  (-> file-zloc
       (z/find-next (fn [zloc]
                      (when (= (z/tag zloc) :list)
                        (let [first-child (z/down zloc)]
                          (when (= (z/sexpr first-child) 'def)
                            (let [next-child (z/right first-child)]
-                             (= (z/sexpr next-child) 'route-map)))))))))
+                             (= (z/sexpr next-child) map-def-name)))))))))
 
-(defn- find-route-map [file]
-  (-> file
-      find-route-map-def
+(defn- find-route-map [file-zloc map-def-name]
+  (-> file-zloc
+      (find-route-map-def map-def-name)
       z/down
       (z/find-next #(= (z/tag %) :map))))
 
-(defn- check-routes-map []
-  (with-open [r (clojure.lang.LineNumberingPushbackReader. (java.io.FileReader. "src/metabase/api_routes/routes.clj"))]
-    (let [zloc        (z/of-node (rewrite-clj.parser/parse-all r))
-          route-map   (find-route-map zloc)
-          actual-keys (find-map-keys route-map)]
-      (is (= (sort actual-keys)
-             actual-keys)))))
+(defn check-routes-map
+  ([]
+   (check-routes-map
+    {:filename                  "src/metabase/api_routes/routes.clj"
+     :map-def-name              'route-map
+     :legacy-snake-cased-routes #{"/preview_embed"}}))
+  ([{:keys [^String filename map-def-name legacy-snake-cased-routes]}]
+   (with-open [r (clojure.lang.LineNumberingPushbackReader. (java.io.FileReader. filename))]
+     (let [zloc        (z/of-node (rewrite-clj.parser/parse-all r))
+           route-map   (find-route-map zloc map-def-name)
+           actual-keys (find-map-keys route-map)]
+       (assert (seq actual-keys))
+       (testing "route-map keys should be sorted"
+         (is (= (sort actual-keys)
+                actual-keys)))
+       (testing "REST API routes should use kebab-case names"
+         (doseq [route actual-keys
+                 :when (not (contains? legacy-snake-cased-routes route))]
+           (is (= (str/replace route #"_" "-")
+                  route))))))))
 
-(deftest ^:parallel keep-routes-sorted-test
-  (testing "route-map keys should be sorted"
-    (check-routes-map)))
+(deftest ^:parallel check-route-map-test
+  (check-routes-map))

--- a/test/metabase/query_permissions/impl_test.clj
+++ b/test/metabase/query_permissions/impl_test.clj
@@ -6,12 +6,15 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.models.interface :as mi]
+   [metabase.permissions.core :as perms]
+   [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.permissions.path :as permissions.path]
    [metabase.query-permissions.core :as query-perms]
    [metabase.query-processor.preprocess :as qp.preprocess]
    [metabase.query-processor.test-util :as qp.test-util]
    [metabase.test :as mt]
-   [metabase.util :as u]))
+   [metabase.util :as u]
+   [toucan2.core :as t2]))
 
 ;;; ---------------------------------------------- Permissions Checking ----------------------------------------------
 
@@ -320,3 +323,24 @@
                 :perms/create-queries {(mt/id :products) :query-builder}
                 :perms/view-data      {(mt/id :products) :unrestricted}}
                (query-perms/required-perms-for-query query :already-preprocessed? true)))))))
+
+(deftest table-symlink-test
+  (let [mbql-query   (mt/mbql-query venues)
+        native-query (mt/native-query {:query "SELECT * FROM venues;"})]
+    (binding [*current-user-id*              (mt/user->id :rasta)
+              *current-user-permissions-set* (atom #{})]
+      (t2/with-transaction [_conn nil {:rollback-only true}]
+        (data-perms/set-table-permission! (perms/all-users-group) (mt/id :venues) :perms/create-queries :no)
+        (testing "WITHOUT symlink"
+          (is (not (query-perms/can-run-query? mbql-query)))
+          (is (not (query-perms/can-run-query? native-query))))
+        (mt/with-temp [:model/Collection   {collection-id :id} {}
+                       :model/TableSymlink {}                  {:collection_id collection-id, :table_id (mt/id :venues)}]
+          (perms/grant-collection-read-permissions! (perms/all-users-group) collection-id)
+          (testing "WITH symlink"
+            (is (query-perms/can-run-query? mbql-query))
+            (is (not (query-perms/can-run-query? native-query))))
+          (testing "WITH symlink, but perms/view-data is set to BLOCKED"
+            (mt/with-no-data-perms-for-all-users!
+              (is (not (query-perms/can-run-query? mbql-query)))
+              (is (not (query-perms/can-run-query? native-query))))))))))


### PR DESCRIPTION
- [x] Add database migration(s)
- [x] Add a new Toucan model, it will be pretty barebones I think. 
  - [x] I will put this in the warehouse_schema module but will consider making a new module instead
  - [ ] SerDes will have to know about how to serialize this but hopefully I can punt on that until Monday
- [x] Add API endpoint to create a table symlink (add tables to collections) (requires collection curate perms and data perms for the table)
- [x] Add API endpoint to delete table symlink
- [x] Add API endpoint to move table symlink
- [ ] Table symlinks should come back in the Collection items list endpoint
- [x] Query perms check code needs to be updated to look at symlinks the current user can see (i.e., which ones live in collections that a group they belong to has view perms for) to see if the current user has perms for a table or not (this will basically be the equivalent of having full data perms for that table)
- [ ] The API endpoint that powers the data selector for the QB needs to be updated to include these tables that would otherwise have been filtered out as well (I think this is `GET /api/tables/` but I'll have to double-check) -- I can test that the FE works for this by manually creating some rows here (needs to work for both the query source and for joins)
   - [ ] Check if I need to update `GET /api/table/:id` / Table metadata endpoints as well or not to make the QB work