### PR TITLE
Change 'support agent' wording to 'Success Engineer'

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/support/components/SupportSettingsSection/GrantAccessModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/support/components/SupportSettingsSection/GrantAccessModal.tsx
@@ -70,7 +70,7 @@ export const GrantAccessModal = ({ onClose }: GrantAccessModalProps) => {
             {t`You are about to allow a Metabase team member to access your instance.`}{" "}
           </Text>
           <Text fw="bold" display="inline">
-            {t`The support agent will have full admin access until the grant expires or is revoked.`}
+            {t`The Success Engineer will have full admin access until the grant expires or is revoked.`}
           </Text>
         </Box>
         <FormProvider initialValues={initialValues} onSubmit={handleSubmit}>

--- a/enterprise/frontend/src/metabase-enterprise/support/components/SupportSettingsSection/SupportSettingsSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/support/components/SupportSettingsSection/SupportSettingsSection.tsx
@@ -34,7 +34,7 @@ export function SupportSettingsSection() {
         <>
           <Text c="text-medium" mt="sm">
             {/* eslint-disable-next-line no-literal-metabase-strings -- This string only shows for admins. */}
-            {t`Let a Metabase support agent log in to your instance with a troubleshooting account to help resolve problems for you.`}
+            {t`Let a Metabase Success Engineer log in to your instance with a troubleshooting account to help resolve problems for you.`}
           </Text>
           <Text c="text-medium">
             {t`Access always auto expires after the period you select.`}


### PR DESCRIPTION
Closes [UXW-2470](https://linear.app/metabase/issue/UXW-2470/update-helping-hand-page-copy-to-success-engineer) & [UXW-2471](https://linear.app/metabase/issue/UXW-2471/update-grant-access-modal-copy-to-success-engineer-wording)

### Description

This PR changes some instances of the title 'support agent' to be 'Success Engineer'.

### How to verify

1. Go to Admin > Tools > Help page, verify the wording to be:
  > Let a Metabase Success Engineer log in to your instance with a troubleshooting account to help resolve problems for you.
  > Access always auto expires after the period you select.
2. Open the "Grant Access: modal for Helping hand, verify the wording to be:
  > You are about to allow a Metabase team member to access your instance. The Success Engineer will have full admin access until the grant expires or is revoked.

### Demo

<img width="1736" height="422" alt="CleanShot 2025-12-05 at 20 40 18@2x" src="https://github.com/user-attachments/assets/3ef30e9b-e777-4f81-a5cf-e6adf990307f" />

<img width="1310" height="310" alt="CleanShot 2025-12-05 at 20 40 32@2x" src="https://github.com/user-attachments/assets/51eb137b-4e4d-4302-9107-d41e73f58396" />


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
