### PR TITLE
Fix reconcile-metadata to handle long names in native sql queries

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
@@ -164,11 +164,11 @@
 
 (mu/defn- reconcile-metadata :- [:+ :map]
   "Combine the metadata in `source-query-metadata` with the `table-metadata` from the Table being sandboxed.
-  For native queries with long column names, we also try matching by truncated name since the native query
-  may return truncated column names that don't match the full field names in table metadata.
+  For native queries with long column names, we also try matching by truncated name since the native query may return
+  truncated column names that don't match the full field names in table metadata.
 
-  We preserve the source query's column :name since that's what the query actually returns, but merge in
-  the table metadata's other attributes (like :id, :field_ref, etc.) for proper field resolution."
+  We preserve the source query's column :name since that's what the query actually returns, but merge in the table
+  metadata's other attributes (like :id, :field_ref, etc.) for proper field resolution."
   [source-query-metadata :- [:+ :map] table-metadata]
   (let [col-name->table-metadata (m/index-by :name table-metadata)
         truncated-name->table-metadata (m/index-by (comp lib.util/truncate-alias :name) table-metadata)]

--- a/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
@@ -17,6 +17,7 @@
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.id :as lib.schema.id]
+   [metabase.lib.util :as lib.util]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.premium-features.core :as premium-features :refer [defenterprise]]
    [metabase.query-processor.error-type :as qp.error-type]
@@ -162,16 +163,24 @@
    :ttl/threshold (u/minutes->ms 1)))
 
 (mu/defn- reconcile-metadata :- [:+ :map]
-  "Combine the metadata in `source-query-metadata` with the `table-metadata` from the Table being sandboxed."
+  "Combine the metadata in `source-query-metadata` with the `table-metadata` from the Table being sandboxed.
+  For native queries with long column names, we also try matching by truncated name since the native query
+  may return truncated column names that don't match the full field names in table metadata.
+
+  We preserve the source query's column :name since that's what the query actually returns, but merge in
+  the table metadata's other attributes (like :id, :field_ref, etc.) for proper field resolution."
   [source-query-metadata :- [:+ :map] table-metadata]
-  (let [col-name->table-metadata (m/index-by :name table-metadata)]
+  (let [col-name->table-metadata (m/index-by :name table-metadata)
+        truncated-name->table-metadata (m/index-by (comp lib.util/truncate-alias :name) table-metadata)]
     (vec
      (for [col   source-query-metadata
-           :let  [table-col (get col-name->table-metadata (:name col))]
+           :let [col-name (:name col)
+                 table-col (or (get col-name->table-metadata col-name)
+                               (get truncated-name->table-metadata col-name))]
            :when table-col]
        (do
          (gtap/check-column-types-match col table-col)
-         table-col)))))
+         (merge table-col (select-keys col [:name])))))))
 
 (mu/defn- native-query-metadata :- [:+ :map]
   [source-query :- [:map [:source-query :any]]]
@@ -201,6 +210,7 @@
    card-id                                     :- [:maybe ::lib.schema.id/card]]
   (let [table-metadata   (original-table-metadata table-id)
         ;; make sure source query has `:source-metadata`; add it if needed
+        native-source-query? (get-in source-query [:source-query :native])
         [metadata save?] (cond
                            ;; if it already has `:source-metadata`, we're good to go.
                            (seq source-metadata)
@@ -208,14 +218,22 @@
 
                            ;; if it doesn't have source metadata, but it's an MBQL query, we can preprocess the query to
                            ;; get the expected metadata.
-                           (not (get-in source-query [:source-query :native]))
+                           (not native-source-query?)
                            [(mbql-query-metadata source-query) true]
 
                            ;; otherwise if it's a native query we'll have to run the query really quickly to get the
                            ;; expected metadata.
                            :else
                            [(native-query-metadata source-query) true])
-        metadata (reconcile-metadata metadata table-metadata)]
+        metadata (reconcile-metadata metadata table-metadata)
+        ;; For native source queries, set :field_ref to a name-based reference. This ensures the outer query
+        ;; uses the actual column names returned by the native query, not truncated aliases derived from field IDs.
+        ;; We keep :id for features like FK remapping.
+        metadata (if native-source-query?
+                   (mapv (fn [{:keys [name base_type] :as col}]
+                           (assoc col :field_ref [:field name {:base-type base_type}]))
+                         metadata)
+                   metadata)]
     (assert (seq metadata))
     ;; save the result metadata so we don't have to do it again next time if applicable
     (when (and card-id save?)

--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
@@ -1600,54 +1600,62 @@
           (is (thrown-with-msg? clojure.lang.ExceptionInfo sandboxing-disabled-error (run-venues-count-query))))))))
 
 (def ^:private long-names-dataset
-  (tx/dataset-definition "long-column-names"
-                         [["long_table"
-                           [{:field-name "column_name_with_an_incredibly_verbose_and_exceedingly_detailed_description_that_never_seems_to_end"
-                             :base-type :type/Text}
-                            {:field-name "second_column_name_that_is_even_more_over_the_top_with_its_unnecessarily_expansive_wording"
-                             :base-type :type/Text}]
-                           [["First row, first column" "First row, second column"]
-                            ["Second row, first column" "Second row, second column"]]]]))
+  (tx/dataset-definition
+   "long-column-names"
+   [["long_table"
+     [{:field-name "column_name_with_an_incredibly_verbose_and_exceedingly_detailed_description_that_never_seems_to_end"
+       :base-type  :type/Text}
+      {:field-name "second_column_name_that_is_even_more_over_the_top_with_its_unnecessarily_expansive_wording"
+       :base-type  :type/Text}]
+     [["First row, first column" "First row, second column"]
+      ["Second row, first column" "Second row, second column"]]]]))
 
