### PR TITLE
Eliminate `enterprise/sso` dep on `channel`

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2203,7 +2203,6 @@
    :uses #{api
            appearance
            auth-identity
-           channel
            embedding
            premium-features
            request

--- a/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
@@ -11,6 +11,7 @@
    [metabase.api.macros :as api.macros]
    [metabase.request.core :as request]
    [metabase.session.core :as session]
+   [metabase.system.core :as system]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]

--- a/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
@@ -9,7 +9,6 @@
    [metabase-enterprise.sso.integrations.saml]
    [metabase-enterprise.sso.settings :as sso-settings]
    [metabase.api.macros :as api.macros]
-   [metabase.channel.urls :as urls]
    [metabase.request.core :as request]
    [metabase.session.core :as session]
    [metabase.util :as u]
@@ -105,7 +104,7 @@
         :issuer (sso-settings/saml-application-name)
         :user-email email
         :relay-state (u/encode-base64
-                      (str (urls/site-url) metabase-slo-redirect-url))))}))
+                      (str (system/site-url) metabase-slo-redirect-url))))}))
 
 ;; POST /auth/sso/to_session
 ;;

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
@@ -38,7 +38,6 @@
    [metabase-enterprise.sso.settings :as sso-settings]
    [metabase.api.common :as api]
    [metabase.auth-identity.core :as auth-identity]
-   [metabase.channel.urls :as urls]
    [metabase.embedding.util :as embed.util]
    [metabase.premium-features.core :as premium-features]
    [metabase.request.core :as request]
@@ -221,6 +220,6 @@
       (if-let [metabase-session-key (and (saml/logout-success? response) (get-in cookies [request/metabase-session-cookie :value]))]
         (do
           (t2/delete! :model/Session {:where [:or [:= (session/hash-session-key metabase-session-key) :key_hashed] [:= metabase-session-key :id]]})
-          (request/clear-session-cookie (response/redirect (urls/site-url))))
+          (request/clear-session-cookie (response/redirect (system/site-url))))
         {:status 500 :body "SAML logout failed."}))
     (log/warn "SAML SLO is not enabled, not continuing Single Log Out flow.")))


### PR DESCRIPTION
Pursuant to eliminating the transient dep of `driver` on `channel`

No reason to use the notification-specific version of `system/site-url` as discussed here [dev.deps-graph](https://metaboat.slack.com/archives/CKZEMT1MJ/p1765232057266099)