### PR TITLE
GDGT-1315 add an ability to toggle table rows without changing selection

### DIFF
--- a/e2e/support/helpers/e2e-datamodel-helpers.ts
+++ b/e2e/support/helpers/e2e-datamodel-helpers.ts
@@ -13,9 +13,11 @@ export const DataModel = {
   TablePicker: {
     get: getTablePicker,
     getDatabase: getTablePickerDatabase,
+    getDatabaseToggle: getTablePickerDatabaseToggle,
     getDatabases: getTablePickerDatabases,
     getSchemas: getTablePickerSchemas,
     getSchema: getTablePickerSchema,
+    getSchemaToggle: getTablePickerSchemaToggle,
     getTables: getTablePickerTables,
     getTable: getTablePickerTable,
     getSearchInput: getTablePickerSearchInput,
@@ -216,6 +218,10 @@ function getTablePickerDatabase(name: string) {
     .filter(`:contains("${name}")`);
 }
 
+function getTablePickerDatabaseToggle(name: string) {
+  return getTablePickerDatabase(name).find("[aria-expanded]");
+}
+
 function getTablePickerDatabases() {
   return cy.findAllByTestId("tree-item").filter('[data-type="database"]');
 }
@@ -225,6 +231,10 @@ function getTablePickerSchema(name: string) {
     .findAllByTestId("tree-item")
     .filter('[data-type="schema"]')
     .filter(`:contains("${name}")`);
+}
+
+function getTablePickerSchemaToggle(name: string) {
+  return getTablePickerSchema(name).find("[aria-expanded]");
 }
 
 function getTablePickerSchemas() {

--- a/e2e/test/scenarios/data-studio/data-model/datamodel-data-studio-search.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-model/datamodel-data-studio-search.cy.spec.ts
@@ -144,19 +144,16 @@ describe("Search", () => {
       TablePicker.getTable(table).should("be.visible");
     });
 
-    TablePicker.getDatabase(sampleDatabaseName).click();
-    TablePicker.getDatabase(sampleDatabaseName).click();
+    TablePicker.getDatabaseToggle(sampleDatabaseName).click();
     sampleDbTables.forEach((table) => {
       TablePicker.getTable(table).should("not.exist");
     });
 
     TablePicker.getTable("Animals").should("have.length", 2);
-    TablePicker.getSchema(domesticSchema).click();
-    TablePicker.getSchema(domesticSchema).click();
+    TablePicker.getSchemaToggle(domesticSchema).click();
     TablePicker.getTable("Animals").should("have.length", 1);
 
-    TablePicker.getDatabase(postgres).click();
-    TablePicker.getDatabase(postgres).click();
+    TablePicker.getDatabaseToggle(postgres).click();
     TablePicker.getTables().should("have.length", 0);
     TablePicker.getDatabases().should("have.length", 2);
   });

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/Results.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/Results.module.css
@@ -101,6 +101,10 @@
   display: flex;
   align-items: center;
   justify-content: center;
+
+  &.hasChildren {
+    cursor: pointer;
+  }
 }
 
 .chevron {

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/Results.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/Results.tsx
@@ -1,6 +1,12 @@
 import { useVirtualizer } from "@tanstack/react-virtual";
 import cx from "classnames";
-import { type KeyboardEvent, useEffect, useMemo, useRef } from "react";
+import {
+  type KeyboardEvent,
+  type MouseEvent,
+  useEffect,
+  useMemo,
+  useRef,
+} from "react";
 import { Link } from "react-router";
 import { useLatest } from "react-use";
 import { t } from "ttag";
@@ -475,6 +481,17 @@ const ResultsItem = ({
     }
   };
 
+  // Dedicated toggle target: always toggles expansion without navigating
+  // regardless of whether the item is currently active.
+  const handleChevronClick = (e: MouseEvent<HTMLDivElement>) => {
+    if (disabled || !itemHasChildren) {
+      return;
+    }
+    e.preventDefault();
+    e.stopPropagation();
+    toggle?.(key);
+  };
+
   return (
     <Flex
       component={Link}
@@ -524,7 +541,14 @@ const ResultsItem = ({
       <Flex align="center" py="xs" w="100%" pl={indent} gap="sm">
         <Flex align="flex-start" gap="xs" className={S.content}>
           <Flex align="center" gap="xs">
-            <Box className={S.chevronSlot} w={INDENT_OFFSET}>
+            <Box
+              className={cx(S.chevronSlot, {
+                [S.hasChildren]: itemHasChildren,
+              })}
+              w={INDENT_OFFSET}
+              aria-expanded={Boolean(isExpanded)}
+              onClick={handleChevronClick}
+            >
               {itemHasChildren && (
                 <Icon
                   name="chevronright"


### PR DESCRIPTION
Closes GDGT-1315
Based on https://github.com/metabase/metabase/pull/66393#discussion_r2576699579

### Description
Now a first click on the database/schema row in data-studio/data selects it and only second click toggles it. We need to find a way to collapse/expand databases/schemas without double clicking. 

There are several ways to achieve that. However, in order to keep existing semantic of working with the hierarchy, I added small adjustments that allows a user to toggle database/schema by clicking on dedicated area with chevron icon.

### How to verify
1. Open /data-studio/data with two or more databases/schemas
2. Select one of database/schema
3. Click on chevron icon area of other database/schema
4. See that it toggles (expands/collapses) without changing selections
5. The same works in search mode (add some filters to data-studio/data

### Demo
Before:
https://github.com/user-attachments/assets/ddfc812d-3038-441c-9cf8-97020b98595c

After:
https://github.com/user-attachments/assets/4e9a5be5-8e12-428c-856d-1ffe65797287

### Checklist
- [x] Tests have been added/updated to cover changes in this PR
