### PR TITLE
Remove custom `MB_IS_CYPRESS` flag

### DIFF
--- a/e2e/runner/cypress-runner-backend.js
+++ b/e2e/runner/cypress-runner-backend.js
@@ -54,7 +54,6 @@ const CypressBackend = {
         MB_DB_CONNECTION_URI: "", // ignore connection URI in favor of the db file
         MB_CONFIG_FILE_PATH: "__cypress__", // ignore config.yml
         MB_HTTP_CHANNEL_HOST_STRATEGY: "allow-all", // we use a local webhook service for testing
-        MB_IS_CYPRESS: "true", // custom flag so we can detect we're running in Cypress, used in tests.
         MB_SNOWPLOW_AVAILABLE: true,
         MB_SNOWPLOW_URL: "http://localhost:9090",
       };

--- a/src/metabase/server/middleware/embedding_sdk_bundle.clj
+++ b/src/metabase/server/middleware/embedding_sdk_bundle.clj
@@ -37,6 +37,5 @@
     (let [base (response/resource-response bundle-resource)]
       (cond
         (nil? base)                         (not-found)
-        (config/config-bool :mb-is-cypress) (serve-for-dev base)
         config/is-prod?                     (serve-for-prod base request)
         :else                               (serve-for-dev base)))))


### PR DESCRIPTION
We don't need it anymore because running Cypress now requires a backend to be running in e2e mode.

