### PR TITLE
Show breadcrumbs on published table page (Library > Data > table)

### DIFF
--- a/e2e/support/helpers/e2e-data-studio-helpers.ts
+++ b/e2e/support/helpers/e2e-data-studio-helpers.ts
@@ -11,6 +11,7 @@ const metricQueryEditor = () => cy.findByTestId("metric-query-editor");
 
 export const DataStudio = {
   nav: () => cy.findByTestId("data-studio-nav"),
+  breadcrumbs: () => cy.findByTestId("data-studio-breadcrumbs"),
   Transforms: {
     header: () => cy.findByTestId("transforms-header"),
     list: () => cy.findByTestId("transforms-list"),

--- a/e2e/test/scenarios/data-studio/data-studio-tables.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-studio-tables.cy.spec.ts
@@ -59,7 +59,7 @@ describe("scenarios > data studio > library > tables", () => {
     it("should show page breadcrumbs", () => {
       H.DataStudio.breadcrumbs().within(() => {
         cy.findByRole("link", { name: "Library" }).should("be.visible");
-        cy.findByText("Data").should("be.visible");
+        cy.findByRole("link", { name: "Data" }).should("be.visible");
         cy.findByText("Orders").should("be.visible");
       });
     });

--- a/e2e/test/scenarios/data-studio/data-studio-tables.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-studio-tables.cy.spec.ts
@@ -50,11 +50,21 @@ describe("scenarios > data studio > library > tables", () => {
   });
 
   describe("overview", () => {
-    it("should be able to view the table data", () => {
+    beforeEach(() => {
       H.createLibrary();
       H.publishTables({ table_ids: [ORDERS_ID] });
-
       H.DataStudio.Tables.visitOverviewPage(ORDERS_ID);
+    });
+
+    it("should show page breadcrumbs", () => {
+      H.DataStudio.breadcrumbs().within(() => {
+        cy.findByRole("link", { name: "Library" }).should("be.visible");
+        cy.findByText("Data").should("be.visible");
+        cy.findByText("Orders").should("be.visible");
+      });
+    });
+
+    it("should be able to view the table data", () => {
       H.queryVisualizationRoot().within(() => {
         cy.findByText("Subtotal").should("be.visible");
         cy.findByText("110.93").should("be.visible");
@@ -62,10 +72,6 @@ describe("scenarios > data studio > library > tables", () => {
     });
 
     it("should be able to change the description", () => {
-      H.createLibrary();
-      H.publishTables({ table_ids: [ORDERS_ID] });
-
-      H.DataStudio.Tables.visitOverviewPage(ORDERS_ID);
       H.DataStudio.Tables.Overview.descriptionText()
         .should("contain.text", "orders for a product")
         .click();

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/DataStudioBreadcrumbs/DataStudioBreadcrumbs.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/DataStudioBreadcrumbs/DataStudioBreadcrumbs.tsx
@@ -13,6 +13,7 @@ export const DataStudioBreadcrumbs = ({
     fz="sm"
     c="text-secondary"
     style={{ visibility: loading ? "hidden" : undefined }}
+    data-testid="data-studio-breadcrumbs"
     {...rest}
   />
 );

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/DataStudioBreadcrumbs/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/DataStudioBreadcrumbs/index.ts
@@ -1,0 +1,1 @@
+export { DataStudioBreadcrumbs } from "./DataStudioBreadcrumbs";

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/tables/components/TableHeader/TableHeader.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/tables/components/TableHeader/TableHeader.tsx
@@ -1,3 +1,8 @@
+import { t } from "ttag";
+
+import Link from "metabase/common/components/Link/Link";
+import * as Urls from "metabase/lib/urls";
+import { DataStudioBreadcrumbs } from "metabase-enterprise/data-studio/common/components/DataStudioBreadcrumbs";
 import type { Table } from "metabase-types/api";
 
 import { PaneHeader } from "../../../common/components/PaneHeader";
@@ -18,6 +23,13 @@ export function TableHeader({ table }: TableHeaderProps) {
       icon="table"
       menu={<TableMoreMenu table={table} />}
       tabs={<TableTabs table={table} />}
+      breadcrumbs={
+        <DataStudioBreadcrumbs>
+          <Link to={Urls.dataStudioLibrary()}>{t`Library`}</Link>
+          <span>{t`Data`}</span>
+          <span>{table.display_name}</span>
+        </DataStudioBreadcrumbs>
+      }
     />
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/tables/components/TableHeader/TableHeader.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/tables/components/TableHeader/TableHeader.tsx
@@ -1,8 +1,7 @@
-import { t } from "ttag";
-
 import Link from "metabase/common/components/Link/Link";
 import * as Urls from "metabase/lib/urls";
 import { DataStudioBreadcrumbs } from "metabase-enterprise/data-studio/common/components/DataStudioBreadcrumbs";
+import { useCollectionPath } from "metabase-enterprise/data-studio/common/hooks/use-collection-path/useCollectionPath";
 import type { Table } from "metabase-types/api";
 
 import { PaneHeader } from "../../../common/components/PaneHeader";
@@ -16,6 +15,9 @@ type TableHeaderProps = {
 };
 
 export function TableHeader({ table }: TableHeaderProps) {
+  const { path, isLoadingPath } = useCollectionPath({
+    collectionId: table.collection_id,
+  });
   return (
     <PaneHeader
       data-testid="table-pane-header"
@@ -24,9 +26,17 @@ export function TableHeader({ table }: TableHeaderProps) {
       menu={<TableMoreMenu table={table} />}
       tabs={<TableTabs table={table} />}
       breadcrumbs={
-        <DataStudioBreadcrumbs>
-          <Link to={Urls.dataStudioLibrary()}>{t`Library`}</Link>
-          <span>{t`Data`}</span>
+        <DataStudioBreadcrumbs loading={isLoadingPath}>
+          {path?.map((collection, i) => (
+            <Link
+              key={collection.id}
+              to={Urls.dataStudioLibrary({
+                expandedIds: path.slice(1, i + 1).map((c) => c.id),
+              })}
+            >
+              {collection.name}
+            </Link>
+          ))}
           <span>{table.display_name}</span>
         </DataStudioBreadcrumbs>
       }


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-2524/published-tables-dont-have-breadcrumbs

### How to verify

0. Publish a table (if you don't have any yet)
1. Data Studio Library -> Data -> Table 
2. Notice you see the breadcrumbs

### Demo
<img width="1129" height="183" alt="image" src="https://github.com/user-attachments/assets/bdab475c-1d9e-4ad6-8e9e-d83db2da65f2" />

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
