### PR TITLE
Adjust layout of Metabot purchase page and add video demo

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotPurchasePage/MetabotPurchasePage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotPurchasePage/MetabotPurchasePage.tsx
@@ -14,7 +14,11 @@ export function MetabotPurchasePage(): ReactElement {
 
   return (
     <SettingsPageWrapper title={t`Metabot AI`}>
-      <Text maw="26rem">{t`Metabot helps you move faster and understand your data better. You can ask it to generate SQL, and build or explain queries.`}</Text>
+      <Text>
+        {t`Metabot helps you move faster and understand your data better.`}
+        <br />
+        {t`You can ask it to generate SQL, and build or explain queries.`}
+      </Text>
       {isStoreUser ? (
         <MetabotPurchasePageForStoreUser />
       ) : (

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotPurchasePage/MetabotPurchasePage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotPurchasePage/MetabotPurchasePage.unit.spec.tsx
@@ -18,38 +18,25 @@ import { createMockSettingsState } from "metabase-types/store/mocks";
 
 import { MetabotPurchasePage } from ".";
 
+const nonStoreUserPageRegex = /Please ask a Metabase Store Admin/;
+const storeUserPageRegex = /After 14 days of free trial an additional amount/;
+const errorPageRegex = /Error fetching information/;
 const expectNonStoreUserPage = async () => {
-  expect(
-    await screen.findByText(/Please ask a Metabase Store Admin/),
-  ).toBeVisible();
-  expect(
-    screen.queryByText(/Additional amount for the add-on/),
-  ).not.toBeInTheDocument();
-  expect(
-    screen.queryByText(/Error fetching information/),
-  ).not.toBeInTheDocument();
+  expect(await screen.findByText(nonStoreUserPageRegex)).toBeVisible();
+  expect(screen.queryByText(storeUserPageRegex)).not.toBeInTheDocument();
+  expect(screen.queryByText(errorPageRegex)).not.toBeInTheDocument();
 };
 
 const expectStoreUserPage = async () => {
-  expect(
-    screen.queryByText(/Please ask a Metabase Store Admin/),
-  ).not.toBeInTheDocument();
-  expect(
-    await screen.findByText(/Additional amount for the add-on/),
-  ).toBeVisible();
-  expect(
-    screen.queryByText(/Error fetching information/),
-  ).not.toBeInTheDocument();
+  expect(screen.queryByText(nonStoreUserPageRegex)).not.toBeInTheDocument();
+  expect(await screen.findByText(storeUserPageRegex)).toBeVisible();
+  expect(screen.queryByText(errorPageRegex)).not.toBeInTheDocument();
 };
 
 const expectErrorPage = async () => {
-  expect(
-    screen.queryByText(/Please ask a Metabase Store Admin/),
-  ).not.toBeInTheDocument();
-  expect(
-    screen.queryByText(/Additional amount for the add-on/),
-  ).not.toBeInTheDocument();
-  expect(await screen.findByText(/Error fetching information/)).toBeVisible();
+  expect(screen.queryByText(nonStoreUserPageRegex)).not.toBeInTheDocument();
+  expect(screen.queryByText(storeUserPageRegex)).not.toBeInTheDocument();
+  expect(await screen.findByText(errorPageRegex)).toBeVisible();
 };
 
 const setupRefreshableProperties = ({

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotPurchasePage/MetabotPurchasePageForNonStoreUser.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotPurchasePage/MetabotPurchasePageForNonStoreUser.tsx
@@ -7,10 +7,19 @@ import type { IPageForNonStoreUserProps } from "./types";
 export const MetabotPurchasePageForNonStoreUser = ({
   anyStoreUserEmailAddress,
 }: IPageForNonStoreUserProps) => (
-  <Text fw="bold">
-    {
-      /* eslint-disable-next-line no-literal-metabase-strings -- This string only shows for admins. */
-      t`Please ask a Metabase Store Admin${anyStoreUserEmailAddress && ` (${anyStoreUserEmailAddress})`} of your organization to enable this for you.`
-    }
-  </Text>
+  <>
+    <video controls aria-label={t`Demonstration of Metabot AI features`}>
+      <source
+        src="https://www.metabase.com/images/features/metabot.mp4"
+        type="video/mp4"
+      />
+      {t`Your browser does not support the video tag.`}
+    </video>
+    <Text fw="bold">
+      {
+        /* eslint-disable-next-line no-literal-metabase-strings -- This string only shows for admins. */
+        t`Please ask a Metabase Store Admin${anyStoreUserEmailAddress && ` (${anyStoreUserEmailAddress})`} of your organization to enable this for you.`
+      }
+    </Text>
+  </>
 );

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotPurchasePage/MetabotPurchasePageForStoreUser.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotPurchasePage/MetabotPurchasePageForStoreUser.tsx
@@ -90,13 +90,23 @@ export const MetabotPurchasePageForStoreUser = () => {
 
   return (
     <>
+      <video controls aria-label={t`Demonstration of Metabot AI features`}>
+        <source
+          src="https://www.metabase.com/images/features/metabot.mp4"
+          type="video/mp4"
+        />
+        {t`Your browser does not support the video tag.`}
+      </video>
       <SettingsSection
-        title={t`Monthly usage limit`}
+        title={t`Start free 14-day trial of Metabot`}
         description={
-          <Text
-            maw="35rem"
-            mt="sm"
-          >{t`Usage is measured in Metabot requests. If a chat has multiple questions, they are counted as separate Metabot requests. Usage limit applies to your whole organization.`}</Text>
+          <Text mt="sm">
+            {t`Pick a usage limit below. Usage is measured in Metabot requests.`}
+            <br />
+            {t`If a chat has multiple questions, they are counted as separate Metabot requests.`}
+            <br />
+            {t`Usage limit applies to your whole organization.`}
+          </Text>
         }
       >
         <FormProvider
@@ -117,9 +127,6 @@ export const MetabotPurchasePageForStoreUser = () => {
                 />
 
                 <Stack gap="md">
-                  {/* eslint-disable-next-line no-literal-metabase-strings -- This string only shows for admins. */}
-                  <Text maw="35rem">{t`Additional amount for the add-on will be added to your next billing period invoice. You can cancel the add-on anytime in Metabase Store.`}</Text>
-
                   <Card
                     bg="var(--mb-color-bg-light)"
                     p={12}
@@ -137,6 +144,9 @@ export const MetabotPurchasePageForStoreUser = () => {
                       }
                     />
                   </Card>
+
+                  {/* eslint-disable-next-line no-literal-metabase-strings -- This string only shows for admins. */}
+                  <Text>{t`After 14 days of free trial an additional amount for the add-on will be added to your next billing period invoice. You can cancel the add-on anytime in Metabase Store.`}</Text>
 
                   <FormSubmitButton
                     disabled={!values.terms_of_service}


### PR DESCRIPTION
### Description

In https://github.com/metabase/metabase/pull/65343 we added a page to purchase Metabase AI (Metabot).  Now we are improving the layout and content to better present the product.

### How to verify

1. Ensure you have a token with the `offer-metabase-ai-tiered` feature, but without the `metabot-v3` and `offer-metabase-ai` features.
2. Navigate to `/admin/metabot` and see the page look like in the mock ups.

### Demo

#### Store user

When your Metabase user account email matches the store user account email, you'll see this:

<img width="2641" height="2224" alt="image" src="https://github.com/user-attachments/assets/587a71b1-93bd-434e-9cca-40167322c59e" />

Otherwise, you'll see this:

<img width="1552" height="1119" alt="image" src="https://github.com/user-attachments/assets/126be969-6b34-483c-8b6d-ce60db288f97" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

Closes: https://linear.app/metabase/issue/CLO-4669/make-small-changes-to-ai-page-in-admin