### PR TITLE
test(sdk): add tests for jwt attributes in click behavior

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/dashboard-click-behavior.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/dashboard-click-behavior.cy.spec.tsx
@@ -449,7 +449,7 @@ describe("scenarios > embedding-sdk > dashboard-click-behavior - jwt attributes"
     cy.signOut();
   });
 
-  it("should substitute JWT user attributes from in click behavior link templates (metabase#65942)", () => {
+  it("should substitute JWT user attribute in click behavior link templates (metabase#65942)", () => {
     const jwtAttributeValue = "attribute_value";
 
     cy.task<string>("signJwt", {


### PR DESCRIPTION
Adds a sdk test for https://github.com/metabase/metabase/pull/66274

You can verify this manually by following the [original issue](https://github.com/metabase/metabase/issues/65942) and then embedding the dashboard via the sdk