### PR TITLE
wraps transforms execute! multimethod with a function

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -298,6 +298,7 @@
    metabase.lib.convert/->legacy-MBQL                 {:message "Conversion to legacy MBQL is discouraged, please use Lib to manipulate MBQL queries"}
    metabase.lib.core/->legacy-MBQL                    {:message "Conversion to legacy MBQL is discouraged, please use Lib to manipulate MBQL queries"}
    metabase.lib.equality/find-column-indexes-for-refs {:message "Use lib.equality/closest-matches-in-metadata or lib.equality/find-closest-matches-for-refs instead of lib.equality/find-column-indexes-for-refs"}
+   metabase-enterprise.transforms.interface/execute!  {:message "Use metabase-enterprise.transforms.execute/execute! instead of metabase-enterprise.transforms.interface/execute!"}
    next.jdbc/active-tx?                               {:message "Use metabase.app-db.core/in-transaction? to see if we are in a transaction"}
    toucan2.core/debug                                 {:message "Don't commit code using t2/debug"}
    toucan2.tools.debug/debug                          {:message "Don't commit code using t2/debug"}}

--- a/enterprise/backend/src/metabase_enterprise/transforms/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/api.clj
@@ -4,6 +4,7 @@
    [metabase-enterprise.transforms.api.transform-job]
    [metabase-enterprise.transforms.api.transform-tag]
    [metabase-enterprise.transforms.canceling :as transforms.canceling]
+   [metabase-enterprise.transforms.execute :as transforms.execute]
    [metabase-enterprise.transforms.interface :as transforms.i]
    [metabase-enterprise.transforms.models.transform :as transform.model]
    [metabase-enterprise.transforms.models.transform-run :as transform-run]
@@ -264,8 +265,8 @@
         _         (check-feature-enabled! transform)
         start-promise (promise)]
     (u.jvm/in-virtual-thread*
-     (transforms.i/execute! transform {:start-promise start-promise
-                                       :run-method :manual}))
+     (transforms.execute/execute! transform {:start-promise start-promise
+                                             :run-method :manual}))
     (when (instance? Throwable @start-promise)
       (throw @start-promise))
     (let [result @start-promise

--- a/enterprise/backend/src/metabase_enterprise/transforms/execute.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/execute.clj
@@ -1,81 +1,16 @@
 (ns metabase-enterprise.transforms.execute
   (:require
-   [metabase-enterprise.transforms.instrumentation :as transforms.instrumentation]
-   [metabase-enterprise.transforms.util :as transforms.util]
-   [metabase.driver :as driver]
-   [metabase.driver.util :as driver.u]
-   [metabase.events.core :as events]
-   [metabase.lib.schema.common :as schema.common]
-   [metabase.query-processor.compile :as qp.compile]
-   [metabase.util.log :as log]
-   [metabase.util.malli.registry :as mr]
-   [toucan2.core :as t2]))
+   [metabase-enterprise.transforms.interface :as transforms.i]))
 
 (set! *warn-on-reflection* true)
 
