### PR TITLE
fix(sdk-bundle): Fix can't drill numeric string ID dashboard

### DIFF
--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/use-common-dashboard-params.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/use-common-dashboard-params.tsx
@@ -8,6 +8,7 @@ import {
 } from "metabase/dashboard/actions";
 import { getNewCardUrl } from "metabase/dashboard/actions/getNewCardUrl";
 import type { NavigateToNewCardFromDashboardOpts } from "metabase/dashboard/components/DashCard/types";
+import { parseNumber } from "metabase/lib/number";
 import * as Urls from "metabase/lib/urls";
 import { isJWT } from "metabase/lib/utils";
 import { navigateBackToDashboard } from "metabase/query_builder/actions";
@@ -149,5 +150,5 @@ const findDashboardById = (
 };
 
 function isNumericStringOrNumber(value: string | number): boolean {
-  return Number.isFinite(Number(value));
+  return parseNumber(String(value)) !== null;
 }

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/use-common-dashboard-params.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/use-common-dashboard-params.tsx
@@ -13,7 +13,11 @@ import { isJWT } from "metabase/lib/utils";
 import { navigateBackToDashboard } from "metabase/query_builder/actions";
 import { getMetadata } from "metabase/selectors/metadata";
 import type Question from "metabase-lib/v1/Question";
-import type { DashboardId, QuestionDashboardCard } from "metabase-types/api";
+import {
+  type DashboardId,
+  type QuestionDashboardCard,
+  isBaseEntityID,
+} from "metabase-types/api";
 import type { StoreDashboard } from "metabase-types/store";
 
 export const useCommonDashboardParams = ({
@@ -127,13 +131,9 @@ const findDashboardById = (
   dashboardId: DashboardId,
   dashboards: Record<DashboardId, StoreDashboard>,
 ): StoreDashboard | null => {
-  if (typeof dashboardId === "number" || isJWT(dashboardId)) {
-    return dashboards[dashboardId] ?? null;
-  }
-
   // Lookup via entity ids.
   // Dashboards are a mapping of numeric id to dashboard.
-  if (typeof dashboardId === "string") {
+  if (isBaseEntityID(dashboardId)) {
     return (
       Object.values(dashboards).find(
         (dashboard) => dashboard.entity_id === dashboardId,
@@ -141,5 +141,13 @@ const findDashboardById = (
     );
   }
 
+  if (isNumericStringOrNumber(dashboardId) || isJWT(dashboardId)) {
+    return dashboards[dashboardId] ?? null;
+  }
+
   return null;
 };
+
+function isNumericStringOrNumber(value: string | number): boolean {
+  return Number.isFinite(Number(value));
+}


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #66807
closes EMB-1120

### Backport reason
we're backporting this to 57

### Description

Properly check if an ID is an entity ID or a numeric ID, if it's a numeric ID also try to parse them if users pass them as string.

### How to verify

The new Cypress test should pass. You can verify the test works by reverting the code.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
