### PR TITLE
[analysis] Foundation for new persisted analysis findings

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/dependencies/analysis.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/analysis.clj
@@ -1,0 +1,83 @@
+(ns metabase-enterprise.dependencies.analysis
+  (:require
+   [medley.core :as m]
+   [metabase-enterprise.dependencies.native-validation :as deps.native]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.schema :as lib.schema]
+   [metabase.lib.schema.metadata :as lib.schema.metadata]
+   [metabase.lib.schema.ref :as lib.schema.ref]
+   [metabase.util.malli :as mu]
+   [metabase.util.malli.registry :as mr]))
+
+;; Analyzing an entity in memroy ================================================================
+(mu/defn- check-query
+  "Find any bad refs in a `query`."
+  [driver :- :keyword
+   query  :- ::lib.schema/query]
+  (if (lib/any-native-stage? query)
+    (deps.native/validate-native-query driver query)
+    (lib/find-bad-refs query)))
+
+#_(defmulti check-entity
+    "Given an entity type and an entity id, find any bad refs in that entity.
+
+  To control the `MetadataProvider` used for the analysis, bind [[*analysis-metadata-provider*]]."
+    {:arglists '([entity-type entity-id])}
+    (fn [entity-type _entity-id]
+      entity-type))
+
+#_(defmethod check-entity :default
+    [_entity-type _entity-id]
+    nil)
+
+(mr/def ::query-findings
+  [:map
+   [:bad-refs      {:optional true} [:sequential ::lib.schema.ref/ref]]
+   [:native-issues {:optional true} :any]])
+
+(mr/def ::card-findings
+  [:ref ::query-findings])
+
+(mu/defn analyze-entity:card :- [:maybe ::card-findings]
+  "Given a `MetadataProvider` and a card ID, analyses the card's query to find any bad refs or other issues.
+  Returns any findings, and `nil` for a clean query."
+  [metadata-provider :- ::lib.schema.metadata/metadata-provider
+   card-id           :- pos-int?]
+  (let [query  (lib/query metadata-provider (:dataset-query (lib.metadata/card metadata-provider card-id)))
+        driver (:engine (lib.metadata/database query))]
+    (check-query driver query)))
+
+(mr/def ::transform-findings
+  [:merge
+   [:ref ::query-findings]
+   [:map
+    [:duplicated-fields {:optional true} [:sequential ::lib.schema.metadata/metadata-provider]]]])
+
+(mu/defn analyze-entity:transform :- [:maybe ::transform-findings]
+  "Given a `MetadataProvider` and a transform ID, analyses the transform's query to find any bad refs or other issues.
+
+  Returns any findings, and `nil` for a clean transform."
+  [metadata-provider :- ::lib.schema.metadata/metadata-provider
+   transform-id      :- pos-int?]
+  (let [{{target-schema :schema target-name :name} :target
+         {query :query} :source
+         :as _transform}  (lib.metadata/transform metadata-provider transform-id)
+        driver            (:engine (lib.metadata/database metadata-provider))
+        query             (lib/query metadata-provider query)
+        output-table      (m/find-first #(and (= (:schema %) target-schema)
+                                              (= (:name %)   target-name))
+                                        (lib.metadata/tables metadata-provider))
+        output-fields     (lib.metadata/active-fields metadata-provider (:id output-table))
+        duplicated-fields (->> output-fields
+                               (group-by :name)
+                               vals
+                               (mapcat #(when (> (count %) 1)
+                                          %))
+                               not-empty)]
+    (cond-> (check-query driver query)
+      duplicated-fields (assoc :duplicated-fields duplicated-fields))))
+
+(mu/defn check-entity :- :boolean
+  "Given a `MetadataProvider`, an `entity-type` and its `id`, check that entity."
+  [metadata-provider :- ::lib.schema.metadata/metadata-provider])

--- a/enterprise/backend/src/metabase_enterprise/dependencies/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/core.clj
@@ -3,14 +3,12 @@
 
   Call [[errors-from-proposed-edits]] to find out what things will break downstream of a set of new/updated entities."
   (:require
+   [metabase-enterprise.dependencies.analysis :as deps.analysis]
    [metabase-enterprise.dependencies.metadata-provider :as deps.provider]
    [metabase-enterprise.dependencies.models.dependency :as deps.graph]
-   [metabase-enterprise.dependencies.native-validation :as deps.native]
    [metabase.graph.core :as graph]
    [metabase.lib-be.core :as lib-be]
-   [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
-   [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.util :as u]
    [metabase.util.log :as log]
@@ -40,55 +38,6 @@
    (let [dependents (or dependents (deps.graph/transitive-dependents graph updated-entities))]
      (deps.provider/override-metadata-provider base-provider updated-entities dependents))))
 
