### PR TITLE
Fix typo in segment revision exclusion list

### DIFF
--- a/src/metabase/revisions/impl/segment.clj
+++ b/src/metabase/revisions/impl/segment.clj
@@ -5,7 +5,7 @@
    [metabase.revisions.models.revision :as revision]))
 
 (def ^:private excluded-columns-for-segment-revision
-  #{:created_at :updated_at :dependency_analysis_versions})
+  #{:created_at :updated_at :dependency_analysis_version})
 
 (defmethod revision/serialize-instance :model/Segment
   [_model _id instance]

--- a/test/metabase/revisions/impl/segment_test.clj
+++ b/test/metabase/revisions/impl/segment_test.clj
@@ -26,7 +26,10 @@
              :archived                false}
             (into {} (-> (revision/serialize-instance :model/Segment (:id segment) segment)
                          (update :id boolean)
-                         (update :table_id boolean)))))))
+                         (update :table_id boolean)))))
+    (testing "excluded columns are not present"
+      (is (not-any? #{:created_at :updated_at :dependency_analysis_version}
+                    (keys (revision/serialize-instance :model/Segment (:id segment) segment)))))))
 
 (deftest ^:parallel diff-segments-test
   (mt/with-temp [:model/Database {database-id :id} {}


### PR DESCRIPTION
### Description

Fix typo in `excluded-columns-for-segment-revision`

### How to verify

See test

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
