### PR TITLE
Fix admins aren't shown subscription list page after creating first subscription

### DIFF
--- a/.github/workflows/embedding-sdk-component-tests.yml
+++ b/.github/workflows/embedding-sdk-component-tests.yml
@@ -175,6 +175,19 @@ jobs:
         with:
           ref: ${{ needs.decide-target-ref.outputs.target-ref }}
 
+      - name: Prepare Docker containers
+        uses: ./.github/actions/e2e-prepare-containers
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          maildev: true
+          openldap: false
+          webhook: false
+          snowplow: false
+          postgres: false
+          mysql: false
+          mongo: false
+
       - name: Get the actual commit SHA from the checked out branch
         id: get-commit-sha
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"

--- a/e2e/test-component/scenarios/embedding-sdk/subscriptions.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/subscriptions.cy.spec.tsx
@@ -69,14 +69,10 @@ describe("scenarios > embedding-sdk > subscriptions", () => {
         cy.findByRole("button", { name: "Done" }).click();
         cy.wait("@createPulse");
 
-        // Doing this twice, remove when EMB-1060 (https://github.com/metabase/metabase/pull/66372) is fixed
-        cy.findByRole("button", { name: "Done" }).click();
-        cy.wait("@createPulse");
-
         cy.findByText("Subscriptions").should("be.visible");
 
         // check that there are 2 subscriptions
-        cy.findAllByText("Emailed hourly").should("have.length", 2);
+        cy.findByText("Emailed hourly").should("be.visible");
       });
     });
 
@@ -98,14 +94,10 @@ describe("scenarios > embedding-sdk > subscriptions", () => {
         cy.findByRole("button", { name: "Done" }).click();
         cy.wait("@createPulse");
 
-        // Doing this twice, remove when EMB-1060 (https://github.com/metabase/metabase/pull/66372) is fixed
-        cy.findByRole("button", { name: "Done" }).click();
-        cy.wait("@createPulse");
-
         cy.findByText("Subscriptions").should("be.visible");
 
         // check that there are 2 subscriptions
-        cy.findAllByText("Emailed hourly").should("have.length", 2);
+        cy.findByText("Emailed hourly").should("be.visible");
       });
     });
 
@@ -127,14 +119,10 @@ describe("scenarios > embedding-sdk > subscriptions", () => {
         cy.findByRole("button", { name: "Done" }).click();
         cy.wait("@createPulse");
 
-        // Doing this twice, remove when EMB-1060 (https://github.com/metabase/metabase/pull/66372) is fixed
-        cy.findByRole("button", { name: "Done" }).click();
-        cy.wait("@createPulse");
-
         cy.findByText("Subscriptions").should("be.visible");
 
         // check that there are 2 subscriptions
-        cy.findAllByText("Emailed hourly").should("have.length", 2);
+        cy.findByText("Emailed hourly").should("be.visible");
       });
     });
   });

--- a/frontend/src/metabase-types/api/mocks/user.ts
+++ b/frontend/src/metabase-types/api/mocks/user.ts
@@ -1,29 +1,33 @@
 import type { User, UserInfo, UserListResult } from "metabase-types/api";
 
