### PR TITLE
Split Redshift driver tests into two jobs

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -972,12 +972,22 @@ jobs:
             test-args: >-
               :only-tags [:mb/upload-tests]
               :fail-fast? true
-          - name: Redshift (Excluding Upload Tests)
+          - name: Redshift (Excluding Upload Tests) Part 1
             skip: false
             test-args: >-
               :only-tags [:mb/driver-tests]
               :exclude-tags '[:mb/upload-tests :mb/transforms-python-test]'
               :fail-fast? true
+              :partition/total 2
+              :partition/index 0
+          - name: Redshift (Excluding Upload Tests) Part 2
+            skip: false
+            test-args: >-
+              :only-tags [:mb/driver-tests]
+              :exclude-tags '[:mb/upload-tests :mb/transforms-python-test]'
+              :fail-fast? true
+              :partition/total 2
+              :partition/index 1
           - name: Redshift Transforms Python Tests
             skip: false
             test-args: >-


### PR DESCRIPTION
Goals here: 

- Instead of taking ~60 minutes it should now take ~30 minutes
- If there is a test flake then we'll (hopefully) only need to re-run a single ~30 minute job instead of a ~60 minute one (less load on the Redshift CI instance)

Redshift tests reuse datasets so this shouldn't add extra load on it