### PR TITLE
fix: update mongo docker/add :drivers to e2e startup

### DIFF
--- a/e2e/runner/cypress-runner-backend.js
+++ b/e2e/runner/cypress-runner-backend.js
@@ -55,7 +55,7 @@ const CypressBackend = {
 
       this.server.process = spawn(
         "clojure",
-        [`-M:run:${edition}:dev:dev-start:e2e`, "--hot"],
+        [`-M:run:${edition}:dev:dev-start:drivers:e2e`, "--hot"],
         {
           env: process.env,
           stdio: process.env.CI ? "ignore" : "inherit",

--- a/e2e/test/scenarios/docker-compose.yml
+++ b/e2e/test/scenarios/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - 5404:5432
 
   mongo-sample:
-    image: metabase/qa-databases:mongo-sample-5.0
+    image: metabase/qa-databases:mongo-sample-5
     ports:
       - 27004:27017
 


### PR DESCRIPTION
### Description

Adds the `:drivers` alias to the command to start the backend so we don't need to build driver jars to run tests. Updates the mongo image in the docker compose to use a version with Apple Silicon support. 