### PR TITLE
Update library empty state

### DIFF
--- a/e2e/support/helpers/e2e-data-studio-helpers.ts
+++ b/e2e/support/helpers/e2e-data-studio-helpers.ts
@@ -94,13 +94,18 @@ export const DataStudio = {
     },
   },
   Library: {
-    emptyPage: () =>
+    visit: () => {
+      cy.visit("/data-studio/library");
+      DataStudio.Library.libraryPage().should("be.visible");
+    },
+    noResults: () =>
       libraryPage().findByText("No tables, metrics, or snippets yet"),
     libraryPage,
     metricItem: (name: string) =>
       cy.findAllByTestId("metric-name").contains(name),
+    allTableItems: () => libraryPage().findAllByTestId("table-name"),
     tableItem: (name: string) =>
-      libraryPage().findAllByTestId("table-name").contains(name),
+      DataStudio.Library.allTableItems().contains(name),
     result: (name: string) => libraryPage().findByText(name).closest("tr"),
     newButton: () => libraryPage().findByRole("button", { name: /New/ }),
     collectionItem: (name: string) =>

--- a/e2e/test/scenarios/data-studio/data-model/data-studio-single-table.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-model/data-studio-single-table.cy.spec.ts
@@ -94,9 +94,7 @@ describe("Table editing", () => {
       H.modal().findByText("Unpublish this table").click();
       cy.wait("@unpublishTables");
       H.DataStudio.nav().findByLabelText("Library").click();
-      H.DataStudio.Library.libraryPage()
-        .findByText("No tables, metrics, or snippets yet")
-        .should("be.visible");
+      H.DataStudio.Library.allTableItems().should("have.length", 0);
     },
   );
 

--- a/e2e/test/scenarios/data-studio/data-studio-library.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-studio-library.cy.spec.ts
@@ -41,16 +41,6 @@ describe("scenarios > data studio > library", () => {
       event: "data_studio_library_created",
     });
 
-    cy.log("Verify empty state shows on library root");
-    H.DataStudio.Library.emptyPage().should("be.visible");
-
-    H.DataStudio.Library.libraryPage().button(/New/).click();
-    H.popover().findByText("New snippet folder").click();
-    H.modal().within(() => {
-      cy.findByLabelText("Give your folder a name").type("My Snippets");
-      cy.button("Create").click();
-    });
-
     cy.log("Verify library collections appear in the library table");
     H.DataStudio.Library.collectionItem("Data").should("be.visible");
     H.DataStudio.Library.collectionItem("Metrics").should("be.visible");

--- a/e2e/test/scenarios/data-studio/data-studio-metrics.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-studio-metrics.cy.spec.ts
@@ -17,7 +17,7 @@ describe("scenarios > data studio > library > metrics", () => {
   });
 
   it("should create a new metric with proper validation and save to collection", () => {
-    visitLibraryPage();
+    H.DataStudio.Library.visit();
 
     cy.log("Create a new metric");
     H.DataStudio.Library.newButton().click();
@@ -332,8 +332,3 @@ describe("scenarios > data studio > library > metrics", () => {
       .should("not.exist");
   });
 });
-
-function visitLibraryPage() {
-  cy.visit("/data-studio/library");
-  H.DataStudio.Library.libraryPage().should("be.visible");
-}

--- a/e2e/test/scenarios/data-studio/data-studio-tables.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-studio-tables.cy.spec.ts
@@ -40,12 +40,12 @@ describe("scenarios > data studio > library > tables", () => {
     it("should be able to unpublish a table", () => {
       H.createLibrary();
       H.publishTables({ table_ids: [ORDERS_ID] });
-
-      H.DataStudio.Tables.visitOverviewPage(ORDERS_ID);
+      H.DataStudio.Library.visit();
+      H.DataStudio.Library.tableItem("Orders").click();
       H.DataStudio.Tables.moreMenu().click();
       H.popover().findByText("Unpublish").click();
       H.modal().findByText("Unpublish this table").click();
-      H.DataStudio.Library.emptyPage().should("be.visible");
+      H.DataStudio.Library.allTableItems().should("have.length", 0);
     });
   });
 

--- a/e2e/test/scenarios/data-studio/snippets.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/snippets.cy.spec.ts
@@ -16,7 +16,7 @@ describe("scenarios > data studio > snippets", () => {
 
   describe("creation", () => {
     it("should create a new snippet with proper validation", () => {
-      visitLibraryPage();
+      H.DataStudio.Library.visit();
 
       H.DataStudio.Library.newButton().click();
       H.popover().findByText("New snippet").click();
@@ -62,7 +62,7 @@ describe("scenarios > data studio > snippets", () => {
         content: "SELECT * FROM orders",
       });
 
-      visitLibraryPage();
+      H.DataStudio.Library.visit();
 
       H.DataStudio.Library.libraryPage().findByText("Test snippet").click();
 
@@ -85,7 +85,7 @@ describe("scenarios > data studio > snippets", () => {
         content: "SELECT * FROM orders",
       });
 
-      visitLibraryPage();
+      H.DataStudio.Library.visit();
 
       H.DataStudio.Library.libraryPage().findByText("Test snippet").click();
 
@@ -106,7 +106,7 @@ describe("scenarios > data studio > snippets", () => {
         content: "SELECT * FROM orders",
       });
 
-      visitLibraryPage();
+      H.DataStudio.Library.visit();
 
       H.DataStudio.Library.libraryPage().findByText("Test snippet").click();
 
@@ -131,7 +131,7 @@ describe("scenarios > data studio > snippets", () => {
         description: "**Bold text** and *italic text*",
       });
 
-      visitLibraryPage();
+      H.DataStudio.Library.visit();
 
       H.DataStudio.Library.libraryPage().findByText("Test snippet").click();
       H.DataStudio.Snippets.editPage().within(() => {
@@ -148,7 +148,7 @@ describe("scenarios > data studio > snippets", () => {
         content: "SELECT * FROM orders",
       });
 
-      visitLibraryPage();
+      H.DataStudio.Library.visit();
 
       H.DataStudio.Library.libraryPage().findByText("Test snippet").click();
 
@@ -175,7 +175,7 @@ describe("scenarios > data studio > snippets", () => {
     });
 
     it("should be able to create a folder and snippet inside it", () => {
-      visitLibraryPage();
+      H.DataStudio.Library.visit();
 
       H.DataStudio.Library.newButton().click();
       H.popover().findByText("New snippet folder").click();
@@ -218,7 +218,7 @@ describe("scenarios > data studio > snippets", () => {
         name: "Test Folder",
       });
 
-      visitLibraryPage();
+      H.DataStudio.Library.visit();
 
       H.DataStudio.Library.result("Test Folder").icon("ellipsis").click();
 
@@ -242,7 +242,7 @@ describe("scenarios > data studio > snippets", () => {
         name: "Test Folder",
       });
 
-      visitLibraryPage();
+      H.DataStudio.Library.visit();
 
       H.DataStudio.Library.result("Test Folder").icon("ellipsis").click();
 
@@ -256,8 +256,3 @@ describe("scenarios > data studio > snippets", () => {
     });
   });
 });
-
-function visitLibraryPage() {
-  cy.visit("/data-studio/library");
-  H.DataStudio.Library.libraryPage().should("be.visible");
-}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/LibrarySectionLayout.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/LibrarySectionLayout.tsx
@@ -84,19 +84,16 @@ export function LibrarySectionLayout() {
   );
   const {
     tree: tablesTree,
-    hasChildren: hasTables,
     isLoading: loadingTables,
     error: tablesError,
   } = useBuildTreeForCollection(tableCollection);
   const {
     tree: metricsTree,
-    hasChildren: hasMetrics,
     isLoading: loadingMetrics,
     error: metricsError,
   } = useBuildTreeForCollection(metricCollection);
   const {
     tree: snippetTree,
-    hasChildren: hasSnippets,
     isLoading: loadingSnippets,
     error: snippetsError,
   } = useBuildSnippetTree();
@@ -107,13 +104,10 @@ export function LibrarySectionLayout() {
     searchProps: ["name"],
   });
 
-  const libraryHasContent = hasTables || hasMetrics || hasSnippets;
   const isLoading = loadingTables || loadingMetrics || loadingSnippets;
   useErrorHandling(tablesError || metricsError || snippetsError);
-  const filterReturnedEmpty =
-    !!searchQuery && filteredTree.length === 0 && libraryHasContent;
-  const showEmptyState =
-    !isLoading && (!libraryHasContent || filterReturnedEmpty);
+  const filterReturnedEmpty = !!searchQuery && filteredTree.length === 0;
+  const showEmptyState = !isLoading && filterReturnedEmpty;
 
   const libraryColumnDef = useMemo<ColumnDef<TreeItem, ReactNode>[]>(
     () => [

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/hooks.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/hooks.ts
@@ -20,7 +20,6 @@ export const useBuildTreeForCollection = (
   collection?: Collection,
 ): {
   isLoading: boolean;
-  hasChildren?: boolean;
   tree: TreeItem[];
   error?: unknown;
 } => {
@@ -43,7 +42,6 @@ export const useBuildTreeForCollection = (
     return {
       isLoading,
       error,
-      hasChildren: items.data.length > 0,
       tree: [
         {
           name: collection.name,
@@ -68,7 +66,6 @@ export const useBuildTreeForCollection = (
 export const useBuildSnippetTree = (): {
   isLoading: boolean;
   tree: TreeItem[];
-  hasChildren?: boolean;
   error?: unknown;
 } => {
   const {
@@ -99,7 +96,6 @@ export const useBuildSnippetTree = (): {
       isLoading: false,
       error,
       tree: buildSnippetTree(snippetCollections, snippets),
-      hasChildren: snippets.length > 0 || snippetCollections.length > 1,
     };
   }, [
     loadingSnippets,


### PR DESCRIPTION
### Description
Changes the empty state of the library to always show the top level containers, even if they are all empty

### How to verify
1. Start a new instance and create the library
2. See the library page has no content, but still shows Data, Metrics, and SQL Snippets folders

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
