### PR TITLE
Show a spinner button for the Download button when exporting

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.tsx
@@ -106,9 +106,10 @@ export const DashCardMenu = ({
         <QuestionDownloadWidget
           question={question}
           result={result}
-          onDownload={(opts) => {
+          onDownload={async (opts) => {
             close();
-            handleDownload(opts);
+
+            await handleDownload(opts);
           }}
         />
       );

--- a/frontend/src/metabase/dashboard/components/DashCard/PublicOrEmbeddedDashCardMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/PublicOrEmbeddedDashCardMenu.tsx
@@ -76,9 +76,10 @@ export const PublicOrEmbeddedDashCardMenu = ({
           <QuestionDownloadWidget
             question={question}
             result={result}
-            onDownload={(opts) => {
+            onDownload={async (opts) => {
               close();
-              handleDownload(opts);
+
+              await handleDownload(opts);
             }}
           />
         ) : (

--- a/frontend/src/metabase/query_builder/components/QuestionDownloadPopover/QuestionDownloadPopover.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionDownloadPopover/QuestionDownloadPopover.tsx
@@ -87,9 +87,10 @@ const BaseQuestionDownloadPopover = ({
           question={question}
           result={result}
           formatPreference={formatPreference}
-          onDownload={(opts) => {
+          onDownload={async (opts) => {
             setIsPopoverOpen(false);
-            handleDownload(opts);
+
+            await handleDownload(opts);
           }}
         />
       </Popover.Dropdown>

--- a/frontend/src/metabase/query_builder/components/QuestionDownloadWidget/QuestionDownloadWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionDownloadWidget/QuestionDownloadWidget.tsx
@@ -35,7 +35,7 @@ type QuestionDownloadWidgetProps = {
     type: string;
     enableFormatting: boolean;
     enablePivot: boolean;
-  }) => void;
+  }) => Promise<void>;
   disabled?: boolean;
   formatPreference?: FormatPreference;
 } & StackProps;
@@ -106,6 +106,8 @@ export const QuestionDownloadWidget = ({
     PLUGIN_FEATURE_LEVEL_PERMISSIONS.getDownloadWidgetMessageOverride(result) ??
     t`The maximum download size is 1 million rows.`;
 
+  const [loading, setLoading] = useState(false);
+
   const handleFormatChange = (newFormat: ExportFormat) => {
     setUserSelectedFormat(newFormat);
 
@@ -132,12 +134,16 @@ export const QuestionDownloadWidget = ({
     setDismissedExcelPivotExportsBanner,
   ] = useUserSetting("dismissed-excel-pivot-exports-banner");
 
-  const handleDownload = () => {
-    onDownload({
+  const handleDownload = async () => {
+    setLoading(true);
+
+    await onDownload({
       type: format,
       enableFormatting: isFormatted,
       enablePivot: isPivoted,
     });
+
+    setLoading(false);
   };
 
   const showPivotXlsxExportHint =
@@ -215,6 +221,7 @@ export const QuestionDownloadWidget = ({
         mt="auto"
         ml="auto"
         variant="filled"
+        loading={loading}
         onClick={handleDownload}
         disabled={disabled}
       >{t`Download`}</Button>

--- a/frontend/src/metabase/redux/downloads.ts
+++ b/frontend/src/metabase/redux/downloads.ts
@@ -161,7 +161,7 @@ export const downloadQueryResults = createAsyncThunk(
         dispatch(downloadToImage(false));
       }
     } else {
-      dispatch(downloadDataset({ opts, id: Date.now() }));
+      await dispatch(downloadDataset({ opts, id: Date.now() }));
     }
   },
 );

--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedMenuDropdown.tsx
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedMenuDropdown.tsx
@@ -23,7 +23,7 @@ export interface CardEmbedMenuActions {
     type: string;
     enableFormatting: boolean;
     enablePivot: boolean;
-  }) => void;
+  }) => Promise<void>;
   handleEditVisualizationSettings: () => void;
   setIsModifyModalOpen: (open: boolean) => void;
   handleReplaceQuestion: () => void;
@@ -66,9 +66,10 @@ export const CardEmbedMenuDropdown = ({
       <QuestionDownloadWidget
         question={question}
         result={dataset}
-        onDownload={(opts) => {
+        onDownload={async (opts) => {
           setMenuView(null);
-          handleDownload(opts);
+
+          await handleDownload(opts);
         }}
       />
     );

--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/CardEmbed/PublicDocumentCardMenu.tsx
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/CardEmbed/PublicDocumentCardMenu.tsx
@@ -70,9 +70,10 @@ export const PublicDocumentCardMenu = ({
           <QuestionDownloadWidget
             question={question}
             result={dataset}
-            onDownload={(opts) => {
+            onDownload={async (opts) => {
               close();
-              handleDownload(opts);
+
+              await handleDownload(opts);
             }}
           />
         ) : (


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #65605
Show a spinner button for the Download button when exporting

How to verify:
- embed statically a question with `allow downloads`, most likely via SDK it also can be tested
- download its data as any of its 3 allowed formats
- button should have a spinner