### PR TITLE
GDGT-1386 Auto-populate table name based on transform name

### DIFF
--- a/e2e/test/scenarios/data-studio/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms.cy.spec.ts
@@ -65,8 +65,16 @@ describe("scenarios > admin > transforms", () => {
       });
       getQueryEditor().button("Save").click();
       H.modal().within(() => {
-        cy.findByLabelText("Name").clear().type("MBQL transform");
-        cy.findByLabelText("Table name").type(TARGET_TABLE);
+        cy.findByLabelText("Name").clear().type("MBQL");
+
+        cy.log("should auto-populate table name based on transform name...");
+        cy.findByLabelText("Table name").should("have.value", "mbql");
+        cy.findByLabelText("Table name").clear().type(TARGET_TABLE);
+
+        cy.log("...unless user has manually modified the table name");
+        cy.findByLabelText("Name").type(" transform");
+        cy.findByLabelText("Table name").should("have.value", TARGET_TABLE);
+
         cy.button("Save").click();
         cy.wait("@createTransform");
       });
@@ -442,7 +450,7 @@ LIMIT
       getQueryEditor().button("Save").click();
       H.modal().within(() => {
         cy.findByLabelText("Name").clear().type("MBQL transform");
-        cy.findByLabelText("Table name").type(SOURCE_TABLE);
+        cy.findByLabelText("Table name").clear().type(SOURCE_TABLE);
         cy.button("Save").click();
         cy.wait("@createTransform");
       });
@@ -464,7 +472,7 @@ LIMIT
       getQueryEditor().button("Save").click();
       H.modal().within(() => {
         cy.findByLabelText("Name").clear().type("MBQL transform");
-        cy.findByLabelText("Table name").type(TARGET_TABLE);
+        cy.findByLabelText("Table name").clear().type(TARGET_TABLE);
         cy.findByLabelText("Schema").clear().type(CUSTOM_SCHEMA);
       });
       H.popover().findByText("Create new schema").click();
@@ -502,7 +510,7 @@ LIMIT
       H.assertQueryBuilderRowCount(3);
     });
 
