### PR TITLE
Add :database_type to metabot tools that return column metadata

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
@@ -299,6 +299,9 @@
    [:name :string]
    [:type [:maybe ::field-type]]
    [:description {:optional true} [:maybe :string]]
+   [:database_type {:optional true
+                    :decode/tool-api-response #(some-> % name u/->snake_case_en)}
+    [:maybe :string]]
    [:semantic_type {:optional true
                     :decode/tool-api-response #(some-> % name u/->snake_case_en)}
     [:maybe :string]]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
@@ -73,6 +73,7 @@
          :display_name (lib/display-name query column)
          :type (convert-field-type column)}
         (m/assoc-some :description (:description column)
+                      :database_type (:database-type column)
                       :semantic_type semantic-type
                       :field_values (:field-values column)
                       :table_reference (:table-reference column)))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/table_utils_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/table_utils_test.clj
@@ -340,6 +340,7 @@
             (is (every? #(every? (fn [field] (contains? field :field_id)) (:fields %)) tables))
             (is (every? #(every? (fn [field] (contains? field :name)) (:fields %)) tables))
             (is (every? #(every? (fn [field] (contains? field :type)) (:fields %)) tables))
+            (is (every? #(every? (fn [field] (contains? field :database_type)) (:fields %)) tables))
             (is (every? #(contains? % :metrics) tables)))))
 
       (testing "includes table_reference for implicitly joined fields"

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
@@ -1203,36 +1203,15 @@
            {:name "TOTAL",      :type "number",   :database_type "double_precision"}
            {:name "DISCOUNT",   :type "number",   :database_type "double_precision"}
            {:name "CREATED_AT", :type "datetime", :database_type "timestamp_with_time_zone"}
-           {:name "QUANTITY",   :type "number",   :database_type "integer"}
-           {:name "ID",         :type "number",   :database_type "bigint",                   :table_reference "User"}
-           {:name "ADDRESS",    :type "string",   :database_type "character_varying",        :table_reference "User"}
-           {:name "EMAIL",      :type "string",   :database_type "character_varying",        :table_reference "User"}
-           {:name "PASSWORD",   :type "string",   :database_type "character_varying",        :table_reference "User"}
-           {:name "NAME",       :type "string",   :database_type "character_varying",        :table_reference "User"}
-           {:name "CITY",       :type "string",   :database_type "character_varying",        :table_reference "User"}
-           {:name "LONGITUDE",  :type "number",   :database_type "double_precision",         :table_reference "User"}
-           {:name "STATE",      :type "string",   :database_type "character_varying",        :table_reference "User"}
-           {:name "SOURCE",     :type "string",   :database_type "character_varying",        :table_reference "User"}
-           {:name "BIRTH_DATE", :type "date",     :database_type "date",                     :table_reference "User"}
-           {:name "ZIP",        :type "string",   :database_type "character_varying",        :table_reference "User"}
-           {:name "LATITUDE",   :type "number",   :database_type "double_precision",         :table_reference "User"}
-           {:name "CREATED_AT", :type "datetime", :database_type "timestamp_with_time_zone", :table_reference "User"}
-           {:name "ID",         :type "number",   :database_type "bigint",                   :table_reference "Product"}
-           {:name "EAN",        :type "string",   :database_type "character_varying",        :table_reference "Product"}
-           {:name "TITLE",      :type "string",   :database_type "character_varying",        :table_reference "Product"}
-           {:name "CATEGORY",   :type "string",   :database_type "character_varying",        :table_reference "Product"}
-           {:name "VENDOR",     :type "string",   :database_type "character_varying",        :table_reference "Product"}
-           {:name "PRICE",      :type "number",   :database_type "double_precision",         :table_reference "Product"}
-           {:name "RATING",     :type "number",   :database_type "double_precision",         :table_reference "Product"}
-           {:name "CREATED_AT", :type "datetime", :database_type "timestamp_with_time_zone", :table_reference "Product"}]
+           {:name "QUANTITY",   :type "number",   :database_type "integer"}]
           request (fn [arguments]
                     (mt/user-http-request :rasta :post 200 "ee/metabot-tools/get-table-details"
                                           {:request-options {:headers {"x-metabase-session" ai-token}}}
                                           {:arguments arguments
                                            :conversation_id conversation-id}))
           expected-fields (cond->> expected-fields-with-h2-db-types
-                            ;; For non-h2 app dbs, just verify we get some string?. We're sanity checking the result,
-                            ;; not exhaustively testing :database_type column metadata.
+                            ;; For non-h2 dbs, just verify we get some string?. We're sanity checking the result, not
+                            ;; exhaustively testing :database_type column metadata.
                             (not= "h2" (db-engine-name)) (mapv #(assoc % :database_type string?)))]
       (is (=? {:structured_output {:name "ORDERS"
                                    :display_name "Orders"
@@ -1241,7 +1220,7 @@
                                    :database_schema "PUBLIC"
                                    :id table-id
                                    :type "table"
-                                   :fields (map-indexed #(assoc %2 :field_id (format "t%d/%d" table-id %1))
+                                   :fields (map-indexed #(assoc %2 :field_id (format "t%d-%d" table-id %1))
                                                         expected-fields)}
                :conversation_id conversation-id}
               (request {:table_id table-id}))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
@@ -269,16 +269,19 @@
                       :name "CREATED_AT"
                       :display_name "Created At: Week"
                       :type "datetime"
+                      :database_type string?
                       :semantic_type "creation_timestamp"}
                      {:field_id (str "q" query-id "-1")
                       :name "CREATED_AT_2"
                       :display_name "Created At: Day"
                       :type "datetime"
+                      :database_type string?
                       :semantic_type "creation_timestamp"}
                      {:field_id (str "q" query-id "-2")
                       :name "avg"
                       :display_name "Metrica"
                       :type "number"
+                      :database_type missing-value
                       :semantic_type "score"}]}
                    :conversation_id conversation-id}
                   (-> response
@@ -658,8 +661,16 @@
                                    :query_id string?
                                    :query map?
                                    :result_columns
-                                   [{:field_id (str "q" generated-id "-0"), :name "CREATED_AT", :display_name "Created At: Week", :type "datetime"}
-                                    {:field_id (str "q" generated-id "-1"), :name "avg", :display_name "Average of Rating", :type "number"}]}
+                                   [{:field_id (str "q" generated-id "-0"),
+                                     :name "CREATED_AT",
+                                     :display_name "Created At: Week",
+                                     :type "datetime"
+                                     :database_type string?}
+                                    {:field_id (str "q" generated-id "-1"),
+                                     :name "avg",
+                                     :display_name "Average of Rating",
+                                     :type "number"
+                                     :database_type missing-value}]}
                :conversation_id conversation-id}
               response))
       ;; Verify the query is normalized (supports both MBQL v4 and v5)
@@ -687,10 +698,22 @@
                                                 {:request-options {:headers {"x-metabase-session" ai-token}}}
                                                 {:arguments arguments
                                                  :conversation_id conversation-id}))
-                expected-fields [{:name "VENDOR" :display_name "Vendor", :type "string", :semantic_type "company"
+                expected-fields [{:name "VENDOR"
+                                  :display_name "Vendor"
+                                  :type "string"
+                                  :semantic_type "company"
+                                  :database_type string?
                                   :field_values string-sequence?}
-                                 {:name "CREATED_AT" :display_name "Created At: Week", :type "datetime", :semantic_type "creation_timestamp"}
-                                 {:name "avg" :display_name "Average of Rating", :type "number", :semantic_type "score"}]]
+                                 {:name "CREATED_AT"
+                                  :display_name "Created At: Week"
+                                  :type "datetime"
+                                  :semantic_type "creation_timestamp"
+                                  :database_type string?}
+                                 {:name "avg"
+                                  :display_name "Average of Rating"
+                                  :type "number"
+                                  :semantic_type "score"
+                                  :database_type missing-value}]]
             (testing "Normal call"
               (is (=? {:structured_output (-> question-data
                                               (select-keys [:name :description :database_id])
@@ -1164,6 +1187,64 @@
                     (request (assoc arguments
                                     :with_fields false
                                     :with_metrics false))))))))))
