### PR TITLE
Fix table info tooltip popover background

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/utils.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/utils.tsx
@@ -164,7 +164,7 @@ function QuestionTableBadges({
               table={table}
               icon="info"
               size={16}
-              position="top"
+              position="bottom"
               className={HeaderS.HeaderBadgeIcon}
             />
           </span>


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #66240
Closes #66034 → [UXW-2324](https://linear.app/metabase/issue/UXW-2324/background-of-tooltip-disappears-in-info-icon)

### Description

After the Table Info popover was set to anchor via `position="top"`, content had a hard-limit since it was being used in the table header's breadcrumbs, and had little vertical space between the origin and the top of the page. This PR rolls the change back to `bottom` to properly expand down the page. 

### How to verify

From #66034:

> 1. Go to any table with a description
> 2. Hover on the info icon
> 3. See error

### Demo

Before (`position="top"`):

<img width="1568" height="1092" alt="CleanShot 2025-11-24 at 21 06 20@2x" src="https://github.com/user-attachments/assets/269c4047-3092-4076-a17f-88a85392b002" />

After (`position="bottom"`):

<img width="1984" height="1480" alt="CleanShot 2025-11-24 at 21 06 41@2x" src="https://github.com/user-attachments/assets/b5de53fa-304d-4f5b-b450-f7011872b42f" />

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
