### PR TITLE
Fix analysis and permission grants for postgres workspaces

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/workspaces/models/workspace_transform.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/models/workspace_transform.clj
@@ -3,6 +3,9 @@
    and edited within a workspace."
   (:require
    [clojure.string :as str]
+   [medley.core :as m]
+   [metabase.lib-be.core :as lib-be]
+   [metabase.lib.core :as lib]
    [metabase.models.interface :as mi]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
@@ -75,9 +78,25 @@
   (derive :hook/timestamped?)
   (derive :hook/entity-id))
 
+;; TODO (chris 2025/12/11) we need to share a bunch of stuff with transforms, i think we'll need to reorganize modules
+;;      suggestion: add a transforms-interfaces module which both transforms and workspaces depend on.
+
+(defn- transform-source-out-DUPLICATED [m]
+  (-> m
+      mi/json-out-without-keywordization
+      (update-keys keyword)
+      (m/update-existing :query lib-be/normalize-query)
+      (m/update-existing :type keyword)
+      (m/update-existing :source-incremental-strategy #(update-keys % keyword))))
+
+(defn- transform-source-in-DUPLICATED [m]
+  (-> m
+      (m/update-existing :query (comp lib/prepare-for-serialization lib-be/normalize-query))
+      mi/json-in))
+
 (t2/deftransforms :model/WorkspaceTransform
   {:ref_id {:in identity :out str/trim}
-   :source mi/transform-json
+   :source {:out transform-source-out-DUPLICATED, :in transform-source-in-DUPLICATED}
    :target mi/transform-json})
 
 (t2/define-before-insert :model/WorkspaceTransform


### PR DESCRIPTION
Fixes a bunch of stuff:

1. We were trying to hydrate data that isn't defined for workspace transforms.
2. We weren't normalizing the source properly - FE sends version our analysis couldn't handle.
3. We weren't handling null schemas in the driver code.
4. We weren't quoting references in the driver code, so could have collisions with reserved words.
5. We were mixing up the workspace and table schemas for the general schema grant.

Phew!

Well, things are starting to work on a basic level after this.

I suspect we'll need to audit the other drivers too now. Also I haven't been very thorough with adding quoting. 