### PR TITLE
chore(sdk): move setting cypress baseUrl to global beforeEach for sdk tests

### DIFF
--- a/e2e/support/component-cypress.js
+++ b/e2e/support/component-cypress.js
@@ -1,6 +1,12 @@
 import "./cypress";
 import { deleteConflictingCljsGlobals } from "metabase/embedding-sdk/test/delete-conflicting-cljs-globals";
 
+import { METABASE_INSTANCE_URL } from "./helpers";
+
 beforeEach(() => {
   deleteConflictingCljsGlobals();
+
+  // Cypress doesn't allow setting the baseUrl in the component config
+  // but all of our helpers expect it to be set.
+  Cypress.config("baseUrl", METABASE_INSTANCE_URL);
 });

--- a/e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers.ts
+++ b/e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers.ts
@@ -5,7 +5,6 @@ import { USERS } from "e2e/support/cypress_data";
 import {
   AUTH_PROVIDER_URL,
   JWT_SHARED_SECRET,
-  METABASE_INSTANCE_URL,
   activateToken,
   restore,
   updateSetting,
@@ -73,8 +72,6 @@ export const mockAuthProviderAndJwtSignIn = (
 };
 
 export function signInAsAdminAndEnableEmbeddingSdk() {
-  Cypress.config("baseUrl", METABASE_INSTANCE_URL);
-
   restore();
 
   cy.signInAsAdmin();
@@ -90,8 +87,6 @@ export function signInAsAdminAndSetupGuestEmbedding({
 }: {
   token: "starter" | "pro-cloud" | "bleeding-edge";
 }) {
-  Cypress.config("baseUrl", METABASE_INSTANCE_URL);
-
   restore();
 
   cy.signInAsAdmin();


### PR DESCRIPTION
Cypress doesn't seem to let us put `baseUrl` in the global config for component tests, but at the same time, all of our helpers use relative paths so we need it.
What we've been doing so far was setting it in a helper that was used in all of our e2e tests.
Some weeks ago I needed to write a test without that helper and every request failed, and I thought it's just best if we set it in the setup file and forget about it (the same way we don't have to think about it for normal core app e2e tests)


Note: I opened this PR just before going OOO for two weeks, when it gets the approve of both embedding and devex, feel free to merge it if CI is green🙏 