### PR TITLE
Add dashboard subscriptions option to EAJS dashboards

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
@@ -126,7 +126,7 @@ describe(suiteTitle, () => {
     H.expectUnstructuredSnowplowEvent({
       event: "embed_wizard_options_completed",
       event_detail:
-        "settings=custom,experience=dashboard,auth=user-session,drills=false,withDownloads=false,withTitle=true,isSaveEnabled=false,theme=default",
+        "settings=custom,experience=dashboard,auth=user-session,drills=false,withDownloads=false,withSubscriptions=false,withTitle=true,isSaveEnabled=false,theme=default",
     });
 
     codeBlock().should("contain", 'drills="false"');
@@ -137,6 +137,7 @@ describe(suiteTitle, () => {
       experience: "dashboard",
       resourceName: DASHBOARD_NAME,
     });
+    cy.findByLabelText("Existing Metabase session").click();
 
     getEmbedSidebar()
       .findByLabelText("Allow downloads")
@@ -162,10 +163,49 @@ describe(suiteTitle, () => {
     H.expectUnstructuredSnowplowEvent({
       event: "embed_wizard_options_completed",
       event_detail:
-        'settings=custom,experience=dashboard,guestEmbedEnabled=false,auth=guest-embed,drills=false,withDownloads=true,withTitle=true,params={"disabled":0,"locked":0,"enabled":0},theme=default',
+        "settings=custom,experience=dashboard,auth=user-session,drills=true,withDownloads=true,withSubscriptions=false,withTitle=true,isSaveEnabled=false,theme=default",
     });
 
-    codeBlock().should("contain", 'with-downloads="true"');
+    codeBlock().should("contain", 'with-subscriptions="false"');
+  });
+
+  it("toggles subscriptions for dashboard when email is enabled", () => {
+    H.setupSMTP();
+
+    navigateToEmbedOptionsStep({
+      experience: "dashboard",
+      resourceName: DASHBOARD_NAME,
+    });
+    cy.findByLabelText("Existing Metabase session").click();
+
+    getEmbedSidebar()
+      .findByLabelText("Allow subscriptions")
+      .should("not.be.checked");
+
+    H.getSimpleEmbedIframeContent()
+      .findByRole("button", { name: "Subscriptions" })
+      .should("not.exist");
+
+    cy.log("turn on subscriptions");
+    getEmbedSidebar()
+      .findByLabelText("Allow subscriptions")
+      .click()
+      .should("be.checked");
+
+    H.getSimpleEmbedIframeContent()
+      .findByRole("button", { name: "Subscriptions" })
+      .should("be.visible");
+
+    cy.log("snippet should be updated");
+    getEmbedSidebar().findByText("Get code").click();
+
+    H.expectUnstructuredSnowplowEvent({
+      event: "embed_wizard_options_completed",
+      event_detail:
+        "settings=custom,experience=dashboard,auth=user-session,drills=true,withDownloads=false,withSubscriptions=true,withTitle=true,isSaveEnabled=false,theme=default",
+    });
+
+    codeBlock().should("contain", 'with-subscriptions="true"');
   });
 
   it("toggles dashboard title for dashboards", () => {
@@ -198,7 +238,7 @@ describe(suiteTitle, () => {
     H.expectUnstructuredSnowplowEvent({
       event: "embed_wizard_options_completed",
       event_detail:
-        'settings=custom,experience=dashboard,guestEmbedEnabled=false,auth=guest-embed,drills=false,withDownloads=false,withTitle=false,params={"disabled":0,"locked":0,"enabled":0},theme=default',
+        'settings=custom,experience=dashboard,guestEmbedEnabled=false,auth=guest-embed,drills=false,withDownloads=false,withSubscriptions=false,withTitle=false,params={"disabled":0,"locked":0,"enabled":0},theme=default',
     });
 
     codeBlock().should("contain", 'with-title="false"');
@@ -472,7 +512,7 @@ describe(suiteTitle, () => {
     H.expectUnstructuredSnowplowEvent({
       event: "embed_wizard_options_completed",
       event_detail:
-        'settings=custom,experience=dashboard,guestEmbedEnabled=false,auth=guest-embed,drills=false,withDownloads=false,withTitle=true,params={"disabled":0,"locked":0,"enabled":0},theme=custom',
+        'settings=custom,experience=dashboard,guestEmbedEnabled=false,auth=guest-embed,drills=false,withDownloads=false,withSubscriptions=false,withTitle=true,params={"disabled":0,"locked":0,"enabled":0},theme=custom',
     });
 
     codeBlock().should("contain", '"theme": {');
@@ -541,7 +581,7 @@ describe(suiteTitle, () => {
     H.expectUnstructuredSnowplowEvent({
       event: "embed_wizard_options_completed",
       event_detail:
-        "settings=custom,experience=dashboard,auth=user-session,drills=true,withDownloads=false,withTitle=true,isSaveEnabled=false,theme=custom",
+        "settings=custom,experience=dashboard,auth=user-session,drills=true,withDownloads=false,withSubscriptions=false,withTitle=true,isSaveEnabled=false,theme=custom",
     });
 
     // derived-colors-for-embed-flow.unit.spec.ts contains the tests for other derived colors.

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
@@ -186,7 +186,7 @@ describe(suiteTitle, () => {
       .closest("[data-testid=tooltip-warning]")
       .icon("info")
       .realHover();
-    H.hovercard().should(
+    H.tooltip().should(
       "contain.text",
       "Not available if Guest Mode is selected",
     );
@@ -212,7 +212,7 @@ describe(suiteTitle, () => {
         .icon("info")
         .realHover();
     });
-    H.hovercard().should(
+    H.tooltip().should(
       "contain.text",
       "Please set up email to allow subscriptions",
     );

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
@@ -178,12 +178,18 @@ describe(suiteTitle, () => {
     getEmbedSidebar()
       .findByLabelText("Allow subscriptions")
       .should("not.be.checked")
-      .and("be.disabled")
-      .realHover();
+      .and("be.disabled");
 
-    H.tooltip()
-      .findByText("Please set up email to allow subscriptions")
-      .should("be.visible");
+    cy.log("Email warning should only be shown on non-guest embedding");
+    getEmbedSidebar()
+      .findByLabelText("Allow subscriptions")
+      .closest("[data-testid=tooltip-warning]")
+      .icon("info")
+      .realHover();
+    H.hovercard().should(
+      "contain.text",
+      "Not available if Guest Mode is selected",
+    );
 
     H.getSimpleEmbedIframeContent()
       .findByRole("button", { name: "Subscriptions" })
@@ -197,7 +203,19 @@ describe(suiteTitle, () => {
       event_detail: "settings=default",
     });
 
-    codeBlock().should("contain", 'with-subscriptions="false"');
+    cy.log("test non-guest embeds");
+    getEmbedSidebar().within(() => {
+      cy.button("Back").click();
+      cy.findByLabelText("Existing Metabase session").click();
+      cy.findByLabelText("Allow subscriptions")
+        .closest("[data-testid=tooltip-warning]")
+        .icon("info")
+        .realHover();
+    });
+    H.hovercard().should(
+      "contain.text",
+      "Please set up email to allow subscriptions",
+    );
   });
 
   it("toggles subscriptions for dashboard when email is set up", () => {

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/InteractiveDashboard/InteractiveDashboard.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/InteractiveDashboard/InteractiveDashboard.tsx
@@ -1,10 +1,9 @@
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useMemo } from "react";
 
 import { withPublicComponentWrapper } from "embedding-sdk-bundle/components/private/PublicComponentWrapper";
-import { useSdkDispatch, useSdkSelector } from "embedding-sdk-bundle/store";
+import { useSdkSelector } from "embedding-sdk-bundle/store";
 import { getPlugins } from "embedding-sdk-bundle/store/selectors";
 import type { MetabasePluginsConfig } from "embedding-sdk-bundle/types/plugins";
-import { setSharing as setDashboardSubscriptionSidebarOpen } from "metabase/dashboard/actions";
 import { PublicOrEmbeddedDashCardMenu } from "metabase/dashboard/components/DashCard/PublicOrEmbeddedDashCardMenu";
 import { DASHBOARD_ACTION } from "metabase/dashboard/components/DashboardHeader/DashboardHeaderButtonRow/dashboard-action-keys";
 import { isQuestionCard } from "metabase/dashboard/utils";
@@ -40,13 +39,6 @@ const InteractiveDashboardInner = (props: InteractiveDashboardProps) => {
       }),
     [plugins],
   );
-
-  const dispatch = useSdkDispatch();
-  useEffect(() => {
-    if (!props.withSubscriptions) {
-      dispatch(setDashboardSubscriptionSidebarOpen(false));
-    }
-  }, [dispatch, props.withSubscriptions]);
 
   return (
     <SdkDashboard

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/InteractiveDashboard/InteractiveDashboard.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/InteractiveDashboard/InteractiveDashboard.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 
 import { withPublicComponentWrapper } from "embedding-sdk-bundle/components/private/PublicComponentWrapper";
-import { useSdkSelector } from "embedding-sdk-bundle/store";
+import { useSdkDispatch, useSdkSelector } from "embedding-sdk-bundle/store";
 import { getPlugins } from "embedding-sdk-bundle/store/selectors";
 import type { MetabasePluginsConfig } from "embedding-sdk-bundle/types/plugins";
+import { setSharing as setDashboardSubscriptionSidebarOpen } from "metabase/dashboard/actions";
 import { PublicOrEmbeddedDashCardMenu } from "metabase/dashboard/components/DashCard/PublicOrEmbeddedDashCardMenu";
 import { DASHBOARD_ACTION } from "metabase/dashboard/components/DashboardHeader/DashboardHeaderButtonRow/dashboard-action-keys";
 import { isQuestionCard } from "metabase/dashboard/utils";
@@ -39,6 +40,13 @@ const InteractiveDashboardInner = (props: InteractiveDashboardProps) => {
       }),
     [plugins],
   );
+
+  const dispatch = useSdkDispatch();
+  useEffect(() => {
+    if (!props.withSubscriptions) {
+      dispatch(setDashboardSubscriptionSidebarOpen(false));
+    }
+  }, [dispatch, props.withSubscriptions]);
 
   return (
     <SdkDashboard

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
@@ -36,6 +36,7 @@ import type { MetabasePluginsConfig } from "embedding-sdk-bundle/types/plugins";
 import { useConfirmation } from "metabase/common/hooks";
 import { useLocale } from "metabase/common/hooks/use-locale";
 import {
+  closeSidebarIfSubscriptionsSidebarOpen,
   setEditingDashboard,
   toggleSidebar,
   updateDashboardAndCards,
@@ -271,6 +272,12 @@ const SdkDashboardInner = ({
       dispatch(resetErrorPage());
     }
   }, [dispatch, dashboardId]);
+
+  useEffect(() => {
+    if (!withSubscriptions) {
+      dispatch(closeSidebarIfSubscriptionsSidebarOpen());
+    }
+  }, [dispatch, withSubscriptions]);
 
   const { modalContent, show } = useConfirmation();
   const isDashboardDirty = useSelector(getIsDirty);

--- a/frontend/src/metabase/dashboard/actions/sharing.ts
+++ b/frontend/src/metabase/dashboard/actions/sharing.ts
@@ -17,6 +17,15 @@ export const setSharing = (isSharing: boolean) => (dispatch: Dispatch) => {
   }
 };
 
+export const closeSidebarIfSubscriptionsSidebarOpen =
+  () => (dispatch: Dispatch, getState: GetState) => {
+    const state = getState();
+    const isSharing = getIsSharing(state);
+    if (isSharing) {
+      dispatch(closeSidebar());
+    }
+  };
+
 export const toggleSharing = () => (dispatch: Dispatch, getState: GetState) => {
   const state = getState();
   const isSharing = getIsSharing(state);

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/analytics.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/analytics.ts
@@ -32,6 +32,7 @@ const EMBED_SETTINGS_TO_TRACK: SdkIframeEmbedSettingKey[] = [
   "drills",
   "withTitle",
   "withDownloads",
+  "withSubscriptions",
   "isSaveEnabled",
   "readOnly",
   "layout",

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SelectEmbedOptionsStep.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SelectEmbedOptionsStep.tsx
@@ -262,6 +262,21 @@ const BehaviorSection = () => {
                 />
               )}
             </WithNotAvailableWithoutSimpleEmbeddingFeatureWarning>
+
+            <WithNotAvailableForGuestEmbedsWarning
+              campaign={UPSELL_CAMPAIGN_BEHAVIOR}
+            >
+              {({ disabled }) => (
+                <Checkbox
+                  label={t`Allow subscriptions`}
+                  disabled={disabled}
+                  checked={settings.withSubscriptions}
+                  onChange={(e) =>
+                    updateSettings({ withSubscriptions: e.target.checked })
+                  }
+                />
+              )}
+            </WithNotAvailableForGuestEmbedsWarning>
           </Stack>
         ),
       )

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SelectEmbedOptionsStep.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SelectEmbedOptionsStep.tsx
@@ -20,6 +20,7 @@ import {
   Radio,
   Stack,
   Text,
+  Tooltip,
 } from "metabase/ui";
 
 import { useSdkIframeEmbedSetupContext } from "../context";
@@ -279,20 +280,15 @@ const BehaviorSection = () => {
                       }
                     />
                     {!hasEmailSetup && !disabledInGuestEmbedding && (
-                      <HoverCard position="bottom">
-                        <HoverCard.Target>
-                          <Icon
-                            name="info"
-                            size={14}
-                            c="var(--mb-color-text-secondary)"
-                          />
-                        </HoverCard.Target>
-                        <HoverCard.Dropdown>
-                          <Text lh="md" p="md">
-                            {t`Please set up email to allow subscriptions`}
-                          </Text>
-                        </HoverCard.Dropdown>
-                      </HoverCard>
+                      <Tooltip
+                        label={t`Please set up email to allow subscriptions`}
+                      >
+                        <Icon
+                          name="info"
+                          size={14}
+                          c="var(--mb-color-text-secondary)"
+                        />
+                      </Tooltip>
                     )}
                   </Flex>
                 );
@@ -424,11 +420,7 @@ const WithGuestEmbedsDisabledWarning = ({
 
   return (
     <TooltipWarning
-      warning={
-        <Text lh="md" p="md">
-          {t`Disabled in the admin settings`}
-        </Text>
-      }
+      tooltip={t`Disabled in the admin settings`}
       disabled={disabled}
     >
       {children}
@@ -477,11 +469,7 @@ const WithNotAvailableForGuestEmbedsWarning = ({
       {({ disabled: disabledForOss, hoverCard: disabledForOssHoverCard }) => (
         <TooltipWarning
           enableTooltip={!disabledForOss}
-          warning={
-            <Text lh="md" p="md">
-              {t`Not available if Guest Mode is selected`}
-            </Text>
-          }
+          tooltip={t`Not available if Guest Mode is selected`}
           disabled={!!settings.isGuest}
         >
           {({

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SelectEmbedOptionsStep.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SelectEmbedOptionsStep.tsx
@@ -20,8 +20,6 @@ import {
   Radio,
   Stack,
   Text,
-  Tooltip,
-  useHover,
 } from "metabase/ui";
 
 import { useSdkIframeEmbedSetupContext } from "../context";
@@ -169,7 +167,6 @@ const AuthenticationSection = () => {
 const BehaviorSection = () => {
   const { settings, updateSettings } = useSdkIframeEmbedSetupContext();
   const hasEmailSetup = useHasEmailSetup();
-  const hoverTarget = useHover();
 
   const behaviorSection = useMemo(() => {
     return match(settings)
@@ -270,27 +267,36 @@ const BehaviorSection = () => {
             <WithNotAvailableForGuestEmbedsWarning
               campaign={UPSELL_CAMPAIGN_BEHAVIOR}
             >
-              {({ disabled }) => (
-                <Flex ref={hoverTarget.ref} align="center" gap="xs">
-                  <Checkbox
-                    disabled={!hasEmailSetup || disabled}
-                    label={t`Allow subscriptions`}
-                    checked={settings.withSubscriptions}
-                    onChange={(e) =>
-                      updateSettings({ withSubscriptions: e.target.checked })
-                    }
-                  />
-                  {!hasEmailSetup && (
-                    <Tooltip
-                      // Allow the tooltip to open when hovering over the whole checkbox line, but positioning it on the info icon
-                      opened={hoverTarget.hovered}
-                      label={t`Please set up email to allow subscriptions`}
-                    >
-                      <Icon name="info" c="var(--mb-color-text-tertiary)" />
-                    </Tooltip>
-                  )}
-                </Flex>
-              )}
+              {({ disabled: disabledInGuestEmbedding }) => {
+                return (
+                  <Flex align="center" gap="xs">
+                    <Checkbox
+                      disabled={!hasEmailSetup || disabledInGuestEmbedding}
+                      label={t`Allow subscriptions`}
+                      checked={settings.withSubscriptions}
+                      onChange={(e) =>
+                        updateSettings({ withSubscriptions: e.target.checked })
+                      }
+                    />
+                    {!hasEmailSetup && !disabledInGuestEmbedding && (
+                      <HoverCard position="bottom">
+                        <HoverCard.Target>
+                          <Icon
+                            name="info"
+                            size={14}
+                            c="var(--mb-color-text-secondary)"
+                          />
+                        </HoverCard.Target>
+                        <HoverCard.Dropdown>
+                          <Text lh="md" p="md">
+                            {t`Please set up email to allow subscriptions`}
+                          </Text>
+                        </HoverCard.Dropdown>
+                      </HoverCard>
+                    )}
+                  </Flex>
+                );
+              }}
             </WithNotAvailableForGuestEmbedsWarning>
           </Stack>
         ),
@@ -307,13 +313,7 @@ const BehaviorSection = () => {
         ),
       )
       .otherwise(() => null);
-  }, [
-    hasEmailSetup,
-    hoverTarget.hovered,
-    hoverTarget.ref,
-    settings,
-    updateSettings,
-  ]);
+  }, [hasEmailSetup, settings, updateSettings]);
 
   if (behaviorSection === null) {
     return null;

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/test-setup.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/test-setup.tsx
@@ -3,6 +3,7 @@ import {
   findRequests,
   setupDashboardEndpoints,
   setupDashboardQueryMetadataEndpoint,
+  setupNotificationChannelsEndpoints,
   setupRecentViewsAndSelectionsEndpoints,
   setupSearchEndpoints,
   setupUpdateSettingEndpoint,
@@ -60,6 +61,7 @@ export const setup = (options?: {
   );
   setupUpdateSettingsEndpoint();
   setupUpdateSettingEndpoint();
+  setupNotificationChannelsEndpoints({});
 
   renderWithProviders(
     <SdkIframeEmbedSetupModal

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/warnings/TooltipWarning.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/warnings/TooltipWarning.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 
+import CS from "metabase/css/core/index.css";
 import { Flex, HoverCard, Icon } from "metabase/ui";
 
 export type TooltipWarningMode = "default" | "custom";
@@ -37,7 +38,11 @@ export const TooltipWarning = ({
   );
   const hoverCard = disabled ? (
     <HoverCard position="bottom">
-      <HoverCard.Target>{iconElement}</HoverCard.Target>
+      <HoverCard.Target>
+        <Flex align="center" className={CS.cursorPointer}>
+          {iconElement}
+        </Flex>
+      </HoverCard.Target>
       <HoverCard.Dropdown>{warning}</HoverCard.Dropdown>
     </HoverCard>
   ) : null;

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/warnings/TooltipWarning.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/warnings/TooltipWarning.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from "react";
 
-import CS from "metabase/css/core/index.css";
-import { Box, Flex, HoverCard, Icon } from "metabase/ui";
+import { Flex, HoverCard, Icon } from "metabase/ui";
 
 export type TooltipWarningMode = "default" | "custom";
 
@@ -27,24 +26,18 @@ export const TooltipWarning = ({
     return children({ disabled: false, hoverCard: null });
   }
 
-  const iconElement = (
-    <Box>
-      {icon ?? (
-        <Icon
-          name={"info"}
-          size={14}
-          c="text-medium"
-          cursor="pointer"
-          style={{ flexShrink: 0 }}
-        />
-      )}
-    </Box>
+  const iconElement = icon ?? (
+    <Icon
+      name={"info"}
+      size={14}
+      c="var(--mb-color-text-secondary)"
+      cursor="pointer"
+      style={{ flexShrink: 0 }}
+    />
   );
   const hoverCard = disabled ? (
     <HoverCard position="bottom">
-      <HoverCard.Target>
-        <Box className={CS.cursorPointer}>{iconElement}</Box>
-      </HoverCard.Target>
+      <HoverCard.Target>{iconElement}</HoverCard.Target>
       <HoverCard.Dropdown>{warning}</HoverCard.Dropdown>
     </HoverCard>
   ) : null;

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/warnings/WithSimpleEmbeddingFeatureUpsellTooltip.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/warnings/WithSimpleEmbeddingFeatureUpsellTooltip.tsx
@@ -35,7 +35,7 @@ export const WithSimpleEmbeddingFeatureUpsellTooltip = ({
       mode={mode}
       enableTooltip={enableTooltip}
       icon={<UpsellGem />}
-      warning={
+      hovercard={
         <UpsellCard
           title={t`Get more powerful embedding`}
           buttonLink={upgradeUrl}

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-default-sdk-iframe-embed-setting.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-default-sdk-iframe-embed-setting.ts
@@ -36,6 +36,7 @@ export const getDefaultSdkIframeEmbedSettings = ({
         dashboardId: resourceId,
         drills: true,
         withDownloads: false,
+        withSubscriptions: false,
         withTitle: true,
       }),
     )

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
@@ -188,6 +188,7 @@ const SdkIframeEmbedView = ({
             token={settings.token}
             withTitle={settings.withTitle}
             withDownloads={settings.withDownloads}
+            withSubscriptions={settings.withSubscriptions}
             initialParameters={settings.initialParameters}
             hiddenParameters={settings.hiddenParameters}
             drillThroughQuestionHeight="100%"

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/constants.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/constants.ts
@@ -31,6 +31,7 @@ export const ALLOWED_EMBED_SETTING_KEYS_MAP = {
     "dashboardId",
     "withTitle",
     "withDownloads",
+    "withSubscriptions",
     "initialParameters",
     "hiddenParameters",
     "drills",

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
@@ -489,6 +489,7 @@ const MetabaseDashboardElement = createCustomElement("metabase-dashboard", [
   "token",
   "with-title",
   "with-downloads",
+  "with-subscriptions",
   "drills",
   "initial-parameters",
   "hidden-parameters",

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
@@ -75,6 +75,7 @@ export type DashboardEmbedOptions = StrictUnion<
   drills?: boolean;
   withTitle?: boolean;
   withDownloads?: boolean;
+  withSubscriptions?: boolean;
 
   // parameters
   initialParameters?: ParameterValues;


### PR DESCRIPTION
closes EMB-995

### Description
Add subscriptions supports to EAJS

> [!note]
> There's a bug when creating a subscription within EAJS, after clicking "done", you would stay on the new subscription form instead of being brought to the subscription list page. That'll be addressed in https://linear.app/metabase/issue/EMB-1060/fix-issue-where-creating-the-first-subscription-wont-bring-you-to-the

### How to verify
1. Run Metabase EE edition with token `MB_ALL_FEATURES_TOKEN`
2. Go to the example dashboard
3. Sharing icon > Embed > Embedded Analytics JS
4. You should see `Allow subscriptions` option
    1.1 It's disabled on guest embeds
    1.2 It's disabled on non-guest embeds, but has no email setup

### Demo


<img width="387" height="337" alt="image" src="https://github.com/user-attachments/assets/8fd94cfe-dbde-4a6d-813b-34b4d38becbf" />

<img width="376" height="184" alt="image" src="https://github.com/user-attachments/assets/3201ef3c-5cf5-4595-9d05-c0557ba4b996" />

<img width="380" height="175" alt="image" src="https://github.com/user-attachments/assets/89e80367-e39e-4fc2-bdc9-998ee3b770ec" />

<img width="2471" height="1317" alt="image" src="https://github.com/user-attachments/assets/989a4dfb-164e-4666-87e7-eb662d4ed681" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
