### PR TITLE
fix: restore deleted migration

### DIFF
--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -1160,6 +1160,37 @@ databaseChangeLog:
                   value: 'library-models'
             where: type = 'library-data'
 
+  - changeSet:
+      id: v58.2025-12-09T00:00:00
+      author: nmezzopera
+      comment: Usage analytics; Add entity_type, visibility_type, estimated_row_count, view_count, owner_email, owner_user_id to tables
+      changes:
+        - sqlFile:
+            dbms: postgresql
+            path: instance_analytics_views/tables/v3/postgres-tables.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: mysql,mariadb
+            path: instance_analytics_views/tables/v3/mysql-tables.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: h2
+            path: instance_analytics_views/tables/v3/h2-tables.sql
+            relativeToChangelogFile: true
+      rollback:
+        - sqlFile:
+            dbms: postgresql
+            path: instance_analytics_views/tables/v1/postgres-tables.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: mysql,mariadb
+            path: instance_analytics_views/tables/v2/mysql-tables.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: h2
+            path: instance_analytics_views/tables/v1/h2-tables.sql
+            relativeToChangelogFile: true
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################


### PR DESCRIPTION
### Description

This migration was dropped by the tenants merge. I caught this on review but lost track of my todo to restore it.
