### PR TITLE
Uxw 2391 update the main sidenav to expand collapse and move

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/api/library.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/library.ts
@@ -3,6 +3,12 @@ import type { Collection, CollectionItem } from "metabase-types/api";
 import { EnterpriseApi } from "./api";
 import { listTag, tag } from "./tags";
 
+type LibraryChild = {
+  description: string;
+  id: number;
+  name: string;
+};
+
 export const libraryApi = EnterpriseApi.injectEndpoints({
   endpoints: (builder) => ({
     createLibrary: builder.mutation<Collection, void>({
@@ -12,7 +18,10 @@ export const libraryApi = EnterpriseApi.injectEndpoints({
       }),
       invalidatesTags: [listTag("collection")],
     }),
-    getLibraryCollection: builder.query<CollectionItem, void>({
+    getLibraryCollection: builder.query<
+      CollectionItem & { effective_children: LibraryChild[] },
+      void
+    >({
       query: () => ({
         url: `/api/ee/library`,
         method: "GET",

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/DataStudioLayout/DataStudioLayout.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/DataStudioLayout/DataStudioLayout.module.css
@@ -2,8 +2,18 @@
   border-right: 1px solid var(--mb-color-border);
 }
 
+.opened {
+  width: 300px;
+}
+
+.icon {
+  color: var(--mb-color-text-secondary);
+}
+
 .tab {
-  background-color: var(--mb-color-bg-secondary);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 
   &:hover,
   &.selected {
@@ -18,5 +28,9 @@
   &:hover,
   &.selected {
     color: var(--mb-color-brand);
+
+    .icon {
+      color: inherit;
+    }
   }
 }

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/DataStudioLayout/DataStudioLayout.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/DataStudioLayout/DataStudioLayout.tsx
@@ -86,6 +86,7 @@ function DataStudioNav({
     PLUGIN_TRANSFORMS.canAccessTransforms,
   );
   const isDataTab = pathname.startsWith(Urls.dataStudioData());
+  const isGlossaryTab = pathname.startsWith(Urls.dataStudioGlossary());
   const isTransformsTab = pathname.startsWith(Urls.transformList());
   const isModelingTab = pathname.startsWith(Urls.dataStudioModeling());
   const isDependenciesTab = pathname.startsWith(Urls.dependencyGraph());
@@ -104,6 +105,13 @@ function DataStudioNav({
           isNavbarOpened={isNavbarOpened}
           onNavbarToggle={onNavbarToggle}
         />
+        <DataStudioTab
+          label={t`Library`}
+          icon="model"
+          to={Urls.dataStudioModeling()}
+          isSelected={isModelingTab}
+          showLabel={isNavbarOpened}
+        />
 
         {canAccessDataModel && (
           <DataStudioTab
@@ -114,28 +122,30 @@ function DataStudioNav({
             showLabel={isNavbarOpened}
           />
         )}
-        {canAccessTransforms && (
+        {canAccessDataModel && (
           <DataStudioTab
-            label={t`Transforms`}
-            icon="transform"
-            to={Urls.transformList()}
-            isSelected={isTransformsTab}
+            label={t`Glossary`}
+            icon="reference"
+            to={Urls.dataStudioGlossary()}
+            isSelected={isGlossaryTab}
             showLabel={isNavbarOpened}
           />
         )}
-        <DataStudioTab
-          label={t`Modeling`}
-          icon="model"
-          to={Urls.dataStudioModeling()}
-          isSelected={isModelingTab}
-          showLabel={isNavbarOpened}
-        />
         {PLUGIN_DEPENDENCIES.isEnabled && (
           <DataStudioTab
             label={t`Dependency graph`}
             icon="schema"
             to={Urls.dependencyGraph()}
             isSelected={isDependenciesTab}
+            showLabel={isNavbarOpened}
+          />
+        )}
+        {canAccessTransforms && (
+          <DataStudioTab
+            label={t`Transforms`}
+            icon="transform"
+            to={Urls.transformList()}
+            isSelected={isTransformsTab}
             showLabel={isNavbarOpened}
           />
         )}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/ModelingSectionLayout/ModelingSectionLayout.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/ModelingSectionLayout/ModelingSectionLayout.tsx
@@ -1,64 +1,102 @@
-import type { Location } from "history";
-import { type ReactNode, useContext, useLayoutEffect } from "react";
+import { useCallback } from "react";
+import { push } from "react-router-redux";
 import { t } from "ttag";
 
+import {
+  skipToken,
+  useListCollectionItemsQuery,
+  useListCollectionsTreeQuery,
+} from "metabase/api";
+import { isLibraryCollection } from "metabase/collections/utils";
+import { Tree } from "metabase/common/components/tree";
+import type { ITreeNodeItem } from "metabase/common/components/tree/types";
 import { usePageTitle } from "metabase/hooks/use-page-title";
+import { useDispatch } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
-import { Box, Flex } from "metabase/ui";
-import { DataStudioContext } from "metabase-enterprise/data-studio/common/contexts/DataStudioContext";
+import { Button, Card, Flex, Icon, Stack, TextInput } from "metabase/ui";
 
-import { SectionLayout, SectionTitle } from "../../components/SectionLayout";
+import { SectionLayout } from "../../components/SectionLayout";
 
-import { ModelingSidebar } from "./ModelingSidebar";
+import { getWritableCollection } from "./ModelingSidebar/LibrarySection/LibraryCollectionTree/utils";
 
-type ModelingSectionLayoutParams = {
-  collectionId?: string;
-  snippetId?: string;
-};
-
-type ModelingSectionLayoutProps = {
-  params: ModelingSectionLayoutParams;
-  location: Location;
-  children?: ReactNode;
-};
-
-export function ModelingSectionLayout({
-  params,
-  location,
-  children,
-}: ModelingSectionLayoutProps) {
-  const collectionId = Urls.extractCollectionId(params?.collectionId);
-  const snippetId = Urls.extractEntityId(params?.snippetId);
-  const isGlossaryActive = location.pathname === Urls.dataStudioGlossary();
-
-  const { isSidebarOpened, setIsSidebarOpened, setIsSidebarAvailable } =
-    useContext(DataStudioContext);
-
+export function ModelingSectionLayout() {
   usePageTitle(t`Modeling`);
+  const dispatch = useDispatch();
 
-  useLayoutEffect(() => {
-    setIsSidebarOpened(true);
-    setIsSidebarAvailable(true);
-    return () => {
-      setIsSidebarOpened(false);
-      setIsSidebarAvailable(false);
-    };
-  }, [setIsSidebarOpened, setIsSidebarAvailable]);
+  const { data: collections = [], isLoading: loadingCollections } =
+    useListCollectionsTreeQuery({
+      "exclude-other-user-collections": true,
+      "exclude-archived": true,
+      "include-library": true,
+    });
+
+  const libraryCollection = collections.find(isLibraryCollection);
+
+  const modelCollection =
+    libraryCollection &&
+    getWritableCollection(libraryCollection, "library-models");
+
+  const metricCollection =
+    libraryCollection &&
+    getWritableCollection(libraryCollection, "library-metrics");
+
+  const { data: libraryModels, isLoading: loadingModels } =
+    useListCollectionItemsQuery(
+      modelCollection ? { id: modelCollection.id } : skipToken,
+    );
+  const { data: libraryMetrics, isLoading: loadingMetrics } =
+    useListCollectionItemsQuery(
+      metricCollection ? { id: metricCollection.id } : skipToken,
+    );
+
+  const handleCollectionSelect = useCallback(
+    (item: ITreeNodeItem) => {
+      if (item.model === "dataset") {
+        dispatch(push(Urls.dataStudioModel(item.id)));
+      } else if (item.model === "metric") {
+        dispatch(push(Urls.dataStudioMetric(item.id)));
+      }
+    },
+    [dispatch],
+  );
+
+  if (loadingModels || loadingMetrics || loadingCollections) {
+    return null;
+  }
+
+  const modelsTree = {
+    ...modelCollection,
+    icon: "model",
+    children: libraryModels?.data.map((x) => ({ ...x, icon: "model" })) || [],
+  };
+
+  const metricsTree = {
+    ...metricCollection,
+    icon: "metric",
+    children: libraryMetrics?.data.map((x) => ({ ...x, icon: "metric" })) || [],
+  };
+
+  // Missing Snippets
 
   return (
-    <SectionLayout title={<SectionTitle title={t`Modeling`} />}>
-      <Flex direction="row" w="100%" h="100%">
-        {isSidebarOpened && (
-          <ModelingSidebar
-            selectedCollectionId={collectionId}
-            selectedSnippetId={snippetId}
-            isGlossaryActive={isGlossaryActive}
+    <SectionLayout>
+      <Stack px="3.5rem" pt="4rem">
+        <Flex gap="0.5rem">
+          <TextInput
+            placeholder="Search..."
+            leftSection={<Icon name="search" />}
+            bdrs="md"
+            flex="1"
           />
-        )}
-        <Box flex={1} miw={0}>
-          {children}
-        </Box>
-      </Flex>
+          <Button leftSection={<Icon name="add" />}>{t`New`}</Button>
+        </Flex>
+        <Card withBorder>
+          <Tree
+            data={[modelsTree, metricsTree]}
+            onSelect={handleCollectionSelect}
+          />
+        </Card>
+      </Stack>
     </SectionLayout>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/ModelingSectionLayout/ModelingSidebar/ModelingSidebarView/ModelingSidebarView.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/ModelingSectionLayout/ModelingSidebar/ModelingSidebarView/ModelingSidebarView.tsx
@@ -1,6 +1,3 @@
-import { t } from "ttag";
-
-import * as Urls from "metabase/lib/urls";
 import { Box, Stack } from "metabase/ui";
 import { LibrarySection } from "metabase-enterprise/data-studio/app/pages/ModelingSectionLayout/ModelingSidebar/LibrarySection";
 import type {
@@ -8,8 +5,6 @@ import type {
   CollectionId,
   NativeQuerySnippetId,
 } from "metabase-types/api";
-
-import { ModelingSidebarSection } from "../ModelingSidebarSection";
 
 import S from "./ModelingSidebarView.module.css";
 import { SnippetsSection } from "./SnippetsSection";
@@ -27,7 +22,6 @@ export function ModelingSidebarView({
   collections,
   selectedCollectionId,
   selectedSnippetId,
-  isGlossaryActive,
   hasDataAccess,
   hasNativeWrite,
 }: ModelingSidebarViewProps) {
@@ -48,15 +42,6 @@ export function ModelingSidebarView({
             <SnippetsSection selectedSnippetId={selectedSnippetId} />
           </Box>
         )}
-
-        <Box p="md" data-testid="glossary-section">
-          <ModelingSidebarSection
-            icon="book_open"
-            title={t`Glossary`}
-            to={Urls.dataStudioGlossary()}
-            isActive={isGlossaryActive}
-          />
-        </Box>
       </Stack>
     </Box>
   );

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/TransformsSectionLayout/TransformsSectionLayout.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/TransformsSectionLayout/TransformsSectionLayout.tsx
@@ -3,12 +3,6 @@ import type { ReactNode } from "react";
 import { t } from "ttag";
 
 import { usePageTitle } from "metabase/hooks/use-page-title";
-import * as Urls from "metabase/lib/urls";
-import { Group } from "metabase/ui";
-import {
-  type PaneHeaderTab,
-  PaneHeaderTabs,
-} from "metabase-enterprise/data-studio/common/components/PaneHeader";
 
 import { SectionLayout } from "../../components/SectionLayout";
 
@@ -18,53 +12,9 @@ type TransformsSectionLayoutProps = {
 };
 
 export function TransformsSectionLayout({
-  location,
   children,
 }: TransformsSectionLayoutProps) {
   usePageTitle(t`Transforms`);
 
-  return (
-    <SectionLayout tabs={<DataSectionTabs location={location} />}>
-      {children}
-    </SectionLayout>
-  );
-}
-
-type DataSectionTabsProps = {
-  location: Location;
-};
-
-function DataSectionTabs({ location }: DataSectionTabsProps) {
-  return (
-    <Group>
-      <PaneHeaderTabs tabs={getTabs(location)} withBackground />
-    </Group>
-  );
-}
-
-function getTabs({ pathname }: Location): PaneHeaderTab[] {
-  const isTransforms = pathname.startsWith(Urls.transformList());
-  const isJobs = pathname.startsWith(Urls.transformJobList());
-  const isRuns = pathname.startsWith(Urls.transformRunList());
-
-  return [
-    {
-      label: t`Transforms`,
-      to: Urls.transformList(),
-      icon: "transform",
-      isSelected: isTransforms && !isJobs && !isRuns,
-    },
-    {
-      label: t`Jobs`,
-      to: Urls.transformJobList(),
-      icon: "clock",
-      isSelected: isJobs,
-    },
-    {
-      label: t`Runs`,
-      to: Urls.transformRunList(),
-      icon: "play",
-      isSelected: isRuns,
-    },
-  ];
+  return <SectionLayout>{children}</SectionLayout>;
 }

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/index.ts
@@ -11,6 +11,7 @@ import {
   getLibraryCollectionType,
   useGetLibraryChildCollectionByType,
   useGetLibraryCollection,
+  useGetResolvedLibraryCollection,
 } from "./utils";
 
 export function initializePlugin() {
@@ -27,5 +28,7 @@ export function initializePlugin() {
     PLUGIN_DATA_STUDIO.useGetLibraryCollection = useGetLibraryCollection;
     PLUGIN_DATA_STUDIO.useGetLibraryChildCollectionByType =
       useGetLibraryChildCollectionByType;
+    PLUGIN_DATA_STUDIO.useGetResolvedLibraryCollection =
+      useGetResolvedLibraryCollection;
   }
 }

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/routes.tsx
@@ -48,12 +48,13 @@ export function getDataStudioRoutes(
             </Route>
           </Route>
         )}
-        <Route path="modeling" component={ModelingSectionLayout}>
+        {getDataStudioGlossaryRoutes()}
+        <Route path="modeling">
+          <IndexRoute component={ModelingSectionLayout} />
           {getDataStudioModelingRoutes()}
           {getDataStudioModelRoutes()}
           {getDataStudioMetricRoutes()}
           {getDataStudioSnippetRoutes()}
-          {getDataStudioGlossaryRoutes()}
         </Route>
         {PLUGIN_DEPENDENCIES.isEnabled && (
           <Route path="dependencies" component={DependenciesSectionLayout}>

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/utils.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { match } from "ts-pattern";
 
 import { skipToken, useListCollectionItemsQuery } from "metabase/api";
 import type { LibraryCollectionType } from "metabase/plugins";
@@ -110,4 +111,44 @@ export const useGetLibraryChildCollectionByType = ({
       ),
     [libraryCollections, type],
   );
+};
+
+// This hook will return the library collection if there are both metrics and models in the library,
+// the library-metrics collection if the library has no models, or the library-models collection
+// if the library has no metrics
+export const useGetResolvedLibraryCollection = ({
+  skip = false,
+}: { skip?: boolean } = {}) => {
+  const { data: libraryCollection, isLoading: isLoadingCollection } =
+    useGetLibraryCollectionQuery(undefined, { skip });
+
+  const hasStuff = Boolean(
+    libraryCollection &&
+      (libraryCollection?.below?.length || libraryCollection?.here?.length),
+  );
+  const { data: libraryItems, isLoading: isLoadingItems } =
+    useListCollectionItemsQuery(
+      libraryCollection && hasStuff ? { id: libraryCollection.id } : skipToken,
+    );
+
+  const subcollectionsWithStuff =
+    libraryItems?.data.filter(
+      (item) =>
+        item.model === "collection" &&
+        (item.here?.length || item.below?.length),
+    ) ?? [];
+
+  const showableLibrary = match({ subcollectionsWithStuff, hasStuff })
+    .when(
+      // if there's only one subcollection with stuff, we want to go straight into it
+      ({ subcollectionsWithStuff }) => subcollectionsWithStuff?.length === 1,
+      () => subcollectionsWithStuff[0],
+    )
+    .with({ hasStuff: true }, () => libraryCollection)
+    .otherwise(() => undefined);
+
+  return {
+    isLoading: isLoadingCollection || isLoadingItems,
+    data: showableLibrary,
+  };
 };

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/JobListPage/JobListPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/JobListPage/JobListPage.tsx
@@ -1,0 +1,133 @@
+import { useDebouncedValue } from "@mantine/hooks";
+import { useMemo, useState } from "react";
+import { push } from "react-router-redux";
+import { t } from "ttag";
+
+import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
+import { useSetting } from "metabase/common/hooks";
+import { useUserKeyValue } from "metabase/common/hooks/use-user-key-value";
+import { useDispatch } from "metabase/lib/redux";
+import * as Urls from "metabase/lib/urls";
+import { Button, Flex, Icon, Tooltip } from "metabase/ui";
+import { useListTransformJobsQuery } from "metabase-enterprise/api";
+import { ListEmptyState } from "metabase-enterprise/transforms/components/ListEmptyState";
+import { SidebarListItem } from "metabase-enterprise/transforms/pages/TransformSidebarLayout/SidebarListItem/SidebarListItem";
+
+import S from "../TransformSidebarLayout/JobsSidebar/JobsSidebar.module.css";
+import { SidebarList } from "../TransformSidebarLayout/SidebarList";
+import { SidebarLoadingState } from "../TransformSidebarLayout/SidebarLoadingState";
+import { SidebarSearchAndControls } from "../TransformSidebarLayout/SidebarSearchAndControls";
+import { JOB_SORT_OPTIONS } from "../TransformSidebarLayout/SidebarSortControl";
+import {
+  lastModifiedSorter,
+  nameSorter,
+} from "../TransformSidebarLayout/utils";
+
+const DEFAULT_SORT_TYPE = "alphabetical";
+
+interface JobListPagerProps {
+  selectedJobId?: number;
+}
+
+export const JobListPage = ({ selectedJobId }: JobListPagerProps) => {
+  const dispatch = useDispatch();
+  const systemTimezone = useSetting("system-timezone");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [debouncedSearchQuery] = useDebouncedValue(searchQuery, 300);
+  const { value: sortType, setValue: setSortType } = useUserKeyValue({
+    namespace: "transforms",
+    key: "jobs-sort-type",
+    defaultValue: DEFAULT_SORT_TYPE,
+  });
+
+  const { data: jobs, error, isLoading } = useListTransformJobsQuery({});
+
+  const filteredJobs = useMemo(() => {
+    if (!jobs) {
+      return [];
+    }
+
+    if (!debouncedSearchQuery) {
+      return jobs;
+    }
+
+    const query = debouncedSearchQuery.toLowerCase();
+    return jobs.filter((job) => job.name.toLowerCase().includes(query));
+  }, [jobs, debouncedSearchQuery]);
+
+  const sortFn = sortType === "last-modified" ? lastModifiedSorter : nameSorter;
+
+  const jobsSorted = useMemo(
+    () => [...filteredJobs].sort(sortFn),
+    [filteredJobs, sortFn],
+  );
+
+  const handleAdd = () => {
+    dispatch(push(Urls.newTransformJob()));
+  };
+
+  if (error) {
+    return <LoadingAndErrorWrapper loading={false} error={error} />;
+  }
+
+  return (
+    <>
+      <Flex direction="column" gap="md" px="md" pt="md" pb="md">
+        <SidebarSearchAndControls
+          searchValue={searchQuery}
+          onSearchChange={setSearchQuery}
+          sortValue={sortType}
+          sortOptions={JOB_SORT_OPTIONS}
+          onSortChange={setSortType}
+          sortLabel={t`Sort jobs`}
+          addButton={
+            <Tooltip label={t`Create a job`}>
+              <Button
+                variant="filled"
+                p="sm"
+                w={32}
+                h={32}
+                leftSection={<Icon name="add" size={16} />}
+                aria-label={t`Create a job`}
+                onClick={handleAdd}
+                classNames={{ root: S.button }}
+              />
+            </Tooltip>
+          }
+        />
+      </Flex>
+      <Flex direction="column" flex={1} mih={0}>
+        {isLoading ? (
+          <SidebarLoadingState />
+        ) : jobsSorted.length === 0 ? (
+          <ListEmptyState
+            label={debouncedSearchQuery ? t`No jobs found` : t`No jobs yet`}
+          />
+        ) : (
+          <SidebarList>
+            {jobsSorted.map((job) => {
+              const subtitle =
+                job.last_run?.start_time &&
+                `${job.last_run?.status === "failed" ? t`Failed` : t`Last run`}: ${new Date(
+                  job.last_run.start_time,
+                ).toLocaleString("en-US", {
+                  timeZone: systemTimezone ?? undefined,
+                })}`;
+
+              return (
+                <SidebarListItem
+                  key={job.id}
+                  icon="play_outlined"
+                  href={Urls.transformJob(job.id)}
+                  label={job.name}
+                  subtitle={subtitle}
+                  isActive={job.id === selectedJobId}
+                />
+              );
+            })}
+          </SidebarList>
+        )}
+      </Flex>
+    </>
+  );
+};

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/JobListPage/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/JobListPage/index.ts
@@ -1,0 +1,1 @@
+export * from "./JobListPage";

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformListPage/TransformListPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformListPage/TransformListPage.tsx
@@ -1,0 +1,152 @@
+import { useDebouncedValue } from "@mantine/hooks";
+import { useMemo, useState } from "react";
+import { push } from "react-router-redux";
+import { t } from "ttag";
+
+import { useListDatabasesQuery } from "metabase/api";
+import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
+import { VirtualizedTree } from "metabase/common/components/tree/VirtualizedTree";
+import { useUserKeyValue } from "metabase/common/hooks/use-user-key-value";
+import { useDispatch, useSelector } from "metabase/lib/redux";
+import * as Urls from "metabase/lib/urls";
+import { PLUGIN_TRANSFORMS_PYTHON } from "metabase/plugins";
+import { getUserIsAdmin } from "metabase/selectors/user";
+import { Box, Flex } from "metabase/ui";
+import { useListTransformsQuery } from "metabase-enterprise/api";
+import { ListEmptyState } from "metabase-enterprise/transforms/components/ListEmptyState";
+import { SidebarListItem } from "metabase-enterprise/transforms/pages/TransformSidebarLayout/SidebarListItem/SidebarListItem";
+import { TransformListItem } from "metabase-enterprise/transforms/pages/TransformSidebarLayout/SidebarListItem/TransformListItem";
+import { SHARED_LIB_IMPORT_PATH } from "metabase-enterprise/transforms-python/constants";
+
+import { CreateTransformMenu } from "../TransformSidebarLayout/CreateTransformMenu";
+import { SidebarList } from "../TransformSidebarLayout/SidebarList";
+import { SidebarLoadingState } from "../TransformSidebarLayout/SidebarLoadingState";
+import { SidebarSearchAndControls } from "../TransformSidebarLayout/SidebarSearchAndControls";
+import { TRANSFORM_SORT_OPTIONS } from "../TransformSidebarLayout/SidebarSortControl";
+import S from "../TransformSidebarLayout/TransformsSidebar/TransformsSidebar.module.css";
+import { TransformsTreeNode } from "../TransformSidebarLayout/TransformsSidebar/TransformsTreeNode";
+import { buildTreeData } from "../TransformSidebarLayout/TransformsSidebar/utils";
+import {
+  lastModifiedSorter,
+  nameSorter,
+} from "../TransformSidebarLayout/utils";
+
+const DEFAULT_SORT_TYPE = "tree";
+
+interface TransformsSidebarProps {
+  selectedTransformId?: number;
+}
+
+export const TransformListPageSidebar = ({
+  selectedTransformId,
+}: TransformsSidebarProps) => {
+  const dispatch = useDispatch();
+  const isAdmin = useSelector(getUserIsAdmin);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [debouncedSearchQuery] = useDebouncedValue(searchQuery, 300);
+  const { value: sortType, setValue: setSortType } = useUserKeyValue({
+    namespace: "transforms",
+    key: "transforms-sort-type",
+    defaultValue: DEFAULT_SORT_TYPE,
+  });
+
+  const { data: transforms, error, isLoading } = useListTransformsQuery({});
+  const { data: databaseData } = useListDatabasesQuery();
+
+  const filteredTransforms = useMemo(() => {
+    if (!transforms) {
+      return [];
+    }
+
+    if (!debouncedSearchQuery) {
+      return transforms;
+    }
+
+    const query = debouncedSearchQuery.toLowerCase();
+    return transforms.filter(
+      (transform) =>
+        transform.name.toLowerCase().includes(query) ||
+        transform.target.name.toLowerCase().includes(query),
+    );
+  }, [transforms, debouncedSearchQuery]);
+
+  const sortFn = sortType === "last-modified" ? lastModifiedSorter : nameSorter;
+
+  const transformsSorted = useMemo(
+    () => [...filteredTransforms].sort(sortFn),
+    [filteredTransforms, sortFn],
+  );
+
+  const treeData = useMemo(
+    () =>
+      databaseData && sortType === "tree"
+        ? buildTreeData(transformsSorted, databaseData.data)
+        : [],
+    [databaseData, transformsSorted, sortType],
+  );
+
+  if (error) {
+    return <LoadingAndErrorWrapper loading={false} error={error} />;
+  }
+
+  return (
+    <>
+      <Flex direction="column" gap="md" p="md">
+        <SidebarSearchAndControls
+          searchValue={searchQuery}
+          onSearchChange={setSearchQuery}
+          sortValue={sortType}
+          sortOptions={TRANSFORM_SORT_OPTIONS}
+          onSortChange={setSortType}
+          addButton={<CreateTransformMenu />}
+          sortLabel={t`Sort transforms`}
+        />
+      </Flex>
+      <Flex direction="column" flex={1} mih={0}>
+        {isLoading ? (
+          <SidebarLoadingState />
+        ) : transformsSorted.length === 0 ? (
+          <ListEmptyState
+            label={
+              debouncedSearchQuery
+                ? t`No transforms found`
+                : t`No transforms yet`
+            }
+          />
+        ) : sortType === "tree" ? (
+          <VirtualizedTree
+            initiallyExpanded
+            data={treeData}
+            selectedId={selectedTransformId}
+            onSelect={(node) => {
+              if (typeof node.id === "number") {
+                dispatch(push(Urls.transform(node.id)));
+              }
+            }}
+            TreeNode={TransformsTreeNode}
+          />
+        ) : (
+          <SidebarList>
+            {transformsSorted.map((transform) => (
+              <TransformListItem
+                key={transform.id}
+                transform={transform}
+                selectedId={selectedTransformId}
+              />
+            ))}
+          </SidebarList>
+        )}
+      </Flex>
+      {isAdmin && PLUGIN_TRANSFORMS_PYTHON.isEnabled && (
+        <Box p="sm" className={S.footer}>
+          <SidebarListItem
+            icon="code_block"
+            href={Urls.transformPythonLibrary({ path: SHARED_LIB_IMPORT_PATH })}
+            label={t`Python library`}
+            subtitle={t`Shared helper functions`}
+          />
+        </Box>
+      )}
+    </>
+  );
+};

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformListPage/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformListPage/index.ts
@@ -1,0 +1,1 @@
+export * from "./TransformListPage";

--- a/enterprise/frontend/src/metabase-enterprise/transforms/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/routes.tsx
@@ -5,7 +5,7 @@ import {
   PLUGIN_TRANSFORMS_PYTHON,
 } from "metabase/plugins";
 
-import { JobEmptyPage } from "./pages/JobEmptyPage";
+import { JobListPage } from "./pages/JobListPage";
 import { JobPage } from "./pages/JobPage";
 import { NewJobPage } from "./pages/NewJobPage";
 import {
@@ -16,10 +16,9 @@ import {
 } from "./pages/NewTransformPage";
 import { RunListPage } from "./pages/RunListPage";
 import { TransformDependenciesPage } from "./pages/TransformDependenciesPage";
-import { TransformEmptyPage } from "./pages/TransformEmptyPage";
+import { TransformListPageSidebar } from "./pages/TransformListPage";
 import { TransformQueryPage } from "./pages/TransformQueryPage";
 import { TransformRunPage } from "./pages/TransformRunPage";
-import { TransformSidebarLayout } from "./pages/TransformSidebarLayout";
 import { TransformTargetPage } from "./pages/TransformTargetPage";
 import { TransformTopNavLayout } from "./pages/TransformTopNavLayout";
 
@@ -29,9 +28,9 @@ export function getDataStudioTransformRoutes() {
       <Route path="runs" component={TransformTopNavLayout}>
         <IndexRoute component={RunListPage} />
       </Route>
-      <Route component={TransformSidebarLayout}>
-        <IndexRoute component={TransformEmptyPage} />
-        <Route path="jobs" component={JobEmptyPage} />
+      <Route>
+        <IndexRoute component={TransformListPageSidebar} />
+        <Route path="jobs" component={JobListPage} />
         <Route path="jobs/new" component={NewJobPage} />
         <Route path="jobs/:jobId" component={JobPage} />
         <Route path="new/query" component={NewQueryTransformPage} />

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/test/ee.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/test/ee.unit.spec.tsx
@@ -50,6 +50,27 @@ describe("library", () => {
   it("should hide an empty library collection", async () => {
     fetchMock.get("/api/ee/library", {
       ...LIBRARY_COLLECTION,
+      below: [],
+    });
+    setupCollectionItemsEndpoint({
+      collection: LIBRARY_COLLECTION,
+      collectionItems: [
+        { ...LIBRARY_MODELS_COLELCTION, here: undefined },
+        { ...LIBRARY_METRICS_COLELCTION, here: undefined },
+      ],
+    });
+
+    setup(
+      { models: ["dataset", "metric"] },
+      createMockTokenFeatures({ data_studio: true }),
+    );
+
+    expect(await screen.findByText("Our analytics")).toBeInTheDocument();
+  });
+
+  it("should drill into child folders when you only have metrics or models", async () => {
+    fetchMock.get("/api/ee/library", {
+      ...LIBRARY_COLLECTION,
       below: ["dataset"],
     });
     setupCollectionItemsEndpoint({
@@ -60,9 +81,18 @@ describe("library", () => {
       ],
     });
 
-    setup({}, createMockTokenFeatures({ data_studio: true }));
+    setupCollectionItemsEndpoint({
+      collection: LIBRARY_MODELS_COLELCTION,
+      collectionItems: [
+        createMockCollectionItem({ model: "dataset", name: "Surprise" }),
+      ],
+    });
 
-    expect(await screen.findByText("data")).toBeInTheDocument();
+    setup(
+      { models: ["dataset", "metric"] },
+      createMockTokenFeatures({ data_studio: true }),
+    );
+    expect(await screen.findByText("Surprise")).toBeInTheDocument();
     expect(screen.queryByText("metrics")).not.toBeInTheDocument();
   });
 

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
@@ -55,7 +55,7 @@ function RootItemList() {
   const { setPath, isHidden, models, shouldShowLibrary } =
     useMiniPickerContext();
   const { data: libraryCollection, isLoading } =
-    PLUGIN_DATA_STUDIO.useGetLibraryCollection();
+    PLUGIN_DATA_STUDIO.useGetResolvedLibraryCollection();
   const enableNestedQueries = useSetting("enable-nested-queries");
 
   if (isLoading) {
@@ -84,9 +84,13 @@ function RootItemList() {
       </ItemList>
     );
   }
+
   if (
     libraryCollection &&
-    _.intersection(models, libraryCollection.below || []).length &&
+    _.intersection(models, [
+      ...(libraryCollection.below || []),
+      ...(libraryCollection.here || []),
+    ]).length &&
     shouldShowLibrary
   ) {
     return (

--- a/frontend/src/metabase/lib/urls/data-studio.ts
+++ b/frontend/src/metabase/lib/urls/data-studio.ts
@@ -88,7 +88,7 @@ export function dataStudioMetricDependencies(cardId: CardId) {
 }
 
 export function dataStudioGlossary() {
-  return `${dataStudioModeling()}/glossary`;
+  return `${dataStudio()}/glossary`;
 }
 
 export function dataStudioCollection(collectionId: CollectionId) {

--- a/frontend/src/metabase/plugins/oss/data-studio.ts
+++ b/frontend/src/metabase/plugins/oss/data-studio.ts
@@ -58,6 +58,10 @@ type DataStudioPlugin = {
     data: undefined | MiniPickerCollectionItem;
     isLoading: boolean;
   };
+  useGetResolvedLibraryCollection: (props?: { skip?: boolean }) => {
+    data: undefined | MiniPickerCollectionItem;
+    isLoading: boolean;
+  };
 };
 
 const getDefaultPluginDataStudio = (): DataStudioPlugin => ({
@@ -72,6 +76,10 @@ const getDefaultPluginDataStudio = (): DataStudioPlugin => ({
   useGetLibraryChildCollectionByType: ({ skip: _skip, type: _type }) =>
     undefined,
   useGetLibraryCollection: (_props) => ({ data: undefined, isLoading: false }),
+  useGetResolvedLibraryCollection: (_props) => ({
+    data: undefined,
+    isLoading: false,
+  }),
 });
 
 export const PLUGIN_DATA_STUDIO = getDefaultPluginDataStudio();


### PR DESCRIPTION
### Description
In the mini picker, we should be drilling into library collections when they are the only viable path

### How to verify
1. Set up your library so that you only have metrics or models in it (you may need to empty your trash)
2. Go to the notebook editor
3. You should be pulled directly into the library folder with things in them
4. If your library it totally empty, you should start at our analytics and databases

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