-(mr/def ::transform-details
-  [:map
-   [:transform-type [:enum {:decode/normalize schema.common/normalize-keyword} :table :table-incremental]]
-   [:conn-spec :any]
-   [:query ::qp.compile/compiled]
-   [:output-table [:keyword {:decode/normalize schema.common/normalize-keyword}]]])
-
-(mr/def ::transform-opts
-  [:map
-   [:overwrite? :boolean]])
-
-(defn- transform-opts [{:keys [transform-type]}]
-  (case transform-type
-    :table {:overwrite? true}
-
-    ;; once we have more than just append, dispatch on :target-incremental-strategy
-    :table-incremental {}))
-
-(defn run-mbql-transform!
+(defn execute!
   "Run `transform` and sync its target table.
 
   This is executing synchronously, but supports being kicked off in the background
   by delivering the `start-promise` just before the start when the beginning of the execution has been booked
   in the database."
-  ([transform] (run-mbql-transform! transform nil))
-  ([{:keys [id source target] :as transform} {:keys [run-method start-promise]}]
-   (try
-     (let [db (get-in source [:query :database])
-           {driver :engine :as database} (t2/select-one :model/Database db)
-           transform-details {:db-id db
-                              :database database
-                              :transform-id   id
-                              :transform-type (keyword (:type target))
-                              :conn-spec (driver/connection-spec driver database)
-                              :query (transforms.util/compile-source transform)
-                              :output-schema (:schema target)
-                              :output-table (transforms.util/qualified-table-name driver target)}
-           opts (transform-opts transform-details)
-           features (transforms.util/required-database-features transform)]
-
-       (when (transforms.util/db-routing-enabled? database)
-         (throw (ex-info "Transforms are not supported on databases with DB routing enabled."
-                         {:driver driver, :database database})))
-       (when-not (every? (fn [feature] (driver.u/supports? (:engine database) feature database)) features)
-         (throw (ex-info "The database does not support the requested transform target type."
-                         {:driver driver, :database database, :features features})))
-       ;; mark the execution as started and notify any observers
-       (let [{run-id :id} (transforms.util/try-start-unless-already-running id run-method)]
-         (when start-promise
-           (deliver start-promise [:started run-id]))
-         (log/info "Executing transform" id "with target" (pr-str target))
-         (transforms.instrumentation/with-stage-timing [run-id [:computation :mbql-query]]
-           (transforms.util/run-cancelable-transform!
-            run-id driver transform-details
-            (fn [_cancel-chan] (driver/run-transform! driver transform-details opts))))
-         (transforms.instrumentation/with-stage-timing [run-id [:import :table-sync]]
-           (transforms.util/sync-target! target database)
-         ;; This event must be published only after the sync is complete - the new table needs to be in AppDB.
-           (events/publish-event! :event/transform-run-complete {:object transform-details}))))
-     (catch Throwable t
-       (log/error t "Error executing transform")
-       (when start-promise
-         ;; if the start-promise has been delivered, this is a no-op,
-         ;; but we assume nobody would catch the exception anyway
-         (deliver start-promise t))
-       (throw t)))))
+  ([transform]
+   (execute! transform nil))
+  ([transform opts]
+   (transforms.i/execute! transform opts)))

--- a/enterprise/backend/src/metabase_enterprise/transforms/execute.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/execute.clj
@@ -13,4 +13,5 @@
   ([transform]
    (execute! transform nil))
   ([transform opts]
+   #_{:clj-kondo/ignore [:discouraged-var]}
    (transforms.i/execute! transform opts)))

--- a/enterprise/backend/src/metabase_enterprise/transforms/interface.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/interface.clj
@@ -35,7 +35,9 @@
 
   - `:run-method`
      Expected to be either `:cron` (for scheduled runs) or `:manual` (for ad-hoc or test runs)
-     Used for instrumentation / metadata purposes."
+     Used for instrumentation / metadata purposes.
+
+  Do not use this directly. Use [[metabase-enterprise.transforms.execute/execute!]] instead."
   {:added "0.57.0" :arglists '([transform options])}
   (fn [transform _options]
     (transform->transform-type transform)))

--- a/enterprise/backend/src/metabase_enterprise/transforms/jobs.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/jobs.clj
@@ -5,8 +5,8 @@
    [clojurewerkz.quartzite.schedule.calendar-interval :as calendar-interval]
    [clojurewerkz.quartzite.triggers :as triggers]
    [flatland.ordered.set :as ordered-set]
+   [metabase-enterprise.transforms.execute :as transforms.execute]
    [metabase-enterprise.transforms.instrumentation :as transforms.instrumentation]
-   [metabase-enterprise.transforms.interface :as transforms.i]
    [metabase-enterprise.transforms.models.job-run :as transforms.job-run]
    [metabase-enterprise.transforms.models.transform-run :as transform-run]
    [metabase-enterprise.transforms.ordering :as transforms.ordering]
