### PR TITLE
Hide tenant collections section when there are no visible shared collections

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/MainNavSharedCollections/MainNavSharedCollections.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/MainNavSharedCollections/MainNavSharedCollections.tsx
@@ -100,9 +100,9 @@ export const MainNavSharedCollections = () => {
   }
 
   const userTenantCollectionId = currentUser?.tenant_collection_id;
-  const hasSharedTenantCollections = tenantCollectionsList.length > 0;
+  const hasVisibleTenantCollections = tenantCollectionTree.length > 0;
   const shouldShowSharedCollectionsSection =
-    isAdmin || hasSharedTenantCollections;
+    isAdmin || hasVisibleTenantCollections;
 
   return (
     <>


### PR DESCRIPTION
Closes UXW-2472
