### PR TITLE
drill into library collections when apropriate

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data-studio/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/index.ts
@@ -11,6 +11,7 @@ import {
   getLibraryCollectionType,
   useGetLibraryChildCollectionByType,
   useGetLibraryCollection,
+  useGetResolvedLibraryCollection,
 } from "./utils";
 
 export function initializePlugin() {
@@ -27,5 +28,7 @@ export function initializePlugin() {
     PLUGIN_DATA_STUDIO.useGetLibraryCollection = useGetLibraryCollection;
     PLUGIN_DATA_STUDIO.useGetLibraryChildCollectionByType =
       useGetLibraryChildCollectionByType;
+    PLUGIN_DATA_STUDIO.useGetResolvedLibraryCollection =
+      useGetResolvedLibraryCollection;
   }
 }

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/utils.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { match } from "ts-pattern";
 
 import { skipToken, useListCollectionItemsQuery } from "metabase/api";
 import type { LibraryCollectionType } from "metabase/plugins";
@@ -110,4 +111,44 @@ export const useGetLibraryChildCollectionByType = ({
       ),
     [libraryCollections, type],
   );
+};
+
+// This hook will return the library collection if there are both metrics and models in the library,
+// the library-metrics collection if the library has no models, or the library-models collection
+// if the library has no metrics
+export const useGetResolvedLibraryCollection = ({
+  skip = false,
+}: { skip?: boolean } = {}) => {
+  const { data: libraryCollection, isLoading: isLoadingCollection } =
+    useGetLibraryCollectionQuery(undefined, { skip });
+
+  const hasStuff = Boolean(
+    libraryCollection &&
+      (libraryCollection?.below?.length || libraryCollection?.here?.length),
+  );
+  const { data: libraryItems, isLoading: isLoadingItems } =
+    useListCollectionItemsQuery(
+      libraryCollection && hasStuff ? { id: libraryCollection.id } : skipToken,
+    );
+
+  const subcollectionsWithStuff =
+    libraryItems?.data.filter(
+      (item) =>
+        item.model === "collection" &&
+        (item.here?.length || item.below?.length),
+    ) ?? [];
+
+  const showableLibrary = match({ subcollectionsWithStuff, hasStuff })
+    .when(
+      // if there's only one subcollection with stuff, we want to go straight into it
+      ({ subcollectionsWithStuff }) => subcollectionsWithStuff?.length === 1,
+      () => subcollectionsWithStuff[0],
+    )
+    .with({ hasStuff: true }, () => libraryCollection)
+    .otherwise(() => undefined);
+
+  return {
+    isLoading: isLoadingCollection || isLoadingItems,
+    data: showableLibrary,
+  };
 };

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/test/ee.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/test/ee.unit.spec.tsx
@@ -50,6 +50,27 @@ describe("library", () => {
   it("should hide an empty library collection", async () => {
     fetchMock.get("/api/ee/library", {
       ...LIBRARY_COLLECTION,
+      below: [],
+    });
+    setupCollectionItemsEndpoint({
+      collection: LIBRARY_COLLECTION,
+      collectionItems: [
+        { ...LIBRARY_MODELS_COLELCTION, here: undefined },
+        { ...LIBRARY_METRICS_COLELCTION, here: undefined },
+      ],
+    });
+
+    setup(
+      { models: ["dataset", "metric"] },
+      createMockTokenFeatures({ data_studio: true }),
+    );
+
+    expect(await screen.findByText("Our analytics")).toBeInTheDocument();
+  });
+
+  it("should drill into child folders when you only have metrics or models", async () => {
+    fetchMock.get("/api/ee/library", {
+      ...LIBRARY_COLLECTION,
       below: ["dataset"],
     });
     setupCollectionItemsEndpoint({
@@ -60,9 +81,18 @@ describe("library", () => {
       ],
     });
 
-    setup({}, createMockTokenFeatures({ data_studio: true }));
+    setupCollectionItemsEndpoint({
+      collection: LIBRARY_MODELS_COLELCTION,
+      collectionItems: [
+        createMockCollectionItem({ model: "dataset", name: "Surprise" }),
+      ],
+    });
 
-    expect(await screen.findByText("data")).toBeInTheDocument();
+    setup(
+      { models: ["dataset", "metric"] },
+      createMockTokenFeatures({ data_studio: true }),
+    );
+    expect(await screen.findByText("Surprise")).toBeInTheDocument();
     expect(screen.queryByText("metrics")).not.toBeInTheDocument();
   });
 

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
@@ -55,7 +55,7 @@ function RootItemList() {
   const { setPath, isHidden, models, shouldShowLibrary } =
     useMiniPickerContext();
   const { data: libraryCollection, isLoading } =
-    PLUGIN_DATA_STUDIO.useGetLibraryCollection();
+    PLUGIN_DATA_STUDIO.useGetResolvedLibraryCollection();
   const enableNestedQueries = useSetting("enable-nested-queries");
 
   if (isLoading) {
@@ -84,9 +84,13 @@ function RootItemList() {
       </ItemList>
     );
   }
+
   if (
     libraryCollection &&
-    _.intersection(models, libraryCollection.below || []).length &&
+    _.intersection(models, [
+      ...(libraryCollection.below || []),
+      ...(libraryCollection.here || []),
+    ]).length &&
     shouldShowLibrary
   ) {
     return (

--- a/frontend/src/metabase/plugins/oss/data-studio.ts
+++ b/frontend/src/metabase/plugins/oss/data-studio.ts
@@ -58,6 +58,10 @@ type DataStudioPlugin = {
     data: undefined | MiniPickerCollectionItem;
     isLoading: boolean;
   };
+  useGetResolvedLibraryCollection: (props?: { skip?: boolean }) => {
+    data: undefined | MiniPickerCollectionItem;
+    isLoading: boolean;
+  };
 };
 
 const getDefaultPluginDataStudio = (): DataStudioPlugin => ({
@@ -72,6 +76,10 @@ const getDefaultPluginDataStudio = (): DataStudioPlugin => ({
   useGetLibraryChildCollectionByType: ({ skip: _skip, type: _type }) =>
     undefined,
   useGetLibraryCollection: (_props) => ({ data: undefined, isLoading: false }),
+  useGetResolvedLibraryCollection: (_props) => ({
+    data: undefined,
+    isLoading: false,
+  }),
 });
 
 export const PLUGIN_DATA_STUDIO = getDefaultPluginDataStudio();


### PR DESCRIPTION
### Description
In the mini picker, we should be drilling into library collections when they are the only viable path

### How to verify
1. Set up your library so that you only have metrics or models in it (you may need to empty your trash)
2. Go to the notebook editor
3. You should be pulled directly into the library folder with things in them
4. If your library it totally empty, you should start at our analytics and databases

### Checklist
- [x] Tests have been added/updated to cover changes in this PR