### PR TITLE
Index incremental filter column for OLTP databases

### DIFF
--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -8,6 +8,15 @@ title: Driver interface changelog
 
 - Added `sql-jdbc.execute/db-type-name` multimethod. Override this if something more than the default is needed in your sql-jdbc-based driver. See the `:mysql` implementation as an example.
 
+- To support secondary indexes on incremental transform (target) tables, added the following index maintenance methods:
+    - `metabase.driver/create-index!`
+    - `metabase.driver/drop-index!`
+    - `metabase.driver.sql-jdbc/create-index-sql`
+    - `metabase.driver.sql-jdbc/drop-index-sql`
+  Creating indexes can accelerate the `MAX` queries that incremental transforms use to determine watermark position.
+  We only use them where the `:transforms/index-ddl` feature is enabled.
+  Implementing these methods is optional, transforms work without them.
+
 ## Metabase 0.58.0
 
 - Added a `:collate` feature for drivers that support collation settings on text fields

--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -8,12 +8,6 @@ title: Driver interface changelog
 
 - Added `sql-jdbc.execute/db-type-name` multimethod. Override this if something more than the default is needed in your sql-jdbc-based driver. See the `:mysql` implementation as an example.
 
-- Added `metabase.driver/create-index!`, `metabase.driver/drop-index!` multimethods.
-  For JDBC databases, a default implementation is provided - and `metabase.driver.sql-jdbc/create-index-sql`,
-  `metabase.driver.sql-jdbc/drop-index-sql` can be used to specialize the DDL.
-  Creating indexes can accelerate the `MAX` queries that incremental transforms use to determine watermark position.
-  These methods are invoked only when the `:transforms/index-ddl` feature is enabled, and are otherwise optional.
-
 ## Metabase 0.58.0
 
 - Added a `:collate` feature for drivers that support collation settings on text fields
@@ -22,6 +16,12 @@ title: Driver interface changelog
 
 - All tests in `metabase.query-processor-test.*` namespaces have been moved to `metabase.query-processor.*` (This is
   only relevant if you run individual test namespaces as part of your development workflow).
+
+- Added `metabase.driver/create-index!`, `metabase.driver/drop-index!` multimethods.
+  For JDBC databases, a default implementation is provided - and `metabase.driver.sql-jdbc/create-index-sql`,
+  `metabase.driver.sql-jdbc/drop-index-sql` can be used to specialize the DDL.
+  Creating indexes can accelerate the `MAX` queries that incremental transforms use to determine watermark position.
+  These methods are invoked only when the `:transforms/index-ddl` feature is enabled and therefore are opt-in.
 
 ## Metabase 0.57.7
 

--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -8,14 +8,11 @@ title: Driver interface changelog
 
 - Added `sql-jdbc.execute/db-type-name` multimethod. Override this if something more than the default is needed in your sql-jdbc-based driver. See the `:mysql` implementation as an example.
 
-- To support secondary indexes on incremental transform (target) tables, added the following index maintenance methods:
-    - `metabase.driver/create-index!`
-    - `metabase.driver/drop-index!`
-    - `metabase.driver.sql-jdbc/create-index-sql`
-    - `metabase.driver.sql-jdbc/drop-index-sql`
+- Added `metabase.driver/create-index!`, `metabase.driver/drop-index!` multimethods.
+  For JDBC databases, a default implementation is provided - and `metabase.driver.sql-jdbc/create-index-sql`,
+  `metabase.driver.sql-jdbc/drop-index-sql` can be used to specialize the DDL.
   Creating indexes can accelerate the `MAX` queries that incremental transforms use to determine watermark position.
-  We only use them where the `:transforms/index-ddl` feature is enabled.
-  Implementing these methods is optional, transforms work without them.
+  These methods are invoked only when the `:transforms/index-ddl` feature is enabled, and are otherwise optional.
 
 ## Metabase 0.58.0
 

--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -21,7 +21,7 @@ title: Driver interface changelog
   For JDBC databases, a default implementation is provided - and `metabase.driver.sql-jdbc/create-index-sql`,
   `metabase.driver.sql-jdbc/drop-index-sql` can be used to specialize the DDL.
   Creating indexes can accelerate the `MAX` queries that incremental transforms use to determine watermark position.
