### PR TITLE
Modular embedding subscription analytics

### DIFF
--- a/frontend/src/metabase-types/analytics/embedded-analytics-js.ts
+++ b/frontend/src/metabase-types/analytics/embedded-analytics-js.ts
@@ -7,6 +7,7 @@ export type EmbeddedAnalyticsJsEventSchema = {
     drills: BOOLEAN_COUNT;
     with_downloads: BOOLEAN_COUNT;
     with_title: BOOLEAN_COUNT;
+    with_subscriptions: BOOLEAN_COUNT;
   };
   question?: {
     drills: BOOLEAN_COUNT;
@@ -30,7 +31,7 @@ type EVENTS = "setup";
 /**
  * Authentication method used for the Embedded Analytics JS.
  */
-export type AUTH_TYPES = "session" | "api_key" | "sso";
+export type AUTH_TYPES = "session" | "api_key" | "sso" | "guest";
 
 type BOOLEAN_COUNT = {
   true: number;
@@ -70,6 +71,7 @@ type EmbeddedAnalyticsJsSetupEvent = ValidateEvent<{
     drills: BOOLEAN_COUNT;
     with_downloads: BOOLEAN_COUNT;
     with_title: BOOLEAN_COUNT;
+    with_subscriptions: BOOLEAN_COUNT;
   };
   question?: {
     drills: BOOLEAN_COUNT;

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/analytics.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/analytics.ts
@@ -19,6 +19,8 @@ const DEFAULT_VALUES: DefaultValues = {
     with_downloads: false,
     /** @see {@link https://github.com/metabase/metabase/blob/9e62f8c2b7d3739670d9f4259e1d4e28f5b654cc/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx#L159} */
     with_title: true,
+    /** @see {@link https://github.com/metabase/metabase/blob/9e62f8c2b7d3739670d9f4259e1d4e28f5b654cc/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx#L161} */
+    with_subscriptions: false,
   },
   question: {
     /** @see {@link https://github.com/metabase/metabase/blob/7aa3f7fed11113ed32901aad4e4227be68cff78f/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx#L149} */

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/analytics.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/analytics.ts
@@ -6,6 +6,7 @@ import type { FlattenObjectKeys } from "metabase/embedding-sdk/types/utils";
 import type {
   AUTH_TYPES,
   DefaultValues,
+  EmbeddedAnalyticsJsEvent,
   EmbeddedAnalyticsJsEventSchema,
 } from "metabase-types/analytics/embedded-analytics-js";
 
@@ -92,7 +93,8 @@ export function createEmbeddedAnalyticsJsUsage(
             drills: { true: 0, false: 0 },
             with_downloads: { true: 0, false: 0 },
             with_title: { true: 0, false: 0 },
-          });
+            with_subscriptions: { true: 0, false: 0 },
+          } satisfies EmbeddedAnalyticsJsEvent["dashboard"]);
         }
         usage = incrementComponentPropertyCount(
           "dashboard.drills",
@@ -116,7 +118,7 @@ export function createEmbeddedAnalyticsJsUsage(
           if (!usage.exploration) {
             usage = assocIn(usage, ["exploration"], {
               is_save_enabled: { true: 0, false: 0 },
-            });
+            } satisfies EmbeddedAnalyticsJsEvent["exploration"]);
           }
           usage = incrementComponentPropertyCount(
             "exploration.is_save_enabled",
@@ -136,7 +138,7 @@ export function createEmbeddedAnalyticsJsUsage(
               with_downloads: { true: 0, false: 0 },
               with_title: { true: 0, false: 0 },
               is_save_enabled: { true: 0, false: 0 },
-            });
+            } satisfies EmbeddedAnalyticsJsEvent["question"]);
           }
           usage = incrementComponentPropertyCount(
             "question.drills",
@@ -164,7 +166,7 @@ export function createEmbeddedAnalyticsJsUsage(
         if (!usage.browser) {
           usage = assocIn(usage, ["browser"], {
             read_only: { true: 0, false: 0 },
-          });
+          } satisfies EmbeddedAnalyticsJsEvent["browser"]);
         }
         usage = incrementComponentPropertyCount(
           "browser.read_only",

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/analytics.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/analytics.ts
@@ -13,29 +13,33 @@ import type { MetabaseEmbedElement } from "./embed";
 
 const DEFAULT_VALUES: DefaultValues = {
   dashboard: {
-    /** @see {@link https://github.com/metabase/metabase/blob/7aa3f7fed11113ed32901aad4e4227be68cff78f/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx#L119} */
+    /** @see {@link https://github.com/metabase/metabase/blob/9e62f8c2b7d3739670d9f4259e1d4e28f5b654cc/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx#L188} */
     drills: true,
-    /** @see {@link https://github.com/metabase/metabase/blob/7aa3f7fed11113ed32901aad4e4227be68cff78f/enterprise/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx#L129} */
+    /** @see {@link https://github.com/metabase/metabase/blob/9e62f8c2b7d3739670d9f4259e1d4e28f5b654cc/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx#L160} */
     with_downloads: false,
-    /** @see {@link https://github.com/metabase/metabase/blob/master/enterprise/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx#L127} */
+    /** @see {@link https://github.com/metabase/metabase/blob/9e62f8c2b7d3739670d9f4259e1d4e28f5b654cc/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx#L159} */
     with_title: true,
   },
   question: {
     /** @see {@link https://github.com/metabase/metabase/blob/7aa3f7fed11113ed32901aad4e4227be68cff78f/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx#L149} */
+    // XXX: This depends on the question types. For guest embeds, defaults to false, for non guest embeds, defaults to true.
     drills: true,
-    /** @see {@link https://github.com/metabase/metabase/blob/7aa3f7fed11113ed32901aad4e4227be68cff78f/enterprise/frontend/src/embedding-sdk-bundle/components/public/SdkQuestion/SdkQuestion.tsx#L129} */
+    /** @see {@link https://github.com/metabase/metabase/blob/9e62f8c2b7d3739670d9f4259e1d4e28f5b654cc/frontend/src/embedding-sdk-bundle/components/public/SdkQuestion/SdkQuestion.tsx#L132} */
     with_downloads: false,
-    /** @see {@link https://github.com/metabase/metabase/blob/7aa3f7fed11113ed32901aad4e4227be68cff78f/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx#L145} */
+    /**
+     * @see {@link https://github.com/metabase/metabase/blob/9e62f8c2b7d3739670d9f4259e1d4e28f5b654cc/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx#L234}
+     * @see {@link https://github.com/metabase/metabase/blob/9e62f8c2b7d3739670d9f4259e1d4e28f5b654cc/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx#L255}
+     */
     with_title: true,
-    /** @see {@link https://github.com/metabase/metabase/blob/7aa3f7fed11113ed32901aad4e4227be68cff78f/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx#L157} */
+    /** @see {@link https://github.com/metabase/metabase/blob/9e62f8c2b7d3739670d9f4259e1d4e28f5b654cc/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx#L256} */
     is_save_enabled: false,
   },
   exploration: {
-    /** @see {@link https://github.com/metabase/metabase/blob/7aa3f7fed11113ed32901aad4e4227be68cff78f/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx#L157} */
+    /** @see {@link https://github.com/metabase/metabase/blob/9e62f8c2b7d3739670d9f4259e1d4e28f5b654cc/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx#L256} */
     is_save_enabled: false,
   },
   browser: {
-    /** @see {@link https://github.com/metabase/metabase/blob/7aa3f7fed11113ed32901aad4e4227be68cff78f/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/MetabaseBrowser.tsx#L39} */
+    /** @see {@link https://github.com/metabase/metabase/blob/9e62f8c2b7d3739670d9f4259e1d4e28f5b654cc/frontend/src/metabase/embedding/embedding-iframe-sdk/components/MetabaseBrowser.tsx#L39} */
     read_only: true,
   },
 };

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/analytics.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/analytics.ts
@@ -124,6 +124,11 @@ export function createEmbeddedAnalyticsJsUsage(
           properties.withTitle,
           usage,
         );
+        usage = incrementComponentPropertyCount(
+          "dashboard.with_subscriptions",
+          properties.withSubscriptions,
+          usage,
+        );
       })
       .with(
         { componentName: "metabase-question", questionId: "new" },

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/analytics.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/analytics.ts
@@ -228,9 +228,9 @@ function getAuthMethod(firstEmbed: MetabaseEmbedElement): AUTH_TYPES {
 
 function incrementComponentPropertyCount(
   propertyPath: FlattenObjectKeys<DefaultValues>,
-  value: any | undefined,
+  value: boolean | undefined,
   usage: EmbeddedAnalyticsJsEventSchema,
-  getDefaultValue: (path: string[]) => any = defaultGetDefaultValue,
+  getDefaultValue: (path: string[]) => boolean = defaultGetDefaultValue,
 ) {
   const path = propertyPath.split(".");
 
@@ -241,6 +241,6 @@ function incrementComponentPropertyCount(
   );
 }
 
-function defaultGetDefaultValue(path: string[]): any {
+function defaultGetDefaultValue(path: string[]): boolean {
   return getIn(DEFAULT_VALUES, path);
 }

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/analytics.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/analytics.ts
@@ -210,6 +210,12 @@ function getAuthMethod(firstEmbed: MetabaseEmbedElement): AUTH_TYPES {
       },
       () => "api_key",
     )
+    .with(
+      {
+        isGuest: true,
+      },
+      () => "guest",
+    )
     .otherwise(() => {
       return "sso";
     });

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/analytics.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/analytics.unit.spec.tsx
@@ -106,6 +106,7 @@ describe("createEmbeddedAnalyticsJsUsage", () => {
               drills: { true: 1, false: 0 },
               with_downloads: { true: 0, false: 1 },
               with_title: { true: 1, false: 0 },
+              with_subscriptions: { true: 0, false: 1 },
             },
           }),
         );
