### PR TITLE
Fix for missing table id scenarios

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/workspaces/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/api.clj
@@ -133,7 +133,7 @@
                [:table :string]
                [:table_id [:maybe ::ws.t/appdb-id]]]]])
 
-(defn- batch-lookup-table-ids*
+(defn- batch-lookup-table-ids
   "Given a bounded list of tables, all within the same database, return an association list of [db schema table] => id"
   [db-id schema-key table-key table-refs]
   (when (seq table-refs)
@@ -154,7 +154,7 @@
                 :let [db_id (:db_id (first table-refs))]
                 ;; Guesstimating a number that prevents this query being too large.
                 table-refs (partition-all 20 table-refs)
-                map-entry (batch-lookup-table-ids* db_id schema-key table-key table-refs)]
+                map-entry (batch-lookup-table-ids db_id schema-key table-key table-refs)]
       map-entry)))
 
 (api.macros/defendpoint :get "/:id/table"

--- a/enterprise/backend/src/metabase_enterprise/workspaces/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/api.clj
@@ -136,13 +136,14 @@
 (defn- batch-lookup-table-ids*
   "Given a bounded list of tables all, within the same database, return an association list of [db schema table] => id"
   [db-id schema-key table-key table-refs]
-  (t2/select-fn-vec (juxt (juxt (constantly db-id) :schema :name) :id)
-                    [:model/Table :id :schema :name]
-                    :db_id db-id
-                    {:where (into [:or] (for [tr table-refs]
-                                          [:and
-                                           [:= :schema (get tr schema-key)]
-                                           [:= :name (get tr table-key)]]))}))
+  (when (seq table-refs)
+    (t2/select-fn-vec (juxt (juxt (constantly db-id) :schema :name) :id)
+                      [:model/Table :id :schema :name]
+                      :db_id db-id
+                      {:where (into [:or] (for [tr table-refs]
+                                            [:and
+                                             [:= :schema (get tr schema-key)]
+                                             [:= :name (get tr table-key)]]))})))
 
 (defn- table-ids-fallbacks
   "Given a list of maps holding [db_id schema table], return a mapping from those tuples => table_id"

--- a/enterprise/backend/src/metabase_enterprise/workspaces/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/api.clj
@@ -171,6 +171,7 @@
                                    :workspace_id id order-by)
         raw-inputs      (t2/select [:model/WorkspaceInput :db_id :schema :table :table_id]
                                    :workspace_id id {:order-by [:db_id :schema :table]})
+        ;; Some of our inputs may be shadowed by the outputs of other transforms. We only want external inputs.
         shadowed?       (into #{} (map (juxt :db_id :global_schema :global_table)) outputs)
         inputs          (remove (comp shadowed? (juxt :db_id :schema :table)) raw-inputs)
         ;; Build a map of [d s t] => id for every table that has been synced since the output row was written.

--- a/enterprise/backend/src/metabase_enterprise/workspaces/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/api.clj
@@ -137,7 +137,7 @@
   "Given a bounded list of tables all, within the same database, return an association list of [db schema table] => id"
   [db-id schema-key table-key table-refs]
   (t2/select-fn-vec (juxt (juxt (constantly db-id) :schema :name) :id)
-                    [:model/Table :id :schema [:name]]
+                    [:model/Table :id :schema :name]
                     :db_id db-id
                     {:where (into [:or] (for [tr table-refs]
                                           [:and

--- a/enterprise/backend/src/metabase_enterprise/workspaces/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/api.clj
@@ -134,7 +134,7 @@
                [:table_id [:maybe ::ws.t/appdb-id]]]]])
 
 (defn- batch-lookup-table-ids*
-  "Given a bounded list of tables all, within the same database, return an association list of [db schema table] => id"
+  "Given a bounded list of tables, all within the same database, return an association list of [db schema table] => id"
   [db-id schema-key table-key table-refs]
   (when (seq table-refs)
     (t2/select-fn-vec (juxt (juxt (constantly db-id) :schema :name) :id)

--- a/enterprise/backend/src/metabase_enterprise/workspaces/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/api.clj
@@ -178,18 +178,17 @@
                          (table-ids-fallbacks :global_schema :global_table :global_table_id outputs)
                          (table-ids-fallbacks :isolated_schema :isolated_table :isolated_table_id outputs))]
     {:inputs  inputs
-     ;; Yes, neither _table_id field is in the table yet - but they will (sometimes) be when the above issue is fixed.
-     :outputs (for [{:keys [ref_id db_id schema table global_table_id isolated_table_id]} outputs
-                    :let [isolated-name (ws.u/isolated-table-name schema table)]]
+     :outputs (for [{:keys [ref_id db_id global_schema global_table global_table_id
+                            isolated_schema isolated_table isolated_table_id]} outputs]
                 {:db_id    db_id
                  :global   {:transform_id nil
-                            :schema       schema
-                            :table        table
-                            :table_id     (or global_table_id (get fallback-map [db_id schema table]))}
+                            :schema       global_schema
+                            :table        global_table
+                            :table_id     (or global_table_id (get fallback-map [db_id global_schema global_table]))}
                  :isolated {:transform_id ref_id
-                            :schema       isolated-schema
-                            :table        isolated-name
-                            :table_id     (or isolated_table_id (get fallback-map [db_id isolated-schema isolated-name]))}})}))
+                            :schema       isolated_schema
+                            :table        isolated_table
+                            :table_id     (or isolated_table_id (get fallback-map [db_id isolated_schema isolated_table]))}})}))
 
 (api.macros/defendpoint :get "/:id" :- Workspace
   "Get a single workspace by ID"

--- a/enterprise/backend/src/metabase_enterprise/workspaces/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/api.clj
@@ -133,6 +133,47 @@
                [:table :string]
                [:table_id [:maybe ::ws.t/appdb-id]]]]])
 
