### PR TITLE
Clarify MB_PREMIUM_EMBEDDING_TOKEN env var usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -154,7 +154,11 @@ SLACK_WEBHOOK_URL="op://qzcmvvcryrgijigzl2f6xlabhu/SLACK_WEBHOOK_URL/password"
 
 # Use staging server for license validation (avoids hitting production)
 METASTORE_DEV_SERVER_URL="https://token-check.staging.metabase.com"
-MB_PREMIUM_EMBEDDING_TOKEN="op://Shared/Metabase License Dev Tokens/Licenses/MB_ALL_FEATURES_TOKEN"
+
+# Metabase license token
+# Uncomment this line only when running local dev and NEVER when running Cypress
+# Tests need to start from zero, and set different tokens programmatically (on-demand)
+# MB_PREMIUM_EMBEDDING_TOKEN="op://Shared/Metabase License Dev Tokens/Licenses/MB_ALL_FEATURES_TOKEN"
 
 # Skip embedding SDK build for faster frontend compilation
 # SKIP_EMBEDDING_SDK="true"


### PR DESCRIPTION
Comment out MB_PREMIUM_EMBEDDING_TOKEN in .env.example to prevent conflicts with Cypress tests that need to start from a clean state and set tokens programmatically.

## Problem

E2E tests need to start from a clean/unlicensed state and set different license tokens programmatically during test runs. When developers have `MB_PREMIUM_EMBEDDING_TOKEN` set in their environment (from .env.example), it can interfere with these tests.
