### PR TITLE
Adjusted auth controls

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
@@ -54,7 +54,13 @@ describe("scenarios > embedding > smoke tests", { tags: "@OSS" }, () => {
     it("should not let you use non-guest auth methods", () => {
       H.visitQuestion(ORDERS_QUESTION_ID);
 
-      ensureEmbeddingIsDisabled();
+      H.openEmbedJsModal();
+      H.embedModalEnableEmbedding();
+
+      H.embedModalContent().within(() => {
+        cy.findByLabelText("Guest").should("be.checked");
+        cy.findByLabelText("Metabase account (SSO)").should("be.disabled");
+      });
     });
   });
 
@@ -293,16 +299,6 @@ describe("scenarios > embedding > smoke tests", { tags: "@OSS" }, () => {
 function resetEmbedding() {
   H.updateSetting("enable-embedding-static", false);
   H.updateSetting("embedding-secret-key", null);
-}
-
-function ensureEmbeddingIsDisabled() {
-  H.openEmbedJsModal();
-  H.embedModalEnableEmbedding();
-
-  H.embedModalContent().within(() => {
-    cy.findByLabelText("Single sign-on (SSO)").should("be.disabled");
-    cy.findByLabelText("Existing Metabase session").should("be.disabled");
-  });
 }
 
 function visitAndEnableSharing(object, unpublishBeforeOpen = true) {

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/embed-flow-enable-embed-js.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/embed-flow-enable-embed-js.cy.spec.ts
@@ -60,7 +60,9 @@ describe(
       });
 
       cy.log("shows tooltip with fair usage info");
-      getEmbedSidebar().findByLabelText("info icon").trigger("mouseover");
+      embedModalEnableEmbeddingCard()
+        .findByLabelText("info icon")
+        .trigger("mouseover");
 
       H.hovercard()
         .contains(
@@ -68,7 +70,9 @@ describe(
         )
         .should("be.visible");
 
-      getEmbedSidebar().findByLabelText("info icon").trigger("mouseout");
+      embedModalEnableEmbeddingCard()
+        .findByLabelText("info icon")
+        .trigger("mouseout");
 
       cy.findByRole("button", { name: "Agree and enable" }).should(
         "be.visible",

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
@@ -3,13 +3,9 @@ import {
   ORDERS_DASHBOARD_ID,
 } from "e2e/support/cypress_sample_instance_data";
 import { enableJwtAuth } from "e2e/support/helpers/e2e-jwt-helpers";
+import { enableSamlAuth } from "e2e/support/helpers/embedding-sdk-testing";
 
-import {
-  codeBlock,
-  getEmbedSidebar,
-  navigateToEmbedOptionsStep,
-  navigateToGetCodeStep,
-} from "./helpers";
+import { codeBlock, getEmbedSidebar, navigateToGetCodeStep } from "./helpers";
 
 const { H } = cy;
 
@@ -39,6 +35,44 @@ describe(suiteTitle, () => {
     H.expectNoBadSnowplowEvents();
   });
 
+  it("should disable SSO radio button when JWT and SAML are not configured", () => {
+    navigateToGetCodeStep({
+      experience: "dashboard",
+      resourceName: DASHBOARD_NAME,
+      toggleSso: true,
+    });
+
+    getEmbedSidebar().within(() => {
+      cy.findByLabelText("Single sign-on").should("be.disabled");
+    });
+  });
+
+  it("should enable SSO radio button when JWT is configured", () => {
+    enableJwtAuth();
+    navigateToGetCodeStep({
+      experience: "dashboard",
+      resourceName: DASHBOARD_NAME,
+      toggleSso: true,
+    });
+
+    getEmbedSidebar().within(() => {
+      cy.findByLabelText("Single sign-on").should("not.be.disabled");
+    });
+  });
+
+  it("should enable SSO radio button when SAML is configured", () => {
+    enableSamlAuth();
+    navigateToGetCodeStep({
+      experience: "dashboard",
+      resourceName: DASHBOARD_NAME,
+      toggleSso: true,
+    });
+
+    getEmbedSidebar().within(() => {
+      cy.findByLabelText("Single sign-on").should("not.be.disabled");
+    });
+  });
+
   it("should display code snippet with syntax highlighting", () => {
     navigateToGetCodeStep({
       experience: "dashboard",
@@ -54,15 +88,14 @@ describe(suiteTitle, () => {
   });
 
   it("should include useExistingUserSession when user session is selected", () => {
-    navigateToEmbedOptionsStep({
+    enableJwtAuth();
+    navigateToGetCodeStep({
       experience: "dashboard",
       resourceName: DASHBOARD_NAME,
       toggleSso: true,
     });
 
     getEmbedSidebar().within(() => {
-      cy.findByText("Get code").click();
-
       codeBlock().should("not.contain", '"useExistingUserSession": true');
       cy.findByLabelText("Existing session (local testing only)").click();
       codeBlock().should("contain", '"useExistingUserSession": true');
@@ -78,15 +111,14 @@ describe(suiteTitle, () => {
   });
 
   it("should track embed_wizard_code_copied when copy event triggers", () => {
-    navigateToEmbedOptionsStep({
+    enableJwtAuth();
+    navigateToGetCodeStep({
       experience: "dashboard",
       resourceName: DASHBOARD_NAME,
       toggleSso: true,
     });
 
     getEmbedSidebar().within(() => {
-      cy.findByText("Get code").click();
-
       codeBlock().should("not.contain", '"useExistingUserSession": true');
       cy.findByLabelText("Existing session (local testing only)").click();
       codeBlock().should("contain", '"useExistingUserSession": true');
@@ -104,15 +136,13 @@ describe(suiteTitle, () => {
   it("should not include useExistingUserSession when SSO is selected", () => {
     enableJwtAuth();
 
-    navigateToEmbedOptionsStep({
+    navigateToGetCodeStep({
       experience: "dashboard",
       resourceName: DASHBOARD_NAME,
       toggleSso: true,
     });
 
     getEmbedSidebar().within(() => {
-      cy.findByText("Get code").click();
-
       codeBlock().should("not.contain", "useExistingUserSession");
 
       cy.findByText(/Copy code/).click();
@@ -125,30 +155,27 @@ describe(suiteTitle, () => {
   });
 
   it("should set dashboard-id for regular dashboard experience", () => {
-    navigateToEmbedOptionsStep({
+    navigateToGetCodeStep({
       experience: "dashboard",
       resourceName: DASHBOARD_NAME,
       toggleSso: true,
     });
 
     getEmbedSidebar().within(() => {
-      cy.findByText("Get code").click();
-
       codeBlock().should("contain", `dashboard-id="${ORDERS_DASHBOARD_ID}"`);
     });
   });
 
   it("should set question-id for regular chart experience", () => {
-    navigateToEmbedOptionsStep({
+    enableJwtAuth();
+    navigateToGetCodeStep({
       experience: "chart",
       resourceName: QUESTION_NAME,
       toggleSso: true,
     });
 
     getEmbedSidebar().within(() => {
-      cy.findByLabelText("Existing Metabase session").click();
-
-      cy.findByText("Get code").click();
+      cy.findByLabelText("Existing session (local testing only)").click();
 
       codeBlock().should(
         "contain",

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
@@ -39,7 +39,7 @@ describe(suiteTitle, () => {
     navigateToGetCodeStep({
       experience: "dashboard",
       resourceName: DASHBOARD_NAME,
-      toggleSso: true,
+      preselectSso: true,
     });
 
     getEmbedSidebar().within(() => {
@@ -56,13 +56,13 @@ describe(suiteTitle, () => {
     });
   });
 
-  it("should not display a warning when a user session is selected", () => {
+  it("should not display a warning when a user session is selected and JWT is configured", () => {
     enableJwtAuth();
 
     navigateToGetCodeStep({
       experience: "dashboard",
       resourceName: DASHBOARD_NAME,
-      toggleSso: true,
+      preselectSso: true,
     });
 
     getEmbedSidebar().within(() => {
@@ -78,7 +78,7 @@ describe(suiteTitle, () => {
     navigateToGetCodeStep({
       experience: "dashboard",
       resourceName: DASHBOARD_NAME,
-      toggleSso: true,
+      preselectSso: true,
     });
 
     getEmbedSidebar().within(() => {
@@ -91,7 +91,7 @@ describe(suiteTitle, () => {
     navigateToGetCodeStep({
       experience: "dashboard",
       resourceName: DASHBOARD_NAME,
-      toggleSso: true,
+      preselectSso: true,
     });
 
     getEmbedSidebar().within(() => {
@@ -118,7 +118,7 @@ describe(suiteTitle, () => {
     navigateToGetCodeStep({
       experience: "dashboard",
       resourceName: DASHBOARD_NAME,
-      toggleSso: true,
+      preselectSso: true,
     });
 
     getEmbedSidebar().within(() => {
@@ -131,7 +131,7 @@ describe(suiteTitle, () => {
       H.expectUnstructuredSnowplowEvent({
         event: "embed_wizard_code_copied",
         event_detail:
-          "experience=dashboard,snippetType=frontend,ssoType=user-session",
+          "experience=dashboard,snippetType=frontend,authSubType=user-session",
       });
     });
   });
@@ -141,7 +141,7 @@ describe(suiteTitle, () => {
     navigateToGetCodeStep({
       experience: "dashboard",
       resourceName: DASHBOARD_NAME,
-      toggleSso: true,
+      preselectSso: true,
     });
 
     getEmbedSidebar().within(() => {
@@ -154,7 +154,7 @@ describe(suiteTitle, () => {
       H.expectUnstructuredSnowplowEvent({
         event: "embed_wizard_code_copied",
         event_detail:
-          "experience=dashboard,snippetType=frontend,ssoType=user-session",
+          "experience=dashboard,snippetType=frontend,authSubType=user-session",
       });
     });
   });
@@ -165,7 +165,7 @@ describe(suiteTitle, () => {
     navigateToGetCodeStep({
       experience: "dashboard",
       resourceName: DASHBOARD_NAME,
-      toggleSso: true,
+      preselectSso: true,
     });
 
     getEmbedSidebar().within(() => {
@@ -175,7 +175,8 @@ describe(suiteTitle, () => {
 
       H.expectUnstructuredSnowplowEvent({
         event: "embed_wizard_code_copied",
-        event_detail: "experience=dashboard,snippetType=frontend,ssoType=sso",
+        event_detail:
+          "experience=dashboard,snippetType=frontend,authSubType=sso",
       });
     });
   });
@@ -184,7 +185,7 @@ describe(suiteTitle, () => {
     navigateToGetCodeStep({
       experience: "dashboard",
       resourceName: DASHBOARD_NAME,
-      toggleSso: true,
+      preselectSso: true,
     });
 
     getEmbedSidebar().within(() => {
@@ -197,7 +198,7 @@ describe(suiteTitle, () => {
     navigateToGetCodeStep({
       experience: "chart",
       resourceName: QUESTION_NAME,
-      toggleSso: true,
+      preselectSso: true,
     });
 
     getEmbedSidebar().within(() => {

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
@@ -57,13 +57,14 @@ describe(suiteTitle, () => {
     navigateToEmbedOptionsStep({
       experience: "dashboard",
       resourceName: DASHBOARD_NAME,
+      toggleSso: true,
     });
 
     getEmbedSidebar().within(() => {
-      cy.findByLabelText("Existing Metabase session").click();
-
       cy.findByText("Get code").click();
 
+      codeBlock().should("not.contain", '"useExistingUserSession": true');
+      cy.findByLabelText("Existing session (local testing only)").click();
       codeBlock().should("contain", '"useExistingUserSession": true');
 
       cy.findByText(/Copy code/).click();
@@ -80,14 +81,16 @@ describe(suiteTitle, () => {
     navigateToEmbedOptionsStep({
       experience: "dashboard",
       resourceName: DASHBOARD_NAME,
+      toggleSso: true,
     });
 
     getEmbedSidebar().within(() => {
-      cy.findByLabelText("Existing Metabase session").click();
-
       cy.findByText("Get code").click();
 
+      codeBlock().should("not.contain", '"useExistingUserSession": true');
+      cy.findByLabelText("Existing session (local testing only)").click();
       codeBlock().should("contain", '"useExistingUserSession": true');
+
       codeBlock().trigger("copy");
 
       H.expectUnstructuredSnowplowEvent({
@@ -104,11 +107,10 @@ describe(suiteTitle, () => {
     navigateToEmbedOptionsStep({
       experience: "dashboard",
       resourceName: DASHBOARD_NAME,
+      toggleSso: true,
     });
 
     getEmbedSidebar().within(() => {
-      cy.findByLabelText("Single sign-on (SSO)").click();
-
       cy.findByText("Get code").click();
 
       codeBlock().should("not.contain", "useExistingUserSession");

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
@@ -35,7 +35,7 @@ describe(suiteTitle, () => {
     H.expectNoBadSnowplowEvents();
   });
 
-  it("should disable SSO radio button when JWT and SAML are not configured", () => {
+  it("should disable SSO radio button (and show info message) when JWT and SAML are not configured", () => {
     navigateToGetCodeStep({
       experience: "dashboard",
       resourceName: DASHBOARD_NAME,
@@ -44,6 +44,32 @@ describe(suiteTitle, () => {
 
     getEmbedSidebar().within(() => {
       cy.findByLabelText("Single sign-on").should("be.disabled");
+      cy.findByLabelText("Existing session (local testing only)").should(
+        "be.enabled",
+      );
+      cy.findByLabelText("Existing session (local testing only)").should(
+        "be.checked",
+      );
+      cy.findByText(/The code below will only work for local testing/).should(
+        "be.visible",
+      );
+    });
+  });
+
+  it("should not display a warning when a user session is selected", () => {
+    enableJwtAuth();
+
+    navigateToGetCodeStep({
+      experience: "dashboard",
+      resourceName: DASHBOARD_NAME,
+      toggleSso: true,
+    });
+
+    getEmbedSidebar().within(() => {
+      cy.findByLabelText("Existing session (local testing only)").click();
+      cy.findByText(/The code below will only work for local testing/).should(
+        "not.exist",
+      );
     });
   });
 

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
@@ -131,7 +131,7 @@ describe(suiteTitle, () => {
       H.expectUnstructuredSnowplowEvent({
         event: "embed_wizard_code_copied",
         event_detail:
-          "experience=dashboard,snippetType=frontend,auth=user-session",
+          "experience=dashboard,snippetType=frontend,ssoType=user-session",
       });
     });
   });
@@ -154,7 +154,7 @@ describe(suiteTitle, () => {
       H.expectUnstructuredSnowplowEvent({
         event: "embed_wizard_code_copied",
         event_detail:
-          "experience=dashboard,snippetType=frontend,auth=user-session",
+          "experience=dashboard,snippetType=frontend,ssoType=user-session",
       });
     });
   });
@@ -175,7 +175,7 @@ describe(suiteTitle, () => {
 
       H.expectUnstructuredSnowplowEvent({
         event: "embed_wizard_code_copied",
-        event_detail: "experience=dashboard,snippetType=frontend,auth=sso",
+        event_detail: "experience=dashboard,snippetType=frontend,ssoType=sso",
       });
     });
   });

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
@@ -126,11 +126,10 @@ describe(suiteTitle, () => {
     navigateToEmbedOptionsStep({
       experience: "dashboard",
       resourceName: DASHBOARD_NAME,
+      toggleSso: true,
     });
 
     getEmbedSidebar().within(() => {
-      cy.findByLabelText("Existing Metabase session").click();
-
       cy.findByText("Get code").click();
 
       codeBlock().should("contain", `dashboard-id="${ORDERS_DASHBOARD_ID}"`);
@@ -141,6 +140,7 @@ describe(suiteTitle, () => {
     navigateToEmbedOptionsStep({
       experience: "chart",
       resourceName: QUESTION_NAME,
+      toggleSso: true,
     });
 
     getEmbedSidebar().within(() => {

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/guest-embed-ee.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/guest-embed-ee.cy.spec.ts
@@ -207,7 +207,7 @@ describe("scenarios > embedding > sdk iframe embed setup > guest-embed", () => {
       H.expectUnstructuredSnowplowEvent({
         event: "embed_wizard_options_completed",
         event_detail:
-          'settings=custom,experience=chart,guestEmbedEnabled=true,guestEmbedType=guest-embed,auth=guest-embed,drills=false,withDownloads=false,withTitle=true,isSaveEnabled=false,params={"disabled":0,"locked":1,"enabled":0},theme=default',
+          'settings=custom,experience=chart,guestEmbedEnabled=true,guestEmbedType=guest-embed,authType=guest-embed,drills=false,withDownloads=false,withTitle=true,isSaveEnabled=false,params={"disabled":0,"locked":1,"enabled":0},theme=default',
       });
 
       // Get code step

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/guest-embed-ee.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/guest-embed-ee.cy.spec.ts
@@ -145,7 +145,8 @@ describe("scenarios > embedding > sdk iframe embed setup > guest-embed", () => {
 
       H.expectUnstructuredSnowplowEvent({
         event: "embed_wizard_experience_completed",
-        event_detail: "auth=sso,experience=chart,isDefaultExperience=true",
+        event_detail:
+          "auth=guest-embed,experience=chart,isDefaultExperience=true",
       });
 
       // Entity selection step

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/guest-embed-ee.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/guest-embed-ee.cy.spec.ts
@@ -146,7 +146,7 @@ describe("scenarios > embedding > sdk iframe embed setup > guest-embed", () => {
       H.expectUnstructuredSnowplowEvent({
         event: "embed_wizard_experience_completed",
         event_detail:
-          "auth=guest-embed,experience=chart,isDefaultExperience=true",
+          "authType=guest-embed,experience=chart,isDefaultExperience=true",
       });
 
       // Entity selection step
@@ -220,7 +220,7 @@ describe("scenarios > embedding > sdk iframe embed setup > guest-embed", () => {
       H.expectUnstructuredSnowplowEvent({
         event: "embed_wizard_code_copied",
         event_detail:
-          "experience=chart,snippetType=frontend,guestEmbedEnabled=true,guestEmbedType=guest-embed,ssoType=none",
+          "experience=chart,snippetType=frontend,guestEmbedEnabled=true,guestEmbedType=guest-embed,authSubType=none",
       });
 
       // Visit embed page

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/guest-embed-ee.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/guest-embed-ee.cy.spec.ts
@@ -145,7 +145,7 @@ describe("scenarios > embedding > sdk iframe embed setup > guest-embed", () => {
 
       H.expectUnstructuredSnowplowEvent({
         event: "embed_wizard_experience_completed",
-        event_detail: "custom=chart",
+        event_detail: "auth=sso,experience=chart,isDefaultExperience=true",
       });
 
       // Entity selection step
@@ -219,7 +219,7 @@ describe("scenarios > embedding > sdk iframe embed setup > guest-embed", () => {
       H.expectUnstructuredSnowplowEvent({
         event: "embed_wizard_code_copied",
         event_detail:
-          "experience=chart,snippetType=frontend,guestEmbedEnabled=true,guestEmbedType=guest-embed,auth=guest-embed",
+          "experience=chart,snippetType=frontend,guestEmbedEnabled=true,guestEmbedType=guest-embed,ssoType=none",
       });
 
       // Visit embed page

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/guest-embed-ee.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/guest-embed-ee.cy.spec.ts
@@ -146,7 +146,7 @@ describe("scenarios > embedding > sdk iframe embed setup > guest-embed", () => {
       H.expectUnstructuredSnowplowEvent({
         event: "embed_wizard_experience_completed",
         event_detail:
-          "authType=guest-embed,experience=chart,isDefaultExperience=true",
+          "authType=guest-embed,experience=chart,isDefaultExperience=false",
       });
 
       // Entity selection step

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/guest-embed-ee.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/guest-embed-ee.cy.spec.ts
@@ -135,6 +135,8 @@ describe("scenarios > embedding > sdk iframe embed setup > guest-embed", () => {
 
       // Experience step
       getEmbedSidebar().within(() => {
+        cy.findByLabelText("Guest").should("be.visible").should("be.checked");
+
         cy.findByTestId("upsell-gem").should("not.exist");
 
         cy.findByText("Chart").click();
@@ -167,8 +169,7 @@ describe("scenarios > embedding > sdk iframe embed setup > guest-embed", () => {
       });
 
       // Options step
-      cy.findByLabelText("Guest").should("be.visible").should("be.checked");
-
+      cy.findByLabelText("Guest").should("not.exist");
       cy.findByLabelText("Allow people to drill through on data points")
         .should("be.visible")
         .should("be.disabled");
@@ -337,7 +338,7 @@ describe("scenarios > embedding > sdk iframe embed setup > guest-embed", () => {
         });
 
         getEmbedSidebar().within(() => {
-          cy.findByLabelText("Guest").should("be.visible").should("be.checked");
+          cy.findByLabelText("Guest").should("not.exist");
         });
 
         H.setEmbeddingParameter("Product ID", "Locked");
@@ -352,9 +353,14 @@ describe("scenarios > embedding > sdk iframe embed setup > guest-embed", () => {
           codeBlock().first().should("not.contain", "locked-parameters=");
 
           cy.findByText("Back").click();
+          cy.findByText("Back").click();
+          cy.findByText("Back").click();
 
-          cy.findByLabelText("Single sign-on (SSO)").click();
+          cy.findByLabelText("Guest").should("be.visible").should("be.checked");
+          cy.findByLabelText("Metabase account (SSO)").click();
 
+          cy.findByText("Next").click();
+          cy.findByText("Next").click();
           cy.findByText("Get code").click();
 
           codeBlock().first().should("contain", "dashboard-id=");

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/guest-embed-oss.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/guest-embed-oss.cy.spec.ts
@@ -153,7 +153,7 @@ describe(
         H.expectUnstructuredSnowplowEvent({
           event: "embed_wizard_experience_completed",
           event_detail:
-            "authType=guest-embed,experience=chart,isDefaultExperience=true",
+            "authType=guest-embed,experience=chart,isDefaultExperience=false",
         });
 
         // Entity selection step

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/guest-embed-oss.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/guest-embed-oss.cy.spec.ts
@@ -127,6 +127,16 @@ describe(
 
         // Experience step
         getEmbedSidebar().within(() => {
+          cy.findByLabelText("Guest").should("be.visible").should("be.checked");
+
+          ["Metabase account (SSO)"].forEach((text) => {
+            cy.findAllByTestId("tooltip-warning")
+              .filter(`:contains("${text}")`)
+              .within(() => {
+                cy.findByTestId("upsell-gem").should("be.visible");
+              });
+          });
+
           ["Exploration", "Browser"].forEach((label) => {
             cy.findByLabelText(label).should("be.disabled");
             cy.get("label")
@@ -166,9 +176,6 @@ describe(
         });
 
         // Options step
-        cy.findByLabelText("Guest").should("be.visible").should("be.checked");
-        cy.findByLabelText("Single sign-on (SSO)").should("be.disabled");
-
         cy.findByLabelText("Allow people to drill through on data points")
           .should("be.visible")
           .should("be.disabled");
@@ -181,7 +188,6 @@ describe(
           .should("be.disabled");
 
         [
-          "Single sign-on (SSO)",
           "Allow people to drill through on data points",
           "Allow downloads",
           "Allow people to save new questions",

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/guest-embed-oss.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/guest-embed-oss.cy.spec.ts
@@ -152,7 +152,7 @@ describe(
 
         H.expectUnstructuredSnowplowEvent({
           event: "embed_wizard_experience_completed",
-          event_detail: "custom=chart",
+          event_detail: "auth=sso,experience=chart,isDefaultExperience=true",
         });
 
         // Entity selection step
@@ -255,7 +255,7 @@ describe(
         H.expectUnstructuredSnowplowEvent({
           event: "embed_wizard_code_copied",
           event_detail:
-            "experience=chart,snippetType=frontend,guestEmbedEnabled=true,guestEmbedType=guest-embed,auth=guest-embed",
+            "experience=chart,snippetType=frontend,guestEmbedEnabled=true,guestEmbedType=guest-embed,ssoType=none",
         });
 
         // Visit embed page

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/guest-embed-oss.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/guest-embed-oss.cy.spec.ts
@@ -239,7 +239,7 @@ describe(
         H.expectUnstructuredSnowplowEvent({
           event: "embed_wizard_options_completed",
           event_detail:
-            'settings=custom,experience=chart,guestEmbedEnabled=true,guestEmbedType=guest-embed,auth=guest-embed,drills=false,withDownloads=true,withTitle=true,isSaveEnabled=false,params={"disabled":0,"locked":1,"enabled":0},theme=default',
+            'settings=custom,experience=chart,guestEmbedEnabled=true,guestEmbedType=guest-embed,authType=guest-embed,drills=false,withDownloads=true,withTitle=true,isSaveEnabled=false,params={"disabled":0,"locked":1,"enabled":0},theme=default',
         });
 
         // Get code step

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/guest-embed-oss.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/guest-embed-oss.cy.spec.ts
@@ -152,7 +152,8 @@ describe(
 
         H.expectUnstructuredSnowplowEvent({
           event: "embed_wizard_experience_completed",
-          event_detail: "auth=sso,experience=chart,isDefaultExperience=true",
+          event_detail:
+            "auth=guest-embed,experience=chart,isDefaultExperience=true",
         });
 
         // Entity selection step

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/guest-embed-oss.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/guest-embed-oss.cy.spec.ts
@@ -153,7 +153,7 @@ describe(
         H.expectUnstructuredSnowplowEvent({
           event: "embed_wizard_experience_completed",
           event_detail:
-            "auth=guest-embed,experience=chart,isDefaultExperience=true",
+            "authType=guest-embed,experience=chart,isDefaultExperience=true",
         });
 
         // Entity selection step
@@ -256,7 +256,7 @@ describe(
         H.expectUnstructuredSnowplowEvent({
           event: "embed_wizard_code_copied",
           event_detail:
-            "experience=chart,snippetType=frontend,guestEmbedEnabled=true,guestEmbedType=guest-embed,ssoType=none",
+            "experience=chart,snippetType=frontend,guestEmbedEnabled=true,guestEmbedType=guest-embed,authSubType=none",
         });
 
         // Visit embed page

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
@@ -72,18 +72,18 @@ type NavigateToStepOptions =
   | {
       experience: "exploration" | "metabot";
       resourceName?: never;
-      toggleSso?: boolean;
+      preselectSso?: boolean;
     }
   | {
       experience: "dashboard" | "chart" | "browser";
       resourceName: string;
-      toggleSso?: boolean;
+      preselectSso?: boolean;
     };
 
 export const navigateToEntitySelectionStep = (
   options: NavigateToStepOptions,
 ) => {
-  const { experience, toggleSso } = options;
+  const { experience, preselectSso } = options;
 
   visitNewEmbedPage();
 
@@ -94,7 +94,7 @@ export const navigateToEntitySelectionStep = (
   const hasEntitySelection =
     experience !== "exploration" && experience !== "metabot";
 
-  if (toggleSso || !isQuestionOrDashboardExperience) {
+  if (preselectSso || !isQuestionOrDashboardExperience) {
     cy.findByLabelText("Metabase account (SSO)").click();
   }
 

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
@@ -72,23 +72,31 @@ type NavigateToStepOptions =
   | {
       experience: "exploration" | "metabot";
       resourceName?: never;
+      toggleSso?: boolean;
     }
   | {
       experience: "dashboard" | "chart" | "browser";
       resourceName: string;
+      toggleSso?: boolean;
     };
 
 export const navigateToEntitySelectionStep = (
   options: NavigateToStepOptions,
 ) => {
-  const { experience } = options;
+  const { experience, toggleSso } = options;
 
   visitNewEmbedPage();
 
   cy.log("select an experience");
 
+  const isQuestionOrDashboardExperience =
+    experience === "chart" || experience === "dashboard";
   const hasEntitySelection =
     experience !== "exploration" && experience !== "metabot";
+
+  if (toggleSso || !isQuestionOrDashboardExperience) {
+    cy.findByLabelText("Metabase account (SSO)").click();
+  }
 
   const labelByExperience = match(experience)
     .with("chart", () => "Chart")

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
@@ -220,6 +220,8 @@ describe(suiteTitle, () => {
     visitNewEmbedPage();
 
     getEmbedSidebar().within(() => {
+      cy.findByLabelText("Metabase account (SSO)").click();
+
       cy.findByText("Browser").click();
       cy.findByText("Next").click();
       cy.findByText("Select a collection to embed").should("be.visible");
@@ -301,6 +303,8 @@ describe(suiteTitle, () => {
 
     it("can open a collection picker from browser empty state", () => {
       getEmbedSidebar().within(() => {
+        cy.findByLabelText("Metabase account (SSO)").click();
+
         cy.findByText("Browser").click();
         cy.findByText("Next").click();
 

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
@@ -81,7 +81,8 @@ describe(suiteTitle, () => {
 
       H.expectUnstructuredSnowplowEvent({
         event: "embed_wizard_experience_completed",
-        event_detail: "custom=chart",
+        event_detail:
+          "auth=guest-embed,experience=chart,isDefaultExperience=false",
       });
 
       H.getSimpleEmbedIframeContent().within(() => {
@@ -102,7 +103,8 @@ describe(suiteTitle, () => {
 
       H.expectUnstructuredSnowplowEvent({
         event: "embed_wizard_experience_completed",
-        event_detail: "custom=exploration",
+        event_detail:
+          "auth=sso,experience=exploration,isDefaultExperience=false",
       });
 
       H.waitForSimpleEmbedIframesToLoad();
@@ -125,7 +127,7 @@ describe(suiteTitle, () => {
 
       H.expectUnstructuredSnowplowEvent({
         event: "embed_wizard_experience_completed",
-        event_detail: "custom=browser",
+        event_detail: "auth=sso,experience=browser,isDefaultExperience=false",
       });
 
       H.getSimpleEmbedIframeContent().within(() => {
@@ -178,7 +180,8 @@ describe(suiteTitle, () => {
 
         H.expectUnstructuredSnowplowEvent({
           event: "embed_wizard_experience_completed",
-          event_detail: "custom=chart",
+          event_detail:
+            "auth=guest-embed,experience=chart,isDefaultExperience=false",
         });
 
         H.waitForSimpleEmbedIframesToLoad();
@@ -221,7 +224,7 @@ describe(suiteTitle, () => {
 
     H.expectUnstructuredSnowplowEvent({
       event: "embed_wizard_experience_completed",
-      event_detail: "custom=metabot",
+      event_detail: "auth=sso,experience=metabot,isDefaultExperience=false",
     });
 
     H.getSimpleEmbedIframeContent().within(() => {

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
@@ -52,7 +52,7 @@ describe(suiteTitle, () => {
       H.expectUnstructuredSnowplowEvent({
         event: "embed_wizard_experience_completed",
         event_detail:
-          "auth=guest-embed,experience=dashboard,isDefaultExperience=true",
+          "authType=guest-embed,experience=dashboard,isDefaultExperience=true",
       });
 
       H.getSimpleEmbedIframeContent().within(() => {
@@ -83,7 +83,7 @@ describe(suiteTitle, () => {
       H.expectUnstructuredSnowplowEvent({
         event: "embed_wizard_experience_completed",
         event_detail:
-          "auth=guest-embed,experience=chart,isDefaultExperience=false",
+          "authType=guest-embed,experience=chart,isDefaultExperience=false",
       });
 
       H.getSimpleEmbedIframeContent().within(() => {
@@ -105,7 +105,7 @@ describe(suiteTitle, () => {
       H.expectUnstructuredSnowplowEvent({
         event: "embed_wizard_experience_completed",
         event_detail:
-          "auth=sso,experience=exploration,isDefaultExperience=false",
+          "authType=sso,experience=exploration,isDefaultExperience=false",
       });
 
       H.waitForSimpleEmbedIframesToLoad();
@@ -128,7 +128,8 @@ describe(suiteTitle, () => {
 
       H.expectUnstructuredSnowplowEvent({
         event: "embed_wizard_experience_completed",
-        event_detail: "auth=sso,experience=browser,isDefaultExperience=false",
+        event_detail:
+          "authType=sso,experience=browser,isDefaultExperience=false",
       });
 
       H.getSimpleEmbedIframeContent().within(() => {
@@ -182,7 +183,7 @@ describe(suiteTitle, () => {
         H.expectUnstructuredSnowplowEvent({
           event: "embed_wizard_experience_completed",
           event_detail:
-            "auth=guest-embed,experience=chart,isDefaultExperience=false",
+            "authType=guest-embed,experience=chart,isDefaultExperience=false",
         });
 
         H.waitForSimpleEmbedIframesToLoad();
@@ -225,7 +226,7 @@ describe(suiteTitle, () => {
 
     H.expectUnstructuredSnowplowEvent({
       event: "embed_wizard_experience_completed",
-      event_detail: "auth=sso,experience=metabot,isDefaultExperience=false",
+      event_detail: "authType=sso,experience=metabot,isDefaultExperience=false",
     });
 
     H.getSimpleEmbedIframeContent().within(() => {

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
@@ -51,7 +51,8 @@ describe(suiteTitle, () => {
 
       H.expectUnstructuredSnowplowEvent({
         event: "embed_wizard_experience_completed",
-        event_detail: "default",
+        event_detail:
+          "auth=guest-embed,experience=dashboard,isDefaultExperience=true",
       });
 
       H.getSimpleEmbedIframeContent().within(() => {

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
@@ -2,8 +2,6 @@ import {
   ORDERS_COUNT_QUESTION_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import { enableJwtAuth } from "e2e/support/helpers/e2e-jwt-helpers";
-import { enableSamlAuth } from "e2e/support/helpers/embedding-sdk-testing";
 
 import {
   assertDashboard,
@@ -35,32 +33,6 @@ describe(suiteTitle, () => {
 
   afterEach(() => {
     H.expectNoBadSnowplowEvents();
-  });
-
-  it("should disable SSO radio button when JWT and SAML are not configured", () => {
-    visitNewEmbedPage();
-
-    getEmbedSidebar().within(() => {
-      cy.findByLabelText("Metabase account (SSO)").should("be.disabled");
-    });
-  });
-
-  it("should enable SSO radio button when JWT is configured", () => {
-    enableJwtAuth();
-    visitNewEmbedPage();
-
-    getEmbedSidebar().within(() => {
-      cy.findByLabelText("Metabase account (SSO)").should("not.be.disabled");
-    });
-  });
-
-  it("should enable SSO radio button when SAML is configured", () => {
-    enableSamlAuth();
-    visitNewEmbedPage();
-
-    getEmbedSidebar().within(() => {
-      cy.findByLabelText("Metabase account (SSO)").should("not.be.disabled");
-    });
   });
 
   describe("select embed experiences with a non-empty activity log", () => {

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
@@ -94,6 +94,8 @@ describe(suiteTitle, () => {
       visitNewEmbedPage();
 
       getEmbedSidebar().within(() => {
+        cy.findByLabelText("Metabase account (SSO)").click();
+
         cy.findByText("Exploration").click();
         cy.findByText("Next").click();
       });
@@ -115,6 +117,8 @@ describe(suiteTitle, () => {
       visitNewEmbedPage();
 
       getEmbedSidebar().within(() => {
+        cy.findByLabelText("Metabase account (SSO)").click();
+
         cy.findByText("Browser").click();
         cy.findByText("Next").click();
       });
@@ -209,6 +213,8 @@ describe(suiteTitle, () => {
     visitNewEmbedPage();
 
     getEmbedSidebar().within(() => {
+      cy.findByLabelText("Metabase account (SSO)").click();
+
       cy.findByText("Metabot").click();
       cy.findByText("Next").click();
     });

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
@@ -2,6 +2,8 @@ import {
   ORDERS_COUNT_QUESTION_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
+import { enableJwtAuth } from "e2e/support/helpers/e2e-jwt-helpers";
+import { enableSamlAuth } from "e2e/support/helpers/embedding-sdk-testing";
 
 import {
   assertDashboard,
@@ -33,6 +35,32 @@ describe(suiteTitle, () => {
 
   afterEach(() => {
     H.expectNoBadSnowplowEvents();
+  });
+
+  it("should disable SSO radio button when JWT and SAML are not configured", () => {
+    visitNewEmbedPage();
+
+    getEmbedSidebar().within(() => {
+      cy.findByLabelText("Metabase account (SSO)").should("be.disabled");
+    });
+  });
+
+  it("should enable SSO radio button when JWT is configured", () => {
+    enableJwtAuth();
+    visitNewEmbedPage();
+
+    getEmbedSidebar().within(() => {
+      cy.findByLabelText("Metabase account (SSO)").should("not.be.disabled");
+    });
+  });
+
+  it("should enable SSO radio button when SAML is configured", () => {
+    enableSamlAuth();
+    visitNewEmbedPage();
+
+    getEmbedSidebar().within(() => {
+      cy.findByLabelText("Metabase account (SSO)").should("not.be.disabled");
+    });
   });
 
   describe("select embed experiences with a non-empty activity log", () => {

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
@@ -140,7 +140,7 @@ describe(suiteTitle, () => {
     H.expectUnstructuredSnowplowEvent({
       event: "embed_wizard_options_completed",
       event_detail:
-        "settings=custom,experience=dashboard,auth=user-session,drills=false,withDownloads=false,withSubscriptions=false,withTitle=true,isSaveEnabled=false,theme=default",
+        "settings=custom,experience=dashboard,auth=sso,drills=false,withDownloads=false,withSubscriptions=false,withTitle=true,isSaveEnabled=false,theme=default",
     });
 
     codeBlock().should("contain", 'drills="false"');
@@ -177,7 +177,7 @@ describe(suiteTitle, () => {
     H.expectUnstructuredSnowplowEvent({
       event: "embed_wizard_options_completed",
       event_detail:
-        "settings=custom,experience=dashboard,auth=user-session,drills=true,withDownloads=true,withSubscriptions=false,withTitle=true,isSaveEnabled=false,theme=default",
+        "settings=custom,experience=dashboard,auth=sso,drills=true,withDownloads=true,withSubscriptions=false,withTitle=true,isSaveEnabled=false,theme=default",
     });
 
     codeBlock().should("contain", 'with-subscriptions="false"');
@@ -295,7 +295,7 @@ describe(suiteTitle, () => {
     H.expectUnstructuredSnowplowEvent({
       event: "embed_wizard_options_completed",
       event_detail:
-        "settings=custom,experience=dashboard,auth=user-session,drills=true,withDownloads=false,withSubscriptions=true,withTitle=true,isSaveEnabled=false,theme=default",
+        "settings=custom,experience=dashboard,auth=sso,drills=true,withDownloads=false,withSubscriptions=true,withTitle=true,isSaveEnabled=false,theme=default",
     });
 
     codeBlock().should("contain", 'with-subscriptions="true"');
@@ -523,8 +523,8 @@ describe(suiteTitle, () => {
         event: "embed_wizard_options_completed",
         event_detail:
           experience === "chart"
-            ? "settings=custom,experience=chart,auth=user-session,drills=true,withDownloads=false,withTitle=true,isSaveEnabled=true,theme=default"
-            : "settings=custom,experience=exploration,auth=user-session,isSaveEnabled=true,theme=default",
+            ? "settings=custom,experience=chart,auth=sso,drills=true,withDownloads=false,withTitle=true,isSaveEnabled=true,theme=default"
+            : "settings=custom,experience=exploration,auth=sso,isSaveEnabled=true,theme=default",
       });
 
       codeBlock().should("contain", 'is-save-enabled="true"');
@@ -561,7 +561,7 @@ describe(suiteTitle, () => {
     H.expectUnstructuredSnowplowEvent({
       event: "embed_wizard_options_completed",
       event_detail:
-        "settings=custom,experience=browser,auth=user-session,readOnly=false,theme=default",
+        "settings=custom,experience=browser,auth=sso,readOnly=false,theme=default",
     });
 
     codeBlock().should("contain", 'read-only="false"');
@@ -686,7 +686,7 @@ describe(suiteTitle, () => {
     H.expectUnstructuredSnowplowEvent({
       event: "embed_wizard_options_completed",
       event_detail:
-        "settings=custom,experience=dashboard,auth=user-session,drills=true,withDownloads=false,withSubscriptions=false,withTitle=true,isSaveEnabled=false,theme=custom",
+        "settings=custom,experience=dashboard,auth=sso,drills=true,withDownloads=false,withSubscriptions=false,withTitle=true,isSaveEnabled=false,theme=custom",
     });
 
     // derived-colors-for-embed-flow.unit.spec.ts contains the tests for other derived colors.
@@ -712,7 +712,7 @@ describe(suiteTitle, () => {
     H.expectUnstructuredSnowplowEvent({
       event: "embed_wizard_options_completed",
       event_detail:
-        "settings=custom,experience=metabot,auth=user-session,layout=stacked,theme=default",
+        "settings=custom,experience=metabot,auth=sso,layout=stacked,theme=default",
     });
 
     getEmbedSidebar().findByText("Back").click();
@@ -728,7 +728,7 @@ describe(suiteTitle, () => {
     H.expectUnstructuredSnowplowEvent({
       event: "embed_wizard_options_completed",
       event_detail:
-        "settings=custom,experience=metabot,auth=user-session,layout=sidebar,theme=default",
+        "settings=custom,experience=metabot,auth=sso,layout=sidebar,theme=default",
     });
   });
 });

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
@@ -1,6 +1,4 @@
 import { mockEmbedJsToDevServer } from "e2e/support/helpers";
-import { enableJwtAuth } from "e2e/support/helpers/e2e-jwt-helpers";
-import { enableSamlAuth } from "e2e/support/helpers/embedding-sdk-testing";
 
 import {
   codeBlock,
@@ -132,42 +130,7 @@ describe(suiteTitle, () => {
     });
   });
 
-  it("should disable SSO radio button when JWT and SAML are not configured", () => {
-    navigateToEmbedOptionsStep({
-      experience: "dashboard",
-      resourceName: DASHBOARD_NAME,
-    });
-
-    getEmbedSidebar().within(() => {
-      cy.findByLabelText("Single sign-on (SSO)").should("be.disabled");
-    });
-  });
-
-  it("should enable SSO radio button when JWT is configured", () => {
-    enableJwtAuth();
-    navigateToEmbedOptionsStep({
-      experience: "dashboard",
-      resourceName: DASHBOARD_NAME,
-    });
-
-    getEmbedSidebar().within(() => {
-      cy.findByLabelText("Single sign-on (SSO)").should("not.be.disabled");
-    });
-  });
-
-  it("should enable SSO radio button when SAML is configured", () => {
-    enableSamlAuth();
-    navigateToEmbedOptionsStep({
-      experience: "dashboard",
-      resourceName: DASHBOARD_NAME,
-    });
-
-    getEmbedSidebar().within(() => {
-      cy.findByLabelText("Single sign-on (SSO)").should("not.be.disabled");
-    });
-  });
-
-  it("toggles drill-throughs for dashboards when non-authorized auth method is selected", () => {
+  it("toggles drill-throughs for dashboards when SSO auth method is selected", () => {
     navigateToGetCodeStep({
       experience: "dashboard",
       resourceName: DASHBOARD_NAME,
@@ -202,7 +165,7 @@ describe(suiteTitle, () => {
     H.expectUnstructuredSnowplowEvent({
       event: "embed_wizard_options_completed",
       event_detail:
-        "settings=custom,experience=dashboard,auth=user-session,drills=false,withDownloads=false,withSubscriptions=false,withTitle=true,isSaveEnabled=false,theme=default",
+        "settings=custom,experience=dashboard,auth=sso,drills=false,withDownloads=false,withSubscriptions=false,withTitle=true,isSaveEnabled=false,theme=default",
     });
 
     codeBlock().should("contain", 'drills="false"');
@@ -212,8 +175,8 @@ describe(suiteTitle, () => {
     navigateToEmbedOptionsStep({
       experience: "dashboard",
       resourceName: DASHBOARD_NAME,
+      toggleSso: true,
     });
-    cy.findByLabelText("Existing Metabase session").click();
 
     getEmbedSidebar()
       .findByLabelText("Allow downloads")
@@ -239,7 +202,7 @@ describe(suiteTitle, () => {
     H.expectUnstructuredSnowplowEvent({
       event: "embed_wizard_options_completed",
       event_detail:
-        "settings=custom,experience=dashboard,auth=user-session,drills=true,withDownloads=true,withSubscriptions=false,withTitle=true,isSaveEnabled=false,theme=default",
+        "settings=custom,experience=dashboard,auth=sso,drills=true,withDownloads=true,withSubscriptions=false,withTitle=true,isSaveEnabled=false,theme=default",
     });
 
     codeBlock().should("contain", 'with-subscriptions="false"');
@@ -249,6 +212,7 @@ describe(suiteTitle, () => {
     navigateToEmbedOptionsStep({
       experience: "dashboard",
       resourceName: DASHBOARD_NAME,
+      toggleSso: true,
     });
 
     getEmbedSidebar()
@@ -300,8 +264,8 @@ describe(suiteTitle, () => {
     navigateToEmbedOptionsStep({
       experience: "dashboard",
       resourceName: DASHBOARD_NAME,
+      toggleSso: true,
     });
-    cy.findByLabelText("Existing Metabase session").click();
 
     getEmbedSidebar()
       .findByLabelText("Allow subscriptions")
@@ -392,12 +356,12 @@ describe(suiteTitle, () => {
     codeBlock().should("contain", 'with-title="false"');
   });
 
-  it("toggles drill-through for charts for non-authorized auth mode", () => {
+  it("toggles drill-through for charts for SSO auth mode", () => {
     navigateToEmbedOptionsStep({
       experience: "chart",
       resourceName: QUESTION_NAME,
+      toggleSso: true,
     });
-    cy.findByLabelText("Existing Metabase session").click();
 
     getEmbedSidebar()
       .findByLabelText("Allow people to drill through on data points")
@@ -469,8 +433,8 @@ describe(suiteTitle, () => {
     navigateToEmbedOptionsStep({
       experience: "chart",
       resourceName: QUESTION_NAME,
+      toggleSso: true,
     });
-    cy.findByLabelText("Existing Metabase session").click();
 
     cy.log("chart title should be visible by default");
     getEmbedSidebar().findByLabelText("Show chart title").should("be.checked");
@@ -578,8 +542,8 @@ describe(suiteTitle, () => {
         event: "embed_wizard_options_completed",
         event_detail:
           experience === "chart"
-            ? "settings=custom,experience=chart,auth=user-session,drills=true,withDownloads=false,withTitle=true,isSaveEnabled=true,theme=default"
-            : "settings=custom,experience=exploration,auth=user-session,isSaveEnabled=true,theme=default",
+            ? "settings=custom,experience=chart,auth=sso,drills=true,withDownloads=false,withTitle=true,isSaveEnabled=true,theme=default"
+            : "settings=custom,experience=exploration,auth=sso,isSaveEnabled=true,theme=default",
       });
 
       codeBlock().should("contain", 'is-save-enabled="true"');
@@ -706,8 +670,8 @@ describe(suiteTitle, () => {
     navigateToEmbedOptionsStep({
       experience: "dashboard",
       resourceName: DASHBOARD_NAME,
+      toggleSso: true,
     });
-    cy.findByLabelText("Existing Metabase session").click();
 
     cy.log("click on brand color picker");
     cy.findByTestId("brand-color-picker").findByRole("button").click();

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
@@ -109,7 +109,7 @@ describe(suiteTitle, () => {
     navigateToEmbedOptionsStep({
       experience: "dashboard",
       resourceName: DASHBOARD_NAME,
-      toggleSso: true,
+      preselectSso: true,
     });
 
     getEmbedSidebar()
@@ -150,7 +150,7 @@ describe(suiteTitle, () => {
     navigateToEmbedOptionsStep({
       experience: "dashboard",
       resourceName: DASHBOARD_NAME,
-      toggleSso: true,
+      preselectSso: true,
     });
 
     getEmbedSidebar()
@@ -245,7 +245,7 @@ describe(suiteTitle, () => {
     navigateToEmbedOptionsStep({
       experience: "dashboard",
       resourceName: DASHBOARD_NAME,
-      toggleSso: true,
+      preselectSso: true,
     });
 
     getEmbedSidebar()
@@ -341,7 +341,7 @@ describe(suiteTitle, () => {
     navigateToEmbedOptionsStep({
       experience: "chart",
       resourceName: QUESTION_NAME,
-      toggleSso: true,
+      preselectSso: true,
     });
 
     getEmbedSidebar()
@@ -414,7 +414,7 @@ describe(suiteTitle, () => {
     navigateToEmbedOptionsStep({
       experience: "chart",
       resourceName: QUESTION_NAME,
-      toggleSso: true,
+      preselectSso: true,
     });
 
     cy.log("chart title should be visible by default");
@@ -478,9 +478,9 @@ describe(suiteTitle, () => {
           ? {
               experience: "chart",
               resourceName: QUESTION_NAME,
-              toggleSso: true,
+              preselectSso: true,
             }
-          : { experience: "exploration", toggleSso: true },
+          : { experience: "exploration", preselectSso: true },
       );
 
       if (experience === "exploration") {
@@ -651,7 +651,7 @@ describe(suiteTitle, () => {
     navigateToEmbedOptionsStep({
       experience: "dashboard",
       resourceName: DASHBOARD_NAME,
-      toggleSso: true,
+      preselectSso: true,
     });
 
     cy.log("click on brand color picker");

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
@@ -6,6 +6,7 @@ import {
   codeBlock,
   getEmbedSidebar,
   navigateToEmbedOptionsStep,
+  navigateToGetCodeStep,
 } from "./helpers";
 
 const { H } = cy;
@@ -167,12 +168,11 @@ describe(suiteTitle, () => {
   });
 
   it("toggles drill-throughs for dashboards when non-authorized auth method is selected", () => {
-    navigateToEmbedOptionsStep({
+    navigateToGetCodeStep({
       experience: "dashboard",
       resourceName: DASHBOARD_NAME,
+      toggleSso: true,
     });
-
-    cy.findByLabelText("Existing Metabase session").click();
 
     getEmbedSidebar()
       .findByLabelText("Allow people to drill through on data points")
@@ -530,11 +530,13 @@ describe(suiteTitle, () => {
     it(`toggles save button for ${experience}`, () => {
       navigateToEmbedOptionsStep(
         experience === "chart"
-          ? { experience: "chart", resourceName: QUESTION_NAME }
-          : { experience: "exploration" },
+          ? {
+              experience: "chart",
+              resourceName: QUESTION_NAME,
+              toggleSso: true,
+            }
+          : { experience: "exploration", toggleSso: true },
       );
-
-      cy.findByLabelText("Existing Metabase session").click();
 
       if (experience === "exploration") {
         cy.log("visualize a question to enable the save button");

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
@@ -140,7 +140,7 @@ describe(suiteTitle, () => {
     H.expectUnstructuredSnowplowEvent({
       event: "embed_wizard_options_completed",
       event_detail:
-        "settings=custom,experience=dashboard,auth=sso,drills=false,withDownloads=false,withSubscriptions=false,withTitle=true,isSaveEnabled=false,theme=default",
+        "settings=custom,experience=dashboard,authType=sso,drills=false,withDownloads=false,withSubscriptions=false,withTitle=true,isSaveEnabled=false,theme=default",
     });
 
     codeBlock().should("contain", 'drills="false"');
@@ -177,7 +177,7 @@ describe(suiteTitle, () => {
     H.expectUnstructuredSnowplowEvent({
       event: "embed_wizard_options_completed",
       event_detail:
-        "settings=custom,experience=dashboard,auth=sso,drills=true,withDownloads=true,withSubscriptions=false,withTitle=true,isSaveEnabled=false,theme=default",
+        "settings=custom,experience=dashboard,authType=sso,drills=true,withDownloads=true,withSubscriptions=false,withTitle=true,isSaveEnabled=false,theme=default",
     });
 
     codeBlock().should("contain", 'with-subscriptions="false"');
@@ -295,7 +295,7 @@ describe(suiteTitle, () => {
     H.expectUnstructuredSnowplowEvent({
       event: "embed_wizard_options_completed",
       event_detail:
-        "settings=custom,experience=dashboard,auth=sso,drills=true,withDownloads=false,withSubscriptions=true,withTitle=true,isSaveEnabled=false,theme=default",
+        "settings=custom,experience=dashboard,authType=sso,drills=true,withDownloads=false,withSubscriptions=true,withTitle=true,isSaveEnabled=false,theme=default",
     });
 
     codeBlock().should("contain", 'with-subscriptions="true"');
@@ -331,7 +331,7 @@ describe(suiteTitle, () => {
     H.expectUnstructuredSnowplowEvent({
       event: "embed_wizard_options_completed",
       event_detail:
-        'settings=custom,experience=dashboard,guestEmbedEnabled=false,auth=guest-embed,drills=false,withDownloads=false,withSubscriptions=false,withTitle=false,params={"disabled":0,"locked":0,"enabled":0},theme=default',
+        'settings=custom,experience=dashboard,guestEmbedEnabled=false,authType=guest-embed,drills=false,withDownloads=false,withSubscriptions=false,withTitle=false,params={"disabled":0,"locked":0,"enabled":0},theme=default',
     });
 
     codeBlock().should("contain", 'with-title="false"');
@@ -404,7 +404,7 @@ describe(suiteTitle, () => {
     H.expectUnstructuredSnowplowEvent({
       event: "embed_wizard_options_completed",
       event_detail:
-        'settings=custom,experience=chart,guestEmbedEnabled=false,auth=guest-embed,drills=false,withDownloads=true,withTitle=true,isSaveEnabled=false,params={"disabled":0,"locked":0,"enabled":0},theme=default',
+        'settings=custom,experience=chart,guestEmbedEnabled=false,authType=guest-embed,drills=false,withDownloads=true,withTitle=true,isSaveEnabled=false,params={"disabled":0,"locked":0,"enabled":0},theme=default',
     });
 
     codeBlock().should("contain", 'with-downloads="true"');
@@ -523,8 +523,8 @@ describe(suiteTitle, () => {
         event: "embed_wizard_options_completed",
         event_detail:
           experience === "chart"
-            ? "settings=custom,experience=chart,auth=sso,drills=true,withDownloads=false,withTitle=true,isSaveEnabled=true,theme=default"
-            : "settings=custom,experience=exploration,auth=sso,isSaveEnabled=true,theme=default",
+            ? "settings=custom,experience=chart,authType=sso,drills=true,withDownloads=false,withTitle=true,isSaveEnabled=true,theme=default"
+            : "settings=custom,experience=exploration,authType=sso,isSaveEnabled=true,theme=default",
       });
 
       codeBlock().should("contain", 'is-save-enabled="true"');
@@ -561,7 +561,7 @@ describe(suiteTitle, () => {
     H.expectUnstructuredSnowplowEvent({
       event: "embed_wizard_options_completed",
       event_detail:
-        "settings=custom,experience=browser,auth=sso,readOnly=false,theme=default",
+        "settings=custom,experience=browser,authType=sso,readOnly=false,theme=default",
     });
 
     codeBlock().should("contain", 'read-only="false"');
@@ -607,7 +607,7 @@ describe(suiteTitle, () => {
     H.expectUnstructuredSnowplowEvent({
       event: "embed_wizard_options_completed",
       event_detail:
-        'settings=custom,experience=dashboard,guestEmbedEnabled=false,auth=guest-embed,drills=false,withDownloads=false,withSubscriptions=false,withTitle=true,params={"disabled":0,"locked":0,"enabled":0},theme=custom',
+        'settings=custom,experience=dashboard,guestEmbedEnabled=false,authType=guest-embed,drills=false,withDownloads=false,withSubscriptions=false,withTitle=true,params={"disabled":0,"locked":0,"enabled":0},theme=custom',
     });
 
     codeBlock().should("contain", '"theme": {');
@@ -686,7 +686,7 @@ describe(suiteTitle, () => {
     H.expectUnstructuredSnowplowEvent({
       event: "embed_wizard_options_completed",
       event_detail:
-        "settings=custom,experience=dashboard,auth=sso,drills=true,withDownloads=false,withSubscriptions=false,withTitle=true,isSaveEnabled=false,theme=custom",
+        "settings=custom,experience=dashboard,authType=sso,drills=true,withDownloads=false,withSubscriptions=false,withTitle=true,isSaveEnabled=false,theme=custom",
     });
 
     // derived-colors-for-embed-flow.unit.spec.ts contains the tests for other derived colors.
@@ -712,7 +712,7 @@ describe(suiteTitle, () => {
     H.expectUnstructuredSnowplowEvent({
       event: "embed_wizard_options_completed",
       event_detail:
-        "settings=custom,experience=metabot,auth=sso,layout=stacked,theme=default",
+        "settings=custom,experience=metabot,authType=sso,layout=stacked,theme=default",
     });
 
     getEmbedSidebar().findByText("Back").click();
@@ -728,7 +728,7 @@ describe(suiteTitle, () => {
     H.expectUnstructuredSnowplowEvent({
       event: "embed_wizard_options_completed",
       event_detail:
-        "settings=custom,experience=metabot,auth=sso,layout=sidebar,theme=default",
+        "settings=custom,experience=metabot,authType=sso,layout=sidebar,theme=default",
     });
   });
 });

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
@@ -35,8 +35,6 @@ describe("OSS", { tags: "@OSS" }, () => {
         resourceName: DASHBOARD_NAME,
       });
 
-      assertUpsellForOption("Existing Metabase session");
-      assertUpsellForOption("Single sign-on (SSO)");
       assertUpsellForOption("Allow people to drill through on data points");
       assertUpsellForOption("Allow downloads");
       assertUpsellForOption("Allow subscriptions");
@@ -64,7 +62,6 @@ describe("EE without license", () => {
       navigateToEmbedOptionsStep({
         experience: "dashboard",
         resourceName: DASHBOARD_NAME,
-        toggleSso: true,
       });
 
       assertUpsellForOption("Allow people to drill through on data points");
@@ -143,7 +140,7 @@ describe(suiteTitle, () => {
     H.expectUnstructuredSnowplowEvent({
       event: "embed_wizard_options_completed",
       event_detail:
-        "settings=custom,experience=dashboard,auth=sso,drills=false,withDownloads=false,withSubscriptions=false,withTitle=true,isSaveEnabled=false,theme=default",
+        "settings=custom,experience=dashboard,auth=user-session,drills=false,withDownloads=false,withSubscriptions=false,withTitle=true,isSaveEnabled=false,theme=default",
     });
 
     codeBlock().should("contain", 'drills="false"');

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
@@ -4,7 +4,6 @@ import {
   codeBlock,
   getEmbedSidebar,
   navigateToEmbedOptionsStep,
-  navigateToGetCodeStep,
 } from "./helpers";
 
 const { H } = cy;
@@ -65,10 +64,9 @@ describe("EE without license", () => {
       navigateToEmbedOptionsStep({
         experience: "dashboard",
         resourceName: DASHBOARD_NAME,
+        toggleSso: true,
       });
 
-      assertUpsellForOption("Existing Metabase session");
-      assertUpsellForOption("Single sign-on (SSO)");
       assertUpsellForOption("Allow people to drill through on data points");
       assertUpsellForOption("Allow downloads");
       assertUpsellForOption("Allow subscriptions");
@@ -110,28 +108,8 @@ describe(suiteTitle, () => {
     H.expectNoBadSnowplowEvents();
   });
 
-  it("should select user session auth method by default", () => {
-    navigateToEmbedOptionsStep({
-      experience: "dashboard",
-      resourceName: DASHBOARD_NAME,
-    });
-
-    getEmbedSidebar().within(() => {
-      cy.findByText("Authentication").should("be.visible");
-
-      cy.findByLabelText("Guest").should("be.visible").should("be.checked");
-      cy.findByLabelText("Existing Metabase session")
-        .should("be.visible")
-        .should("not.be.checked");
-
-      cy.findByLabelText("Single sign-on (SSO)")
-        .should("be.visible")
-        .should("not.be.checked");
-    });
-  });
-
   it("toggles drill-throughs for dashboards when SSO auth method is selected", () => {
-    navigateToGetCodeStep({
+    navigateToEmbedOptionsStep({
       experience: "dashboard",
       resourceName: DASHBOARD_NAME,
       toggleSso: true,
@@ -202,7 +180,7 @@ describe(suiteTitle, () => {
     H.expectUnstructuredSnowplowEvent({
       event: "embed_wizard_options_completed",
       event_detail:
-        "settings=custom,experience=dashboard,auth=sso,drills=true,withDownloads=true,withSubscriptions=false,withTitle=true,isSaveEnabled=false,theme=default",
+        "settings=custom,experience=dashboard,auth=user-session,drills=true,withDownloads=true,withSubscriptions=false,withTitle=true,isSaveEnabled=false,theme=default",
     });
 
     codeBlock().should("contain", 'with-subscriptions="false"');
@@ -212,7 +190,6 @@ describe(suiteTitle, () => {
     navigateToEmbedOptionsStep({
       experience: "dashboard",
       resourceName: DASHBOARD_NAME,
-      toggleSso: true,
     });
 
     getEmbedSidebar()
@@ -246,7 +223,14 @@ describe(suiteTitle, () => {
     cy.log("test non-guest embeds");
     getEmbedSidebar().within(() => {
       cy.button("Back").click();
-      cy.findByLabelText("Existing Metabase session").click();
+      cy.button("Back").click();
+      cy.button("Back").click();
+
+      cy.findByLabelText("Metabase account (SSO)").click();
+
+      cy.button("Next").click();
+      cy.button("Next").click();
+
       cy.findByLabelText("Allow subscriptions")
         .closest("[data-testid=tooltip-warning]")
         .icon("info")
@@ -542,8 +526,8 @@ describe(suiteTitle, () => {
         event: "embed_wizard_options_completed",
         event_detail:
           experience === "chart"
-            ? "settings=custom,experience=chart,auth=sso,drills=true,withDownloads=false,withTitle=true,isSaveEnabled=true,theme=default"
-            : "settings=custom,experience=exploration,auth=sso,isSaveEnabled=true,theme=default",
+            ? "settings=custom,experience=chart,auth=user-session,drills=true,withDownloads=false,withTitle=true,isSaveEnabled=true,theme=default"
+            : "settings=custom,experience=exploration,auth=user-session,isSaveEnabled=true,theme=default",
       });
 
       codeBlock().should("contain", 'is-save-enabled="true"');

--- a/e2e/test/scenarios/sharing/public-sharing-embed-flow.cy.spec.ts
+++ b/e2e/test/scenarios/sharing/public-sharing-embed-flow.cy.spec.ts
@@ -41,6 +41,7 @@ describe(suiteTitle, () => {
       .findByText("Orders in a dashboard", { timeout: 10_000 })
       .should("be.visible");
 
+    getEmbedSidebar().findByText("Back").should("not.exist");
     getEmbedSidebar().findByText("Get code").click();
 
     H.expectUnstructuredSnowplowEvent({
@@ -67,51 +68,12 @@ describe(suiteTitle, () => {
       .findByText("Orders", { timeout: 10_000 })
       .should("be.visible");
 
+    getEmbedSidebar().findByText("Back").should("not.exist");
     getEmbedSidebar().findByText("Get code").click();
 
     H.expectUnstructuredSnowplowEvent({
       event: "embed_wizard_options_completed",
       event_detail: "settings=default",
-    });
-  });
-
-  it("tracks default resources for pre-selected dashboard", () => {
-    H.visitDashboard(ORDERS_DASHBOARD_ID);
-    H.openSharingMenu("Embed");
-    H.embedModalEnableEmbedding();
-
-    H.expectUnstructuredSnowplowEvent({ event: "embed_wizard_opened" });
-
-    cy.log("go back to resource selection step");
-    getEmbedSidebar().within(() => {
-      cy.findByText("Back").click();
-      cy.findByText("Select a dashboard to embed").should("be.visible");
-      cy.findByText("Next").click();
-    });
-
-    H.expectUnstructuredSnowplowEvent({
-      event: "embed_wizard_resource_selection_completed",
-      event_detail: "isDefaultResource=true,experience=dashboard",
-    });
-  });
-
-  it("tracks default resources for pre-selected question", () => {
-    H.visitQuestion(ORDERS_QUESTION_ID);
-    H.openSharingMenu("Embed");
-    H.embedModalEnableEmbedding();
-
-    H.expectUnstructuredSnowplowEvent({ event: "embed_wizard_opened" });
-
-    cy.log("go back to resource selection step");
-    getEmbedSidebar().within(() => {
-      cy.findByText("Back").click();
-      cy.findByText("Select a chart to embed").should("be.visible");
-      cy.findByText("Next").click();
-    });
-
-    H.expectUnstructuredSnowplowEvent({
-      event: "embed_wizard_resource_selection_completed",
-      event_detail: "isDefaultResource=true,experience=chart",
     });
   });
 });

--- a/frontend/src/metabase-types/analytics/event.ts
+++ b/frontend/src/metabase-types/analytics/event.ts
@@ -213,7 +213,7 @@ export type EmbedWizardOpenedEvent = ValidateEvent<{
 
 export type EmbedWizardExperienceCompletedEvent = ValidateEvent<{
   event: "embed_wizard_experience_completed";
-  event_detail: "default" | `custom=${SdkIframeEmbedSetupExperience}`;
+  event_detail: string;
 }>;
 
 export type EmbedWizardResourceSelectionCompletedEvent = ValidateEvent<{

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/analytics.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/analytics.ts
@@ -96,6 +96,7 @@ export const trackEmbedWizardOptionsCompleted = ({
   settings,
   isSimpleEmbedFeatureAvailable,
   isGuestEmbedsEnabled,
+  isSsoEnabledAndConfigured,
   embeddingParameters,
 }: {
   initialState: SdkIframeEmbedSetupModalInitialState | undefined;
@@ -104,6 +105,7 @@ export const trackEmbedWizardOptionsCompleted = ({
   settings: Partial<SdkIframeEmbedSetupSettings>;
   isSimpleEmbedFeatureAvailable: boolean;
   isGuestEmbedsEnabled: boolean;
+  isSsoEnabledAndConfigured: boolean;
   embeddingParameters: EmbeddingParameters;
 }) => {
   // Get defaults for this experience type (with a dummy resource ID)
@@ -113,6 +115,7 @@ export const trackEmbedWizardOptionsCompleted = ({
     resourceId: 0,
     isSimpleEmbedFeatureAvailable,
     isGuestEmbedsEnabled,
+    isSsoEnabledAndConfigured,
   });
 
   // Does the embed settings diverge from the experience defaults?

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/analytics.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/analytics.ts
@@ -20,9 +20,13 @@ import {
   getResourceIdFromSettings,
 } from "./utils/get-default-sdk-iframe-embed-setting";
 
+export const UTM_LOCATION = "embedded_analytics_js_wizard";
+
 export const UPSELL_CAMPAIGN_EXPERIENCE = "embedding_experience";
 export const UPSELL_CAMPAIGN_AUTH = "embedding_auth";
 export const UPSELL_CAMPAIGN_BEHAVIOR = "embedding_behavior";
+
+export const SETUP_SSO_CAMPAIGN = "embedding_get_code";
 
 /**
  * Tracking every embed settings would bloat Snowplow, so we only track

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/analytics.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/analytics.ts
@@ -94,7 +94,6 @@ const getEmbedSettingsToCompare = (settings: Partial<SdkIframeEmbedSettings>) =>
   _.omit(_.omit(settings, ...EMBED_SETTINGS_TO_IGNORE), _.isUndefined);
 
 export const trackEmbedWizardOptionsCompleted = ({
-  initialState,
   experience,
   resource,
   settings,
@@ -114,12 +113,13 @@ export const trackEmbedWizardOptionsCompleted = ({
 }) => {
   // Get defaults for this experience type (with a dummy resource ID)
   const defaultSettings = getDefaultSdkIframeEmbedSettings({
-    initialState,
     experience,
     resourceId: 0,
     isSimpleEmbedFeatureAvailable,
     isGuestEmbedsEnabled,
     isSsoEnabledAndConfigured,
+    isGuest: !!settings.isGuest,
+    useExistingUserSession: !!settings.useExistingUserSession,
   });
 
   // Does the embed settings diverge from the experience defaults?

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/analytics.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/analytics.ts
@@ -71,7 +71,7 @@ export const trackEmbedWizardExperienceCompleted = ({
   const isDefaultExperience = experience === defaultExperience;
 
   const eventDetailsParts: string[] = [
-    `auth=${authType}`,
+    `authType=${authType}`,
     `experience=${experience}`,
     `isDefaultExperience=${isDefaultExperience}`,
   ];
@@ -156,7 +156,7 @@ export const trackEmbedWizardOptionsCompleted = ({
       ...[
         `experience=${experience}`,
         ...buldEventDetailsPartsForGuestEmbedResource({ resource, settings }),
-        `auth=${authType}`,
+        `authType=${authType}`,
         ...buildEventDetailsPartsForSettings(settings),
         ...(settings.isGuest ? [`params=${JSON.stringify(params)}`] : []),
         `theme=${hasCustomTheme ? "custom" : "default"}`,

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/analytics.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/analytics.ts
@@ -4,8 +4,8 @@ import type {
   SdkIframeEmbedSettingKey,
   SdkIframeEmbedSettings,
 } from "metabase/embedding/embedding-iframe-sdk/types/embed";
+import { getAuthSubTypeForSettings } from "metabase/embedding/embedding-iframe-sdk-setup/utils/get-auth-sub-type-for-settings";
 import { getAuthTypeForSettings } from "metabase/embedding/embedding-iframe-sdk-setup/utils/get-auth-type-for-settings";
-import { getSsoTypeForSettings } from "metabase/embedding/embedding-iframe-sdk-setup/utils/get-sso-type-for-settings";
 import { countEmbeddingParameterOptions } from "metabase/embedding/lib/count-embedding-parameter-options";
 import { trackSimpleEvent } from "metabase/lib/analytics";
 import type { SdkIframeEmbedSetupModalInitialState } from "metabase/plugins";
@@ -181,13 +181,13 @@ export const trackEmbedWizardCodeCopied = ({
   snippetType: "frontend" | "server";
   settings: SdkIframeEmbedSetupSettings;
 }) => {
-  const ssoType = getSsoTypeForSettings(settings);
+  const authSubType = getAuthSubTypeForSettings(settings);
 
   const eventDetailsParts: (string | null)[] = [
     `experience=${experience}`,
     `snippetType=${snippetType}`,
     ...buldEventDetailsPartsForGuestEmbedResource({ resource, settings }),
-    `ssoType=${ssoType}`,
+    `authSubType=${authSubType}`,
   ];
 
   trackSimpleEvent({

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Authentication/AuthenticationSection.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Authentication/AuthenticationSection.tsx
@@ -29,7 +29,7 @@ export const AuthenticationSection = () => {
 
   const handleAuthTypeChange = (value: string) => {
     const isGuest = value === "guest-embed";
-    const isSso = !isGuest;
+    const isSso = value === "sso";
 
     if (isGuest) {
       // Reset experience to default when switching to guest embeds

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Authentication/AuthenticationSection.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Authentication/AuthenticationSection.tsx
@@ -1,0 +1,97 @@
+import type { ReactNode } from "react";
+import { t } from "ttag";
+
+import { UPSELL_CAMPAIGN_AUTH } from "metabase/embedding/embedding-iframe-sdk-setup/analytics";
+import { TooltipWarning } from "metabase/embedding/embedding-iframe-sdk-setup/components/warnings/TooltipWarning";
+import { WithSimpleEmbeddingFeatureUpsellTooltip } from "metabase/embedding/embedding-iframe-sdk-setup/components/warnings/WithSimpleEmbeddingFeatureUpsellTooltip";
+import { useSdkIframeEmbedSetupContext } from "metabase/embedding/embedding-iframe-sdk-setup/context";
+import { getAuthTypeForSettings } from "metabase/embedding/embedding-iframe-sdk-setup/utils/get-auth-type-for-settings";
+import { Card, Radio, Stack, Text } from "metabase/ui";
+
+export const AuthenticationSection = () => {
+  const {
+    isSimpleEmbedFeatureAvailable,
+    isFirstStep,
+    settings,
+    updateSettings,
+  } = useSdkIframeEmbedSetupContext();
+
+  if (!isFirstStep) {
+    return null;
+  }
+
+  const authType = getAuthTypeForSettings(settings);
+
+  const handleAuthTypeChange = (value: string) => {
+    const isGuest = value === "guest-embed";
+    const useExistingUserSession = value === "user-session";
+
+    updateSettings({
+      isGuest,
+      useExistingUserSession,
+    });
+  };
+
+  return (
+    <Card p="md">
+      <Stack gap="md" p="xs">
+        <Text size="lg" fw="bold">
+          {t`Authentication`}
+        </Text>
+
+        <Radio.Group value={authType} onChange={handleAuthTypeChange}>
+          <Stack gap="sm">
+            <WithGuestEmbedsDisabledWarning>
+              {({ disabled }) => (
+                <Radio
+                  disabled={disabled}
+                  value="guest-embed"
+                  label={t`Guest`}
+                />
+              )}
+            </WithGuestEmbedsDisabledWarning>
+
+            <WithSimpleEmbeddingFeatureUpsellTooltip
+              enableTooltip={!isSimpleEmbedFeatureAvailable}
+              campaign={UPSELL_CAMPAIGN_AUTH}
+            >
+              {({ disabled }) => (
+                <Radio
+                  value="sso"
+                  label={
+                    // eslint-disable-next-line no-literal-metabase-strings -- Public Facing string
+                    t`Metabase account (SSO)`
+                  }
+                  disabled={disabled}
+                />
+              )}
+            </WithSimpleEmbeddingFeatureUpsellTooltip>
+          </Stack>
+        </Radio.Group>
+      </Stack>
+    </Card>
+  );
+};
+
+const WithGuestEmbedsDisabledWarning = ({
+  children,
+}: {
+  children: (data: { disabled: boolean }) => ReactNode;
+}) => {
+  const { isGuestEmbedsEnabled } = useSdkIframeEmbedSetupContext();
+
+  const disabled = !isGuestEmbedsEnabled;
+
+  return (
+    <TooltipWarning
+      warning={
+        <Text lh="md" p="md">
+          {t`Disabled in the admin settings`}
+        </Text>
+      }
+      disabled={disabled}
+    >
+      {children}
+    </TooltipWarning>
+  );
+};

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Authentication/AuthenticationSection.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Authentication/AuthenticationSection.tsx
@@ -9,6 +9,7 @@ import {
   DEFAULT_EXPERIENCE,
   useHandleExperienceChange,
 } from "metabase/embedding/embedding-iframe-sdk-setup/hooks/use-handle-experience-change";
+import { getAuthTypeForSettings } from "metabase/embedding/embedding-iframe-sdk-setup/utils/get-auth-type-for-settings";
 import { Card, Radio, Stack, Text } from "metabase/ui";
 
 export const AuthenticationSection = () => {
@@ -24,7 +25,7 @@ export const AuthenticationSection = () => {
     return null;
   }
 
-  const authType = settings.isGuest ? "guest-embed" : "sso";
+  const authType = getAuthTypeForSettings(settings);
 
   const handleAuthTypeChange = (value: string) => {
     const isGuest = value === "guest-embed";

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Authentication/AuthenticationSection.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Authentication/AuthenticationSection.tsx
@@ -5,7 +5,10 @@ import { UPSELL_CAMPAIGN_AUTH } from "metabase/embedding/embedding-iframe-sdk-se
 import { TooltipWarning } from "metabase/embedding/embedding-iframe-sdk-setup/components/warnings/TooltipWarning";
 import { WithSimpleEmbeddingFeatureUpsellTooltip } from "metabase/embedding/embedding-iframe-sdk-setup/components/warnings/WithSimpleEmbeddingFeatureUpsellTooltip";
 import { useSdkIframeEmbedSetupContext } from "metabase/embedding/embedding-iframe-sdk-setup/context";
-import { getAuthTypeForSettings } from "metabase/embedding/embedding-iframe-sdk-setup/utils/get-auth-type-for-settings";
+import {
+  DEFAULT_EXPERIENCE,
+  useHandleExperienceChange,
+} from "metabase/embedding/embedding-iframe-sdk-setup/hooks/use-handle-experience-change";
 import { Card, Radio, Stack, Text } from "metabase/ui";
 
 export const AuthenticationSection = () => {
@@ -15,20 +18,26 @@ export const AuthenticationSection = () => {
     settings,
     updateSettings,
   } = useSdkIframeEmbedSetupContext();
+  const handleEmbedExperienceChange = useHandleExperienceChange();
 
   if (!isFirstStep) {
     return null;
   }
 
-  const authType = getAuthTypeForSettings(settings);
+  const authType = settings.isGuest ? "guest-embed" : "sso";
 
   const handleAuthTypeChange = (value: string) => {
     const isGuest = value === "guest-embed";
-    const useExistingUserSession = value === "user-session";
+    const isSso = !isGuest;
+
+    if (isGuest) {
+      // Reset experience to default when switching to guest embeds
+      handleEmbedExperienceChange(DEFAULT_EXPERIENCE);
+    }
 
     updateSettings({
       isGuest,
-      useExistingUserSession,
+      isSso,
     });
   };
 

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Authentication/AuthenticationSection.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Authentication/AuthenticationSection.tsx
@@ -93,11 +93,7 @@ const WithGuestEmbedsDisabledWarning = ({
 
   return (
     <TooltipWarning
-      warning={
-        <Text lh="md" p="md">
-          {t`Disabled in the admin settings`}
-        </Text>
-      }
+      tooltip={t`Disabled in the admin settings`}
       disabled={disabled}
     >
       {children}

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Authentication/MetabaseAccountSection.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Authentication/MetabaseAccountSection.tsx
@@ -6,7 +6,7 @@ import {
   UTM_LOCATION,
 } from "metabase/embedding/embedding-iframe-sdk-setup/analytics";
 import { useSdkIframeEmbedSetupContext } from "metabase/embedding/embedding-iframe-sdk-setup/context";
-import { getSsoTypeForSettings } from "metabase/embedding/embedding-iframe-sdk-setup/utils/get-sso-type-for-settings";
+import { getAuthSubTypeForSettings } from "metabase/embedding/embedding-iframe-sdk-setup/utils/get-auth-sub-type-for-settings";
 import { Alert, Anchor, Card, Icon, Radio, Stack, Text } from "metabase/ui";
 
 const utmTags = {
@@ -16,26 +16,24 @@ const utmTags = {
   utm_content: UTM_LOCATION,
 };
 
-export const SsoTypeSection = () => {
+export const MetabaseAccountSection = () => {
   const { isSsoEnabledAndConfigured, settings, updateSettings } =
     useSdkIframeEmbedSetupContext();
 
   const isGuestEmbed = !!settings.isGuest;
 
-  const { url: setupSsoUrl, showMetabaseLinks } = useDocsUrl(
-    "embedding/sdk/authentication",
-    {
-      utm: utmTags,
-    },
-  );
+  // eslint-disable-next-line no-unconditional-metabase-links-render -- Only for admins
+  const { url: setupSsoUrl } = useDocsUrl("embedding/sdk/authentication", {
+    utm: utmTags,
+  });
 
   if (isGuestEmbed) {
     return null;
   }
 
-  const ssoTypeValue = getSsoTypeForSettings(settings);
+  const authSubType = getAuthSubTypeForSettings(settings);
 
-  const handleSsoTypeChange = (value: string) => {
+  const handleAuthSubTypeChange = (value: string) => {
     const useExistingUserSession = value === "user-session";
 
     updateSettings({ useExistingUserSession });
@@ -52,7 +50,7 @@ export const SsoTypeSection = () => {
             }
           </Text>
 
-          <Radio.Group value={ssoTypeValue} onChange={handleSsoTypeChange}>
+          <Radio.Group value={authSubType} onChange={handleAuthSubTypeChange}>
             <Stack gap="sm">
               <Radio
                 disabled={!isSsoEnabledAndConfigured}
@@ -72,21 +70,17 @@ export const SsoTypeSection = () => {
       {!isSsoEnabledAndConfigured && !!settings.useExistingUserSession && (
         <Alert icon={<Icon name="warning" size={16} />} color="warning">
           <Text size="md" lh="lg">
-            {jt`The code below will only work for local testing. To get production ready code, configure ${
-              showMetabaseLinks ? (
-                <Anchor
-                  key="configure-sso"
-                  href={setupSsoUrl}
-                  target="_blank"
-                  size="md"
-                  lh="lg"
-                >
-                  {t`JWT SSO or SAML`}
-                </Anchor>
-              ) : (
-                t`JWT SSO or SAML`
-              )
-            }.`}
+            {jt`The code below will only work for local testing. To get production ready code, configure ${(
+              <Anchor
+                key="configure-sso"
+                href={setupSsoUrl}
+                target="_blank"
+                size="md"
+                lh="lg"
+              >
+                {t`JWT SSO or SAML`}
+              </Anchor>
+            )}.`}
           </Text>
         </Alert>
       )}

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Authentication/MetabseAccountSection.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Authentication/MetabseAccountSection.tsx
@@ -1,0 +1,60 @@
+import { t } from "ttag";
+
+import { useSetting } from "metabase/common/hooks";
+import { useSdkIframeEmbedSetupContext } from "metabase/embedding/embedding-iframe-sdk-setup/context";
+import { getAuthTypeForSettings } from "metabase/embedding/embedding-iframe-sdk-setup/utils/get-auth-type-for-settings";
+import { Card, Radio, Stack, Text } from "metabase/ui";
+
+export const MetabaseAccountSection = () => {
+  const { settings, updateSettings } = useSdkIframeEmbedSetupContext();
+
+  const isGuestEmbed = !!settings.isGuest;
+
+  const isJwtEnabled = useSetting("jwt-enabled");
+  const isSamlEnabled = useSetting("saml-enabled");
+  const isJwtConfigured = useSetting("jwt-configured");
+  const isSamlConfigured = useSetting("saml-configured");
+
+  if (isGuestEmbed) {
+    return null;
+  }
+
+  const isSsoEnabledAndConfigured =
+    (isJwtEnabled && isJwtConfigured) || (isSamlEnabled && isSamlConfigured);
+
+  const authType = getAuthTypeForSettings(settings);
+
+  const handleAuthTypeChange = (value: string) => {
+    const useExistingUserSession = value === "user-session";
+
+    updateSettings({ useExistingUserSession });
+  };
+
+  return (
+    <Card p="md">
+      <Stack gap="md" p="xs">
+        <Text size="lg" fw="bold">
+          {
+            // eslint-disable-next-line no-literal-metabase-strings -- Public Facing string
+            t`Metabase account`
+          }
+        </Text>
+
+        <Radio.Group value={authType} onChange={handleAuthTypeChange}>
+          <Stack gap="sm">
+            <Radio
+              disabled={!isSsoEnabledAndConfigured}
+              value="sso"
+              label={t`Single sign-on`}
+            />
+
+            <Radio
+              value="sso"
+              label={t`Existing session (local testing only)`}
+            />
+          </Stack>
+        </Radio.Group>
+      </Stack>
+    </Card>
+  );
+};

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Authentication/MetabseAccountSection.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Authentication/MetabseAccountSection.tsx
@@ -1,28 +1,19 @@
 import { t } from "ttag";
 
-import { useSetting } from "metabase/common/hooks";
 import { useSdkIframeEmbedSetupContext } from "metabase/embedding/embedding-iframe-sdk-setup/context";
-import { getAuthTypeForSettings } from "metabase/embedding/embedding-iframe-sdk-setup/utils/get-auth-type-for-settings";
 import { Card, Radio, Stack, Text } from "metabase/ui";
 
 export const MetabaseAccountSection = () => {
-  const { settings, updateSettings } = useSdkIframeEmbedSetupContext();
+  const { isSsoEnabledAndConfigured, settings, updateSettings } =
+    useSdkIframeEmbedSetupContext();
 
   const isGuestEmbed = !!settings.isGuest;
-
-  const isJwtEnabled = useSetting("jwt-enabled");
-  const isSamlEnabled = useSetting("saml-enabled");
-  const isJwtConfigured = useSetting("jwt-configured");
-  const isSamlConfigured = useSetting("saml-configured");
 
   if (isGuestEmbed) {
     return null;
   }
 
-  const isSsoEnabledAndConfigured =
-    (isJwtEnabled && isJwtConfigured) || (isSamlEnabled && isSamlConfigured);
-
-  const authType = getAuthTypeForSettings(settings);
+  const ssoTypeValue = settings.useExistingUserSession ? "user-session" : "sso";
 
   const handleAuthTypeChange = (value: string) => {
     const useExistingUserSession = value === "user-session";
@@ -40,7 +31,7 @@ export const MetabaseAccountSection = () => {
           }
         </Text>
 
-        <Radio.Group value={authType} onChange={handleAuthTypeChange}>
+        <Radio.Group value={ssoTypeValue} onChange={handleAuthTypeChange}>
           <Stack gap="sm">
             <Radio
               disabled={!isSsoEnabledAndConfigured}
@@ -49,7 +40,7 @@ export const MetabaseAccountSection = () => {
             />
 
             <Radio
-              value="sso"
+              value="user-session"
               label={t`Existing session (local testing only)`}
             />
           </Stack>

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Authentication/MetabseAccountSection.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Authentication/MetabseAccountSection.tsx
@@ -1,13 +1,32 @@
-import { t } from "ttag";
+import { jt, t } from "ttag";
 
+import { useDocsUrl } from "metabase/common/hooks";
+import {
+  SETUP_SSO_CAMPAIGN,
+  UTM_LOCATION,
+} from "metabase/embedding/embedding-iframe-sdk-setup/analytics";
 import { useSdkIframeEmbedSetupContext } from "metabase/embedding/embedding-iframe-sdk-setup/context";
-import { Alert, Card, Icon, Radio, Stack, Text } from "metabase/ui";
+import { Alert, Anchor, Card, Icon, Radio, Stack, Text } from "metabase/ui";
+
+const utmTags = {
+  utm_source: "product",
+  utm_medium: "docs",
+  utm_campaign: SETUP_SSO_CAMPAIGN,
+  utm_content: UTM_LOCATION,
+};
 
 export const MetabaseAccountSection = () => {
   const { isSsoEnabledAndConfigured, settings, updateSettings } =
     useSdkIframeEmbedSetupContext();
 
   const isGuestEmbed = !!settings.isGuest;
+
+  const { url: setupSsoUrl, showMetabaseLinks } = useDocsUrl(
+    "embedding/sdk/authentication",
+    {
+      utm: utmTags,
+    },
+  );
 
   if (isGuestEmbed) {
     return null;
@@ -51,7 +70,23 @@ export const MetabaseAccountSection = () => {
 
       {!isSsoEnabledAndConfigured && !!settings.useExistingUserSession && (
         <Alert icon={<Icon name="warning" size={16} />} color="warning">
-          {t`The code below will only work for local testing. To get production ready code, configure JWT SSO or SAML.`}
+          <Text size="md" lh="lg">
+            {jt`The code below will only work for local testing. To get production ready code, configure ${
+              showMetabaseLinks ? (
+                <Anchor
+                  key="configure-sso"
+                  href={setupSsoUrl}
+                  target="_blank"
+                  size="md"
+                  lh="lg"
+                >
+                  {t`JWT SSO or SAML`}
+                </Anchor>
+              ) : (
+                t`JWT SSO or SAML`
+              )
+            }.`}
+          </Text>
         </Alert>
       )}
     </>

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Authentication/MetabseAccountSection.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Authentication/MetabseAccountSection.tsx
@@ -1,7 +1,7 @@
 import { t } from "ttag";
 
 import { useSdkIframeEmbedSetupContext } from "metabase/embedding/embedding-iframe-sdk-setup/context";
-import { Card, Radio, Stack, Text } from "metabase/ui";
+import { Alert, Card, Icon, Radio, Stack, Text } from "metabase/ui";
 
 export const MetabaseAccountSection = () => {
   const { isSsoEnabledAndConfigured, settings, updateSettings } =
@@ -22,30 +22,38 @@ export const MetabaseAccountSection = () => {
   };
 
   return (
-    <Card p="md">
-      <Stack gap="md" p="xs">
-        <Text size="lg" fw="bold">
-          {
-            // eslint-disable-next-line no-literal-metabase-strings -- Public Facing string
-            t`Metabase account`
-          }
-        </Text>
+    <>
+      <Card p="md">
+        <Stack gap="md" p="xs">
+          <Text size="lg" fw="bold">
+            {
+              // eslint-disable-next-line no-literal-metabase-strings -- Public Facing string
+              t`Metabase account`
+            }
+          </Text>
 
-        <Radio.Group value={ssoTypeValue} onChange={handleAuthTypeChange}>
-          <Stack gap="sm">
-            <Radio
-              disabled={!isSsoEnabledAndConfigured}
-              value="sso"
-              label={t`Single sign-on`}
-            />
+          <Radio.Group value={ssoTypeValue} onChange={handleAuthTypeChange}>
+            <Stack gap="sm">
+              <Radio
+                disabled={!isSsoEnabledAndConfigured}
+                value="sso"
+                label={t`Single sign-on`}
+              />
 
-            <Radio
-              value="user-session"
-              label={t`Existing session (local testing only)`}
-            />
-          </Stack>
-        </Radio.Group>
-      </Stack>
-    </Card>
+              <Radio
+                value="user-session"
+                label={t`Existing session (local testing only)`}
+              />
+            </Stack>
+          </Radio.Group>
+        </Stack>
+      </Card>
+
+      {!isSsoEnabledAndConfigured && !!settings.useExistingUserSession && (
+        <Alert icon={<Icon name="warning" size={16} />} color="warning">
+          {t`The code below will only work for local testing. To get production ready code, configure JWT SSO or SAML.`}
+        </Alert>
+      )}
+    </>
   );
 };

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Authentication/SsoTypeSection.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Authentication/SsoTypeSection.tsx
@@ -6,6 +6,7 @@ import {
   UTM_LOCATION,
 } from "metabase/embedding/embedding-iframe-sdk-setup/analytics";
 import { useSdkIframeEmbedSetupContext } from "metabase/embedding/embedding-iframe-sdk-setup/context";
+import { getSsoTypeForSettings } from "metabase/embedding/embedding-iframe-sdk-setup/utils/get-sso-type-for-settings";
 import { Alert, Anchor, Card, Icon, Radio, Stack, Text } from "metabase/ui";
 
 const utmTags = {
@@ -15,7 +16,7 @@ const utmTags = {
   utm_content: UTM_LOCATION,
 };
 
-export const MetabaseAccountSection = () => {
+export const SsoTypeSection = () => {
   const { isSsoEnabledAndConfigured, settings, updateSettings } =
     useSdkIframeEmbedSetupContext();
 
@@ -32,9 +33,9 @@ export const MetabaseAccountSection = () => {
     return null;
   }
 
-  const ssoTypeValue = settings.useExistingUserSession ? "user-session" : "sso";
+  const ssoTypeValue = getSsoTypeForSettings(settings);
 
-  const handleAuthTypeChange = (value: string) => {
+  const handleSsoTypeChange = (value: string) => {
     const useExistingUserSession = value === "user-session";
 
     updateSettings({ useExistingUserSession });
@@ -51,7 +52,7 @@ export const MetabaseAccountSection = () => {
             }
           </Text>
 
-          <Radio.Group value={ssoTypeValue} onChange={handleAuthTypeChange}>
+          <Radio.Group value={ssoTypeValue} onChange={handleSsoTypeChange}>
             <Stack gap="sm">
               <Radio
                 disabled={!isSsoEnabledAndConfigured}

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Common/WithNotAvailableForGuestEmbedsWarning.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Common/WithNotAvailableForGuestEmbedsWarning.tsx
@@ -1,0 +1,53 @@
+import type { ReactNode } from "react";
+import { t } from "ttag";
+
+import {
+  TooltipWarning,
+  type TooltipWarningMode,
+} from "metabase/embedding/embedding-iframe-sdk-setup/components/warnings/TooltipWarning";
+import { useSdkIframeEmbedSetupContext } from "metabase/embedding/embedding-iframe-sdk-setup/context";
+import { Text } from "metabase/ui";
+
+import { WithNotAvailableWithoutSimpleEmbeddingFeatureWarning } from "./WithNotAvailableWithoutSimpleEmbeddingFeatureWarning";
+
+export const WithNotAvailableForGuestEmbedsWarning = ({
+  mode,
+  children,
+  campaign,
+}: {
+  mode?: TooltipWarningMode;
+  children: (data: { disabled: boolean; hoverCard: ReactNode }) => ReactNode;
+  campaign: string;
+}) => {
+  const { settings } = useSdkIframeEmbedSetupContext();
+
+  return (
+    <WithNotAvailableWithoutSimpleEmbeddingFeatureWarning
+      mode={mode}
+      campaign={campaign}
+    >
+      {({ disabled: disabledForOss, hoverCard: disabledForOssHoverCard }) => (
+        <TooltipWarning
+          enableTooltip={!disabledForOss}
+          warning={
+            <Text lh="md" p="md">
+              {t`Not available if Guest Mode is selected`}
+            </Text>
+          }
+          disabled={!!settings.isGuest}
+        >
+          {({
+            disabled: disabledForGuestEmbeds,
+            hoverCard: disabledForGuestEmbedsHoverCard,
+          }) =>
+            children({
+              disabled: disabledForOss || disabledForGuestEmbeds,
+              hoverCard:
+                disabledForOssHoverCard || disabledForGuestEmbedsHoverCard,
+            })
+          }
+        </TooltipWarning>
+      )}
+    </WithNotAvailableWithoutSimpleEmbeddingFeatureWarning>
+  );
+};

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Common/WithNotAvailableForGuestEmbedsWarning.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Common/WithNotAvailableForGuestEmbedsWarning.tsx
@@ -6,7 +6,6 @@ import {
   type TooltipWarningMode,
 } from "metabase/embedding/embedding-iframe-sdk-setup/components/warnings/TooltipWarning";
 import { useSdkIframeEmbedSetupContext } from "metabase/embedding/embedding-iframe-sdk-setup/context";
-import { Text } from "metabase/ui";
 
 import { WithNotAvailableWithoutSimpleEmbeddingFeatureWarning } from "./WithNotAvailableWithoutSimpleEmbeddingFeatureWarning";
 
@@ -29,11 +28,7 @@ export const WithNotAvailableForGuestEmbedsWarning = ({
       {({ disabled: disabledForOss, hoverCard: disabledForOssHoverCard }) => (
         <TooltipWarning
           enableTooltip={!disabledForOss}
-          warning={
-            <Text lh="md" p="md">
-              {t`Not available if Guest Mode is selected`}
-            </Text>
-          }
+          tooltip={t`Not available if Guest Mode is selected`}
           disabled={!!settings.isGuest}
         >
           {({

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Common/WithNotAvailableWithoutSimpleEmbeddingFeatureWarning.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Common/WithNotAvailableWithoutSimpleEmbeddingFeatureWarning.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from "react";
+
+import { useSdkIframeEmbedSetupContext } from "metabase/embedding/embedding-iframe-sdk-setup/context";
+
+import type { TooltipWarningMode } from "../warnings/TooltipWarning";
+import { WithSimpleEmbeddingFeatureUpsellTooltip } from "../warnings/WithSimpleEmbeddingFeatureUpsellTooltip";
+
+export const WithNotAvailableWithoutSimpleEmbeddingFeatureWarning = ({
+  mode,
+  children,
+  campaign,
+}: {
+  mode?: TooltipWarningMode;
+  children: (data: { disabled: boolean; hoverCard: ReactNode }) => ReactNode;
+  campaign: string;
+}) => {
+  const { isSimpleEmbedFeatureAvailable } = useSdkIframeEmbedSetupContext();
+
+  return (
+    <WithSimpleEmbeddingFeatureUpsellTooltip
+      mode={mode}
+      enableTooltip={!isSimpleEmbedFeatureAvailable}
+      campaign={campaign}
+    >
+      {({ disabled, hoverCard }) => children({ disabled, hoverCard })}
+    </WithSimpleEmbeddingFeatureUpsellTooltip>
+  );
+};

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/GetCodeStep.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/GetCodeStep.tsx
@@ -3,6 +3,7 @@ import { t } from "ttag";
 import { useUpdateSettingsMutation } from "metabase/api";
 import { CodeEditor } from "metabase/common/components/CodeEditor";
 import { MoreServerSnippetExamplesLink } from "metabase/embedding/components/MoreServerSnippetExamplesLink/MoreServerSnippetExamplesLink";
+import { MetabaseAccountSection } from "metabase/embedding/embedding-iframe-sdk-setup/components/Authentication/MetabseAccountSection";
 import { CopyCodeSnippetButton } from "metabase/embedding/embedding-iframe-sdk-setup/components/CodeSnippet/CopyCodeSnippetButton";
 import { useSdkIframeEmbedServerSnippet } from "metabase/embedding/embedding-iframe-sdk-setup/hooks/use-sdk-iframe-embed-server-snippet";
 import { EmbedServerSnippetLanguageSelect } from "metabase/public/components/EmbedServerSnippetLanguageSelect/EmbedServerSnippetLanguageSelect";
@@ -16,6 +17,8 @@ import { useSdkIframeEmbedSnippet } from "../hooks/use-sdk-iframe-embed-snippet"
 export const GetCodeStep = () => {
   const { experience, resource, settings } = useSdkIframeEmbedSetupContext();
   const [updateInstanceSettings] = useUpdateSettingsMutation();
+
+  const isGuestEmbed = !!settings.isGuest;
 
   const serverSnippetData = useSdkIframeEmbedServerSnippet();
   const snippet = useSdkIframeEmbedSnippet();
@@ -44,6 +47,8 @@ export const GetCodeStep = () => {
 
   return (
     <Stack gap="md">
+      {!isGuestEmbed && <MetabaseAccountSection />}
+
       <Card p="md">
         <Text size="lg" fw="bold" mb="md">
           {t`Embed code`}

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/GetCodeStep.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/GetCodeStep.tsx
@@ -3,7 +3,7 @@ import { t } from "ttag";
 import { useUpdateSettingsMutation } from "metabase/api";
 import { CodeEditor } from "metabase/common/components/CodeEditor";
 import { MoreServerSnippetExamplesLink } from "metabase/embedding/components/MoreServerSnippetExamplesLink/MoreServerSnippetExamplesLink";
-import { MetabaseAccountSection } from "metabase/embedding/embedding-iframe-sdk-setup/components/Authentication/MetabseAccountSection";
+import { SsoTypeSection } from "metabase/embedding/embedding-iframe-sdk-setup/components/Authentication/SsoTypeSection";
 import { CopyCodeSnippetButton } from "metabase/embedding/embedding-iframe-sdk-setup/components/CodeSnippet/CopyCodeSnippetButton";
 import { useSdkIframeEmbedServerSnippet } from "metabase/embedding/embedding-iframe-sdk-setup/hooks/use-sdk-iframe-embed-server-snippet";
 import { EmbedServerSnippetLanguageSelect } from "metabase/public/components/EmbedServerSnippetLanguageSelect/EmbedServerSnippetLanguageSelect";
@@ -47,7 +47,7 @@ export const GetCodeStep = () => {
 
   return (
     <Stack gap="md">
-      {!isGuestEmbed && <MetabaseAccountSection />}
+      {!isGuestEmbed && <SsoTypeSection />}
 
       <Card p="md">
         <Text size="lg" fw="bold" mb="md">

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/GetCodeStep.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/GetCodeStep.tsx
@@ -3,7 +3,7 @@ import { t } from "ttag";
 import { useUpdateSettingsMutation } from "metabase/api";
 import { CodeEditor } from "metabase/common/components/CodeEditor";
 import { MoreServerSnippetExamplesLink } from "metabase/embedding/components/MoreServerSnippetExamplesLink/MoreServerSnippetExamplesLink";
-import { SsoTypeSection } from "metabase/embedding/embedding-iframe-sdk-setup/components/Authentication/SsoTypeSection";
+import { MetabaseAccountSection } from "metabase/embedding/embedding-iframe-sdk-setup/components/Authentication/MetabaseAccountSection";
 import { CopyCodeSnippetButton } from "metabase/embedding/embedding-iframe-sdk-setup/components/CodeSnippet/CopyCodeSnippetButton";
 import { useSdkIframeEmbedServerSnippet } from "metabase/embedding/embedding-iframe-sdk-setup/hooks/use-sdk-iframe-embed-server-snippet";
 import { EmbedServerSnippetLanguageSelect } from "metabase/public/components/EmbedServerSnippetLanguageSelect/EmbedServerSnippetLanguageSelect";
@@ -47,7 +47,7 @@ export const GetCodeStep = () => {
 
   return (
     <Stack gap="md">
-      {!isGuestEmbed && <SsoTypeSection />}
+      {!isGuestEmbed && <MetabaseAccountSection />}
 
       <Card p="md">
         <Text size="lg" fw="bold" mb="md">

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeEmbedSetupModal.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeEmbedSetupModal.tsx
@@ -1,5 +1,5 @@
 import cx from "classnames";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { ResizableBox } from "react-resizable";
 import { match } from "ts-pattern";
 import { t } from "ttag";
@@ -11,6 +11,7 @@ import { useUpdateSettingsMutation } from "metabase/api";
 import CS from "metabase/css/core/index.css";
 import { SdkIframeGuestEmbedStatusBar } from "metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeGuestEmbedStatusBar";
 import { SdkIframeStepHeader } from "metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeStepHeader";
+import { EMBED_STEPS } from "metabase/embedding/embedding-iframe-sdk-setup/constants";
 import { useDispatch } from "metabase/lib/redux";
 import type { SdkIframeEmbedSetupModalProps } from "metabase/plugins";
 import { closeModal } from "metabase/redux/ui";
@@ -28,7 +29,6 @@ import {
 import type { SettingKey } from "metabase-types/api";
 
 import { useSdkIframeEmbedSetupContext } from "../context";
-import { useSdkIframeEmbedNavigation } from "../hooks";
 
 import { SdkIframeEmbedPreview } from "./SdkIframeEmbedPreview";
 import S from "./SdkIframeEmbedSetup.module.css";
@@ -44,11 +44,17 @@ export const SdkIframeEmbedSetupContent = () => {
     isGuestEmbedsEnabled,
     isGuestEmbedsTermsAccepted,
     currentStep,
+    handleNext,
+    handleBack,
+    canGoBack,
     settings,
   } = useSdkIframeEmbedSetupContext();
 
-  const { handleNext, handleBack, canGoBack, StepContent } =
-    useSdkIframeEmbedNavigation();
+  const StepContent = useMemo(
+    () =>
+      EMBED_STEPS.find((step) => step.id === currentStep)?.component ?? noop,
+    [currentStep],
+  );
 
   function handleEmbedDone() {
     // Embedding Hub: track step completion
@@ -118,15 +124,17 @@ export const SdkIframeEmbedSetupContent = () => {
           </Stack>
 
           <Group className={S.Navigation} justify="space-between">
-            <Button
-              variant="default"
-              onClick={handleBack}
-              disabled={!canGoBack || !allowPreviewAndNavigation}
-            >
-              {t`Back`}
-            </Button>
+            {canGoBack && (
+              <Button
+                variant="default"
+                onClick={handleBack}
+                disabled={!allowPreviewAndNavigation}
+              >
+                {t`Back`}
+              </Button>
+            )}
 
-            {nextStepButton}
+            <Box ml="auto">{nextStepButton}</Box>
           </Group>
         </Box>
       </SidebarResizer>
@@ -192,3 +200,5 @@ export const SdkIframeEmbedSetupModal = ({
     </Modal.Content>
   </Modal>
 );
+
+const noop = () => null;

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeEmbedSetupProvider.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeEmbedSetupProvider.tsx
@@ -20,6 +20,7 @@ import {
   useGetCurrentResource,
   useParametersValues,
   useRecentItems,
+  useSdkIframeEmbedNavigation,
 } from "../hooks";
 import { useSdkIframeEmbedSettings } from "../hooks/use-sdk-iframe-embed-settings";
 import type { SdkIframeEmbedSetupStep } from "../types";
@@ -141,6 +142,21 @@ export const SdkIframeEmbedSetupProvider = ({
     embeddingParameters,
   });
 
+  const { handleNext, handleBack, canGoBack, isFirstStep, isLastStep } =
+    useSdkIframeEmbedNavigation({
+      isSimpleEmbedFeatureAvailable,
+      isGuestEmbedsEnabled,
+      initialState,
+      experience,
+      resource,
+      currentStep,
+      defaultStep,
+      setCurrentStep,
+      settings,
+      defaultSettings,
+      embeddingParameters,
+    });
+
   const value: SdkIframeEmbedSetupContextType = {
     isSimpleEmbedFeatureAvailable,
     isSimpleEmbeddingEnabled,
@@ -149,6 +165,11 @@ export const SdkIframeEmbedSetupProvider = ({
     isGuestEmbedsTermsAccepted,
     currentStep,
     setCurrentStep,
+    handleNext,
+    handleBack,
+    canGoBack,
+    isFirstStep,
+    isLastStep,
     initialState,
     experience,
     resource,

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeEmbedSetupProvider.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeEmbedSetupProvider.tsx
@@ -6,6 +6,7 @@ import { useSetting } from "metabase/common/hooks";
 import { trackEmbedWizardOpened } from "metabase/embedding/embedding-iframe-sdk-setup/analytics";
 import { useEmbeddingParameters } from "metabase/embedding/embedding-iframe-sdk-setup/hooks/use-embedding-parameters";
 import { useGetGuestEmbedSignedToken } from "metabase/embedding/embedding-iframe-sdk-setup/hooks/use-get-guest-embed-signed-token";
+import { useIsSsoEnabledAndConfigured } from "metabase/embedding/embedding-iframe-sdk-setup/hooks/use-is-sso-enabled-and-configured";
 import {
   PLUGIN_EMBEDDING_IFRAME_SDK_SETUP,
   type SdkIframeEmbedSetupModalInitialState,
@@ -45,6 +46,8 @@ export const SdkIframeEmbedSetupProvider = ({
 
   const isGuestEmbedsEnabled = useSetting("enable-embedding-static");
   const isGuestEmbedsTermsAccepted = !useSetting("show-static-embed-terms");
+
+  const isSsoEnabledAndConfigured = useIsSsoEnabledAndConfigured();
 
   useMount(() => {
     trackEmbedWizardOpened();
@@ -93,6 +96,7 @@ export const SdkIframeEmbedSetupProvider = ({
     modelCount,
     isSimpleEmbedFeatureAvailable,
     isGuestEmbedsEnabled,
+    isSsoEnabledAndConfigured,
   });
 
   // Which embed experience are we setting up?
@@ -146,6 +150,7 @@ export const SdkIframeEmbedSetupProvider = ({
     useSdkIframeEmbedNavigation({
       isSimpleEmbedFeatureAvailable,
       isGuestEmbedsEnabled,
+      isSsoEnabledAndConfigured,
       initialState,
       experience,
       resource,
@@ -163,6 +168,7 @@ export const SdkIframeEmbedSetupProvider = ({
     isSimpleEmbeddingTermsAccepted,
     isGuestEmbedsEnabled,
     isGuestEmbedsTermsAccepted,
+    isSsoEnabledAndConfigured,
     currentStep,
     setCurrentStep,
     handleNext,

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SelectEmbedExperienceStep.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SelectEmbedExperienceStep.tsx
@@ -4,6 +4,7 @@ import _ from "underscore";
 
 import { ALLOWED_EMBED_SETTING_KEYS_MAP } from "metabase/embedding/embedding-iframe-sdk/constants";
 import { UPSELL_CAMPAIGN_EXPERIENCE } from "metabase/embedding/embedding-iframe-sdk-setup/analytics";
+import { AuthenticationSection } from "metabase/embedding/embedding-iframe-sdk-setup/components/Authentication/AuthenticationSection";
 import { WithSimpleEmbeddingFeatureUpsellTooltip } from "metabase/embedding/embedding-iframe-sdk-setup/components/warnings/WithSimpleEmbeddingFeatureUpsellTooltip";
 import { PLUGIN_METABOT } from "metabase/plugins";
 import { Card, Flex, Radio, Stack, Text } from "metabase/ui";
@@ -29,6 +30,7 @@ export const SelectEmbedExperienceStep = () => {
     recentQuestions,
   } = useSdkIframeEmbedSetupContext();
 
+  const isGuestEmbed = !!settings.isGuest;
   const isMetabotAvailable = PLUGIN_METABOT.isEnabled();
 
   const handleEmbedExperienceChange = (
@@ -71,44 +73,51 @@ export const SelectEmbedExperienceStep = () => {
   });
 
   return (
-    <Card p="md" mb="md">
-      <Text size="lg" fw="bold" mb="md">
-        {t`Select your embed experience`}
-      </Text>
+    <>
+      <AuthenticationSection />
 
-      <Radio.Group
-        value={experience}
-        onChange={(experience) =>
-          handleEmbedExperienceChange(
-            experience as SdkIframeEmbedSetupExperience,
-          )
-        }
-      >
-        <Stack gap="md">
-          {experiences.map((experience) => (
-            <WithSimpleEmbeddingFeatureUpsellTooltip
-              key={experience.value}
-              mode="custom"
-              enableTooltip={experience.showUpsell === true}
-              campaign={UPSELL_CAMPAIGN_EXPERIENCE}
-            >
-              {({ disabled, hoverCard }) => (
-                <Radio
-                  value={experience.value}
-                  label={
-                    <Flex gap="xs" align="center">
-                      {experience.title}
-                      {hoverCard}
-                    </Flex>
-                  }
-                  description={experience.description}
-                  disabled={disabled}
-                />
-              )}
-            </WithSimpleEmbeddingFeatureUpsellTooltip>
-          ))}
-        </Stack>
-      </Radio.Group>
-    </Card>
+      <Card p="md" mb="md">
+        <Text size="lg" fw="bold" mb="md">
+          {t`Select your embed experience`}
+        </Text>
+
+        <Radio.Group
+          value={experience}
+          onChange={(experience) =>
+            handleEmbedExperienceChange(
+              experience as SdkIframeEmbedSetupExperience,
+            )
+          }
+        >
+          <Stack gap="md">
+            {experiences.map((experience) => (
+              <WithSimpleEmbeddingFeatureUpsellTooltip
+                key={experience.value}
+                mode="custom"
+                enableTooltip={experience.showUpsell === true}
+                campaign={UPSELL_CAMPAIGN_EXPERIENCE}
+              >
+                {({ disabled, hoverCard }) => (
+                  <Radio
+                    value={experience.value}
+                    label={
+                      <Flex gap="xs" align="center">
+                        {experience.title}
+                        {hoverCard}
+                      </Flex>
+                    }
+                    description={experience.description}
+                    disabled={
+                      disabled ||
+                      (isGuestEmbed && !experience.supportsGuestEmbed)
+                    }
+                  />
+                )}
+              </WithSimpleEmbeddingFeatureUpsellTooltip>
+            ))}
+          </Stack>
+        </Radio.Group>
+      </Card>
+    </>
   );
 };

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SelectEmbedExperienceStep.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SelectEmbedExperienceStep.tsx
@@ -1,71 +1,24 @@
-import { P, match } from "ts-pattern";
 import { t } from "ttag";
-import _ from "underscore";
 
-import { ALLOWED_EMBED_SETTING_KEYS_MAP } from "metabase/embedding/embedding-iframe-sdk/constants";
 import { UPSELL_CAMPAIGN_EXPERIENCE } from "metabase/embedding/embedding-iframe-sdk-setup/analytics";
 import { AuthenticationSection } from "metabase/embedding/embedding-iframe-sdk-setup/components/Authentication/AuthenticationSection";
 import { WithSimpleEmbeddingFeatureUpsellTooltip } from "metabase/embedding/embedding-iframe-sdk-setup/components/warnings/WithSimpleEmbeddingFeatureUpsellTooltip";
+import { useHandleExperienceChange } from "metabase/embedding/embedding-iframe-sdk-setup/hooks/use-handle-experience-change";
 import { PLUGIN_METABOT } from "metabase/plugins";
 import { Card, Flex, Radio, Stack, Text } from "metabase/ui";
 
-import {
-  EMBED_FALLBACK_DASHBOARD_ID,
-  EMBED_FALLBACK_QUESTION_ID,
-  getEmbedExperiences,
-} from "../constants";
+import { getEmbedExperiences } from "../constants";
 import { useSdkIframeEmbedSetupContext } from "../context";
 import type { SdkIframeEmbedSetupExperience } from "../types";
-import { getDefaultSdkIframeEmbedSettings } from "../utils/get-default-sdk-iframe-embed-setting";
 
 export const SelectEmbedExperienceStep = () => {
-  const {
-    isSimpleEmbedFeatureAvailable,
-    isGuestEmbedsEnabled,
-    initialState,
-    experience,
-    settings,
-    replaceSettings,
-    recentDashboards,
-    recentQuestions,
-  } = useSdkIframeEmbedSetupContext();
+  const { isSimpleEmbedFeatureAvailable, experience, settings } =
+    useSdkIframeEmbedSetupContext();
 
   const isGuestEmbed = !!settings.isGuest;
   const isMetabotAvailable = PLUGIN_METABOT.isEnabled();
 
-  const handleEmbedExperienceChange = (
-    experience: SdkIframeEmbedSetupExperience,
-  ) => {
-    const persistedSettings = _.pick(
-      settings,
-      ALLOWED_EMBED_SETTING_KEYS_MAP.base,
-    );
-
-    // Use the most recent item for the selected type.
-    // If the activity log is completely empty, use the fallback.
-    const defaultResourceId = match(experience)
-      .with("chart", () => recentQuestions[0]?.id ?? EMBED_FALLBACK_QUESTION_ID)
-      .with(
-        "dashboard",
-        () => recentDashboards[0]?.id ?? EMBED_FALLBACK_DASHBOARD_ID,
-      )
-      .with(P.union("exploration", "browser", "metabot"), () => 0) // resource id does not apply
-      .exhaustive();
-
-    replaceSettings({
-      // these settings do not change when the embed type changes
-      ...persistedSettings,
-
-      // these settings are overridden when the embed type changes
-      ...getDefaultSdkIframeEmbedSettings({
-        initialState,
-        experience,
-        resourceId: defaultResourceId,
-        isSimpleEmbedFeatureAvailable,
-        isGuestEmbedsEnabled,
-      }),
-    });
-  };
+  const handleEmbedExperienceChange = useHandleExperienceChange();
 
   const experiences = getEmbedExperiences({
     isSimpleEmbedFeatureAvailable,

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/SdkIframeEmbedSetup-embedding-hub.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/SdkIframeEmbedSetup-embedding-hub.unit.spec.tsx
@@ -35,17 +35,19 @@ describe("Embed flow > embedding hub step completion tracking", () => {
         },
       });
 
-      await userEvent.click(screen.getByRole("button", { name: "Next" }));
-      await userEvent.click(screen.getByRole("button", { name: "Next" }));
-
-      const authRadio = screen.getByDisplayValue(
-        useExistingUserSession ? "user-session" : "sso",
-      );
-
+      const authRadio = screen.getByDisplayValue("sso");
       await userEvent.click(authRadio);
       expect(authRadio).toBeChecked();
 
+      await userEvent.click(screen.getByRole("button", { name: "Next" }));
+      await userEvent.click(screen.getByRole("button", { name: "Next" }));
       await userEvent.click(screen.getByRole("button", { name: "Get code" }));
+
+      const ssoTypeRadio = screen.getByDisplayValue(
+        useExistingUserSession ? "user-session" : "sso",
+      );
+      await userEvent.click(ssoTypeRadio);
+      expect(ssoTypeRadio).toBeChecked();
 
       const actionButton = screen.getByRole("button", {
         name: trigger === "copy" ? /Copy code/ : /Done/,

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/SdkIframeEmbedSetup.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/SdkIframeEmbedSetup.unit.spec.tsx
@@ -43,6 +43,8 @@ describe("Embed flow > forward and backward navigation", () => {
   it("navigates forward through the embed flow", async () => {
     setup({ simpleEmbeddingEnabled: true });
 
+    expect(screen.getByText("Authentication")).toBeInTheDocument();
+
     expect(
       screen.getByText("Select your embed experience"),
     ).toBeInTheDocument();
@@ -53,7 +55,6 @@ describe("Embed flow > forward and backward navigation", () => {
 
     await userEvent.click(screen.getByRole("button", { name: "Next" }));
 
-    expect(screen.getByText("Authentication")).toBeInTheDocument();
     expect(screen.getByText("Behavior")).toBeInTheDocument();
     expect(screen.getByText("Appearance")).toBeInTheDocument();
     expect(
@@ -88,7 +89,9 @@ describe("Embed flow > forward and backward navigation", () => {
     expect(
       screen.getByText("Select your embed experience"),
     ).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Back" })).toBeDisabled();
+    expect(
+      screen.queryByRole("button", { name: "Back" }),
+    ).not.toBeInTheDocument();
   });
 
   it("skips the 'select resource' step for exploration", async () => {
@@ -110,10 +113,12 @@ describe("Embed flow > forward and backward navigation", () => {
     setup({ simpleEmbeddingEnabled: false });
 
     expect(screen.getByRole("button", { name: "Next" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Back" })).toBeDisabled();
+    expect(
+      screen.queryByRole("button", { name: "Back" }),
+    ).not.toBeInTheDocument();
   });
 
-  it("pre-selects question when resourceType: question is the initial state", async () => {
+  it("does not allow to go back when resourceType: question is the initial state", async () => {
     const mockDatabase = createMockDatabase();
     const mockCard = createMockCard({ id: 456 });
 
@@ -137,12 +142,8 @@ describe("Embed flow > forward and backward navigation", () => {
     expect(screen.getByText("Behavior")).toBeInTheDocument();
     expect(screen.getByText("Appearance")).toBeInTheDocument();
 
-    // Going back to the "select resource" step shows that it is expecting a chart.
-    await userEvent.click(screen.getByRole("button", { name: "Back" }));
-    expect(screen.getByText("Select a chart to embed")).toBeInTheDocument();
-
-    // Going back to the "select experience" step shows that it is expecting a chart.
-    await userEvent.click(screen.getByRole("button", { name: "Back" }));
-    expect(screen.getByRole("radio", { name: /Chart/ })).toBeChecked();
+    expect(
+      screen.queryByRole("button", { name: "Back" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/warnings/WithSimpleEmbeddingFeatureUpsellTooltip.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/warnings/WithSimpleEmbeddingFeatureUpsellTooltip.tsx
@@ -3,6 +3,7 @@ import { t } from "ttag";
 
 import { UpsellGem } from "metabase/admin/upsells/components";
 import { UpsellCard } from "metabase/common/components/UpsellCard";
+import { UTM_LOCATION } from "metabase/embedding/embedding-iframe-sdk-setup/analytics";
 import { useSdkIframeEmbedSetupContext } from "metabase/embedding/embedding-iframe-sdk-setup/context";
 import { useSelector } from "metabase/lib/redux";
 import { getUpgradeUrl } from "metabase/selectors/settings";
@@ -40,7 +41,7 @@ export const WithSimpleEmbeddingFeatureUpsellTooltip = ({
           title={t`Get more powerful embedding`}
           buttonLink={upgradeUrl}
           campaign={campaign}
-          location="embedded_analytics_js_wizard"
+          location={UTM_LOCATION}
           /* eslint-disable-next-line no-literal-metabase-strings -- Button text */
           buttonText={t`Upgrade to Metabase Pro`}
           maxWidth={UPSELL_CARD_WIDTH}

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/constants.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/constants.ts
@@ -24,23 +24,27 @@ export const getEmbedExperiences = ({
       value: "dashboard",
       title: t`Dashboard`,
       description: t`Embed an entire dashboard with multiple charts and filters`,
+      supportsGuestEmbed: true,
     },
     {
       value: "chart",
       title: t`Chart`,
       description: t`Embed a single chart`,
+      supportsGuestEmbed: true,
     },
     {
       value: "exploration",
       title: t`Exploration`,
       description: t`Embed an interactive data exploration experience`,
       showUpsell: !isSimpleEmbedFeatureAvailable,
+      supportsGuestEmbed: false,
     },
     {
       value: "browser",
       title: t`Browser`,
       description: t`Embed a browser to manage dashboards and charts`,
       showUpsell: !isSimpleEmbedFeatureAvailable,
+      supportsGuestEmbed: false,
     },
     ...(isMetabotAvailable
       ? [
@@ -49,6 +53,7 @@ export const getEmbedExperiences = ({
             title: t`Metabot`,
             description: t`Embed a Metabot chat interface`,
             showUpsell: !isSimpleEmbedFeatureAvailable,
+            supportsGuestEmbed: false,
           },
         ]
       : []),
@@ -57,6 +62,7 @@ export const getEmbedExperiences = ({
     description: string;
     value: SdkIframeEmbedSetupExperience;
     showUpsell?: boolean;
+    supportsGuestEmbed: boolean;
   }[];
 
 type EmbedStepConfig = {

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/context.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/context.ts
@@ -26,6 +26,8 @@ export interface SdkIframeEmbedSetupContextType {
   isGuestEmbedsEnabled: boolean;
   isGuestEmbedsTermsAccepted: boolean;
 
+  isSsoEnabledAndConfigured: boolean;
+
   // Navigation
   currentStep: SdkIframeEmbedSetupStep;
   setCurrentStep: (step: SdkIframeEmbedSetupStep) => void;

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/context.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/context.ts
@@ -29,6 +29,11 @@ export interface SdkIframeEmbedSetupContextType {
   // Navigation
   currentStep: SdkIframeEmbedSetupStep;
   setCurrentStep: (step: SdkIframeEmbedSetupStep) => void;
+  handleNext: () => void;
+  handleBack: () => void;
+  canGoBack: boolean;
+  isFirstStep: boolean;
+  isLastStep: boolean;
 
   // Initial state
   initialState: SdkIframeEmbedSetupModalInitialState | undefined;

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-handle-experience-change.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-handle-experience-change.ts
@@ -18,7 +18,6 @@ export const useHandleExperienceChange = () => {
     isSimpleEmbedFeatureAvailable,
     isGuestEmbedsEnabled,
     isSsoEnabledAndConfigured,
-    initialState,
     settings,
     replaceSettings,
     recentDashboards,
@@ -52,17 +51,17 @@ export const useHandleExperienceChange = () => {
 
         // these settings are overridden when the embed type changes
         ...getDefaultSdkIframeEmbedSettings({
-          initialState,
           experience,
           resourceId: defaultResourceId,
           isSimpleEmbedFeatureAvailable,
           isGuestEmbedsEnabled,
           isSsoEnabledAndConfigured,
+          isGuest: !!settings.isGuest,
+          useExistingUserSession: !!settings.useExistingUserSession,
         }),
       });
     },
     [
-      initialState,
       isGuestEmbedsEnabled,
       isSsoEnabledAndConfigured,
       isSimpleEmbedFeatureAvailable,

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-handle-experience-change.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-handle-experience-change.ts
@@ -1,0 +1,77 @@
+import { useCallback } from "react";
+import { P, match } from "ts-pattern";
+import _ from "underscore";
+
+import { ALLOWED_EMBED_SETTING_KEYS_MAP } from "metabase/embedding/embedding-iframe-sdk/constants";
+import {
+  EMBED_FALLBACK_DASHBOARD_ID,
+  EMBED_FALLBACK_QUESTION_ID,
+} from "metabase/embedding/embedding-iframe-sdk-setup/constants";
+import { useSdkIframeEmbedSetupContext } from "metabase/embedding/embedding-iframe-sdk-setup/context";
+import type { SdkIframeEmbedSetupExperience } from "metabase/embedding/embedding-iframe-sdk-setup/types";
+import { getDefaultSdkIframeEmbedSettings } from "metabase/embedding/embedding-iframe-sdk-setup/utils/get-default-sdk-iframe-embed-setting";
+
+export const DEFAULT_EXPERIENCE = "dashboard";
+
+export const useHandleExperienceChange = () => {
+  const {
+    isSimpleEmbedFeatureAvailable,
+    isGuestEmbedsEnabled,
+    isSsoEnabledAndConfigured,
+    initialState,
+    settings,
+    replaceSettings,
+    recentDashboards,
+    recentQuestions,
+  } = useSdkIframeEmbedSetupContext();
+
+  const handleEmbedExperienceChange = useCallback(
+    (experience: SdkIframeEmbedSetupExperience) => {
+      const persistedSettings = _.pick(
+        settings,
+        ALLOWED_EMBED_SETTING_KEYS_MAP.base,
+      );
+
+      // Use the most recent item for the selected type.
+      // If the activity log is completely empty, use the fallback.
+      const defaultResourceId = match(experience)
+        .with(
+          "chart",
+          () => recentQuestions[0]?.id ?? EMBED_FALLBACK_QUESTION_ID,
+        )
+        .with(
+          "dashboard",
+          () => recentDashboards[0]?.id ?? EMBED_FALLBACK_DASHBOARD_ID,
+        )
+        .with(P.union("exploration", "browser", "metabot"), () => 0) // resource id does not apply
+        .exhaustive();
+
+      replaceSettings({
+        // these settings do not change when the embed type changes
+        ...persistedSettings,
+
+        // these settings are overridden when the embed type changes
+        ...getDefaultSdkIframeEmbedSettings({
+          initialState,
+          experience,
+          resourceId: defaultResourceId,
+          isSimpleEmbedFeatureAvailable,
+          isGuestEmbedsEnabled,
+          isSsoEnabledAndConfigured,
+        }),
+      });
+    },
+    [
+      initialState,
+      isGuestEmbedsEnabled,
+      isSsoEnabledAndConfigured,
+      isSimpleEmbedFeatureAvailable,
+      recentDashboards,
+      recentQuestions,
+      replaceSettings,
+      settings,
+    ],
+  );
+
+  return handleEmbedExperienceChange;
+};

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-is-sso-enabled-and-configured.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-is-sso-enabled-and-configured.ts
@@ -1,0 +1,12 @@
+import { useSetting } from "metabase/common/hooks";
+
+export const useIsSsoEnabledAndConfigured = () => {
+  const isJwtEnabled = useSetting("jwt-enabled");
+  const isSamlEnabled = useSetting("saml-enabled");
+  const isJwtConfigured = useSetting("jwt-configured");
+  const isSamlConfigured = useSetting("saml-configured");
+
+  return (
+    (isJwtEnabled && isJwtConfigured) || (isSamlEnabled && isSamlConfigured)
+  );
+};

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-sdk-iframe-embed-navigation.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-sdk-iframe-embed-navigation.ts
@@ -1,28 +1,43 @@
 import { useMemo } from "react";
 import { match } from "ts-pattern";
 
+import type { SdkIframeEmbedSetupStep } from "metabase/embedding/embedding-iframe-sdk-setup/types";
+
 import {
   trackEmbedWizardExperienceCompleted,
   trackEmbedWizardOptionsCompleted,
   trackEmbedWizardResourceSelectionCompleted,
 } from "../analytics";
 import { EMBED_STEPS } from "../constants";
-import { useSdkIframeEmbedSetupContext } from "../context";
+import type { SdkIframeEmbedSetupContextType } from "../context";
 
-export function useSdkIframeEmbedNavigation() {
-  const {
-    isSimpleEmbedFeatureAvailable,
-    isGuestEmbedsEnabled,
-    initialState,
-    experience,
-    resource,
-    currentStep,
-    setCurrentStep,
-    settings,
-    defaultSettings,
-    embeddingParameters,
-  } = useSdkIframeEmbedSetupContext();
-
+export function useSdkIframeEmbedNavigation({
+  isSimpleEmbedFeatureAvailable,
+  isGuestEmbedsEnabled,
+  initialState,
+  experience,
+  resource,
+  defaultStep,
+  currentStep,
+  setCurrentStep,
+  settings,
+  defaultSettings,
+  embeddingParameters,
+}: Pick<
+  SdkIframeEmbedSetupContextType,
+  | "isSimpleEmbedFeatureAvailable"
+  | "isGuestEmbedsEnabled"
+  | "initialState"
+  | "experience"
+  | "resource"
+  | "currentStep"
+  | "setCurrentStep"
+  | "settings"
+  | "defaultSettings"
+  | "embeddingParameters"
+> & {
+  defaultStep: SdkIframeEmbedSetupStep;
+}) {
   const availableSteps = useMemo(() => {
     // Exclude non-applicable steps for the current embed type
     return EMBED_STEPS.filter((step) => !step.skipFor?.includes(experience));
@@ -82,16 +97,15 @@ export function useSdkIframeEmbedNavigation() {
     (step) => step.id === currentStep,
   );
 
-  const canGoNext = currentIndex < availableSteps.length - 1;
-  const canGoBack = currentIndex > 0;
-
+  const isFirstStep = currentStep === defaultStep;
   const isLastStep = currentIndex === availableSteps.length - 1;
 
-  const StepContent = useMemo(
-    () =>
-      EMBED_STEPS.find((step) => step.id === currentStep)?.component ?? noop,
-    [currentStep],
+  const defaultStepIndex = EMBED_STEPS.findIndex(
+    ({ id }) => id === defaultStep,
   );
+
+  const canGoNext = currentIndex < availableSteps.length - 1;
+  const canGoBack = currentIndex > defaultStepIndex;
 
   return {
     handleNext,
@@ -100,9 +114,7 @@ export function useSdkIframeEmbedNavigation() {
     canGoNext,
     canGoBack,
 
+    isFirstStep,
     isLastStep,
-    StepContent,
   };
 }
-
-const noop = () => null;

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-sdk-iframe-embed-navigation.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-sdk-iframe-embed-navigation.ts
@@ -54,10 +54,11 @@ export function useSdkIframeEmbedNavigation({
 
     match(currentStep)
       .with("select-embed-experience", () => {
-        trackEmbedWizardExperienceCompleted(
+        trackEmbedWizardExperienceCompleted({
           experience,
-          defaultSettings.experience,
-        );
+          defaultExperience: defaultSettings.experience,
+          settings,
+        });
       })
       .with("select-embed-resource", () => {
         trackEmbedWizardResourceSelectionCompleted({

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-sdk-iframe-embed-navigation.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-sdk-iframe-embed-navigation.ts
@@ -14,6 +14,7 @@ import type { SdkIframeEmbedSetupContextType } from "../context";
 export function useSdkIframeEmbedNavigation({
   isSimpleEmbedFeatureAvailable,
   isGuestEmbedsEnabled,
+  isSsoEnabledAndConfigured,
   initialState,
   experience,
   resource,
@@ -27,6 +28,7 @@ export function useSdkIframeEmbedNavigation({
   SdkIframeEmbedSetupContextType,
   | "isSimpleEmbedFeatureAvailable"
   | "isGuestEmbedsEnabled"
+  | "isSsoEnabledAndConfigured"
   | "initialState"
   | "experience"
   | "resource"
@@ -72,6 +74,7 @@ export function useSdkIframeEmbedNavigation({
           settings,
           isSimpleEmbedFeatureAvailable,
           isGuestEmbedsEnabled,
+          isSsoEnabledAndConfigured,
           embeddingParameters,
         });
       });

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-sdk-iframe-embed-settings.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-sdk-iframe-embed-settings.ts
@@ -75,6 +75,7 @@ export const useSdkIframeEmbedSettings = ({
   modelCount,
   isSimpleEmbedFeatureAvailable,
   isGuestEmbedsEnabled,
+  isSsoEnabledAndConfigured,
 }: {
   initialState: SdkIframeEmbedSetupModalInitialState | undefined;
   recentDashboards: SdkIframeEmbedSetupRecentItem[];
@@ -82,6 +83,7 @@ export const useSdkIframeEmbedSettings = ({
   modelCount: number;
   isSimpleEmbedFeatureAvailable: boolean;
   isGuestEmbedsEnabled: boolean;
+  isSsoEnabledAndConfigured: boolean;
 }) => {
   const [isEmbedSettingsLoaded, setEmbedSettingsLoaded] = useState(false);
   const [persistedSettings, persistSettings] = usePersistedSettings({
@@ -99,6 +101,7 @@ export const useSdkIframeEmbedSettings = ({
             resourceId: initialState.resourceId,
             isSimpleEmbedFeatureAvailable,
             isGuestEmbedsEnabled,
+            isSsoEnabledAndConfigured,
           }),
       )
       .with(
@@ -110,6 +113,7 @@ export const useSdkIframeEmbedSettings = ({
             resourceId: initialState.resourceId,
             isSimpleEmbedFeatureAvailable,
             isGuestEmbedsEnabled,
+            isSsoEnabledAndConfigured,
           }),
       )
       .otherwise((initialState) =>
@@ -119,13 +123,15 @@ export const useSdkIframeEmbedSettings = ({
           resourceId: recentDashboards[0]?.id ?? EMBED_FALLBACK_DASHBOARD_ID,
           isSimpleEmbedFeatureAvailable,
           isGuestEmbedsEnabled,
+          isSsoEnabledAndConfigured,
         }),
       );
   }, [
-    recentDashboards,
     initialState,
     isSimpleEmbedFeatureAvailable,
     isGuestEmbedsEnabled,
+    isSsoEnabledAndConfigured,
+    recentDashboards,
   ]);
 
   const [rawSettings, setRawSettings] = useState<SdkIframeEmbedSetupSettings>();
@@ -164,13 +170,19 @@ export const useSdkIframeEmbedSettings = ({
           prevSettings: prevSettings ?? defaultSettings,
           settings: mergedSettings,
           isGuestEmbedsEnabled,
+          isSsoEnabledAndConfigured,
         });
 
         persistSettings(adjustedSettings);
 
         return adjustedSettings;
       }),
-    [defaultSettings, persistSettings, isGuestEmbedsEnabled],
+    [
+      defaultSettings,
+      isGuestEmbedsEnabled,
+      isSsoEnabledAndConfigured,
+      persistSettings,
+    ],
   );
 
   const replaceSettings = useCallback(
@@ -196,6 +208,7 @@ export const useSdkIframeEmbedSettings = ({
           prevSettings: prevSettings ?? defaultSettings,
           settings: mergedSettings,
           isGuestEmbedsEnabled,
+          isSsoEnabledAndConfigured,
         });
 
         return adjustedSettings;
@@ -211,6 +224,7 @@ export const useSdkIframeEmbedSettings = ({
     initialState,
     defaultSettings,
     isGuestEmbedsEnabled,
+    isSsoEnabledAndConfigured,
   ]);
 
   return {

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-sdk-iframe-embed-settings.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-sdk-iframe-embed-settings.ts
@@ -96,34 +96,37 @@ export const useSdkIframeEmbedSettings = ({
         { resourceType: "dashboard", resourceId: P.nonNullable },
         (initialState) =>
           getDefaultSdkIframeEmbedSettings({
-            initialState,
             experience: "dashboard",
             resourceId: initialState.resourceId,
             isSimpleEmbedFeatureAvailable,
             isGuestEmbedsEnabled,
             isSsoEnabledAndConfigured,
+            isGuest: !!initialState.isGuest,
+            useExistingUserSession: !!initialState.useExistingUserSession,
           }),
       )
       .with(
         { resourceType: "question", resourceId: P.nonNullable },
         (initialState) =>
           getDefaultSdkIframeEmbedSettings({
-            initialState,
             experience: "chart",
             resourceId: initialState.resourceId,
             isSimpleEmbedFeatureAvailable,
             isGuestEmbedsEnabled,
             isSsoEnabledAndConfigured,
+            isGuest: !!initialState.isGuest,
+            useExistingUserSession: !!initialState.useExistingUserSession,
           }),
       )
       .otherwise((initialState) =>
         getDefaultSdkIframeEmbedSettings({
-          initialState,
           experience: "dashboard",
           resourceId: recentDashboards[0]?.id ?? EMBED_FALLBACK_DASHBOARD_ID,
           isSimpleEmbedFeatureAvailable,
           isGuestEmbedsEnabled,
           isSsoEnabledAndConfigured,
+          isGuest: !!initialState?.isGuest,
+          useExistingUserSession: !!initialState?.useExistingUserSession,
         }),
       );
   }, [

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/types.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/types.ts
@@ -4,8 +4,8 @@ import type {
   ExplorationEmbedOptions,
   MetabotEmbedOptions,
   QuestionEmbedOptions,
+  SdkIframeEmbedAuthTypeSettings,
   SdkIframeEmbedBaseSettings,
-  SdkIframeEmbedGuestEmbedSettings,
 } from "metabase/embedding/embedding-iframe-sdk/types/embed";
 import type { BaseRecentItem } from "metabase-types/api";
 
@@ -33,7 +33,7 @@ export type SdkIframeEmbedSetupRecentItem = Pick<
 > & { id: string | number };
 
 export type SdkIframeEmbedSetupGuestEmbedSettings =
-  SdkIframeEmbedGuestEmbedSettings;
+  SdkIframeEmbedAuthTypeSettings;
 
 export type SdkIframeDashboardEmbedSettings = DashboardEmbedOptions & {
   lockedParameters?: string[];

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-adjusted-sdk-iframe-embed-setting.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-adjusted-sdk-iframe-embed-setting.ts
@@ -59,7 +59,6 @@ export const getAdjustedSdkIframeEmbedSetting = ({
           isGuestEmbedsEnabled,
           isSsoEnabledAndConfigured,
         }),
-        useExistingUserSession: settings.useExistingUserSession,
       }),
     )
     .otherwise(({ settings }) => settings);

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-adjusted-sdk-iframe-embed-setting.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-adjusted-sdk-iframe-embed-setting.ts
@@ -11,11 +11,13 @@ export const getAdjustedSdkIframeEmbedSetting = ({
   prevSettings,
   settings,
   isGuestEmbedsEnabled,
+  isSsoEnabledAndConfigured,
 }: {
   defaultSettings: SdkIframeEmbedSetupSettings;
   prevSettings: SdkIframeEmbedSetupSettings;
   settings: SdkIframeEmbedSetupSettings;
   isGuestEmbedsEnabled: boolean;
+  isSsoEnabledAndConfigured: boolean;
 }): SdkIframeEmbedSetupSettings => {
   const experience = getExperienceFromSettings(settings);
 
@@ -34,6 +36,7 @@ export const getAdjustedSdkIframeEmbedSetting = ({
           },
           experience,
           isGuestEmbedsEnabled,
+          isSsoEnabledAndConfigured,
         }),
       }),
     )
@@ -54,6 +57,7 @@ export const getAdjustedSdkIframeEmbedSetting = ({
           },
           experience,
           isGuestEmbedsEnabled,
+          isSsoEnabledAndConfigured,
         }),
         useExistingUserSession: settings.useExistingUserSession,
       }),

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-adjusted-sdk-iframe-embed-setting.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-adjusted-sdk-iframe-embed-setting.ts
@@ -30,13 +30,11 @@ export const getAdjustedSdkIframeEmbedSetting = ({
       ({ settings }) => ({
         ...settings,
         ...getCommonEmbedSettings({
-          state: {
-            isGuest: settings.isGuest,
-            useExistingUserSession: settings.useExistingUserSession,
-          },
           experience,
           isGuestEmbedsEnabled,
           isSsoEnabledAndConfigured,
+          isGuest: settings.isGuest,
+          useExistingUserSession: !!settings.useExistingUserSession,
         }),
       }),
     )
@@ -51,13 +49,11 @@ export const getAdjustedSdkIframeEmbedSetting = ({
         isSaveEnabled:
           "isSaveEnabled" in defaultSettings && defaultSettings.isSaveEnabled,
         ...getCommonEmbedSettings({
-          state: {
-            isGuest: settings.isGuest,
-            useExistingUserSession: settings.useExistingUserSession,
-          },
           experience,
           isGuestEmbedsEnabled,
           isSsoEnabledAndConfigured,
+          isGuest: settings.isGuest,
+          useExistingUserSession: !!settings.useExistingUserSession,
         }),
       }),
     )

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-auth-sub-type-for-settings.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-auth-sub-type-for-settings.ts
@@ -1,6 +1,6 @@
 import type { SdkIframeEmbedSetupSettings } from "metabase/embedding/embedding-iframe-sdk-setup/types";
 
-export const getSsoTypeForSettings = (
+export const getAuthSubTypeForSettings = (
   settings: Partial<SdkIframeEmbedSetupSettings>,
 ) =>
   settings.isGuest

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-common-embed-settings.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-common-embed-settings.ts
@@ -44,17 +44,15 @@ const GET_ENABLE_GUEST_EMBED_SETTINGS: (data: {
 };
 
 const GET_DISABLE_GUEST_EMBED_SETTINGS: (data: {
-  state:
-    | Pick<SdkIframeEmbedSetupSettings, "isGuest" | "useExistingUserSession">
-    | undefined;
   experience: SdkIframeEmbedSetupExperience;
   isSsoEnabledAndConfigured: boolean;
+  useExistingUserSession: boolean;
 }) => SdkIframeEmbedSetupGuestEmbedSettings &
   Pick<SdkIframeEmbedSetupSettings, "useExistingUserSession"> &
   Pick<
     SdkIframeDashboardEmbedSettings | SdkIframeQuestionEmbedSettings,
     "lockedParameters"
-  > = ({ state, experience, isSsoEnabledAndConfigured }) => {
+  > = ({ experience, isSsoEnabledAndConfigured, useExistingUserSession }) => {
   const isQuestionOrDashboardEmbed =
     isQuestionOrDashboardExperience(experience);
   const isQuestionEmbed = experience === "chart";
@@ -65,14 +63,14 @@ const GET_DISABLE_GUEST_EMBED_SETTINGS: (data: {
           isGuest: false,
           isSso: true,
           useExistingUserSession:
-            !isSsoEnabledAndConfigured || state?.useExistingUserSession,
+            !isSsoEnabledAndConfigured || useExistingUserSession,
           drills: true,
         }
       : {
           isGuest: false,
           isSso: true,
           useExistingUserSession:
-            !isSsoEnabledAndConfigured || state?.useExistingUserSession,
+            !isSsoEnabledAndConfigured || useExistingUserSession,
         }),
     ...(isQuestionEmbed && {
       // Currently, a chart should not have hidden parameters in non-guest embed mode
@@ -82,31 +80,31 @@ const GET_DISABLE_GUEST_EMBED_SETTINGS: (data: {
 };
 
 export const getCommonEmbedSettings = ({
-  state,
   experience,
   isGuestEmbedsEnabled,
   isSsoEnabledAndConfigured,
+  isGuest,
+  useExistingUserSession,
 }: {
-  state:
-    | Pick<SdkIframeEmbedSetupSettings, "isGuest" | "useExistingUserSession">
-    | undefined;
   experience: SdkIframeEmbedSetupExperience;
   isGuestEmbedsEnabled: boolean;
   isSsoEnabledAndConfigured: boolean;
+  isGuest: boolean;
+  useExistingUserSession: boolean;
 }) => {
   const isSimpleEmbedFeatureAvailable =
     PLUGIN_EMBEDDING_IFRAME_SDK_SETUP.isEnabled();
 
   if (isSimpleEmbedFeatureAvailable) {
-    return isGuestEmbedsEnabled && state?.isGuest
+    return isGuestEmbedsEnabled && isGuest
       ? GET_ENABLE_GUEST_EMBED_SETTINGS({
           experience,
           isSimpleEmbedFeatureAvailable,
         })
       : GET_DISABLE_GUEST_EMBED_SETTINGS({
-          state,
           experience,
           isSsoEnabledAndConfigured,
+          useExistingUserSession,
         });
   } else {
     return GET_ENABLE_GUEST_EMBED_SETTINGS({

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-common-embed-settings.unit.spec.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-common-embed-settings.unit.spec.ts
@@ -87,10 +87,11 @@ describe("getCommonEmbedSettings", () => {
         "should return correct settings for $experience experience",
         ({ experience, useExistingUserSession, expected }) => {
           const result = getCommonEmbedSettings({
-            state: { isGuest: true, useExistingUserSession },
             experience,
             isGuestEmbedsEnabled: true,
             isSsoEnabledAndConfigured: true,
+            isGuest: true,
+            useExistingUserSession,
           });
 
           expect(result).toEqual(expected);
@@ -158,10 +159,11 @@ describe("getCommonEmbedSettings", () => {
           expected,
         }) => {
           const result = getCommonEmbedSettings({
-            state: { isGuest: false, useExistingUserSession },
             experience,
             isGuestEmbedsEnabled: false,
             isSsoEnabledAndConfigured,
+            isGuest: false,
+            useExistingUserSession,
           });
 
           expect(result).toEqual(expected);
@@ -170,45 +172,49 @@ describe("getCommonEmbedSettings", () => {
 
       it("should reset hiddenParameters for chart but not for dashboard in non-guest mode", () => {
         const chartResult = getCommonEmbedSettings({
-          state: { isGuest: false, useExistingUserSession: true },
           experience: "chart",
           isGuestEmbedsEnabled: false,
           isSsoEnabledAndConfigured: true,
+          isGuest: false,
+          useExistingUserSession: true,
         });
 
         const dashboardResult = getCommonEmbedSettings({
-          state: { isGuest: false, useExistingUserSession: true },
           experience: "dashboard",
           isGuestEmbedsEnabled: false,
           isSsoEnabledAndConfigured: true,
+          isGuest: false,
+          useExistingUserSession: true,
         });
 
         expect(chartResult).toHaveProperty("hiddenParameters", []);
         expect(dashboardResult).not.toHaveProperty("hiddenParameters");
       });
 
-      it("should handle undefined state", () => {
+      it("should handle `false` for isGuest and `useExistingUserSession`", () => {
         const result = getCommonEmbedSettings({
-          state: undefined,
           experience: "dashboard",
           isGuestEmbedsEnabled: false,
           isSsoEnabledAndConfigured: true,
+          isGuest: false,
+          useExistingUserSession: false,
         });
 
         expect(result).toEqual({
           isGuest: false,
           isSso: true,
-          useExistingUserSession: undefined,
+          useExistingUserSession: false,
           drills: true,
         });
       });
 
       it("should set useExistingUserSession to true when isSsoEnabledAndConfigured is false", () => {
         const result = getCommonEmbedSettings({
-          state: { isGuest: false, useExistingUserSession: false },
           experience: "dashboard",
           isGuestEmbedsEnabled: false,
           isSsoEnabledAndConfigured: false,
+          isGuest: false,
+          useExistingUserSession: false,
         });
 
         expect(result).toHaveProperty("useExistingUserSession", true);
@@ -244,10 +250,11 @@ describe("getCommonEmbedSettings", () => {
         "should return non-guest settings for $experience experience",
         ({ experience, useExistingUserSession, expected }) => {
           const result = getCommonEmbedSettings({
-            state: { isGuest: false, useExistingUserSession },
             experience,
             isGuestEmbedsEnabled: true,
             isSsoEnabledAndConfigured: true,
+            isGuest: false,
+            useExistingUserSession,
           });
 
           expect(result).toEqual(expected);
@@ -318,10 +325,11 @@ describe("getCommonEmbedSettings", () => {
       "should return correct settings for $experience experience",
       ({ experience, expected }) => {
         const result = getCommonEmbedSettings({
-          state: { isGuest: false, useExistingUserSession: false },
           experience,
           isGuestEmbedsEnabled: false,
           isSsoEnabledAndConfigured: false,
+          isGuest: false,
+          useExistingUserSession: false,
         });
 
         expect(result).toEqual(expected);
@@ -330,17 +338,19 @@ describe("getCommonEmbedSettings", () => {
 
     it("should ignore isGuestEmbedsEnabled parameter for dashboard/chart", () => {
       const resultWithTrue = getCommonEmbedSettings({
-        state: { isGuest: false, useExistingUserSession: false },
         experience: "dashboard",
         isGuestEmbedsEnabled: true,
         isSsoEnabledAndConfigured: false,
+        isGuest: false,
+        useExistingUserSession: false,
       });
 
       const resultWithFalse = getCommonEmbedSettings({
-        state: { isGuest: false, useExistingUserSession: false },
         experience: "dashboard",
         isGuestEmbedsEnabled: false,
         isSsoEnabledAndConfigured: false,
+        isGuest: false,
+        useExistingUserSession: false,
       });
 
       expect(resultWithTrue).toEqual(resultWithFalse);
@@ -356,21 +366,23 @@ describe("getCommonEmbedSettings", () => {
 
     it("should force withDownloads=true for dashboard/chart", () => {
       const result = getCommonEmbedSettings({
-        state: undefined,
         experience: "dashboard",
         isGuestEmbedsEnabled: true,
         isSsoEnabledAndConfigured: false,
+        isGuest: false,
+        useExistingUserSession: false,
       });
 
       expect(result).toHaveProperty("withDownloads", true);
     });
 
-    it("should handle undefined state", () => {
+    it("should handle false for isGuest and useExistingUserSession", () => {
       const result = getCommonEmbedSettings({
-        state: undefined,
         experience: "chart",
         isGuestEmbedsEnabled: false,
         isSsoEnabledAndConfigured: false,
+        isGuest: false,
+        useExistingUserSession: false,
       });
 
       expect(result).toEqual({

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-common-embed-settings.unit.spec.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-common-embed-settings.unit.spec.ts
@@ -36,6 +36,7 @@ describe("getCommonEmbedSettings", () => {
           useExistingUserSession: false,
           expected: {
             isGuest: true,
+            isSso: false,
             useExistingUserSession: false,
             drills: false,
             hiddenParameters: [],
@@ -46,6 +47,7 @@ describe("getCommonEmbedSettings", () => {
           useExistingUserSession: false,
           expected: {
             isGuest: true,
+            isSso: false,
             useExistingUserSession: false,
             drills: false,
             hiddenParameters: [],
@@ -56,6 +58,7 @@ describe("getCommonEmbedSettings", () => {
           useExistingUserSession: true,
           expected: {
             isGuest: false,
+            isSso: true,
             useExistingUserSession: true,
             hiddenParameters: [],
           },
@@ -65,6 +68,7 @@ describe("getCommonEmbedSettings", () => {
           useExistingUserSession: true,
           expected: {
             isGuest: false,
+            isSso: true,
             useExistingUserSession: true,
             hiddenParameters: [],
           },
@@ -74,6 +78,7 @@ describe("getCommonEmbedSettings", () => {
           useExistingUserSession: true,
           expected: {
             isGuest: false,
+            isSso: true,
             useExistingUserSession: true,
             hiddenParameters: [],
           },
@@ -85,6 +90,7 @@ describe("getCommonEmbedSettings", () => {
             state: { isGuest: true, useExistingUserSession },
             experience,
             isGuestEmbedsEnabled: true,
+            isSsoEnabledAndConfigured: true,
           });
 
           expect(result).toEqual(expected);
@@ -96,13 +102,27 @@ describe("getCommonEmbedSettings", () => {
       it.each<{
         experience: SdkIframeEmbedSetupExperience;
         useExistingUserSession: boolean;
+        isSsoEnabledAndConfigured: boolean;
         expected: Record<string, unknown>;
       }>([
         {
           experience: "dashboard",
           useExistingUserSession: true,
+          isSsoEnabledAndConfigured: true,
           expected: {
             isGuest: false,
+            isSso: true,
+            useExistingUserSession: true,
+            drills: true,
+          },
+        },
+        {
+          experience: "dashboard",
+          useExistingUserSession: false,
+          isSsoEnabledAndConfigured: false,
+          expected: {
+            isGuest: false,
+            isSso: true,
             useExistingUserSession: true,
             drills: true,
           },
@@ -110,8 +130,10 @@ describe("getCommonEmbedSettings", () => {
         {
           experience: "chart",
           useExistingUserSession: false,
+          isSsoEnabledAndConfigured: true,
           expected: {
             isGuest: false,
+            isSso: true,
             useExistingUserSession: false,
             drills: true,
             hiddenParameters: [],
@@ -120,18 +142,26 @@ describe("getCommonEmbedSettings", () => {
         {
           experience: "exploration",
           useExistingUserSession: true,
+          isSsoEnabledAndConfigured: true,
           expected: {
             isGuest: false,
+            isSso: true,
             useExistingUserSession: true,
           },
         },
       ])(
-        "should return non-guest settings for $experience experience",
-        ({ experience, useExistingUserSession, expected }) => {
+        "should return non-guest settings for $experience experience (useExistingUserSession=$useExistingUserSession, isSsoEnabledAndConfigured=$isSsoEnabledAndConfigured)",
+        ({
+          experience,
+          useExistingUserSession,
+          isSsoEnabledAndConfigured,
+          expected,
+        }) => {
           const result = getCommonEmbedSettings({
             state: { isGuest: false, useExistingUserSession },
             experience,
             isGuestEmbedsEnabled: false,
+            isSsoEnabledAndConfigured,
           });
 
           expect(result).toEqual(expected);
@@ -143,12 +173,14 @@ describe("getCommonEmbedSettings", () => {
           state: { isGuest: false, useExistingUserSession: true },
           experience: "chart",
           isGuestEmbedsEnabled: false,
+          isSsoEnabledAndConfigured: true,
         });
 
         const dashboardResult = getCommonEmbedSettings({
           state: { isGuest: false, useExistingUserSession: true },
           experience: "dashboard",
           isGuestEmbedsEnabled: false,
+          isSsoEnabledAndConfigured: true,
         });
 
         expect(chartResult).toHaveProperty("hiddenParameters", []);
@@ -160,13 +192,26 @@ describe("getCommonEmbedSettings", () => {
           state: undefined,
           experience: "dashboard",
           isGuestEmbedsEnabled: false,
+          isSsoEnabledAndConfigured: true,
         });
 
         expect(result).toEqual({
           isGuest: false,
+          isSso: true,
           useExistingUserSession: undefined,
           drills: true,
         });
+      });
+
+      it("should set useExistingUserSession to true when isSsoEnabledAndConfigured is false", () => {
+        const result = getCommonEmbedSettings({
+          state: { isGuest: false, useExistingUserSession: false },
+          experience: "dashboard",
+          isGuestEmbedsEnabled: false,
+          isSsoEnabledAndConfigured: false,
+        });
+
+        expect(result).toHaveProperty("useExistingUserSession", true);
       });
     });
 
@@ -181,6 +226,7 @@ describe("getCommonEmbedSettings", () => {
           useExistingUserSession: true,
           expected: {
             isGuest: false,
+            isSso: true,
             useExistingUserSession: true,
             drills: true,
           },
@@ -190,6 +236,7 @@ describe("getCommonEmbedSettings", () => {
           useExistingUserSession: false,
           expected: {
             isGuest: false,
+            isSso: true,
             useExistingUserSession: false,
           },
         },
@@ -200,6 +247,7 @@ describe("getCommonEmbedSettings", () => {
             state: { isGuest: false, useExistingUserSession },
             experience,
             isGuestEmbedsEnabled: true,
+            isSsoEnabledAndConfigured: true,
           });
 
           expect(result).toEqual(expected);
@@ -221,6 +269,7 @@ describe("getCommonEmbedSettings", () => {
         experience: "dashboard",
         expected: {
           isGuest: true,
+          isSso: false,
           useExistingUserSession: false,
           drills: false,
           withDownloads: true,
@@ -231,6 +280,7 @@ describe("getCommonEmbedSettings", () => {
         experience: "chart",
         expected: {
           isGuest: true,
+          isSso: false,
           useExistingUserSession: false,
           drills: false,
           withDownloads: true,
@@ -241,6 +291,7 @@ describe("getCommonEmbedSettings", () => {
         experience: "exploration",
         expected: {
           isGuest: false,
+          isSso: true,
           useExistingUserSession: true,
           hiddenParameters: [],
         },
@@ -249,6 +300,7 @@ describe("getCommonEmbedSettings", () => {
         experience: "browser",
         expected: {
           isGuest: false,
+          isSso: true,
           useExistingUserSession: true,
           hiddenParameters: [],
         },
@@ -257,6 +309,7 @@ describe("getCommonEmbedSettings", () => {
         experience: "metabot",
         expected: {
           isGuest: false,
+          isSso: true,
           useExistingUserSession: true,
           hiddenParameters: [],
         },
@@ -268,6 +321,7 @@ describe("getCommonEmbedSettings", () => {
           state: { isGuest: false, useExistingUserSession: false },
           experience,
           isGuestEmbedsEnabled: false,
+          isSsoEnabledAndConfigured: false,
         });
 
         expect(result).toEqual(expected);
@@ -279,17 +333,20 @@ describe("getCommonEmbedSettings", () => {
         state: { isGuest: false, useExistingUserSession: false },
         experience: "dashboard",
         isGuestEmbedsEnabled: true,
+        isSsoEnabledAndConfigured: false,
       });
 
       const resultWithFalse = getCommonEmbedSettings({
         state: { isGuest: false, useExistingUserSession: false },
         experience: "dashboard",
         isGuestEmbedsEnabled: false,
+        isSsoEnabledAndConfigured: false,
       });
 
       expect(resultWithTrue).toEqual(resultWithFalse);
       expect(resultWithTrue).toEqual({
         isGuest: true,
+        isSso: false,
         useExistingUserSession: false,
         drills: false,
         withDownloads: true,
@@ -302,6 +359,7 @@ describe("getCommonEmbedSettings", () => {
         state: undefined,
         experience: "dashboard",
         isGuestEmbedsEnabled: true,
+        isSsoEnabledAndConfigured: false,
       });
 
       expect(result).toHaveProperty("withDownloads", true);
@@ -312,10 +370,12 @@ describe("getCommonEmbedSettings", () => {
         state: undefined,
         experience: "chart",
         isGuestEmbedsEnabled: false,
+        isSsoEnabledAndConfigured: false,
       });
 
       expect(result).toEqual({
         isGuest: true,
+        isSso: false,
         useExistingUserSession: false,
         drills: false,
         withDownloads: true,

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-default-sdk-iframe-embed-setting.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-default-sdk-iframe-embed-setting.ts
@@ -9,7 +9,6 @@ import type {
   QuestionEmbedOptions,
   SdkIframeEmbedBaseSettings,
 } from "metabase/embedding/embedding-iframe-sdk/types/embed";
-import type { SdkIframeEmbedSetupModalInitialState } from "metabase/plugins";
 
 import type {
   SdkIframeEmbedSetupExperience,
@@ -19,19 +18,21 @@ import type {
 import { getCommonEmbedSettings } from "./get-common-embed-settings";
 
 export const getDefaultSdkIframeEmbedSettings = ({
-  initialState,
   experience,
   resourceId,
   isSimpleEmbedFeatureAvailable,
   isGuestEmbedsEnabled,
   isSsoEnabledAndConfigured,
+  isGuest,
+  useExistingUserSession,
 }: {
-  initialState: SdkIframeEmbedSetupModalInitialState | undefined;
   experience: SdkIframeEmbedSetupExperience;
   resourceId: SdkDashboardId | SdkQuestionId;
   isSimpleEmbedFeatureAvailable: boolean;
   isGuestEmbedsEnabled: boolean;
   isSsoEnabledAndConfigured: boolean;
+  isGuest: boolean;
+  useExistingUserSession: boolean;
 }): SdkIframeEmbedSetupSettings => {
   const baseSettingsDefaults: Partial<SdkIframeEmbedBaseSettings> = {
     useExistingUserSession: true,
@@ -92,10 +93,11 @@ export const getDefaultSdkIframeEmbedSettings = ({
     ...baseSettingsDefaults,
     ...experienceSettingsDefaults,
     ...getCommonEmbedSettings({
-      state: initialState,
       experience,
       isGuestEmbedsEnabled,
       isSsoEnabledAndConfigured,
+      isGuest,
+      useExistingUserSession,
     }),
   };
 };

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-default-sdk-iframe-embed-setting.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-default-sdk-iframe-embed-setting.ts
@@ -24,12 +24,14 @@ export const getDefaultSdkIframeEmbedSettings = ({
   resourceId,
   isSimpleEmbedFeatureAvailable,
   isGuestEmbedsEnabled,
+  isSsoEnabledAndConfigured,
 }: {
   initialState: SdkIframeEmbedSetupModalInitialState | undefined;
   experience: SdkIframeEmbedSetupExperience;
   resourceId: SdkDashboardId | SdkQuestionId;
   isSimpleEmbedFeatureAvailable: boolean;
   isGuestEmbedsEnabled: boolean;
+  isSsoEnabledAndConfigured: boolean;
 }): SdkIframeEmbedSetupSettings => {
   const baseSettingsDefaults: Partial<SdkIframeEmbedBaseSettings> = {
     useExistingUserSession: true,
@@ -93,6 +95,7 @@ export const getDefaultSdkIframeEmbedSettings = ({
       state: initialState,
       experience,
       isGuestEmbedsEnabled,
+      isSsoEnabledAndConfigured,
     }),
   };
 };

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-default-sdk-iframe-embed-setting.unit.spec.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-default-sdk-iframe-embed-setting.unit.spec.ts
@@ -15,6 +15,7 @@ const BASE_PARAMS = {
   resourceId: 123,
   isSimpleEmbedFeatureAvailable: true,
   isGuestEmbedsEnabled: false,
+  isSsoEnabledAndConfigured: true,
 } as const;
 
 describe("getDefaultSdkIframeEmbedSettings", () => {

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-default-sdk-iframe-embed-setting.unit.spec.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-default-sdk-iframe-embed-setting.unit.spec.ts
@@ -67,6 +67,8 @@ describe("getDefaultSdkIframeEmbedSettings", () => {
         const result = getDefaultSdkIframeEmbedSettings({
           ...BASE_PARAMS,
           experience,
+          isGuest: false,
+          useExistingUserSession: false,
         });
 
         expect(result).toMatchObject({
@@ -84,6 +86,8 @@ describe("getDefaultSdkIframeEmbedSettings", () => {
         ...BASE_PARAMS,
         experience: "dashboard",
         isSimpleEmbedFeatureAvailable: false,
+        isGuest: false,
+        useExistingUserSession: false,
       });
 
       expect(result.theme).toEqual({ preset: "light" });
@@ -96,6 +100,8 @@ describe("getDefaultSdkIframeEmbedSettings", () => {
         ...BASE_PARAMS,
         experience: "dashboard",
         isSimpleEmbedFeatureAvailable: true,
+        isGuest: false,
+        useExistingUserSession: false,
       });
 
       expect(result.theme).toBeUndefined();

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-sso-type-for-settings.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-sso-type-for-settings.ts
@@ -2,4 +2,9 @@ import type { SdkIframeEmbedSetupSettings } from "metabase/embedding/embedding-i
 
 export const getSsoTypeForSettings = (
   settings: Partial<SdkIframeEmbedSetupSettings>,
-) => (settings.useExistingUserSession ? "user-session" : "sso");
+) =>
+  settings.isGuest
+    ? "none"
+    : settings.useExistingUserSession
+      ? "user-session"
+      : "sso";

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-sso-type-for-settings.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-sso-type-for-settings.ts
@@ -1,5 +1,5 @@
 import type { SdkIframeEmbedSetupSettings } from "metabase/embedding/embedding-iframe-sdk-setup/types";
 
-export const getAuthTypeForSettings = (
+export const getSsoTypeForSettings = (
   settings: Partial<SdkIframeEmbedSetupSettings>,
-) => (settings.isGuest ? "guest-embed" : "sso");
+) => (settings.useExistingUserSession ? "user-session" : "sso");

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
@@ -189,7 +189,8 @@ export type SdkIframeEmbedBaseSettings = {
   _isLocalhost?: boolean;
 };
 
-export type SdkIframeEmbedGuestEmbedSettings = {
+export type SdkIframeEmbedAuthTypeSettings = {
+  isSso: boolean;
   isGuest: boolean;
 };
 


### PR DESCRIPTION
Adjusted auth controls

We: 
- move Auth Type control to the initial step in a wizard (initial step is the step that is displayed when wizard is opened), it allows to select Guest or SSO
- we prevent going back from the initial step by hiding the back button (dicsussed with @AlessioLaiso)
- on the last step we show `session` and `sso` select. The SSO is enabled only when JWT or SAML is configured
- if method is `session` and SSO and SAML are not configured - we show yellow warning with a link 