### PR TITLE
Keep bars with 100% height when hiding segments in a 100% stacked chart

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/stack.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/stack.ts
@@ -13,8 +13,12 @@ export const getStackModels = (
     return [];
   }
 
+  const visibleSeriesModels = seriesModels.filter(
+    (seriesModel) => seriesModel.visible,
+  );
+
   const seriesModelsByDisplay = _.groupBy(
-    seriesModels,
+    visibleSeriesModels,
     (seriesModel) =>
       settings.series(seriesModel.legacySeriesSettingsObjectKey).display,
   );

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/stack.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/stack.unit.spec.ts
@@ -1,0 +1,23 @@
+import { createMockSeriesModel } from "__support__/echarts";
+import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
+
+import { getStackModels } from "./stack";
+
+describe("getStackModels", () => {
+  it("should exclude hidden series from stack models (#66149)", () => {
+    const seriesModels = [
+      createMockSeriesModel({ dataKey: "series1", visible: true }),
+      createMockSeriesModel({ dataKey: "series2", visible: false }),
+      createMockSeriesModel({ dataKey: "series3", visible: true }),
+    ];
+    const mockSettings: ComputedVisualizationSettings = {
+      "stackable.stack_type": "stacked",
+      series: () => ({ display: "bar" }),
+    };
+
+    const result = getStackModels(seriesModels, mockSettings);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].seriesKeys).toEqual(["series1", "series3"]);
+  });
+});


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #66149
Closes https://linear.app/metabase/issue/UXW-2364/when-you-hide-a-segment-in-a-100percent-stacked-bar-chart-the-bars-are

### Description

Bug: _If you create a 100% stacked bar chart and then hide one of the segments by clicking the circle for that segment, the stacked bar doesn't show 100%._

### How to verify

1. Go to or create a 100% stacked bar chart. (the sample question "Product category orders per age" works);
2. Click the colored checkbox next to a segment legend item to hide it from the chart;
3. Notice the chart adjusts itself to keep bars with 100% height.

### Demo
Before (Doohickey segment hidden):
<img width="1901" height="815" alt="image" src="https://github.com/user-attachments/assets/11d3e150-c71d-4b1c-b353-cfa7d1f98a5e" />

After:
<img width="1901" height="815" alt="image" src="https://github.com/user-attachments/assets/8ab43643-7ba9-4fb2-974a-5d683c2e3402" />


### Checklist

- [X] Tests have been added/updated to cover changes in this PR
