### PR TITLE
fix(sdk-bundle, embed-js): Avoid flashing of subscription channel selections sidebar

### DIFF
--- a/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/DashboardSubscriptionsSidebar.jsx
+++ b/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/DashboardSubscriptionsSidebar.jsx
@@ -481,7 +481,7 @@ class DashboardSubscriptionsSidebarInner extends Component {
       );
     }
 
-    if (shouldDisplayNewPulse(editingMode, pulses)) {
+    if (shouldDisplayNewPulse(editingMode, pulses) && !isEmbeddingSdk()) {
       const emailConfigured = formInput?.channels?.email?.configured || false;
       const slackConfigured = formInput?.channels?.slack?.configured || false;
 

--- a/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/common.unit.spec.ts
+++ b/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/common.unit.spec.ts
@@ -202,6 +202,11 @@ describe("DashboardSubscriptionsSidebar", () => {
       // Create the first subscription
       await userEvent.click(screen.getByRole("button", { name: "Done" }));
 
+      // (EMB-1099) The subscription channel options sidebar shouldn't be shown
+      expect(
+        screen.queryByText("Set up a dashboard subscription"),
+      ).not.toBeInTheDocument();
+
       expect(await screen.findByText("Subscriptions")).toBeInTheDocument();
       expect(await screen.findByText("Emailed hourly")).toBeInTheDocument();
       expect(await screen.findByText("John Doe")).toBeInTheDocument();
@@ -227,6 +232,11 @@ describe("DashboardSubscriptionsSidebar", () => {
 
       // Create the first subscription
       await userEvent.click(screen.getByRole("button", { name: "Done" }));
+
+      // (EMB-1099) The subscription channel options sidebar shouldn't be shown
+      expect(
+        screen.queryByText("Set up a dashboard subscription"),
+      ).not.toBeInTheDocument();
 
       expect(await screen.findByText("Subscriptions")).toBeInTheDocument();
       expect(await screen.findByText("Emailed hourly")).toBeInTheDocument();


### PR DESCRIPTION
closes EMB-1099
### Backport reasons
Not backporting this as it should go straight to 58

### Description

The easy solution is to not render the intermediate state in the first place, as we can't just avoid not transitioning to the intermediate state.

### How to verify

You can revert the code part and the test should fail. Also try testing these 2 scenarios.
1. When opening the subscription sidebar from the subscriptions menu button
1. After clicking "Done" button to create the first subscription

There shouldn't be no noticeable flash of the subscription channel selections sidebar.

### Demo
_Please note that it's not super apparent on my setup so I didn't show the before version of the fix_ Please see the problem on the original issue for a clear visual problem.
https://www.loom.com/share/5238e93fd6aa4fd2bf01978f9a48ba95

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
