### PR TITLE
Close the subscription sidebar when the last pulse is archived

### DIFF
--- a/frontend/src/metabase/notifications/AddEditSidebar/DeleteSubscriptionAction.tsx
+++ b/frontend/src/metabase/notifications/AddEditSidebar/DeleteSubscriptionAction.tsx
@@ -107,7 +107,6 @@ export function DeleteSubscriptionAction({
                 <Checkbox
                   label={item}
                   checked={checked[index]}
-                  data-testid={`confirm-item-${index}`}
                   onChange={(e) =>
                     setChecked({
                       ...checked,

--- a/frontend/src/metabase/notifications/AddEditSidebar/DeleteSubscriptionAction.tsx
+++ b/frontend/src/metabase/notifications/AddEditSidebar/DeleteSubscriptionAction.tsx
@@ -107,6 +107,7 @@ export function DeleteSubscriptionAction({
                 <Checkbox
                   label={item}
                   checked={checked[index]}
+                  data-testid={`confirm-item-${index}`}
                   onChange={(e) =>
                     setChecked({
                       ...checked,

--- a/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/DashboardSubscriptionsSidebar.jsx
+++ b/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/DashboardSubscriptionsSidebar.jsx
@@ -323,11 +323,18 @@ class DashboardSubscriptionsSidebarInner extends Component {
   };
 
   handleArchive = async () => {
-    await this.props.setPulseArchived(this.props.pulse, true);
-    this.setState({
-      editingMode: EDITING_MODES.LIST_PULSES_OR_NEW_PULSE,
-      returnMode: [],
-    });
+    const { pulse, pulses, setPulseArchived, onCancel } = this.props;
+
+    await setPulseArchived(pulse, true);
+
+    if (isEmbeddingSdk() && pulses.length === 1) {
+      onCancel();
+    } else {
+      this.setState({
+        editingMode: EDITING_MODES.LIST_PULSES_OR_NEW_PULSE,
+        returnMode: [],
+      });
+    }
   };
 
   // Because you can navigate down the sidebar, we need to wrap

--- a/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/common.unit.spec.ts
+++ b/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/common.unit.spec.ts
@@ -120,20 +120,11 @@ describe("DashboardSubscriptionsSidebar", () => {
 
       // Dynamically modify `pulses` so that we get the new updated list of pulses after archiving
       fetchMock.put({
-        url: "path:/api/pulse/10",
-        response: () => {
+        url: "express:/api/pulse/:id",
+        response: ({ expressParams = {} }) => {
+          const pulseId = parseInt(expressParams?.id);
           pulses.splice(
-            pulses.findIndex((pulse) => pulse.id === 10),
-            1,
-          );
-          return {};
-        },
-      });
-      fetchMock.put({
-        url: "path:/api/pulse/11",
-        response: () => {
-          pulses.splice(
-            pulses.findIndex((pulse) => pulse.id === 11),
+            pulses.findIndex((pulse) => pulse.id === pulseId),
             1,
           );
           return {};

--- a/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/setup.tsx
+++ b/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/setup.tsx
@@ -166,7 +166,7 @@ export function setup(
   fetchMock.get({
     url: `path:/api/pulse`,
     query: { dashboard_id: dashboard.id },
-    response: [...pulses],
+    response: () => pulses,
   });
 
   fetchMock.post("path:/api/pulse/test", 200);

--- a/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/setup.tsx
+++ b/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/setup.tsx
@@ -13,6 +13,7 @@ import type { UiParameter } from "metabase-lib/v1/parameters/types";
 import type {
   Dashboard,
   DashboardCard,
+  Pulse,
   TokenFeatures,
 } from "metabase-types/api";
 import {
@@ -88,6 +89,8 @@ type SetupOpts = {
   dashcards?: DashboardCard[];
   parameters?: UiParameter[];
   isEmbeddingSdk?: boolean;
+  setSharing?: (sharing: boolean) => void;
+  pulses?: (Partial<Pulse> & { id: number })[];
 };
 
 export function setup(
@@ -100,6 +103,8 @@ export function setup(
     dashcards = defaultDashcards,
     parameters = defaultParameters,
     isEmbeddingSdk = false,
+    setSharing,
+    pulses = [],
   }: SetupOpts = {
     email: true,
     slack: true,
@@ -161,7 +166,7 @@ export function setup(
   fetchMock.get({
     url: `path:/api/pulse`,
     query: { dashboard_id: dashboard.id },
-    response: [],
+    response: [...pulses],
   });
 
   fetchMock.post("path:/api/pulse/test", 200);
@@ -174,7 +179,7 @@ export function setup(
   }
 
   renderWithProviders(
-    <MockDashboardContext dashboard={dashboard}>
+    <MockDashboardContext dashboard={dashboard} setSharing={setSharing}>
       <DashboardSubscriptionsSidebar />
     </MockDashboardContext>,
     {


### PR DESCRIPTION
Closes [EMB-1071: Close the sidebar after deleting the last subscription](https://linear.app/metabase/issue/EMB-1071/close-the-sidebar-after-deleting-the-last-subscription)

### Description

When the last subscription is archived in an embedded (SDK) dashboard, the sidebar should go away.

### Demo

https://github.com/user-attachments/assets/b3673002-8dd2-4821-9c77-68a0ededcdd4


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
