### PR TITLE
[Metabot] Show parent collection or db + schema for entities in @mention menu

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/shared/MenuComponents.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/shared/MenuComponents.tsx
@@ -3,6 +3,7 @@ import { t } from "ttag";
 
 import {
   Avatar,
+  Box,
   Group,
   Icon,
   type IconName,
@@ -28,6 +29,7 @@ export interface MenuItem {
   model?: SuggestionModel;
   id?: number | string;
   href?: string;
+  parentName?: string;
   hasSubmenu?: boolean;
 }
 
@@ -48,16 +50,33 @@ export const MenuItemComponent = ({
     aria-selected={isSelected}
     {...rest}
   >
-    <Group gap="sm" wrap="nowrap" align="center">
-      {item.model === "user" && <Avatar name={item.label} size={16} />}
-
-      {item.model !== "user" && (
-        <Icon name={item.icon} size={16} color={item.iconColor || "inherit"} />
-      )}
+    <Group gap="sm" wrap="nowrap" align="flex-start">
+      <Box mt=".125rem">
+        {item.model === "user" ? (
+          <Avatar name={item.label} size={16} />
+        ) : (
+          <Icon
+            name={item.icon}
+            size={16}
+            color={item.iconColor || "inherit"}
+          />
+        )}
+      </Box>
 
       <Stack gap={2} className={S.menuItemStack}>
         <Text size="md" lh="lg" c="inherit">
           {item.label}
+          {item.parentName && (
+            <Text
+              component="span"
+              mt=".125rem"
+              size="sm"
+              c="text-light"
+              lh="md"
+            >
+              {` – ${item.parentName}`}
+            </Text>
+          )}
         </Text>
         {item.description && (
           <Text size="sm" c="text-light" lh="md">
@@ -67,7 +86,7 @@ export const MenuItemComponent = ({
       </Stack>
 
       {item.hasSubmenu && (
-        <Icon name="chevronright" size=".75rem" color="text-light" />
+        <Icon name="chevronright" size=".75rem" c="text-light" />
       )}
     </Group>
   </UnstyledButton>

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/Command/CommandSuggestion.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/Command/CommandSuggestion.tsx
@@ -375,7 +375,6 @@ export const CommandSuggestion = forwardRef<
           onItemSelect={entityHandlers.selectItem}
           onItemHover={entityHandlers.hoverHandler}
           onFooterClick={entityHandlers.openModal}
-          query={query}
           searchResults={searchResults}
           modal={entityModal}
           onModalSelect={entityHandlers.handleModalSelect}

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/Mention/MentionSuggestion.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/Mention/MentionSuggestion.tsx
@@ -102,7 +102,6 @@ const MentionSuggestionComponent = forwardRef<
         selectedIndex={selectedIndex}
         onItemSelect={handlers.selectItem}
         onFooterClick={handlers.openModal}
-        query={query}
         searchResults={searchResults}
         modal={modal}
         onModalSelect={handlers.handleModalSelect}

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/shared/EntitySearchSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/shared/EntitySearchSection.tsx
@@ -18,7 +18,6 @@ interface EntitySearchSectionProps {
   selectedIndex: number;
   onItemSelect: (index: number) => void;
   onFooterClick: () => void;
-  query: string;
   searchResults: SearchResult[];
   modal: "question-picker" | null;
   onModalSelect: (item: QuestionPickerValueItem) => void;
@@ -35,7 +34,6 @@ export function EntitySearchSection({
   selectedIndex,
   onItemSelect,
   onFooterClick,
-  query,
   searchResults,
   modal,
   onModalSelect,
@@ -47,7 +45,6 @@ export function EntitySearchSection({
   onTriggerCreateNew,
 }: EntitySearchSectionProps) {
   const hasNoItems = menuItems.length === 0 && searchResults.length === 0;
-  const shouldShowNoResults = query.length > 0 && hasNoItems;
 
   const browseAllItemIndex = getBrowseAllItemIndex(
     menuItems.length,
@@ -81,14 +78,13 @@ export function EntitySearchSection({
         />
       ))}
 
-      {shouldShowNoResults ? (
+      {hasNoItems ? (
         <Box p="sm" ta="center">
           <Text size="md" c="text-medium">{t`No results found`}</Text>
         </Box>
       ) : null}
 
-      {(shouldShowNoResults || !hasNoItems) &&
-        (canCreateNewQuestion || canBrowseAll) && <Divider my="sm" mx="sm" />}
+      {(canCreateNewQuestion || canBrowseAll) && <Divider my="sm" mx="sm" />}
 
       {canCreateNewQuestion && (
         <CreateNewQuestionFooter

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/shared/suggestionUtils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/shared/suggestionUtils.ts
@@ -4,6 +4,7 @@ import { getTranslatedEntityName } from "metabase/common/utils/model-names";
 import { getIcon } from "metabase/lib/icon";
 import { getName } from "metabase/lib/name";
 import { type UrlableModel, modelToUrl } from "metabase/lib/urls/modelToUrl";
+import { getSchemaDisplayName } from "metabase/metadata/utils/schema";
 import type { MenuItem } from "metabase-enterprise/documents/components/Editor/shared/MenuComponents";
 import type { MetabaseProtocolEntityModel } from "metabase-enterprise/metabot/utils/links";
 import type {
@@ -30,12 +31,18 @@ export function buildSearchMenuItems(
     });
     const urlableModel = entityToUrlableModel(result, result.model);
     const href = modelToUrl(urlableModel);
+    const parentName =
+      result.model === "table"
+        ? `${result.database_name} ${result.table_schema ? "(" + getSchemaDisplayName(result.table_schema) + ")" : ""}`
+        : result.collection.name;
+
     return {
       icon: iconData.name,
       label: result.name,
       id: result.id,
       model: result.model,
       href: href || undefined,
+      parentName,
       action: () => onSelect(result),
     };
   });

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/shared/useEntitySuggestions.ts
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/shared/useEntitySuggestions.ts
@@ -27,6 +27,7 @@ interface UseEntitySuggestionsOptions {
     model: string;
     label?: string;
     href: string | null;
+    collectionName?: string;
   }) => void;
   enabled?: boolean;
   searchModels?: SuggestionModel[];


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/[issue_number]

### Description

This PR shows the parent collection name or db + schema for entities in @mention menu.

<img width="960" height="638" alt="CleanShot 2025-11-25 at 19 50 13@2x" src="https://github.com/user-attachments/assets/1f84f933-8e1e-4208-91b7-cf3ff3ea938b" />

<img width="978" height="672" alt="CleanShot 2025-11-25 at 19 49 55@2x" src="https://github.com/user-attachments/assets/a07f7fab-3d0e-4221-83cb-864993ad4363" />

This is helpful in cases where there's two entities with the same name:

<img width="748" height="568" alt="CleanShot 2025-11-25 at 20 05 14@2x" src="https://github.com/user-attachments/assets/ad50ebfc-55ea-42a9-9247-24bc65749889" />

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
