### PR TITLE
Fix mage doctor to work without mise and add tests

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -399,10 +399,17 @@
    :data       {:a [:b :c] :b [:d]}}
 
   -test {:doc      "run all mage tests"
-         :requires [[mage.core-test] ;; loads the actual tests
-                    [mage.util :as u]
-                    [clojure.test]]
-         :task     (let [results (clojure.test/run-all-tests (re-pattern "^mage\\..*"))]
+         :requires [[clojure.string :as str]
+                    [clojure.test]
+                    [mage.core-test] ;; loads the actual tests
+                    [mage.util :as u]]
+         :arg-schema [:sequential [:string {:name "test-matching-pattern"}]]
+         :task     (let [{:keys [arguments]} (task! parsed)
+                         pattern (if (seq arguments)
+                                   (str "^mage\\..*(" (str/join "|" arguments) ").*")
+                                   "^mage\\..*")
+                         _ (u/debug ["test regex matching pattern" pattern])
+                         results (clojure.test/run-all-tests (re-pattern pattern))]
                      (if (zero? (+ (:fail results) (:error results)))
                        (println (c/green "All mage tests passed!"))
                        (do

--- a/mage/src/mage/doctor.clj
+++ b/mage/src/mage/doctor.clj
@@ -6,90 +6,29 @@
    [babashka.json :as json]
    [babashka.process :as p]
    [clojure.string :as str]
+   [mage.be-dev :as backend]
    [mage.color :as c]
    [mage.util :as u]))
 
 (set! *warn-on-reflection* true)
 
-;;; -------------------------------------------------- Configuration --------------------------------------------------
-
-(def config
-  "Declarative configuration for all doctor checks."
-  {:version-managers
-   ;; Detected by: command exists OR home directory exists OR env var set
-   {"nvm" {:name "nvm (Node Version Manager)"
-           :home "~/.nvm"
-           :env ["NVM_DIR"]}
-    "fnm" {:name "fnm (Fast Node Manager)"
-           :home "~/.fnm"}
-    "volta" {:name "Volta"
-             :home "~/.volta"}
-    "asdf" {:name "asdf"
-            :home "~/.asdf"}
-    "mise" {:name "mise"}
-    "jenv" {:name "jenv"
-            :home "~/.jenv"}
-    "sdkman" {:name "SDKMAN!"
-              :home "~/.sdkman"
-              :env ["SDKMAN_DIR"]}}
-
-   :required-tools
-   ;; Tools required for Metabase development
-   ;; :validate - fn that takes version string, returns {:ok true} or {:ok false :msg "..." :hint "..."}
-   [{:tool "node"
-     :name "Node.js"
-     :validate :node-22+}
-    {:tool "yarn"
-     :name "Yarn"
-     :validate :yarn-classic}
-    {:tool "java"
-     :name "Java"
-     :validate :java-21-temurin}
-    {:tool "clojure"
-     :name "Clojure CLI"}
-    {:tool "babashka"
-     :name "Babashka"}]
-
-   :dev-tools
-   ;; Optional but recommended (not managed by mise)
-   [{:cmd "docker"
-     :name "Docker"
-     :hint "Optional: Install Docker for database testing (OrbStack recommended on macOS)"}]
-
-   :project-checks
-   [{:path "node_modules"
-     :name "node_modules"
-     :ok-message "Present"
-     :missing-status :warn
-     :missing-hint "Run `yarn install` to install frontend dependencies"}
-    {:path ".nrepl-port"
-     :name ".nrepl-port"
-     :special :nrepl-port}
-    {:name "Git hooks"
-     :special :git-hooks}
-    {:path "mise.local.toml"
-     :name "mise.local.toml"
-     :ok-message "Present (personal overrides)"
-     :missing-status :info
-     :missing-hint "Optional: Create mise.local.toml for personal tool overrides"}]
-
-   :conflict-checks
-   [{:path "yarn.lock"
-     :name "yarn.lock"
-     :missing-status :warn
-     :missing-hint "Run `yarn install` to generate"}
-    {:path "deps.edn"
-     :name "deps.edn"
-     :missing-status :error
-     :missing-hint "deps.edn is required"}]})
-
-;;; -------------------------------------------------- Shell Helpers --------------------------------------------------
+;;; -------------------------------------------------- Helpers --------------------------------------------------
 
 (defn- sh
-  "Run a command and return its stdout, or nil if command fails."
+  "Run a command and return its stdout, or nil if command fails. Suppresses stderr."
   [& cmd]
   (try
-    (not-empty (apply u/sh cmd))
+    (let [result @(apply p/process {:out :string :err :string :dir u/project-root-directory} cmd)]
+      (when (zero? (:exit result))
+        (not-empty (str/trim (:out result)))))
+    (catch Exception _ nil)))
+
+(defn- sh+err
+  "Run a command and return combined stdout+stderr (for commands like java -version)."
+  [& cmd]
+  (try
+    (let [result @(apply p/process {:out :string :err :string} cmd)]
+      (not-empty (str/trim (str (:out result) "\n" (:err result)))))
     (catch Exception _ nil)))
 
 (defn- can-run?
@@ -103,314 +42,331 @@
   [env-var]
   (some? (u/env env-var (constantly nil))))
 
-;;; -------------------------------------------------- Check Result --------------------------------------------------
-
-(defn- check-result
-  "Create a check result map."
-  [name status message & {:keys [hint]}]
-  {:name name
-   :status status
-   :message message
-   :hint hint})
-
 ;;; -------------------------------------------------- Version Parsing --------------------------------------------------
 
-(defn- parse-major-version
-  "Extract major version number from a version string like '21.0.1' or 'v22.13.1'."
+(defn parse-version
+  "Parse a version string into comparable parts. Returns vector of integers."
   [version-str]
   (when version-str
-    (some-> (re-find #"(\d+)" (str/replace version-str #"^v" ""))
-            second
-            parse-long)))
+    (->> (re-seq #"\d+" version-str)
+         (take 3)
+         (mapv parse-long))))
 
-;;; -------------------------------------------------- Mise Integration --------------------------------------------------
+(defn version>=
+  "Check if version a >= version b. Compares major.minor.patch semantically."
+  [a b]
+  (let [a-parts (parse-version a)
+        b-parts (parse-version b)
+        ;; Pad shorter vector with zeros for proper comparison
+        max-len (max (count a-parts) (count b-parts))
+        pad (fn [v] (into v (repeat (- max-len (count v)) 0)))
+        a-padded (pad a-parts)
+        b-padded (pad b-parts)]
+    (>= (compare a-padded b-padded) 0)))
 
-(defn- get-mise-doctor-info
-  "Get parsed output from `mise doctor --json`. Returns nil if mise not available."
+;;; -------------------------------------------------- Tool Info Gathering --------------------------------------------------
+
+(defn- get-tool-version
+  "Get version string for a tool by running it directly."
+  [tool]
+  (case tool
+    "git"      (some-> (sh "git" "--version") (str/replace #"git version\s*" ""))
+    "node"     (some-> (sh "node" "--version") (str/replace #"^v" ""))
+    "yarn"     (sh "yarn" "--version")
+    "java"     (when-let [output (sh+err "java" "-version")]
+                 (when-let [match (re-find #"version\s+\"([^\"]+)\"" output)]
+                   (second match)))
+    "clojure"  (some-> (sh "clojure" "--version")
+                       (str/replace #"Clojure CLI version\s*" ""))
+    "babashka" (some-> (sh "bb" "--version")
+                       (str/replace #"babashka\s*v?" ""))
+    "docker"   (some-> (sh "docker" "--version")
+                       (str/replace #"Docker version\s*" "")
+                       (str/replace #",.*" ""))
+    "mise"     (sh "mise" "--version")
+    nil))
+
+(def ^:private tool-commands
+  "Map of tool name to the command used to run it."
+  {"babashka" "bb"})
+
+(defn- check-tool
+  "Check if a tool is installed and get its version.
+   Returns {:installed? bool, :version str-or-nil}.
+   A tool is considered installed only if we can successfully get its version."
+  [tool]
+  (let [cmd (get tool-commands tool tool)]
+    (if (can-run? cmd)
+      (if-let [version (get-tool-version tool)]
+        {:installed? true :version version}
+        ;; Command exists but version check failed (e.g., yarn without node)
+        {:installed? false :binary-exists? true})
+      {:installed? false})))
+
+(defn- java-vendor
+  "Detect Java vendor from version output."
   []
-  (when (can-run? "mise")
-    (try
-      (let [output (sh "mise" "doctor" "--json")]
-        (when output
-          (json/read-str output)))
-      (catch Exception _ nil))))
-
-(defn- get-mise-toolset
-  "Get the toolset map from mise doctor, keyed by tool name."
-  [mise-info]
-  (when-let [toolset (:toolset mise-info)]
-    ;; toolset is {"node" [{:version "22.13.1"}], ...}
-    ;; Flatten to {"node" "22.13.1", ...}
-    (into {}
-          (for [[tool versions] toolset
-                :let [version (-> versions first :version)]
-                :when version]
-            [tool version]))))
-
-(defn- get-mise-project-tools
-  "Get list of tools configured for this project from mise config --json."
-  []
-  (when (can-run? "mise")
-    (try
-      (let [output (sh "mise" "config" "--json")
-            configs (when output (json/read-str output))
-            project-config (->> configs
-                                (filter #(str/starts-with? (:path %) u/project-root-directory))
-                                first)]
-        (set (:tools project-config)))
-      (catch Exception _ nil))))
-
-;;; -------------------------------------------------- Tool Validators --------------------------------------------------
-
-(defmulti validate-tool
-  "Validate a tool version. Returns {:ok true} or {:ok false :msg \"...\" :hint \"...\"}."
-  (fn [validator _version] validator))
-
-(defmethod validate-tool :default [_ _]
-  {:ok true})
-
-(defmethod validate-tool :node-22+ [_ version]
-  (let [major (parse-major-version version)]
-    (if (and major (>= major 22))
-      {:ok true}
-      {:ok false
-       :msg (str version " (requires >= 22)")
-       :hint "Upgrade Node.js to version 22+"})))
-
-(defmethod validate-tool :yarn-classic [_ version]
-  (if (and version (str/starts-with? version "1."))
-    {:ok true :suffix " (Classic)"}
-    {:ok false
-     :msg (str version " (requires Yarn Classic 1.x, NOT Berry/2+)")
-     :hint "Metabase requires Yarn Classic 1.x"}))
-
-(defmethod validate-tool :java-21-temurin [_ version]
-  (let [major (parse-major-version version)
-        is-temurin (and version (str/includes? (str/lower-case version) "temurin"))]
+  (when-let [output (sh+err "java" "-version")]
     (cond
-      (nil? version)
-      {:ok false :msg "Not installed" :hint "Run `mise install`"}
+      (str/includes? (str/lower-case output) "temurin") :temurin
+      (str/includes? (str/lower-case output) "openjdk") :openjdk
+      (str/includes? (str/lower-case output) "oracle")  :oracle
+      (str/includes? (str/lower-case output) "zulu")    :zulu
+      (str/includes? (str/lower-case output) "corretto") :corretto
+      :else :unknown)))
 
-      (not= major 21)
-      {:ok false
-       :msg (str version " (requires Java 21)")
-       :hint "Install Java 21 Eclipse Temurin"}
+;;; -------------------------------------------------- Mise Info --------------------------------------------------
 
-      (not is-temurin)
-      {:ok :warn
-       :msg (str version " (recommend Eclipse Temurin)")
-       :hint "Consider switching to Eclipse Temurin for consistency"}
-
-      :else
-      {:ok true
-       ;; Clean up the version display
-       :version (-> version
-                    (str/replace #"temurin-" "")
-                    (str/replace #"\+.*" "")
-                    (str " Temurin"))})))
-
-;;; -------------------------------------------------- Tool Checks --------------------------------------------------
-
-(defn- check-required-tool
-  "Check a required tool using mise toolset."
-  [toolset {:keys [tool name validate]}]
-  (let [version (get toolset (keyword tool))]
-    (if (nil? version)
-      (check-result name :error "Not installed"
-                    :hint "Run `mise install` or `./bin/dev-install`")
-      (let [validation (validate-tool validate version)]
-        (case (:ok validation)
-          true
-          (check-result name :ok
-                        (str (or (:version validation) version)
-                             (:suffix validation "")))
-          :warn
-          (check-result name :warn (:msg validation)
-                        :hint (:hint validation))
-          ;; false
-          (check-result name :error (:msg validation)
-                        :hint (:hint validation)))))))
-
-(defn- check-dev-tool
-  "Check an optional development tool (not mise-managed)."
-  [{:keys [cmd name hint]}]
-  (if (can-run? cmd)
-    (let [version (some-> (sh cmd "--version")
-                          (str/split #"\n")
-                          first
-                          (str/replace #"^Docker version " ""))]
-      (check-result name :ok (or version "installed")))
-    (check-result name :warn "Not installed" :hint hint)))
-
-(defn- check-optional-tool
-  "Check an optional tool from mise toolset. Returns nil if not installed."
-  [toolset tool-name]
-  (when-let [version (get toolset (keyword tool-name))]
-    (check-result tool-name :ok version)))
-
-(defn- check-git
-  "Check git is installed (not managed by mise)."
+(defn- get-mise-info
+  "Get mise installation and configuration info.
+   Returns {:installed? bool, :activated? bool, :toolset map}."
   []
-  (if-let [version (sh "git" "--version")]
-    (check-result "Git" :ok (str/replace version #"git version " ""))
-    (check-result "Git" :error "Not installed"
-                  :hint "Git is required for Metabase development")))
+  (if-not (can-run? "mise")
+    {:installed? false}
+    (let [doctor-json (try
+                        (some-> (sh "mise" "doctor" "--json")
+                                json/read-str)
+                        (catch Exception _ nil))
+          config-json (try
+                        (some-> (sh "mise" "config" "--json")
+                                json/read-str)
+                        (catch Exception _ nil))
+          project-config (->> config-json
+                              (filter #(str/starts-with? (str (:path %)) u/project-root-directory))
+                              first)]
+      {:installed? true
+       :activated? (:activated doctor-json false)
+       :toolset (when-let [ts (:toolset doctor-json)]
+                  (into {}
+                        (for [[tool versions] ts
+                              :let [v (-> versions first :version)]
+                              :when v]
+                          [(keyword tool) v])))
+       :project-tools (set (:tools project-config))})))
 
 ;;; -------------------------------------------------- Version Manager Detection --------------------------------------------------
 
-(defn- version-manager-present?
-  "Check if a version manager is present based on its config."
-  [cmd {:keys [home env]}]
-  (or (can-run? cmd)
-      (and home (fs/exists? (fs/expand-home home)))
-      (and env (some env-set? env))))
+(def ^:private version-manager-config
+  {"nvm"    {:name "nvm (Node Version Manager)" :home "~/.nvm" :env ["NVM_DIR"]}
+   "fnm"    {:name "fnm (Fast Node Manager)" :home "~/.fnm"}
+   "volta"  {:name "Volta" :home "~/.volta"}
+   "asdf"   {:name "asdf" :home "~/.asdf"}
+   "mise"   {:name "mise"}
+   "jenv"   {:name "jenv" :home "~/.jenv"}
+   "sdkman" {:name "SDKMAN!" :home "~/.sdkman" :env ["SDKMAN_DIR"]}})
 
 (defn- detect-version-managers
-  "Detect installed version managers from config."
+  "Detect which version managers are present."
   []
-  (->> (:version-managers config)
-       (filter (fn [[cmd cfg]] (version-manager-present? cmd cfg)))
-       (mapv (fn [[cmd cfg]] {:cmd cmd :name (:name cfg)}))
-       (sort-by :cmd)))
+  (into {}
+        (for [[cmd {:keys [name home env]}] version-manager-config
+              :let [present? (or (can-run? cmd)
+                                 (and home (fs/exists? (fs/expand-home home)))
+                                 (and env (some env-set? env)))]
+              :when present?]
+          [(keyword cmd) {:name name}])))
 
-;;; -------------------------------------------------- Project Health Checks --------------------------------------------------
+;;; -------------------------------------------------- Project State --------------------------------------------------
 
-(defn- check-git-hooks-special
-  "Check if git hooks are configured (supports both .git/hooks and custom hooksPath like Husky)."
+(defn- check-path-exists
+  "Check if a path exists relative to project root."
+  [path]
+  (fs/exists? (str u/project-root-directory "/" path)))
+
+(defn- check-file-conflicts
+  "Check if a file has merge conflict markers."
+  [path]
+  (let [full-path (str u/project-root-directory "/" path)]
+    (when (fs/exists? full-path)
+      (str/includes? (slurp full-path) "<<<<<<<"))))
+
+(defn- check-nrepl-port
+  "Check .nrepl-port file status."
+  []
+  (let [path (str u/project-root-directory "/.nrepl-port")]
+    (if-not (fs/exists? path)
+      {:exists? false}
+      (let [port (try (parse-long (str/trim (slurp path))) (catch Exception _ nil))]
+        (if-not port
+          {:exists? true :valid? false}
+          (let [result (try
+                         @(p/process {:out :string :err :string} "lsof" "-i" (str ":" port) "-sTCP:LISTEN")
+                         (catch Exception _ nil))
+                listening? (and result
+                                (zero? (:exit result))
+                                (not (str/blank? (:out result))))
+                nrepl-type (when listening? (backend/nrepl-type nil))]
+            {:exists? true
+             :valid? true
+             :port port
+             :listening? listening?
+             :nrepl-type nrepl-type}))))))
+
+(defn- check-git-hooks
+  "Check git hooks configuration."
   []
   (let [hooks-path (-> (sh "git" "config" "--get" "core.hooksPath")
                        (or "")
                        str/trim)]
     (if (not (str/blank? hooks-path))
       ;; Custom hooks path (e.g., Husky)
-      (let [full-path (str u/project-root-directory "/" hooks-path "/pre-commit")]
-        (if (fs/exists? full-path)
-          (check-result "Git hooks" :ok (str "Configured (" hooks-path ")"))
-          (check-result "Git hooks" :warn "Missing"
-                        :hint "Run `yarn install` to set up Husky git hooks")))
+      {:configured? (fs/exists? (str u/project-root-directory "/" hooks-path "/pre-commit"))
+       :path hooks-path}
       ;; Default .git/hooks
-      (let [default-path (str u/project-root-directory "/.git/hooks/pre-commit")]
-        (if (fs/exists? default-path)
-          (check-result "Git hooks" :ok "Configured")
-          (check-result "Git hooks" :warn "Missing"
-                        :hint "Run `yarn install` to set up git hooks"))))))
+      {:configured? (fs/exists? (str u/project-root-directory "/.git/hooks/pre-commit"))
+       :path ".git/hooks"})))
 
-(defn- check-nrepl-port-special
-  "Check if .nrepl-port exists and if the port is actually listening."
+(defn- get-project-state
+  "Get project file/directory state."
   []
-  (let [path (str u/project-root-directory "/.nrepl-port")]
-    (if (fs/exists? path)
-      (let [port (try (parse-long (str/trim (slurp path))) (catch Exception _ nil))]
-        (if port
-          (let [result (try
-                         @(p/process {:out :string :err :string}
-                                     "lsof" "-i" (str ":" port) "-sTCP:LISTEN")
-                         (catch Exception _ nil))]
-            (if (and result (zero? (:exit result)) (not (str/blank? (:out result))))
-              (check-result ".nrepl-port" :ok (str "Port " port " (backend running)"))
-              (check-result ".nrepl-port" :warn (str "Port " port " (backend not running)")
-                            :hint "Stale .nrepl-port file - delete it or restart backend")))
-          (check-result ".nrepl-port" :warn "Invalid port file"
-                        :hint "Delete .nrepl-port and restart your backend")))
-      (check-result ".nrepl-port" :info "Not present (backend not started)"
-                    :hint "Start the backend REPL to enable mage REPL commands"))))
+  {:node-modules {:exists? (check-path-exists "node_modules")}
+   :nrepl-port (check-nrepl-port)
+   :git-hooks (check-git-hooks)
+   :mise-local {:exists? (check-path-exists "mise.local.toml")}
+   :yarn-lock {:exists? (check-path-exists "yarn.lock")
+               :conflicts? (check-file-conflicts "yarn.lock")}
+   :deps-edn {:exists? (check-path-exists "deps.edn")
+              :conflicts? (check-file-conflicts "deps.edn")}})
 
-(defn- check-project-item
-  "Check a project file/directory from config.
-   Returns nil for optional missing items (missing-status :info)."
-  [{:keys [path name ok-message missing-status missing-hint special]}]
-  (case special
-    :nrepl-port (check-nrepl-port-special)
-    :git-hooks (check-git-hooks-special)
-    ;; default: simple path check
-    (let [full-path (str u/project-root-directory "/" path)]
-      (if (fs/exists? full-path)
-        (check-result name :ok (or ok-message "Present"))
-        ;; Return nil for optional items, otherwise return the missing status
-        (when-not (= missing-status :info)
-          (check-result name missing-status "Missing"
-                        :hint missing-hint))))))
+;;; -------------------------------------------------- Git Status --------------------------------------------------
 
-(defn- check-conflict
-  "Check a file for merge conflict markers."
-  [{:keys [path name missing-status missing-hint]}]
-  (let [full-path (str u/project-root-directory "/" path)]
-    (if (fs/exists? full-path)
-      (let [content (slurp full-path)]
-        (if (str/includes? content "<<<<<<<")
-          (check-result name :error "Has merge conflicts"
-                        :hint (str "Resolve conflicts in " path))
-          (check-result name :ok "No conflicts")))
-      (check-result name missing-status "Missing"
-                    :hint missing-hint))))
-
-(defn- check-git-status
-  "Check git working directory status."
-  []
-  (let [status (sh "git" "status" "--porcelain")]
-    (if (str/blank? status)
-      (check-result "Working tree" :ok "Clean")
-      (let [lines (str/split-lines status)]
-        (check-result "Working tree" :info (str (count lines) " uncommitted change(s)")
-                      :hint "You have local changes")))))
-
-(defn- check-git-branch-status
-  "Check if current branch is up to date with remote."
+(defn get-git-status
+  "Get git repository status. Separate function since it may be slow (fetches)."
   []
   (let [_ (try @(p/process {:out :string :err :string :dir u/project-root-directory}
                            "git" "fetch" "--quiet")
                (catch Exception _ nil))
         branch (sh "git" "rev-parse" "--abbrev-ref" "HEAD")
-        status (sh "git" "rev-list" "--left-right" "--count"
-                   (str "HEAD...origin/" branch))]
-    (if (and branch status)
-      (let [[ahead behind] (map parse-long (str/split status #"\t"))]
-        (cond
-          (and (zero? ahead) (zero? behind))
-          (check-result "Branch" :ok (str branch (c/white " (up to date)")))
+        porcelain (sh "git" "status" "--porcelain")
+        rev-list (when branch
+                   (sh "git" "rev-list" "--left-right" "--count"
+                       (str "HEAD...origin/" branch)))
+        [ahead behind] (when rev-list
+                         (map parse-long (str/split rev-list #"\t")))]
+    {:branch branch
+     :ahead (or ahead 0)
+     :behind (or behind 0)
+     :clean? (str/blank? porcelain)
+     :uncommitted-count (if (str/blank? porcelain)
+                          0
+                          (count (str/split-lines porcelain)))}))
 
-          (and (pos? ahead) (zero? behind))
-          (check-result "Branch" :info (str branch " (" ahead " ahead)")
-                        :hint "You have unpushed commits")
+;;; -------------------------------------------------- Main Diagnose Function --------------------------------------------------
 
-          (and (zero? ahead) (pos? behind))
-          (check-result "Branch" :warn (str branch " (" behind " behind)")
-                        :hint "Run `git pull` to update")
+(defn diagnose
+  "Gather all environment diagnostic info. Returns a map with:
+   - :mise - mise installation/activation status
+   - :version-managers - detected version managers
+   - :tools - map of tool-name to {:installed? :version ...}
+   - :project - project file states
 
-          :else
-          (check-result "Branch" :warn (str branch " (" ahead " ahead, " behind " behind)")
-                        :hint "Branch has diverged — consider rebasing")))
-      (check-result "Branch" :info (or branch "unknown")
-                    :hint "Could not determine remote status"))))
+   Note: Does NOT include git status (use get-git-status separately for that)."
+  []
+  (let [mise (get-mise-info)
+        toolset (:toolset mise)]
+    {:mise mise
+     :version-managers (detect-version-managers)
+     :tools {:git (check-tool "git")
+             :node (let [info (check-tool "node")]
+                     (if-not (:installed? info)
+                       (if-let [v (:node toolset)]
+                         {:installed? true :version v :source :mise}
+                         info)
+                       info))
+             :yarn (let [info (check-tool "yarn")]
+                     (if-not (:installed? info)
+                       (if-let [v (:yarn toolset)]
+                         {:installed? true :version v :source :mise}
+                         info)
+                       info))
+             :java (let [info (check-tool "java")]
+                     (if (:installed? info)
+                       (assoc info :vendor (java-vendor))
+                       (if-let [v (:java toolset)]
+                         {:installed? true :version v :source :mise}
+                         info)))
+             :clojure (let [info (check-tool "clojure")]
+                        (if-not (:installed? info)
+                          (if-let [v (:clojure toolset)]
+                            {:installed? true :version v :source :mise}
+                            info)
+                          info))
+             :babashka (check-tool "babashka")
+             :docker (check-tool "docker")}
+     :project (get-project-state)}))
 
-;;; -------------------------------------------------- Output Formatting --------------------------------------------------
+;;; -------------------------------------------------- Formatting / Printing --------------------------------------------------
+
+(defn- format-tool-status
+  "Format a tool check for display. Returns {:name :status :message :hint}."
+  [tool-name {:keys [installed? version vendor]} & {:keys [required-version vendor-hint]}]
+  (let [display-name (case tool-name
+                       :git "Git"
+                       :node "Node.js"
+                       :yarn "Yarn"
+                       :java "Java"
+                       :clojure "Clojure CLI"
+                       :babashka "Babashka"
+                       :docker "Docker"
+                       (name tool-name))]
+    (cond
+      (not installed?)
+      {:name display-name
+       :status :error
+       :message "Not installed"
+       :hint "Run `./bin/dev-install` to set up your environment"}
+
+      ;; Version validation
+      (and required-version (not (version>= version required-version)))
+      {:name display-name
+       :status :error
+       :message (str version " (requires >= " required-version ")")
+       :hint (str "Upgrade " display-name " to version " required-version "+")}
+
+      ;; Yarn must be 1.x
+      (and (= tool-name :yarn) version (not (str/starts-with? version "1.")))
+      {:name display-name
+       :status :error
+       :message (str version " (requires Yarn Classic 1.x)")
+       :hint "Metabase requires Yarn Classic 1.x, NOT Berry/2+"}
+
+      ;; Java vendor warning
+      (and (= tool-name :java) vendor-hint (not= vendor :temurin))
+      {:name display-name
+       :status :warn
+       :message (str version " (" (name (or vendor :unknown)) ")")
+       :hint "Consider using Eclipse Temurin for consistency"}
+
+      :else
+      {:name display-name
+       :status :ok
+       :message (str (or version "installed")
+                     (when (and (= tool-name :yarn) version) " (Classic)")
+                     (when (= vendor :temurin) " Temurin"))})))
 
 (defn- status-icon [status]
   (case status
     :ok (c/green "✓")
-    :warn (c/yellow "⚠")
+    :warn "⚠"
     :error (c/red "✗")
     :info (c/yellow "–")))
 
-(defn- format-check
-  "Format and print a check result. Returns nil for nil input (skips output)."
-  [{:keys [name status message hint] :as check}]
-  (when check
-    (let [icon (status-icon status)
-          msg (case status
-                :ok (c/green message)
-                :warn (c/yellow message)
-                :error (c/red message)
-                :info (c/yellow message))]
-      (if hint
-        (println (str "- " icon " **" name "**: " msg " " (c/gray (str "— " hint))))
-        (println (str "- " icon " **" name "**: " msg))))))
+(defn- print-check [{:keys [name status message hint]}]
+  (let [icon (status-icon status)
+        msg (case status
+              :ok (c/green message)
+              :warn (c/yellow message)
+              :error (c/red message)
+              :info (c/yellow message))]
+    (if hint
+      (println (str "- " icon " **" name "**: " msg " " (c/gray (str "— " hint))))
+      (println (str "- " icon " **" name "**: " msg)))))
 
 (defn- print-section [title]
   (println)
   (println (str "## " (c/bold title))))
 
-;;; -------------------------------------------------- Main Entry Point --------------------------------------------------
+;;; -------------------------------------------------- Doctor Command --------------------------------------------------
 
 (defn doctor!
   "Run all health checks and print results."
@@ -418,91 +374,152 @@
   (println)
   (println (c/bold "# 🩺 Metabase Development Environment Doctor"))
 
-  ;; Get mise info upfront
-  (let [mise-info (get-mise-doctor-info)
-        toolset (get-mise-toolset mise-info)
-        project-tools (get-mise-project-tools)]
+  (let [{:keys [mise version-managers tools project]} (diagnose)
+        *git-status (future (get-git-status))
 
-    ;; Check mise first
-    (when-not mise-info
-      (print-section "⚠️  mise not installed")
-      (println (c/red "mise is required for managing development tools."))
-      (println (str "Run " (c/green "./bin/dev-install") " to set up your environment."))
-      (println)
-      (u/exit 1))
+        ;; Format all tool checks
+        tool-checks [(format-tool-status :git (:git tools))
+                     (format-tool-status :node (:node tools) :required-version "22")
+                     (format-tool-status :yarn (:yarn tools))
+                     (format-tool-status :java (:java tools) :required-version "21" :vendor-hint true)
+                     (format-tool-status :clojure (:clojure tools))
+                     (format-tool-status :babashka (:babashka tools))]
+
+        mise-check (cond
+                     (not (:installed? mise))
+                     {:name "mise" :status :warn :message "not installed"
+                      :hint "Run `./bin/dev-install` to set up your environment"}
+                     (not (:activated? mise))
+                     {:name "mise" :status :warn :message "not activated"
+                      :hint "Run `mise activate` in your shell"}
+                     :else
+                     {:name "mise" :status :ok :message "activated"})
+
+        docker-check (if (:installed? (:docker tools))
+                       {:name "Docker" :status :ok :message (:version (:docker tools))}
+                       {:name "Docker" :status :warn :message "Not installed"
+                        :hint "Optional: Install Docker for database testing"})
+
+        ;; Project checks
+        project-checks
+        [(if (get-in project [:node-modules :exists?])
+           {:name "node_modules" :status :ok :message "Present"}
+           {:name "node_modules" :status :warn :message "Missing"
+            :hint "Run `yarn install` to install frontend dependencies"})
+
+         (let [{:keys [exists? valid? port listening? nrepl-type]} (:nrepl-port project)]
+           (cond
+             (not exists?)
+             {:name ".nrepl-port" :status :info :message "Not present (backend not started)"}
+             (not valid?)
+             {:name ".nrepl-port" :status :warn :message "Invalid port file"
+              :hint "Delete .nrepl-port and restart your backend"}
+             listening?
+             {:name ".nrepl-port" :status :ok :message (str "Port " port " (backend running)"
+                                                            (when nrepl-type (str " (repl type " nrepl-type ")")))}
+             :else
+             {:name ".nrepl-port" :status :warn :message (str "Port " port " (backend not running)")
+              :hint "Stale .nrepl-port file - delete it or restart backend"}))
+
+         (let [{:keys [configured? path]} (:git-hooks project)]
+           (if configured?
+             {:name "Git hooks" :status :ok :message (str "Configured (" path ")")}
+             {:name "Git hooks" :status :warn :message "Missing"
+              :hint "Run `yarn install` to set up git hooks"}))]
+
+        conflict-checks
+        [(if-not (get-in project [:yarn-lock :exists?])
+           {:name "yarn.lock" :status :warn :message "Missing"
+            :hint "Run `yarn install` to generate"}
+           (if (get-in project [:yarn-lock :conflicts?])
+             {:name "yarn.lock" :status :error :message "Has merge conflicts"
+              :hint "Resolve conflicts in yarn.lock"}
+             {:name "yarn.lock" :status :ok :message "No conflicts"}))
+
+         (if-not (get-in project [:deps-edn :exists?])
+           {:name "deps.edn" :status :error :message "Missing"
+            :hint "deps.edn is required"}
+           (if (get-in project [:deps-edn :conflicts?])
+             {:name "deps.edn" :status :error :message "Has merge conflicts"
+              :hint "Resolve conflicts in deps.edn"}
+             {:name "deps.edn" :status :ok :message "No conflicts"}))]
+
+        git-checks
+        (let [{:keys [branch ahead behind] :as git-status} @*git-status]
+          [(cond
+             (and (zero? ahead) (zero? behind))
+             {:name "Branch" :status :ok :message (str branch " (up to date)")}
+             (and (pos? ahead) (zero? behind))
+             {:name "Branch" :status :info :message (str branch " (" ahead " ahead)")
+              :hint "You have unpushed commits"}
+             (and (zero? ahead) (pos? behind))
+             {:name "Branch" :status :warn :message (str branch " (" behind " behind)")
+              :hint "Run `git pull` to update"}
+             :else
+             {:name "Branch" :status :warn :message (str branch " (" ahead " ahead, " behind " behind)")
+              :hint "Branch has diverged — consider rebasing"})
+           (if (:clean? git-status)
+             {:name "Working tree" :status :ok :message "Clean"}
+             {:name "Working tree" :status :info
+              :message (str (:uncommitted-count git-status) " uncommitted change(s)")
+              :hint "You have local changes"})])
+
+        ;; Collect all for summary
+        all-checks (concat [mise-check] tool-checks project-checks conflict-checks)
+        errors (filterv #(= :error (:status %)) all-checks)
+        warnings (filterv #(= :warn (:status %)) all-checks)]
 
     ;; Version managers
-    (let [managers (detect-version-managers)]
-      (print-section "Version Managers")
-      (if (empty? managers)
-        (println (str "- " (c/gray "None detected (using system tools)")))
-        (do
-          (doseq [{:keys [name]} managers]
-            (println (str "- " (c/green "✓") " " name)))
-          (when (> (count managers) 1)
-            (println (str "- " (c/yellow "⚠") " **Warning**: Multiple version managers detected — can cause conflicts"))))))
+    (print-section "Version Managers")
+    (if (empty? version-managers)
+      (println (str "- " (c/gray "None detected (using system tools)")))
+      (do
+        (doseq [[_ {:keys [name]}] (sort-by key version-managers)]
+          (println (str "- " (c/green "✓") " " name)))
+        (when (> (count version-managers) 1)
+          (println (str "- " (c/yellow "⚠") " **Warning**: Multiple version managers detected — can cause conflicts")))))
 
     ;; Required tools
     (print-section "Required Tools")
-    (format-check (check-git))
-    (doseq [tool-cfg (:required-tools config)]
-      (format-check (check-required-tool toolset tool-cfg)))
+    (doseq [check tool-checks]
+      (print-check check))
 
-    ;; Development tools (non-mise)
+    ;; Development tools
     (print-section "Development Tools")
-    ;; Show mise status
-    (if (:activated mise-info)
-      (format-check (check-result "mise" :ok (str "activated"
-                                                  (when (:self_update_available mise-info)
-                                                    " (update available)"))))
-      (format-check (check-result "mise" :warn "not activated"
-                                  :hint "Run `mise activate` in your shell")))
-    (doseq [tool-cfg (:dev-tools config)]
-      (format-check (check-dev-tool tool-cfg)))
-
-    ;; Optional tools from mise
-    (print-section "Optional Tools")
-    (let [required-tool-names (set (map :tool (:required-tools config)))
-          optional-tools (->> project-tools
-                              (remove #(contains? required-tool-names %))
-                              sort)]
-      (if (seq optional-tools)
-        (doseq [tool optional-tools]
-          (format-check (check-optional-tool toolset tool)))
-        (println (c/gray "- No optional tools configured in mise.toml"))))
+    (print-check mise-check)
+    (print-check docker-check)
 
     ;; Git status
     (print-section "Git Status")
-    (format-check (check-git-branch-status))
-    (format-check (check-git-status))
-    (doseq [check-cfg (:conflict-checks config)]
-      (format-check (check-conflict check-cfg)))
+    (doseq [check git-checks]
+      (print-check check))
+    (doseq [check conflict-checks]
+      (print-check check))
 
     ;; Project state
     (print-section "Project State")
-    (doseq [check-cfg (:project-checks config)]
-      (format-check (check-project-item check-cfg)))
+    (doseq [check project-checks]
+      (print-check check))
 
     ;; Summary
-    (let [all-checks (concat [(check-git)]
-                             (map #(check-required-tool toolset %) (:required-tools config))
-                             (map check-project-item (:project-checks config))
-                             (map check-conflict (:conflict-checks config)))
-          errors (filter #(= :error (:status %)) all-checks)
-          warnings (filter #(= :warn (:status %)) all-checks)]
-      (println)
-      (cond
-        (seq errors)
-        (do
-          (println (c/red (c/bold (str "✗ " (count errors) " error(s) found."))))
-          (println (str "Run " (c/green "./bin/dev-install") " to fix most issues."))
-          (u/exit 1))
-        (seq warnings)
-        (println (c/yellow (str "⚠ " (count warnings)
-                                " warning" (if (= 1 (count warnings)) "" "s")
-                                " — environment should work, but consider fixing.")))
-        :else
-        (println (c/green (c/bold "✓ All checks passed!")))))
+    (println)
+    (when (seq errors)
+      (let [n (count errors)]
+        (println (c/red (c/bold (str "✗ " n " error" (when (not= n 1) "s") " found."))))
+        (doseq [err errors]
+          (print-check err))
+        (println (str "Run " (c/green "./bin/dev-install") " to fix most issues."))
+        (u/exit 1)))
+
+    (when (seq warnings)
+      (let [n (count warnings)]
+        (println (c/yellow (c/bold (str "⚠ " n " warning" (when (not= n 1) "s") " found."))))
+        (doseq [warn warnings]
+          (print-check warn))
+        (println (c/yellow "Environment should work, but consider fixing."))))
+
+    (when (and (empty? errors) (empty? warnings))
+      (println (c/green (c/bold "✓ All checks passed!"))))
 
     (println)
     (println (c/gray "Docs: docs/developers-guide/devenv.md"))))

--- a/mage/test/mage/core_test.clj
+++ b/mage/test/mage/core_test.clj
@@ -6,12 +6,15 @@
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [mage.alias-test]
+   [mage.doctor-test]
    [mage.merge-yaml-migrations-test :as merge-yaml-migrations-test]
    [mage.token-scan-test]
    [mage.util :as u]
    [mage.util-test]))
 
 (comment
+  ;; Load test namespaces to ensure code coverage
+  mage.doctor-test/keep-me
   mage.util-test/keep-me
   merge-yaml-migrations-test/keep-me
   token-scan-test/keep-me)

--- a/mage/test/mage/doctor_test.clj
+++ b/mage/test/mage/doctor_test.clj
@@ -1,0 +1,125 @@
+(ns mage.doctor-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [mage.doctor :as doctor]))
+
+(deftest diagnose-returns-expected-structure
+  (testing "diagnose returns a map with all expected keys"
+    (let [result (doctor/diagnose)]
+      (is (map? result))
+      (is (contains? result :mise))
+      (is (contains? result :version-managers))
+      (is (contains? result :tools))
+      (is (contains? result :project))))
+
+  (testing "mise info has expected keys"
+    (let [mise (:mise (doctor/diagnose))]
+      (is (contains? mise :installed?))))
+
+  (testing "version-managers is a map"
+    (let [result (doctor/diagnose)]
+      (is (map? (:version-managers result)))))
+
+  (testing "tools contains expected tool keys"
+    (let [tools (:tools (doctor/diagnose))]
+      (is (contains? tools :git))
+      (is (contains? tools :node))
+      (is (contains? tools :yarn))
+      (is (contains? tools :java))
+      (is (contains? tools :clojure))
+      (is (contains? tools :babashka))
+      (is (contains? tools :docker))))
+
+  (testing "each tool has :installed? key"
+    (let [tools (:tools (doctor/diagnose))]
+      (doseq [[tool-name tool-info] tools]
+        (is (contains? tool-info :installed?)
+            (str "Tool " tool-name " missing :installed? key")))))
+
+  (testing "project state has expected keys"
+    (let [project (:project (doctor/diagnose))]
+      (is (contains? project :node-modules))
+      (is (contains? project :nrepl-port))
+      (is (contains? project :git-hooks))
+      (is (contains? project :yarn-lock))
+      (is (contains? project :deps-edn)))))
+
+(deftest get-git-status-returns-expected-structure
+  (testing "git status has expected keys"
+    (let [status (doctor/get-git-status)]
+      (is (contains? status :branch))
+      (is (contains? status :ahead))
+      (is (contains? status :behind))
+      (is (contains? status :clean?))
+      (is (contains? status :uncommitted-count))))
+
+  (testing "git status values have correct types"
+    (let [status (doctor/get-git-status)]
+      (is (or (string? (:branch status)) (nil? (:branch status))))
+      (is (integer? (:ahead status)))
+      (is (integer? (:behind status)))
+      (is (boolean? (:clean? status)))
+      (is (integer? (:uncommitted-count status))))))
+
+(deftest version-parsing-tests
+  (testing "parse-version extracts version parts"
+    (is (= [21 0 1] (doctor/parse-version "21.0.1")))
+    (is (= [22 13 1] (doctor/parse-version "22.13.1")))
+    (is (= [1 22 0] (doctor/parse-version "1.22.0")))
+    (is (= [22 13 1] (doctor/parse-version "v22.13.1"))))
+
+  (testing "parse-version handles nil"
+    (is (nil? (doctor/parse-version nil))))
+
+  (testing "version>= comparisons"
+    (is (true? (doctor/version>= "22.0.0" "22")))
+    (is (true? (doctor/version>= "22.1.0" "22")))
+    (is (true? (doctor/version>= "23.0.0" "22")))
+    (is (false? (doctor/version>= "21.9.0" "22")))
+    (is (true? (doctor/version>= "21.0.9" "21")))
+    (is (true? (doctor/version>= "21.0.9" "21.0.1")))))
+
+(deftest project-state-checks
+  (testing "node-modules has :exists? key"
+    (let [nm (get-in (doctor/diagnose) [:project :node-modules])]
+      (is (contains? nm :exists?))
+      (is (boolean? (:exists? nm)))))
+
+  (testing "nrepl-port has :exists? key"
+    (let [nrepl (get-in (doctor/diagnose) [:project :nrepl-port])]
+      (is (contains? nrepl :exists?))
+      (is (boolean? (:exists? nrepl)))))
+
+  (testing "git-hooks has expected keys"
+    (let [hooks (get-in (doctor/diagnose) [:project :git-hooks])]
+      (is (contains? hooks :configured?))
+      (is (contains? hooks :path))))
+
+  (testing "yarn-lock has expected keys"
+    (let [yl (get-in (doctor/diagnose) [:project :yarn-lock])]
+      (is (contains? yl :exists?))))
+
+  (testing "deps-edn has expected keys"
+    (let [de (get-in (doctor/diagnose) [:project :deps-edn])]
+      (is (contains? de :exists?)))))
+
+(deftest installed-tools-have-versions
+  (testing "installed tools have version strings"
+    (let [tools (:tools (doctor/diagnose))]
+      (doseq [[tool-name tool-info] tools
+              :when (:installed? tool-info)]
+        (is (string? (:version tool-info))
+            (str "Installed tool " tool-name " should have version string"))))))
+
+(deftest mise-info-structure
+  (testing "mise info has expected keys"
+    (let [mise (:mise (doctor/diagnose))]
+      (is (contains? mise :installed?))
+      (when (:installed? mise)
+        (is (contains? mise :activated?))
+        (is (boolean? (:activated? mise)))
+        (is (contains? mise :toolset)))))
+
+  (testing "mise info does not contain update-available? (that field was misinterpreted)"
+    (let [mise (:mise (doctor/diagnose))]
+      (is (not (contains? mise :update-available?))))))


### PR DESCRIPTION
The doctor command previously relied heavily on mise for tool version detection,
which didn't work for developers using other version managers (nvm, asdf, etc.).

Changes:
- Get tool versions directly by running each tool's version command instead of
  querying mise toolset
- Add sh+err helper for commands that output to stderr (like `java -version`)
- Make parse-version and version>= public for testing and reuse
- Remove large static config map in favor of inline tool definitions
- Add comprehensive test suite for doctor functionality (diagnose structure,
  git status, version parsing, project state checks)
- Add test filtering to `bb -test` task (e.g., `bb -test doctor` runs only
  doctor tests)

The doctor now properly detects tools regardless of how they were installed.
