### PR TITLE
Data Model UX

### DIFF
--- a/e2e/support/helpers/e2e-datamodel-helpers.ts
+++ b/e2e/support/helpers/e2e-datamodel-helpers.ts
@@ -21,6 +21,7 @@ export const DataModel = {
     getTables: getTablePickerTables,
     getTable: getTablePickerTable,
     getSearchInput: getTablePickerSearchInput,
+    getFilterForm: getTablePickerFilter,
   },
   TableSection: {
     get: getTableSection,
@@ -250,6 +251,10 @@ function getTablePickerTable(name: string) {
 
 function getTablePickerSearchInput() {
   return cy.findByPlaceholderText("Search tables");
+}
+
+function getTablePickerFilter() {
+  return cy.findByTestId("table-picker-filter");
 }
 
 function getTablePickerTables() {

--- a/e2e/test/scenarios/data-studio/data-model/datamodel-data-studio.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-model/datamodel-data-studio.cy.spec.ts
@@ -933,6 +933,9 @@ describe("scenarios > data studio > datamodel", () => {
 
       TableSection.clickField("ID");
 
+      // Sometimes in CI this doesn't happen
+      FieldSection.get().scrollIntoView();
+
       FieldSection.getDataType()
         .should("be.visible")
         .and("have.text", "BIGINT");

--- a/e2e/test/scenarios/data-studio/data-model/datamodel-data-studio.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-model/datamodel-data-studio.cy.spec.ts
@@ -1970,6 +1970,7 @@ describe("scenarios > data studio > datamodel", () => {
           cy.wait(["@metadata", "@metadata"]);
 
           FieldSection.getSemanticTypeFkTarget()
+            .scrollIntoView() //This should not be necessary, but CI consistently fails to scroll into view on mount
             .should("be.visible")
             .and("have.value", "Products → ID");
         });

--- a/e2e/test/scenarios/data-studio/data-model/datamodel-data-studio.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-model/datamodel-data-studio.cy.spec.ts
@@ -97,10 +97,7 @@ describe("scenarios > data studio > datamodel", () => {
 
       TablePicker.getDatabases().should("have.length", 1);
       TablePicker.getTables().should("have.length", 8);
-      H.DataModel.get()
-        .findByText("Not found.")
-        .scrollIntoView()
-        .should("be.visible");
+      H.DataModel.get().findByText("Not found.").should("be.visible");
       cy.location("pathname").should(
         "eq",
         `/data-studio/data/database/${SAMPLE_DB_ID}/schema/${SAMPLE_DB_SCHEMA_ID}/table/${ORDERS_ID}/field/12345`,
@@ -585,6 +582,12 @@ describe("scenarios > data studio > datamodel", () => {
         H.DataModel.visitDataStudio();
 
         openFilterPopover();
+
+        cy.log("Filter popover should close on click outside");
+        H.DataModel.TablePicker.getSearchInput().click();
+        H.DataModel.TablePicker.getFilterForm().should("not.exist");
+
+        openFilterPopover();
         selectFilterOption("Visibility type", "Gold");
         applyFilters();
 
@@ -930,8 +933,6 @@ describe("scenarios > data studio > datamodel", () => {
 
       TableSection.clickField("ID");
 
-      // Navbar expansion causes these panels to be off screen
-      FieldSection.get().scrollIntoView();
       FieldSection.getDataType()
         .should("be.visible")
         .and("have.text", "BIGINT");
@@ -1934,8 +1935,6 @@ describe("scenarios > data studio > datamodel", () => {
           verifyAndCloseToast("Semantic type of Quantity updated");
 
           cy.log("verify preview");
-          // Navbar expansion causes these panels to be off screen
-          FieldSection.get().scrollIntoView();
           FieldSection.getPreviewButton().click();
           cy.wait("@dataset");
           PreviewSection.get()
@@ -1966,9 +1965,6 @@ describe("scenarios > data studio > datamodel", () => {
 
           cy.reload();
           cy.wait(["@metadata", "@metadata"]);
-
-          // Navbar expansion causes these panels to be off screen
-          FieldSection.get().scrollIntoView();
 
           FieldSection.getSemanticTypeFkTarget()
             .should("be.visible")

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/FilterPopover.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/FilterPopover.tsx
@@ -34,6 +34,7 @@ export function FilterPopover({ filters, onSubmit }: Props) {
         event.preventDefault();
         onSubmit(form);
       }}
+      data-testid="table-picker-filter"
     >
       <Stack gap="xl" p="lg">
         <LayerInput

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/FilterPopover.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/FilterPopover.tsx
@@ -47,6 +47,7 @@ export function FilterPopover({ filters, onSubmit }: Props) {
             withinPortal: false,
             floatingStrategy: "fixed",
           }}
+          autoFocus
         />
 
         <UserInput

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/FilterPopover.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/FilterPopover.tsx
@@ -42,6 +42,10 @@ export function FilterPopover({ filters, onSubmit }: Props) {
           onChange={(dataLayer) => {
             setForm((form) => ({ ...form, dataLayer }));
           }}
+          comboboxProps={{
+            withinPortal: false,
+            floatingStrategy: "fixed",
+          }}
         />
 
         <UserInput
@@ -55,6 +59,10 @@ export function FilterPopover({ filters, onSubmit }: Props) {
           onUserIdChange={(ownerUserId) => {
             setForm((form) => ({ ...form, ownerEmail: null, ownerUserId }));
           }}
+          comboboxProps={{
+            withinPortal: false,
+            floatingStrategy: "fixed",
+          }}
         />
 
         <DataSourceInput
@@ -63,6 +71,10 @@ export function FilterPopover({ filters, onSubmit }: Props) {
           value={form.dataSource}
           onChange={(dataSource) => {
             setForm((form) => ({ ...form, dataSource }));
+          }}
+          comboboxProps={{
+            withinPortal: false,
+            floatingStrategy: "fixed",
           }}
         />
 

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/TablePicker.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/TablePicker.tsx
@@ -92,9 +92,14 @@ export function TablePicker({
           onChange={(event) => setQuery(event.target.value)}
         />
 
-        <Popover width={rem(340)} position="bottom-start" opened={isOpen}>
+        <Popover
+          width={rem(340)}
+          position="bottom-start"
+          opened={isOpen}
+          onChange={toggle}
+        >
           <Popover.Target>
-            <Tooltip label={t`Filter`}>
+            <Tooltip label={t`Filter`} disabled={isOpen}>
               <Button
                 aria-label={t`Filter`}
                 leftSection={

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/TableSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/TableSection.tsx
@@ -198,7 +198,7 @@ const TableSectionBase = ({
 
   return (
     <Stack data-testid="table-section" gap="md" pb="xl">
-      <Box className={S.header} bg="accent-gray-light" px="lg" mt="lg">
+      <Box className={S.header} px="lg" mt="lg">
         <NameDescriptionInput
           description={table.description ?? ""}
           descriptionPlaceholder={t`Give this table a description`}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/pages/DataModel/DataModel.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/pages/DataModel/DataModel.tsx
@@ -1,5 +1,5 @@
 import { useDisclosure, useWindowEvent } from "@mantine/hooks";
-import { type ReactNode, useMemo, useState } from "react";
+import { type ReactNode, useCallback, useMemo, useState } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -134,6 +134,10 @@ function DataModelContent({ params }: Props) {
     },
   );
 
+  const scrollToPanel = useCallback((el: HTMLDivElement | null) => {
+    el?.scrollIntoView({ behavior: "smooth" });
+  }, []);
+
   if (databasesData?.data?.length === 0) {
     return <NoDatabasesEmptyState />;
   }
@@ -244,7 +248,7 @@ function DataModelContent({ params }: Props) {
             }
             maw={COLUMN_CONFIG.field.max}
             miw={COLUMN_CONFIG.field.min}
-            ref={(el) => el?.scrollIntoView({ behavior: "smooth" })}
+            ref={scrollToPanel}
           >
             <LoadingAndErrorWrapper error={error} loading={isLoading}>
               {field && table && databaseId != null && (
@@ -282,7 +286,7 @@ function DataModelContent({ params }: Props) {
             p="lg"
             maw={COLUMN_CONFIG.preview.max}
             miw={COLUMN_CONFIG.preview.min}
-            ref={(el) => el?.scrollIntoView({ behavior: "smooth" })}
+            ref={scrollToPanel}
           >
             <PreviewSection
               className={S.preview}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/pages/DataModel/DataModel.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/pages/DataModel/DataModel.tsx
@@ -245,6 +245,7 @@ function DataModelContent({ params }: Props) {
             }
             maw={COLUMN_CONFIG.field.max}
             miw={COLUMN_CONFIG.field.min}
+            ref={(el) => el?.scrollIntoView({ behavior: "smooth" })}
           >
             <LoadingAndErrorWrapper error={error} loading={isLoading}>
               {field && table && databaseId != null && (
@@ -283,6 +284,7 @@ function DataModelContent({ params }: Props) {
             p="lg"
             maw={COLUMN_CONFIG.preview.max}
             miw={COLUMN_CONFIG.preview.min}
+            ref={(el) => el?.scrollIntoView({ behavior: "smooth" })}
           >
             <PreviewSection
               className={S.preview}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/pages/DataModel/DataModel.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/pages/DataModel/DataModel.tsx
@@ -236,7 +236,6 @@ function DataModelContent({ params }: Props) {
 
         {showFieldDetails && (
           <Stack
-            bg="white"
             className={S.column}
             flex={COLUMN_CONFIG.field.flex}
             h="100%"
@@ -278,7 +277,6 @@ function DataModelContent({ params }: Props) {
 
         {showFieldPreview && databaseId != null && fieldId != null && (
           <Box
-            bg="accent-gray-light"
             flex={COLUMN_CONFIG.preview.flex}
             h="100%"
             p="lg"

--- a/frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx
+++ b/frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx
@@ -89,7 +89,7 @@ const FieldSectionBase = ({
   };
 
   return (
-    <Stack data-testid="field-section" gap={0} pb="lg" bg="bg-white">
+    <Stack data-testid="field-section" gap={0} pb="lg">
       <Stack gap="md" pb="md" pt="lg" px="lg">
         <NameDescriptionInput
           description={field.description ?? ""}


### PR DESCRIPTION
Closes UXW-2509
Closes UXW-2505
Closes UXW-2510

### Description
Fixes the filter popover to close when you click outside of it. Closing on Esc involves moving a whole lot of handlers around and probably deserves it's own PR. Also scrolls to the Field and Preview panels when they mount, which is a nice quality of life improvement

### How to verify
1. To go Data Studio -> Data Structure
2. Click the filter button, and see that clicking outside the popover dismisses the popover
3. Click on a table, then select a field, the field panel should scroll into view
4. Click the preview button on the field panel, the preview panel should scroll into view.


### Checklist
In this case, I removed some `scrollIntoView()` calls that I had previously added to tests to ensure scrolling is happening on it's own.
- [x] Tests have been added/updated to cover changes in this PR
