### PR TITLE
Show location of minipicker search items

### DIFF
--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/test/oss.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/test/oss.unit.spec.tsx
@@ -224,6 +224,16 @@ describe("MiniPicker", () => {
       expect(await screen.findByText("london (lydia)")).toBeInTheDocument();
     });
 
+    it("shows collection name for a table in a collection", async () => {
+      await setup({ searchQuery: "kit" });
+      expect(await screen.findByText("Kitty")).toBeInTheDocument();
+      expect(await screen.findByText("Misc Tables")).toBeInTheDocument();
+
+      // should not show table or schema
+      expect(screen.queryByText(/big_secret/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/also_secret/)).not.toBeInTheDocument();
+    });
+
     it("properly filters search results", async () => {
       await setup({ searchQuery: "a" });
       expect(await screen.findByText("Lucas")).toBeInTheDocument();

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/test/oss.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/test/oss.unit.spec.tsx
@@ -212,6 +212,18 @@ describe("MiniPicker", () => {
       expect(await screen.findByText("Bingley")).toBeInTheDocument();
     });
 
+    it("shows the collection name for collection items in search results", async () => {
+      await setup({ searchQuery: "bing" });
+      expect(await screen.findByText("Bingley")).toBeInTheDocument();
+      expect(await screen.findByText("Misc Metrics")).toBeInTheDocument();
+    });
+
+    it("shows db and schema names for table items in search results", async () => {
+      await setup({ searchQuery: "wick" });
+      expect(await screen.findByText("wickham")).toBeInTheDocument();
+      expect(await screen.findByText("london (lydia)")).toBeInTheDocument();
+    });
+
     it("properly filters search results", async () => {
       await setup({ searchQuery: "a" });
       expect(await screen.findByText("Lucas")).toBeInTheDocument();

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/test/setup.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/test/setup.tsx
@@ -222,6 +222,17 @@ export const setup = async (
         name: "Misc Metrics",
       },
     }),
+    createMockSearchResult({
+      id: 303,
+      model: "table",
+      name: "Kitty",
+      database_name: "big_secret",
+      table_schema: "also_secret",
+      collection: {
+        id: 7891,
+        name: "Misc Tables",
+      },
+    }),
     createMockSearchResult({ id: 304, model: "document", name: "Wickham" }),
     createMockSearchResult({ id: 305, model: "collection", name: "Reynolds" }),
     createMockSearchResult({
@@ -230,6 +241,11 @@ export const setup = async (
       name: "wickham",
       table_schema: "lydia",
       database_name: "london",
+      collection: {
+        // @ts-expect-error - can be null in search results
+        id: null,
+        name: "",
+      },
     }),
   ]);
 

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/test/setup.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/test/setup.tsx
@@ -213,9 +213,24 @@ export const setup = async (
   setupSearchEndpoints([
     createMockSearchResult({ id: 301, model: "card", name: "Lucas" }),
     createMockSearchResult({ id: 302, model: "dataset", name: "Forster" }),
-    createMockSearchResult({ id: 303, model: "metric", name: "Bingley" }),
+    createMockSearchResult({
+      id: 303,
+      model: "metric",
+      name: "Bingley",
+      collection: {
+        id: 789,
+        name: "Misc Metrics",
+      },
+    }),
     createMockSearchResult({ id: 304, model: "document", name: "Wickham" }),
     createMockSearchResult({ id: 305, model: "collection", name: "Reynolds" }),
+    createMockSearchResult({
+      id: 401,
+      model: "table",
+      name: "wickham",
+      table_schema: "lydia",
+      database_name: "london",
+    }),
   ]);
 
   setupRecentViewsAndSelectionsEndpoints([], ["selections", "views"], {}, true);

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
@@ -1,3 +1,4 @@
+import { useDebouncedValue } from "@mantine/hooks";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -15,7 +16,6 @@ import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErr
 import { canCollectionCardBeUsed } from "metabase/common/components/Pickers/utils";
 import { VirtualizedList } from "metabase/common/components/VirtualizedList";
 import { useSetting } from "metabase/common/hooks";
-import { useDebouncedValue } from "metabase/common/hooks/use-debounced-value";
 import { getIcon } from "metabase/lib/icon";
 import { PLUGIN_DATA_STUDIO } from "metabase/plugins";
 import { Box, Flex, Icon, Text } from "metabase/ui";
@@ -294,8 +294,7 @@ function CollectionItemList({ parent }: { parent: MiniPickerCollectionItem }) {
 
 function SearchItemList({ query }: { query: string }) {
   const { onChange, models, isHidden } = useMiniPickerContext();
-
-  const debouncedQuery = useDebouncedValue(query, 500);
+  const [debouncedQuery] = useDebouncedValue(query, 500);
 
   const { data: searchResponse, isLoading } = useSearchQuery({
     q: debouncedQuery,

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
@@ -341,7 +341,7 @@ export const MiniPickerListLoader = () => (
 const isInCollection = (
   item: MiniPickerPickableItem,
 ): item is MiniPickerCollectionItem => {
-  return "collection" in item && !!item.name;
+  return "collection" in item && !!item.collection && !!item.collection.name;
 };
 
 const ItemList = ({ children }: { children: React.ReactNode[] }) => {

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
@@ -15,6 +15,7 @@ import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErr
 import { canCollectionCardBeUsed } from "metabase/common/components/Pickers/utils";
 import { VirtualizedList } from "metabase/common/components/VirtualizedList";
 import { useSetting } from "metabase/common/hooks";
+import { useDebouncedValue } from "metabase/common/hooks/use-debounced-value";
 import { getIcon } from "metabase/lib/icon";
 import { PLUGIN_DATA_STUDIO } from "metabase/plugins";
 import { Box, Flex, Icon, Text } from "metabase/ui";
@@ -295,8 +296,10 @@ function CollectionItemList({ parent }: { parent: MiniPickerCollectionItem }) {
 function SearchItemList({ query }: { query: string }) {
   const { onChange, models, isHidden } = useMiniPickerContext();
 
+  const debouncedQuery = useDebouncedValue(query, 500);
+
   const { data: searchResponse, isLoading } = useSearchQuery({
-    q: query,
+    q: debouncedQuery,
     models: models as SearchModel[],
     limit: 50,
   });
@@ -359,10 +362,10 @@ const LocationInfo = ({ item }: { item: MiniPickerPickableItem }) => {
       });
 
   return (
-    <Flex gap="xs">
+    <Flex gap="xs" align="center">
       {iconProps && <Icon {...iconProps} size={12} />}
       <Text size="sm" c="text-medium">
-        <Ellipsified maw="12rem">{itemText}</Ellipsified>
+        <Ellipsified maw="18rem">{itemText}</Ellipsified>
       </Text>
     </Flex>
   );

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
@@ -22,12 +22,11 @@ import { Box, Flex, Icon, Text } from "metabase/ui";
 import type { SchemaName, SearchModel } from "metabase-types/api";
 
 import { useMiniPickerContext } from "../context";
-import {
-  type MiniPickerCollectionItem,
-  type MiniPickerDatabaseItem,
-  type MiniPickerPickableItem,
-  type MiniPickerSchemaItem,
-  isTableItem,
+import type {
+  MiniPickerCollectionItem,
+  MiniPickerDatabaseItem,
+  MiniPickerPickableItem,
+  MiniPickerSchemaItem,
 } from "../types";
 
 import { MiniPickerItem } from "./MiniPickerItem";
@@ -339,27 +338,33 @@ export const MiniPickerListLoader = () => (
   </Box>
 );
 
+const isInCollection = (
+  item: MiniPickerPickableItem,
+): item is MiniPickerCollectionItem => {
+  return "collection" in item && !!item.name;
+};
+
 const ItemList = ({ children }: { children: React.ReactNode[] }) => {
   return <VirtualizedList extraPadding={2}>{children}</VirtualizedList>;
 };
 
 const LocationInfo = ({ item }: { item: MiniPickerPickableItem }) => {
-  const isTable = isTableItem(item);
+  const isCollectionItem = isInCollection(item);
 
-  const itemText = isTable
-    ? `${item.database_name}${item.table_schema ? ` (${item.table_schema})` : ""}`
-    : item?.collection?.name;
+  const itemText = isCollectionItem
+    ? item?.collection?.name
+    : `${item.database_name}${item.table_schema ? ` (${item.table_schema})` : ""}`;
 
   if (!itemText) {
     return null;
   }
 
-  const iconProps = isTable
-    ? null
-    : getIcon({
+  const iconProps = isCollectionItem
+    ? getIcon({
         ...item.collection,
         model: "collection",
-      });
+      })
+    : null;
 
   return (
     <Flex gap="xs" align="center">

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
@@ -10,20 +10,23 @@ import {
   useListDatabasesQuery,
   useSearchQuery,
 } from "metabase/api";
+import { Ellipsified } from "metabase/common/components/Ellipsified";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { canCollectionCardBeUsed } from "metabase/common/components/Pickers/utils";
 import { VirtualizedList } from "metabase/common/components/VirtualizedList";
 import { useSetting } from "metabase/common/hooks";
+import { getIcon } from "metabase/lib/icon";
 import { PLUGIN_DATA_STUDIO } from "metabase/plugins";
-import { Box, Text } from "metabase/ui";
+import { Box, Flex, Icon, Text } from "metabase/ui";
 import type { SchemaName, SearchModel } from "metabase-types/api";
 
 import { useMiniPickerContext } from "../context";
-import type {
-  MiniPickerCollectionItem,
-  MiniPickerDatabaseItem,
-  MiniPickerPickableItem,
-  MiniPickerSchemaItem,
+import {
+  type MiniPickerCollectionItem,
+  type MiniPickerDatabaseItem,
+  type MiniPickerPickableItem,
+  type MiniPickerSchemaItem,
+  isTableItem,
 } from "../types";
 
 import { MiniPickerItem } from "./MiniPickerItem";
@@ -319,6 +322,7 @@ function SearchItemList({ query }: { query: string }) {
             onClick={() => {
               onChange(item);
             }}
+            rightSection={<LocationInfo item={item} />}
           />
         );
       })}
@@ -334,4 +338,32 @@ export const MiniPickerListLoader = () => (
 
 const ItemList = ({ children }: { children: React.ReactNode[] }) => {
   return <VirtualizedList extraPadding={2}>{children}</VirtualizedList>;
+};
+
+const LocationInfo = ({ item }: { item: MiniPickerPickableItem }) => {
+  const isTable = isTableItem(item);
+
+  const itemText = isTable
+    ? `${item.database_name}${item.table_schema ? ` (${item.table_schema})` : ""}`
+    : item?.collection?.name;
+
+  if (!itemText) {
+    return null;
+  }
+
+  const iconProps = isTable
+    ? null
+    : getIcon({
+        ...item.collection,
+        model: "collection",
+      });
+
+  return (
+    <Flex gap="xs">
+      {iconProps && <Icon {...iconProps} size={12} />}
+      <Text size="sm" c="text-medium">
+        <Ellipsified maw="12rem">{itemText}</Ellipsified>
+      </Text>
+    </Flex>
+  );
 };

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerPane.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerPane.tsx
@@ -12,7 +12,7 @@ export function MiniPickerPane() {
   const isRoot = path.length === 0;
 
   return (
-    <Stack mah="30rem" w={searchQuery ? "34rem" : "20rem"} gap={0}>
+    <Stack mah="30rem" w={searchQuery ? "40rem" : "20rem"} gap={0}>
       {!isRoot && !searchQuery && <MiniPickerHeader />}
       <MiniPickerItemList />
       {(isRoot || searchQuery) && <MiniPickerFooter />}

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerPane.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerPane.tsx
@@ -12,7 +12,7 @@ export function MiniPickerPane() {
   const isRoot = path.length === 0;
 
   return (
-    <Stack mah="30rem" w="20rem" gap={0}>
+    <Stack mah="30rem" w={searchQuery ? "34rem" : "20rem"} gap={0}>
       {!isRoot && !searchQuery && <MiniPickerHeader />}
       <MiniPickerItemList />
       {(isRoot || searchQuery) && <MiniPickerFooter />}

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/types.ts
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/types.ts
@@ -8,7 +8,7 @@ import type {
 
 export type MiniPickerCollectionItem = Pick<
   CollectionItem,
-  "id" | "name" | "model" | "here" | "below" | "display"
+  "id" | "name" | "model" | "here" | "below" | "display" | "collection"
 > & {
   id: CollectionItem["id"] | CollectionId;
 };
@@ -33,7 +33,15 @@ export type MiniPickerTableItem = {
   model: "table";
   id: TableId;
   db_id: DatabaseId;
+  database_name?: string;
+  table_schema?: string;
   name: string;
+};
+
+export const isTableItem = (
+  item: MiniPickerItem,
+): item is MiniPickerTableItem => {
+  return item.model === "table";
 };
 
 export type MiniPickerDatabaseItem = {


### PR DESCRIPTION
Closes UXW-2467

### Description


https://github.com/user-attachments/assets/195fc7d1-a631-48f1-871f-60805fabc3e7

- widens the miniPicker in search mode
- shows db (schema) context for table results
- shows collection context for question/model results.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
