### PR TITLE
docs: embedding renames

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -204,10 +204,15 @@ Metabase's reference documentation.
 
 - [Embedding overview](./embedding/start.md)
 - [Embedding introduction](./embedding/introduction.md)
-- [Interactive embedding](./embedding/interactive-embedding.md)
-- [Interactive embedding quick start](./embedding/interactive-embedding-quick-start-guide.md)
-- [Static embedding](./embedding/static-embedding.md)
-- [Parameters for static embeds](./embedding/static-embedding-parameters.md)
+- [Modular embedding](./embedding/modular-embedding.md)
+- [Modular embedding SDK](./embedding/sdk/introduction.md)
+- Full app embedding
+  - [Full app embedding overview](./embedding/full-app-embedding.md)
+  - [Full app embedding quick start](./embedding/full-app-embedding-quick-start-guide.md)
+- Static embedding
+  - [Static embedding overview](./embedding/static-embedding.md)
+  - [Parameters for static embeds](./embedding/static-embedding-parameters.md)
+  - [Translate embedded dashboards and questions](./embedding/translations.md)
 - [Securing embedded Metabase](./embedding/securing-embeds.md)
 
 ### Configuration

--- a/docs/cloud/how-billing-works.md
+++ b/docs/cloud/how-billing-works.md
@@ -60,9 +60,9 @@ A user account is any account which has been added to your Metabase instance (ma
 
 ## How billing works with embedding
 
-Interactive Embedding requires viewers to sign in to your Metabase, which means they will count as users for billing purposes.
+Full app embedding and modular embedding (unless using Guest embeds) requires viewers to sign in to your Metabase, which means they will count as users for billing purposes.
 
-Static Embedding doesn’t require viewers to sign in to your Metabase, which means they won’t count as additional users for billing purposes.
+Guest Embedding doesn’t require viewers to sign in to your Metabase, which means they won’t count as additional users for billing purposes.
 
 ## How we count active user accounts each day
 

--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -1638,8 +1638,8 @@ Should new email notifications be sent to admins, for all new SSO users?
 
 Value for the session cookie's `SameSite` directive.
 
-See [Embedding Metabase in a different domain](../embedding/interactive-embedding.md#embedding-metabase-in-a-different-domain).
-        Read more about [interactive Embedding](../embedding/interactive-embedding.md).
+See [Embedding Metabase in a different domain](../embedding/full-app-embedding.md#embedding-metabase-in-a-different-domain).
+        Read more about [interactive Embedding](../embedding/full-app-embedding.md).
         Learn more about [SameSite cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite).
 
 ### `MB_SESSION_COOKIES`

--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -1639,7 +1639,7 @@ Should new email notifications be sent to admins, for all new SSO users?
 Value for the session cookie's `SameSite` directive.
 
 See [Embedding Metabase in a different domain](../embedding/full-app-embedding.md#embedding-metabase-in-a-different-domain).
-        Read more about [interactive Embedding](../embedding/full-app-embedding.md).
+        Read more about [modular embedding](../embedding/full-app-embedding.md).
         Learn more about [SameSite cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite).
 
 ### `MB_SESSION_COOKIES`

--- a/docs/dashboards/actions.md
+++ b/docs/dashboards/actions.md
@@ -54,7 +54,7 @@ You can add as many buttons as you want, and wire them up to one or more filters
 
 While you can add actions to dashboards and use them in your Metabase, actions won't work on dashboards accessed via [public links](./introduction.md#sharing-dashboards-with-public-links), or dashboards in static embeds.
 
-If you want people outside of your Metabase to use an action, you can create a [public form for an action](../actions/custom.md#make-public), or expose actions via [interactive embedding](../embedding/interactive-embedding.md).
+If you want people outside of your Metabase to use an action, you can create a [public form for an action](../actions/custom.md#make-public), or expose actions via [Full app embedding](../embedding/full-app-embedding.md).
 
 ## Further reading
 

--- a/docs/embedding/full-app-embedding-quick-start-guide.md
+++ b/docs/embedding/full-app-embedding-quick-start-guide.md
@@ -1,10 +1,12 @@
 ---
-title: "Interactive embedding quickstart"
+title: "Full app embedding quickstart"
+redirect_from:
+  - /docs/latest/embedding/interactive-embedding-quickstart
 ---
 
-# Interactive embedding quickstart
+# Full app embedding quickstart
 
-> If you are just starting out with Metabase embedding, consider using [Embedded Analytics JS](./embedded-analytics-js.md) - an improved, more customizable option for embedding interactive Metabase elements. Interactive embedding remains fully supported.
+> If you are just starting out with Metabase embedding, consider using [Modular embedding](./modular-embedding.md) - an improved, more customizable option for embedding Metabase components.
 
 You'll embed the full Metabase application in your app. Once logged in, people can view a Metabase dashboard in your web app, and be able to use the full Metabase application to explore their data, and only their data.
 
@@ -17,7 +19,7 @@ You'll embed the full Metabase application in your app. Once logged in, people c
 
 The code featured in this guide can be found in our [sample repo](https://github.com/metabase/metabase-nodejs-express-interactive-embedding-sample).
 
-## Set up SSO and interactive embedding in Metabase
+## Set up SSO and full app embedding in Metabase
 
 ### Have a dashboard ready to embed
 
@@ -27,21 +29,21 @@ Visit that dashboard and make a note of its URL, e.g. `/dashboard/1-e-commerce-i
 
 You could also use the dashboard's [Entity ID](../installation-and-operation/serialization.md#metabase-uses-entity-ids-to-identify-and-reference-metabase-items). On the dashboard, click on the **info** button. On the **Overview** tab, look for the dashboard's **Entity ID**. Copy that Entity ID. You'll use that Entity ID in the iframe's `src` URL: (e.g., `src=/dashboard/entity/[Entity ID]`).
 
-### Enable interactive embedding
+### Enable full app embedding
 
-In Metabase, click on the **gear** icon in the upper right and go to **Admin > Embedding > Interactive Embedding** and toggle on **Enable interactive embedding**.
+In Metabase, click on the **gear** icon in the upper right and go to **Admin > Embedding** and toggle on **Enable full app embedding**.
 
 Under **Authorized origins**, add the URL of the website or web app where you want to embed Metabase. If you're running your app locally, you can add localhost and specify the port number, e.g. `http://localhost:8080`.
 
 #### SameSite configuration
 
-If you're embedding Metabase in a different domain, you may need to [set the session cookie's SameSite value to `none`](./interactive-embedding.md#embedding-metabase-in-a-different-domain)
+If you're embedding Metabase in a different domain, you may need to [set the session cookie's SameSite value to `none`](./full-app-embedding.md#embedding-metabase-in-a-different-domain).
 
 ### Set up SSO with JWT in your Metabase
 
 #### Enable authentication with JWT
 
-While still in the **Interactive embedding** section, click on **Authentication** under **Related settings**.
+While still in the **Embedding settings** section, scroll down and click on **Authentication** under **Related settings**.
 
 On the card that says **JWT**, click the **Setup** button (you may have to scroll down to view the JWT card).
 
@@ -151,7 +153,7 @@ How to test: Sign in to your app and visit the `/analytics` route. You should se
 
 ## Set up a group in Metabase
 
-Now that you have SSO and interactive embedding set up, it's time to set up groups so that you can apply permissions to your embedded Metabase entities (questions, dashboards, collections, and so on).
+Now that you have SSO and full app embedding set up, it's time to set up groups so that you can apply permissions to your embedded Metabase entities (questions, dashboards, collections, and so on).
 
 ### Add a `groups` key to your token
 
@@ -243,7 +245,7 @@ Log in to your app, navigate to `/analytics`. The dashboard will now present dif
 
 ## Hiding Metabase elements
 
-You can decide to [show or hide various Metabase elements](./interactive-embedding.md#showing-or-hiding-metabase-ui-components), like whether to show the nav bar, search or the **+New** button, and so on.
+You can decide to [show or hide various Metabase elements](./full-app-embedding.md#showing-or-hiding-metabase-ui-components), like whether to show the nav bar, search or the **+New** button, and so on.
 
 For example, to hide the logo and the top navigation bar of your embedded Metabase, you'd append the query string parameters `?logo=false&top_nav=false` to the `return_to` URL that you include in the SSO redirect.
 

--- a/docs/embedding/full-app-embedding.md
+++ b/docs/embedding/full-app-embedding.md
@@ -1,31 +1,32 @@
 ---
-title: Interactive embedding
+title: Full app embedding
 redirect_from:
   - /docs/latest/enterprise-guide/full-app-embedding
   - /docs/latest/embedding/full-app-embedding
+  - /docs/latest/embedding/interactive-embedding
 ---
 
-# Interactive embedding
+# Full app embedding
 
-{% include plans-blockquote.html feature="Interactive embedding" convert_pro_link_to_embbedding=true %}
+{% include plans-blockquote.html feature="Full app embedding" convert_pro_link_to_embbedding=true %}
 
 {% include shared/in-page-promo-embedding-workshop.html %}
 
-**Interactive embedding** lets you embed the entire Metabase app in an iframe. Interactive embedding integrates your [permissions](../permissions/introduction.md) and [SSO](../people-and-groups/start.md#authentication) to give people the right level of access to [query](../questions/query-builder/editor.md) and [drill-down](https://www.metabase.com/learn/metabase-basics/querying-and-dashboards/questions/drill-through) into your data.
+**Full app embedding** (previously called "interactive embedding") lets you embed the entire Metabase app in an iframe. Full app embedding integrates your [permissions](../permissions/introduction.md) and [SSO](../people-and-groups/start.md#authentication) to give people the right level of access to [query](../questions/query-builder/editor.md) and [drill-down](https://www.metabase.com/learn/metabase-basics/querying-and-dashboards/questions/drill-through) into your data.
 
-> If you are just starting out with Metabase embedding, consider using [Embedded Analytics JS](./embedded-analytics-js.md) instead of interactive embedding - it's an improved, more customizable option for embedding interactive Metabase elements. Interactive embedding remains fully supported.
+> If you are just starting out with Metabase embedding, consider using [Modular embedding](./modular-embedding.md) instead of full app embedding - it's an improved, more customizable option for embedding individual Metabase components.
 
-## Interactive embedding demo
+## Full app embedding demo
 
-To get a feel for what you can do with interactive embedding, check out our [interactive embedding demo](https://www.metabase.com/embedding-demo).
+To get a feel for what you can do with full app embedding, check out our [Full app embedding demo](https://www.metabase.com/embedding-demo).
 
 To see the query builder in action, click on **Reports** > **+ New** > **Question**.
 
 ## Quick start
 
-Check out the [Interactive embedding quick start](./interactive-embedding-quick-start-guide.md).
+Check out the [Full app embedding quick start](./full-app-embedding-quick-start-guide.md).
 
-## Prerequisites for interactive embedding
+## Prerequisites for full app embedding
 
 1. Make sure you have a [license token](../installation-and-operation/activating-the-enterprise-edition.md) for a [Pro or Enterprise plan](https://store.metabase.com/checkout/login-details).
 2. Organize people into Metabase [groups](../people-and-groups/start.md).
@@ -36,10 +37,10 @@ If you're dealing with a [multi-tenant](https://www.metabase.com/learn/metabase-
 
 If you have your app running locally, and you're using the Pro Cloud version, or hosting Metabase and your app in different domains, you'll need to set your Metabase environment's session cookie SameSite option to "none".
 
-## Enabling interactive embedding in Metabase
+## Enabling full app embedding in Metabase
 
-1. Go to **Admin > Embedding > Interactive**.
-2. Click **Enable interactive embedding**.
+1. Go to **Admin > Embedding**.
+2. Click **Enable Full app embedding**.
 3. Under **Authorized origins**, add the URL of the website or web app where you want to embed Metabase (such as `https://*.example.com`).
 
 ## Setting up embedding on your website
@@ -50,13 +51,13 @@ If you have your app running locally, and you're using the Pro Cloud version, or
 2. Optional: Depending on the way your web app is set up, set [environment variables](../configuring-metabase/environment-variables.md) to:
    - [Add your license token](../configuring-metabase/environment-variables.md#mb_premium_embedding_token).
    - [Embed Metabase in a different domain](#embedding-metabase-in-a-different-domain).
-   - [Secure your interactive embed](#securing-interactive-embeds).
+   - [Secure your embed](#securing-full-app-embeds).
 3. Optional: Enable communication to and from the embedded Metabase using supported [`postMessage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) messages:
    - [From Metabase](#supported-postmessage-messages-from-embedded-metabase)
    - [To Metabase](#supported-postmessage-messages-to-embedded-metabase)
 4. Optional: Set parameters to [show or hide Metabase UI components](#showing-or-hiding-metabase-ui-components).
 
-Once you're ready to roll out your interactive embed, make sure that people **allow** browser cookies from Metabase, otherwise they won't be able to log in.
+Once you're ready to roll out your full app embed, make sure that people **allow** browser cookies from Metabase, otherwise they won't be able to log in.
 
 ### Pointing an iframe to a Metabase URL
 
@@ -120,7 +121,7 @@ https://metabase.example.com/auth/sso?jwt=<token>&redirect=%2Fdashboard%2F1%3Ffi
 
 To make sure that your embedded Metabase works in all browsers, put Metabase and the embedding app in the same top-level domain (TLD). The TLD is indicated by the last part of a web address, like `.com` or `.org`.
 
-Note that your interactive embed must be compatible with Safari to run on _any_ browser in iOS (such as Chrome on iOS).
+Note that your full app embed must be compatible with Safari to run on _any_ browser in iOS (such as Chrome on iOS).
 
 ## Embedding Metabase in a different domain
 
@@ -142,9 +143,9 @@ If you're using Safari, you'll need to [allow cross-site tracking](https://suppo
 
 Learn more about [SameSite cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite).
 
-## Securing interactive embeds
+## Securing full app embeds
 
-Metabase uses HTTP cookies to authenticate people and keep them signed into your embedded Metabase, even when someone closes their browser session. If you enjoy diagrammed auth flows, check out [Interactive embedding with SSO](./securing-embeds.md).
+Metabase uses HTTP cookies to authenticate people and keep them signed into your embedded Metabase, even when someone closes their browser session. If you enjoy diagrammed auth flows, check out [Full app embedding with SSO](./securing-embeds.md).
 
 To limit the amount of time that a person stays logged in, set [`MAX_SESSION_AGE`](../configuring-metabase/environment-variables.md#max_session_age) to a number in minutes. The default value is 20,160 (two weeks).
 
@@ -231,18 +232,18 @@ Additionally, each person within a single customer account could also be a membe
 
 ## Showing or hiding Metabase UI components
 
-See [interactive UI components](./interactive-ui-components.md)
+See [full app UI components](./full-app-ui-components.md). For more granular control over embedded components, consider using [Modular embedding](./modular-embedding.md) instead.
 
 ## Reference apps
 
-To build a sample interactive embed using SSO with JWT, see our reference apps:
+To build a sample full app embed using SSO with JWT, see our reference apps:
 
-- [Node.js + Express](https://github.com/metabase/metabase-nodejs-express-interactive-embedding-sample) (with [quick start guide](./interactive-embedding-quick-start-guide.md))
+- [Node.js + Express](https://github.com/metabase/metabase-nodejs-express-interactive-embedding-sample) (with [quick start guide](./full-app-embedding-quick-start-guide.md))
 - [Node.js + React](https://github.com/metabase/sso-examples/tree/master/app-embed-example)
 
 ## Further reading
 
-- [Interactive embedding quick start](./interactive-embedding-quick-start-guide.md)
+- [Full app embedding quick start](./full-app-embedding-quick-start-guide.md)
 - [Strategies for delivering customer-facing analytics](https://www.metabase.com/learn/metabase-basics/embedding/overview).
 - [Permissions strategies](https://www.metabase.com/learn/metabase-basics/administration/permissions/strategy).
 - [Customizing Metabase's appearance](../configuring-metabase/appearance.md).

--- a/docs/embedding/full-app-ui-components.md
+++ b/docs/embedding/full-app-ui-components.md
@@ -2,7 +2,7 @@
 title: Full app embedding UI components
 description: Customize the UI components in your full app Metabase embed by adding parameters to the embedding URL.
 redirect_from:
-  - /docs/latest/embedding/interactive-components
+  - /docs/latest/embedding/interactive-ui-components
 ---
 
 # Full app embedding UI components

--- a/docs/embedding/full-app-ui-components.md
+++ b/docs/embedding/full-app-ui-components.md
@@ -1,13 +1,15 @@
 ---
-title: Interactive embedding UI components
-description: Customize the UI components in your interactive Metabase embed by adding parameters to the embedding URL.
+title: Full app embedding UI components
+description: Customize the UI components in your full app Metabase embed by adding parameters to the embedding URL.
+redirect_from:
+  - /docs/latest/embedding/interactive-components
 ---
 
-# Interactive embedding UI components
+# Full app embedding UI components
 
-To change the interface of your interactive embed, you can add parameters to the end of your embedding URL. If you want to change the colors or fonts in your embed, see [Customizing appearance](../configuring-metabase/appearance.md).
+To change the interface of your full app embed, you can add parameters to the end of your embedding URL. If you want to change the colors or fonts in your embed, see [Customizing appearance](../configuring-metabase/appearance.md).
 
-> If you are just starting out with Metabase embedding, consider using [Embedded Analytics JS](./embedded-analytics-js.md) instead of interactive embedding - it's an improved, more customizable option for embedding interactive Metabase elements. Interactive embedding remains fully supported.
+> For more granular control of embedded components, consider using [Modular embedding](./modular-embedding.md) instead of full app embedding - it's an improved, more customizable option for embedding Metabase elements.
 
 For example, you can disable Metabase's [top nav bar](#top_nav) and [side nav menu](#side_nav) like this:
 

--- a/docs/embedding/introduction.md
+++ b/docs/embedding/introduction.md
@@ -12,11 +12,11 @@ Here are the different ways you can embed Metabase.
 
 {% include shared/in-page-promo-embedding-workshop.html %}
 
-## Embedded analytics JS
+## Modular embedding
 
-With [Embedded analytics JS](./embedded-analytics-js.md), you can embed individual Metabase components in your web app with JavaScript — no React required. Choose from dashboards, questions, or the query builder, and configure per‑component options like drill‑through, parameters, downloads, and theming. Embedded Analytics JS integrates with [SSO](securing-embeds.md) and [data permissions](../permissions/embedding.md).
+With [modular embedding](./modular-embedding.md), you can embed individual Metabase components in your web app. Choose from dashboards, questions, or the query builder, and configure per‑component options like drill‑through, parameters, downloads, and theming. Modular embedding integrates with [SSO](securing-embeds.md) and [data permissions](../permissions/embedding.md).
 
-**When to use Embedded analytics JS**: You want to [offer multi-tenant, self-service analytics](https://www.metabase.com/blog/why-full-app-embedding), you’re not using React (or want a drop‑in script) and want to embed Metabase components with per‑component controls and theming.
+**When to use modular embedding**: You want to [offer multi-tenant, self-service analytics](https://www.metabase.com/blog/why-full-app-embedding), you want a drop‑in script, and want to embed Metabase components with per‑component controls and theming.
 
 ## Static embedding
 
@@ -30,40 +30,36 @@ If you'd like to share your data with the good people of the internet, admins ca
 
 **When to use public links and embeds**: public links and embeds are good for one-off charts and dashboards. Admins can use them when you just need to show someone a chart or dashboard without giving people access to your Metabase. And you don't care who sees the data; you want to make those stats available to everyone.
 
-## Interactive embedding
+## Full app embedding
 
-[Interactive embedding](./interactive-embedding.md) allows you to embed the entire Metabase app in an iframe, and integrate Metabase SSO with your app's authentication.
+[Full app embedding](./full-app-embedding.md) allows you to embed the entire Metabase app in an iframe, and integrate Metabase SSO with your app's authentication.
 
 ## Comparison of embedding types
 
-| Action                                                                                                                          | [React SDK](./sdk/introduction.md) | [JS](./embedded-analytics-js.md) | [Interactive](./interactive-embedding.md) | [Static](./static-embedding.md) | [Public](../embedding/public-links.md) |
-| ------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- | -------------------------------- | ----------------------------------------- | ------------------------------- | -------------------------------------- |
-| Display charts and dashboards                                                                                                   | ✅                                 | ✅                               | ✅                                        | ✅                              | ✅                                     |
-| Display interactive [filter widgets](https://www.metabase.com/glossary/filter-widget)                                           | ✅                                 | ✅                               | ✅                                        | ✅                              | ✅                                     |
-| Export results\*                                                                                                                | ✅                                 | ✅                               | ✅                                        | ✅                              | ✅                                     |
-| Restrict data with [locked filters](./static-embedding-parameters.md#restricting-data-in-a-static-embed-with-locked-parameters) | ❌                                 | ❌                               | ❌                                        | ✅                              | ❌                                     |
-| [Data segregation](../permissions/embedding.md)                                                                                 | ✅                                 | ✅                               | ✅                                        | ❌                              | ❌                                     |
-| Use the [drill-through menu](https://www.metabase.com/learn/metabase-basics/querying-and-dashboards/questions/drill-through)    | ✅                                 | ✅                               | ✅                                        | ❌                              | ❌                                     |
-| Self-serve via [query builder](../questions/query-builder/editor.md)                                                            | ✅                                 | ✅                               | ✅                                        | ❌                              | ❌                                     |
-| [Basic appearance customization](../configuring-metabase/appearance.md)\*\*                                                     | ✅                                 | ✅                               | ✅                                        | ✅                              | ✅                                     |
-| [Advanced theming](./sdk/appearance.md)                                                                                         | ✅                                 | ✅                               | ❌                                        | ❌                              | ❌                                     |
-| View usage of embeds with [usage analytics](../usage-and-performance-tools/usage-analytics.md)                                  | ✅                                 | ✅                               | ✅                                        | ❌                              | ❌                                     |
-| Embed individual Metabase components                                                                                            | ✅                                 | ✅                               | ❌                                        | ❌                              | ❌                                     |
-| Manage access and interactivity per component                                                                                   | ✅                                 | ✅                               | ❌                                        | ❌                              | ❌                                     |
-| Custom layouts                                                                                                                  | ✅                                 | ❌                               | ❌                                        | ❌                              | ❌                                     |
-| Customize behavior with [plugins](./sdk/plugins.md)                                                                             | ✅                                 | ❌                               | ❌                                        | ❌                              | ❌                                     |
+| Action                                                                                                                          | [React SDK](./sdk/introduction.md) | [Modular](./modular-embedding.md) | [Full app](./full-app-embedding.md) | [Static](./static-embedding.md) | [Public](../embedding/public-links.md) |
+| ------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- | --------------------------------- | ----------------------------------- | ------------------------------- | -------------------------------------- |
+| Display charts and dashboards                                                                                                   | ✅                                 | ✅                                | ✅                                  | ✅                              | ✅                                     |
+| Display interactive [filter widgets](https://www.metabase.com/glossary/filter-widget)                                           | ✅                                 | ✅                                | ✅                                  | ✅                              | ✅                                     |
+| Export results\*                                                                                                                | ✅                                 | ✅                                | ✅                                  | ✅                              | ✅                                     |
+| Restrict data with [locked filters](./static-embedding-parameters.md#restricting-data-in-a-static-embed-with-locked-parameters) | ❌                                 | ❌                                | ❌                                  | ✅                              | ❌                                     |
+| [Data segregation](../permissions/embedding.md)                                                                                 | ✅                                 | ✅                                | ✅                                  | ❌                              | ❌                                     |
+| Use the [drill-through menu](https://www.metabase.com/learn/metabase-basics/querying-and-dashboards/questions/drill-through)    | ✅                                 | ✅                                | ✅                                  | ❌                              | ❌                                     |
+| Self-serve via [query builder](../questions/query-builder/editor.md)                                                            | ✅                                 | ✅                                | ✅                                  | ❌                              | ❌                                     |
+| [Basic appearance customization](../configuring-metabase/appearance.md)\*\*                                                     | ✅                                 | ✅                                | ✅                                  | ✅                              | ✅                                     |
+| [Advanced theming](./sdk/appearance.md)                                                                                         | ✅                                 | ✅                                | ❌                                  | ❌                              | ❌                                     |
+| View usage of embeds with [usage analytics](../usage-and-performance-tools/usage-analytics.md)                                  | ✅                                 | ✅                                | ✅                                  | ❌                              | ❌                                     |
+| Embed individual Metabase components                                                                                            | ✅                                 | ✅                                | ❌                                  | ❌                              | ❌                                     |
+| Manage access and interactivity per component                                                                                   | ✅                                 | ✅                                | ❌                                  | ❌                              | ❌                                     |
+| Custom layouts                                                                                                                  | ✅                                 | ❌                                | ❌                                  | ❌                              | ❌                                     |
+| Customize behavior with [plugins](./sdk/plugins.md)                                                                             | ✅                                 | ❌                                | ❌                                  | ❌                              | ❌                                     |
 
 \* Each embedding type allows data downloads by default, but only [Pro and Enterprise](https://www.metabase.com/pricing/) plans can disable data downloads.
 
 \*\* Requires a [Pro and Enterprise](https://www.metabase.com/pricing/) plan for any embedding type.
 
-### Embedded analytics SDK vs JS
+## Switching from static embedding to Modular embedding
 
-When deciding between the Embedded analytics SDK and Embedded analytics JS: if your app uses React, you should use the SDK. Otherwise, use the JS library. The JS library uses the SDK under the hood, but you can have more control with React and the SDK.
-
-## Switching from static embedding to Embedded Analytics JS
-
-[Embedded Analytics JS](./embedded-analytics-js.md) requires authentication via single sign-on (SSO), so you'll need to set that up both in your Metabase and in your application's server. Check out our [Modular embedding authentication](../embedding/sdk/authentication.md).
+[Modular embedding](./modular-embedding.md) requires authentication via single sign-on (SSO), so you'll need to set that up both in your Metabase and in your application's server. Check out our [Modular embedding authentication](../embedding/sdk/authentication.md).
 
 ## Further reading
 

--- a/docs/embedding/modular-embedding.md
+++ b/docs/embedding/modular-embedding.md
@@ -1,20 +1,23 @@
 ---
-title: Embedded analytics JS
-summary: Getting started with Embedded Analytics JS for embedding Metabase entities into external applications
+title: Modular embedding
+summary: Getting started with modular embedding for embedding Metabase entities into external applications
+redirect_from:
+  - /docs/latest/embedding/embedded-analytics-js
 ---
 
-# Embedded analytics JS
+# Modular embedding
 
-{% include plans-blockquote.html feature="Embedded analytics JS" convert_pro_link_to_embbedding=true %}
+{% include plans-blockquote.html feature="Modular embedding" convert_pro_link_to_embbedding=true %}
 
-Embedded analytics JS lets you embed Metabase entities like questions, dashboards, or even the query builder into your own application using customizable components.
+Modular embedding lets you embed Metabase entities like questions, dashboards, or even the query builder into your own application using customizable components.
 
 {% include shared/in-page-promo-embedding-workshop.html %}
 
-Embedded Analytics JS is a JavaScript library built on top of Metabase's [Embedded Analytics React SDK](./sdk/introduction.md). But it does not require using React or setting up full SDK embedding.
-Unlike with [interactive embedding](./interactive-embedding.md), where you embed the entire Metabase app in an iframe, Embedded Analytics JS lets you choose from a set of predefined components like a single chart, a dashboard with optional drill-through, or query builder, and customize those components.
+Modular embedding allows you to embed individual Metabase components (like questions, dashboards, or a query builder) using a simple drop-in script. You don't need to write embedding code on your own - just use the built-in wizard to create a code snippet, and paste it into your app.
 
-Embedded Analytics JS uses [JWT](../people-and-groups/authenticating-with-jwt.md) or [SAML](../people-and-groups/authenticating-with-saml.md) to authenticate people and automatically apply the right permissions.
+Unlike with [full app embedding](./full-app-embedding.md), where you embed the entire Metabase app in an iframe, modular embedding lets you choose from a set of predefined components like a single chart, a dashboard with optional drill-through, or query builder, and customize those components.
+
+Modular embedding uses [JWT](../people-and-groups/authenticating-with-jwt.md) or [SAML](../people-and-groups/authenticating-with-saml.md) to authenticate people and automatically apply the right permissions.
 
 Currently you can choose to embed:
 
@@ -28,18 +31,18 @@ Currently you can choose to embed:
 
 You can also follow the setup guide directly in Metabase in **Admin settings > Embedding > Setup guide**. We're recording the steps here for convenience.
 
-### 1. Enable Embedded Analytics JS
+### 1. Enable modular embedding
 
-1. In Metabase, go to **Admin settings > Embedding > Modular embedding**.
-2. Toggle on **Embedded Analytics JS**.
+1. In Metabase, go to **Admin settings > Embedding**.
+2. Toggle on **Enable modular embedding**.
 3. Under **Cross-Origin Resource Sharing (CORS)**, add the URLs of the websites where you want to embed Metabase (such as `https://*.example.com`). For testing embeds, you can use `localhost` which is always included in CORS policy.
 4. If you are embedding Metabase components in a domain that's different from your Metabase's domain (including when you're testing the app locally but use Metabase Cloud), go to **Admin settings > Embedding > Security** and set **SameSite cookie** to **None**.
 
 ### 2. Create a new embed
 
-1. In Metabase, go to **Admin > Embedding > Modular embedding**, and select **New embed** next to **Embedded analytics JS**.
+1. In Metabase, open a command palette with Ctrl/Cmd+K, type "New embed" and select "new embed" command. This will open the interactive wizard that you can use to set up your embed.
 
-   If you're planning to embed an existing question or dashboard, you can instead go straight to that question or dashboard, click on the **Share** button, and choose **Embedded Analytics JS**.
+   If you're planning to embed an existing question or dashboard, you can instead go straight to that question or dashboard, click on the **Share** button, and choose **Embed**.
 
 2. Choose the _type_ of entity to embed:
 
@@ -83,17 +86,17 @@ Add the code snippet into your app, and refresh the page.
 
 Each end-user must have their own Metabase account.
 
-The problem with having end-users share a Metabase account is that, even if you filter data on the client side via the Embedded analytics JS, all end-users will still have access to the session token, which they could use to access Metabase directly via the API to get data they’re not supposed to see.
+The problem with having end-users share a Metabase account is that, even if you filter data on the client side via the modular embedding, all end-users will still have access to the session token, which they could use to access Metabase directly via the API to get data they’re not supposed to see.
 
 If each end-user has their own Metabase account, however, you can configure permissions in Metabase and everyone will only have access to the data they should.
 
-In addition to this, we consider shared accounts to be unfair usage. Fair usage of Embedded Analytics JS involves giving each end-user of the embedded analytics their own Metabase account.
+In addition to this, we consider shared accounts to be unfair usage. Fair usage of modular embedding involves giving each end-user of the embedded analytics their own Metabase account.
 
 ## Embed code snippets
 
-The code snippets to embed Metabase entities using Embedded Analytics JS should have three parts:
+The code snippets to embed Metabase entities using modular embedding should have three parts:
 
-1. Loading the Embedded Analytics JS library from your Metabase instance.
+1. Loading the modular embedding library from your Metabase instance.
 2. Global configuration settings to be used for all embeds, like the URL of your Metabase instance, appearance themes, etc. See [Configuring embeds](#configuring-embeds).
 3. Components for Metabase entities to be embedded, with their parameters. See [Components](#components).
 
@@ -131,7 +134,7 @@ Note the `defer` attribute and the reference to your Metabase URL in the script 
 
 If you're embedding multiple entities in a single page, you only need to include the `<script>` tags once globally.
 
-You can also generate the code snippet for Embedded Analytics JS interactively in Metabase through **Admin > Embedding > Setup guide > Embed in your code**. Check out the [quickstart](#quickstart).
+You can also generate the code snippet for modular embedding interactively in Metabase through **Admin > Embedding > Setup guide > Embed in your code**. Check out the [quickstart](#quickstart).
 
 ## Customizing embeds
 

--- a/docs/embedding/sdk/ai-chat.md
+++ b/docs/embedding/sdk/ai-chat.md
@@ -1,21 +1,22 @@
 ---
-title: "Embedded analytics SDK - AI chat"
+title: "Modular embedding SDK - AI chat"
 summary: Embed an AI chat component in your app that can create queries from natural language questions.
 ---
 
-# Embedded analytics SDK - AI chat
+# Modular embedding SDK - AI chat
 
 ![Embedded AI chat](../images/ai-chat.png)
 
-{% include plans-blockquote.html feature="Embedded analytics SDK" sdk=true %}
+{% include plans-blockquote.html feature="Modular embedding SDK" sdk=true %}
 
-You can embed an AI chat in your application similar to [Metabot](../embedded-analytics-js.md) in Metabase.
+You can embed an AI chat in your application similar to [Metabot](../modular-embedding.md) in Metabase.
 
 Embedded Metabot is a more focused version of [Metabot](../../ai/metabot.md) designed to work well in an embedded context. Embedded Metabot can only display ad-hoc questions and metrics; it doesn't know about dashboards.
 
 To help embedded Metabot more easily find and focus on the data you care about most, select the collection containing the models and metrics it should be able to use to create queries.
 
 If you're embedding the Metabot component in an app, you can specify a different collection that embedded Metabot is allowed to use for creating queries.
+
 ## Chat preview
 
 You can check out a [demo of the AI chat component](https://embedded-analytics-sdk-demo.metabase.com/admin/analytics/new/ask-metabot) on our Shoppy demo site.

--- a/docs/embedding/sdk/authentication.md
+++ b/docs/embedding/sdk/authentication.md
@@ -56,12 +56,12 @@ Example using Next.js Pages Router:
 {% include_file "{{ dirname }}/snippets/next-js/pages-router-authentication-api-route.ts" %}
 ```
 
-#### Handling interactive and SDK embeds with the same endpoint
+#### Handling full app and SDK embeds with the same endpoint
 
-If you have an existing backend endpoint configured for interactive embedding and want to use the same endpoint for SDK embedding, you can differentiate between the requests by checking for the `response=json` query parameter that the SDK adds to its requests.
+If you have an existing backend endpoint configured for full app embedding and want to use the same endpoint for SDK embedding, you can differentiate between the requests by checking for the `response=json` query parameter that the SDK adds to its requests.
 
 - For SDK requests, you should return a JSON object with the JWT (`{ jwt: string }`).
-- For interactive embedding requests, you would proceed with the redirect.
+- For full app embedding requests, you would proceed with the redirect.
 
 Here's an example of an Express.js endpoint that handles both:
 
@@ -243,7 +243,7 @@ const authConfig = defineMetabaseAuthConfig({
 
 ### Update your JWT endpoint to handle SDK requests
 
-Your JWT endpoint must now handle both SDK requests and interactive embedding requests. The SDK adds a `response=json` query parameter to distinguish its requests. For SDK requests, return a JSON object with the JWT. For interactive embedding, continue redirecting as before.
+Your JWT endpoint must now handle both SDK requests and full app embedding requests. The SDK adds a `response=json` query parameter to distinguish its requests. For SDK requests, return a JSON object with the JWT. For full app embedding, continue redirecting as before.
 
 If you were using a custom `fetchRequestToken`, you'll need to update the endpoint to detect `req.query.response === "json"` for SDK requests.
 
@@ -269,7 +269,7 @@ app.get("/sso/metabase", async (req, res) => {
     // For SDK requests, return JSON object with jwt property
     res.status(200).json({ jwt: token });
   } else {
-    // For interactive embedding, redirect as before
+    // For full app embedding, redirect as before
     const ssoUrl = `${METABASE_INSTANCE_URL}/auth/sso?token=true&jwt=${token}`;
     res.redirect(ssoUrl);
   }

--- a/docs/embedding/sdk/collections.md
+++ b/docs/embedding/sdk/collections.md
@@ -1,10 +1,11 @@
 ---
-title: Embedded analytics SDK - collections
+title: Modular embedding SDK - collections
+summary: Embed Metabase collection browser in your application using the MetabaseProvider SDK component.
 ---
 
-# Embedded analytics SDK - collections
+# Modular embedding SDK - collections
 
-{% include plans-blockquote.html feature="Embedded analytics SDK" sdk=true %}
+{% include plans-blockquote.html feature="Modular embedding SDK" sdk=true %}
 
 ## Embedding a collection browser
 

--- a/docs/embedding/sdk/config.md
+++ b/docs/embedding/sdk/config.md
@@ -1,10 +1,11 @@
 ---
-title: Embedded analytics SDK - config
+title: Modular embedding SDK - config
+summary: Configure the Metabase modular embedding SDK with MetabaseProvider, set up authentication, handle global events, and reload embedded components.
 ---
 
-# Embedded analytics SDK - config
+# Modular embedding SDK - config
 
-{% include plans-blockquote.html feature="Embedded analytics SDK" sdk=true %}
+{% include plans-blockquote.html feature="Modular embedding SDK" sdk=true %}
 
 ## Passing a configuration object to `MetabaseProvider`
 

--- a/docs/embedding/sdk/dashboards.md
+++ b/docs/embedding/sdk/dashboards.md
@@ -1,10 +1,11 @@
 ---
-title: "Embedded analytics SDK - dashboards"
+title: "Modular embedding SDK - dashboards"
+summary: Embed static or interactive Metabase dashboards using the Modular embedding SDK. Customize dashboard layout, drill-through, and add custom actions.
 ---
 
-# Embedded analytics SDK - dashboards
+# Modular embedding SDK - dashboards
 
-{% include plans-blockquote.html feature="Embedded analytics SDK" sdk=true %}
+{% include plans-blockquote.html feature="Modular embedding SDK" sdk=true %}
 
 You can embed an interactive, editable, or static dashboard.
 
@@ -141,7 +142,7 @@ Creating a dashboard could be done with `useCreateDashboardApi` hook or `CreateD
 
 Use this hook if you'd like to have total control over the UI and settings.
 
-Until the Embedded analytics SDK is fully loaded and initialized, the hook returns `null`.
+Until the SDK is fully loaded and initialized, the hook returns `null`.
 
 #### API Reference
 

--- a/docs/embedding/sdk/introduction.md
+++ b/docs/embedding/sdk/introduction.md
@@ -1,24 +1,24 @@
 ---
-title: Embedded analytics SDK
+title: Modular embedding SDK
 redirect_from:
   - /docs/latest/embedding/sdk
 ---
 
-# Embedded analytics SDK
+# Modular embedding SDK
 
-{% include plans-blockquote.html feature="Embedded analytics SDK" sdk=true %}
+{% include plans-blockquote.html feature="Modular embedding SDK" sdk=true %}
 
-With the Embedded analytics SDK, you can embed individual Metabase components with React (like standalone charts, dashboards, the query builder, and more). You can manage access and interactivity per component, and you have advanced customization for seamless styling.
+With the modular embedding SDK, you can embed individual Metabase components with React (like standalone charts, dashboards, the query builder, and more). You can manage access and interactivity per component, and you have advanced customization for seamless styling.
 
-## Example apps built with the embedded analytics SDK
+## Example apps built with the modular embedding SDK
 
 To give you an idea of what's possible with the SDK, we've put together example sites at [metaba.se/sdk-demo](https://metaba.se/sdk-demo). Navigate between different shop websites. Check them out and poke around their products and analytics sections, as well as the New Question and New Dashboard options.
 
-![Pug and play example app built with embedded analytics SDK](../images/pug-and-play.png)
+![Pug and play example app built with modular embedding SDK](../images/pug-and-play.png)
 
 Here's the [Shoppy source code](https://github.com/metabase/shoppy).
 
-## Embedded analytics SDK prerequisites
+## Modular embedding SDK prerequisites
 
 - React application using React 18 or React 19.
 - Nodejs 20.x or higher.
@@ -26,10 +26,10 @@ Here's the [Shoppy source code](https://github.com/metabase/shoppy).
 
 ## Quickstarts
 
-The best way to get started with Embedded Analytics SDK depends on what you already have:
+The best way to get started with Modular embedding SDK depends on what you already have:
 
 - You have an app and a Metabase instance: go to [main quickstart](./quickstart.md)
-- You have an app but no Metabase: go to [quickstart with CLI](./quickstart-cli.md) 
+- You have an app but no Metabase: go to [quickstart with CLI](./quickstart-cli.md)
 - You don't have an app: go to [quickstart with a sample React app](./quickstart-with-sample-app.md)
 
 ## Installation
@@ -38,13 +38,13 @@ To use the SDK, you'll need to enable the SDK in Metabase, and install the SDK i
 
 ### Enable the SDK in Metabase
 
-1. Enable the Embedded analytics SDK by going to **Admin settings > Embedding > Modular**.
-2. Toggle on **SDK for React**.
+1. Enable the Modular embedding SDK by going to **Admin settings > Embedding**.
+2. Toggle on **Modular embedding SDK**.
 3. In **Cross-Origin Resource Sharing (CORS)**, enter the origins for your website or app where you want to allow SDK embedding, separated by a space. Localhost is automatically included.
 
 ### Install the SDK in your React application
 
-You can install the Embedded analytics SDK for React via npm. Make sure to use the dist-tag that corresponds to your Metabase version, example: 56-stable for Metabase 56:
+You can install the modular embedding SDK for React via npm. Make sure to use the dist-tag that corresponds to your Metabase version, example: 56-stable for Metabase 56:
 
 ```bash
 npm install @metabase/embedding-sdk-react@56-stable
@@ -58,7 +58,7 @@ yarn add @metabase/embedding-sdk-react@56-stable
 
 ### Resolving `@types/react` version mismatches
 
-In rare scenarios, the Embedding SDK and your application may use different major versions of `@types/react`, causing TypeScript conflicts.
+In rare scenarios, the modular embedding SDK and your application may use different major versions of `@types/react`, causing TypeScript conflicts.
 
 To enforce a single `@types/react` version across all dependencies, add an `overrides` (npm) or `resolutions` (Yarn) section to your `package.json` and specify the `@types/react` version your application uses.
 
@@ -89,7 +89,7 @@ Starting with Metabase 57, the SDK consists of two parts:
 - **SDK Package** – The `@metabase/embedding-sdk-react` npm package is a lightweight bootstrapper library. Its primary purpose is to load and run the main SDK Bundle code.
 - **SDK Bundle** – The full SDK code, served directly from your self-hosted Metabase instance or Metabase Cloud, and it's the part of the Metabase. This ensures that the main SDK code is always compatible with its corresponding Metabase instance.
 
-## Developing with the Embedded analytics SDK
+## Developing with the modular embedding SDK
 
 Start with one of the quickstarts, then see these pages for more info on components, theming, and more.
 
@@ -104,9 +104,9 @@ Start with one of the quickstarts, then see these pages for more info on compone
 - [Versioning](./version.md)
 - [Notes on Next.js](./next-js.md)
 
-## Embedded analytics SDK source code
+## Modular embedding SDK source code
 
-You can find the [Embedded analytics SDK source code in the Metabase repo](https://github.com/metabase/metabase/tree/master/enterprise/frontend/src/embedding-sdk).
+You can find the [Modular embedding SDK source code in the Metabase repo](https://github.com/metabase/metabase/tree/master/enterprise/frontend/src/embedding-sdk).
 
 ## Changelog
 
@@ -118,9 +118,9 @@ View the SDK's changelog:
 - [53-stable](https://github.com/metabase/metabase/blob/release-x.53.x/enterprise/frontend/src/embedding-sdk/CHANGELOG.md)
 - [52-stable](https://github.com/metabase/metabase/blob/release-x.52.x/enterprise/frontend/src/embedding-sdk/CHANGELOG.md)
 
-## Embedded analytics SDK on npm
+## Modular embedding SDK on npm
 
-Check out the Metabase Embedded analytics SDK on npm: [metaba.se/sdk-npm](https://metaba.se/sdk-npm).
+Check out the Metabase Modular embedding SDK on npm: [metaba.se/sdk-npm](https://metaba.se/sdk-npm).
 
 ## SDK limitations
 

--- a/docs/embedding/sdk/next-js.md
+++ b/docs/embedding/sdk/next-js.md
@@ -1,24 +1,25 @@
 ---
-title: Embedded analytics SDK - Using the SDK with Next.js
+title: Using the modular embedding SDK with Next.js
+summary: Set up the Modular embedding SDK with Next.js using App Router or Pages Router. Learn how to handle JWT authentication and server-side rendering.
 ---
 
-# Embedded analytics SDK - Using the SDK with Next.js
+# Using the modular embedding SDK with Next.js
 
-{% include plans-blockquote.html feature="Embedded analytics SDK" sdk=true %}
+{% include plans-blockquote.html feature="Modular embedding SDK" sdk=true %}
 
 {% include youtube.html id='UfL8okz36d0' %}
 
-Some notes on using the Embedded analytics SDK with [Next.js](https://nextjs.org/). The SDK is tested to work with Next.js 14, although it may work with other versions.
+Some notes on using the modular embedding SDK with [Next.js](https://nextjs.org/). The SDK is tested to work with Next.js 14, although it may work with other versions.
 
 See a [sample Next.js app that uses the SDK](https://github.com/metabase/metabase-nextjs-sdk-embedding-sample).
 
 ## SDK components with Server Side Rendering (SSR) or React Server Components
 
-As of Embedded Analytics SDK v57, SDK components automatically skip server-side rendering (SSR) and render only on the client.
+As of modular embedding SDK v57, SDK components automatically skip server-side rendering (SSR) and render only on the client.
 
 ### Compatibility layer for Server Side Rendering (SSR) (DEPRECATED)
 
-As of Embedded Analytics SDK 57, the compatibility layer for server-side rendering (SSR) is deprecated and no longer required. If you use the compatibility layer, change your imports from `@metabase/embedding-sdk-react/next` to `@metabase/embedding-sdk-react`.
+As of modular embedding SDK 57, the compatibility layer for server-side rendering (SSR) is deprecated and no longer required. If you use the compatibility layer, change your imports from `@metabase/embedding-sdk-react/next` to `@metabase/embedding-sdk-react`.
 
 ## Handling authentication
 

--- a/docs/embedding/sdk/plugins.md
+++ b/docs/embedding/sdk/plugins.md
@@ -1,12 +1,13 @@
 ---
-title: Embedded analytics SDK - plugins
+title: Modular embedding SDK - plugins
+summary: Customize modular embedding SDK components with plugins. Control click actions, link handling, and no-data illustrations globally or per-component.
 ---
 
-# Embedded analytics SDK - plugins
+# Modular embedding SDK - plugins
 
-{% include plans-blockquote.html feature="Embedded analytics SDK" sdk=true %}
+{% include plans-blockquote.html feature="Modular embedding SDK" sdk=true %}
 
-The Metabase Embedded analytics SDK supports plugins to customize the behavior of components. These plugins can be used in a global context or on a per-component basis.
+The Metabase modular embedding SDK supports plugins to customize the behavior of components. These plugins can be used in a global context or on a per-component basis.
 
 ## Plugin scope
 

--- a/docs/embedding/sdk/questions.md
+++ b/docs/embedding/sdk/questions.md
@@ -1,11 +1,11 @@
 ---
-title: "Embedded analytics SDK - questions"
-description: How to embed charts in your app with the Embedded analytics SDK.
+title: "Modular embedding SDK - questions"
+description: How to embed charts in your app with the Modular embedding SDK.
 ---
 
-# Embedded analytics SDK - questions
+# Modular embedding SDK - questions
 
-{% include plans-blockquote.html feature="Embedded analytics SDK" sdk=true %}
+{% include plans-blockquote.html feature="Modular embedding SDK" sdk=true %}
 
 There are different ways you can embed questions:
 
@@ -77,7 +77,7 @@ See [AI chat](./ai-chat.md).
 
 ## Customizing interactive questions
 
-By default, the Embedded analytics SDK provides a default layout for interactive questions that allows you to view your questions, apply filters and aggregations, and access functionality within the query builder.
+By default, the modular embedding SDK provides a default layout for interactive questions that allows you to view your questions, apply filters and aggregations, and access functionality within the query builder.
 
 Here's an example of using the `InteractiveQuestion` component with its default layout:
 

--- a/docs/embedding/sdk/quickstart-cli.md
+++ b/docs/embedding/sdk/quickstart-cli.md
@@ -1,10 +1,11 @@
 ---
-title: Embedded analytics SDK - CLI quickstart
+title: Modular embedding SDK - CLI quickstart
+summary: Get started with the Modular embedding SDK using a single CLI command. Automatically set up Metabase with Docker, create dashboards, and generate React components.
 ---
 
-# Embedded analytics SDK - CLI quickstart
+# Modular embedding SDK - CLI quickstart
 
-{% include plans-blockquote.html feature="Embedded analytics SDK" sdk=true convert_pro_link_to_embbedding=true %}
+{% include plans-blockquote.html feature="Modular embedding SDK" sdk=true convert_pro_link_to_embbedding=true %}
 
 We built a single command to spin up a Metabase and help you get an embedded dashboard in your app. This setup with API keys won't work in production; it's only intended for you to quickly try out the SDK on your local machine. A production setup requires a Pro/Enterprise license, and SSO with JWT.
 

--- a/docs/embedding/sdk/quickstart-with-sample-app.md
+++ b/docs/embedding/sdk/quickstart-with-sample-app.md
@@ -70,7 +70,6 @@ This script will:
 That's it!
 
 If you want to log in to the sample Metabase this command set up, visit [http://localhost:4300](http://localhost:4300). You can log in with email and password as Rene Descartes:
-E
 
 - email: rene@example.com
 - password: foobarbaz

--- a/docs/embedding/sdk/quickstart-with-sample-app.md
+++ b/docs/embedding/sdk/quickstart-with-sample-app.md
@@ -1,12 +1,13 @@
 ---
-title: Embedded analytics SDK - quickstart with sample app
+title: Modular embedding SDK - quickstart with sample app
+summary: Set up the Modular embedding SDK with a sample React app and JWT authentication. Includes Docker quickstart and detailed walkthrough for Metabase configuration.
 ---
 
-# Embedded analytics SDK - quickstart with sample app
+# Modular embedding SDK - quickstart with sample app
 
-{% include plans-blockquote.html feature="Embedded analytics SDK" sdk=true convert_pro_link_to_embbedding=true %}
+{% include plans-blockquote.html feature="Modular embedding SDK" sdk=true convert_pro_link_to_embbedding=true %}
 
-This guide sets up the embedded analytics SDK with a [sample React app](https://github.com/metabase/metabase-nodejs-react-sdk-embedding-sample/tree/{{page.version | remove: "v0."}}-stable), but you can follow along with your own application.
+This guide sets up the modular embedding SDK with a [sample React app](https://github.com/metabase/metabase-nodejs-react-sdk-embedding-sample/tree/{{page.version | remove: "v0."}}-stable), but you can follow along with your own application.
 
 {% include youtube.html id='AtMn-G-Al80' %}
 
@@ -70,6 +71,7 @@ That's it!
 
 If you want to log in to the sample Metabase this command set up, visit [http://localhost:4300](http://localhost:4300). You can log in with email and password as Rene Descartes:
 E
+
 - email: rene@example.com
 - password: foobarbaz
 
@@ -89,8 +91,8 @@ Here's a quick overview of what you'll be doing:
 ### Start up the sample application
 
 5. [Set up the application environment](#set-up-the-application-environment).
-6.. [Run the app server](#set-up-the-application-server) to handle authentication with JWT and serve the embedded Metabase components.
-7. [Run the client application](#set-up-the-client-application) that will contain Metabase components built with the SDK.
+6. [Run the app server](#set-up-the-application-server) to handle authentication with JWT and serve the embedded Metabase components.
+6. [Run the client application](#set-up-the-client-application) that will contain Metabase components built with the SDK.
 
 And then fiddle around with styling.
 
@@ -126,7 +128,7 @@ From any Metabase page, click on the **gear** icon in the upper right and select
 
 Turn on:
 
-- Embedded analytics SDK (it's in the **Modular** section)
+- Modular embedding SDK
 - Static embedding
 
 Otherwise, this whole thing is hopeless.
@@ -222,7 +224,7 @@ Install dependencies:
 npm install
 ```
 
-This command will install the [Metabase embedded analytics SDK](https://www.npmjs.com/package/@metabase/embedding-sdk-react), in addition to the application's other dependencies.
+This command will install the [Metabase modular embedding SDK](https://www.npmjs.com/package/@metabase/embedding-sdk-react), in addition to the application's other dependencies.
 
 You can also install a [different version of the SDK](./version.md). Just make sure that the major version of the SDK matches the major version of the Metabase you're using.
 

--- a/docs/embedding/sdk/quickstart-with-sample-app.md
+++ b/docs/embedding/sdk/quickstart-with-sample-app.md
@@ -91,7 +91,7 @@ Here's a quick overview of what you'll be doing:
 
 5. [Set up the application environment](#set-up-the-application-environment).
 6. [Run the app server](#set-up-the-application-server) to handle authentication with JWT and serve the embedded Metabase components.
-6. [Run the client application](#set-up-the-client-application) that will contain Metabase components built with the SDK.
+7. [Run the client application](#set-up-the-client-application) that will contain Metabase components built with the SDK.
 
 And then fiddle around with styling.
 

--- a/docs/embedding/sdk/quickstart.md
+++ b/docs/embedding/sdk/quickstart.md
@@ -1,11 +1,11 @@
 ---
-title: Embedded analytics SDK - quickstart
-description: "This guide walks you through how to set up the Embedded analytics SDK in your application with your Metabase."
+title: Modular embedding SDK - quickstart
+description: "This guide walks you through how to set up the modular embedding SDK in your application with your Metabase."
 ---
 
-# Embedded analytics SDK - quickstart
+# Modular embedding SDK - quickstart
 
-This guide walks you through how to set up the Embedded analytics SDK in your application with your Metabase using API keys.
+This guide walks you through how to set up the Modular embedding SDK in your application with your Metabase using API keys.
 
 This setup:
 
@@ -18,7 +18,7 @@ If you want to use the SDK in production, however, you'll also need to [set up J
 ## Prerequisites
 
 - [Metabase](https://github.com/metabase/metabase/releases) version 52 or higher (OSS or EE). See [Installing Metabase](../../installation-and-operation/installing-metabase.md).
-- Make sure your [React version is compatible](./introduction.md#embedded-analytics-sdk-prerequisites). (You could also use the [sample React app](https://github.com/metabase/metabase-nodejs-react-sdk-embedding-sample/tree/{{page.version | remove: "v0."}}-stable).)
+- Make sure your [React version is compatible](./introduction.md#modular-embedding-sdk-prerequisites). (You could also use the [sample React app](https://github.com/metabase/metabase-nodejs-react-sdk-embedding-sample/tree/{{page.version | remove: "v0."}}-stable).)
 
 If you _don't_ have a Metabase up and running, check out the [Quickstart CLI](./quickstart-cli.md).
 
@@ -42,7 +42,7 @@ In Metabase, click on the gear icon in the upper right and navigate to **Admin S
 
 Still in the Admin console, go to **Settings > Authentication** and click on the **API keys** tab. [Create a new API key](../../people-and-groups/api-keys.md).
 
-- Key name: "Embedded analytics SDK" (just to make the key easy to identify).
+- Key name: "Modular embedding SDK" (just to make the key easy to identify).
 - Group: select “Admin” (since this is only for local testing).
 
 ## 3. Install the SDK in your app

--- a/docs/embedding/sdk/upgrade.md
+++ b/docs/embedding/sdk/upgrade.md
@@ -1,17 +1,17 @@
 ---
-title: Upgrading Metabase and the Embedded analytics SDK
-summary: How to upgrade your Metabase and Embedded analytics SDK versions, test the changes, and check for breaking changes that might affect your app.
+title: Upgrading Metabase and the modular embedding SDK
+summary: How to upgrade your Metabase and modular embedding SDK versions, test the changes, and check for breaking changes that might affect your app.
 ---
 
-# Upgrading Metabase and the Embedded analytics SDK
+# Upgrading Metabase and the modular embedding SDK
 
 Here's a basic overview of the steps you'll want to take when upgrading your SDK.
 
-## 1. Read the release post and changelog for Metabase and the Embedded analytics SDK
+## 1. Read the release post and changelog for Metabase and the modular embedding SDK
 
 - [Release posts](https://www.metabase.com/releases) give a good overview of what's in each release, and call out breaking changes (which are rare).
-- [Metabase changelog](https://www.metabase.com/changelog) lists all Metabase and Embedded analytics SDK changes.
-- [Embedded analytics SDK changelog](https://github.com/metabase/metabase/blob/master/enterprise/frontend/src/embedding-sdk-package/CHANGELOG.md) lists changes specific to the SDK's `@metabase/embedding-sdk-react` package.
+- [Metabase changelog](https://www.metabase.com/changelog) lists all Metabase and modular embedding SDK changes.
+- [Modular embedding SDK changelog](https://github.com/metabase/metabase/blob/master/enterprise/frontend/src/embedding-sdk-package/CHANGELOG.md) lists changes specific to the SDK's `@metabase/embedding-sdk-react` package.
 
 Check for any relevant changes, especially deprecations or breaking changes that require you to update your application's code. If there are deprecation changes, we'll have docs that'll walk you through what changes you'll need to make and why.
 

--- a/docs/embedding/sdk/version.md
+++ b/docs/embedding/sdk/version.md
@@ -1,10 +1,11 @@
 ---
-title: Embedded analytics SDK - versions
+title: Modular embedding SDK - versions
+summary: Learn about Modular embedding SDK versioning and compatibility with Metabase. Install compatible versions and pin your Metabase Cloud instance version.
 ---
 
-# Embedded analytics SDK - versions
+# Modular embedding SDK - versions
 
-{% include plans-blockquote.html feature="Embedded analytics SDK" sdk=true %}
+{% include plans-blockquote.html feature="Modular embedding SDK" sdk=true %}
 
 The SDK stable version tracks with the Metabase version.
 
@@ -20,7 +21,7 @@ To grab the latest version of the SDK that works with Metabase nightly builds, u
 
 ## Minimum SDK version
 
-Version 52 is the minimum version supported for the Embedded analytics SDK.
+Version 52 is the minimum version supported for the Modular embedding SDK.
 
 ## You can pin instances to a version on Metabase Cloud
 

--- a/docs/embedding/securing-embeds.md
+++ b/docs/embedding/securing-embeds.md
@@ -12,7 +12,7 @@ There are two basic ways to secure stuff on the internet:
 1. **Authentication** looks at _who_ someone is (using standards such as [JWT](../people-and-groups/authenticating-with-jwt.md) or [SAML](../people-and-groups/authenticating-with-saml.md)).
 2. **Authorization** looks at _what_ someone has access to (using standards such as OAuth 2.0).
 
-In this guide, we'll talk primarily about authentication. 
+In this guide, we'll talk primarily about authentication.
 
 ## Public embedding
 
@@ -73,13 +73,13 @@ Static embeds don't authenticate people's identities on the Metabase side, so pe
 - Any filter selections in a static embed will reset once the signed JWT expires.
 - All Static embed usage will show up in [usage analytics](../usage-and-performance-tools/usage-analytics.md) under "External user".
 
-## Security in static embedding vs. modular and interactive embedding
+## Security in static embedding vs. modular and full app embedding
 
 Static embedding only guarantees authorized access to your Metabase data (you decide _what_ is accessible).
 
 If you want to secure your static embeds based on someone's identity (you decide _who_ gets access to _what_), you'll need to set up your own authentication flow and manually wire that up to [locked parameters](#example-sending-user-attributes-to-a-locked-parameter) on each of your static embeds. Note that locked parameters are essentially filters, so you can only set up **row-level** restrictions in a static embed.
 
-If you want an easier way to embed different views of data for different customers (without allowing the customers to see each other’s data), learn how [Modular and interactive embedding authenticates and authorizes people in one flow](#modular-and-interactive-embedding-auth-with-jwt-or-saml).
+If you want an easier way to embed different views of data for different customers (without allowing the customers to see each other’s data), learn how [Modular and full app embedding authenticates and authorizes people in one flow](#modular-and-full-app-embedding-auth-with-jwt-or-saml).
 
 ### Static embedding with JWT authorization
 
@@ -160,21 +160,21 @@ The flow might look something like this:
 
 For code samples, see the [static embedding reference app](https://github.com/metabase/embedding-reference-apps).
 
-## Modular and interactive embedding auth with JWT or SAML
+## Modular and full app embedding auth with JWT or SAML
 
-Modular embedding (using Embedded Analytics [SDK](./sdk/introduction.md) or [JS](./embedded-analytics-js.md) components), and [interactive full-app embedding](./interactive-embedding.md) integrate  with SSO (either [JWT](../people-and-groups/authenticating-with-jwt.md) or [SAML](../people-and-groups/authenticating-with-saml.md)) to authenticate and authorize people in one flow. The auth integration makes it easy to map user attributes (such as a person's role or department) to granular levels of data access, including:
+Modular embedding (including using the [SDK](./sdk/introduction.md)), and [full-app embedding](./full-app-embedding.md) integrate with SSO (either [JWT](../people-and-groups/authenticating-with-jwt.md) or [SAML](../people-and-groups/authenticating-with-saml.md)) to authenticate and authorize people in one flow. The auth integration makes it easy to map user attributes (such as a person's role or department) to granular levels of data access, including:
 
 - [Tables](../permissions/data.md)
 - [Rows](../permissions/row-and-column-security.md#row-level-security-filter-by-a-column-in-the-table)
 - [Columns](../permissions/row-and-column-security.md#custom-row-and-column-security-use-a-sql-question-to-create-a-custom-view-of-a-table)
 - [Other data permissions](../permissions/data.md), such as data download permissions or SQL access.
 
-![Interactive embedding with SSO.](./images/full-app-embedding-sso.png)
+![Full app embedding with SSO.](./images/full-app-embedding-sso.png)
 
-This diagram shows you how an interactive embed gets secured with [SSO](../people-and-groups/start.md#sso-for-metabase-pro-and-enterprise-plans):
+This diagram shows you how a full app embed gets secured with [SSO](../people-and-groups/start.md#sso-for-metabase-pro-and-enterprise-plans):
 
 1. **Visitor arrives**: your frontend gets a request to display all content, including a Metabase component (such as a React component).
-2. **Load embed**: your frontend component loads the Metabase frontend using your [embedding URL](./interactive-embedding.md#pointing-an-iframe-to-a-metabase-url).
+2. **Load embed**: your frontend component loads the Metabase frontend using your [embedding URL](./full-app-embedding.md#pointing-an-iframe-to-a-metabase-url).
 3. **Check session**: to display data at the embedding URL, your Metabase backend checks for a valid session (a logged-in visitor).
 4. **If there's no valid session**:
    - **Redirect to SSO**: your Metabase frontend redirects the visitor to your SSO login page.
@@ -190,7 +190,7 @@ The mechanics of step 4 will vary a bit depending on whether you use [JWT](../pe
 
 In our static embedding example, we used [locked parameters](#example-securing-data-with-locked-parameters-on-a-static-embed) to display secure filtered views of the Accounts table.
 
-The nice thing about modular/interactive embedding and [SSO](../people-and-groups/start.md#sso-for-metabase-pro-and-enterprise-plans) integration is that we don't have to manually manage locked parameters for each embed. Instead, we can map user attributes from our identity provider (IdP) to [permissions](../permissions/introduction.md) and [row and column security](../permissions/row-and-column-security.md) in Metabase. People can get authenticated and authorized to self-serve specific subsets of data from their very first login.
+The nice thing about modular and full app embedding and [SSO](../people-and-groups/start.md#sso-for-metabase-pro-and-enterprise-plans) integration is that we don't have to manually manage locked parameters for each embed. Instead, we can map user attributes from our identity provider (IdP) to [permissions](../permissions/introduction.md) and [row and column security](../permissions/row-and-column-security.md) in Metabase. People can get authenticated and authorized to self-serve specific subsets of data from their very first login.
 
 Let's expand on our Accounts example to include a Tenant ID. The Tenant ID represents the parent org for a group of customers:
 
@@ -243,8 +243,8 @@ When Customer 1 logs in, they'll see a different filtered version of the Account
 
 - [Modular embedding demo](https://embedded-analytics-sdk-demo.metabase.com)
 - [Modular embedding with SDK reference app](https://github.com/metabase/metabase-nodejs-react-sdk-embedding-sample)
-- [Interactive embedding demo](https://embedding-demo.metabase.com/)
-- [Interactive embedding reference app](https://github.com/metabase/sso-examples/tree/master/app-embed-example)
+- [Full app embedding demo](https://embedding-demo.metabase.com/)
+- [Full app embedding reference app](https://github.com/metabase/sso-examples/tree/master/app-embed-example)
 - [Static embedding reference app](https://github.com/metabase/embedding-reference-apps)
 
 ## Further reading

--- a/docs/embedding/start.md
+++ b/docs/embedding/start.md
@@ -10,15 +10,15 @@ redirect_from:
 
 What is embedding, and how does it work?
 
-## [Embedded analytics SDK](./sdk/introduction.md)
+## [Modular embedding](./modular-embedding.md)
 
-With the Embedded analytics SDK, you can embed individual Metabase components with React (like standalone charts, dashboards, the query builder, and more). You can manage access and interactivity per component, and you have advanced customization for seamless styling.
+Embed individual dashboards, questions, or the query builder in your app with an interactive wizard and simple drop-in script, with minimal or no coding required. Control component UI and theming. Integrate your app's auth with Metabase SSO.
 
-## [Embedded analytics JS](./embedded-analytics-js.md)
+## [Modular embedding SDK](./sdk/introduction.md)
 
-Embed dashboards, questions, or the query builder in your app with JavaScript (no React required). Built on the Embedded analytics SDK with per-component controls and theming. Integrate your app's auth with Metabase SSO.
+With the Modular embedding SDK, you can embed individual Metabase components with React (like standalone charts, dashboards, the query builder, and more). You can manage access and interactivity per component, and you have advanced customization for seamless styling.
 
-## [Embedded analytics SDK quickstart](./sdk/quickstart.md)
+## [Modular embedding SDK quickstart](./sdk/quickstart.md)
 
 Jump to a SDK quickstart with a sample React application.
 
@@ -30,17 +30,17 @@ Also known as Signed Embedding, Static embedding is a secure way to embed charts
 
 You can pass parameters between Metabase and your website via the embedding URL to specify how Metabase items should look and behave inside the iframe on your website.
 
-## [Interactive embedding](./interactive-embedding.md)
+## [Full app embedding](./full-app-embedding.md)
 
-Interactive embedding allows you to embed full Metabase app in an iframe. Interactive embedding integrates with your data permissions to let people slice and dice data on their own using Metabase's query builder.
+Full app embedding allows you to embed full Metabase app in an iframe. Full app embedding integrates with your data permissions to let people slice and dice data on their own using Metabase's query builder.
 
-## [Interactive embedding quickstart](./interactive-embedding-quick-start-guide.md)
+## [Full app embedding quickstart](./full-app-embedding-quick-start-guide.md)
 
 You'll embed the full Metabase application in your app. Once logged in, people can view a Metabase dashboard in your web app, and be able to use the full Metabase application to explore their data, and only their data.
 
-## [Interactive UI components](./interactive-ui-components.md)
+## [Full app UI components](./full-app-ui-components.md)
 
-Customize the UI components in your interactive embed by adding parameters to the embedding URL.
+Customize the UI components in your full app embed by adding parameters to the embedding URL.
 
 ## [Public embeds](./public-links.md)
 

--- a/docs/embedding/static-embedding.md
+++ b/docs/embedding/static-embedding.md
@@ -12,7 +12,7 @@ Also known as: standalone embedding, or signed embedding.
 
 In general, embedding works by displaying a Metabase URL inside an iframe in your website. A **static embed** (or signed embed) is an iframe that's loading a Metabase URL secured with a signed JSON Web Token (JWT). Metabase will only load the URL if the request supplies a JWT signed with the secret shared between your app and your Metabase. The JWT also includes a reference to the resource to load, e.g., the dashboard ID, and any values for locked parameters.
 
-You can't use static embeds with [row and column security](../permissions/row-and-column-security.md), [drill-through](https://www.metabase.com/learn/metabase-basics/querying-and-dashboards/questions/drill-through), and user-specific data isn't captured in [usage analytics](../usage-and-performance-tools/usage-analytics.md) because signed JWTs don't create user sessions (server-side sessions). For those features, check out [Embedded analytics JS](./embedded-analytics-js.md).
+You can't use static embeds with [row and column security](../permissions/row-and-column-security.md), [drill-through](https://www.metabase.com/learn/metabase-basics/querying-and-dashboards/questions/drill-through), and user-specific data isn't captured in [usage analytics](../usage-and-performance-tools/usage-analytics.md) because signed JWTs don't create user sessions (server-side sessions). For those features, check out [Modular embedding](./modular-embedding.md).
 
 You can, however, restrict data in static embeds for specific people or groups by [locking parameters](./static-embedding-parameters.md#restricting-data-in-a-static-embed-with-locked-parameters).
 
@@ -34,7 +34,7 @@ your_metabase_embedding_url/your_signed_jwt?filter=true
 
 The signed JWT is generated using your [Metabase secret key](#regenerating-the-static-embedding-secret-key). The secret key tells Metabase that the request for filtered data can be trusted, so it's safe to display the results at the new embedding URL. Note that this secret key is shared for all static embeds, so whoever has access to that key will have access to all embedded artifacts.
 
-If you want to embed charts with additional interactive features, like [drill-down](https://www.metabase.com/learn/metabase-basics/querying-and-dashboards/questions/drill-through) and [self-service querying](../questions/query-builder/editor.md), see [Embedded analytics JS](./embedded-analytics-js.md).
+If you want to embed charts with additional interactive features, like [drill-down](https://www.metabase.com/learn/metabase-basics/querying-and-dashboards/questions/drill-through) and [self-service querying](../questions/query-builder/editor.md), see [Modular embedding](./modular-embedding.md).
 
 ## Turning on the embedding feature in Metabase
 

--- a/docs/embedding/translations.md
+++ b/docs/embedding/translations.md
@@ -7,7 +7,7 @@ summary: Upload a translation dictionary to translate questions and dashboards i
 
 {% include plans-blockquote.html feature="Translation of embedded content" convert_pro_link_to_embbedding=true %}
 
-For now, translations are only available for [static embeds](./static-embedding.md), not Interactive embedding or the Embedded analytics JS/SDK.
+For now, translations are only available for [guest embed](./static-embedding.md). Translations aren't available for SSO-based modular embedding or full app embedding.
 
 You can upload a translation dictionary to translate strings both in Metabase content (like dashboard titles) and in the data itself (like column names and values).
 

--- a/docs/exploration-and-organization/exploration.md
+++ b/docs/exploration-and-organization/exploration.md
@@ -24,7 +24,7 @@ You can use the command palette to:
 
 So anytime you want to do or find anything in Metabase, just hit `cmd/ctrl + k` and start typing what you want to do.
 
-> The command palette is currently unavailable in [Embedded analytics JS](../embedding/embedded-analytics-js.md) and [interactive embedding](../embedding/interactive-embedding.md) contexts.
+> The command palette is currently unavailable in [Modular embedding](../embedding/modular-embedding.md) and [full app embedding](../embedding/full-app-embedding.md) contexts.
 
 ## Advanced search
 

--- a/docs/installation-and-operation/information-collection.md
+++ b/docs/installation-and-operation/information-collection.md
@@ -54,7 +54,7 @@ The token validation request includes:
 - Count of internal users
 - Count of email domains
 - Count of embedded dashboards and questions
-- Types of embedding (static, interactive, Embedded analytics SDK, Embedded analytics JS)
+- Types of embedding (modular, guest, SDK, full app)
 - Site UUID (just an identifier for your Metabase)
 - Metabase version
 - Query execution timestamp (last UTC day)

--- a/docs/installation-and-operation/serialization.md
+++ b/docs/installation-and-operation/serialization.md
@@ -298,7 +298,7 @@ This ID refers to the collection where the question was saved. In a real export,
 
 ### Entity IDs work with embedding
 
-Metabase supports working with [Entity IDs](#metabase-uses-entity-ids-to-identify-and-reference-metabase-items) for questions, dashboards, and collections in [Static Embedding](../embedding/static-embedding.md), [Embedded analytics JS](../embedding/embedded-analytics-js.md), [Interactive embedding](../embedding/interactive-embedding.md), and the [Embedded analytics SDK](../embedding/sdk/introduction.md).
+Metabase supports working with [Entity IDs](#metabase-uses-entity-ids-to-identify-and-reference-metabase-items) for questions, dashboards, and collections in [Static Embedding](../embedding/static-embedding.md), [Modular embedding](../embedding/modular-embedding.md), [SDK](../embedding/sdk/introduction.md), and [Full app embedding](../embedding/full-app-embedding.md).
 
 A high-level workflow for using Entity IDs when embedding Metabase in your app would look something like:
 

--- a/docs/installation-and-operation/upgrading-metabase.md
+++ b/docs/installation-and-operation/upgrading-metabase.md
@@ -25,7 +25,7 @@ Cloud customers can request an early upgrade by emailing support at help@metabas
 
 ### Instances using the modular embedding SDK on Metabase Cloud must request an upgrade
 
-If you're using the [modular embedding SDK SDK](../embedding/sdk/introduction.md) on Metabase Cloud, we pin your version so that it doesn't upgrade automatically, as you should test the changes before upgrading.
+If you're using the [modular embedding SDK](../embedding/sdk/introduction.md) on Metabase Cloud, we pin your version so that it doesn't upgrade automatically, as you should test the changes before upgrading.
 
 To upgrade your Metabase, you'll need to request an upgrade by [contacting support](https://www.metabase.com/help-premium).
 

--- a/docs/installation-and-operation/upgrading-metabase.md
+++ b/docs/installation-and-operation/upgrading-metabase.md
@@ -14,7 +14,7 @@ This page covers how to upgrade to a new Metabase release.
 
 ## Upgrading Metabase Cloud
 
-If you're on a [Metabase Cloud](https://www.metabase.com/pricing/) plan, we'll upgrade your Metabase automatically with each new release; no action needed on your end ([unless you're using the Embedded analytics SDK](#instances-using-the-embedded-analytics-sdk-on-metabase-cloud-must-request-an-upgrade)).
+If you're on a [Metabase Cloud](https://www.metabase.com/pricing/) plan, we'll upgrade your Metabase automatically with each new release; no action needed on your end ([unless you're using the modular embedding SDK](#instances-using-the-modular-embedding-sdk-on-metabase-cloud-must-request-an-upgrade)).
 
 How soon we upgrade you depends on the type of release:
 
@@ -23,13 +23,13 @@ How soon we upgrade you depends on the type of release:
 
 Cloud customers can request an early upgrade by emailing support at help@metabase.com. Include the URL of the Metabase you want us to upgrade.
 
-### Instances using the Embedded analytics SDK on Metabase Cloud must request an upgrade
+### Instances using the modular embedding SDK on Metabase Cloud must request an upgrade
 
-If you're using the [Embedded analytics SDK](../embedding/sdk/introduction.md) on Metabase Cloud, we pin your version so that it doesn't upgrade automatically, as you should test the changes before upgrading.
+If you're using the [modular embedding SDK SDK](../embedding/sdk/introduction.md) on Metabase Cloud, we pin your version so that it doesn't upgrade automatically, as you should test the changes before upgrading.
 
 To upgrade your Metabase, you'll need to request an upgrade by [contacting support](https://www.metabase.com/help-premium).
 
-See our [upgrade guide for the Embedded analytics SDK](../embedding/sdk/upgrade.md).
+See our [upgrade guide for the modular embedding SDK](../embedding/sdk/upgrade.md).
 
 ## Upgrading a self-hosted Metabase
 

--- a/docs/permissions/database-routing.md
+++ b/docs/permissions/database-routing.md
@@ -11,7 +11,7 @@ With database routing, an admin can build a question once using one database, an
 
 Database routing is useful for:
 
-- Managing interactive embedding setups where each customer has their own database with identical schemas.
+- Managing modular and full app embedding setups where each customer has their own database with identical schemas.
 
   Database routing can't be used with static embedding, because database routing requires people who use the embedded questions and dashboards to have a Metabase account. Without a Metabase account, Metabase can't route the queries because it doesn't know who is viewing the embed.
 
@@ -19,14 +19,13 @@ Database routing is useful for:
 - Changing the target data warehouse for certain teams.
 - Managing separate connections to the same data warehouse, with each connection having separate privileges. This connection management is akin to [connection impersonation](./impersonation.md) for databases that prevent the same connection from changing roles.
 
-
 ## Database routing limitations
 
 > Database routing is **not supported** on ClickHouse, Oracle, Spark SQL, and Vertica.
 
 Different database have different setups, so _what_ you can route between (database, schema, data catalog, etc.) will differ slightly depending on which data warehouse you're using.
 
-- [Athena](../databases/connections/athena.md): Only routing between different connections is supported (e.g., different buckets, roles, or catalogs). 
+- [Athena](../databases/connections/athena.md): Only routing between different connections is supported (e.g., different buckets, roles, or catalogs).
 - [BigQuery](../databases/connections/bigquery.md): Only routing between databases in different projects is supported.
 - [Databricks](../databases/connections/databricks.md): When multi-catalog is not enabled, you can route between catalogs on the same host. If multi-catalog is enabled, then you can only route between databases on separate hosts.
 

--- a/src/metabase/request/settings.clj
+++ b/src/metabase/request/settings.clj
@@ -62,8 +62,8 @@
   :default :lax
   :getter #'-session-cookie-samesite
   :setter #'-session-cookie-samesite!
-  :doc "See [Embedding Metabase in a different domain](../embedding/interactive-embedding.md#embedding-metabase-in-a-different-domain).
-        Read more about [interactive Embedding](../embedding/interactive-embedding.md).
+  :doc "See [Embedding Metabase in a different domain](../embedding/full-app-embedding.md#embedding-metabase-in-a-different-domain).
+        Read more about [Full app embedding](../embedding/full-app-embedding.md).
         Learn more about [SameSite cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite).")
 
 (defn- check-session-timeout


### PR DESCRIPTION
interactive -> full app
eajs -> modular
SDK -> modular embedding sdk

Not touching static embedding, or appearance/auth docs for SDK