### PR TITLE
Include "all entries for" in `mt/all-entries-for`

### DIFF
--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -1592,12 +1592,12 @@
   [topic model model-id]
   (assert (int? model-id) "Must provide an integer id for the model")
   (assert (isa? model :metabase/model))
-  (t2/select-one [:model/AuditLog :topic :user_id :model :model_id :details]
-                 {:order-by [[:id :desc]]
-                  :where [:and
-                          [:= :model (name model)]
-                          [:= :model_id model-id]
-                          (when topic [:= :topic (name topic)])]}))
+  (t2/select [:model/AuditLog :topic :user_id :model :model_id :details]
+             {:order-by [[:id :desc]]
+              :where [:and
+                      [:= :model (name model)]
+                      [:= :model_id model-id]
+                      (when topic [:= :topic (name topic)])]}))
 
 (defn repeat-concurrently
   "Run `f` `n` times concurrently. Returns a vector of the results of each invocation of `f`."


### PR DESCRIPTION
this should get all audit log entries for a given model and model-id. but previously it was using t2/select-one. now it uses t2/select. whoops