### PR TITLE
Data Studio: Add a horizontal border across the top of the dependencies pages

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyGraphPage/DependencyGraphPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyGraphPage/DependencyGraphPage.tsx
@@ -1,6 +1,7 @@
 import type { Location } from "history";
 import { useContext } from "react";
 
+import CS from "metabase/css/core/index.css";
 import * as Urls from "metabase/lib/urls";
 import { PLUGIN_DEPENDENCIES } from "metabase/plugins";
 import { Stack } from "metabase/ui";
@@ -28,7 +29,7 @@ export function DependencyGraphPage({ location }: DependencyGraphPageProps) {
     defaultEntry == null || (entry != null && !isSameNode(entry, defaultEntry));
 
   return (
-    <Stack h="100%">
+    <Stack h="100%" className={CS.borderTop}>
       <DependencyGraph
         entry={entry ?? defaultEntry}
         getGraphUrl={(entry) => Urls.dependencyGraph({ entry, baseUrl })}

--- a/enterprise/frontend/src/metabase-enterprise/transforms/components/TransformHeader/TransformHeader.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/components/TransformHeader/TransformHeader.tsx
@@ -29,7 +29,7 @@ export function TransformHeader({
   return (
     <PaneHeader
       px={0}
-      py={0}
+      pt={0}
       title={<TransformNameInput transform={transform} />}
       icon="transform"
       menu={hasMenu && <TransformMoreMenu transform={transform} />}


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-2552/add-a-horizontal-border-across-the-top-of-the-dependency-graph

### Description

A top border should be added to the dependencies page in Transforms. This is also applied to dependencies in metrics and published table.

### How to verify

Navigate to Data Studio > Transforms > Pick one > Dependencies tab.
Check that the dependencies tab in metrics or data tables will also have the top border.

### Demo

In transforms
<img width="1909" height="236" alt="image" src="https://github.com/user-attachments/assets/56407db7-8216-497f-a35b-695ae576d4c4" />

In metrics
<img width="1909" height="226" alt="image" src="https://github.com/user-attachments/assets/9f3ffed9-3f55-4323-be74-e7c23a1f9e74" />

Table
<img width="1909" height="347" alt="image" src="https://github.com/user-attachments/assets/ee8aed1a-a4ff-45ee-8be1-ac79c5b2a534" />


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
