### PR TITLE
docs - pin docker version

### DIFF
--- a/docs/installation-and-operation/running-metabase-on-docker.md
+++ b/docs/installation-and-operation/running-metabase-on-docker.md
@@ -144,13 +144,15 @@ services:
       timeout: 5s
       retries: 5
   postgres:
-    image: postgres:latest
+    image: postgres:16
     container_name: postgres
     hostname: postgres
     environment:
       POSTGRES_USER: metabase
       POSTGRES_DB: metabaseappdb
       POSTGRES_PASSWORD: mysecretpassword
+    volumes:
+      - ./pg_data:/var/lib/postgresql/data
     networks:
       - metanet1
 networks:


### PR DESCRIPTION
Manual backport of https://github.com/metabase/metabase/commit/7ad802575762e562d26d8573ab62dd16cf2764c2.