-(mu/defn- check-query
-  "Find any bad refs in a `query`."
-  [driver :- :keyword
-   query  :- ::lib.schema/query]
-  (if (lib/any-native-stage? query)
-    (deps.native/validate-native-query driver query)
-    (lib/find-bad-refs query)))
-
-(defmulti ^:private check-entity
-  "Given a `MetadataProvider`, and entity type, and an entity id, find any bad refs in that entity."
-  {:arglists '([metadata-provider entity-type entity-id])}
-  (fn [_mp entity-type _entity-id]
-    entity-type))
-
-(defmethod check-entity :default
-  [_mp _entity-type _entity-id]
-  nil)
-
-;; TODO (Cam 10/2/25) -- we already have keywords for these things, `:model/Card` and `:model/Transform`, can use
-;; those for consistency and discoverability?
-(defmethod check-entity :card
-  [mp _entity-type card-id]
-  (let [query  (lib/query mp (:dataset-query (lib.metadata/card mp card-id)))
-        driver (:engine (lib.metadata/database query))]
-    (check-query driver query)))
-
-(defmethod check-entity :transform
-  [mp _entity-type entity-id]
-  (let [{{target-schema :schema target-name :name} :target
-         {query :query} :source
-         :as _transform} (lib.metadata/transform mp entity-id)
-        driver (:engine (lib.metadata/database mp))
-        query (lib/query mp query)
-        output-table (some #(when (and (= (:schema %) target-schema)
-                                       (= (:name %) target-name))
-                              %)
-                           (lib.metadata/tables mp))
-        output-fields (lib.metadata/active-fields mp (:id output-table))
-        {:keys [duplicate-fields]} (reduce (fn [{:keys [seen duplicate-fields]}
-                                                {name :name :as field}]
-                                             (if (seen name)
-                                               {:seen seen
-                                                :duplicate-fields (conj duplicate-fields field)}
-                                               {:seen (conj seen name)
-                                                :duplicate-fields duplicate-fields}))
-                                           {:seen #{}}
-                                           output-fields)]
-    (into duplicate-fields (check-query driver query))))
-
 (mu/defn- check-query-soundness ;; :- [:map-of ::lib.schema.id/card [:sequential ::lib.schema.mbql-clause/clause]]
   "Given a `MetadataProvider` as returned by [[metadata-provider]], scan all its updated entities and their dependents
   to check that everything is still sound.
@@ -106,7 +55,7 @@
         errors    (volatile! {})]
     (doseq [[entity-type ids] overrides
             id ids
-            :let [bad-refs (check-entity provider entity-type id)]]
+            :let [bad-refs (deps.analysis/check-entity provider entity-type id)]]
       (when (seq bad-refs)
         (vswap! errors assoc-in [entity-type id] bad-refs)))
     @errors))

--- a/enterprise/backend/src/metabase_enterprise/dependencies/findings.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/findings.clj
@@ -1,16 +1,40 @@
 (ns metabase-enterprise.dependencies.findings
   (:require
    [metabase-enterprise.dependencies.analysis :as deps.analysis]
+   [metabase-enterprise.dependencies.models.analysis-finding :as deps.analysis-finding]
    [metabase.lib-be.core :as lib-be]
+   [metabase.models.interface :as mi]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [toucan2.core :as t2]))
+
+(def ^:private model->dependency-type
+  {:model/Card :card
+   :model/Transform :transform})
 
 (mu/defn upsert-analysis!
   "Given a Toucan entity, run its analysis and write the results into `:model/AnalysisFinding`.
 
   If any row exists already, it is replaced. If it does not exist, it is created."
-  [entity-type toucan-instance]
+  [toucan-instance]
   (when-not (lib-be/metadata-provider-cache)
     (log/warn "FIXME: deps.findings/upsert-analysis! ran without reusing `MetadataProvider`s"))
-  (let [mp (lib-be/application-database-metadata-provider)]))
+  (let [mp (lib-be/application-database-metadata-provider (:database_id toucan-instance))
+        model (t2/model toucan-instance)
+        results (try (deps.analysis/check-entity mp (model->dependency-type model) (:id toucan-instance))
+                     (catch Exception e
+                       {:exception (.getMessage e)}))
+        success (empty? results)]
+    (deps.analysis-finding/upsert-analysis! model (:id toucan-instance) success results)))
+
+(mu/defn analyze-entities :- :int
+  [model :- [:enum :model/Card :model/Transform]
+   batch-size :- :int]
+  (lib-be/with-metadata-provider-cache
+    (let [instances (deps.analysis-finding/instances-for-analysis model batch-size)]
+      (doseq [instance instances]
+        (try (upsert-analysis! instance)
+             (catch Exception e
+               (log/errorf e "Analyzing entity %s %s failed"
+                           model (:id instance)))))
+      (count instances))))

