### PR TITLE
Spin off `channel-interface` from `channel`

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -208,7 +208,7 @@
   {:team "UX West"
    :api  #{metabase.auth-identity.core
            metabase.auth-identity.init}
-   :uses #{channel
+   :uses #{channel-interface
            events
            login-history
            models
@@ -285,6 +285,7 @@
            api
            app-db
            appearance
+           channel-interface
            collections
            config
            dashboards
@@ -305,6 +306,11 @@
            timeline
            types
            util}}
+
+  channel-interface
+  {:team "Gadget"
+   :api  #{metabase.channel-interface.core}
+   :uses #{}}
 
   classloader
   {:team "DevEx"
@@ -464,7 +470,7 @@
            analytics
            api
            app-db
-           channel
+           channel-interface
            collections
            collections-rest
            dashboards
@@ -782,7 +788,7 @@
            metabase.login-history.init}
    :uses #{analytics
            api
-           channel
+           channel-interface
            request
            settings
            util}}
@@ -851,6 +857,7 @@
            appearance
            auth-identity
            channel
+           channel-interface
            config
            dashboards
            driver
@@ -958,6 +965,7 @@
            api
            app-db
            channel
+           channel-interface
            config
            premium-features
            settings
@@ -1030,7 +1038,7 @@
            app-db
            audit-app
            cache
-           channel
+           channel-interface
            collections
            config
            content-verification
@@ -1292,7 +1300,7 @@
    :uses #{api
            app-db
            auth-identity
-           channel
+           channel-interface
            config
            events
            request
@@ -1508,7 +1516,7 @@
            metabase.users.settings}
    :uses #{api
            batch-processing
-           channel
+           channel-interface
            config
            events
            models

--- a/src/metabase/auth_identity/providers/emailed_secret.clj
+++ b/src/metabase/auth_identity/providers/emailed_secret.clj
@@ -3,7 +3,7 @@
   (:require
    [java-time.api :as t]
    [metabase.auth-identity.provider :as provider]
-   [metabase.channel.email.messages :as messages]
+   [metabase.channel-interface.core :as channel-interface]
    [metabase.events.core :as events]
    [metabase.util :as u]
    [metabase.util.log :as log]
@@ -190,7 +190,7 @@
   (when (:success? result)
     (if (:last_login user)
       (events/publish-event! :event/password-reset-successful {:object (assoc user :token (t2/select-one-fn :reset_token :model/User (:id user)))})
-      (messages/send-user-joined-admin-notification-email! (t2/select-one :model/User (:id user))))
+      (channel-interface/send-user-joined-admin-notification-email! (t2/select-one :model/User (:id user))))
     (t2/with-transaction [_]
       (t2/update! :model/AuthIdentity (:id auth-identity) (mark-token-consumed auth-identity))
       (t2/update! :model/User (:id user) {:password password})))

--- a/src/metabase/channel/events/persisted_model_refresh_error.clj
+++ b/src/metabase/channel/events/persisted_model_refresh_error.clj
@@ -2,7 +2,7 @@
   "Event handler for the `:event/persisted-model-refresh-error` event defined
   in [[metabase.model-persistence.events.persisted-model-refresh-error]]."
   (:require
-   [metabase.channel.email.messages :as messages]
+   [metabase.channel-interface.core :as channel-interface]
    [metabase.events.core :as events]
    [methodical.core :as methodical]))
 
