### PR TITLE
Make GET /api/ee/library return null instead of message

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/library/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/library/api.clj
@@ -42,7 +42,8 @@
         (t2/hydrate
          :can_write
          :effective_children)
-        (add-here-and-below))
+        (add-here-and-below)
+        (assoc :model "collection"))
     {:data nil}))
 
 (defn- select-collections

--- a/enterprise/backend/src/metabase_enterprise/library/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/library/api.clj
@@ -43,7 +43,7 @@
          :can_write
          :effective_children)
         (add-here-and-below))
-    {:message "Library does not exist"}))
+    {:data nil}))
 
 (defn- select-collections
   []

--- a/enterprise/backend/test/metabase_enterprise/library/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/library/api_test.clj
@@ -12,7 +12,7 @@
       (without-library
        (testing "When there is no library, returns a message but still 200"
          (let [response (mt/user-http-request :crowberto :get 200 "ee/library")]
-           (is (= {:message "Library does not exist"} response))))
+           (is (= {:data nil} response))))
        (let [_          (collection/create-library-collection!)
              models-id  (t2/select-one-pk :model/Collection :type collection/library-models-collection-type)
              metrics-id (t2/select-one-pk :model/Collection :type collection/library-metrics-collection-type)

--- a/enterprise/frontend/src/metabase-enterprise/api/library.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/library.ts
@@ -12,7 +12,7 @@ export const libraryApi = EnterpriseApi.injectEndpoints({
       }),
       invalidatesTags: [listTag("collection")],
     }),
-    getLibraryCollection: builder.query<CollectionItem, void>({
+    getLibraryCollection: builder.query<CollectionItem | { data: null }, void>({
       query: () => ({
         url: `/api/ee/library`,
         method: "GET",

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/utils.ts
@@ -78,10 +78,14 @@ export function canPlaceEntityInCollectionOrDescendants(
   return false;
 }
 
+const isLibrary = (
+  collection: CollectionItem | { data: null } | undefined,
+): collection is CollectionItem => !!collection && "name" in collection;
+
 export const useGetLibraryCollection = ({
   skip = false,
 }: { skip?: boolean } = {}) => {
-  const { data: libraryCollection, isLoading: isLoadingCollection } =
+  const { data: maybeLibrary, isLoading: isLoadingCollection } =
     useGetLibraryCollectionQuery(undefined, { skip });
 
   return {
@@ -97,10 +101,7 @@ export const useGetLibraryChildCollectionByType = ({
   skip?: boolean;
   type: CollectionType;
 }) => {
-  const { data: rootLibraryCollection } = useGetLibraryCollectionQuery(
-    undefined,
-    { skip },
-  );
+  const { data: rootLibraryCollection } = useGetLibraryCollection({ skip });
   const { data: libraryCollections } = useListCollectionItemsQuery(
     rootLibraryCollection ? { id: rootLibraryCollection.id } : skipToken,
   );

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/utils.ts
@@ -85,12 +85,19 @@ const isLibrary = (
 export const useGetLibraryCollection = ({
   skip = false,
 }: { skip?: boolean } = {}) => {
-  const { data: maybeLibrary, isLoading: isLoadingCollection } =
-    useGetLibraryCollectionQuery(undefined, { skip });
+  const { data, isLoading: isLoadingCollection } = useGetLibraryCollectionQuery(
+    undefined,
+    { skip },
+  );
+
+  const maybeLibrary = useMemo(
+    () => (isLibrary(data) ? data : undefined),
+    [data],
+  );
 
   return {
     isLoading: isLoadingCollection,
-    data: libraryCollection,
+    data: maybeLibrary,
   };
 };
 

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/utils.ts
@@ -128,7 +128,7 @@ export const useGetResolvedLibraryCollection = ({
   skip = false,
 }: { skip?: boolean } = {}) => {
   const { data: libraryCollection, isLoading: isLoadingCollection } =
-    useGetLibraryCollectionQuery(undefined, { skip });
+    useGetLibraryCollection({ skip });
 
   const hasStuff = Boolean(
     libraryCollection &&


### PR DESCRIPTION
It was weird to get a message on a missing library, this returns `{ data: null }` instead.


<img width="178" height="54" alt="CleanShot 2025-12-01 at 14 10 36" src="https://github.com/user-attachments/assets/e4543c9a-4927-4dc9-bc5d-3f67454c4aec" />