--- a/enterprise/backend/src/metabase_enterprise/dependencies/findings.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/findings.clj
@@ -25,10 +25,10 @@
                      (catch Exception e
                        {:exception (.getMessage e)}))
         success (empty? results)]
-    (deps.analysis-finding/upsert-analysis! model (:id toucan-instance) success results)))
+    (deps.analysis-finding/upsert-analysis! (model->dependency-type model) (:id toucan-instance) success results)))
 
 (mu/defn analyze-entities :- :int
-  [model :- [:enum :model/Card :model/Transform]
+  [model :- [:enum :card :transform]
    batch-size :- :int]
   (lib-be/with-metadata-provider-cache
     (let [instances (deps.analysis-finding/instances-for-analysis model batch-size)]

--- a/enterprise/backend/src/metabase_enterprise/dependencies/findings.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/findings.clj
@@ -1,0 +1,16 @@
+(ns metabase-enterprise.dependencies.findings
+  (:require
+   [metabase-enterprise.dependencies.analysis :as deps.analysis]
+   [metabase.lib-be.core :as lib-be]
+   [metabase.util.log :as log]
+   [metabase.util.malli :as mu]
+   [toucan2.core :as t2]))
+
+(mu/defn upsert-analysis!
+  "Given a Toucan entity, run its analysis and write the results into `:model/AnalysisFinding`.
+
+  If any row exists already, it is replaced. If it does not exist, it is created."
+  [entity-type toucan-instance]
+  (when-not (lib-be/metadata-provider-cache)
+    (log/warn "FIXME: deps.findings/upsert-analysis! ran without reusing `MetadataProvider`s"))
+  (let [mp (lib-be/application-database-metadata-provider)]))

--- a/enterprise/backend/src/metabase_enterprise/dependencies/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/init.clj
@@ -4,4 +4,5 @@
    [metabase-enterprise.dependencies.events]
    [metabase-enterprise.dependencies.schema]
    [metabase-enterprise.dependencies.settings]
-   [metabase-enterprise.dependencies.task.backfill]))
+   [metabase-enterprise.dependencies.task.backfill]
+   [metabase-enterprise.dependencies.task.entity-check]))

