### PR TITLE
Correctly handle non-string `@tenants` in JWTs

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/providers/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/providers/jwt.clj
@@ -85,15 +85,20 @@
             email (get jwt-data (jwt-attribute-email))
             first-name (get jwt-data (jwt-attribute-firstname))
             last-name (get jwt-data (jwt-attribute-lastname))
-            tenant-slug (get jwt-data (jwt-attribute-tenant))
+            tenant-slug (u/prog1 (get jwt-data (jwt-attribute-tenant))
+                          (when-not (or (nil? <>)
+                                        (string? <>)
+                                        (integer? <>))
+                            (throw (ex-info "Value of `@tenant` must be a string" {:status-code 400
+                                                                                   :error :invalid-tenant}))))
             user-attributes (jwt-data->user-attributes jwt-data)]
         (when-not email
-          (throw (ex-info (str (tru "JWT token missing email claim"))
+          (throw (ex-info "JWT token missing email claim"
                           {:status-code 400
                            :error :missing-email})))
         (log/infof "Successfully authenticated JWT token for: %s %s" first-name last-name)
         {:success? true
-         :tenant-slug tenant-slug
+         :tenant-slug (some-> tenant-slug str)
          :user-data (->> {:email email
                           :first_name first-name
                           :last_name last-name

--- a/enterprise/backend/src/metabase_enterprise/sso/providers/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/providers/jwt.clj
@@ -93,7 +93,7 @@
                                                                                    :error :invalid-tenant}))))
             user-attributes (jwt-data->user-attributes jwt-data)]
         (when-not email
-          (throw (ex-info "JWT token missing email claim"
+          (throw (ex-info (tru "JWT token missing email claim")
                           {:status-code 400
                            :error :missing-email})))
         (log/infof "Successfully authenticated JWT token for: %s %s" first-name last-name)

--- a/enterprise/backend/src/metabase_enterprise/tenants/auth_provider.clj
+++ b/enterprise/backend/src/metabase_enterprise/tenants/auth_provider.clj
@@ -67,7 +67,7 @@
 (methodical/defmethod auth-identity/login! ::create-tenant-if-not-exists
   [provider {:keys [tenant-slug]
              :as request}]
-  (let [existing-tenant (t2/select-one :model/Tenant :slug tenant-slug)]
+  (let [existing-tenant (when tenant-slug (t2/select-one :model/Tenant :slug tenant-slug))]
     (next-method provider (create-tenant-if-not-exists! request existing-tenant))))
 
 (methodical/prefer-method! #'auth-identity/login! :metabase.auth-identity.provider/provider ::create-tenant-if-not-exists)


### PR DESCRIPTION
Previously we threw exceptions if we received an invalid non-string `@tenant`, like `123` or `false` or `{:foo "bar"}`.

Now we:

- convert integers to strings,

- take strings as-is, and

- throw a meaningful exception for anything else
