### PR TITLE
Fix icons in data studio collection table

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data-studio/modeling/pages/CollectionPage/CollectionItemsTable/NameCell/NameCell.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/modeling/pages/CollectionPage/CollectionItemsTable/NameCell/NameCell.tsx
@@ -5,11 +5,11 @@ import {
   ItemNameCell,
   MaybeItemLink,
 } from "metabase/common/components/ItemsTable/BaseItemsTable.styled";
-import { entityForObject } from "metabase/lib/schema";
+import { getIcon } from "metabase/lib/icon";
 import * as Urls from "metabase/lib/urls";
 import { FixedSizeIcon, type IconName, Skeleton } from "metabase/ui";
 
-import type { ItemIcon, ModelingItem } from "../types";
+import type { ModelingItem } from "../types";
 
 import S from "./NameCell.module.css";
 
@@ -27,18 +27,10 @@ function preventDefault(event: MouseEvent) {
   event.preventDefault();
 }
 
-function getItemIcon(item: ModelingItem): ItemIcon {
-  const entityIcon = entityForObject(item)?.objectSelectors?.getIcon?.(item) as
-    | ItemIcon
-    | undefined;
-
-  return entityIcon ?? { name: "folder" as IconName };
-}
-
 export function NameCell({ item }: NameCellProps) {
   const headingId = item ? `${item.model}-${item.id}-heading` : "dummy-heading";
 
-  const icon = item ? getItemIcon(item) : { name: "folder" as IconName };
+  const icon = item ? getIcon(item) : { name: "folder" as IconName };
 
   const itemUrl = item
     ? item.model === "metric"

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/modeling/pages/CollectionPage/CollectionPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/modeling/pages/CollectionPage/CollectionPage.unit.spec.tsx
@@ -1,0 +1,212 @@
+import fetchMock from "fetch-mock";
+
+import {
+  findRequests,
+  setupCollectionByIdEndpoint,
+  setupCollectionItemsEndpoint,
+} from "__support__/server-mocks";
+import {
+  renderWithProviders,
+  screen,
+  waitForLoaderToBeRemoved,
+} from "__support__/ui";
+import {
+  createMockCollection,
+  createMockCollectionItem,
+} from "metabase-types/api/mocks";
+
+import { CollectionPage } from "./CollectionPage";
+
+const TEST_COLLECTION = createMockCollection({
+  id: 1,
+  name: "Test Collection",
+});
+
+const TEST_MODEL_ITEM = createMockCollectionItem({
+  id: 1,
+  name: "Test Model",
+  model: "dataset",
+  collection_id: TEST_COLLECTION.id,
+});
+
+const TEST_METRIC_ITEM = createMockCollectionItem({
+  id: 2,
+  name: "Test Metric",
+  model: "metric",
+  collection_id: TEST_COLLECTION.id,
+});
+
+const TEST_CARD_ITEM = createMockCollectionItem({
+  id: 3,
+  name: "Test Question",
+  model: "card",
+  collection_id: TEST_COLLECTION.id,
+});
+
+interface SetupOpts {
+  collection?: typeof TEST_COLLECTION;
+  collectionItems?: (typeof TEST_MODEL_ITEM)[];
+  collectionError?: string;
+  itemsError?: string;
+}
+
+const setup = async ({
+  collection = TEST_COLLECTION,
+  collectionItems = [],
+  collectionError,
+  itemsError,
+}: SetupOpts = {}) => {
+  setupCollectionByIdEndpoint({
+    collections: [collection],
+    error: collectionError,
+  });
+
+  if (itemsError) {
+    fetchMock.get(`path:/api/collection/${collection.id}/items`, {
+      status: 500,
+      body: itemsError,
+    });
+  } else {
+    setupCollectionItemsEndpoint({
+      collection,
+      collectionItems,
+      models: ["dataset", "metric"],
+    });
+  }
+
+  renderWithProviders(
+    <CollectionPage params={{ collectionId: String(collection.id) }} />,
+  );
+};
+
+describe("CollectionPage", () => {
+  it("should show loading state initially", async () => {
+    await setup();
+    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
+  });
+
+  it("should render collection name in header", async () => {
+    await setup({
+      collectionItems: [TEST_MODEL_ITEM],
+    });
+
+    await waitForLoaderToBeRemoved();
+
+    expect(screen.getByText(TEST_COLLECTION.name)).toBeInTheDocument();
+  });
+
+  it("should display empty state when collection has no items", async () => {
+    await setup({
+      collectionItems: [],
+    });
+
+    await waitForLoaderToBeRemoved();
+    expect(
+      await screen.findByText("No models or metrics yet"),
+    ).toBeInTheDocument();
+  });
+
+  it("should display items table when collection has models", async () => {
+    await setup({
+      collectionItems: [TEST_MODEL_ITEM],
+    });
+
+    await waitForLoaderToBeRemoved();
+
+    expect(screen.getByTestId("collection-page")).toBeInTheDocument();
+    expect(screen.getByText(TEST_MODEL_ITEM.name)).toBeInTheDocument();
+  });
+
+  it("should display items table when collection has metrics", async () => {
+    await setup({
+      collectionItems: [TEST_METRIC_ITEM],
+    });
+
+    await waitForLoaderToBeRemoved();
+
+    expect(screen.getByTestId("collection-page")).toBeInTheDocument();
+    expect(screen.getByText(TEST_METRIC_ITEM.name)).toBeInTheDocument();
+  });
+
+  it("should display both models and metrics in items table", async () => {
+    await setup({
+      collectionItems: [TEST_MODEL_ITEM, TEST_METRIC_ITEM, TEST_CARD_ITEM],
+    });
+
+    await waitForLoaderToBeRemoved();
+
+    expect(screen.getByText(TEST_MODEL_ITEM.name)).toBeInTheDocument();
+    expect(screen.getByText(TEST_METRIC_ITEM.name)).toBeInTheDocument();
+    // should filter out cards
+    expect(screen.queryByText(TEST_CARD_ITEM.name)).not.toBeInTheDocument();
+  });
+
+  it("should show model icons", async () => {
+    await setup({
+      collectionItems: [TEST_MODEL_ITEM],
+    });
+
+    await waitForLoaderToBeRemoved();
+
+    expect(await screen.findByLabelText("model icon")).toBeInTheDocument();
+  });
+
+  it("should show metric icons", async () => {
+    await setup({
+      collectionItems: [TEST_METRIC_ITEM],
+    });
+
+    await waitForLoaderToBeRemoved();
+
+    expect(await screen.findByLabelText("metric icon")).toBeInTheDocument();
+  });
+
+  it("should display error when collection fails to load", async () => {
+    const errorMessage = "Failed to load collection";
+    await setup({
+      collectionError: errorMessage,
+    });
+    await waitForLoaderToBeRemoved();
+    expect(await screen.findByText(errorMessage)).toBeInTheDocument();
+  });
+
+  it("should display error when items fail to load", async () => {
+    const errorMessage = "Failed to load items";
+    await setup({
+      itemsError: errorMessage,
+    });
+    await waitForLoaderToBeRemoved();
+    expect(screen.getByText(errorMessage)).toBeInTheDocument();
+  });
+
+  it("should request only models and metrics from API", async () => {
+    await setup({
+      collectionItems: [TEST_MODEL_ITEM, TEST_METRIC_ITEM],
+    });
+
+    await waitForLoaderToBeRemoved();
+
+    const calls = await findRequests("GET");
+    expect(calls).toHaveLength(2);
+    const [collectionCall, itemsCall] = calls;
+    expect(collectionCall.url).toContain(`/collection/${TEST_COLLECTION.id}`);
+    expect(itemsCall.url).toContain("/items");
+
+    const url = new URL(itemsCall.url);
+    const models = url.searchParams.getAll("models");
+    expect(models).toEqual(["dataset", "metric"]);
+  });
+
+  it("should show collection name in page header", async () => {
+    await setup({
+      collectionItems: [TEST_MODEL_ITEM],
+    });
+
+    await waitForLoaderToBeRemoved();
+
+    const page = screen.getByTestId("collection-page");
+    expect(page).toBeInTheDocument();
+
+    expect(screen.getByText(TEST_COLLECTION.name)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### Description

Uses correct icon function. Icons no longer run through entities.

### How to verify

Before | After
----|----
 <img width="667" height="267" alt="CleanShot 2025-12-03 at 15 09 26" src="https://github.com/user-attachments/assets/4ddab7df-bc9b-4f5c-bf62-1d32ae3e56d2" /> | <img width="675" height="234" alt="CleanShot 2025-12-03 at 15 09 36" src="https://github.com/user-attachments/assets/7213a89d-5f07-436a-846c-e714a1e03c2c" />

