### PR TITLE
Fix Question parameters remapping, add more e2e

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/guest-embed-error-handling.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/guest-embed-error-handling.cy.spec.tsx
@@ -1,7 +1,12 @@
+import { MetabotQuestion } from "@metabase/embedding-sdk-react";
+
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { createQuestion, getSignedJwtForResource } from "e2e/support/helpers";
 import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
-import { mountGuestEmbedQuestion } from "e2e/support/helpers/embedding-sdk-component-testing";
+import {
+  mountGuestEmbedQuestion,
+  mountSdkContent,
+} from "e2e/support/helpers/embedding-sdk-component-testing";
 import { signInAsAdminAndSetupGuestEmbedding } from "e2e/support/helpers/embedding-sdk-testing";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -86,6 +91,18 @@ describe("scenarios > embedding-sdk > guest-embed-error-handling", () => {
           "A valid JWT token is required to be passed in guest embeds mode.",
         ).should("be.visible");
       });
+    });
+  });
+
+  it("should show an error when a component does not support guest embed", () => {
+    mountSdkContent(<MetabotQuestion />, {
+      sdkProviderProps: { authConfig: { isGuest: true } },
+    });
+
+    getSdkRoot().within(() => {
+      cy.findByText("This component does not support guest embeds").should(
+        "be.visible",
+      );
     });
   });
 });

--- a/e2e/test-component/scenarios/embedding-sdk/guest-embed-happy-path.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/guest-embed-happy-path.cy.spec.tsx
@@ -18,7 +18,7 @@ import { questionAsPinMapWithTiles } from "e2e/test/scenarios/embedding/shared/e
 import type { Card, TemplateTags } from "metabase-types/api";
 import { createMockParameter } from "metabase-types/api/mocks";
 
-const { ORDERS, ORDERS_ID, PEOPLE_ID } = SAMPLE_DATABASE;
+const { ORDERS, ORDERS_ID, PEOPLE, PEOPLE_ID, PRODUCTS } = SAMPLE_DATABASE;
 
 const WAIT_FOR_INTERNAL_API_REQUESTS_MS = 1000;
 
@@ -72,7 +72,7 @@ const TEMPLATE_TAGS: TemplateTags = {
     "display-name": "PK->Name",
     type: "dimension",
     "widget-type": "id",
-    dimension: ["field", PEOPLE_ID, null],
+    dimension: ["field", PEOPLE.ID, null],
   },
 };
 
