### PR TITLE
Bumps babashka from v0.5.25 to 0.5.27 to get a bugfix (v0.56)

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -8,7 +8,7 @@
                                              :exclusions  [org.clojure/clojure
                                                            org.clojure/clojurescript]}
   amalloy/ring-gzip-middleware              {:mvn/version "0.1.4"}              ; Ring middleware to GZIP responses if client can handle it
-  babashka/fs                               {:mvn/version "0.5.25"}             ; Portable filesystem operations
+  babashka/fs                               {:mvn/version "0.5.27"}             ; Portable filesystem operations
   bigml/histogram                           {:mvn/version "5.0.0"               ; Histogram data structure
                                              :exclusions  [junit/junit]}
   buddy/buddy-core                          {:mvn/version "1.12.0-430"          ; various cryptographic functions


### PR DESCRIPTION
Babashka had an incorrect type hint (see bb.fs commit d6c4bd1). On newer JVM versions this would cause Metabase to fail on startup when running from source.

- java.nio.file.Files/getPosixFilePermissions returns a Set.
- Up until v0.5.26, babasha.fs assumed this would be a HashSet.
- This was fixed in v0.5.27, presumably do to JDK impl details changing.

The dependency has already been bumped in v0.57.

### How to verify

Run `yarn dev-ee` or your favorite flavor of launching from source.