### PR TITLE
Fix uberjar fetching for SDK host-apps

### DIFF
--- a/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
+++ b/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
@@ -249,9 +249,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Retrieve uberjar artifact for ee
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/fetch-artifact
         with:
           name: metabase-ee-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
+          extract-path: "target/uberjar"
+          output-name: "metabase.jar"
 
       - name: Retrieve Embedding SDK dist artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Fixes the artifact "compatibility problem":
https://github.com/metabase/metabase/actions/runs/19635216226/job/56227663457

I was 1000% convinced I fixed it all [here](https://github.com/metabase/metabase/pull/66165), but it seems that some parts slipped through.