@@ -278,6 +278,175 @@ describe("scenarios > embedding-sdk > guest-embed-happy-path", () => {
           cy.findByTestId("table-body")
             .findAllByRole("row")
             .should("have.length", 1);
+        });
+      });
+    });
+
+    it("should show remapped parameter values and trigger proper `/embed remapping endpoint", () => {
+      signInAsAdminAndSetupGuestEmbedding({
+        token: "starter",
+      });
+
+      // Set up internal remapping for ORDERS.QUANTITY
+      cy.request("POST", `/api/field/${ORDERS.QUANTITY}/dimension`, {
+        name: "Quantity",
+        type: "internal",
+        human_readable_field_id: null,
+      });
+
+      cy.request("GET", `/api/field/${ORDERS.QUANTITY}/values`).then(
+        ({ body }: { body: { values: [number][] } }) => {
+          cy.request("POST", `/api/field/${ORDERS.QUANTITY}/values`, {
+            values: body.values.map(([value]) => [value, `N${value}`]),
+          });
+        },
+      );
+
+      // Set up external remapping: ORDERS.PRODUCT_ID -> PRODUCTS.TITLE
+      cy.request("POST", `/api/field/${ORDERS.PRODUCT_ID}/dimension`, {
+        name: "Product ID",
+        type: "external",
+        human_readable_field_id: PRODUCTS.TITLE,
+      });
+
+      const questionTemplateTags: TemplateTags = {
+        quantity: {
+          id: "quantity",
+          name: "quantity",
+          "display-name": "Internal",
+          type: "dimension",
+          "widget-type": "number/=",
+          dimension: ["field", ORDERS.QUANTITY, null],
+        },
+        product_id_fk: {
+          id: "product_id_fk",
+          name: "product_id_fk",
+          "display-name": "FK",
+          type: "dimension",
+          "widget-type": "id",
+          dimension: ["field", ORDERS.PRODUCT_ID, null],
+        },
+        user_id_pk: {
+          id: "user_id_pk",
+          name: "user_id_pk",
+          "display-name": "PK->Name",
+          type: "dimension",
+          "widget-type": "id",
+          dimension: ["field", PEOPLE.ID, null],
+        },
+      };
+
+      const questionParameters = [
+        createMockParameter({
+          id: "quantity",
+          name: "Internal",
+          slug: "quantity",
+          type: "number/=",
+          target: ["dimension", ["template-tag", "quantity"]],
+        }),
+        createMockParameter({
+          id: "product_id_fk",
+          name: "FK",
+          slug: "product_id_fk",
+          type: "id",
+          target: ["dimension", ["template-tag", "product_id_fk"]],
+        }),
+        createMockParameter({
+          id: "user_id_pk",
+          name: "PK->Name",
+          slug: "user_id_pk",
+          type: "id",
+          target: ["dimension", ["template-tag", "user_id_pk"]],
+        }),
+      ];
+
+      createNativeQuestion(
+        {
+          name: "Orders native question",
+          native: {
+            query:
+              "SELECT * " +
+              "FROM ORDERS " +
+              "JOIN PEOPLE ON ORDERS.USER_ID = PEOPLE.ID " +
+              "WHERE {{quantity}} AND {{product_id_fk}} AND {{user_id_pk}}",
+            "template-tags": questionTemplateTags,
+          },
+          parameters: questionParameters,
+          enable_embedding: true,
+          embedding_params: {
+            quantity: "enabled",
+            product_id_fk: "enabled",
+            user_id_pk: "enabled",
+          },
+        },
+        {
+          wrapId: true,
+        },
+      );
+
+      cy.signOut();
+
+      cy.intercept("GET", "/api/embed/card/*/params/*/remapping*").as(
+        "parameterRemappingApiRequest",
+      );
+
+      cy.get("@questionId").then(async (questionId) => {
+        const token = await getSignedJwtForResource({
+          resourceId: questionId as unknown as number,
+          resourceType: "question",
+        });
+
+        mountGuestEmbedQuestion(
+          { token },
+          {
+            shouldAssertCardQuery: false,
+          },
+        );
+
+        getSdkRoot().within(() => {
+          cy.findAllByTestId("parameter-widget").should("have.length", 3);
+        });
+
+        cy.log("internal remapping");
+        getSdkRoot()
+          .findAllByTestId("parameter-widget")
+          .filter(':contains("Internal")')
+          .click();
+        cy.findByText("N5").click();
+        cy.findByText("Add filter").click();
+        getSdkRoot()
+          .findAllByTestId("parameter-widget")
+          .filter(':contains("Internal")')
+          .should("contain.text", "N5");
+
+        cy.log("FK remapping");
+        getSdkRoot()
+          .findAllByTestId("parameter-widget")
+          .filter(':contains("FK")')
+          .click();
+        cy.findByPlaceholderText("Enter an ID").type("1,");
+        cy.findByText("Rustic Paper Wallet").should("exist");
+        cy.findByText("Add filter").click();
+        getSdkRoot()
+          .findAllByTestId("parameter-widget")
+          .filter(':contains("FK")')
+          .should("contain.text", "Rustic Paper Wallet");
+
+        cy.log("PK->Name remapping");
+        getSdkRoot()
+          .findAllByTestId("parameter-widget")
+          .filter(':contains("PK->Name")')
+          .click();
+        cy.findByPlaceholderText("Enter an ID").type("1,");
+        cy.findByText("Hudson Borer").should("exist");
+        cy.findByText("Add filter").click();
+        getSdkRoot()
+          .findAllByTestId("parameter-widget")
+          .filter(':contains("PK->Name")')
+          .should("contain.text", "Hudson Borer");
+
+        cy.get("@parameterRemappingApiRequest.all").then((interceptions) => {
+          expect(interceptions).to.have.length.greaterThan(0);
         });
       });
     });

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/embed-parameters-remapping.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/embed-parameters-remapping.cy.spec.ts
@@ -1,0 +1,339 @@
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { JWT_SHARED_SECRET } from "e2e/support/helpers";
+import type { GetFieldValuesResponse, TemplateTags } from "metabase-types/api";
+import { createMockParameter } from "metabase-types/api/mocks";
+
+import { navigateToEmbedOptionsStep } from "./helpers";
+
+const { ORDERS, PEOPLE, PRODUCTS } = SAMPLE_DATABASE;
+
+const { H } = cy;
+
+const suiteTitle =
+  "scenarios > embedding > sdk iframe embed setup > embed parameters";
+
+describe(suiteTitle, () => {
+  beforeEach(() => {
+    H.restore();
+    H.resetSnowplow();
+    cy.signInAsAdmin();
+    H.activateToken("bleeding-edge");
+    H.enableTracking();
+    H.updateSetting("enable-embedding-static", true);
+    H.updateSetting("embedding-secret-key", JWT_SHARED_SECRET);
+    H.mockEmbedJsToDevServer();
+  });
+
+  afterEach(() => {
+    H.expectNoBadSnowplowEvents();
+  });
+
+  describe("dashboard parameter remapping", () => {
+    beforeEach(() => {
+      // Set up internal remapping for ORDERS.QUANTITY
+      cy.request("POST", `/api/field/${ORDERS.QUANTITY}/dimension`, {
+        name: "Quantity",
+        type: "internal",
+        human_readable_field_id: null,
+      });
+
+      cy.request("GET", `/api/field/${ORDERS.QUANTITY}/values`).then(
+        ({ body }: { body: GetFieldValuesResponse }) => {
+          cy.request("POST", `/api/field/${ORDERS.QUANTITY}/values`, {
+            values: body.values.map(([value]) => [value, `N${value}`]),
+          });
+        },
+      );
+
+      // Set up external remapping: ORDERS.PRODUCT_ID -> PRODUCTS.TITLE
+      cy.request("POST", `/api/field/${ORDERS.PRODUCT_ID}/dimension`, {
+        name: "Product ID",
+        type: "external",
+        human_readable_field_id: PRODUCTS.TITLE,
+      });
+
+      const dashboardTemplateTags: TemplateTags = {
+        quantity: {
+          id: "quantity",
+          name: "quantity",
+          "display-name": "Internal",
+          type: "dimension",
+          "widget-type": "number/=",
+          dimension: ["field", ORDERS.QUANTITY, null],
+        },
+        product_id_fk: {
+          id: "product_id_fk",
+          name: "product_id_fk",
+          "display-name": "FK",
+          type: "dimension",
+          "widget-type": "id",
+          dimension: ["field", ORDERS.PRODUCT_ID, null],
+        },
+        user_id_pk: {
+          id: "user_id_pk",
+          name: "user_id_pk",
+          "display-name": "PK->Name",
+          type: "dimension",
+          "widget-type": "id",
+          dimension: ["field", PEOPLE.ID, null],
+        },
+      };
+
+      const dashboardParameters = [
+        createMockParameter({
+          id: "quantity",
+          name: "Internal",
+          slug: "quantity",
+          type: "number/=",
+        }),
+        createMockParameter({
+          id: "product_id_fk",
+          name: "FK",
+          slug: "product_id_fk",
+          type: "id",
+        }),
+        createMockParameter({
+          id: "user_id_pk",
+          name: "PK->Name",
+          slug: "user_id_pk",
+          type: "id",
+        }),
+      ];
+
+      H.createNativeQuestionAndDashboard({
+        questionDetails: {
+          name: "Orders native question",
+          native: {
+            query:
+              "SELECT * " +
+              "FROM ORDERS " +
+              "JOIN PEOPLE ON ORDERS.USER_ID = PEOPLE.ID " +
+              "WHERE {{quantity}} AND {{product_id_fk}} AND {{user_id_pk}}",
+            "template-tags": dashboardTemplateTags,
+          },
+        },
+        dashboardDetails: {
+          name: "Dashboard with Remapping",
+          parameters: dashboardParameters,
+        },
+      }).then(({ body: { id: dashcardId, card_id, dashboard_id } }) => {
+        // Connect dashboard parameters to the card's template-tags
+        cy.request("PUT", `/api/dashboard/${dashboard_id}`, {
+          dashcards: [
+            {
+              id: dashcardId,
+              card_id,
+              row: 0,
+              col: 0,
+              size_x: 16,
+              size_y: 8,
+              parameter_mappings: [
+                {
+                  parameter_id: "quantity",
+                  card_id,
+                  target: ["dimension", ["template-tag", "quantity"]],
+                },
+                {
+                  parameter_id: "product_id_fk",
+                  card_id,
+                  target: ["dimension", ["template-tag", "product_id_fk"]],
+                },
+                {
+                  parameter_id: "user_id_pk",
+                  card_id,
+                  target: ["dimension", ["template-tag", "user_id_pk"]],
+                },
+              ],
+            },
+          ],
+        });
+      });
+    });
+
+    it("should show remapped parameter values in embed preview", () => {
+      navigateToEmbedOptionsStep({
+        experience: "dashboard",
+        resourceName: "Dashboard with Remapping",
+      });
+
+      H.setEmbeddingParameter("Internal", "Editable");
+      H.setEmbeddingParameter("FK", "Editable");
+      H.setEmbeddingParameter("PK->Name", "Editable");
+
+      H.getSimpleEmbedIframeContent().within(() => {
+        cy.log("internal remapping - select N5 and verify it shows N5");
+        cy.findAllByTestId("parameter-widget")
+          .filter(':contains("Internal")')
+          .click();
+        cy.findByText("N5").click();
+        cy.findByText("Add filter").click();
+        cy.findAllByTestId("parameter-widget")
+          .filter(':contains("Internal")')
+          .should("contain.text", "N5");
+
+        cy.log("FK remapping - enter ID 1 and verify product title appears");
+        cy.findAllByTestId("parameter-widget")
+          .filter(':contains("FK")')
+          .click();
+        cy.findByPlaceholderText("Enter an ID").type("1,");
+        cy.findByText("Rustic Paper Wallet").should("exist");
+        cy.findByText("Add filter").click();
+        cy.findAllByTestId("parameter-widget")
+          .filter(':contains("FK")')
+          .should("contain.text", "Rustic Paper Wallet");
+
+        cy.log(
+          "PK->Name remapping - enter ID 1 and verify person name appears",
+        );
+        cy.findAllByTestId("parameter-widget")
+          .filter(':contains("PK->Name")')
+          .click();
+        cy.findByPlaceholderText("Enter an ID").type("1,");
+        cy.findByText("Hudson Borer").should("exist");
+        cy.findByText("Add filter").click();
+        cy.findAllByTestId("parameter-widget")
+          .filter(':contains("PK->Name")')
+          .should("contain.text", "Hudson Borer");
+      });
+    });
+  });
+
+  describe("question parameter remapping in Guest Embed mode", () => {
+    beforeEach(() => {
+      // Set up internal remapping for ORDERS.QUANTITY
+      cy.request("POST", `/api/field/${ORDERS.QUANTITY}/dimension`, {
+        name: "Quantity",
+        type: "internal",
+        human_readable_field_id: null,
+      });
+
+      cy.request("GET", `/api/field/${ORDERS.QUANTITY}/values`).then(
+        ({ body }: { body: GetFieldValuesResponse }) => {
+          cy.request("POST", `/api/field/${ORDERS.QUANTITY}/values`, {
+            values: body.values.map(([value]) => [value, `N${value}`]),
+          });
+        },
+      );
+
+      // Set up external remapping: ORDERS.PRODUCT_ID -> PRODUCTS.TITLE
+      cy.request("POST", `/api/field/${ORDERS.PRODUCT_ID}/dimension`, {
+        name: "Product ID",
+        type: "external",
+        human_readable_field_id: PRODUCTS.TITLE,
+      });
+
+      const questionTemplateTags: TemplateTags = {
+        quantity: {
+          id: "quantity",
+          name: "quantity",
+          "display-name": "Internal",
+          type: "dimension",
+          "widget-type": "number/=",
+          dimension: ["field", ORDERS.QUANTITY, null],
+        },
+        product_id_fk: {
+          id: "product_id_fk",
+          name: "product_id_fk",
+          "display-name": "FK",
+          type: "dimension",
+          "widget-type": "id",
+          dimension: ["field", ORDERS.PRODUCT_ID, null],
+        },
+        user_id_pk: {
+          id: "user_id_pk",
+          name: "user_id_pk",
+          "display-name": "PK->Name",
+          type: "dimension",
+          "widget-type": "id",
+          dimension: ["field", PEOPLE.ID, null],
+        },
+      };
+
+      const questionParameters = [
+        createMockParameter({
+          id: "quantity",
+          name: "Internal",
+          slug: "quantity",
+          type: "number/=",
+          target: ["dimension", ["template-tag", "quantity"]],
+        }),
+        createMockParameter({
+          id: "product_id_fk",
+          name: "FK",
+          slug: "product_id_fk",
+          type: "id",
+          target: ["dimension", ["template-tag", "product_id_fk"]],
+        }),
+        createMockParameter({
+          id: "user_id_pk",
+          name: "PK->Name",
+          slug: "user_id_pk",
+          type: "id",
+          target: ["dimension", ["template-tag", "user_id_pk"]],
+        }),
+      ];
+
+      H.createNativeQuestion({
+        name: "Question with Remapping",
+        native: {
+          query:
+            "SELECT * " +
+            "FROM ORDERS " +
+            "JOIN PEOPLE ON ORDERS.USER_ID = PEOPLE.ID " +
+            "WHERE {{quantity}} AND {{product_id_fk}} AND {{user_id_pk}}",
+          "template-tags": questionTemplateTags,
+        },
+        parameters: questionParameters,
+      });
+    });
+
+    it("should show remapped parameter values in embed preview", () => {
+      navigateToEmbedOptionsStep({
+        experience: "chart",
+        resourceName: "Question with Remapping",
+      });
+
+      H.setEmbeddingParameter("Internal", "Editable");
+      H.setEmbeddingParameter("FK", "Editable");
+      H.setEmbeddingParameter("PK->Name", "Editable");
+
+      H.getSimpleEmbedIframeContent().within(() => {
+        cy.findByText("Question with Remapping").should("be.visible");
+
+        cy.log("internal remapping - select N5 and verify it shows N5");
+        cy.findAllByTestId("parameter-widget")
+          .filter(':contains("Internal")')
+          .click();
+        cy.findByText("N5").click();
+        cy.findByText("Add filter").click();
+        cy.findAllByTestId("parameter-widget")
+          .filter(':contains("Internal")')
+          .should("contain.text", "N5");
+
+        cy.log("FK remapping - enter ID 1 and verify product title appears");
+        cy.findAllByTestId("parameter-widget")
+          .filter(':contains("FK")')
+          .click();
+        cy.findByPlaceholderText("Enter an ID").type("1,");
+        cy.findByText("Rustic Paper Wallet").should("exist");
+        cy.findByText("Add filter").click();
+        cy.findAllByTestId("parameter-widget")
+          .filter(':contains("FK")')
+          .should("contain.text", "Rustic Paper Wallet");
+
+        cy.log(
+          "PK->Name remapping - enter ID 1 and verify person name appears",
+        );
+        cy.findAllByTestId("parameter-widget")
+          .filter(':contains("PK->Name")')
+          .click();
+        cy.findByPlaceholderText("Enter an ID").type("1,");
+        cy.findByText("Hudson Borer").should("exist");
+        cy.findByText("Add filter").click();
+        cy.findAllByTestId("parameter-widget")
+          .filter(':contains("PK->Name")')
+          .should("contain.text", "Hudson Borer");
+      });
+    });
+  });
+});

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/embed-parameters-remapping.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/embed-parameters-remapping.cy.spec.ts
@@ -161,6 +161,9 @@ describe(suiteTitle, () => {
       H.setEmbeddingParameter("PK->Name", "Editable");
 
       H.getSimpleEmbedIframeContent().within(() => {
+        // Wait for the last parameter widget is rendered
+        cy.findByText("PK->Name").should("be.visible");
+
         cy.log("internal remapping - select N5 and verify it shows N5");
         cy.findAllByTestId("parameter-widget")
           .filter(':contains("Internal")')
@@ -299,6 +302,9 @@ describe(suiteTitle, () => {
 
       H.getSimpleEmbedIframeContent().within(() => {
         cy.findByText("Question with Remapping").should("be.visible");
+
+        // Wait for the last parameter widget is rendered
+        cy.findByText("PK->Name").should("be.visible");
 
         cy.log("internal remapping - select N5 and verify it shows N5");
         cy.findAllByTestId("parameter-widget")

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/SqlParametersList/SqlParametersList.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/SqlParametersList/SqlParametersList.tsx
@@ -52,8 +52,8 @@ export const SqlParametersList = () => {
     const uiParameters = getCardUiParameters(
       question.card(),
       metadataRef.current,
-      {},
-      question.card().parameters || undefined,
+      parameterValues,
+      question.parameters() || undefined,
     );
 
     return uiParameters.filter(
@@ -62,7 +62,13 @@ export const SqlParametersList = () => {
           (originalParameter) => originalParameter.id === id,
         ) && !hiddenParameters?.includes(slug),
     );
-  }, [question, originalQuestion, metadataRef, hiddenParameters]);
+  }, [
+    question,
+    originalQuestion,
+    metadataRef,
+    parameterValues,
+    hiddenParameters,
+  ]);
 
   if (!question || !isNativeQuestion || !parameters.length) {
     return null;

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/SqlParametersList/SqlParametersList.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/SqlParametersList/SqlParametersList.tsx
@@ -29,7 +29,7 @@ export const SqlParametersList = () => {
   } = useSdkQuestionContext();
 
   const metadata = useSelector(getMetadata);
-  // we cannot use `metadata` directly otherwise hooks will re-run on every metadata change
+  // we cannot use `metadata` directly otherwise component will re-run on every metadata change
   const metadataRef = useLatest(metadata);
 
   const isNativeQuestion = useMemo(() => {

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/SqlParametersList/SqlParametersList.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/SqlParametersList/SqlParametersList.tsx
@@ -1,9 +1,13 @@
 import { useMemo } from "react";
+import { useLatest } from "react-use";
 
 import { useSdkQuestionContext } from "embedding-sdk-bundle/components/private/SdkQuestion/context";
+import { useSelector } from "metabase/lib/redux";
 import { ResponsiveParametersList } from "metabase/query_builder/components/ResponsiveParametersList";
+import { getMetadata } from "metabase/selectors/metadata";
 import { Box } from "metabase/ui";
 import * as Lib from "metabase-lib";
+import { getCardUiParameters } from "metabase-lib/v1/parameters/utils/cards";
 import type { ParameterId } from "metabase-types/api";
 
 import SqlParametersListS from "./SqlParametersList.module.css";
@@ -24,6 +28,10 @@ export const SqlParametersList = () => {
     hiddenParameters,
   } = useSdkQuestionContext();
 
+  const metadata = useSelector(getMetadata);
+  // we cannot use `metadata` directly otherwise hooks will re-run on every metadata change
+  const metadataRef = useLatest(metadata);
+
   const isNativeQuestion = useMemo(() => {
     if (!question) {
       return false;
@@ -41,15 +49,20 @@ export const SqlParametersList = () => {
 
     const originalParameters = originalQuestion.card().parameters ?? [];
 
-    return question
-      .parameters()
-      .filter(
-        ({ id, slug }) =>
-          originalParameters.find(
-            (originalParameter) => originalParameter.id === id,
-          ) && !hiddenParameters?.includes(slug),
-      );
-  }, [question, originalQuestion, hiddenParameters]);
+    const uiParameters = getCardUiParameters(
+      question.card(),
+      metadataRef.current,
+      {},
+      question.card().parameters || undefined,
+    );
+
+    return uiParameters.filter(
+      ({ id, slug }) =>
+        originalParameters.find(
+          (originalParameter) => originalParameter.id === id,
+        ) && !hiddenParameters?.includes(slug),
+    );
+  }, [question, originalQuestion, metadataRef, hiddenParameters]);
 
   if (!question || !isNativeQuestion || !parameters.length) {
     return null;

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/context/types.ts
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/context/types.ts
@@ -17,6 +17,7 @@ import type {
 } from "metabase/visualizations/types";
 import type Question from "metabase-lib/v1/Question";
 import type { CardDisplayType, DashboardId } from "metabase-types/api";
+import type { EntityToken } from "metabase-types/api/entity";
 import type { EmbeddingEntityType } from "metabase-types/store/embedding-data-picker";
 
 type SdkQuestionConfig = {
@@ -148,7 +149,7 @@ export type SdkQuestionContextType = Omit<
     plugins: SdkQuestionConfig["componentPlugins"] | null;
     mode: QueryClickActionsMode | Mode | null | undefined;
     originalId: SdkQuestionId | null;
-    token: string | null | undefined;
+    token: EntityToken | null | undefined;
     resetQuestion: () => void;
     onReset: () => void;
     onCreate: (question: Question) => Promise<Question>;

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-load-question.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-load-question.ts
@@ -20,6 +20,7 @@ import { isStaticEmbeddingEntityLoadingError } from "metabase/lib/errors/is-stat
 import { type Deferred, defer } from "metabase/lib/promise";
 import type Question from "metabase-lib/v1/Question";
 import type { ParameterValuesMap } from "metabase-types/api";
+import type { EntityToken } from "metabase-types/api/entity";
 import { isObject } from "metabase-types/guards";
 
 type LoadQuestionResult = Promise<
@@ -59,7 +60,7 @@ export interface LoadQuestionHookResult {
 
 type UseLoadQuestionParams = LoadSdkQuestionParams & {
   isGuestEmbed: boolean;
-  token: string | null | undefined;
+  token: EntityToken | null | undefined;
 };
 
 export function useLoadQuestion({

--- a/frontend/src/embedding-sdk-bundle/lib/override-requests-for-guest-embeds.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/override-requests-for-guest-embeds.ts
@@ -49,7 +49,7 @@ const EMBED_URL_TRANSFORMATIONS: Record<
     method: "GET",
   }),
   [URL_PATTERNS.CARD_PARAMETER_SEARCH]: () => ({
-    url: `${getEmbedBase()}/card/:token/ms/:paramId/search/:query`,
+    url: `${getEmbedBase()}/card/:token/params/:paramId/search/:query`,
     method: "GET",
   }),
   [URL_PATTERNS.CARD_PARAMETER_REMAPPING]: ({ url }) => ({

--- a/frontend/src/embedding-sdk-bundle/lib/override-requests-for-guest-embeds.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/override-requests-for-guest-embeds.ts
@@ -31,47 +31,35 @@ const URL_PATTERNS = {
  */
 const EMBED_URL_TRANSFORMATIONS: Record<
   string,
-  (data: Pick<RequestData, "url" | "method">) => {
+  {
     url: string;
     method: "GET" | "POST";
   }
 > = {
-  [URL_PATTERNS.CARD_QUERY]: () => ({
+  [URL_PATTERNS.CARD_QUERY]: {
     url: `${getEmbedBase()}/card/:token/query`,
     method: "GET",
-  }),
-  [URL_PATTERNS.CARD_PIVOT_QUERY]: () => ({
+  },
+  [URL_PATTERNS.CARD_PIVOT_QUERY]: {
     url: `${getEmbedBase()}/pivot/card/:token/query`,
     method: "GET",
-  }),
-  [URL_PATTERNS.CARD_PARAMETER_VALUES]: () => ({
+  },
+  [URL_PATTERNS.CARD_PARAMETER_VALUES]: {
     url: `${getEmbedBase()}/card/:token/params/:paramId/values`,
     method: "GET",
-  }),
-  [URL_PATTERNS.CARD_PARAMETER_SEARCH]: () => ({
+  },
+  [URL_PATTERNS.CARD_PARAMETER_SEARCH]: {
     url: `${getEmbedBase()}/card/:token/params/:paramId/search/:query`,
     method: "GET",
-  }),
-  [URL_PATTERNS.CARD_PARAMETER_REMAPPING]: ({ url }) => ({
-    // We don't override URL, just the base path via `replaceWithEmbedBase`,
-    // because we already receive an url with replaced values, It happens in `frontend/src/metabase/plugins/oss/api.ts`
-    url,
-    method: "GET",
-  }),
-  [URL_PATTERNS.DASHBOARD_PARAMETER_VALUES]: () => ({
+  },
+  [URL_PATTERNS.DASHBOARD_PARAMETER_VALUES]: {
     url: `${getEmbedBase()}/dashboard/:token/params/:paramId/values`,
     method: "GET",
-  }),
-  [URL_PATTERNS.DASHBOARD_PARAMETER_SEARCH]: () => ({
+  },
+  [URL_PATTERNS.DASHBOARD_PARAMETER_SEARCH]: {
     url: `${getEmbedBase()}/dashboard/:token/params/:paramId/search/:query`,
     method: "GET",
-  }),
-  [URL_PATTERNS.DASHBOARD_PARAMETER_REMAPPING]: ({ url }) => ({
-    // We don't override URL, just the base path via `replaceWithEmbedBase`,
-    // because we already receive an url with replaced values, It happens in `frontend/src/metabase/plugins/oss/api.ts`
-    url,
-    method: "GET",
-  }),
+  },
 } as const;
 
 type RequestData = {
@@ -138,10 +126,7 @@ function getRequestTransformation({
   }
 
   // Apply the transformation for this pattern
-  const transformation = EMBED_URL_TRANSFORMATIONS[matchedPattern]({
-    url,
-    method,
-  });
+  const transformation = EMBED_URL_TRANSFORMATIONS[matchedPattern];
   if (!transformation) {
     return { method, url, options };
   }

--- a/frontend/src/embedding-sdk-bundle/lib/override-requests-for-guest-embeds.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/override-requests-for-guest-embeds.ts
@@ -31,40 +31,47 @@ const URL_PATTERNS = {
  */
 const EMBED_URL_TRANSFORMATIONS: Record<
   string,
-  { url: string; method: "GET" | "POST" }
+  (data: Pick<RequestData, "url" | "method">) => {
+    url: string;
+    method: "GET" | "POST";
+  }
 > = {
-  [URL_PATTERNS.CARD_QUERY]: {
+  [URL_PATTERNS.CARD_QUERY]: () => ({
     url: `${getEmbedBase()}/card/:token/query`,
     method: "GET",
-  },
-  [URL_PATTERNS.CARD_PIVOT_QUERY]: {
+  }),
+  [URL_PATTERNS.CARD_PIVOT_QUERY]: () => ({
     url: `${getEmbedBase()}/pivot/card/:token/query`,
     method: "GET",
-  },
-  [URL_PATTERNS.CARD_PARAMETER_VALUES]: {
+  }),
+  [URL_PATTERNS.CARD_PARAMETER_VALUES]: () => ({
     url: `${getEmbedBase()}/card/:token/params/:paramId/values`,
     method: "GET",
-  },
-  [URL_PATTERNS.CARD_PARAMETER_SEARCH]: {
-    url: `${getEmbedBase()}/card/:token/params/:paramId/search/:query`,
+  }),
+  [URL_PATTERNS.CARD_PARAMETER_SEARCH]: () => ({
+    url: `${getEmbedBase()}/card/:token/ms/:paramId/search/:query`,
     method: "GET",
-  },
-  [URL_PATTERNS.CARD_PARAMETER_REMAPPING]: {
-    url: `${getEmbedBase()}/card/:token/params/:paramId/remapping`,
+  }),
+  [URL_PATTERNS.CARD_PARAMETER_REMAPPING]: ({ url }) => ({
+    // We don't overrider URL, just the base path via `replaceWithEmbedBase`,
+    // because we already receive an url with replaced values, It happens in `frontend/src/metabase/plugins/oss/api.ts`
+    url,
     method: "GET",
-  },
-  [URL_PATTERNS.DASHBOARD_PARAMETER_VALUES]: {
+  }),
+  [URL_PATTERNS.DASHBOARD_PARAMETER_VALUES]: () => ({
     url: `${getEmbedBase()}/dashboard/:token/params/:paramId/values`,
     method: "GET",
-  },
-  [URL_PATTERNS.DASHBOARD_PARAMETER_SEARCH]: {
+  }),
+  [URL_PATTERNS.DASHBOARD_PARAMETER_SEARCH]: () => ({
     url: `${getEmbedBase()}/dashboard/:token/params/:paramId/search/:query`,
     method: "GET",
-  },
-  [URL_PATTERNS.DASHBOARD_PARAMETER_REMAPPING]: {
-    url: `${getEmbedBase()}/dashboard/:token/params/:paramId/remapping`,
+  }),
+  [URL_PATTERNS.DASHBOARD_PARAMETER_REMAPPING]: ({ url }) => ({
+    // We don't overrider URL, just the base path via `replaceWithEmbedBase`,
+    // because we already receive an url with replaced values, It happens in `frontend/src/metabase/plugins/oss/api.ts`
+    url,
     method: "GET",
-  },
+  }),
 } as const;
 
 type RequestData = {
@@ -131,7 +138,10 @@ function getRequestTransformation({
   }
 
   // Apply the transformation for this pattern
-  const transformation = EMBED_URL_TRANSFORMATIONS[matchedPattern];
+  const transformation = EMBED_URL_TRANSFORMATIONS[matchedPattern]({
+    url,
+    method,
+  });
   if (!transformation) {
     return { method, url, options };
   }

--- a/frontend/src/embedding-sdk-bundle/lib/override-requests-for-guest-embeds.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/override-requests-for-guest-embeds.ts
@@ -53,7 +53,7 @@ const EMBED_URL_TRANSFORMATIONS: Record<
     method: "GET",
   }),
   [URL_PATTERNS.CARD_PARAMETER_REMAPPING]: ({ url }) => ({
-    // We don't overrider URL, just the base path via `replaceWithEmbedBase`,
+    // We don't override URL, just the base path via `replaceWithEmbedBase`,
     // because we already receive an url with replaced values, It happens in `frontend/src/metabase/plugins/oss/api.ts`
     url,
     method: "GET",
@@ -67,7 +67,7 @@ const EMBED_URL_TRANSFORMATIONS: Record<
     method: "GET",
   }),
   [URL_PATTERNS.DASHBOARD_PARAMETER_REMAPPING]: ({ url }) => ({
-    // We don't overrider URL, just the base path via `replaceWithEmbedBase`,
+    // We don't override URL, just the base path via `replaceWithEmbedBase`,
     // because we already receive an url with replaced values, It happens in `frontend/src/metabase/plugins/oss/api.ts`
     url,
     method: "GET",

--- a/frontend/src/embedding-sdk-bundle/lib/override-requests-for-guest-embeds.unit.spec.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/override-requests-for-guest-embeds.unit.spec.ts
@@ -64,6 +64,16 @@ describe("matchUrlPattern", () => {
     ).toBe(true);
   });
 
+  it("should match card parameter remapping pattern with JWT token", () => {
+    const jwtToken = "token";
+    expect(
+      matchUrlPattern(
+        "/api/card/:cardId/params/:paramId/remapping",
+        `/api/card/${jwtToken}/params/290ead16/remapping`,
+      ),
+    ).toBe(true);
+  });
+
   it("should match dashboard parameter values pattern", () => {
     expect(
       matchUrlPattern(
@@ -87,6 +97,16 @@ describe("matchUrlPattern", () => {
       matchUrlPattern(
         "/api/dashboard/:dashId/params/:paramId/remapping",
         "/api/dashboard/789/params/456/remapping",
+      ),
+    ).toBe(true);
+  });
+
+  it("should match dashboard parameter remapping pattern with JWT token", () => {
+    const jwtToken = "token";
+    expect(
+      matchUrlPattern(
+        "/api/dashboard/:dashId/params/:paramId/remapping",
+        `/api/dashboard/${jwtToken}/params/290ead16/remapping`,
       ),
     ).toBe(true);
   });

--- a/frontend/src/embedding-sdk-bundle/lib/override-requests-for-guest-embeds.unit.spec.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/override-requests-for-guest-embeds.unit.spec.ts
@@ -64,16 +64,6 @@ describe("matchUrlPattern", () => {
     ).toBe(true);
   });
 
-  it("should match card parameter remapping pattern with JWT token", () => {
-    const jwtToken = "token";
-    expect(
-      matchUrlPattern(
-        "/api/card/:cardId/params/:paramId/remapping",
-        `/api/card/${jwtToken}/params/290ead16/remapping`,
-      ),
-    ).toBe(true);
-  });
-
   it("should match dashboard parameter values pattern", () => {
     expect(
       matchUrlPattern(
@@ -97,16 +87,6 @@ describe("matchUrlPattern", () => {
       matchUrlPattern(
         "/api/dashboard/:dashId/params/:paramId/remapping",
         "/api/dashboard/789/params/456/remapping",
-      ),
-    ).toBe(true);
-  });
-
-  it("should match dashboard parameter remapping pattern with JWT token", () => {
-    const jwtToken = "token";
-    expect(
-      matchUrlPattern(
-        "/api/dashboard/:dashId/params/:paramId/remapping",
-        `/api/dashboard/${jwtToken}/params/290ead16/remapping`,
       ),
     ).toBe(true);
   });

--- a/frontend/src/embedding-sdk-bundle/lib/sdk-question/load-question.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/sdk-question/load-question.ts
@@ -15,9 +15,10 @@ import { loadMetadataForCard } from "metabase/questions/actions";
 import { addFields } from "metabase/redux/metadata";
 import { getMetadata } from "metabase/selectors/metadata";
 import Question from "metabase-lib/v1/Question";
+import type { EntityToken } from "metabase-types/api/entity";
 
 type LoadQuestionSdkParams = LoadSdkQuestionParams & {
-  token: string | null | undefined;
+  token: EntityToken | null | undefined;
 };
 
 export const loadQuestionSdk =

--- a/frontend/src/embedding-sdk-bundle/lib/sdk-question/load-question.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/sdk-question/load-question.ts
@@ -12,6 +12,7 @@ import type {
 import { resolveCards } from "metabase/query_builder/actions";
 import { getParameterValuesForQuestion } from "metabase/query_builder/actions/core/parameterUtils";
 import { loadMetadataForCard } from "metabase/questions/actions";
+import { addFields } from "metabase/redux/metadata";
 import { getMetadata } from "metabase/selectors/metadata";
 import Question from "metabase-lib/v1/Question";
 
@@ -86,6 +87,12 @@ export const loadQuestionSdk =
 
     if (parameterValues) {
       question = question.setParameterValues(parameterValues);
+    }
+
+    if ("param_fields" in card && card.param_fields) {
+      // This is needed to make some parameter widget populate the dropdown list
+      // otherwise they will use a normal text input
+      dispatch(addFields(Object.values(card.param_fields).flat()));
     }
 
     return { question, originalQuestion, parameterValues };

--- a/frontend/src/embedding-sdk-bundle/lib/sdk-question/run-question-on-navigate.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/sdk-question/run-question-on-navigate.ts
@@ -10,13 +10,14 @@ import { getCardAfterVisualizationClick } from "metabase/visualizations/lib/util
 import Question from "metabase-lib/v1/Question";
 import { cardIsEquivalent } from "metabase-lib/v1/queries/utils/card";
 import type { ParameterValuesMap } from "metabase-types/api";
+import type { EntityToken } from "metabase-types/api/entity";
 import type { Dispatch, GetState } from "metabase-types/store";
 
 interface RunQuestionOnNavigateParams extends NavigateToNewCardParams {
   originalQuestion?: Question;
   parameterValues?: ParameterValuesMap;
   isGuestEmbed: boolean;
-  token: string | null | undefined;
+  token: EntityToken | null | undefined;
   onQuestionChange: (question: Question) => void;
   onClearQueryResults: () => void;
 }

--- a/frontend/src/embedding-sdk-bundle/lib/sdk-question/run-question-query.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/sdk-question/run-question-query.ts
@@ -6,11 +6,12 @@ import { getSensibleDisplays } from "metabase/visualizations";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
 import type { ParameterValuesMap } from "metabase-types/api";
+import type { EntityToken } from "metabase-types/api/entity";
 
 interface RunQuestionQueryParams {
   question: Question;
   isGuestEmbed: boolean;
-  token: string | null | undefined;
+  token: EntityToken | null | undefined;
   originalQuestion?: Question;
   parameterValues?: ParameterValuesMap;
   cancelDeferred?: Deferred;

--- a/frontend/src/embedding-sdk-bundle/lib/sdk-question/update-question.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/sdk-question/update-question.ts
@@ -10,6 +10,7 @@ import { getMetadata } from "metabase/selectors/metadata";
 import * as Lib from "metabase-lib";
 import Question from "metabase-lib/v1/Question";
 import type { ParameterValuesMap } from "metabase-types/api";
+import type { EntityToken } from "metabase-types/api/entity";
 import type { Dispatch, GetState } from "metabase-types/store";
 
 import { runQuestionQuerySdk } from "./run-question-query";
@@ -35,7 +36,7 @@ interface UpdateQuestionParams {
   queryResults?: any[];
   cancelDeferred?: Deferred;
   isGuestEmbed: boolean;
-  token: string | null | undefined;
+  token: EntityToken | null | undefined;
 
   /** Optimistic update the question in the query builder UI */
   optimisticUpdateQuestion: (question: Question) => void;

--- a/frontend/src/embedding-sdk-bundle/types/question.ts
+++ b/frontend/src/embedding-sdk-bundle/types/question.ts
@@ -38,7 +38,7 @@ export type SdkQuestionEntityPublicProps =
 export interface SdkQuestionState {
   question?: InternalQuestion;
   originalQuestion?: InternalQuestion;
-  token?: string | null;
+  token?: SdkEntityToken | null;
   queryResults?: any[];
   parameterValues?: ParameterValuesMap;
 }

--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -476,7 +476,7 @@ export type GetPublicCard = Pick<Card, "id" | "name" | "public_uuid">;
 export type GetEmbeddableCard = Pick<Card, "id" | "name">;
 
 export type GetRemappedCardParameterValueRequest = {
-  card_id: CardId;
+  card_id: CardId | string;
   parameter_id: ParameterId;
   value: ParameterValueOrArray;
 };

--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -4,6 +4,7 @@ import type {
 } from "metabase/public/lib/types";
 import type { IconName } from "metabase/ui";
 import type { PieRow } from "metabase/visualizations/echarts/pie/model/types";
+import type { EntityToken } from "metabase-types/api/entity";
 
 import type { Collection, CollectionId, LastEditInfo } from "./collection";
 import type {
@@ -476,7 +477,7 @@ export type GetPublicCard = Pick<Card, "id" | "name" | "public_uuid">;
 export type GetEmbeddableCard = Pick<Card, "id" | "name">;
 
 export type GetRemappedCardParameterValueRequest = {
-  card_id: CardId | string;
+  card_id: CardId | EntityToken;
   parameter_id: ParameterId;
   value: ParameterValueOrArray;
 };

--- a/frontend/src/metabase-types/api/entity.ts
+++ b/frontend/src/metabase-types/api/entity.ts
@@ -1,0 +1,1 @@
+export type EntityToken = string;

--- a/frontend/src/metabase/dashboard/context/context.tsx
+++ b/frontend/src/metabase/dashboard/context/context.tsx
@@ -20,6 +20,7 @@ import type {
   DashboardId,
   ParameterValuesMap,
 } from "metabase-types/api";
+import type { EntityToken } from "metabase-types/api/entity";
 
 import type { DashboardCardMenu } from "../components/DashCard/DashCardMenu/dashcard-menu";
 import type { NavigateToNewCardFromDashboardOpts } from "../components/DashCard/types";
@@ -51,7 +52,7 @@ type DashboardActionButtonList = DashboardActionKey[] | null;
 
 export type DashboardContextOwnProps = {
   dashboardId: DashboardId;
-  token?: string | null;
+  token?: EntityToken | null;
   parameterQueryParams?: ParameterValuesMap;
   onLoad?: (dashboard: Dashboard) => void;
   onError?: (error: unknown) => void;
@@ -214,7 +215,7 @@ const DashboardContextProviderInner = forwardRef(
           token,
         }: {
           dashboardId: DashboardId;
-          token: string | null | undefined;
+          token: EntityToken | null | undefined;
         },
         option: FetchOption = {},
       ) => {

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/build-embed-attributes.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/build-embed-attributes.ts
@@ -18,6 +18,7 @@ import type {
   SdkIframeQuestionEmbedSettings,
 } from "metabase/embedding/embedding-iframe-sdk-setup/types";
 import { getVisibleParameters } from "metabase/embedding/embedding-iframe-sdk-setup/utils/get-visible-parameters";
+import type { EntityToken } from "metabase-types/api/entity";
 
 export const buildEmbedAttributes = ({
   settings,
@@ -27,7 +28,7 @@ export const buildEmbedAttributes = ({
 }: {
   settings: SdkIframeEmbedSetupSettings;
   experience: SdkIframeEmbedSetupExperience;
-  token: string | null;
+  token: EntityToken | null;
   wrapWithQuotes: boolean;
 }) => {
   const isGuestEmbed = !!settings.isGuest;

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
@@ -19,6 +19,7 @@ import type {
 import type { StrictUnion } from "metabase/embedding-sdk/types/utils";
 import type { EmbeddedAnalyticsJsEventSchema } from "metabase-types/analytics/embedded-analytics-js";
 import type { CollectionId } from "metabase-types/api";
+import type { EntityToken } from "metabase-types/api/entity";
 import type { EmbeddingEntityType } from "metabase-types/store/embedding-data-picker";
 
 /** Events that the embed.js script listens for */
@@ -68,7 +69,7 @@ export type SdkIframeEmbedReportAnalytics = {
 // --- Embed Option Interfaces ---
 
 export type DashboardEmbedOptions = StrictUnion<
-  { dashboardId: number | string | null } | { token: string }
+  { dashboardId: number | string | null } | { token: EntityToken }
 > & {
   componentName: "metabase-dashboard";
 
@@ -87,7 +88,7 @@ export type DashboardEmbedOptions = StrictUnion<
 };
 
 export type QuestionEmbedOptions = StrictUnion<
-  { questionId: number | string | null } | { token: string }
+  { questionId: number | string | null } | { token: EntityToken }
 > & {
   componentName: "metabase-question";
 

--- a/frontend/src/metabase/hoc/Remapped.jsx
+++ b/frontend/src/metabase/hoc/Remapped.jsx
@@ -55,7 +55,7 @@ export default (ComposedComponent) =>
             field: this.props.column,
             cardId: nextProps.cardId,
             dashboardId: nextProps.dashboardId,
-            token: this.props.token,
+            token: nextProps.token,
           });
         }
       }

--- a/frontend/src/metabase/hoc/Remapped.jsx
+++ b/frontend/src/metabase/hoc/Remapped.jsx
@@ -35,6 +35,7 @@ export default (ComposedComponent) =>
             field: this.props.column,
             cardId: this.props.cardId,
             dashboardId: this.props.dashboardId,
+            token: this.props.token,
           });
         }
       }
@@ -45,7 +46,8 @@ export default (ComposedComponent) =>
             this.props.column?.id !== nextProps.column.id ||
             this.props.parameter?.id !== nextProps.parameter?.id ||
             this.props.cardId !== nextProps.cardId ||
-            this.props.dashboardId !== nextProps.dashboardId)
+            this.props.dashboardId !== nextProps.dashboardId ||
+            this.props.token !== nextProps.token)
         ) {
           this.props.fetchRemapping({
             parameter: nextProps.parameter,
@@ -53,6 +55,7 @@ export default (ComposedComponent) =>
             field: this.props.column,
             cardId: nextProps.cardId,
             dashboardId: nextProps.dashboardId,
+            token: this.props.token,
           });
         }
       }

--- a/frontend/src/metabase/lib/urls/dashboards.ts
+++ b/frontend/src/metabase/lib/urls/dashboards.ts
@@ -7,6 +7,7 @@ import type {
   DashboardId,
   DashboardTabId,
 } from "metabase-types/api";
+import type { EntityToken } from "metabase-types/api/entity";
 
 import { appendSlug } from "./utils";
 
@@ -53,7 +54,7 @@ export function publicDashboard(uuid: string) {
   return `${siteUrl}/public/dashboard/${uuid}`;
 }
 
-export function embedDashboard(token: string) {
+export function embedDashboard(token: EntityToken) {
   const siteUrl = MetabaseSettings.get("site-url");
   return `${siteUrl}/embed/dashboard/${token}`;
 }

--- a/frontend/src/metabase/lib/urls/questions.ts
+++ b/frontend/src/metabase/lib/urls/questions.ts
@@ -6,6 +6,7 @@ import type { QuestionCreatorOpts } from "metabase-lib/v1/Question";
 import Question from "metabase-lib/v1/Question";
 import * as ML_Urls from "metabase-lib/v1/urls";
 import type { CardId, Card as SavedCard } from "metabase-types/api";
+import type { EntityToken } from "metabase-types/api/entity";
 
 import { appendSlug, getEncodedUrlSearchParams } from "./utils";
 
@@ -150,7 +151,7 @@ export function publicQuestion({
   );
 }
 
-export function embedCard(token: string, type: string | null = null) {
+export function embedCard(token: EntityToken, type: string | null = null) {
   return `/embed/question/${token}` + (type ? `.${type}` : ``);
 }
 

--- a/frontend/src/metabase/lib/utils.ts
+++ b/frontend/src/metabase/lib/utils.ts
@@ -2,6 +2,7 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import { PLUGIN_IS_EE_BUILD } from "metabase/plugins";
+import type { EntityToken } from "metabase-types/api/entity";
 
 export function isEmpty(str: string | null) {
   if (str != null) {
@@ -163,7 +164,7 @@ export function versionIsLatest({
 export const isEEBuild = () => PLUGIN_IS_EE_BUILD.isEEBuild();
 
 // Extract resource id from signed JWT token used in Static Embedding
-export const extractResourceIdFromJwtToken = (jwtToken: string) => {
+export const extractResourceIdFromJwtToken = (jwtToken: EntityToken) => {
   try {
     const parts = jwtToken.split(".");
     const payloadPart = parts[1];

--- a/frontend/src/metabase/parameters/actions.ts
+++ b/frontend/src/metabase/parameters/actions.ts
@@ -10,6 +10,7 @@ import type {
   ParameterId,
   ParameterValues,
 } from "metabase-types/api";
+import type { EntityToken } from "metabase-types/api/entity";
 import type { Dispatch, GetState } from "metabase-types/store";
 
 import { getParameterValuesCache } from "./selectors";
@@ -49,7 +50,7 @@ export const fetchParameterValues =
 
 export interface FetchCardParameterValuesOpts {
   cardId: CardId;
-  token?: string | null;
+  token?: EntityToken | null;
   parameter: Parameter;
   query?: string;
 }
@@ -73,7 +74,7 @@ export const fetchCardParameterValues =
 
 export interface FetchDashboardParameterValuesOpts {
   dashboardId: DashboardId;
-  token?: string | null;
+  token?: EntityToken | null;
   parameter: Parameter;
   parameters: Parameter[];
   query?: string;
@@ -122,7 +123,7 @@ const loadParameterValues = async (request: ParameterValuesRequest) => {
 
 interface CardParameterValuesRequest {
   cardId?: CardId;
-  token?: string | null;
+  token?: EntityToken | null;
   paramId: ParameterId;
   query?: string;
 }
@@ -140,7 +141,7 @@ const loadCardParameterValues = async (request: CardParameterValuesRequest) => {
 
 interface DashboardParameterValuesRequest {
   dashId?: DashboardId;
-  token?: string | null;
+  token?: EntityToken | null;
   paramId: ParameterId;
   query?: string;
 }

--- a/frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx
+++ b/frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx
@@ -28,6 +28,7 @@ export type FormattedParameterValueProps = {
   value: string | number | number[] | ParameterValue;
   cardId?: CardId;
   dashboardId?: DashboardId;
+  token?: string | null;
   placeholder?: string;
   isPopoverOpen?: boolean;
   dataTestId?: string;
@@ -38,6 +39,7 @@ function FormattedParameterValue({
   value,
   cardId,
   dashboardId,
+  token,
   placeholder,
   isPopoverOpen = false,
 }: FormattedParameterValueProps) {
@@ -69,6 +71,7 @@ function FormattedParameterValue({
           parameter={parameter}
           cardId={cardId}
           dashboardId={dashboardId}
+          token={token}
           displayValue={label}
         />
       );

--- a/frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx
+++ b/frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx
@@ -22,13 +22,14 @@ import type {
   ParameterValue,
   RowValue,
 } from "metabase-types/api";
+import type { EntityToken } from "metabase-types/api/entity";
 
 export type FormattedParameterValueProps = {
   parameter: UiParameter;
   value: string | number | number[] | ParameterValue;
   cardId?: CardId;
   dashboardId?: DashboardId;
-  token?: string | null;
+  token?: EntityToken | null;
   placeholder?: string;
   isPopoverOpen?: boolean;
   dataTestId?: string;

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.tsx
@@ -290,6 +290,7 @@ export const ParameterValueWidget = ({
                   value={value}
                   cardId={cardId}
                   dashboardId={dashboardId}
+                  token={token}
                   placeholder={placeholderText}
                   isPopoverOpen={isOpen}
                 />

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.tsx
@@ -23,6 +23,7 @@ import {
   parameterHasNoDisplayValue,
 } from "metabase-lib/v1/parameters/utils/parameter-values";
 import type { CardId, DashboardId, ParameterId } from "metabase-types/api";
+import type { EntityToken } from "metabase-types/api/entity";
 
 import {
   ParameterDropdownWidget,
@@ -44,7 +45,7 @@ export type ParameterValueWidgetProps = {
   parameters?: UiParameter[];
   cardId?: CardId;
   dashboardId?: DashboardId;
-  token?: string | null;
+  token?: EntityToken | null;
   setParameterValueToDefault?: (parameterId: ParameterId) => void;
   // This means the widget will take care of the default value.
   // Should be used for dashboards and native questions in the parameter bar,

--- a/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.tsx
@@ -21,6 +21,7 @@ import type {
   Parameter,
   ParameterId,
 } from "metabase-types/api";
+import type { EntityToken } from "metabase-types/api/entity";
 
 import { ParameterValueWidget } from "../ParameterValueWidget";
 
@@ -34,7 +35,7 @@ export type ParameterWidgetProps = PropsWithChildren<
       setValue: (value: any) => void;
       cardId?: CardId;
       dashboardId?: DashboardId;
-      token?: string | null;
+      token?: EntityToken | null;
 
       editingParameter: Parameter | null;
       commitImmediately: boolean;

--- a/frontend/src/metabase/parameters/components/ParametersList/types.ts
+++ b/frontend/src/metabase/parameters/components/ParametersList/types.ts
@@ -8,6 +8,7 @@ import type {
   Parameter,
   ParameterId,
 } from "metabase-types/api";
+import type { EntityToken } from "metabase-types/api/entity";
 
 import type { ParameterWidgetProps } from "../ParameterWidget";
 
@@ -19,7 +20,7 @@ export type ParametersListProps = {
 
     cardId?: CardId;
     dashboardId?: DashboardId;
-    token?: string | null;
+    token?: EntityToken | null;
     editingParameter: Parameter | null | undefined;
     linkedFilterParameters: Parameter[];
 

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/FieldValuesWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/FieldValuesWidget.tsx
@@ -751,7 +751,7 @@ function RemappedValue({
   const { data: cardData } = useGetRemappedCardParameterValueQuery(
     cardId != null && value != null && isRemapped
       ? {
-          card_id: (token as unknown as number) ?? cardId,
+          card_id: token ?? cardId,
           parameter_id: parameter.id,
           value,
         }

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/FieldValuesWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/FieldValuesWidget.tsx
@@ -328,6 +328,7 @@ export const FieldValuesWidgetInner = forwardRef<
         parameter,
         cardId,
         dashboardId,
+        token,
         autoLoad: true,
         compact: false,
         displayValue: option?.[1],
@@ -344,6 +345,7 @@ export const FieldValuesWidgetInner = forwardRef<
         parameter,
         cardId,
         dashboardId,
+        token,
         autoLoad: false,
         displayValue: option[1],
       });
@@ -486,6 +488,7 @@ export const FieldValuesWidgetInner = forwardRef<
                 fields={fields}
                 dashboardId={dashboardId}
                 cardId={cardId}
+                token={token}
                 value={isNumericParameter ? parseNumericValue(value) : value}
                 tc={tc}
               />
@@ -675,6 +678,7 @@ function renderValue({
   parameter,
   cardId,
   dashboardId,
+  token,
   fields,
   value,
   formatOptions,
@@ -688,6 +692,7 @@ function renderValue({
   parameter?: Parameter;
   cardId?: CardId;
   dashboardId?: DashboardId;
+  token?: string | null;
   autoLoad?: boolean;
   compact?: boolean;
   displayValue?: string;
@@ -699,6 +704,7 @@ function renderValue({
       parameter={parameter}
       cardId={cardId}
       dashboardId={dashboardId}
+      token={token}
       maximumFractionDigits={20}
       remap={displayValue || Field.remappedField(fields) != null}
       displayValue={displayValue}
@@ -715,6 +721,7 @@ type RemappedValueProps = {
   value: ParameterValueOrArray | null;
   dashboardId?: DashboardId;
   cardId?: CardId;
+  token?: string | null;
   tc: ContentTranslationFunction;
 };
 
@@ -724,6 +731,7 @@ function RemappedValue({
   value,
   dashboardId,
   cardId,
+  token,
   tc,
 }: RemappedValueProps) {
   const isRemapped =
@@ -733,7 +741,7 @@ function RemappedValue({
   const { data: dashboardData } = useGetRemappedDashboardParameterValueQuery(
     dashboardId != null && value != null && isRemapped
       ? {
-          dashboard_id: dashboardId,
+          dashboard_id: token ?? dashboardId,
           parameter_id: parameter.id,
           value,
         }
@@ -743,7 +751,7 @@ function RemappedValue({
   const { data: cardData } = useGetRemappedCardParameterValueQuery(
     cardId != null && value != null && isRemapped
       ? {
-          card_id: cardId,
+          card_id: (token as unknown as number) ?? cardId,
           parameter_id: parameter.id,
           value,
         }

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/FieldValuesWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/FieldValuesWidget.tsx
@@ -54,6 +54,7 @@ import type {
   ParameterValueOrArray,
   RowValue,
 } from "metabase-types/api";
+import type { EntityToken } from "metabase-types/api/entity";
 import type { State } from "metabase-types/store";
 
 import { Value as ValueComponent } from "../Value";
@@ -113,7 +114,7 @@ export interface IFieldValuesWidgetProps {
   fields: Field[];
   dashboardId?: DashboardId;
   cardId?: CardId;
-  token?: string | null;
+  token?: EntityToken | null;
 
   value: RowValue[];
   onChange: (value: RowValue[]) => void;
@@ -692,7 +693,7 @@ function renderValue({
   parameter?: Parameter;
   cardId?: CardId;
   dashboardId?: DashboardId;
-  token?: string | null;
+  token?: EntityToken | null;
   autoLoad?: boolean;
   compact?: boolean;
   displayValue?: string;
@@ -721,7 +722,7 @@ type RemappedValueProps = {
   value: ParameterValueOrArray | null;
   dashboardId?: DashboardId;
   cardId?: CardId;
-  token?: string | null;
+  token?: EntityToken | null;
   tc: ContentTranslationFunction;
 };
 

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/ParameterFieldWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/ParameterFieldWidget.tsx
@@ -18,6 +18,7 @@ import {
   hasValue,
 } from "metabase-lib/v1/parameters/utils/parameter-values";
 import type { CardId, DashboardId, RowValue } from "metabase-types/api";
+import type { EntityToken } from "metabase-types/api/entity";
 
 import { Footer } from "../Widget";
 import { MIN_WIDTH } from "../constants";
@@ -34,7 +35,7 @@ interface ParameterFieldWidgetProps {
   value?: string | string[];
   cardId?: CardId;
   dashboardId?: DashboardId;
-  token?: string | null;
+  token?: EntityToken | null;
 }
 
 export function ParameterFieldWidget({

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/ParameterFieldWidgetValue/ParameterFieldWidgetValue.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/ParameterFieldWidgetValue/ParameterFieldWidgetValue.tsx
@@ -11,6 +11,7 @@ type ParameterFieldWidgetValueProps = {
   parameter: Parameter;
   cardId?: CardId;
   dashboardId?: DashboardId;
+  token?: string | null;
   displayValue?: string;
 };
 
@@ -20,6 +21,7 @@ export function ParameterFieldWidgetValue({
   parameter,
   cardId,
   dashboardId,
+  token,
   displayValue,
 }: ParameterFieldWidgetValueProps) {
   const values = normalizeValue(value);
@@ -37,6 +39,7 @@ export function ParameterFieldWidgetValue({
       parameter={parameter}
       cardId={cardId}
       dashboardId={dashboardId}
+      token={token}
       displayValue={displayValue}
     />
   );

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/ParameterFieldWidgetValue/ParameterFieldWidgetValue.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/ParameterFieldWidgetValue/ParameterFieldWidgetValue.tsx
@@ -1,6 +1,7 @@
 import { renderNumberOfSelections } from "metabase/parameters/utils/formatting";
 import Field from "metabase-lib/v1/metadata/Field";
 import type { CardId, DashboardId, Parameter } from "metabase-types/api";
+import type { EntityToken } from "metabase-types/api/entity";
 
 import { Value } from "../Value";
 import { normalizeValue } from "../normalizeValue";
@@ -11,7 +12,7 @@ type ParameterFieldWidgetValueProps = {
   parameter: Parameter;
   cardId?: CardId;
   dashboardId?: DashboardId;
-  token?: string | null;
+  token?: EntityToken | null;
   displayValue?: string;
 };
 

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/Value/Value.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/Value/Value.tsx
@@ -18,6 +18,7 @@ export const Value = ({
   parameter?: Parameter;
   cardId?: number;
   dashboardId?: DashboardId;
+  token?: string | null;
 } & OptionsType) => {
   const tc = useTranslateContent<unknown>();
 

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/Value/Value.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/Value/Value.tsx
@@ -4,6 +4,7 @@ import { useTranslateContent } from "metabase/i18n/hooks";
 import { formatValue } from "metabase/lib/formatting";
 import type { OptionsType } from "metabase/lib/formatting/types";
 import type { DashboardId, Parameter } from "metabase-types/api";
+import type { EntityToken } from "metabase-types/api/entity";
 
 import RemappedValue from "./RemappedValue";
 
@@ -18,7 +19,7 @@ export const Value = ({
   parameter?: Parameter;
   cardId?: number;
   dashboardId?: DashboardId;
-  token?: string | null;
+  token?: EntityToken | null;
 } & OptionsType) => {
   const tc = useTranslateContent<unknown>();
 

--- a/frontend/src/metabase/plugins/oss/api.ts
+++ b/frontend/src/metabase/plugins/oss/api.ts
@@ -2,7 +2,7 @@ import type { CardId, DashboardId, ParameterId } from "metabase-types/api";
 
 const getDefaultPluginApi = () => ({
   getRemappedCardParameterValueUrl: (
-    cardId: CardId,
+    cardId: CardId | string,
     parameterId: ParameterId,
   ) =>
     `/api/card/${cardId}/params/${encodeURIComponent(parameterId)}/remapping`,

--- a/frontend/src/metabase/plugins/oss/content-translation.ts
+++ b/frontend/src/metabase/plugins/oss/content-translation.ts
@@ -4,11 +4,12 @@ import type { ContentTranslationFunction } from "metabase/i18n/types";
 import { PluginPlaceholder } from "metabase/plugins/components/PluginPlaceholder";
 import type { HoveredObject } from "metabase/visualizations/types";
 import type { Series } from "metabase-types/api";
+import type { EntityToken } from "metabase-types/api/entity";
 
 const getDefaultPluginContentTranslation = () => ({
   isEnabled: false,
   getDictionaryBasePath: null as string | null,
-  setEndpointsForStaticEmbedding: (_encodedToken: string) => {},
+  setEndpointsForStaticEmbedding: (_encodedToken: EntityToken) => {},
   ContentTranslationConfiguration: PluginPlaceholder,
   useTranslateContent: <
     T = string | null | undefined,

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion.tsx
@@ -28,6 +28,7 @@ import type {
   ParameterId,
   ParameterValuesMap,
 } from "metabase-types/api";
+import type { EntityToken } from "metabase-types/api/entity";
 
 import { PublicOrEmbeddedQuestionView } from "../PublicOrEmbeddedQuestionView";
 
@@ -36,7 +37,7 @@ export const PublicOrEmbeddedQuestion = ({
   location,
 }: {
   location: Location;
-  params: { uuid: string; token: string };
+  params: { uuid: string; token: EntityToken };
 }) => {
   const dispatch = useDispatch();
   const metadata = useSelector(getMetadata);

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestionView.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestionView.tsx
@@ -24,6 +24,7 @@ import type {
   RawSeries,
   VisualizationSettings,
 } from "metabase-types/api";
+import type { EntityToken } from "metabase-types/api/entity";
 
 export interface PublicOrEmbeddedQuestionViewProps {
   initialized: boolean;
@@ -31,7 +32,7 @@ export interface PublicOrEmbeddedQuestionViewProps {
   metadata: Metadata;
   result: Dataset | null;
   uuid: string;
-  token: string;
+  token: EntityToken;
   getParameters: () => UiParameter[];
   parameterValues: ParameterValuesMap;
   setParameterValue: (parameterId: ParameterId, value: any) => Promise<void>;

--- a/frontend/src/metabase/query_builder/actions/core/card.ts
+++ b/frontend/src/metabase/query_builder/actions/core/card.ts
@@ -1,4 +1,5 @@
 import { Questions } from "metabase/entities/questions";
+import type { EntityToken } from "metabase-types/api/entity";
 import type { Dispatch, GetState } from "metabase-types/store";
 
 // load a card either by ID or from a base64 serialization.  if both are present then they are merged, which the serialized version taking precedence
@@ -8,7 +9,7 @@ export async function loadCard(
     token,
   }: {
     cardId: string | number;
-    token?: string | null;
+    token?: EntityToken | null;
   },
   { dispatch, getState }: { dispatch: Dispatch; getState: GetState },
 ) {

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -24,6 +24,7 @@ import { updateCardTemplateTagNames } from "metabase-lib/v1/queries/NativeQuery"
 import { cardIsEquivalent } from "metabase-lib/v1/queries/utils/card";
 import { normalize } from "metabase-lib/v1/queries/utils/normalize";
 import type { Card, SegmentId } from "metabase-types/api";
+import type { EntityToken } from "metabase-types/api/entity";
 import { isSavedCard } from "metabase-types/guards";
 import type {
   Dispatch,
@@ -120,7 +121,7 @@ async function fetchAndPrepareSavedQuestionCards(
     token,
   }: {
     cardId: string | number;
-    token?: string | null;
+    token?: EntityToken | null;
   },
   dispatch: Dispatch,
   getState: GetState,
@@ -180,7 +181,7 @@ export async function resolveCards({
   getState,
 }: {
   cardId?: string | number;
-  token?: string | null;
+  token?: EntityToken | null;
   deserializedCard?: Card;
   options: BlankQueryOptions;
   dispatch: Dispatch;

--- a/frontend/src/metabase/query_builder/components/ResponsiveParametersList.tsx
+++ b/frontend/src/metabase/query_builder/components/ResponsiveParametersList.tsx
@@ -6,6 +6,7 @@ import Button from "metabase/common/components/Button";
 import useIsSmallScreen from "metabase/common/hooks/use-is-small-screen";
 import { Box, Flex } from "metabase/ui";
 import type { CardId, DashboardId, Parameter } from "metabase-types/api";
+import type { EntityToken } from "metabase-types/api/entity";
 
 import ResponsiveParametersListS from "./ResponsiveParametersList.module.css";
 import { SyncedParametersList } from "./SyncedParametersList";
@@ -16,7 +17,7 @@ interface ResponsiveParametersListProps {
     parametersList?: string;
   };
   cardId?: CardId;
-  token?: string | null;
+  token?: EntityToken | null;
   dashboardId?: DashboardId;
   parameters: Parameter[];
   setParameterValue: (parameterId: string, value: string) => void;

--- a/frontend/src/metabase/questions/actions.ts
+++ b/frontend/src/metabase/questions/actions.ts
@@ -2,6 +2,7 @@ import { cardApi, datasetApi } from "metabase/api";
 import { Tables } from "metabase/entities/tables";
 import { entityCompatibleQuery } from "metabase/lib/entities";
 import type { Card, TableId, UnsavedCard } from "metabase-types/api";
+import type { EntityToken } from "metabase-types/api/entity";
 import { isSavedCard } from "metabase-types/guards";
 import type { Dispatch } from "metabase-types/store";
 
@@ -15,7 +16,7 @@ export const loadMetadataForTable =
   };
 
 export const loadMetadataForCard =
-  (card: Card | UnsavedCard, { token }: { token?: string | null } = {}) =>
+  (card: Card | UnsavedCard, { token }: { token?: EntityToken | null } = {}) =>
   async (dispatch: Dispatch) => {
     if (isSavedCard(card)) {
       return entityCompatibleQuery(

--- a/frontend/src/metabase/redux/downloads.ts
+++ b/frontend/src/metabase/redux/downloads.ts
@@ -18,6 +18,7 @@ import type {
   Dataset,
   VisualizationSettings,
 } from "metabase-types/api";
+import type { EntityToken } from "metabase-types/api/entity";
 import type { DownloadsState, State } from "metabase-types/store";
 
 import { trackDownloadResults } from "./downloads-analytics";
@@ -31,7 +32,7 @@ export interface DownloadQueryResultsOpts {
   dashboardId?: DashboardId;
   dashcardId?: DashCardId;
   uuid?: string;
-  token?: string | null;
+  token?: EntityToken | null;
   documentUuid?: string;
   documentId?: number;
   params?: Record<string, unknown>;
@@ -255,7 +256,7 @@ const getPublicQuestionParams = (
 };
 
 const getEmbedDashcardParams = (
-  token: string,
+  token: EntityToken,
   cardId: number,
   dashcardId: DashCardId,
   type: string,
@@ -271,7 +272,7 @@ const getEmbedDashcardParams = (
 });
 
 const getEmbedQuestionParams = (
-  token: string,
+  token: EntityToken,
   type: string,
   exportParams: ExportParams,
 ): DownloadQueryResultsParams => {

--- a/frontend/src/metabase/redux/metadata.js
+++ b/frontend/src/metabase/redux/metadata.js
@@ -195,7 +195,7 @@ export const addRemappings = (fieldId, remappings) => {
 const FETCH_REMAPPING = "metabase/metadata/FETCH_REMAPPING";
 export const fetchRemapping = createThunkAction(
   FETCH_REMAPPING,
-  ({ parameter, value, field, cardId, dashboardId }) =>
+  ({ parameter, value, field, cardId, dashboardId, token }) =>
     async (dispatch, getState) => {
       if (
         field == null ||
@@ -208,7 +208,7 @@ export const fetchRemapping = createThunkAction(
       if (dashboardId != null && parameter != null) {
         const remapping = await entityCompatibleQuery(
           {
-            dashboard_id: dashboardId,
+            dashboard_id: token ?? dashboardId,
             parameter_id: parameter.id,
             value,
           },
@@ -222,7 +222,7 @@ export const fetchRemapping = createThunkAction(
       } else if (cardId != null && parameter != null) {
         const remapping = await entityCompatibleQuery(
           {
-            card_id: cardId,
+            card_id: token ?? cardId,
             parameter_id: parameter.id,
             value,
           },

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
@@ -77,6 +77,7 @@ import type {
   TimelineEvent,
   VisualizationSettings,
 } from "metabase-types/api";
+import type { EntityToken } from "metabase-types/api/entity";
 import type { Dispatch, State } from "metabase-types/store";
 
 import { EmptyVizState } from "../EmptyVizState";
@@ -164,7 +165,7 @@ type VisualizationOwnProps = {
   timelineEvents?: TimelineEvent[];
   tc?: ContentTranslationFunction;
   uuid?: string;
-  token?: string;
+  token?: EntityToken;
   zoomedRowIndex?: number;
   onOpenChartSettings?: (data: {
     initialChartSettings: { section: string };

--- a/frontend/src/metabase/visualizations/lib/map.ts
+++ b/frontend/src/metabase/visualizations/lib/map.ts
@@ -2,6 +2,7 @@ import { IS_EMBED_PREVIEW } from "metabase/lib/embed";
 import { isJWT } from "metabase/lib/utils";
 import { isUuid } from "metabase/lib/uuid";
 import type { DashboardId, Dataset, JsonQuery } from "metabase-types/api";
+import type { EntityToken } from "metabase-types/api/entity";
 
 interface TileCoordinate {
   x: number | string;
@@ -18,7 +19,7 @@ interface TileUrlParams {
   lonField: string;
   datasetQuery?: JsonQuery;
   uuid?: string;
-  token?: string;
+  token?: EntityToken;
   datasetResult?: Dataset;
   /**
    * Indicates whether the tile URL is being generated for a preview embed context.
@@ -202,7 +203,7 @@ function dashboardTileUrl(
 }
 
 function publicCardTileUrl(
-  token: string,
+  token: EntityToken,
   zoom: string | number,
   coord: TileCoordinate,
   latField: string,
@@ -220,7 +221,7 @@ function publicCardTileUrl(
 }
 
 function publicDashboardTileUrl(
-  token: string,
+  token: EntityToken,
   dashcardId: number,
   cardId: number,
   zoom: string | number,
@@ -240,7 +241,7 @@ function publicDashboardTileUrl(
 }
 
 function embedCardTileUrl(
-  token: string,
+  token: EntityToken,
   zoom: string | number,
   coord: TileCoordinate,
   latField: string,
@@ -262,7 +263,7 @@ function embedCardTileUrl(
 }
 
 function embedDashboardTileUrl(
-  token: string,
+  token: EntityToken,
   dashcardId: number,
   cardId: number,
   zoom: string | number,

--- a/frontend/src/metabase/visualizations/types/visualization.ts
+++ b/frontend/src/metabase/visualizations/types/visualization.ts
@@ -29,6 +29,7 @@ import type {
   TransformedSeries,
   VisualizationSettings,
 } from "metabase-types/api";
+import type { EntityToken } from "metabase-types/api/entity";
 import type { VisualizationDisplay } from "metabase-types/api/visualization";
 import type { Dispatch, QueryBuilderMode } from "metabase-types/store";
 
@@ -143,7 +144,7 @@ export interface VisualizationProps {
   selectedTimelineEventIds?: TimelineEventId[];
   queryBuilderMode?: QueryBuilderMode;
   uuid?: string;
-  token?: string;
+  token?: EntityToken;
 
   gridSize?: VisualizationGridSize;
   width: number;
@@ -235,7 +236,7 @@ export type VisualizationPassThroughProps = {
 
   // Public & Embedded questions, needed for pin maps to generate the correct tile URL
   uuid?: string;
-  token?: string;
+  token?: EntityToken;
 
   /**
    * Extra buttons to be shown in the table footer (if the visualization is a table)

--- a/frontend/test/__support__/server-mocks/embed.ts
+++ b/frontend/test/__support__/server-mocks/embed.ts
@@ -1,10 +1,11 @@
 import fetchMock from "fetch-mock";
 
 import type { Card, Dashboard, DashboardCard } from "metabase-types/api";
+import type { EntityToken } from "metabase-types/api/entity";
 import { createMockDataset } from "metabase-types/api/mocks";
 
 export function setupEmbedDashboardEndpoints(
-  uuidOrToken: string,
+  uuidOrToken: EntityToken,
   dashboard: Dashboard,
   dashcards?: DashboardCard[],
 ) {

--- a/src/metabase/embedding_rest/api/common.clj
+++ b/src/metabase/embedding_rest/api/common.clj
@@ -303,12 +303,14 @@
   {:pre [((some-fn empty? sequential?) constraints) (even? (count constraints))]}
   (let [pre-card-id  (embed/get-in-unsigned-token-or-throw unsigned-token [:resource :question])
         card-id      (eid-translation/->id :model/Card pre-card-id)
-        token-params (embed/get-in-unsigned-token-or-throw unsigned-token [:params])]
+        token-params (embed/get-in-unsigned-token-or-throw unsigned-token [:params])
+        resolved-embedding-params (or embedding-params
+                                      (t2/select-one-fn :embedding_params :model/Card :id card-id))]
     (-> (apply api.public/public-card :id card-id, constraints)
         api.public/combine-parameters-and-template-tags
         (remove-token-parameters token-params)
-        (remove-locked-and-disabled-params (or embedding-params
-                                               (t2/select-one-fn :embedding_params :model/Card :id card-id))))))
+        (remove-locked-and-disabled-params resolved-embedding-params)
+        (assoc :embedding_params resolved-embedding-params))))
 
 (defn- get-embed-card-context
   "If a certain export-format is given, return the correct embedded card context."

--- a/src/metabase/embedding_rest/api/preview_embed.clj
+++ b/src/metabase/embedding_rest/api/preview_embed.clj
@@ -61,11 +61,7 @@
      :constraints      {:max-results max-results}
      :query-params     (api.embed.common/parse-query-params query-params))))
 
-;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
-;; use our API + we will need it when we make auto-TypeScript-signature generation happen
-;;
-#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
-(api.macros/defendpoint :get "/card/:token/params/:param-key/values"
+(api.macros/defendpoint :get "/card/:token/params/:param-key/values" :- ms/FieldValuesResult
   "Embedded version of api.card filter values endpoint."
   [{:keys [token param-key]} :- [:map
                                  [:token     string?]

--- a/src/metabase/embedding_rest/api/preview_embed.clj
+++ b/src/metabase/embedding_rest/api/preview_embed.clj
@@ -65,6 +65,23 @@
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
 ;;
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
+(api.macros/defendpoint :get "/card/:token/params/:param-key/values"
+  "Embedded version of api.card filter values endpoint."
+  [{:keys [token param-key]} :- [:map
+                                 [:token     string?]
+                                 [:param-key string?]]]
+  (let [unsigned-token (check-and-unsign token)
+        card           (api.embed.common/card-for-unsigned-token
+                        unsigned-token
+                        :embedding-params (embed/get-in-unsigned-token-or-throw unsigned-token [:_embedding_params]))]
+    (api.embed.common/card-param-values {:unsigned-token unsigned-token
+                                         :card           card
+                                         :param-key      param-key})))
+
+;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
+;; use our API + we will need it when we make auto-TypeScript-signature generation happen
+;;
+#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/card/:token/params/:param-key/remapping"
   "Embedded version of api.card filter values endpoint."
   [{:keys [token param-key]} :- [:map


### PR DESCRIPTION
Fix Question parameters field + remapping, added e2e.

During writing e2e, I've found that at some stage before I merged the Guest Embed PR, I broke remapping functionality.

Remapping itself for a question allows mapping other columns of other tables/the same table to a parameter, so the widget/parameter setup of that column is shown for a parameter.
Dashboard remapping allows mapping a column of a question to a parameter of a dashboard.

Also, the PR adds the missing /embed-preview endpoint for parameter values, to correctly display parameter values with the proper widget in an Embed JS wizard.

The PR fixes it so that it now works correctly for a Question. Without the fix, we don't display proper widgets from a target (remapped) colum.

How to verify for a question:
- quite tricky to verify manually
- but generally, create a native question with a param/variable. set its `Variable type` to `field filter`. Select other table/column and be sure that type of the widget or it's content now displays the items of that column. 
- Now via Embed JS wizard ensure that in the Wizard this param widget when opened has the proper type (from mapped column). 
- After it, publish the question, embed it on a page via Embed JS. 
- Ensure that when embedded it also has the proper parameter widget type: not original, but from tha field that we selected. Ensure that values are selectable.
- but overall we have a good e2e that tests it.

For a dashboard (it was not broken for a dashboard, but i added e2e for this case as well):
- New -> Question -> People -> Save as Q1
- New -> Dashboard -> Add Q1 -> Filter -> ID -> Map to People.ID -> Save
- In an embedded dashboard oppen the filter widget -> Set 1 -> Save
- You should see the remapped value (People.Name)