### PR TITLE
[QP] If a `:field` ref by ID needs fallback metadata, include `:join-alias`

### DIFF
--- a/src/metabase/lib/field/resolution.cljc
+++ b/src/metabase/lib/field/resolution.cljc
@@ -671,9 +671,9 @@
                 (resolve-in-join query stage-number join-alias source-field id-or-name))
               (when source-field
                 (resolve-in-implicit-join query stage-number source-field id-or-name))
-              (resolve-from-previous-stage-or-source query stage-number id-or-name)
               (merge
-               (or (fallback-metadata-for-field query stage-number id-or-name)
+               (or (resolve-from-previous-stage-or-source query stage-number id-or-name)
+                   (fallback-metadata-for-field query stage-number id-or-name)
                    (fallback-metadata id-or-name))
                (when (and join-alias
                           (contains? (into #{}


### PR DESCRIPTION
Fixes #66464.

### Description

This was a corner case in `lib.field.resolution` and `qp.util.add-alias-info`
that regressed in 57. It made the QP less smart about repairing a certain
class of broken queries, which regrettably exist in the wild.

The breakage in question was a `:field` ref in later stage, which had a
numeric field ID and a `:join-alias`. If that field ID was not actually
returned as part of the join anymore, fallback metadata would be
generated by looking up the field by ID. That "works" for non-joined
fields but for an explicitly joined field it would use
`source."SOME_FIELD"` rather than `"The Join Alias"."SOME_FIELD"`, which
causes SQL compilation to fail.

### How to verify

It's hard to reproduce this kind of question since it needs broken field refs.
See the new test in `add-alias-info-test` and save a query like that, and you
can repro this.

I verified by using the (soon to be published for review) debugging tools to
fetch metadata from the problem instance and verified it there.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
