### PR TITLE
Add cluster lock around data permissions updates

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -916,6 +916,7 @@
   {:team "UX West"
    :api  #{metabase.permissions-rest.api}
    :uses #{api
+           app-db
            audit-app
            events
            permissions


### PR DESCRIPTION
We currently have the "revision number", but:

- the intent there is slightly different; we want to prohibit one user from making changes to the permissions graph before they *see* changes another user might have made concurrently, not just sequence the concurrent changes, and

- we allow API users to pass the `force` parameter to skip the revision check entirely

Note that the reason we have `force` available is to allow people to change permissions without first making a request to *GET* the permissions graph (which can in some cases be extremely large). It is not intended to allow concurrent updates to permissions.
