### PR TITLE
Fix mongo native preview of queries with variables

### DIFF
--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -15,6 +15,7 @@
    [metabase.driver.settings :as driver.settings]
    [metabase.driver.util :as driver.u]
    [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.query-processor :as qp]
    [metabase.query-processor.compile :as qp.compile]

--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -1174,3 +1174,131 @@
       :type/MongoBSONID        "objectId"
       :type/MongoBinData       "binData"
       :type/IPAddress          "string")))
+
+(deftest ^:parallel prettify-native-form-test
+  (mt/test-driver :mongo
+    (testing "prettifies normal lib query"
+      (let [mp (mt/metadata-provider)
+            products-table (lib.metadata/table mp (mt/id :products))
+            product-category (lib.metadata/field mp (mt/id :products :category))
+            query (-> (lib/query mp products-table)
+                      (lib/filter (lib/= product-category
+                                         "Widget")))]
+        (is (= (str/join "\n"
+                         ["["
+                          "  {"
+                          "    \"$match\": {"
+                          "      \"category\": \"Widget\""
+                          "    }"
+                          "  },"
+                          "  {"
+                          "    \"$project\": {"
+                          "      \"_id\": \"$_id\","
+                          "      \"ean\": \"$ean\","
+                          "      \"title\": \"$title\","
+                          "      \"category\": \"$category\","
+                          "      \"vendor\": \"$vendor\","
+                          "      \"price\": \"$price\","
+                          "      \"rating\": \"$rating\","
+                          "      \"created_at\": \"$created_at\""
+                          "    }"
+                          "  },"
+                          "  {"
+                          "    \"$limit\": 1048575"
+                          "  }"
+                          "]"])
+               (->> (qp.compile/compile-with-inline-parameters query)
+                    :query
+                    (driver/prettify-native-form :mongo))))))
+    (testing "prettifies native query with variable that is valid json"
+      (let [query {:database (mt/id)
+                   :type :native
+                   :native {:collection "products"
+                            :query (str/join "\n"
+                                             ["["
+                                              "  {"
+                                              "    \"$match\": {"
+                                              "      \"category\": {{category_var}}"
+                                              "    }},"
+                                              "  {"
+                                              "    \"$project\": {"
+                                              "      \"_id\": \"$_id\","
+                                              "      \"title\": \"$title\","
+                                              "      \"category\": \"$category\""
+                                              "    }},"
+                                              "  {"
+                                              "    \"$limit\": 1048575"
+                                              "  }"
+                                              "]"])
+                            :template-tags {"category_var" {:name "category_var"
+                                                            :display-name "Category Variable"
+                                                            :type :text}}}
+                   :parameters [{:type :text
+                                 :target [:variable [:template-tag "category_var"]]
+                                 :value "Gadget"}]}]
+        (is (= (str/join "\n"
+                         ["["
+                          "  {"
+                          "    \"$match\": {"
+                          "      \"category\": \"Gadget\""
+                          "    }"
+                          "  },"
+                          "  {"
+                          "    \"$project\": {"
+                          "      \"_id\": \"$_id\","
+                          "      \"title\": \"$title\","
+                          "      \"category\": \"$category\""
+                          "    }"
+                          "  },"
+                          "  {"
+                          "    \"$limit\": 1048575"
+                          "  }"
+                          "]"])
+               (->> (qp.compile/compile-with-inline-parameters query)
+                    :query
+                    (driver/prettify-native-form :mongo))))))
+    (testing "prettifies native query with variable that is not valid json"
+      (let [query {:database (mt/id)
+                   :type :native
+                   :native {:collection "products"
+                            :query (str/join "\n"
+                                             ["["
+                                              "  {"
+                                              "    \"$match\": {"
+                                              "      \"created_at\": {\"$gte\": {{created_at_var}}}"
+                                              "    }},"
+                                              "  {"
+                                              "    \"$project\": {"
+                                              "      \"_id\": \"$_id\","
+                                              "      \"title\": \"$title\","
+                                              "      \"category\": \"$category\""
+                                              "    }},"
+                                              "  {"
+                                              "    \"$limit\": 1048575"
+                                              "  }"
+                                              "]"])
+                            :template-tags {"created_at_var" {:name "created_at_var"
+                                                              :display-name "Created At Variable"
+                                                              :type :date}}}
+                   :parameters [{:type :date/single
+                                 :target [:variable [:template-tag "created_at_var"]]
+                                 :value "2018-01-01"}]}]
+        (is (= (str/join "\n"
+                         ["["
+                          "  {"
+                          "    \"$match\": {"
+                          "      \"created_at\": {\"$gte\": ISODate(\"2018-01-01\")}"
+                          "    }},"
+                          "  {"
+                          "    \"$project\": {"
+                          "      \"_id\": \"$_id\","
+                          "      \"title\": \"$title\","
+                          "      \"category\": \"$category\""
+                          "    }},"
+                          "  {"
+                          "    \"$limit\": 1048575"
+                          "  }"
+                          "]"])
+               (->> (qp.compile/compile-with-inline-parameters query)
+                    :query
+                    (driver/prettify-native-form :mongo))))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/66886

### Description

Check if the form we are prettifying is a string first, and `json/decode` it if so.

### How to verify

1. Create a native mongo query and use a filter variable
2. Preview the native query
3. It should show a formatted mongo query 


### Demo

https://www.loom.com/share/d1bd88c925a14d1ea9f7d334434c4326

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
