### PR TITLE
Fix gauge trims decimal parts of ranges

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingSegmentsEditor/ChartSettingSegmentsEditor.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingSegmentsEditor/ChartSettingSegmentsEditor.tsx
@@ -72,7 +72,7 @@ export const ChartSettingSegmentsEditor = ({
                   className={CS.full}
                   value={segment.min}
                   onBlur={(e) =>
-                    onChangeProperty(index, "min", parseInt(e.target.value))
+                    onChangeProperty(index, "min", parseFloat(e.target.value))
                   }
                   placeholder={t`Min`}
                   w="4rem"
@@ -83,7 +83,7 @@ export const ChartSettingSegmentsEditor = ({
                   className={CS.full}
                   value={segment.max}
                   onBlur={(e) =>
-                    onChangeProperty(index, "max", parseInt(e.target.value))
+                    onChangeProperty(index, "max", parseFloat(e.target.value))
                   }
                   placeholder={t`Max`}
                   w="4rem"

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingSegmentsEditor/ChartSettingSegmentsEditor.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingSegmentsEditor/ChartSettingSegmentsEditor.tsx
@@ -71,9 +71,12 @@ export const ChartSettingSegmentsEditor = ({
                 <NumberInput
                   className={CS.full}
                   value={segment.min}
-                  onBlur={(e) =>
-                    onChangeProperty(index, "min", parseFloat(e.target.value))
-                  }
+                  onBlur={(e) => {
+                    const newValue = parseFloat(e.target.value);
+                    if (newValue !== segment.min) {
+                      onChangeProperty(index, "min", newValue);
+                    }
+                  }}
                   placeholder={t`Min`}
                   w="4rem"
                 />
@@ -82,9 +85,12 @@ export const ChartSettingSegmentsEditor = ({
                 <NumberInput
                   className={CS.full}
                   value={segment.max}
-                  onBlur={(e) =>
-                    onChangeProperty(index, "max", parseFloat(e.target.value))
-                  }
+                  onBlur={(e) => {
+                    const newValue = parseFloat(e.target.value);
+                    if (newValue !== segment.max) {
+                      onChangeProperty(index, "max", newValue);
+                    }
+                  }}
                   placeholder={t`Max`}
                   w="4rem"
                 />

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingSegmentsEditor/ChartSettingSegmentsEditor.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingSegmentsEditor/ChartSettingSegmentsEditor.unit.spec.tsx
@@ -86,3 +86,20 @@ it("Should allow you to add a new segment with apropriate defaults", async () =>
     }),
   ]);
 });
+
+it("Should handle floating point values", async () => {
+  const { onChange } = setup();
+
+  const min = await screen.findByDisplayValue("0");
+
+  await userEvent.clear(min);
+  await userEvent.type(min, "12.5");
+  fireEvent.blur(min);
+
+  expect(onChange).toHaveBeenCalledWith(
+    expect.arrayContaining([
+      expect.objectContaining({ ...DEFAULT_VALUE[0], min: 12.5 }),
+      expect.objectContaining(DEFAULT_VALUE[1]),
+    ]),
+  );
+});

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingSegmentsEditor/ChartSettingSegmentsEditor.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingSegmentsEditor/ChartSettingSegmentsEditor.unit.spec.tsx
@@ -103,3 +103,14 @@ it("Should handle floating point values", async () => {
     ]),
   );
 });
+
+it("Should not call onChange when blurring without changing value", async () => {
+  const { onChange } = setup();
+
+  const min = await screen.findByDisplayValue("0");
+
+  fireEvent.focus(min);
+  fireEvent.blur(min);
+
+  expect(onChange).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/66686

### Description

Updated gauge widget incorrectly applied `parseInt` to values so that the decimal part was lost. Also, it always triggered change event on blur even if the value did not change which I also addressed in this PR.

### How to verify

- Native query: `select 1.5`
- Change to gauge viz type
- Click on gauge range values that contain floating point numbers
- Ensure their decimal parts weren't removed

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
