### PR TITLE
UXW-2534+UXW-2527 Globally rename "Top folder" to "SQL snippets" in snippet collections + Remove the library option when dealing with collections in the snippet picker

### DIFF
--- a/docs/permissions/snippets.md
+++ b/docs/permissions/snippets.md
@@ -16,7 +16,7 @@ Folder permissions should not be considered a security feature, but instead a fe
 
 Folders work similarly to a file system. You can add snippets to folders, and put folders inside of other folders. You can nest as many folders as your Metabase instance can handle or the laws of physics allow (whichever yields first).
 
-The **Top folder** is the snippet sidebar's default folder. It is the root folder that contains all folders and snippets.
+**SQL snippets** is the snippet sidebar's default folder. It is the root folder that contains all folders and snippets.
 
 ### Creating a new Snippet folder
 
@@ -36,7 +36,7 @@ On [some plans](https://www.metabase.com/pricing/), when creating a Snippet, you
 
 ![Add a snippet enterprise modal](./images/enterprise-add-snippet.png)
 
-The default location is the **Top folder**, which is the root folder for all snippets and folders. You can add a snippet to a folder at any time (or relocate a snippet to another folder, provided you have Edit permission to both folders).
+The default location is **SQL snippets**, which is the root folder for all snippets and folders. You can add a snippet to a folder at any time (or relocate a snippet to another folder, provided you have Edit permission to both folders).
 
 Note that snippet names must be unique; folders do not affect this requirement.
 
@@ -48,7 +48,7 @@ Administrators (and only administrators) can set snippet visibility and editabil
 
 Administrators can set the permissions on a folder by clicking on the ellipsis (**...**) next to a folder, and selecting **Change permissions**.
 
-You can additionally change the currently selected folder by mousing over to the top of the Snippets sidebar, clicking on the ellipsis (**...**) to the left of the **+**, and selecting **Change permissions**. When at the **Top folder**, selecting the **...** at the top of the sidebar will give Administrators the option to set permissions for all snippets, folders, and sub-folders.
+You can additionally change the currently selected folder by mousing over to the top of the Snippets sidebar, clicking on the ellipsis (**...**) to the left of the **+**, and selecting **Change permissions**. When at the **SQL snippets** root, selecting the **...** at the top of the sidebar will give Administrators the option to set permissions for all snippets, folders, and sub-folders.
 
 When changing permissions on a folder that has sub-folders, you have an option to extend those permissions to that folder's sub-folders by toggling the **Also change sub-folders** setting.
 

--- a/e2e/test/scenarios/native/snippets.cy.spec.js
+++ b/e2e/test/scenarios/native/snippets.cy.spec.js
@@ -283,7 +283,7 @@ describe("scenarios > question > snippets (EE)", () => {
     });
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    H.modal().within(() => cy.findByText("Top folder").click());
+    H.modal().within(() => cy.findByText("SQL snippets").click());
     H.entityPickerModal().within(() => {
       cy.findByText("my favorite snippets").click();
       cy.findByText("Select").click();

--- a/enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionFormModal.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionFormModal.unit.spec.tsx
@@ -14,7 +14,7 @@ import SnippetCollectionFormModal from "./SnippetCollectionFormModal";
 
 const TOP_SNIPPETS_FOLDER = {
   id: "root",
-  name: "Top folder",
+  name: "SQL snippets",
   can_write: true,
 };
 

--- a/frontend/src/metabase/common/components/Pickers/CollectionPicker/hooks.ts
+++ b/frontend/src/metabase/common/components/Pickers/CollectionPicker/hooks.ts
@@ -110,7 +110,7 @@ export const useRootCollectionPickerItems = (
           location: "/",
           name:
             options.namespace === "snippets"
-              ? t`Top folder`
+              ? t`SQL snippets`
               : rootCollection.name,
         });
       } else if (rootCollectionError) {

--- a/frontend/src/metabase/common/components/Pickers/CollectionPicker/hooks.ts
+++ b/frontend/src/metabase/common/components/Pickers/CollectionPicker/hooks.ts
@@ -77,7 +77,11 @@ export const useRootCollectionPickerItems = (
   const items = useMemo(() => {
     const collectionItems: CollectionPickerItem[] = [];
 
-    if (options.showLibrary && libraryCollection) {
+    if (
+      options.showLibrary &&
+      libraryCollection &&
+      options.namespace !== "snippets"
+    ) {
       collectionItems.push({
         ...libraryCollection,
         model: "collection",

--- a/frontend/src/metabase/common/components/SnippetCollectionName.tsx
+++ b/frontend/src/metabase/common/components/SnippetCollectionName.tsx
@@ -6,7 +6,7 @@ import type { CollectionId } from "metabase-types/api";
 
 function SnippetCollectionName({ id }: { id: CollectionId }) {
   if (isRootCollection({ id })) {
-    return <span>{t`Top folder`}</span>;
+    return <span>{t`SQL snippets`}</span>;
   }
   if (!Number.isSafeInteger(id)) {
     return null;

--- a/frontend/src/metabase/query_builder/components/template_tags/SnippetFormModal/SnippetFormModal.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/SnippetFormModal/SnippetFormModal.unit.spec.tsx
@@ -17,7 +17,7 @@ import { SnippetFormModal } from "./SnippetFormModal";
 
 const TOP_SNIPPETS_FOLDER = {
   id: "root",
-  name: "Top folder",
+  name: "SQL snippets",
   can_write: true,
 };
 

--- a/src/metabase/collections/models/collection/root.clj
+++ b/src/metabase/collections/models/collection/root.clj
@@ -55,7 +55,7 @@
   [collection-namespace]
   (m/assoc-some root-collection
                 :name (case (keyword collection-namespace)
-                        :snippets (tru "Top folder")
+                        :snippets (tru "SQL snippets")
                         (tru "Our analytics"))
                 :namespace collection-namespace
                 :is_personal false


### PR DESCRIPTION
Closes UXW-2534
Closes UXW-2527

### Description

* UXW-2534 Renames "Top folder" to "SQL snippets" everywhere for consistency and clarity
* UXW-2527 Omits "Library" from SQL snippet collection picker

These seemed adjacent enough but lemme know if I should split this PR up into two.

### How to verify
* Create/move a snippet collection in the Data Studio -> verify "Library" is not an option and the root folder is "SQL snippets" (not "Top folder")
* Verify everywhere "Top folder" was used, "SQL snippets" is used instead


### Demo

<img width="1312" height="745" alt="Screenshot 2025-12-10 at 4 56 20 PM" src="https://github.com/user-attachments/assets/463942f8-08ed-468b-8ae8-b91137108d0c" />
<img width="1312" height="745" alt="Screenshot 2025-12-10 at 4 56 35 PM" src="https://github.com/user-attachments/assets/87b8395c-7f6e-4233-87ba-fea9278a1188" />
<img width="1312" height="745" alt="Screenshot 2025-12-10 at 4 59 27 PM" src="https://github.com/user-attachments/assets/ed307664-1b9f-4626-8367-f21a73cff7bf" />
<img width="1312" height="745" alt="Screenshot 2025-12-10 at 5 01 29 PM" src="https://github.com/user-attachments/assets/bce4a3cc-30e5-4585-84da-8ea3e525dc77" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
