### PR TITLE
UXW-2368 Fixes Alert's warning background color

### DIFF
--- a/frontend/src/metabase/common/components/Alert/Alert.styled.tsx
+++ b/frontend/src/metabase/common/components/Alert/Alert.styled.tsx
@@ -3,7 +3,6 @@ import { css } from "@emotion/react";
 // eslint-disable-next-line no-restricted-imports
 import styled from "@emotion/styled";
 
-import { lighten } from "metabase/lib/colors";
 import { Icon } from "metabase/ui";
 import { color } from "metabase/ui/utils/colors";
 
@@ -23,7 +22,7 @@ const colorsByVariant = {
   background: {
     info: "var(--mb-color-bg-light)",
     error: color("background-error"),
-    warning: lighten("warning", 0.5),
+    warning: color("bg-yellow"),
   },
   icon: {
     info: color("text-dark"),


### PR DESCRIPTION
Closes UXW-2368

### Description

Updates warning background color of _legacy_ Alert component.

### How to verify

1. View a warning that uses a _legacy_ Alert, e.g. ImpersonationModal
2. Verify its background is yellow and legible in light and dark modes

### Demo

| | Before | After |
|---|---|---|
| Light | <img width="1312" height="745" alt="Screenshot 2025-12-15 at 2 30 53 PM" src="https://github.com/user-attachments/assets/e8356070-7471-480d-8bea-de4cc86c83d7" /> | <img width="1312" height="745" alt="Screenshot 2025-12-15 at 2 31 38 PM" src="https://github.com/user-attachments/assets/44a85610-a503-49eb-939d-5700d8074ac9" /> |
| Dark  | <img width="1312" height="745" alt="Screenshot 2025-12-15 at 2 31 07 PM" src="https://github.com/user-attachments/assets/b432f330-9b0d-423e-98c8-8253e55fd7e2" /> | <img width="1312" height="745" alt="Screenshot 2025-12-15 at 2 31 26 PM" src="https://github.com/user-attachments/assets/da2372d4-5028-42f2-91e7-b04a337134db" /> |

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR
