### PR TITLE
Eliminate `analytics` dependency on `channel`

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -105,7 +105,6 @@
    :uses #{api
            app-db
            appearance
-           channel
            config
            driver
            eid-translation

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -13,7 +13,6 @@
    [metabase.analytics.snowplow :as snowplow]
    [metabase.app-db.core :as app-db]
    [metabase.appearance.core :as appearance]
-   [metabase.channel.slack :as slack]
    [metabase.config.core :as config]
    [metabase.driver :as driver]
    [metabase.eid-translation.core :as eid-translation]
@@ -130,7 +129,7 @@
    ;; We deprecated advanced humanization but have this here anyways
    :friendly_names                       (= (humanization/humanization-strategy) "advanced")
    :email_configured                     (setting/get :email-configured?)
-   :slack_configured                     (slack/slack-configured?)
+   :slack_configured                     (setting/get :slack-configured?)
    :sso_configured                       (setting/get :google-auth-enabled)
    :instance_started                     (analytics.settings/instance-creation)
    :has_sample_data                      (t2/exists? :model/Database, :is_sample true)
@@ -767,7 +766,7 @@
     :enabled   (setting/get :email-configured?)}
    {:name      :slack
     :available true
-    :enabled   (slack/slack-configured?)}
+    :enabled   (setting/get :slack-configured?)}
    {:name      :sso-google
     :available true
     :enabled   (setting/get :google-auth-configured)}

--- a/src/metabase/channel/settings.clj
+++ b/src/metabase/channel/settings.clj
@@ -321,11 +321,12 @@
 
 (defsetting slack-configured?
   "Is Slack integration configured?"
-  :type :boolean
+  :type       :boolean
   :visibility :internal
-  :getter (fn []
-            (boolean
-             (or
-              (seq (slack-app-token))
-              (seq (slack-token)))))
-  :setter :none)
+  :getter     (fn []
+                (boolean
+                 (or
+                  (seq (slack-app-token))
+                  (seq (slack-token)))))
+  :export?    false
+  :setter     :none)

--- a/src/metabase/channel/settings.clj
+++ b/src/metabase/channel/settings.clj
@@ -318,3 +318,14 @@
                   (assert (#{:external-only :allow-private :allow-all} (keyword new-value))
                           (tru "Invalid http-channel-host-strategy! Only values of external-only, allow-private, and allow-all are allowed.")))
                 (setting/set-value-of-type! :keyword :http-channel-host-strategy new-value)))
+
+(defsetting slack-configured?
+  "Is Slack integration configured?"
+  :type :boolean
+  :visibility :internal
+  :getter (fn []
+            (boolean
+             (or
+              (seq (slack-app-token))
+              (seq (slack-token)))))
+  :setter :none)

--- a/src/metabase/channel/slack.clj
+++ b/src/metabase/channel/slack.clj
@@ -17,11 +17,6 @@
 
 (set! *warn-on-reflection* true)
 
-(defn slack-configured?
-  "Is Slack integration configured?"
-  []
-  (boolean (or (seq (channel.settings/slack-app-token)) (seq (channel.settings/slack-token)))))
-
 (def ^:private slack-token-error-codes
   "List of error codes that indicate an invalid or revoked Slack token."
   ;; If any of these error codes are received from the Slack API, we send an email to all admins indicating that the
@@ -212,7 +207,7 @@
   "Refreshes users and conversations in slack-cache. finds both in parallel, sets
   [[slack-cached-channels-and-usernames]], and resets the [[slack-channels-and-usernames-last-updated]] time."
   []
-  (when (slack-configured?)
+  (when (channel.settings/slack-configured?)
     (log/info "Refreshing slack channels and usernames.")
     (let [users (future (vec (users-list)))
           private-channels? #(contains? (oauth-scopes) "groups:read")
@@ -304,7 +299,7 @@
    the URL of the uploaded file."
   [file       :- NonEmptyByteArray
    filename   :- ms/NonBlankString]
-  {:pre [(slack-configured?)]}
+  {:pre [(channel.settings/slack-configured?)]}
   ;; TODO: we could make uploading files a lot faster by uploading the files in parallel.
   ;; Steps 1 and 2 can be done for all files in parallel, and step 3 can be done once at the end.
   (let [;; Step 1: Get the upload URL using files.getUploadURLExternal

--- a/src/metabase/channel/task/refresh_slack_channel_user_cache.clj
+++ b/src/metabase/channel/task/refresh_slack_channel_user_cache.clj
@@ -13,7 +13,7 @@
 (set! *warn-on-reflection* true)
 
 (defn ^:private job []
-  (if (slack/slack-configured?)
+  (if (channel.settings/slack-configured?)
     (let [_        (log/info "Starting Slack user/channel startup cache refresh...")
           timer    (u/start-timer)
           _        (slack/refresh-channels-and-usernames!)]

--- a/src/metabase/pulse/api/pulse.clj
+++ b/src/metabase/pulse/api/pulse.clj
@@ -264,7 +264,7 @@
   []
   (perms/check-has-application-permission :subscription false)
   (let [chan-types (-> pulse-channel/channel-types
-                       (assoc-in [:slack :configured] (channel.slack/slack-configured?))
+                       (assoc-in [:slack :configured] (channel.settings/slack-configured?))
                        (assoc-in [:email :configured] (channel.settings/email-configured?))
                        (assoc-in [:http :configured] (t2/exists? :model/Channel :type :channel/http :active true)))]
     {:channels (cond

--- a/test/metabase/analytics/stats_test.clj
+++ b/test/metabase/analytics/stats_test.clj
@@ -89,7 +89,7 @@
 
 (deftest anonymous-usage-stats-test
   (with-redefs [channel.settings/email-configured? (constantly false)
-                slack/slack-configured? (constantly false)]
+                channel.settings/slack-configured? (constantly false)]
     (mt/with-temporary-setting-values [site-name          "Metabase"
                                        startup-time-millis 1234.0
                                        google-auth-enabled false
@@ -127,7 +127,7 @@
   ; some settings are behind the whitelabel feature flag
   (mt/with-premium-features #{:whitelabel}
     (with-redefs [channel.settings/email-configured? (constantly false)
-                  slack/slack-configured? (constantly false)]
+                  channel.settings/slack-configured? (constantly false)]
       (mt/with-temporary-setting-values [site-name                   "My Company Analytics"
                                          startup-time-millis          1234.0
                                          google-auth-enabled          false

--- a/test/metabase/analytics/stats_test.clj
+++ b/test/metabase/analytics/stats_test.clj
@@ -8,7 +8,6 @@
    [metabase.analytics.stats :as stats :refer [legacy-anonymous-usage-stats]]
    [metabase.app-db.core :as mdb]
    [metabase.channel.settings :as channel.settings]
-   [metabase.channel.slack :as slack]
    [metabase.config.core :as config]
    [metabase.core.core :as mbc]
    [metabase.premium-features.settings :as premium-features.settings]


### PR DESCRIPTION
Make `slack-configured?` an internal read-only Setting (its value is calculated based on other Settings) rather than a function so its value can be gotten without requiring the `channel` module itself