### PR TITLE
Remove URLs from entities

### DIFF
--- a/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionCard.tsx
+++ b/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionCard.tsx
@@ -13,6 +13,7 @@ import {
 import EventSandbox from "metabase/common/components/EventSandbox";
 import CS from "metabase/css/core/index.css";
 import { getIcon } from "metabase/lib/icon";
+import { modelToUrl } from "metabase/lib/urls";
 import { PLUGIN_MODERATION } from "metabase/plugins";
 import { Box, Flex, Group, Icon, Text } from "metabase/ui";
 import Visualization from "metabase/visualizations/components/Visualization";
@@ -78,7 +79,7 @@ const PinnedQuestionCard = ({
 
   return (
     <CardRoot
-      to={item.getUrl()}
+      to={modelToUrl(item)}
       isPreview={isPreview}
       className={cx(CS.hoverChild, CS.hoverVisibility)}
     >

--- a/frontend/src/metabase/common/components/ItemsTable/Columns.tsx
+++ b/frontend/src/metabase/common/components/ItemsTable/Columns.tsx
@@ -10,6 +10,7 @@ import EntityItem from "metabase/common/components/EntityItem";
 import Markdown from "metabase/common/components/Markdown";
 import { ArchiveButton } from "metabase/embedding/components/ArchiveButton";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
+import { modelToUrl } from "metabase/lib/urls";
 import { getUserName } from "metabase/lib/user";
 import { PLUGIN_MODERATION } from "metabase/plugins";
 import type { IconProps } from "metabase/ui";
@@ -52,7 +53,7 @@ const ItemLinkComponent = ({
     return <ItemButton onClick={() => onClick?.(item)}>{children}</ItemButton>;
   }
   return (
-    <ItemLink to={item.getUrl()} onClick={() => onClick?.(item)}>
+    <ItemLink to={modelToUrl(item)} onClick={() => onClick?.(item)}>
       {children}
     </ItemLink>
   );

--- a/frontend/src/metabase/common/components/ItemsTable/Columns.tsx
+++ b/frontend/src/metabase/common/components/ItemsTable/Columns.tsx
@@ -10,10 +10,12 @@ import EntityItem from "metabase/common/components/EntityItem";
 import Markdown from "metabase/common/components/Markdown";
 import { ArchiveButton } from "metabase/embedding/components/ArchiveButton";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
+import { modelToUrl } from "metabase/lib/urls";
 import { getUserName } from "metabase/lib/user";
 import { PLUGIN_MODERATION } from "metabase/plugins";
 import type { IconProps } from "metabase/ui";
 import { Tooltip } from "metabase/ui";
+import { getUrl } from "metabase-lib/v1/urls";
 import type {
   CollectionItem,
   ListCollectionItemsSortColumn,
@@ -52,7 +54,7 @@ const ItemLinkComponent = ({
     return <ItemButton onClick={() => onClick?.(item)}>{children}</ItemButton>;
   }
   return (
-    <ItemLink to={item.getUrl()} onClick={() => onClick?.(item)}>
+    <ItemLink to={modelToUrl(item)} onClick={() => onClick?.(item)}>
       {children}
     </ItemLink>
   );

--- a/frontend/src/metabase/common/components/ItemsTable/Columns.tsx
+++ b/frontend/src/metabase/common/components/ItemsTable/Columns.tsx
@@ -10,12 +10,10 @@ import EntityItem from "metabase/common/components/EntityItem";
 import Markdown from "metabase/common/components/Markdown";
 import { ArchiveButton } from "metabase/embedding/components/ArchiveButton";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
-import { modelToUrl } from "metabase/lib/urls";
 import { getUserName } from "metabase/lib/user";
 import { PLUGIN_MODERATION } from "metabase/plugins";
 import type { IconProps } from "metabase/ui";
 import { Tooltip } from "metabase/ui";
-import { getUrl } from "metabase-lib/v1/urls";
 import type {
   CollectionItem,
   ListCollectionItemsSortColumn,
@@ -54,7 +52,7 @@ const ItemLinkComponent = ({
     return <ItemButton onClick={() => onClick?.(item)}>{children}</ItemButton>;
   }
   return (
-    <ItemLink to={modelToUrl(item)} onClick={() => onClick?.(item)}>
+    <ItemLink to={item.getUrl()} onClick={() => onClick?.(item)}>
       {children}
     </ItemLink>
   );

--- a/frontend/src/metabase/common/components/QuestionLoader.jsx
+++ b/frontend/src/metabase/common/components/QuestionLoader.jsx
@@ -24,7 +24,7 @@ import { serializeCardForUrl } from "metabase/lib/card";
  *
  *        { // link to a new question created by adding a filter }
  *        <Link
- *          to={question.getUrl()}
+ *          to={modelToUrl(question)}
  *        >
  *          View this ad-hoc exploration
  *        </Link>

--- a/frontend/src/metabase/entities/actions/actions.ts
+++ b/frontend/src/metabase/entities/actions/actions.ts
@@ -12,7 +12,6 @@ import {
   undo,
 } from "metabase/lib/entities";
 import { createThunkAction } from "metabase/lib/redux";
-import * as Urls from "metabase/lib/urls";
 import { ActionSchema } from "metabase/schema";
 import type {
   CreateActionRequest,
@@ -225,10 +224,6 @@ const Actions = createEntity({
         return state;
       }
     }
-  },
-  objectSelectors: {
-    getUrl: (action: WritebackAction) =>
-      Urls.action({ id: action.model_id }, action.id),
   },
 });
 

--- a/frontend/src/metabase/entities/bookmarks.js
+++ b/frontend/src/metabase/entities/bookmarks.js
@@ -141,6 +141,10 @@ const Bookmarks = createEntity({
   },
 });
 
+export function isModelBookmark(bookmark) {
+  return bookmark.type === "card" && bookmark.card_type === "model";
+}
+
 export const getOrderedBookmarks = createSelector(
   [Bookmarks.selectors.getList],
   (bookmarks) => _.sortBy(bookmarks, (bookmark) => bookmark.index),

--- a/frontend/src/metabase/entities/bookmarks.js
+++ b/frontend/src/metabase/entities/bookmarks.js
@@ -141,10 +141,6 @@ const Bookmarks = createEntity({
   },
 });
 
-export function isModelBookmark(bookmark) {
-  return bookmark.type === "card" && bookmark.card_type === "model";
-}
-
 export const getOrderedBookmarks = createSelector(
   [Bookmarks.selectors.getList],
   (bookmarks) => _.sortBy(bookmarks, (bookmark) => bookmark.index),

--- a/frontend/src/metabase/entities/collections/collections.ts
+++ b/frontend/src/metabase/entities/collections/collections.ts
@@ -18,7 +18,6 @@ import {
   entityCompatibleQuery,
   undo,
 } from "metabase/lib/entities";
-import * as Urls from "metabase/lib/urls/collections";
 import { CollectionSchema } from "metabase/schema";
 import { getUserPersonalCollectionId } from "metabase/selectors/user";
 import type {
@@ -141,7 +140,6 @@ const Collections = createEntity({
 
   objectSelectors: {
     getName: (collection?: Collection) => collection?.name,
-    getUrl: (collection?: Collection) => Urls.collection(collection),
   },
 
   selectors: {

--- a/frontend/src/metabase/entities/dashboards.js
+++ b/frontend/src/metabase/entities/dashboards.js
@@ -20,7 +20,6 @@ import {
   undo,
 } from "metabase/lib/entities";
 import { compose, withAction, withRequestState } from "metabase/lib/redux";
-import * as Urls from "metabase/lib/urls/dashboards";
 import { addUndo } from "metabase/redux/undo";
 
 const COPY_ACTION = `metabase/entities/dashboards/COPY`;
@@ -175,7 +174,6 @@ const Dashboards = createEntity({
 
   objectSelectors: {
     getName: (dashboard) => dashboard && dashboard.name,
-    getUrl: (dashboard) => dashboard && Urls.dashboard(dashboard),
     getCollection: (dashboard) =>
       dashboard && normalizedCollection(dashboard.collection),
     getColor: () => color("dashboard"),

--- a/frontend/src/metabase/entities/databases.js
+++ b/frontend/src/metabase/entities/databases.js
@@ -11,7 +11,6 @@ import {
 import { color } from "metabase/lib/colors";
 import { createEntity, entityCompatibleQuery } from "metabase/lib/entities";
 import { createThunkAction, fetchData } from "metabase/lib/redux";
-import * as Urls from "metabase/lib/urls";
 import { DatabaseSchema } from "metabase/schema";
 import {
   getMetadata,
@@ -110,7 +109,6 @@ const Databases = createEntity({
 
   objectSelectors: {
     getName: (db) => db && db.name,
-    getUrl: (db) => db && Urls.browseDatabase(db),
     getColor: (db) => color("database"),
   },
 

--- a/frontend/src/metabase/entities/indexed-entities/indexed-entities.ts
+++ b/frontend/src/metabase/entities/indexed-entities/indexed-entities.ts
@@ -5,7 +5,6 @@
  */
 
 import { createEntity } from "metabase/lib/entities";
-import { indexedEntity as indexedEntityUrl } from "metabase/lib/urls";
 import { IndexedEntitySchema } from "metabase/schema";
 
 /**
@@ -15,7 +14,4 @@ export const IndexedEntities = createEntity({
   name: "indexedEntities",
   nameOne: "indexedEntity",
   schema: IndexedEntitySchema,
-  objectSelectors: {
-    getUrl: indexedEntityUrl,
-  },
 });

--- a/frontend/src/metabase/entities/pulses.js
+++ b/frontend/src/metabase/entities/pulses.js
@@ -12,7 +12,6 @@ import {
   entityCompatibleQuery,
   undo,
 } from "metabase/lib/entities";
-import * as Urls from "metabase/lib/urls";
 import { addUndo } from "metabase/redux/undo";
 
 export const UNSUBSCRIBE = "metabase/entities/pulses/unsubscribe";
@@ -91,7 +90,6 @@ const Pulses = createEntity({
 
   objectSelectors: {
     getName: (pulse) => pulse && pulse.name,
-    getUrl: (pulse) => pulse && Urls.pulse(pulse.id),
     getColor: (pulse) => color("pulse"),
   },
 

--- a/frontend/src/metabase/entities/questions.js
+++ b/frontend/src/metabase/entities/questions.js
@@ -16,7 +16,6 @@ import {
   entityCompatibleQuery,
   undo,
 } from "metabase/lib/entities";
-import * as Urls from "metabase/lib/urls/questions";
 import {
   API_UPDATE_QUESTION,
   SOFT_RELOAD_CARD,
@@ -164,7 +163,6 @@ const Questions = createEntity({
 
   objectSelectors: {
     getName: (card) => card && card.name,
-    getUrl: (card, opts) => card && Urls.question(card, opts),
     getColor: () => color("text-medium"),
     getCollection: (card) => card && normalizedCollection(card.collection),
   },

--- a/frontend/src/metabase/entities/segments.js
+++ b/frontend/src/metabase/entities/segments.js
@@ -5,7 +5,6 @@ import {
 } from "metabase/api";
 import { color } from "metabase/lib/colors";
 import { createEntity, entityCompatibleQuery } from "metabase/lib/entities";
-import * as Urls from "metabase/lib/urls";
 import { SegmentSchema } from "metabase/schema";
 import { getMetadata } from "metabase/selectors/metadata";
 
@@ -71,13 +70,6 @@ const Segments = createEntity({
 
   objectSelectors: {
     getName: (segment) => segment && segment.name,
-    getUrl: (segment) =>
-      Urls.tableRowsQuery(
-        segment.database_id,
-        segment.table_id,
-        null,
-        segment.id,
-      ),
     getColor: (segment) => color("filter"),
   },
 });

--- a/frontend/src/metabase/entities/tables.js
+++ b/frontend/src/metabase/entities/tables.js
@@ -33,7 +33,6 @@ import {
   withCachedDataAndRequestState,
   withNormalize,
 } from "metabase/lib/redux";
-import * as Urls from "metabase/lib/urls";
 import { TableSchema } from "metabase/schema";
 import {
   getMetadata,
@@ -351,8 +350,6 @@ const Tables = createEntity({
     return state;
   },
   objectSelectors: {
-    getUrl: (table) =>
-      Urls.tableRowsQuery(table.database_id, table.table_id, null),
     getColor: (table) => color("accent2"),
   },
 

--- a/frontend/src/metabase/lib/urls/modelToUrl.ts
+++ b/frontend/src/metabase/lib/urls/modelToUrl.ts
@@ -4,13 +4,15 @@ import { browseDatabase } from "./browse";
 import { collection } from "./collections";
 import { dashboard } from "./dashboards";
 import { document } from "./documents";
+import { indexedEntity } from "./indexed-entities";
 import { metric, model } from "./models";
 import { question, tableRowsQuery } from "./questions";
+import { segment } from "./segment";
 import { timeline } from "./timelines";
 import { transform } from "./transforms";
 
 export type UrlableModel = {
-  id: number;
+  id: any;
   model: string;
   name: string;
   database?: {
@@ -19,7 +21,13 @@ export type UrlableModel = {
   collection_id?: CollectionId | null;
 };
 
-export function modelToUrl(item: UrlableModel) {
+const NOT_FOUND_URL = "/404";
+
+/**
+ * this isn't the best-named function in the codebase, but if you want to get a url for basically
+ * anything in metabase, just put it through here
+ */
+export function modelToUrl(item: UrlableModel): string {
   switch (item.model) {
     case "card":
       return question({
@@ -38,7 +46,7 @@ export function modelToUrl(item: UrlableModel) {
       if (item?.database?.id) {
         return tableRowsQuery(item.database.id, item.id);
       }
-      return null;
+      return NOT_FOUND_URL;
     case "collection":
       return collection(item);
     case "document":
@@ -46,10 +54,14 @@ export function modelToUrl(item: UrlableModel) {
     case "timeline":
       return timeline(item);
     case "user":
-      return null;
+      return NOT_FOUND_URL;
     case "transform":
       return transform(item.id);
+    case "indexed-entity":
+      return indexedEntity(item.id);
+    case "segment":
+      return segment(item.id);
     default:
-      return null;
+      return NOT_FOUND_URL;
   }
 }

--- a/frontend/src/metabase/lib/urls/modelToUrl.ts
+++ b/frontend/src/metabase/lib/urls/modelToUrl.ts
@@ -7,7 +7,6 @@ import { document } from "./documents";
 import { indexedEntity } from "./indexed-entities";
 import { metric, model } from "./models";
 import { question, tableRowsQuery } from "./questions";
-import { segment } from "./segment";
 import { timeline } from "./timelines";
 import { transform } from "./transforms";
 
@@ -59,8 +58,6 @@ export function modelToUrl(item: UrlableModel): string {
       return transform(item.id);
     case "indexed-entity":
       return indexedEntity(item.id);
-    case "segment":
-      return segment(item.id);
     default:
       return NOT_FOUND_URL;
   }

--- a/frontend/src/metabase/lib/urls/modelToUrl.ts
+++ b/frontend/src/metabase/lib/urls/modelToUrl.ts
@@ -19,7 +19,9 @@ export type UrlableModel = {
   collection_id?: CollectionId | null;
 };
 
-export function modelToUrl(item: UrlableModel) {
+const NOT_FOUND_URL = "/404";
+
+export function modelToUrl(item: UrlableModel): string {
   switch (item.model) {
     case "card":
       return question({
@@ -38,7 +40,7 @@ export function modelToUrl(item: UrlableModel) {
       if (item?.database?.id) {
         return tableRowsQuery(item.database.id, item.id);
       }
-      return null;
+      return NOT_FOUND_URL;
     case "collection":
       return collection(item);
     case "document":
@@ -46,10 +48,10 @@ export function modelToUrl(item: UrlableModel) {
     case "timeline":
       return timeline(item);
     case "user":
-      return null;
+      return NOT_FOUND_URL;
     case "transform":
       return transform(item.id);
     default:
-      return null;
+      return NOT_FOUND_URL;
   }
 }

--- a/frontend/src/metabase/lib/urls/modelToUrl.ts
+++ b/frontend/src/metabase/lib/urls/modelToUrl.ts
@@ -19,9 +19,7 @@ export type UrlableModel = {
   collection_id?: CollectionId | null;
 };
 
-const NOT_FOUND_URL = "/404";
-
-export function modelToUrl(item: UrlableModel): string {
+export function modelToUrl(item: UrlableModel) {
   switch (item.model) {
     case "card":
       return question({
@@ -40,7 +38,7 @@ export function modelToUrl(item: UrlableModel): string {
       if (item?.database?.id) {
         return tableRowsQuery(item.database.id, item.id);
       }
-      return NOT_FOUND_URL;
+      return null;
     case "collection":
       return collection(item);
     case "document":
@@ -48,10 +46,10 @@ export function modelToUrl(item: UrlableModel): string {
     case "timeline":
       return timeline(item);
     case "user":
-      return NOT_FOUND_URL;
+      return null;
     case "transform":
       return transform(item.id);
     default:
-      return NOT_FOUND_URL;
+      return null;
   }
 }

--- a/frontend/src/metabase/lib/urls/modelToUrl.ts
+++ b/frontend/src/metabase/lib/urls/modelToUrl.ts
@@ -1,4 +1,4 @@
-import type { CollectionId } from "metabase-types/api";
+import type { CollectionId, IndexedEntity } from "metabase-types/api";
 
 import { browseDatabase } from "./browse";
 import { collection } from "./collections";
@@ -57,7 +57,7 @@ export function modelToUrl(item: UrlableModel): string {
     case "transform":
       return transform(item.id);
     case "indexed-entity":
-      return indexedEntity(item.id);
+      return indexedEntity(item as IndexedEntity);
     default:
       return NOT_FOUND_URL;
   }

--- a/frontend/src/metabase/lib/urls/modelToUrl.unit.spec.ts
+++ b/frontend/src/metabase/lib/urls/modelToUrl.unit.spec.ts
@@ -1,13 +1,13 @@
 import { modelToUrl } from "./modelToUrl";
 
 describe("urls > modelToUrl", () => {
-  it("should return null for unknown model", () => {
+  it("should return 404 for unknown model", () => {
     expect(
       // @ts-expect-error - testing the error case
       modelToUrl({
         model: "pikachu",
       }),
-    ).toBeNull();
+    ).toContain("/404");
   });
 
   it("should return a question URL for a card", () => {

--- a/frontend/src/metabase/lib/urls/segment.ts
+++ b/frontend/src/metabase/lib/urls/segment.ts
@@ -1,6 +1,0 @@
-import type { Segment } from "metabase-types/api";
-
-import { tableRowsQuery } from "./questions";
-
-export const segment = (segment: Segment) =>
-  tableRowsQuery(segment.database_id, segment.table_id, null, segment.id);

--- a/frontend/src/metabase/lib/urls/segment.ts
+++ b/frontend/src/metabase/lib/urls/segment.ts
@@ -1,0 +1,6 @@
+import type { Segment } from "metabase-types/api";
+
+import { tableRowsQuery } from "./questions";
+
+export const segment = (segment: Segment) =>
+  tableRowsQuery(segment.database_id, segment.table_id, null, segment.id);

--- a/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.tsx
@@ -16,6 +16,7 @@ import { useOnClickOutside } from "metabase/common/hooks/use-on-click-outside";
 import { useToggle } from "metabase/common/hooks/use-toggle";
 import { isSmallScreen, isWithinIframe } from "metabase/lib/dom";
 import { useDispatch, useSelector } from "metabase/lib/redux";
+import { modelToUrl } from "metabase/lib/urls";
 import { RecentsList } from "metabase/nav/components/search/RecentsList";
 import { SearchResultsDropdown } from "metabase/nav/components/search/SearchResultsDropdown";
 import { zoomInRow } from "metabase/query_builder/actions";
@@ -98,7 +99,7 @@ function SearchBarView({ location, onSearchActive, onSearchInactive }: Props) {
       if (isSameModel && result.model === "indexed-entity") {
         dispatch(zoomInRow({ objectId: result.id }));
       } else {
-        onChangeLocation(result.getUrl());
+        onChangeLocation(modelToUrl(result));
       }
     },
     [dispatch, onChangeLocation, location?.state?.cardId],

--- a/frontend/src/metabase/nav/components/search/SearchResults/SearchResults.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchResults/SearchResults.tsx
@@ -12,6 +12,7 @@ import {
   SEARCH_DEBOUNCE_DURATION,
 } from "metabase/lib/constants";
 import { useDispatch } from "metabase/lib/redux";
+import { modelToUrl } from "metabase/lib/urls";
 import {
   EmptyStateContainer,
   ResultsContainer,
@@ -123,8 +124,8 @@ export const SearchResults = ({
     if (item && typeof item !== "function") {
       if (onEntitySelect) {
         onEntitySelect(Search.wrapEntity(item, dispatch));
-      } else if (item && item.getUrl) {
-        dispatch(push(item.getUrl()));
+      } else if (item && modelToUrl(item)) {
+        dispatch(push(modelToUrl(item)));
       }
     }
   };

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -15,6 +15,7 @@ import { getIcon } from "metabase/lib/icon";
 import { getName } from "metabase/lib/name";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
+import { modelToUrl } from "metabase/lib/urls";
 import { PLUGIN_CACHING } from "metabase/plugins";
 import { trackSearchClick } from "metabase/search/analytics";
 import {
@@ -204,7 +205,7 @@ export const useCommandPalette = ({
             },
             extra: {
               moderatedStatus: result.moderated_status,
-              href: wrappedResult.getUrl?.(),
+              href: modelToUrl(wrappedResult),
               iconColor: icon.color,
               subtext: getSearchResultSubtext(wrappedResult),
             },

--- a/frontend/src/metabase/questions/components/CollectionBadge.tsx
+++ b/frontend/src/metabase/questions/components/CollectionBadge.tsx
@@ -3,6 +3,7 @@ import type { ComponentType, PropsWithChildren } from "react";
 import { Badge } from "metabase/common/components/Badge";
 import Collections from "metabase/entities/collections";
 import { getIcon } from "metabase/lib/icon";
+import { modelToUrl } from "metabase/lib/urls/modelToUrl";
 import { PLUGIN_COLLECTIONS } from "metabase/plugins";
 import type {
   CollectionId,
@@ -43,7 +44,9 @@ const CollectionBadgeInner = ({
     ...(isRegular ? { size: 16 } : IRREGULAR_ICON_PROPS),
   };
 
-  const clickActionProps = onClick ? { onClick } : { to: collection.getUrl() };
+  const clickActionProps = onClick
+    ? { onClick }
+    : { to: modelToUrl(collection) };
   return (
     <Badge
       className={className}

--- a/frontend/src/metabase/questions/components/CollectionBadge.tsx
+++ b/frontend/src/metabase/questions/components/CollectionBadge.tsx
@@ -46,7 +46,7 @@ const CollectionBadgeInner = ({
 
   const clickActionProps = onClick
     ? { onClick }
-    : { to: modelToUrl(collection) };
+    : { to: modelToUrl({ model: "collection", ...collection }) };
   return (
     <Badge
       className={className}

--- a/frontend/src/metabase/search/components/InfoText/InfoText.unit.spec.tsx
+++ b/frontend/src/metabase/search/components/InfoText/InfoText.unit.spec.tsx
@@ -79,12 +79,10 @@ async function setup({
 
   const result = createSearchResult({ model, ...resultProps });
 
-  const getUrl = jest.fn(() => "a/b/c");
   const getCollection = jest.fn(() => result.collection);
 
   const wrappedResult: WrappedResult = {
     ...result,
-    getUrl,
     getCollection,
   };
 
@@ -102,7 +100,6 @@ async function setup({
   await waitForLoadingTextToBeRemoved();
 
   return {
-    getUrl,
     getCollection,
   };
 }

--- a/frontend/src/metabase/search/components/SearchResult/SearchResult.tsx
+++ b/frontend/src/metabase/search/components/SearchResult/SearchResult.tsx
@@ -5,6 +5,7 @@ import { push } from "react-router-redux";
 
 import { useDispatch } from "metabase/lib/redux";
 import { isSyncCompleted } from "metabase/lib/syncing";
+import { modelToUrl } from "metabase/lib/urls";
 import { PLUGIN_MODERATION } from "metabase/plugins";
 import { trackSearchClick } from "metabase/search/analytics";
 import type { WrappedResult } from "metabase/search/types";
@@ -100,7 +101,7 @@ export function SearchResult({
       entityId: typeof result.id === "number" ? result.id : null,
       searchTerm,
     });
-    onChangeLocation(result.getUrl());
+    onChangeLocation(modelToUrl(result));
   };
 
   return (
@@ -128,7 +129,7 @@ export function SearchResult({
             role="heading"
             data-testid="search-result-item-name"
             truncate
-            href={!onClick ? result.getUrl() : undefined}
+            href={!onClick ? modelToUrl(result) : undefined}
           >
             {name}
           </ResultTitle>

--- a/frontend/src/metabase/search/components/SearchResult/tests/SearchResult-Tables.unit.spec.tsx
+++ b/frontend/src/metabase/search/components/SearchResult/tests/SearchResult-Tables.unit.spec.tsx
@@ -34,7 +34,6 @@ const setup = (setupOpts: SetupOpts) => {
     model: "table",
     table_id: TEST_TABLE.id,
     database_id: TEST_DATABASE.id,
-    getUrl: () => `/table/${TEST_TABLE.id}`,
     ...setupOpts,
   });
 

--- a/frontend/src/metabase/search/components/SearchResult/tests/SearchResult.unit.spec.tsx
+++ b/frontend/src/metabase/search/components/SearchResult/tests/SearchResult.unit.spec.tsx
@@ -7,6 +7,7 @@ import {
   setupUsersEndpoints,
 } from "__support__/server-mocks";
 import { getIcon, renderWithProviders, screen } from "__support__/ui";
+import { modelToUrl } from "metabase/lib/urls";
 import { SearchResult } from "metabase/search/components/SearchResult/SearchResult";
 import { createWrappedSearchResult } from "metabase/search/components/SearchResult/tests/util";
 import type { WrappedResult } from "metabase/search/types";
@@ -86,7 +87,7 @@ describe("SearchResult", () => {
 
     await userEvent.click(screen.getByText(TEST_RESULT_QUESTION.name));
 
-    const expectedPath = TEST_RESULT_QUESTION.getUrl();
+    const expectedPath = modelToUrl(TEST_RESULT_QUESTION);
 
     expect(history?.getCurrentLocation().pathname).toEqual(expectedPath);
   });

--- a/frontend/src/metabase/search/components/SearchResult/tests/util.ts
+++ b/frontend/src/metabase/search/components/SearchResult/tests/util.ts
@@ -8,7 +8,6 @@ export const createWrappedSearchResult = (
 
   return {
     ...result,
-    getUrl: options.getUrl ?? (() => "/collection/root"),
     getCollection: options.getCollection ?? (() => result.collection),
   };
 };

--- a/frontend/src/metabase/search/types.ts
+++ b/frontend/src/metabase/search/types.ts
@@ -10,7 +10,6 @@ import type {
 } from "metabase-types/api";
 
 export interface WrappedResult extends SearchResult {
-  getUrl: () => string;
   getCollection: () => SearchResult["collection"];
 }
 

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
@@ -8,6 +8,7 @@ import { getParameterValues } from "metabase/dashboard/selectors";
 import Search from "metabase/entities/search";
 import { getUrlTarget } from "metabase/lib/dom";
 import { useSelector } from "metabase/lib/redux";
+import { modelToUrl } from "metabase/lib/urls";
 import { SearchResults } from "metabase/nav/components/search/SearchResults";
 import { fillParametersInText } from "metabase/visualizations/shared/utils/parameter-substitution";
 import type {
@@ -142,7 +143,7 @@ function LinkVizInner({
       <DisplayLinkCardWrapper>
         <CardLink
           data-testid="entity-view-display-link"
-          to={wrappedEntity.getUrl()}
+          to={modelToUrl(wrappedEntity)}
           rel="noreferrer"
           role="link"
         >


### PR DESCRIPTION
Closes UXW-2376

Removes url generation from entities in favor of using the already-existing `modelToUrl` function