### PR TITLE
Improve how skipped SDK tests are handled

### DIFF
--- a/.github/workflows/embedding-sdk.yml
+++ b/.github/workflows/embedding-sdk.yml
@@ -23,6 +23,10 @@ on:
         description: "Whether to run host and sample apps compatibility tests."
         required: true
         type: boolean
+      skip:
+        description: Whether to skip running tests due to one of the artifacts failing to build.
+        required: true
+        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
@@ -30,7 +34,7 @@ concurrency:
 
 jobs:
   embedding-sdk-cli-snippets-type-check:
-    if: inputs.cli-snippets-type-check
+    if: inputs.cli-snippets-type-check && !inputs.skip
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
@@ -46,7 +50,7 @@ jobs:
         run: yarn run embedding-sdk:cli-snippets:type-check
 
   embedding-sdk-docs-snippets-type-check:
-    if: inputs.docs-snippets-type-check
+    if: inputs.docs-snippets-type-check && !inputs.skip
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
@@ -62,7 +66,7 @@ jobs:
         run: yarn run embedding-sdk:docs-snippets:type-check
 
   embedding-sdk-api-documentation-generation-validation:
-    if: inputs.documentation-validation
+    if: inputs.documentation-validation && !inputs.skip
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
@@ -110,13 +114,13 @@ jobs:
   # See `Component e2e tests` in `enterprise/frontend/src/embedding-sdk-package/dev.md`
   embedding-sdk-component-tests:
     name: "SDK component tests"
-    if: inputs.component-tests
+    if: inputs.component-tests && !inputs.skip
     uses: ./.github/workflows/embedding-sdk-component-tests.yml
     secrets: inherit
 
   not-required-embedding-sdk-apps-compatibility-tests:
     name: "SDK e2e tests for compatibility with (host/sample) apps"
-    if: inputs.host-sample-apps-tests
+    if: inputs.host-sample-apps-tests && !inputs.skip
     uses: ./.github/workflows/embedding-sdk-host-sample-apps-tests.yml
     secrets: inherit
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -110,9 +110,6 @@ jobs:
 
   sdk-tests:
     needs: [uberjar, embedding-sdk-package, files-changed]
-    if: |
-      needs.embedding-sdk-package.result == 'success' &&
-      needs.uberjar.result == 'success'
     uses: ./.github/workflows/embedding-sdk.yml
     secrets: inherit
     with:
@@ -121,6 +118,7 @@ jobs:
       documentation-validation: ${{ needs.files-changed.outputs.frontend_embedding_sdk_sources == 'true' }}
       component-tests: ${{ needs.files-changed.outputs.embedding_sdk_components == 'true' }}
       host-sample-apps-tests: ${{ needs.files-changed.outputs.embedding_sdk_host_sample_apps == 'true' }}
+      skip: ${{ needs.embedding-sdk-package.result != 'success' || needs.uberjar.result != 'success' }}
 
   pr-env:
     needs: [uberjar]


### PR DESCRIPTION
The following SDK tests are required:
- embedding-sdk-cli-snippets-type-check
- embedding-sdk-docs-snippets-type-check
- embedding-sdk-api-documentation-generation-validation
- embedding-sdk-component-tests

They require embedding sdk package to be built, and the Metabase uberjar on top of it. If one of these two fail to build, or is simply not required, we should not run these tests. Since they are required, and GitHub still refuses to do anything about [this three year old request](https://github.com/orgs/community/discussions/13690), we have to make sure that ALL tests are skipped in order for `embedding-sdk-tests-result` to override the exit code and report the job as passing.

Lovely, i know.

Failing to do so results in SDK tests being reported as "pending", which then blocks the PR from merging. Like so:
<img width="834" height="369" alt="image" src="https://github.com/user-attachments/assets/44d1f01a-2113-4f05-89f3-62bd6e1ba364" />

      