### PR TITLE
yaml migrations helper

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Custom merge driver for YAML migration files
+# Treats each changeset as an atomic unit to avoid conflicts within changesets
+# Execute this in your shell to enable custom merge driver:
+# echo '\n[include]\npath=../.gitconfig' >> .git/config
+resources/migrations/*.yaml merge=yaml-migrations

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,5 @@
+# execute this in your shell to enable custom merge driver:
+# echo '\n[include]\npath=../.gitconfig' >> .git/config
+[merge "yaml-migrations"]
+    name = YAML migration changeset-aware merge
+    driver = ./bin/merge-yaml-migrations %O %A %B %L %P

--- a/bin/merge-yaml-migrations
+++ b/bin/merge-yaml-migrations
@@ -1,0 +1,207 @@
+#!/usr/bin/env bb
+
+;; Custom git merge driver for YAML migration files
+;; Treats each changeset as an atomic unit to avoid conflicts within changesets
+;; Preserves original formatting including blank lines and footer warnings
+;;
+;; Usage (called by git):
+;;   merge-yaml-migrations %O %A %B %L %P
+;;   %O = ancestor's version (base)
+;;   %A = current version (ours)
+;;   %B = other branch's version (theirs)
+;;   %L = conflict marker size
+;;   %P = file path
+;;
+;; Exit codes:
+;;   0 = clean merge
+;;   1 = conflicts detected (conflict markers added to file)
+;;   >1 = merge failed
+
+(require
+ '[clj-yaml.core :as yaml]
+ '[clojure.string :as str])
+
+;; Parse YAML file to Clojure data structure
+(defn parse-yaml [file-path]
+  (try
+    (yaml/parse-string (slurp file-path))
+    (catch Exception e
+      (binding [*out* *err*]
+        (println "Error parsing YAML file:" file-path)
+        (println (.getMessage e)))
+      (System/exit 2))))
+
+(def FOOTER-PREFIX
+  "# >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<")
+
+(defn extract-footer [content]
+  (let [idx (some-> content (str/index-of FOOTER-PREFIX))]
+    (if (and idx (pos? idx))
+      (subs content idx)
+      "")))
+
+;; Extract raw text for each changeset from the file
+(defn extract-changeset-texts [file-content parsed-yaml]
+  (let [lines (str/split-lines file-content)
+        changelog (get parsed-yaml :databaseChangeLog)
+        changesets (filterv #(contains? % :changeSet) changelog)]
+    ;; For each changeset, find its text in the original file
+    (into {}
+          (for [cs changesets]
+            (let [cs-id (get-in cs [:changeSet :id])
+                  ;; Find the line with "id: <cs-id>"
+                  id-line-idx (first (keep-indexed
+                                      (fn [idx line]
+                                        (when (str/includes? line (str "id: " cs-id))
+                                          idx))
+                                      lines))
+                  ;; Find the changeset start (line before with "  - changeSet:")
+                  cs-start-idx (when id-line-idx
+                                 (loop [idx (dec id-line-idx)]
+                                   (cond
+                                     (< idx 0) 0
+                                     (str/starts-with? (get lines idx) "  - changeSet:") idx
+                                     :else (recur (dec idx)))))
+                  ;; Find the changeset end (next line with "  - changeSet:" or "  - " at root level or "#" or end)
+                  cs-end-idx (when cs-start-idx
+                               (loop [idx (inc cs-start-idx)]
+                                 (cond
+                                   (>= idx (count lines)) (dec (count lines))
+                                   (let [line (get lines idx)]
+                                     (or (str/starts-with? line "  - changeSet:")
+                                         (and (str/starts-with? line "  - ")
+                                              (not (re-find #"^  - (changeSet|sql|addColumn|createTable|dropTable|addForeignKeyConstraint|dropForeignKeyConstraint|createIndex|dropIndex|addUniqueConstraint|dropUniqueConstraint|addPrimaryKey|dropPrimaryKey):" line)))
+                                         (str/starts-with? line "# ")))
+                                   (dec idx)
+                                   :else (recur (inc idx)))))]
+              (when (and cs-start-idx cs-end-idx)
+                [cs-id (str/join "\n" (subvec (vec lines) cs-start-idx (inc cs-end-idx)))])))
+          )))
+
+(defn extract-changesets [parsed-yaml]
+  (->> (:databaseChangeLog parsed-yaml)
+       (filterv :changeSet)))
+
+(defn cs-id [cs]
+  (-> cs :changeSet :id))
+
+(defn index-by [func xs]
+  (into {} (map (juxt func identity) xs)))
+
+(defn merge-changesets [base-data ours-data theirs-data]
+  (let [base-cs   (index-by cs-id (extract-changesets base-data))
+        ours-cs   (index-by cs-id (extract-changesets ours-data))
+        theirs-cs (index-by cs-id (extract-changesets theirs-data))
+        all-ids   (into #{}
+                        (comp (map keys) cat)
+                        [base-cs ours-cs theirs-cs])]
+    (reduce
+     (fn [acc id]
+       (let [base   (get base-cs id)
+             ours   (get ours-cs id)
+             theirs (get theirs-cs id)]
+         (cond
+           (and ours (not theirs) (not base)) ; Added by us
+           (conj acc {:id id :source :ours})
+           (and theirs (not ours) (not base)) ; Added by them
+           (conj acc {:id id :source :theirs})
+           (and base ours (not theirs))       ; they have deleted it
+           acc
+           (and base theirs (not ours))       ; we have deleted it
+           acc
+           (and base (not ours) (not theirs)) ; only in base, so both deleted
+           acc
+           (and base ours theirs)             ; check for modifications
+           (cond
+             (= ours theirs)                        ; identical
+             (conj acc {:id id :source :ours})
+             (and (= theirs base) (not= ours base)) ; our mod
+             (conj acc {:id id :source :ours})
+             (and (= ours base) (not= theirs base)) ; their mod
+             (conj acc {:id id :source :theirs})
+             :else                                  ; CONFLICT
+             (conj acc {:id     id
+                        :source :conflict
+                        :ours   ours
+                        :theirs theirs}))
+           :else ; was I diligent enough?
+           (do
+             (binding [*out* *err*]
+               (println "Unexpected case for changeset:" id))
+             acc))))
+     []
+     all-ids)))
+
+(defn format-conflict-changeset [id ours theirs]
+  (format
+   (str "<<<<<<< MERGE CONFLICT for changeset: %s, our version:\n"
+        "%s\n"
+        "======= Their version:\n"
+        "%s\n"
+        ">>>>>>>\n")
+   id ours theirs))
+
+(defn merge-files [base ours theirs {:keys [_marker-size]}]
+  (let [ours-text       (slurp ours)
+        theirs-text     (slurp theirs)
+        ;; Parse yaml
+        base-data       (parse-yaml base)
+        ours-data       (parse-yaml ours)
+        theirs-data     (parse-yaml theirs)
+        ;; Extract raw text for each changeset
+        ours-cs-texts   (extract-changeset-texts ours-text ours-data)
+        theirs-cs-texts (extract-changeset-texts theirs-text theirs-data)
+        ;; Extract footer from ours file
+        footer          (extract-footer ours-text)
+        ;; Perform merge
+        merged          (merge-changesets base-data ours-data theirs-data)
+        ;; Sort merged changesets by ID (chronological order)
+        sorted-merged   (sort-by :id merged)
+        ;; Build result by concatenating raw text blocks
+        header          "databaseChangeLog:\n  - objectQuotingStrategy: QUOTE_ALL_OBJECTS\n"
+        changeset-texts
+        (for [cs sorted-merged]
+          (let [text (case (:source cs)
+                       :ours     (get ours-cs-texts (:id cs))
+                       :theirs   (get theirs-cs-texts (:id cs))
+                       :conflict (format-conflict-changeset ;; TODO: use marker-size here
+                                  (:id cs)
+                                  (get ours-cs-texts (:id cs))
+                                  (get theirs-cs-texts (:id cs))))]
+            ;; Remove trailing blank lines from each changeset
+            (str/replace text #"\n+$" "")))]
+    {:result    (str header
+                     "\n"
+                     (str/join "\n\n" (filter some? changeset-texts))
+                     "\n"
+                     (when (seq footer) (str "\n" footer))
+                     (when-not (str/ends-with? footer "\n") "\n"))
+     :conflicts (vec (keep #(when (= (:source %) :conflict) (:id %)) sorted-merged))
+     :cnt       (count sorted-merged)}))
+
+(defn -main [args]
+  (when (< (count args) 3)
+    (binding [*out* *err*]
+      (println "Usage: merge-yaml-migrations <base> <ours> <theirs> [conflict-marker-size] [file-path]")
+      (println "Will modify <ours>!"))
+    (System/exit 2))
+
+  (let [[base ours theirs marker-size target] args
+        {:keys [result
+                conflicts
+                cnt]}                         (merge-files base ours theirs {:marker-size marker-size})]
+
+    (spit (or target *out*) result)
+
+    ;; Exit with appropriate code
+    (when (seq conflicts)
+      (binding [*out* *err*]
+        (println "Merge conflicts detected in changesets:" (str/join ", " conflicts))
+        (println "Conflict markers added to file. Please resolve manually."))
+      (System/exit 1))
+
+    (println "Clean merge of" cnt "changesets")
+    (System/exit 0)))
+
+(when (= *file* (System/getProperty "babashka.file"))
+  (-main *command-line-args*))

--- a/bin/merge-yaml-migrations-test/README.md
+++ b/bin/merge-yaml-migrations-test/README.md
@@ -1,0 +1,45 @@
+# Tests for merge-yaml-migrations
+
+This directory contains tests for the custom git merge driver `merge-yaml-migrations`.
+
+## Running Tests
+
+From the repository root:
+
+```bash
+./bin/merge-yaml-migrations-test/test_merge.clj
+```
+
+Or using babashka:
+
+```bash
+bb bin/merge-yaml-migrations-test/test_merge.clj
+```
+
+## Test Coverage
+
+The tests cover:
+
+1. **Clean merge scenarios:**
+   - Both branches add different changesets
+   - Only one branch adds changesets
+
+2. **Conflict scenarios:**
+   - Both branches modify the same changeset differently
+
+3. **Deletion scenarios:**
+   - One branch deletes a changeset while the other keeps it
+
+4. **Formatting preservation:**
+   - Single blank lines between changesets (not double)
+   - Footer warning preserved from the "ours" file
+   - 2-space indentation maintained
+   - objectQuotingStrategy header preserved
+
+## Test Structure
+
+Tests use temporary files and the `clojure.test` framework. Each test:
+1. Creates temporary YAML files for base, ours, and theirs versions
+2. Runs the merge driver
+3. Verifies the exit code and merged result
+4. Cleans up temp files automatically

--- a/bin/merge-yaml-migrations-test/fixtures/base-conflict.yaml
+++ b/bin/merge-yaml-migrations-test/fixtures/base-conflict.yaml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+  - objectQuotingStrategy: QUOTE_ALL_OBJECTS
+
+  - changeSet:
+      id: v58.2025-10-30T09:03:00
+      author: alice
+      comment: Original
+      changes:
+        - addColumn:
+            tableName: test_table
+            columns:
+              - column:
+                  name: col1
+                  type: varchar(50)

--- a/bin/merge-yaml-migrations-test/fixtures/base-simple.yaml
+++ b/bin/merge-yaml-migrations-test/fixtures/base-simple.yaml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+  - objectQuotingStrategy: QUOTE_ALL_OBJECTS
+
+  - changeSet:
+      id: v58.2025-10-30T09:03:00
+      author: alice
+      comment: Original changeset
+      changes:
+        - addColumn:
+            tableName: test_table
+            columns:
+              - column:
+                  name: test_column
+                  type: varchar(50)

--- a/bin/merge-yaml-migrations-test/fixtures/base-sort.yaml
+++ b/bin/merge-yaml-migrations-test/fixtures/base-sort.yaml
@@ -1,0 +1,8 @@
+databaseChangeLog:
+  - objectQuotingStrategy: QUOTE_ALL_OBJECTS
+
+  - changeSet:
+      id: v58.2025-10-30T09:00:00
+      author: alice
+      comment: First
+      changes: []

--- a/bin/merge-yaml-migrations-test/fixtures/base-two-changesets.yaml
+++ b/bin/merge-yaml-migrations-test/fixtures/base-two-changesets.yaml
@@ -1,0 +1,18 @@
+databaseChangeLog:
+  - objectQuotingStrategy: QUOTE_ALL_OBJECTS
+
+  - changeSet:
+      id: v58.2025-10-30T09:03:00
+      author: alice
+      comment: First
+      changes:
+        - addColumn:
+            tableName: table1
+
+  - changeSet:
+      id: v58.2025-10-31T09:03:00
+      author: bob
+      comment: Second
+      changes:
+        - addColumn:
+            tableName: table2

--- a/bin/merge-yaml-migrations-test/fixtures/base-with-footer.yaml
+++ b/bin/merge-yaml-migrations-test/fixtures/base-with-footer.yaml
@@ -1,0 +1,15 @@
+databaseChangeLog:
+  - objectQuotingStrategy: QUOTE_ALL_OBJECTS
+
+  - changeSet:
+      id: v58.2025-10-30T09:03:00
+      author: alice
+      comment: Test
+      changes:
+        - addColumn:
+            tableName: test
+
+# >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
+
+# ADVICE:
+# Keep this at the bottom

--- a/bin/merge-yaml-migrations-test/fixtures/ours-adds-later.yaml
+++ b/bin/merge-yaml-migrations-test/fixtures/ours-adds-later.yaml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+  - objectQuotingStrategy: QUOTE_ALL_OBJECTS
+
+  - changeSet:
+      id: v58.2025-10-30T09:00:00
+      author: alice
+      comment: First
+      changes: []
+
+  - changeSet:
+      id: v58.2025-11-01T12:00:00
+      author: bob
+      comment: Added later by us
+      changes: []

--- a/bin/merge-yaml-migrations-test/fixtures/ours-adds-one.yaml
+++ b/bin/merge-yaml-migrations-test/fixtures/ours-adds-one.yaml
@@ -1,0 +1,22 @@
+databaseChangeLog:
+  - objectQuotingStrategy: QUOTE_ALL_OBJECTS
+
+  - changeSet:
+      id: v58.2025-10-30T09:03:00
+      author: alice
+      comment: Original changeset
+      changes:
+        - addColumn:
+            tableName: test_table
+            columns:
+              - column:
+                  name: test_column
+                  type: varchar(50)
+
+  - changeSet:
+      id: v58.2025-11-01T10:00:00
+      author: bob
+      comment: Added by us
+      changes:
+        - createTable:
+            tableName: our_table

--- a/bin/merge-yaml-migrations-test/fixtures/ours-adds-with-footer.yaml
+++ b/bin/merge-yaml-migrations-test/fixtures/ours-adds-with-footer.yaml
@@ -1,0 +1,21 @@
+databaseChangeLog:
+  - objectQuotingStrategy: QUOTE_ALL_OBJECTS
+
+  - changeSet:
+      id: v58.2025-10-30T09:03:00
+      author: alice
+      comment: Test
+      changes:
+        - addColumn:
+            tableName: test
+
+  - changeSet:
+      id: v58.2025-11-01T10:00:00
+      author: bob
+      comment: Our change
+      changes: []
+
+# >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
+
+# ADVICE:
+# Keep this at the bottom

--- a/bin/merge-yaml-migrations-test/fixtures/ours-deletes-second.yaml
+++ b/bin/merge-yaml-migrations-test/fixtures/ours-deletes-second.yaml
@@ -1,0 +1,10 @@
+databaseChangeLog:
+  - objectQuotingStrategy: QUOTE_ALL_OBJECTS
+
+  - changeSet:
+      id: v58.2025-10-30T09:03:00
+      author: alice
+      comment: First
+      changes:
+        - addColumn:
+            tableName: table1

--- a/bin/merge-yaml-migrations-test/fixtures/ours-modifies.yaml
+++ b/bin/merge-yaml-migrations-test/fixtures/ours-modifies.yaml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+  - objectQuotingStrategy: QUOTE_ALL_OBJECTS
+
+  - changeSet:
+      id: v58.2025-10-30T09:03:00
+      author: alice
+      comment: Modified by us
+      changes:
+        - addColumn:
+            tableName: test_table
+            columns:
+              - column:
+                  name: col1
+                  type: varchar(100)

--- a/bin/merge-yaml-migrations-test/fixtures/theirs-adds-between.yaml
+++ b/bin/merge-yaml-migrations-test/fixtures/theirs-adds-between.yaml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+  - objectQuotingStrategy: QUOTE_ALL_OBJECTS
+
+  - changeSet:
+      id: v58.2025-10-30T09:00:00
+      author: alice
+      comment: First
+      changes: []
+
+  - changeSet:
+      id: v58.2025-10-31T10:00:00
+      author: charlie
+      comment: Added between by them
+      changes: []

--- a/bin/merge-yaml-migrations-test/fixtures/theirs-adds-one.yaml
+++ b/bin/merge-yaml-migrations-test/fixtures/theirs-adds-one.yaml
@@ -1,0 +1,22 @@
+databaseChangeLog:
+  - objectQuotingStrategy: QUOTE_ALL_OBJECTS
+
+  - changeSet:
+      id: v58.2025-10-30T09:03:00
+      author: alice
+      comment: Original changeset
+      changes:
+        - addColumn:
+            tableName: test_table
+            columns:
+              - column:
+                  name: test_column
+                  type: varchar(50)
+
+  - changeSet:
+      id: v58.2025-11-02T11:00:00
+      author: charlie
+      comment: Added by them
+      changes:
+        - createTable:
+            tableName: their_table

--- a/bin/merge-yaml-migrations-test/fixtures/theirs-modifies.yaml
+++ b/bin/merge-yaml-migrations-test/fixtures/theirs-modifies.yaml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+  - objectQuotingStrategy: QUOTE_ALL_OBJECTS
+
+  - changeSet:
+      id: v58.2025-10-30T09:03:00
+      author: alice
+      comment: Modified by them
+      changes:
+        - addColumn:
+            tableName: test_table
+            columns:
+              - column:
+                  name: col1
+                  type: varchar(200)

--- a/bin/merge-yaml-migrations-test/test_merge.bats
+++ b/bin/merge-yaml-migrations-test/test_merge.bats
@@ -1,0 +1,130 @@
+#!/usr/bin/env bats
+
+# Test suite for merge-yaml-migrations script
+
+setup() {
+  SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  MERGE_SCRIPT="$SCRIPT_DIR/../merge-yaml-migrations"
+  FIXTURES_DIR="$SCRIPT_DIR/fixtures"
+  TEMP_DIR="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$TEMP_DIR"
+}
+
+@test "clean merge: both branches add different changesets" {
+  run "$MERGE_SCRIPT" \
+    "$FIXTURES_DIR/base-simple.yaml" \
+    "$FIXTURES_DIR/ours-adds-one.yaml" \
+    "$FIXTURES_DIR/theirs-adds-one.yaml" \
+    7 \
+    "$TEMP_DIR/result.yaml"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Clean merge"* ]]
+
+  # Should have 3 changesets total
+  changeset_count=$(grep -c "^  - changeSet:" "$TEMP_DIR/result.yaml")
+  [ "$changeset_count" -eq 3 ]
+}
+
+@test "clean merge: only our branch adds a changeset" {
+  run "$MERGE_SCRIPT" \
+    "$FIXTURES_DIR/base-simple.yaml" \
+    "$FIXTURES_DIR/ours-adds-one.yaml" \
+    "$FIXTURES_DIR/base-simple.yaml" \
+    7 \
+    "$TEMP_DIR/result.yaml"
+
+  [ "$status" -eq 0 ]
+
+  # Should have 2 changesets
+  changeset_count=$(grep -c "^  - changeSet:" "$TEMP_DIR/result.yaml")
+  [ "$changeset_count" -eq 2 ]
+}
+
+@test "conflict: both branches modify the same changeset differently" {
+  run "$MERGE_SCRIPT" \
+    "$FIXTURES_DIR/base-conflict.yaml" \
+    "$FIXTURES_DIR/ours-modifies.yaml" \
+    "$FIXTURES_DIR/theirs-modifies.yaml" \
+    7 \
+    "$TEMP_DIR/result.yaml"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Merge conflicts detected"* ]]
+
+  grep -q "MERGE CONFLICT" "$TEMP_DIR/result.yaml"
+}
+
+@test "deletion: changeset deletion is respected" {
+  run "$MERGE_SCRIPT" \
+    "$FIXTURES_DIR/base-two-changesets.yaml" \
+    "$FIXTURES_DIR/ours-deletes-second.yaml" \
+    "$FIXTURES_DIR/base-two-changesets.yaml" \
+    7 \
+    "$TEMP_DIR/result.yaml"
+
+  [ "$status" -eq 0 ]
+
+  # Should have only 1 changeset (deletion respected)
+  changeset_count=$(grep -c "^  - changeSet:" "$TEMP_DIR/result.yaml")
+  [ "$changeset_count" -eq 1 ]
+}
+
+@test "preserves footer warning" {
+  run "$MERGE_SCRIPT" \
+    "$FIXTURES_DIR/base-with-footer.yaml" \
+    "$FIXTURES_DIR/ours-adds-with-footer.yaml" \
+    "$FIXTURES_DIR/base-with-footer.yaml" \
+    7 \
+    "$TEMP_DIR/result.yaml"
+
+  [ "$status" -eq 0 ]
+
+  # Footer should be preserved
+  grep -q "# >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE!" "$TEMP_DIR/result.yaml"
+  grep -q "# ADVICE:" "$TEMP_DIR/result.yaml"
+}
+
+@test "preserves formatting and blank lines" {
+  run "$MERGE_SCRIPT" \
+    "$FIXTURES_DIR/base-simple.yaml" \
+    "$FIXTURES_DIR/ours-adds-one.yaml" \
+    "$FIXTURES_DIR/theirs-adds-one.yaml" \
+    7 \
+    "$TEMP_DIR/result.yaml"
+
+  [ "$status" -eq 0 ]
+
+  # Should preserve quoting strategy line
+  grep -q "  - objectQuotingStrategy: QUOTE_ALL_OBJECTS" "$TEMP_DIR/result.yaml"
+
+  # Should not have consecutive blank lines
+  ! grep -Pzo '\n\n\n' "$TEMP_DIR/result.yaml"
+}
+
+@test "sorts changesets by ID chronologically" {
+  run "$MERGE_SCRIPT" \
+    "$FIXTURES_DIR/base-sort.yaml" \
+    "$FIXTURES_DIR/ours-adds-later.yaml" \
+    "$FIXTURES_DIR/theirs-adds-between.yaml" \
+    7 \
+    "$TEMP_DIR/result.yaml"
+
+  [ "$status" -eq 0 ]
+
+  # Extract changeset IDs in order
+  ids=$(grep "id: v58" "$TEMP_DIR/result.yaml" | sed 's/.*id: //' | tr '\n' ' ')
+
+  # Should be sorted chronologically
+  [[ "$ids" == *"v58.2025-10-30T09:00:00"* ]]
+  [[ "$ids" == *"v58.2025-10-31T10:00:00"* ]]
+  [[ "$ids" == *"v58.2025-11-01T12:00:00"* ]]
+
+  # Verify order by checking the "between" changeset comes before "later"
+  between_line=$(grep -n "v58.2025-10-31T10:00:00" "$TEMP_DIR/result.yaml" | cut -d: -f1)
+  later_line=$(grep -n "v58.2025-11-01T12:00:00" "$TEMP_DIR/result.yaml" | cut -d: -f1)
+  [ "$between_line" -lt "$later_line" ]
+}


### PR DESCRIPTION
Merges and sorts .yaml files on incoming migration conflicts. This way conflicts never look like they've been blown up to pieces.

Needs to be added to `.git/config` to work.
