### PR TITLE
Prevent looping past current-schema-version when already past it

### DIFF
--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -695,7 +695,8 @@
                           {:card-id (:id card)}))
           ;; Plausible and has the schema, so run the upgrades over it.
           (loop [card card]
-            (if (= (:card_schema card) current-schema-version)
+            ;; Use >= to allow for downgrades.
+            (if (>= (:card_schema card) current-schema-version)
               card
               (let [new-version (inc (:card_schema card))]
                 (recur (assoc (upgrade-card-schema-to card new-version)

--- a/test/metabase/queries/models/card_test.clj
+++ b/test/metabase/queries/models/card_test.clj
@@ -700,6 +700,14 @@
                  :visualization_settings
                  json/decode+kw))))))
 
+(deftest upgrade-card-schema-after-downgrade
+  (testing "We exit the loop if a chard_schema is higher than the current schema."
+    (let [card {:id 1
+                :dataset_query {}
+                :card_schema (inc @#'card/current-schema-version)}]
+      (is (= card
+             (#'card/upgrade-card-schema-to-latest card))))))
+
 (deftest storing-metabase-version
   (testing "Newly created Card should know a Metabase version used to create it"
     (mt/with-temp [:model/Card card {}]

--- a/test/metabase/queries/models/card_test.clj
+++ b/test/metabase/queries/models/card_test.clj
@@ -700,7 +700,7 @@
                  :visualization_settings
                  json/decode+kw))))))
 
-(deftest upgrade-card-schema-after-downgrade
+(deftest ^:parallel upgrade-card-schema-after-downgrade
   (testing "We exit the loop if a chard_schema is higher than the current schema."
     (let [card {:id 1
                 :dataset_query {}


### PR DESCRIPTION
We received a report of someone whose instance was attempting to do an upgrade to card schema 24, running on 57.5.5. However, the current-card-schema of 57.5.5 was 22. It's likely that they had a row in report_card with card_schema = 23. If that's the case, the loop would attempt an upgrade.

It turns out that any card_schema > current-card-schema would continue trying. This might be the case in a downgrade.

This PR fixes the loop logic by changing the = check to >=.