+
+(deftest get-table-details-database-type-test
+  ;; get-table-details-test validates other metadata, this test focuses on :database_type.
+  (mt/with-premium-features #{:metabot-v3}
+    (let [table-id (mt/id :orders)
+          conversation-id (str (random-uuid))
+          ai-token (ai-session-token)
+          expected-fields-with-h2-db-types
+          [{:name "ID",         :type "number",   :database_type "bigint"}
+           {:name "USER_ID",    :type "number",   :database_type "integer"}
+           {:name "PRODUCT_ID", :type "number",   :database_type "integer"}
+           {:name "SUBTOTAL",   :type "number",   :database_type "double_precision"}
+           {:name "TAX",        :type "number",   :database_type "double_precision"}
+           {:name "TOTAL",      :type "number",   :database_type "double_precision"}
+           {:name "DISCOUNT",   :type "number",   :database_type "double_precision"}
+           {:name "CREATED_AT", :type "datetime", :database_type "timestamp_with_time_zone"}
+           {:name "QUANTITY",   :type "number",   :database_type "integer"}
+           {:name "ID",         :type "number",   :database_type "bigint",                   :table_reference "User"}
+           {:name "ADDRESS",    :type "string",   :database_type "character_varying",        :table_reference "User"}
+           {:name "EMAIL",      :type "string",   :database_type "character_varying",        :table_reference "User"}
+           {:name "PASSWORD",   :type "string",   :database_type "character_varying",        :table_reference "User"}
+           {:name "NAME",       :type "string",   :database_type "character_varying",        :table_reference "User"}
+           {:name "CITY",       :type "string",   :database_type "character_varying",        :table_reference "User"}
+           {:name "LONGITUDE",  :type "number",   :database_type "double_precision",         :table_reference "User"}
+           {:name "STATE",      :type "string",   :database_type "character_varying",        :table_reference "User"}
+           {:name "SOURCE",     :type "string",   :database_type "character_varying",        :table_reference "User"}
+           {:name "BIRTH_DATE", :type "date",     :database_type "date",                     :table_reference "User"}
+           {:name "ZIP",        :type "string",   :database_type "character_varying",        :table_reference "User"}
+           {:name "LATITUDE",   :type "number",   :database_type "double_precision",         :table_reference "User"}
+           {:name "CREATED_AT", :type "datetime", :database_type "timestamp_with_time_zone", :table_reference "User"}
+           {:name "ID",         :type "number",   :database_type "bigint",                   :table_reference "Product"}
+           {:name "EAN",        :type "string",   :database_type "character_varying",        :table_reference "Product"}
+           {:name "TITLE",      :type "string",   :database_type "character_varying",        :table_reference "Product"}
+           {:name "CATEGORY",   :type "string",   :database_type "character_varying",        :table_reference "Product"}
+           {:name "VENDOR",     :type "string",   :database_type "character_varying",        :table_reference "Product"}
+           {:name "PRICE",      :type "number",   :database_type "double_precision",         :table_reference "Product"}
+           {:name "RATING",     :type "number",   :database_type "double_precision",         :table_reference "Product"}
+           {:name "CREATED_AT", :type "datetime", :database_type "timestamp_with_time_zone", :table_reference "Product"}]
+          request (fn [arguments]
+                    (mt/user-http-request :rasta :post 200 "ee/metabot-tools/get-table-details"
+                                          {:request-options {:headers {"x-metabase-session" ai-token}}}
+                                          {:arguments arguments
+                                           :conversation_id conversation-id}))
+          expected-fields (cond->> expected-fields-with-h2-db-types
+                            ;; For non-h2 app dbs, just verify we get some string?. We're sanity checking the result,
+                            ;; not exhaustively testing :database_type column metadata.
+                            (not= "h2" (db-engine-name)) (mapv #(assoc % :database_type string?)))]
+      (is (=? {:structured_output {:name "ORDERS"
+                                   :display_name "Orders"
+                                   :database_id (mt/id)
+                                   :database_engine (db-engine-name)
+                                   :database_schema "PUBLIC"
+                                   :id table-id
+                                   :type "table"
+                                   :fields (map-indexed #(assoc %2 :field_id (format "t%d/%d" table-id %1))
+                                                        expected-fields)}
+               :conversation_id conversation-id}
+              (request {:table_id table-id}))))))
 
 (deftest get-table-details-related-tables-test
   (mt/with-premium-features #{:metabot-v3}


### PR DESCRIPTION
BOT-568

AI-service PR: https://github.com/metabase/ai-service/pull/515

### Description

Add :database_type to metabot tools that return column metadata in order to give metabot information about the real
database type when generating SQL.

Examples of places the :database_type now appears:

- `:used_tables` in `:user_is_viewing context`
- `{table,card,metric}-details`
- `get-query-details`
- `enhanced-database-tables`

### How to verify

1. New -> SQL query -> Sample Dataset
2. write a simple query `SELECT * FROM PEOPLE`
3. ask metabot to join with orders table

You should see `:database_type`s sent in the `:used_tables` in the `:user_is_viewing` context:

```
 :fields
 [{:field_id "t78/0", :name "id", :display_name "ID", :type :string, :database_type "varchar", :semantic_type "pk"}
  ...
```

as well as in tool call results like `list_available_fields`.

```
The following fields are available in this table:


<field id="t42/0", name=""account_id"", type="string" database_type="varchar">
</field>
<field id="t42/1", name=""account_name"", type="string" database_type="varchar">
</field>
```

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
