### PR TITLE
fix: remote-sync icons matching non-collections

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/collections/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/collections/utils.ts
@@ -64,21 +64,22 @@ export const getIcon = (item: ObjectWithModel): IconData => {
     };
   }
 
-  if (item.is_remote_synced) {
-    return {
-      name: REMOTE_SYNC_COLLECTION.icon,
-    };
-  }
+  if (item.model === "collection") {
+    if (item.is_remote_synced) {
+      return {
+        name: REMOTE_SYNC_COLLECTION.icon,
+      };
+    }
 
-  if (
-    item.model === "collection" &&
-    (item.authority_level === "official" ||
-      item.collection_authority_level === "official")
-  ) {
-    return {
-      name: OFFICIAL_COLLECTION.icon,
-      color: OFFICIAL_COLLECTION.color,
-    };
+    if (
+      item.authority_level === "official" ||
+      item.collection_authority_level === "official"
+    ) {
+      return {
+        name: OFFICIAL_COLLECTION.icon,
+        color: OFFICIAL_COLLECTION.color,
+      };
+    }
   }
 
   if (item.model === "dataset" && item.moderated_status === "verified") {

--- a/enterprise/frontend/src/metabase-enterprise/collections/utils.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/collections/utils.unit.spec.tsx
@@ -91,6 +91,18 @@ describe("Collections plugin utils", () => {
         ).toEqual({ name: "official_collection", color: "saturated-yellow" });
       });
 
+      it("should return the correct icon for a remote synced collection", () => {
+        expect(
+          getIcon({ model: "collection", is_remote_synced: true }),
+        ).toEqual({ name: "synced_collection" });
+      });
+
+      it("should return the correct icon for a remote synced entity", () => {
+        expect(getIcon({ model: "dashboard", is_remote_synced: true })).toEqual(
+          { name: "dashboard" },
+        );
+      });
+
       it("official collection in search", () => {
         const collection = {
           id: 101,


### PR DESCRIPTION
### Description

When moving from the collection_type to flag for remote-syncing collections, we're checking the is_remote_synced property without checking if the item is actually a collection. Non-collections get this value set as well. 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