@@ -10,7 +10,7 @@
 
 (methodical/defmethod events/publish-event! ::event
   [_topic {:keys [database-id persisted-infos trigger]}]
-  (messages/send-persistent-model-error-email!
+  (channel-interface/send-persistent-model-error-email!
    database-id
    persisted-infos
    trigger))

--- a/src/metabase/channel/init.clj
+++ b/src/metabase/channel/init.clj
@@ -2,6 +2,7 @@
   "Load channel implementation namespaces for side effects on system launch. See
   https://metaboat.slack.com/archives/CKZEMT1MJ/p1736556522733279 for rationale behind this pattern."
   (:require
+   [metabase.channel.email.messages] ; to set the default EmailService impl
    [metabase.channel.events.comments]
    [metabase.channel.events.persisted-model-refresh-error]
    [metabase.channel.events.slack]

--- a/src/metabase/channel_interface/core.clj
+++ b/src/metabase/channel_interface/core.clj
@@ -1,0 +1,118 @@
+(ns metabase.channel-interface.core
+  (:require
+   [potemkin :as p]))
+
+(p/defprotocol+ EmailService
+  (-send-alert-stopped-because-archived-email! [this card recipient-emails archiver]
+    "Email to notify users when a card associated to their alert has been archived")
+
+  (-send-broken-subscription-notification! [this dashboard-subscription-info]
+    "Email dashboard and subscription creators information about a broken subscription due to bad parameters")
+
+  (-send-you-unsubscribed-notification-card-email! [this notification unsubscribed-emails]
+    "Send an email to `who-unsubscribed` letting them know they've unsubscribed themselves from `notification`")
+
+  (-send-alert-stopped-because-changed-email! [this card recipient-emails archiver]
+    "Email to notify users when a card associated to their alert changed in a way that invalidates their alert")
+
+  (-send-persistent-model-error-email! [this database-id persisted-infos trigger]
+    "Format and send an email informing the user about errors in the persistent model refresh task.")
+
+  (-send-you-were-removed-notification-card-email! [this notification removed-emails actor]
+    "Send an email to `removed-users` letting them know `admin` has removed them from `notification`")
+
+  (-send-you-were-added-card-notification-email! [this notification added-user-emails adder]
+    "Send an email to `added-users` letting them know `admin-adder` has added them to `notification`")
+
+  (-send-user-joined-admin-notification-email! [this new-user {:keys [google-auth?], :as _options}]
+    "Send an email to the `invitor` (the Admin who invited `new-user`) letting them know `new-user` has joined.")
+
+  (-send-follow-up-email! [this email]
+    "Format and send an email to the system admin following up on the installation.")
+
+  (-send-creator-sentiment-email! [this user blob]
+    "Format and send an email to a creator with a link to a survey. If a [[blob]] is included, it will be turned into
+  json and then base64 encoded.")
+
+  (-send-password-reset-email! [this email sso-source password-reset-url is-active?]
+    "Format and send an email informing the user how to reset their password.")
+
+  (-send-login-from-new-device-email! [this login-history]
+    "Format and send an email informing the user that this is the first time we've seen a login from this device.
+  Expects\n login history information as returned
+  by [[metabase.login-history.models.login-history/human-friendly-infos]]."))
+
+(defonce ^:private ^:dynamic *email-service*
+  (atom nil))
+
+(defn set-email-service!
+  "Set the default email service (default implementation of [[EmailService]])."
+  [email-serivce]
+  (reset! *email-service* email-serivce))
+
+(defn- email-service []
+  @*email-service*)
+
+(defn send-alert-stopped-because-archived-email!
+  "Email to notify users when a card associated to their alert has been archived"
+  [card recipient-emails archiver]
+  (-send-alert-stopped-because-archived-email! (email-service) card recipient-emails archiver))
+
+(defn send-broken-subscription-notification!
+  "Email dashboard and subscription creators information about a broken subscription due to bad parameters"
+  [dashboard-subscription-info]
+  (-send-broken-subscription-notification! (email-service) dashboard-subscription-info))
+
+(defn send-you-unsubscribed-notification-card-email!
+  "Send an email to `who-unsubscribed` letting them know they've unsubscribed themselves from `notification`"
+  [notification unsubscribed-emails]
+  (-send-you-unsubscribed-notification-card-email! (email-service) notification unsubscribed-emails))
+
+(defn send-alert-stopped-because-changed-email!
+  "Email to notify users when a card associated to their alert changed in a way that invalidates their alert"
+  [card recipient-emails archiver]
+  (-send-alert-stopped-because-changed-email! (email-service) card recipient-emails archiver))
+
+(defn send-persistent-model-error-email!
+  "Format and send an email informing the user about errors in the persistent model refresh task."
+  [database-id persisted-infos trigger]
+  (-send-persistent-model-error-email! (email-service) database-id persisted-infos trigger))
+
+(defn send-you-were-removed-notification-card-email!
+  "Send an email to `removed-users` letting them know `admin` has removed them from `notification`"
+  [notification removed-emails actor]
+  (-send-you-were-removed-notification-card-email! (email-service) notification removed-emails actor))
+
+(defn send-you-were-added-card-notification-email!
+  "Send an email to `added-users` letting them know `admin-adder` has added them to `notification`"
+  [notification added-user-emails adder]
+  (-send-you-were-added-card-notification-email! (email-service) notification added-user-emails adder))
+
+(defn send-user-joined-admin-notification-email!
+  "Send an email to the `invitor` (the Admin who invited `new-user`) letting them know `new-user` has joined."
+  ([new-user]
+   (send-user-joined-admin-notification-email! new-user nil))
+  ([new-user {:keys [google-auth?]}]
+   (-send-user-joined-admin-notification-email! (email-service) new-user {:google-auth? google-auth?})))
+
+(defn send-follow-up-email!
+  "Format and send an email to the system admin following up on the installation."
+  [email]
+  (-send-follow-up-email! (email-service) email))
+
+(defn send-creator-sentiment-email!
+  "Format and send an email to a creator with a link to a survey. If a [[blob]] is included, it will be turned into
+  json and then base64 encoded."
+  [user blob]
+  (-send-creator-sentiment-email! (email-service) user blob))
+
+(defn send-password-reset-email!
+  "Format and send an email informing the user how to reset their password."
+  [email sso-source password-reset-url is-active?]
+  (-send-password-reset-email! (email-service) email sso-source password-reset-url is-active?))
+
+(defn send-login-from-new-device-email!
+  "Format and send an email informing the user that this is the first time we've seen a login from this device. Expects
+  login history information as returned by [[metabase.login-history.models.login-history/human-friendly-infos]]."
+  [login-history]
+  (-send-login-from-new-device-email! (email-service) login-history))

--- a/src/metabase/dashboards_rest/api.clj
+++ b/src/metabase/dashboards_rest/api.clj
@@ -10,7 +10,7 @@
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.app-db.core :as app-db]
-   [metabase.channel.email.messages :as messages]
+   [metabase.channel-interface.core :as channel-interface]
    [metabase.collections-rest.api :as api.collection]
    [metabase.collections.core :as collections]
    [metabase.collections.models.collection :as collection]
@@ -928,7 +928,7 @@
     ;; Archive the pulse
     (pulse/update-pulse! {:id pulse-id :archived true})
     ;; Let the pulse and subscription creator know about the broken pulse
-    (messages/send-broken-subscription-notification! broken-subscription)))
+    (channel-interface/send-broken-subscription-notification! broken-subscription)))
 
 ;;;;;;;;;;;;;;;;;;;;; End functions to handle broken subscriptions
 

