### PR TITLE
Support relative-datetime in legacy mbql

### DIFF
--- a/src/metabase/lib/convert.cljc
+++ b/src/metabase/lib/convert.cljc
@@ -412,6 +412,14 @@
   [[_tag & [_column _value _bucket _offset-value _offset-bucket :as args]]]
   (lib.options/ensure-uuid (into [:relative-time-interval {}] (map ->pMBQL) args)))
 
+(defmethod ->pMBQL :relative-datetime
+  [[_tag n unit]]
+  (let [normalized-unit (cond-> unit (string? unit) keyword)]
+    (lib.options/ensure-uuid
+     (if normalized-unit
+       [:relative-datetime {} n normalized-unit]
+       [:relative-datetime {} n]))))
+
 ;; `:offset` is the same in legacy and pMBQL, but we need to update the expr it wraps.
 (defmethod ->pMBQL :offset
   [[tag opts expr n, :as clause]]

--- a/test/metabase/lib/convert_test.cljc
+++ b/test/metabase/lib/convert_test.cljc
@@ -1209,6 +1209,26 @@
   (is (=? [:datetime {:lib/uuid string?} ""]
           (lib.convert/->pMBQL [:datetime ""]))))
 
+(deftest ^:parallel ->pMBQL-relative-datetime-test
+  (testing "Convert legacy relative-datetime with string unit to pMBQL with keyword unit"
+    (is (=? [:relative-datetime {:lib/uuid string?} -1 :quarter]
+            (lib.convert/->pMBQL [:relative-datetime -1 "quarter"])))
+    (is (=? [:relative-datetime {:lib/uuid string?} -1 :month]
+            (lib.convert/->pMBQL [:relative-datetime -1 "month"])))
+    (is (=? [:relative-datetime {:lib/uuid string?} 0 :day]
+            (lib.convert/->pMBQL [:relative-datetime 0 "day"]))))
+  (testing "Convert legacy relative-datetime with keyword unit to pMBQL"
+    (is (=? [:relative-datetime {:lib/uuid string?} -1 :quarter]
+            (lib.convert/->pMBQL [:relative-datetime -1 :quarter]))))
+  (testing "Convert legacy relative-datetime without unit to pMBQL"
+    (is (=? [:relative-datetime {:lib/uuid string?} -1]
+            (lib.convert/->pMBQL [:relative-datetime -1]))))
+  (testing "Convert legacy relative-datetime with :current amount"
+    (is (=? [:relative-datetime {:lib/uuid string?} :current :month]
+            (lib.convert/->pMBQL [:relative-datetime :current "month"])))
+    (is (=? [:relative-datetime {:lib/uuid string?} :current]
+            (lib.convert/->pMBQL [:relative-datetime :current])))))
+
 (deftest ^:parallel ->legacy-MBQL-test
   (is (= [:datetime 10 {:mode :unix-seconds}]
          (lib.convert/->legacy-MBQL [:datetime {:mode :unix-seconds, :lib/uuid "5016882d-8dbf-4271-ab60-4dc96a595ca9"} 10])))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #66121
### Description

Support relative-datetime when parsing legacy mbql

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
