### PR TITLE
fix: scroll position jump when entering field sort mode gdgt-1269

### DIFF
--- a/e2e/support/helpers/e2e-datamodel-helpers.ts
+++ b/e2e/support/helpers/e2e-datamodel-helpers.ts
@@ -276,7 +276,7 @@ function getTableSectionSortableFields() {
 }
 
 function getTableSectionVisibilityTypeInput() {
-  return getTableSection().findByRole("combobox", { name: "Visibility type" });
+  return getTableSection().findByRole("textbox", { name: "Visibility type" });
 }
 
 function getTableSectionFieldNameInput(name: string) {

--- a/e2e/support/helpers/e2e-datamodel-helpers.ts
+++ b/e2e/support/helpers/e2e-datamodel-helpers.ts
@@ -259,8 +259,8 @@ function getTableSortOrderInput() {
   return getTableSection().findByRole("radiogroup", { name: "Column order" });
 }
 
-function getTableSyncOptionsButton(buttonText: string = "Sync settings") {
-  return getTableSection().findByRole("button", { name: buttonText });
+function getTableSyncOptionsButton() {
+  return getTableSection().findByRole("button", { name: /Sync/ });
 }
 
 function getTableSectionField(name: string) {

--- a/e2e/support/helpers/e2e-datamodel-helpers.ts
+++ b/e2e/support/helpers/e2e-datamodel-helpers.ts
@@ -248,27 +248,27 @@ function getTableDescriptionInput() {
 }
 
 function getTableSortButton() {
-  return getTableSection().button(/Sorting/);
+  return getTableSection().findByRole("button", { name: "Sorting" });
 }
 
 function getTableSortDoneButton() {
-  return getTableSection().button(/Done/);
+  return getTableSection().findByRole("button", { name: "Done" });
 }
 
 function getTableSortOrderInput() {
-  return getTableSection().findByLabelText("Column order");
+  return getTableSection().findByRole("radiogroup", { name: "Column order" });
 }
 
 function getTableSyncOptionsButton() {
-  return getTableSection().button(/Sync/);
+  return getTableSection().findByRole("button", { name: "Sync" });
 }
 
 function getTableSectionField(name: string) {
-  return getTableSection().findByLabelText(name);
+  return getTableSection().findByRole("listitem", { name });
 }
 
 function getTableSectionSortableField(name: string) {
-  return getTableSection().findByLabelText(name);
+  return getTableSection().findByRole("listitem", { name });
 }
 
 function getTableSectionSortableFields() {
@@ -276,7 +276,7 @@ function getTableSectionSortableFields() {
 }
 
 function getTableSectionVisibilityTypeInput() {
-  return getTableSection().findByLabelText("Visibility type");
+  return getTableSection().findByRole("combobox", { name: "Visibility type" });
 }
 
 function getTableSectionFieldNameInput(name: string) {

--- a/e2e/support/helpers/e2e-datamodel-helpers.ts
+++ b/e2e/support/helpers/e2e-datamodel-helpers.ts
@@ -259,8 +259,8 @@ function getTableSortOrderInput() {
   return getTableSection().findByRole("radiogroup", { name: "Column order" });
 }
 
-function getTableSyncOptionsButton() {
-  return getTableSection().findByRole("button", { name: /Sync settings/ });
+function getTableSyncOptionsButton(buttonText: string = "Sync settings") {
+  return getTableSection().findByRole("button", { name: buttonText });
 }
 
 function getTableSectionField(name: string) {

--- a/e2e/support/helpers/e2e-datamodel-helpers.ts
+++ b/e2e/support/helpers/e2e-datamodel-helpers.ts
@@ -260,7 +260,7 @@ function getTableSortOrderInput() {
 }
 
 function getTableSyncOptionsButton() {
-  return getTableSection().findByRole("button", { name: "Sync" });
+  return getTableSection().findByRole("button", { name: /Sync settings/ });
 }
 
 function getTableSectionField(name: string) {

--- a/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
+++ b/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
@@ -1363,7 +1363,7 @@ describe("scenarios > admin > datamodel", () => {
           schemaId: SAMPLE_DB_SCHEMA_ID,
           tableId: PRODUCTS_ID,
         });
-        TableSection.getSyncOptionsButton("Sync options").click();
+        TableSection.getSyncOptionsButton().click();
 
         cy.log("sync table schema");
         H.modal().within(() => {

--- a/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
+++ b/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
@@ -1363,7 +1363,7 @@ describe("scenarios > admin > datamodel", () => {
           schemaId: SAMPLE_DB_SCHEMA_ID,
           tableId: PRODUCTS_ID,
         });
-        TableSection.getSyncOptionsButton().click();
+        TableSection.getSyncOptionsButton("Sync options").click();
 
         cy.log("sync table schema");
         H.modal().within(() => {

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/TableSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/TableSection.tsx
@@ -296,7 +296,7 @@ const TableSectionBase = ({
 
               <Box
                 style={{
-                  display: !isSorting ? "block" : "none",
+                  display: isSorting ? "none" : "block",
                 }}
                 aria-hidden={isSorting}
               >

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/TableSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/TableSection.tsx
@@ -278,23 +278,34 @@ const TableSectionBase = ({
 
           {!hasFields && <EmptyState message={t`This table has no fields`} />}
 
+          {/* NOTE: We're using here CSS display property to avoid scroll jump when toggling sorting mode. */}
           {hasFields && (
             <>
-              {isSorting && (
+              <Box
+                style={{
+                  display: isSorting ? "block" : "none",
+                }}
+                aria-hidden={!isSorting}
+              >
                 <TableSortableFieldList
                   activeFieldId={activeFieldId}
                   table={table}
                   onChange={handleCustomFieldOrderChange}
                 />
-              )}
+              </Box>
 
-              {!isSorting && (
+              <Box
+                style={{
+                  display: !isSorting ? "block" : "none",
+                }}
+                aria-hidden={isSorting}
+              >
                 <TableFieldList
                   table={table}
                   activeFieldId={activeFieldId}
                   getFieldHref={getFieldHref}
                 />
-              )}
+              </Box>
             </>
           )}
         </Stack>

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/pages/DataModel/DataModel.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/pages/DataModel/DataModel.unit.spec.tsx
@@ -988,7 +988,7 @@ function getTableSection() {
 }
 
 function getTableSectionField(name: string) {
-  return within(getTableSection()).getByLabelText(name);
+  return within(getTableSection()).getByRole("listitem", { name });
 }
 
 function getTableSectionFieldNameInput(name: string) {


### PR DESCRIPTION
https://linear.app/metabase/issue/GDGT-1269/clicking-sorting-scrolls-the-table-section-up

### Description

Use CSS to hide show fields, instead React removing and adding to the tree to prevent jump scrolling when container looses and then gains height.

### How to verify

1. go to `/data-studio`
2. select some table
3. resize browse to get scroll bar in the table details view
4. scroll down and toggle search
5. scroll position should be preserved