### PR TITLE
Don't crash if both db-level and table-level permissions exist

### DIFF
--- a/src/metabase/permissions/core.clj
+++ b/src/metabase/permissions/core.clj
@@ -37,6 +37,7 @@
 (p/import-vars
  [metabase.permissions.models.data-permissions
   at-least-as-permissive?
+  other-new-perms
   disable-perms-cache
   full-db-permission-for-user
   full-schema-permission-for-user


### PR DESCRIPTION
The permission API attempts to enforce at write time that only either a single db-level permission, or individual table-level permissions exist at the same time. However, we have received reports of crashes during graph generation, which upon investigation indicate a corrupt graph with both db-level and table-level permissions. 
This PR renders graph generation resilient to that corrupted instance, by exploiting at read time the same internal mechanisms for fanning out db-level to individual table-level permissions on write, in case we detect a corrupted graph 