### PR TITLE
UXW-2484 fix chart tooltip color

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartTooltip/TooltipRow/TooltipRow.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip/TooltipRow/TooltipRow.styled.tsx
@@ -71,7 +71,7 @@ export const ValueCell = styled(Cell)`
 
 export const PercentCell = styled(Cell)`
   padding-left: 1rem;
-  color: var(--mb-color-text-light);
+  color: var(--mb-color-tooltip-text-secondary);
   text-align: right;
 `;
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/66581 / UXW-2484

### Description

Fix issue with light theme text on chart tooltip.

| Before | After |
|--------|--------|
| <img width="400" height="525" alt="Screenshot 2025-12-12 at 01 50 23" src="https://github.com/user-attachments/assets/ceb46d9d-6c53-4182-b756-b7c683efac6f" /> | <img width="434" height="517" alt="Screenshot 2025-12-12 at 01 50 05" src="https://github.com/user-attachments/assets/a5d9c21c-9655-4240-81e2-19b290ec7e47" /> |
| <img width="391" height="511" alt="Screenshot 2025-12-12 at 01 50 46" src="https://github.com/user-attachments/assets/e391a96d-d445-4e97-9b6d-aec1a27b3734" /> |<img width="382" height="553" alt="Screenshot 2025-12-12 at 01 49 50" src="https://github.com/user-attachments/assets/f428a8d5-7971-4b70-9d04-3a99b570308e" />  | 







### How to verify

Check steps from https://github.com/metabase/metabase/issues/66581

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR - no tests