+(defn- batch-lookup-global-table-ids*
+  "Given a bounded list of tables all, within the same database, return an association list of [db schema table] => id"
+  [db-id table-refs]
+  (t2/select-fn-vec (juxt (juxt (constantly db-id) :schema :name) :id)
+                    [:model/Table :id :schema [:name]]
+                    :db_id db-id
+                    {:where (into [:or] (for [{:keys [schema table]} table-refs]
+                                          [:and
+                                           [:= :schema schema]
+                                           [:= :name table]]))}))
+
+(defn- batch-lookup-table-ids
+  "Given a list of maps holding [db_id schema table], return a mapping from those tuples => table_id"
+  [table-refs]
+  (when (seq table-refs)
+    ;; These are ordered by db, so this will partition fine.
+    (u/for-map [table-refs (partition-by :db_id table-refs)
+                :let [db_id (:db_id (first table-refs))]
+                ;; Guesstimating a number that prevents this query being too large.
+                table-refs (partition-all 20 table-refs)
+                map-entry (batch-lookup-global-table-ids* db_id table-refs)]
+      map-entry)))
+
+;; TODO (chris 2025/12/12)
+;;   after https://linear.app/metabase/issue/BOT-696/fix-workspace-output-table we should not assume that all the
+;;   isolated tables use the same isolated schema, rather we should just trust the refs in the database, and use
+;;   [batch-lookup-table-ids] (deleting this method)
+(defn- batch-lookup-isolated-table-ids
+  "Batch lookup table_ids for isolated output tables by [isolation-schema isolated-table-name]."
+  [isolated-schema global-output-refs]
+  (when (seq global-output-refs)
+    (u/for-map [table-refs (partition-by :db_id global-output-refs)
+                :let [db-id (:db_id (first table-refs))
+                      isolated-names (for [{:keys [schema table]} table-refs] (ws.u/isolated-table-name schema table))]
+                [table id] (map vector
+                                isolated-names
+                                (t2/select-fn-vec :id [:model/Table :id] :db_id db-id :schema isolated-schema :name [:in isolated-names]))]
+      [[db-id isolated-schema table] id])))
+
+(def ^:private dst (juxt :db_id :schema :table))
+
 (api.macros/defendpoint :get "/:id/table"
   :- [:map {:closed true}
       [:inputs [:sequential ::input-table]]
@@ -140,29 +181,33 @@
   "Get workspace tables"
   [{:keys [id]} :- [:map [:id ms/PositiveInt]]
    _query-params]
-  (api/check-404 (t2/select-one :model/Workspace :id id))
-  (let [order-by        {:order-by [:db_id :global_schema :global_table]}
-        outputs         (t2/select [:model/WorkspaceOutput
-                                    :db_id :global_schema :global_table :global_table_id
-                                    :isolated_schema :isolated_table :isolated_table_id :ref_id]
-                                   :workspace_id id order-by)
-        raw-inputs      (t2/select [:model/WorkspaceInput :db_id :schema :table :table_id]
-                                   :workspace_id id {:order-by [:db_id :schema :table]})
+  (let [isolated-schema (api/check-404 (t2/select-one-fn :schema [:model/Workspace :schema] id))
+        order-by        {:order-by [:db_id :schema :table]}
+        outputs         (t2/select [:model/WorkspaceOutput :db_id :schema :table :ref_id] :workspace_id id order-by)
+        raw-inputs      (t2/select [:model/WorkspaceInput :db_id :schema :table :table_id] :workspace_id id order-by)
         ;; Some of our inputs may be shadowed by the outputs of other transforms. We only want external inputs.
-        shadowed?       (into #{} (map (juxt :db_id :global_schema :global_table)) outputs)
-        inputs          (remove (comp shadowed? (juxt :db_id :schema :table)) raw-inputs)]
+        ;; TODO once the output table has its schema fixed (https://linear.app/metabase/issue/BOT-696) swap this out
+        ;shadowed?             (into #{} (for [{d :db_id, {s :schema, t :table} :global} outputs] [d s t]))
+        shadowed?       (into #{} (map dst) outputs)
+        inputs          (remove (comp shadowed? dst) raw-inputs)
+        ;; Once we've fixed the WorkspaceOutput table, it should contain both of these ids (eventually), and typically
+        ;; we won't need to do any of the following id look-ups. What we'll want to do is group together all the
+        ;; unknown [d s t] references, and look them all up at once for a single fallback map like this.
+        fallback-map    (merge (batch-lookup-table-ids outputs)
+                               (batch-lookup-isolated-table-ids isolated-schema outputs))]
     {:inputs  inputs
-     :outputs (for [{:keys [ref_id db_id global_schema global_table global_table_id
-                            isolated_schema isolated_table isolated_table_id]} outputs]
+     ;; Yes, neither _table_id field is in the table yet - but they will (sometimes) be when the above issue is fixed.
+     :outputs (for [{:keys [ref_id db_id schema table global_table_id isolated_table_id]} outputs
+                    :let [isolated-name (ws.u/isolated-table-name schema table)]]
                 {:db_id    db_id
                  :global   {:transform_id nil
-                            :schema       global_schema
-                            :table        global_table
-                            :table_id     global_table_id}
+                            :schema       schema
+                            :table        table
+                            :table_id     (or global_table_id (get fallback-map [db_id schema table]))}
                  :isolated {:transform_id ref_id
-                            :schema       isolated_schema
-                            :table        isolated_table
-                            :table_id     isolated_table_id}})}))
+                            :schema       isolated-schema
+                            :table        isolated-name
+                            :table_id     (or isolated_table_id (get fallback-map [db_id isolated-schema isolated-name]))}})}))
 
 (api.macros/defendpoint :get "/:id" :- Workspace
   "Get a single workspace by ID"

--- a/enterprise/backend/src/metabase_enterprise/workspaces/dependencies.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/dependencies.clj
@@ -223,12 +223,12 @@
                             {:workspace_id workspace-id
                              :ref_id       ref-id}
                             (fn [existing]
-                              (let [qry-table-id   (fn [schema table]
+                              (let [isolated-table (ws.u/isolated-table-name schema table)
+                                    qry-table-id   (fn [schema table]
                                                      (t2/select-one-fn :id [:model/Table :id]
                                                                        :db_id db_id
                                                                        :schema schema
                                                                        :name table))
-                                    isolated-table (ws.u/isolated-table-name schema table)
                                     id-if-match    (fn [schema-key schema table-key table id-key]
                                                      (when (and (= schema (get existing schema-key))
                                                                 (= table (get existing table-key)))

--- a/enterprise/backend/src/metabase_enterprise/workspaces/dependencies.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/dependencies.clj
@@ -229,21 +229,26 @@
                                                                        :schema schema
                                                                        :name table))
                                     isolated-table (ws.u/isolated-table-name schema table)
-                                    global-id      (or (when (and (= schema (:global_schema existing))
-                                                                  (= table (:global_table existing)))
-                                                         (:global_table_id existing))
-                                                       (->table-id schema table))
-                                    isolated-id    (or (when (and (= isolated-schema (:isolated_schema existing))
-                                                                  (= isolated-table (:isolated_table existing)))
-                                                         (:isolated_table_id existing))
-                                                       (->table-id isolated-schema isolated-table))]
+                                    id-if-match    (fn [schema-key schema table-key table id-key]
+                                                     (when (and (= schema (get existing schema-key))
+                                                                (= table (get existing table-key)))
+                                                       (get existing id-key)))
+                                    id-fallback    (fn [schema-key schema table-key table id-key]
+                                                     (or (id-if-match schema-key schema table-key table id-key)
+                                                         (->table-id schema table)))]
                                 {:db_id             db_id
                                  :global_schema     schema
                                  :global_table      table
-                                 :global_table_id   global-id
+                                 :global_table_id   (id-fallback
+                                                     :global_schema schema
+                                                     :global_table table
+                                                     :global_table_id)
                                  :isolated_schema   isolated-schema
                                  :isolated_table    isolated-table
-                                 :isolated_table_id isolated-id}))))
+                                 :isolated_table_id (id-fallback
+                                                     :isolated_schema isolated-schema
+                                                     :isolated_table isolated-table
+                                                     :isolated_table_id)}))))
 
 (defn- build-output-lookup
   "Build a lookup map for workspace outputs: [db_id global_schema global_table] -> output_id.

--- a/enterprise/backend/src/metabase_enterprise/workspaces/dependencies.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/dependencies.clj
@@ -223,7 +223,7 @@
                             {:workspace_id workspace-id
                              :ref_id       ref-id}
                             (fn [existing]
-                              (let [->table-id     (fn [schema table]
+                              (let [qry-table-id   (fn [schema table]
                                                      (t2/select-one-fn :id [:model/Table :id]
                                                                        :db_id db_id
                                                                        :schema schema
@@ -235,7 +235,7 @@
                                                        (get existing id-key)))
                                     id-fallback    (fn [schema-key schema table-key table id-key]
                                                      (or (id-if-match schema-key schema table-key table id-key)
-                                                         (->table-id schema table)))]
+                                                         (qry-table-id schema table)))]
                                 {:db_id             db_id
                                  :global_schema     schema
                                  :global_table      table

--- a/enterprise/backend/src/metabase_enterprise/workspaces/dependencies.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/dependencies.clj
@@ -237,13 +237,13 @@
                                                                   (= isolated-table (:isolated_table existing)))
                                                          (:isolated_table_id existing))
                                                        (->table-id isolated-schema isolated-table))]
