### PR TITLE
[perf] Fix a sneaky infinite loop in a prod-only error case

### DIFF
--- a/src/metabase/lib/metadata/result_metadata.cljc
+++ b/src/metabase/lib/metadata/result_metadata.cljc
@@ -118,7 +118,8 @@
           (log/error e)
           (mapv merge-col
                 initial-cols
-                (concat lib-cols (repeat nil))))
+                ;; `util.perf/mapv` checks the `count` of all args, so it's NSFIS - Not Safe For Infinite Seqs.
+                (take (count initial-cols) (concat lib-cols (repeat nil)))))
         (throw e)))))
 
 (mu/defn- legacy-source :- ::lib.schema.metadata/column.legacy-source

--- a/src/metabase/util/performance.cljc
+++ b/src/metabase/util/performance.cljc
@@ -198,9 +198,12 @@
      (^long [c1 c2 c3 c4] (min (count c1) (count c2) (count c3) (count c4)))))
 
 (defn mapv
-  "Drop-in replacement for `clojure.core/mapv`.
+  "**Nearly** drop-in replacement for `clojure.core/mapv`.
+
   Iterates multiple collections more efficiently and uses Java iterators under the hood (the CLJ version). CLJS
-  version is only optimized for a single collection arity."
+  version is only optimized for a single collection arity.
+
+  Checks the `count` of all inputs - DO NOT give this infinite sequences!"
   ([f coll1]
    (let [n (count coll1)]
      (cond (= n 0) []


### PR DESCRIPTION
### Description

`util.perf/mapv` checks the `count` of all its collection args, so it's
not safe to call with an infinite `seq`.

`lib.metadata.result-metadata/merge-cols` was doing exactly that in the
case where there was a mismatch between the column counts from lib and
driver. It was passing `(concat short-list (repeat nil))` to `mapv` and
causing an infinite loop!

### How to verify

Tricky to synthesize, you have to trigger a lib vs. driver column count
mismatch, which isn't supposed to be possible.

### Checklist

- ~~Tests have been added/updated to cover changes in this PR~~
    - No tests for this yet - the infinite loop cause is evident and the
      stack traces in the thread dump conclusive this is the cause.
