### PR TITLE
fix: savingModel prop only "collection" matters

### DIFF
--- a/frontend/src/metabase/collections/containers/FormCollectionAndDashboardPicker/FormCollectionAndDashboardPicker.tsx
+++ b/frontend/src/metabase/collections/containers/FormCollectionAndDashboardPicker/FormCollectionAndDashboardPicker.tsx
@@ -81,10 +81,10 @@ interface FormCollectionPickerProps extends HTMLAttributes<HTMLDivElement> {
   zIndex?: number;
   collectionPickerModalProps?: Partial<CollectionPickerModalProps>;
   /**
-   * The type of item being saved. When set to a non-collection model,
-   * namespace root collections (like tenant root) will be disabled.
+   * When set to "collection", allows saving to namespace root collections
+   * (like tenant root). When null/undefined, namespace roots are disabled.
    */
-  savingModel?: "collection" | "dashboard" | "question" | "model";
+  savingModel?: "collection" | null;
 }
 
 export function FormCollectionAndDashboardPicker({

--- a/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
+++ b/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
@@ -38,10 +38,10 @@ interface FormCollectionPickerProps extends HTMLAttributes<HTMLDivElement> {
   collectionPickerModalProps?: Partial<CollectionPickerModalProps>;
   setNamespace?: (namespace: string | undefined) => void;
   /**
-   * The type of item being saved. When set to a non-collection model,
-   * namespace root collections (like tenant root) will be disabled.
+   * When set to "collection", allows saving to namespace root collections
+   * (like tenant root). When null/undefined, namespace roots are disabled.
    */
-  savingModel?: "collection" | "dashboard" | "question" | "model";
+  savingModel?: "collection" | null;
 }
 
 function ItemName({

--- a/frontend/src/metabase/common/components/MoveModal.tsx
+++ b/frontend/src/metabase/common/components/MoveModal.tsx
@@ -37,10 +37,10 @@ interface BaseMoveModalProps {
   entityType?: EntityType;
   recentAndSearchFilter?: (item: CollectionPickerItem) => boolean;
   /**
-   * The type of item being moved. When set to a non-collection model,
-   * namespace root collections (like tenant root) will be disabled.
+   * When set to "collection", allows saving to namespace root collections
+   * (like tenant root). When null/undefined, namespace roots are disabled.
    */
-  savingModel?: "collection" | "dashboard" | "question" | "model";
+  savingModel?: "collection" | null;
   /**
    * The namespace of the collection being moved. Used to restrict which
    * collections are shown in the picker:

--- a/frontend/src/metabase/common/components/Pickers/CollectionPicker/components/CollectionPickerModal.tsx
+++ b/frontend/src/metabase/common/components/Pickers/CollectionPicker/components/CollectionPickerModal.tsx
@@ -157,7 +157,6 @@ export const CollectionPickerModal = ({
 
       // Check if namespace root is disallowed for this savingModel
       if (
-        options.savingModel &&
         options.savingModel !== "collection" &&
         isNamespaceRoot(item as CollectionPickerItem)
       ) {

--- a/frontend/src/metabase/common/components/Pickers/CollectionPicker/types.ts
+++ b/frontend/src/metabase/common/components/Pickers/CollectionPicker/types.ts
@@ -87,10 +87,10 @@ export type CollectionPickerOptions = EntityPickerModalOptions & {
   showRootCollection?: boolean;
   showLibrary?: boolean;
   /**
-   * The type of item being saved. When set to a non-collection model,
-   * namespace root collections (like tenant root) will be disabled.
+   * When set to "collection", allows saving to namespace root collections
+   * (like tenant root). When null/undefined, namespace roots are disabled.
    */
-  savingModel?: "collection" | "dashboard" | "question" | "model";
+  savingModel?: "collection" | null;
   /**
    * Restricts the picker to only show collections in a specific namespace.
    * - When set to "shared-tenant-collection", only the tenant root is shown.

--- a/frontend/src/metabase/common/components/Pickers/utils.ts
+++ b/frontend/src/metabase/common/components/Pickers/utils.ts
@@ -206,10 +206,6 @@ export const shouldDisableItemForSavingModel = (
   item: CollectionPickerItem,
   savingModel?: CollectionPickerOptions["savingModel"],
 ): boolean => {
-  if (!savingModel) {
-    return false;
-  }
-
   if (savingModel === "collection") {
     return false;
   }

--- a/frontend/src/metabase/common/components/Pickers/utils.unit.spec.ts
+++ b/frontend/src/metabase/common/components/Pickers/utils.unit.spec.ts
@@ -404,16 +404,9 @@ describe("shouldDisableItemForSavingModel", () => {
     location: "/tenant/",
   };
 
-  it("should return true for tenant root when saving a dashboard", () => {
-    expect(shouldDisableItemForSavingModel(tenantRoot, "dashboard")).toBe(true);
-  });
-
-  it("should return true for tenant root when saving a question", () => {
-    expect(shouldDisableItemForSavingModel(tenantRoot, "question")).toBe(true);
-  });
-
-  it("should return true for tenant root when saving a model", () => {
-    expect(shouldDisableItemForSavingModel(tenantRoot, "model")).toBe(true);
+  it("should return true for tenant root when savingModel is not 'collection'", () => {
+    expect(shouldDisableItemForSavingModel(tenantRoot, undefined)).toBe(true);
+    expect(shouldDisableItemForSavingModel(tenantRoot, null)).toBe(true);
   });
 
   it("should return false for tenant root when saving a collection", () => {
@@ -422,11 +415,11 @@ describe("shouldDisableItemForSavingModel", () => {
     );
   });
 
-  it("should return false for regular collections when saving any item type", () => {
-    expect(
-      shouldDisableItemForSavingModel(regularCollection, "dashboard"),
-    ).toBe(false);
-    expect(shouldDisableItemForSavingModel(regularCollection, "question")).toBe(
+  it("should return false for regular collections regardless of savingModel", () => {
+    expect(shouldDisableItemForSavingModel(regularCollection, undefined)).toBe(
+      false,
+    );
+    expect(shouldDisableItemForSavingModel(regularCollection, null)).toBe(
       false,
     );
     expect(
@@ -434,18 +427,11 @@ describe("shouldDisableItemForSavingModel", () => {
     ).toBe(false);
   });
 
-  it("should return false for tenant sub-collections when saving any item type", () => {
+  it("should return false for tenant sub-collections regardless of savingModel", () => {
     expect(
-      shouldDisableItemForSavingModel(tenantSubCollection, "dashboard"),
+      shouldDisableItemForSavingModel(tenantSubCollection, undefined),
     ).toBe(false);
-    expect(
-      shouldDisableItemForSavingModel(tenantSubCollection, "question"),
-    ).toBe(false);
-  });
-
-  it("should return false when savingModel is not specified", () => {
-    expect(shouldDisableItemForSavingModel(tenantRoot, undefined)).toBe(false);
-    expect(shouldDisableItemForSavingModel(regularCollection, undefined)).toBe(
+    expect(shouldDisableItemForSavingModel(tenantSubCollection, null)).toBe(
       false,
     );
   });
@@ -466,8 +452,8 @@ describe("getDisabledReasonForSavingModel", () => {
     location: "/",
   };
 
-  it("should return reason for disabled tenant root", () => {
-    const reason = getDisabledReasonForSavingModel(tenantRoot, "dashboard");
+  it("should return reason for disabled tenant root when savingModel is not 'collection'", () => {
+    const reason = getDisabledReasonForSavingModel(tenantRoot, undefined);
 
     expect(reason).toBeDefined();
     expect(reason).toContain("tenant root collection");
@@ -475,13 +461,10 @@ describe("getDisabledReasonForSavingModel", () => {
 
   it("should return undefined for enabled items", () => {
     expect(
-      getDisabledReasonForSavingModel(regularCollection, "dashboard"),
+      getDisabledReasonForSavingModel(regularCollection, undefined),
     ).toBeUndefined();
     expect(
       getDisabledReasonForSavingModel(tenantRoot, "collection"),
-    ).toBeUndefined();
-    expect(
-      getDisabledReasonForSavingModel(tenantRoot, undefined),
     ).toBeUndefined();
   });
 });

--- a/frontend/src/metabase/common/components/SaveQuestionForm/SaveQuestionForm.tsx
+++ b/frontend/src/metabase/common/components/SaveQuestionForm/SaveQuestionForm.tsx
@@ -58,9 +58,6 @@ export const SaveQuestionForm = ({
       ? ["collection", "dashboard"]
       : ["collection"];
 
-  // Determine the savingModel based on question type
-  const savingModel = question.type() === "model" ? "model" : "question";
-
   const showPickerInput =
     values.saveType === "create" && !targetCollection && !saveToDashboard;
 
@@ -128,7 +125,6 @@ export const SaveQuestionForm = ({
                 dashboardIdFieldName="dashboard_id"
                 title={t`Where do you want to save this?`}
                 entityType={getEntityTypeFromCardType(question.type())}
-                savingModel={savingModel}
                 collectionPickerModalProps={{
                   models,
                   recentFilter: (items) =>

--- a/frontend/src/metabase/dashboard/components/DashboardMoveModal.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardMoveModal.tsx
@@ -56,7 +56,6 @@ function DashboardMoveModal({
         onClose();
       }}
       recentAndSearchFilter={recentsAndSearchFilter}
-      savingModel="dashboard"
     />
   );
 }

--- a/frontend/src/metabase/dashboard/containers/CopyDashboardForm.tsx
+++ b/frontend/src/metabase/dashboard/containers/CopyDashboardForm.tsx
@@ -134,7 +134,6 @@ function CopyDashboardForm({
           title={t`Which collection should this go in?`}
           filterPersonalCollections={filterPersonalCollections}
           entityType="dashboard"
-          savingModel="dashboard"
         />
 
         {!hideShallowCopy && (

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardForm.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardForm.tsx
@@ -126,7 +126,6 @@ export function CreateDashboardForm({
             title={t`Which collection should this go in?`}
             filterPersonalCollections={filterPersonalCollections}
             entityType="dashboard"
-            savingModel="dashboard"
           />
           <FormFooter>
             <FormErrorMessage inline />

--- a/frontend/src/metabase/questions/components/MoveCardModal/MoveCardModal.tsx
+++ b/frontend/src/metabase/questions/components/MoveCardModal/MoveCardModal.tsx
@@ -260,9 +260,6 @@ export const MoveCardModal = ({ card, onClose }: MoveCardModalProps) => {
     }
   };
 
-  // Determine the savingModel based on card type
-  const savingModel = card.type === "model" ? "model" : "question";
-
   return (
     <MoveModal
       title={t`Where do you want to save this?`}
@@ -272,7 +269,6 @@ export const MoveCardModal = ({ card, onClose }: MoveCardModalProps) => {
       canMoveToDashboard={card.type === "question"}
       entityType={getEntityTypeFromCardType(card.type)}
       recentAndSearchFilter={recentAndSearchFilter}
-      savingModel={savingModel}
     />
   );
 };


### PR DESCRIPTION
### Description

This is a follow up to the tenants branch. 

The savingModel prop allow "collections" to be written to the shared-tenant-collection namespace root while other model types are disallowed.

Fixes how this prop is calculated because the original implementation left off other types of cards. This prop is now just "collection" | null since collection is the only model type that matters here.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