@@ -76,7 +76,7 @@
           (when (transform-run/running-run-for-transform-id transform-id)
             (recur))))
       (log/info "Executing job transform" (pr-str transform-id))
-      (transforms.i/execute! transform {:run-method run-method})
+      (transforms.execute/execute! transform {:run-method run-method})
       (transforms.job-run/add-run-activity! run-id))))
 
 (defn run-transforms!

--- a/enterprise/backend/src/metabase_enterprise/transforms/query_impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/query_impl.clj
@@ -1,7 +1,16 @@
 (ns metabase-enterprise.transforms.query-impl
   (:require
-   [metabase-enterprise.transforms.execute :as transforms.execute]
-   [metabase-enterprise.transforms.interface :as transforms.i]))
+   [metabase-enterprise.transforms.instrumentation :as transforms.instrumentation]
+   [metabase-enterprise.transforms.interface :as transforms.i]
+   [metabase-enterprise.transforms.util :as transforms.util]
+   [metabase.driver :as driver]
+   [metabase.driver.util :as driver.u]
+   [metabase.events.core :as events]
+   [metabase.lib.schema.common :as schema.common]
+   [metabase.query-processor.compile :as qp.compile]
+   [metabase.util.log :as log]
+   [metabase.util.malli.registry :as mr]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -13,5 +22,67 @@
   [transform]
   (-> transform :source :query :database))
 
+(mr/def ::transform-details
+  [:map
+   [:transform-type [:enum {:decode/normalize schema.common/normalize-keyword} :table :table-incremental]]
+   [:conn-spec :any]
+   [:query ::qp.compile/compiled]
+   [:output-table [:keyword {:decode/normalize schema.common/normalize-keyword}]]])
+
+(mr/def ::transform-opts
+  [:map
+   [:overwrite? :boolean]])
+
+(defn- transform-opts [{:keys [transform-type]}]
+  (case transform-type
+    :table {:overwrite? true}
+
+    ;; once we have more than just append, dispatch on :target-incremental-strategy
+    :table-incremental {}))
+
+(defn- run-mbql-transform!
+  ([transform] (run-mbql-transform! transform nil))
+  ([{:keys [id source target] :as transform} {:keys [run-method start-promise]}]
+   (try
+     (let [db (get-in source [:query :database])
+           {driver :engine :as database} (t2/select-one :model/Database db)
+           transform-details {:db-id db
+                              :database database
+                              :transform-id   id
+                              :transform-type (keyword (:type target))
+                              :conn-spec (driver/connection-spec driver database)
+                              :query (transforms.util/compile-source transform)
+                              :output-schema (:schema target)
+                              :output-table (transforms.util/qualified-table-name driver target)}
+           opts (transform-opts transform-details)
+           features (transforms.util/required-database-features transform)]
+
+       (when (transforms.util/db-routing-enabled? database)
+         (throw (ex-info "Transforms are not supported on databases with DB routing enabled."
+                         {:driver driver, :database database})))
+       (when-not (every? (fn [feature] (driver.u/supports? (:engine database) feature database)) features)
+         (throw (ex-info "The database does not support the requested transform target type."
+                         {:driver driver, :database database, :features features})))
+       ;; mark the execution as started and notify any observers
+       (let [{run-id :id} (transforms.util/try-start-unless-already-running id run-method)]
+         (when start-promise
+           (deliver start-promise [:started run-id]))
+         (log/info "Executing transform" id "with target" (pr-str target))
+         (transforms.instrumentation/with-stage-timing [run-id [:computation :mbql-query]]
+           (transforms.util/run-cancelable-transform!
+            run-id driver transform-details
+            (fn [_cancel-chan] (driver/run-transform! driver transform-details opts))))
+         (transforms.instrumentation/with-stage-timing [run-id [:import :table-sync]]
+           (transforms.util/sync-target! target database)
+         ;; This event must be published only after the sync is complete - the new table needs to be in AppDB.
+           (events/publish-event! :event/transform-run-complete {:object transform-details}))))
+     (catch Throwable t
+       (log/error t "Error executing transform")
+       (when start-promise
+         ;; if the start-promise has been delivered, this is a no-op,
+         ;; but we assume nobody would catch the exception anyway
+         (deliver start-promise t))
+       (throw t)))))
+
 (defmethod transforms.i/execute! :query [transform opts]
-  (transforms.execute/run-mbql-transform! transform opts))
+  (run-mbql-transform! transform opts))

