### PR TITLE
Data studio table filtering improvements

### DIFF
--- a/src/metabase/warehouse_schema_rest/api/table.clj
+++ b/src/metabase/warehouse_schema_rest/api/table.clj
@@ -74,14 +74,17 @@
        [:owner-email {:optional true} :string]
        [:orphan-only {:optional true} [:maybe ms/BooleanValue]]
        [:unused-only {:optional true} [:maybe ms/BooleanValue]]]]
-  (let [like       (case (app-db/db-type) (:h2 :postgres) :ilike :like)
+  (let [like       (fn [field pattern]
+                     (case (app-db/db-type)
+                       (:h2 :postgres) [:ilike field pattern]
+                       [:raw [:like field pattern] " COLLATE " [:inline "utf8mb4_unicode_ci"]]))
         pattern    (some-> term (str/replace "*" "%") (cond-> (not (str/ends-with? term "%")) (str "%")))
         where      (cond-> [:and [:= :active true]]
                      (not (str/blank? term)) (conj [:or
-                                                    [like :name pattern]
-                                                    [like :display_name pattern]
+                                                    (like :name pattern)
+                                                    (like :display_name pattern)
                                                     ;; match word starts after spaces e.g. 'ite' would match 'Order Item'
-                                                    [like :display_name (str "% " pattern)]])
+                                                    (like :display_name (str "% " pattern))])
                      visibility-type         (conj [:= :visibility_type visibility-type])
                      data-layer              (conj [:= :data_layer      (name data-layer)])
                      data-source             (conj [:= :data_source     (name data-source)])

--- a/src/metabase/warehouse_schema_rest/api/table.clj
+++ b/src/metabase/warehouse_schema_rest/api/table.clj
@@ -78,7 +78,12 @@
                      (case (app-db/db-type)
                        (:h2 :postgres) [:ilike field pattern]
                        [:raw [:like field pattern] " COLLATE " [:inline "utf8mb4_unicode_ci"]]))
-        pattern    (some-> term (str/replace "*" "%") (cond-> (not (str/ends-with? term "%")) (str "%")))
+        pattern    (some-> term
+                           (str/replace "\\" "\\\\")
+                           (str/replace "_" "\\_")
+                           (str/replace "%" "\\%")
+                           (str/replace "*" "%")
+                           (cond-> (not (str/ends-with? term "%")) (str "%")))
         where      (cond-> [:and [:= :active true]]
                      (not (str/blank? term)) (conj [:or
                                                     (like :name pattern)

--- a/src/metabase/warehouse_schema_rest/api/table.clj
+++ b/src/metabase/warehouse_schema_rest/api/table.clj
@@ -77,7 +77,11 @@
   (let [like       (case (app-db/db-type) (:h2 :postgres) :ilike :like)
         pattern    (some-> term (str/replace "*" "%") (cond-> (not (str/ends-with? term "%")) (str "%")))
         where      (cond-> [:and [:= :active true]]
-                     (not (str/blank? term)) (conj [like :name pattern])
+                     (not (str/blank? term)) (conj [:or
+                                                    [like :name pattern]
+                                                    [like :display_name pattern]
+                                                    ;; match word starts after spaces e.g. 'ite' would match 'Order Item'
+                                                    [like :display_name (str "% " pattern)]])
                      visibility-type         (conj [:= :visibility_type visibility-type])
                      data-layer              (conj [:= :data_layer      (name data-layer)])
                      data-source             (conj [:= :data_source     (name data-source)])

--- a/test/metabase/warehouse_schema_rest/api/table_test.clj
+++ b/test/metabase/warehouse_schema_rest/api/table_test.clj
@@ -1185,41 +1185,58 @@
              (deref sync-called? timeout :sync-never-called)))))))
 
 (deftest ^:parallel list-table-filtering-test
-  (testing "term filtering"
-    (is (=? [{:display_name "Users"}]
-            (->> (mt/user-http-request :crowberto :get 200 "table" :term "Use")
-                 (filter #(= (:db_id %) (mt/id)))           ; prevent stray tables from affecting unit test results
-                 (map #(select-keys % [:display_name])))))
+  (let [list-tables (fn [& params]
+                      (->> (apply mt/user-http-request :crowberto :get 200 "table" params)
+                           (filter #(= (:db_id %) (mt/id))) ; prevent stray tables from affecting unit test results
+                           (map #(select-keys % [:display_name]))))]
+    (testing "term filtering"
+      (is (=? [{:display_name "Users"}] (list-tables :term "Use")))
+      (testing "wildcard"
+        (is (=? [{:display_name "Users"}] (list-tables :term "*S*rs"))))
+      (testing "escaping"
+        (mt/with-temp [:model/Table _ {:name         "what-a_cool%table\\name"
+                                       :display_name "coolest table ever"
+                                       :db_id        (mt/id)
+                                       :active       true}
+                       :model/Table _ {:name         "what_a_cool_table_name"
+                                       :display_name "not a cool table"
+                                       :db_id        (mt/id)
+                                       :active       true}]
+          (let [match [{:display_name "coolest table ever"}]
+                q     #(list-tables :term %)]
+            (is (= match (q "what-a_cool%table\\name")))
+            (is (= [] (q "what%a%cool%table%name"))))))
+      (testing "display name"
+        (mt/with-temp [:model/Table _ {:name         "order_item_discount"
+                                       :display_name "Order Item Discount"
+                                       :db_id        (mt/id)
+                                       :active       true}]
+          (let [match [{:display_name "Order Item Discount"}]
+                q     #(list-tables :term %)]
+            (is (= match (q "Order Item")))
+            (is (= match (q "Ite")))
+            (is (= match (q "Item Di")))
+            (is (= match (q "Ite* Discount")))
+            (is (= []    (q "order_item discount")))
+            (is (= []    (q "Discount Item")))))))
+    (testing "filter composition"
+      (mt/with-temp [:model/Table {products2-id :id} {:name         "PrOdUcTs2"
+                                                      :display_name "Products2"
+                                                      :db_id        (mt/id)
+                                                      :active       true}]
+        (is (=? [{:display_name "People"}
+                 {:display_name "Products"}
+                 {:display_name "Products2"}]
+                (list-tables :term "P")))
 
-    (testing "wildcard"
-      (is (=? [{:display_name "Users"}]
-              (->> (mt/user-http-request :crowberto :get 200 "table" :term "*S*rs")
-                   (filter #(= (:db_id %) (mt/id)))         ; prevent stray tables from affecting unit test results
-                   (map #(select-keys % [:display_name])))))))
-  (testing "filter composition"
-    (mt/with-temp [:model/Table {products2-id :id} {:name         "PrOdUcTs2"
-                                                    :display_name "Products2"
-                                                    :db_id        (mt/id)
-                                                    :active       true}]
-      (is (=? [{:display_name "People"}
-               {:display_name "Products"}
-               {:display_name "Products2"}]
-              (->> (mt/user-http-request :crowberto :get 200 "table" :term "P")
-                   (filter #(= (:db_id %) (mt/id)))         ; prevent stray tables from affecting unit test results
-                   (map #(select-keys % [:display_name])))))
+        (mt/user-http-request :crowberto :put 200 (format "table/%d" products2-id) {:data_layer "gold"})
 
-      (mt/user-http-request :crowberto :put 200 (format "table/%d" products2-id) {:data_layer "gold"})
-      (is (=? [{:display_name "Products2"}]
-              (->> (mt/user-http-request :crowberto :get 200 "table" :term "P" :data-layer "gold")
-                   (filter #(= (:db_id %) (mt/id)))         ; prevent stray tables from affecting unit test results
-                   (map #(select-keys % [:display_name])))))
+        (is (=? [{:display_name "Products2"}]
+                (list-tables :term "P" :data-layer "gold")))
 
-      (testing "empty filter"
         (is (=? [{:display_name "People"}
                  {:display_name "Products"}]
-                (->> (mt/user-http-request :crowberto :get 200 "table" :term "P" :data-layer "bronze")
-                     (filter #(= (:db_id %) (mt/id)))       ; prevent stray tables from affecting unit test results
-                     (map #(select-keys % [:display_name])))))))))
+                (list-tables :term "P" :data-layer "bronze")))))))
 
 (deftest ^:parallel update-table-visibility-sync-test
   (testing "PUT /api/table/:id visibility field synchronization"

--- a/test/metabase/warehouse_schema_rest/api/table_test.clj
+++ b/test/metabase/warehouse_schema_rest/api/table_test.clj
@@ -1184,19 +1184,17 @@
         (is (true?
              (deref sync-called? timeout :sync-never-called)))))))
 
-;; DEMOWARE bulk-editing APIS
 (deftest ^:parallel list-table-filtering-test
   (testing "term filtering"
-
     (is (=? [{:display_name "Users"}]
-            (->> (mt/user-http-request :crowberto :get 200 "table" :term (if (contains? #{:mysql :mariadb} (mdb/db-type)) "USE" "Use"))
+            (->> (mt/user-http-request :crowberto :get 200 "table" :term "Use")
                  (filter #(= (:db_id %) (mt/id)))           ; prevent stray tables from affecting unit test results
                  (map #(select-keys % [:display_name])))))
 
     (testing "wildcard"
       (is (=? [{:display_name "Users"}]
-              (->> (mt/user-http-request :crowberto :get 200 "table" :term (if (contains? #{:mysql :mariadb} (mdb/db-type)) "*S*RS" "*S*rs"))
-                   (filter #(= (:db_id %) (mt/id)))         ; prevent stray tables from affecting unit test results1
+              (->> (mt/user-http-request :crowberto :get 200 "table" :term "*S*rs")
+                   (filter #(= (:db_id %) (mt/id)))         ; prevent stray tables from affecting unit test results
                    (map #(select-keys % [:display_name])))))))
   (testing "filter composition"
     (mt/with-temp [:model/Table {products2-id :id} {:name         "PrOdUcTs2"

--- a/test/metabase/warehouse_schema_rest/api/table_test.clj
+++ b/test/metabase/warehouse_schema_rest/api/table_test.clj
@@ -5,7 +5,6 @@
    [clojure.test :refer :all]
    [metabase.api.response :as api.response]
    [metabase.api.test-util :as api.test-util]
-   [metabase.app-db.core :as mdb]
    [metabase.driver :as driver]
    [metabase.driver.util :as driver.u]
    [metabase.events.core :as events]


### PR DESCRIPTION
Makes a handful of improvements to table filtering with a string `?term=` parameter. 

- Searches display name
- Matches beginning of words within display name e.g. "item" would match "order item"
- Re-introduced mysql/maria CI collation fix, must have been lost in a merge/rebase somewhere. Case insensitive search applies to the name field on all appdbs again.
- Escape pattern characters

Closes GDGT-1274