### PR TITLE
fix(embed-js): Fix EAJS children with ExplicitSize not scaling down

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
@@ -273,6 +273,24 @@ describe(suiteTitle, () => {
       cy.findByRole("heading", { name: "Email this dashboard" }).should(
         "be.visible",
       );
+
+      /**
+       * It seems `should("be.visible")` above doesn't not work in iframe.
+       * It can only check the existence of the element but not its visibility.
+       */
+      cy.findByTestId("dashboard").then(($dashboard) => {
+        const EXPECTED_APPROX_WIDTH = 800;
+        const ERROR_TOLERANCE = 50;
+        const dashboardWidth = $dashboard.width();
+        expect(
+          dashboardWidth,
+          "EAJS preview should scale when opening a dashboard sidebar (EMB-1120)",
+        ).to.be.greaterThan(EXPECTED_APPROX_WIDTH - ERROR_TOLERANCE);
+        expect(
+          dashboardWidth,
+          "EAJS preview should scale when opening a dashboard sidebar (EMB-1120)",
+        ).to.be.lessThan(EXPECTED_APPROX_WIDTH + ERROR_TOLERANCE);
+      });
     });
 
     getEmbedSidebar()

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
@@ -285,11 +285,10 @@ describe(suiteTitle, () => {
         expect(
           dashboardWidth,
           "EAJS preview should scale when opening a dashboard sidebar (EMB-1120)",
-        ).to.be.greaterThan(EXPECTED_APPROX_WIDTH - ERROR_TOLERANCE);
-        expect(
-          dashboardWidth,
-          "EAJS preview should scale when opening a dashboard sidebar (EMB-1120)",
-        ).to.be.lessThan(EXPECTED_APPROX_WIDTH + ERROR_TOLERANCE);
+        ).to.be.within(
+            EXPECTED_APPROX_WIDTH - ERROR_TOLERANCE,
+            EXPECTED_APPROX_WIDTH + ERROR_TOLERANCE
+        );
       });
     });
 

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
@@ -286,8 +286,8 @@ describe(suiteTitle, () => {
           dashboardWidth,
           "EAJS preview should scale when opening a dashboard sidebar (EMB-1120)",
         ).to.be.within(
-            EXPECTED_APPROX_WIDTH - ERROR_TOLERANCE,
-            EXPECTED_APPROX_WIDTH + ERROR_TOLERANCE
+          EXPECTED_APPROX_WIDTH - ERROR_TOLERANCE,
+          EXPECTED_APPROX_WIDTH + ERROR_TOLERANCE,
         );
       });
     });

--- a/frontend/src/embedding-sdk-bundle/components/private/PublicComponentStylesWrapper.style.css
+++ b/frontend/src/embedding-sdk-bundle/components/private/PublicComponentStylesWrapper.style.css
@@ -3,6 +3,8 @@
   all: initial;
   text-decoration: none;
   font-style: normal;
+  /* Fix the issue with ExplicitSize not resizing when this container is wrapped in a grid container */
+  min-width: 0;
   width: 100%;
   height: 100%;
   font-weight: 400;


### PR DESCRIPTION
closes EMB-1119

### Backport reason
We shouldn't backport this as it's a part of the new 58 feature [Add Subscriptions and Alerts support in SDK/EAJS](https://linear.app/metabase/project/add-subscriptions-and-alerts-support-in-sdkeajs-be341f56edcf)

### Description

Probably scale the children inside the grid container, so when the dashboard sidebar open and closes it scales correctly.

### How to verify

Try to open the subscriptions sidebar on EAJS on small screen e.g. 1080p You shouldn't see the horizontal scroll anymore.

### Demo

#### After
<img width="1435" height="918" alt="image" src="https://github.com/user-attachments/assets/e3b4d0d9-fb29-43f6-be49-2f49613cf1d9" />


#### Before
<img width="2430" height="2510" alt="image" src="https://github.com/user-attachments/assets/5ace4d26-d0d2-480f-890b-33144170525d" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
