### PR TITLE
Workspaces dependent python transforms id adjustments

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/workspaces/context.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/context.clj
@@ -91,3 +91,15 @@
        (-> (select-keys src-output-id->dst-output deps-ids)
            (update-keys src-id->schema+table)
            (update-vals (juxt :schema :name))))))
+
+(defn transform-node->py-tables-remaps
+  "Remaps for python transform node"
+  [ctx transform-node]
+  (let [{:keys [source]} (transform-node->data ctx transform-node)
+        all-mappings (:src-output-id->dst-output ctx)
+        transform-table-ids (-> source :source-tables vals set)]
+    (into {}
+          (keep (fn [src-id]
+                  (when-some [dst-id (get-in all-mappings [src-id :id])]
+                    [src-id dst-id])))
+          transform-table-ids)))

--- a/enterprise/backend/src/metabase_enterprise/workspaces/remap.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/remap.clj
@@ -56,6 +56,15 @@
         remapped-str (remap-sql-tables native-str renames)]
     (assoc-in source query-sql-path remapped-str)))
 
+;;;; Python
+
+(defmethod remapped-transform-source :python
+  [transform-node ctx]
+  (let [{:keys [source]} (ws.ctx/transform-node->data ctx transform-node)
+        remaps (ws.ctx/transform-node->py-tables-remaps ctx transform-node)
+        key-remapper (fn [id] (get remaps id id))]
+    (update source :source-tables update-vals key-remapper)))
+
 ;;;; Public
 
 (defn- source-for-mirrored-transform

--- a/enterprise/backend/src/metabase_enterprise/workspaces/remap.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/remap.clj
@@ -62,8 +62,8 @@
   [transform-node ctx]
   (let [{:keys [source]} (ws.ctx/transform-node->data ctx transform-node)
         remaps (ws.ctx/transform-node->py-tables-remaps ctx transform-node)
-        key-remapper (fn [id] (get remaps id id))]
-    (update source :source-tables update-vals key-remapper)))
+        val-remapper (fn [id] (get remaps id id))]
+    (update source :source-tables update-vals val-remapper)))
 
 ;;;; Public
 


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/BOT-616/remap-python-transform-references

When workspce is created with multiple python transforms that depend on each other, their `{:source {:soruce-tables MAP}}` is adjusted so dependent transforms point to tables that result results of their _duplicated_ dependencies.