### PR TITLE
Get user attributes from attributes map

### DIFF
--- a/frontend/src/metabase-types/api/mocks/user.ts
+++ b/frontend/src/metabase-types/api/mocks/user.ts
@@ -8,6 +8,7 @@ export const createMockUser = (opts?: Partial<User>): User => ({
   custom_homepage: null,
   email: "user@metabase.test",
   locale: null,
+  attributes: null,
   login_attributes: null,
   is_active: true,
   is_qbnewb: false,

--- a/frontend/src/metabase-types/api/user.ts
+++ b/frontend/src/metabase-types/api/user.ts
@@ -42,6 +42,7 @@ export interface BaseUser {
 }
 
 export interface User extends BaseUser {
+  attributes: UserAttributeMap | null;
   login_attributes: UserAttributeMap | null;
   structured_attributes?: StructuredUserAttributes;
   user_group_memberships?: { id: number; is_group_manager: boolean }[];

--- a/frontend/src/metabase/selectors/user.ts
+++ b/frontend/src/metabase/selectors/user.ts
@@ -32,7 +32,7 @@ export const canAccessSettings = createSelector(
 
 export const getUserAttributes = createSelector(
   [getUser],
-  (user) => user?.login_attributes || {},
+  (user) => user?.attributes || {},
 );
 
 export const getUserPersonalCollectionId = createSelector(

--- a/frontend/src/metabase/selectors/user.unit.spec.ts
+++ b/frontend/src/metabase/selectors/user.unit.spec.ts
@@ -1,7 +1,7 @@
 import { createMockUser } from "metabase-types/api/mocks";
 import { createMockState } from "metabase-types/store/mocks";
 
-import { getUserIsAdmin } from "./user";
+import { getUserAttributes, getUserIsAdmin } from "./user";
 
 describe("metabase/selectors/user", () => {
   it("should return true if user is an admin", () => {
@@ -18,5 +18,34 @@ describe("metabase/selectors/user", () => {
     });
 
     expect(getUserIsAdmin(state)).toBe(false);
+  });
+
+  describe("getUserAttributes", () => {
+    it("should return user attributes including JWT-sourced attributes", () => {
+      const state = createMockState({
+        currentUser: createMockUser({
+          attributes: { jwt_attr: "jwt_value", manual_attr: "manual_value" },
+        }),
+      });
+
+      expect(getUserAttributes(state)).toEqual({
+        jwt_attr: "jwt_value",
+        manual_attr: "manual_value",
+      });
+    });
+
+    it("should return empty object when attributes is null", () => {
+      const state = createMockState({
+        currentUser: createMockUser({ attributes: null }),
+      });
+
+      expect(getUserAttributes(state)).toEqual({});
+    });
+
+    it("should return empty object when no current user", () => {
+      const state = createMockState({ currentUser: null });
+
+      expect(getUserAttributes(state)).toEqual({});
+    });
   });
 });


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #65942
### Description

Fixes a bug where we were not looking at the new `attributes` field only looking at manually set user attribtues for JWT users. 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
