### PR TITLE
Fix #66585: Updates static embeds to omit color-scheme settings to preserve legacy transparent iframe behavior

### DIFF
--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/PreviewPane/PreviewPane.module.css
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/PreviewPane/PreviewPane.module.css
@@ -8,5 +8,12 @@
   width: 100%;
   min-height: 17.5rem;
   background-image: var(--background-url);
-  color-scheme: normal; /* Prevents browsers from adding their own "canvas color" to the preview window */
+
+  /*
+  Preserves legacy transparent iframe behavior (metabase#66585).
+  For iframes to be transparent, the `color-scheme` of the iframe and embedded document must match.
+  https://www.w3.org/TR/css-color-adjust-1/#color-scheme-effect
+  Prior to v57, the app's color-scheme was treated as `light` since there were no native "color-scheme" settings defined.
+  */
+  color-scheme: light;
 }

--- a/frontend/src/metabase/styled-components/containers/GlobalStyles/GlobalStyles.tsx
+++ b/frontend/src/metabase/styled-components/containers/GlobalStyles/GlobalStyles.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 
 import { baseStyle, rootStyle } from "metabase/css/core/base.styled";
 import { defaultFontFiles } from "metabase/css/core/fonts.styled";
+import { isStaticEmbedding } from "metabase/embedding/config";
 import { getSitePath } from "metabase/lib/dom";
 import { useSelector } from "metabase/lib/redux";
 import { getMetabaseCssVariables } from "metabase/styled-components/theme/css-variables";
@@ -45,7 +46,7 @@ export const GlobalStyles = (): JSX.Element => {
     ${saveDomImageStyles}
     body {
         font-size: 0.875em;
-        color-scheme: ${colorScheme};
+        ${isStaticEmbedding() ? "" : `color-scheme: ${colorScheme};`}
         ${rootStyle}
       }
 

--- a/frontend/src/metabase/styled-components/containers/GlobalStyles/GlobalStyles.tsx
+++ b/frontend/src/metabase/styled-components/containers/GlobalStyles/GlobalStyles.tsx
@@ -4,7 +4,10 @@ import { useMemo } from "react";
 
 import { baseStyle, rootStyle } from "metabase/css/core/base.styled";
 import { defaultFontFiles } from "metabase/css/core/fonts.styled";
-import { isStaticEmbedding } from "metabase/embedding/config";
+import {
+  isPublicEmbedding,
+  isStaticEmbedding,
+} from "metabase/embedding/config";
 import { getSitePath } from "metabase/lib/dom";
 import { useSelector } from "metabase/lib/redux";
 import { getMetabaseCssVariables } from "metabase/styled-components/theme/css-variables";
@@ -46,7 +49,9 @@ export const GlobalStyles = (): JSX.Element => {
     ${saveDomImageStyles}
     body {
         font-size: 0.875em;
-        ${isStaticEmbedding() ? "" : `color-scheme: ${colorScheme};`}
+        ${isStaticEmbedding() || isPublicEmbedding()
+          ? ""
+          : `color-scheme: ${colorScheme};`}
         ${rootStyle}
       }
 

--- a/src/metabase/server/routes/index.clj
+++ b/src/metabase/server/routes/index.clj
@@ -103,8 +103,8 @@
      :enableGoogleAuth       (boolean google-auth-client-id)
      :enableAnonTracking     (boolean anon-tracking-enabled)
      ;; (metabase#65533) color-scheme meta tag breaks EAJS because it has a transparent background.
-     ;; (metabase#66585) Also omit for static embedding to preserve legacy behavior for transparent iframes.
-     :hasColorSchemeMetaTag  (not (contains? #{"embed-sdk" "embed"} entrypoint-name))}))
+     ;; (metabase#66585) Also omit for static/public embedding to preserve legacy behavior for transparent iframes.
+     :hasColorSchemeMetaTag  (not (contains? #{"embed-sdk" "embed" "public"} entrypoint-name))}))
 
 (defn- load-entrypoint-template [entrypoint-name embeddable? opts]
   (load-template

--- a/src/metabase/server/routes/index.clj
+++ b/src/metabase/server/routes/index.clj
@@ -103,7 +103,8 @@
      :enableGoogleAuth       (boolean google-auth-client-id)
      :enableAnonTracking     (boolean anon-tracking-enabled)
      ;; (metabase#65533) color-scheme meta tag breaks EAJS because it has a transparent background.
-     :hasColorSchemeMetaTag  (not= entrypoint-name "embed-sdk")}))
+     ;; (metabase#66585) Also omit for static embedding to preserve legacy behavior for transparent iframes.
+     :hasColorSchemeMetaTag  (not (contains? #{"embed-sdk" "embed"} entrypoint-name))}))
 
 (defn- load-entrypoint-template [entrypoint-name embeddable? opts]
   (load-template


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/66585

### Description

Omits `<meta name="color-scheme" content="light dark" />` and `color-scheme` from static embeds to preserve legacy transparent iframe behavior.

### How to verify

1. See #66585 for original repro steps. Since static embeds are going away, you'll need to set it up on `release-x.57.x`.
2. Verify color-scheme meta tag and css property are still included in the main (non-embedded) app.
3. Verify background can be transparent when UA theme and embed theme are swapped (browser=light, embed=dark).
4. Verify background can still be made opaque via `background` hash param.
5. Verify embedded contents still looks/works okay in dark and light modes.
6. Verify iframes can still be made transparent if parent site has its own `<meta name="color-scheme" content="light dark" />` and `color-scheme` by adding `color-scheme: light` to iframe. In other words, this issue will come back so we need to be sure it can at least have a workaround: https://github.com/metabase/metabase/pull/64324

### Demo

**BEFORE**
<img width="1312" height="745" alt="before" src="https://github.com/user-attachments/assets/3f35c8e3-06f3-4c21-88be-934c7ace9a42" />

**AFTER (Chrome)**
<img width="1312" height="745" alt="after-chrome" src="https://github.com/user-attachments/assets/64a4d798-14ab-43d8-a9a1-347bf78c018d" />

**AFTER (FF)**
<img width="1312" height="745" alt="after-ff" src="https://github.com/user-attachments/assets/9acb702c-2c68-43c1-aefb-3332d2716106" />

**AFTER (Safari)**
<img width="1312" height="745" alt="after-safari" src="https://github.com/user-attachments/assets/3f546abe-b626-4ae3-b837-e3f89e41c137" />

**AFTER (#background=false&theme=night)**
<img width="1312" height="745" alt="Screenshot 2025-12-08 at 6 24 24 PM" src="https://github.com/user-attachments/assets/551bb8b5-ce21-4045-8979-817632eff01a" />

**AFTER (#background=true&theme=night)**
<img width="1312" height="745" alt="Screenshot 2025-12-08 at 6 24 46 PM" src="https://github.com/user-attachments/assets/9fa45221-4d7c-48d6-8130-f05ab7c602f6" />

**AFTER(#background=true)**
<img width="1312" height="745" alt="Screenshot 2025-12-08 at 6 26 38 PM" src="https://github.com/user-attachments/assets/bb5431d3-99ae-4125-a28f-3c5f4de0b875" />


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR