### PR TITLE
Remove transducers and core.logic deps

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -229,9 +229,6 @@
   {:exclude
    [(build.uberjar/with-duration-ms)
     (cljs.test/is [=? malli=])
-    (clojure.core.logic/fresh)
-    (clojure.core.logic/matcha)
-    (clojure.core.logic/run)
     (clojure.test/is [=? malli= qv=])
     (clojure.tools.macro/macrolet)
     instaparse.core/transform
@@ -410,7 +407,6 @@
  :lint-as
  {cljs.cache/defcache                                                                   clojure.core/deftype
   clojure.core.cache/defcache                                                           clojure.core/deftype
-  clojure.core.logic/defne                                                              clj-kondo.lint-as/def-catch-all
   clojure.test.check.clojure-test/defspec                                               clojure.test/deftest
   clojure.test.check.properties/for-all                                                 clojure.core/let
   clojurewerkz.quartzite.jobs/defjob                                                    clojure.core/defn

--- a/.cljfmt.edn
+++ b/.cljfmt.edn
@@ -43,9 +43,6 @@
   with-meta                                                                                   [[:default]]
   ;; library stuff. Libraries that specify their own `:style/indent` specs are included in the section after this
   ;; since it is generated automatically.
-  clojure.core.logic/fresh                                                                    [[:block 1]]
-  clojure.core.logic/matcha                                                                   [[:block 1]]
-  clojure.core.logic/run                                                                      [[:block 2]]
   clojure.core.match/match                                                                    [[:block 1]]
   clojure.test.check.properties/for-all                                                       [[:block 1]]
   clojure.test.check.properties/for-all*                                                      [[:block 1]]

--- a/LICENSE-AGPL.txt
+++ b/LICENSE-AGPL.txt
@@ -676,14 +676,11 @@ If you modify this Program, or any covered work, by linking or combining it with
 * environ
 * hiccup
 * junit
-* korma
 * medley
 * org.clojure/clojure
 * org.clojure/clojurescript
 * org.clojure/core.async
 * org.clojure/core.cache
-* org.clojure/core.incubator
-* org.clojure/core.logic
 * org.clojure/core.match
 * org.clojure/core.memoize
 * org.clojure/data.csv
@@ -702,10 +699,8 @@ If you modify this Program, or any covered work, by linking or combining it with
 * org.tcrawley/dynapath
 * quoin
 * refactor-nrepl
-* robert/hooke
 * scout
 * slingshot
 * stencil
-* swiss-arrows
 * tigris
 * instaparse

--- a/deps.edn
+++ b/deps.edn
@@ -47,8 +47,6 @@
   com.github.jknack/handlebars              ^:antq/exclude                      ; 4.4.0 requires java 17+
                                             {:mvn/version "4.3.1"}              ; templating engine
   com.github.oliyh/martian-clj-http         {:mvn/version "0.2.1"}             ; openapi client
-  com.github.pangloss/transducers           {:git/sha "c91d39046c8c64dc31b84ebb27154a8084fcda4c" ; like medley for transducers
-                                             :git/url "https://github.com/pangloss/transducers"}
   com.github.seancorfield/honeysql          {:mvn/version "2.7.1350"}           ; Honey SQL 2. SQL generation from Clojure data maps
   com.github.seancorfield/next.jdbc         {:mvn/version "1.3.1070"}           ; Talk to JDBC DBs
   com.github.steffan-westcott/clj-otel-api  {:mvn/version "0.2.8"}              ; Telemetry library
@@ -150,7 +148,6 @@
   org.clojure/clojure                       {:mvn/version "1.12.3"}
   org.clojure/core.async                    {:mvn/version "1.7.701"
                                              :exclusions  [org.clojure/tools.reader]}
-  org.clojure/core.logic                    {:mvn/version "1.1.0"}              ; optimized pattern matching library for Clojure
   org.clojure/core.match                    {:mvn/version "1.1.0"}
   org.clojure/core.memoize                  {:mvn/version "1.1.266"}            ; useful FIFO, LRU, etc. caching mechanisms
   org.clojure/data.csv                      {:mvn/version "1.1.0"}              ; CSV parsing / generation


### PR DESCRIPTION
Both those deps were probably used in the past but now have no mentions in the codebase, and are not included by any other dep transitively.

I also took the liberty of updating LICENSE-AGPL.txt to drop some entries from there that are not used by Metabase anymore. Please tell me if it is important to keep them there.