### PR TITLE
Support building an uberjar with a custom filename 

### DIFF
--- a/bin/build/src/build.clj
+++ b/bin/build/src/build.clj
@@ -76,10 +76,10 @@
 
 (defn- build-uberjar! [edition]
   {:pre [(#{:oss :ee} edition)]}
-  (u/delete-file-if-exists! uberjar/uberjar-filename)
+  (u/delete-file-if-exists! uberjar/uberjar-path)
   (u/step (format "Build uberjar with profile %s" edition)
     (uberjar/uberjar {:edition edition})
-    (u/assert-file-exists uberjar/uberjar-filename)
+    (u/assert-file-exists uberjar/uberjar-path)
     (u/announce "Uberjar built successfully.")))
 
 (def ^:private all-steps

--- a/bin/build/src/build.clj
+++ b/bin/build/src/build.clj
@@ -76,10 +76,10 @@
 
 (defn- build-uberjar! [edition]
   {:pre [(#{:oss :ee} edition)]}
-  (u/delete-file-if-exists! uberjar/uberjar-path)
+  (u/delete-file-if-exists! uberjar/uberjar-filename)
   (u/step (format "Build uberjar with profile %s" edition)
     (uberjar/uberjar {:edition edition})
-    (u/assert-file-exists uberjar/uberjar-path)
+    (u/assert-file-exists uberjar/uberjar-filename)
     (u/announce "Uberjar built successfully.")))
 
 (def ^:private all-steps


### PR DESCRIPTION
Resolves DEV-1121

Add the ability to customize the output filename for the uberjar build via the `MB_JAR_FILENAME` environment variable. This allows backend-only test builds to use a separate filename (e.g., metabase-backend.jar) to avoid overwriting the regular all-in-one metabase.jar.

## Local test
```
❯ MB_JAR_FILENAME="fooooobar.jar" ./bin/build-for-test

      Copy resources
        Copy resources from src
        Copy resources from resources
        Copy resources from enterprise/backend/src
      Create uberjar
        Created uberjar in 78.5 seconds.
      Update META-INF/MANIFEST.MF
      Built /Users/metabase/code/metabase-org/metabase/target/uberjar/fooooobar.jar in 147.2 seconds.
    Uberjar built successfully.
  Did :uberjar in 147223 ms.
  All build steps finished.
```