### PR TITLE
Remove some log levels

### DIFF
--- a/src/metabase/driver/sql_jdbc/sync/describe_database.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_database.clj
@@ -101,7 +101,7 @@
     (try
       (log/debug "have-select-privilege? sql-jdbc: Attempt to execute probe query")
       (execute-select-probe-query driver conn sql-args)
-      (log/infof "%s: SELECT privileges confirmed" (pr-table table-schema table-name))
+      (log/debugf "%s: SELECT privileges confirmed" (pr-table table-schema table-name))
       true
       (catch Throwable e
 

--- a/src/metabase/query_processor/middleware/parameters/mbql.clj
+++ b/src/metabase/query_processor/middleware/parameters/mbql.clj
@@ -168,7 +168,7 @@
             (and (sequential? param-value)
                  (every? nil? param-value)))
         (do
-          (log/infof "Ignoring parameter %s because it has no value" (pr-str param-value))
+          (log/debugf "Ignoring parameter %s because it has no value" (pr-str param-value))
           (recur stage more-params))
 
         (= (:type param) :temporal-unit)


### PR DESCRIPTION
repro:

```clojure
(metabase.sync.core/sync-database! (toucan2.core/select-one :model/Database :is_sample true))
```

and the logs are:

```
2025-11-25 22:03:14,052 INFO sync.describe-database :: "PUBLIC"."ACCOUNTS": SELECT privileges confirmed
2025-11-25 22:03:14,052 INFO sync.describe-database :: "PUBLIC"."ANALYTIC_EVENTS": SELECT privileges confirmed
2025-11-25 22:03:14,052 INFO sync.describe-database :: "PUBLIC"."FEEDBACK": SELECT privileges confirmed
2025-11-25 22:03:14,053 INFO sync.describe-database :: "PUBLIC"."INVOICES": SELECT privileges confirmed
2025-11-25 22:03:14,053 INFO sync.describe-database :: "PUBLIC"."ORDERS": SELECT privileges confirmed
2025-11-25 22:03:14,053 INFO sync.describe-database :: "PUBLIC"."PEOPLE": SELECT privileges confirmed
2025-11-25 22:03:14,053 INFO sync.describe-database :: "PUBLIC"."PRODUCTS": SELECT privileges confirmed
2025-11-25 22:03:14,053 INFO sync.describe-database :: "PUBLIC"."REVIEWS": SELECT privileges confirmed
2025-11-25 22:03:14,053 INFO sync.describe-database :: "PUBLIC"."_METABASE_METADATA": SELECT privileges confirmed
```

We added these because of an issue in snowflake. We run "select false as _ from table limit 0" as a probe to see if we can see a table. this is usually optimized out by the optimizer to just a permissions check. It knows that we don't get any rows so it's just asking the optimizer if we can see the objects.

Snowflake had an issue with views where if the query powering the view took a long time, the optimizer was not smart enough to answer our question quickly and it would time out doing the select no fields and limit 0. In an attempt to debug _where_ this was blowing up we added the logs in here. These are now reduced down to a debug level.

> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform). Also, if you're attempting to fix a translation issue, please submit your changes to our [Crowdin project](https://crowdin.com/project/metabase-i18n) instead of opening a PR.

Closes https://github.com/metabase/metabase/issues/[issue_number]

### Description

Describe the overall approach and the problem being solved.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> ...
2. ...

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