--- a/enterprise/backend/src/metabase_enterprise/transforms/query_impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/query_impl.clj
@@ -84,5 +84,6 @@
          (deliver start-promise t))
        (throw t)))))
 
+#_{:clj-kondo/ignore [:discouraged-var]}
 (defmethod transforms.i/execute! :query [transform opts]
   (run-mbql-transform! transform opts))

--- a/enterprise/backend/src/metabase_enterprise/transforms_python/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms_python/impl.clj
@@ -11,6 +11,7 @@
   [transform]
   (-> transform :source :database))
 
+#_{:clj-kondo/ignore [:discouraged-var]}
 (defmethod transforms.i/execute! :python
   [transform options]
   (transforms-python.execute/execute-python-transform! transform options))

--- a/enterprise/backend/test/metabase_enterprise/transforms/jobs_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/jobs_test.clj
@@ -3,7 +3,7 @@
   (:require
    [clojure.test :refer :all]
    [clojure.tools.logging :as log]
-   [metabase-enterprise.transforms.interface :as transforms.i]
+   [metabase-enterprise.transforms.execute :as transforms.execute]
    [metabase-enterprise.transforms.jobs :as jobs]
    [metabase-enterprise.transforms.models.transform-run :as transform-run]
    [metabase.test :as mt]))
@@ -134,8 +134,8 @@
         (with-redefs [log/log* (fn [_ level _ message]
                                  (swap! logged-messages conj {:level level :message message}))
                       transform-run/running-run-for-transform-id (constantly nil)
-                      transforms.i/execute! (fn [_ _]
-                                              (reset! run-called? true))]
+                      transforms.execute/execute! (fn [_ _]
+                                                    (reset! run-called? true))]
           (#'jobs/run-transform! run-id :scheduled query-transform)
           (is (empty? (filter (comp #{:warn} :level) @logged-messages))
               "Should not log warnings when feature is enabled")

--- a/enterprise/backend/test/metabase_enterprise/transforms/ordering_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/ordering_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.transforms.execute :as transforms.execute]
+   [metabase-enterprise.transforms.interface :as transforms.i]
    [metabase-enterprise.transforms.ordering :as ordering]
    [metabase.driver :as driver]
    [metabase.driver.sql :as driver.sql]

--- a/enterprise/backend/test/metabase_enterprise/transforms/ordering_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/ordering_test.clj
@@ -1,7 +1,7 @@
 (ns ^:mb/driver-tests metabase-enterprise.transforms.ordering-test
   (:require
    [clojure.test :refer :all]
-   [metabase-enterprise.transforms.interface :as transforms.i]
+   [metabase-enterprise.transforms.execute :as transforms.execute]
    [metabase-enterprise.transforms.ordering :as ordering]
    [metabase.driver :as driver]
    [metabase.driver.sql :as driver.sql]
@@ -111,7 +111,7 @@
                                                                   LIMIT 100"}}
                                                 "venues_transform_2")]
         (try
-          (transforms.i/execute! transform1 {:run-method :manual})
+          (transforms.execute/execute! transform1 {:run-method :manual})
           (let [table1 (t2/select-one-pk :model/Table :name "checkins_transform")]
             (is (= #{{:table table1} {:transform t2}}
                    (transform-deps-for-db (t2/select-one :model/Transform  t3)))))


### PR DESCRIPTION
the indirection is good so we can perform side effects when executing any type of transforms. We'll need this for workspaces where we want to execute transform in the scope of an isolated user