### PR TITLE
Only real app-dbs should print setup instructions

### DIFF
--- a/mage/src/mage/start_db.clj
+++ b/mage/src/mage/start_db.clj
@@ -97,6 +97,9 @@
    "--name" container-name
    (str "mongo:" resolved-version)])
 
+(defn- app-db? [db]
+  (contains? #{:postgres :mysql :mariadb} db))
+
 (defn- start-db!
   [database version resolved-version port]
   (let [container-name (->container-name database version)
@@ -107,10 +110,11 @@
     (apply shell/sh cmd)
     (println (c/cyan (format "Started %s %s on port %s\n" (name database) (name version) port)))
     (println)
-    (let [deps-edn-alias (->deps-edn-alias database version)]
-      (printf "Use the %s alias in deps.edn to use this DB:\n" deps-edn-alias)
-      (println (str "  clj -M:dev:ee:ee-dev" deps-edn-alias))
-      (u/debug (str "  clj -M:dev:ee:ee-dev" deps-edn-alias " -e '(dev) (start!)'")))))
+    (when (app-db? database)
+      (let [deps-edn-alias (->deps-edn-alias database version)]
+        (printf "Use the %s alias in deps.edn to use this DB:\n" deps-edn-alias)
+        (println (str "  clj -M:dev:ee:ee-dev" deps-edn-alias))
+        (u/debug (str "  clj -M:dev:ee:ee-dev" deps-edn-alias " -e '(dev) (start!)'"))))))
 
 (defn- usage
   [{:keys [db-info]}]


### PR DESCRIPTION
We were printing instructions to "start the app with mongo as an app-db", which of course is not supported. I'm skipping printing those instructions when starting up mongo.

## before:
```
$ mage start-db mongo oldest
killing existing container:  mb-mongo-oldest  ...
docker runing: mb-mongo-oldest ...
Running: docker run -d -p 27017:27017 --name mb-mongo-oldest mongo:7.0
0291163e3fb190603c26e0b57d75df77c843a199f25bf57c798661fcd2ac6db7
Started mongo oldest on port 27017


Use the :db/mongo-oldest alias in deps.edn to use this DB:
  clj -M:dev:ee:ee-dev:db/mongo-oldest
```
  ^ This alias doesn't exist!

## after:

```
$ mage start-db mongo oldest
killing existing container:  mb-mongo-oldest  ...
docker runing: mb-mongo-oldest ...
Running: docker run -d -p 27017:27017 --name mb-mongo-oldest mongo:7.0
a39b918e3bd020566ad9e10128cee6cae80830646c653eeb3ae3ebde8e0534c7
Started mongo oldest on port 27017
```
