### PR TITLE
fix file-path for sdk component tests

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -130,7 +130,7 @@ embedding_sdk_ci: &embedding_sdk_ci
 embedding_sdk_components:
   - *embedding_sdk_ci
   - *sources
-  - "e2e/component/**/*.cy.*.{js,ts}"
+  - "e2e/test-component/**/*.cy.*.{js,jsx,ts,tsx}"
 
 embedding_sdk_host_sample_apps:
   - *default


### PR DESCRIPTION
Our component tests are in `e2e/test-component` and their extension is .tsx, not .ts
We probably don't even need to filter for the extension at all

Found this because in a[ PR where I only changed a component test](https://github.com/metabase/metabase/pull/66248), tests didn't start
