### PR TITLE
fix: cors popover white-on-white when dark mode

### DIFF
--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/CorsInputWidget.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/CorsInputWidget.tsx
@@ -38,7 +38,7 @@ export const CorsInputWidget = () => {
                 </HoverCard.Target>
 
                 <HoverCard.Dropdown>
-                  <Box p="md" w={270} bg="white">
+                  <Box p="md" w={270}>
                     <Text lh="lg" c="text-medium">
                       {corsHintText}
                     </Text>


### PR DESCRIPTION
Closes EMB-1129

### Description

Describe the overall approach and the problem being solved.

### How to verify

Go to http://localhost:3000/admin/embedding/security with dark mode

### Demo

<img width="1109" height="651" alt="image" src="https://github.com/user-attachments/assets/f87884e2-b4d6-4ffa-a241-577730ebd36f" />
<img width="1109" height="651" alt="image" src="https://github.com/user-attachments/assets/17afda42-b1cf-4b8d-9545-a8deb7b1f8c9" />

