### PR TITLE
Skip fields with inactive table.

### DIFF
--- a/src/metabase/warehouse_schema_rest/api/table.clj
+++ b/src/metabase/warehouse_schema_rest/api/table.clj
@@ -344,7 +344,8 @@
                     [:id ms/PositiveInt]]]
   (api/read-check :model/Table id)
   (when-let [field-ids (seq (t2/select-pks-set :model/Field, :table_id id, :visibility_type [:not= "retired"], :active true))]
-    (for [origin-field (t2/select :model/Field, :fk_target_field_id [:in field-ids], :active true)]
+    (for [origin-field (t2/select :model/Field, :fk_target_field_id [:in field-ids], :active true)
+          :when (-> origin-field :table :active)]
       ;; it's silly to be hydrating some of these tables/dbs
       {:relationship   :Mt1
        :origin_id      (:id origin-field)

--- a/src/metabase/warehouse_schema_rest/api/table.clj
+++ b/src/metabase/warehouse_schema_rest/api/table.clj
@@ -345,12 +345,13 @@
   (api/read-check :model/Table id)
   (when-let [field-ids (seq (t2/select-pks-set :model/Field, :table_id id, :visibility_type [:not= "retired"], :active true))]
     (for [origin-field (t2/select :model/Field, :fk_target_field_id [:in field-ids], :active true)
+          :let [origin-field (-> (t2/hydrate origin-field [:table :db])
+                                 (update :table schema.table/present-table))]
           :when (-> origin-field :table :active)]
       ;; it's silly to be hydrating some of these tables/dbs
       {:relationship   :Mt1
        :origin_id      (:id origin-field)
-       :origin         (-> (t2/hydrate origin-field [:table :db])
-                           (update :table schema.table/present-table))
+       :origin         origin-field
        :destination_id (:fk_target_field_id origin-field)
        :destination    (t2/hydrate (t2/select-one :model/Field :id (:fk_target_field_id origin-field)) :table)})))
 

--- a/test/metabase/warehouse_schema_rest/api/table_test.clj
+++ b/test/metabase/warehouse_schema_rest/api/table_test.clj
@@ -1358,6 +1358,8 @@
         (testing "initially country's continent_id is targeting continent_1"
           (is (= (mt/id :continent :id)
                  (get-fk-target))))
+        (is (= 1 (count (mt/user-http-request :rasta :get 200 (format "table/%d/fks" (mt/id :continent))))))
+
         ;; 2. drop the country table
         (jdbc/execute! db-spec "DROP TABLE country;")
         (sync/sync-database! db {:scan :schema})

--- a/test/metabase/warehouse_schema_rest/api/table_test.clj
+++ b/test/metabase/warehouse_schema_rest/api/table_test.clj
@@ -1,11 +1,13 @@
 (ns ^:mb/driver-tests metabase.warehouse-schema-rest.api.table-test
   "Tests for /api/table endpoints."
   (:require
+   [clojure.java.jdbc :as jdbc]
    [clojure.set :as set]
    [clojure.test :refer :all]
    [metabase.api.response :as api.response]
    [metabase.api.test-util :as api.test-util]
    [metabase.driver :as driver]
+   [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.util :as driver.u]
    [metabase.events.core :as events]
    [metabase.permissions.models.data-permissions :as data-perms]
@@ -1339,3 +1341,26 @@
                       (filter #(= (:db_id %) db-id))
                       (map :id)
                       set))))))))
+
+(deftest no-fks-for-missing-tables-test
+  (testing "Check that we don't return foreign keys for missing/inactive tables"
+    (let []
+      (mt/with-temp-test-data
+        [["continent" []
+          []]
+         ["country" [{:field-name "continent_id", :base-type :type/Integer}]
+          []]]
+        (let [db (mt/db)
+              db-spec (sql-jdbc.conn/db->pooled-connection-spec db)
+              get-fk-target #(t2/select-one-fn :fk_target_field_id :model/Field (mt/id :country :continent_id))]
+          ;; 1. add FK relationship in the database targeting continent_1
+          (jdbc/execute! db-spec "ALTER TABLE country ADD CONSTRAINT country_continent_id_fkey FOREIGN KEY (continent_id) REFERENCES continent(id);")
+          (sync/sync-database! db {:scan :schema})
+          (testing "initially country's continent_id is targeting continent_1"
+            (is (= (mt/id :continent :id)
+                   (get-fk-target))))
+          ;; 2. drop the country table
+          (jdbc/execute! db-spec "DROP TABLE country;")
+          (sync/sync-database! db {:scan :schema})
+
+          (is (= () (mt/user-http-request :rasta :get 200 (format "table/%d/fks" (mt/id :continent))))))))))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #28241
Closes QUE-120

### Description

The /api/test/:id/fks endpoint was returning fields from inactive tables. Let's just filter those out. Also includes a test.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create 2 tables and link them using foreign key in data modeling in admin. Deactivate the table with foreign key mapping by deleting the underlying table and re-scan the schema.
2. View the table that the foreign table has mapped to
3. Click on a value under the entity id column to view the detail box and the sidebar.
4. Sidebar used to show the linked table even though it is inactive as the underlying table has been deleted. Now it doesn't.
