### PR TITLE
Metabot use case configuration UX

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
@@ -60,6 +60,8 @@
         metabot-id (metabot-v3.config/resolve-dynamic-metabot-id metabot_id)
         use-case   (or use_case (metabot-v3.config/default-use-case metabot-id))
         metabot-pk (metabot-v3.config/normalize-metabot-id metabot-id)
+        _             (api/check-400 use-case-info (format "Unknown use case: %s" use_case))
+        _             (api/check-400 (:enabled use-case-info) (format "The %s use case is not enabled" use_case))
         profile    (metabot-v3.config/resolve-profile metabot-pk use-case profile_id)
         session-id (metabot-v3.client/get-ai-service-token api/*current-user-id* metabot-id)]
     (store-message! conversation_id use-case profile [message])

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
@@ -58,9 +58,9 @@
   [{:keys [metabot_id use_case profile_id message context history conversation_id state]}]
   (let [message       (metabot-v3.envelope/user-message message)
         metabot-id    (metabot-v3.config/resolve-dynamic-metabot-id metabot_id)
-        use-case      (or use_case (metabot-v3.config/default-use-case metabot-id))
-        use-case-info (metabot-v3.config/fetch-use-case metabot-id use-case)
         metabot-pk    (metabot-v3.config/normalize-metabot-id metabot-id)
+        use-case      (or use_case (metabot-v3.config/default-use-case metabot-id))
+        use-case-info (metabot-v3.config/fetch-use-case metabot-pk use-case)
         _             (api/check-400 use-case-info (format "Unknown use case: %s" use_case))
         _             (api/check-400 (:enabled use-case-info) (format "The %s use case is not enabled" use_case))
         profile       (or profile_id (:profile use-case-info))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
@@ -67,7 +67,7 @@
         session-id    (metabot-v3.client/get-ai-service-token api/*current-user-id* metabot-id)]
     (store-message! conversation_id use_case profile [message])
     (metabot-v3.client/streaming-request
-     {:context         (metabot-v3.context/create-context context)
+     {:context         (metabot-v3.context/create-context context metabot-pk)
       :metabot-id      metabot-id
       :use-case        use-case
       :profile-id      profile

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/metabot.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/metabot.clj
@@ -1,7 +1,6 @@
 (ns metabase-enterprise.metabot-v3.api.metabot
   "`/api/ee/metabot-v3/metabot` routes"
   (:require
-   [metabase-enterprise.metabot-v3.config :as metabot-v3.config]
    [metabase-enterprise.metabot-v3.suggested-prompts :as metabot-v3.suggested-prompts]
    [metabase-enterprise.metabot-v3.tools.util :as metabot-v3.tools.u]
    [metabase.api.common :as api]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/metabot.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/metabot.clj
@@ -56,11 +56,6 @@
   (api/check-404 (t2/exists? :model/Metabot :id id))
   (let [old-metabot (t2/select-one :model/Metabot :id id)
         metabot-field-updates (dissoc metabot-updates :use_cases)]
-    ;; Prevent updating collection_id on the primary metabot instance
-    (when (and (contains? metabot-updates :collection_id)
-               (= (:entity_id old-metabot)
-                  (get-in metabot-v3.config/metabot-config [metabot-v3.config/internal-metabot-id :entity-id])))
-      (api/check-400 false "Cannot update collection_id for the primary metabot instance."))
     ;; Prevent enabling verified content without the premium feature
     (when (:use_verified_content metabot-updates)
       (premium-features/assert-has-feature :content-verification (tru "Content verification")))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
@@ -11,7 +11,6 @@
    [malli.core :as mc]
    [malli.transform :as mtx]
    [metabase-enterprise.metabot-v3.client.schema :as metabot-v3.client.schema]
-   [metabase-enterprise.metabot-v3.config :as metabot-v3.config]
    [metabase-enterprise.metabot-v3.context :as metabot-v3.context]
    [metabase-enterprise.metabot-v3.settings :as metabot-v3.settings]
    [metabase.api.common :as api]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
@@ -35,7 +35,7 @@
 (defn get-ai-service-token
   "Get the token for the AI service."
   ([]
-   (get-ai-service-token api/*current-user-id* metabot-v3.config/internal-metabot-id))
+   (get-ai-service-token api/*current-user-id* metabot-v3.settings/internal-metabot-uuid))
 
   ([user-id metabot-id]
    (let [secret (buddy-hash/sha256 (metabot-v3.settings/site-uuid-for-metabot-tools))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/config.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/config.clj
@@ -6,17 +6,17 @@
 
 (def internal-metabot-id
   "The UUID of the internal Metabot instance."
-  "b5716059-ad40-4d83-a4e1-673af020b2d8")
+  metabot-v3.settings/internal-metabot-uuid)
 
 (def embedded-metabot-id
   "The UUID of the embedded Metabot instance."
-  "c61bf5f5-1025-47b6-9298-bf1827105bb6")
+  metabot-v3.settings/embedded-metabot-uuid)
 
 (def metabot-config
   "Configuration for the built-in metabot instances."
-  {internal-metabot-id {:entity-id "metabotmetabotmetabot"
+  {internal-metabot-id {:entity-id metabot-v3.settings/internal-metabot-entity-id
                         :default-use-case "omnibot"}
-   embedded-metabot-id {:entity-id "embeddedmetabotmetabo"
+   embedded-metabot-id {:entity-id metabot-v3.settings/embedded-metabot-entity-id
                         :default-use-case "embedding"}})
 
 (defn normalize-metabot-id

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/config.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/config.clj
@@ -41,20 +41,19 @@
       (metabot-v3.settings/metabot-id)
       internal-metabot-id))
 
-(defn resolve-profile
-  "Resolve the AI service profile for a use case.
-   Precedence: explicit profile override > use case profile from DB
+(defn fetch-use-case
+  "Fetch the use case configuration for a metabot instance.
 
    Arguments:
    - metabot-pk: The primary key of the metabot instance
    - use-case: The use case name (e.g., \"nlq\", \"transforms\")
-   - profile-override: Optional explicit profile override (e.g., from /profile command)"
-  [metabot-pk use-case profile-override]
-  (or profile-override
-      (when (and metabot-pk use-case)
-        (let [profile (t2/select-one-fn :profile :model/MetabotUseCase
-                                        :metabot_id metabot-pk
-                                        :name use-case)]
-          (when-not profile
-            (log/warnf "No profile found for metabot %d with use-case %s" metabot-pk use-case))
-          profile))))
+
+   Returns a map with :profile and :enabled keys, or nil if use case not found."
+  [metabot-pk use-case]
+  (when (and metabot-pk use-case)
+    (let [use-case-info (t2/select-one [:model/MetabotUseCase :profile :enabled]
+                                       :metabot_id metabot-pk
+                                       :name use-case)]
+      (when-not use-case-info
+        (log/warnf "No use case found for metabot %d with name %s" metabot-pk use-case))
+      use-case-info)))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/config.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/config.clj
@@ -4,20 +4,12 @@
    [metabase.util.log :as log]
    [toucan2.core :as t2]))
 
-(def internal-metabot-id
-  "The UUID of the internal Metabot instance."
-  metabot-v3.settings/internal-metabot-uuid)
-
-(def embedded-metabot-id
-  "The UUID of the embedded Metabot instance."
-  metabot-v3.settings/embedded-metabot-uuid)
-
 (def metabot-config
   "Configuration for the built-in metabot instances."
-  {internal-metabot-id {:entity-id metabot-v3.settings/internal-metabot-entity-id
-                        :default-use-case "omnibot"}
-   embedded-metabot-id {:entity-id metabot-v3.settings/embedded-metabot-entity-id
-                        :default-use-case "embedding"}})
+  {metabot-v3.settings/internal-metabot-uuid {:entity-id metabot-v3.settings/internal-metabot-entity-id
+                                              :default-use-case "omnibot"}
+   metabot-v3.settings/embedded-metabot-uuid {:entity-id metabot-v3.settings/embedded-metabot-entity-id
+                                              :default-use-case "embedding"}})
 
 (defn normalize-metabot-id
   "Return the primary key for the metabot instance identified by `metabot-id`.
@@ -39,7 +31,7 @@
   [metabot-id]
   (or metabot-id
       (metabot-v3.settings/metabot-id)
-      internal-metabot-id))
+      metabot-v3.settings/internal-metabot-uuid))
 
 (defn fetch-use-case
   "Fetch the use case configuration for a metabot instance.

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/config.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/config.clj
@@ -6,10 +6,12 @@
 
 (def metabot-config
   "Configuration for the built-in metabot instances."
-  {metabot-v3.settings/internal-metabot-uuid {:entity-id metabot-v3.settings/internal-metabot-entity-id
-                                              :default-use-case "omnibot"}
-   metabot-v3.settings/embedded-metabot-uuid {:entity-id metabot-v3.settings/embedded-metabot-entity-id
-                                              :default-use-case "embedding"}})
+  {metabot-v3.settings/internal-metabot-uuid {:entity-id        metabot-v3.settings/internal-metabot-entity-id
+                                              :default-use-case "omnibot"
+                                              :use-cases        #{"nlq" "sql" "omnibot" "transforms"}}
+   metabot-v3.settings/embedded-metabot-uuid {:entity-id        metabot-v3.settings/embedded-metabot-entity-id
+                                              :default-use-case "embedding"
+                                              :use-cases        #{"embedding"}}})
 
 (defn normalize-metabot-id
   "Return the primary key for the metabot instance identified by `metabot-id`.

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/settings.clj
@@ -63,7 +63,7 @@
   :type       :json
   :visibility :public
   :feature    :metabot-v3
-  :export?    true
+  :export?    false
   :doc        false
   :setter     :none
   :getter     (fn []

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/settings.clj
@@ -1,7 +1,24 @@
 (ns metabase-enterprise.metabot-v3.settings
   (:require
    [metabase.settings.core :as setting :refer [defsetting]]
-   [metabase.util.i18n :refer [deferred-tru]]))
+   [metabase.util.i18n :refer [deferred-tru]]
+   [toucan2.core :as t2]))
+
+(def internal-metabot-uuid
+  "The UUID of the internal Metabot instance."
+  "b5716059-ad40-4d83-a4e1-673af020b2d8")
+
+(def embedded-metabot-uuid
+  "The UUID of the embedded Metabot instance."
+  "c61bf5f5-1025-47b6-9298-bf1827105bb6")
+
+(def internal-metabot-entity-id
+  "The entity ID of the internal Metabot instance."
+  "metabotmetabotmetabot")
+
+(def embedded-metabot-entity-id
+  "The entity ID of the embedded Metabot instance."
+  "embeddedmetabotmetabo")
 
 (defsetting ai-service-base-url
   (deferred-tru "URL for the a AI Service")
@@ -40,3 +57,16 @@
   :encryption :no
   :export?    false
   :doc        false)
+
+(defsetting metabot-enabled-use-cases
+  (deferred-tru "List of enabled use case names for the internal Metabot.")
+  :type       :json
+  :visibility :public
+  :feature    :metabot-v3
+  :export?    true
+  :doc        false
+  :setter     :none
+  :getter     (fn []
+                (when-let [metabot (t2/select-one :model/Metabot :entity_id internal-metabot-entity-id)]
+                  (->> (t2/select :model/MetabotUseCase :metabot_id (:id metabot) :enabled true)
+                       (map :name)))))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/task/suggested_prompts_generator.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/task/suggested_prompts_generator.clj
@@ -4,6 +4,7 @@
    [clojurewerkz.quartzite.jobs :as jobs]
    [clojurewerkz.quartzite.triggers :as triggers]
    [metabase-enterprise.metabot-v3.config :as metabot-v3.config]
+   [metabase-enterprise.metabot-v3.settings :as metabot-v3.settings]
    [metabase-enterprise.metabot-v3.suggested-prompts :as metabot-v3.suggested-prompts]
    [metabase.premium-features.core :as premium-features]
    [metabase.task.core :as task]
@@ -23,7 +24,7 @@
   (try
     (when (premium-features/has-feature? :metabot-v3)
       (let [metabot-eid (get-in metabot-v3.config/metabot-config
-                                [metabot-v3.config/internal-metabot-id :entity-id])
+                                [metabot-v3.settings/internal-metabot-uuid :entity-id])
             metabot-id (t2/select-one-pk :model/Metabot :entity_id metabot-eid)
             suggested-prompts-cnt (t2/count :model/MetabotPrompt :metabot_id metabot-id)]
         (if (zero? suggested-prompts-cnt)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
@@ -138,7 +138,7 @@
   "Search for data sources (tables, models, cards, dashboards, metrics, transforms) in Metabase.
   Abstracted from the API endpoint logic."
   [{:keys [term-queries semantic-queries database-id created-at last-edited-at
-           entity-types limit metabot-id search-native-query weights]}]
+           entity-types limit metabot-id use-case search-native-query weights]}]
   (log/infof "[METABOT-SEARCH] Starting search with params: %s"
              {:term-queries        term-queries
               :semantic-queries    semantic-queries
@@ -148,6 +148,7 @@
               :entity-types        entity-types
               :limit               limit
               :metabot-id          metabot-id
+              :use-case            use-case
               :search-native-query search-native-query
               :weights             weights})
   (let [search-models   (if (seq entity-types)
@@ -158,6 +159,9 @@
         use-verified?   (if metabot-id
                           (:use_verified_content metabot)
                           false)
+        ;; For NLQ and omnibot use cases, restrict search to the metabot's configured collection
+        collection-id   (when (#{"nlq" "omnibot"} use-case)
+                          (:collection_id metabot))
         limit           (or limit 50)
         search-fn       (fn [search-string search-engine]
                           (let [search-context (search/search-context
@@ -185,7 +189,9 @@
                                                   weights
                                                   (assoc :weights weights)
                                                   search-engine
-                                                  (assoc :search-engine (name search-engine))))
+                                                  (assoc :search-engine (name search-engine))
+                                                  collection-id
+                                                  (assoc :collection collection-id)))
                                 _              (log/infof "[METABOT-SEARCH] Search context models for query '%s': %s"
                                                           search-string (:models search-context))
                                 search-results (search/search search-context)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
@@ -159,9 +159,8 @@
         use-verified?   (if metabot-id
                           (:use_verified_content metabot)
                           false)
-        ;; For NLQ and omnibot use cases, restrict search to the metabot's configured collection
-        collection-id   (when (#{"nlq" "omnibot"} use-case)
-                          (:collection_id metabot))
+        ;; For NLQ use case, restrict search to the metabot's configured collection
+        collection-id   (when (= use-case "nlq") (:collection_id metabot))
         limit           (or limit 50)
         search-fn       (fn [search-string search-engine]
                           (let [search-context (search/search-context

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/metabot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/metabot_test.clj
@@ -3,8 +3,6 @@
    [clojure.set :as set]
    [clojure.test :refer :all]
    [metabase-enterprise.metabot-v3.client :as metabot-v3.client]
-   [metabase-enterprise.metabot-v3.config :as metabot-v3.config]
-   [metabase-enterprise.metabot-v3.settings :as metabot-v3.settings]
    [metabase-enterprise.metabot-v3.suggested-prompts :as metabot-v3.suggested-prompts]
    [metabase.collections.models.collection :as collection]
    [metabase.lib.core :as lib]

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/metabot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/metabot_test.clj
@@ -289,24 +289,7 @@
                                                    (format "ee/metabot-v3/metabot/%d" metabot-id)
                                                    {:use_verified_content true}))))))
 
-        (testing "should prevent updating collection_id on primary metabot instance"
-          (let [metabot-id (metabot-v3.config/normalize-metabot-id metabot-v3.settings/internal-metabot-uuid)]
-            (is (= "Cannot update collection_id for the primary metabot instance."
-                   (mt/user-http-request :crowberto :put 400
-
-                                         (format "ee/metabot-v3/metabot/%d" metabot-id)
-                                         {:collection_id collection-id-1})))
-            ;; Verify the collection_id was not updated
-            (let [unchanged-metabot (t2/select-one :model/Metabot :id metabot-id)]
-              (is (= nil (:collection_id unchanged-metabot))))
-
-            ;; Verify that updating other fields still works
-            (with-redefs [metabot-v3.suggested-prompts/generate-sample-prompts (constantly nil)]
-              (let [response (mt/user-http-request :crowberto :put 200
-                                                   (format "ee/metabot-v3/metabot/%d" metabot-id)
-                                                   {:use_verified_content true})]
-                (is (true? (:use_verified_content response)))
-                (is (= nil (:collection_id response)))))))))))
+)))))
 
 (deftest metabot-put-use-cases-test
   (testing "PUT /api/ee/metabot-v3/metabot/:id can update use_cases"

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/metabot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/metabot_test.clj
@@ -4,6 +4,7 @@
    [clojure.test :refer :all]
    [metabase-enterprise.metabot-v3.client :as metabot-v3.client]
    [metabase-enterprise.metabot-v3.config :as metabot-v3.config]
+   [metabase-enterprise.metabot-v3.settings :as metabot-v3.settings]
    [metabase-enterprise.metabot-v3.suggested-prompts :as metabot-v3.suggested-prompts]
    [metabase.collections.models.collection :as collection]
    [metabase.lib.core :as lib]
@@ -289,7 +290,7 @@
                                                    {:use_verified_content true}))))))
 
         (testing "should prevent updating collection_id on primary metabot instance"
-          (let [metabot-id (metabot-v3.config/normalize-metabot-id metabot-v3.config/internal-metabot-id)]
+          (let [metabot-id (metabot-v3.config/normalize-metabot-id metabot-v3.settings/internal-metabot-uuid)]
             (is (= "Cannot update collection_id for the primary metabot instance."
                    (mt/user-http-request :crowberto :put 400
 

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/metabot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/metabot_test.clj
@@ -287,9 +287,7 @@
             (is (= "Content verification is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/"
                    (:message (mt/user-http-request :crowberto :put 402
                                                    (format "ee/metabot-v3/metabot/%d" metabot-id)
-                                                   {:use_verified_content true}))))))
-
-)))))
+                                                   {:use_verified_content true}))))))))))
 
 (deftest metabot-put-use-cases-test
   (testing "PUT /api/ee/metabot-v3/metabot/:id can update use_cases"

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api_test.clj
@@ -5,7 +5,6 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [compojure.response]
-   [medley.core :as m]
    [metabase-enterprise.metabot-v3.api :as api]
    [metabase-enterprise.metabot-v3.client :as client]
    [metabase-enterprise.metabot-v3.client-test :as client-test]

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/client_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/client_test.clj
@@ -7,6 +7,7 @@
    [metabase-enterprise.metabot-v3.client :as metabot-v3.client]
    [metabase-enterprise.metabot-v3.client.schema :as metabot-v3.client.schema]
    [metabase-enterprise.metabot-v3.config :as metabot-v3.config]
+   [metabase-enterprise.metabot-v3.settings :as metabot-v3.settings]
    [metabase-enterprise.metabot-v3.suggested-prompts :as metabot-v3.suggested-prompts]
    [metabase-enterprise.metabot-v3.util :as metabot-v3.util]
    [metabase.lib.core :as lib]
@@ -103,7 +104,7 @@
                  (with-redefs [metabot-v3.client/post! (constantly {:status 200
                                                                     :body {:table_questions []
                                                                            :metric_questions []}})]
-                   (let [metabot-eid (get-in metabot-v3.config/metabot-config [metabot-v3.config/internal-metabot-id
+                   (let [metabot-eid (get-in metabot-v3.config/metabot-config [metabot-v3.settings/internal-metabot-uuid
                                                                                :entity-id])
                          metabot-id (t2/select-one-fn :id :model/Metabot :entity_id metabot-eid)]
                      (metabot-v3.suggested-prompts/generate-sample-prompts metabot-id)

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/config_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/config_test.clj
@@ -19,5 +19,5 @@
                    (metabot-v3.config/resolve-dynamic-metabot-id nil)))))
 
         (testing "falls back to internal default when no explicit or env value"
-          (is (= metabot-v3.config/internal-metabot-id
+          (is (= metabot-v3.settings/internal-metabot-uuid
                  (metabot-v3.config/resolve-dynamic-metabot-id nil))))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/context_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/context_test.clj
@@ -3,7 +3,6 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase-enterprise.metabot-v3.context :as context]
-   [metabase-enterprise.metabot-v3.settings :as metabot-v3.settings]
    [metabase-enterprise.metabot-v3.table-utils :as table-utils]
    [metabase.activity-feed.models.recent-views :as recent-views]
    [metabase.lib.core :as lib]

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/models/metabot_use_case_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/models/metabot_use_case_test.clj
@@ -7,21 +7,17 @@
 
 (use-fixtures :once (fixtures/initialize :db))
 
-(deftest resolve-profile-test
+(deftest fetch-use-case-test
   (mt/with-temp [:model/Metabot {metabot-id :id} {:name "Test Metabot"}
                  :model/MetabotUseCase _ {:metabot_id metabot-id :name "nlq" :profile "internal" :enabled true}
                  :model/MetabotUseCase _ {:metabot_id metabot-id :name "sql" :profile "internal" :enabled true}
                  :model/MetabotUseCase _ {:metabot_id metabot-id :name "transforms" :profile "transforms_codegen" :enabled true}
-                 :model/MetabotUseCase _ {:metabot_id metabot-id :name "omnibot" :profile "internal" :enabled true}]
-    (testing "resolves profile from use case in DB"
-      (is (= "internal" (metabot-v3.config/resolve-profile metabot-id "nlq" nil)))
-      (is (= "internal" (metabot-v3.config/resolve-profile metabot-id "sql" nil)))
-      (is (= "transforms_codegen" (metabot-v3.config/resolve-profile metabot-id "transforms" nil)))
-      (is (= "internal" (metabot-v3.config/resolve-profile metabot-id "omnibot" nil))))
-
-    (testing "profile override takes precedence"
-      (is (= "custom-profile" (metabot-v3.config/resolve-profile metabot-id "nlq" "custom-profile")))
-      (is (= "custom-profile" (metabot-v3.config/resolve-profile metabot-id "transforms" "custom-profile"))))
+                 :model/MetabotUseCase _ {:metabot_id metabot-id :name "omnibot" :profile "internal" :enabled false}]
+    (testing "fetches use case from DB"
+      (is (= {:profile "internal" :enabled true} (metabot-v3.config/fetch-use-case metabot-id "nlq")))
+      (is (= {:profile "internal" :enabled true} (metabot-v3.config/fetch-use-case metabot-id "sql")))
+      (is (= {:profile "transforms_codegen" :enabled true} (metabot-v3.config/fetch-use-case metabot-id "transforms")))
+      (is (= {:profile "internal" :enabled false} (metabot-v3.config/fetch-use-case metabot-id "omnibot"))))
 
     (testing "returns nil for unknown use case"
-      (is (nil? (metabot-v3.config/resolve-profile metabot-id "unknown-use-case" nil))))))
+      (is (nil? (metabot-v3.config/fetch-use-case metabot-id "unknown-use-case"))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/task/suggested_prompts_generator_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/task/suggested_prompts_generator_test.clj
@@ -3,6 +3,7 @@
    [clojure.test :refer [deftest is testing]]
    [metabase-enterprise.metabot-v3.client :as metabot-v3.client]
    [metabase-enterprise.metabot-v3.config :as metabot-v3.config]
+   [metabase-enterprise.metabot-v3.settings :as metabot-v3.settings]
    [metabase-enterprise.metabot-v3.task.suggested-prompts-generator
     :as metabot-v3.task.suggested-prompts-generator]
    [metabase.lib.convert :as lib.convert]
@@ -18,7 +19,7 @@
     (mt/with-empty-h2-app-db!
       (let [original-metabot (t2/select-one :model/Metabot
                                             :entity_id (get-in metabot-v3.config/metabot-config
-                                                               [metabot-v3.config/internal-metabot-id :entity-id]))
+                                                               [metabot-v3.settings/internal-metabot-uuid :entity-id]))
             mp (mt/metadata-provider)
             query (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
                       lib.convert/->legacy-MBQL)

--- a/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/requests.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/requests.ts
@@ -56,7 +56,8 @@ export async function aiStreamingQuery(
     });
 
     if (!response.ok) {
-      throw new Error(`Response status: ${response.status}`);
+      const errorMessage = await response.text();
+      throw new Error(errorMessage || `Response status: ${response.status}`);
     }
 
     if (!response.body) {

--- a/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/requests.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/requests.ts
@@ -57,7 +57,11 @@ export async function aiStreamingQuery(
 
     if (!response.ok) {
       const errorMessage = await response.text();
-      throw new Error(errorMessage || `Response status: ${response.status}`);
+      const error = new Error(
+        errorMessage || `Response status: ${response.status}`,
+      );
+      (error as Error & { status: number }).status = response.status;
+      throw error;
     }
 
     if (!response.body) {

--- a/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/requests.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/requests.ts
@@ -5,7 +5,7 @@ import api from "metabase/lib/api";
 import { type AIStreamingConfig, processChatResponse } from "./process-stream";
 import type { JSONValue } from "./types";
 
-// keep track of inflight requests so that can be cancelled programmitcally from other
+// keep track of inflight requests so that can be cancelled programatically from other
 // places in the app w/o passing references to the abort controller directly
 export const inflightAiStreamingRequests = new Map<
   string,

--- a/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/requests.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/requests.ts
@@ -5,7 +5,7 @@ import api from "metabase/lib/api";
 import { type AIStreamingConfig, processChatResponse } from "./process-stream";
 import type { JSONValue } from "./types";
 
-// keep track of inflight requests so that can be cancelled programatically from other
+// keep track of inflight requests so that can be cancelled programmatically from other
 // places in the app w/o passing references to the abort controller directly
 export const inflightAiStreamingRequests = new Map<
   string,

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/Metabot.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/Metabot.tsx
@@ -52,9 +52,6 @@ export const MetabotAuthenticated = ({
     return tinykeys(window, {
       "$mod+e": (e) => {
         e.preventDefault(); // prevent FF from opening bookmark menu
-        // if (!hasRequiredUseCase) {
-        //   return;
-        // }
         if (!visible) {
           trackMetabotChatOpened("keyboard_shortcut");
         }

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/Metabot.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/Metabot.tsx
@@ -58,7 +58,7 @@ export const MetabotAuthenticated = ({
         setVisible(!visible);
       },
     });
-  }, [visible, setVisible, hasRequiredUseCase]);
+  }, [visible, setVisible]);
 
   useEffect(
     function closeViaPropChange() {

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/Metabot.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/Metabot.tsx
@@ -21,7 +21,7 @@ export interface MetabotConfig {
   suggestionModels: SuggestionModel[];
 }
 
-export const SIDEBAR_USE_CASES = ["sql", "nlq", "omnibot"];
+export const DEFAULT_USE_CASES = ["sql", "nlq", "omnibot"];
 
 export interface MetabotProps {
   hide?: boolean;
@@ -33,7 +33,7 @@ export interface MetabotProps {
 export const MetabotAuthenticated = ({
   hide,
   config,
-  requiredUseCases = SIDEBAR_USE_CASES,
+  requiredUseCases = DEFAULT_USE_CASES,
 }: MetabotProps) => {
   const { visible, setVisible } = useMetabotAgent();
   const enabledUseCases = useSetting("metabot-enabled-use-cases");

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/Metabot.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/Metabot.tsx
@@ -8,6 +8,7 @@ import type { SuggestionModel } from "metabase/rich_text_editing/tiptap/extensio
 import { getUser } from "metabase/selectors/user";
 
 import { trackMetabotChatOpened } from "../analytics";
+import { METABOT_USE_CASES } from "../constants";
 import { useMetabotAgent } from "../hooks";
 
 import { MetabotChat } from "./MetabotChat";
@@ -21,7 +22,11 @@ export interface MetabotConfig {
   suggestionModels: SuggestionModel[];
 }
 
-export const DEFAULT_USE_CASES = ["sql", "nlq", "omnibot"];
+export const DEFAULT_USE_CASES = [
+  METABOT_USE_CASES.SQL,
+  METABOT_USE_CASES.NLQ,
+  METABOT_USE_CASES.OMNIBOT,
+];
 
 export interface MetabotProps {
   hide?: boolean;

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/Metabot.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/Metabot.tsx
@@ -52,9 +52,9 @@ export const MetabotAuthenticated = ({
     return tinykeys(window, {
       "$mod+e": (e) => {
         e.preventDefault(); // prevent FF from opening bookmark menu
-        if (!hasRequiredUseCase) {
-          return;
-        }
+        // if (!hasRequiredUseCase) {
+        //   return;
+        // }
         if (!visible) {
           trackMetabotChatOpened("keyboard_shortcut");
         }
@@ -72,7 +72,7 @@ export const MetabotAuthenticated = ({
     [hide, setVisible],
   );
 
-  if (!visible || hide) {
+  if (!visible || hide || !hasRequiredUseCase) {
     return null;
   }
 

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdmin.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdmin.module.css
@@ -1,0 +1,6 @@
+.SectionCard {
+  border-radius: 8px;
+  border: 1px solid var(--mb-color-border);
+  background: var(--mb-color-background);
+  padding: var(--mantine-spacing-lg);
+}

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdmin.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdmin.module.css
@@ -1,6 +1,0 @@
-.SectionCard {
-  border-radius: 8px;
-  border: 1px solid var(--mb-color-border);
-  background: var(--mb-color-background);
-  padding: var(--mantine-spacing-lg);
-}

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminPage.tsx
@@ -91,31 +91,49 @@ export function MetabotAdminPage() {
         >
           {!isEmbedMetabot && (
             <Box className={S.SectionCard}>
-              <MetabotNLQSection metabot={metabot} />
+              <MetabotUseCaseSection
+                metabot={metabot}
+                useCase="nlq"
+                title={t`Natural Language Querying`}
+                description={t`Allow users to query data using natural language`}
+                switchLabel={t`Enable NLQ`}
+              />
             </Box>
           )}
 
           {!isEmbedMetabot && (
             <Box className={S.SectionCard}>
-              <MetabotSQLGenerationSection metabot={metabot} />
+              <MetabotUseCaseSection
+                metabot={metabot}
+                useCase="sql"
+                title={t`SQL Generation`}
+                description={t`Generate SQL queries from natural language inputs`}
+                switchLabel={t`Enable SQL generation`}
+              />
             </Box>
           )}
 
           {!isEmbedMetabot && (
             <Box className={S.SectionCard}>
-              <MetabotOmnibotSection metabot={metabot} />
+              <MetabotUseCaseSection
+                metabot={metabot}
+                useCase="omnibot"
+                title={t`Omnibot`}
+                description={t`Enable the multi-modal AI assistant`}
+                switchLabel={t`Enable Omnibot`}
+              />
             </Box>
           )}
 
           {!isEmbedMetabot && (
             <Box className={S.SectionCard}>
-              <MetabotTransformsSection metabot={metabot} />
-            </Box>
-          )}
-
-          {isEmbedMetabot && (
-            <Box className={S.SectionCard}>
-              <MetabotCollectionConfigurationPane metabot={metabot} />
+              <MetabotUseCaseSection
+                metabot={metabot}
+                useCase="transforms"
+                title={t`Transforms`}
+                description={t`Allow Metabot to write and edit transforms`}
+                switchLabel={t`Enable Transforms`}
+              />
             </Box>
           )}
 
@@ -134,6 +152,9 @@ export function MetabotAdminPage() {
                   metabot={metabot}
                   title={t`Collection for NLQ`}
                 />
+              )}
+              {isEmbedMetabot && (
+                <MetabotCollectionConfigurationPane metabot={metabot} />
               )}
               <MetabotVerifiedContentConfigurationPane metabot={metabot} />
               <MetabotPromptSuggestionPane metabot={metabot} />
@@ -172,100 +193,34 @@ function useUseCaseToggle(metabot: MetabotInfo, useCaseName: MetabotUseCase) {
   return { isEnabled, isLoading, handleToggle };
 }
 
-function MetabotNLQSection({ metabot }: { metabot: MetabotInfo }) {
+function MetabotUseCaseSection({
+  metabot,
+  useCase,
+  title,
+  description,
+  switchLabel,
+}: {
+  metabot: MetabotInfo;
+  useCase: MetabotUseCase;
+  title: string;
+  description: string;
+  switchLabel: string;
+}) {
   const { isEnabled, isLoading, handleToggle } = useUseCaseToggle(
     metabot,
-    "nlq",
+    useCase,
   );
 
   return (
     <Stack gap="sm">
       <Text fw={600} c="text-dark" fz="h4">
-        {t`Natural Language Querying`}
+        {title}
       </Text>
       <Text c="text-medium" maw="38rem">
-        {t`Allow users to query data using natural language`}
+        {description}
       </Text>
       <Switch
-        label={t`Enable NLQ`}
-        checked={isEnabled}
-        onChange={(e) => handleToggle(e.target.checked)}
-        disabled={isLoading}
-        w="auto"
-        size="sm"
-      />
-    </Stack>
-  );
-}
-
-function MetabotSQLGenerationSection({ metabot }: { metabot: MetabotInfo }) {
-  const { isEnabled, isLoading, handleToggle } = useUseCaseToggle(
-    metabot,
-    "sql",
-  );
-
-  return (
-    <Stack gap="sm">
-      <Text fw={600} c="text-dark" fz="h4">
-        {t`SQL Generation`}
-      </Text>
-      <Text c="text-medium" maw="38rem">
-        {t`Generate SQL queries from natural language inputs`}
-      </Text>
-      <Switch
-        label={t`Enable SQL generation`}
-        checked={isEnabled}
-        onChange={(e) => handleToggle(e.target.checked)}
-        disabled={isLoading}
-        w="auto"
-        size="sm"
-      />
-    </Stack>
-  );
-}
-
-function MetabotOmnibotSection({ metabot }: { metabot: MetabotInfo }) {
-  const { isEnabled, isLoading, handleToggle } = useUseCaseToggle(
-    metabot,
-    "omnibot",
-  );
-
-  return (
-    <Stack gap="sm">
-      <Text fw={600} c="text-dark" fz="h4">
-        {t`Omnibot`}
-      </Text>
-      <Text c="text-medium" maw="38rem">
-        {t`Enable the multi-modal AI assistant`}
-      </Text>
-      <Switch
-        label={t`Enable Omnibot`}
-        checked={isEnabled}
-        onChange={(e) => handleToggle(e.target.checked)}
-        disabled={isLoading}
-        w="auto"
-        size="sm"
-      />
-    </Stack>
-  );
-}
-
-function MetabotTransformsSection({ metabot }: { metabot: MetabotInfo }) {
-  const { isEnabled, isLoading, handleToggle } = useUseCaseToggle(
-    metabot,
-    "transforms",
-  );
-
-  return (
-    <Stack gap="sm">
-      <Text fw={600} c="text-dark" fz="h4">
-        {t`Transforms`}
-      </Text>
-      <Text c="text-medium" maw="38rem">
-        {t`Allow Metabot to write and edit transforms`}
-      </Text>
-      <Switch
-        label={t`Enable Transforms`}
+        label={switchLabel}
         checked={isEnabled}
         onChange={(e) => handleToggle(e.target.checked)}
         disabled={isLoading}

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminPage.tsx
@@ -10,7 +10,10 @@ import {
   AdminNavItem,
   AdminNavWrapper,
 } from "metabase/admin/components/AdminNav";
-import { SettingsPageWrapper } from "metabase/admin/components/SettingsSection";
+import {
+  SettingsPageWrapper,
+  SettingsSection,
+} from "metabase/admin/components/SettingsSection";
 import { SettingHeader } from "metabase/admin/settings/components/SettingHeader";
 import { skipToken, useGetCollectionQuery } from "metabase/api";
 import { canonicalCollectionId } from "metabase/collections/utils";
@@ -47,7 +50,6 @@ import type {
   MetabotUseCase,
 } from "metabase-types/api";
 
-import S from "./MetabotAdmin.module.css";
 import { MetabotPromptSuggestionPane } from "./MetabotAdminSuggestedPrompts";
 import { useMetabotIdPath } from "./utils";
 
@@ -91,54 +93,47 @@ export function MetabotAdminPage() {
           description={description}
         >
           {!isEmbedMetabot && (
-            <Box className={S.SectionCard}>
-              <MetabotUseCaseSection
-                metabot={metabot}
-                useCase={METABOT_USE_CASES.NLQ}
-                title={t`Natural Language Querying`}
-                description={t`Allow users to query data using natural language`}
-                switchLabel={t`Enable NLQ`}
-              />
-            </Box>
+            <>
+              <SettingsSection>
+                <MetabotUseCaseSection
+                  metabot={metabot}
+                  useCase={METABOT_USE_CASES.NLQ}
+                  title={t`Natural Language Querying`}
+                  description={t`Allow users to query data using natural language`}
+                  switchLabel={t`Enable NLQ`}
+                />
+              </SettingsSection>
+              <SettingsSection>
+                <MetabotUseCaseSection
+                  metabot={metabot}
+                  useCase={METABOT_USE_CASES.SQL}
+                  title={t`SQL Generation`}
+                  description={t`Generate SQL queries from natural language inputs`}
+                  switchLabel={t`Enable SQL generation`}
+                />
+              </SettingsSection>
+              <SettingsSection>
+                <MetabotUseCaseSection
+                  metabot={metabot}
+                  useCase={METABOT_USE_CASES.OMNIBOT}
+                  title={t`Omnibot`}
+                  description={t`Enable the multi-modal AI assistant`}
+                  switchLabel={t`Enable Omnibot`}
+                />
+              </SettingsSection>
+              <SettingsSection>
+                <MetabotUseCaseSection
+                  metabot={metabot}
+                  useCase={METABOT_USE_CASES.TRANSFORMS}
+                  title={t`Transforms`}
+                  description={t`Allow Metabot to write and edit transforms`}
+                  switchLabel={t`Enable Transforms`}
+                />
+              </SettingsSection>
+            </>
           )}
 
-          {!isEmbedMetabot && (
-            <Box className={S.SectionCard}>
-              <MetabotUseCaseSection
-                metabot={metabot}
-                useCase={METABOT_USE_CASES.SQL}
-                title={t`SQL Generation`}
-                description={t`Generate SQL queries from natural language inputs`}
-                switchLabel={t`Enable SQL generation`}
-              />
-            </Box>
-          )}
-
-          {!isEmbedMetabot && (
-            <Box className={S.SectionCard}>
-              <MetabotUseCaseSection
-                metabot={metabot}
-                useCase={METABOT_USE_CASES.OMNIBOT}
-                title={t`Omnibot`}
-                description={t`Enable the multi-modal AI assistant`}
-                switchLabel={t`Enable Omnibot`}
-              />
-            </Box>
-          )}
-
-          {!isEmbedMetabot && (
-            <Box className={S.SectionCard}>
-              <MetabotUseCaseSection
-                metabot={metabot}
-                useCase={METABOT_USE_CASES.TRANSFORMS}
-                title={t`Transforms`}
-                description={t`Allow Metabot to write and edit transforms`}
-                switchLabel={t`Enable Transforms`}
-              />
-            </Box>
-          )}
-
-          <Box className={S.SectionCard}>
+          <SettingsSection>
             <Stack gap="lg">
               <Stack gap="sm">
                 <Text fw={600} c="text-dark" fz="h4">
@@ -148,19 +143,14 @@ export function MetabotAdminPage() {
                   {t`Fine-tune query behavior and data sources`}
                 </Text>
               </Stack>
-              {!isEmbedMetabot && (
-                <MetabotCollectionConfigurationPane
-                  metabot={metabot}
-                  title={t`Collection for NLQ`}
-                />
-              )}
-              {isEmbedMetabot && (
-                <MetabotCollectionConfigurationPane metabot={metabot} />
-              )}
+              <MetabotCollectionConfigurationPane
+                metabot={metabot}
+                title={isEmbedMetabot ? undefined : t`Collection for NLQ`}
+              />
               <MetabotVerifiedContentConfigurationPane metabot={metabot} />
               <MetabotPromptSuggestionPane metabot={metabot} />
             </Stack>
-          </Box>
+          </SettingsSection>
         </SettingsPageWrapper>
       </ErrorBoundary>
     </AdminSettingsLayout>

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminPage.tsx
@@ -97,37 +97,33 @@ export function MetabotAdminPage() {
               <SettingsSection>
                 <MetabotUseCaseSection
                   metabot={metabot}
-                  useCase={METABOT_USE_CASES.NLQ}
-                  title={t`Natural Language Querying`}
-                  description={t`Allow users to query data using natural language`}
-                  switchLabel={t`Enable NLQ`}
+                  useCase={METABOT_USE_CASES.OMNIBOT}
+                  title={t`Metabot chat`}
+                  switchLabel={t`Let users chat with Metabot via the chat sidebar`}
                 />
               </SettingsSection>
               <SettingsSection>
                 <MetabotUseCaseSection
                   metabot={metabot}
                   useCase={METABOT_USE_CASES.SQL}
-                  title={t`SQL Generation`}
-                  description={t`Generate SQL queries from natural language inputs`}
-                  switchLabel={t`Enable SQL generation`}
+                  title={t`SQL editor`}
+                  switchLabel={t`Enable the in-editor SQL assistant when writing native queries`}
                 />
               </SettingsSection>
               <SettingsSection>
                 <MetabotUseCaseSection
                   metabot={metabot}
-                  useCase={METABOT_USE_CASES.OMNIBOT}
-                  title={t`Omnibot`}
-                  description={t`Enable the multi-modal AI assistant`}
-                  switchLabel={t`Enable Omnibot`}
+                  useCase={METABOT_USE_CASES.NLQ}
+                  title={t`Natural language questions`}
+                  switchLabel={t`Enable starting new queries via natural language`}
                 />
               </SettingsSection>
               <SettingsSection>
                 <MetabotUseCaseSection
                   metabot={metabot}
                   useCase={METABOT_USE_CASES.TRANSFORMS}
-                  title={t`Transforms`}
-                  description={t`Allow Metabot to write and edit transforms`}
-                  switchLabel={t`Enable Transforms`}
+                  title={t`Data studio`}
+                  switchLabel={t`Enable transform assistant`}
                 />
               </SettingsSection>
             </>
@@ -194,7 +190,7 @@ function MetabotUseCaseSection({
   metabot: MetabotInfo;
   useCase: MetabotUseCase;
   title: string;
-  description: string;
+  description?: string;
   switchLabel: string;
 }) {
   const { isEnabled, isLoading, handleToggle } = useUseCaseToggle(
@@ -207,9 +203,11 @@ function MetabotUseCaseSection({
       <Text fw={600} c="text-dark" fz="h4">
         {title}
       </Text>
-      <Text c="text-medium" maw="38rem">
-        {description}
-      </Text>
+      {description && (
+        <Text c="text-medium" maw="38rem">
+          {description}
+        </Text>
+      )}
       <Switch
         label={switchLabel}
         checked={isEnabled}

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminPage.tsx
@@ -107,6 +107,12 @@ export function MetabotAdminPage() {
             </Box>
           )}
 
+          {!isEmbedMetabot && (
+            <Box className={S.SectionCard}>
+              <MetabotTransformsSection metabot={metabot} />
+            </Box>
+          )}
+
           {isEmbedMetabot && (
             <Box className={S.SectionCard}>
               <MetabotCollectionConfigurationPane metabot={metabot} />
@@ -123,6 +129,12 @@ export function MetabotAdminPage() {
                   {t`Fine-tune query behavior and data sources`}
                 </Text>
               </Stack>
+              {!isEmbedMetabot && (
+                <MetabotCollectionConfigurationPane
+                  metabot={metabot}
+                  title={t`Collection for NLQ`}
+                />
+              )}
               <MetabotVerifiedContentConfigurationPane metabot={metabot} />
               <MetabotPromptSuggestionPane metabot={metabot} />
             </Stack>
@@ -238,6 +250,32 @@ function MetabotOmnibotSection({ metabot }: { metabot: MetabotInfo }) {
   );
 }
 
+function MetabotTransformsSection({ metabot }: { metabot: MetabotInfo }) {
+  const { isEnabled, isLoading, handleToggle } = useUseCaseToggle(
+    metabot,
+    "transforms",
+  );
+
+  return (
+    <Stack gap="sm">
+      <Text fw={600} c="text-dark" fz="h4">
+        {t`Transforms`}
+      </Text>
+      <Text c="text-medium" maw="38rem">
+        {t`Allow Metabot to write and edit transforms`}
+      </Text>
+      <Switch
+        label={t`Enable Transforms`}
+        checked={isEnabled}
+        onChange={(e) => handleToggle(e.target.checked)}
+        disabled={isLoading}
+        w="auto"
+        size="sm"
+      />
+    </Stack>
+  );
+}
+
 function MetabotNavPane() {
   const { data, isLoading } = useListMetabotsQuery();
   const metabotId = useMetabotIdPath();
@@ -320,8 +358,10 @@ function MetabotVerifiedContentConfigurationPane({
 
 function MetabotCollectionConfigurationPane({
   metabot,
+  title,
 }: {
   metabot: MetabotInfo;
+  title?: string;
 }) {
   const metabotId = metabot.id;
   const metabotName = metabot.name;
@@ -364,13 +404,12 @@ function MetabotCollectionConfigurationPane({
     }
   };
 
+  const defaultTitle = c("{0} is the name of an AI assistant")
+    .t`Collection ${metabotName} can use`;
+
   return (
     <Box>
-      <SettingHeader
-        id="allow-metabot"
-        title={c("{0} is the name of an AI assistant")
-          .t`Collection ${metabotName} can use`}
-      />
+      <SettingHeader id="allow-metabot" title={title ?? defaultTitle} />
       <CollectionInfo collection={collection} />
       <Flex gap="md" mt="md">
         <Button onClick={open} leftSection={isUpdating && <Loader size="xs" />}>

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminPage.tsx
@@ -37,6 +37,7 @@ import {
 import {
   FIXED_METABOT_ENTITY_IDS,
   FIXED_METABOT_IDS,
+  METABOT_USE_CASES,
 } from "metabase-enterprise/metabot/constants";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 import type {
@@ -93,7 +94,7 @@ export function MetabotAdminPage() {
             <Box className={S.SectionCard}>
               <MetabotUseCaseSection
                 metabot={metabot}
-                useCase="nlq"
+                useCase={METABOT_USE_CASES.NLQ}
                 title={t`Natural Language Querying`}
                 description={t`Allow users to query data using natural language`}
                 switchLabel={t`Enable NLQ`}
@@ -105,7 +106,7 @@ export function MetabotAdminPage() {
             <Box className={S.SectionCard}>
               <MetabotUseCaseSection
                 metabot={metabot}
-                useCase="sql"
+                useCase={METABOT_USE_CASES.SQL}
                 title={t`SQL Generation`}
                 description={t`Generate SQL queries from natural language inputs`}
                 switchLabel={t`Enable SQL generation`}
@@ -117,7 +118,7 @@ export function MetabotAdminPage() {
             <Box className={S.SectionCard}>
               <MetabotUseCaseSection
                 metabot={metabot}
-                useCase="omnibot"
+                useCase={METABOT_USE_CASES.OMNIBOT}
                 title={t`Omnibot`}
                 description={t`Enable the multi-modal AI assistant`}
                 switchLabel={t`Enable Omnibot`}
@@ -129,7 +130,7 @@ export function MetabotAdminPage() {
             <Box className={S.SectionCard}>
               <MetabotUseCaseSection
                 metabot={metabot}
-                useCase="transforms"
+                useCase={METABOT_USE_CASES.TRANSFORMS}
                 title={t`Transforms`}
                 description={t`Allow Metabot to write and edit transforms`}
                 switchLabel={t`Enable Transforms`}

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAppBarButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAppBarButton.tsx
@@ -7,7 +7,7 @@ import { useMetabotAgent } from "metabase-enterprise/metabot/hooks";
 
 import { trackMetabotChatOpened } from "../analytics";
 
-import { SIDEBAR_USE_CASES } from "./Metabot";
+import { DEFAULT_USE_CASES } from "./Metabot";
 
 interface MetabotAppBarButtonProps extends ActionIconProps {
   className?: string;
@@ -19,7 +19,7 @@ export function MetabotAppBarButton({
 }: MetabotAppBarButtonProps) {
   const metabot = useMetabotAgent();
   const enabledUseCases = useSetting("metabot-enabled-use-cases");
-  const hasSidebarUseCase = SIDEBAR_USE_CASES.some((useCase) =>
+  const hasDefaultUseCase = DEFAULT_USE_CASES.some((useCase) =>
     enabledUseCases?.includes(useCase),
   );
 
@@ -31,7 +31,7 @@ export function MetabotAppBarButton({
     metabot.setVisible(!metabot.visible);
   };
 
-  if (!hasSidebarUseCase) {
+  if (!hasDefaultUseCase) {
     return null;
   }
 

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAppBarButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAppBarButton.tsx
@@ -1,10 +1,13 @@
 import { t } from "ttag";
 
+import { useSetting } from "metabase/common/hooks";
 import { METAKEY } from "metabase/lib/browser";
 import { ActionIcon, type ActionIconProps, Icon, Tooltip } from "metabase/ui";
 import { useMetabotAgent } from "metabase-enterprise/metabot/hooks";
 
 import { trackMetabotChatOpened } from "../analytics";
+
+import { SIDEBAR_USE_CASES } from "./Metabot";
 
 interface MetabotAppBarButtonProps extends ActionIconProps {
   className?: string;
@@ -15,6 +18,10 @@ export function MetabotAppBarButton({
   ...rest
 }: MetabotAppBarButtonProps) {
   const metabot = useMetabotAgent();
+  const enabledUseCases = useSetting("metabot-enabled-use-cases");
+  const hasSidebarUseCase = SIDEBAR_USE_CASES.some((useCase) =>
+    enabledUseCases?.includes(useCase),
+  );
 
   const handleClick = () => {
     if (!metabot.visible) {
@@ -23,6 +30,10 @@ export function MetabotAppBarButton({
 
     metabot.setVisible(!metabot.visible);
   };
+
+  if (!hasSidebarUseCase) {
+    return null;
+  }
 
   const label = t`Chat with Metabot (${METAKEY}+E)`;
 

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAppBarButton.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAppBarButton.unit.spec.tsx
@@ -1,0 +1,48 @@
+import { setupEnterprisePlugins } from "__support__/enterprise";
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen } from "__support__/ui";
+import { createMockTokenFeatures } from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks";
+
+import { MetabotProvider } from "../context";
+import { getMetabotInitialState } from "../state";
+
+import { MetabotAppBarButton } from "./MetabotAppBarButton";
+
+function setup(enabledUseCases: string[] = []) {
+  const settings = mockSettings({
+    "token-features": createMockTokenFeatures({ metabot_v3: true }),
+    "metabot-enabled-use-cases": enabledUseCases,
+  });
+
+  setupEnterprisePlugins();
+
+  return renderWithProviders(
+    <MetabotProvider>
+      <MetabotAppBarButton />
+    </MetabotProvider>,
+    {
+      storeInitialState: createMockState({
+        settings,
+        plugins: { metabotPlugin: getMetabotInitialState() },
+      } as any),
+    },
+  );
+}
+
+describe("MetabotAppBarButton", () => {
+  it("should render when default use cases are enabled", () => {
+    setup(["nlq", "sql", "omnibot"]);
+    expect(screen.getByRole("button")).toBeInTheDocument();
+  });
+
+  it("should not render when only non-default use cases are enabled", () => {
+    setup(["transforms"]);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("should not render when use cases list is empty", () => {
+    setup([]);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotDataStudioButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotDataStudioButton.tsx
@@ -8,13 +8,15 @@ import { getLocation } from "metabase/selectors/routing";
 import { ActionIcon, Icon, Tooltip } from "metabase/ui";
 
 import { trackMetabotChatOpened } from "../analytics";
+import { METABOT_USE_CASES } from "../constants";
 import { useMetabotAgent } from "../hooks";
 
 export const MetabotDataStudioButton = () => {
   const metabot = useMetabotAgent();
   const location = useSelector(getLocation);
   const enabledUseCases = useSetting("metabot-enabled-use-cases");
-  const isTransformsEnabled = enabledUseCases?.includes("transforms") ?? false;
+  const isTransformsEnabled =
+    enabledUseCases?.includes(METABOT_USE_CASES.TRANSFORMS) ?? false;
   const isOnTransformsPage = location.pathname?.startsWith(
     Urls.transformList(),
   );

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotDataStudioButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotDataStudioButton.tsx
@@ -1,5 +1,6 @@
 import { t } from "ttag";
 
+import { useSetting } from "metabase/common/hooks";
 import { METAKEY } from "metabase/lib/browser";
 import { useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
@@ -12,7 +13,12 @@ import { useMetabotAgent } from "../hooks";
 export const MetabotDataStudioButton = () => {
   const metabot = useMetabotAgent();
   const location = useSelector(getLocation);
-  const disabled = !location.pathname?.startsWith(Urls.transformList());
+  const enabledUseCases = useSetting("metabot-enabled-use-cases");
+  const isTransformsEnabled = enabledUseCases?.includes("transforms") ?? false;
+  const isOnTransformsPage = location.pathname?.startsWith(
+    Urls.transformList(),
+  );
+  const disabled = !isOnTransformsPage || !isTransformsEnabled;
 
   const handleClick = () => {
     if (!metabot.visible) {
@@ -22,9 +28,11 @@ export const MetabotDataStudioButton = () => {
     metabot.setVisible(!metabot.visible);
   };
 
-  const label = disabled
-    ? `Metabot can't be viewed on this page`
-    : t`Chat with Metabot (${METAKEY}+E)`;
+  const label = !isTransformsEnabled
+    ? t`Metabot has not been enabled for transforms`
+    : !isOnTransformsPage
+      ? t`Metabot can't be viewed on this page`
+      : t`Chat with Metabot (${METAKEY}+E)`;
 
   return (
     <Tooltip label={label}>

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotDataStudioSidebar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotDataStudioSidebar.tsx
@@ -1,5 +1,6 @@
 import { t } from "ttag";
 
+import { useSetting } from "metabase/common/hooks";
 import { useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { getLocation } from "metabase/selectors/routing";
@@ -8,11 +9,17 @@ import { Metabot } from "./Metabot";
 
 export function MetabotDataStudioSidebar() {
   const location = useSelector(getLocation);
-  const disabled = !location.pathname?.startsWith(Urls.transformList());
+  const enabledUseCases = useSetting("metabot-enabled-use-cases");
+  const isTransformsEnabled = enabledUseCases?.includes("transforms") ?? false;
+  const isOnTransformsPage = location.pathname?.startsWith(
+    Urls.transformList(),
+  );
+  const disabled = !isOnTransformsPage || !isTransformsEnabled;
 
   return (
     <Metabot
       hide={disabled}
+      requiredUseCases={["transforms"]}
       config={{
         preventRetryMessage: true,
         preventClose: true,

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotDataStudioSidebar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotDataStudioSidebar.tsx
@@ -5,12 +5,15 @@ import { useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { getLocation } from "metabase/selectors/routing";
 
+import { METABOT_USE_CASES } from "../constants";
+
 import { Metabot } from "./Metabot";
 
 export function MetabotDataStudioSidebar() {
   const location = useSelector(getLocation);
   const enabledUseCases = useSetting("metabot-enabled-use-cases");
-  const isTransformsEnabled = enabledUseCases?.includes("transforms") ?? false;
+  const isTransformsEnabled =
+    enabledUseCases?.includes(METABOT_USE_CASES.TRANSFORMS) ?? false;
   const isOnTransformsPage = location.pathname?.startsWith(
     Urls.transformList(),
   );
@@ -19,7 +22,7 @@ export function MetabotDataStudioSidebar() {
   return (
     <Metabot
       hide={disabled}
-      requiredUseCases={["transforms"]}
+      requiredUseCases={[METABOT_USE_CASES.TRANSFORMS]}
       config={{
         preventRetryMessage: true,
         preventClose: true,

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotDataStudioSidebar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotDataStudioSidebar.tsx
@@ -1,6 +1,5 @@
 import { t } from "ttag";
 
-import { useSetting } from "metabase/common/hooks";
 import { useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { getLocation } from "metabase/selectors/routing";
@@ -11,17 +10,13 @@ import { Metabot } from "./Metabot";
 
 export function MetabotDataStudioSidebar() {
   const location = useSelector(getLocation);
-  const enabledUseCases = useSetting("metabot-enabled-use-cases");
-  const isTransformsEnabled =
-    enabledUseCases?.includes(METABOT_USE_CASES.TRANSFORMS) ?? false;
   const isOnTransformsPage = location.pathname?.startsWith(
     Urls.transformList(),
   );
-  const disabled = !isOnTransformsPage || !isTransformsEnabled;
 
   return (
     <Metabot
-      hide={disabled}
+      hide={!isOnTransformsPage}
       requiredUseCases={[METABOT_USE_CASES.TRANSFORMS]}
       config={{
         preventRetryMessage: true,

--- a/enterprise/frontend/src/metabase-enterprise/metabot/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/constants.ts
@@ -1,5 +1,13 @@
 import { t } from "ttag";
 
+export const METABOT_USE_CASES = {
+  NLQ: "nlq",
+  SQL: "sql",
+  OMNIBOT: "omnibot",
+  TRANSFORMS: "transforms",
+  EMBEDDING: "embedding",
+} as const;
+
 export const LONG_CONVO_MSG_LENGTH_THRESHOLD = 120000;
 
 // NOTE: this is not ideal, but will get fixed w/ BOT-189 allowing us to use fixed entity_ids

--- a/enterprise/frontend/src/metabase-enterprise/metabot/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/constants.ts
@@ -24,6 +24,9 @@ export const METABOT_ERR_MSG = {
   get agentOffline() {
     return t`Metabot is currently offline. Please try again later.`;
   },
+  get useCaseDisabled() {
+    return t`Sorry, Metabot hasn't been enabled for this use case.`;
+  },
 };
 
 export const TOOL_CALL_MESSAGES: Record<string, string | undefined> = {

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/actions.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/actions.ts
@@ -83,13 +83,22 @@ const handleResponseError = (error: unknown): PromptErrorOutcome => {
         shouldRetry: true,
       }),
     )
-    .otherwise(() => ({
+    .with({ message: P.string.includes("use case is not enabled") }, () => ({
       errorMessage: {
         type: "message" as const,
-        message: METABOT_ERR_MSG.default,
+        message: METABOT_ERR_MSG.useCaseDisabled,
       },
-      shouldRetry: true,
-    }));
+      shouldRetry: false,
+    }))
+    .otherwise(() => {
+      return {
+        errorMessage: {
+          type: "message" as const,
+          message: METABOT_ERR_MSG.default,
+        },
+        shouldRetry: true,
+      };
+    });
 };
 
 export const setVisible =

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/actions.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/actions.ts
@@ -72,17 +72,13 @@ const handleResponseError = (error: unknown): PromptErrorOutcome => {
       errorMessage: false as const,
       shouldRetry: false,
     }))
-    .with(
-      { message: P.string.startsWith("Response status: 5") },
-      { status: 500 },
-      () => ({
-        errorMessage: {
-          type: "alert" as const,
-          message: METABOT_ERR_MSG.agentOffline,
-        },
-        shouldRetry: true,
-      }),
-    )
+    .with({ status: P.number.between(500, 599) }, () => ({
+      errorMessage: {
+        type: "alert" as const,
+        message: METABOT_ERR_MSG.agentOffline,
+      },
+      shouldRetry: true,
+    }))
     .with({ message: P.string.includes("use case is not enabled") }, () => ({
       errorMessage: {
         type: "message" as const,

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.ts
@@ -4,7 +4,7 @@ import _ from "underscore";
 import * as Urls from "metabase/lib/urls";
 import { getIsEmbedding } from "metabase/selectors/embed";
 import { getLocation } from "metabase/selectors/routing";
-import type { TransformId } from "metabase-types/api";
+import type { MetabotUseCase, TransformId } from "metabase-types/api";
 
 import {
   FIXED_METABOT_IDS,
@@ -139,7 +139,11 @@ export const getProfileOverride = createSelector(
 
 export const getUseCase = createSelector(
   getLocation,
-  (location): "transforms" | "omnibot" => {
+  getIsEmbedding,
+  (location, isEmbedding): MetabotUseCase => {
+    if (isEmbedding) {
+      return METABOT_USE_CASES.EMBEDDING;
+    }
     return location.pathname.startsWith(Urls.transformList())
       ? METABOT_USE_CASES.TRANSFORMS
       : METABOT_USE_CASES.OMNIBOT;

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.ts
@@ -10,6 +10,7 @@ import {
   FIXED_METABOT_IDS,
   LONG_CONVO_MSG_LENGTH_THRESHOLD,
   METABOT_REQUEST_IDS,
+  METABOT_USE_CASES,
 } from "../constants";
 
 import type { MetabotUserChatMessage } from "./reducer";
@@ -140,8 +141,8 @@ export const getUseCase = createSelector(
   getLocation,
   (location): "transforms" | "omnibot" => {
     return location.pathname.startsWith(Urls.transformList())
-      ? "transforms"
-      : "omnibot";
+      ? METABOT_USE_CASES.TRANSFORMS
+      : METABOT_USE_CASES.OMNIBOT;
   },
 );
 

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -362,6 +362,7 @@ export const createMockSettings = (
   "show-homepage-xrays": false,
   "show-metabase-links": true,
   "show-metabot": true,
+  "metabot-enabled-use-cases": ["omnibot", "transforms", "nlq", "sql"],
   "show-updated-permission-modal": false,
   "show-updated-permission-banner": false,
   "site-locale": "en",

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -551,6 +551,7 @@ interface PublicSettings {
   "setup-token": string | null;
   "show-metabase-links": boolean;
   "show-metabot": boolean;
+  "metabot-enabled-use-cases": string[] | null;
   "show-google-sheets-integration": boolean;
   "site-locale": string;
   "site-url": string;


### PR DESCRIPTION
eUpdates the Metabot configuration page to make use of use cases introduced in https://github.com/metabase/metabase/pull/66673. See https://www.notion.so/metabase/Metabot-Use-Cases-23169354c901809792baea22daef8629 for a summary of the architecture & product decisions
* Adds on/off toggles for each use case for the internal metabot
* Adds frontend and backend enforcement that requests can only be made for enabled use cases
* Adds back a collection picker for the internal metabot, scoped to the NLQ use case
* Currently the only use cases being used by the frontend are `omnibot` and `transforms`. In a follow-up PR I'll integrate the inline SQL use case, and eventually `nlq` will be sent if invoked by omnibot.

<img width="1458" height="817" alt="image" src="https://github.com/user-attachments/assets/ea2c4087-d502-4fac-9bfa-040a86869fce" />

<img width="1459" height="826" alt="image" src="https://github.com/user-attachments/assets/d3d5a55d-1300-4880-9b0a-a59f5a7f75cd" />

<img width="1512" height="827" alt="image" src="https://github.com/user-attachments/assets/fc6237dd-5325-495b-88d6-099950bc84cc" />
