### PR TITLE
test(sdk): add minimal SAML e2e test

### DIFF
--- a/e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers.ts
+++ b/e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers.ts
@@ -93,7 +93,7 @@ export function signInAsAdminAndSetupGuestEmbedding({
   updateSetting("embedding-secret-key", JWT_SHARED_SECRET);
 }
 
-const MOCK_SAML_IDP_URI = "https://example.test/saml";
+export const MOCK_SAML_IDP_URI = "https://example.test/saml";
 
 export function enableSamlAuth() {
   cy.readFile<string>("test_resources/sso/auth0-public-idp.cert", "utf8").then(
@@ -134,33 +134,36 @@ export function stubWindowOpenForSamlPopup({
       },
     };
 
-    // stub `window.open(IDP_URI, ...)` for the SAML popup
-    cy.stub(win, "open")
-      .withArgs(MOCK_SAML_IDP_URI)
-      .callsFake(() => {
-        setTimeout(() => {
-          // Simulate the SAML_AUTH_COMPLETE message
-          win.dispatchEvent(
-            new MessageEvent("message", {
-              data: {
-                type: "SAML_AUTH_COMPLETE",
+    // Stub window.open for URLs starting with our IdP URI
+    // (real SAML URLs include SAMLRequest params)
+    cy.stub(win, "open").callsFake((url: string) => {
+      if (!url?.startsWith(MOCK_SAML_IDP_URI)) {
+        return null;
+      }
 
-                // The snapshot creator populates the cache with a real session token.
-                // Without this, we get an "invalid user" error as we need a valid session.
-                authData: {
-                  id: isUserValid
-                    ? loginCache.normal?.sessionId
-                    : "invalid-session-token",
-                  exp: Math.floor(Date.now() / 1000) + 600, // 10 minutes
-                },
+      setTimeout(() => {
+        // Simulate the SAML_AUTH_COMPLETE message
+        win.dispatchEvent(
+          new MessageEvent("message", {
+            data: {
+              type: "SAML_AUTH_COMPLETE",
+
+              // The snapshot creator populates the cache with a real session token.
+              // Without this, we get an "invalid user" error as we need a valid session.
+              authData: {
+                id: isUserValid
+                  ? loginCache.normal?.sessionId
+                  : "invalid-session-token",
+                exp: Math.floor(Date.now() / 1000) + 600, // 10 minutes
               },
-              origin: "*",
-            }),
-          );
-          popup.close();
-        }, 100); // simulate async delay
+            },
+            origin: "*",
+          }),
+        );
+        popup.close();
+      }, 100); // simulate async delay
 
-        return popup;
-      });
+      return popup;
+    });
   });
 }

--- a/e2e/test-component/scenarios/embedding-sdk/loading-performance.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/loading-performance.cy.spec.tsx
@@ -1,0 +1,80 @@
+import { InteractiveQuestion } from "@metabase/embedding-sdk-react";
+
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
+import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
+import { mountSdkContent } from "e2e/support/helpers/embedding-sdk-component-testing";
+import {
+  AUTH_PROVIDER_URL,
+  METABASE_INSTANCE_URL,
+} from "e2e/support/helpers/embedding-sdk-helpers/constants";
+import {
+  mockAuthProviderAndJwtSignIn,
+  signInAsAdminAndEnableEmbeddingSdk,
+} from "e2e/support/helpers/embedding-sdk-testing";
+
+describe("scenarios > embedding-sdk > loading-performance", () => {
+  beforeEach(() => {
+    signInAsAdminAndEnableEmbeddingSdk();
+    cy.signOut();
+    mockAuthProviderAndJwtSignIn();
+
+    // Intercept SSO discovery request (without jwt parameter)
+    cy.intercept("GET", /\/auth\/sso(\?preferred_method=\w+)?$/).as(
+      "authSsoDiscovery",
+    );
+    // Intercept token exchange request (with jwt parameter)
+    cy.intercept("GET", /\/auth\/sso\?.*jwt=/).as("authSsoTokenExchange");
+    cy.intercept("GET", "/api/user/current").as("getCurrentUser");
+    cy.intercept("GET", "/api/session/properties").as("getSessionProperties");
+  });
+
+  describe("Baseline: when jwtProviderUri is not provided", () => {
+    it("should make SSO discovery request, then token exchange", () => {
+      mountSdkContent(<InteractiveQuestion questionId={ORDERS_QUESTION_ID} />, {
+        sdkProviderProps: {
+          authConfig: {
+            metabaseInstanceUrl: METABASE_INSTANCE_URL,
+          },
+        },
+      });
+
+      // Verify question renders
+      getSdkRoot().within(() => {
+        cy.findByText("Orders").should("exist");
+        cy.findByTestId("visualization-root").should("be.visible");
+      });
+
+      // Baseline: discovery + token exchange
+      cy.get("@authSsoDiscovery.all").should("have.length", 1);
+      cy.get("@authSsoTokenExchange.all").should("have.length", 1);
+      cy.get("@getCurrentUser.all").should("have.length", 1);
+      cy.get("@getSessionProperties.all").should("have.length", 1);
+    });
+  });
+
+  describe("when jwtProviderUri is provided", () => {
+    it("should skip the initial /auth/sso request", () => {
+      mountSdkContent(<InteractiveQuestion questionId={ORDERS_QUESTION_ID} />, {
+        sdkProviderProps: {
+          authConfig: {
+            metabaseInstanceUrl: METABASE_INSTANCE_URL,
+            preferredAuthMethod: "jwt",
+            jwtProviderUri: AUTH_PROVIDER_URL,
+          },
+        },
+      });
+
+      // Verify question renders
+      getSdkRoot().within(() => {
+        cy.findByText("Orders").should("exist");
+        cy.findByTestId("visualization-root").should("be.visible");
+      });
+
+      // Optimized: no discovery, only token exchange
+      cy.get("@authSsoDiscovery.all").should("have.length", 0);
+      cy.get("@authSsoTokenExchange.all").should("have.length", 1);
+      cy.get("@getCurrentUser.all").should("have.length", 1);
+      cy.get("@getSessionProperties.all").should("have.length", 1);
+    });
+  });
+});

--- a/e2e/test-component/scenarios/embedding-sdk/requests.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/requests.cy.spec.tsx
@@ -38,6 +38,8 @@ describe("scenarios > embedding-sdk > requests", () => {
     });
 
     it("properly performs session token refresh request when multiple data requests are triggered at the same time", () => {
+      cy.intercept("POST", "/api/dataset").as("dataset");
+
       const expiredInSeconds = 60;
       cy.clock(Date.now());
 
@@ -63,9 +65,10 @@ describe("scenarios > embedding-sdk > requests", () => {
         cy.findByRole("dialog").contains(/^ID$/).click();
         cy.findByRole("dialog").findByTestId("badge-remove-button").click();
 
-        cy.wait("@jwtProvider");
+        // The requests should be done after we refresh the token, so where we should have 0
+        cy.get("@dataset.all").should("have.length", 0);
 
-        cy.intercept("POST", "/api/dataset").as("dataset");
+        cy.wait("@jwtProvider");
         // We ensure that both `dataset` requests are made after the token refresh request
         cy.get("@dataset.all").should("have.length", 2);
       });

--- a/e2e/test-component/scenarios/embedding-sdk/saml-authentication.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/saml-authentication.cy.spec.tsx
@@ -1,0 +1,98 @@
+import { StaticQuestion } from "@metabase/embedding-sdk-react";
+
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { METABASE_INSTANCE_URL, createQuestion } from "e2e/support/helpers";
+import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
+import { mountSdkContent } from "e2e/support/helpers/embedding-sdk-component-testing";
+import {
+  MOCK_SAML_IDP_URI,
+  enableSamlAuth,
+  stubWindowOpenForSamlPopup,
+} from "e2e/support/helpers/embedding-sdk-testing";
+
+const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+
+const { H } = cy;
+
+/**
+ * Adds the Origin header to all requests.
+ * The backend requires this header but component tests don't send it.
+ */
+function addOriginHeader() {
+  cy.intercept("*", (req) => {
+    req.headers["origin"] = "http://localhost";
+    req.continue();
+  });
+}
+
+describe("scenarios > embedding-sdk > saml-authentication", () => {
+  beforeEach(() => {
+    Cypress.config("baseUrl", METABASE_INSTANCE_URL);
+
+    H.restore();
+
+    cy.signInAsAdmin();
+    H.activateToken("pro-cloud");
+    enableSamlAuth();
+    cy.request("PUT", "/api/setting", {
+      "enable-embedding-sdk": true,
+    });
+
+    createQuestion({
+      name: "SAML Test Question",
+      query: {
+        "source-table": ORDERS_ID,
+        aggregation: [["count"]],
+        breakout: [["field", ORDERS.PRODUCT_ID, null]],
+        limit: 2,
+      },
+    }).then(({ body: question }) => {
+      cy.wrap(question.id).as("questionId");
+    });
+
+    cy.signOut();
+  });
+
+  it("can authenticate via SAML and load question content", () => {
+    addOriginHeader();
+    cy.intercept("GET", "/auth/sso*").as("authSso");
+
+    stubWindowOpenForSamlPopup();
+
+    cy.get<number>("@questionId").then((questionId) => {
+      mountSdkContent(<StaticQuestion questionId={questionId} />);
+    });
+
+    // Verify the SDK called the real /auth/sso endpoint and got SAML response
+    cy.wait("@authSso").then(({ response }) => {
+      expect(response?.statusCode).to.equal(200);
+      expect(response?.body).to.have.property("method", "saml");
+      // The URL should contain our configured IdP URI with SAMLRequest
+      expect(response?.body.url).to.include(MOCK_SAML_IDP_URI);
+      expect(response?.body.url).to.include("SAMLRequest");
+    });
+
+    getSdkRoot().within(() => {
+      cy.findByText("Product ID").should("be.visible");
+      cy.findByText("Count").should("be.visible");
+    });
+  });
+
+  it("shows an error when SAML authentication fails with invalid session", () => {
+    addOriginHeader();
+    stubWindowOpenForSamlPopup({ isUserValid: false });
+
+    cy.get<number>("@questionId").then((questionId) => {
+      mountSdkContent(<StaticQuestion questionId={questionId} />, {
+        waitForUser: false,
+      });
+    });
+
+    getSdkRoot().within(() => {
+      cy.findByRole("alert", { timeout: 10000 }).should(
+        "contain",
+        "Failed to fetch the user",
+      );
+    });
+  });
+});

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -5,7 +5,6 @@
    [java-time.api :as t]
    [metabase-enterprise.sso.api.interface :as sso.i]
    [metabase-enterprise.sso.integrations.sso-utils :as sso-utils]
-   [metabase-enterprise.sso.integrations.token-utils :as token-utils]
    [metabase-enterprise.sso.settings :as sso-settings]
    [metabase.auth-identity.core :as auth-identity]
    [metabase.embedding.settings :as embed.settings]
@@ -87,7 +86,7 @@
       (and is-embedded-analytics-js? (not (embed.settings/enable-embedding-simple)))
       (throw-simple-embedding-disabled)
 
-      (and is-modular-embedding? (token-utils/has-token request))
+      (and is-modular-embedding? jwt)
       (generate-response-token (:session result) (:jwt-data result))
 
       ;; JWT provided - use auth-identity/login!
@@ -99,8 +98,8 @@
 
       ;; No JWT - return IdP URL for modular embedding or redirect
       is-modular-embedding?
-      (response/response (token-utils/with-token {:url (sso-settings/jwt-identity-provider-uri)
-                                                  :method "jwt"}))
+      (response/response {:url (sso-settings/jwt-identity-provider-uri)
+                          :method "jwt"})
 
       :else
       (redirect-to-idp (sso-settings/jwt-identity-provider-uri) redirect))))

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/token_utils.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/token_utils.clj
@@ -38,21 +38,3 @@
             (t/< (t/instant) (Instant/ofEpochSecond (Long/parseLong expiration))))
           (catch Exception _
             false)))))
