### PR TITLE
hide Our Analytics if user does not have access

### DIFF
--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/test/ee.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/test/ee.unit.spec.tsx
@@ -41,7 +41,10 @@ describe("library", () => {
       collectionItems: [LIBRARY_MODELS_COLELCTION, LIBRARY_METRICS_COLELCTION],
     });
 
-    setup({}, createMockTokenFeatures({ data_studio: true }));
+    setup(
+      {},
+      { tokenFeatures: createMockTokenFeatures({ data_studio: true }) },
+    );
 
     expect(await screen.findByText("metrics")).toBeInTheDocument();
     expect(await screen.findByText("data")).toBeInTheDocument();
@@ -62,7 +65,7 @@ describe("library", () => {
 
     setup(
       { models: ["dataset", "metric"] },
-      createMockTokenFeatures({ data_studio: true }),
+      { tokenFeatures: createMockTokenFeatures({ data_studio: true }) },
     );
 
     expect(await screen.findByText("Our analytics")).toBeInTheDocument();
@@ -90,7 +93,7 @@ describe("library", () => {
 
     setup(
       { models: ["dataset", "metric"] },
-      createMockTokenFeatures({ data_studio: true }),
+      { tokenFeatures: createMockTokenFeatures({ data_studio: true }) },
     );
     expect(await screen.findByText("Surprise")).toBeInTheDocument();
     expect(screen.queryByText("metrics")).not.toBeInTheDocument();
@@ -105,7 +108,7 @@ describe("library", () => {
 
     setup(
       { shouldShowLibrary: false },
-      createMockTokenFeatures({ data_studio: true }),
+      { tokenFeatures: createMockTokenFeatures({ data_studio: true }) },
     );
 
     expect(await screen.findByText("Mini Db")).toBeInTheDocument();

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/test/oss.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/test/oss.unit.spec.tsx
@@ -45,6 +45,17 @@ describe("MiniPicker", () => {
     });
   });
 
+  it("shows 'Collections' when an adult decides you can't have access to Our analytics", async () => {
+    await setup({}, { hasAccessToRoot: false });
+
+    expect(await screen.findByText("Collections")).toBeInTheDocument();
+    expect(screen.queryByText("Our analytics")).not.toBeInTheDocument();
+
+    // Should still be able to navigate into collections
+    await userEvent.click(await screen.findByText("Collections"));
+    expect(await screen.findByText("more things")).toBeInTheDocument();
+  });
+
   describe("tables", () => {
     it("can pick a table from a db with multiple schemas", async () => {
       const { onChangeSpy } = await setup();

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/test/setup.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/test/setup.tsx
@@ -1,5 +1,6 @@
 import { setupEnterprisePlugins } from "__support__/enterprise";
 import {
+  setupCollectionByIdEndpoint,
   setupCollectionItemsEndpoint,
   setupDatabasesEndpoints,
   setupRecentViewsAndSelectionsEndpoints,
@@ -32,7 +33,10 @@ const collectionItemModels = [
 
 export const setup = async (
   props: Partial<MiniPickerProps> = {},
-  tokenFeatures: TokenFeatures | null = null,
+  {
+    tokenFeatures = null,
+    hasAccessToRoot = true,
+  }: { tokenFeatures?: TokenFeatures | null; hasAccessToRoot?: boolean } = {},
 ) => {
   const onChangeSpy = jest.fn();
   const onCloseSpy = jest.fn();
@@ -111,6 +115,16 @@ export const setup = async (
     ],
   });
   setupDatabasesEndpoints([db, db2, db3]);
+
+  const ROOT_COLLECTION = createMockCollection({
+    id: "root",
+    name: "Our analytics",
+  });
+
+  setupCollectionByIdEndpoint({
+    collections: [ROOT_COLLECTION],
+    error: hasAccessToRoot ? undefined : "You can't do that Ryan",
+  });
 
   setupCollectionItemsEndpoint({
     collection: createMockCollection({ id: "root", name: "Our analytics" }),

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
@@ -3,6 +3,7 @@ import _ from "underscore";
 
 import {
   skipToken,
+  useGetCollectionQuery,
   useListCollectionItemsQuery,
   useListDatabaseSchemaTablesQuery,
   useListDatabaseSchemasQuery,
@@ -54,11 +55,13 @@ function RootItemList() {
   const { data: databases } = useListDatabasesQuery();
   const { setPath, isHidden, models, shouldShowLibrary } =
     useMiniPickerContext();
+  const { isLoading: isLoadingRootCollection, error: rootCollectionError } =
+    useGetCollectionQuery({ id: "root" });
   const { data: libraryCollection, isLoading } =
     PLUGIN_DATA_STUDIO.useGetResolvedLibraryCollection();
   const enableNestedQueries = useSetting("enable-nested-queries");
 
-  if (isLoading) {
+  if (isLoading || isLoadingRootCollection) {
     return <MiniPickerListLoader />;
   }
 
@@ -119,7 +122,7 @@ function RootItemList() {
         />
       )) ?? <MiniPickerListLoader />}
       <MiniPickerItem
-        name={t`Our analytics`}
+        name={rootCollectionError ? t`Collections` : t`Our analytics`}
         model="collection"
         isFolder
         onClick={() => {
@@ -127,7 +130,7 @@ function RootItemList() {
             {
               model: "collection",
               id: "root" as any, // cmon typescript, trust me
-              name: t`Our analytics`,
+              name: rootCollectionError ? t`Collections` : t`Our analytics`,
             },
           ]);
         }}

--- a/frontend/src/metabase/querying/notebook/components/DataStep/tests/setup.tsx
+++ b/frontend/src/metabase/querying/notebook/components/DataStep/tests/setup.tsx
@@ -1,13 +1,16 @@
 import { setupEnterprisePlugins } from "__support__/enterprise";
 import {
+  setupCollectionByIdEndpoint,
   setupDatabasesEndpoints,
   setupRecentViewsAndSelectionsEndpoints,
   setupSearchEndpoints,
 } from "__support__/server-mocks";
 import { renderWithProviders } from "__support__/ui";
 import { createMockModelResult } from "metabase/browse/models/test-utils";
+import { ROOT_COLLECTION } from "metabase/entities/collections";
 import * as Lib from "metabase-lib";
 import { columnFinder } from "metabase-lib/test-helpers";
+import { createMockCollection } from "metabase-types/api/mocks";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
 
 import { createMockNotebookStep } from "../../../test-utils";
@@ -33,6 +36,9 @@ export const setup = ({
   const mockWindowOpen = jest.spyOn(window, "open").mockImplementation();
 
   const updateQuery = jest.fn();
+  setupCollectionByIdEndpoint({
+    collections: [createMockCollection(ROOT_COLLECTION)],
+  });
   setupDatabasesEndpoints([createSampleDatabase()]);
   setupRecentViewsAndSelectionsEndpoints([], ["selections"]);
 

--- a/frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.unit.spec.tsx
@@ -1,12 +1,15 @@
 import userEvent from "@testing-library/user-event";
 
 import {
+  setupCollectionByIdEndpoint,
   setupDatabasesEndpoints,
   setupRecentViewsAndSelectionsEndpoints,
   setupSearchEndpoints,
 } from "__support__/server-mocks";
 import { renderWithProviders, screen } from "__support__/ui";
+import { ROOT_COLLECTION } from "metabase/entities/collections";
 import type Question from "metabase-lib/v1/Question";
+import { createMockCollection } from "metabase-types/api/mocks";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
 
 import { createMockNotebookStep } from "../../test-utils";
@@ -30,6 +33,9 @@ function setup({ step = createMockNotebookStep() }: SetupOpts = {}) {
   setupDatabasesEndpoints([createSampleDatabase()]);
   setupSearchEndpoints([]);
   setupRecentViewsAndSelectionsEndpoints([], ["selections"]);
+  setupCollectionByIdEndpoint({
+    collections: [createMockCollection(ROOT_COLLECTION)],
+  });
 
   renderWithProviders(
     <NotebookProvider>

--- a/frontend/test/__support__/server-mocks/collection.ts
+++ b/frontend/test/__support__/server-mocks/collection.ts
@@ -214,7 +214,7 @@ function setupCollectionWithErrorById({
   error: string;
   status?: number;
 }) {
-  fetchMock.get(/api\/collection\/\d+|root/, {
+  fetchMock.get(/api\/collection\/\d+|root$/, {
     body: error,
     status,
   });


### PR DESCRIPTION
### Description

Mini Picker does a quick check to see if you have access to Our Analytics. If not, we replace the name "Our Analytics" with "Collections", but ensure that you can still navigate down the tree if you have access to sub collections.

Note: We don't currently have a good mechanism to know if you have access to anything below Collections, so it's possible there is no selectable leaf


### How to verify
1. Set up a user that does not have access to Our analytics, but does have access to sub collections
2. log in with that user, and navigate to the Notebook editor
3. You should see "Collections" in place of Our Analytics, and be able to navigate there


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
