### PR TITLE
Trying to fix the infamous app palette loki flaky

### DIFF
--- a/frontend/src/metabase/palette/components/Palette.stories.tsx
+++ b/frontend/src/metabase/palette/components/Palette.stories.tsx
@@ -132,6 +132,7 @@ export const Search = {
     );
 
     await canvas.findByRole("option", { name: "Results" });
+    await canvas.findByText("Orders for each product"); // make sure we see the last item in the list
 
     asyncCallback();
   },

--- a/frontend/src/metabase/palette/components/Palette.stories.tsx
+++ b/frontend/src/metabase/palette/components/Palette.stories.tsx
@@ -2,7 +2,7 @@
 import createAsyncCallback from "@loki/create-async-callback";
 import type { Store } from "@reduxjs/toolkit";
 import type { StoryFn } from "@storybook/react/*";
-import { userEvent, within } from "@storybook/test";
+import { expect, userEvent, within } from "@storybook/test";
 import { KBarProvider, VisualState, useKBar } from "kbar";
 import { HttpResponse, http } from "msw";
 import _ from "underscore";
@@ -132,7 +132,12 @@ export const Search = {
     );
 
     await canvas.findByRole("option", { name: "Results" });
-    await canvas.findByText("Orders for each product"); // make sure we see the last item in the list
+
+    // Wait for the result to all show up because "Results" will be
+    // present when the search query is still loading
+    await expect(
+      await canvas.findByText("Product breakdown"),
+    ).toBeInTheDocument();
 
     asyncCallback();
   },


### PR DESCRIPTION
This fixes the Palette/Search loki test flakiness by waiting for the dialog to populate with results before taking the screenshots, hence giving it more time to resize. Hopefully. Here are [three green runs of loki](https://github.com/metabase/metabase/actions/runs/20233322150?pr=66935) on this branch.