### PR TITLE
Have a dedicated runner for SDK host/sample apps

### DIFF
--- a/e2e/runner/embedding-sdk/sample-apps/start-sample-app-containers.ts
+++ b/e2e/runner/embedding-sdk/sample-apps/start-sample-app-containers.ts
@@ -19,7 +19,7 @@ const userOptions = {
   ...process.env,
 } as const;
 
-printBold(`Running Cypress Sample App Tests with options:
+printBold(`Setting up the Sample App environment with options:
   - EMBEDDING_SDK_VERSION      : ${userOptions.EMBEDDING_SDK_VERSION}
   - SAMPLE_APP_BRANCH_NAME     : ${userOptions.SAMPLE_APP_BRANCH_NAME}
 `);

--- a/e2e/runner/run_cypress_host_sample_apps.ts
+++ b/e2e/runner/run_cypress_host_sample_apps.ts
@@ -1,52 +1,41 @@
-import { BACKEND_PORT } from "./constants/backend-port";
 import { FAILURE_EXIT_CODE, SUCCESS_EXIT_CODE } from "./constants/exit-code";
 import runCypress from "./cypress-node-js-runner";
-import { booleanify, printBold, unBooleanify } from "./cypress-runner-utils";
+import { booleanify, printBold } from "./cypress-runner-utils";
 import { startHostAppContainers } from "./embedding-sdk/host-apps/start-host-app-containers";
 import { startSampleAppContainers } from "./embedding-sdk/sample-apps/start-sample-app-containers";
 import { resolveSdkE2EConfig } from "./resolve-sdk-e2e-config";
 
 // if you want to change these, set them as environment variables in your shell
-const userOptions = {
-  SDK_TEST_SUITE: undefined, // one of the many sample-app, or host-app Embedding SDK suites
-  BACKEND_PORT: BACKEND_PORT, // override with MB_JETTY_PORT in your env
+const options = {
+  SDK_TEST_SUITE: "vite-6-host-app-e2e", // one of the many sample-app, or host-app Embedding SDK suites
   OPEN_UI: true,
   ...booleanify(process.env),
 };
 
-const options = {
-  ...userOptions,
-};
-
-process.env = unBooleanify(options);
-
 printBold(`Running Cypress with options:
   - SDK_TEST_SUITE       : ${options.SDK_TEST_SUITE}
-  - BACKEND_PORT         : ${options.BACKEND_PORT}
   - OPEN_UI              : ${options.OPEN_UI}
 `);
 
 const init = async () => {
-  if (options.SDK_TEST_SUITE) {
-    switch (options.SDK_TEST_SUITE) {
-      case "metabase-nodejs-react-sdk-embedding-sample-e2e":
-      case "metabase-nextjs-sdk-embedding-sample-e2e":
-      case "shoppy-e2e":
-        await startSampleAppContainers(options.SDK_TEST_SUITE);
-        break;
+  switch (options.SDK_TEST_SUITE) {
+    case "metabase-nodejs-react-sdk-embedding-sample-e2e":
+    case "metabase-nextjs-sdk-embedding-sample-e2e":
+    case "shoppy-e2e":
+      await startSampleAppContainers(options.SDK_TEST_SUITE);
+      break;
 
-      case "vite-6-host-app-e2e":
-      case "next-15-app-router-host-app-e2e":
-      case "next-15-pages-router-host-app-e2e":
-      case "angular-20-host-app-e2e":
-        await startHostAppContainers(options.SDK_TEST_SUITE);
-        break;
-    }
-
-    printBold("⏳ Starting Sample/Host App Cypress Tests");
-    const config = resolveSdkE2EConfig(options.SDK_TEST_SUITE);
-    await runCypress(config);
+    case "vite-6-host-app-e2e":
+    case "next-15-app-router-host-app-e2e":
+    case "next-15-pages-router-host-app-e2e":
+    case "angular-20-host-app-e2e":
+      await startHostAppContainers(options.SDK_TEST_SUITE);
+      break;
   }
+
+  printBold("⏳ Starting Sample/Host App Cypress Tests");
+  const config = resolveSdkE2EConfig(options.SDK_TEST_SUITE);
+  await runCypress(config);
 };
 
 init()

--- a/e2e/runner/run_cypress_host_sample_apps.ts
+++ b/e2e/runner/run_cypress_host_sample_apps.ts
@@ -1,0 +1,57 @@
+import { BACKEND_PORT } from "./constants/backend-port";
+import { FAILURE_EXIT_CODE, SUCCESS_EXIT_CODE } from "./constants/exit-code";
+import runCypress from "./cypress-node-js-runner";
+import { booleanify, printBold, unBooleanify } from "./cypress-runner-utils";
+import { startHostAppContainers } from "./embedding-sdk/host-apps/start-host-app-containers";
+import { startSampleAppContainers } from "./embedding-sdk/sample-apps/start-sample-app-containers";
+import { resolveSdkE2EConfig } from "./resolve-sdk-e2e-config";
+
+// if you want to change these, set them as environment variables in your shell
+const userOptions = {
+  SDK_TEST_SUITE: undefined, // one of the many sample-app, or host-app Embedding SDK suites
+  BACKEND_PORT: BACKEND_PORT, // override with MB_JETTY_PORT in your env
+  OPEN_UI: true,
+  ...booleanify(process.env),
+};
+
+const options = {
+  ...userOptions,
+};
+
+process.env = unBooleanify(options);
+
+printBold(`Running Cypress with options:
+  - SDK_TEST_SUITE       : ${options.SDK_TEST_SUITE}
+  - BACKEND_PORT         : ${options.BACKEND_PORT}
+  - OPEN_UI              : ${options.OPEN_UI}
+`);
+
+const init = async () => {
+  if (options.SDK_TEST_SUITE) {
+    switch (options.SDK_TEST_SUITE) {
+      case "metabase-nodejs-react-sdk-embedding-sample-e2e":
+      case "metabase-nextjs-sdk-embedding-sample-e2e":
+      case "shoppy-e2e":
+        await startSampleAppContainers(options.SDK_TEST_SUITE);
+        break;
+
+      case "vite-6-host-app-e2e":
+      case "next-15-app-router-host-app-e2e":
+      case "next-15-pages-router-host-app-e2e":
+      case "angular-20-host-app-e2e":
+        await startHostAppContainers(options.SDK_TEST_SUITE);
+        break;
+    }
+
+    printBold("⏳ Starting Sample/Host App Cypress Tests");
+    const config = resolveSdkE2EConfig(options.SDK_TEST_SUITE);
+    await runCypress(config);
+  }
+};
+
+init()
+  .then(() => process.exit(SUCCESS_EXIT_CODE))
+  .catch((e) => {
+    console.error(e);
+    process.exit(FAILURE_EXIT_CODE);
+  });

--- a/e2e/runner/run_cypress_host_sample_apps.ts
+++ b/e2e/runner/run_cypress_host_sample_apps.ts
@@ -8,7 +8,7 @@ import { resolveSdkE2EConfig } from "./resolve-sdk-e2e-config";
 // if you want to change these, set them as environment variables in your shell
 const options = {
   SDK_TEST_SUITE: "vite-6-host-app-e2e", // one of the many sample-app, or host-app Embedding SDK suites
-  OPEN_UI: true,
+  OPEN_UI: false,
   ...booleanify(process.env),
 };
 

--- a/e2e/runner/run_cypress_local.ts
+++ b/e2e/runner/run_cypress_local.ts
@@ -13,16 +13,12 @@ import {
   shell,
   unBooleanify,
 } from "./cypress-runner-utils";
-import { startHostAppContainers } from "./embedding-sdk/host-apps/start-host-app-containers";
-import { startSampleAppContainers } from "./embedding-sdk/sample-apps/start-sample-app-containers";
-import { resolveSdkE2EConfig } from "./resolve-sdk-e2e-config";
 
 let tempSampleDBDir: string | null = null;
 
 // if you want to change these, set them as environment variables in your shell
 const userOptions = {
   CYPRESS_TESTING_TYPE: "e2e", // e2e | component
-  SDK_TEST_SUITE: undefined, // one of the many sample-app, or host-app Embedding SDK suites
   MB_EDITION: "ee", // ee | oss
   START_CONTAINERS: true,
   STOP_CONTAINERS: false,
@@ -66,7 +62,6 @@ if (options.MB_EDITION === "ee" && missingTokens.length > 0) {
 
 printBold(`Running Cypress with options:
   - CYPRESS_TESTING_TYPE : ${options.CYPRESS_TESTING_TYPE}
-  - SDK_TEST_SUITE       : ${options.SDK_TEST_SUITE}
   - MB_EDITION           : ${options.MB_EDITION}
   - START_CONTAINERS     : ${options.START_CONTAINERS}
   - STOP_CONTAINERS      : ${options.STOP_CONTAINERS}
@@ -143,27 +138,6 @@ const init = async () => {
     printBold(
       "⚠️⚠️ You don't have your frontend running. You should probably run yarn build-hot ⚠️⚠️",
     );
-  }
-
-  if (options.SDK_TEST_SUITE) {
-    switch (options.SDK_TEST_SUITE) {
-      case "metabase-nodejs-react-sdk-embedding-sample-e2e":
-      case "metabase-nextjs-sdk-embedding-sample-e2e":
-      case "shoppy-e2e":
-        await startSampleAppContainers(options.SDK_TEST_SUITE);
-        break;
-
-      case "vite-6-host-app-e2e":
-      case "next-15-app-router-host-app-e2e":
-      case "next-15-pages-router-host-app-e2e":
-      case "angular-20-host-app-e2e":
-        await startHostAppContainers(options.SDK_TEST_SUITE);
-        break;
-    }
-
-    printBold("⏳ Starting Sample/Host App Cypress Tests");
-    const config = resolveSdkE2EConfig(options.SDK_TEST_SUITE);
-    await runCypress(config);
   }
 
   if (options.CYPRESS_TESTING_TYPE === "component") {

--- a/enterprise/frontend/src/embedding-sdk-package/dev.md
+++ b/enterprise/frontend/src/embedding-sdk-package/dev.md
@@ -78,7 +78,7 @@ Define one of the following environment variables with enterprise token: `CYPRES
 To run these tests locally, run:
 
 ```
-SDK_TEST_SUITE=<sample_app_repo_name>-e2e OPEN_UI=false EMBEDDING_SDK_VERSION=local START_METABASE=false GENERATE_SNAPSHOTS=false START_CONTAINERS=false yarn test-cypress
+SDK_TEST_SUITE=<sample_app_repo_name>-e2e yarn test-cypress-host-sample-apps
 ```
 
 For example for the `metabase-nodejs-react-sdk-embedding-sample`, run:

--- a/enterprise/frontend/src/embedding-sdk-package/dev.md
+++ b/enterprise/frontend/src/embedding-sdk-package/dev.md
@@ -84,7 +84,7 @@ SDK_TEST_SUITE=<sample_app_repo_name>-e2e yarn test-cypress-host-sample-apps
 For example for the `metabase-nodejs-react-sdk-embedding-sample`, run:
 
 ```
-SDK_TEST_SUITE=metabase-nodejs-react-sdk-embedding-sample-e2e OPEN_UI=false EMBEDDING_SDK_VERSION=local START_METABASE=false GENERATE_SNAPSHOTS=false START_CONTAINERS=false yarn test-cypress
+SDK_TEST_SUITE=metabase-nodejs-react-sdk-embedding-sample-e2e yarn test-cypress-host-sample-apps
 ```
 
 ##### :warning: Obtaining the Shoppy's Metabase App DB Dump locally
@@ -130,13 +130,13 @@ Tests a bit similar to Sample App tests, but:
 To run these tests locally, run:
 
 ```
-ENTERPRISE_TOKEN=<token> SDK_TEST_SUITE=<host_app_name>-e2e OPEN_UI=false EMBEDDING_SDK_VERSION=local HOST_APP_ENVIRONMENT=production yarn test-cypress
+ENTERPRISE_TOKEN=<token> SDK_TEST_SUITE=<host_app_name>-e2e HOST_APP_ENVIRONMENT=production yarn test-cypress-host-sample-apps
 ```
 
 For example for the `vite-6-host-app` Host App, run:
 
 ```
-ENTERPRISE_TOKEN=<token> SDK_TEST_SUITE=vite-6-host-app-e2e OPEN_UI=false EMBEDDING_SDK_VERSION=local HOST_APP_ENVIRONMENT=production yarn test-cypress
+ENTERPRISE_TOKEN=<token> SDK_TEST_SUITE=vite-6-host-app-e2e HOST_APP_ENVIRONMENT=production yarn test-cypress-host-sample-apps
 ```
 
 #### CI runs

--- a/package.json
+++ b/package.json
@@ -467,6 +467,7 @@
     "test": "yarn test-unit && yarn test-timezones && yarn test-cypress",
     "test-cljs": "yarn && shadow-cljs compile test && node target/node-tests.js",
     "test-cypress": "tsx ./e2e/runner/run_cypress_local.ts",
+    "test-cypress-host-sample-apps": "tsx ./e2e/runner/run_cypress_host_sample_apps.ts",
     "test-debug": "yarn build:cljs && node --inspect-brk node_modules/.bin/jest --runInBand --detectOpenHandles",
     "test-timezones": "yarn && ./frontend/test/__runner__/run_timezone_tests",
     "test-timezones-unit": "yarn build:cljs && jest --silent --maxWorkers=4 --config jest.tz.unit.conf.js",


### PR DESCRIPTION
This pull request refactors how Cypress end-to-end (E2E) tests for Embedding SDK sample and host apps are run, separating their execution into a new dedicated script and updating documentation and scripts accordingly. The main goal is to provide a clearer, more maintainable way to run these tests, especially distinguishing between local and host/sample app E2E runs.

**Test runner refactor and new script:**

- Introduced a new script, `run_cypress_host_sample_apps.ts`, to handle running Cypress E2E tests for host and sample apps, separating this logic from the local runner. This script sets up the appropriate environment, starts the necessary containers, and invokes Cypress with the correct configuration. (`e2e/runner/run_cypress_host_sample_apps.ts`)
- Added a new npm script, `test-cypress-host-sample-apps`, to the `package.json` for running the new test runner. (`package.json`)

**Documentation updates:**

- Updated the developer documentation to instruct users to use the new `test-cypress-host-sample-apps` script for running host and sample app E2E tests, removing unnecessary environment variables and clarifying usage examples. (`enterprise/frontend/src/embedding-sdk-package/dev.md`) [[1]](diffhunk://#diff-46d474a37cffcde6c927cc7ad99cc0fbe77e1449e06d9b3ddc2e808dd7868b80L81-R87) [[2]](diffhunk://#diff-46d474a37cffcde6c927cc7ad99cc0fbe77e1449e06d9b3ddc2e808dd7868b80L133-R139)

**Code cleanup in the local test runner:**

- Removed logic related to starting sample/host app containers and resolving their configs from `run_cypress_local.ts`, delegating these responsibilities to the new dedicated script. (`e2e/runner/run_cypress_local.ts`) [[1]](diffhunk://#diff-3d2bcf835645559b2ee649b31b08a4a9cb383315d6bc6bbbff1cdd4736ab1282L16-L25) [[2]](diffhunk://#diff-3d2bcf835645559b2ee649b31b08a4a9cb383315d6bc6bbbff1cdd4736ab1282L69) [[3]](diffhunk://#diff-3d2bcf835645559b2ee649b31b08a4a9cb383315d6bc6bbbff1cdd4736ab1282L148-L168)

**Minor improvements:**

- Improved and clarified log messages in the sample app container setup script for better readability. (`e2e/runner/embedding-sdk/sample-apps/start-sample-app-containers.ts`)