### PR TITLE
Make file-path triggers more robust

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -45,10 +45,12 @@ frontend_sources: &frontend_sources
   - "enterprise/frontend/!(test)**/**/{!(*.spec),}.{js,jsx,ts,tsx,css}"
   - "frontend/!(test)**/**/{!(*.spec),}.{js,jsx,ts,tsx,css}"
 
+# Used only in .github/workflows/conventional-commit-pr-title-reminder.yml
 frontend_embedding_sources:
   - "enterprise/frontend/src/{embedding,embedding-*}/**/{!(*.spec),}.{js,jsx,ts,tsx,css}"
   - "enterprise/frontend/src/metabase-enterprise/{embedding,embedding-*}**/{!(*.spec),}.{js,jsx,ts,tsx,css}"
 
+# Used only in .github/workflows/embedding-sdk-labels-reminder.yml
 frontend_embedding_sdk_package_sources:
   - "enterprise/frontend/src/embedding-sdk-package/**/!(*.spec).{js,jsx,ts,tsx,css}"
 

--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -11,9 +11,13 @@ shared_specs: &shared_specs
   - "test/**/*.cljc"
   - "test/**/*.cljs"
 
-frontend_ci: &frontend_ci
+shared_ci: &shared_ci
   - ".github/actions/prepare-frontend/**"
   - ".github/actions/prepare-backend/**"
+  - ".github/workflows/run-tests.yml"
+
+frontend_ci: &frontend_ci
+  - *shared_ci
   - ".github/workflows/frontend.yml"
 
 frontend_configs: &frontend_configs
@@ -71,8 +75,7 @@ frontend_loki_ci: &frontend_loki_ci
   - ".storybook/**"
 
 backend_ci: &backend_ci
-  - ".github/actions/prepare-frontend/**"
-  - ".github/actions/prepare-backend/**"
+  - *shared_ci
   - ".github/actions/test-driver/**"
   - ".github/workflows/backend.yml"
   - ".github/workflows/drivers.yml"
@@ -112,8 +115,7 @@ sources: &sources
   - *backend_sources
 
 e2e_ci: &e2e_ci
-  - ".github/actions/prepare-frontend/**"
-  - ".github/actions/prepare-backend/**"
+  - *shared_ci
   - ".github/actions/prepare-uberjar-artifact/**"
   - ".github/actions/e2e-prepare-containers/**"
   - ".github/actions/prepare-cypress/**"
@@ -123,8 +125,7 @@ e2e_specs: &e2e_specs
   - e2e/!(test-host-app)**/*.cy.*.{js,ts}
 
 embedding_sdk_ci: &embedding_sdk_ci
-  - ".github/actions/prepare-frontend/**"
-  - ".github/actions/prepare-backend/**"
+  - *shared_ci
   - ".github/workflows/embedding-sdk*.yml"
 
 embedding_sdk_components:

--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -44,10 +44,6 @@ frontend_embedding_sources:
   - "enterprise/frontend/src/{embedding,embedding-*}/**/{!(*.spec),}.{js,jsx,ts,tsx,css}"
   - "enterprise/frontend/src/metabase-enterprise/{embedding,embedding-*}**/{!(*.spec),}.{js,jsx,ts,tsx,css}"
 
-frontend_embedding_sdk_sources:
-  - *frontend_configs
-  - "enterprise/frontend/!(test)**/**/{!(*.spec),}.{js,jsx,ts,tsx,css}"
-
 frontend_embedding_sdk_package_sources:
   - "enterprise/frontend/src/embedding-sdk-package/**/!(*.spec).{js,jsx,ts,tsx,css}"
 

--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -113,6 +113,7 @@ sources: &sources
 e2e_ci: &e2e_ci
   - *shared_ci
   - ".github/actions/prepare-uberjar-artifact/**"
+  - ".github/actions/fetch-artifact/action.yml"
   - ".github/actions/e2e-prepare-containers/**"
   - ".github/actions/prepare-cypress/**"
   - ".github/workflows/e2e-*"
@@ -122,6 +123,9 @@ e2e_specs: &e2e_specs
 
 embedding_sdk_ci: &embedding_sdk_ci
   - *shared_ci
+  - ".github/actions/prepare-uberjar-artifact/**"
+  - ".github/actions/fetch-artifact/action.yml"
+  - ".github/actions/prepare-cypress/**"
   - ".github/workflows/embedding-sdk*.yml"
 
 embedding_sdk_components:

--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -16,6 +16,11 @@ shared_ci: &shared_ci
   - ".github/actions/prepare-backend/**"
   - ".github/workflows/run-tests.yml"
 
+shared_e2e: &shared_e2e
+  - "e2e/runner/**"
+  - "e2e/snapshot-creators/**"
+  - "e2e/support/**"
+
 frontend_ci: &frontend_ci
   - *shared_ci
   - ".github/workflows/frontend.yml"
@@ -132,6 +137,7 @@ embedding_sdk_components:
   - *default
   - *embedding_sdk_ci
   - *sources
+  - *shared_e2e
   - "e2e/test-component/**/*.cy.*.{js,jsx,ts,tsx}"
 
 embedding_sdk_host_sample_apps:
@@ -139,8 +145,8 @@ embedding_sdk_host_sample_apps:
   - *embedding_sdk_ci
   - *frontend_sources
   - *backend_sources
