### PR TITLE
handle uploads from matrix jobs

### DIFF
--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -82,7 +82,7 @@ runs:
       if: always() && steps.run-test.outcome != 'success' && steps.check-driver.outputs.skip != 'true'
       uses: actions/upload-artifact@v4
       with:
-        name: test-logs-${{ github.job }}
+        name: ${{ format('test-logs-{0}{1}', github.job, (inputs.logs-artifact-suffix == '' || inputs.logs-artifact-suffix == null) && '' || format('-{0}', inputs.logs-artifact-suffix)) }}
         path: logs/test-log.json
         retention-days: 1
       # Failing to upload the artifact should never affect the outcome of the whole test run.

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -128,6 +128,7 @@ jobs:
       with:
         junit-name: 'be-tests-bigquery-cloud-sdk-ee'
         test-args: ${{ matrix.job.test-args }}
+        logs-artifact-suffix: ${{ matrix.job.name }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
@@ -199,6 +200,7 @@ jobs:
       with:
         junit-name: 'be-tests-clickhouse-ee'
         test-args: ${{ matrix.job.test-args }}
+        logs-artifact-suffix: ${{ matrix.job.name }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
@@ -513,6 +515,7 @@ jobs:
         uses: ./.github/actions/test-driver
         with:
           junit-name: ${{ matrix.version.junit-name }}
+          logs-artifact-suffix: ${{ matrix.job.name }}
           test-args: >-
             ${{ matrix.job.test-args }}
             :exclude-tags '[ ${{ matrix.job.exclude-tag }} ${{ env.__ADDITIONAL_EXCLUDED_TAG__ }}]'
@@ -585,6 +588,7 @@ jobs:
       with:
         junit-name: ${{ matrix.version.junit-name }}
         test-args: ${{ matrix.job.test-args }}
+        logs-artifact-suffix: ${{ matrix.job.name }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
@@ -763,6 +767,7 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: ${{ matrix.version.junit-name }}
+        logs-artifact-suffix: ${{ matrix.version.name }}
         test-args: >-
           :only-tags [:mb/driver-tests]
           :exclude-tags [:mb/transforms-python-test]
@@ -1019,6 +1024,7 @@ jobs:
         junit-name: 'be-tests-redshift-ee'
         test-args: >-
           ${{ matrix.job.test-args }}
+        logs-artifact-suffix: ${{ matrix.job.name }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: ${{ !matrix.job.skip && !cancelled() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
@@ -1089,6 +1095,7 @@ jobs:
       with:
         junit-name: 'be-tests-snowflake-ee'
         test-args: ${{ matrix.job.test-args }}
+        logs-artifact-suffix: ${{ matrix.job.name }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
@@ -1227,6 +1234,7 @@ jobs:
       with:
         junit-name: ${{ matrix.version.junit-name }}
         test-args: ${{ matrix.job.test-args }}
+        logs-artifact-suffix: ${{ matrix.version.name }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'


### PR DESCRIPTION
motivating example:
we ran the redshift tests, and had three failures: redshift 1, redshift 2, and redshift transforms.

redshifts 1 and 2 timedout at 60 minutes. But the log upload failed because the python transform tests failed in 24 minutes and then uploaded:

from the transform failure run:

```
Run actions/upload-artifact@v4
  with:
    name: test-logs-be-tests-redshift-ee
    path: logs/test-log.json
    retention-days: 1
    if-no-files-found: warn
    compression-level: 6
    overwrite: false
    include-hidden-files: false
  env:
    CI: true
    ...
With the provided path, there will be 1 file uploaded
Artifact name is valid!
Root directory input is valid!
Beginning upload of artifact content to blob storage
Uploaded bytes 1072768
Finished uploading artifact content to blob storage!
SHA256 digest of uploaded artifact zip is 267d4b085d49ca4d682fedca97832fecb603bbb5a52c0e1d99bd4daa49984ba3
Finalizing artifact upload
Artifact test-logs-be-tests-redshift-ee.zip successfully finalized. Artifact ID 4816135520
Artifact test-logs-be-tests-redshift-ee has been successfully uploaded! Final size is 1072768 bytes. Artifact ID is 4816135520
```

And then from the redshift tests:

```
Run actions/upload-artifact@v4
  with:
    name: test-logs-be-tests-redshift-ee
    path: logs/test-log.json
    retention-days: 1
    if-no-files-found: warn
    compression-level: 6
    overwrite: false
    include-hidden-files: false
  env:
    CI: true
    ...
With the provided path, there will be 1 file uploaded
Artifact name is valid!
Root directory input is valid!
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```

The same happens on redshift part 1.

```
Error: Failed to CreateArtifact: Received non-retryable error: Failed
request: (409) Conflict: an artifact with this name already exists on
the workflow run
```

This just introduces on the driver action to look for a logs-artifact-suffix and use it if present. And on driver jobs that use a matrix include the matrix.job.name (or matrix.version.name depending on the exact structure).

links:
- transforms: https://github.com/metabase/metabase/actions/runs/20076661758/job/57592852234?pr=66722
- redshift 1: https://github.com/metabase/metabase/actions/runs/20076661758/job/57592852229?pr=66722
- redshift 2: https://github.com/metabase/metabase/actions/runs/20076661758/job/57592852240?pr=66722

<img width="1033" height="312" alt="image" src="https://github.com/user-attachments/assets/b085fad5-21a6-4223-8152-74bb94a11fbf" />

<img width="1027" height="238" alt="image" src="https://github.com/user-attachments/assets/f0b775ef-5642-42e5-808d-8c81f4ff3abe" />
<img width="1012" height="218" alt="image" src="https://github.com/user-attachments/assets/909462d2-67e5-45c9-8f05-2c23f198ac9b" />

