### PR TITLE
UXW-2352 Fix issue where CopyCardForm resets when the destination collection is changed

### DIFF
--- a/e2e/test/scenarios/data-studio/modeling-metrics.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/modeling-metrics.cy.spec.ts
@@ -346,6 +346,7 @@ describe("scenarios > data studio > modeling > metrics", () => {
     H.modal().button("Duplicate").click();
 
     cy.wait("@createCard");
+    H.modal().should("not.exist");
 
     cy.log("Verify duplicate metric is created");
     H.DataStudio.Metrics.overviewPage()

--- a/e2e/test/scenarios/data-studio/modeling-metrics.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/modeling-metrics.cy.spec.ts
@@ -304,7 +304,7 @@ describe("scenarios > data studio > modeling > metrics", () => {
       .and("match", /\/metric\/\d+/);
   });
 
-  it.skip("should duplicate metric via more menu", () => {
+  it("should duplicate metric via more menu", () => {
     cy.log("Navigate to Data Studio Modeling");
     cy.visit("/data-studio/modeling");
 

--- a/e2e/test/scenarios/data-studio/modeling-models.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/modeling-models.cy.spec.ts
@@ -224,6 +224,7 @@ describe("scenarios > data studio > modeling > models", () => {
     H.modal().button("Duplicate").click();
 
     cy.wait("@createCard");
+    H.modal().should("not.exist");
 
     cy.log("Verify duplicate model is created");
     H.DataStudio.Models.overviewPage()

--- a/e2e/test/scenarios/data-studio/modeling-models.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/modeling-models.cy.spec.ts
@@ -184,7 +184,7 @@ describe("scenarios > data studio > modeling > models", () => {
       .and("match", /\/model\/\d+/);
   });
 
-  it.skip("should duplicate model via more menu", () => {
+  it("should duplicate model via more menu", () => {
     cy.log("Navigate to Data Studio Modeling");
     cy.visit("/data-studio/modeling");
 

--- a/frontend/src/metabase/questions/components/CardCopyModal/CardCopyModal.tsx
+++ b/frontend/src/metabase/questions/components/CardCopyModal/CardCopyModal.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { useLatest } from "react-use";
 
 import { useCreateCardMutation } from "metabase/api";
 import { useGetDefaultCollectionId } from "metabase/collections/hooks";
@@ -16,12 +17,15 @@ export function CardCopyModal({ card, onCopy, onClose }: CardCopyModalProps) {
   const [createCard] = useCreateCardMutation();
   const initialCollectionId = useGetDefaultCollectionId();
 
+  const cardRef = useLatest(card);
   const initialValues = useMemo(
     () => ({
-      ...card,
-      collection_id: card.can_write ? card.collection_id : initialCollectionId,
+      ...cardRef.current,
+      collection_id: cardRef.current.can_write
+        ? cardRef.current.collection_id
+        : initialCollectionId,
     }),
-    [card, initialCollectionId],
+    [cardRef, initialCollectionId],
   );
 
   const handleCopy = async (values: CopyCardProperties) => {

--- a/frontend/src/metabase/questions/components/CardCopyModal/CardCopyModal.tsx
+++ b/frontend/src/metabase/questions/components/CardCopyModal/CardCopyModal.tsx
@@ -40,6 +40,7 @@ export function CardCopyModal({ card, onCopy, onClose }: CardCopyModalProps) {
   };
 
   const handleCopySucceeded = (newCard: Card) => {
+    onClose();
     onCopy?.(newCard);
   };
 


### PR DESCRIPTION
Closes UXW-2352

### Description

Prevents CopyCardForm from resetting when the destination collection is changed.

The forms in EntityCopyModal all use enableReinitialize. When a collection is selected, it calls `tryLogRecentItem` which invalidates the `card` which causes the "copy" form to reset. This PR makes it so the initialValues are computed when the modal opens; they won't recompute if the `card` is refreshed while it's open.

ℹ️ This also fixes an issue where the "copy" modals didn't close on success.

### How to verify

1. Navigate to a model in the Data Studio, click the [...] next to its name, then "Duplicate"
2. Change the copy destination
3. Verify the form displays the correct destination and copies it correctly
4. Verify the modal closes on success
5. Repeat for a metric

### Demo

**BEFORE**

https://github.com/user-attachments/assets/5ac77416-e281-43a0-83fc-7da1510df6b3


**AFTER**

https://github.com/user-attachments/assets/25a56220-e342-4f35-bbcb-95c6f1235500


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
