### PR TITLE
fix white on white popover on cors on the 57 release branch

### DIFF
--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
@@ -185,7 +185,7 @@ export function EmbeddingSdkSettings() {
                       </HoverCard.Target>
 
                       <HoverCard.Dropdown>
-                        <Box p="md" w={270} bg="white">
+                        <Box p="md" w={270}>
                           <Text lh="lg" c="text-medium">
                             {corsHintText}
                           </Text>


### PR DESCRIPTION
https://github.com/metabase/metabase/pull/66881 but on release 57
https://linear.app/metabase/issue/EMB-1129/fix-cors-admin-popover-text-in-dark-mode
<img width="530" height="281" alt="image" src="https://github.com/user-attachments/assets/c2d27542-1d40-4c0a-bfe7-738701292619" />
