### PR TITLE
Fix broken PDF export layout due to CSP violation for inline styles

### DIFF
--- a/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
+++ b/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
@@ -236,6 +236,14 @@ export const saveDashboardPdf = async ({
     useCORS: true,
     backgroundColor,
     scale: window.devicePixelRatio || 1,
+    /**
+     * html2canvas-pro creates inline <style> elements that can be blocked by
+     * CSP (observed from Firefox). We created a temporary patch to support
+     * nonce until the library officially implements it.
+     *
+     * @see https://github.com/metabase/metabase/issues/66234
+     */
+    nonce: window.MetabaseNonce,
     onclone: (_doc: Document, node: HTMLElement) => {
       node.classList.add(SAVING_DOM_IMAGE_CLASS);
       node.style.height = `${contentHeight}px`;

--- a/patches/html2canvas-pro+1.5.0.patch
+++ b/patches/html2canvas-pro+1.5.0.patch
@@ -1,0 +1,66 @@
+diff --git a/node_modules/html2canvas-pro/dist/html2canvas-pro.js b/node_modules/html2canvas-pro/dist/html2canvas-pro.js
+index 86a610e..c74cc94 100644
+--- a/node_modules/html2canvas-pro/dist/html2canvas-pro.js
++++ b/node_modules/html2canvas-pro/dist/html2canvas-pro.js
+@@ -802,6 +802,7 @@
+             : undefined;
+         return [indicies, classTypes, forbiddenBreakpoints];
+     };
++    var nonceAttributeValue
+     var Break = /** @class */ (function () {
+         function Break(codePoints, lineBreak, start, end) {
+             this.codePoints = codePoints;
+@@ -6060,6 +6061,11 @@
+             documentClone.write(serializeDoctype(document.doctype) + "<html></html>");
+             // Chrome scrolls the parent document for some reason after the write to the cloned window???
+             restoreOwnerScroll(this.referenceElement.ownerDocument, scrollX, scrollY);
++
++            if (isStyleElement(documentClone.documentElement) && nonceAttributeValue) {
++              documentClone.documentElement.setAttribute('nonce', nonceAttributeValue);
++            }
++
+             documentClone.replaceChild(documentClone.adoptNode(this.documentElement), documentClone.documentElement);
+             documentClone.close();
+             return iframeLoad;
+@@ -6188,6 +6194,11 @@
+                 (!isScriptElement(child) &&
+                     !child.hasAttribute(IGNORE_ATTRIBUTE) &&
+                     (typeof this.options.ignoreElements !== 'function' || !this.options.ignoreElements(child)))) {
++
++              if (isStyleElement(child) && nonceAttributeValue) {
++                  child.setAttribute('nonce', nonceAttributeValue);
++                }
++
+                 if (!this.options.copyStyles || !isElementNode(child) || !isStyleElement(child)) {
+                     clone.appendChild(this.cloneNode(child, copyStyles));
+                 }
+@@ -6464,6 +6475,9 @@
+         var document = body.ownerDocument;
+         if (document) {
+             var style = document.createElement('style');
++            if (nonceAttributeValue) {
++                style.setAttribute('nonce', nonceAttributeValue);
++            }
+             style.textContent = styles;
+             body.appendChild(style);
+         }
+@@ -8570,6 +8584,7 @@
+ 
+     var html2canvas = function (element, options) {
+         if (options === void 0) { options = {}; }
++        nonceAttributeValue = options.nonce
+         return renderElement(element, options);
+     };
+     if (typeof window !== 'undefined') {
+diff --git a/node_modules/html2canvas-pro/dist/types/index.d.ts b/node_modules/html2canvas-pro/dist/types/index.d.ts
+index c481902..60b03fe 100644
+--- a/node_modules/html2canvas-pro/dist/types/index.d.ts
++++ b/node_modules/html2canvas-pro/dist/types/index.d.ts
+@@ -5,6 +5,7 @@ export declare type Options = CloneOptions & WindowOptions & RenderOptions & Con
+     backgroundColor: string | null;
+     foreignObjectRendering: boolean;
+     removeContainer?: boolean;
++    nonce?: string;
+ };
+ declare const html2canvas: (element: HTMLElement, options?: Partial<Options>) => Promise<HTMLCanvasElement>;
+ export default html2canvas;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/66234

### Description

Inline styles generated by `html2canvas-pro` when exporting a dashboard to PDF got blocked due to CSP restrictions on Firefox (does not seem to happen on Chrome). 

### How to verify

- Run yarn install;
- Open Metabase from Firefox;
- Then please follow the reproduction steps present in the issue https://github.com/metabase/metabase/issues/66234 description.

### Demo
Before (example):
<img width="647" height="382" alt="image" src="https://github.com/user-attachments/assets/c610774f-6557-4312-bbaf-86b6856fa6d6" />

After:
<img width="647" height="382" alt="image" src="https://github.com/user-attachments/assets/fd1222c0-fc4d-4a25-af85-d054c1f45cc9" />
