### PR TITLE
Remove superfluous cache-key in stress-test workflow

### DIFF
--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -118,8 +118,6 @@ jobs:
       - name: Prepare back-end environment
         if: ${{ needs.determine-test-type.outputs.type == 'component' }}
         uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: "cljs"
       - name: Build Embedding SDK package
         if: ${{ needs.determine-test-type.outputs.type == 'component' }}
         run: yarn build-embedding-sdk-package


### PR DESCRIPTION
This input is invalid (doesn't exist anymore). It results in the following warning:

<img width="779" height="141" alt="image" src="https://github.com/user-attachments/assets/0d0df34a-1568-4de3-b52b-0e7cc6b0ccde" />
