### PR TITLE
Remove toggle to disable anonymous analytics on cloud

### DIFF
--- a/frontend/src/metabase/admin/settings/components/SettingsPages/GeneralSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/GeneralSettingsPage.tsx
@@ -7,7 +7,9 @@ import {
 import { UpsellDevInstances } from "metabase/admin/upsells";
 import ExternalLink from "metabase/common/components/ExternalLink";
 import { useDocsUrl } from "metabase/common/hooks";
+import { useSelector } from "metabase/lib/redux";
 import { PLUGIN_LANDING_PAGE, PLUGIN_SEMANTIC_SEARCH } from "metabase/plugins";
+import { getSetting } from "metabase/selectors/settings";
 
 import { DevInstanceBanner } from "../GeneralSettings/DevInstanceBanner";
 import { AdminSettingInput } from "../widgets/AdminSettingInput";
@@ -20,6 +22,9 @@ export function GeneralSettingsPage() {
   const { url: iframeDocsUrl } = useDocsUrl("configuring-metabase/settings", {
     anchor: "allowed-domains-for-iframes-in-dashboards",
   });
+  const { hosting: isCloudPlan = false } = useSelector((state) =>
+    getSetting(state, "token-features"),
+  );
 
   return (
     <SettingsPageWrapper title={t`General`}>
@@ -50,7 +55,7 @@ export function GeneralSettingsPage() {
           inputType="text"
         />
 
-        <AnonymousTrackingInput />
+        {!isCloudPlan && <AnonymousTrackingInput />}
       </SettingsSection>
 
       <SettingsSection title={t`Tables, X-Rays and domains`}>

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/GeneralSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/GeneralSettingsPage.tsx
@@ -6,10 +6,8 @@ import {
 } from "metabase/admin/components/SettingsSection";
 import { UpsellDevInstances } from "metabase/admin/upsells";
 import ExternalLink from "metabase/common/components/ExternalLink";
-import { useDocsUrl } from "metabase/common/hooks";
-import { useSelector } from "metabase/lib/redux";
+import { useDocsUrl, useHasTokenFeature } from "metabase/common/hooks";
 import { PLUGIN_LANDING_PAGE, PLUGIN_SEMANTIC_SEARCH } from "metabase/plugins";
-import { getSetting } from "metabase/selectors/settings";
 
 import { DevInstanceBanner } from "../GeneralSettings/DevInstanceBanner";
 import { AdminSettingInput } from "../widgets/AdminSettingInput";
@@ -22,9 +20,8 @@ export function GeneralSettingsPage() {
   const { url: iframeDocsUrl } = useDocsUrl("configuring-metabase/settings", {
     anchor: "allowed-domains-for-iframes-in-dashboards",
   });
-  const { hosting: isCloudPlan = false } = useSelector((state) =>
-    getSetting(state, "token-features"),
-  );
+  const hasHostingFeature = useHasTokenFeature("hosting");
+  const enableAnonymousTracking = !hasHostingFeature;
 
   return (
     <SettingsPageWrapper title={t`General`}>
@@ -48,14 +45,16 @@ export function GeneralSettingsPage() {
         <PLUGIN_LANDING_PAGE.LandingPageWidget />
       </SettingsSection>
 
-      <SettingsSection title={t`Email and tracking`}>
+      <SettingsSection
+        title={enableAnonymousTracking ? t`Email and tracking` : t`Email`}
+      >
         <AdminSettingInput
           name="admin-email"
           title={t`Email address for help requests`}
           inputType="text"
         />
 
-        {!isCloudPlan && <AnonymousTrackingInput />}
+        {enableAnonymousTracking && <AnonymousTrackingInput />}
       </SettingsSection>
 
       <SettingsSection title={t`Tables, X-Rays and domains`}>

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/GeneralSettingsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/GeneralSettingsPage.unit.spec.tsx
@@ -16,6 +16,7 @@ import {
   createMockDashboard,
   createMockSettingDefinition,
   createMockSettings,
+  createMockTokenFeatures,
 } from "metabase-types/api/mocks";
 
 import { GeneralSettingsPage } from "./GeneralSettingsPage";
@@ -35,8 +36,15 @@ const generalSettings = {
   "search-engine": "appdb",
 } as const;
 
-const setup = async () => {
-  const settings = createMockSettings(generalSettings);
+const setup = async (
+  { isCloudPlan }: { isCloudPlan: boolean } = { isCloudPlan: false },
+) => {
+  const settings = createMockSettings({
+    ...generalSettings,
+    "token-features": createMockTokenFeatures({
+      hosting: isCloudPlan,
+    }),
+  });
 
   fetchMock.get("https://mysite.biz/api/health", { status: 200 });
 
@@ -69,7 +77,8 @@ const setup = async () => {
     </>,
   );
 
-  await screen.findByText("Redirect to HTTPS");
+  // NOTE: For cloud plans, "Site name" will appear, so we assert for it instead of "Redirect to HTTPS"
+  await screen.findByText(isCloudPlan ? "Site name" : "Redirect to HTTPS");
 };
 
 describe("GeneralSettingsPage", () => {
@@ -154,5 +163,17 @@ describe("GeneralSettingsPage", () => {
       const toasts = screen.getAllByLabelText("check_filled icon");
       expect(toasts).toHaveLength(2);
     });
+  });
+
+  it("should show Anonymous Tracking input for non-cloud plans", async () => {
+    await setup({ isCloudPlan: false });
+
+    expect(screen.getByText("Anonymous tracking")).toBeInTheDocument();
+  });
+
+  it("should not show Anonymous Tracking input if the plan is cloud", async () => {
+    await setup({ isCloudPlan: true });
+
+    expect(screen.queryByText("Anonymous tracking")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/GeneralSettingsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/GeneralSettingsPage.unit.spec.tsx
@@ -77,8 +77,7 @@ const setup = async (
     </>,
   );
 
-  // NOTE: For cloud plans, "Site name" will appear, so we assert for it instead of "Redirect to HTTPS"
-  await screen.findByText(isCloudPlan ? "Site name" : "Redirect to HTTPS");
+  await screen.findByText("Site name");
 };
 
 describe("GeneralSettingsPage", () => {


### PR DESCRIPTION
Closes [UXW-2404](https://linear.app/metabase/issue/UXW-2404/remove-toggle-to-disable-anonymous-analytics-on-cloud-instances)

### Description

This PR hides the "Anonymous tracking" toggle within the "Email and tracking" section under `/admin/settings/general` for cloud instances.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Spin up a local environment simulating any cloud plan
2. Head over to `/admin/settings/general`
3. Verify that there's no "Anonymous tracking" switch under the "Email and tracking" section

For context, this was the command I used:

```sh
METASTORE_DEV_SERVER_URL=https://token-check.staging.metabase.com \
  MB_RUN_MODE=dev \
  MB_PREMIUM_EMBEDDING_TOKEN={your-cloud-token} \
  yarn dev-ee
```

### Demo

| Instance type | Section |
| - | - |
| Regular (`oss`) | <img width="1682" height="726" alt="CleanShot 2025-12-02 at 11 23 33@2x" src="https://github.com/user-attachments/assets/d73783d0-f9be-4e9c-82ea-3bffbd9a6488" /> |
| Cloud (`pro-cloud`) | <img width="1670" height="572" alt="CleanShot 2025-12-02 at 13 42 10@2x" src="https://github.com/user-attachments/assets/a5e65b0e-6323-42c3-9e48-996554c698b6" /> |

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
