### PR TITLE
Tree Filter should not be case sensitive

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/Table/useTreeFilter.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/Table/useTreeFilter.ts
@@ -29,11 +29,15 @@ export const useTreeFilter = <
 
           if (
             searchProps.some((s) => {
-              if (typeof node[s] !== "string") {
-                return false;
+              if (
+                typeof node[s] === "string" &&
+                typeof searchQuery === "string"
+              ) {
+                return node[s]
+                  .toLowerCase()
+                  .includes(searchQuery.toLowerCase());
               }
-
-              return !!node[s].includes(searchQuery);
+              return false;
             })
           ) {
             return node;

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/Table/useTreeFilter.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/Table/useTreeFilter.unit.spec.tsx
@@ -1,0 +1,96 @@
+import { renderHook } from "__support__/ui";
+
+import { useTreeFilter } from "./useTreeFilter";
+
+type Node = {
+  name: string;
+  category: string;
+  children?: Node[];
+};
+
+const TEST_TREE: Node[] = [
+  {
+    name: "FOO",
+    category: "Doohickey",
+    children: [
+      {
+        name: "Hudson Borer",
+        category: "Doohickey",
+      },
+      {
+        name: "Domenica Williamson",
+        category: "Doohickey",
+      },
+      {
+        name: "Lina Heaney",
+        category: "Gadget",
+      },
+      {
+        name: "Arnold Adams",
+        category: "Doohickey",
+      },
+    ],
+  },
+  {
+    name: "BAR",
+    category: "Gadget",
+    children: [
+      {
+        name: "Rene Muller",
+        category: "Gadget",
+      },
+      {
+        name: "Roselyn Bosco",
+        category: "Gadget",
+        children: [
+          {
+            name: "Lavonne Senger",
+            category: "Doohickey",
+          },
+        ],
+      },
+      {
+        name: "Aracely Jenkins",
+        category: "Gadget",
+      },
+      {
+        name: "Anais Ward",
+        category: "Doohickey",
+      },
+    ],
+  },
+];
+
+describe("useTreeFilter", () => {
+  it("should filter child nodes using specified props", () => {
+    const {
+      result: { current: tree },
+    } = renderHook(() =>
+      useTreeFilter({
+        data: TEST_TREE,
+        searchProps: ["category"],
+        searchQuery: "gadg",
+      }),
+    );
+
+    // This is actually asserting many things
+    // - Only leaf nodes are considered in search,
+    // - parent nodes with no filtered children should not be returned. this is why Roselyn was filtered out
+    // - We shouldn't change the order that of returned values
+    // - That search is not case sensitive
+
+    expect(tree).toMatchObject([
+      {
+        name: "FOO",
+        children: [expect.objectContaining({ name: "Lina Heaney" })],
+      },
+      {
+        name: "BAR",
+        children: [
+          expect.objectContaining({ name: "Rene Muller" }),
+          expect.objectContaining({ name: "Aracely Jenkins" }),
+        ],
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
### Description
Changes values to lowercase inside of `useTreeFilter` when doing comparisons

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Go to the library page and do a search in all caps
2. Notice that values are getting returned

### Demo
<img width="1479" height="989" alt="image" src="https://github.com/user-attachments/assets/a2cb6f87-fbac-443f-936a-b78f2b42313f" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
