### PR TITLE
GDGT-1312 add ability to select a range of items of any type

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/bulk-selection.utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/bulk-selection.utils.ts
@@ -377,16 +377,16 @@ export function toggleSchemaSelection(
 
 /**
  * Computes which tables, schemas, and databases are selected within a sliced
- * hierarchical range. The function tracks "open" items by level and adds them
+ * hierarchical range. The function tracks candidate items by level and adds them
  * to the result only when the traversal explicitly exits their scope:
  *
- * - An item is considered "closed" when:
+ * - An item is considered "committed" when:
  *     1) The next item appears on the same level (i.e., a sibling replaces it), or
  *     2) The next item appears on a higher level (level decrease, moving upward).
  *
  * - Tables are collected immediately.
- * - Items that remain open at the end of the range are NOT included — only those
- *   that were explicitly closed during traversal.
+ * - Items that remain to be as a candidate at the end of the range are NOT included — only those
+ *   that were explicitly committed during traversal.
  *
  * This ensures the result reflects only the structures that the slice fully
  * exits, matching typical range-selection behavior in hierarchical trees.
@@ -400,13 +400,13 @@ export const computeRangeSelectionFromSlice = (
     databases: new Set<DatabaseId>(),
   };
 
-  // Tracks currently "open" expanded items per level
-  const openByLevel = new Map<number, ExpandedItem[]>();
+  // Tracks current candidate items per level
+  const itemsByLevel = new Map<number, ExpandedItem[]>();
   const getLevel = (i: number) => rangeItems[i]?.level ?? 0;
 
-  // Closes all items registered at a given level
-  const closeLevel = (level: number) => {
-    const items = openByLevel.get(level) ?? [];
+  // Commit all items registered at a given level
+  const commitLevel = (level: number) => {
+    const items = itemsByLevel.get(level) ?? [];
     for (const candidate of items) {
       if (isSchemaItem(candidate)) {
         const sid = getSchemaId(candidate);
@@ -417,7 +417,7 @@ export const computeRangeSelectionFromSlice = (
         selection.databases.add(candidate.value.databaseId);
       }
     }
-    openByLevel.delete(level);
+    itemsByLevel.delete(level);
   };
 
   for (let i = 0; i < rangeItems.length; i++) {
@@ -431,24 +431,24 @@ export const computeRangeSelectionFromSlice = (
     const deltaLevel = currentLevel - prevLevel;
 
     // If another item appears at the same level,
-    // the previous ones at this level are considered "closed".
-    if (openByLevel.has(currentLevel)) {
-      closeLevel(currentLevel);
+    // the previous ones at this level are considered committed.
+    if (itemsByLevel.has(currentLevel)) {
+      commitLevel(currentLevel);
     }
 
-    // Register current item as "open" for its level
-    openByLevel.set(currentLevel, [item]);
+    // Register current item as a candidate for its level
+    itemsByLevel.set(currentLevel, [item]);
 
     // Tables are collected immediately
     if (isTableNode(item)) {
       selection.tables.add(item.value.tableId);
     }
 
-    // On upward movement: close all levels above currentLevel
+    // On upward movement: commit all levels above currentLevel
     if (deltaLevel < 0) {
       let level = prevLevel;
       while (level > currentLevel) {
-        closeLevel(level);
+        commitLevel(level);
         level--;
       }
     }

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/Results.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/Results.tsx
@@ -132,10 +132,8 @@ export function TablePickerResults({
     }
 
     const isShiftPressed = Boolean(options?.isShiftPressed);
-    const isTable = isTableNode(item);
-    const hasRangeAnchor =
-      lastSelectedTableIndex.current != null && onRangeSelect != null;
-    const isRangeSelection = isShiftPressed && isTable && hasRangeAnchor;
+    const hasRangeAnchor = lastSelectedTableIndex.current != null;
+    const isRangeSelection = isShiftPressed && hasRangeAnchor;
 
     if (isRangeSelection) {
       if (!lastSelectedTableIndex.current) {
@@ -156,7 +154,7 @@ export function TablePickerResults({
     }
 
     onItemToggle(item);
-    lastSelectedTableIndex.current = isTable ? itemIndex : null;
+    lastSelectedTableIndex.current = itemIndex;
   };
 
   return (

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/SearchNew.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/SearchNew.tsx
@@ -10,6 +10,7 @@ import type { Table } from "metabase-types/api";
 import { useSelection } from "../../../pages/DataModel/contexts/SelectionContext";
 import type { RouteParams } from "../../../pages/DataModel/types";
 import {
+  computeRangeSelectionFromSlice,
   toggleDatabaseSelection,
   toggleSchemaSelection,
 } from "../bulk-selection.utils";
@@ -101,6 +102,8 @@ export function SearchNew({ query, params, filters }: SearchNewProps) {
     selectedSchemas,
     selectedDatabases,
     resetSelection,
+    setSelectedDatabases,
+    setSelectedSchemas,
   } = useSelection();
   const routeParams = parseRouteParams(params);
   const { data: tables, isLoading: isLoadingTables } = useListTablesQuery({
@@ -192,17 +195,18 @@ export function SearchNew({ query, params, filters }: SearchNewProps) {
   };
 
   const handleRangeSelect = (items: FlatItem[]) => {
-    const tableItems = items.filter((item) => isTableNode(item) && item.table);
+    const { databases, schemas, tables } =
+      computeRangeSelectionFromSlice(items);
 
-    setSelectedTables((prev) => {
-      const newSet = new Set(prev);
-      tableItems.forEach((item) => {
-        if (isTableNode(item) && item.table) {
-          newSet.add(item.table.id);
-        }
-      });
-      return newSet;
-    });
+    if (databases.size) {
+      setSelectedDatabases((prev) => new Set([...prev, ...databases]));
+    }
+    if (schemas.size) {
+      setSelectedSchemas((prev) => new Set([...prev, ...schemas]));
+    }
+    if (tables.size) {
+      setSelectedTables((prev) => new Set([...prev, ...tables]));
+    }
   };
 
   if (isLoading) {

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/SearchNew.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/SearchNew.tsx
@@ -102,8 +102,6 @@ export function SearchNew({ query, params, filters }: SearchNewProps) {
     selectedSchemas,
     selectedDatabases,
     resetSelection,
-    setSelectedDatabases,
-    setSelectedSchemas,
   } = useSelection();
   const routeParams = parseRouteParams(params);
   const { data: tables, isLoading: isLoadingTables } = useListTablesQuery({
@@ -195,15 +193,12 @@ export function SearchNew({ query, params, filters }: SearchNewProps) {
   };
 
   const handleRangeSelect = (items: FlatItem[]) => {
-    const { databases, schemas, tables } =
-      computeRangeSelectionFromSlice(items);
+    const { tables } = computeRangeSelectionFromSlice(items);
 
-    if (databases.size) {
-      setSelectedDatabases((prev) => new Set([...prev, ...databases]));
-    }
-    if (schemas.size) {
-      setSelectedSchemas((prev) => new Set([...prev, ...schemas]));
-    }
+    /**
+     * We must select only the tables, otherwise a bulk request will be sent for the whole database/schemas,
+     * even though they’re filtered out, and we only want to update the filtered tables.
+     */
     if (tables.size) {
       setSelectedTables((prev) => new Set([...prev, ...tables]));
     }


### PR DESCRIPTION
Closes [GDGT-1312](https://linear.app/metabase/issue/GDGT-1312/adjust-range-selection-to-work-also-with-schemas-and-dbs) 
### Description
Previously, when holding Shift, everything except tables was ignored: schemas and databases were never included in the range calculation. I've changed the logic so that Shift-selection now respects the full hierarchy: schemas, databases, and tables are all detected and included when they fall inside the selected range. Shift-click can now be performed on any of these node types, not just tables.

### How to verify
1. Go to Data Studio
2. Select some nested table
3. While holding SHIFT select another schema/database or table from another schema/database
4. See, that all what is covered by the range is selected

### Demo

Before
https://github.com/user-attachments/assets/b9acc4cf-8858-453e-b65a-63f399627ac4

After:
https://github.com/user-attachments/assets/e018ff38-8eec-4e70-9c3f-65d656cfff98






### Checklist

- [x] Tests have been added/updated to cover changes in this PR
