### PR TITLE
Closes EMB-1069 create new embed -> embed

### DIFF
--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -442,13 +442,13 @@ describe("command palette", () => {
       H.activateToken("bleeding-edge");
     });
 
-    it("should show the 'Create a new embed' command palette item", () => {
+    it("should show the 'New embed' command palette item", () => {
       cy.visit("/");
       cy.findByRole("button", { name: /search/i }).click();
 
       H.commandPalette().within(() => {
         H.commandPaletteInput().should("exist").type("new embed");
-        cy.findByText("Create a new embed").should("be.visible");
+        cy.findByText("New embed").should("be.visible");
       });
     });
 

--- a/frontend/src/metabase/palette/shortcuts/global.ts
+++ b/frontend/src/metabase/palette/shortcuts/global.ts
@@ -136,7 +136,7 @@ export const globalShortcuts = {
 
   "navigate-embed-js": {
     get name() {
-      return t`Create a new embed`;
+      return t`New embed`;
     },
 
     shortcut: ["c e"],


### PR DESCRIPTION
Closes [EMB-1068: Command palette embed action label inconsistent with others](https://linear.app/metabase/issue/EMB-1068/command-palette-embed-action-label-inconsistent-with-others)

### Description
Copy update

Before:
<img width="1778" height="566" alt="image" src="https://github.com/user-attachments/assets/0d4a9157-0626-4914-b996-79cb587e3ab8" />

After:
<img width="1778" height="568" alt="image" src="https://github.com/user-attachments/assets/df1d6f8d-126d-4a7d-a6c3-3e98c215392f" />
