### PR TITLE
UXW-2481 Add a button in the Library to publish a table

### DIFF
--- a/e2e/test/scenarios/data-studio/data-studio-library.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-studio-library.cy.spec.ts
@@ -103,4 +103,25 @@ describe("scenarios > data studio > library", () => {
     H.entityPickerModalItem(1, "Data").click();
     H.entityPickerModalItem(2, "Orders").should("exist");
   });
+
+  describe("+New button", () => {
+    it("should allow you to publish a table", () => {
+      H.createLibrary();
+      H.DataStudio.Library.visit();
+
+      cy.log("Publish a table from the 'New' menu");
+      H.DataStudio.Library.newButton().click();
+      H.popover().findByText("Publish a table").click();
+
+      cy.log("Select a table and click 'Publish'");
+      H.entityPickerModalItem(3, "Orders").click();
+      H.entityPickerModal().button("Publish").click();
+
+      cy.log("Verify the newly published table shows up in the Library");
+      H.DataStudio.Library.tableItem("Orders").should("exist");
+
+      cy.log("Verify tables are disabled if they've already been published");
+      // TODO
+    });
+  });
 });

--- a/e2e/test/scenarios/data-studio/data-studio-library.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-studio-library.cy.spec.ts
@@ -117,11 +117,22 @@ describe("scenarios > data studio > library", () => {
       H.entityPickerModalItem(3, "Orders").click();
       H.entityPickerModal().button("Publish").click();
 
-      cy.log("Verify the newly published table shows up in the Library");
+      cy.log("Verify the table is published");
+      H.DataStudio.Tables.overviewPage().should("exist");
+      H.DataStudio.Tables.header().findByDisplayValue("Orders").should("exist");
+      H.DataStudio.breadcrumbs().findByRole("link", { name: "Data" }).click();
       H.DataStudio.Library.tableItem("Orders").should("exist");
 
-      cy.log("Verify tables are disabled if they've already been published");
-      // TODO
+      cy.log(
+        "Verify tables in the entity picker are disabled if already published",
+      );
+      H.DataStudio.Library.newButton().click();
+      H.popover().findByText("Publish a table").click();
+      H.entityPickerModalItem(3, "Orders").should("have.attr", "data-disabled");
+      H.entityPickerModalItem(3, "People").should(
+        "not.have.attr",
+        "data-disabled",
+      );
     });
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/CreateMenu.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/CreateMenu.tsx
@@ -5,7 +5,10 @@ import { t } from "ttag";
 import { ForwardRefLink } from "metabase/common/components/Link";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