-(deftest long-column-names-sandbox-native-query-test
+(deftest long-native-query-names-sandboxed-basic-test
   (testing "Issue #66405: Sandboxing with native SQL query should work with long column names"
     (data/dataset long-names-dataset
-      (testing "with SELECT * (no filtering)"
-        (met/with-gtaps! {:gtaps {:long_table {:query (mt/native-query {:query "SELECT * FROM LONG_TABLE"})}}}
-          (is (=? {:status "completed"
+      (met/with-gtaps! {:gtaps {:long_table {:query (mt/native-query {:query "SELECT * FROM LONG_TABLE"})}}}
+        (is (=? {:status "completed"
+                 :row_count 2}
+                (mt/user-http-request :rasta :post 202 "dataset"
+                                      (mt/mbql-query long_table {:limit 5}))))))))
+
+(deftest long-native-query-names-sandboxed-row-filtering-test
+  (testing "Issue #66405: with row filtering (verifies sandbox is actually applied)"
+    (data/dataset long-names-dataset
+      (met/with-gtaps! {:gtaps {:long_table {:query (mt/native-query {:query "SELECT * FROM LONG_TABLE WHERE LONG_TABLE.COLUMN_NAME_WITH_AN_INCREDIBLY_VERBOSE_AND_EXCEEDINGLY_DETAILED_DESCRIPTION_THAT_NEVER_SEEMS_TO_END LIKE 'First%'"})}}}
+        (let [result (mt/user-http-request :rasta :post 202 "dataset"
+                                           (mt/mbql-query long_table))]
+          (is (=? {:status    "completed"
+                   :row_count 1}
+                  result))
+          (is (= "First row, first column"
+                 ;; The first column (index 0) is the auto-generated ID, the text column is at index 1
+                 (-> result :data :rows first second))))))))
+
+(deftest long-native-query-names-sandboxed-column-filtering-test
+  (testing "Issue #66405: with column restriction (only returns subset of columns)"
+    (data/dataset long-names-dataset
+      (met/with-gtaps! {:gtaps {:long_table {:query (mt/native-query {:query "SELECT COLUMN_NAME_WITH_AN_INCREDIBLY_VERBOSE_AND_EXCEEDINGLY_DETAILED_DESCRIPTION_THAT_NEVER_SEEMS_TO_END FROM LONG_TABLE"})}}}
+        (let [result (mt/user-http-request :rasta :post 202 "dataset"
+                                           (mt/mbql-query long_table))]
+          (is (=? {:status    "completed"
                    :row_count 2}
-                  (mt/user-http-request :rasta :post 202 "dataset"
-                                        (mt/mbql-query long_table {:limit 5}))))))
-      (testing "with row filtering (verifies sandbox is actually applied)"
-        (met/with-gtaps! {:gtaps {:long_table {:query (mt/native-query {:query "SELECT * FROM LONG_TABLE WHERE LONG_TABLE.COLUMN_NAME_WITH_AN_INCREDIBLY_VERBOSE_AND_EXCEEDINGLY_DETAILED_DESCRIPTION_THAT_NEVER_SEEMS_TO_END LIKE 'First%'"})}}}
-          (let [result (mt/user-http-request :rasta :post 202 "dataset"
-                                             (mt/mbql-query long_table))]
-            (is (=? {:status "completed"
-                     :row_count 1}
-                    result))
-            (is (= "First row, first column"
-                   ;; The first column (index 0) is the auto-generated ID, the text column is at index 1
-                   (-> result :data :rows first second))))))
-      (testing "with column restriction (only returns subset of columns)"
-        (met/with-gtaps! {:gtaps {:long_table {:query (mt/native-query {:query "SELECT COLUMN_NAME_WITH_AN_INCREDIBLY_VERBOSE_AND_EXCEEDINGLY_DETAILED_DESCRIPTION_THAT_NEVER_SEEMS_TO_END FROM LONG_TABLE"})}}}
-          (let [result (mt/user-http-request :rasta :post 202 "dataset"
-                                             (mt/mbql-query long_table))]
-            (is (=? {:status "completed"
-                     :row_count 2}
-                    result))
-            ;; Should only have 1 column (the long-named one), not 2 text columns + ID
-            (is (= 1 (count (-> result :data :cols))))
-            (is (= [["First row, first column"]
-                    ["Second row, first column"]]
-                   (-> result :data :rows))))))
-      (testing "with attribute-based sandbox (no query, just remappings)"
-        (met/with-gtaps! {:gtaps {:long_table {:remappings {:col1 ["variable" [:field (data/id :long_table :column_name_with_an_incredibly_verbose_and_exceedingly_detailed_description_that_never_seems_to_end) nil]]}}}
-                          :attributes {:col1 "First row, first column"}}
-          (let [result (mt/user-http-request :rasta :post 202 "dataset"
-                                             (mt/mbql-query long_table))]
-            (is (=? {:status "completed"
-                     :row_count 1}
-                    result))
-            ;; Verify we got the correct row matching the attribute filter
-            (is (= ["First row, first column" "First row, second column"]
-                   (->> result :data :rows first (drop 1))))))))))
+                  result))
+          ;; Should only have 1 column (the long-named one), not 2 text columns + ID
+          (is (= 1 (count (-> result :data :cols))))
+          (is (= [["First row, first column"]
+                  ["Second row, first column"]]
+                 (-> result :data :rows))))))))
+
+(deftest long-native-query-names-sandboxed-attribute-test
+  (testing "Issue #66405: with attribute-based sandbox (no query, just remappings)"
+    (data/dataset long-names-dataset
+      (met/with-gtaps! {:gtaps      {:long_table {:remappings {:col1 ["variable" [:field (data/id :long_table :column_name_with_an_incredibly_verbose_and_exceedingly_detailed_description_that_never_seems_to_end) nil]]}}}
+                        :attributes {:col1 "First row, first column"}}
+        (let [result (mt/user-http-request :rasta :post 202 "dataset"
+                                           (mt/mbql-query long_table))]
+          (is (=? {:status    "completed"
+                   :row_count 1}
+                  result))
+          (is (= ["First row, first column" "First row, second column"]
+                 (->> result :data :rows first (drop 1)))))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/66405.

### Description

When a native SQL question is used as a sandbox source for a table with long column names, the generated SQL fails because:
1. The outer query selects columns using Metabase-truncated aliases
2. The inner native subquery returns columns with the actual database names (possibly truncated, depending on database)

As I understand it, `apply-sandboxing` middleware intercepts the query and builds the sandbox source query, then `source-query-form-ensure-metadata` ensures that metadata exists and calls `reconcile-metadata`. `add-implicit-clauses` middleware adds `:fields` to the outer query using `source-metadata->fields`, with `add-alias-info` computing aliases with truncation.

This PR makes two changes:
1. It changes `reconcile-metadata` to handle truncated name matching
2. In `source-query-form-ensure-metadata` It overwrites `:field_ref` to use the field name when the source query is native. Using the field ID will get default truncation.

### How to verify

Run new tests or follow instructions in https://github.com/metabase/metabase/issues/66405.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
