### PR TITLE
Fix a couple reflection/performance warnings

### DIFF
--- a/src/metabase/cache/api.clj
+++ b/src/metabase/cache/api.clj
@@ -221,7 +221,8 @@
                                        :with-overrides? (= include :overrides)})]
     {:status (if (= cnt -1) 404 200)
      :body   {:count   cnt
-              :message (case [(= include :overrides) (if (pos? cnt) 1 cnt)]
+              ;; Use condp instead of case to avoid Clojure compiler warnings.
+              :message (condp = [(= include :overrides) (if (pos? cnt) 1 cnt)]
                          [true -1]  (tru "Could not find any questions for the criteria you specified.")
                          [true 0]   (tru "No cached results to clear.")
                          [true 1]   (trun "Cleared a cached result." "Cleared {0} cached results." cnt)

--- a/src/metabase/lib/metadata/column.cljc
+++ b/src/metabase/lib/metadata/column.cljc
@@ -33,6 +33,6 @@
     unique-key   :- ::lib.schema/column-unique-key]
    (let [[version column-key] (unpack-unique-key unique-key)]
      (m/find-first
-      (case version
+      (case (long version)
         1 #(= (:lib/desired-column-alias %) column-key))
       (lib.metadata.calculation/returned-columns query stage-number)))))


### PR DESCRIPTION
Here are a few minor warnings that appear during Metabase REPL initialization. They are harmless, but pollute init log if `*warn-on-reflection*` is enabled, so they better go away.
