### PR TITLE
Add specific error messages for JWT tenant errors

### DIFF
--- a/docs/people-and-groups/assigning-users-to-tenants.md
+++ b/docs/people-and-groups/assigning-users-to-tenants.md
@@ -1,0 +1,52 @@
+---
+title: Assigning external users to tenants
+description: How to automatically assign users to tenants using SSO authentication (JWT and SAML).
+---
+
+# Assigning external users to tenants
+
+{% include plans-blockquote.html feature="Tenants" %}
+
+If you're running a multi-tenant application, you can assign users to tenants based on a claim in the JWT token.
+
+## Prerequisites
+
+- Multi-tenant user strategy must be enabled in Metabase
+- JWT authentication must be configured
+
+## How it works
+
+When a user logs in with JWT:
+
+1. Metabase reads the tenant identifier from the JWT claim. By default, this is the `tenant` key.
+2. If the tenant doesn't exist, Metabase automatically creates it
+3. New users are automatically assigned to the tenant from their JWT
+
+## Example JWT with tenant claim
+
+```json
+{
+  "email": "user@example.com",
+  "first_name": "Jane",
+  "last_name": "Doe",
+  "tenant": "acme-corp"
+}
+```
+
+## Important restrictions
+
+**Users cannot change tenants.** Once an external user is assigned to a tenant, they cannot switch to other tenant.
+
+If a user attempts to log in with mismatched tenant information, they will receive one of these errors:
+
+- `Cannot add tenant claim to internal user` - JWT includes a tenant, but the user is an internal user. Only external users can have a tenant.
+- `Tenant claim required for external user` - JWT lacks a tenant claim, but the user is an external user.
+- `Tenant ID mismatch with existing user` - JWT has a different tenant than the user's assigned tenant
+- `Tenant is not active` - The tenant exists but has been deactivated
+
+# Configuring the tenant claim
+
+By default, Metabase looks for a `tenant` key in your JWT. You can customize this:
+
+1. Go to **Admin** > **Settings** > **Authentication** > **JWT** > **User attribute configuration**
+2. Change the **Tenant assignment attribute** key to your preferred identifier.

--- a/docs/people-and-groups/authenticating-with-jwt.md
+++ b/docs/people-and-groups/authenticating-with-jwt.md
@@ -42,6 +42,7 @@ These are additional settings you can fill in to pass user attributes to Metabas
 - **First name attribute:** the key to retrieve each JWT user's first name.
 - **Last name attribute:** if you guessed that this is the key to retrieve each JWT user's last name, well then you have been paying attention.
 - **Group assignment attribute:** the key to retrieve each JWT user's group assignments.
+- **Tenant attribute:** the key to retrieve each JWT user's tenant. Default is `tenant`. See [Assigning external users to tenants](./assigning-users-to-tenants.md).
 
 You can send additional user attributes to Metabase by adding the attributes as key/value pairs to your JWT. These attributes will be synced on every login.
 
@@ -105,6 +106,10 @@ Metabase accounts created with an external identity provider login don't have pa
 To require people to log in with SSO, disable password authentication from **Admin settings** > **Authentication**.
 
 ![Password disable](images/password-disable.png)
+
+## Assigning external users to tenants
+
+If you're running a multi-tenant application, you can use JWT to automatically assign users to tenants based on a claim in the JWT token. See [Assigning external users to tenants](./assigning-users-to-tenants.md) for details.
 
 ## Note about Azure
 


### PR DESCRIPTION
Closes EMB-1012

### Description

Today, we are throwing a really generic "Tenant info mismatch" error for all of these very different conditions:
- Internal users trying to use tenant claim in JWT, or external users does not have a tenant claim in JWT
- Tenant ID mismatch with the existing user
- The tenant is not active

```clj
(when (or (atsxnd user-exists?
               (not= user-will-have-tenant? user-has-tenant?))
          (and user-exists?
               (not= tenant_id (u/the-id existing-tenant)))
          (and existing-tenant
               (not (:is_active existing-tenant))))
  (throw (ex-info "Tenant info mismatch" {:user/tenant-id tenant_id
                                          :user/tenant-slug (t2/select-one-fn :slug :model/Tenant :id tenant_id)
                                          :tenant-slug/tenant-id (:id existing-tenant)
                                          :tenant-slug/slug (:slug existing-tenant)
                                          :tenant-slug/is-active (:is_active existing-tenant)
                                          :status-code 403})))))
```

This PR throws 4 separate error messages instead of the above generic error:

1. Tenant ID mismatch with existing user
2. Tenant is not active
3. Cannot add tenant claim to internal user
4. Tenant claim required for external user

### How to verify

Try to add JWT tokens using these conditions:

- Adding a `tenant` claim using a different tenant slug than the user's current slug should result in `Tenant ID mismatch with existing user`
- Adding a `tenant` claim using a deactivated tenant's slug results in `Tenant is not active`
- Adding a `tenant` claim to an internal user results in `Cannot add tenant claim to internal user`
- Not defining a `tenant` claim to an already registered external user results in `Tenant claim required for external user`

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
