### PR TITLE
fix: apply deep serialization sort for remote-sync

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/remote_sync/source.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/source.clj
@@ -60,7 +60,8 @@
     ;; Just short-circuit if there are errors.
     (throw entity))
   (u/prog1 {:path (remote-sync-path opts entity)
-            :content (yaml/generate-string entity {:dumper-options {:flow-style :block :split-lines false}})}
+            :content (yaml/generate-string (serialization/serialization-deep-sort entity)
+                                           {:dumper-options {:flow-style :block :split-lines false}})}
     (remote-sync.task/update-progress! task-id (-> (inc idx) (/ count) (* 0.65) (+ 0.3)))))
 
 (defn store!

--- a/enterprise/backend/src/metabase_enterprise/serialization/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/core.clj
@@ -1,5 +1,6 @@
 (ns metabase-enterprise.serialization.core
   (:require
+   [metabase-enterprise.serialization.dump]
    [metabase-enterprise.serialization.v2.extract]
    [metabase-enterprise.serialization.v2.ingest]
    [metabase-enterprise.serialization.v2.load]
@@ -7,12 +8,15 @@
    [potemkin :as p]))
 
 (comment
+  metabase-enterprise.serialization.dump/keep-me
   metabase-enterprise.serialization.v2.extract/keep-me
   metabase-enterprise.serialization.v2.ingest/keep-me
   metabase-enterprise.serialization.v2.load/keep-me
   metabase-enterprise.serialization.v2.storage/keep-me)
 
 (p/import-vars
+ [metabase-enterprise.serialization.dump
+  serialization-deep-sort]
  [metabase-enterprise.serialization.v2.extract
   make-targets-of-type
   extract]

--- a/enterprise/backend/src/metabase_enterprise/serialization/dump.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/dump.clj
@@ -25,7 +25,8 @@
 
 (def ^:private serialization-sorted-map (memoize serialization-sorted-map*))
 
-(defn- serialization-deep-sort
+(defn serialization-deep-sort
+  "Provide a deterministic sort for maps before serialization."
   ([m]
    (let [model (-> (:serdes/meta m) last :model)]
      (serialization-deep-sort m [(keyword model)])))

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/source_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/source_test.clj
@@ -135,3 +135,54 @@
 
         (testing "files list is empty"
           (is (empty? (:files @written-files))))))))
+
+(deftest store!-deterministic-yaml-test
+  (testing "store! produces deterministic YAML output with consistent key ordering"
+    (mt/with-temp [:model/User user {:first_name "Test"
+                                     :last_name "User"
+                                     :email "test2@example.com"
+                                     :password "password123"}
+                   :model/RemoteSyncTask {task-id :id} {:sync_task_type "export"
+                                                        :initiated_by (:id user)}]
+      (let [written-files-1 (atom nil)
+            written-files-2 (atom nil)
+            mock-source-1 (->MockSource written-files-1)
+            mock-source-2 (->MockSource written-files-2)
+            ;; Create entity with keys in non-alphabetical order to test sorting
+            test-entity {:serdes/meta [{:id "test-id" :label "test-entity" :model "Card"}]
+                         :z_last_field "should be last (unknown)"
+                         :a_first_field "should be after known fields (unknown)"
+                         :name "Test Card"
+                         :description "A test card"
+                         :entity_id "test-id"
+                         :display "table"
+                         :dataset_query {:z_field 1 :a_field 2 :database 3}
+                         :visualization_settings {:zebra true :apple false}}]
+
+        ;; Store the same entity twice
+        (source/store! [test-entity] (source.p/snapshot mock-source-1) task-id "First commit")
+        (source/store! [test-entity] (source.p/snapshot mock-source-2) task-id "Second commit")
+
+        (testing "YAML content is identical between runs"
+          (let [content-1 (-> @written-files-1 :files first :content)
+                content-2 (-> @written-files-2 :files first :content)]
+            (is (= content-1 content-2)
+                "YAML content should be identical for the same entity")))
+
+        (testing "known keys appear in serialization-order.edn order"
+          (let [content (-> @written-files-1 :files first :content)
+                name-pos (str/index-of content "name:")
+                description-pos (str/index-of content "description:")
+                display-pos (str/index-of content "display:")]
+            ;; Per serialization-order.edn, Card order is: name, description, entity_id, ... display
+            (is (< name-pos description-pos)
+                "name should appear before description")
+            (is (< description-pos display-pos)
+                "description should appear before display")))
+
+        (testing "unknown keys are sorted alphabetically after known keys"
+          (let [content (-> @written-files-1 :files first :content)
+                a-first-pos (str/index-of content "a_first_field:")
+                z-last-pos (str/index-of content "z_last_field:")]
+            (is (< a-first-pos z-last-pos)
+                "a_first_field should appear before z_last_field (alphabetical)")))))))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #66739
### Description

Apply the serialization yaml sort to the remote-sync export to reduce churn in diffs. 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
