### PR TITLE
Free up disk space for sdk compatibility tests

### DIFF
--- a/.github/workflows/e2e-embedding-sdk-compatibility-tests.yml
+++ b/.github/workflows/e2e-embedding-sdk-compatibility-tests.yml
@@ -227,6 +227,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: false
+
       # We have to use the latest version that does not have this issue https://github.com/docker/compose/pull/12752
       - name: Set up Docker Compose
         uses: docker/setup-compose-action@v1

--- a/.github/workflows/e2e-embedding-sdk-compatibility-tests.yml
+++ b/.github/workflows/e2e-embedding-sdk-compatibility-tests.yml
@@ -230,9 +230,9 @@ jobs:
       - name: Free disk space
         uses: jlumbroso/free-disk-space@main
         with:
-          android: true
+          android: false
           dotnet: true
-          haskell: true
+          haskell: false
           large-packages: false
           docker-images: false
           swap-storage: false

--- a/.github/workflows/e2e-embedding-sdk-compatibility-tests.yml
+++ b/.github/workflows/e2e-embedding-sdk-compatibility-tests.yml
@@ -227,15 +227,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Docker has been running out of space on ubuntu runners recently, this is a workaround to free some space
+      # removes dotnet which is not needed for our tests, for more comprehensive space cleanup see jlumbroso/free-disk-space@main
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
-        with:
-          android: false
-          dotnet: true
-          haskell: false
-          large-packages: false
-          docker-images: false
-          swap-storage: false
+        run: sudo rm -rf /usr/share/dotnet
 
       # We have to use the latest version that does not have this issue https://github.com/docker/compose/pull/12752
       - name: Set up Docker Compose

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/EmailSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/EmailSettingsPage.tsx
@@ -28,6 +28,9 @@ export function EmailSettingsPage() {
     return <LoadingAndErrorWrapper loading />;
   }
 
+  // eslint-disable-next-line no-console
+  console.log("kick");
+
   return (
     <>
       <SettingsPageWrapper title={t`Email`}>

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/EmailSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/EmailSettingsPage.tsx
@@ -28,9 +28,6 @@ export function EmailSettingsPage() {
     return <LoadingAndErrorWrapper loading />;
   }
 
-  // eslint-disable-next-line no-console
-  console.log("kick");
-
   return (
     <>
       <SettingsPageWrapper title={t`Email`}>


### PR DESCRIPTION
Closes DEV-1138

- Failures started after the "Cache yarn in ci" backport to release-x.56.x.
- The yarn cache adds ~400MB and appears to push the runner out of disk space.

We changed the workflow setup in https://github.com/metabase/metabase/pull/66075 and that freed up disk space, but it didn't get backported to 56. I don't think it's a straightforward backport to 56, so let's just do this targeted fix against 56. 
