### PR TITLE
Use the correct icons for questions in the MiniPicker

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/collections/utils.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/collections/utils.unit.spec.tsx
@@ -75,7 +75,7 @@ describe("Collections plugin utils", () => {
     });
 
     it("should return the default icon for a regular question", () => {
-      expect(getIcon({ model: "card" })).toEqual({ name: "table" });
+      expect(getIcon({ model: "card" })).toEqual({ name: "table2" });
     });
 
     describe("enterprise icons", () => {

--- a/frontend/src/metabase-lib/v1/metadata/utils/saved-questions.js
+++ b/frontend/src/metabase-lib/v1/metadata/utils/saved-questions.js
@@ -52,6 +52,7 @@ export function convertSavedQuestionToVirtualTable(card) {
     moderated_status: card.moderated_status,
     // we may not have permissions
     db_id: card.dataset_query?.database,
+    type: "question",
     schema: getCollectionVirtualSchemaId(card.collection),
     schema_name: getCollectionVirtualSchemaName(card.collection),
   };

--- a/frontend/src/metabase-lib/v1/metadata/utils/saved-questions.unit.spec.js
+++ b/frontend/src/metabase-lib/v1/metadata/utils/saved-questions.unit.spec.js
@@ -165,6 +165,7 @@ describe("saved question helpers", () => {
         description: question.description,
         moderated_status: question.moderated_status,
         db_id: question.dataset_query.database,
+        type: "question",
         schema: `${SAVED_QUESTIONS_VIRTUAL_DB_ID}:${question.collection.name}`,
         schema_name: question.collection.name,
       });
@@ -182,6 +183,7 @@ describe("saved question helpers", () => {
         description: question.description,
         moderated_status: question.moderated_status,
         db_id: question.dataset_query.database,
+        type: "question",
         schema: `${SAVED_QUESTIONS_VIRTUAL_DB_ID}:${encodeURIComponent(
           "Everything else",
         )}`,

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItem.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItem.tsx
@@ -2,7 +2,10 @@ import { Ellipsified } from "metabase/common/components/Ellipsified";
 import { getIcon } from "metabase/lib/icon";
 import { Box, Icon, Menu, type MenuItemProps } from "metabase/ui";
 
-import type { MiniPickerItem as MiniPickerItemType } from "../types";
+import type {
+  MiniPickerCollectionItem,
+  MiniPickerItem as MiniPickerItemType,
+} from "../types";
 
 export const MiniPickerItem = ({
   model,
@@ -10,10 +13,12 @@ export const MiniPickerItem = ({
   onClick,
   isFolder,
   isHidden,
+  display,
   ...menuItemProps
 }: {
   name: string;
   model?: MiniPickerItemType["model"];
+  display?: MiniPickerCollectionItem["display"];
   onClick?: () => void;
   isFolder?: boolean;
   isHidden?: boolean;
@@ -24,7 +29,9 @@ export const MiniPickerItem = ({
   return (
     <Box px="sm" py="2px">
       <Menu.Item
-        leftSection={model ? <Icon {...getIcon({ model })} /> : undefined}
+        leftSection={
+          model ? <Icon {...getIcon({ model, display })} /> : undefined
+        }
         rightSection={isFolder ? <Icon name="chevronright" /> : undefined}
         onClick={onClick}
         {...menuItemProps}

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
@@ -261,6 +261,7 @@ function CollectionItemList({ parent }: { parent: MiniPickerCollectionItem }) {
             key={`${item.model}-${item.id}`}
             name={item.name}
             model={item.model}
+            display={item.display}
             isFolder={isFolder(item)}
             isHidden={isHidden(item)}
             onClick={() => {

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/types.ts
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/types.ts
@@ -8,7 +8,7 @@ import type {
 
 export type MiniPickerCollectionItem = Pick<
   CollectionItem,
-  "id" | "name" | "model" | "here" | "below"
+  "id" | "name" | "model" | "here" | "below" | "display"
 > & {
   id: CollectionItem["id"] | CollectionId;
 };

--- a/frontend/src/metabase/lib/icon.ts
+++ b/frontend/src/metabase/lib/icon.ts
@@ -45,7 +45,7 @@ export const modelIconMap: Record<IconModel, IconName> = {
   action: "bolt",
   "indexed-entity": "index",
   dashboard: "dashboard",
-  card: "table",
+  card: "table2",
   segment: "segment",
   metric: "metric",
   snippet: "unknown",

--- a/frontend/src/metabase/lib/icon.ts
+++ b/frontend/src/metabase/lib/icon.ts
@@ -16,8 +16,10 @@ import type { ColorName } from "./colors/types";
 export type IconModel =
   | SearchModel
   | CollectionItemModel
+  | "model"
   | "schema"
   | "timeline"
+  | "question"
   | "transform"
   | "user";
 
@@ -45,6 +47,8 @@ export const modelIconMap: Record<IconModel, IconName> = {
   action: "bolt",
   "indexed-entity": "index",
   dashboard: "dashboard",
+  question: "table2",
+  model: "model",
   card: "table2",
   segment: "segment",
   metric: "metric",

--- a/frontend/src/metabase/lib/icon.unit.spec.ts
+++ b/frontend/src/metabase/lib/icon.unit.spec.ts
@@ -58,10 +58,10 @@ describe("getIcon", () => {
     });
 
     it("should return the default icon for no display type", () => {
-      expect(getIcon({ model: "card" })).toEqual({ name: "table" });
+      expect(getIcon({ model: "card" })).toEqual({ name: "table2" });
     });
 
-    it("should return the correct icon for a card with a table chare", () => {
+    it("should return the correct icon for a card with a table chart", () => {
       expect(getIcon({ model: "card", display: "table" })).toEqual({
         name: "table2",
       });

--- a/frontend/src/metabase/lib/icon.unit.spec.ts
+++ b/frontend/src/metabase/lib/icon.unit.spec.ts
@@ -41,7 +41,7 @@ describe("getIcon", () => {
   });
 
   it("should return the correct icon for a card without a display type", () => {
-    expect(getIcon({ model: "card" })).toEqual({ name: "table" });
+    expect(getIcon({ model: "card" })).toEqual({ name: "table2" });
   });
 
   it("should return the default icon for an invalid model", () => {

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/utils.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/utils.tsx
@@ -1,7 +1,7 @@
 import { type ReactElement, isValidElement } from "react";
-import { match } from "ts-pattern";
 
 import { TableInfoIcon } from "metabase/common/components/MetadataInfo/TableInfoIcon/TableInfoIcon";
+import { getIcon } from "metabase/lib/icon";
 import { isNotNull } from "metabase/lib/types";
 import * as Urls from "metabase/lib/urls";
 import type { IconName } from "metabase/ui";
@@ -194,10 +194,5 @@ function getTableURL(table: Table) {
 }
 
 export function getQuestionIcon(question: Question): IconName {
-  return match(question.type())
-    .returnType<IconName>()
-    .with("question", () => "table2")
-    .with("model", () => "model")
-    .with("metric", () => "metric")
-    .exhaustive();
+  return getIcon({ model: "card", type: question.type() }).name;
 }

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/components/QuestionSources.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/components/QuestionSources.tsx
@@ -3,6 +3,7 @@ import { c } from "ttag";
 
 import Link from "metabase/common/components/Link";
 import { SidesheetCardSection } from "metabase/common/components/Sidesheet";
+import { getIcon } from "metabase/lib/icon";
 import { useSelector } from "metabase/lib/redux";
 import { getQuestionWithoutComposing } from "metabase/query_builder/selectors";
 import { Flex, FixedSizeIcon as Icon } from "metabase/ui";
@@ -10,7 +11,6 @@ import { Flex, FixedSizeIcon as Icon } from "metabase/ui";
 import { getDataSourceParts } from "../../../ViewHeader/components/QuestionDataSource/utils";
 
 import type { QuestionSource } from "./types";
-import { getIconPropsForSource } from "./utils";
 
 export const QuestionSources = () => {
   /** Retrieve current question from the Redux store */
@@ -23,11 +23,11 @@ export const QuestionSources = () => {
           subHead: false,
           isObjectDetail: true,
           formatTableAsComponent: false,
-        }) as QuestionSource[])
+        }) as QuestionSource[]) // note: this type cast is horrendous
       : [];
     return sources.map((source) => ({
       ...source,
-      iconProps: getIconPropsForSource(source),
+      iconProps: getIcon({ model: source.model ?? "card" }),
     }));
   }, [underlyingQuestion]);
 

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/components/types.ts
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/components/types.ts
@@ -1,8 +1,9 @@
 import type { IconData } from "metabase/lib/icon";
+import type { SearchModel } from "metabase-types/api";
 
 export interface QuestionSource {
   href: string;
   name: string;
-  model?: string;
+  model?: SearchModel;
   iconProps?: IconData;
 }

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/components/utils.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/components/utils.tsx
@@ -1,27 +1,7 @@
-import { match } from "ts-pattern";
-
-import { type IconData, type IconModel, getIcon } from "metabase/lib/icon";
+import { getIcon } from "metabase/lib/icon";
 import { getUrl } from "metabase/querying/notebook/components/NotebookDataPicker/utils";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
-
-import type { QuestionSource } from "./types";
-
-export const getIconPropsForSource = (
-  source: QuestionSource,
-): IconData | undefined => {
-  const iconModel: IconModel | undefined = match(source.model)
-    .with("question", () => "card" as const)
-    .with("model", () => "dataset" as const)
-    .with("database", () => "database" as const)
-
-    .with("metric", () => "metric" as const)
-    .with("schema", () => undefined)
-    .otherwise(() => "table" as const);
-
-  const iconProps = iconModel ? getIcon({ model: iconModel }) : undefined;
-  return iconProps;
-};
 
 export const getJoinedTablesWithIcons = (question: Question) => {
   const query = question?.query();
@@ -42,6 +22,6 @@ export const getJoinedTablesWithIcons = (question: Question) => {
 
   return joinedTables.map((source) => ({
     ...source,
-    iconProps: getIconPropsForSource(source),
+    iconProps: getIcon({ model: "table" }),
   }));
 };

--- a/frontend/src/metabase/search/components/SearchResult/tests/SearchResult.unit.spec.tsx
+++ b/frontend/src/metabase/search/components/SearchResult/tests/SearchResult.unit.spec.tsx
@@ -68,7 +68,7 @@ describe("SearchResult", () => {
     expect(
       screen.getByText(TEST_RESULT_QUESTION.description as string),
     ).toBeInTheDocument();
-    expect(getIcon("table")).toBeInTheDocument();
+    expect(getIcon("table2")).toBeInTheDocument();
   });
 
   it("renders a search result collection item", () => {


### PR DESCRIPTION
Uses the visualization sensitive icons for questions in the MiniPicker

<img width="368" height="519" alt="CleanShot 2025-12-02 at 15 38 49" src="https://github.com/user-attachments/assets/e6264c7c-bf0d-4ab6-8bc2-64215bd177a1" />