-                                (constantly {:db_id             db_id
-                                             :global_schema     schema
-                                             :global_table      table
-                                             :global_table_id   global-id
-                                             :isolated_schema   isolated-schema
-                                             :isolated_table    isolated-table
-                                             :isolated_table_id isolated-id})))))
+                                {:db_id             db_id
+                                 :global_schema     schema
+                                 :global_table      table
+                                 :global_table_id   global-id
+                                 :isolated_schema   isolated-schema
+                                 :isolated_table    isolated-table
+                                 :isolated_table_id isolated-id}))))
 
 (defn- build-output-lookup
   "Build a lookup map for workspace outputs: [db_id global_schema global_table] -> output_id.

--- a/enterprise/backend/src/metabase_enterprise/workspaces/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/impl.clj
@@ -3,6 +3,7 @@
   (:require
    [metabase-enterprise.workspaces.dependencies :as ws.deps]
    [metabase-enterprise.workspaces.isolation :as ws.isolation]
+   [metabase.util.log :as log]
    [toucan2.core :as t2]))
 
 (defn- query-external-inputs
@@ -37,7 +38,9 @@
         _               (ws.deps/write-dependencies! workspace-id isolated-schema :transform (:ref_id transform) analysis)
         external-inputs (query-external-inputs workspace-id)]
     (if-not (:database_details workspace)
-      (throw (ex-info "No database details, unable to grant read only access to the service account." {}))
+      ;; TODO (chris 2025/12/15) we will want to make this strict before merging to master
+      #_(throw (ex-info "No database details, unable to grant read only access to the service account." {}))
+      (log/warn "No database details, unable to grant read only access to the service account.")
       (when (seq external-inputs)
         (let [database (t2/select-one :model/Database :id (:database_id workspace))
               tables   (mapv external-input->table external-inputs)]

--- a/enterprise/backend/test/metabase_enterprise/workspaces/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/api_test.clj
@@ -485,7 +485,7 @@
 
       (testing "Conflict inside of workspace"
         (let [table (t2/select-one :model/Table :active true)]
-          (is (= "Must not target an isolated workspace schema"
+          (is (= "Another transform in this workspace already targets that table"
                  (mt/with-log-level [metabase.driver.sql-jdbc.sync.describe-table :fatal]
                    (mt/user-http-request :crowberto :post 403 (ws-url (:id ws) "/transform/validate/target")
                                          {:db_id  (:db_id table)

--- a/enterprise/backend/test/metabase_enterprise/workspaces/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/api_test.clj
@@ -783,3 +783,106 @@
                         xf5-id nil #_native-is-supported
                         xf6-id "card-reference"}
                        (u/index-by :id :checkout_disabled transforms)))))))))))
+
+;;; ---------------------------------------- Table ID Fallback Tests ----------------------------------------
+
+(deftest tables-endpoint-fallback-global-table-id-test
+  (testing "GET /api/ee/workspace/:id/table uses fallback for null global_table_id"
+    (mt/with-temp [:model/Workspace          workspace {:name        "Fallback Test WS"
+                                                        :database_id (mt/id)
+                                                        :schema      "ws_fallback_test"}
+                   :model/WorkspaceTransform ws-tx     {:workspace_id (:id workspace)
+                                                        :name         "Test Transform"
+                                                        :target       {:type     "table"
+                                                                       :database (mt/id)
+                                                                       :schema   "public"
+                                                                       :name     "fallback_test_table"}}
+                   ;; Create a table that exists but WorkspaceOutput doesn't know about yet
+                   :model/Table              table     {:db_id  (mt/id)
+                                                        :schema "public"
+                                                        :name   "fallback_test_table"
+                                                        :active true}
+                   ;; Create WorkspaceOutput with null global_table_id (simulating pre-sync state)
+                   :model/WorkspaceOutput    _         {:workspace_id    (:id workspace)
+                                                        :ref_id          (:ref_id ws-tx)
+                                                        :db_id           (mt/id)
+                                                        :global_schema   "public"
+                                                        :global_table    "fallback_test_table"
+                                                        :global_table_id nil
+                                                        :isolated_schema (:schema workspace)
+                                                        :isolated_table  "public__fallback_test_table"
+                                                        :isolated_table_id nil}]
+      (let [result (mt/user-http-request :crowberto :get 200 (ws-url (:id workspace) "/table"))]
+        (testing "fallback populates global table_id from metabase_table"
+          (is (= (:id table)
+                 (-> result :outputs first :global :table_id))))
+        (testing "isolated table_id remains nil when table doesn't exist"
+          (is (nil? (-> result :outputs first :isolated :table_id))))))))
+
+(deftest tables-endpoint-fallback-isolated-table-id-test
+  (testing "GET /api/ee/workspace/:id/table uses fallback for null isolated_table_id"
+    (mt/with-temp [:model/Workspace          workspace {:name        "Isolated Fallback Test WS"
+                                                        :database_id (mt/id)
+                                                        :schema      "ws_iso_fallback"}
+                   :model/WorkspaceTransform ws-tx     {:workspace_id (:id workspace)
+                                                        :name         "Test Transform"
+                                                        :target       {:type     "table"
+                                                                       :database (mt/id)
+                                                                       :schema   "public"
+                                                                       :name     "iso_fallback_table"}}
+                   ;; Create the isolated table in metabase_table
+                   :model/Table              iso-table {:db_id  (mt/id)
+                                                        :schema "ws_iso_fallback"
+                                                        :name   "public__iso_fallback_table"
+                                                        :active true}
+                   ;; Create WorkspaceOutput with null isolated_table_id
+                   :model/WorkspaceOutput    _         {:workspace_id      (:id workspace)
+                                                        :ref_id            (:ref_id ws-tx)
+                                                        :db_id             (mt/id)
+                                                        :global_schema     "public"
+                                                        :global_table      "iso_fallback_table"
+                                                        :global_table_id   nil
+                                                        :isolated_schema   "ws_iso_fallback"
+                                                        :isolated_table    "public__iso_fallback_table"
+                                                        :isolated_table_id nil}]
+      (let [result (mt/user-http-request :crowberto :get 200 (ws-url (:id workspace) "/table"))]
+        (testing "fallback populates isolated table_id from metabase_table"
+          (is (= (:id iso-table)
+                 (-> result :outputs first :isolated :table_id))))))))
+
+(deftest tables-endpoint-fallback-both-table-ids-test
+  (testing "GET /api/ee/workspace/:id/table uses fallback for both null table IDs"
+    (mt/with-temp [:model/Workspace          workspace    {:name        "Both Fallback Test WS"
+                                                           :database_id (mt/id)
+                                                           :schema      "ws_both_fallback"}
+                   :model/WorkspaceTransform ws-tx        {:workspace_id (:id workspace)
+                                                           :name         "Test Transform"
+                                                           :target       {:type     "table"
+                                                                          :database (mt/id)
+                                                                          :schema   "public"
+                                                                          :name     "both_fallback_table"}}
+                   ;; Create both tables
+                   :model/Table              global-table {:db_id  (mt/id)
+                                                           :schema "public"
+                                                           :name   "both_fallback_table"
+                                                           :active true}
+                   :model/Table              iso-table    {:db_id  (mt/id)
+                                                           :schema "ws_both_fallback"
+                                                           :name   "public__both_fallback_table"
+                                                           :active true}
+                   ;; Create WorkspaceOutput with both table IDs null
+                   :model/WorkspaceOutput    _            {:workspace_id      (:id workspace)
+                                                           :ref_id            (:ref_id ws-tx)
+                                                           :db_id             (mt/id)
+                                                           :global_schema     "public"
+                                                           :global_table      "both_fallback_table"
+                                                           :global_table_id   nil
+                                                           :isolated_schema   "ws_both_fallback"
+                                                           :isolated_table    "public__both_fallback_table"
+                                                           :isolated_table_id nil}]
+      (let [result (mt/user-http-request :crowberto :get 200 (ws-url (:id workspace) "/table"))]
+        (testing "fallback populates both table IDs"
+          (is (= (:id global-table)
+                 (-> result :outputs first :global :table_id)))
+          (is (= (:id iso-table)
+                 (-> result :outputs first :isolated :table_id))))))))

--- a/enterprise/backend/test/metabase_enterprise/workspaces/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/api_test.clj
@@ -785,104 +785,109 @@
                        (u/index-by :id :checkout_disabled transforms)))))))))))
 
 ;;; ---------------------------------------- Table ID Fallback Tests ----------------------------------------