@@ -120,6 +121,7 @@ describe("createEmbeddedAnalyticsJsUsage", () => {
                 drills: true,
                 "with-downloads": false,
                 "with-title": true,
+                "with-subscriptions": false,
               }),
             ]),
           ),
@@ -129,6 +131,7 @@ describe("createEmbeddedAnalyticsJsUsage", () => {
               drills: { true: 1, false: 0 },
               with_downloads: { true: 0, false: 1 },
               with_title: { true: 1, false: 0 },
+              with_subscriptions: { true: 0, false: 1 },
             },
           }),
         );
@@ -141,6 +144,7 @@ describe("createEmbeddedAnalyticsJsUsage", () => {
                 drills: false,
                 "with-downloads": true,
                 "with-title": false,
+                "with-subscriptions": true,
               }),
             ]),
           ),
@@ -150,6 +154,7 @@ describe("createEmbeddedAnalyticsJsUsage", () => {
               drills: { true: 0, false: 1 },
               with_downloads: { true: 1, false: 0 },
               with_title: { true: 0, false: 1 },
+              with_subscriptions: { true: 1, false: 0 },
             },
           }),
         );
@@ -164,6 +169,7 @@ describe("createEmbeddedAnalyticsJsUsage", () => {
                 drills: false,
                 "with-downloads": true,
                 "with-title": false,
+                "with-subscriptions": true,
               }),
             ]),
           ),
