### PR TITLE
[dashboards] Handle parallel FKs with dashboard filter values

### DIFF
--- a/src/metabase/parameters/chain_filter.clj
+++ b/src/metabase/parameters/chain_filter.clj
@@ -223,17 +223,20 @@
                                      [:not= :fk-field.fk_target_field_id nil]
                                      :fk-field.active]
                          :order-by [[:fk-field.id :desc]
-                                    [:pk-field.id :desc]]})]
-    (reduce
-     (partial merge-with merge)
-     {}
-     (for [{:keys [t1 f1 t2 f2]} rows]
-       (merge
-        {t1 {t2 [{:lhs {:table t1, :field f1}, :rhs {:table t2, :field f2}}]}}
-        (let [reverse-join {:lhs {:table t2, :field f2}, :rhs {:table t1, :field f1}}]
-          (if enable-reverse-joins?
-            {t2 {t1 [reverse-join]}}
-            (log/tracef "Not including reverse join (disabled) %s" (format-join-for-logging reverse-join)))))))))
+                                    [:pk-field.id :desc]]})
+        joins (for [{:keys [t1 f1 t2 f2]} rows]
+                {:lhs {:table t1, :field f1}
+                 :rhs {:table t2, :field f2}})
+        reversed (map (fn [{:keys [lhs rhs]}]
+                        {:lhs rhs, :rhs lhs})
+                      joins)
+        joins (if enable-reverse-joins?
+                (concat joins reversed)
+                (do (doseq [rev-join reversed]
+                      (log/tracef "Not including reverse join (disabled) %s" (format-join-for-logging rev-join)))
+                    joins))]
+    (-> (group-by (comp :table :lhs) joins)                ; Outer grouping: LHS table ID
+        (update-vals #(group-by (comp :table :rhs) %)))))  ; Inner grouping: RHS table ID
 
 (def ^:private ^{:arglists '([database-id enable-reverse-joins?])} database-fk-relationships
   "Return a sequence of FK relationships that exist in a database, in the format
@@ -288,6 +291,8 @@
     ;;
     ;; the general idea here is to see if LHS can join directly against RHS, otherwise recursively try all of the
     ;; tables LHS can join against and see if we can find a path that way.
+    ;; TODO: (bshepherdson 2025/11/25) This bespoke graph construction and traversal would be better migrated to
+    ;; use `metabase.graph.core`.
     (u/prog1 (traverse-graph fk-relationships source-table-id other-table-id max-traversal-depth)
       (when (seq <>)
         (log/tracef (format-joins-for-logging <>))))))
@@ -295,7 +300,10 @@
 (def ^:private ^{:arglists '([database-id source-table-id other-table-id]
                              [database-id source-table-id other-table-id enable-reverse-joins?])} find-joins
   "Find the joins that must be done to make fields in Table with `other-table-id` accessible in a query whose
-  primary (source) Table is the Table with `source-table-id`. Information about joins is returned in the format
+  primary (source) Table is the Table with `source-table-id`. Note that if there are multiple FKs for a particular
+  link between two tables, both will be returned as possible joins.
+
+  Information about joins is returned in the format:
 
     [{:lhs {:table <id>, :field <id>}, :rhs {table <id>, :field <id>}}
      ...]
@@ -330,11 +338,11 @@
         (f database-id source-table-id other-table-id enable-reverse-joins?)))
      (meta f))))
 
-(def ^:private ^{:arglists '([source-table other-table-ids enable-reverse-joins?])} find-all-joins*
+(def ^:private ^{:arglists '([source-table field-ids other-table-ids enable-reverse-joins?])} find-all-joins*
   (memoize/ttl
-   ^{::memoize/args-fn (fn [[source-table-id other-table-ids enable-reverse-joins?]]
-                         [(mdb/unique-identifier) source-table-id other-table-ids enable-reverse-joins?])}
-   (fn [source-table-id other-table-ids enable-reverse-joins?]
+   ^{::memoize/args-fn (fn [[source-table-id field-ids other-table-ids enable-reverse-joins?]]
+                         [(mdb/unique-identifier) source-table-id field-ids other-table-ids enable-reverse-joins?])}
+   (fn [source-table-id field-ids other-table-ids enable-reverse-joins?]
      (let [db-id     (database/table-id->database-id source-table-id)
            all-joins (mapcat #(find-joins db-id source-table-id % enable-reverse-joins?)
                              other-table-ids)]
@@ -344,7 +352,7 @@
                      (str/join ", " (map (partial name-for-logging :model/Table)
                                          other-table-ids))
                      (format-joins-for-logging all-joins))
-         (u/prog1 (vec (dedupe/dedupe-joins source-table-id all-joins other-table-ids))
+         (u/prog1 (vec (dedupe/dedupe-joins source-table-id field-ids all-joins other-table-ids))
            (when-not (= all-joins <>)
              (log/tracef "Deduplicated:\n%s" (format-joins-for-logging <>)))))))
    :ttl/threshold find-joins-cache-duration-ms))
@@ -355,7 +363,7 @@
    field-ids       :- [:set ::lib.schema.id/field]]
   (when-let [other-table-ids (not-empty (disj (set (map field/field-id->table-id (set field-ids)))
                                               source-table-id))]
-    (find-all-joins* source-table-id other-table-ids *enable-reverse-joins*)))
+    (find-all-joins* source-table-id field-ids other-table-ids *enable-reverse-joins*)))
 
 (mu/defn- add-joins :- ::lib.schema/query
   "Add joins to the MBQL `query` we're generating. The Field for which we are returning values is the \"source Field\",

--- a/test/metabase/parameters/chain_filter/dedupe_joins_test.clj
+++ b/test/metabase/parameters/chain_filter/dedupe_joins_test.clj
@@ -12,7 +12,7 @@
   ([joins start-id keep-ids]
    (map (juxt (comp :table :lhs) (comp :table :rhs))
         (dedupe/dedupe-joins
-         start-id
+         start-id #{}
          (for [[lhs rhs] joins]
            {:lhs {:table lhs}, :rhs {:table rhs}})
          keep-ids))))
@@ -75,8 +75,8 @@
   (testing "Node 3 is omitted from the above graph."
     (is (= [[0 1]
             [1 2] [2 5] [5 6]
-            [5 4] [4 8] [8 9]
-            [4 7]]
+            [5 4] [4 8] [4 7]
+            [8 9]]
            (dedupe-joins
             [[0 1]
              [1 3] [3 4] [4 7]
@@ -114,7 +114,7 @@
            {:lhs {:table 30, :field 334}, :rhs {:table 38, :field 399}}
            {:lhs {:table 30, :field 333}, :rhs {:table 37, :field 396}}]
           result
-          (dedupe/dedupe-joins 24 in-joins #{32 40 28 38 37})]
+          (dedupe/dedupe-joins 24 #{} in-joins #{32 40 28 38 37})]
       (is (= (first expected)
              (first result)))
       (is (= (-> expected rest set)


### PR DESCRIPTION
Fixes #65838.

### Description

This issue was about dashboard filters showing the wrong value when
the filter was bound to an FK field from a table with multiple FKs to
the same foreign table. The dashboard parameters logic on the BE was
choosing which FK to use for the filter values arbitrarily, meaning that
binding the filter to one of them would work fine, but the other would
give incoherent results.

The fix is to be deliberate about selecting the parameter's column. That
doesn't solve all ambiguous cases, but we really can't help if there's
a multi-hop join that has parallel edges in the middle!

### How to verify

Reproduce with the instructions on the bug. The `avian-singles` test database has
parallel FKs.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
