### PR TITLE
Provide minimal sane defaults to the Cypress runner

### DIFF
--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -22,14 +22,10 @@ on:
         required: false
         default: "ee"
       qa_db:
-        description: "Select the type of Database you want to run your tests with"
-        type: choice
+        description: "Whether to set up and include external QA databases"
+        type: boolean
         required: true
-        default: "none"
-        options:
-          - none
-          - sql
-          - mongo
+        default: false
       enable_network_throttling:
         description: "Enable network throttling simulation (4g slow like in chrome dev tools)"
         type: boolean
@@ -81,8 +77,6 @@ jobs:
     name: Stress test E2E flake fix
     env:
       DISPLAY: ""
-      QA_DB_ENABLED: ${{ contains(fromJSON('["sql", "mongo"]'), inputs.qa_db) }}
-      CYPRESS_QA_DB_MONGO: ${{ inputs.qa_db == 'mongo' }}
       MB_RUN_MODE: e2e
       METASTORE_DEV_SERVER_URL: ${{ secrets.METASTORE_DEV_SERVER_URL }}
       CYPRESS_MB_ALL_FEATURES_TOKEN: ${{ secrets.STAGING_MB_ALL_FEATURES_TOKEN }}
@@ -109,9 +103,9 @@ jobs:
           maildev: true
           openldap: true
           snowplow: true
-          postgres: ${{ inputs.qa_db == 'sql' }}
-          mysql: ${{ inputs.qa_db == 'sql' }}
-          mongo: ${{ inputs.qa_db == 'mongo' }}
+          postgres: ${{ inputs.qa_db }}
+          mysql: ${{ inputs.qa_db }}
+          mongo: ${{ inputs.qa_db }}
 
       - name: Download Metabase ${{ matrix.edition }} uberjar
         uses: ./.github/actions/e2e-download-uberjar

--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -134,8 +134,11 @@ jobs:
         uses: ./.github/actions/prepare-cypress
       - name: Run Metabase
         run: node e2e/runner/run_cypress_ci.js start
+
       - name: Generate database snapshots
-        run: node e2e/runner/run_cypress_ci.js snapshot
+        run: |
+          node e2e/runner/run_cypress_ci.js snapshot \
+            --env grepTags="${{inputs.qa_db && '' || '-@external'}}"
 
       # For all options and fine-grained control, take a look at the documentation
       # https://github.com/cypress-io/cypress/tree/develop/npm/grep

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -37,7 +37,6 @@ jobs:
     env:
       MB_EDITION: ${{ inputs.edition }}
       DISPLAY: ""
-      QA_DB_ENABLED: true
       PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       HASH: ${{ github.event.pull_request.head.sha || github.sha }}-${{ github.run_attempt }}
@@ -58,7 +57,6 @@ jobs:
       MB_SNOWPLOW_URL: "http://localhost:9090" # Snowplow micro
       TZ: US/Pacific # to make node match the instance tz
       CYPRESS_CI: true
