### PR TITLE
Rename Metabot dummy-tools to entity-details

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/suggested_prompts.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/suggested_prompts.clj
@@ -2,7 +2,7 @@
   (:require
    [medley.core :as m]
    [metabase-enterprise.metabot-v3.client :as metabot-v3.client]
-   [metabase-enterprise.metabot-v3.dummy-tools :as metabot-v3.dummy-tools]
+   [metabase-enterprise.metabot-v3.tools.entity-details :as metabot-v3.tools.entity-details]
    [metabase-enterprise.metabot-v3.tools.util :as metabot-v3.tools.u]
    [metabase.lib-be.core :as lib-be]
    [toucan2.core :as t2]))
@@ -44,7 +44,7 @@
             {metrics :metric, models :model}
             (->> (for [[[card-type database-id] group-cards] (group-by (juxt :type :database_id) limited-cards)
                        detail (map (fn [detail card] (assoc detail ::origin card))
-                                   (metabot-v3.dummy-tools/cards-details card-type database-id group-cards nil)
+                                   (metabot-v3.tools.entity-details/cards-details card-type database-id group-cards nil)
                                    group-cards)]
                    detail)
                  (group-by :type))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
@@ -4,7 +4,6 @@
    [buddy.core.hash :as buddy-hash]
    [buddy.sign.jwt :as jwt]
    [clojure.set :as set]
-   [metabase-enterprise.metabot-v3.dummy-tools :as metabot-v3.dummy-tools]
    [metabase-enterprise.metabot-v3.reactions]
    [metabase-enterprise.metabot-v3.settings :as metabot-v3.settings]
    [metabase-enterprise.metabot-v3.table-utils :as table-utils]
@@ -12,6 +11,7 @@
     :as metabot-v3.tools.create-dashboard-subscription]
    [metabase-enterprise.metabot-v3.tools.deftool :refer [deftool]]
    [metabase-enterprise.metabot-v3.tools.dependencies :as metabot-v3.tools.dependencies]
+   [metabase-enterprise.metabot-v3.tools.entity-details :as metabot-v3.tools.entity-details]
    [metabase-enterprise.metabot-v3.tools.field-stats :as metabot-v3.tools.field-stats]
    [metabase-enterprise.metabot-v3.tools.filters :as metabot-v3.tools.filters]
    [metabase-enterprise.metabot-v3.tools.find-outliers :as metabot-v3.tools.find-outliers]
@@ -360,7 +360,7 @@
   {:args-schema    ::answer-sources-arguments
    :args-optional? true
    :result-schema  ::answer-sources-result
-   :handler        metabot-v3.dummy-tools/answer-sources})
+   :handler        metabot-v3.tools.entity-details/answer-sources})
 
 (mr/def ::search-arguments
   [:and
@@ -559,7 +559,7 @@
 (deftool "/get-current-user"
   "Get information about user that started the conversation."
   {:result-schema ::get-current-user-result
-   :handler       metabot-v3.dummy-tools/get-current-user})
+   :handler       metabot-v3.tools.entity-details/get-current-user})
 
 (mr/def ::get-dashboard-details-arguments
   [:and
@@ -582,7 +582,7 @@
   "Get information about a given dashboard."
   {:args-schema   ::get-dashboard-details-arguments
    :result-schema ::get-dashboard-details-result
-   :handler       metabot-v3.dummy-tools/get-dashboard-details})
+   :handler       metabot-v3.tools.entity-details/get-dashboard-details})
 
 (mr/def ::get-metric-details-arguments
   [:and
@@ -607,7 +607,7 @@
   "Get information about a given metric."
   {:args-schema   ::get-metric-details-arguments
    :result-schema ::get-metric-details-result
-   :handler       metabot-v3.dummy-tools/get-metric-details})
+   :handler       metabot-v3.tools.entity-details/get-metric-details})
 
 (mr/def ::get-query-details-arguments
   [:map [:query :map]])
