### PR TITLE
fix(sdk-cli): Fixes CLI quickstart not passing in the proper revision in query

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-package/cli/steps/setup-permission/index.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/cli/steps/setup-permission/index.ts
@@ -1,0 +1,5 @@
+export {
+  setupPermissions,
+  grantAccessToModelCollection,
+} from "./setup-permission";
+export type { GrantAccessToModelCollectionOptions } from "./setup-permission";

--- a/enterprise/frontend/src/embedding-sdk-package/cli/steps/setup-permission/setup-permission.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/cli/steps/setup-permission/setup-permission.ts
@@ -22,8 +22,6 @@ export const setupPermissions: CliStepMethod = async (state) => {
   let res;
   const collectionIds: number[] = [];
 
-  console.log(" 0. Setting up permissions and collections...");
-
   // Create new customer collections sequentially
   try {
     for (const groupName of SANDBOXED_GROUP_NAMES) {
@@ -40,8 +38,6 @@ export const setupPermissions: CliStepMethod = async (state) => {
 
     return [cliError(message, error), state];
   }
-
-  console.log(" 1. Setting up permission groups and mappings...");
 
   // Example: { "Customer A": [3], "Customer B": [4], "Customer C": [5] }
   const jwtGroupMappings: Record<string, number[]> = {};
@@ -76,8 +72,6 @@ export const setupPermissions: CliStepMethod = async (state) => {
     return [cliError(message, error), state];
   }
 
-  console.log(" 2. Setting up sandboxed permissions...");
-
   const groupIds: number[] = Object.values(jwtGroupMappings).flat();
 
   try {
@@ -109,8 +103,6 @@ export const setupPermissions: CliStepMethod = async (state) => {
     return [cliError(message, error), state];
   }
 
-  console.log(" 3. Granting access to model collection...");
-
   try {
     await grantAccessToModelCollection({
       groupIds,
@@ -124,8 +116,6 @@ export const setupPermissions: CliStepMethod = async (state) => {
 
     return [cliError(message, error), state];
   }
-
-  console.log(" 4. Sampling tenancy column values...");
 
   try {
     const { tenantIdsMap, unsampledTableNames } =

--- a/enterprise/frontend/src/embedding-sdk-package/cli/steps/setup-permission/setup-permission.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/cli/steps/setup-permission/setup-permission.unit.spec.ts
@@ -1,0 +1,172 @@
+import fetchMock from "fetch-mock";
+
+import { getSandboxedCollectionPermissions } from "../../utils/get-sandboxed-collection-permissions";
+import { propagateErrorResponse } from "../../utils/propagate-error-response";
+
+import { grantAccessToModelCollection } from "./setup-permission";
+
+// Mock the utility functions
+jest.mock("../../utils/get-sandboxed-collection-permissions", () => ({
+  getSandboxedCollectionPermissions: jest.fn(),
+}));
+
+jest.mock("../../utils/propagate-error-response", () => ({
+  propagateErrorResponse: jest.fn(),
+}));
+
+describe("grantAccessToModelCollection", () => {
+  const defaultOptions = {
+    groupIds: [101, 102],
+    collectionIds: [1, 2],
+    modelCollectionId: 123,
+    instanceUrl: "http://localhost:3000",
+    cookie: "test-cookie",
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should fetch current revision from collection graph and pass it to permissions update", async () => {
+    const mockCurrentGraph = {
+      revision: 42,
+      groups: {},
+    };
+
+    // Mock API calls
+    fetchMock
+      .get("http://localhost:3000/api/collection/graph", mockCurrentGraph)
+      .put("http://localhost:3000/api/collection/graph?skip-graph=true", {});
+
+    // Mock utility functions
+    (
+      propagateErrorResponse as jest.MockedFunction<
+        typeof propagateErrorResponse
+      >
+    ).mockResolvedValue(undefined);
+
+    (
+      getSandboxedCollectionPermissions as jest.MockedFunction<
+        typeof getSandboxedCollectionPermissions
+      >
+    ).mockReturnValue({
+      101: { 1: "write" },
+      102: { 2: "write" },
+    });
+
+    await grantAccessToModelCollection(defaultOptions);
+
+    // Verify that we fetched the current collection graph
+    const graphGetCalls = fetchMock.callHistory.calls(
+      "http://localhost:3000/api/collection/graph",
+      { method: "GET" },
+    );
+    expect(graphGetCalls).toHaveLength(1);
+
+    // Verify that we passed the current revision to the permissions update
+    const collectionUpdateCalls = fetchMock.callHistory.calls(
+      "http://localhost:3000/api/collection/graph?skip-graph=true",
+      { method: "PUT" },
+    );
+    expect(collectionUpdateCalls).toHaveLength(1);
+
+    const requestBody = JSON.parse(
+      collectionUpdateCalls[0].options?.body as string,
+    );
+    expect(requestBody.revision).toBe(42); // This is the key assertion
+    expect(requestBody.groups[101][123]).toBe("write"); // modelCollectionId access
+    expect(requestBody.groups[102][123]).toBe("write"); // modelCollectionId access
+  });
+
+  it("should handle missing revision in current graph by defaulting to 0", async () => {
+    const mockCurrentGraphWithoutRevision = {
+      groups: {},
+      // No revision property
+    };
+
+    // Mock API calls
+    fetchMock
+      .get(
+        "http://localhost:3000/api/collection/graph",
+        mockCurrentGraphWithoutRevision,
+      )
+      .put("http://localhost:3000/api/collection/graph?skip-graph=true", {});
+
+    // Mock utility functions
+    (
+      propagateErrorResponse as jest.MockedFunction<
+        typeof propagateErrorResponse
+      >
+    ).mockResolvedValue(undefined);
+
+    (
+      getSandboxedCollectionPermissions as jest.MockedFunction<
+        typeof getSandboxedCollectionPermissions
+      >
+    ).mockReturnValue({
+      101: { 1: "write" },
+      102: { 2: "write" },
+    });
+
+    await grantAccessToModelCollection(defaultOptions);
+
+    // Verify that we passed revision 0 when it's missing from the graph
+    const collectionUpdateCalls = fetchMock.callHistory.calls(
+      "http://localhost:3000/api/collection/graph?skip-graph=true",
+      { method: "PUT" },
+    );
+    expect(collectionUpdateCalls).toHaveLength(1);
+
+    const requestBody = JSON.parse(
+      collectionUpdateCalls[0].options?.body as string,
+    );
+    expect(requestBody.revision).toBe(0); // Should default to 0 when revision is missing
+  });
+
+  it("should add modelCollectionId with write permission to all group permissions", async () => {
+    const mockCurrentGraph = {
+      revision: 10,
+      groups: {},
+    };
+
+    fetchMock
+      .get("http://localhost:3000/api/collection/graph", mockCurrentGraph)
+      .put("http://localhost:3000/api/collection/graph?skip-graph=true", {});
+
+    (
+      propagateErrorResponse as jest.MockedFunction<
+        typeof propagateErrorResponse
+      >
+    ).mockResolvedValue(undefined);
+
+    // Mock initial permissions without modelCollectionId access
+    (
+      getSandboxedCollectionPermissions as jest.MockedFunction<
+        typeof getSandboxedCollectionPermissions
+      >
+    ).mockReturnValue({
+      101: { 1: "write", 2: "none" },
+      102: { 1: "none", 2: "write" },
+    });
+
+    await grantAccessToModelCollection(defaultOptions);
+
+    const collectionUpdateCalls = fetchMock.callHistory.calls(
+      "http://localhost:3000/api/collection/graph?skip-graph=true",
+      { method: "PUT" },
+    );
+    const requestBody = JSON.parse(
+      collectionUpdateCalls[0].options?.body as string,
+    );
+
+    // Verify that modelCollectionId (123) was added with "write" permission for all groups
+    expect(requestBody.groups[101][123]).toBe("write");
+    expect(requestBody.groups[102][123]).toBe("write");
+
+    // Verify that existing permissions were preserved
+    expect(requestBody.groups[101][1]).toBe("write");
+    expect(requestBody.groups[101][2]).toBe("none");
+    expect(requestBody.groups[102][1]).toBe("none");
+    expect(requestBody.groups[102][2]).toBe("write");
+  });
+});


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #65445
Closes [EMB-1073: \[SDK\] CLI quickstart fails when setting up sandboxing](https://linear.app/metabase/issue/EMB-1073/sdk-cli-quickstart-fails-when-setting-up-sandboxing)

### Description

Fetch the revision number to avoid conflicts when modifying graph permission in embedding quickstart CLI (also did a bit of reorg)

### How to verify

 1. Start a postgres with any table in it
 1. npx @metabase/embedding-sdk-react@latest start
 1. Fill out the steps, adding the postgres DB
 1. Enter your Metabase Pro license key
 1. Set up a column for tenancy
 1. Error should not come out

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