-      CYPRESS_QA_DB_MONGO: ${{ inputs.name == 'mongo' }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -78,9 +78,9 @@ jobs:
           openldap: true
           webhook: true
           snowplow: true
-          postgres: ${{ inputs.name != 'mongo' }}
-          mysql: ${{ inputs.name != 'mongo' }}
-          mongo: ${{ inputs.name == 'mongo' }}
+          postgres: true
+          mysql: true
+          mongo: true
 
       - name: Retrieve uberjar artifact for ${{ inputs.edition }}
         uses: ./.github/actions/fetch-artifact

--- a/.github/workflows/embedding-sdk-component-tests.yml
+++ b/.github/workflows/embedding-sdk-component-tests.yml
@@ -62,7 +62,10 @@ jobs:
       - name: Make app db snapshot
         env:
           CYPRESS_BROWSER: ${{ steps.cypress-prep.outputs.chrome-path }}
-        run: node e2e/runner/run_cypress_ci.js snapshot
+        # Component tests do not need QA database snapshots so we skip them by ommitting the @external tag
+        run: |
+          node e2e/runner/run_cypress_ci.js snapshot \
+           --env grepTags="-@external"
 
       # Has to be run after the app db snapshot is made, as it is not compatible with React 19
       - name: Change React version to ${{ matrix.react-version }}

--- a/.github/workflows/embedding-sdk-component-tests.yml
+++ b/.github/workflows/embedding-sdk-component-tests.yml
@@ -62,10 +62,10 @@ jobs:
       - name: Make app db snapshot
         env:
           CYPRESS_BROWSER: ${{ steps.cypress-prep.outputs.chrome-path }}
-        # Component tests do not need QA database snapshots so we skip them by ommitting the @external tag
+        # Component tests only need the default snapshot
         run: |
           node e2e/runner/run_cypress_ci.js snapshot \
-           --env grepTags="-@external"
+            --spec "e2e/snapshot-creators/default.cy.snap.js"
 
       # Has to be run after the app db snapshot is made, as it is not compatible with React 19
       - name: Change React version to ${{ matrix.react-version }}

--- a/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
+++ b/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
@@ -278,7 +278,9 @@ jobs:
         run: node e2e/runner/run_cypress_ci.js start
 
       - name: Generate database snapshots
-        run: node e2e/runner/run_cypress_ci.js snapshot
+        run: |
+          node e2e/runner/run_cypress_ci.js snapshot \
+            --spec "e2e/snapshot-creators/default.cy.snap.js"
 
       - name: Prepare and launch Host App
         run: npx tsx ./e2e/runner/embedding-sdk/host-apps/start-ci.ts ${{ matrix.test_suite }}

--- a/cypress.env.json.example
+++ b/cypress.env.json.example
@@ -10,5 +10,4 @@
   "MB_PRO_CLOUD_TOKEN": "get it from the password manager",
   "MB_PRO_SELF_HOSTED_TOKEN": "get it from the password manager",
   "MB_EDITION": "ee",
-  "QA_DB_ENABLED": "true"
 }

--- a/docs/developers-guide/e2e-tests.md
+++ b/docs/developers-guide/e2e-tests.md
@@ -122,28 +122,27 @@ One great feature of Cypress is that you can use the Chrome inspector after each
 
 `yarn build` and `yarn build-hot` each overwrite an HTML template to reference the correct JavaScript files. If you run `yarn build` before building an Uberjar for Cypress tests, you won’t see changes to your JavaScript reflected even if you then start `yarn build-hot`.
 
-### Running Cypress on M1 machines
+### Running Cypress on Apple Silicon
 
