### PR TITLE
Disallow transforms with card dependencies in workspaces

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/workspaces/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/api.clj
@@ -205,7 +205,8 @@
                                                  :id [:in transform-ids]
                                                  :workspace_id [:not= nil])]
       (when (seq workspace-transforms)
-        (api/check-400 false "Cannot add transforms that belong to another workspace"))))
+        (api/check-400 false "Cannot add transforms that belong to another workspace")))
+    (ws.common/check-no-card-dependencies! transform-ids))
 
   (-> (ws.common/create-workspace! api/*current-user-id* body)
       ws->response))
@@ -289,7 +290,8 @@
                                                    :id [:in transform-ids]
                                                    :workspace_id [:not= nil])]
         (when (seq workspace-transforms)
-          (api/check-400 false "Cannot add transforms that belong to another workspace"))))
+          (api/check-400 false "Cannot add transforms that belong to another workspace")))
+      (ws.common/check-no-card-dependencies! transform-ids))
 
     (let [existing-upstream-ids (t2/select-fn-set :upstream_id :model/WorkspaceMappingTransform
                                                   :workspace_id id)

--- a/enterprise/backend/src/metabase_enterprise/workspaces/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/common.clj
@@ -11,6 +11,14 @@
    [metabase.util :as u]
    [toucan2.core :as t2]))
 
+(defn check-no-card-dependencies!
+  "Check that transforms don't depend on cards. Throws 400 if they do."
+  [transform-ids]
+  (when-let [card-ids (seq (ws.dag/card-dependencies transform-ids))]
+    (api/check-400 false
+                   (format "Cannot add transforms that depend on saved questions (cards). Found dependencies on card IDs: %s"
+                           (pr-str (vec card-ids))))))
+
 (defn- extract-suffix-number
   "Extract the numeric suffix from a workspace name like 'Foo (3)', or nil if no valid suffix."
   [ws-name base-name]

--- a/enterprise/backend/test/metabase_enterprise/workspaces/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/api_test.clj
@@ -182,3 +182,90 @@
                                                       :query (mt/mbql-query transforms_products)}
                                              :target {:type   "table"
                                                       :name   table-name}}))))))))))
+
+;;;; Card dependency rejection tests
+
+(defn- query-with-source-card
+  "Create a pMBQL query that uses a card as its source."
+  [card-id]
+  {:lib/type :mbql/query
+   :database (mt/id)
+   :stages   [{:lib/type    :mbql.stage/mbql
+               :source-card card-id}]})
+
+(defn- create-transform-with-card-source!
+  "Create a transform whose source query depends on a card.
+   The after-insert hook triggers dependency calculation automatically."
+  [card]
+  (t2/insert-returning-instance! :model/Transform
+                                 {:name   "Transform depending on card"
+                                  :source {:type  :query
+                                           :query (query-with-source-card (:id card))}
+                                  :target {:type     "table"
+                                           :database (mt/id)
+                                           :schema   "public"
+                                           :name     "card_dep_output"}}))
+
+(deftest create-workspace-rejects-card-dependencies-test
+  (testing "Cannot create workspace with transforms that depend on cards"
+    (mt/with-premium-features #{:workspaces :dependencies :transforms}
+      (mt/with-model-cleanup [:model/Dependency :model/Transform]
+        (mt/with-temp [:model/Card card {:name         "Test Card"
+                                         :database_id  (mt/id)
+                                         :dataset_query (mt/mbql-query venues)}]
+          (let [tx       (create-transform-with-card-source! card)
+                response (mt/user-http-request :crowberto :post 400 "ee/workspace"
+                                               {:name        "Card Dep Workspace"
+                                                :database_id (mt/id)
+                                                :upstream    {:transforms [(:id tx)]}})]
+            (is (re-find #"Cannot add transforms that depend on saved questions" response))))))))
+
+(deftest create-workspace-rejects-transitive-card-dependencies-test
+  (testing "Cannot create workspace with transforms that transitively depend on cards"
+    (mt/with-premium-features #{:workspaces :dependencies :transforms}
+      (mt/with-model-cleanup [:model/Dependency :model/Transform]
+        (mt/with-temp [:model/Card card {:name          "Base Card"
+                                         :database_id   (mt/id)
+                                         :dataset_query (mt/mbql-query venues)}]
+          ;; tx1 depends on card
+          (let [tx1 (create-transform-with-card-source! card)
+                ;; tx2 depends on tx1 (via a manually created dependency - simulating transform chain)
+                tx2 (t2/insert-returning-instance! :model/Transform
+                                                   {:name   "Transform 2 - depends on tx1"
+                                                    :source {:type  :query
+                                                             :query {:database (mt/id)
+                                                                     :type     :native
+                                                                     :native   {:query "SELECT 1"}}}
+                                                    :target {:type     "table"
+                                                             :database (mt/id)
+                                                             :schema   "public"
+                                                             :name     "tx2_output"}})]
+            ;; Create dependency: tx2 depends on tx1
+            (t2/insert! :model/Dependency
+                        {:from_entity_type "transform"
+                         :from_entity_id   (:id tx2)
+                         :to_entity_type   "transform"
+                         :to_entity_id     (:id tx1)})
+            ;; Try to create workspace with tx2 (which transitively depends on card via tx1)
+            (let [response (mt/user-http-request :crowberto :post 400 "ee/workspace"
+                                                 {:name        "Transitive Card Dep Workspace"
+                                                  :database_id (mt/id)
+                                                  :upstream    {:transforms [(:id tx2)]}})]
+              (is (re-find #"Cannot add transforms that depend on saved questions" response)))))))))
+
+(deftest add-entities-rejects-card-dependencies-test
+  (testing "Cannot add transforms with card dependencies to existing workspace"
+    (mt/with-premium-features #{:workspaces :dependencies :transforms}
+      (mt/with-model-cleanup [:model/Workspace :model/Dependency :model/Collection :model/Transform]
+        (mt/with-temp [:model/Card card {:name          "Test Card"
+                                         :database_id   (mt/id)
+                                         :dataset_query (mt/mbql-query venues)}]
+          (let [tx (create-transform-with-card-source! card)
+                ;; Create a workspace without the card-dependent transform
+                workspace-id (:id (mt/user-http-request :crowberto :post 200 "ee/workspace"
+                                                        {:name        "Empty Workspace"
+                                                         :database_id (mt/id)}))
+                response     (mt/user-http-request :crowberto :post 400
+                                                   (str "ee/workspace/" workspace-id "/contents")
+                                                   {:add {:transforms [(:id tx)]}})]
+            (is (re-find #"Cannot add transforms that depend on saved questions" response))))))))


### PR DESCRIPTION
Note that this doesn't protect us from transforms inside the workspace being edited to take on a card dependency.
