### PR TITLE
[perf] Add metric for `lib.computed/weak-map` size; speculative fixes

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/dependencies/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/core.clj
@@ -10,6 +10,7 @@
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.util :as u]
@@ -37,6 +38,8 @@
   ([base-provider    :- ::lib.schema.metadata/metadata-provider
     updated-entities :- ::updates-map
     & {:keys [graph dependents]}]
+   ;; Reusing the cache with different overrides breaks the caching of [[lib.metadata/card]] calls.
+   (lib.metadata.protocols/clear-cache! base-provider)
    (let [dependents (or dependents (deps.graph/transitive-dependents graph updated-entities))]
      (deps.provider/override-metadata-provider base-provider updated-entities dependents))))
 

--- a/enterprise/backend/src/metabase_enterprise/dependencies/metadata_provider.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/metadata_provider.clj
@@ -90,6 +90,8 @@
     (lib.metadata.protocols/cache-value! delegate k v))
   (has-cache? [_this]
     (lib.metadata.protocols/has-cache? delegate))
+  (clear-cache! [_this]
+    (lib.metadata.protocols/clear-cache! delegate))
 
   pretty/PrettyPrintable
   (pretty [this]

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -249,6 +249,8 @@
                        {:description "Number of queries with metrics processed by the metrics adjust middleware."})
    (prometheus/counter :metabase-query-processor/metrics-adjust-errors
                        {:description "Number of errors when processing metrics in the metrics adjust middleware."})
+   (prometheus/gauge   :metabase-query-processor/computed-weak-map-queries
+                       {:description "Number of queries cached in lib.computed/weak-map."})
    (prometheus/gauge :metabase-database/status
                      {:description "Does a given database using driver pass a health check."
                       :labels [:driver :healthy :reason]})

