### PR TITLE
Trust the model's FK semantic type even for MBQL models

### DIFF
--- a/src/metabase/warehouse_schema/table.clj
+++ b/src/metabase/warehouse_schema/table.clj
@@ -114,14 +114,19 @@
                      (merge (select-keys (underlying col-id)
                                          [:semantic_type :fk_target_field_id :has_field_values :target :dimensions :name_field]))
                      (assoc
-                      :table_id     (str "card__" card-id)
-                      :id           (or col-id
-                                        ;; TODO -- what????
-                                        [:field (:name col) {:base-type (or (:base_type col) :type/*)}])
+                      :table_id      (str "card__" card-id)
+                      :id            (or col-id
+                                         ;; TODO -- what????
+                                         [:field (:name col) {:base-type (or (:base_type col) :type/*)}])
                       ;; Assoc semantic_type at least temprorarily. We need the correct semantic type in place to make
                       ;; decisions about what kind of dimension options should be added. PK/FK values will be removed
                       ;; after we've added the dimension options
-                      :semantic_type (keyword (:semantic_type col)))))]
+                      :semantic_type (keyword (:semantic_type col)))
+                     (m/assoc-some
+                      ;; If the semantic type is a FK, and the target is defined, keep it too.
+                      :fk_target_field_id (when (and (:semantic_type col)
+                                                     (isa? (keyword (:semantic_type col)) :type/FK))
+                                            (:fk_target_field_id col)))))]
     fields))
 
 (defn root-collection-schema-name
@@ -215,9 +220,11 @@
                                          cards)
           readable-cards (t2/hydrate (filter mi/can-read? cards) :metrics)]
       (for [card readable-cards]
-        ;; a native model can have columns with keys as semantic types only if a user configured them
-        (let [trust-semantic-keys? (and (= (:type card) :model)
-                                        (= (-> card :dataset_query :type) :native))]
+        ;; Models can have user configured FK columns which, for MBQL models, we cannot distinguish from
+        ;; stale data that remained there from a time when the given column was still FK. We assume
+        ;; treating a not-FK-anymore column as FK is not that bad as not supporting user defined FK
+        ;; settings, so we trust the model's information.
+        (let [trust-semantic-keys? (= (:type card) :model)]
           (-> card
               (card->virtual-table :include-database? include-database?
                                    :include-fields? true

--- a/test/metabase/queries/metadata_test.clj
+++ b/test/metabase/queries/metadata_test.clj
@@ -1,11 +1,48 @@
 (ns metabase.queries.metadata-test
   (:require
    [clojure.test :refer :all]
+   [medley.core :as m]
    [metabase.queries.metadata :as queries.metadata]
-   [metabase.util.malli :as mu]))
+   [metabase.test :as mt]
+   [metabase.util.malli :as mu]
+   [metabase.warehouse-schema.table :as schema.table]))
 
 (deftest ^:parallel batch-fetch-card-metadata-empty-queries-test
   ;; disable Malli because we want to make sure this works in prod
   (mu/disable-enforcement
     (is (= {:databases [], :fields [], :snippets [], :tables []}
            (queries.metadata/batch-fetch-card-metadata [{}])))))
+
+(deftest only-models-trust-fk-semantic-types-test
+  (testing "FK semantic types set by user should be preserved for models but stripped for questions"
+    (let [target-field-id (mt/id :orders :product_id)
+          ;; Create result_metadata with a computed column (no numeric :id) that has FK set
+          ;; This simulates a user setting FK on a column that doesn't map to a real database field
+          result-metadata [{:name               "COMPUTED_FK"
+                            :display_name       "Computed FK"
+                            :base_type          :type/Integer
+                            :semantic_type      :type/FK
+                            :fk_target_field_id target-field-id}
+                           {:name         "OTHER"
+                            :display_name "Other"
+                            :base_type    :type/Text}]
+          model-data      {:name            "Test Model"
+                           :type            :model
+                           :database_id     (mt/id)
+                           :dataset_query   (mt/mbql-query users)
+                           :result_metadata result-metadata}]
+      (mt/with-temp [:model/Card model    model-data
+                     :model/Card question (assoc model-data
+                                                 :name "Test Question"
+                                                 :type :question)]
+        (mt/with-test-user :crowberto
+          (let [[model-table]     (schema.table/batch-fetch-card-query-metadatas [(:id model)] {})
+                [question-table]  (schema.table/batch-fetch-card-query-metadatas [(:id question)] {})
+                model-fk-field    (m/find-first #(= (:name %) "COMPUTED_FK") (:fields model-table))
+                question-fk-field (m/find-first #(= (:name %) "COMPUTED_FK") (:fields question-table))]
+            (testing "Model preserves FK semantic_type for computed columns"
+              (is (= :type/FK (:semantic_type model-fk-field))))
+            (testing "Model preserves fk_target_field_id for computed columns"
+              (is (= target-field-id (:fk_target_field_id model-fk-field))))
+            (testing "Question strips FK semantic_type for computed columns (no numeric id)"
+              (is (nil? (:semantic_type question-fk-field))))))))))


### PR DESCRIPTION
Closes #48427

### Description

Trust the model's FK semantic type even for MBQL models. The idea is that is less wrong than using stale information about a field that was FK once but is not anymore.

### How to verify

After the repro steps, implicit joins to users should be available.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
