### PR TITLE
Always pass the input conditions to sdk jobs

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -110,6 +110,7 @@ jobs:
 
   sdk-tests:
     needs: [uberjar, embedding-sdk-package, files-changed]
+    if: always()
     uses: ./.github/workflows/embedding-sdk.yml
     secrets: inherit
     with:


### PR DESCRIPTION
This is another attempt at solving the required SDK tests left hanging as "pending". The previous attempt was https://github.com/metabase/metabase/pull/66211.

I am not 100% sure this will resolve the issue but it should.
The gist of the change is: we always want to trigger the embedding-sdk.yml workflow, and to pass the inputs to its jobs. embedding-sdk.yml then decides whether to skip individual jobs or not.

Again, this whole dance is needed because of https://github.com/orgs/community/discussions/13690

Should resolve DEV-1120

## How to test?

This PR alone was a good test for the validity of the fix. Uberjar was built, while embedding-sdk-package wasn't. This is the exact same condition that was resulting in sdk-results hanging in the past. As we can see, it now correctly resolves when all jobs are skipped.

<img width="330" height="717" alt="image" src="https://github.com/user-attachments/assets/661ca752-27c2-4155-a8ad-6c2ee8602c64" />