+;; These tests verify that when WorkspaceOutput rows have null table IDs (e.g., because sync
+;; hasn't run yet), the /table endpoint will look up the IDs from metabase_table as a fallback.
 
-(deftest tables-endpoint-fallback-global-table-id-test
+(deftest ^:parallel tables-endpoint-fallback-global-table-id-test
   (testing "GET /api/ee/workspace/:id/table uses fallback for null global_table_id"
-    (mt/with-temp [:model/Workspace          workspace {:name        "Fallback Test WS"
-                                                        :database_id (mt/id)
-                                                        :schema      "ws_fallback_test"}
-                   :model/WorkspaceTransform ws-tx     {:workspace_id (:id workspace)
-                                                        :name         "Test Transform"
-                                                        :target       {:type     "table"
-                                                                       :database (mt/id)
-                                                                       :schema   "public"
-                                                                       :name     "fallback_test_table"}}
-                   ;; Create a table that exists but WorkspaceOutput doesn't know about yet
-                   :model/Table              table     {:db_id  (mt/id)
-                                                        :schema "public"
-                                                        :name   "fallback_test_table"
-                                                        :active true}
-                   ;; Create WorkspaceOutput with null global_table_id (simulating pre-sync state)
-                   :model/WorkspaceOutput    _         {:workspace_id    (:id workspace)
-                                                        :ref_id          (:ref_id ws-tx)
-                                                        :db_id           (mt/id)
-                                                        :global_schema   "public"
-                                                        :global_table    "fallback_test_table"
-                                                        :global_table_id nil
-                                                        :isolated_schema (:schema workspace)
-                                                        :isolated_table  "public__fallback_test_table"
-                                                        :isolated_table_id nil}]
-      (let [result (mt/user-http-request :crowberto :get 200 (ws-url (:id workspace) "/table"))]
-        (testing "fallback populates global table_id from metabase_table"
-          (is (= (:id table)
-                 (-> result :outputs first :global :table_id))))
-        (testing "isolated table_id remains nil when table doesn't exist"
-          (is (nil? (-> result :outputs first :isolated :table_id))))))))
+    (mt/with-premium-features #{:workspaces}
+      (mt/with-temp [:model/Workspace          workspace {:name        "Fallback Test WS"
+                                                          :database_id (mt/id)
+                                                          :schema      "ws_fallback_test"}
+                     :model/WorkspaceTransform ws-tx     {:workspace_id (:id workspace)
+                                                          :name         "Test Transform"
+                                                          :target       {:type     "table"
+                                                                         :database (mt/id)
+                                                                         :schema   "public"
+                                                                         :name     "fallback_test_table"}}
+                     ;; Create a table that exists but WorkspaceOutput doesn't know about yet
+                     :model/Table              table     {:db_id  (mt/id)
+                                                          :schema "public"
+                                                          :name   "fallback_test_table"
+                                                          :active true}
+                     ;; Create WorkspaceOutput with null global_table_id (simulating pre-sync state)
+                     :model/WorkspaceOutput    _         {:workspace_id      (:id workspace)
+                                                          :ref_id            (:ref_id ws-tx)
+                                                          :db_id             (mt/id)
+                                                          :global_schema     "public"
+                                                          :global_table      "fallback_test_table"
+                                                          :global_table_id   nil
+                                                          :isolated_schema   (:schema workspace)
+                                                          :isolated_table    "public__fallback_test_table"
+                                                          :isolated_table_id nil}]
+        (let [result (mt/user-http-request :crowberto :get 200 (ws-url (:id workspace) "/table"))]
+          (testing "fallback populates global table_id from metabase_table"
+            (is (= (:id table)
+                   (-> result :outputs first :global :table_id))))
+          (testing "isolated table_id remains nil when table doesn't exist"
+            (is (nil? (-> result :outputs first :isolated :table_id)))))))))
 