--- a/enterprise/backend/src/metabase_enterprise/dependencies/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/init.clj
@@ -1,5 +1,6 @@
 (ns metabase-enterprise.dependencies.init
   (:require
+   #_[metabase-enterprise.dependencies.task.analysis]
    [metabase-enterprise.dependencies.events]
    [metabase-enterprise.dependencies.schema]
    [metabase-enterprise.dependencies.settings]

--- a/enterprise/backend/src/metabase_enterprise/dependencies/models/analysis_finding.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/models/analysis_finding.clj
@@ -19,35 +19,41 @@
   The background task will re-analyze anything with out-of-date analyses."
   1)
 
-(defn upsert-analysis! [model instance-id result finding-details]
+(defn upsert-analysis! [type instance-id result finding-details]
   (let [update {:analyzed_at (mi/now)
                 :analysis_version current-analysis-version
                 :result result
                 :finding_details finding-details}
         existing-id (t2/select-one-fn :id [:model/AnalysisFinding :id]
-                                      :analyzed_entity_type model
+                                      :analyzed_entity_type type
                                       :analyzed_entity_id instance-id)]
     (if existing-id
       (t2/update! :model/AnalysisFinding existing-id update)
       (t2/insert! :model/AnalysisFinding
                   (assoc update
-                         :analyzed_entity_type model
+                         :analyzed_entity_type type
                          :analyzed_entity_id instance-id)))))
 
 (def ^:private table-info
-  {:model/Card [:report_card :report_card.* :report_card.id]
-   :model/Transform [:transform :transform.* :transform.id]})
+  {:card [:model/Card :report_card :report_card.* :report_card.id]
+   :transform [:model/Transform :transform :transform.* :transform.id]})
 
-(defn instances-for-analysis [model batch-size]
-  (let [[table-name table-wildcard table-id] (table-info model)
-        model-str (subs (str model) 1)]
+(defn instances-for-analysis [type batch-size]
+  (let [[model table-name table-wildcard table-id] (table-info type)]
     (t2/select model
                {:select [table-wildcard]
                 :from table-name
                 :left-join [:analysis_finding [:and
                                                [:= :analysis_finding.analyzed_entity_id table-id]
-                                               [:= :analysis_finding.analyzed_entity_type model-str]]]
+                                               [:= :analysis_finding.analyzed_entity_type (name type)]]]
                 :where [:or
                         [:= :analysis_finding.analysis_version nil]
                         [:< :analysis_finding.analysis_version current-analysis-version]]
                 :limit batch-size})))
+
+(defn reset-analysis! [type instance-ids]
+  (doseq [ids-batch (partition 50 50 nil instance-ids)]
+    (t2/update! :model/AnalysisFinding
+                :analyzed_entity_id [:in ids-batch]
+                :analyzed_entity_type type
+                {:analysis_version -1})))

--- a/enterprise/backend/src/metabase_enterprise/dependencies/models/analysis_finding.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/models/analysis_finding.clj
@@ -5,16 +5,49 @@
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
-(def current-analysis-version
-  "Current version of the analysis logic.
-  This should be incremented when the analysis logic changes.
-  The background task will re-analyze anything with out-of-date analyses."
-  1)
-
 (methodical/defmethod t2/table-name :model/AnalysisFinding [_model] :analysis_finding)
 
 (derive :model/AnalysisFinding :metabase/model)
 
 (t2/deftransforms :model/AnalysisFinding
   {:analyzed_entity_type mi/transform-keyword
-   :result               mi/transform-keyword})
+   :finding_details mi/transform-json})
+
+(def current-analysis-version
+  "Current version of the analysis logic.
+  This should be incremented when the analysis logic changes.
+  The background task will re-analyze anything with out-of-date analyses."
+  1)
+
+(defn upsert-analysis! [model instance-id result finding-details]
+  (let [update {:analyzed_at (mi/now)
+                :analysis_version current-analysis-version
+                :result result
+                :finding_details finding-details}
+        existing-id (t2/select-one-fn :id [:model/AnalysisFinding :id]
+                                      :analyzed_entity_type model
+                                      :analyzed_entity_id instance-id)]
+    (if existing-id
+      (t2/update! :model/AnalysisFinding existing-id update)
+      (t2/insert! :model/AnalysisFinding
+                  (assoc update
+                         :analyzed_entity_type model
+                         :analyzed_entity_id instance-id)))))
+
+(def ^:private table-info
+  {:model/Card [:report_card :report_card.* :report_card.id]
+   :model/Transform [:transform :transform.* :transform.id]})
+
+(defn instances-for-analysis [model batch-size]
+  (let [[table-name table-wildcard table-id] (table-info model)
+        model-str (subs (str model) 1)]
+    (t2/select model
+               {:select [table-wildcard]
+                :from table-name
+                :left-join [:analysis_finding [:and
+                                               [:= :analysis_finding.analyzed_entity_id table-id]
+                                               [:= :analysis_finding.analyzed_entity_type model-str]]]
+                :where [:or
+                        [:= :analysis_finding.analysis_version nil]
+                        [:< :analysis_finding.analysis_version current-analysis-version]]
+                :limit batch-size})))

--- a/enterprise/backend/src/metabase_enterprise/dependencies/models/analysis_finding.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/models/analysis_finding.clj
@@ -1,0 +1,20 @@
+(ns metabase-enterprise.dependencies.models.analysis-finding
+  (:require
+   [metabase.models.interface :as mi]
+   [metabase.util.malli :as mu]
+   [methodical.core :as methodical]
+   [toucan2.core :as t2]))
+
+(def current-analysis-version
+  "Current version of the analysis logic.
+  This should be incremented when the analysis logic changes.
+  The background task will re-analyze anything with out-of-date analyses."
+  1)
+
+(methodical/defmethod t2/table-name :model/AnalysisFinding [_model] :analysis_finding)
+
+(derive :model/AnalysisFinding :metabase/model)
+
+(t2/deftransforms :model/AnalysisFinding
+  {:analyzed_entity_type mi/transform-keyword
+   :result               mi/transform-keyword})

