### PR TITLE
[MBQL lib] Allow string literals as arg to aggregations like `:max`

### DIFF
--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -1230,12 +1230,19 @@
    [:value    [:ref ::value]]
    [:else     [:ref ::FieldOrExpressionRef]]])
 
+(mr/def ::AggregationArg
+  "Schema for the argument to an aggregation clause like `:sum`.
+
+  Strings are allowed as literals here, unlike at the top level as `::Expressions`, so `::FieldOrExpressionDef` is
+  not enough. However, nested aggregations are not allowed here, so we can't use `::ExpressionArg` either. (#66199)"
+  [:or ::FieldOrExpressionDef :string])
+
 ;; For all of the 'normal' Aggregations below (excluding Metrics) fields are implicit Field IDs
 
 ;; cum-sum and cum-count are SUGAR because they're implemented in middleware. The clauses are swapped out with
 ;; `count` and `sum` aggregations respectively and summation is done in Clojure-land
-(defclause count,     field (optional [:ref ::FieldOrExpressionRef]))
-(defclause cum-count, field (optional [:ref ::FieldOrExpressionRef]))
+(defclause count,     field (optional [:ref ::AggregationArg]))
+(defclause cum-count, field (optional [:ref ::AggregationArg]))
 
 ;; technically aggregations besides count can also accept expressions as args, e.g.
 ;;
@@ -1245,18 +1252,18 @@
 ;;
 ;;    SUM(field_1 + field_2)
 
-(defclause avg,      field-or-expression [:ref ::FieldOrExpressionDef])
-(defclause cum-sum,  field-or-expression [:ref ::FieldOrExpressionDef])
-(defclause distinct, field-or-expression [:ref ::FieldOrExpressionDef])
-(defclause sum,      field-or-expression [:ref ::FieldOrExpressionDef])
-(defclause min,      field-or-expression [:ref ::FieldOrExpressionDef])
-(defclause max,      field-or-expression [:ref ::FieldOrExpressionDef])
+(defclause avg,      field-or-expression [:ref ::AggregationArg])
+(defclause cum-sum,  field-or-expression [:ref ::AggregationArg])
+(defclause distinct, field-or-expression [:ref ::AggregationArg])
+(defclause sum,      field-or-expression [:ref ::AggregationArg])
+(defclause min,      field-or-expression [:ref ::AggregationArg])
+(defclause max,      field-or-expression [:ref ::AggregationArg])
 
 (defclause distinct-where
-  field-or-expression [:ref ::FieldOrExpressionDef], pred [:ref ::Filter])
+  field-or-expression [:ref ::AggregationArg], pred [:ref ::Filter])
 
 (defclause sum-where
-  field-or-expression [:ref ::FieldOrExpressionDef], pred [:ref ::Filter])
+  field-or-expression [:ref ::AggregationArg], pred [:ref ::Filter])
 
 (defclause count-where
   pred [:ref ::Filter])
@@ -1265,16 +1272,16 @@
   pred [:ref ::Filter])
 
 (defclause stddev
-  field-or-expression [:ref ::FieldOrExpressionDef])
+  field-or-expression [:ref ::AggregationArg])
 
 (defclause var
-  field-or-expression [:ref ::FieldOrExpressionDef])
+  field-or-expression [:ref ::AggregationArg])
 
 (defclause median
-  field-or-expression [:ref ::FieldOrExpressionDef])
+  field-or-expression [:ref ::AggregationArg])
 
 (defclause percentile
-  field-or-expression [:ref ::FieldOrExpressionDef], percentile [:ref ::NumericExpressionArg])
+  field-or-expression [:ref ::AggregationArg], percentile [:ref ::NumericExpressionArg])
 
 ;;; V1 (Legacy) Metrics (which lived in their own table) do not exist anymore! A V2 Metric is just a subtype of a Card.
 (defclause metric

--- a/test/metabase/legacy_mbql/normalize_test.cljc
+++ b/test/metabase/legacy_mbql/normalize_test.cljc
@@ -1678,3 +1678,17 @@
              ["field" 3]
              nil]]
            {"default" ["field" 5 {}]}]))))
+
+(deftest ^:parallel normalize-literal-strings-in-custom-aggregations-test
+  (testing "Strings are allowed as arguments to a custom aggregation (#66199)"
+    (is (= [:max "Literal String"]
+           (mbql.normalize/normalize ["max" "Literal String"])))
+    (is (= [:aggregation-options
+            [:max "Literal String"]
+            {:name         "foo"
+             :display-name "Foo"}]
+           (mbql.normalize/normalize
+            ["aggregation-options"
+             ["max" "Literal String"]
+             {"name"         "foo"
+              "display-name" "Foo"}])))))


### PR DESCRIPTION
Fixes #66199.

### Description

`metabase.legacy-mbql.schema`, now used for normalizing MBQL 4 in
place of the old bespoke normalization in earlier versions, regressed in
this weird but legitimate use case: Writing a custom aggregation like
`MAX("String Literal")`.

That's an odd thing to do, but it can be useful to provide a label in an
aggregated query. This is the MBQL equivalent of
`(SELECT ..., 'A' as label FROM ...) UNION ALL (SELECT ..., 'B' as label ...)`

### How to verify

Write a custom expression like `MAX("String Literal")`.

It doesn't work in 57 or master without this change, and works after it.

(Note that some DWHs, like H2, don't like passing a string into `MAX` like that. Postgres and Snowflake work though.)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
