### PR TITLE
feat: support remote-syncs from 58 -> 57

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/remote_sync/test_helpers.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/test_helpers.clj
@@ -40,6 +40,46 @@ is_sample: false
           name entity-id (str/replace (u/lower-case-en name) #"\s+" "_")
           (or parent-id "null") entity-id (str/replace (u/lower-case-en name) #"\s+" "_")))
 
+(defn generate-v58-collection-yaml
+  "Generates YAML content for a collection in v58 format.
+
+  In v58, remote-synced collections use `is_remote_synced: true` instead of
+  `type: remote-synced`. This helper is used to test backward compatibility
+  when importing exports from v58 Metabase instances into v57.
+
+  Args:
+    entity-id: The unique identifier for the collection.
+    name: The name of the collection.
+    parent-id: Optional parent collection ID.
+    is-remote-synced: Optional boolean for is_remote_synced field (default false).
+
+  Returns:
+    A string containing the v58-format YAML representation of the collection."
+  [entity-id name & {:keys [parent-id is-remote-synced]}]
+  (format "name: %s
+description: null
+entity_id: %s
+slug: %s
+created_at: '2024-08-28T09:46:18.671622Z'
+archived: false
+type: null
+parent_id: %s
+personal_owner_id: null
+namespace: null
+authority_level: null
+serdes/meta:
+- id: %s
+  label: %s
+  model: Collection
+archive_operation_id: null
+archived_directly: null
+is_sample: false
+is_remote_synced: %s
+"
+          name entity-id (str/replace (u/lower-case-en name) #"\s+" "_")
+          (or parent-id "null") entity-id (str/replace (u/lower-case-en name) #"\s+" "_")
+          (if is-remote-synced "true" "false")))
+
 (defn generate-card-yaml
   "Generates YAML content for a card.
 

--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -1825,10 +1825,15 @@
           :is_sample
           :name
           :namespace
-          :slug
-          :type]
+          :slug]
    :skip []
-   :transform {:created_at        (serdes/date)
+   :transform {;; handle importing v58 remote-sync exports into a v57 instance
+               :type {:import-with-context
+                      (fn [ingested _k _v]
+                        (or (:type ingested)
+                            (when (:is_remote_synced ingested) "remote-synced")))
+                      :export identity}
+               :created_at        (serdes/date)
                ;; We only dump the parent id, and recalculate the location from that on load.
                :location          (serdes/as :parent_id
                                              (serdes/compose


### PR DESCRIPTION
### Description

Handles cross version imports (at least for the remote-sync type itself) from metabase 58 to metabase 57.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
