### PR TITLE
Fix issue where having a metabot block inside a document prevents it from loading when publicly shared

### DIFF
--- a/e2e/test/scenarios/documents/public-documents.cy.spec.ts
+++ b/e2e/test/scenarios/documents/public-documents.cy.spec.ts
@@ -244,12 +244,11 @@ describe("scenarios > documents > public", () => {
     visitPublicDocument();
 
     cy.log("Click the metabot block and enter text");
-    const char = "a";
     H.documentContent().findByText(text).click();
-    cy.realType(char);
+    cy.realType("a");
 
     cy.log("Verify the text wasn't updated");
-    H.documentContent().findByText(`${text}${char}`).should("not.exist");
+    H.documentContent().findByText(text).should("exist");
 
     cy.log("Verify that run/close buttons don't exist but a metabot icon does");
     H.documentContent().find("button").should("not.exist");

--- a/e2e/test/scenarios/documents/public-documents.cy.spec.ts
+++ b/e2e/test/scenarios/documents/public-documents.cy.spec.ts
@@ -225,6 +225,37 @@ describe("scenarios > documents > public", () => {
     verifyDocumentIsReadOnly();
   });
 
+  it("should display metabot blocks in a read-only state", () => {
+    const text = "Some metabot prompt";
+    H.createDocument({
+      name: "Document with metabot block",
+      document: {
+        content: [
+          {
+            type: "metabot",
+            content: [{ type: "text", text }],
+          },
+        ],
+        type: "doc",
+      },
+      collection_id: null,
+      idAlias: "documentId",
+    });
+    visitPublicDocument();
+
+    cy.log("Click the metabot block and enter text");
+    const char = "a";
+    H.documentContent().findByText(text).click();
+    cy.realType(char);
+
+    cy.log("Verify the text wasn't updated");
+    H.documentContent().findByText(`${text}${char}`).should("not.exist");
+
+    cy.log("Verify that run/close buttons don't exist but a metabot icon does");
+    H.documentContent().find("button").should("not.exist");
+    H.documentContent().icon("metabot").should("exist");
+  });
+
   it("should allow downloading results from embedded cards", () => {
     // Create a document with an embedded card
     createTestDocumentWithCard("Download Test Document");

--- a/frontend/src/metabase/public/containers/PublicDocument/PublicDocument.tsx
+++ b/frontend/src/metabase/public/containers/PublicDocument/PublicDocument.tsx
@@ -17,6 +17,7 @@ import { setErrorPage } from "metabase/redux/app";
 import { CardEmbed } from "metabase/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedNode";
 import { CustomStarterKit } from "metabase/rich_text_editing/tiptap/extensions/CustomStarterKit/CustomStarterKit";
 import { FlexContainer } from "metabase/rich_text_editing/tiptap/extensions/FlexContainer/FlexContainer";
+import { MetabotNode } from "metabase/rich_text_editing/tiptap/extensions/MetabotEmbed";
 import { ResizeNode } from "metabase/rich_text_editing/tiptap/extensions/ResizeNode/ResizeNode";
 import { SmartLink } from "metabase/rich_text_editing/tiptap/extensions/SmartLink/SmartLinkNode";
 import { SupportingText } from "metabase/rich_text_editing/tiptap/extensions/SupportingText/SupportingText";
@@ -86,6 +87,7 @@ export const PublicDocument = ({ location, params }: PublicDocumentProps) => {
       FlexContainer,
       ResizeNode,
       SupportingText,
+      MetabotNode,
     ],
     [siteUrl],
   );

--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/MetabotEmbed/MetabotEmbed.tsx
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/MetabotEmbed/MetabotEmbed.tsx
@@ -295,21 +295,24 @@ export const MetabotComponent = memo(
           direction="column"
           mb="md"
         >
-          <Button
-            variant="subtle"
+          <Box
             pos="absolute"
             top={0}
             right={0}
             p="sm"
             m="sm"
-            size="sm"
             opacity="0.5"
             className={S.closeButton}
-            onClick={() => deleteNode()}
           >
-            <Icon name="close" data-hide-on-print />
-            <Icon name="metabot" data-show-on-print />
-          </Button>
+            {editor.options.editable ? (
+              <Button variant="subtle" size="sm" onClick={() => deleteNode()}>
+                <Icon name="close" data-hide-on-print />
+                <Icon name="metabot" data-show-on-print />
+              </Button>
+            ) : (
+              <Icon name="metabot" />
+            )}
+          </Box>
           <Flex flex={1} direction="column" className={S.contentWrapper}>
             <Box
               className={S.placeholder}
@@ -319,7 +322,7 @@ export const MetabotComponent = memo(
               {t`Ask Metabot to generate a chart for you, and use @ to select a specific Database to use`}
             </Box>
             <NodeViewContent
-              contentEditable={!isLoading}
+              contentEditable={isLoading ? false : undefined}
               className={S.codeBlockTextArea}
             />
           </Flex>
@@ -343,25 +346,27 @@ export const MetabotComponent = memo(
                 </Flex>
               ) : null}
             </Flex>
-            <Tooltip
-              label={tooltip}
-              disabled={tooltip == null}
-              position="bottom"
-            >
-              <Button
-                size="sm"
-                disabled={!isMetabotEnabled}
-                onClick={() =>
-                  isLoading ? handleStopMetabot() : handleRunMetabot()
-                }
-                classNames={{
-                  label: CS.flex, // ensures icon is vertically centered
-                }}
-                data-hide-on-print
+            {editor.options.editable && (
+              <Tooltip
+                label={tooltip}
+                disabled={tooltip == null}
+                position="bottom"
               >
-                {isLoading ? <Icon name="close" /> : t`Run`}
-              </Button>
-            </Tooltip>
+                <Button
+                  size="sm"
+                  disabled={!isMetabotEnabled}
+                  onClick={() =>
+                    isLoading ? handleStopMetabot() : handleRunMetabot()
+                  }
+                  classNames={{
+                    label: CS.flex, // ensures icon is vertically centered
+                  }}
+                  data-hide-on-print
+                >
+                  {isLoading ? <Icon name="close" /> : t`Run`}
+                </Button>
+              </Tooltip>
+            )}
           </Flex>
         </Flex>
       </NodeViewWrapper>

--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/MetabotEmbed/MetabotEmbed.tsx
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/MetabotEmbed/MetabotEmbed.tsx
@@ -299,18 +299,24 @@ export const MetabotComponent = memo(
             pos="absolute"
             top={0}
             right={0}
-            p="sm"
-            m="sm"
             opacity="0.5"
             className={S.closeButton}
           >
             {editor.options.editable ? (
-              <Button variant="subtle" size="sm" onClick={() => deleteNode()}>
+              <Button
+                variant="subtle"
+                p="sm"
+                m="sm"
+                size="sm"
+                onClick={() => deleteNode()}
+              >
                 <Icon name="close" data-hide-on-print />
                 <Icon name="metabot" data-show-on-print />
               </Button>
             ) : (
-              <Icon name="metabot" />
+              <Box p="md">
+                <Icon name="metabot" />
+              </Box>
             )}
           </Box>
           <Flex flex={1} direction="column" className={S.contentWrapper}>

--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/MetabotEmbed/__support__/editor-mocks.ts
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/MetabotEmbed/__support__/editor-mocks.ts
@@ -1,6 +1,6 @@
 import type { Editor } from "@tiptap/react";
 
-export const createMockEditor = (overrides = {}): Editor =>
+export const createMockEditor = (overrides: Partial<Editor> = {}): Editor =>
   ({
     on: jest.fn(),
     off: jest.fn(),
@@ -14,6 +14,10 @@ export const createMockEditor = (overrides = {}): Editor =>
     state: {
       selection: { $from: {}, empty: true },
       doc: { nodeAt: jest.fn(), resolve: jest.fn() },
+    },
+    options: {
+      editable: true,
+      ...overrides.options,
     },
     ...overrides,
   }) as unknown as Editor;

--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/SupportingText/SupportingText.tsx
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/SupportingText/SupportingText.tsx
@@ -204,29 +204,31 @@ const SupportingTextComponent = ({
       </div>
 
       {/* Would be nice to use a real `button` here, but that prevents ProseMirror plugin dragstart events from firing */}
-      <div
-        role="button"
-        tabIndex={0}
-        data-drag-handle
-        ref={dragElRef}
-        contentEditable={false}
-        aria-label={t`Supporting text`}
-        className={S.handle}
-        onClick={() => {
-          const pos = getPos();
-          pos && editor.commands.setNodeSelection(pos);
-        }}
-        onKeyDown={(e) => {
-          if (e.key === "Backspace" || e.key === "Delete") {
+      {canWrite && (
+        <div
+          role="button"
+          tabIndex={0}
+          data-drag-handle
+          ref={dragElRef}
+          contentEditable={false}
+          aria-label={t`Supporting text`}
+          className={S.handle}
+          onClick={() => {
             const pos = getPos();
-            deleteNode();
-            cleanupFlexContainerNodes(editor.view);
-            if (pos != null) {
-              editor.commands.focus(pos);
+            pos && editor.commands.setNodeSelection(pos);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Backspace" || e.key === "Delete") {
+              const pos = getPos();
+              deleteNode();
+              cleanupFlexContainerNodes(editor.view);
+              if (pos != null) {
+                editor.commands.focus(pos);
+              }
             }
-          }
-        }}
-      />
+          }}
+        />
+      )}
       {document && !isWithinIframe() && (
         <Box
           pos="absolute"


### PR DESCRIPTION
### Description

* Adds metabot extension to public document viewer so public documents don't crash if they contain a metabot block
* Improves metabot block's read-only state

### How to verify

1. Add a metabot block to a document and save it
2. Create a public link for the document and go to it
3. Verify the document loads and the metabot block displays similar to how it shows up in the print version

### Demo

**BEFORE**

https://github.com/user-attachments/assets/dc741590-e644-4b80-bf35-b21724c5c18a

**AFTER**

https://github.com/user-attachments/assets/9d8ad9c7-3e5d-44f7-9525-430806551367

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
