### PR TITLE
Fixes a flaky e2e test

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/dashboard-click-behavior.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/dashboard-click-behavior.cy.spec.tsx
@@ -244,13 +244,14 @@ describe("scenarios > embedding-sdk > dashboard-click-behavior", () => {
   });
 
   it("columns that return a string url should be rendered as a link", () => {
+    cy.intercept("GET", "/api/card/*").as("getCard");
+
     // We can't map them easily to click behaviors, so they stay as links for now
     // see https://github.com/metabase/metabase/issues/64622
     cy.get<string>("@questionId").then((questionId) => {
       mountSdkContent(<InteractiveQuestion questionId={questionId} />);
     });
 
-    cy.intercept("GET", "/api/card/*").as("getCard");
     cy.wait("@getCard");
 
     cy.findByRole("link", { name: "https://example.org/979" })


### PR DESCRIPTION
Closes [EMB-1122: \[Flaky Test\] \[e2e-embedding-sdk-react-18\] scenarios > embedding-sdk > dashboard-click-behavior scenarios > embedding-sdk > dashboard-click-behavior columns that return a string url should be rendered as a link](https://linear.app/metabase/issue/EMB-1122/flaky-test-e2e-embedding-sdk-react-18-scenarios-embedding-sdk)
100 burns stress test run [here](https://github.com/metabase/metabase/actions/runs/20135659904)