-
-(defn- get-token-from-header
-  "Extract the token from the request headers"
-  [request]
-  (get-in request [:headers "x-metabase-sdk-jwt-hash"] nil))
-
-(defn with-token
-  "Add a newly generated token to a response"
-  [response]
-  (assoc response :hash (generate-token)))
-
-(defn has-token
-  "Check if a request has a valid token"
-  [request]
-  (let [token (get-token-from-header request)]
-    (if token
-      (validate-token token)
-      false)))

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
@@ -672,7 +672,7 @@
           (is (partial= {:url (sso-settings/jwt-identity-provider-uri)
                          :method "jwt"}
                         (:body result)))
-          (is (not (nil? (get-in result [:body :hash])))))))))
+          (is (nil? (get-in result [:body :hash]))))))))
 
 (deftest jwt-token-sdk-session-token-test
   (testing "should return a session token when a JWT token and sdk headers are passed"
@@ -689,16 +689,20 @@
                              :iat        jwt-iat-time
                              :exp        jwt-exp-time}
                             default-jwt-secret)
-              result (client/client-real-response :get 200 "/auth/sso"
-                                                  {:request-options {:headers {"x-metabase-client" "embedding-sdk-react"
-                                                                               "x-metabase-sdk-jwt-hash" (token-utils/generate-token)}}}
-                                                  :jwt jwt-payload)]
-          (is
-           (=?
-            {:id  (mt/malli=? ms/UUIDString)
-             :iat jwt-iat-time
-             :exp jwt-exp-time}
-            (:body result))))))))
+              do-request (fn [headers]
+                           (client/client-real-response :get 200 "/auth/sso"
+                                                        {:request-options {:headers headers}}
+                                                        :jwt jwt-payload))
+              expected-body {:id  (mt/malli=? ms/UUIDString)
+                             :iat jwt-iat-time
+                             :exp jwt-exp-time}]
+          (testing "without hash header"
+            (is (=? expected-body
+                    (:body (do-request {"x-metabase-client" "embedding-sdk-react"})))))
+          (testing "with hash header (legacy usage)"
+            (is (=? expected-body
+                    (:body (do-request {"x-metabase-client" "embedding-sdk-react"
+                                        "x-metabase-sdk-jwt-hash" (token-utils/generate-token)}))))))))))
 
 (deftest jwt-token-not-configured-test
   (testing "should not return a session token when jwt is not configured"

--- a/enterprise/frontend/src/embedding-sdk-ee/auth/auth.ts
+++ b/enterprise/frontend/src/embedding-sdk-ee/auth/auth.ts
@@ -40,14 +40,15 @@ let refreshTokenPromise: ReturnType<
 
 // Side effect happening here.
 PLUGIN_EMBEDDING_SDK_AUTH.initAuth = async (
-  {
-    metabaseInstanceUrl,
-    preferredAuthMethod,
-    apiKey,
-    isLocalHost,
-  }: MetabaseAuthConfig & { isLocalHost?: boolean },
+  authConfig: MetabaseAuthConfig & { isLocalHost?: boolean },
   { dispatch }: { dispatch: SdkDispatch },
 ) => {
+  const { metabaseInstanceUrl, preferredAuthMethod, apiKey, isLocalHost } =
+    authConfig;
+  const jwtProviderUri =
+    preferredAuthMethod === "jwt" && "jwtProviderUri" in authConfig
+      ? authConfig.jwtProviderUri
+      : undefined;
   // remove any stale tokens that might be there from a previous session=
   samlTokenStorage.remove();
 
@@ -69,6 +70,7 @@ PLUGIN_EMBEDDING_SDK_AUTH.initAuth = async (
           getOrRefreshSession({
             metabaseInstanceUrl,
             preferredAuthMethod,
+            jwtProviderUri,
           }),
         ).unwrap();
         if (session?.id) {
@@ -81,6 +83,7 @@ PLUGIN_EMBEDDING_SDK_AUTH.initAuth = async (
         getOrRefreshSession({
           metabaseInstanceUrl,
           preferredAuthMethod,
+          jwtProviderUri,
         }),
       ).unwrap();
     } catch (e) {
@@ -116,7 +119,12 @@ const refreshTokenImpl = async (
   {
     metabaseInstanceUrl,
     preferredAuthMethod,
-  }: Pick<MetabaseAuthConfig, "metabaseInstanceUrl" | "preferredAuthMethod">,
+    jwtProviderUri,
+  }: {
+    metabaseInstanceUrl: string;
+    preferredAuthMethod?: MetabaseAuthConfig["preferredAuthMethod"];
+    jwtProviderUri?: string;
+  },
   { getState }: { getState: () => unknown },
 ): Promise<MetabaseEmbeddingSessionToken | null> => {
   const state = getState() as SdkStoreState;
@@ -130,6 +138,7 @@ const refreshTokenImpl = async (
   const session = await getRefreshToken({
     metabaseInstanceUrl,
     preferredAuthMethod,
+    jwtProviderUri,
     fetchRequestToken: customGetRefreshToken,
   });
   validateSession(session);
@@ -149,10 +158,11 @@ PLUGIN_EMBEDDING_SDK_AUTH.refreshTokenAsync = refreshTokenImpl;
 export const getOrRefreshSession = createAsyncThunk(
   GET_OR_REFRESH_SESSION,
   async (
-    authConfig: Pick<
-      MetabaseAuthConfig,
-      "metabaseInstanceUrl" | "preferredAuthMethod"
-    >,
+    authConfig: {
+      metabaseInstanceUrl: string;
+      preferredAuthMethod?: MetabaseAuthConfig["preferredAuthMethod"];
+      jwtProviderUri?: string;
+    },
     { dispatch, getState },
   ) => {
     // necessary to ensure that we don't use a popup every time the user
@@ -190,14 +200,23 @@ const getRefreshToken = async ({
   metabaseInstanceUrl,
   preferredAuthMethod,
   fetchRequestToken: customGetRequestToken,
-}: Pick<
-  MetabaseAuthConfig,
-  "metabaseInstanceUrl" | "fetchRequestToken" | "preferredAuthMethod"
->) => {
-  const urlResponseJson = await connectToInstanceAuthSso(metabaseInstanceUrl, {
-    preferredAuthMethod,
-    headers: getSdkRequestHeaders(),
-  });
+  jwtProviderUri,
+}: {
+  metabaseInstanceUrl: string;
+  preferredAuthMethod?: MetabaseAuthConfig["preferredAuthMethod"];
+  fetchRequestToken?: MetabaseAuthConfig["fetchRequestToken"];
+  jwtProviderUri?: string;
+}) => {
+  const shouldSkipSsoDiscovery =
+    preferredAuthMethod === "jwt" && Boolean(jwtProviderUri);
+
+  const urlResponseJson = shouldSkipSsoDiscovery
+    ? { method: "jwt", url: jwtProviderUri }
+    : await connectToInstanceAuthSso(metabaseInstanceUrl, {
+        preferredAuthMethod,
+        headers: getSdkRequestHeaders(),
+      });
+
   const { method, url: responseUrl, hash } = urlResponseJson || {};
   if (method === "saml") {
     const token = await openSamlLoginPopup(responseUrl);
@@ -205,13 +224,19 @@ const getRefreshToken = async ({
 
     return token;
   }
-  if (method === "jwt") {
+  if (method === "jwt" && responseUrl) {
     return jwtDefaultRefreshTokenFunction(
       responseUrl,
       metabaseInstanceUrl,
       getSdkRequestHeaders(hash),
       customGetRequestToken,
     );
+  }
+  if (method === "jwt") {
+    throw MetabaseError.CANNOT_CONNECT_TO_INSTANCE({
+      instanceUrl: metabaseInstanceUrl,
+      message: "Missing JWT provider URI",
+    });
   }
   throw MetabaseError.INVALID_AUTH_METHOD({ method });
 };

--- a/enterprise/frontend/src/embedding-sdk-ee/tests/auth-flow/jwt.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk-ee/tests/auth-flow/jwt.unit.spec.tsx
@@ -29,10 +29,25 @@ const setup = ({
   locale,
 }: Pick<MetabaseProviderProps, "authConfig" | "locale">) => {
   setupMockJwtEndpoints();
+
+  const getFirstSsoDiscoveryCall = () => {
+    // This is `/auth/sso`/`auth/sso?preferred_method=...`
+    // that returns the method (jwt/saml) and the url of the sso provider
+    // `auth/sso?jwt=...` is the second call and should be excluded from this
+    return fetchMock.callHistory
+      .calls()
+      .filter(
+        (call) =>
+          new URL(call.url).pathname === "/auth/sso" &&
+          !new URL(call.url).searchParams.has("jwt"),
+      );
+  };
+
   return {
     ...baseSetup({ authConfig, locale }),
     getLastAuthProviderApiCall: () =>
       fetchMock.callHistory.lastCall(`${MOCK_JWT_PROVIDER_URI}?response=json`),
+    getFirstSsoDiscoveryCall,
   };
 };
 
@@ -46,7 +61,7 @@ describe("Auth Flow - JWT", () => {
       metabaseInstanceUrl: MOCK_INSTANCE_URL,
     });
 
-    const { rerender } = setup({ authConfig });
+    const { rerender, getFirstSsoDiscoveryCall } = setup({ authConfig });
 
     await waitForLoaderToBeRemoved();
     expect(
@@ -64,6 +79,8 @@ describe("Auth Flow - JWT", () => {
     expect(
       fetchMock.callHistory.calls(`${MOCK_JWT_PROVIDER_URI}?response=json`),
     ).toHaveLength(1);
+
+    expect(getFirstSsoDiscoveryCall()).toHaveLength(1);
 
     const loader = screen.queryByTestId("loading-indicator");
     expect(loader).not.toBeInTheDocument();
@@ -104,6 +121,22 @@ describe("Auth Flow - JWT", () => {
     );
   });
 
+  it("should skip the initial /auth/sso request when jwtProviderUri is provided", async () => {
+    const authConfig = defineMetabaseAuthConfig({
+      metabaseInstanceUrl: MOCK_INSTANCE_URL,
+      preferredAuthMethod: "jwt",
+      jwtProviderUri: MOCK_JWT_PROVIDER_URI,
+    });
+
+    const { getLastAuthProviderApiCall, getFirstSsoDiscoveryCall } = setup({
+      authConfig,
+    });
+
+    await waitForRequest(() => getLastAuthProviderApiCall());
+
+    expect(getFirstSsoDiscoveryCall()).toHaveLength(0);
+  });
+
   it("should use `fetchRequestToken` if provided", async () => {
     const customFetchFunction = jest.fn().mockImplementation(() => ({
       jwt: MOCK_VALID_JWT_RESPONSE,
@@ -115,13 +148,19 @@ describe("Auth Flow - JWT", () => {
       fetchRequestToken: customFetchFunction,
     });
 
-    const { getLastCardQueryApiCall, getLastUserApiCall } = setup({
+    const {
+      getLastCardQueryApiCall,
+      getLastUserApiCall,
+      getFirstSsoDiscoveryCall,
+    } = setup({
       authConfig,
     });
 
     await waitForRequest(() => getLastUserApiCall());
 
     expect(customFetchFunction).toHaveBeenCalled();
+
+    expect(getFirstSsoDiscoveryCall()).toHaveLength(1);
 
     expect(getLastUserApiCall()?.options.headers).toHaveProperty(
       "x-metabase-session",

--- a/frontend/src/embedding-sdk-bundle/store/auth/auth.ts
+++ b/frontend/src/embedding-sdk-bundle/store/auth/auth.ts
@@ -21,20 +21,23 @@ export const PLUGIN_EMBEDDING_SDK_AUTH = {
 export const initAuth = createAsyncThunk(
   "sdk/token/INIT_AUTH",
   async (
-    {
-      metabaseInstanceUrl,
-      preferredAuthMethod,
-      apiKey,
-      isLocalHost,
-    }: MetabaseAuthConfig & { isLocalHost?: boolean },
+    config: MetabaseAuthConfig & { isLocalHost?: boolean },
     { dispatch },
   ) => {
+    const { metabaseInstanceUrl, preferredAuthMethod, apiKey, isLocalHost } =
+      config;
+    const jwtProviderUri =
+      preferredAuthMethod === "jwt" && "jwtProviderUri" in config
+        ? config.jwtProviderUri
+        : undefined;
+
     return await PLUGIN_EMBEDDING_SDK_AUTH.initAuth(
       {
         metabaseInstanceUrl,
         preferredAuthMethod,
         apiKey,
         isLocalHost,
+        jwtProviderUri,
       },
       { dispatch },
     );
@@ -47,13 +50,19 @@ export const refreshTokenAsync = createAsyncThunk(
     {
       metabaseInstanceUrl,
       preferredAuthMethod,
-    }: Pick<MetabaseAuthConfig, "metabaseInstanceUrl" | "preferredAuthMethod">,
+      jwtProviderUri,
+    }: {
+      metabaseInstanceUrl: string;
+      preferredAuthMethod?: MetabaseAuthConfig["preferredAuthMethod"];
+      jwtProviderUri?: string;
+    },
     { getState },
   ): Promise<MetabaseEmbeddingSessionToken | null> => {
     return await PLUGIN_EMBEDDING_SDK_AUTH.refreshTokenAsync(
       {
         metabaseInstanceUrl,
         preferredAuthMethod,
+        jwtProviderUri,
       },
       { getState },
     );

--- a/frontend/src/embedding-sdk-bundle/types/auth-config.ts
+++ b/frontend/src/embedding-sdk-bundle/types/auth-config.ts
@@ -19,6 +19,11 @@ export type MetabaseAuthConfigWithJwt = BaseMetabaseAuthConfig & {
   preferredAuthMethod?: "jwt";
 
   /**
+   * Uri of the jwt provider. If provided the sdk will use jwt and will skip the first `/auth/sso` discovery request.
+   */
+  jwtProviderUri?: string;
+
+  /**
    * Specifies a function to fetch the refresh token.
    * The refresh token should be in the format of {@link UserBackendJwtResponse}
    */


### PR DESCRIPTION
Stacked on top of  [skip first /auth/sso request when jwtProviderUri is passed](https://github.com/metabase/metabase/pull/66120) and [remove hash logic in /auth/sso to speed up auth flow](https://github.com/metabase/metabase/pull/66076) to check if everything works fine there too