### PR TITLE
Properly display "our analytics" in mini picker item search

### DIFF
--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/test/oss.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/test/oss.unit.spec.tsx
@@ -218,6 +218,12 @@ describe("MiniPicker", () => {
       expect(await screen.findByText("Misc Metrics")).toBeInTheDocument();
     });
 
+    it("shows the collection name for our analytics", async () => {
+      await setup({ searchQuery: "Fan" });
+      expect(await screen.findByText("Fanny")).toBeInTheDocument();
+      expect(await screen.findByText("Our analytics")).toBeInTheDocument();
+    });
+
     it("shows db and schema names for table items in search results", async () => {
       await setup({ searchQuery: "wick" });
       expect(await screen.findByText("wickham")).toBeInTheDocument();

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/test/setup.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/test/setup.tsx
@@ -236,6 +236,17 @@ export const setup = async (
     createMockSearchResult({ id: 304, model: "document", name: "Wickham" }),
     createMockSearchResult({ id: 305, model: "collection", name: "Reynolds" }),
     createMockSearchResult({
+      id: 306,
+      model: "metric",
+      name: "Fanny",
+      collection: {
+        // @ts-expect-error - can be null in search results
+        id: null,
+        // @ts-expect-error - can be null in search results
+        name: null,
+      },
+    }),
+    createMockSearchResult({
       id: 401,
       model: "table",
       name: "wickham",
@@ -244,7 +255,8 @@ export const setup = async (
       collection: {
         // @ts-expect-error - can be null in search results
         id: null,
-        name: "",
+        // @ts-expect-error - can be null in search results
+        name: null,
       },
     }),
   ]);

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
@@ -27,6 +27,7 @@ import type {
   MiniPickerDatabaseItem,
   MiniPickerPickableItem,
   MiniPickerSchemaItem,
+  MiniPickerTableItem,
 } from "../types";
 
 import { MiniPickerItem } from "./MiniPickerItem";
@@ -337,10 +338,16 @@ export const MiniPickerListLoader = () => (
   </Box>
 );
 
-const isInCollection = (
+const isTableInDb = (
   item: MiniPickerPickableItem,
-): item is MiniPickerCollectionItem => {
-  return "collection" in item && !!item.collection && !!item.collection.name;
+): item is MiniPickerTableItem => {
+  // note: if you publish a table to Our analytics, we just can't figure that out
+  return (
+    item.model === "table" &&
+    "collection" in item &&
+    !!item.collection &&
+    !item.collection.name
+  );
 };
 
 const ItemList = ({ children }: { children: React.ReactNode[] }) => {
@@ -348,22 +355,22 @@ const ItemList = ({ children }: { children: React.ReactNode[] }) => {
 };
 
 const LocationInfo = ({ item }: { item: MiniPickerPickableItem }) => {
-  const isCollectionItem = isInCollection(item);
+  const isTable = isTableInDb(item);
 
-  const itemText = isCollectionItem
-    ? item?.collection?.name
-    : `${item.database_name}${item.table_schema ? ` (${item.table_schema})` : ""}`;
+  const itemText = isTable
+    ? `${item.database_name}${item.table_schema ? ` (${item.table_schema})` : ""}`
+    : (item?.collection?.name ?? t`Our analytics`);
 
   if (!itemText) {
     return null;
   }
 
-  const iconProps = isCollectionItem
-    ? getIcon({
+  const iconProps = isTable
+    ? null
+    : getIcon({
         ...item.collection,
         model: "collection",
-      })
-    : null;
+      });
 
   return (
     <Flex gap="xs" align="center">


### PR DESCRIPTION


### Description

"Our analytics" doesn't actually exist so we have to summon hordes of smoke and mirrors to make it look real.

<img width="717" height="604" alt="CleanShot 2025-12-12 at 15 42 58" src="https://github.com/user-attachments/assets/a8284580-58c8-4f59-992f-877900e41ab4" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
