### PR TITLE
fix: format week of year ordinal string safely

### DIFF
--- a/frontend/src/metabase/lib/formatting/date.tsx
+++ b/frontend/src/metabase/lib/formatting/date.tsx
@@ -1110,7 +1110,11 @@ export function formatDateTimeWithUnit(
   }
 
   if (unit === "week-of-year") {
-    return dayjs().localeData().ordinal(m.isoWeek()).slice(1, -1);
+    const ordinal = String(dayjs().localeData().ordinal(m.isoWeek()));
+    if (ordinal.startsWith("[") && ordinal.endsWith("]")) {
+      return ordinal.slice(1, -1);
+    }
+    return ordinal;
   }
 
   // expand "week" into a range in specific contexts

--- a/frontend/test/metabase/lib/formatting.unit.spec.js
+++ b/frontend/test/metabase/lib/formatting.unit.spec.js
@@ -789,6 +789,25 @@ describe("formatting", () => {
         const endYear = formatDateTimeWithUnit("2023-12-25", "week-of-year");
         expect(endYear).toMatch(/^5[0-3][a-z]+$/);
       });
+
+      it("should remove square brackets from English ordinals", () => {
+        expect(formatDateTimeWithUnit(1, "week-of-year")).toEqual("1st");
+        expect(formatDateTimeWithUnit(2, "week-of-year")).toEqual("2nd");
+        expect(formatDateTimeWithUnit(3, "week-of-year")).toEqual("3rd");
+      });
+
+      it("should handle non-English locales where ordinals are not wrapped in brackets (#66658)", () => {
+        const originalLocale = dayjs.locale();
+        try {
+          require("dayjs/locale/fr");
+          dayjs.locale("fr");
+          expect(formatDateTimeWithUnit(1, "week-of-year")).toEqual("1er");
+          expect(formatDateTimeWithUnit(2, "week-of-year")).toEqual("2");
+          expect(formatDateTimeWithUnit(3, "week-of-year")).toEqual("3");
+        } finally {
+          dayjs.locale(originalLocale);
+        }
+      });
     });
   });
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/66658

### Description

Checks if we can remove the square brackets from the week of year ordinal safely before doing so

### How to verify

See repro steps in the issue. It should work as expected. 

### Demo

https://github.com/user-attachments/assets/26e71a25-b4c1-4bf1-886d-f69413349158

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
