### PR TITLE
UXW-2257 fix theme override after table render

### DIFF
--- a/e2e/test/scenarios/onboarding/setup/user_settings.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/setup/user_settings.cy.spec.js
@@ -287,6 +287,75 @@ describe("user > settings", () => {
       cy.visit("/account/profile");
       assertDarkMode();
     });
+
+    it("should apply user's selected theme instead of browser's OS theme preference", () => {
+      cy.visit("/account/profile");
+
+      cy.findByDisplayValue("Use system default").click();
+      H.popover().findByText("Light").click();
+
+      assertLightMode();
+
+      H.navigationSidebar().findByText("Our analytics").click();
+      H.collectionTable().findByText("Orders").should("exist").click();
+
+      cy.findByTestId("table-body").should("be.visible"); // wait for table to be rendered
+
+      cy.window().then((win) => {
+        H.appBar()
+          .findByLabelText("Settings")
+          .should("exist")
+          .then(($button) => {
+            cy.wrap(win.getComputedStyle($button[0]).color).should(
+              "eq",
+              "rgba(7, 23, 34, 0.84)", // text-dark
+            );
+          });
+
+        cy.findByTestId("viz-type-button").click();
+        cy.findByTestId("sidebar-left")
+          .findByText("Other charts")
+          .then(($text) => {
+            cy.wrap(win.getComputedStyle($text[0]).color).should(
+              "eq",
+              "rgba(7, 23, 34, 0.62)", // text-medium
+            );
+          });
+      });
+
+      H.appBar().findByLabelText("Settings").click();
+      H.popover().findByText("Account settings").click();
+      cy.findByDisplayValue("Light").click();
+      H.popover().findByText("Dark").click();
+
+      H.openNavigationSidebar();
+      H.navigationSidebar().findByText("Our analytics").click();
+      H.collectionTable().findByText("Orders").should("exist").click();
+
+      cy.findByTestId("table-body").should("be.visible"); // wait for table to be rendered
+
+      cy.window().then((win) => {
+        H.appBar()
+          .findByLabelText("Settings")
+          .should("exist")
+          .then(($button) => {
+            cy.wrap(win.getComputedStyle($button[0]).color).should(
+              "eq",
+              "rgba(255, 255, 255, 0.95)", // text-dark
+            );
+          });
+
+        cy.findByTestId("viz-type-button").click();
+        cy.findByTestId("sidebar-left")
+          .findByText("Other charts")
+          .then(($text) => {
+            cy.wrap(win.getComputedStyle($text[0]).color).should(
+              "eq",
+              "rgba(255, 255, 255, 0.69)", // text-medium
+            );
+          });
+      });
+    });
   });
 });
 

--- a/frontend/src/metabase/app.js
+++ b/frontend/src/metabase/app.js
@@ -37,7 +37,6 @@ import { initializePlugins } from "ee-plugins";
 import { ModifiedBackend } from "metabase/common/components/dnd/ModifiedBackend";
 import { createTracker } from "metabase/lib/analytics";
 import api from "metabase/lib/api";
-import { getUserColorScheme } from "metabase/lib/color-scheme";
 import { initializeEmbedding } from "metabase/lib/embed";
 import { captureConsoleErrors } from "metabase/lib/errors";
 import { MetabaseReduxProvider } from "metabase/lib/redux/custom-context";
@@ -81,7 +80,7 @@ function _init(reducers, getRoutes, callback) {
     <MetabaseReduxProvider store={store}>
       <EmotionCacheProvider>
         <DragDropContextProvider backend={ModifiedBackend} context={{ window }}>
-          <ThemeProvider initialColorScheme={getUserColorScheme()}>
+          <ThemeProvider>
             <GlobalStyles />
             <MetabotProvider>
               <HistoryProvider history={syncedHistory}>

--- a/frontend/src/metabase/lib/color-scheme.ts
+++ b/frontend/src/metabase/lib/color-scheme.ts
@@ -13,3 +13,7 @@ export const getUserColorScheme = (): ColorScheme | undefined => {
     return window.MetabaseUserColorScheme;
   }
 };
+
+export const setUserColorSchemeAfterUpdate = (value: ColorScheme) => {
+  window.MetabaseUserColorScheme = value;
+};

--- a/frontend/src/metabase/ui/components/theme/ThemeProvider/ThemeProvider.tsx
+++ b/frontend/src/metabase/ui/components/theme/ThemeProvider/ThemeProvider.tsx
@@ -23,6 +23,10 @@ import type {
   ColorScheme,
   ResolvedColorScheme,
 } from "metabase/lib/color-scheme";
+import {
+  getUserColorScheme,
+  setUserColorSchemeAfterUpdate,
+} from "metabase/lib/color-scheme";
 import { mutateColors } from "metabase/lib/colors/colors";
 import type { DisplayTheme } from "metabase/public/lib/types";
 
@@ -176,11 +180,13 @@ export const ThemeProvider = (props: ThemeProviderProps) => {
       key: "color-scheme",
       value: value,
     });
+
+    setUserColorSchemeAfterUpdate(value);
   }, []);
 
   return (
     <ColorSchemeProvider
-      defaultColorScheme={props.initialColorScheme}
+      defaultColorScheme={getUserColorScheme()}
       forceColorScheme={forceColorScheme}
       onUpdateColorScheme={handleUpdateColorScheme}
     >


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #65665
Relates to UXW-2257 and fixes extra issue found after https://github.com/metabase/metabase/pull/66250

### Description

This fixes an issue that certain elements lose theme settings after a table is rendered.

When we render a table, we create a separate DOM node that is not attached to the main tree. In this DOM node we also use ThemeProvider to construct a theme, provide all regular size tokens and variables and then render table cells off-the-screen to measure them and apply sensible column widths before rendering a real table.
https://github.com/metabase/metabase/blob/a87175627ab6b27078343720cbf18fba2a23e107/frontend/src/metabase/data-grid/hooks/use-body-cell-measure.tsx#L28-L47

Before this fix we haven't been providing proper initial colors theme there, so it messed global mantine state in a weird way.

### How to verify

1. Set display theme in Account settings that doesn't match to the current OS theme (e.g. light theme in the evening).
2. Navigate to any rendered table (e.g. new question based on Orders)
3. Check that "Settings menu" in the top bar still has visible icon. 

Components that use variables from mantine theme, rather than css variables were affected.

### Demo


https://github.com/user-attachments/assets/d8042c70-2cc1-4b6a-b965-b636fab393cd


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