-export const createMockUser = (opts?: Partial<User>): User => ({
-  id: 1,
-  first_name: "Testy",
-  last_name: "Tableton",
-  common_name: `Testy Tableton`,
-  custom_homepage: null,
-  email: "user@metabase.test",
-  locale: null,
-  attributes: null,
-  login_attributes: null,
-  is_active: true,
-  is_qbnewb: false,
-  is_superuser: false,
-  is_installer: false,
-  has_invited_second_user: false,
-  has_question_and_dashboard: false,
-  personal_collection_id: 1,
-  date_joined: new Date().toISOString(),
-  first_login: new Date().toISOString(),
-  last_login: new Date().toISOString(),
-  updated_at: new Date().toISOString(),
-  sso_source: null,
-  ...opts,
-});
+export const createMockUser = (opts?: Partial<User>): User => {
+  const firstName = opts?.first_name ?? "Testy";
+  const lastName = opts?.last_name ?? "Tableton";
+  return {
+    id: 1,
+    first_name: firstName,
+    last_name: lastName,
+    common_name: [firstName, lastName].filter(Boolean).join(" "),
+    custom_homepage: null,
+    email: "user@metabase.test",
+    locale: null,
+    attributes: null,
+    login_attributes: null,
+    is_active: true,
+    is_qbnewb: false,
+    is_superuser: false,
+    is_installer: false,
+    has_invited_second_user: false,
+    has_question_and_dashboard: false,
+    personal_collection_id: 1,
+    date_joined: new Date().toISOString(),
+    first_login: new Date().toISOString(),
+    last_login: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    sso_source: null,
+    ...opts,
+  };
+};
 
 export const createMockUserListResult = (
   opts?: Partial<UserListResult>,

--- a/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/DashboardSubscriptionsSidebar.jsx
+++ b/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/DashboardSubscriptionsSidebar.jsx
@@ -154,9 +154,8 @@ class DashboardSubscriptionsSidebarInner extends Component {
       isEmbeddingSdk() &&
       shouldDisplayNewPulse(editingMode, pulses) &&
       /**
-       * This last condition ensures that after deleting the last subscription, we do not immediately
-       * go back to EDITING_MODES.ADD_EMAIL while the pulse list is still loading, as shouldDisplayNewPulse(editingMode, pulses)
-       * will change to false (no items in the list) when the pulse list finishes loading.
+       * Ensure we don't prematurely switch to ADD_EMAIL while the pulse list is loading.
+       * When loading completes, shouldDisplayNewPulse() will correctly return false if the list is empty.
        */
       !isSubscriptionListLoading
     ) {

--- a/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/DashboardSubscriptionsSidebar.jsx
+++ b/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/DashboardSubscriptionsSidebar.jsx
@@ -129,6 +129,8 @@ class DashboardSubscriptionsSidebarInner extends Component {
     onCancel: PropTypes.func.isRequired,
     setPulseArchived: PropTypes.func.isRequired,
     params: PropTypes.object,
+    // From Pulses.loadList HOC
+    loading: PropTypes.bool,
   };
 
   componentDidMount() {
@@ -138,7 +140,7 @@ class DashboardSubscriptionsSidebarInner extends Component {
 
   componentDidUpdate(prevProps) {
     const { editingMode } = this.state;
-    const { isAdmin, pulses } = this.props;
+    const { isAdmin, pulses, loading: isSubscriptionListLoading } = this.props;
 
     /**
      * (EMB-976): In SDK/EAJS context we need to avoid showing the NEW_PULSE view (the view that lets users select
@@ -148,7 +150,16 @@ class DashboardSubscriptionsSidebarInner extends Component {
      * Otherwise, we won't show the subscription button to open this sidebar
      * in the first place.
      */
-    if (isEmbeddingSdk() && shouldDisplayNewPulse(editingMode, pulses)) {
+    if (
+      isEmbeddingSdk() &&
+      shouldDisplayNewPulse(editingMode, pulses) &&
+      /**
+       * This last condition ensures that after deleting the last subscription, we do not immediately
+       * go back to EDITING_MODES.ADD_EMAIL while the pulse list is still loading, as shouldDisplayNewPulse(editingMode, pulses)
+       * will change to false (no items in the list) when the pulse list finishes loading.
+       */
+      !isSubscriptionListLoading
+    ) {
       this.setState({
         editingMode: EDITING_MODES.ADD_EMAIL,
       });

--- a/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/common.unit.spec.ts
+++ b/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/common.unit.spec.ts
@@ -178,6 +178,60 @@ describe("DashboardSubscriptionsSidebar", () => {
 
       expect(setSharing).toHaveBeenCalledWith(false);
     });
+
+    /**
+     * Isn't needed for EMB-1060 but I added it for completeness.
+     */
+    it(`should show pulse list view after creating the first subscription by a non-admin user ${testScenarioCondition}`, async () => {
+      const user = {
+        firstName: "John",
+        lastName: "Doe",
+      };
+      setup({
+        isEmbeddingSdk: true,
+        email: true,
+        slack,
+        currentUser: user,
+        pulseListDelay: 100,
+      });
+
+      expect(
+        await screen.findByText("Email this dashboard"),
+      ).toBeInTheDocument();
+
+      // Create the first subscription
+      await userEvent.click(screen.getByRole("button", { name: "Done" }));
+
+      expect(await screen.findByText("Subscriptions")).toBeInTheDocument();
+      expect(await screen.findByText("Emailed hourly")).toBeInTheDocument();
+      expect(await screen.findByText("John Doe")).toBeInTheDocument();
+    });
+
+    it(`should show pulse list view after creating the first subscription by a admin user ${testScenarioCondition} (EMB-1060)`, async () => {
+      const user = {
+        firstName: "Admin",
+        lastName: "User",
+      };
+      setup({
+        isAdmin: true,
+        isEmbeddingSdk: true,
+        email: true,
+        slack,
+        currentUser: user,
+        pulseListDelay: 100,
+      });
+
+      expect(
+        await screen.findByText("Email this dashboard"),
+      ).toBeInTheDocument();
+
+      // Create the first subscription
+      await userEvent.click(screen.getByRole("button", { name: "Done" }));
+
+      expect(await screen.findByText("Subscriptions")).toBeInTheDocument();
+      expect(await screen.findByText("Emailed hourly")).toBeInTheDocument();
+      expect(await screen.findByText("Admin User")).toBeInTheDocument();
+    });
   });
 
   describe("Slack Subscription sidebar", () => {

--- a/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/common.unit.spec.ts
+++ b/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/common.unit.spec.ts
@@ -207,7 +207,7 @@ describe("DashboardSubscriptionsSidebar", () => {
       expect(await screen.findByText("John Doe")).toBeInTheDocument();
     });
 
-    it(`should show pulse list view after creating the first subscription by a admin user ${testScenarioCondition} (EMB-1060)`, async () => {
+    it(`should show pulse list view after creating the first subscription by an admin user ${testScenarioCondition} (EMB-1060)`, async () => {
       const user = {
         firstName: "Admin",
         lastName: "User",

--- a/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/setup.tsx
+++ b/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/setup.tsx
@@ -7,6 +7,7 @@ import { setupNotificationChannelsEndpoints } from "__support__/server-mocks/pul
 import { mockSettings } from "__support__/settings";
 import type { Screen } from "__support__/ui";
 import { renderWithProviders } from "__support__/ui";
+import { getNextId } from "__support__/utils";
 import { isEmbeddingSdk as mockIsEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { MockDashboardContext } from "metabase/public/containers/PublicOrEmbeddedDashboard/mock-context";
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
@@ -91,28 +92,27 @@ type SetupOpts = {
   isEmbeddingSdk?: boolean;
   setSharing?: (sharing: boolean) => void;
   pulses?: (Partial<Pulse> & { id: number })[];
+  currentUser?: {
+    firstName: string;
+    lastName: string;
+  };
+  pulseListDelay?: number;
 };
 
-export function setup(
-  {
-    email,
-    slack,
-    tokenFeatures = {},
-    hasEnterprisePlugins = false,
-    isAdmin = false,
-    dashcards = defaultDashcards,
-    parameters = defaultParameters,
-    isEmbeddingSdk = false,
-    setSharing,
-    pulses = [],
-  }: SetupOpts = {
-    email: true,
-    slack: true,
-    tokenFeatures: {},
-    hasEnterprisePlugins: false,
-    isAdmin: false,
-  },
-) {
+export function setup({
+  email = true,
+  slack = true,
+  tokenFeatures = {},
+  hasEnterprisePlugins = false,
+  isAdmin = false,
+  dashcards = defaultDashcards,
+  parameters = defaultParameters,
+  isEmbeddingSdk = false,
+  setSharing,
+  pulses = [],
+  currentUser,
+  pulseListDelay = 0,
+}: SetupOpts = {}) {
   const dashboard = createMockDashboard({
     dashcards,
     parameters,
@@ -167,6 +167,16 @@ export function setup(
     url: `path:/api/pulse`,
     query: { dashboard_id: dashboard.id },
     response: () => pulses,
+    // Delay is crucial to reproduce (EMB-1060), otherwise, the state updates too fast which isn't realistic
+    delay: pulseListDelay,
+  });
+
+  // Mock POST that updates the GET response
+  fetchMock.post("path:/api/pulse", ({ options }) => {
+    const body = JSON.parse(options.body as string);
+    const newPulse = { ...body, id: getNextId() } as Pulse & { id: number };
+    pulses.push(newPulse);
+    return newPulse;
   });
 
   fetchMock.post("path:/api/pulse/test", 200);
@@ -186,6 +196,8 @@ export function setup(
       storeInitialState: createMockState({
         settings: storeSettings,
         currentUser: createMockUser({
+          first_name: currentUser?.firstName,
+          last_name: currentUser?.lastName,
           is_superuser: isAdmin,
         }),
         dashboard: createDashboardState(dashboard, dashcards),


### PR DESCRIPTION
Closes EMB-1060

### Description

There was an issue where admins creating the first subsscriptions aren't brought to the subscription list page. This doesn't happen to non-admin users.

### How to verify

You can test this with EAJS.
1. Run MB
1. Ensure EAJS is enabled
1. Go to the example dashboard
1. Sharing button > Embed > Embeded analytics JS
1. Check "Allow subscription"
1. In the preview, click the subscriptions button
1. In the sidebar, click done and you should now see the subscription list view

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
