### PR TITLE
Prefix users and groups as "Internal" in admin settings when tenants are active

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/ExternalGroupsListingApp/ExternalGroupsListingApp.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/ExternalGroupsListingApp/ExternalGroupsListingApp.tsx
@@ -5,7 +5,6 @@ import { GroupsListingApp } from "metabase/admin/people/containers/GroupsListing
 export const ExternalGroupsListingApp = () => {
   return (
     <GroupsListingApp
-      title={t`Tenant Groups`}
       description={t`Use tenant groups to manage access for external users. Every tenant has access to these groups.`}
       external
     />

--- a/frontend/src/metabase/admin/people/components/PeopleNav.tsx
+++ b/frontend/src/metabase/admin/people/components/PeopleNav.tsx
@@ -14,7 +14,7 @@ import { Divider, Stack } from "metabase/ui";
 
 export function PeopleNav() {
   const shouldNudge = useSelector(shouldNudgeToPro) as boolean;
-  const tenantEnabled = useSetting("use-tenants");
+  const isUsingTenants = useSetting("use-tenants");
 
   return (
     <AdminNavWrapper justify="space-between" aria-label="people-nav">
@@ -22,16 +22,16 @@ export function PeopleNav() {
         <PeopleNavItem
           path="/admin/people"
           data-testid="nav-item"
-          label={t`People`}
+          label={isUsingTenants ? t`Internal Users` : t`People`}
           icon="person"
         />
         <PeopleNavItem
           path="/admin/people/groups"
           data-testid="nav-item"
-          label={t`Groups`}
+          label={isUsingTenants ? t`Internal Groups` : t`Groups`}
           icon="group"
         />
-        {tenantEnabled && (
+        {isUsingTenants && (
           <>
             <Divider my="sm" />
             <PeopleNavItem

--- a/frontend/src/metabase/admin/people/containers/AdminPeopleApp/AdminPeopleApp.unit.spec.tsx
+++ b/frontend/src/metabase/admin/people/containers/AdminPeopleApp/AdminPeopleApp.unit.spec.tsx
@@ -64,8 +64,8 @@ describe("AdminPeopleApp", () => {
     it("should render both internal and external people links if tenants is enabled", async () => {
       await setup({ useTenants: true });
 
-      assertNavLink("People", "/admin/people");
-      assertNavLink("Groups", "/admin/people/groups");
+      assertNavLink("Internal Users", "/admin/people");
+      assertNavLink("Internal Groups", "/admin/people/groups");
       assertNavLink("Tenants", "/admin/tenants");
       assertNavLink("External Users", "/admin/tenants/people");
     });

--- a/frontend/src/metabase/admin/people/containers/GroupsListingApp.tsx
+++ b/frontend/src/metabase/admin/people/containers/GroupsListingApp.tsx
@@ -13,6 +13,7 @@ import {
   useUpdatePermissionsGroupMutation,
 } from "metabase/api";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
+import { useSetting } from "metabase/common/hooks";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { PLUGIN_GROUP_MANAGERS, PLUGIN_TENANTS } from "metabase/plugins";
 import { getUserIsAdmin } from "metabase/selectors/user";
@@ -22,15 +23,14 @@ import { GroupsListing } from "../components/GroupsListing";
 
 export const GroupsListingApp = ({
   external,
-  title,
   description,
 }: {
   external?: boolean;
-  title?: string;
   description?: string;
 }) => {
   const dispatch = useDispatch();
   const isAdmin = useSelector(getUserIsAdmin);
+  const isUsingTenants = useSetting("use-tenants");
 
   const { data, isLoading, error } = useListPermissionsGroupsQuery({});
   const groups = useMemo(() => {
@@ -67,8 +67,16 @@ export const GroupsListingApp = ({
     }
   };
 
+  const pageTitle = useMemo(() => {
+    if (!isUsingTenants) {
+      return t`Groups`;
+    }
+
+    return external ? t`Tenant Groups` : t`Internal Groups`;
+  }, [external, isUsingTenants]);
+
   return (
-    <SettingsPageWrapper title={title ?? t`Groups`}>
+    <SettingsPageWrapper title={pageTitle}>
       <SettingsSection>
         <LoadingAndErrorWrapper error={error} loading={isLoading}>
           <GroupsListing

--- a/frontend/src/metabase/admin/people/containers/PeopleListingApp/PeopleListingApp.tsx
+++ b/frontend/src/metabase/admin/people/containers/PeopleListingApp/PeopleListingApp.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useMemo, useMemo } from "react";
 import { Link } from "react-router";
 import { t } from "ttag";
 
@@ -8,6 +8,7 @@ import {
 } from "metabase/admin/components/SettingsSection";
 import { useListPermissionsGroupsQuery, useListUsersQuery } from "metabase/api";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
+import { useSetting } from "metabase/common/hooks";
 import { useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { PLUGIN_TENANTS } from "metabase/plugins";
@@ -38,6 +39,7 @@ export function PeopleListingApp({
 }) {
   const isAdmin = useSelector(getUserIsAdmin);
   const currentUser = useSelector(getUser);
+  const isUsingTenants = useSetting("use-tenants");
 
   const {
     data: groups = [],
@@ -87,8 +89,16 @@ export function PeopleListingApp({
     }
   }, [hasDeactivatedUsers, updateStatus]);
 
+  const pageTitle = useMemo(() => {
+    if (!isUsingTenants) {
+      return t`People`;
+    }
+
+    return external ? t`External Users` : t`Internal Users`;
+  }, [external, isUsingTenants]);
+
   return (
-    <SettingsPageWrapper title={external ? t`External Users` : t`People`}>
+    <SettingsPageWrapper title={pageTitle}>
       <Stack gap={0}>
         {isAdmin && hasDeactivatedUsers && (
           <Tabs value={status} onChange={handleTabChange} pl="md">

--- a/frontend/src/metabase/admin/people/containers/PeopleListingApp/PeopleListingApp.tsx
+++ b/frontend/src/metabase/admin/people/containers/PeopleListingApp/PeopleListingApp.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { Link } from "react-router";
 import { t } from "ttag";
 

--- a/frontend/src/metabase/admin/people/containers/PeopleListingApp/PeopleListingApp.unit.spec.tsx
+++ b/frontend/src/metabase/admin/people/containers/PeopleListingApp/PeopleListingApp.unit.spec.tsx
@@ -26,6 +26,7 @@ const setup = ({
     is_superuser: true,
   }),
   tenants = [],
+  useTenants = true,
 }: {
   external?: boolean;
   showInviteButton?: boolean;
@@ -33,11 +34,13 @@ const setup = ({
   users?: User[];
   currentUser?: User;
   tenants?: Tenant[];
+  useTenants?: boolean;
 } = {}) => {
   const settings = mockSettings({
     "token-features": createMockTokenFeatures({
       tenants: true,
     }),
+    "use-tenants": useTenants,
   });
 
   setupEnterprisePlugins();
@@ -72,6 +75,32 @@ const setup = ({
     },
   );
 };
+
+describe("page title", () => {
+  it("should show 'People' when tenants is disabled", async () => {
+    setup({ useTenants: false });
+
+    expect(
+      await screen.findByRole("heading", { name: "People", level: 1 }),
+    ).toBeInTheDocument();
+  });
+
+  it("should show 'Internal Users' when tenants is enabled and viewing internal users", async () => {
+    setup({ useTenants: true, external: false });
+
+    expect(
+      await screen.findByRole("heading", { name: "Internal Users", level: 1 }),
+    ).toBeInTheDocument();
+  });
+
+  it("should show 'External Users' when tenants is enabled and viewing external users", async () => {
+    setup({ useTenants: true, external: true });
+
+    expect(
+      await screen.findByRole("heading", { name: "External Users", level: 1 }),
+    ).toBeInTheDocument();
+  });
+});
 
 describe("people table", () => {
   it("should show group association when viewing internal users", async () => {


### PR DESCRIPTION
Closes EMB-1041

### Description

When tenants are active in admin settings, change “People” to “Internal Users” and "Groups" to "Internal Groups" in the admin page title and admin page sidebar.

### How to verify

- Use the MB_ALL_FEATURES_TOKEN as this is an in-development feature
- Go to "Admin Settings > People" page
- You should see sidebar has "People" and "Groups".
- Clicking on each nav should show the page title as "People" and "Groups" as usual
- Go to "People" > Settings Button > User Strategy > Multi tenant
- You should see sidebar now has "Internal People" and "Internal Groups".
- Clicking on each nav should show the page title as "Internal People" and "Internal Groups"

### Demo

<img width="2464" height="1236" alt="CleanShot 2568-11-22 at 08 17 45@2x" src="https://github.com/user-attachments/assets/4f274cf9-68f5-435d-bec7-da3445eddbff" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