@@ -628,7 +628,7 @@
   "Get information about a given query."
   {:args-schema   ::get-query-details-arguments
    :result-schema ::get-query-details-result
-   :handler       metabot-v3.dummy-tools/get-query-details})
+   :handler       metabot-v3.tools.entity-details/get-query-details})
 
 (mr/def ::get-report-details-arguments
   [:and
@@ -659,7 +659,7 @@
   "Get information about a given report."
   {:args-schema   ::get-report-details-arguments
    :result-schema ::get-report-details-result
-   :handler       metabot-v3.dummy-tools/get-report-details})
+   :handler       metabot-v3.tools.entity-details/get-report-details})
 
 (mr/def ::get-document-details-arguments
   [:and
@@ -683,7 +683,7 @@
   "Get information about a given document."
   {:args-schema   ::get-document-details-arguments
    :result-schema ::get-document-details-result
-   :handler       metabot-v3.dummy-tools/get-document-details})
+   :handler       metabot-v3.tools.entity-details/get-document-details})
 
 (mr/def ::get-table-details-arguments
   [:and
@@ -716,7 +716,7 @@
   "Get information about a given table or model."
   {:args-schema   ::get-table-details-arguments
    :result-schema ::get-table-details-result
-   :handler       metabot-v3.dummy-tools/get-table-details})
+   :handler       metabot-v3.tools.entity-details/get-table-details})
 
 (mr/def ::get-tables-arguments
   [:and

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/entity_details.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/entity_details.clj
@@ -1,4 +1,4 @@
-(ns metabase-enterprise.metabot-v3.dummy-tools
+(ns metabase-enterprise.metabot-v3.tools.entity-details
   (:require
    [medley.core :as m]
    [metabase-enterprise.metabot-v3.config :as metabot-v3.config]
@@ -18,7 +18,7 @@
 
 (set! *warn-on-reflection* true)
 
-(defn- verified-review?
+(defn verified-review?
   "Return true if the most recent ModerationReview for the given item id/type is verified."
   [id item-type]
   (let [review (t2/select-one [:model/ModerationReview :status]

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
@@ -5,10 +5,10 @@
    [malli.transform :as mtx]
    [medley.core :as m]
    [metabase-enterprise.metabot-v3.client :as metabot-v3.client]
-   [metabase-enterprise.metabot-v3.dummy-tools :as metabot-v3.tools.dummy-tools]
    [metabase-enterprise.metabot-v3.tools.api :as metabot-v3.tools.api]
    [metabase-enterprise.metabot-v3.tools.create-dashboard-subscription :as metabot-v3.tools.create-dashboard-subscription]
    [metabase-enterprise.metabot-v3.tools.dependencies-test :as metabot-v3.tools.dependencies-test]
+   [metabase-enterprise.metabot-v3.tools.entity-details :as metabot-v3.tools.entity-details]
    [metabase-enterprise.metabot-v3.tools.filters :as metabot-v3.tools.filters]
    [metabase-enterprise.metabot-v3.tools.find-outliers :as metabot-v3.tools.find-outliers]
    [metabase-enterprise.metabot-v3.tools.generate-insights :as metabot-v3.tools.generate-insights]
@@ -393,7 +393,7 @@
                      :model/Card {model-id :id}  (assoc model-data  :collection_id collection-id)
                      :model/Metabot {metabot-eid :entity_id} {:name "Test Metabot"
                                                               :collection_id collection-id}]
-        (with-redefs [metabot-v3.tools.dummy-tools/verified-review? (constantly true)]
+        (with-redefs [metabot-v3.tools.entity-details/verified-review? (constantly true)]
           (let [model-metric-base-query (lib/query mp (lib.metadata/card mp model-id))
                 rating-column (m/find-first (comp #{"RATING"} :name) (lib/visible-columns model-metric-base-query))
                 created-at-column (m/find-first (comp #{"CREATED_AT"} :name) (lib/breakoutable-columns model-metric-base-query))
@@ -519,7 +519,7 @@
   (mt/with-premium-features #{:metabot-v3}
     (let [dash-data {:name "dashing dash", :description "dash description"}]
       (mt/with-temp [:model/Dashboard {dash-id :id} dash-data]
-        (with-redefs [metabot-v3.tools.dummy-tools/verified-review? (constantly true)]
+        (with-redefs [metabot-v3.tools.entity-details/verified-review? (constantly true)]
           (let [conversation-id (str (random-uuid))
                 ai-token (ai-session-token)
                 response (mt/user-http-request :rasta :post 200 "ee/metabot-tools/get-dashboard-details"
@@ -590,7 +590,7 @@
                                           {:arguments arguments
                                            :conversation_id conversation-id}))]
       (mt/with-temp [:model/Card {metric-id :id} metric-data]
-        (with-redefs [metabot-v3.tools.dummy-tools/verified-review? (constantly true)]
+        (with-redefs [metabot-v3.tools.entity-details/verified-review? (constantly true)]
           (testing "Normal call"
             (is (=? {:structured_output (-> metric-data
                                             (select-keys [:name :display_name :description])
@@ -689,7 +689,7 @@
                          :dataset_query (lib/->legacy-MBQL source-query)
                          :type :question}]
       (mt/with-temp [:model/Card {question-id :id} question-data]
-        (with-redefs [metabot-v3.tools.dummy-tools/verified-review? (constantly true)]
+        (with-redefs [metabot-v3.tools.entity-details/verified-review? (constantly true)]
           (let [conversation-id (str (random-uuid))
                 ai-token (ai-session-token)
                 arguments {:report_id question-id}
@@ -832,7 +832,7 @@
                                                           {:source-table (str "card__" model-id)
                                                            :aggregation [[:count]]
                                                            :breakout [!month.*created_at *quantity]}))]
-        (with-redefs [metabot-v3.tools.dummy-tools/verified-review? (constantly true)]
+        (with-redefs [metabot-v3.tools.entity-details/verified-review? (constantly true)]
           (let [request (fn [arguments]
                           (mt/user-http-request :rasta :post 200 "ee/metabot-tools/get-table-details"
                                                 {:request-options {:headers {"x-metabase-session" ai-token}}}
@@ -876,7 +876,7 @@
                                                           {:source-table (str "card__" model-id)
                                                            :aggregation [[:count]]
                                                            :breakout [!month.*created_at *quantity]}))]
-        (with-redefs [metabot-v3.tools.dummy-tools/verified-review? (constantly true)]
+        (with-redefs [metabot-v3.tools.entity-details/verified-review? (constantly true)]
           (let [request (fn [arguments]
                           (mt/user-http-request :rasta :post 200 "ee/metabot-tools/get-table-details"
                                                 {:request-options {:headers {"x-metabase-session" ai-token}}}
@@ -925,7 +925,7 @@
                                                           {:source-table (str "card__" model-id)
                                                            :aggregation [[:count]]
                                                            :breakout [!month.*created_at *quantity]}))]
-        (with-redefs [metabot-v3.tools.dummy-tools/verified-review? (constantly true)]
+        (with-redefs [metabot-v3.tools.entity-details/verified-review? (constantly true)]
           (let [request (fn [arguments]
                           (mt/user-http-request :rasta :post 200 "ee/metabot-tools/get-table-details"
                                                 {:request-options {:headers {"x-metabase-session" ai-token}}}
@@ -961,7 +961,7 @@
                                                           {:source-table (str "card__" model-id)
                                                            :aggregation [[:count]]
                                                            :breakout [!month.*created_at *quantity]}))]
-        (with-redefs [metabot-v3.tools.dummy-tools/verified-review? (constantly true)]
+        (with-redefs [metabot-v3.tools.entity-details/verified-review? (constantly true)]
           (let [request (fn [arguments]
                           (mt/user-http-request :rasta :post 200 "ee/metabot-tools/get-table-details"
                                                 {:request-options {:headers {"x-metabase-session" ai-token}}}
@@ -999,7 +999,7 @@
                                                            {:source-table (str "card__" model-id)
                                                             :aggregation [[:count]]
                                                             :breakout [!month.*created_at *quantity]}))]
-        (with-redefs [metabot-v3.tools.dummy-tools/verified-review? (constantly true)]
+        (with-redefs [metabot-v3.tools.entity-details/verified-review? (constantly true)]
           (let [request (fn [arguments]
                           (mt/user-http-request :rasta :post 200 "ee/metabot-tools/get-table-details"
                                                 {:request-options {:headers {"x-metabase-session" ai-token}}}
@@ -1034,7 +1034,7 @@
                                                            {:source-table (str "card__" model-id)
                                                             :aggregation [[:count]]
                                                             :breakout [!month.*created_at *quantity]}))]
-        (with-redefs [metabot-v3.tools.dummy-tools/verified-review? (constantly true)]
+        (with-redefs [metabot-v3.tools.entity-details/verified-review? (constantly true)]
           (let [request (fn [arguments]
                           (mt/user-http-request :rasta :post 200 "ee/metabot-tools/get-table-details"
                                                 {:request-options {:headers {"x-metabase-session" ai-token}}}

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/entity_details_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/entity_details_test.clj
@@ -1,7 +1,7 @@
-(ns metabase-enterprise.metabot-v3.dummy-tools-test
+(ns metabase-enterprise.metabot-v3.tools.entity-details-test
   (:require
    [clojure.test :refer :all]
-   [metabase-enterprise.metabot-v3.dummy-tools :as dummy-tools]
+   [metabase-enterprise.metabot-v3.tools.entity-details :as entity-details]
    [metabase.lib.core :as lib]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]))
@@ -10,9 +10,9 @@
 
 (deftest get-document-details-invalid-document-id-test
   (testing "returns error for invalid document-id"
-    (is (= {:output "invalid document_id"} (dummy-tools/get-document-details {:document-id "invalid"})))
-    (is (= {:output "invalid document_id"} (dummy-tools/get-document-details {:document-id nil})))
-    (is (= {:output "invalid document_id"} (dummy-tools/get-document-details {:document-id 1.5})))))
+    (is (= {:output "invalid document_id"} (entity-details/get-document-details {:document-id "invalid"})))
+    (is (= {:output "invalid document_id"} (entity-details/get-document-details {:document-id nil})))
+    (is (= {:output "invalid document_id"} (entity-details/get-document-details {:document-id 1.5})))))
 
 (deftest get-document-details-valid-document-test
   (testing "returns document details for valid document-id"
@@ -22,7 +22,7 @@
                                                  :collection_id coll-id
                                                  :creator_id (mt/user->id :crowberto)}]
       (mt/with-current-user (mt/user->id :crowberto)
-        (let [result (dummy-tools/get-document-details {:document-id doc-id})]
+        (let [result (entity-details/get-document-details {:document-id doc-id})]
           (is (contains? result :structured-output))
           (let [doc-info (:structured-output result)]
             (is (= doc-id (:id doc-info)))
@@ -32,7 +32,7 @@
 
 (deftest get-document-details-nonexistent-document-test
   (testing "returns 'document not found' for non-existent document"
-    (let [result (dummy-tools/get-document-details {:document-id 99999})]
+    (let [result (entity-details/get-document-details {:document-id 99999})]
       (is (= {:output "error fetching document: Not found."} result)))))
 
 (deftest get-document-details-archived-document-test
@@ -44,7 +44,7 @@
                                                  :creator_id (mt/user->id :crowberto)
                                                  :archived true}]
       (mt/with-current-user (mt/user->id :crowberto)
-        (let [result (dummy-tools/get-document-details {:document-id doc-id})]
+        (let [result (entity-details/get-document-details {:document-id doc-id})]
           (is (contains? result :structured-output))
           (let [doc-info (:structured-output result)]
             (is (= doc-id (:id doc-info)))
@@ -57,7 +57,7 @@
                                                  :document "{\"type\":\"doc\"}"
                                                  :creator_id (mt/user->id :crowberto)}]
       (mt/with-current-user (mt/user->id :crowberto)
-        (let [result (dummy-tools/get-document-details {:document-id doc-id})]
+        (let [result (entity-details/get-document-details {:document-id doc-id})]
           (is (contains? result :structured-output))
           (let [doc-info (:structured-output result)]
             (is (= doc-id (:id doc-info)))
@@ -70,7 +70,7 @@
                                                  :document ""
                                                  :creator_id (mt/user->id :crowberto)}]
       (mt/with-current-user (mt/user->id :crowberto)
-        (let [result (dummy-tools/get-document-details {:document-id doc-id})]
+        (let [result (entity-details/get-document-details {:document-id doc-id})]
           (is (contains? result :structured-output))
           (let [doc-info (:structured-output result)]
             (is (= doc-id (:id doc-info)))
@@ -85,7 +85,7 @@
                                                    :creator_id (mt/user->id :crowberto)}]
         (mt/with-current-user (mt/user->id :rasta)
           (is (= {:output "error fetching document: You don't have permissions to do that."}
-                 (dummy-tools/get-document-details {:document-id doc-id}))))))))
+                 (entity-details/get-document-details {:document-id doc-id}))))))))
 
 (deftest get-query-details-mbql-v4-test
   (testing "get-query-details works with MBQL v4 (legacy) queries"
@@ -95,7 +95,7 @@
                             :type :query
                             :query {:source-table (mt/id :venues)
                                     :limit 10}}
-              result (dummy-tools/get-query-details {:query legacy-query})]
+              result (entity-details/get-query-details {:query legacy-query})]
           (is (contains? result :structured-output))
           (let [output (:structured-output result)]
             (is (= :query (:type output)))
@@ -110,7 +110,7 @@
     (mt/test-driver :h2
       (mt/with-current-user (mt/user->id :crowberto)
         (let [mbql-v5-query (lib/query (mt/metadata-provider) (mt/mbql-query venues {:limit 10}))
-              result (dummy-tools/get-query-details {:query mbql-v5-query})]
+              result (entity-details/get-query-details {:query mbql-v5-query})]
           (is (contains? result :structured-output))
           (let [output (:structured-output result)]
             (is (= :query (:type output)))
@@ -125,7 +125,7 @@
     (mt/test-driver :h2
       (mt/with-current-user (mt/user->id :crowberto)
         (let [native-query (lib/native-query (mt/metadata-provider) "SELECT * FROM VENUES LIMIT 10")
-              result (dummy-tools/get-query-details {:query native-query})]
+              result (entity-details/get-query-details {:query native-query})]
           (is (contains? result :structured-output))
           (let [output (:structured-output result)]
             (is (= :query (:type output)))
@@ -144,7 +144,7 @@
               products-query (lib/query (mt/metadata-provider) (mt/mbql-query products))
               expected-products-field-count (count (lib/visible-columns products-query -1 {:include-implicitly-joinable? false}))
               ;; Get Orders table details with related tables
-              result (dummy-tools/get-table-details {:table-id orders-id})
+              result (entity-details/get-table-details {:table-id orders-id})
               output (:structured-output result)
               related-tables (:related_tables output)
               products-related (first (filter #(= products-id (:id %)) related-tables))]

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/filters_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/filters_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [medley.core :as m]
-   [metabase-enterprise.metabot-v3.dummy-tools :as metabot-v3.dummy-tools]
+   [metabase-enterprise.metabot-v3.tools.entity-details :as metabot-v3.tools.entity-details]
    [metabase-enterprise.metabot-v3.tools.filters :as metabot-v3.tools.filters]
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
@@ -37,7 +37,7 @@
                                 :filters []
                                 :group-by []}))))
       (mt/with-current-user (mt/user->id :crowberto)
-        (let [metric-details (metabot-v3.dummy-tools/metric-details metric-id)
+        (let [metric-details (metabot-v3.tools.entity-details/metric-details metric-id)
               ->field-id #(u/prog1 (-> metric-details :queryable-dimensions (by-name %) :field_id)
                             (when-not <>
                               (throw (ex-info (str "Column " % " not found") {:column %}))))]
@@ -175,7 +175,7 @@
                               :filters []
                               :group-by []}))))
     (mt/with-current-user (mt/user->id :crowberto)
-      (let [model-details (-> (metabot-v3.dummy-tools/get-table-details {:model-id model-id})
+      (let [model-details (-> (metabot-v3.tools.entity-details/get-table-details {:model-id model-id})
                               :structured-output)
             model-card-id (str "card__" model-id)
             ->field-id #(u/prog1 (-> model-details :fields (by-name %) :field_id)
@@ -314,7 +314,7 @@
   (mt/with-current-user (mt/user->id :crowberto)
     (let [mp (mt/metadata-provider)
           table-id (mt/id :orders)
-          table-details (#'metabot-v3.dummy-tools/table-details table-id {:metadata-provider mp})
+          table-details (#'metabot-v3.tools.entity-details/table-details table-id {:metadata-provider mp})
           ->field-id #(u/prog1 (-> table-details :fields (by-name %) :field_id)
                         (when-not <>
                           (throw (ex-info (str "Column " % " not found") {:column %}))))]
@@ -373,7 +373,7 @@
                                {:data-source {:table-id (str "card__" model-id)}
                                 :filters []}))))
       (mt/with-current-user (mt/user->id :crowberto)
-        (let [model-details (#'metabot-v3.dummy-tools/card-details model-id)
+        (let [model-details (#'metabot-v3.tools.entity-details/card-details model-id)
               table-id (str "card__" model-id)
               ->field-id #(u/prog1 (-> model-details :fields (by-name %) :field_id)
                             (when-not <>
@@ -420,7 +420,7 @@
                                {:data-source {:report-id card-id}
                                 :filters []}))))
       (mt/with-current-user (mt/user->id :crowberto)
-        (let [report-details (#'metabot-v3.dummy-tools/card-details card-id)
+        (let [report-details (#'metabot-v3.tools.entity-details/card-details card-id)
               ->field-id #(u/prog1 (-> report-details :fields (by-name %) :field_id)
                             (when-not <>
                               (throw (ex-info (str "Column " % " not found") {:column %}))))]
@@ -461,7 +461,7 @@
         query (lib/query mp (lib.metadata/table mp table-id))
         legacy-query (lib.convert/->legacy-MBQL query)
         query-details (mt/with-current-user (mt/user->id :crowberto)
-                        (#'metabot-v3.dummy-tools/execute-query query-id legacy-query))
+                        (#'metabot-v3.tools.entity-details/execute-query query-id legacy-query))
         ->field-id #(u/prog1 (-> query-details :result-columns (by-name %) :field_id)
                       (when-not <>
                         (throw (ex-info (str "Column " % " not found") {:column %}))))
@@ -498,7 +498,7 @@
   (mt/with-current-user (mt/user->id :crowberto)
     (let [mp (mt/metadata-provider)
           table-id (mt/id :orders)
-          table-details (#'metabot-v3.dummy-tools/table-details table-id {:metadata-provider mp})
+          table-details (#'metabot-v3.tools.entity-details/table-details table-id {:metadata-provider mp})
           ->field-id #(u/prog1 (-> table-details :fields (by-name %) :field_id)
                         (when-not <>
                           (throw (ex-info (str "Column " % " not found") {:column %}))))]
@@ -600,7 +600,7 @@
                                              :description "Test model for orders"
                                              :type :model}]
     (mt/with-current-user (mt/user->id :crowberto)
-      (let [model-details (-> (metabot-v3.dummy-tools/get-table-details {:model-id model-id})
+      (let [model-details (-> (metabot-v3.tools.entity-details/get-table-details {:model-id model-id})
                               :structured-output)
             model-card-id (str "card__" model-id)
             ->field-id #(u/prog1 (-> model-details :fields (by-name %) :field_id)

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/find_outliers_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/find_outliers_test.clj
@@ -3,7 +3,7 @@
    [clojure.test :refer :all]
    [medley.core :as m]
    [metabase-enterprise.metabot-v3.client :as metabot-v3.client]
-   [metabase-enterprise.metabot-v3.dummy-tools :as metabot-v3.dummy-tools]
+   [metabase-enterprise.metabot-v3.tools.entity-details :as metabot-v3.tools.entity-details]
    [metabase-enterprise.metabot-v3.tools.find-outliers :as metabot-v3.tools.find-outliers]
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
@@ -69,7 +69,7 @@
 (deftest report-find-outliers-test
   (mt/with-temp [:model/Card {report-id :id} (assoc (test-card) :type :question)]
     (let [report-details (mt/with-current-user (mt/user->id :crowberto)
-                           (#'metabot-v3.dummy-tools/card-details report-id))
+                           (#'metabot-v3.tools.entity-details/card-details report-id))
           ->field-id #(u/prog1 (-> report-details :fields (by-name %) :field_id)
                         (when-not <>
                           (throw (ex-info (str "Column " % " not found") {:column %}))))
@@ -81,7 +81,7 @@
 (deftest query-find-outliers-test
   (let [query-id (u/generate-nano-id)
         query-details (mt/with-current-user (mt/user->id :crowberto)
-                        (#'metabot-v3.dummy-tools/execute-query query-id (:dataset_query (test-card))))
+                        (#'metabot-v3.tools.entity-details/execute-query query-id (:dataset_query (test-card))))
         ->field-id #(u/prog1 (-> query-details :result-columns (by-name %) :field_id)
                       (when-not <>
                         (throw (ex-info (str "Column " % " not found") {:column %}))))
@@ -117,7 +117,7 @@
 (deftest ^:parallel find-outliers-wrong-query-test
   (let [query-id (u/generate-nano-id)
         query-details (mt/with-current-user (mt/user->id :crowberto)
-                        (#'metabot-v3.dummy-tools/execute-query query-id (:dataset_query (test-card))))
+                        (#'metabot-v3.tools.entity-details/execute-query query-id (:dataset_query (test-card))))
         ->field-id #(u/prog1 (-> query-details :result-columns (by-name %) :field_id)
                       (when-not <>
                         (throw (ex-info (str "Column " % " not found") {:column %}))))


### PR DESCRIPTION
Quick follow-up to https://github.com/metabase/metabase/pull/66614 since that was getting large. Renames `dummy-tools` to `entity-details` since that's what's actually in there.