### PR TITLE
Cache trunk between runs

### DIFF
--- a/.github/actions/upload-test-results/action.yml
+++ b/.github/actions/upload-test-results/action.yml
@@ -20,7 +20,7 @@ inputs:
     required: true
   variant:
     required: false
-    default: ''
+    default: ""
 
 runs:
   using: "composite"
@@ -56,3 +56,4 @@ runs:
         org-slug: metabase
         dry-run: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft == true }} # quarantine, but do not upload results
         token: ${{ inputs.trunk-api-token }}
+        use-cache: true


### PR DESCRIPTION
Trunk action supports `use-cache` that should prevent us hitting GitHub's API rate limits.

https://metaboat.slack.com/archives/C05PX79QTQA/p1763758226696809?thread_ts=1755795626.401139&cid=C05PX79QTQA

The latest example of the failed run because of the API rate limit:
https://github.com/metabase/metabase/actions/runs/19967525480/job/57264000317?pr=66592#step:15:163