### PR TITLE
Properly mention available subscription & alert channels for non-admins

### DIFF
--- a/e2e/test/scenarios/sharing/alert/alert.cy.spec.js
+++ b/e2e/test/scenarios/sharing/alert/alert.cy.spec.js
@@ -21,10 +21,10 @@ describe("scenarios > alert", () => {
 
       H.modal().within(() => {
         cy.findByText(
-          "To get notified when something happens, or to send this chart on a schedule, first set up SMTP, Slack, or a webhook.",
+          "To get notified when something happens, or to send this chart on a schedule, first set up email, Slack, or a webhook.",
         );
 
-        cy.findByText("Set up SMTP")
+        cy.findByText("Set up email")
           .should("be.visible")
           .closest("a")
           .should("have.attr", "href", "/admin/settings/email");

--- a/e2e/test/scenarios/sharing/alert/alert.cy.spec.js
+++ b/e2e/test/scenarios/sharing/alert/alert.cy.spec.js
@@ -49,10 +49,10 @@ describe("scenarios > alert", () => {
 
       H.modal().within(() => {
         cy.findByText(
-          "To get notified when something happens, or to send this chart on a schedule, ask your Admin to set up SMTP or Slack.",
+          "To get notified when something happens, or to send this chart on a schedule, ask your admin to set up email, Slack, or a webhook.",
         );
 
-        cy.findByText("Set up SMTP").should("not.exist");
+        cy.findByText("Set up email").should("not.exist");
         cy.findByText("Set up Slack").should("not.exist");
         cy.findByText("Add a webhook").should("not.exist");
       });

--- a/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
@@ -522,7 +522,13 @@ describe("scenarios > dashboard > subscriptions", () => {
       H.openSharingMenu();
       H.sharingMenu()
         .findByText("Can't send subscriptions")
-        .should("be.visible");
+        .should("be.visible")
+        .within(() => {
+          cy.findByText("Can't send subscriptions").should("be.visible");
+          cy.findByText("Ask your admin to set up email or Slack").should(
+            "be.visible",
+          );
+        });
     });
   });
 

--- a/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
@@ -516,19 +516,11 @@ describe("scenarios > dashboard > subscriptions", () => {
         .should("not.be.disabled");
     });
 
-    it("should disable subscriptions for non-admin users", () => {
+    it("should allow non-admin users to create subscriptions", () => {
       cy.signInAsNormalUser();
       H.visitDashboard(ORDERS_DASHBOARD_ID);
       H.openSharingMenu();
-      H.sharingMenu()
-        .findByText("Can't send subscriptions")
-        .should("be.visible")
-        .within(() => {
-          cy.findByText("Can't send subscriptions").should("be.visible");
-          cy.findByText("Ask your admin to set up email or Slack").should(
-            "be.visible",
-          );
-        });
+      H.sharingMenu().findByText("Subscriptions").should("be.visible");
     });
   });
 

--- a/frontend/src/metabase/common/hooks/use-notification-channels/use-notification-channels.ts
+++ b/frontend/src/metabase/common/hooks/use-notification-channels/use-notification-channels.ts
@@ -13,3 +13,9 @@ export const useHasEmailSetup = (): boolean => {
 
   return !!channelInfo?.channels?.email?.configured;
 };
+
+export const useHasSlackSetup = (): boolean => {
+  const { data: channelInfo } = useGetChannelInfoQuery();
+
+  return !!channelInfo?.channels?.slack?.configured;
+};

--- a/frontend/src/metabase/embedding/components/SharingMenu/test/DashboardSharingMenu.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/components/SharingMenu/test/DashboardSharingMenu.unit.spec.tsx
@@ -76,7 +76,7 @@ describe("DashboardSharingMenu", () => {
     });
 
     describe("non-admins", () => {
-      it("should show 'subscriptions' option when email is set up", async () => {
+      it("should show 'subscriptions' option when email is set up, but slack is not setup", async () => {
         setupDashboardSharingMenu({
           isAdmin: false,
           isEmailSetup: true,
@@ -86,7 +86,7 @@ describe("DashboardSharingMenu", () => {
         expect(screen.getByText("Subscriptions")).toBeInTheDocument();
       });
 
-      it("should show disabled 'subscriptions' option when email is not set up", async () => {
+      it("should show 'subscriptions' option when email is not set up, but slack is setup", async () => {
         setupDashboardSharingMenu({
           isAdmin: false,
           isEmailSetup: false,
@@ -94,7 +94,7 @@ describe("DashboardSharingMenu", () => {
         });
         await openMenu();
         expect(
-          await screen.findByText("Can't send subscriptions"),
+          await screen.findByText("Subscriptions", { exact: true }),
         ).toBeInTheDocument();
       });
 

--- a/frontend/src/metabase/notifications/NotificationsActionsMenu/DashboardSubscriptionMenuItem.tsx
+++ b/frontend/src/metabase/notifications/NotificationsActionsMenu/DashboardSubscriptionMenuItem.tsx
@@ -1,6 +1,6 @@
 import { t } from "ttag";
 
-import { useHasEmailSetup } from "metabase/common/hooks";
+import { useHasEmailSetup, useHasSlackSetup } from "metabase/common/hooks";
 import { useSelector } from "metabase/lib/redux";
 import {
   canManageSubscriptions as canManageSubscriptionsSelector,
@@ -18,6 +18,7 @@ export function DashboardSubscriptionMenuItem({
 }) {
   const isAdmin = useSelector(getUserIsAdmin);
   const hasEmailSetup = useHasEmailSetup();
+  const hasSlackSetup = useHasSlackSetup();
 
   const canManageSubscriptions = useSelector(canManageSubscriptionsSelector);
 
@@ -26,11 +27,13 @@ export function DashboardSubscriptionMenuItem({
     (dashCard) => !["text", "heading"].includes(dashCard.card.display),
   );
 
+  const hasAnySubscriptionChannel = hasEmailSetup || hasSlackSetup;
+
   if (!canManageSubscriptions || !hasDataCards) {
     return null;
   }
 
-  if (!isAdmin && !hasEmailSetup) {
+  if (!isAdmin && !hasAnySubscriptionChannel) {
     return (
       <Menu.Item
         data-testid="dashboard-subscription-menu-item"
@@ -38,7 +41,10 @@ export function DashboardSubscriptionMenuItem({
         disabled
       >
         <Text size="md" c="inherit">{t`Can't send subscriptions`}</Text>
-        <Text size="sm" c="inherit">{t`Ask your admin to set up email`}</Text>
+        <Text
+          size="sm"
+          c="inherit"
+        >{t`Ask your admin to set up email, or Slack`}</Text>
       </Menu.Item>
     );
   }

--- a/frontend/src/metabase/notifications/NotificationsActionsMenu/DashboardSubscriptionMenuItem.tsx
+++ b/frontend/src/metabase/notifications/NotificationsActionsMenu/DashboardSubscriptionMenuItem.tsx
@@ -44,7 +44,7 @@ export function DashboardSubscriptionMenuItem({
         <Text
           size="sm"
           c="inherit"
-        >{t`Ask your admin to set up email, or Slack`}</Text>
+        >{t`Ask your admin to set up email or Slack`}</Text>
       </Menu.Item>
     );
   }

--- a/frontend/src/metabase/notifications/NotificationsActionsMenu/DashboardSubscriptionMenuItem.unit.spec.tsx
+++ b/frontend/src/metabase/notifications/NotificationsActionsMenu/DashboardSubscriptionMenuItem.unit.spec.tsx
@@ -61,19 +61,17 @@ const setup = ({
 };
 
 describe("DashboardSubscriptionMenuItem", () => {
-  describe("when user can manage subscriptions and dashboard has data cards", () => {
-    it("should show 'Subscriptions' menu item when email and slack are not set up", async () => {
-      setup({
-        isSuperuser: true,
-        hasEmailSetup: false,
-        hasSlackSetup: false,
-      });
-
-      expect(
-        screen.getByTestId("dashboard-subscription-menu-item"),
-      ).toBeInTheDocument();
-      expect(await screen.findByText("Subscriptions")).toBeInTheDocument();
+  it("should show 'Subscriptions' menu item when can manage subscriptions and has no email or slack setup", async () => {
+    setup({
+      isSuperuser: true,
+      hasEmailSetup: false,
+      hasSlackSetup: false,
     });
+
+    expect(
+      screen.getByTestId("dashboard-subscription-menu-item"),
+    ).toBeInTheDocument();
+    expect(await screen.findByText("Subscriptions")).toBeInTheDocument();
   });
 
   describe("when user can't manage subscriptions and dashboard has data cards", () => {

--- a/frontend/src/metabase/notifications/NotificationsActionsMenu/DashboardSubscriptionMenuItem.unit.spec.tsx
+++ b/frontend/src/metabase/notifications/NotificationsActionsMenu/DashboardSubscriptionMenuItem.unit.spec.tsx
@@ -1,0 +1,115 @@
+import { setupNotificationChannelsEndpoints } from "__support__/server-mocks/pulse";
+import { renderWithProviders, screen } from "__support__/ui";
+import { Menu } from "metabase/ui";
+import type { ChannelApiResponse } from "metabase-types/api";
+import {
+  createMockCard,
+  createMockDashboard,
+  createMockDashboardCard,
+  createMockUser,
+} from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks";
+
+import { DashboardSubscriptionMenuItem } from "./DashboardSubscriptionMenuItem";
+
+const mockOnClick = jest.fn();
+
+const createDashboardWithDataCards = () => {
+  return createMockDashboard({
+    dashcards: [
+      createMockDashboardCard({
+        card: createMockCard({ display: "table" }),
+      }),
+    ],
+  });
+};
+
+const setup = ({
+  isSuperuser = false,
+  hasEmailSetup = false,
+  hasSlackSetup = false,
+  dashboard: mockDashboard = createDashboardWithDataCards(),
+}: {
+  isSuperuser?: boolean;
+  hasEmailSetup?: boolean;
+  hasSlackSetup?: boolean;
+  dashboard?: ReturnType<typeof createMockDashboard>;
+} = {}) => {
+  const currentUser = createMockUser({
+    is_superuser: isSuperuser,
+  });
+  const storeInitialState = createMockState({
+    currentUser,
+  });
+
+  setupNotificationChannelsEndpoints({
+    email: { configured: hasEmailSetup },
+    slack: { configured: hasSlackSetup },
+  } as ChannelApiResponse["channels"]);
+
+  renderWithProviders(
+    <Menu opened>
+      <Menu.Dropdown>
+        <DashboardSubscriptionMenuItem
+          onClick={mockOnClick}
+          dashboard={mockDashboard}
+        />
+      </Menu.Dropdown>
+    </Menu>,
+    { storeInitialState },
+  );
+};
+
+describe("DashboardSubscriptionMenuItem", () => {
+  describe("when user can manage subscriptions and dashboard has data cards", () => {
+    it("should show 'Subscriptions' menu item when email and slack are not set up", async () => {
+      setup({
+        isSuperuser: true,
+        hasEmailSetup: false,
+        hasSlackSetup: false,
+      });
+
+      expect(
+        screen.getByTestId("dashboard-subscription-menu-item"),
+      ).toBeInTheDocument();
+      expect(await screen.findByText("Subscriptions")).toBeInTheDocument();
+    });
+  });
+
+  describe("when user can't manage subscriptions and dashboard has data cards", () => {
+    it.each([
+      { hasEmailSetup: true, hasSlackSetup: false },
+      { hasEmailSetup: false, hasSlackSetup: true },
+      { hasEmailSetup: true, hasSlackSetup: true },
+    ])(
+      "should show 'Subscriptions' menu item when email is $hasEmailSetup and slack is $hasSlackSetup",
+      async ({ hasEmailSetup, hasSlackSetup }) => {
+        setup({
+          isSuperuser: false,
+          hasEmailSetup,
+          hasSlackSetup,
+        });
+
+        expect(
+          screen.getByTestId("dashboard-subscription-menu-item"),
+        ).toBeInTheDocument();
+        expect(await screen.findByText("Subscriptions")).toBeInTheDocument();
+      },
+    );
+
+    it('should show "Can\'t send subscriptions" menu item when email and slack are not set up', async () => {
+      setup({
+        isSuperuser: false,
+        hasEmailSetup: false,
+        hasSlackSetup: false,
+      });
+
+      expect(
+        screen.getByTestId("dashboard-subscription-menu-item"),
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByText("Can't send subscriptions"),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/metabase/notifications/modals/ChannelSetupModal.tsx
+++ b/frontend/src/metabase/notifications/modals/ChannelSetupModal.tsx
@@ -52,7 +52,7 @@ export const ChannelSetupModal = ({
         <Text mb="1rem">
           {userCanAccessSettings
             ? t`To get notified when something happens, or to send this chart on a schedule, first set up SMTP, Slack, or a webhook.`
-            : t`To get notified when something happens, or to send this chart on a schedule, ask your Admin to set up SMTP or Slack.`}
+            : t`To get notified when something happens, or to send this chart on a schedule, ask your Admin to set up SMTP, Slack, or a webhook.`}
         </Text>
 
         {userCanAccessSettings &&

--- a/frontend/src/metabase/notifications/modals/ChannelSetupModal.tsx
+++ b/frontend/src/metabase/notifications/modals/ChannelSetupModal.tsx
@@ -11,7 +11,7 @@ const CHANNELS_CONFIG: {
 }[] = [
   {
     get title() {
-      return t`Set up SMTP`;
+      return t`Set up email`;
     },
     icon: "mail",
     link: "/admin/settings/email",
@@ -51,8 +51,8 @@ export const ChannelSetupModal = ({
       <Stack gap="0.5rem">
         <Text mb="1rem">
           {userCanAccessSettings
-            ? t`To get notified when something happens, or to send this chart on a schedule, first set up SMTP, Slack, or a webhook.`
-            : t`To get notified when something happens, or to send this chart on a schedule, ask your Admin to set up SMTP, Slack, or a webhook.`}
+            ? t`To get notified when something happens, or to send this chart on a schedule, first set up email, Slack, or a webhook.`
+            : t`To get notified when something happens, or to send this chart on a schedule, ask your admin to set up email, Slack, or a webhook.`}
         </Text>
 
         {userCanAccessSettings &&


### PR DESCRIPTION
Closes #65526 → [UXW-2228](https://linear.app/metabase/issue/UXW-2228/incomplete-non-admin-user-warning-when-setting-up-subscriptions-and)

### Description

This PR fixes an inconsistency between admin & non-admin views when attempting to set up subscriptions & alerts on a dashboard. Before, non-admin views wouldn't mention Webhooks for subscriptions, and subscriptions wouldn't mention Slack. 

It also fixes an underlying bug where, if Slack was configured, the option for subscriptions still wouldn't be available as it was only checking for email configuration. Wording was also adjusted to always use lowercase 'admin' and 'email' instead of 'SMTP'.

### How to verify

From #65526:

> 1. Create a new instance
> 2. Add a non-admin user
> 3. Sign in as non-admin user
> 4. check an example dashboard, and try to subscribe
> 5. check any question in the Example collection, and try to set up and alert

Step 3 should mention email, Slack, and webhooks. Step 5 should mention email, and Slack.

### Demo

| Place | Before | After |
| --- | --- | --- |
| Subscriptions | <img width="770" height="242" alt="CleanShot 2025-11-25 at 15 18 28@2x" src="https://github.com/user-attachments/assets/9c17b1ca-312e-41f1-b7d4-fed8f684a988" /> | <img width="648" height="224" alt="CleanShot 2025-11-25 at 15 21 47@2x" src="https://github.com/user-attachments/assets/04ba0dc6-4987-487b-b524-3bf55f3ee0e6" /> |
| Alerts | <img width="848" height="444" alt="CleanShot 2025-11-25 at 15 20 35@2x" src="https://github.com/user-attachments/assets/2718ab58-6bd6-4032-9757-3f96c4fc6df0" /> | <img width="834" height="422" alt="CleanShot 2025-11-25 at 15 21 13@2x" src="https://github.com/user-attachments/assets/5f5d6848-b2ca-456d-acc0-1053cbae03fd" /> |

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
