### PR TITLE
uninstall the custom migration yaml merge driver

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,5 +3,5 @@
 # Execute this in your shell to enable custom merge driver:
 # echo '\n[include]\npath=../.gitconfig' >> .git/config
 #
-# TODO: double check that this works and re-enable it:
+# TODO (Bryan 12/12/25) -- reenable this when we can completely verify correctness
 # resources/migrations/*.yaml merge=yaml-migrations

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,6 @@
 # Treats each changeset as an atomic unit to avoid conflicts within changesets
 # Execute this in your shell to enable custom merge driver:
 # echo '\n[include]\npath=../.gitconfig' >> .git/config
-resources/migrations/*.yaml merge=yaml-migrations
+#
+# TODO: double check that this works and re-enable it:
+# resources/migrations/*.yaml merge=yaml-migrations

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,5 +1,7 @@
 # execute this in your shell to enable custom merge driver:
 # echo '\n[include]\npath=../.gitconfig' >> .git/config
-[merge "yaml-migrations"]
-    name = YAML migration changeset-aware merge
-    driver = mage -merge-yaml-migrations %O %A %B %L %P
+#
+# TODO (Bryan 12/12/25) -- reenable this when we can completely verify correctness
+# [merge "yaml-migrations"]
+#     name = YAML migration changeset-aware merge
+#     driver = mage -merge-yaml-migrations %O %A %B %L %P

--- a/bb.edn
+++ b/bb.edn
@@ -285,6 +285,21 @@
                 (when-not (str/includes? (slurp git-config-file) the-include)
                   (spit git-config-file the-include :append true))))}
 
+  ;; opposite of -install-merge-drivers, removes the include while it's causing issues.
+  -uninstall-merge-drivers
+  {:doc      "Uninstalls custom git merge drivers for YAML migration files."
+   :requires [[clojure.string :as str]
+              [mage.util :as u]]
+   :task     (task!
+              (let [git-config-file (str u/project-root-directory "/.git/config")
+                    the-include     (str "\n"
+                                         "[include]\n"
+                                         "    path=../.gitconfig\n")]
+                (when (str/includes? (slurp git-config-file) the-include)
+                  (let [includeless (-> (slurp git-config-file)
+                                            (str/replace the-include ""))]
+                    (spit git-config-file includeless)))))}
+
   -merge-yaml-migrations
   {:doc "Custom git merge driver for YAML migration files."
    :usage-fn (fn [_]

--- a/lint-staged.config.cjs
+++ b/lint-staged.config.cjs
@@ -33,6 +33,7 @@ module.exports = {
      */
     (files) =>
       `./bin/mage -token-scan ${files.map((item) => `"${item}"`).join(" ")}`,
-    "./bin/mage -install-merge-drivers",
+    // TODO (Bryan 12/12/25) -- reenable this when we can completely verify correctness
+    "./bin/mage -uninstall-merge-drivers",
   ],
 };

--- a/package.json
+++ b/package.json
@@ -519,7 +519,7 @@
     ],
     "**/*": [
       "./bin/mage -token-scan",
-      "./bin/mage -install-merge-drivers"
+      "./bin/mage -uninstall-merge-drivers"
     ]
   },
   "browserslist": [


### PR DESCRIPTION
This merge driver was causing problems by dropping migrations :scream:, so let's pull it out until we can 100% verify correctness

More context: https://metaboat.slack.com/archives/CKZEMT1MJ/p1765569186613889