### PR TITLE
Don't add newline to commented out clauses in native query preview

### DIFF
--- a/frontend/src/metabase/lib/engine.ts
+++ b/frontend/src/metabase/lib/engine.ts
@@ -44,14 +44,39 @@ export function isDeprecatedEngine(
   return engines[engine] != null && engines[engine]["superseded-by"] != null;
 }
 
+function isOnCommentLine(sql: string, position: number): boolean {
+  const lineStart = sql.lastIndexOf("\n", position);
+  const lineContent = sql.substring(lineStart);
+  return lineContent.trimStart().startsWith("--");
+}
+
+function replaceFirstNotOnCommentLine(
+  sql: string,
+  pattern: RegExp,
+  replacement: string,
+): string {
+  const replacePattern = new RegExp(pattern.source, "g");
+  let match;
+  while ((match = replacePattern.exec(sql)) !== null) {
+    if (!isOnCommentLine(sql, match.index)) {
+      return (
+        sql.substring(0, match.index) +
+        replacement +
+        sql.substring(match.index + match[0].length)
+      );
+    }
+  }
+  return sql;
+}
+
 function formatSQL(sql: string) {
-  sql = sql.replace(/\sFROM/, "\nFROM");
-  sql = sql.replace(/\sLEFT JOIN/, "\nLEFT JOIN");
-  sql = sql.replace(/\sWHERE/, "\nWHERE");
-  sql = sql.replace(/\sGROUP BY/, "\nGROUP BY");
-  sql = sql.replace(/\sORDER BY/, "\nORDER BY");
-  sql = sql.replace(/\sLIMIT/, "\nLIMIT");
-  sql = sql.replace(/\sAND\s/, "\n   AND ");
-  sql = sql.replace(/\sOR\s/, "\n    OR ");
+  sql = replaceFirstNotOnCommentLine(sql, /\sFROM/, "\nFROM");
+  sql = replaceFirstNotOnCommentLine(sql, /\sLEFT JOIN/, "\nLEFT JOIN");
+  sql = replaceFirstNotOnCommentLine(sql, /\sWHERE/, "\nWHERE");
+  sql = replaceFirstNotOnCommentLine(sql, /\sGROUP BY/, "\nGROUP BY");
+  sql = replaceFirstNotOnCommentLine(sql, /\sORDER BY/, "\nORDER BY");
+  sql = replaceFirstNotOnCommentLine(sql, /\sLIMIT/, "\nLIMIT");
+  sql = replaceFirstNotOnCommentLine(sql, /\sAND\s/, "\n   AND ");
+  sql = replaceFirstNotOnCommentLine(sql, /\sOR\s/, "\n    OR ");
   return sql;
 }

--- a/frontend/src/metabase/lib/engine.ts
+++ b/frontend/src/metabase/lib/engine.ts
@@ -20,20 +20,7 @@ function formatJsonQuery(query: JSONQuery) {
   return JSON.stringify(query, null, 2);
 }
 
