### PR TITLE
Pagerduty for querying on-call

### DIFF
--- a/.github/workflows/querying-team-pagerduty.yml
+++ b/.github/workflows/querying-team-pagerduty.yml
@@ -1,0 +1,44 @@
+name: Querying Team PagerDuty Alert
+
+on:
+  issues:
+    types:
+      - labeled
+  # Remove these after testing:
+  workflow_dispatch:  # Allows manual triggering from Actions tab
+    inputs:
+      test_issue_number:
+        description: 'Issue number to simulate (for testing)'
+        required: false
+        default: '12345'
+
+jobs:
+  notify-querying-team:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    # Trigger when both .Team/Querying AND .Test labels are present, OR when manually triggered
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (contains(github.event.issue.labels.*.name, '.Team/Querying') &&
+       contains(github.event.issue.labels.*.name, '.Test'))
+    steps:
+      - name: Debug output
+        run: |
+          echo "🚨 Querying Team PagerDuty workflow triggered!"
+          echo ""
+          echo "Event type: ${{ github.event_name }}"
+          echo ""
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "This is a MANUAL TEST run"
+            echo "Test issue number input: ${{ github.event.inputs.test_issue_number }}"
+          else
+            echo "Issue Number: ${{ github.event.issue.number }}"
+            echo "Issue Title: ${{ github.event.issue.title }}"
+            echo "Issue URL: ${{ github.event.issue.html_url }}"
+            echo "Issue Author: ${{ github.event.issue.user.login }}"
+            echo ""
+            echo "Labels on issue:"
+            echo '${{ toJson(github.event.issue.labels.*.name) }}'
+            echo ""
+            echo "Label that triggered this workflow: ${{ github.event.label.name }}"
+          fi

--- a/.github/workflows/querying-team-pagerduty.yml
+++ b/.github/workflows/querying-team-pagerduty.yml
@@ -1,44 +1,38 @@
-name: Querying Team PagerDuty Alert
+name: Querying On-call PagerDuty Alert
 
 on:
   issues:
     types:
       - labeled
-  # Remove these after testing:
-  workflow_dispatch:  # Allows manual triggering from Actions tab
-    inputs:
-      test_issue_number:
-        description: 'Issue number to simulate (for testing)'
-        required: false
-        default: '12345'
 
 jobs:
-  notify-querying-team:
+  notify-querying-on-call:
     runs-on: ubuntu-22.04
     timeout-minutes: 5
-    # Trigger when both .Team/Querying AND .Test labels are present, OR when manually triggered
     if: |
-      github.event_name == 'workflow_dispatch' ||
-      (contains(github.event.issue.labels.*.name, '.Team/Querying') &&
-       contains(github.event.issue.labels.*.name, '.Test'))
+      (github.event.label.name == 'Priority: P1' || github.event.label.name == '.Escalation') &&
+      contains(github.event.issue.labels.*.name, '.Team/Querying')
     steps:
-      - name: Debug output
+      - name: Trigger PagerDuty Incident
         run: |
-          echo "🚨 Querying Team PagerDuty workflow triggered!"
-          echo ""
-          echo "Event type: ${{ github.event_name }}"
-          echo ""
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            echo "This is a MANUAL TEST run"
-            echo "Test issue number input: ${{ github.event.inputs.test_issue_number }}"
-          else
-            echo "Issue Number: ${{ github.event.issue.number }}"
-            echo "Issue Title: ${{ github.event.issue.title }}"
-            echo "Issue URL: ${{ github.event.issue.html_url }}"
-            echo "Issue Author: ${{ github.event.issue.user.login }}"
-            echo ""
-            echo "Labels on issue:"
-            echo '${{ toJson(github.event.issue.labels.*.name) }}'
-            echo ""
-            echo "Label that triggered this workflow: ${{ github.event.label.name }}"
-          fi
+          curl -X POST https://events.pagerduty.com/v2/enqueue \
+            -H 'Content-Type: application/json' \
+            -d '{
+              "routing_key": "${{ secrets.QUERYING_PAGERDUTY_INTEGRATION_KEY }}",
+              "event_action": "trigger",
+              "dedup_key": "github-issue-${{ github.event.issue.number }}",
+              "payload": {
+                "summary": "[${{ github.event.label.name }}] ${{ github.event.issue.title }}",
+                "source": "GitHub Issues - ${{ github.repository }}",
+                "severity": "critical",
+                "custom_details": {
+                  "Labels": "${{ join(github.event.issue.labels.*.name, ', ') }}"
+                }
+              },
+              "links": [
+                {
+                  "href": "${{ github.event.issue.html_url }}",
+                  "text": "View GitHub Issue"
+                }
+              ]
+            }'


### PR DESCRIPTION
### Description

Sets up pager duty notifications for the querying team on call. Tested on my fork https://github.com/rileythomp/metabase/ because only workflows in master can be run

**NOTE:** We'll need to add the secret `QUERYING_PAGERDUTY_INTEGRATION_KEY`

**NOTE:** @metabase/core-backend-querying @metabase/core-frontend-querying will want to configure their notification settings for the PagerDuty app. It can produce loud notifications that override do not disturb if "Critical Alerts" are enabled. You'll also want to configure your PagerDuty notification rules in your profile.

### How to verify

1. Create a Github issue with labels `.Team/Querying`, and `Priority: P1` or `.Escalation`. 
2. The on-call should receive a pager duty notification

### Demo

<details> 

<summary>Create issue with labels</summary>

<img width="1722" height="1028" alt="Screenshot 2025-12-10 at 4 03 46 PM" src="https://github.com/user-attachments/assets/1a03a084-9c06-4dda-bd16-bf414144c67c" />

</details>

<details> 

<summary>Github workflow is triggered</summary>

<img width="1726" height="943" alt="Screenshot 2025-12-10 at 4 04 08 PM" src="https://github.com/user-attachments/assets/e89e7750-d4e7-4f4c-8fd1-bc3a2c6715fe" />

</details>

<details> 

<summary>Receive PagerDuty notification</summary>

<img width="1170" height="2532" alt="IMG_5231" src="https://github.com/user-attachments/assets/b615737d-8a7d-48cf-b935-9076f2ab5241" />

</details>

<details> 

<summary>Details of PagerDuty notification</summary>

<img width="1170" height="2532" alt="IMG_5232" src="https://github.com/user-attachments/assets/b6258e18-95e5-4ca3-ba44-414ca78c345d" />

</details>

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
