### PR TITLE
New Feature: Custom CSV Table Name Validation (#65715)

### DIFF
--- a/src/metabase/util/custom_name.clj
+++ b/src/metabase/util/custom_name.clj
@@ -1,0 +1,9 @@
+(ns metabase.util.custom-name
+  (:require [clojure.string :as str]))
+
+(defn validate-name [name-string]
+  ;; Refatoração: Primeiro substitui espaços por _, depois valida
+  (let [sanitized (str/replace name-string #" " "_")]
+    (if (re-matches #"^[a-zA-Z0-9_]+$" sanitized)
+      sanitized
+      (throw (Exception. "Nome de tabela inválido: use apenas letras, números e underline.")))))

--- a/test/metabase/util/custom_name_test.clj
+++ b/test/metabase/util/custom_name_test.clj
@@ -1,0 +1,15 @@
+(ns metabase.util.custom-name-test
+  (:require [clojure.test :refer :all]
+            [metabase.util.custom-name :as sut]))
+
+(deftest validate-table-name-test
+  (testing "Deve aceitar um nome simples e válido"
+    (is (= "minha_tabela" (sut/validate-name "minha_tabela")))))
+
+(deftest reject-invalid-chars-test
+  (testing "Deve rejeitar nomes com caracteres especiais"
+    (is (thrown? Exception (sut/validate-name "tabela$inválida")))))
+
+(deftest sanitize-spaces-test
+  (testing "Deve converter espaços em underlines automaticamente"
+    (is (= "tabela_com_espacos" (sut/validate-name "tabela com espacos")))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/65715

### Description

This PR implements a backend utility module (`metabase.util.custom-name`) to validate and sanitize custom table names for CSV uploads.

**Problem:**
When uploading a CSV, users need a way to specify a custom table name that is safe for the database.

**Solution:**
I created a validation function that:
1. **Validates:** Ensures the name only contains alphanumeric characters and underscores.
2. **Sanitizes:** Automatically converts spaces to underscores (e.g., "my table" -> "my_table") to improve user experience.
3. **Rejects:** Throws an exception if invalid characters (like symbols) are present.

### How to verify

Since this is a backend utility module, verification is done via the new unit tests provided.

1. Open your terminal in the project root.
2. Run the specific test namespace:
   ```bash
       clojure -X:dev:test :only metabase.util.custom-name-test 
   

3. Verify that all 3 tests pass:

- validate-table-name-test (Valid names)

- reject-invalid-chars-test (Invalid characters)

- sanitize-spaces-test (Space to underscore conversion)

###Demo
Test Execution Results: (Cole aqui aquele seu print final do terminal VERDE mostrando "All tests passed")

###Checklist
[x] Tests have been added/updated to cover changes in this PR