### PR TITLE
handle users with no first or last names in document comments

### DIFF
--- a/e2e/support/helpers/e2e-comment-helpers.ts
+++ b/e2e/support/helpers/e2e-comment-helpers.ts
@@ -7,6 +7,8 @@ export const Comments = {
   getCommentInput,
   getCommentInputs,
   getCommentByText,
+  getAllComments,
+  getMentionDialog,
   getPlaceholder,
   getEmojiPicker,
   resolveCommentByText,
@@ -63,6 +65,10 @@ function getCommentByText(text: string | RegExp) {
   return cy.findByText(text).closest("[data-testid='discussion-comment']");
 }
 
+function getAllComments() {
+  return cy.findAllByTestId("discussion-comment");
+}
+
 function openAllComments() {
   cy.findByRole("link", { name: "Show all comments" }).click();
   getSidebar().should("contain.text", "All comments");
@@ -114,4 +120,8 @@ function getSidebar() {
 
 function closeSidebar() {
   cy.icon("close").click();
+}
+
+function getMentionDialog() {
+  return cy.findByRole("dialog", { name: "Mention Dialog" });
 }

--- a/e2e/test/scenarios/documents/comments.cy.spec.ts
+++ b/e2e/test/scenarios/documents/comments.cy.spec.ts
@@ -1574,6 +1574,21 @@ describe("document comments", () => {
       });
     });
   });
+
+  it("handles commenting with users without first and last names", () => {
+    cy.request("post", "/api/user", { email: "no-name@metabase.test" });
+    startNewCommentIn1ParagraphDocument();
+    Comments.getNewThreadInput().type("@No");
+    Comments.getMentionDialog().findByText("no-name@metabase.test").click();
+    Comments.getNewThreadInput().type("needs to see this");
+    cy.realPress([META_KEY, "Enter"]);
+
+    // assert that the comment was created
+    Comments.getAllComments().should("have.length", 1);
+    // mention is it's own span, so we need to search for the pieces individually
+    Comments.getCommentByText("@no-name@metabase.test").should("exist");
+    Comments.getCommentByText("needs to see this").should("exist");
+  });
 });
 
 function selectCharactersLeft(count: number) {

--- a/enterprise/backend/src/metabase_enterprise/comments/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/comments/api.clj
@@ -270,7 +270,7 @@
                                                       :offset (request/offset)})]
     ;; returns nothing while we're trying to figure out how do we deal with sandboxes and tenants etc
     ;; do not forget to uncomment tests (both api and e2e)
-    {:data   (->> (t2/select [:model/User :id :first_name :last_name]
+    {:data   (->> (t2/select [:model/User :id :first_name :last_name :email]
                              (-> clauses
                                  (sql.helpers/order-by [:%lower.first_name :asc]
                                                        [:%lower.last_name :asc]


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #66447
### Description
Adds email to the response to the /mentions endpoint, which will ensure that a common_name is populated for users (even when they don't have first / last names)

### How to verify
1. Set up a user with no first or last name
2. go to a document
3. try to mention someone on a comment block
4. documents should not crash, and you should be able to mention the user with no name you just created


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
