### PR TITLE
ci(sdk): only setup specific enterprise plugins in sdk unit tests as needed

### DIFF
--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/EditableDashboard/EditableDashboard.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/EditableDashboard/EditableDashboard.unit.spec.tsx
@@ -1,7 +1,6 @@
 import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 
-import { setupEnterpriseOnlyPlugin } from "__support__/enterprise";
 import {
   setupCollectionItemsEndpoint,
   setupEmbeddingDataPickerDecisionEndpoints,
@@ -99,8 +98,7 @@ describe("EditableDashboard", () => {
   });
 
   it("should allow to create a new question in addition to adding existing questions", async () => {
-    setupEnterpriseOnlyPlugin("embedding");
-    await setup();
+    await setup({ hasEmbeddingEnterprisePlugin: true });
     setupSimpleDataPickerEndpoints();
 
     expect(screen.getByTestId("dashboard-header")).toBeInTheDocument();

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/EditableDashboard/EditableDashboard.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/EditableDashboard/EditableDashboard.unit.spec.tsx
@@ -1,6 +1,7 @@
 import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 
+import { setupEnterpriseOnlyPlugin } from "__support__/enterprise";
 import {
   setupCollectionItemsEndpoint,
   setupEmbeddingDataPickerDecisionEndpoints,
@@ -98,6 +99,7 @@ describe("EditableDashboard", () => {
   });
 
   it("should allow to create a new question in addition to adding existing questions", async () => {
+    setupEnterpriseOnlyPlugin("embedding");
     await setup();
     setupSimpleDataPickerEndpoints();
 
@@ -130,9 +132,7 @@ describe("EditableDashboard", () => {
   });
 
   it("should allow to go back to the dashboard after seeing the query builder", async () => {
-    await setup({
-      dashboardName: "Test dashboard",
-    });
+    await setup({ dashboardName: "Test dashboard" });
     setupSimpleDataPickerEndpoints();
 
     expect(screen.getByTestId("dashboard-header")).toBeInTheDocument();

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/tests/setup.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/tests/setup.tsx
@@ -1,5 +1,6 @@
 import { indexBy } from "underscore";
 
+import { setupEnterpriseOnlyPlugin } from "__support__/enterprise";
 import {
   setupAlertsEndpoints,
   setupBookmarksEndpoints,
@@ -116,6 +117,7 @@ export interface SetupSdkDashboardOptions {
   dashboardName?: string;
   dataPickerProps?: EditableDashboardProps["dataPickerProps"];
   dashcards?: DashboardCard[];
+  hasEmbeddingEnterprisePlugin?: boolean;
 }
 
 jest.mock("metabase/common/hooks/use-locale", () => ({
@@ -130,6 +132,7 @@ export const setupSdkDashboard = async ({
   dashboardName = "Dashboard",
   dataPickerProps,
   dashcards = DEFAULT_DASHCARDS,
+  hasEmbeddingEnterprisePlugin = false,
 }: SetupSdkDashboardOptions) => {
   const useLocaleMock = useLocale as jest.Mock;
   useLocaleMock.mockReturnValue({ isLocaleLoading });
@@ -182,6 +185,10 @@ export const setupSdkDashboard = async ({
   setupBookmarksEndpoints([]);
 
   const user = createMockUser();
+
+  if (hasEmbeddingEnterprisePlugin) {
+    setupEnterpriseOnlyPlugin("embedding");
+  }
 
   const state = setupSdkState({
     currentUser: user,

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/tests/setup.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/tests/setup.tsx
@@ -1,6 +1,5 @@
 import { indexBy } from "underscore";
 
-import { setupEnterprisePlugins } from "__support__/enterprise";
 import {
   setupAlertsEndpoints,
   setupBookmarksEndpoints,
@@ -197,9 +196,6 @@ export const setupSdkDashboard = async ({
       dashcards: indexBy(dashcards, "id"),
     }),
   });
-
-  // Used in simple data picker
-  setupEnterprisePlugins();
 
   renderWithSDKProviders(
     <Box h="500px">

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/tests/setup.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/tests/setup.tsx
@@ -186,10 +186,6 @@ export const setupSdkDashboard = async ({
 
   const user = createMockUser();
 
-  if (hasEmbeddingEnterprisePlugin) {
-    setupEnterpriseOnlyPlugin("embedding");
-  }
-
   const state = setupSdkState({
     currentUser: user,
     dashboard: createMockDashboardState({
@@ -203,6 +199,10 @@ export const setupSdkDashboard = async ({
       dashcards: indexBy(dashcards, "id"),
     }),
   });
+
+  if (hasEmbeddingEnterprisePlugin) {
+    setupEnterpriseOnlyPlugin("embedding");
+  }
 
   renderWithSDKProviders(
     <Box h="500px">


### PR DESCRIPTION
Closes DEV-1118

For some reason, `setupEnterprisePlugins` is super slow. Only loading the data picker tests with `setupEnterpriseOnlyPlugin("embedding")` on demand helps a lot. We really only use this in 1 test, so I just add it directly there instead of in the `setup` of every unit test.

When running locally, make sure to use `yarn jest --clearCache` before running the test! Jest cache can be super misleading as the module loading can be cached.

Before: `yarn jest --clearCache && yarn jest frontend/src/embedding-sdk-bundle/components/public/dashboard/EditableDashboard/EditableDashboard.unit.spec.tsx --verbose` takes 7770ms

<img width="2956" height="1090" alt="CleanShot 2568-11-25 at 16 59 47@2x" src="https://github.com/user-attachments/assets/c6d5cc99-cca9-43db-9ccf-94c9fdff3a5a" />

After: `yarn jest --clearCache && yarn jest frontend/src/embedding-sdk-bundle/components/public/dashboard/EditableDashboard/EditableDashboard.unit.spec.tsx --verbose` takes 440ms

<img width="3018" height="910" alt="CleanShot 2568-11-25 at 16 58 16@2x" src="https://github.com/user-attachments/assets/1cb5466c-2fdc-4101-8548-f8e56cf9df23" />
