### PR TITLE
Revert "Quick ci test disabling (#63030)"

### DIFF
--- a/test/metabase/test_runner.clj
+++ b/test/metabase/test_runner.clj
@@ -2,8 +2,6 @@
 (ns metabase.test-runner
   "The only purpose of this namespace is to make sure all of the other stuff below gets loaded."
   (:require
-   #_{:clj-kondo/ignore [:discouraged-namespace]}
-   [cheshire.core :as json]
    [clojure.java.classpath :as classpath]
    [clojure.java.io :as io]
    [clojure.set :as set]
@@ -53,7 +51,7 @@
 (defn- all-drivers []
   (into #{:h2 :postgres :mysql}
         (for [^java.io.File file (.listFiles (io/file "modules/drivers"))
-              :when (.isDirectory file)]
+              :when              (.isDirectory file)]
           (keyword (.getName file)))))
 
 (defn- excluded-drivers []
@@ -64,16 +62,16 @@
   [_nil options]
   (let [excluded-driver-dirs (for [driver (excluded-drivers)]
                                (format "modules/drivers/%s" (name driver)))
-        exclude-directory? (fn [dir]
-                             (let [dir (str dir)]
-                               (some (fn [excluded]
-                                       (or (str/ends-with? dir excluded)
-                                           (str/includes? dir (str excluded "/"))))
-                                     excluded-driver-dirs)))
-        directories (for [^java.io.File file (classpath/system-classpath)
-                          :when (and (.isDirectory file)
-                                     (not (exclude-directory? file)))]
-                      file)]
+        exclude-directory?   (fn [dir]
+                               (let [dir (str dir)]
+                                 (some (fn [excluded]
+                                         (or (str/ends-with? dir excluded)
+                                             (str/includes? dir (str excluded "/"))))
+                                       excluded-driver-dirs)))
+        directories          (for [^java.io.File file (classpath/system-classpath)
+                                   :when              (and (.isDirectory file)
+                                                           (not (exclude-directory? file)))]
+                               file)]
     (hawk/find-tests directories options)))
 
 (def ^:private excluded-directories
@@ -89,70 +87,17 @@
    "test_config"
    "test_resources"])
 
-(defn- json-config->edn-ignored
-  "Convert JSON config to hawk's EDN ignored format. Right now we only support individually ignored vars. In the future
-  will extend to namespaces, drivers. Ideally e2e tests as well. Example config:
-  ```javascript
-     {
-       \"ignored\": {
-         \"vars\": [
-           \"metabase.util.queue-test/bounded-transfer-queue-test\",
-           \"metabase.util.queue-test/take-batch-test\"
-         ]
-       }
-     }
-  ```"
-  [json-config]
-  (try
-    (let [{:keys [ignored] :as config} (json/parse-string (slurp json-config) true)]
-      (when (seq ignored)
-        #_{:clj-kondo/ignore [:discouraged-var]}
-        (println (format "using config file: \n%s\n" config)))
-      (cond-> {}
-        (seq (:vars ignored))
-        (assoc :vars (-> ignored :vars set))))
-    (catch Exception e
-      (log/warnf "Error parsing json config: %s '%s'" json-config (ex-message e)))))
-
-(defn- default-options
-  "Default options for test runner, with optional CI config integration."
-  ([]
-   (default-options {}))
-  ([{:keys [ci-config-file]
-     :or {ci-config-file "ci-test-config.json"}}]
-   (let [base-options {:namespace-pattern #"^(?:(?:metabase.*)|(?:hooks\..*))" ; anything starting with `metabase*` (including `metabase-enterprise`) or `hooks.*`
-                       :exclude-directories excluded-directories
-                       :test-warn-time 3000}]
-     (cond (and ci-config-file (.exists (io/file ci-config-file)))
-           (do
-             #_{:clj-kondo/ignore [:discouraged-var]}
-             (println (format "Loading CI config file from %s" ci-config-file))
-             (assoc base-options :ignored (json-config->edn-ignored ci-config-file)))
-           ci-config-file
-           (do (log/warnf "CI config file was specified but does not exist: %s" ci-config-file)
-               base-options)
-           :else
-           base-options))))
-
-(defn- build-final-options
-  "Build final options by merging defaults, CI config, and runtime options.
-   This centralizes all the option merging logic in one place."
-  [runtime-options]
-  (let [default-opts (default-options runtime-options)
-        runtime-ignored (:ignored runtime-options)
-        ;; Simple merge: if both have :ignored, merge them; otherwise use whichever exists
-        final-ignored (if (and (:ignored default-opts) runtime-ignored)
-                        (merge-with set/union (:ignored default-opts) runtime-ignored)
-                        (or runtime-ignored (:ignored default-opts)))]
-    (-> (merge default-opts runtime-options)
-        (cond-> (seq final-ignored) (assoc :ignored final-ignored)))))
+(defn- default-options []
+  {:namespace-pattern   #"^(?:(?:metabase.*)|(?:hooks\..*))" ; anything starting with `metabase*` (including `metabase-enterprise`) or `hooks.*`
+   :exclude-directories excluded-directories
+   :test-warn-time      3000})
 
 (defn find-tests
   "Find all tests, in case you wish to run them yourself."
   ([]
    (find-tests {}))
   ([options]
-   (hawk/find-tests-with-options (build-final-options options))))
+   (hawk/find-tests-with-options (merge (default-options) options))))
 
 (defn- initialize-all-fixtures []
   (let [steps (initialize/all-components)]
@@ -165,10 +110,10 @@
   "Find and run tests from the REPL."
   [options]
   (initialize-all-fixtures)
-  (hawk/find-and-run-tests-repl (build-final-options options)))
+  (hawk/find-and-run-tests-repl (merge (default-options) options)))
 
 (defn find-and-run-tests-cli
   "Entrypoint for `clojure -X:test`."
   [options]
   (initialize-all-fixtures)
-  (hawk/find-and-run-tests-cli (build-final-options options)))
+  (hawk/find-and-run-tests-cli (merge (default-options) options)))


### PR DESCRIPTION
This reverts commit 9191713854f099973ab0e7b15885bf6ba3a91bfe.

used to do this in-house but now we use trunk for this. Old way has ultimate flexibility. But trunk has some really nice workflows built in (reporting, creating issues in linear, etc).
