### PR TITLE
Revert "Bump com.clickhouse/clickhouse-jdbc from 0.8.4 to 0.9.2"

### DIFF
--- a/modules/drivers/clickhouse/deps.edn
+++ b/modules/drivers/clickhouse/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "resources"]
  :deps
- {com.clickhouse/clickhouse-jdbc {:mvn/version "0.9.2"
+ {com.clickhouse/clickhouse-jdbc {:mvn/version "0.8.4"
                                   :exclusions [org.apache.commons/commons-lang3]}
   org.lz4/lz4-java {:mvn/version "1.8.0"}}}


### PR DESCRIPTION
Reverts metabase/metabase#64168

Breaks tests, shouldn't have been merged