-(deftest tables-endpoint-fallback-isolated-table-id-test
+(deftest ^:parallel tables-endpoint-fallback-isolated-table-id-test
   (testing "GET /api/ee/workspace/:id/table uses fallback for null isolated_table_id"
-    (mt/with-temp [:model/Workspace          workspace {:name        "Isolated Fallback Test WS"
-                                                        :database_id (mt/id)
-                                                        :schema      "ws_iso_fallback"}
-                   :model/WorkspaceTransform ws-tx     {:workspace_id (:id workspace)
-                                                        :name         "Test Transform"
-                                                        :target       {:type     "table"
-                                                                       :database (mt/id)
-                                                                       :schema   "public"
-                                                                       :name     "iso_fallback_table"}}
-                   ;; Create the isolated table in metabase_table
-                   :model/Table              iso-table {:db_id  (mt/id)
-                                                        :schema "ws_iso_fallback"
-                                                        :name   "public__iso_fallback_table"
-                                                        :active true}
-                   ;; Create WorkspaceOutput with null isolated_table_id
-                   :model/WorkspaceOutput    _         {:workspace_id      (:id workspace)
-                                                        :ref_id            (:ref_id ws-tx)
-                                                        :db_id             (mt/id)
-                                                        :global_schema     "public"
-                                                        :global_table      "iso_fallback_table"
-                                                        :global_table_id   nil
-                                                        :isolated_schema   "ws_iso_fallback"
-                                                        :isolated_table    "public__iso_fallback_table"
-                                                        :isolated_table_id nil}]
-      (let [result (mt/user-http-request :crowberto :get 200 (ws-url (:id workspace) "/table"))]
-        (testing "fallback populates isolated table_id from metabase_table"
-          (is (= (:id iso-table)
-                 (-> result :outputs first :isolated :table_id))))))))
+    (mt/with-premium-features #{:workspaces}
+      (mt/with-temp [:model/Workspace          workspace {:name        "Isolated Fallback Test WS"
+                                                          :database_id (mt/id)
+                                                          :schema      "ws_iso_fallback"}
+                     :model/WorkspaceTransform ws-tx     {:workspace_id (:id workspace)
+                                                          :name         "Test Transform"
+                                                          :target       {:type     "table"
+                                                                         :database (mt/id)
+                                                                         :schema   "public"
+                                                                         :name     "iso_fallback_table"}}
+                     ;; Create the isolated table in metabase_table
+                     :model/Table              iso-table {:db_id  (mt/id)
+                                                          :schema "ws_iso_fallback"
+                                                          :name   "public__iso_fallback_table"
+                                                          :active true}
+                     ;; Create WorkspaceOutput with null isolated_table_id
+                     :model/WorkspaceOutput    _         {:workspace_id      (:id workspace)
+                                                          :ref_id            (:ref_id ws-tx)
+                                                          :db_id             (mt/id)
+                                                          :global_schema     "public"
+                                                          :global_table      "iso_fallback_table"
+                                                          :global_table_id   nil
+                                                          :isolated_schema   "ws_iso_fallback"
+                                                          :isolated_table    "public__iso_fallback_table"
+                                                          :isolated_table_id nil}]
+        (let [result (mt/user-http-request :crowberto :get 200 (ws-url (:id workspace) "/table"))]
+          (testing "fallback populates isolated table_id from metabase_table"
+            (is (= (:id iso-table)
+                   (-> result :outputs first :isolated :table_id)))))))))
 