@@ -173,6 +179,7 @@ describe("createEmbeddedAnalyticsJsUsage", () => {
               drills: { true: 2, false: 1 },
               with_downloads: { true: 1, false: 2 },
               with_title: { true: 2, false: 1 },
+              with_subscriptions: { true: 1, false: 2 },
             },
           }),
         );

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/analytics.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/analytics.unit.spec.tsx
@@ -72,6 +72,25 @@ describe("createEmbeddedAnalyticsJsUsage", () => {
         }),
       );
     });
+
+    it('should capture "guest" auth method', () => {
+      defineMetabaseConfig({
+        isGuest: true,
+        instanceUrl: "https://example.com",
+      });
+
+      expect(
+        createEmbeddedAnalyticsJsUsage(
+          new Set([createEmbeddedAnalyticsJsElement("metabase-question")]),
+        ),
+      ).toEqual(
+        expect.objectContaining({
+          global: {
+            auth_method: "guest",
+          },
+        }),
+      );
+    });
   });
 
   describe("Component usage", () => {

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/embedded_analytics_js/jsonschema/1-0-1
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/embedded_analytics_js/jsonschema/1-0-1
@@ -1,0 +1,258 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Modular embedding configuration",
+  "self": {
+    "vendor": "com.metabase",
+    "name": "embedded_analytics_js",
+    "format": "jsonschema",
+    "version": "1-0-1"
+  },
+  "type": "object",
+  "properties": {
+    "event": {
+      "description": "The type of event being recorded. For example, when the modular embedding is initialized, or when the Metabase configuration is updated.",
+      "type": "string",
+      "enum": [
+        "setup"
+      ],
+      "maxLength": 1024
+    },
+    "global": {
+      "description": "Global configuration for modular embedding.",
+      "type": "object",
+      "properties": {
+        "auth_method": {
+          "description": "Authentication method used for the modular embedding.",
+          "type": "string",
+          "enum": [
+            "session",
+            "api_key",
+            "sso",
+            "guest"
+          ],
+          "maxLength": 1024
+        }
+      }
+    },
+    "dashboard": {
+      "description": "Counts of <metabase-dashboard> component properties.",
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "drills": {
+          "description": "Counts of dashboards with drills enabled or disabled.",
+          "type": "object",
+          "properties": {
+            "true": {
+              "description": "Number of dashboards with drills enabled.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            },
+            "false": {
+              "description": "Number of dashboards with drills disabled.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            }
+          }
+        },
+        "with_downloads": {
+          "description": "Counts of dashboards with downloads enabled or disabled.",
+          "type": "object",
+          "properties": {
+            "true": {
+              "description": "Number of dashboards with downloads enabled.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            },
+            "false": {
+              "description": "Number of dashboards with downloads disabled.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            }
+          }
+        },
+        "with_title": {
+          "description": "Counts of dashboards with title shown or hidden.",
+          "type": "object",
+          "properties": {
+            "true": {
+              "description": "Number of dashboards with title shown.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            },
+            "false": {
+              "description": "Number of dashboards with title hidden.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            }
+          }
+        },
+        "with_subscriptions": {
+          "description": "Counts of dashboards with subscriptions enabled or disabled.",
+          "type": "object",
+          "properties": {
+            "true": {
+              "description": "Number of dashboards with subscriptions enabled.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            },
+            "false": {
+              "description": "Number of dashboards with subscriptions disabled.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            }
+          }
+        }
+      }
+    },
+    "question": {
+      "description": "Counts of <metabase-question> component properties.",
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "drills": {
+          "description": "Counts of questions with drills enabled or disabled.",
+          "type": "object",
+          "properties": {
+            "true": {
+              "description": "Number of questions with drills enabled.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            },
+            "false": {
+              "description": "Number of questions with drills disabled.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            }
+          }
+        },
+        "with_downloads": {
+          "description": "Counts of questions with downloads enabled or disabled.",
+          "type": "object",
+          "properties": {
+            "true": {
+              "description": "Number of questions with downloads enabled.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            },
+            "false": {
+              "description": "Number of questions with downloads disabled.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            }
+          }
+        },
+        "with_title": {
+          "description": "Counts of questions with title shown or hidden.",
+          "type": "object",
+          "properties": {
+            "true": {
+              "description": "Number of questions with title shown.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            },
+            "false": {
+              "description": "Number of questions with title hidden.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            }
+          }
+        },
+        "is_save_enabled": {
+          "description": "Counts of questions with save enabled or disabled.",
+          "type": "object",
+          "properties": {
+            "true": {
+              "description": "Number of questions with save enabled.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            },
+            "false": {
+              "description": "Number of questions with save disabled.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            }
+          }
+        }
+      }
+    },
+    "exploration": {
+      "description": "Counts of <metabase-question> component with question-id=\"new\" properties.",
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "is_save_enabled": {
+          "description": "Counts of explorations with save enabled or disabled.",
+          "type": "object",
+          "properties": {
+            "true": {
+              "description": "Number of explorations with save enabled.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            },
+            "false": {
+              "description": "Number of explorations with save disabled.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            }
+          }
+        }
+      }
+    },
+    "browser": {
+      "description": "Counts of <metabase-browser> component properties.",
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "read_only": {
+          "description": "Counts of browsers with read-only mode enabled or disabled.",
+          "type": "object",
+          "properties": {
+            "true": {
+              "description": "Number of browsers with read-only mode enabled.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            },
+            "false": {
+              "description": "Number of browsers with read-only mode disabled.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            }
+          }
+        }
+      }
+    }
+  },
+  "required": [
+    "event",
+    "global"
+  ]
+}


### PR DESCRIPTION
closes EMB-1066

### Backport reasons
Since we just cut 58, and this is targeting 58, we need to backport it.

### Description

This PR tracks `with-subscriptions` in actual modular embedding usage (not the wizard).

The Snowplow change is as follows:
1. Add a new value `guest` to an enum
2. Add a new nullable property `with_subscriptions` under `dashboard` property.

### How to verify

You can try this out yourself with snowplow.


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
