### PR TITLE
ci(sdk): fix broken docgen by adding interface modifier

### DIFF
--- a/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.tsx
@@ -40,6 +40,7 @@ import type Question from "metabase-lib/v1/Question";
 import { staticQuestionSchema } from "./StaticQuestion.schema";
 
 /**
+ * @interface
  * @expand
  * @category StaticQuestion
  */

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/StaticDashboard/StaticDashboard.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/StaticDashboard/StaticDashboard.tsx
@@ -13,6 +13,7 @@ import { SdkDashboard, type SdkDashboardProps } from "../SdkDashboard";
 import { staticDashboardSchema } from "./StaticDashboard.schema";
 
 /**
+ * @interface
  * @expand
  * @category Dashboard
  */


### PR DESCRIPTION
Closes EMB-1107

Removing the `@interface` modifier from the docstring caused it to be inlined, breaking docs CI. See [this Slack thread for more info](https://metaboat.slack.com/archives/C063Q3F1HPF/p1765245246263569?thread_ts=1763567831.165189&cid=C063Q3F1HPF).