--- a/enterprise/backend/src/metabase_enterprise/dependencies/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/settings.clj
@@ -25,3 +25,27 @@
   :default    30
   :setter     :none
   :export?    false)
+
+(defsetting dependency-entity-check-batch-size
+  "Batch size."
+  :visibility :internal
+  :type       :integer
+  :default    500
+  :setter     :none
+  :export?    false)
+
+(defsetting dependency-entity-check-delay-minutes
+  "Backfill delay in minutes."
+  :visibility :internal
+  :type       :integer
+  :default    60
+  :setter     :none
+  :export?    false)
+
+(defsetting dependency-entity-check-variance-minutes
+  "Backfill variance (?) whatever that means."
+  :visibility :internal
+  :type       :integer
+  :default    30
+  :setter     :none
+  :export?    false)

--- a/enterprise/backend/src/metabase_enterprise/dependencies/task/entity_check.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/task/entity_check.clj
@@ -24,18 +24,17 @@
   (t/to-millis-from-epoch (t/instant)))
 
 (def ^:private entities
-  [:model/Card
-   :model/Transform])
+  [:card :transform])
 
 (defn- check-entities!
   []
   (when (premium-features/has-feature? :dependencies)
-    (-> (reduce (fn [batch-size model-kw]
+    (-> (reduce (fn [batch-size entity-type]
                   (if (< batch-size 1)
                     (reduced 0)
-                    (let [processed (deps.findings/analyze-entities model-kw batch-size)]
+                    (let [processed (deps.findings/analyze-entities entity-type batch-size)]
                       (when (pos? processed)
-                        (log/info "Updated" processed "entities of type" model-kw))
+                        (log/info "Updated" processed "entities of type" entity-type))
                       (- batch-size processed))))
                 (deps.settings/dependency-entity-check-batch-size)
                 entities)

--- a/enterprise/backend/src/metabase_enterprise/dependencies/task/entity_check.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/task/entity_check.clj
@@ -32,7 +32,7 @@
     (-> (reduce (fn [batch-size entity-type]
                   (if (< batch-size 1)
                     (reduced 0)
-                    (let [processed (deps.findings/analyze-entities entity-type batch-size)]
+                    (let [processed (deps.findings/analyze-batch! entity-type batch-size)]
                       (when (pos? processed)
                         (log/info "Updated" processed "entities of type" entity-type))
                       (- batch-size processed))))

--- a/enterprise/backend/src/metabase_enterprise/dependencies/task/entity_check.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/task/entity_check.clj
@@ -1,0 +1,79 @@
+(ns metabase-enterprise.dependencies.task.entity-check
+  (:require
+   [clojurewerkz.quartzite.jobs :as jobs]
+   [clojurewerkz.quartzite.scheduler :as qs]
+   [clojurewerkz.quartzite.triggers :as triggers]
+   [java-time.api :as t]
+   [metabase-enterprise.dependencies.findings :as deps.findings]
+   [metabase-enterprise.dependencies.models.dependency :as models.dependency]
+   [metabase-enterprise.dependencies.settings :as deps.settings]
+   [metabase.events.core :as events]
+   [metabase.premium-features.core :as premium-features]
+   [metabase.task.core :as task]
+   [metabase.util.log :as log]
+   [toucan2.core :as t2])
+  (:import
+   (java.util Map Set)
+   (java.util.concurrent ConcurrentHashMap)))
+
+(set! *warn-on-reflection* true)
+
+(defn- current-millis
+  "Returns the current epoch millis. Uses java-time so that clock settings can be used in tests."
+  []
+  (t/to-millis-from-epoch (t/instant)))
+
+(def ^:private entities
+  [:model/Card
+   :model/Transform])
+
+(defn- check-entities!
+  []
+  (when (premium-features/has-feature? :dependencies)
+    (-> (reduce (fn [batch-size model-kw]
+                  (if (< batch-size 1)
+                    (reduced 0)
+                    (let [processed (deps.findings/analyze-entities model-kw batch-size)]
+                      (when (pos? processed)
+                        (log/info "Updated" processed "entities of type" model-kw))
+                      (- batch-size processed))))
+                (deps.settings/dependency-entity-check-batch-size)
+                entities)
+        (< 1))))
+
+(declare schedule-next-run!)
+
+(task/defjob
+  ^{:doc "Check all entities for validity"
+    org.quartz.DisallowConcurrentExecution true}
+  DependencyEntityCheck [ctx]
+  (log/info "Executing DependencyEntityCheck job...")
+  (check-entities!)
+  (let [delay-seconds    (* (deps.settings/dependency-entity-check-delay-minutes) 1 #_60)
+        variance-seconds (* (deps.settings/dependency-entity-check-variance-minutes) 1 #_60)
+        delay-in-seconds (max 0 (+ (- delay-seconds variance-seconds) (rand-int (* 2 variance-seconds))))]
+    (schedule-next-run! delay-in-seconds (.getScheduler ctx))))
+
+(def ^:private job-key     "metabase.dependencies.task.entity-check.job")
+(def ^:private trigger-key "metabase.dependencies.task.entity-check.trigger")
+
+(defn- schedule-next-run!
+  ([delay-in-seconds] (schedule-next-run! delay-in-seconds nil))
+  ([delay-in-seconds scheduler]
+   (let [start-at (java.util.Date. (long (+ (current-millis) (* delay-in-seconds 1000))))
+         trigger  (triggers/build
+                   (triggers/with-identity (triggers/key (str trigger-key \. (random-uuid))))
+                   (triggers/for-job job-key)
+                   (triggers/start-at start-at))]
+     (log/info "Scheduling next run at" start-at)
+     (if scheduler
+       ;; re-scheduling from the job
+       (qs/add-trigger scheduler trigger)
+       ;; first schedule
+       (let [job (jobs/build (jobs/of-type DependencyEntityCheck) (jobs/with-identity job-key))]
+         (task/schedule-task! job trigger))))))
+
+(defmethod task/init! ::DependencyEntityCheck [_]
+  (if (pos? (deps.settings/dependency-entity-check-batch-size))
+    (schedule-next-run! (rand-int (* (deps.settings/dependency-entity-check-variance-minutes) 1 #_60)))
+    (log/info "Not starting dependency entity check job because the batch size is not positive")))

--- a/enterprise/backend/test/metabase_enterprise/dependencies/events_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/events_test.clj
@@ -379,7 +379,7 @@
                          (t2/select-one-fn :dependency_analysis_version :model/Sandbox :id sandbox-id)))
                   (is (empty? (t2/select :model/Dependency :from_entity_id sandbox-id :from_entity_type :sandbox))))))))))))
 
-(deftest card-update-works-with-no-analyses-test
+(deftest ^:sequential card-update-works-with-no-analyses-test
   (mt/with-test-user :rasta
     (let [mp (mt/metadata-provider)
           products-id (mt/id :products)
@@ -400,7 +400,7 @@
                                    :analyzed_entity_type :card
                                    :analyzed_entity_id [:in [parent-card-id child-card-id]]))))))))
 
