### PR TITLE
Hide `analytics-dev-mode` setting from generated docs

### DIFF
--- a/src/metabase/audit_app/settings.clj
+++ b/src/metabase/audit_app/settings.clj
@@ -71,11 +71,11 @@ If set to 0, Metabase will keep all rows.")
   :export?    false)
 
 (defsetting analytics-dev-mode
-  "Enable analytics development mode. When true, makes analytics content editable."
+  (str "Setting this environment variable to true will  make the Usage analytics collection editable for"
+       "local development.")
   :type       :boolean
   :default    false
   :visibility :internal
   :audit      :never
   :export?    false
-  :doc        (str "Setting this environment variable to true will  make the Usage analytics collection editable for"
-                   "local development."))
+  :doc        false)


### PR DESCRIPTION
docs scoop up all settings and has ways to avoid. In `metabase.cmd.env-var-dox/avoid?` This had a docstring and then an extra docstring. We can just copy the nice docstring to the docstring slot and put `:doc false`.

```clojure
(defn- avoid?
  "Used to filter out environment variables with high foot-gun indices."
  [env-var]
  (or (false? (:doc env-var))
      (false? (:can-read-from-env? env-var))
              ;; Ideally, we'd move off of this list completely,
              ;; but not all environment variables are defsettings.
      (contains? env-vars-not-to-mess-with (format-prefix env-var))))
```