### PR TITLE
Show different copy on Metabot AI purchase page after trial

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotPurchasePage/MetabotPurchasePageForStoreUser.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotPurchasePage/MetabotPurchasePageForStoreUser.tsx
@@ -24,8 +24,14 @@ import { useAddOnsBilling } from "./hooks";
 import type { IMetabotPurchaseFormFields } from "./types";
 
 export const MetabotPurchasePageForStoreUser = () => {
-  const { isLoading, error, billingPeriodMonths, tiers, defaultQuantity } =
-    useAddOnsBilling();
+  const {
+    isLoading,
+    error,
+    billingPeriodMonths,
+    defaultQuantity,
+    hadMetabot,
+    tiers,
+  } = useAddOnsBilling();
   const hasData =
     billingPeriodMonths !== undefined &&
     defaultQuantity !== undefined &&
@@ -98,12 +104,16 @@ export const MetabotPurchasePageForStoreUser = () => {
         {t`Your browser does not support the video tag.`}
       </video>
       <SettingsSection
-        title={t`Start free 14-day trial of Metabot`}
+        title={
+          hadMetabot
+            ? t`Pick Metabot usage limit`
+            : t`Start free 14-day trial of Metabot`
+        }
         description={
           <Text mt="sm">
             {t`Pick a usage limit below. Usage is measured in Metabot requests.`}
             <br />
-            {t`If a chat has multiple questions, they are counted as separate Metabot requests.`}
+            {t`Each message sent to Metabot is counted as a request. `}
             <br />
             {t`Usage limit applies to your whole organization.`}
           </Text>
@@ -145,8 +155,13 @@ export const MetabotPurchasePageForStoreUser = () => {
                     />
                   </Card>
 
-                  {/* eslint-disable-next-line no-literal-metabase-strings -- This string only shows for admins. */}
-                  <Text>{t`After 14 days of free trial an additional amount for the add-on will be added to your next billing period invoice. You can cancel the add-on anytime in Metabase Store.`}</Text>
+                  <Text>
+                    {hadMetabot
+                      ? /* eslint-disable-next-line no-literal-metabase-strings -- This string only shows for admins. */
+                        t`An additional amount for the add-on will be added to your next billing period invoice. You can cancel the add-on anytime in Metabase Store.`
+                      : /* eslint-disable-next-line no-literal-metabase-strings -- This string only shows for admins. */
+                        t`After 14 days of free trial an additional amount for the add-on will be added to your next billing period invoice. You can cancel the add-on anytime in Metabase Store.`}
+                  </Text>
 
                   <FormSubmitButton
                     disabled={!values.terms_of_service}

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotPurchasePage/hooks.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotPurchasePage/hooks.ts
@@ -4,11 +4,17 @@ import {
 } from "metabase-enterprise/api";
 import type { ICloudAddOnProductTier } from "metabase-types/api";
 
+const METABASE_AI_PRODUCT_TYPES = [
+  "metabase-ai",
+  "metabase-ai-tiered",
+] as const;
+
 export function useAddOnsBilling(): {
   error: unknown;
   isLoading: boolean;
   billingPeriodMonths: number | undefined;
   defaultQuantity: number | undefined;
+  hadMetabot: boolean;
   tiers: ICloudAddOnProductTier[];
 } {
   const {
@@ -25,6 +31,13 @@ export function useAddOnsBilling(): {
 
   const billingPeriodMonths =
     billingInfo?.data?.billing_period_months ?? undefined;
+  const hadMetabot =
+    billingInfo?.data?.previous_add_ons?.some(
+      ({ product_type, self_service }) =>
+        METABASE_AI_PRODUCT_TYPES.includes(
+          product_type as (typeof METABASE_AI_PRODUCT_TYPES)[number],
+        ) && self_service,
+    ) ?? false;
   const tiers =
     addOns?.find(
       ({ active, billing_period_months, product_type, self_service }) =>
@@ -42,5 +55,6 @@ export function useAddOnsBilling(): {
     billingPeriodMonths,
     defaultQuantity,
     tiers,
+    hadMetabot,
   };
 }

--- a/frontend/src/metabase-types/api/store.ts
+++ b/frontend/src/metabase-types/api/store.ts
@@ -37,6 +37,7 @@ export type BillingInfoLineItem = BillingInfoFormatType &
 
 interface IBillingInfoData {
   billing_period_months?: number | null;
+  previous_add_ons?: { product_type: string; self_service: boolean }[] | null;
 }
 
 export type BillingInfo = {

--- a/frontend/test/__support__/server-mocks/store.ts
+++ b/frontend/test/__support__/server-mocks/store.ts
@@ -1,21 +1,25 @@
 import fetchMock from "fetch-mock";
 import { match } from "ts-pattern";
 
-import type { StoreTokenStatus } from "metabase-types/api";
 import { createMockCloudAddOns } from "metabase-types/api/mocks/add-ons";
-
-export function setupStoreTokenEndpoint(tokenStatus: StoreTokenStatus) {
-  fetchMock.get("path:/api/premium-features/token/status", tokenStatus);
-}
 
 export function setupStoreEEBillingEndpoint(
   billing_period_months: number,
+  had_metabot: false | "trial" | "tiered" = false,
   simulate_http_get_error: boolean = false,
 ) {
   fetchMock.get("path:/api/ee/billing", {
     body: {
       version: "v1",
-      data: { billing_period_months },
+      data: {
+        billing_period_months,
+        previous_add_ons:
+          had_metabot === "trial"
+            ? [{ product_type: "metabase-ai", self_service: true }]
+            : had_metabot === "tiered"
+              ? [{ product_type: "metabase-ai-tiered", self_service: true }]
+              : null,
+      },
     },
     status: simulate_http_get_error ? 500 : 200,
   });


### PR DESCRIPTION
### Description

In https://github.com/metabase/metabase/pull/65343 we added a page to purchase Metabase AI (Metabot).  Now we are improving the text to:
* Show information about trial only if Metabot was not already trialed
* Improve wording regarding multiple questions / messages in chat

### How to verify

1. Ensure you have a token with the `offer-metabase-ai-tiered` feature, but without the `metabot-v3` feature.
2. Check that the subscription associated with the token had either with (test case 1) or without (test case 2) the `metabase-ai` or the `metabase-ai-tiered` add-on.
3. Navigate to `/admin/metabot` and see the page look like in the mock ups.

### Demo

Without any previous Metabot add-on:
<img width="1600" height="1156" alt="image" src="https://github.com/user-attachments/assets/fb11becb-3ce1-46b9-b607-0b718281c79b" />

With previous Metabot add-on:
<img width="1600" height="1156" alt="image" src="https://github.com/user-attachments/assets/5fe9dcf1-64a4-4c73-967b-db3594b9bff5" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

Closes: https://linear.app/metabase/issue/CLO-4673/show-different-copy-on-metabot-ai-purchase-page-after-trial
Closes: https://linear.app/metabase/issue/CLO-4688/copy-correction-in-the-admin-panel