### PR TITLE
UXW-2531 Omits "New snippet" option in Library "New" dropdown if user lacks permission

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/CreateMenu.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/CreateMenu.tsx
@@ -5,7 +5,10 @@ import { ForwardRefLink } from "metabase/common/components/Link";
 import { useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { PLUGIN_SNIPPET_FOLDERS } from "metabase/plugins";
-import { canUserCreateQueries } from "metabase/selectors/user";
+import {
+  canUserCreateNativeQueries,
+  canUserCreateQueries,
+} from "metabase/selectors/user";
 import { Button, FixedSizeIcon, Icon, Menu } from "metabase/ui";
 import type { CollectionId } from "metabase-types/api";
 
@@ -17,9 +20,49 @@ export const CreateMenu = ({
 }) => {
   const [creatingSnippetFolder, setCreatingSnippetFolder] = useState(false);
 
+  const hasNativeWrite = useSelector(canUserCreateNativeQueries);
   const hasDataAccess = useSelector(canUserCreateQueries);
 
   const canCreateMetric = hasDataAccess && metricCollectionId;
+
+  const menuItems = [
+    canCreateMetric && (
+      <Menu.Item
+        key="metric"
+        component={ForwardRefLink}
+        to={Urls.newDataStudioMetric({
+          collectionId: metricCollectionId,
+        })}
+        leftSection={<FixedSizeIcon name="metric" />}
+      >
+        {t`Metric`}
+      </Menu.Item>
+    ),
+    hasNativeWrite && (
+      <Menu.Item
+        key="snippet"
+        component={ForwardRefLink}
+        to={Urls.newDataStudioSnippet()}
+        leftSection={<FixedSizeIcon name="snippet" />}
+        aria-label={t`Create new snippet`}
+      >
+        {t`New snippet`}
+      </Menu.Item>
+    ),
+    hasNativeWrite && PLUGIN_SNIPPET_FOLDERS.isEnabled && (
+      <Menu.Item
+        key="snippet-folder"
+        leftSection={<FixedSizeIcon name="folder" />}
+        onClick={() => setCreatingSnippetFolder(true)}
+      >
+        {t`New snippet folder`}
+      </Menu.Item>
+    ),
+  ].filter(Boolean);
+
+  if (!menuItems.length) {
+    return null;
+  }
 
   return (
     <>
@@ -27,35 +70,7 @@ export const CreateMenu = ({
         <Menu.Target>
           <Button leftSection={<Icon name="add" />}>{t`New`}</Button>
         </Menu.Target>
-        <Menu.Dropdown>
-          {canCreateMetric && (
-            <Menu.Item
-              component={ForwardRefLink}
-              to={Urls.newDataStudioMetric({
-                collectionId: metricCollectionId,
-              })}
-              leftSection={<FixedSizeIcon name="metric" />}
-            >
-              {t`Metric`}
-            </Menu.Item>
-          )}
-          <Menu.Item
-            component={ForwardRefLink}
-            to={Urls.newDataStudioSnippet()}
-            leftSection={<FixedSizeIcon name="snippet" />}
-            aria-label={t`Create new snippet`}
-          >
-            {t`New snippet`}
-          </Menu.Item>
-          {PLUGIN_SNIPPET_FOLDERS.isEnabled && (
-            <Menu.Item
-              leftSection={<FixedSizeIcon name="folder" />}
-              onClick={() => setCreatingSnippetFolder(true)}
-            >
-              {t`New snippet folder`}
-            </Menu.Item>
-          )}
-        </Menu.Dropdown>
+        <Menu.Dropdown>{menuItems}</Menu.Dropdown>
       </Menu>
       <PLUGIN_SNIPPET_FOLDERS.CollectionFormModal
         opened={creatingSnippetFolder}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/CreateMenu.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/CreateMenu.tsx
@@ -15,7 +15,6 @@ import type { CollectionId } from "metabase-types/api";
 export const CreateMenu = ({
   metricCollectionId,
 }: {
-  modelCollectionId?: CollectionId;
   metricCollectionId?: CollectionId;
 }) => {
   const [creatingSnippetFolder, setCreatingSnippetFolder] = useState(false);

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/CreateMenu.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/CreateMenu.unit.spec.tsx
@@ -1,0 +1,64 @@
+import userEvent from "@testing-library/user-event";
+
+import { setupEnterprisePlugins } from "__support__/enterprise";
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen } from "__support__/ui";
+import {
+  createMockTokenFeatures,
+  createMockUser,
+} from "metabase-types/api/mocks";
+import type { UserPermissions } from "metabase-types/api/user";
+import { createMockState } from "metabase-types/store/mocks/state";
+
+import { CreateMenu } from "./CreateMenu";
+
+const setup = ({ permissions }: { permissions?: UserPermissions } = {}) => {
+  const state = createMockState({
+    settings: mockSettings({
+      "token-features": createMockTokenFeatures({
+        snippet_collections: true,
+      }),
+    }),
+    currentUser: createMockUser({
+      permissions,
+    }),
+  });
+  setupEnterprisePlugins();
+  return renderWithProviders(<CreateMenu metricCollectionId={1} />, {
+    storeInitialState: state,
+  });
+};
+
+describe("CreateMenu", () => {
+  it("renders nothing if menu does not have any options (user lacks permissions)", () => {
+    setup();
+    expect(
+      screen.queryByRole("button", { name: /New/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render snippet menu items if user only has query builder access", async () => {
+    setup({ permissions: { can_create_queries: true } });
+
+    await userEvent.click(screen.getByRole("button", { name: /New/ }));
+
+    expect(
+      screen.getAllByRole("menuitem").map((item) => item.textContent),
+    ).toEqual(["Metric"]);
+  });
+
+  it("renders all options when user has full permissions", async () => {
+    setup({
+      permissions: {
+        can_create_queries: true,
+        can_create_native_queries: true,
+      },
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: /New/ }));
+
+    expect(
+      screen.getAllByRole("menuitem").map((item) => item.textContent),
+    ).toEqual(["Metric", "New snippet", "New snippet folder"]);
+  });
+});


### PR DESCRIPTION
Closes UXW-2531

### Description

We're still figuring out Data Studio permissions but we might as well do this now.

❗ We currently hide the Data Studio behind an is-admin check but eventually other users will have access (probably).

### How to verify

Make sure users who don't have native write access don't have the option to create snippets or snippet folders.

If the "New" menu would be empty, it should not be shown.


### Demo

**Full access**
<img width="1310" height="270" alt="Screenshot 2025-12-11 at 2 07 33 PM" src="https://github.com/user-attachments/assets/6644cc74-d7e5-4c35-aaef-2e8b529398ea" />

**Query builder access only**
<img width="1308" height="221" alt="Screenshot 2025-12-11 at 2 08 20 PM" src="https://github.com/user-attachments/assets/16f4e068-469a-4315-8aa1-5626b696e576" />

**No write access**
<img width="1309" height="191" alt="Screenshot 2025-12-11 at 2 08 37 PM" src="https://github.com/user-attachments/assets/4f140d66-9b63-4820-ade1-0bee6a3ae0cb" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
