### PR TITLE
Optimize u/index-by when used with vf

### DIFF
--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -1213,11 +1213,8 @@
   ([kf coll]
    (into {} (index-by kf) coll))
   ([kf vf coll]
-   (into {}
-         (comp (index-by kf)
-               (map (fn [[k v]]
-                      [k (vf v)])))
-         coll)))
+   (for-map [x coll]
+     [(kf x) (vf x)])))
 
 (defn rfirst
   "Return first item from Reducible"

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -1213,8 +1213,7 @@
   ([kf coll]
    (into {} (index-by kf) coll))
   ([kf vf coll]
-   (for-map [x coll]
-     [(kf x) (vf x)])))
+   (into {} (map (juxt kf vf)) coll)))
 
 (defn rfirst
   "Return first item from Reducible"


### PR DESCRIPTION
~~The existing implementation wastefully builds a temporary map, and then loops again.~~

I am illiterate, it was using a transducer, not a double-pass. Well, updated to at least save some unnecessary function composition.
