### PR TITLE
Move audit installation before search initialization again

### DIFF
--- a/src/metabase/core/core.clj
+++ b/src/metabase/core/core.clj
@@ -207,6 +207,7 @@
         ;; otherwise update if appropriate
         (sample-data/update-sample-database-if-needed!)))
     (init-status/set-progress! 0.8))
+  (ensure-audit-db-installed!)
   (notification/seed-notification!)
 
   (init-status/set-progress! 0.85)
@@ -216,7 +217,6 @@
   (database/check-health!)
   (startup/run-startup-logic!)
   (init-status/set-progress! 0.95)
-  (ensure-audit-db-installed!)
   (task/start-scheduler!)
   (queue/start-listeners!)
   (init-status/set-complete!)


### PR DESCRIPTION
Reverts the core piece of https://github.com/metabase/metabase/pull/66045/ so that we install audit content before triggering search index initialization to avoid indexing audit content immediately and blocking startup.

Ideally we _should_ be able to index audit content right away, but apparently there are other issues at play that make this non-trivial, so this is a quick revert.