### PR TITLE
Add :database_engine to metabot table-details and card-details

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/dummy_tools.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/dummy_tools.clj
@@ -164,6 +164,9 @@
                      (metabot-v3.tools.u/get-table id :db_id :description :name :schema))]
      (let [query-needed? (or with-fields? with-related-tables? with-metrics?)
            db-id (if metadata-provider (:db-id base) (:db_id base))
+           db-engine (:engine (if metadata-provider
+                                (lib.metadata/database metadata-provider)
+                                (metabot-v3.tools.u/get-database db-id :engine)))
            mp (when query-needed?
                 (or metadata-provider
                     (lib-be/application-database-metadata-provider db-id)))
@@ -185,6 +188,7 @@
             :display_name (some->> (:name base)
                                    (u.humanization/name->human-readable-name :simple))
             :database_id db-id
+            :database_engine db-engine
             :database_schema (:schema base)}
            (m/assoc-some :description (:description base)
                          :related_tables related-tables
@@ -221,6 +225,8 @@
                                    with-metrics?        true}
                             :as   options}]
    (let [id (:id base)
+         database-id (:database_id base)
+         database-engine (:engine (lib.metadata/database metadata-provider))
          card-metadata (lib.metadata/card metadata-provider id)
          dataset-query (get card-metadata :dataset-query)
          query-needed? (or with-fields? with-related-tables? with-metrics?)
@@ -244,7 +250,8 @@
           :name (:name base)
           :display_name (some->> (:name base)
                                  (u.humanization/name->human-readable-name :simple))
-          :database_id (:database_id base)
+          :database_id database-id
+          :database_engine database-engine
           :verified (verified-review? id "card")}
          (m/assoc-some
           :description (:description base)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
@@ -609,6 +609,7 @@
    [:name :string]
    [:display_name :string]
    [:database_id :int]
+   [:database_engine :keyword]
    [:database_schema {:optional true} [:maybe :string]] ; Schema name, if applicable
    [:fields ::columns]
    [:related_tables {:optional true} [:sequential [:ref ::table-result]]]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
@@ -101,6 +101,12 @@
   (let [index (resolve-column-index field-id field-id-prefix)]
     (assoc item :column (nth columns index))))
 
+(defn get-database
+  "Get the `fields` of the database with ID `id`."
+  [id & fields]
+  (-> (t2/select-one (into [:model/Database :id] fields) id)
+      api/read-check))
+
 (defn get-table
   "Get the `fields` of the table with ID `id`."
   [id & fields]

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
@@ -23,6 +23,9 @@
    [metabase.util.malli.registry :as mr]
    [toucan2.core :as t2]))
 
+(defn- db-engine-name []
+  (-> (mt/db) :engine name))
+
 (def missing-value (symbol "nil #_\"key is not present.\""))
 
 (deftest column-decode-test
@@ -444,6 +447,7 @@
                                          (assoc :id model-id
                                                 :type "model"
                                                 :verified true
+                                                :database_engine (db-engine-name)
                                                 :display_name "Model Model"
                                                 :fields (map-indexed #(assoc %2 :field_id (format "c%d/%d" model-id %1))
                                                                      expected-fields)
@@ -483,6 +487,7 @@
                             :models [(-> model-data
                                          (select-keys [:name :description :database_id])
                                          (assoc :id model-id
+                                                :database_engine (db-engine-name)
                                                 :display_name "Model Model"
                                                 :verified true
                                                 :type "model"
@@ -815,6 +820,7 @@
                                                 (select-keys [:name :description :database_id])
                                                 (assoc :id model-id
                                                        :type "model"
+                                                       :database_engine (db-engine-name)
                                                        :display_name "Model Model"
                                                        :verified true
                                                        :fields (add-field-ids (format "c%d/%%d" model-id) expected-core-fields)
@@ -852,6 +858,7 @@
                                               (select-keys [:name :description :database_id])
                                               (assoc :id model-id
                                                      :type "model"
+                                                     :database_engine (db-engine-name)
                                                      :display_name "Model Model"
                                                      :verified true
                                                      :fields
@@ -893,6 +900,7 @@
                                               (select-keys [:name :description :database_id])
                                               (assoc :id model-id
                                                      :type "model"
+                                                     :database_engine (db-engine-name)
                                                      :display_name "Model Model"
                                                      :verified true
                                                      :fields []
@@ -928,6 +936,7 @@
                                               (select-keys [:name :description :database_id])
                                               (assoc :id model-id
                                                      :type "model"
+                                                     :database_engine (db-engine-name)
                                                      :display_name "Model Model"
                                                      :verified true
                                                      :fields []
@@ -965,6 +974,7 @@
                                               (select-keys [:name :description :database_id])
                                               (assoc :id model-id
                                                      :type "model"
+                                                     :database_engine (db-engine-name)
                                                      :display_name "Model Model"
                                                      :verified true
                                                      :fields []
@@ -998,6 +1008,7 @@
                                               (select-keys [:name :description :database_id])
                                               (assoc :id model-id
                                                      :type "model"
+                                                     :database_engine (db-engine-name)
                                                      :display_name "Model Model"
                                                      :verified true
                                                      :fields []
@@ -1095,6 +1106,7 @@
             (is (=? {:structured_output {:name "ORDERS"
                                          :display_name "Orders"
                                          :database_id (mt/id)
+                                         :database_engine (db-engine-name)
                                          :database_schema "PUBLIC"
                                          :id table-id
                                          :type "table"
@@ -1111,6 +1123,7 @@
             (is (=? {:structured_output {:name "ORDERS"
                                          :display_name "Orders"
                                          :database_id (mt/id)
+                                         :database_engine (db-engine-name)
                                          :database_schema "PUBLIC"
                                          :id table-id
                                          :type "table"
@@ -1128,6 +1141,7 @@
             (is (=? {:structured_output {:name "ORDERS"
                                          :display_name "Orders"
                                          :database_id (mt/id)
+                                         :database_engine (db-engine-name)
                                          :database_schema "PUBLIC"
                                          :id table-id
                                          :type "table"
@@ -1142,6 +1156,7 @@
             (is (=? {:structured_output {:name "ORDERS"
                                          :display_name "Orders"
                                          :database_id (mt/id)
+                                         :database_engine (db-engine-name)
                                          :database_schema "PUBLIC"
                                          :id table-id
                                          :type "table"
@@ -1158,6 +1173,7 @@
             (is (=? {:structured_output {:name "ORDERS"
                                          :display_name "Orders"
                                          :database_id (mt/id)
+                                         :database_engine (db-engine-name)
                                          :database_schema "PUBLIC"
                                          :id table-id
                                          :type "table"


### PR DESCRIPTION
BOT-568

### Description

Related ai-service PR: https://github.com/metabase/ai-service/pull/510

These tools already included `:database_id` in the results; we now include the `:database_engine` as well, to give metabot a reminder about which SQL dialect it should generate.

### How to verify

You should now see the `:database_engine` added to tool call results for:
- `/api/ee/metabot-tools/get-table-details`
- `/api/ee/metabot-tools/answer-sources`
- `metabase-enterprise.metabot-v3.dummy-tools/card-details`
- `metabase-enterprise.metabot-v3.dummy-tools/table-details`

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
