### PR TITLE
Enforce table collection permissions in search correctly

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/data_studio/search_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_studio/search_test.clj
@@ -5,7 +5,8 @@
    [medley.core :as m]
    [metabase.collections.models.collection :as collection]
    [metabase.search.core :as search]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.util.random :refer [random-name]]))
 
 (deftest published-table-collection-filter-test
   (mt/with-premium-features #{:data-studio}
@@ -113,4 +114,20 @@
                           :name "ContextTestTableUnpub"
                           :collection {:id nil}
                           :database_name "Context Test DB"}]
-                        our-result))))))))))
+                        our-result))))))))
+    (testing "Collection does not matter for permissions for unpublished tables"
+      (let [search-term (random-name)
+            name-1 (str search-term " 1")
+            name-2 (str search-term " 2")]
+        (mt/with-temp [:model/Table {unpub-table :id} {:collection_id nil :is_published false :name name-1}
+                       :model/Table {pub-table :id} {:collection_id nil :is_published true :name name-2}]
+          (search/reindex! {:async? false :in-place? true})
+          (mt/with-non-admin-groups-no-root-collection-perms
+            (let [results (mt/user-http-request :rasta :get 200 "search"
+                                                :q search-term :models "table")
+                  our-result (->> (filter (comp #{pub-table unpub-table} :id) (:data results))
+                                  (sort-by :id)
+                                  (map #(select-keys % [:id])))]
+              (testing "only the unpublished table appears"
+                (is (= [{:id unpub-table}]
+                       our-result))))))))))

--- a/src/metabase/search/appdb/core.clj
+++ b/src/metabase/search/appdb/core.clj
@@ -69,6 +69,7 @@
        :bookmark   (pos? (:bookmarked index-row 0))
        :score      (:total_score index-row 1)
        :all-scores (search.scoring/all-scores weights active-scorers index-row))
+      (dissoc :is_published)
       (update :created_at parse-datetime)
       (update :updated_at parse-datetime)
       (update :last_edited_at parse-datetime)))

--- a/src/metabase/search/spec.clj
+++ b/src/metabase/search/spec.clj
@@ -77,7 +77,8 @@
    :view-count              :int
    :non-temporal-dim-ids    :text
    :has-temporal-dim        :boolean
-   :display-type            :text})
+   :display-type            :text
+   :is-published            :boolean})
 
 (def ^:private explicit-attrs
   "These attributes must be explicitly defined, omitting them could be a source of bugs."
@@ -100,7 +101,8 @@
          :view-count
          :updated-at
          :non-temporal-dim-ids
-         :has-temporal-dim])
+         :has-temporal-dim
+         :is-published])
        distinct
        vec))
 

--- a/src/metabase/warehouse_schema/models/table.clj
+++ b/src/metabase/warehouse_schema/models/table.clj
@@ -485,7 +485,8 @@
                   :database-id   :db_id
                   :view-count    true
                   :created-at    true
-                  :updated-at    true}
+                  :updated-at    true
+                  :is-published  :is_published}
    :search-terms {:name         search.spec/explode-camel-case
                   :display_name true
                   :description  true}


### PR DESCRIPTION
previously:

- legacy search completely ignored collection permissions for both published and unpublished tables

- indexed search enforced collection permissions for both published and unpublished tables

Now we will enforce permissions correctly on both search engines, enforcing collection perms for published tables but not for unpublished tables
