### PR TITLE
Dont limit mini picker data search to library

### DIFF
--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
@@ -289,14 +289,12 @@ function CollectionItemList({ parent }: { parent: MiniPickerCollectionItem }) {
 }
 
 function SearchItemList({ query }: { query: string }) {
-  const { onChange, models, libraryCollection, isHidden } =
-    useMiniPickerContext();
+  const { onChange, models, isHidden } = useMiniPickerContext();
 
   const { data: searchResponse, isLoading } = useSearchQuery({
     q: query,
     models: models as SearchModel[],
     limit: 50,
-    ...(libraryCollection ? { collection: libraryCollection.id } : {}),
   });
 
   const searchResults: MiniPickerPickableItem[] = (


### PR DESCRIPTION


### Description

it's annoying if you know what you want to have to open the big picker. let's make search work globally even if you have a library

<img width="448" height="637" alt="CleanShot 2025-12-04 at 16 54 55" src="https://github.com/user-attachments/assets/fb82b960-6b59-48e3-96ba-a0b050346133" />