-import { PLUGIN_SNIPPET_FOLDERS } from "metabase/plugins";
+import {
+  PLUGIN_FEATURE_LEVEL_PERMISSIONS,
+  PLUGIN_SNIPPET_FOLDERS,
+} from "metabase/plugins";
 import {
   canUserCreateNativeQueries,
   canUserCreateQueries,
@@ -24,13 +27,16 @@ export const CreateMenu = ({
   const [modal, setModal] = useState<"snippet-folder" | "publish-table">();
   const closeModal = () => setModal(undefined);
 
+  const canAccessDataModel = useSelector(
+    PLUGIN_FEATURE_LEVEL_PERMISSIONS.canAccessDataModel,
+  );
   const hasNativeWrite = useSelector(canUserCreateNativeQueries);
   const hasDataAccess = useSelector(canUserCreateQueries);
 
   const canCreateMetric = hasDataAccess && metricCollectionId;
 
   const menuItems = [
-    hasDataAccess && (
+    canAccessDataModel && (
       <Menu.Item
         key="publish-table"
         leftSection={<FixedSizeIcon name="publish" />}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/CreateMenu.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/CreateMenu.tsx
@@ -5,13 +5,11 @@ import { t } from "ttag";
 import { ForwardRefLink } from "metabase/common/components/Link";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
-import {
-  PLUGIN_FEATURE_LEVEL_PERMISSIONS,
-  PLUGIN_SNIPPET_FOLDERS,
-} from "metabase/plugins";
+import { PLUGIN_SNIPPET_FOLDERS } from "metabase/plugins";
 import {
   canUserCreateNativeQueries,
   canUserCreateQueries,
+  getUserIsAdmin,
 } from "metabase/selectors/user";
 import { Button, FixedSizeIcon, Icon, Menu } from "metabase/ui";
 import type { CollectionId } from "metabase-types/api";
@@ -27,16 +25,14 @@ export const CreateMenu = ({
   const [modal, setModal] = useState<"snippet-folder" | "publish-table">();
   const closeModal = () => setModal(undefined);
 
-  const canAccessDataModel = useSelector(
-    PLUGIN_FEATURE_LEVEL_PERMISSIONS.canAccessDataModel,
-  );
+  const isAdmin = useSelector(getUserIsAdmin);
   const hasNativeWrite = useSelector(canUserCreateNativeQueries);
   const hasDataAccess = useSelector(canUserCreateQueries);
 
   const canCreateMetric = hasDataAccess && metricCollectionId;
 
   const menuItems = [
-    canAccessDataModel && (
+    isAdmin && (
       <Menu.Item
         key="publish-table"
         leftSection={<FixedSizeIcon name="publish" />}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/CreateMenu.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/CreateMenu.tsx
@@ -12,12 +12,15 @@ import {
 import { Button, FixedSizeIcon, Icon, Menu } from "metabase/ui";
 import type { CollectionId } from "metabase-types/api";
 
+import { PublishTableModal } from "./PublishTableModal";
+
 export const CreateMenu = ({
   metricCollectionId,
 }: {
   metricCollectionId?: CollectionId;
 }) => {
-  const [creatingSnippetFolder, setCreatingSnippetFolder] = useState(false);
+  const [modal, setModal] = useState<"snippet-folder" | "publish-table">();
+  const closeModal = () => setModal(undefined);
 
   const hasNativeWrite = useSelector(canUserCreateNativeQueries);
   const hasDataAccess = useSelector(canUserCreateQueries);
@@ -25,6 +28,15 @@ export const CreateMenu = ({
   const canCreateMetric = hasDataAccess && metricCollectionId;
 
   const menuItems = [
+    hasDataAccess && (
+      <Menu.Item
+        key="publish-table"
+        leftSection={<FixedSizeIcon name="publish" />}
+        onClick={() => setModal("publish-table")}
+      >
+        {t`Publish a table`}
+      </Menu.Item>
+    ),
     canCreateMetric && (
       <Menu.Item
         key="metric"
@@ -52,7 +64,7 @@ export const CreateMenu = ({
       <Menu.Item
         key="snippet-folder"
         leftSection={<FixedSizeIcon name="folder" />}
-        onClick={() => setCreatingSnippetFolder(true)}
+        onClick={() => setModal("snippet-folder")}
       >
         {t`New snippet folder`}
       </Menu.Item>
@@ -72,13 +84,17 @@ export const CreateMenu = ({
         <Menu.Dropdown>{menuItems}</Menu.Dropdown>
       </Menu>
       <PLUGIN_SNIPPET_FOLDERS.CollectionFormModal
-        opened={creatingSnippetFolder}
+        opened={modal === "snippet-folder"}
         collection={{
           name: "",
           description: null,
         }}
-        onClose={() => setCreatingSnippetFolder(false)}
-        onSaved={() => setCreatingSnippetFolder(false)}
+        onClose={closeModal}
+        onSaved={closeModal}
+      />
+      <PublishTableModal
+        opened={modal === "publish-table"}
+        onClose={closeModal}
       />
     </>
   );

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/CreateMenu.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/CreateMenu.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
+import { push } from "react-router-redux";
 import { t } from "ttag";
 
 import { ForwardRefLink } from "metabase/common/components/Link";
-import { useSelector } from "metabase/lib/redux";
+import { useDispatch, useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { PLUGIN_SNIPPET_FOLDERS } from "metabase/plugins";
 import {
@@ -19,6 +20,7 @@ export const CreateMenu = ({
 }: {
   metricCollectionId?: CollectionId;
 }) => {
+  const dispatch = useDispatch();
   const [modal, setModal] = useState<"snippet-folder" | "publish-table">();
   const closeModal = () => setModal(undefined);
 
@@ -95,6 +97,7 @@ export const CreateMenu = ({
       <PublishTableModal
         opened={modal === "publish-table"}
         onClose={closeModal}
+        onPublished={(table) => dispatch(push(Urls.dataStudioTable(table.id)))}
       />
     </>
   );

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/CreateMenu.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/CreateMenu.unit.spec.tsx
@@ -7,22 +7,19 @@ import {
   createMockTokenFeatures,
   createMockUser,
 } from "metabase-types/api/mocks";
-import type { UserPermissions } from "metabase-types/api/user";
+import type { User } from "metabase-types/api/user";
 import { createMockState } from "metabase-types/store/mocks/state";
 
 import { CreateMenu } from "./CreateMenu";
 
-const setup = ({ permissions }: { permissions?: UserPermissions } = {}) => {
+const setup = ({ user }: { user?: Partial<User> } = {}) => {
   const state = createMockState({
     settings: mockSettings({
       "token-features": createMockTokenFeatures({
         snippet_collections: true,
-        advanced_permissions: true,
       }),
     }),
-    currentUser: createMockUser({
-      permissions,
-    }),
+    currentUser: createMockUser(user),
   });
   setupEnterprisePlugins();
   return renderWithProviders(<CreateMenu metricCollectionId={1} />, {
@@ -39,7 +36,7 @@ describe("CreateMenu", () => {
   });
 
   it("does not render snippet menu items if user only has query builder access", async () => {
-    setup({ permissions: { can_create_queries: true } });
+    setup({ user: { permissions: { can_create_queries: true } } });
 
     await userEvent.click(screen.getByRole("button", { name: /New/ }));
 
@@ -50,10 +47,12 @@ describe("CreateMenu", () => {
 
   it("renders all options when user has full permissions", async () => {
     setup({
-      permissions: {
-        can_create_queries: true,
-        can_create_native_queries: true,
-        can_access_data_model: true,
+      user: {
+        is_superuser: true,
+        permissions: {
+          can_create_queries: true,
+          can_create_native_queries: true,
+        },
       },
     });
 

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/CreateMenu.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/CreateMenu.unit.spec.tsx
@@ -17,6 +17,7 @@ const setup = ({ permissions }: { permissions?: UserPermissions } = {}) => {
     settings: mockSettings({
       "token-features": createMockTokenFeatures({
         snippet_collections: true,
+        advanced_permissions: true,
       }),
     }),
     currentUser: createMockUser({
@@ -52,6 +53,7 @@ describe("CreateMenu", () => {
       permissions: {
         can_create_queries: true,
         can_create_native_queries: true,
+        can_access_data_model: true,
       },
     });
 
@@ -59,6 +61,11 @@ describe("CreateMenu", () => {
 
     expect(
       screen.getAllByRole("menuitem").map((item) => item.textContent),
-    ).toEqual(["Metric", "New snippet", "New snippet folder"]);
+    ).toEqual([
+      "Publish a table",
+      "Metric",
+      "New snippet",
+      "New snippet folder",
+    ]);
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/PublishTableModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/PublishTableModal.tsx
@@ -1,0 +1,65 @@
+import { useState } from "react";
+import { t } from "ttag";
+import { noop } from "underscore";
+
+import { EntityPickerModal } from "metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal";
+import {
+  TablePicker,
+  type TablePickerStatePath,
+} from "metabase/common/components/Pickers/TablePicker";
+import { Box } from "metabase/ui";
+
+interface PublishTableModalProps {
+  opened: boolean;
+  onClose: () => void;
+}
+
+export function PublishTableModal({ opened, onClose }: PublishTableModalProps) {
+  const [tablesPath, setTablesPath] = useState<TablePickerStatePath>();
+
+  if (!opened) {
+    return null;
+  }
+
+  return (
+    <EntityPickerModal
+      title={t`Select a table to publish`}
+      searchModels={["table"]}
+      canSelectItem
+      options={{
+        hasRecents: false,
+        hasConfirmButtons: true,
+        confirmButtonText: t`Publish`,
+      }}
+      tabs={[
+        {
+          id: "tables-tab",
+          displayName: t`Tables`,
+          models: ["table"],
+          folderModels: ["database", "schema"],
+          icon: "table",
+          render: ({ onItemSelect }) => (
+            <Box h="100%" style={{ overflow: "auto" }}>
+              <TablePicker
+                path={tablesPath}
+                value={undefined}
+                onItemSelect={onItemSelect}
+                onPathChange={setTablesPath}
+                shouldDisableItem={(item) =>
+                  item.model === "table" && !!item.is_published
+                }
+              />
+            </Box>
+          ),
+        },
+      ]}
+      onItemSelect={noop}
+      onClose={onClose}
+      onConfirm={() => {
+        // TODO: Publish table
+        onClose();
+      }}
+      selectedItem={null}
+    />
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/PublishTableModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/PublishTableModal.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { push } from "react-router-redux";
 import { t } from "ttag";
 
 import { EntityPickerModal } from "metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal";
@@ -8,37 +7,36 @@ import {
   type TablePickerItem,
   type TablePickerStatePath,
 } from "metabase/common/components/Pickers/TablePicker";
-import { useDispatch } from "metabase/lib/redux";
 import { useMetadataToasts } from "metabase/metadata/hooks/useMetadataToasts";
 import { Box } from "metabase/ui";
 import { usePublishTablesMutation } from "metabase-enterprise/api/table";
 import { trackDataStudioTablePublished } from "metabase-enterprise/data-studio/analytics";
-import { Urls } from "metabase-enterprise/urls";
 
 interface PublishTableModalProps {
   opened: boolean;
   onClose: () => void;
+  onPublished: (table: TablePickerItem) => void;
 }
 
-export function PublishTableModal({ opened, onClose }: PublishTableModalProps) {
-  const dispatch = useDispatch();
+export function PublishTableModal({
+  opened,
+  onClose,
+  onPublished,
+}: PublishTableModalProps) {
   const [tablesPath, setTablesPath] = useState<TablePickerStatePath>();
   const { sendSuccessToast } = useMetadataToasts();
   const [publishTables] = usePublishTablesMutation();
-  const [item, setItem] = useState<TablePickerItem | null>(null);
+  const [table, setTable] = useState<TablePickerItem | null>(null);
 
   const onConfirm = async () => {
-    if (!item) {
+    if (!table) {
       return;
     }
-    await publishTables({ table_ids: [item.id] });
+    await publishTables({ table_ids: [table.id] });
     onClose();
-    sendSuccessToast(
-      t`Published`,
-      () => dispatch(push(Urls.dataStudioTable(item.id))),
-      t`Go to ${item.name}`,
-    );
-    trackDataStudioTablePublished(item.id);
+    sendSuccessToast(t`Published`);
+    trackDataStudioTablePublished(table.id);
+    onPublished(table);
   };
 
   if (!opened) {
@@ -77,10 +75,10 @@ export function PublishTableModal({ opened, onClose }: PublishTableModalProps) {
           ),
         },
       ]}
-      onItemSelect={setItem}
+      onItemSelect={setTable}
       onClose={onClose}
       onConfirm={onConfirm}
-      selectedItem={item}
+      selectedItem={table}
     />
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/PublishTableModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/PublishTableModal.tsx
@@ -32,7 +32,7 @@ export function PublishTableModal({
     if (!item) {
       return;
     }
-    await publishTables({ table_ids: [item.id] });
+    await publishTables({ table_ids: [item.id] }).unwrap(); // unwrap() allows EntityPicker's error handling to take over
     onClose();
     sendSuccessToast(t`Published`);
     trackDataStudioTablePublished(item.id);

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/PublishTableModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/PublishTableModal.tsx
@@ -26,17 +26,17 @@ export function PublishTableModal({
   const [tablesPath, setTablesPath] = useState<TablePickerStatePath>();
   const { sendSuccessToast } = useMetadataToasts();
   const [publishTables] = usePublishTablesMutation();
-  const [table, setTable] = useState<TablePickerItem | null>(null);
+  const [item, setItem] = useState<TablePickerItem | null>(null);
 
   const onConfirm = async () => {
-    if (!table) {
+    if (!item) {
       return;
     }
-    await publishTables({ table_ids: [table.id] });
+    await publishTables({ table_ids: [item.id] });
     onClose();
     sendSuccessToast(t`Published`);
-    trackDataStudioTablePublished(table.id);
-    onPublished(table);
+    trackDataStudioTablePublished(item.id);
+    onPublished(item);
   };
 
   if (!opened) {
@@ -47,7 +47,7 @@ export function PublishTableModal({
     <EntityPickerModal
       title={t`Select a table to publish`}
       searchModels={["table"]}
-      canSelectItem
+      canSelectItem={item?.model === "table"}
       options={{
         hasRecents: false,
         hasConfirmButtons: true,
@@ -75,10 +75,10 @@ export function PublishTableModal({
           ),
         },
       ]}
-      onItemSelect={setTable}
+      onItemSelect={setItem}
       onClose={onClose}
       onConfirm={onConfirm}
-      selectedItem={table}
+      selectedItem={item}
     />
   );
 }

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/ButtonBar.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/ButtonBar.tsx
@@ -20,6 +20,7 @@ export const ButtonBar = ({
   cancelButtonText?: string;
 }) => {
   const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     const handleKeyPress = (e: KeyboardEvent) => {
@@ -61,13 +62,15 @@ export const ButtonBar = ({
           onClick={async () => {
             try {
               setError(null);
+              setLoading(true);
               await onConfirm();
             } catch (e: any) {
               console.error(e);
               setError(getErrorMessage(e));
             }
+            setLoading(false);
           }}
-          disabled={!canConfirm}
+          disabled={!canConfirm || loading}
           data-testid="entity-picker-select-button"
         >
           {confirmButtonText ?? t`Select`}

--- a/frontend/src/metabase/common/components/Pickers/TablePicker/TableList.tsx
+++ b/frontend/src/metabase/common/components/Pickers/TablePicker/TableList.tsx
@@ -34,6 +34,7 @@ export const TableList = ({
       name: table.display_name,
       database: { id: table.db_id },
       database_id: table.db_id,
+      is_published: table.is_published,
     }));
   }, [tables]);
 

--- a/frontend/src/metabase/common/components/Pickers/TablePicker/types.ts
+++ b/frontend/src/metabase/common/components/Pickers/TablePicker/types.ts
@@ -23,6 +23,7 @@ export type TableItem = {
   name: string;
   model: "table";
   database_id?: DatabaseId;
+  is_published?: boolean;
 };
 
 export type TablePickerValue = {


### PR DESCRIPTION
Closes UXW-2481

### Description

Adds a button in the Library's "+New" menu to publish a table

### How to verify

* See UXW-2481 for feature definition
* Verify you can only publish tables from this modal (not databases or schemas)
* Verify the "Publish a table" option isn't displayed if you lack the permissions to publish a table

### Demo

https://github.com/user-attachments/assets/67aa1ce4-8ec8-46b5-aa60-4b4a475ec3fd

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
