### PR TITLE
UXW-2425 Add event timeline label

### DIFF
--- a/frontend/src/metabase/timelines/common/components/EventForm/EventForm.tsx
+++ b/frontend/src/metabase/timelines/common/components/EventForm/EventForm.tsx
@@ -83,6 +83,9 @@ const EventForm = ({
       initialValues={{
         ...initialValues,
         timestamp: initialValues.timestamp || dayjs().utc(true).toISOString(),
+        timeline_id: initialValues.timeline_id
+          ? String(initialValues.timeline_id)
+          : undefined,
       }}
       validationSchema={EVENT_SCHEMA}
       onSubmit={onSubmit}
@@ -165,10 +168,10 @@ const EventForm = ({
                 </Group>
               )}
             />
-            {timelines.length > 1 && (
+            {timelines?.length > 1 && (
               <FormSelect
                 name="timeline_id"
-                title={t`Timeline`}
+                label={t`Timeline`}
                 data={timelineOptions}
               />
             )}

--- a/frontend/src/metabase/timelines/common/components/EventForm/EventForm.tsx
+++ b/frontend/src/metabase/timelines/common/components/EventForm/EventForm.tsx
@@ -1,5 +1,5 @@
 import dayjs from "dayjs";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { t } from "ttag";
 import * as Yup from "yup";
 
@@ -39,8 +39,12 @@ const EVENT_SCHEMA = Yup.object({
   timestamp: Yup.string().required(Errors.required),
   time_matters: Yup.boolean(),
   icon: Yup.string().required(Errors.required),
-  timeline_id: Yup.number(),
+  timeline_id: Yup.string(),
 });
+
+type TimelineEventFormData = Omit<TimelineEventData, "timeline_id"> & {
+  timeline_id: string | undefined;
+};
 
 export interface EventFormOwnProps {
   initialValues: TimelineEventData;
@@ -78,17 +82,31 @@ const EventForm = ({
     }));
   }, [timelines]);
 
+  const preparedInitialValues: TimelineEventFormData = {
+    ...initialValues,
+    timestamp: initialValues.timestamp || dayjs().utc(true).toISOString(),
+    timeline_id: initialValues.timeline_id
+      ? String(initialValues.timeline_id)
+      : undefined,
+  };
+
+  const handleSubmit = useCallback(
+    (values: TimelineEventFormData) => {
+      return onSubmit({
+        ...values,
+        timeline_id: values.timeline_id
+          ? parseInt(values.timeline_id, 10)
+          : undefined,
+      });
+    },
+    [onSubmit],
+  );
+
   return (
     <FormProvider
-      initialValues={{
-        ...initialValues,
-        timestamp: initialValues.timestamp || dayjs().utc(true).toISOString(),
-        timeline_id: initialValues.timeline_id
-          ? String(initialValues.timeline_id)
-          : undefined,
-      }}
+      initialValues={preparedInitialValues}
       validationSchema={EVENT_SCHEMA}
-      onSubmit={onSubmit}
+      onSubmit={handleSubmit}
     >
       {({ dirty, values, setFieldValue }) => (
         <Form disabled={!dirty} data-testid="event-form">


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/66428 / UXW-2425

### Description

This adds missing label to Timeline field in Event form

### How to verify

1. Go to root collection (Our analytics), click on calendar icon, create a new event
2. Go to any nested collection (e.g. your Personal Collection), click on calendar icon, create a new event - this creates a second timeline.
3. Create a new question in your nested collection, then click calendar icon in footer, create a new event
4. Timeline picker should be displayed, it should has a label

### Demo

https://github.com/user-attachments/assets/4417144a-57da-4a6a-817b-b482ae97d028

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR - I don't think we need a test for that