-(deftest tables-endpoint-fallback-both-table-ids-test
+(deftest ^:parallel tables-endpoint-fallback-both-table-ids-test
   (testing "GET /api/ee/workspace/:id/table uses fallback for both null table IDs"
-    (mt/with-temp [:model/Workspace          workspace    {:name        "Both Fallback Test WS"
-                                                           :database_id (mt/id)
-                                                           :schema      "ws_both_fallback"}
-                   :model/WorkspaceTransform ws-tx        {:workspace_id (:id workspace)
-                                                           :name         "Test Transform"
-                                                           :target       {:type     "table"
-                                                                          :database (mt/id)
-                                                                          :schema   "public"
-                                                                          :name     "both_fallback_table"}}
-                   ;; Create both tables
-                   :model/Table              global-table {:db_id  (mt/id)
-                                                           :schema "public"
-                                                           :name   "both_fallback_table"
-                                                           :active true}
-                   :model/Table              iso-table    {:db_id  (mt/id)
-                                                           :schema "ws_both_fallback"
-                                                           :name   "public__both_fallback_table"
-                                                           :active true}
-                   ;; Create WorkspaceOutput with both table IDs null
-                   :model/WorkspaceOutput    _            {:workspace_id      (:id workspace)
-                                                           :ref_id            (:ref_id ws-tx)
-                                                           :db_id             (mt/id)
-                                                           :global_schema     "public"
-                                                           :global_table      "both_fallback_table"
-                                                           :global_table_id   nil
-                                                           :isolated_schema   "ws_both_fallback"
-                                                           :isolated_table    "public__both_fallback_table"
-                                                           :isolated_table_id nil}]
-      (let [result (mt/user-http-request :crowberto :get 200 (ws-url (:id workspace) "/table"))]
-        (testing "fallback populates both table IDs"
-          (is (= (:id global-table)
-                 (-> result :outputs first :global :table_id)))
-          (is (= (:id iso-table)
-                 (-> result :outputs first :isolated :table_id))))))))
+    (mt/with-premium-features #{:workspaces}
+      (mt/with-temp [:model/Workspace          workspace    {:name        "Both Fallback Test WS"
+                                                             :database_id (mt/id)
+                                                             :schema      "ws_both_fallback"}
+                     :model/WorkspaceTransform ws-tx        {:workspace_id (:id workspace)
+                                                             :name         "Test Transform"
+                                                             :target       {:type     "table"
+                                                                            :database (mt/id)
+                                                                            :schema   "public"
+                                                                            :name     "both_fallback_table"}}
+                     ;; Create both tables
+                     :model/Table              global-table {:db_id  (mt/id)
+                                                             :schema "public"
+                                                             :name   "both_fallback_table"
+                                                             :active true}
+                     :model/Table              iso-table    {:db_id  (mt/id)
+                                                             :schema "ws_both_fallback"
+                                                             :name   "public__both_fallback_table"
+                                                             :active true}
+                     ;; Create WorkspaceOutput with both table IDs null
+                     :model/WorkspaceOutput    _            {:workspace_id      (:id workspace)
+                                                             :ref_id            (:ref_id ws-tx)
+                                                             :db_id             (mt/id)
+                                                             :global_schema     "public"
+                                                             :global_table      "both_fallback_table"
+                                                             :global_table_id   nil
+                                                             :isolated_schema   "ws_both_fallback"
+                                                             :isolated_table    "public__both_fallback_table"
+                                                             :isolated_table_id nil}]
+        (let [result (mt/user-http-request :crowberto :get 200 (ws-url (:id workspace) "/table"))]
+          (testing "fallback populates both table IDs"
+            (is (= (:id global-table)
+                   (-> result :outputs first :global :table_id)))
+            (is (= (:id iso-table)
+                   (-> result :outputs first :isolated :table_id)))))))))


### PR DESCRIPTION
Two fixes:

1. Write the isolated table id after analysis.
2. Query for table id in case sync happened after output was updated.
