### PR TITLE
Add SSH tunnelling support for Starburst

### DIFF
--- a/modules/drivers/starburst/resources/metabase-plugin.yaml
+++ b/modules/drivers/starburst/resources/metabase-plugin.yaml
@@ -40,6 +40,7 @@ driver:
       required: false
       default: false
       description: Requires Starburst Galaxy, Starburst Enterprise (version 420-e or higher), or Trino (version 418 or higher)
+    - ssh-tunnel
     - advanced-options-start
     - merge:
         - additional-options

--- a/modules/drivers/starburst/src/metabase/driver/starburst.clj
+++ b/modules/drivers/starburst/src/metabase/driver/starburst.clj
@@ -907,7 +907,7 @@
 (defn- jdbc-spec
   "Creates a spec for `clojure.java.jdbc` to use for connecting to starburst via JDBC, from the given `opts`."
   [{:keys [host port catalog schema]
-    :or   {host "localhost", port 5432, catalog ""}
+    :or   {host "localhost", port 8080, catalog ""}
     :as   details}]
   (-> details
       (merge {:classname   "io.trino.jdbc.TrinoDriver"

--- a/modules/drivers/starburst/test/metabase/test/data/starburst.clj
+++ b/modules/drivers/starburst/test/metabase/test/data/starburst.clj
@@ -49,7 +49,7 @@
 (defmethod tx/dbdef->connection-details :starburst
   [_ _ {:keys [database-name]}]
   {:host                               (tx/db-test-env-var-or-throw :starburst :host "localhost")
-   :port                               (tx/db-test-env-var :starburst :port "8080")
+   :port                               (tx/db-test-env-var :starburst :port 8080)
    :user                               (tx/db-test-env-var-or-throw :starburst :user "metabase")
    :additional-options                 (tx/db-test-env-var :starburst :additional-options nil)
    :prepared-optimized                 (tx/db-test-env-var :starburst :prepared-optimized (not= (System/getProperty "explicitPrepare" "true") "true"))

--- a/src/metabase/driver/sql_jdbc/connection/ssh_tunnel.clj
+++ b/src/metabase/driver/sql_jdbc/connection/ssh_tunnel.clj
@@ -100,10 +100,11 @@
   [details]
   (if (use-ssh-tunnel? details)
     (let [[_ proto host]                           (re-find #"(.*://)?(.*)" (:host details))
-          [session ^PortForwardingTracker tracker] (start-ssh-tunnel! (assoc details :host host))
+          orig-port                                (let [p (:port details)]
+                                                     (if (string? p) (Integer/parseInt p) p))
+          [session ^PortForwardingTracker tracker] (start-ssh-tunnel! (assoc details :host host :port orig-port))
           tunnel-entrance-port                     (.. tracker getBoundAddress getPort)
           tunnel-entrance-host                     (.. tracker getBoundAddress getHostName)
-          orig-port                                (:port details)
           details-with-tunnel                      (assoc details
                                                           :port tunnel-entrance-port ;; This parameter is set dynamically when the connection is established
                                                           :host (str proto "localhost") ;; SSH tunnel will always be through localhost


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/65845

### Description

Adds SSH tunnelling support for Starburst

### How to verify

See demos

1. Set up an SSH server container
2. Set up a Trino DB container
3. Select `Use an SSH-tunnel` when connecting to the Trino DB from Metabase. Fill in the appropriate credentials for the Trino DB and the SSH server. The Trino DB values should be the ones that the SSH server would see.

<details>

<summary>docker-compose-ssh-test.yml</summary>

```
services:
  # Trino/Starburst server in a private network
  trino:
    image: trinodb/trino:latest
    container_name: trino-private
    ports:
      - "8081:8080"
    networks:
      - private-nw
    environment:
      - TRINO_ENVIRONMENT=test

  # SSH bastion host (accessible from host, can reach Trino)
  ssh-bastion:
    image: lscr.io/linuxserver/openssh-server:latest
    container_name: ssh-bastion
    ports:
      - "2223:2222"
    networks:
      - private-nw
      - public-nw
    environment:
      - PUID=1000
      - PGID=1000
      - TZ=America/New_York
      - PASSWORD_ACCESS=false
      - USER_NAME=testuser
      - DOCKER_MODS=linuxserver/mods:openssh-server-ssh-tunnel
    volumes:
      - ./ssh-bastion-config-4:/config
      - ./ssh-bastion-config-4/sshd_config:/etc/ssh/sshd_config:ro

networks:
  private-nw:
    driver: bridge
  public-nw:
    driver: bridge
```

</details>

<details>

<summary>sshd_config</summary>

```
# SSH Server Configuration for Testing
Port 2222
PermitRootLogin no
PasswordAuthentication yes
PubkeyAuthentication yes
ChallengeResponseAuthentication no

# Enable TCP Forwarding (required for SSH tunneling)
AllowTcpForwarding yes
GatewayPorts no
X11Forwarding no

# Security
PermitEmptyPasswords no
UsePAM yes
```

</details>

### Demo

https://www.loom.com/share/b34d736e40604d989577e2a49775a5f8

https://www.loom.com/share/b5ce8dd690ae4b20ba29d0956c4bd854

https://www.loom.com/share/5df31faa51b24f939de59de9a1d5441f

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
