### PR TITLE
fix(issue #65526): Incomplete non-admin user warning

### DIFF
--- a/e2e/test/scenarios/sharing/alert/alert.cy.spec.js
+++ b/e2e/test/scenarios/sharing/alert/alert.cy.spec.js
@@ -49,7 +49,7 @@ describe("scenarios > alert", () => {
 
       H.modal().within(() => {
         cy.findByText(
-          "To get notified when something happens, or to send this chart on a schedule, ask your Admin to set up SMTP or Slack.",
+          "To get notified when something happens, or to send this chart on a schedule, ask your Admin to set up SMTP, Slack, or a webhook.",
         );
 
         cy.findByText("Set up SMTP").should("not.exist");

--- a/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
@@ -521,8 +521,10 @@ describe("scenarios > dashboard > subscriptions", () => {
       H.visitDashboard(ORDERS_DASHBOARD_ID);
       H.openSharingMenu();
       H.sharingMenu()
-        .findByText("Can't send subscriptions")
-        .should("be.visible");
+        .within(() => {
+          cy.findByText("Can't send subscriptions").should("be.visible");
+          cy.findByText("Ask your admin to set up email or Slack").should("be.visible");
+        });
     });
   });
 

--- a/frontend/src/metabase/notifications/NotificationsActionsMenu/DashboardSubscriptionMenuItem.tsx
+++ b/frontend/src/metabase/notifications/NotificationsActionsMenu/DashboardSubscriptionMenuItem.tsx
@@ -38,7 +38,7 @@ export function DashboardSubscriptionMenuItem({
         disabled
       >
         <Text size="md" c="inherit">{t`Can't send subscriptions`}</Text>
-        <Text size="sm" c="inherit">{t`Ask your admin to set up email`}</Text>
+        <Text size="sm" c="inherit">{t`Ask your admin to set up email or Slack`}</Text>
       </Menu.Item>
     );
   }

--- a/frontend/src/metabase/notifications/modals/ChannelSetupModal.tsx
+++ b/frontend/src/metabase/notifications/modals/ChannelSetupModal.tsx
@@ -52,7 +52,7 @@ export const ChannelSetupModal = ({
         <Text mb="1rem">
           {userCanAccessSettings
             ? t`To get notified when something happens, or to send this chart on a schedule, first set up SMTP, Slack, or a webhook.`
-            : t`To get notified when something happens, or to send this chart on a schedule, ask your Admin to set up SMTP or Slack.`}
+            : t`To get notified when something happens, or to send this chart on a schedule, ask your Admin to set up SMTP, Slack, or a webhook.`}
         </Text>
 
         {userCanAccessSettings &&


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/65526

### Description

Describe the overall approach and the problem being solved.

### How to verify

1. Create a new instance
2. Add a non-admin user
3. Sign in as non-admin user
4. check an example dashboard, and try to subscribe
5. check any question in the Example collection, and try to set up and alert

Expected Behavior: non-admin notification channels options number now match Admin user number


### Checklist

- [X ] Tests have been added/updated to cover changes in this PR.
- [ ] I manually verified the behavior described in the "How to verify" section.
- [ ] I reviewed the changes for potential regressions.