### PR TITLE
use performance get-in

### DIFF
--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -1,7 +1,7 @@
 (ns metabase.driver.sql-jdbc.connection
   "Logic for creating and managing connection pools for SQL JDBC drivers. Implementations for connection-related driver
   multimethods for SQL JDBC drivers."
-  (:refer-clojure :exclude [some select-keys])
+  (:refer-clojure :exclude [get-in some select-keys])
   (:require
    [clojure.java.jdbc :as jdbc]
    [metabase.driver :as driver]
@@ -13,7 +13,7 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [some select-keys]]
+   [metabase.util.performance :refer [get-in some select-keys]]
    [potemkin :as p]
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2])


### PR DESCRIPTION
Here's a handwavy sequence of events (i don't think being more precise has benefits):

bronsa merges a pr using get-in at a time when it is fine https://github.com/metabase/metabase/pull/66430. Sashko added a performance get-in to
master (https://github.com/metabase/metabase/pull/65889).  Eric makes a PR against master and sees random failing stuff fixes it there (https://github.com/metabase/metabase/pull/66719). In eric’s backport the backport of the performance get-in hasn’t made it back yet so he has to fix this and not include
it (https://github.com/metabase/metabase/pull/66729/commits and https://github.com/metabase/metabase/pull/66729/commits/003a2305a3b2473345bc558c33571089ac8c738f). Sashko’s backport finally lands in 57 so just a dumb dance to this. Nothing alarming and an easy fix

Note this is specifically targeting 57.x and doesn't need to backport.