-export function formatNativeQuery(
-  query: string | JSONQuery,
-  engine: string,
-): string {
-  const engineType = getEngineNativeType(engine);
-
-  if (typeof query === "string" && engineType === "sql") {
-    return formatSQL(query);
-  }
-
-  if (engineType === "json") {
-    return typeof query === "object" ? formatJsonQuery(query) : query;
-  }
-
+export function formatNativeQuery(query: string | JSONQuery): string {
   return typeof query === "string" ? query : formatJsonQuery(query);
 }
 
@@ -42,41 +29,4 @@ export function isDeprecatedEngine(
   engine: string,
 ) {
   return engines[engine] != null && engines[engine]["superseded-by"] != null;
-}
-
-function isOnCommentLine(sql: string, position: number): boolean {
-  const lineStart = sql.lastIndexOf("\n", position);
-  const lineContent = sql.substring(lineStart);
-  return lineContent.trimStart().startsWith("--");
-}
-
-function replaceFirstNotOnCommentLine(
-  sql: string,
-  pattern: RegExp,
-  replacement: string,
-): string {
-  const replacePattern = new RegExp(pattern.source, "g");
-  let match;
-  while ((match = replacePattern.exec(sql)) !== null) {
-    if (!isOnCommentLine(sql, match.index)) {
-      return (
-        sql.substring(0, match.index) +
-        replacement +
-        sql.substring(match.index + match[0].length)
-      );
-    }
-  }
-  return sql;
-}
-
-function formatSQL(sql: string) {
-  sql = replaceFirstNotOnCommentLine(sql, /\sFROM/, "\nFROM");
-  sql = replaceFirstNotOnCommentLine(sql, /\sLEFT JOIN/, "\nLEFT JOIN");
-  sql = replaceFirstNotOnCommentLine(sql, /\sWHERE/, "\nWHERE");
-  sql = replaceFirstNotOnCommentLine(sql, /\sGROUP BY/, "\nGROUP BY");
-  sql = replaceFirstNotOnCommentLine(sql, /\sORDER BY/, "\nORDER BY");
-  sql = replaceFirstNotOnCommentLine(sql, /\sLIMIT/, "\nLIMIT");
-  sql = replaceFirstNotOnCommentLine(sql, /\sAND\s/, "\n   AND ");
-  sql = replaceFirstNotOnCommentLine(sql, /\sOR\s/, "\n    OR ");
-  return sql;
 }

--- a/frontend/src/metabase/lib/engine.unit.spec.ts
+++ b/frontend/src/metabase/lib/engine.unit.spec.ts
@@ -38,83 +38,35 @@ describe("getNativeQueryLanguage", () => {
 
 describe("formatNativeQuery", () => {
   it("should return formatted SQL", () => {
-    expect(formatNativeQuery("select 1", "postgres")).toEqual("select 1");
-    expect(
-      formatNativeQuery("SELECT * FROM PUBLIC.ORDERS", "postgres"),
-    ).toEqual("SELECT *\nFROM PUBLIC.ORDERS");
+    expect(formatNativeQuery("select 1")).toEqual("select 1");
+    expect(formatNativeQuery("SELECT * FROM PUBLIC.ORDERS")).toEqual(
+      "SELECT * FROM PUBLIC.ORDERS",
+    );
   });
 
   it("should return any valid string if the engine type is sql", () => {
-    expect(formatNativeQuery("foo", "postgres")).toEqual("foo");
-    expect(formatNativeQuery("FOO BAR baz", "postgres")).toEqual("FOO BAR baz");
-    expect(formatNativeQuery("FOO: BAR, baz.", "postgres")).toEqual(
-      "FOO: BAR, baz.",
-    );
-    expect(formatNativeQuery("-- foo", "postgres")).toEqual("-- foo");
+    expect(formatNativeQuery("foo")).toEqual("foo");
+    expect(formatNativeQuery("FOO BAR baz")).toEqual("FOO BAR baz");
+    expect(formatNativeQuery("FOO: BAR, baz.")).toEqual("FOO: BAR, baz.");
+    expect(formatNativeQuery("-- foo")).toEqual("-- foo");
   });
 
   it("should not format SQL keywords inside comment lines", () => {
     expect(
       formatNativeQuery(
         "-- SELECT * FROM products WHERE category = 'Widget'\nSELECT * FROM products WHERE category = 'Widget'",
-        "postgres",
       ),
     ).toEqual(
-      "-- SELECT * FROM products WHERE category = 'Widget'\nSELECT *\nFROM products\nWHERE category = 'Widget'",
-    );
-
-    expect(
-      formatNativeQuery(
-        "-- SELECT * FROM products LEFT JOIN orders ON products.id = orders.product_id\nSELECT * FROM products LEFT JOIN orders ON products.id = orders.product_id",
-        "postgres",
-      ),
-    ).toEqual(
-      "-- SELECT * FROM products LEFT JOIN orders ON products.id = orders.product_id\nSELECT *\nFROM products\nLEFT JOIN orders ON products.id = orders.product_id",
-    );
-
-    expect(
-      formatNativeQuery(
-        "-- SELECT * FROM products GROUP BY category\nSELECT * FROM products GROUP BY category",
-        "postgres",
-      ),
-    ).toEqual(
-      "-- SELECT * FROM products GROUP BY category\nSELECT *\nFROM products\nGROUP BY category",
-    );
-
-    expect(
-      formatNativeQuery(
-        "-- SELECT * FROM products ORDER BY category\nSELECT * FROM products ORDER BY category",
-        "postgres",
-      ),
-    ).toEqual(
-      "-- SELECT * FROM products ORDER BY category\nSELECT *\nFROM products\nORDER BY category",
-    );
-
-    expect(
-      formatNativeQuery(
-        "-- SELECT * FROM products LIMIT 3\nSELECT * FROM products LIMIT 3",
-        "postgres",
-      ),
-    ).toEqual(
-      "-- SELECT * FROM products LIMIT 3\nSELECT *\nFROM products\nLIMIT 3",
-    );
-
-    expect(
-      formatNativeQuery(
-        "-- SELECT * FROM products WHERE category = 'Widget' AND (rating > 4 OR rating < 2)\nSELECT * FROM products WHERE category = 'Widget' AND (rating > 4 OR rating < 2)",
-        "postgres",
-      ),
-    ).toEqual(
-      "-- SELECT * FROM products WHERE category = 'Widget' AND (rating > 4 OR rating < 2)\nSELECT *\nFROM products\nWHERE category = 'Widget'\n   AND (rating > 4\n    OR rating < 2)",
+      "-- SELECT * FROM products WHERE category = 'Widget'\nSELECT * FROM products WHERE category = 'Widget'",
     );
   });
 
   it("should return formatted JSON", () => {
-    expect(formatNativeQuery({}, "mongo")).toEqual("{}");
-    expect(formatNativeQuery([], "mongo")).toEqual("[]");
-    expect(formatNativeQuery(["foo"], "mongo")).toEqual('[\n  "foo"\n]');
-    expect(formatNativeQuery({ a: 1 }, "mongo")).toEqual('{\n  "a": 1\n}');
-    expect(formatNativeQuery('["foo"]', "mongo")).toEqual('["foo"]');
+    expect(formatNativeQuery({})).toEqual("{}");
+    expect(formatNativeQuery([])).toEqual("[]");
+    expect(formatNativeQuery(["foo"])).toEqual('[\n  "foo"\n]');
+    expect(formatNativeQuery({ a: 1 })).toEqual('{\n  "a": 1\n}');
+    expect(formatNativeQuery('["foo"]')).toEqual('["foo"]');
   });
 });
 

--- a/frontend/src/metabase/lib/engine.unit.spec.ts
+++ b/frontend/src/metabase/lib/engine.unit.spec.ts
@@ -53,6 +53,62 @@ describe("formatNativeQuery", () => {
     expect(formatNativeQuery("-- foo", "postgres")).toEqual("-- foo");
   });
 
+  it("should not format SQL keywords inside comment lines", () => {
+    expect(
+      formatNativeQuery(
+        "-- SELECT * FROM products WHERE category = 'Widget'\nSELECT * FROM products WHERE category = 'Widget'",
+        "postgres",
+      ),
+    ).toEqual(
+      "-- SELECT * FROM products WHERE category = 'Widget'\nSELECT *\nFROM products\nWHERE category = 'Widget'",
+    );
+
+    expect(
+      formatNativeQuery(
+        "-- SELECT * FROM products LEFT JOIN orders ON products.id = orders.product_id\nSELECT * FROM products LEFT JOIN orders ON products.id = orders.product_id",
+        "postgres",
+      ),
+    ).toEqual(
+      "-- SELECT * FROM products LEFT JOIN orders ON products.id = orders.product_id\nSELECT *\nFROM products\nLEFT JOIN orders ON products.id = orders.product_id",
+    );
+
+    expect(
+      formatNativeQuery(
+        "-- SELECT * FROM products GROUP BY category\nSELECT * FROM products GROUP BY category",
+        "postgres",
+      ),
+    ).toEqual(
+      "-- SELECT * FROM products GROUP BY category\nSELECT *\nFROM products\nGROUP BY category",
+    );
+
+    expect(
+      formatNativeQuery(
+        "-- SELECT * FROM products ORDER BY category\nSELECT * FROM products ORDER BY category",
+        "postgres",
+      ),
+    ).toEqual(
+      "-- SELECT * FROM products ORDER BY category\nSELECT *\nFROM products\nORDER BY category",
+    );
+
+    expect(
+      formatNativeQuery(
+        "-- SELECT * FROM products LIMIT 3\nSELECT * FROM products LIMIT 3",
+        "postgres",
+      ),
+    ).toEqual(
+      "-- SELECT * FROM products LIMIT 3\nSELECT *\nFROM products\nLIMIT 3",
+    );
+
+    expect(
+      formatNativeQuery(
+        "-- SELECT * FROM products WHERE category = 'Widget' AND (rating > 4 OR rating < 2)\nSELECT * FROM products WHERE category = 'Widget' AND (rating > 4 OR rating < 2)",
+        "postgres",
+      ),
+    ).toEqual(
+      "-- SELECT * FROM products WHERE category = 'Widget' AND (rating > 4 OR rating < 2)\nSELECT *\nFROM products\nWHERE category = 'Widget'\n   AND (rating > 4\n    OR rating < 2)",
+    );
+  });
+
   it("should return formatted JSON", () => {
     expect(formatNativeQuery({}, "mongo")).toEqual("{}");
     expect(formatNativeQuery([], "mongo")).toEqual("[]");

--- a/frontend/src/metabase/querying/notebook/components/NativeQueryPreview/NativeQueryPreview.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NativeQueryPreview/NativeQueryPreview.tsx
@@ -82,7 +82,7 @@ function getFormattedQuery(
   if (engine === null) {
     return data.query;
   }
-  return formatNativeQuery(data.query, engine);
+  return formatNativeQuery(data.query);
 }
 
 function NativeCodePanel({

--- a/frontend/src/metabase/querying/notebook/components/NotebookNativePreview/utils.ts
+++ b/frontend/src/metabase/querying/notebook/components/NotebookNativePreview/utils.ts
@@ -16,7 +16,7 @@ export function createNativeQuestion(
     database.id,
     question.metadata(),
   );
-  const rawQuery = formatNativeQuery(response.query, database.engine);
+  const rawQuery = formatNativeQuery(response.query);
   const newQuery = Lib.nativeQuery(database.id, metadataProvider, rawQuery);
   const newQueryWithCollection =
     response.collection != null


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/66690

### Description

In the native query preview were adding newlines to clauses like FROM and WHERE even if they were commented out, which meant that they were no longer commented out.

~~Instead we should only add this newline if the clause is not commented out.~~

~~Note: Queries commented out with `/* */` will be formatted but will remain commented out within the `/* */`~~

The BE already formats the native queries so we can remove the formatting and display them as is. 

### How to verify

See steps in reported issue. The commented out query should stay commented out now.

### Demo

https://github.com/user-attachments/assets/3230e839-ad4f-4754-a897-43b4ff82ad3a

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