+  - *shared_e2e
   - "e2e/embedding-sdk-host-apps/**"
-  - "e2e/runner/embedding-sdk/**"
   - "e2e/test-host-app/**/*.cy.*.{js,ts}"
 
 snowplow: &snowplow

--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -125,6 +125,7 @@ embedding_sdk_ci: &embedding_sdk_ci
   - ".github/workflows/embedding-sdk*.yml"
 
 embedding_sdk_components:
+  - *default
   - *embedding_sdk_ci
   - *sources
   - "e2e/test-component/**/*.cy.*.{js,jsx,ts,tsx}"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,7 +25,6 @@ jobs:
       frontend_all: ${{ steps.changes.outputs.frontend_all }}
       frontend_sources: ${{ steps.changes.outputs.frontend_sources }}
       documentation: ${{ steps.changes.outputs.documentation }}
-      frontend_embedding_sdk_sources: ${{ steps.changes.outputs.frontend_embedding_sdk_sources }}
       embedding_documentation: ${{ steps.changes.outputs.embedding_documentation }}
       embedding_sdk_components: ${{ steps.changes.outputs.embedding_sdk_components }}
       embedding_sdk_host_sample_apps: ${{ steps.changes.outputs.embedding_sdk_host_sample_apps }}
@@ -102,7 +101,7 @@ jobs:
     if: |
       !cancelled() &&
       (needs.files-changed.outputs.embedding_sdk_components == 'true' ||
-      needs.files-changed.outputs.frontend_embedding_sdk_sources == 'true' ||
+      needs.files-changed.outputs.frontend_sources == 'true' ||
       needs.files-changed.outputs.embedding_documentation == 'true' ||
       needs.files-changed.outputs.embedding_sdk_ci == 'true')
     uses: ./.github/workflows/embedding-sdk-package-build.yml
@@ -114,9 +113,9 @@ jobs:
     uses: ./.github/workflows/embedding-sdk.yml
     secrets: inherit
     with:
-      cli-snippets-type-check: ${{ needs.files-changed.outputs.frontend_embedding_sdk_sources == 'true' }}
+      cli-snippets-type-check: ${{ needs.files-changed.outputs.frontend_sources == 'true' }}
       docs-snippets-type-check: ${{ needs.files-changed.outputs.embedding_documentation == 'true' }}
-      documentation-validation: ${{ needs.files-changed.outputs.frontend_embedding_sdk_sources == 'true' }}
+      documentation-validation: ${{ needs.files-changed.outputs.frontend_sources == 'true' }}
       component-tests: ${{ needs.files-changed.outputs.embedding_sdk_components == 'true' }}
       host-sample-apps-tests: ${{ needs.files-changed.outputs.embedding_sdk_host_sample_apps == 'true' }}
       skip: ${{ needs.embedding-sdk-package.result != 'success' || needs.uberjar.result != 'success' }}


### PR DESCRIPTION
Resolves DEV-1124

This pull request refactors and streamlines the configuration for CI workflows and file path groupings in `.github/file-paths.yaml` and updates related workflow logic in `.github/workflows/run-tests.yml`. The changes focus on consolidating shared configuration, improving maintainability, and removing redundant or unused path groups.

**CI Configuration Consolidation and Refactoring:**

- Introduced new shared anchors (`shared_ci` and `shared_e2e`) in `.github/file-paths.yaml` to centralize and reuse common CI and E2E configuration across multiple CI job definitions, reducing duplication and making future updates easier.
- Updated `frontend_ci`, `backend_ci`, `e2e_ci`, and `embedding_sdk_ci` to use the new `shared_ci` anchor, ensuring consistent inclusion of shared CI-related files and workflows. [[1]](diffhunk://#diff-e1efa15d3b81fb0728ad28251d13e6e0791213aac383839fa74881fa18ed60aeL14-R25) [[2]](diffhunk://#diff-e1efa15d3b81fb0728ad28251d13e6e0791213aac383839fa74881fa18ed60aeL74-R79) [[3]](diffhunk://#diff-e1efa15d3b81fb0728ad28251d13e6e0791213aac383839fa74881fa18ed60aeL115-R121) [[4]](diffhunk://#diff-e1efa15d3b81fb0728ad28251d13e6e0791213aac383839fa74881fa18ed60aeL126-L141)
- Added `shared_e2e` to relevant E2E and embedding SDK path groups, ensuring all E2E-related files are consistently included where needed.

**Removal of Redundant or Unused Path Groups:**

- Removed the `frontend_embedding_sdk_sources` path group from `.github/file-paths.yaml` and all references to it in `.github/workflows/run-tests.yml`, simplifying the configuration and preventing unnecessary workflow triggers. [[1]](diffhunk://#diff-e1efa15d3b81fb0728ad28251d13e6e0791213aac383839fa74881fa18ed60aeL43-L46) [[2]](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642L28) [[3]](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642L105-R104) [[4]](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642L117-R118)

**Workflow Logic Updates:**

- Updated workflow conditions and inputs in `.github/workflows/run-tests.yml` to use `frontend_sources` instead of the removed `frontend_embedding_sdk_sources`, ensuring that the correct sets of files trigger the relevant jobs and checks. [[1]](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642L105-R104) [[2]](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642L117-R118)

These changes collectively make the CI configuration more maintainable and less error-prone by centralizing shared logic and removing unused definitions.