-  These methods are invoked only when the `:transforms/index-ddl` feature is enabled and therefore are opt-in.
+  These methods run only when the `:transforms/index-ddl` feature is enabled, making them opt-in.
 
 ## Metabase 0.57.7
 

--- a/enterprise/backend/src/metabase_enterprise/transforms/query_impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/query_impl.clj
@@ -74,8 +74,9 @@
             (fn [_cancel-chan] (driver/run-transform! driver transform-details opts))))
          (transforms.instrumentation/with-stage-timing [run-id [:import :table-sync]]
            (transforms.util/sync-target! target database)
-         ;; This event must be published only after the sync is complete - the new table needs to be in AppDB.
-           (events/publish-event! :event/transform-run-complete {:object transform-details}))))
+           ;; This event must be published only after the sync is complete - the new table needs to be in AppDB.
+           (events/publish-event! :event/transform-run-complete {:object transform-details}))
+         (transforms.util/execute-secondary-index-ddl-if-required! transform run-id database target)))
      (catch Throwable t
        (log/error t "Error executing transform")
        (when start-promise

--- a/enterprise/backend/src/metabase_enterprise/transforms/query_impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/query_impl.clj
@@ -76,6 +76,8 @@
            (transforms.util/sync-target! target database)
            ;; This event must be published only after the sync is complete - the new table needs to be in AppDB.
            (events/publish-event! :event/transform-run-complete {:object transform-details}))
+         ;; Creating an index after sync means the filter column is known in the appdb.
+         ;; The index would be synced the next time sync runs, but at time of writing, index sync is disabled.
          (transforms.util/execute-secondary-index-ddl-if-required! transform run-id database target)))
      (catch Throwable t
        (log/error t "Error executing transform")

--- a/enterprise/backend/src/metabase_enterprise/transforms/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/util.clj
@@ -1,14 +1,18 @@
 (ns metabase-enterprise.transforms.util
   (:require
+   [buddy.core.codecs :as codecs]
+   [buddy.core.hash :as buddy-hash]
    [clojure.core.async :as a]
    [clojure.string :as str]
    [java-time.api :as t]
    [metabase-enterprise.transforms.canceling :as canceling]
+   [metabase-enterprise.transforms.instrumentation :as transforms.instrumentation]
    [metabase-enterprise.transforms.interface :as transforms.i]
    [metabase-enterprise.transforms.models.transform-run :as transform-run]
    [metabase-enterprise.transforms.settings :as transforms.settings]
    [metabase.driver :as driver]
    [metabase.driver.sql.query-processor :as sql.qp]
+   [metabase.driver.util :as driver.u]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
@@ -555,3 +559,85 @@
     (if tag-ids
       (filter #(some tag-ids (get-in % field-path)))
       identity)))
+
+(def ^:private metabase-index-prefix "mb_transform_idx_")
+
+(defn- incremental-filter-index-name [schema table-name filter-column-name]
+  (let [prefix metabase-index-prefix
+        suffix (codecs/bytes->hex (buddy-hash/md5 (str/join "|" [schema table-name filter-column-name])))]
+    (str prefix suffix)))
+
+(defn- should-index-incremental-filter-column? [driver database]
+  (and (driver.u/supports? driver :describe-indexes database)
+       (driver.u/supports? driver :transforms/index-ddl database)))
+
+(defn- metabase-owned-index? [index]
+  (str/starts-with? (:index-name index) metabase-index-prefix))
+
+(defn- metabase-incremental-filter-index [filter-column target]
+  (let [table-name  (:name target)
+        schema      (:schema target)
+        filter-name (:name filter-column)]
+    ;; match the schema used by describe-table-indexes (:value denotes the column name, assumed leading column if a composite index)
+    {:index-name (incremental-filter-index-name schema table-name filter-name)
+     :value      filter-name}))
+
+(defn- decide-secondary-index-ddl
+  "Decides which indexes should be dropped/created on the target table.
+
+  e.g. Indexing the incremental :filter-column to accelerate MAX(target.checkpoint) queries on OLTP databases.
+
+  Indexes are represented as maps with at least the keys :index-name, :value.
+  This matches the form used by [[metabase.driver/describe-table-indexes]].
+
+  Returns a map:
+  :drop   - a vector of indexes that are redundant and should be dropped.
+  :create - a vector of desirable indexes that do not exist and that should be created.
+
+  Notes:
+  - If user covering indexes exist they should be reused.
+  - Will never drop user indexes.
+  - Indexes we previously created and are no longer required are dropped."
+  [{:keys [filter-column indexes target database]}]
+  (let [[mb-indexes user-indexes] ((juxt filter remove) metabase-owned-index? indexes)
+        default-mb-index    (when filter-column (metabase-incremental-filter-index filter-column target))
+        column-name         (:name filter-column)
+        existing-user-index (first (filter #(= (:value %) column-name) user-indexes))
+        existing-mb-index   (first (filter #(= (:index-name %) (:index-name default-mb-index)) mb-indexes))
+        driver              (:engine database)
+        intended-index      (when (should-index-incremental-filter-column? driver database)
+                              ;; Prefer reuse to not create redundant indexes
+                              (or existing-user-index default-mb-index))
+        drop                (if intended-index
+                              (remove #(= (:index-name intended-index) (:index-name %)) mb-indexes)
+                              mb-indexes)
+        create              (when (and intended-index
+                                       (not= (:index-name intended-index) (:index-name existing-user-index))
+                                       (not= (:index-name intended-index) (:index-name existing-mb-index)))
+                              [intended-index])]
+    {:drop   (vec drop)
+     :create (vec create)}))
+
+(defn execute-secondary-index-ddl-if-required!
+  "If target table index modifications are required, executes those CREATE/DROP commands.
+  See [[metabase.transforms-util/decide-secondary-index-ddl]] for details."
+  [transform run-id database target]
+  (let [driver     (:engine database)
+        indexes    (when (driver.u/supports? driver :describe-indexes database)
+                     (driver/describe-table-indexes driver database target))
+        checkpoint (next-checkpoint (:id transform))
+        {:keys [drop create]}
+        (when indexes
+          (decide-secondary-index-ddl
+           {:filter-column (:filter-column checkpoint)
+            :database      database
+            :target        target
+            :indexes       indexes}))]
+    (doseq [{:keys [index-name value]} drop]
+      (transforms.instrumentation/with-stage-timing [run-id [:import :drop-incremental-filter-index]]
+        (log/infof "Dropping secondary index %s(%s) for target %s" index-name value (pr-str target))
+        (driver/drop-index! driver (:id database) (:schema target) (:name target) index-name)))
+    (doseq [{:keys [index-name value]} create]
+      (transforms.instrumentation/with-stage-timing [run-id [:import :create-incremental-filter-index]]
+        (log/infof "Creating secondary index %s(%s) for target %s" index-name value (pr-str target))
+        (driver/create-index! driver (:id database) (:schema target) (:name target) index-name [value])))))

--- a/enterprise/backend/src/metabase_enterprise/transforms_python/execute.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms_python/execute.clj
@@ -375,6 +375,7 @@
                                 (transforms.util/run-cancelable-transform! run-id driver transform-details run-fn :ex-message-fn ex-message-fn))]
         (transforms.instrumentation/with-stage-timing [run-id [:import :table-sync]]
           (transforms.util/sync-target! target db))
+        (transforms.util/execute-secondary-index-ddl-if-required! transform run-id db target)
         {:run_id run-id
          :result result}))
     (catch Throwable t

--- a/enterprise/backend/test/metabase_enterprise/transforms/incremental_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/incremental_test.clj
@@ -745,6 +745,6 @@
                     (execute-transform-with-ordering! transform transform-type new-field {:run-method :manual})
                     (let [table              (t2/select-one :model/Table :name target-table)
                           indexes            (driver/describe-table-indexes driver/*driver* (mt/id) {:schema (:schema table) :name target-table})]
-                      (testing "Old index removed, new checkpoint column is now indexed")
-                      (is (= 1 (count indexes)))
-                      (is (=? {:value new-field :index-name #"^mb_transform_idx_.*$"} (first indexes))))))))))))))
+                      (testing "Old index removed, new checkpoint column is now indexed"
+                        (is (= 1 (count indexes)))
+                        (is (=? {:value new-field :index-name #"^mb_transform_idx_.*$"} (first indexes)))))))))))))))

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -51,6 +51,7 @@
                               :test/jvm-timezone-setting        false
                               :transforms/python                true
                               :transforms/table                 true
+                              :transforms/index-ddl             false
                               :uuid-type                        false}]
   (defmethod driver/database-supports? [:redshift feature] [_driver _feat _db] supported?))
 

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -58,6 +58,7 @@
                               :metadata/table-existence-check         true
                               :transforms/python                      true
                               :transforms/table                       true
+                              :transforms/index-ddl                   true
                               :jdbc/statements                        false
                               :describe-default-expr                  true
                               :describe-is-nullable                   true
@@ -1069,3 +1070,10 @@
   [_driver]
   ;; https://learn.microsoft.com/en-us/previous-versions/sql/sql-server-2008-r2/ms191240(v=sql.105)#sysname
   128)
+
+(defmethod sql-jdbc/drop-index-sql :sqlserver [_ schema table-name index-name]
+  (let [{quote-identifier :quote} (sql/get-dialect :sqlserver)]
+    (format "DROP INDEX %s ON %s" (quote-identifier (name index-name))
+            (if schema
+              (str (quote-identifier (name schema)) "." (quote-identifier (name table-name)))
+              (quote-identifier (name table-name))))))

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -1365,6 +1365,20 @@
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)
 
+(defmulti drop-index!
+  "Drops an index named `index-name` created by [[metabase.driver/create-index!]]. Throws if the index does not exist."
+  {:added "0.58.0", :arglists '([driver database-id table-name index-name & args])}
+  dispatch-on-initialized-driver
+  :hierarchy #'hierarchy)
+
+(defmulti create-index!
+  "Create a (sorted/btree) index named `index-name`.
+  Should be assumed to block until the index is created.
+  Throws if the index already exists."
+  {:added "0.58.0", :arglists '([driver database-id schema table-name index-name column-names & args])}
+  dispatch-on-initialized-driver
+  :hierarchy #'hierarchy)
+
 (defmulti drop-table!
   "Drop a table named `table-name`. If the table doesn't exist it will not be dropped. `table-name` may be qualified
   by schema e.g.

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -1367,7 +1367,7 @@
 
 (defmulti drop-index!
   "Drops an index named `index-name` created by [[metabase.driver/create-index!]]. Throws if the index does not exist."
-  {:added "0.58.0", :arglists '([driver database-id table-name index-name & args])}
+  {:added "0.58.0", :arglists '([driver database-id schema table-name index-name & args])}
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)
 

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -95,6 +95,8 @@
                               :metadata/table-existence-check         true
                               :transforms/python                      true
                               :transforms/table                       true
+                              ;; currently disabled as :describe-indexes is not supported
+                              :transforms/index-ddl                   false
                               :describe-default-expr                  true
                               :describe-is-nullable                   true
                               :describe-is-generated                  true}]
@@ -1160,6 +1162,10 @@
 (defmethod sql-jdbc/impl-query-canceled? :mysql [_ ^SQLException e]
   ;; ok to hardcode driver name here because this function only supports app DB types
   (driver-api/query-canceled-exception? :mysql e))
+
+(defmethod sql-jdbc/drop-index-sql :mysql [_ _schema table-name index-name]
+  (let [{quote-identifier :quote} (sql/get-dialect :mysql)]
+    (format "DROP INDEX %s ON %s" (quote-identifier (name index-name)) (quote-identifier (name table-name)))))
 
 ;;; ------------------------------------------------- User Impersonation --------------------------------------------------
 

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -88,6 +88,7 @@
                               :database-routing         true
                               :transforms/table         true
                               :transforms/python        true
+                              :transforms/index-ddl     true
                               :metadata/table-existence-check true}]
   (defmethod driver/database-supports? [:postgres feature] [_driver _feature _db] supported?))
 

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -168,6 +168,50 @@
     (jdbc/with-db-transaction [conn (sql-jdbc.conn/db->pooled-connection-spec db-id)]
       (jdbc/execute! conn sql))))
 
+(defmulti create-index-sql
+  "Implementing method to produce the SQL (string) that will create the secondary index."
+  {:added "0.58.0", :arglists '([driver schema table-name index-name column-names & opts])}
+  driver/dispatch-on-initialized-driver
+  :hierarchy #'driver/hierarchy)
+
+(defmethod create-index-sql :default
+  [driver schema table-name index-name column-names & _]
+  (with-quoting driver
+    (let [index-spec (into [(keyword (if schema (str (name schema) "." (name table-name)) table-name))]
+                           (map keyword)
+                           column-names)]
+      (first (sql/format {:create-index [(keyword index-name) index-spec]}
+                         :quoted true
+                         :dialect (sql.qp/quote-style driver))))))
+
+(defmethod driver/create-index! :sql-jdbc
+  [driver database-id schema table-name index-name column-names & _]
+  (let [sql (create-index-sql driver schema table-name index-name column-names)]
+    (jdbc/with-db-transaction [conn (sql-jdbc.conn/db->pooled-connection-spec database-id)]
+      (jdbc/execute! conn sql))
+    nil))
+
+(defmulti drop-index-sql
+  "Implementing method to produce the SQL (string) that will drop the index."
+  {:added "0.58.0" :arglists '([driver schema table-name index-name])}
+  driver/dispatch-on-initialized-driver
+  :hierarchy #'driver/hierarchy)
+
+(defmethod drop-index-sql :default
+  [driver schema _table-name index-name]
+  (first (sql/format {:drop-index [(keyword (if schema
+                                              (str (name schema) "." (name index-name))
+                                              (name index-name)))]}
+                     :quoted true
+                     :dialect (sql.qp/quote-style driver))))
+
+(defmethod driver/drop-index! :sql-jdbc
+  [driver database-id schema table-name index-name & _]
+  (let [sql (drop-index-sql driver schema table-name index-name)]
+    (jdbc/with-db-transaction [conn (sql-jdbc.conn/db->pooled-connection-spec database-id)]
+      (jdbc/execute! conn sql))
+    nil))
+
 (defmethod driver/truncate! :sql-jdbc
   [driver db-id table-name]
   (let [table-name (keyword table-name)

--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -458,15 +458,16 @@
                                               ;; when true, result is allowed to reflect approximate or out of data
                                               ;; values. when false, results are requested to be accurate
                                               false)]
-       (->> (vals (group-by :index_name (into []
-                                              ;; filtered indexes are ignored
-                                              (filter #(nil? (:filter_condition %)))
-                                              (jdbc/reducible-result-set index-info-rs {}))))
-            (keep (fn [idx-values]
+       (->> (group-by :index_name (into []
+                                        ;; filtered indexes are ignored
+                                        (filter #(nil? (:filter_condition %)))
+                                        (jdbc/reducible-result-set index-info-rs {})))
+            (keep (fn [[index-name idx-values]]
                     ;; we only sync columns that are either singlely indexed or is the first key in a composite index
-                    (when-let [index-name (some :column_name (sort-by :ordinal_position idx-values))]
+                    (when-let [column-name (some :column_name (sort-by :ordinal_position idx-values))]
                       {:type  :normal-column-index
-                       :value index-name})))
+                       :index-name index-name
+                       :value column-name})))
             set)))))
 
 (def ^:const max-nested-field-columns

--- a/test/metabase/driver_test.clj
+++ b/test/metabase/driver_test.clj
@@ -16,6 +16,7 @@
    [metabase.test.data.interface :as tx]
    [metabase.util :as u]
    [metabase.util.json :as json]
+   [metabase.util.log :as log]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -480,3 +481,52 @@
 (deftest deps-flags-when-supported-driver-is-not-covered-test
   (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Database that supports :dependencies/native does not provide an implementation of driver/native-query-deps"
                         (driver/native-query-deps ::mock-deps-driver nil nil))))
+
+(defn- create-index-test-impl! [schema]
+  (let [driver      driver/*driver*
+        suffix      (str (System/currentTimeMillis))
+        table-name  (str "test_table_" suffix)
+        qualified-table-name (keyword schema table-name)
+        index-name  #(str "test_index_" % "_" suffix)
+        database-id (mt/id)
+        cleanup     (fn []
+                      (try
+                        (driver/drop-table! driver database-id qualified-table-name)
+                        (catch Throwable t
+                          (log/fatal t "Could not clean up test table!")
+                          (throw t))))]
+    (when schema
+      (driver/create-schema-if-needed! driver (driver/connection-spec driver database-id) schema))
+    (testing "Throws a driver-specific exception if the table does not exist"
+      (is (thrown? Throwable (driver/create-index! driver database-id schema table-name (index-name "a") [:a]))))
+    (try
+      (driver/create-table! driver database-id qualified-table-name {:a [:int], :b [:int], :c [:int]})
+      (testing "Create a single column index"
+        (is (nil? (driver/create-index! driver database-id schema table-name (index-name "a") [:a])))
+        (testing "Index now exists"
+          (is (= #{{:type       :normal-column-index
+                    :index-name (index-name "a")
+                    :value      "a"}}
+                 (driver/describe-table-indexes driver database-id {:schema schema :name table-name}))))
+        (testing "Drop the index"
+          (is (nil? (driver/drop-index! driver database-id schema table-name (index-name "a"))))
+          (testing "Index no longer exists"
+            (is (empty? (driver/describe-table-indexes driver database-id {:schema schema :name table-name}))))))
+      (testing "Create a multi column index"
+        (driver/create-index! driver database-id schema table-name (index-name "b_c") [:b :c])
+        (testing "Index now exists"
+          ;; single-part only as non-leading columns currently dropped by describe-table-indexes
+          (is (= #{{:type       :normal-column-index
+                    :index-name (index-name "b_c")
+                    :value      "b"}}
+                 (driver/describe-table-indexes driver database-id {:schema schema :name table-name})))))
+      (finally
+        (cleanup)))))
+
+(deftest create-index-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :transforms/index-ddl)
+    (create-index-test-impl! nil)))
+
+(deftest create-index-schema-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :transforms/index-ddl :schemas)
+    (create-index-test-impl! "flibble")))


### PR DESCRIPTION
## Problem

Incremental transforms issue a `MAX` query to the target table to determine the watermark. There is concern that such a query is necessarily a table scan on certain OLTP databases (such as postgres) and that this might cause poor performance if the table is large.

## Discussion

A proposal to add indexes was made to accelerate these queries. It was observed that that benefitting from indexes would depend on several factors:
- Size of tables
- Ratio of index reads to table writes
- Availability of zonemaps or other metadata based approaches in OLAP stores, or stores that might not have an analog for the traditional btree index.

Still, we can create the indexes only if a driver feature is enabled - and if we are later in a position, measure the cost/benefit in terms of performance as well as code complexity. It is too early to make any judgement here!

## Solution

This PR modifies transforms so that indexes are created on the target tables filter column.  They are created when the `:transforms/index-ddl` feature (and the dependent `:describe-indexes` feature) is enabled. A new pair of driver methods have been added: `create-index!` and `drop-index!`, an implementation of which is available for all sql-jdbc drivers. 

- Indexes are maintained on transform run for all transform types, after table sync (so that filter metadata is known to the system)
- If the filter column is later changed, the index is dropped and recreated on a subsequent run
- If the transform is edited to no longer be incremental, the index is dropped
- If a user index already exists that covers the filter column, we prefer it and do not create (or drop!) indexes. This is to avoid waste but more importantly some RDBMS may now or in the future consider duplication of indexes an error (sql server have talked about this).

Closes GDGT-1296