### PR TITLE
Sort ids before comparison in published-models-test

### DIFF
--- a/test/metabase/warehouse_schema/models/table_test.clj
+++ b/test/metabase/warehouse_schema/models/table_test.clj
@@ -418,4 +418,4 @@
                    :model/Card  {_c5 :id} {:type :metric :published_table_id t2}]
       (is (= {t1 [c1 c3], t2 []}
              (->> (t2/hydrate [table1 table2] :published_models)
-                  (u/index-by :id (comp (partial mapv :id) :published_models))))))))
+                  (u/index-by :id (comp sort (partial mapv :id) :published_models))))))))


### PR DESCRIPTION
Fixes a flake I just saw on another PR: https://github.com/metabase/metabase/actions/runs/19975960786/job/57292106908?pr=66614