### PR TITLE
Fix mbql 4 schema to handle aggregations as part of filters

### DIFF
--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -425,10 +425,6 @@
 ;; Currently aggregate Field references can only be used inside order-by clauses. In the future once we support SQL
 ;; `HAVING` we can allow them in filter clauses too
 ;;
-;; TODO - shouldn't we allow composing aggregations in expressions? e.g.
-;;
-;;    {:order-by [[:asc [:+ [:aggregation 0] [:aggregation 1]]]]}
-;;
 ;; TODO - it would be nice if we could check that there's actually an aggregation with the corresponding index,
 ;; wouldn't it
 ;;
@@ -901,6 +897,7 @@
            :string
            [:ref ::TemporalLiteral]
            [:ref ::ExpressionArg]
+           [:ref ::aggregation]
            [:ref ::FieldOrExpressionRefOrRelativeDatetime]]]])
 
 ;; For all of the non-compound Filter clauses below the first arg is an implicit Field ID

--- a/test/metabase/lib/convert_test.cljc
+++ b/test/metabase/lib/convert_test.cljc
@@ -3,6 +3,7 @@
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
    [clojure.test :refer [are deftest is testing]]
    [medley.core :as m]
+   [metabase.legacy-mbql.normalize :as mbql.normalize]
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
    [metabase.lib.options :as lib.options]
@@ -1634,3 +1635,14 @@
                           :expressions  {"TestColumn" [:+ 1 1]}}}]
     (is (= query
            (lib.convert/->legacy-MBQL query)))))
+
+(deftest ^:parallel case-schema-aggregation-test
+  (is (= [:aggregation-options
+          [:case
+           [[[:< [:aggregation 0 {"base-type" "type/Float"}] 0.591] "60%"]]]
+          {:name "A", :display-name "B"}]
+         (mbql.normalize/normalize :metabase.legacy-mbql.schema/aggregation-options
+                                   ["aggregation-options"
+                                    ["case"
+                                     [[["<" ["aggregation" 0 {"base-type" "type/Float"}] 0.591] "60%"]]]
+                                    {"name" "A", "display-name" "B"}]))))


### PR DESCRIPTION
Some legacy queries have aggregations as the operand of a filter (like `[:<= [:aggregation 0] 10]`). So I added it so the schema will pass on them.