### PR TITLE
Remove SLACK_WEBHOOK_URL from .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -145,10 +145,6 @@ MB_EMAIL_SMTP_PORT=1025
 MB_EMAIL_SMTP_USERNAME="admin"
 MB_EMAIL_SMTP_PASSWORD="admin"
 
-# Slack for testing alerts and pulses
-# https://api.slack.com/messaging/webhooks
-SLACK_WEBHOOK_URL="op://qzcmvvcryrgijigzl2f6xlabhu/SLACK_WEBHOOK_URL/password"
-
 # 3.3 Feature Flags & Tokens
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
See https://metaboat.slack.com/archives/C010L1Z4F9S/p1765196759434329?thread_ts=1764942818.644339&cid=C010L1Z4F9S