--- a/src/metabase/login_history/record.clj
+++ b/src/metabase/login_history/record.clj
@@ -1,7 +1,7 @@
 (ns metabase.login-history.record
   (:require
    [metabase.analytics.snowplow :as snowplow]
-   [metabase.channel.email.messages :as messages]
+   [metabase.channel-interface.core :as channel-interface]
    [metabase.login-history.models.login-history :as login-history]
    [metabase.login-history.settings :as login-history.settings]
    [metabase.request.core :as request]
@@ -24,7 +24,7 @@
         ;; off thread for both IP lookup and email sending. Either one could block and slow down user login (#16169)
         (try
           (let [[info] (login-history/human-friendly-infos [history-record])]
-            (messages/send-login-from-new-device-email! info))
+            (channel-interface/send-login-from-new-device-email! info))
           (catch Throwable e
             (log/error e "Error sending 'login from new device' notification email")))))))
 

--- a/src/metabase/notification/api/notification.clj
+++ b/src/metabase/notification/api/notification.clj
@@ -6,7 +6,7 @@
    [medley.core :as m]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
-   [metabase.channel.email.messages :as messages]
+   [metabase.channel-interface.core :as channel-interface]
    [metabase.channel.settings :as channel.settings]
    [metabase.events.core :as events]
    [metabase.models.interface :as mi]
