### PR TITLE
Fix upsell CTA misalignment & stepper card overflow on custom fonts

### DIFF
--- a/frontend/src/metabase/admin/upsells/components/UpsellCta.module.css
+++ b/frontend/src/metabase/admin/upsells/components/UpsellCta.module.css
@@ -1,6 +1,7 @@
 @import "./Upsells.base.module.css";
 
 .UpsellCTALink {
+  white-space: nowrap;
   display: flex;
   gap: 0.5rem;
   align-items: center;

--- a/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.tsx
@@ -105,6 +105,8 @@ export const StepperWithCards = ({ steps }: { steps: StepperStep[] }) => {
                     >
                       <CardAction card={card}>
                         <Card
+                          h="100%"
+                          mih="8.75rem"
                           className={cx(S.stepCard, {
                             [S.lockedStepCard]: card.locked,
                             [S.nextStepCard]: isNextCard,


### PR DESCRIPTION
Closes [UXW-2310](https://linear.app/metabase/issue/UXW-2310/dev-instance-upsell-misaligned-when-using-poppins-font)

### Description

When the "Poppins" font is set in"Appearance" (`/admin/settings/whitelabel/branding`), the development-instance upsell UI looks off. Similarly, text within the additional cards for steps on the embedding setup guide (`/admin/embedding/setup-guide`) was being cut-off under the same appearance change.

### How to verify

1. Run `yarn dev-ee`
2. Head over to `/admin/settings/whitelabel/branding` and scroll to the bottom, set the "Font" to "Poppins"
3. Head back to `/admin/settings/general`, scroll to the bottom
  3.1. The upsell CTA shouldn't be squished
4. Head over to `/admin/embedding/setup-guide`
  4.1. The text "optional" within step 4 should be visible in its entirety

### Demo

| Place | Before | After |
| - | - | - |
| Upsell CTA | <img width="446" height="262" alt="CleanShot 2025-12-01 at 17 15 58@2x" src="https://github.com/user-attachments/assets/1af53854-2652-49d6-8743-1c5c6f0bb76d" /> | <img width="446" height="262" alt="CleanShot 2025-12-01 at 17 16 05@2x" src="https://github.com/user-attachments/assets/b9ab38d0-9b8e-46b3-b71b-0bcc4c53b8dc" /> |
| Embedding steps | <img width="1728" height="532" alt="CleanShot 2025-12-01 at 17 14 45@2x" src="https://github.com/user-attachments/assets/905d6ae8-7d00-431b-9732-1b40bf4f7ef4" /> | <img width="1728" height="532" alt="CleanShot 2025-12-01 at 17 14 55@2x" src="https://github.com/user-attachments/assets/96d46e74-847a-40b4-a43e-e407d3c79cea" /> |


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