-You might run into problems when running Cypress on M1 machine.
+You might run into problems when running Cypress on Apple Silicon processors.
+
 This is caused by the `@bahmutov/cypress-esbuild-preprocessor` that is using `esbuild` as a dependency. The error might look [like this](https://github.com/evanw/esbuild/issues/1819#issuecomment-1018771557). [The solution](https://github.com/evanw/esbuild/issues/1819#issuecomment-1080720203) is to install NodeJS using one of the Node version managers like [nvm](https://github.com/nvm-sh/nvm) or [n](https://github.com/tj/n).
 
-Another issue you will almost surely face is the inability to connect to our Mongo QA Database. You can solve it by providing the following env:
+Another issue you will almost surely face is the inability to connect to our Mongo QA Database. The supported Docker image is incompatible (AMD64). You can solve it by providing the following env:
 
 ```shell
 export EXPERIMENTAL_DOCKER_DESKTOP_FORCE_QEMU=1
 ```
 
+Please note that some users experienced Mongo connection timeouts even with this env var set. If that happens, try using OrbStack instead of Docker Desktop.
+
 ### Running tests that depend on Docker images
 
-A subset of our tests depend on the external services that are available through the Docker images. At the time of this writing, those are the three supported external QA databases, Webmail, Snowplow and LDAP servers. The default cypress command will spin up all necessary docker containers for these tests to function properly, but you can toggle them off if you want
-
-```sh
-START_CONTAINERS=false yarn test-cypress
-```
+A large portion of our tests depend on the external services that are available through the Docker images. At the time of this writing, those are the three supported external QA databases, Webmail, Snowplow and LDAP servers. See `e2e/test/scenarios/docker-compose.yml` for up to date information. The default cypress command will spin up all necessary Docker containers for the tests to function properly. You can manually set up the e2e environment without them but be aware that you will run into test failures.
 
 ### Running tests with Snowplow involved
 
-Tests that depend on Snowplow expect a running server. This is enabled by default. You can manually enable them as well by spinning up the snowplow micro docker container and setting the appropriate environment variables:
+Tests that depend on Snowplow expect a running server. This is enabled by default. You can manually enable them as well by spinning up the Snowplow micro Docker container and setting the appropriate environment variables:
 
 ```
 docker-compose -f ./snowplow/docker-compose.yml up -d

--- a/e2e/runner/cypress-runner-backend.js
+++ b/e2e/runner/cypress-runner-backend.js
@@ -33,6 +33,11 @@ const CypressBackend = {
         "-Djava.awt.headless=true", // when running on macOS prevent little Java icon from popping up in Dock
         "-Dmail.smtps.ssl.trust=*", // trust self signed certs for testing
         "-Duser.timezone=US/Pacific",
+        // FIXME @nemanjaglumac 2025-11-28
+        // This is a bit convoluted because this particular log4j config outputs all logs to a file (logs/test.log)
+        // See: https://github.com/metabase/metabase/pull/21360
+        // If we want them in the console, we'd have to unset the log4j config, to let stdio inherit the logs.
+        // Override in your .env if you need to see the logs in the console locally.
         process.env.SHOW_BACKEND_LOGS === "true"
           ? null
           : `-Dlog4j.configurationFile=file:${__dirname}/../../frontend/test/__runner__/log4j2.xml`,

--- a/e2e/runner/cypress-runner-backend.js
+++ b/e2e/runner/cypress-runner-backend.js
@@ -50,6 +50,8 @@ const CypressBackend = {
         MB_CONFIG_FILE_PATH: "__cypress__", // ignore config.yml
         MB_HTTP_CHANNEL_HOST_STRATEGY: "allow-all", // we use a local webhook service for testing
         MB_IS_CYPRESS: "true", // custom flag so we can detect we're running in Cypress, used in tests.
+        MB_SNOWPLOW_AVAILABLE: true,
+        MB_SNOWPLOW_URL: "http://localhost:9090",
       };
 
       this.server.process = spawn("java", [...javaFlags, "-jar", jarPath], {

--- a/e2e/runner/run_cypress_ci.js
+++ b/e2e/runner/run_cypress_ci.js
@@ -46,7 +46,10 @@ if (command === "start") {
 }
 
 if (command === "snapshot") {
-  runTests({ configFile: "e2e/support/cypress-snapshots.config.js" });
+  runTests(
+    { configFile: "e2e/support/cypress-snapshots.config.js" },
+    cliArguments,
+  );
 }
 
 // Metabase component or e2e tests

--- a/e2e/runner/run_cypress_local.ts
+++ b/e2e/runner/run_cypress_local.ts
@@ -17,7 +17,6 @@ const options = {
   BUILD_BACKEND: false,
   BACKEND_PORT: BACKEND_PORT, // override with MB_JETTY_PORT in your env
   OPEN_UI: true,
-  SHOW_BACKEND_LOGS: false,
   GENERATE_SNAPSHOTS: true,
   TZ: "UTC",
   ...booleanify(process.env),
@@ -45,7 +44,6 @@ printBold(`Running Cypress with options:
   - GENERATE_SNAPSHOTS   : ${options.GENERATE_SNAPSHOTS}
   - BACKEND_PORT         : ${options.BACKEND_PORT}
   - OPEN_UI              : ${options.OPEN_UI}
-  - SHOW_BACKEND_LOGS    : ${options.SHOW_BACKEND_LOGS}
   - TZ                   : ${options.TZ}
 `);
 

--- a/e2e/runner/run_cypress_local.ts
+++ b/e2e/runner/run_cypress_local.ts
@@ -28,17 +28,16 @@ const options = {
 process.env = unBooleanify(options);
 
 const missingTokens = [
-  "MB_ALL_FEATURES_TOKEN",
-  "MB_STARTER_CLOUD_TOKEN",
-  "MB_PRO_CLOUD_TOKEN",
-  "MB_PRO_SELF_HOSTED_TOKEN",
+  "CYPRESS_MB_ALL_FEATURES_TOKEN",
+  "CYPRESS_MB_STARTER_CLOUD_TOKEN",
+  "CYPRESS_MB_PRO_CLOUD_TOKEN",
+  "CYPRESS_MB_PRO_SELF_HOSTED_TOKEN",
 ].filter((token) => !process.env[token]);
 
 if (options.MB_EDITION === "ee" && missingTokens.length > 0) {
   printBold(
     `⚠️ Missing tokens: ${missingTokens.join(", ")}. Either set them or run with MB_EDITION=oss`,
   );
-  process.exit(FAILURE_EXIT_CODE);
 }
 
 printBold(`Running Cypress with options:

--- a/e2e/runner/run_cypress_local.ts
+++ b/e2e/runner/run_cypress_local.ts
@@ -20,19 +20,17 @@ let tempSampleDBDir: string | null = null;
 const userOptions = {
   CYPRESS_TESTING_TYPE: "e2e", // e2e | component
   MB_EDITION: "ee", // ee | oss
-  START_CONTAINERS: true,
-  STOP_CONTAINERS: false,
   BACKEND_PORT: BACKEND_PORT, // override with MB_JETTY_PORT in your env
   OPEN_UI: true,
   SHOW_BACKEND_LOGS: false,
   GENERATE_SNAPSHOTS: true,
+  QA_DB_ENABLED: true,
   QUIET: false,
   TZ: "UTC",
   ...booleanify(process.env),
 };
 
 const derivedOptions = {
-  QA_DB_ENABLED: userOptions.START_CONTAINERS,
   BUILD_JAR: userOptions.BACKEND_PORT === 4000,
   START_BACKEND: userOptions.BACKEND_PORT === 4000,
   MB_SNOWPLOW_AVAILABLE: true,
@@ -63,8 +61,6 @@ if (options.MB_EDITION === "ee" && missingTokens.length > 0) {
 printBold(`Running Cypress with options:
   - CYPRESS_TESTING_TYPE : ${options.CYPRESS_TESTING_TYPE}
   - MB_EDITION           : ${options.MB_EDITION}
-  - START_CONTAINERS     : ${options.START_CONTAINERS}
-  - STOP_CONTAINERS      : ${options.STOP_CONTAINERS}
   - BUILD_JAR            : ${options.BUILD_JAR}
   - GENERATE_SNAPSHOTS   : ${options.GENERATE_SNAPSHOTS}
   - BACKEND_PORT         : ${options.BACKEND_PORT}
@@ -78,10 +74,8 @@ const init = async () => {
   const cliArguments = process.argv.slice(2);
   const userOverrides = await parseArguments(cliArguments);
 
-  if (options.START_CONTAINERS) {
-    printBold("⏳ Starting containers");
-    shell("docker compose -f ./e2e/test/scenarios/docker-compose.yml up -d");
-  }
+  printBold("⏳ Starting containers");
+  shell("docker compose -f ./e2e/test/scenarios/docker-compose.yml up -d");
 
   if (options.BUILD_JAR) {
     printBold("⏳ Building backend");
@@ -176,10 +170,9 @@ const cleanup = async (exitCode: string | number = SUCCESS_EXIT_CODE) => {
     }
   }
 
-  if (options.STOP_CONTAINERS) {
-    printBold("⏳ Stopping containers");
-    shell("docker compose -f ./e2e/test/scenarios/docker-compose.yml down");
-  }
+  printBold(
+    "🧹 Containers are running in background. If you wish to stop them, run:\n`docker compose -f ./e2e/test/scenarios/docker-compose.yml down`",
+  );
 
   typeof exitCode === "number"
     ? process.exit(exitCode)

--- a/e2e/runner/run_cypress_local.ts
+++ b/e2e/runner/run_cypress_local.ts
@@ -40,9 +40,9 @@ if (options.MB_EDITION === "ee" && missingTokens.length > 0) {
 printBold(`Running Cypress with options:
   - CYPRESS_TESTING_TYPE : ${options.CYPRESS_TESTING_TYPE}
   - MB_EDITION           : ${options.MB_EDITION}
+  - BACKEND_PORT         : ${options.BACKEND_PORT}
   - BUILD_BACKEND        : ${options.BUILD_BACKEND}
   - GENERATE_SNAPSHOTS   : ${options.GENERATE_SNAPSHOTS}
-  - BACKEND_PORT         : ${options.BACKEND_PORT}
   - OPEN_UI              : ${options.OPEN_UI}
   - TZ                   : ${options.TZ}
 `);

--- a/e2e/runner/run_cypress_local.ts
+++ b/e2e/runner/run_cypress_local.ts
@@ -18,7 +18,6 @@ const options = {
   BACKEND_PORT: BACKEND_PORT, // override with MB_JETTY_PORT in your env
   OPEN_UI: true,
   GENERATE_SNAPSHOTS: true,
-  TZ: "UTC",
   ...booleanify(process.env),
 };
 
@@ -44,7 +43,6 @@ printBold(`Running Cypress with options:
   - BUILD_BACKEND        : ${options.BUILD_BACKEND}
   - GENERATE_SNAPSHOTS   : ${options.GENERATE_SNAPSHOTS}
   - OPEN_UI              : ${options.OPEN_UI}
-  - TZ                   : ${options.TZ}
 `);
 
 const init = async () => {

--- a/e2e/runner/run_cypress_local.ts
+++ b/e2e/runner/run_cypress_local.ts
@@ -1,3 +1,5 @@
+import path from "path";
+
 import { BACKEND_PORT } from "./constants/backend-port";
 import { FAILURE_EXIT_CODE, SUCCESS_EXIT_CODE } from "./constants/exit-code";
 import runCypress from "./cypress-node-js-runner";
@@ -69,7 +71,10 @@ const init = async () => {
     }
 
     // Use a temporary copy of the sample db so it won't use and lock the db used for local development
-    process.env.MB_INTERNAL_DO_NOT_USE_SAMPLE_DB_DIR = "e2e/tmp"; // already .gitignored
+    process.env.MB_INTERNAL_DO_NOT_USE_SAMPLE_DB_DIR = path.resolve(
+      __dirname,
+      "../../e2e/tmp", // already exists and is .gitignored
+    );
 
     printBold("⏳ Starting backend");
     await CypressBackend.start("target/uberjar/metabase-backend.jar");

--- a/e2e/runner/run_cypress_local.ts
+++ b/e2e/runner/run_cypress_local.ts
@@ -1,7 +1,3 @@
-import fs from "fs";
-import os from "os";
-import path from "path";
-
 import { BACKEND_PORT } from "./constants/backend-port";
 import { FAILURE_EXIT_CODE, SUCCESS_EXIT_CODE } from "./constants/exit-code";
 import runCypress from "./cypress-node-js-runner";
@@ -13,8 +9,6 @@ import {
   shell,
   unBooleanify,
 } from "./cypress-runner-utils";
-
-let tempSampleDBDir: string | null = null;
 
 // if you want to change these, set them as environment variables in your shell
 const options = {
@@ -82,12 +76,7 @@ const init = async () => {
     }
 
     // Use a temporary copy of the sample db so it won't use and lock the db used for local development
-    tempSampleDBDir = path.join(
-      os.tmpdir(),
-      `metabase-sample-db-e2e-${process.pid}`,
-    );
-    fs.mkdirSync(tempSampleDBDir, { recursive: true });
-    process.env.MB_INTERNAL_DO_NOT_USE_SAMPLE_DB_DIR = tempSampleDBDir;
+    process.env.MB_INTERNAL_DO_NOT_USE_SAMPLE_DB_DIR = "e2e/tmp"; // already .gitignored
 
     printBold("⏳ Starting backend");
     await CypressBackend.start("target/uberjar/metabase-backend.jar");
@@ -140,20 +129,6 @@ const cleanup = async (exitCode: string | number = SUCCESS_EXIT_CODE) => {
   if (options.BUILD_BACKEND) {
     printBold("⏳ Cleaning up...");
     await CypressBackend.stop();
-  }
-
-  // Add cleanup for the temporary sample database directory
-  if (tempSampleDBDir) {
-    try {
-      fs.rmSync(tempSampleDBDir, { recursive: true, force: true });
-      printBold(
-        `🗑️ Cleaned up temporary sample database directory: ${tempSampleDBDir}`,
-      );
-    } catch (e) {
-      console.error(
-        `Error cleaning up temporary sample database directory: ${e}`,
-      );
-    }
   }
 
   printBold(

--- a/e2e/runner/run_cypress_local.ts
+++ b/e2e/runner/run_cypress_local.ts
@@ -20,7 +20,6 @@ const options = {
   SHOW_BACKEND_LOGS: false,
   GENERATE_SNAPSHOTS: true,
   QA_DB_ENABLED: true,
-  QUIET: false,
   TZ: "UTC",
   ...booleanify(process.env),
 };

--- a/e2e/runner/run_cypress_local.ts
+++ b/e2e/runner/run_cypress_local.ts
@@ -19,7 +19,6 @@ const options = {
   OPEN_UI: true,
   SHOW_BACKEND_LOGS: false,
   GENERATE_SNAPSHOTS: true,
-  QA_DB_ENABLED: true,
   TZ: "UTC",
   ...booleanify(process.env),
 };
@@ -93,7 +92,12 @@ const init = async () => {
 
     printBold("⏳ Generating app db snapshots");
     process.env.OPEN_UI = "false";
-    await runCypress({ configFile: "e2e/support/cypress-snapshots.config.js" });
+    await runCypress({
+      configFile: "e2e/support/cypress-snapshots.config.js",
+      ...(options.CYPRESS_TESTING_TYPE === "component" && {
+        env: { grepTags: "-@external" }, // component tests do not need QA DB snapshots for now
+      }),
+    });
     process.env.OPEN_UI = `${options.OPEN_UI}`;
   } else {
     printBold("Skipping snapshot generation, beware of stale snapshot caches");

--- a/e2e/runner/run_cypress_local.ts
+++ b/e2e/runner/run_cypress_local.ts
@@ -14,7 +14,7 @@ import {
 const options = {
   CYPRESS_TESTING_TYPE: "e2e", // e2e | component
   MB_EDITION: "ee", // ee | oss
-  BUILD_BACKEND: false,
+  BUILD_BACKEND: true,
   BACKEND_PORT: BACKEND_PORT, // override with MB_JETTY_PORT in your env
   OPEN_UI: true,
   GENERATE_SNAPSHOTS: true,

--- a/e2e/snapshot-creators/qa-db.cy.snap.js
+++ b/e2e/snapshot-creators/qa-db.cy.snap.js
@@ -9,29 +9,29 @@ import {
 
 describe("qa databases snapshots", { tags: "@external" }, () => {
   it("creates snapshots for supported qa databases", () => {
-    if (Cypress.env("QA_DB_MONGO") === true) {
-      restoreAndAuthenticate();
-      addMongoDatabase();
-      snapshot("mongo-5");
-    } else {
-      // Postgres
-      restoreAndAuthenticate();
+    // Mongo
+    restoreAndAuthenticate();
 
-      addPostgresDatabase();
-      snapshot("postgres-12");
+    addMongoDatabase();
+    snapshot("mongo-5");
 
-      convertToWritable("postgres");
-      snapshot("postgres-writable");
+    // Postgres
+    restoreAndAuthenticate();
 
-      // MySQL
-      restoreAndAuthenticate();
+    addPostgresDatabase();
+    snapshot("postgres-12");
 
-      addMySQLDatabase({});
-      snapshot("mysql-8");
+    convertToWritable("postgres");
+    snapshot("postgres-writable");
 
-      convertToWritable("mysql");
-      snapshot("mysql-writable");
-    }
+    // MySQL
+    restoreAndAuthenticate();
+
+    addMySQLDatabase({});
+    snapshot("mysql-8");
+
+    convertToWritable("mysql");
+    snapshot("mysql-writable");
 
     restore("blank");
   });

--- a/e2e/support/cypress-snapshots.config.js
+++ b/e2e/support/cypress-snapshots.config.js
@@ -2,15 +2,10 @@ const { defineConfig } = require("cypress");
 
 const { defaultConfig } = require("./config");
 
-const isQaDatabase = process.env["QA_DB_ENABLED"] === "true";
-
 module.exports = defineConfig({
   e2e: {
     ...defaultConfig,
     specPattern: "e2e/snapshot-creators/**/*.cy.snap.js",
-    excludeSpecPattern: !isQaDatabase
-      ? "e2e/snapshot-creators/qa-db.cy.snap.js"
-      : undefined,
     video: false,
   },
 });

--- a/e2e/support/helpers/e2e-setup-helpers.js
+++ b/e2e/support/helpers/e2e-setup-helpers.js
@@ -19,8 +19,6 @@ export function snapshot(name) {
  * } name
  */
 export function restore(name = "default") {
-  cy.skipOn(name.includes("mongo") && Cypress.env("QA_DB_MONGO") !== true);
-
   cy.log("Restore Data Set");
 
   // automatically reset the data db if this is a test that uses a writable db


### PR DESCRIPTION
## My Summary

The gist of the changes in this PR:
- If you decide to build the backend, you should run it
    - Speaking of which, building backend is now an explicit instruction rather than a derived option
- There are no more derived options - everything is explicit
- Running Docker containers is a non-negotiable
    - Tests need these supporting services to run
    - If you really insist on not running them, either comment out those lines temporarily or do not use this script to set up the e2e environment
    - Because of this, there are no more custom envs `QA_DB_ENABLED` and `CYPRESS_QA_DB_MONGO`
- Alternative location (directory) for the e2e copy of the sample-application.db is now set to be `e2e/tmp` since it's already gitignored

> [!NOTE]
> This reduces the complexity of the config by providing the defaults that are needed for all tests to work. We'll refine this even further in the following PRs.

## Copilot Summary

This pull request refactors and simplifies the handling of external QA database setup for E2E Cypress tests. It replaces the previous approach of selecting specific databases via input options with a simpler boolean flag, updates related environment variables and workflow logic, and clarifies documentation. The changes also streamline local and CI test runner scripts, reducing conditional logic and improving maintainability.

**Workflow and QA Database Setup Simplification:**

- Changed the `qa_db` workflow input from a multi-choice (none/sql/mongo) to a boolean flag indicating whether to include external QA databases, simplifying related environment variable logic and container setup in `.github/workflows/e2e-stress-test-flake-fix.yml`. [[1]](diffhunk://#diff-4646af354e953ac4599a2f11e0a846f2541bb1c751594e889063d6f20da35adcL25-R28) [[2]](diffhunk://#diff-4646af354e953ac4599a2f11e0a846f2541bb1c751594e889063d6f20da35adcL84-L85) [[3]](diffhunk://#diff-4646af354e953ac4599a2f11e0a846f2541bb1c751594e889063d6f20da35adcL112-R108)
- Updated the logic for starting database containers in both E2E and component test workflows to always include all supported databases, removing conditional checks based on the previous input value. [[1]](diffhunk://#diff-5cc2c864012004f60ee3f9078fa1c4a8721c6b841e386c57f12bea58b692e6e2L83-R83) [[2]](diffhunk://#diff-5cc2c864012004f60ee3f9078fa1c4a8721c6b841e386c57f12bea58b692e6e2L40) [[3]](diffhunk://#diff-5cc2c864012004f60ee3f9078fa1c4a8721c6b841e386c57f12bea58b692e6e2L61)

**Test Runner and Snapshot Generation Improvements:**

- Refactored `run_cypress_local.ts` to remove unnecessary derived options, always start containers, and use a fixed temporary directory for the sample database, simplifying environment setup and cleanup. [[1]](diffhunk://#diff-3d2bcf835645559b2ee649b31b08a4a9cb383315d6bc6bbbff1cdd4736ab1282L1-L2) [[2]](diffhunk://#diff-3d2bcf835645559b2ee649b31b08a4a9cb383315d6bc6bbbff1cdd4736ab1282L17-L90) [[3]](diffhunk://#diff-3d2bcf835645559b2ee649b31b08a4a9cb383315d6bc6bbbff1cdd4736ab1282L104-L113) [[4]](diffhunk://#diff-3d2bcf835645559b2ee649b31b08a4a9cb383315d6bc6bbbff1cdd4736ab1282L129-R101) [[5]](diffhunk://#diff-3d2bcf835645559b2ee649b31b08a4a9cb383315d6bc6bbbff1cdd4736ab1282L160-L182)
- Updated the snapshot generation steps in CI workflows and runner scripts to use CLI arguments and environment tags for more flexible and explicit control over which snapshots are generated (e.g., excluding external QA DBs for component tests). [[1]](diffhunk://#diff-1ee4f2eaf8feaa4c69048796f85a042405e434cbfce18db847d23856937a7624L65-R68) [[2]](diffhunk://#diff-edecf078a230641c6ff284a490e8271d76bd8c0227188d97d3b36dc20357fd55L281-R283) [[3]](diffhunk://#diff-e0cefc9b31081c17e99e244a3e3492c2d59e52ccd1544ee284936fc20573e882L49-R52) [[4]](diffhunk://#diff-4646af354e953ac4599a2f11e0a846f2541bb1c751594e889063d6f20da35adcR137-R141)

**Code and Configuration Cleanup:**

- Removed obsolete environment variables and configuration checks related to QA database selection, including `QA_DB_ENABLED` and `CYPRESS_QA_DB_MONGO`, from workflow files, Cypress configs, and example env files. [[1]](diffhunk://#diff-2b27cdf82123133e2c5d55abf3acb415647abf1cd6eac2de8a2c04496dea276eL13) [[2]](diffhunk://#diff-610e6ad292de4b1c04643a6291adb58741e6c190c414059eec54daa3a75f52c6L5-L13) [[3]](diffhunk://#diff-a9a78612a7217041662dc55444000e6878396b37323a0c47f234c4b9858115f4L12-R17) [[4]](diffhunk://#diff-a9a78612a7217041662dc55444000e6878396b37323a0c47f234c4b9858115f4L34) [[5]](diffhunk://#diff-a76002d02775ba6969c84b09d40b078ca34a575a01d77f26fffb827e8e956102L22-L23)
- Added explicit backend environment variables for Snowplow availability and URL in the Cypress backend runner, improving test reliability and clarity. [[1]](diffhunk://#diff-5a05a4ab7e57955487a77a96d8723fcb457bda82c4af48a0a96bfc4ea887887fR36-R40) [[2]](diffhunk://#diff-5a05a4ab7e57955487a77a96d8723fcb457bda82c4af48a0a96bfc4ea887887fR58-R59)

**Documentation Updates:**

- Updated E2E test documentation to clarify Apple Silicon (M1) compatibility issues, Docker image requirements, and best practices for running tests with or without external services, making setup instructions more accurate and user-friendly.