### PR TITLE
Ensure Claude prefers clojure-mcp if it is available

### DIFF
--- a/.claude/skills/_shared/clojure-commands.md
+++ b/.claude/skills/_shared/clojure-commands.md
@@ -29,6 +29,11 @@ to run 3 tests, or
 
 ## REPL Usage
 
+> **Note:** If you have `clojure-mcp` tools available (check for tools like `clojure_eval`),
+> **always prefer those over `./bin/mage -repl`**. The MCP tools provide better integration,
+> richer feedback, and avoid shell escaping issues. Only use `./bin/mage -repl` as a fallback
+> when clojure-mcp is not available.
+
 - **Evaluating Clojure Code:** `./bin/mage -repl '<code>'`
   - See "Sending Code to the REPL" section for more details
 

--- a/.claude/skills/clojure-write/SKILL.md
+++ b/.claude/skills/clojure-write/SKILL.md
@@ -5,6 +5,16 @@ description: Guide Clojure and ClojureScript development using REPL-driven workf
 
 # Clojure Development Skill
 
+## Tool Preference
+
+When `clojure-mcp` tools are available (e.g., `clojure_eval`, `clojure_edit`), **always use them**
+instead of shell commands like `./bin/mage -repl`. The MCP tools provide:
+- Direct REPL integration without shell escaping issues
+- Better error messages and feedback
+- Structural Clojure editing that prevents syntax errors
+
+Only fall back to `./bin/mage` commands when clojure-mcp is not available.
+
 @./../_shared/development-workflow.md
 @./../_shared/clojure-style-guide.md
 @./../_shared/clojure-commands.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,3 +18,7 @@ For detailed guidance on writing and reviewing code and documentation, see the s
 
 - **[docs-write](.claude/skills/docs-write/SKILL.md)** - Documentation writing with Metabase style guide
 - **[docs-review](.claude/skills/docs-review/SKILL.md)** - Documentation review checklist
+
+## Tool Preferences
+
+If `clojure-mcp` tools are available, prefer them over shell-based alternatives for Clojure development.


### PR DESCRIPTION
### Description

For those of us who use [clojure-mcp](https://github.com/bhauman/clojure-mcp), our Claude configuration directly contradicts instructions we're giving it. This PR only adds to our `CLAUDE.md` and our skills a note that **if** clojure-mcp is available, it should prefer it over shell-based methods (like `./bin/mage -repl`).

### How to verify

Play with Claude.