-(deftest card-update-clears-analyses-test
+(deftest ^:sequential card-update-clears-analyses-test
   (mt/with-test-user :rasta
     (let [mp (mt/metadata-provider)
           products-id (mt/id :products)
@@ -440,7 +440,7 @@
                                   :analyzed_entity_type :card
                                   :analyzed_entity_id [:in [parent-card-id child-card-id other-card-id]])))))))))
 
-(deftest transform-update-works-with-no-analyses-test
+(deftest ^:sequential transform-update-works-with-no-analyses-test
   (mt/with-test-user :rasta
     (let [mp (mt/metadata-provider)
           products-id (mt/id :products)
@@ -469,7 +469,7 @@
                                    :analyzed_entity_type :transform
                                    :analyzed_entity_id transform-id))))))))
 
-(deftest transform-update-clears-analyses-test
+(deftest ^:sequential transform-update-clears-analyses-test
   (mt/with-test-user :rasta
     (let [mp (mt/metadata-provider)
           products-id (mt/id :products)

--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -859,8 +859,8 @@ databaseChangeLog:
                     nullable: false
               - column:
                   name: result
-                  type: varchar(20)
-                  remarks: The result of the analysis - ok, broken, etc.
+                  type: ${boolean.type}
+                  remarks: The result of the analysis - true for passed, false for failed
                   constraints:
                     nullable: false
               - column:

--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -816,7 +816,7 @@ databaseChangeLog:
             sql: UPDATE collection SET type = 'remote-synced' WHERE is_remote_synced = true
 
   - changeSet:
-      id: v57.2025-10-22T14:12:00
+      id: v58.2025-12-02T00:00:01
       author: bshepherdson
       comment: Create analysis finding table
       changes:
@@ -871,7 +871,7 @@ databaseChangeLog:
                     nullable: true
 
   - changeSet:
-      id: v57.2025-10-28T14:55:00
+      id: v58.2025-12-02T00:00:02
       author: bshepherdson
       comment: Unique constraint to prevent duplicate analyses
       changes:
@@ -881,7 +881,7 @@ databaseChangeLog:
             constraintName: idx_unique_analysis_finding
 
   - changeSet:
-      id: v57.2025-10-22T14:13:00
+      id: v58.2025-12-02T00:00:03
       author: bshepherdson
       comment: Index for analysis_finding by analyzed entity
       changes:
@@ -895,7 +895,7 @@ databaseChangeLog:
                   name: analyzed_entity_id
 
   - changeSet:
-      id: v57.2025-10-22T14:14:00
+      id: v58.2025-12-02T00:00:04
       author: bshepherdson
       comment: Index for analysis_finding by analysis result
       changes:

--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -815,6 +815,97 @@ databaseChangeLog:
         - sql:
             sql: UPDATE collection SET type = 'remote-synced' WHERE is_remote_synced = true
 
+  - changeSet:
+      id: v57.2025-10-22T14:12:00
+      author: bshepherdson
+      comment: Create analysis finding table
+      changes:
+        - createTable:
+            tableName: analysis_finding
+            remarks: Findings from analysis of cards, transforms, dashboards, etc.
+            columns:
+              - column:
+                  name: id
+                  remarks: Unique ID
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: analyzed_entity_type
+                  type: varchar(20)
+                  remarks: The type of the analyzed entity
+                  constraints:
+                    nullable: false
+              - column:
+                  name: analyzed_entity_id
+                  type: int
+                  remarks: The ID of the analyzed entity
+                  constraints:
+                    nullable: false
+              - column:
+                  name: analysis_version
+                  remarks: The version of the analysis that was performed
+                  type: int
+                  constraints:
+                    nullable: false
+              - column:
+                  name: analyzed_at
+                  remarks: The timestamp of when the analysis was performed
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+              - column:
+                  name: result
+                  type: varchar(20)
+                  remarks: The result of the analysis - ok, broken, etc.
+                  constraints:
+                    nullable: false
+              - column:
+                  name: finding_details
+                  type: ${text.type}
+                  remarks: Arbitrary EDN text of the findings
+                  constraints:
+                    nullable: true
+
+  - changeSet:
+      id: v57.2025-10-28T14:55:00
+      author: bshepherdson
+      comment: Unique constraint to prevent duplicate analyses
+      changes:
+        - addUniqueConstraint:
+            tableName: analysis_finding
+            columnNames: analyzed_entity_type, analyzed_entity_id
+            constraintName: idx_unique_analysis_finding
+
+  - changeSet:
+      id: v57.2025-10-22T14:13:00
+      author: bshepherdson
+      comment: Index for analysis_finding by analyzed entity
+      changes:
+        - createIndex:
+            tableName: analysis_finding
+            indexName: idx_analyzed_entity
+            columns:
+              - column:
+                  name: analyzed_entity_type
+              - column:
+                  name: analyzed_entity_id
+
+  - changeSet:
+      id: v57.2025-10-22T14:14:00
+      author: bshepherdson
+      comment: Index for analysis_finding by analysis result
+      changes:
+        - createIndex:
+            tableName: analysis_finding
+            indexName: idx_analysis_result
+            columns:
+              - column:
+                  name: result
+
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 


### PR DESCRIPTION
**DO NOT SUBMIT** - unfinished draft for sharing with the team.

### Description

The idea is to maintain a table of (eventually up-to-date) analyses of
all the major entities in Metabase - cards, transforms, dashboards - to
ensure that they are consistent and working. These analyses would be
written synchronously when editing an entity and in the background for
its (possibly *very* numerous) dependents, and stored in this table.

This new table will power new (EE) analyst power features, like a global
view of broken things.
