### PR TITLE
Prepare backend in e2e stress test

### DIFF
--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -116,17 +116,12 @@ jobs:
         uses: ./.github/actions/prepare-frontend
 
       - name: Prepare back-end environment
-        if: ${{ needs.determine-test-type.outputs.type == 'component' }}
         uses: ./.github/actions/prepare-backend
+
       - name: Build Embedding SDK package
         if: ${{ needs.determine-test-type.outputs.type == 'component' }}
         run: yarn build-embedding-sdk-package
 
-      - name: Prepare JDK 21
-        uses: actions/setup-java@v4
-        with:
-          java-version: 21
-          distribution: "temurin"
       - name: Prepare Cypress environment
         id: cypress-prep
         uses: ./.github/actions/prepare-cypress


### PR DESCRIPTION
E2E stress-test runs are failing in some environments because the E2E test environment setup introduced in #66431 now relies on reading deps.edn, which requires clojure to be available.

We already setup the JDK, we may as well setup the full backend. It's super-duper quick with caching anyway.

[Here's a successful run with the fix](https://github.com/metabase/metabase/actions/runs/20155135570)