### PR TITLE
Update design of the user strategy modal for tenants

### DIFF
--- a/e2e/test/scenarios/admin-2/tenants.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/tenants.cy.spec.js
@@ -113,9 +113,10 @@ describe("Tenants - management", () => {
 
     cy.findByRole("link", { name: /gear/ }).click();
 
-    H.modal().findByRole("textbox", { name: "User strategy" }).click();
-    H.popover().findByText("Multi tenant").click();
-    H.modal().button("Close").click();
+    H.modal().within(() => {
+      cy.findByRole("radio", { name: /Multi tenant/i }).click();
+      cy.button("Apply").click();
+    });
 
     cy.findByRole("link", { name: /External Users/ }).should("exist");
     cy.findByRole("link", { name: /Tenants/ }).click();

--- a/enterprise/frontend/src/metabase-enterprise/tenants/EditUserStrategyModal/EditUserStrategyModal.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/EditUserStrategyModal/EditUserStrategyModal.module.css
@@ -1,0 +1,8 @@
+.radioCard {
+  cursor: pointer;
+  border: 1px solid var(--mb-color-border);
+}
+
+.radioCard[data-checked] {
+  border-color: var(--mb-color-brand);
+}

--- a/enterprise/frontend/src/metabase-enterprise/tenants/EditUserStrategyModal/EditUserStrategyModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/EditUserStrategyModal/EditUserStrategyModal.tsx
@@ -46,6 +46,11 @@ export const EditUserStrategyModal = ({
     onClose();
   };
 
+  const handleCancel = () => {
+    setSelectedStrategy(initialStrategy);
+    onClose();
+  };
+
   const strategyOptions = [
     {
       value: "single-tenant",
@@ -99,7 +104,7 @@ export const EditUserStrategyModal = ({
           </Radio.Group>
 
           <Flex justify="flex-end" gap="md" mt="md">
-            <Button variant="outline" onClick={onClose}>
+            <Button variant="outline" onClick={handleCancel}>
               {t`Cancel`}
             </Button>
 

--- a/enterprise/frontend/src/metabase-enterprise/tenants/EditUserStrategyModal/EditUserStrategyModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/EditUserStrategyModal/EditUserStrategyModal.tsx
@@ -1,10 +1,13 @@
+import { useEffect, useState } from "react";
 import { t } from "ttag";
 
 import { permissionApi } from "metabase/api";
 import { useAdminSetting } from "metabase/api/utils";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { useDispatch } from "metabase/lib/redux";
-import { Modal, Select, Stack, Text } from "metabase/ui";
+import { Button, Flex, Group, Modal, Radio, Stack, Text } from "metabase/ui";
+
+import S from "./EditUserStrategyModal.module.css";
 
 interface EditUserStrategyModalProps {
   onClose: () => void;
@@ -18,44 +21,93 @@ export const EditUserStrategyModal = ({
   const { isLoading, error, value, updateSetting } =
     useAdminSetting("use-tenants");
 
-  const strategy = value ? "multi-tenant" : "single-tenant";
+  const initialStrategy = value ? "multi-tenant" : "single-tenant";
 
-  const data = [
-    { label: t`Single tenant`, value: "single-tenant" },
-    { label: t`Multi tenant`, value: "multi-tenant" },
-  ];
+  // Needed to disable the apply button when the strategy does not change
+  const [selectedStrategy, setSelectedStrategy] = useState(initialStrategy);
 
-  const handleStrategyChange = async (value: string) => {
-    await updateSetting({
+  useEffect(() => {
+    setSelectedStrategy(initialStrategy);
+  }, [initialStrategy]);
+
+  const handleApply = async () => {
+    const response = await updateSetting({
       key: "use-tenants",
-      value: value === "multi-tenant",
+      value: selectedStrategy === "multi-tenant",
     });
-    await dispatch(permissionApi.util.invalidateTags(["permissions-group"]));
+
+    // Revert selection to initial value if update fails
+    if (response.error) {
+      setSelectedStrategy(initialStrategy);
+      return;
+    }
+
+    dispatch(permissionApi.util.invalidateTags(["permissions-group"]));
+    onClose();
   };
+
+  const strategyOptions = [
+    {
+      value: "single-tenant",
+      title: t`Single tenant`,
+      // eslint-disable-next-line no-literal-metabase-strings -- in admin settings
+      description: t`All users exist in the same world and are managed via Metabase groups. Ideal for internal company analytics, proof of concept, or simple embedding setups.`,
+    },
+    {
+      value: "multi-tenant",
+      title: t`Multi tenant`,
+      description: t`Each tenant operates in an isolated environment with dedicated resources and permissions. Best for SaaS platforms, scalable embedding, or strict data isolation needs.`,
+    },
+  ];
 
   return (
     <Modal
       opened
-      title={t`People settings`}
+      title={t`User strategy`}
       padding="xl"
-      size="lg"
+      size="md"
       onClose={onClose}
     >
       <LoadingAndErrorWrapper loading={isLoading} error={error}>
-        <Stack gap="md" mt="lg" mb="xl">
-          <Select
-            label={t`User strategy`}
-            placeholder={t`Pick value`}
-            data={data}
-            defaultValue="single-tenant"
-            value={strategy}
-            onChange={handleStrategyChange}
-          />
+        <Stack gap="md" mt="sm">
+          <Radio.Group value={selectedStrategy} onChange={setSelectedStrategy}>
+            <Stack gap="md">
+              {strategyOptions.map((option) => (
+                <Radio.Card
+                  key={option.value}
+                  value={option.value}
+                  radius="md"
+                  p="md"
+                  className={S.radioCard}
+                >
+                  <Group wrap="nowrap">
+                    <Radio.Indicator />
 
-          <Text c="text-secondary">
-            {/* eslint-disable-next-line no-literal-metabase-strings -- This link only shows for admins. */}
-            {t`All users exist in the same world and are managed via Metabase groups. Best for internal company analytics or one off embedding setups or proofs of concept.`}
-          </Text>
+                    <div>
+                      <Text fw={700} fz="lg" lh="xl" mb="xs">
+                        {option.title}
+                      </Text>
+
+                      <Text c="text-secondary" fz="sm" lh="lg">
+                        {option.description}
+                      </Text>
+                    </div>
+                  </Group>
+                </Radio.Card>
+              ))}
+            </Stack>
+          </Radio.Group>
+
+          <Flex justify="flex-end" gap="md" mt="md">
+            <Button variant="outline" onClick={onClose}>
+              {t`Cancel`}
+            </Button>
+
+            <Button
+              onClick={handleApply}
+              disabled={initialStrategy === selectedStrategy}
+            >{t`Apply`}</Button>
+          </Flex>
         </Stack>
       </LoadingAndErrorWrapper>
     </Modal>

--- a/enterprise/frontend/src/metabase-enterprise/tenants/EditUserStrategyModal/EditUserStrategyModal.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/EditUserStrategyModal/EditUserStrategyModal.unit.spec.tsx
@@ -46,64 +46,109 @@ describe("EditUserStrategyModal", () => {
   it("should handle loading state", async () => {
     await setup();
     expect(screen.getByText("Loading...")).toBeInTheDocument();
-    await screen.findByLabelText("User strategy");
+    await screen.findByText("User strategy");
   });
 
-  it("should correctly set to single-tenancy if use-tenants setting is false", async () => {
+  it("should correctly display single-tenancy as selected if use-tenants setting is false", async () => {
     await setup();
 
-    const select = await userStrategySelect();
-    expect(select).toBeInTheDocument();
-    expect(select).toHaveValue("Single tenant");
+    expect(
+      await screen.findByRole("radio", {
+        name: /Single tenant/,
+        checked: true,
+      }),
+    ).toBeInTheDocument();
   });
 
-  it("should correctly set to multi-tenancy if use-tenants setting is true", async () => {
+  it("should correctly display multi-tenancy as selected if use-tenants setting is true", async () => {
     await setup({ useTenants: true });
 
-    const select = await userStrategySelect();
-    expect(select).toBeInTheDocument();
-    expect(select).toHaveValue("Multi tenant");
+    expect(
+      await screen.findByRole("radio", {
+        name: /Multi tenant/,
+        checked: true,
+      }),
+    ).toBeInTheDocument();
   });
 
-  it("should correctly update user strategy", async () => {
+  it("should allow changing selection and applying the change", async () => {
     await setup();
 
-    const select1 = await userStrategySelect();
-    expect(select1).toBeInTheDocument();
-    expect(select1).toHaveValue("Single tenant");
+    const multiTenantCard = await screen.findByRole("radio", {
+      name: /Multi tenant/,
+      checked: false,
+    });
+    expect(multiTenantCard).toBeInTheDocument();
+    await userEvent.click(multiTenantCard);
 
-    await userEvent.click(select1);
-    setupPropertiesEndpoints(createMockSettings({ "use-tenants": true }));
-    await userEvent.click(await screen.findByText("Multi tenant"));
+    expect(
+      screen.getByRole("radio", { name: /Multi tenant/, checked: true }),
+    ).toBeInTheDocument();
+
+    const applyButton = screen.getByRole("button", { name: /Apply/ });
+    await userEvent.click(applyButton);
+
     await waitFor(async () => {
       const puts = await findRequests("PUT");
       expect(puts).toHaveLength(1);
     });
 
-    const select2 = await userStrategySelect();
-    expect(select2).toBeInTheDocument();
-    expect(select2).toHaveValue("Multi tenant");
+    const puts = await findRequests("PUT");
+    expect(puts[0].body).toEqual({ value: true });
   });
 
-  it("should handle failing to update", async () => {
-    await setup({
-      setupEndpoints: () => {
-        fetchMock.put("path:/api/setting/use-tenants", 500);
-      },
+  it("reverts the selected user strategy if the setting update fails", async () => {
+    fetchMock.put(
+      "path:/api/setting/use-tenants",
+      { throws: new Error("Internal server error") },
+      { overwriteRoutes: true },
+    );
+
+    await setup();
+
+    expect(
+      await screen.findByRole("radio", {
+        name: /Single tenant/,
+        checked: true,
+      }),
+    ).toBeInTheDocument();
+
+    const multiTenantCard = screen.getByRole("radio", {
+      name: /Multi tenant/,
     });
+    await userEvent.click(multiTenantCard);
 
-    const select1 = await userStrategySelect();
-    expect(select1).toBeInTheDocument();
-    expect(select1).toHaveValue("Single tenant");
+    const applyButton = screen.getByRole("button", { name: /Apply/ });
+    await userEvent.click(applyButton);
 
-    await userEvent.click(select1);
-    await userEvent.click(await screen.findByText("Multi tenant"));
     await waitFor(() => findRequests("PUT"));
 
-    const select2 = await userStrategySelect();
-    expect(select2).toBeInTheDocument();
-    expect(select2).toHaveValue("Single tenant");
+    // Revert to single tenant as the API call failed
+    expect(
+      await screen.findByRole("radio", {
+        name: /Single tenant/,
+        checked: true,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("should disable the apply button when the user strategy has not changed", async () => {
+    await setup();
+
+    expect(
+      await screen.findByRole("radio", {
+        name: /Single tenant/,
+        checked: true,
+      }),
+    ).toBeInTheDocument();
+
+    const applyButton = screen.getByRole("button", { name: /Apply/ });
+    expect(applyButton).toBeDisabled();
+
+    await userEvent.click(screen.getByRole("radio", { name: /Multi tenant/ }));
+    expect(applyButton).toBeEnabled();
+
+    await userEvent.click(screen.getByRole("radio", { name: /Single tenant/ }));
+    expect(applyButton).toBeDisabled();
   });
 });
-
-const userStrategySelect = () => screen.findByLabelText("User strategy");

--- a/enterprise/frontend/src/metabase-enterprise/tenants/EditUserStrategyModal/EditUserStrategyModal.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/EditUserStrategyModal/EditUserStrategyModal.unit.spec.tsx
@@ -102,11 +102,9 @@ describe("EditUserStrategyModal", () => {
   });
 
   it("reverts the selected user strategy if the setting update fails", async () => {
-    fetchMock.put(
-      "path:/api/setting/use-tenants",
-      { throws: new Error("Internal server error") },
-      { overwriteRoutes: true },
-    );
+    fetchMock.put("path:/api/setting/use-tenants", {
+      throws: new Error("Internal server error"),
+    });
 
     await setup();
 

--- a/enterprise/frontend/src/metabase-enterprise/tenants/EditUserStrategyModal/EditUserStrategyModal.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/EditUserStrategyModal/EditUserStrategyModal.unit.spec.tsx
@@ -49,7 +49,7 @@ describe("EditUserStrategyModal", () => {
     await screen.findByText("User strategy");
   });
 
-  it("should correctly display single-tenancy as selected if use-tenants setting is false", async () => {
+  it("should correctly select single-tenancy if use-tenants setting is false", async () => {
     await setup();
 
     expect(


### PR DESCRIPTION
Closes EMB-1047

### Description

Updates the design of the user strategy modal in the People page:

<img width="1328" height="754" alt="CleanShot 2568-11-24 at 17 47 43@2x" src="https://github.com/user-attachments/assets/d7885d0c-d08a-4112-88b0-91e3cebd7c56" />

### How to verify

- Use the MB_ALL_FEATURES_TOKEN as this is an in-development feature
- Go to "Admin Settings > People"
- Click on the setting button
- You should see the new design with radio cards

### Demo

<img width="2466" height="1724" alt="CleanShot 2568-11-24 at 17 48 21@2x" src="https://github.com/user-attachments/assets/9da8ac8e-ef70-47ce-93d4-5a66577af7c4" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