-    it("should be able to create a new table in an existing when saving a transform", () => {
+    it("should be able to create a new table in an existing transform when saving a transform", () => {
       visitTransformListPage();
       cy.button("Create a transform").click();
       H.popover().findByText("Query builder").click();
@@ -514,7 +522,7 @@ LIMIT
       getQueryEditor().button("Save").click();
       H.modal().within(() => {
         cy.findByLabelText("Name").clear().type("MBQL transform");
-        cy.findByLabelText("Table name").type(TARGET_TABLE);
+        cy.findByLabelText("Table name").clear().type(TARGET_TABLE);
         cy.button("Save").click();
         cy.wait("@createTransform");
       });

--- a/enterprise/frontend/src/metabase-enterprise/transforms/components/RunStatus/RunStatus.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/components/RunStatus/RunStatus.tsx
@@ -4,9 +4,8 @@ import { useSetting } from "metabase/common/hooks";
 import { Box, Group, Icon } from "metabase/ui";
 import type { TransformRun } from "metabase-types/api";
 
+import { parseTimestampWithTimezone } from "../../utils";
 import { RunInfo } from "../RunInfo";
-
-import { parseTimestampWithTimezone } from "./../../utils";
 
 type RunStatusSectionProps = {
   run: TransformRun | null;

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/NewTransformPage/CreateTransformModal/CreateTransformModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/NewTransformPage/CreateTransformModal/CreateTransformModal.tsx
@@ -188,8 +188,10 @@ function getInitialValues(
     targetSchema: schemas?.[0] || null,
     ...defaultValues,
     targetName: defaultValues.targetName
-      ? slugify(defaultValues.targetName)
-      : "",
+      ? defaultValues.targetName
+      : defaultValues.name
+        ? slugify(defaultValues.name)
+        : "",
     checkpointFilter: null,
     checkpointFilterUniqueKey: null,
     incremental: false,

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/NewTransformPage/CreateTransformModal/CreateTransformModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/NewTransformPage/CreateTransformModal/CreateTransformModal.tsx
@@ -19,6 +19,7 @@ import {
   FormTextInput,
 } from "metabase/forms";
 import * as Errors from "metabase/lib/errors";
+import { slugify } from "metabase/lib/formatting/url";
 import { Box, Button, Group, Modal, Stack } from "metabase/ui";
 import { useCreateTransformMutation } from "metabase-enterprise/api";
 import { IncrementalTransformSettings } from "metabase-enterprise/transforms/components/IncrementalTransform/IncrementalTransformSettings";
@@ -31,6 +32,7 @@ import type {
 import { trackTransformCreated } from "../../../analytics";
 
 import { SchemaFormSelect } from "./../../../components/SchemaFormSelect";
+import { TargetNameInput } from "./TargetNameInput";
 
 function getValidationSchema() {
   return Yup.object({
@@ -162,11 +164,7 @@ function CreateTransformForm({
               data={schemas}
             />
           )}
-          <FormTextInput
-            name="targetName"
-            label={t`Table name`}
-            placeholder={t`descriptive_name`}
-          />
+          <TargetNameInput />
           <IncrementalTransformSettings source={source} />
           <Group>
             <Box flex={1}>
@@ -187,9 +185,11 @@ function getInitialValues(
 ): NewTransformValues {
   return {
     name: "",
-    targetName: "",
     targetSchema: schemas?.[0] || null,
     ...defaultValues,
+    targetName: defaultValues.targetName
+      ? slugify(defaultValues.targetName)
+      : "",
     checkpointFilter: null,
     checkpointFilterUniqueKey: null,
     incremental: false,

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/NewTransformPage/CreateTransformModal/CreateTransformModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/NewTransformPage/CreateTransformModal/CreateTransformModal.tsx
@@ -30,8 +30,8 @@ import type {
 } from "metabase-types/api";
 
 import { trackTransformCreated } from "../../../analytics";
+import { SchemaFormSelect } from "../../../components/SchemaFormSelect";
 
-import { SchemaFormSelect } from "./../../../components/SchemaFormSelect";
 import { TargetNameInput } from "./TargetNameInput";
 
 function getValidationSchema() {

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/NewTransformPage/CreateTransformModal/TargetNameInput.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/NewTransformPage/CreateTransformModal/TargetNameInput.tsx
@@ -1,0 +1,33 @@
+import { useField } from "formik";
+import { useEffect, useRef } from "react";
+import { t } from "ttag";
+
+import { FormTextInput } from "metabase/forms";
+import { slugify } from "metabase/lib/formatting/url";
+
+export const TargetNameInput = () => {
+  const isDirtyRef = useRef(false);
+
+  const [{ value: name }] = useField<string>("name");
+  const [, , { setValue: setTargetName }] = useField<string>("targetName");
+
+  useEffect(() => {
+    if (!isDirtyRef.current) {
+      const slugified = slugify(name);
+      setTargetName(slugified);
+    }
+  }, [name, setTargetName]);
+
+  const handleTargetNameChange = () => {
+    isDirtyRef.current = true;
+  };
+
+  return (
+    <FormTextInput
+      name="targetName"
+      label={t`Table name`}
+      placeholder={t`descriptive_name`}
+      onChange={handleTargetNameChange}
+    />
+  );
+};

--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionContext/utils.ts
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionContext/utils.ts
@@ -1,6 +1,6 @@
 import type { WritebackQueryAction } from "metabase-types/api";
 
-import { getDefaultFormSettings } from "./../../../utils";
+import { getDefaultFormSettings } from "../../../utils";
 
 export function createEmptyWritebackAction(): Partial<WritebackQueryAction> {
   return {

--- a/frontend/src/metabase/dashboard/actions/utils.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/actions/utils.unit.spec.ts
@@ -7,7 +7,8 @@ import {
   createMockTextDashboardCard,
 } from "metabase-types/api/mocks";
 
-import { createMockCard } from "./../../../metabase-types/api/mocks/card";
+import { createMockCard } from "../../../metabase-types/api/mocks/card";
+
 import {
   getDashCardMoveToTabUndoMessage,
   hasDashboardChanged,


### PR DESCRIPTION
Closes [GDGT-1386: Auto populate table name based on transform name](https://linear.app/metabase/issue/GDGT-1386/auto-populate-table-name-based-on-transform-name)

### Description

When saving a transform, auto-populates "Table name" input based on "Name" input, unless user has manually changed "Table name".

Also fixes imports from `./../` to be `../`. Otherwise linter gets confused.

### How to verify

1. Data studio > Transforms > New > SQL Query
2. Select a DB
3. Type anything in the query editor
4. Set transform name to "Gadget"
5. Click "Save"

:heavy_check_mark: Table name should be "gadget"

6. Change transform name to "Gadget team"

:heavy_check_mark: Table name should be "gadget_team"

7. Change table name to "gadget_team_1"
8. Change transform name to "Gadget team 2"

:heavy_check_mark: Table name should be "gadget_team_1"
