### PR TITLE
Closes EMB-1051 (flaky test) issue 38176 restoring a question to a previous version should preserve the variables (metabase#38176)

### DIFF
--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -233,12 +233,16 @@ describe("issue 38176", () => {
         .blur();
 
       cy.wait("@updateQuestion");
+      cy.wait("@cardQuery");
       cy.findByRole("tab", { name: "History" }).click();
       cy.findByText(/added a description/i);
       cy.findByTestId("question-revert-button").click();
+      cy.wait("@cardQuery");
 
       cy.findByRole("tab", { name: "History" }).click();
-      cy.findByText(/reverted to an earlier version/i).should("be.visible");
+      cy.findByText(/reverted to an earlier version/i, {
+        timeout: 10000,
+      }).should("be.visible");
     });
 
     cy.findByLabelText("Close").click();


### PR DESCRIPTION
Closes [EMB-1051: \[Flaky Test\] \[e2e-tests\] issue 38176 issue 38176 restoring a question to a previous version should preserve the variables (metabase#38176)](https://linear.app/metabase/issue/EMB-1051/flaky-test-e2e-tests-issue-38176-issue-38176-restoring-a-question-to-a)

Stress test: https://github.com/metabase/metabase/actions/runs/19700974111