@@ -143,7 +143,7 @@
       (when-let [recipients-except-creator (->> (all-email-recipients notification)
                                                 (remove current-user?)
                                                 seq)]
-        (messages/send-you-were-added-card-notification-email!
+        (channel-interface/send-you-were-added-card-notification-email!
          (update notification :payload t2/hydrate :card) recipients-except-creator @api/*current-user*)))))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
@@ -180,18 +180,18 @@
       (cond
         ;; Notification was just archived - notify all users they were unsubscribed
         (and was-active? (not is-active?))
-        (messages/send-you-were-removed-notification-card-email! notification old-emails current-user)
+        (channel-interface/send-you-were-removed-notification-card-email! notification old-emails current-user)
 
         ;; Notification was just unarchived - notify all users they were added
         (and (not was-active?) is-active?)
-        (messages/send-you-were-added-card-notification-email! notification new-emails @api/*current-user*)
+        (channel-interface/send-you-were-added-card-notification-email! notification new-emails @api/*current-user*)
 
         (not= old-emails new-emails)
         (let [[removed-recipients added-recipients _] (diff old-emails new-emails)]
           (when (seq removed-recipients)
-            (messages/send-you-were-removed-notification-card-email! notification removed-recipients current-user))
+            (channel-interface/send-you-were-removed-notification-card-email! notification removed-recipients current-user))
           (when (seq added-recipients)
-            (messages/send-you-were-added-card-notification-email! notification added-recipients @api/*current-user*)))))))
+            (channel-interface/send-you-were-added-card-notification-email! notification added-recipients @api/*current-user*)))))))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
@@ -265,7 +265,7 @@
     (u/prog1 (get-notification notification-id)
       (when (card-notification? <>)
         (u/ignore-exceptions
-          (messages/send-you-unsubscribed-notification-card-email!
+          (channel-interface/send-you-unsubscribed-notification-card-email!
            (update <> :payload t2/hydrate :card)
            [(:email @api/*current-user*)])))
       (events/publish-event! :event/notification-unsubscribe {:object {:id notification-id}

--- a/src/metabase/product_feedback/task/creator_sentiment_emails.clj
+++ b/src/metabase/product_feedback/task/creator_sentiment_emails.clj
@@ -6,7 +6,7 @@
    [java-time.api :as t]
    [metabase.analytics.core :as analytics]
    [metabase.app-db.core :as mdb]
-   [metabase.channel.email.messages :as messages]
+   [metabase.channel-interface.core :as channel-interface]
    [metabase.channel.settings :as channel.settings]
    [metabase.config.core :as config]
    [metabase.premium-features.core :as premium-features]
@@ -97,7 +97,7 @@
                  (count all-creators) (count recipients))
       (doseq [creator recipients]
         (try
-          (messages/send-creator-sentiment-email! creator (blob creator))
+          (channel-interface/send-creator-sentiment-email! creator (blob creator))
           (catch Throwable e
             (log/error e "Problem sending creator sentiment email:")))))))
 

--- a/src/metabase/product_feedback/task/follow_up_emails.clj
+++ b/src/metabase/product_feedback/task/follow_up_emails.clj
@@ -6,7 +6,7 @@
    [clojurewerkz.quartzite.triggers :as triggers]
    [java-time.api :as t]
    [metabase.analytics.core :as analytics]
-   [metabase.channel.email.messages :as messages]
+   [metabase.channel-interface.core :as channel-interface]
    [metabase.channel.settings :as channel.settings]
    [metabase.product-feedback.settings :as product-feedback.settings]
    [metabase.task.core :as task]
@@ -29,7 +29,7 @@
     ;; TODO - Does it make to send to this user instead of `(system/admin-email)`?
     (when-let [admin (t2/select-one :model/User :is_superuser true, :is_active true, {:order-by [:date_joined]})]
       (try
-        (messages/send-follow-up-email! (:email admin))
+        (channel-interface/send-follow-up-email! (:email admin))
         (catch Throwable e
           (log/error e "Problem sending follow-up email:"))
         (finally

--- a/src/metabase/queries/events/cards_notification_deleted_on_card_save.clj
+++ b/src/metabase/queries/events/cards_notification_deleted_on_card_save.clj
@@ -1,6 +1,6 @@
 (ns metabase.queries.events.cards-notification-deleted-on-card-save
   (:require
-   [metabase.channel.email.messages :as messages]
+   [metabase.channel-interface.core :as channel-interface]
    [metabase.events.core :as events]
    [metabase.util.log :as log]
    [methodical.core :as methodical]))
@@ -17,10 +17,10 @@
   (try
     (let [send-message! (case topic
                           :event/card-update.notification-deleted.card-archived
-                          messages/send-alert-stopped-because-archived-email!
+                          channel-interface/send-alert-stopped-because-archived-email!
 
                           :event/card-update.notification-deleted.card-changed
-                          messages/send-alert-stopped-because-changed-email!)
+                          channel-interface/send-alert-stopped-because-changed-email!)
           recipients (->> notifications
                           (mapcat :handlers)
                           (filter #(= :channel/email (:channel_type %)))

--- a/src/metabase/session/api.clj
+++ b/src/metabase/session/api.clj
@@ -6,7 +6,7 @@
    [metabase.api.macros :as api.macros]
    [metabase.api.open-api :as open-api]
    [metabase.auth-identity.core :as auth-identity]
-   [metabase.channel.email.messages :as messages]
+   [metabase.channel-interface.core :as channel-interface]
    [metabase.config.core :as config]
    [metabase.events.core :as events]
    [metabase.request.core :as request]
@@ -187,11 +187,11 @@
       (if (password-reset-disabled? user-id sso-source)
         ;; If user uses any SSO method to log in, no need to generate a reset token. Some cases for Google SSO
         ;; are exempted see `password-reset-allowed?`
-        (messages/send-password-reset-email! email sso-source nil is-active?)
+        (channel-interface/send-password-reset-email! email sso-source nil is-active?)
         (let [reset-token        (auth-identity/create-password-reset! user-id)
               password-reset-url (str (system/site-url) "/auth/reset_password/" reset-token)]
           (log/info password-reset-url)
-          (messages/send-password-reset-email! email nil password-reset-url is-active?)))
+          (channel-interface/send-password-reset-email! email nil password-reset-url is-active?)))
       (events/publish-event! :event/password-reset-initiated
                              {:object (assoc user :token (t2/select-one-fn :reset_token :model/User :id user-id))}))))
 

--- a/src/metabase/users/models/user.clj
+++ b/src/metabase/users/models/user.clj
@@ -5,6 +5,7 @@
    [honey.sql.helpers :as sql.helpers]
    [java-time.api :as t]
    [metabase.api.common :as api]
+   [metabase.channel-interface.core :as channel-interface]
    [metabase.config.core :as config]
    [metabase.events.core :as events]
    [metabase.models.interface :as mi]
@@ -451,7 +452,7 @@
   (u/prog1 (t2/insert-returning-instance! :model/User new-user)
     ;; send an email to everyone including the site admin if that's set
     (when (setting/get :send-new-sso-user-admin-email?)
-      ((requiring-resolve 'metabase.channel.email.messages/send-user-joined-admin-notification-email!) <>, :google-auth? true))))
+      (channel-interface/send-user-joined-admin-notification-email! <> {:google-auth? true}))))
 
 (defn form-password-reset-url
   "Generate a properly formed password reset url given a password reset token."


### PR DESCRIPTION
This allows code to fire off events to send emails without having to depend on the implementation for sending emails, sort of like how our event system lets us decouple the code that fires off events from the code that consumes it.