### PR TITLE
Get rid of peridot dependency by embedding necessary functions

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -259,8 +259,6 @@
     lambdaisland/deep-diff2      {:mvn/version "2.12.219"}                  ; way better diffs
     net.solovyov/hashp           {:mvn/version "0.4.0-1"}                   ; debugging/spying utility
     nrepl/nrepl                  {:mvn/version "1.5.1"}                     ; nREPL server
-    peridot/peridot              {:git/url "https://github.com/piranha/peridot.git"
-                                  :sha "db627c627db3b527a63caf472f0422e4cbfdf574"} ; mocking Ring requests; waiting for upstream release of commit 0fc7c01 (explicit charset)
     pjstadig/humane-test-output  {:mvn/version "0.11.0"}
     refactor-nrepl/refactor-nrepl {:mvn/version "3.11.0"}                   ; refactoring helpers for cider
     reifyhealth/specmonstah      {:mvn/version "2.1.0"

--- a/test/metabase/test/http_client.clj
+++ b/test/metabase/test/http_client.clj
@@ -23,11 +23,15 @@
    [metabase.util.malli.humanize :as mu.humanize]
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]
-   [peridot.multipart]
-   [ring.util.codec :as codec])
+   [ring.util.codec :as codec]
+   [ring.util.mime-type :as mime-type])
   (:import
-   (java.io ByteArrayInputStream InputStream)
-   (metabase.server.streaming_response StreamingResponse)))
+   (java.io ByteArrayInputStream ByteArrayOutputStream File InputStream)
+   (java.nio.charset Charset)
+   (metabase.server.streaming_response StreamingResponse)
+   (org.apache.http HttpEntity)
+   (org.apache.http.entity ContentType)
+   (org.apache.http.entity.mime MultipartEntityBuilder)))
 
 (set! *warn-on-reflection* true)
 
@@ -65,6 +69,53 @@
          (when (seq query-parameters)
            (str "?" (build-query-string query-parameters))))))
 
+;; Multipart body params. Adapted from https://github.com/xeqi/peridot which looks abandoned, and we only need this
+;; little thing from there.
+
+(defn- ensure-string
+  "Ensures that the resulting key is a form-encoded string."
+  ^String [k]
+  (codec/form-encode (if (keyword? k) (name k) (str k))))
+
+(defmulti add-part
+  {:arglists '([builder key value])
+   :private true}
+  (fn [_builder _key value] (type value)))
+
+(defmethod add-part File [^MultipartEntityBuilder m k ^File f]
+  (let [mime-type (mime-type/ext-mime-type (.getName f))
+        ctype (ContentType/create ^String mime-type "UTF-8")]
+    (.addBinaryBody m (ensure-string k) f ctype (.getName f))))
+
+(defmethod add-part InputStream [^MultipartEntityBuilder m k ^InputStream v]
+  (.addBinaryBody m (ensure-string k) v ContentType/APPLICATION_OCTET_STREAM "input-stream.tmp"))
+
+(defmethod add-part byte/1 [^MultipartEntityBuilder m k ^bytes v]
+  (.addBinaryBody m (ensure-string k) v ContentType/APPLICATION_OCTET_STREAM "byte-array.tmp"))
+
+(defmethod add-part :default [^MultipartEntityBuilder m k v]
+  (.addTextBody m (ensure-string k) v (ContentType/create "text/plain" "UTF-8")))
+
+(defn- multipart-entity [params]
+  (let [builder (MultipartEntityBuilder/create)]
+    (.setCharset builder (Charset/forName "UTF-8"))
+    (doseq [[k v] params]
+      (add-part builder k v))
+    (.build builder)))
+
+(defn build-multipart [params]
+  (let [^HttpEntity mpe (multipart-entity params)
+        length          (.getContentLength mpe)
+        ctype           (.getValue (.getContentType mpe))]
+    {:body (let [out (ByteArrayOutputStream.)]
+             (.writeTo mpe out)
+             (.close out)
+             (io/input-stream (.toByteArray out)))
+     :content-length length
+     :content-type   ctype
+     :headers        {"content-type"   ctype
+                      "content-length" (str length)}}))
+
 (defn- build-body-params [http-body content-type]
   (when http-body
     (cond
@@ -75,7 +126,7 @@
       {:body (ByteArrayInputStream. (.getBytes (json/encode http-body) "UTF-8"))}
 
       (= "multipart/form-data" content-type)
-      (peridot.multipart/build http-body)
+      (build-multipart http-body)
 
       (= "application/x-www-form-urlencoded" content-type)
       {:body (ByteArrayInputStream. (.getBytes ^String (codec/form-encode http-body) "UTF-8"))}


### PR DESCRIPTION
This has several benefits:

- Upstream peridot library looks stale/abandoned. Bad dependency to have.
- We currently point our `deps.edn` at a technical fork by @piranha, not the upstream. So the dep is even less reliable.
- Upstream dependency produces quite a few reflection warnings when initializing Metabase `*warn-on-reflection*` enabled. Since it is not maintained, getting the reflection fixes into upstream would be hard.

All in all, might as well embed those few necessary functions into Metabase test code.
