### PR TITLE
Hide create shared tenant collection button on sidebar for non-admin users

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/MainNavSharedCollections/MainNavSharedCollections.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/MainNavSharedCollections/MainNavSharedCollections.tsx
@@ -118,11 +118,16 @@ export const MainNavSharedCollections = () => {
       <SidebarSection>
         <Flex align="center" justify="space-between">
           <SidebarHeading>{t`Tenant collections`}</SidebarHeading>
-          <Tooltip label={t`Create a new tenant collection`}>
-            <ActionIcon color="text-medium" onClick={() => setModalOpen(true)}>
-              <Icon name="add" />
-            </ActionIcon>
-          </Tooltip>
+          {isAdmin && (
+            <Tooltip label={t`Create a new tenant collection`}>
+              <ActionIcon
+                color="text-medium"
+                onClick={() => setModalOpen(true)}
+              >
+                <Icon name="add" />
+              </ActionIcon>
+            </Tooltip>
+          )}
         </Flex>
         <Tree
           data={tenantCollectionTree}

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/MainNavSharedCollections/MainNavSharedCollections.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/MainNavSharedCollections/MainNavSharedCollections.unit.spec.tsx
@@ -1,0 +1,51 @@
+import { setupCollectionsEndpoints } from "__support__/server-mocks";
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen } from "__support__/ui";
+import type { Collection } from "metabase-types/api";
+import { createMockCollection, createMockUser } from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks";
+
+import { MainNavSharedCollections } from "./MainNavSharedCollections";
+
+const MOCK_TENANT_COLLECTIONS = [
+  createMockCollection({
+    id: 1,
+    name: "Tenant Collection 1",
+    namespace: "shared-tenant-collection",
+  }),
+];
+
+const setup = ({
+  isAdmin = false,
+  tenantCollections = MOCK_TENANT_COLLECTIONS,
+  currentUser = createMockUser({ is_superuser: isAdmin }),
+}: {
+  isAdmin?: boolean;
+  tenantCollections?: Collection[];
+  currentUser?: ReturnType<typeof createMockUser>;
+} = {}) => {
+  const settings = mockSettings({ "use-tenants": true });
+  setupCollectionsEndpoints({ collections: tenantCollections });
+
+  renderWithProviders(<MainNavSharedCollections />, {
+    storeInitialState: createMockState({ settings, currentUser }),
+  });
+};
+
+describe("MainNavSharedCollections > create shared tenant collection button", () => {
+  it("shows the create button for admin users", async () => {
+    setup({ isAdmin: true });
+    await screen.findByText("Tenant collections");
+
+    expect(screen.getByRole("button", { name: /add/i })).toBeInTheDocument();
+  });
+
+  it("hides the create button for non-admin users", async () => {
+    setup({ isAdmin: false });
+    await screen.findByText("Tenant collections");
+
+    expect(
+      screen.queryByRole("button", { name: /add/i }),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes UXW-2441