### PR TITLE
Fix props normalization. Adjust Interactive Embedding text.

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/embedding/components/InteractiveEmbeddingSettingsCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding/components/InteractiveEmbeddingSettingsCard.tsx
@@ -29,7 +29,7 @@ export function InteractiveEmbeddingSettingsCard() {
 
   return (
     <EmbeddingSettingsCard
-      title={t`Enable legacy interactive embedding`}
+      title={t`Enable interactive embedding`}
       description={t`A way to embed the entire Metabase app in an iframe. It integrates your permissions and SSO to give people the right level ofaccess to query and drill-down into your data.`}
       settingKey="enable-embedding-interactive"
       alertInfoText={c(

--- a/enterprise/frontend/src/metabase-enterprise/embedding/components/InteractiveEmbeddingSettingsCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding/components/InteractiveEmbeddingSettingsCard.tsx
@@ -29,13 +29,13 @@ export function InteractiveEmbeddingSettingsCard() {
 
   return (
     <EmbeddingSettingsCard
-      title={t`Enable interactive embedding`}
+      title={t`Enable full app embedding`}
       description={t`A way to embed the entire Metabase app in an iframe. It integrates your permissions and SSO to give people the right level ofaccess to query and drill-down into your data.`}
       settingKey="enable-embedding-interactive"
       alertInfoText={c(
         "{0} is the link to switch binaries. {1} is the link to upsell the SDK. {2} is the link to implement JWT or SAML authentication.",
       )
-        .jt`The new embedding methods give you more flexibility. Interactive embedding and Static embedding will be deprecated in a future version of Metabase. ${(
+        .jt`The new embedding methods give you more flexibility. Full app embedding and Static embedding will be deprecated in a future version of Metabase. ${(
         <ExternalLink
           key="migration-guide-from-legacy-embedding"
           href={quickStartUrl}

--- a/enterprise/frontend/src/metabase-enterprise/embedding/components/InteractiveEmbeddingSettingsCard.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding/components/InteractiveEmbeddingSettingsCard.unit.spec.tsx
@@ -36,14 +36,14 @@ describe("InteractiveEmbeddingSettingsCard", () => {
     await setup({ enabled: true });
 
     expect(
-      await screen.findByText("Enable legacy interactive embedding"),
+      await screen.findByText("Enable interactive embedding"),
     ).toBeInTheDocument();
   });
 
   it("should toggle interactive embedding on", async () => {
     await setup({ enabled: false });
     const toggle = await screen.findByLabelText(
-      "Enable legacy interactive embedding toggle",
+      "Enable interactive embedding toggle",
     );
 
     await userEvent.click(toggle);

--- a/enterprise/frontend/src/metabase-enterprise/embedding/components/InteractiveEmbeddingSettingsCard.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding/components/InteractiveEmbeddingSettingsCard.unit.spec.tsx
@@ -36,14 +36,14 @@ describe("InteractiveEmbeddingSettingsCard", () => {
     await setup({ enabled: true });
 
     expect(
-      await screen.findByText("Enable interactive embedding"),
+      await screen.findByText("Enable full app embedding"),
     ).toBeInTheDocument();
   });
 
   it("should toggle interactive embedding on", async () => {
     await setup({ enabled: false });
     const toggle = await screen.findByLabelText(
-      "Enable interactive embedding toggle",
+      "Enable full app embedding toggle",
     );
 
     await userEvent.click(toggle);

--- a/frontend/src/embedding-sdk-bundle/components/public/ComponentProvider/ComponentProvider.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/ComponentProvider/ComponentProvider.tsx
@@ -29,7 +29,7 @@ import { PortalContainer } from "../../private/SdkPortalContainer";
 import { SdkUsageProblemDisplay } from "../../private/SdkUsageProblem";
 import { METABOT_SDK_EE_PLUGIN } from "../MetabotQuestion/MetabotQuestion";
 
-type ComponentProviderInternalProps = ComponentProviderProps & {
+export type ComponentProviderInternalProps = ComponentProviderProps & {
   reduxStore: SdkStore;
   isLocalHost?: boolean;
 };
@@ -52,19 +52,23 @@ function useInitPlugins() {
   }, [tokenFeatures]);
 }
 
-export const ComponentProviderInternal = ({
-  children,
-  authConfig,
-  pluginsConfig,
-  eventHandlers,
-  theme,
-  reduxStore,
-  locale,
-  errorComponent,
-  loaderComponent,
-  allowConsoleLog,
-  isLocalHost,
-}: ComponentProviderInternalProps): JSX.Element => {
+export const ComponentProviderInternal = (
+  props: ComponentProviderInternalProps,
+): JSX.Element => {
+  const {
+    children,
+    authConfig,
+    pluginsConfig,
+    eventHandlers,
+    theme,
+    reduxStore,
+    locale,
+    errorComponent,
+    loaderComponent,
+    allowConsoleLog,
+    isLocalHost,
+  } = useNormalizeComponentProviderProps(props);
+
   const isGuestEmbed = !!authConfig.isGuest;
   const { fontFamily } = theme ?? {};
 
@@ -164,13 +168,11 @@ export const ComponentProvider = memo(function ComponentProvider({
     reduxStoreRef.current = props.reduxStore ?? getSdkStore();
   }
 
-  const normalizedProps = useNormalizeComponentProviderProps(props);
-
   return (
     <MetabaseReduxProvider store={reduxStoreRef.current!}>
       <METABOT_SDK_EE_PLUGIN.MetabotProvider>
         <ComponentProviderInternal
-          {...normalizedProps}
+          {...props}
           reduxStore={reduxStoreRef.current!}
         >
           {children}

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-normalize-component-provider-props.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-normalize-component-provider-props.ts
@@ -9,8 +9,8 @@ export const useNormalizeComponentProviderProps = (
 
   // For OSS usage we prevent defining a locale or theme
   if (!isEmbeddingSdkFeatureEnabled) {
-    delete props.locale;
-    delete props.theme;
+    delete normalizedProps.locale;
+    delete normalizedProps.theme;
   }
 
   return normalizedProps;

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-normalize-component-provider-props.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-normalize-component-provider-props.ts
@@ -1,10 +1,10 @@
-import type { ComponentProviderProps } from "embedding-sdk-bundle/components/public/ComponentProvider";
+import type { ComponentProviderInternalProps } from "embedding-sdk-bundle/components/public/ComponentProvider";
 import { useSdkSelector } from "embedding-sdk-bundle/store";
 import { getHasTokenFeature } from "embedding-sdk-bundle/store/selectors";
 
 export const useNormalizeComponentProviderProps = (
-  props: Omit<ComponentProviderProps, "children">,
-): Omit<ComponentProviderProps, "children"> => {
+  props: ComponentProviderInternalProps,
+): ComponentProviderInternalProps => {
   const hasTokenFeature = useSdkSelector(getHasTokenFeature);
   const normalizedProps = { ...props };
 

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-normalize-component-provider-props.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-normalize-component-provider-props.ts
@@ -1,14 +1,15 @@
 import type { ComponentProviderProps } from "embedding-sdk-bundle/components/public/ComponentProvider";
-import { PLUGIN_EMBEDDING_SDK } from "metabase/plugins";
+import { getHasTokenFeature } from "embedding-sdk-bundle/store/selectors";
+import { useLazySelector } from "embedding-sdk-shared/hooks/use-lazy-selector";
 
 export const useNormalizeComponentProviderProps = (
   props: Omit<ComponentProviderProps, "children">,
 ): Omit<ComponentProviderProps, "children"> => {
-  const isEmbeddingSdkFeatureEnabled = PLUGIN_EMBEDDING_SDK.isEnabled();
+  const hasTokenFeature = useLazySelector(getHasTokenFeature);
   const normalizedProps = { ...props };
 
   // For OSS usage we prevent defining a locale or theme
-  if (!isEmbeddingSdkFeatureEnabled) {
+  if (!hasTokenFeature) {
     delete normalizedProps.locale;
     delete normalizedProps.theme;
   }

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-normalize-component-provider-props.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-normalize-component-provider-props.ts
@@ -1,11 +1,11 @@
 import type { ComponentProviderProps } from "embedding-sdk-bundle/components/public/ComponentProvider";
+import { useSdkSelector } from "embedding-sdk-bundle/store";
 import { getHasTokenFeature } from "embedding-sdk-bundle/store/selectors";
-import { useLazySelector } from "embedding-sdk-shared/hooks/use-lazy-selector";
 
 export const useNormalizeComponentProviderProps = (
   props: Omit<ComponentProviderProps, "children">,
 ): Omit<ComponentProviderProps, "children"> => {
-  const hasTokenFeature = useLazySelector(getHasTokenFeature);
+  const hasTokenFeature = useSdkSelector(getHasTokenFeature);
   const normalizedProps = { ...props };
 
   // For OSS usage we prevent defining a locale or theme


### PR DESCRIPTION
Remove `legacy` for Interactive embedding.
Also fixes a typo in normalized props

Context https://metaboat.slack.com/archives/C063Q3F1HPF/p1764684259286849