--- a/src/metabase/lib/metadata.cljc
+++ b/src/metabase/lib/metadata.cljc
@@ -2,8 +2,9 @@
   (:refer-clojure :exclude [every? empty? #?(:clj doseq) get-in #?(:clj for)])
   (:require
    [medley.core :as m]
-   [metabase.lib.computed :as lib.computed]
+   [metabase.lib.metadata.cache :as lib.metadata.cache]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
+   [metabase.lib.metadata.util :as lib.metadata.util]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
@@ -12,6 +13,7 @@
    [metabase.util :as u]
    [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]
+   [metabase.util.namespaces :as shared.ns]
    [metabase.util.performance :refer [every? empty? #?(:clj doseq) get-in #?(:clj for)]]))
 
 ;;; TODO -- deprecate all the schemas below, and just use the versions in [[lib.schema.metadata]] instead.
@@ -24,28 +26,9 @@
 ;;; returns a `Column` called `count`, but it's not a `Field` because it's not associated with an actual Field in the
 ;;; application database.
 
-(mu/defn ->metadata-provider :- ::lib.schema.metadata/metadata-provider
-  "Get a MetadataProvider from something that can provide one."
-  ([metadata-providerable]
-   (->metadata-provider metadata-providerable nil))
-
-  ([metadata-providerable :- ::lib.schema.metadata/metadata-providerable
-    database-id           :- [:maybe
-                              [:or
-                               ::lib.schema.id/database
-                               ::lib.schema.id/saved-questions-virtual-database]]]
-   (cond
-     (lib.metadata.protocols/metadata-provider? metadata-providerable)
-     metadata-providerable
-
-     (map? metadata-providerable)
-     (some-> metadata-providerable :lib/metadata ->metadata-provider)
-
-     ((some-fn fn? var?) metadata-providerable)
-     (if (pos-int? database-id)
-       (metadata-providerable database-id)
-       (throw (ex-info "Cannot initialize new metadata provider without a Database ID"
-                       {:f metadata-providerable}))))))
+(shared.ns/import-fns
+ [lib.metadata.util
+  ->metadata-provider])
 
 (mu/defn database :- ::lib.schema.metadata/database
   "Get metadata about the Database we're querying."
@@ -153,10 +136,9 @@
   "Get metadata for a Card, aka Saved Question, with `card-id`, if it can be found."
   [metadata-providerable :- ::lib.schema.metadata/metadata-providerable
    card-id               :- ::lib.schema.id/card]
-  (lib.computed/with-cache-sticky* metadata-providerable [:metadata/card card-id :metadata]
-    (fn []
-      (some-> (lib.metadata.protocols/card (->metadata-provider metadata-providerable) card-id)
-              (m/update-existing :dataset-query normalize-query metadata-providerable)))))
+  (lib.metadata.cache/with-cached-value metadata-providerable [:metadata/card card-id :metadata]
+    (some-> (lib.metadata.protocols/card (->metadata-provider metadata-providerable) card-id)
+            (m/update-existing :dataset-query normalize-query metadata-providerable))))
 
 (mu/defn native-query-snippet :- [:maybe ::lib.schema.metadata/native-query-snippet]
   "Get metadata for a NativeQuerySnippet with `snippet-id` if it can be found."

--- a/src/metabase/lib/metadata/cache.cljc
+++ b/src/metabase/lib/metadata/cache.cljc
@@ -6,8 +6,8 @@
   (:require
    [medley.core :as m]
    [metabase.lib.dispatch :as lib.dispatch]
-   [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
+   [metabase.lib.metadata.util :as lib.metadata.util]
    [metabase.lib.util :as lib.util]
    [metabase.util :as u]
    [metabase.util.log :as log]
@@ -88,7 +88,7 @@
 
 (mu/defn- ->cached-metadata-provider :- [:maybe ::lib.metadata.protocols/cached-metadata-provider]
   [metadata-providerable :- ::lib.metadata.protocols/metadata-providerable]
-  (let [metadata-provider (lib.metadata/->metadata-provider metadata-providerable)]
+  (let [metadata-provider (lib.metadata.util/->metadata-provider metadata-providerable)]
     (when (lib.metadata.protocols/cached-metadata-provider? metadata-provider)
       metadata-provider)))
 

--- a/src/metabase/lib/metadata/cached_provider.cljc
+++ b/src/metabase/lib/metadata/cached_provider.cljc
@@ -144,6 +144,9 @@
     (cache-value! cache k v))
   (has-cache? [_this]
     true)
+  (clear-cache! [_this]
+    (reset! cache {})
+    nil)
 
   #?(:clj Object :cljs IEquiv)
   (#?(:clj equals :cljs -equiv) [_this another]

--- a/src/metabase/lib/metadata/invocation_tracker.cljc
+++ b/src/metabase/lib/metadata/invocation_tracker.cljc
@@ -69,14 +69,18 @@
     (when (lib.metadata.protocols/cached-metadata-provider? metadata-provider)
       (lib.metadata.protocols/store-metadata! metadata-provider object)))
   (cached-value [_this k not-found]
-    (when (lib.metadata.protocols/cached-metadata-provider? metadata-provider)
-      (lib.metadata.protocols/cached-value metadata-provider k not-found)))
+    (if (lib.metadata.protocols/cached-metadata-provider? metadata-provider)
+      (lib.metadata.protocols/cached-value metadata-provider k not-found)
+      not-found))
   (cache-value! [_this k v]
     (when (lib.metadata.protocols/cached-metadata-provider? metadata-provider)
       (lib.metadata.protocols/cache-value! metadata-provider k v)))
   (has-cache? [_this]
     (when (lib.metadata.protocols/cached-metadata-provider? metadata-provider)
       (lib.metadata.protocols/has-cache? metadata-provider)))
+  (clear-cache! [_this]
+    (when (lib.metadata.protocols/cached-metadata-provider? metadata-provider)
+      (lib.metadata.protocols/clear-cache! metadata-provider)))
 
   #?(:clj Object :cljs IEquiv)
   (#?(:clj equals :cljs -equiv) [_this another]

--- a/src/metabase/lib/metadata/protocols.cljc
+++ b/src/metabase/lib/metadata/protocols.cljc
@@ -305,7 +305,10 @@
   (has-cache? [cached-metadata-provider]
     "Whether this metadata provider actually has a cache or not. (Some metadata providers like
   ComposedMetadataProvider implement this method but can only cache stuff if one of the providers they wrap is a cached
-  metadata provider.)"))
+  metadata provider.)")
+  (clear-cache! [cached-metadata-provider]
+    "Removes everything from the cache of this `CachedMetadataProvider`. Should not need to be called in general,
+    but some tests want to eg. reuse card numbers and caching can return stale cards."))
 
 (defn cached-metadata-provider?
   "Whether `x` satisfies the [[CachedMetadataProvider]] protocol. This does not necessarily mean it actually caches

--- a/src/metabase/lib/metadata/util.cljc
+++ b/src/metabase/lib/metadata/util.cljc
@@ -1,0 +1,30 @@
+(ns metabase.lib.metadata.util
+  "Helpers for use in `lib.metadata.*` without creating circular deps."
+  (:require
+   [metabase.lib.metadata.protocols :as lib.metadata.protocols]
+   [metabase.lib.schema.id :as lib.schema.id]
+   [metabase.lib.schema.metadata :as lib.schema.metadata]
+   [metabase.util.malli :as mu]))
+
+(mu/defn ->metadata-provider :- ::lib.schema.metadata/metadata-provider
+  "Get a MetadataProvider from something that can provide one."
+  ([metadata-providerable]
+   (->metadata-provider metadata-providerable nil))
+
+  ([metadata-providerable :- ::lib.schema.metadata/metadata-providerable
+    database-id           :- [:maybe
+                              [:or
+                               ::lib.schema.id/database
+                               ::lib.schema.id/saved-questions-virtual-database]]]
+   (cond
+     (lib.metadata.protocols/metadata-provider? metadata-providerable)
+     metadata-providerable
+
+     (map? metadata-providerable)
+     (some-> metadata-providerable :lib/metadata ->metadata-provider)
+
+     ((some-fn fn? var?) metadata-providerable)
+     (if (pos-int? database-id)
+       (metadata-providerable database-id)
+       (throw (ex-info "Cannot initialize new metadata provider without a Database ID"
+                       {:f metadata-providerable}))))))

--- a/src/metabase/query_processor/middleware/process_userland_query.clj
+++ b/src/metabase/query_processor/middleware/process_userland_query.clj
@@ -10,6 +10,7 @@
    [java-time.api :as t]
    [metabase.analytics.core :as analytics]
    [metabase.events.core :as events]
+   [metabase.lib.computed :as lib.computed]
    [metabase.queries.models.query :as query]
    [metabase.query-processor.schema :as qp.schema]
    [metabase.query-processor.util :as qp.util]
@@ -168,6 +169,9 @@
   [qp :- ::qp.schema/qp]
   (mu/fn [query :- ::qp.schema/any-query
           rff   :- ::qp.schema/rff]
+    ;; Update a gauge metric with the present number of queries in the WeakHashMap it maintains.
+    ;; This has to live somewhere and while processing each query seems like a natural place.
+    (analytics/set! :metabase.query-processor/computed-weak-map-queries (lib.computed/weak-map-population))
     (if-not (qp.util/userland-query? query)
       (qp query rff)
       (let [query          (assoc-in query [:info :query-hash] (qp.util/query-hash query))

--- a/test/metabase/lib/card_test.cljc
+++ b/test/metabase/lib/card_test.cljc
@@ -478,20 +478,18 @@
                                             %)
                :effective-type            :type/Text}
               (m/find-first #(= (:name %) "CATEGORY")
-                            (lib/returned-columns query))))
-      (testing "If the source card was a model, then propagate its display name as :lib/model-display-name"
-        (let [mp    (lib.tu/merged-mock-metadata-provider
-                     (lib.metadata/->metadata-provider query)
-                     {:cards [{:id 1, :type :model}]})
-              query (lib/query mp query)]
-          (is (=? {:name                   "CATEGORY"
-                   :display-name           "Products → Category"
-                   :lib/model-display-name "Products → Category"
-                   :lib/original-display-name #(#{(symbol "nil #_\"key is not present.\"")
-                                                  "Category"} %)
-                   :effective-type         :type/Text}
-                  (m/find-first #(= (:name %) "CATEGORY")
-                                (lib/returned-columns query)))))))))
+                            (lib/returned-columns query))))))
+  (testing "If the source card was a model, then propagate its display name as :lib/model-display-name"
+    (let [query (lib.tu.mocks-31368/query-with-legacy-source-card true :model)]
+      (binding [lib.metadata.calculation/*display-name-style* :long]
+        (is (=? {:name                   "CATEGORY"
+                 :display-name           "Products → Category"
+                 :lib/model-display-name "Products → Category"
+                 :lib/original-display-name #(#{(symbol "nil #_\"key is not present.\"")
+                                                "Category"} %)
+                 :effective-type         :type/Text}
+                (m/find-first #(= (:name %) "CATEGORY")
+                              (lib/returned-columns query))))))))
 
 (deftest ^:parallel do-not-propagate-lib-expression-names-from-cards-test
   (testing "Columns coming from a source card should not propagate :lib/expression-name"

--- a/test/metabase/lib/drill_thru/automatic_insights_test.cljc
+++ b/test/metabase/lib/drill_thru/automatic_insights_test.cljc
@@ -1,7 +1,7 @@
 (ns metabase.lib.drill-thru.automatic-insights-test
   (:require
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
-   [clojure.test :refer [deftest is testing]]
+   [clojure.test :refer [deftest is testing use-fixtures]]
    [medley.core :as m]
    [metabase.lib.core :as lib]
    [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]
@@ -12,6 +12,8 @@
    [metabase.util :as u]))
 
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
+
+(use-fixtures :each lib.drill-thru.tu/with-native-card-id)
 
 (deftest ^:parallel returns-automatic-insights-test-1
   (lib.drill-thru.tu/test-returns-drill

--- a/test/metabase/lib/drill_thru/column_extract_test.cljc
+++ b/test/metabase/lib/drill_thru/column_extract_test.cljc
@@ -2,7 +2,7 @@
   "See also [[metabase.query-processor.drill-thru-e2e-test/quick-filter-on-bucketed-date-test]]"
   (:require
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
-   [clojure.test :refer [deftest is testing]]
+   [clojure.test :refer [deftest is testing use-fixtures]]
    [metabase.lib.core :as lib]
    [metabase.lib.drill-thru.column-extract :as lib.drill-thru.column-extract]
    [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]
@@ -12,6 +12,8 @@
    [metabase.lib.test-util :as lib.tu]))
 
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
+
+(use-fixtures :each lib.drill-thru.tu/with-native-card-id)
 
 (def ^:private time-extraction-units
   [{:tag :hour-of-day, :display-name "Hour of day"}])

--- a/test/metabase/lib/drill_thru/column_filter_test.cljc
+++ b/test/metabase/lib/drill_thru/column_filter_test.cljc
@@ -1,7 +1,7 @@
 (ns metabase.lib.drill-thru.column-filter-test
   (:require
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
-   [clojure.test :refer [deftest is testing]]
+   [clojure.test :refer [deftest is testing use-fixtures]]
    [medley.core :as m]
    [metabase.lib.core :as lib]
    [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]
@@ -11,6 +11,8 @@
    [metabase.lib.test-util :as lib.tu]))
 
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
+
+(use-fixtures :each lib.drill-thru.tu/with-native-card-id)
 
 (deftest ^:parallel column-filter-availability-test
   (testing "column-filter is available for any header click, and nothing else"

--- a/test/metabase/lib/drill_thru/distribution_test.cljc
+++ b/test/metabase/lib/drill_thru/distribution_test.cljc
@@ -2,7 +2,7 @@
   "See also [[metabase.query-processor.drill-thru-e2e-test/distribution-drill-on-longitude-from-sql-source-card-test]]"
   (:require
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
-   [clojure.test :refer [deftest is testing]]
+   [clojure.test :refer [deftest is testing use-fixtures]]
    [medley.core :as m]
    [metabase.lib.core :as lib]
    [metabase.lib.drill-thru.distribution :as lib.drill-thru.distribution]
@@ -12,6 +12,8 @@
    [metabase.lib.types.isa :as lib.types.isa]))
 
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
+
+(use-fixtures :each lib.drill-thru.tu/with-native-card-id)
 
 (deftest ^:parallel distribution-availability-test
   (testing "distribution is available only for header clicks on non-aggregate, non-breakout columns which are not PKs, JSON, comments or descriptions"

--- a/test/metabase/lib/drill_thru/fk_details_test.cljc
+++ b/test/metabase/lib/drill_thru/fk_details_test.cljc
@@ -1,7 +1,7 @@
 (ns metabase.lib.drill-thru.fk-details-test
   (:require
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
-   [clojure.test :refer [deftest is testing]]
+   [clojure.test :refer [deftest is testing use-fixtures]]
    [medley.core :as m]
    [metabase.lib.core :as lib]
    [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]
@@ -11,6 +11,8 @@
    [metabase.lib.test-util.metadata-providers.merged-mock :as merged-mock]))
 
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
+
+(use-fixtures :each lib.drill-thru.tu/with-native-card-id)
 
 (deftest ^:parallel fk-details-availability-test
   (testing "FK details is available for cell clicks on non-NULL FKs"

--- a/test/metabase/lib/drill_thru/fk_filter_test.cljc
+++ b/test/metabase/lib/drill_thru/fk_filter_test.cljc
@@ -1,7 +1,7 @@
 (ns metabase.lib.drill-thru.fk-filter-test
   (:require
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
-   [clojure.test :refer [deftest is testing]]
+   [clojure.test :refer [deftest is testing use-fixtures]]
    [medley.core :as m]
    [metabase.lib.core :as lib]
    [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]
@@ -9,6 +9,8 @@
    [metabase.lib.test-metadata :as meta]))
 
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
+
+(use-fixtures :each lib.drill-thru.tu/with-native-card-id)
 
 (deftest ^:parallel fk-filter-availability-test
   (testing "fk-filter is available for cell clicks on FKs with any value including NULL"

--- a/test/metabase/lib/drill_thru/pivot_test.cljc
+++ b/test/metabase/lib/drill_thru/pivot_test.cljc
@@ -1,7 +1,7 @@
 (ns metabase.lib.drill-thru.pivot-test
   (:require
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
-   [clojure.test :refer [deftest is testing]]
+   [clojure.test :refer [deftest is testing use-fixtures]]
    [metabase.lib.core :as lib]
    [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]
    [metabase.lib.drill-thru.test-util.canned :as canned]
@@ -17,6 +17,8 @@
 ;; 2. Category + Location: a. date, b. date + category
 ;; 3. Category + Time: a. address, b. category, c. category + category
 ;; 4. All types: a. no breakouts.
+
+(use-fixtures :each lib.drill-thru.tu/with-native-card-id)
 
 (deftest ^:parallel pivot-availability-test
   (testing "pivot drill is available only for cell clicks"

--- a/test/metabase/lib/drill_thru/quick_filter_test.cljc
+++ b/test/metabase/lib/drill_thru/quick_filter_test.cljc
@@ -2,7 +2,7 @@
   "See also [[metabase.query-processor.drill-thru-e2e-test/quick-filter-on-bucketed-date-test]]"
   (:require
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
-   [clojure.test :refer [deftest is testing]]
+   [clojure.test :refer [deftest is testing use-fixtures]]
    [medley.core :as m]
    [metabase.lib.core :as lib]
    [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]
@@ -11,6 +11,8 @@
    [metabase.lib.types.isa :as lib.types.isa]))
 
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
+
+(use-fixtures :each lib.drill-thru.tu/with-native-card-id)
 
 (deftest ^:parallel quick-filter-availability-test
   (testing "quick-filter is avaiable for cell clicks on non-PK/FK columns"

--- a/test/metabase/lib/drill_thru/sort_test.cljc
+++ b/test/metabase/lib/drill_thru/sort_test.cljc
@@ -1,7 +1,7 @@
 (ns metabase.lib.drill-thru.sort-test
   (:require
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
-   [clojure.test :refer [are deftest is testing]]
+   [clojure.test :refer [are deftest is testing use-fixtures]]
    [medley.core :as m]
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
@@ -13,6 +13,8 @@
    [metabase.util.malli :as mu]))
 
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
+
+(use-fixtures :each lib.drill-thru.tu/with-native-card-id)
 
 (deftest ^:parallel sort-drill-availability-test
   (testing "sort is available on column headers only"

--- a/test/metabase/lib/drill_thru/summarize_column_by_time_test.cljc
+++ b/test/metabase/lib/drill_thru/summarize_column_by_time_test.cljc
@@ -1,7 +1,7 @@
 (ns metabase.lib.drill-thru.summarize-column-by-time-test
   (:require
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
-   [clojure.test :refer [deftest is testing]]
+   [clojure.test :refer [deftest is testing use-fixtures]]
    [medley.core :as m]
    [metabase.lib.core :as lib]
    [metabase.lib.drill-thru.summarize-column-by-time
@@ -11,6 +11,8 @@
    [metabase.lib.test-metadata :as meta]))
 
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
+
+(use-fixtures :each lib.drill-thru.tu/with-native-card-id)
 
 (deftest ^:parallel summarize-column-by-time-availability-test
   (testing (str "summarize-column-by-time is available for header click with no aggregations or breakouts, "

--- a/test/metabase/lib/drill_thru/summarize_column_test.cljc
+++ b/test/metabase/lib/drill_thru/summarize_column_test.cljc
@@ -1,11 +1,13 @@
 (ns metabase.lib.drill-thru.summarize-column-test
   (:require
-   [clojure.test :refer [deftest testing]]
+   [clojure.test :refer [deftest testing use-fixtures]]
    [metabase.lib.core :as lib]
    [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]
    [metabase.lib.drill-thru.test-util.canned :as canned]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.types.isa :as lib.types.isa]))
+
+(use-fixtures :each lib.drill-thru.tu/with-native-card-id)
 
 (deftest ^:parallel summarize-column-availability-test
   (testing "summarize-column is available for column headers with no aggregations or breakouts"

--- a/test/metabase/lib/drill_thru/underlying_records_test.cljc
+++ b/test/metabase/lib/drill_thru/underlying_records_test.cljc
@@ -3,7 +3,7 @@
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal])
        :clj  ([java-time.api :as t]
               [metabase.util.malli.fn :as mu.fn]))
-   [clojure.test :refer [deftest is testing]]
+   [clojure.test :refer [deftest is testing use-fixtures]]
    [medley.core :as m]
    [metabase.lib.core :as lib]
    [metabase.lib.drill-thru :as lib.drill-thru]
@@ -20,6 +20,8 @@
    [metabase.lib.underlying :as lib.underlying]))
 
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
+
+(use-fixtures :each lib.drill-thru.tu/with-native-card-id)
 
 (deftest ^:parallel underlying-records-availability-test
   (testing "underlying-records is available for non-header clicks with at least one breakout"

--- a/test/metabase/lib/drill_thru/zoom_in_bins_test.cljc
+++ b/test/metabase/lib/drill_thru/zoom_in_bins_test.cljc
@@ -1,7 +1,7 @@
 (ns metabase.lib.drill-thru.zoom-in-bins-test
   (:require
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
-   [clojure.test :refer [deftest is testing]]
+   [clojure.test :refer [deftest is testing use-fixtures]]
    [medley.core :as m]
    [metabase.lib.core :as lib]
    [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]
@@ -10,6 +10,8 @@
    [metabase.lib.test-metadata :as meta]))
 
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
+
+(use-fixtures :each lib.drill-thru.tu/with-native-card-id)
 
 (defn- variant-expected-query-with-count-filter-stage [base-expected-query]
   (let [base-filters (get-in base-expected-query [:stages 0 :filters])]

--- a/test/metabase/lib/drill_thru/zoom_in_geographic_test.cljc
+++ b/test/metabase/lib/drill_thru/zoom_in_geographic_test.cljc
@@ -1,7 +1,7 @@
 (ns metabase.lib.drill-thru.zoom-in-geographic-test
   (:require
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
-   [clojure.test :refer [deftest is testing]]
+   [clojure.test :refer [deftest is testing use-fixtures]]
    [medley.core :as m]
    [metabase.lib.core :as lib]
    [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]
@@ -10,6 +10,8 @@
    [metabase.lib.test-util :as lib.tu]))
 
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
+
+(use-fixtures :each lib.drill-thru.tu/with-native-card-id)
 
 (deftest ^:parallel country-test
   (testing "Country => Binned LatLon"

--- a/test/metabase/lib/drill_thru/zoom_in_timeseries_test.cljc
+++ b/test/metabase/lib/drill_thru/zoom_in_timeseries_test.cljc
@@ -1,7 +1,7 @@
 (ns metabase.lib.drill-thru.zoom-in-timeseries-test
   (:require
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
-   [clojure.test :refer [deftest is testing]]
+   [clojure.test :refer [deftest is testing use-fixtures]]
    [medley.core :as m]
    [metabase.lib.core :as lib]
    [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]
@@ -14,6 +14,8 @@
    [metabase.util.malli :as mu]))
 
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
+
+(use-fixtures :each lib.drill-thru.tu/with-native-card-id)
 
 (deftest ^:parallel zoom-in-timeseries-available-test
   (testing "zoom-in for bins is available for cells, pivots and legends on numeric columns which have binning set"

--- a/test/metabase/lib/drill_thru/zoom_test.cljc
+++ b/test/metabase/lib/drill_thru/zoom_test.cljc
@@ -1,11 +1,13 @@
 (ns metabase.lib.drill-thru.zoom-test
   (:require
-   [clojure.test :refer [deftest is testing]]
+   [clojure.test :refer [deftest is testing use-fixtures]]
    [medley.core :as m]
    [metabase.lib.core :as lib]
    [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]
    [metabase.lib.drill-thru.test-util.canned :as canned]
    [metabase.lib.test-metadata :as meta]))
+
+(use-fixtures :each lib.drill-thru.tu/with-native-card-id)
 
 (deftest ^:parallel zoom-availability-test
   (testing "zoom drill is available for cell clicks on non-FKs in tables with only 1 PK, and the PK in the result set"

--- a/test/metabase/lib/drill_thru_test.cljc
+++ b/test/metabase/lib/drill_thru_test.cljc
@@ -1,7 +1,7 @@
 (ns metabase.lib.drill-thru-test
   (:require
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
-   [clojure.test :refer [deftest is testing]]
+   [clojure.test :refer [deftest is testing use-fixtures]]
    [malli.error :as me]
    [medley.core :as m]
    [metabase.lib.core :as lib]
@@ -17,6 +17,8 @@
    [metabase.util.malli.registry :as mr]))
 
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
+
+(use-fixtures :each lib.drill-thru.tu/with-native-card-id)
 
 (def ^:private orders-query
   (lib/query meta/metadata-provider (meta/table-metadata :orders)))

--- a/test/metabase/lib/test_util/mocks_31368.cljc
+++ b/test/metabase/lib/test_util/mocks_31368.cljc
@@ -29,12 +29,15 @@
 
 (defn query-with-legacy-source-card
   "An MLv2 query that has a `:source-card` that has a legacy query, and legacy metadata."
-  [has-result-metadata?]
-  (let [metadata-provider (lib.tu/mock-metadata-provider
-                           meta/metadata-provider
-                           {:cards [(cond-> {:id            1
-                                             :database-id   (meta/id)
-                                             :name          "Card 1"
-                                             :dataset-query legacy-card-query}
-                                      has-result-metadata? (assoc :result-metadata (legacy-card-metadata)))]})]
-    (lib/query metadata-provider (lib.metadata/card metadata-provider 1))))
+  ([has-result-metadata?]
+   (query-with-legacy-source-card has-result-metadata? :question))
+  ([has-result-metadata? card-type]
+   (let [metadata-provider (lib.tu/mock-metadata-provider
+                            meta/metadata-provider
+                            {:cards [(cond-> {:id            1
+                                              :database-id   (meta/id)
+                                              :name          "Card 1"
+                                              :type          card-type
+                                              :dataset-query legacy-card-query}
+                                       has-result-metadata? (assoc :result-metadata (legacy-card-metadata)))]})]
+     (lib/query metadata-provider (lib.metadata/card metadata-provider 1)))))


### PR DESCRIPTION
### Description

OOMs in cloud are linked to this weak map retaining too much. The
exported heap dump reports are suggestive but not conclusive, and I
can't reproduce locally.

Adds `:metabase-query-processor/computed-weak-map-queries` to measure
the size of the weak map. That should sawtooth with GCs as it
accumulates queries and then discards them, but we'll see if it rises
forever on the problem instances.

This also adjusts the caching for a `MetadataProvider`-level entity
(`:metadata/card`) from the weak map to the `MetadataProvider`'s
internal cache. That's speculative, since there's no evidence to link
it to the issue, but it should be at least as effective a cache and
there's less risk of accidentally retaining too much.

### How to verify

Nothing visible aside from the new metric.

### Checklist

- ~~Tests have been added/updated to cover changes in this PR~~
