### PR TITLE
Improve database form dirty state awareness

### DIFF
--- a/frontend/src/metabase/admin/databases/components/DatabaseEditConnectionForm.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditConnectionForm.tsx
@@ -98,7 +98,7 @@ export const DatabaseEditConnectionForm = withRouter(
               config={{ isAdvanced: true, ...config }}
               onCancel={onCancel}
               onSubmit={handleSubmit}
-              setIsDirty={setIsDirty}
+              onDirtyStateChange={setIsDirty}
               location={formLocation}
               onEngineChange={onEngineChange}
             />

--- a/frontend/src/metabase/databases/components/DatabaseForm/DatabaseForm.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseForm/DatabaseForm.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { Form, FormProvider } from "metabase/forms";
 import { useSelector } from "metabase/lib/redux";
@@ -64,7 +64,9 @@ export const DatabaseForm = ({
   const engineFieldState = config.engine?.fieldState;
 
   const engines = useSelector(getEngines);
-  const initialEngineKey = getEngineKey(engines, initialData, isAdvanced);
+  const initialEngineKey = useMemo(() => {
+    return getEngineKey(engines, initialData, isAdvanced);
+  }, [engines, initialData, isAdvanced]);
   const [engineKey, setEngineKey] = useState(initialEngineKey);
   const engine = getEngine(engines, engineKey);
 
@@ -78,6 +80,11 @@ export const DatabaseForm = ({
       { stripUnknown: true },
     );
   }, [initialData, engineKey, validationSchema]);
+
+  useEffect(() => {
+    // during page load, if initialData changes, initialEngineKey will also change
+    setEngineKey(initialEngineKey);
+  }, [initialEngineKey]);
 
   const handleSubmit = useCallback(
     (values: DatabaseData) => {

--- a/frontend/src/metabase/databases/components/DatabaseForm/DatabaseForm.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseForm/DatabaseForm.tsx
@@ -10,6 +10,7 @@ import { getSubmitValues, getValidationSchema } from "../../utils/schema";
 
 import { DatabaseFormBody } from "./DatabaseFormBody";
 import { DatabaseFormFooter } from "./DatabaseFormFooter";
+import { FormDirtyStateProvider } from "./context";
 import { getEngine, getEngineKey } from "./utils";
 
 export type EngineFieldState = "default" | "hidden" | "disabled";
@@ -37,7 +38,7 @@ interface DatabaseFormProps {
   onSubmit?: (values: DatabaseData) => void;
   onEngineChange?: (engineKey: string | undefined) => void;
   onCancel?: () => void;
-  setIsDirty?: (isDirty: boolean) => void;
+  onDirtyStateChange?: (isDirty: boolean) => void;
   config?: DatabaseFormConfig;
   location: FormLocation;
   /**
@@ -54,7 +55,7 @@ export const DatabaseForm = ({
   onSubmit,
   onCancel,
   onEngineChange,
-  setIsDirty,
+  onDirtyStateChange,
   location,
   showSampleDatabase = false,
   ContinueWithoutDataSlot,
@@ -112,27 +113,28 @@ export const DatabaseForm = ({
         data-testid="database-form"
         pt={location === "full-page" ? undefined : "md"}
       >
-        <DatabaseFormBody
-          engine={engine}
-          // casting won't be needed after migrating all usages of engineKey
-          engineKey={engineKey as EngineKey}
-          engines={engines}
-          engineFieldState={engineFieldState}
-          autofocusFieldName={autofocusFieldName}
-          isAdvanced={isAdvanced}
-          onEngineChange={handleEngineChange}
-          setIsDirty={setIsDirty}
-          config={config}
-          showSampleDatabase={showSampleDatabase}
-          location={location}
-        />
-        <DatabaseFormFooter
-          ContinueWithoutDataSlot={ContinueWithoutDataSlot}
-          isAdvanced={isAdvanced}
-          location={location}
-          onCancel={onCancel}
-          showSampleDatabase={showSampleDatabase}
-        />
+        <FormDirtyStateProvider onDirtyStateChange={onDirtyStateChange}>
+          <DatabaseFormBody
+            engine={engine}
+            // casting won't be needed after migrating all usages of engineKey
+            engineKey={engineKey as EngineKey}
+            engines={engines}
+            engineFieldState={engineFieldState}
+            autofocusFieldName={autofocusFieldName}
+            isAdvanced={isAdvanced}
+            onEngineChange={handleEngineChange}
+            config={config}
+            showSampleDatabase={showSampleDatabase}
+            location={location}
+          />
+          <DatabaseFormFooter
+            ContinueWithoutDataSlot={ContinueWithoutDataSlot}
+            isAdvanced={isAdvanced}
+            location={location}
+            onCancel={onCancel}
+            showSampleDatabase={showSampleDatabase}
+          />
+        </FormDirtyStateProvider>
       </Form>
     </FormProvider>
   );

--- a/frontend/src/metabase/databases/components/DatabaseForm/DatabaseFormBody.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseForm/DatabaseFormBody.tsx
@@ -1,5 +1,5 @@
 import { useFormikContext } from "formik";
-import { type JSX, useEffect, useMemo } from "react";
+import { type JSX, useMemo } from "react";
 import { match } from "ts-pattern";
 
 import type {
@@ -27,7 +27,6 @@ interface DatabaseFormBodyProps {
   autofocusFieldName?: string;
   isAdvanced: boolean;
   onEngineChange: (engineKey: string | undefined) => void;
-  setIsDirty?: (isDirty: boolean) => void;
   config: DatabaseFormConfig;
   showSampleDatabase?: boolean;
   location: FormLocation;
@@ -41,17 +40,12 @@ export const DatabaseFormBody = ({
   autofocusFieldName,
   isAdvanced,
   onEngineChange,
-  setIsDirty,
   config,
   showSampleDatabase = false,
   location,
 }: DatabaseFormBodyProps): JSX.Element => {
-  const { values, dirty, setValues } = useFormikContext<DatabaseData>();
+  const { values, setValues } = useFormikContext<DatabaseData>();
   const hasConnectionError = useHasConnectionError();
-
-  useEffect(() => {
-    setIsDirty?.(dirty);
-  }, [dirty, setIsDirty]);
 
   const fields = useMemo(() => {
     return engine ? getVisibleFields(engine, values, isAdvanced) : [];

--- a/frontend/src/metabase/databases/components/DatabaseForm/DatabaseFormFooter.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseForm/DatabaseFormFooter.tsx
@@ -1,5 +1,4 @@
 import { useFormikContext } from "formik";
-import { useMemo } from "react";
 import { c, t } from "ttag";
 
 import ExternalLink from "metabase/common/components/ExternalLink";
@@ -15,7 +14,7 @@ import type { DatabaseData } from "metabase-types/api";
 
 import { DatabaseFormError } from "../DatabaseFormError";
 
-import { checkFormIsDirty, useHasConnectionError } from "./utils";
+import { useHasConnectionError, useIsFormDirty } from "./utils";
 
 interface DatabaseFormFooterProps {
   isAdvanced: boolean;
@@ -32,13 +31,10 @@ export const DatabaseFormFooter = ({
   ContinueWithoutDataSlot,
   location,
 }: DatabaseFormFooterProps) => {
-  const { values, initialValues } = useFormikContext<DatabaseData>();
-  const isDirty = useMemo(
-    () => checkFormIsDirty(initialValues, values),
-    [initialValues, values],
-  );
+  const { values } = useFormikContext<DatabaseData>();
   const isNew = values.id == null;
   const hasConnectionError = useHasConnectionError();
+  const isDirty = useIsFormDirty();
 
   // eslint-disable-next-line no-unconditional-metabase-links-render -- Metabase setup + admin pages only
   const { url: docsUrl } = useDocsUrl("databases/connecting");

--- a/frontend/src/metabase/databases/components/DatabaseForm/DatabaseFormFooter.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseForm/DatabaseFormFooter.tsx
@@ -1,4 +1,5 @@
 import { useFormikContext } from "formik";
+import { useMemo } from "react";
 import { c, t } from "ttag";
 
 import ExternalLink from "metabase/common/components/ExternalLink";
@@ -14,7 +15,7 @@ import type { DatabaseData } from "metabase-types/api";
 
 import { DatabaseFormError } from "../DatabaseFormError";
 
-import { useHasConnectionError } from "./utils";
+import { checkFormIsDirty, useHasConnectionError } from "./utils";
 
 interface DatabaseFormFooterProps {
   isAdvanced: boolean;
@@ -31,7 +32,11 @@ export const DatabaseFormFooter = ({
   ContinueWithoutDataSlot,
   location,
 }: DatabaseFormFooterProps) => {
-  const { values, dirty } = useFormikContext<DatabaseData>();
+  const { values, initialValues } = useFormikContext<DatabaseData>();
+  const isDirty = useMemo(
+    () => checkFormIsDirty(initialValues, values),
+    [initialValues, values],
+  );
   const isNew = values.id == null;
   const hasConnectionError = useHasConnectionError();
 
@@ -62,7 +67,7 @@ export const DatabaseFormFooter = ({
           <Flex gap="sm">
             <Button onClick={onCancel}>{t`Cancel`}</Button>
             <FormSubmitButton
-              disabled={!dirty}
+              disabled={!isDirty}
               label={isNew ? t`Save` : t`Save changes`}
               variant="filled"
             />

--- a/frontend/src/metabase/databases/components/DatabaseForm/context/FormDirtyStateContext.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseForm/context/FormDirtyStateContext.tsx
@@ -1,0 +1,45 @@
+import { useFormikContext } from "formik";
+import {
+  type PropsWithChildren,
+  createContext,
+  useEffect,
+  useState,
+} from "react";
+
+import type { DatabaseData } from "metabase-types/api";
+
+import { checkFormIsDirty } from "./utils";
+
+export const FormDirtyStateContext = createContext<boolean>(false);
+
+type ProviderProps = PropsWithChildren<{
+  onDirtyStateChange?: (isDirty: boolean) => void;
+}>;
+
+/**
+ * Custom definition for form dirty state.
+ * This is needed because Formik's `dirty` value is not accurate to track actual field updates on our database form (#65988).
+ *
+ * This should be wrapped in a FormProvider.
+ */
+export const FormDirtyStateProvider = ({
+  children,
+  onDirtyStateChange,
+}: ProviderProps) => {
+  const [isDirty, setIsDirty] = useState<boolean>(false);
+  const { initialValues, values } = useFormikContext<DatabaseData>();
+
+  useEffect(() => {
+    setIsDirty(checkFormIsDirty(initialValues, values));
+  }, [initialValues, values]);
+
+  useEffect(() => {
+    onDirtyStateChange?.(isDirty);
+  }, [isDirty, onDirtyStateChange]);
+
+  return (
+    <FormDirtyStateContext.Provider value={isDirty}>
+      {children}
+    </FormDirtyStateContext.Provider>
+  );
+};

--- a/frontend/src/metabase/databases/components/DatabaseForm/context/index.ts
+++ b/frontend/src/metabase/databases/components/DatabaseForm/context/index.ts
@@ -1,0 +1,4 @@
+export {
+  FormDirtyStateProvider,
+  FormDirtyStateContext,
+} from "./FormDirtyStateContext";

--- a/frontend/src/metabase/databases/components/DatabaseForm/context/utils.ts
+++ b/frontend/src/metabase/databases/components/DatabaseForm/context/utils.ts
@@ -1,0 +1,24 @@
+import _ from "underscore";
+
+import type { DatabaseData } from "metabase-types/api";
+
+export const checkFormIsDirty = (
+  initialValues: DatabaseData,
+  currentValues: DatabaseData,
+) => {
+  const sanitizeValues = (values: DatabaseData) => {
+    return {
+      ...values,
+      // Ignore "advanced-options" when checking if the form is dirty. It is not an actual field.
+      details: _.omit(values.details, ["advanced-options"]),
+      // These boolean fields are nullable. When null, they are treated as false in the form.
+      refingerprint: values.refingerprint || false,
+      auto_run_queries: values.auto_run_queries || false,
+    };
+  };
+
+  return !_.isEqual(
+    sanitizeValues(initialValues),
+    sanitizeValues(currentValues),
+  );
+};

--- a/frontend/src/metabase/databases/components/DatabaseForm/context/utils.unit.spec.ts
+++ b/frontend/src/metabase/databases/components/DatabaseForm/context/utils.unit.spec.ts
@@ -1,0 +1,54 @@
+import { createMockDatabaseData } from "metabase-types/api/mocks";
+
+import { checkFormIsDirty } from "./utils";
+
+describe("checkFormIsDirty", () => {
+  it("should return false when values are equal", () => {
+    const initialValues = createMockDatabaseData();
+    const currentValues = createMockDatabaseData();
+
+    // Everything is the same
+    expect(checkFormIsDirty(initialValues, currentValues)).toBe(false);
+
+    // Name changed
+    expect(
+      checkFormIsDirty(initialValues, {
+        ...currentValues,
+        name: "another name",
+      }),
+    ).toBe(true);
+  });
+
+  it("should ignore advanced-options field when checking dirty state", () => {
+    const initialValues = createMockDatabaseData({
+      details: {
+        "advanced-options": false,
+      },
+    });
+    const currentValues = createMockDatabaseData({
+      details: {
+        "advanced-options": true,
+      },
+    });
+
+    expect(checkFormIsDirty(initialValues, currentValues)).toBe(false);
+  });
+
+  it("should treat null refingerprint as false", () => {
+    const initialValues = createMockDatabaseData({
+      refingerprint: null as any,
+    });
+    const currentValues = createMockDatabaseData({ refingerprint: false });
+
+    expect(checkFormIsDirty(initialValues, currentValues)).toBe(false);
+  });
+
+  it("should treat null auto_run_queries as false", () => {
+    const initialValues = createMockDatabaseData({
+      auto_run_queries: null as any,
+    });
+    const currentValues = createMockDatabaseData({ auto_run_queries: false });
+
+    expect(checkFormIsDirty(initialValues, currentValues)).toBe(false);
+  });
+});

--- a/frontend/src/metabase/databases/components/DatabaseForm/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseForm/tests/common.unit.spec.tsx
@@ -106,6 +106,45 @@ describe("DatabaseForm", () => {
 
     expect(screen.getByPlaceholderText("Our H2")).toBeInTheDocument();
   });
+
+  describe("updating existing database", () => {
+    it("should mark form as dirty only when actual fields are changed (#66684)", async () => {
+      setup({
+        initialValues: {
+          id: 1,
+          name: "My Original H2 Database name",
+          details: {
+            db: "file:/somewhere",
+          },
+        },
+      });
+      const getSaveButton = () =>
+        screen.getByRole("button", { name: "Save changes" });
+      const getNameInput = () => screen.getByLabelText("Display name");
+      const getRefingerprintToggle = () =>
+        screen.getByLabelText(/Periodically refingerprint tables/);
+
+      expect(getSaveButton()).toBeDisabled();
+      await userEvent.click(screen.getByText("Show advanced options"));
+      // Still disabled after opening up advanced options
+      await waitFor(() => expect(getSaveButton()).toBeDisabled());
+
+      // Button gets enabled when a field is changed, and disabled again when it is reset
+      await userEvent.clear(getNameInput());
+      await userEvent.type(getNameInput(), "My updated name");
+      await waitFor(() => expect(getSaveButton()).toBeEnabled());
+
+      await userEvent.clear(getNameInput());
+      await userEvent.type(getNameInput(), "My Original H2 Database name");
+      await waitFor(() => expect(getSaveButton()).toBeDisabled());
+
+      // Check also for a toggle field in advanced options
+      await userEvent.click(getRefingerprintToggle());
+      await waitFor(() => expect(getSaveButton()).toBeEnabled());
+      await userEvent.click(getRefingerprintToggle());
+      await waitFor(() => expect(getSaveButton()).toBeDisabled());
+    });
+  });
 });
 
 describe("DatabaseForm with provider name", () => {

--- a/frontend/src/metabase/databases/components/DatabaseForm/utils.ts
+++ b/frontend/src/metabase/databases/components/DatabaseForm/utils.ts
@@ -1,8 +1,10 @@
-import _ from "underscore";
+import { useContext } from "react";
 
 import { getDefaultEngineKey } from "metabase/databases/utils/engine";
 import { useFormErrorMessage } from "metabase/forms";
 import type { DatabaseData, Engine } from "metabase-types/api";
+
+import { FormDirtyStateContext } from "./context";
 
 export const useHasConnectionError = () => {
   const errorMessage = useFormErrorMessage();
@@ -28,23 +30,6 @@ export const getEngineKey = (
   }
 };
 
-export const checkFormIsDirty = (
-  initialValues: DatabaseData,
-  currentValues: DatabaseData,
-) => {
-  const sanitizeValues = (values: DatabaseData) => {
-    return {
-      ...values,
-      // Ignore "advanced-options" when checking if the form is dirty (#65988). It is not an actual field.
-      details: _.omit(values.details, ["advanced-options"]),
-      // These boolean fields are nullable. When null, they are treated false in the form.
-      refingerprint: values.refingerprint || false,
-      auto_run_queries: values.auto_run_queries || false,
-    };
-  };
-
-  return !_.isEqual(
-    sanitizeValues(initialValues),
-    sanitizeValues(currentValues),
-  );
+export const useIsFormDirty = () => {
+  return useContext(FormDirtyStateContext);
 };

--- a/frontend/src/metabase/databases/components/DatabaseForm/utils.ts
+++ b/frontend/src/metabase/databases/components/DatabaseForm/utils.ts
@@ -1,3 +1,5 @@
+import _ from "underscore";
+
 import { getDefaultEngineKey } from "metabase/databases/utils/engine";
 import { useFormErrorMessage } from "metabase/forms";
 import type { DatabaseData, Engine } from "metabase-types/api";
@@ -24,4 +26,25 @@ export const getEngineKey = (
   } else if (isAdvanced) {
     return getDefaultEngineKey(engines);
   }
+};
+
+export const checkFormIsDirty = (
+  initialValues: DatabaseData,
+  currentValues: DatabaseData,
+) => {
+  const sanitizeValues = (values: DatabaseData) => {
+    return {
+      ...values,
+      // Ignore "advanced-options" when checking if the form is dirty (#65988). It is not an actual field.
+      details: _.omit(values.details, ["advanced-options"]),
+      // These boolean fields are nullable. When null, they are treated false in the form.
+      refingerprint: values.refingerprint || false,
+      auto_run_queries: values.auto_run_queries || false,
+    };
+  };
+
+  return !_.isEqual(
+    sanitizeValues(initialValues),
+    sanitizeValues(currentValues),
+  );
 };


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #65988
Closes https://linear.app/metabase/issue/UXW-2321/toggling-advanced-options-section-on-database-connection-details

### Description

Issue 1: Formik's dirty state is not enough for our database form. It is considering the 'advanced-options' boolean field, which is just used to expand or not the advanced fields section. 

Issue 2: When we execute the sequence enable -> disable on toggle fields (e.g. "Periodically refingerprint tables"), the form was still being marked as dirty, because the value was originally `null`, not `false`. 

The solution is having a custom function to compute the dirty state instead of using Formik's dirty value.

### How to verify

1. Go to databases > select a postgres or mysql one > edit connection details 
2. Check that when you expand the advanced settings, the Save changes button remains disabled. When you change an actual field it gets enabled, if you rollback the updates it will get disabled again. 
3. If you hit the cancel button while the save button is enabled (form is dirty), you'll get the "Discard your changes?" popup. And you shouldn't get it if you update the form to have the original values.

### Demo

Before:
https://www.loom.com/share/3777bf6d683a4d4aa91800667764bf93

After:
https://www.loom.com/share/ae7216f2c6e54676bf380e43b01d6039

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
