### PR TITLE
Disable nonworking email and URL extractions for BigQuery and 7 other broken drivers

### DIFF
--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -13,6 +13,13 @@ title: Driver interface changelog
 - All tests in `metabase.query-processor-test.*` namespaces have been moved to `metabase.query-processor.*` (This is
   only relevant if you run individual test namespaces as part of your development workflow).
 
+## Metabase 0.57.7
+
+- Added the new `:regex/lookaheads-and-lookbehinds` driver feature flag; by default this is true for all drivers that
+  support `:regex` and false for all drivers that do not. If your driver supports regular expressions but does not
+  support lookaheads or lookbehinds, add a `metabase.driver/database-supports?` method implementation -- see the
+  `:bigquery-cloud-sdk` driver for example.
+
 ## Metabase 0.57.0
 
 - `driver/field-reference-mlv2` is now deprecated, and is no longer used. Please remove your implementations.

--- a/frontend/src/metabase-types/api/database.ts
+++ b/frontend/src/metabase-types/api/database.ts
@@ -39,6 +39,7 @@ export type DatabaseFeature =
   | "persist-models"
   | "persist-models-enabled"
   | "regex"
+  | "regex/lookaheads-and-lookbehinds"
   | "schemas"
   | "set-timezone"
   | "left-join"

--- a/frontend/src/metabase/querying/expressions/config.ts
+++ b/frontend/src/metabase/querying/expressions/config.ts
@@ -506,7 +506,7 @@ const STRING = defineClauses(
     path: {
       displayName: "path",
       type: "string",
-      requiresFeature: "regex",
+      requiresFeature: "regex/lookaheads-and-lookbehinds",
       description: () =>
         t`Extracts the pathname from a URL. E.g., \`${'path("https://www.example.com/path/to/page.html?key1=value)'}\` would return \`${"/path/to/page.html"}\`.`,
       args: () => [
@@ -627,7 +627,7 @@ const STRING = defineClauses(
     domain: {
       displayName: "domain",
       type: "string",
-      requiresFeature: "regex",
+      requiresFeature: "regex/lookaheads-and-lookbehinds",
       description: () =>
         t`Extracts the domain name (eg. \`"metabase"\`) from a URL or email`,
       args: () => [
@@ -642,7 +642,7 @@ const STRING = defineClauses(
     subdomain: {
       displayName: "subdomain",
       type: "string",
-      requiresFeature: "regex",
+      requiresFeature: "regex/lookaheads-and-lookbehinds",
       description: () =>
         t`Extracts the first subdomain (eg. \`"status"\` from \`"status.metabase.com"\`, \`""\` from \`"bbc.co.uk"\`) from a URL. Ignores \`"www"\`.`,
       args: () => [
@@ -657,7 +657,7 @@ const STRING = defineClauses(
     host: {
       displayName: "host",
       type: "string",
-      requiresFeature: "regex",
+      requiresFeature: "regex/lookaheads-and-lookbehinds",
       description: () =>
         t`Extracts the host (domain name and TLD, eg. \`"metabase.com"\` from \`"status.metabase.com"\`) from a URL or email`,
       args: () => [

--- a/modules/drivers/athena/src/metabase/driver/athena.clj
+++ b/modules/drivers/athena/src/metabase/driver/athena.clj
@@ -33,15 +33,16 @@
 ;;; |                                          metabase.driver method impls                                          |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(doseq [[feature supported?] {:datetime-diff                 true
-                              :nested-fields                 false
-                              :uuid-type                     true
-                              :connection/multiple-databases true
-                              :expression-literals           true
-                              :identifiers-with-spaces       false
-                              :metadata/key-constraints      false
-                              :test/jvm-timezone-setting     false
-                              :database-routing              true}]
+(doseq [[feature supported?] {:connection/multiple-databases    true
+                              :database-routing                 true
+                              :datetime-diff                    true
+                              :expression-literals              true
+                              :identifiers-with-spaces          false
+                              :metadata/key-constraints         false
+                              :nested-fields                    false
+                              :regex/lookaheads-and-lookbehinds false
+                              :test/jvm-timezone-setting        false
+                              :uuid-type                        true}]
   (defmethod driver/database-supports? [:athena feature] [_driver _feature _db] supported?))
 
 (defmethod driver/database-supports? [:athena :schemas]

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -775,30 +775,31 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (doseq [[feature supported?] {:convert-timezone                 true
-                              :describe-fields                  true
-                              :nested-fields                    true
+                              :database-routing                 true
                               :datetime-diff                    true
+                              :describe-fields                  true
+                              :expression-literals              true
                               :expressions                      true
+                              :expressions/date                 true
+                              :expressions/float                true
+                              :expressions/integer              true
+                              :expressions/text                 true
+                              :identifiers-with-spaces          true
+                              :metadata/key-constraints         false
+                              :metadata/table-existence-check   true
+                              :nested-fields                    true
                               :now                              true
                               :percentile-aggregations          true
-                              ;; we can't support `alter table .. rename ..`  in general
-                              ;; since it won't work for streaming tables
+                              :regex/lookaheads-and-lookbehinds false
+                              ;; we can't support `alter table .. rename ..` in general since it won't work for
+                              ;; streaming tables
                               :rename                           false
-                              :metadata/key-constraints         false
-                              :identifiers-with-spaces          true
-                              :expressions/integer              true
-                              :expressions/float                true
-                              :expressions/date                 true
-                              :expressions/text                 true
-                              :split-part                       true
                               ;; BigQuery uses timezone operators and arguments on calls like extract() and
                               ;; timezone_trunc() rather than literally using SET TIMEZONE, but we need to flag it as
                               ;; supporting set-timezone anyway so that reporting timezones are returned and used, and
                               ;; tests expect the converted values.
                               :set-timezone                     true
-                              :expression-literals              true
-                              :database-routing                 true
-                              :metadata/table-existence-check   true
+                              :split-part                       true
                               :transforms/python                true
                               :transforms/table                 true}]
   (defmethod driver/database-supports? [:bigquery-cloud-sdk feature] [_driver _feature _db] supported?))

--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
@@ -33,35 +33,36 @@
   [_ native-form]
   (sql.u/format-sql-and-fix-params :mysql native-form))
 
-(doseq [[feature supported?] {:standard-deviation-aggregations true
-                              :now                             true
-                              :set-timezone                    true
-                              :convert-timezone                false
-                              :test/jvm-timezone-setting       false
-                              :test/date-time-type             false
-                              :test/time-type                  false
-                              :datetime-diff                   true
-                              :expression-literals             true
-                              :expressions/integer             true
-                              :expressions/float               true
-                              :expressions/text                true
-                              :expressions/date                true
-                              :split-part                      true
-                              :upload-with-auto-pk             false
-                              :window-functions/offset         false
-                              :window-functions/cumulative     (not driver-api/is-test?)
-                              :left-join                       (not driver-api/is-test?)
-                              :describe-fks                    false
-                              :rename                          true
-                              :actions                         false
-                              :metadata/key-constraints        false
-                              :database-routing                false
-                              :transforms/python               true
-                              :transforms/table                true
+(doseq [[feature supported?] {:actions                          false
+                              :convert-timezone                 false
+                              :database-routing                 false
+                              :datetime-diff                    true
+                              :describe-default-expr            true
+                              :describe-fks                     false
                               ;; JDBC driver always provides "NO" for the IS_GENERATEDCOLUMN JDBC metadata
-                              :describe-is-generated           false
-                              :describe-is-nullable            true
-                              :describe-default-expr           true}]
+                              :describe-is-generated            false
+                              :describe-is-nullable             true
+                              :expression-literals              true
+                              :expressions/date                 true
+                              :expressions/float                true
+                              :expressions/integer              true
+                              :expressions/text                 true
+                              :left-join                        (not driver-api/is-test?)
+                              :metadata/key-constraints         false
+                              :now                              true
+                              :regex/lookaheads-and-lookbehinds false
+                              :rename                           true
+                              :set-timezone                     true
+                              :split-part                       true
+                              :standard-deviation-aggregations  true
+                              :test/date-time-type              false
+                              :test/jvm-timezone-setting        false
+                              :test/time-type                   false
+                              :transforms/python                true
+                              :transforms/table                 true
+                              :upload-with-auto-pk              false
+                              :window-functions/cumulative      (not driver-api/is-test?)
+                              :window-functions/offset          false}]
   (defmethod driver/database-supports? [:clickhouse feature] [_driver _feature _db] supported?))
 
 (defmethod driver/database-supports? [:clickhouse :schemas]

--- a/modules/drivers/oracle/src/metabase/driver/oracle.clj
+++ b/modules/drivers/oracle/src/metabase/driver/oracle.clj
@@ -50,16 +50,19 @@
 (driver/register! :oracle, :parent #{:sql-jdbc
                                      ::sql.qp.empty-string-is-null/empty-string-is-null})
 
-(doseq [[feature supported?] {:datetime-diff           true
-                              :expression-literals     true
-                              :now                     true
-                              :identifiers-with-spaces true
-                              :convert-timezone        true
-                              :expressions/date        false
-                              :database-routing        false
-                              :describe-default-expr   true
-                              :describe-is-generated   true
-                              :describe-is-nullable    true}]
+(doseq [[feature supported?] {:convert-timezone                 true
+                              :database-routing                 false
+                              :datetime-diff                    true
+                              :describe-default-expr            true
+                              :describe-is-generated            true
+                              :describe-is-nullable             true
+                              :expression-literals              true
+                              :expressions/date                 false
+                              :identifiers-with-spaces          true
+                              :now                              true
+                              ;; these don't seem to ERROR on Oracle but they don't work as expected either, see
+                              ;; https://github.com/metabase/metabase/pull/66982#issuecomment-3667113995
+                              :regex/lookaheads-and-lookbehinds false}]
   (defmethod driver/database-supports? [:oracle feature] [_driver _feature _db] supported?))
 
 (mr/def ::details

--- a/modules/drivers/presto-jdbc/src/metabase/driver/presto_jdbc.clj
+++ b/modules/drivers/presto-jdbc/src/metabase/driver/presto_jdbc.clj
@@ -49,17 +49,18 @@
 (driver/register! :presto-jdbc, :parent #{:sql-jdbc
                                           ::sql-jdbc.legacy/use-legacy-classes-for-read-and-set})
 
-(doseq [[feature supported?] {:basic-aggregations              true
-                              :binning                         true
-                              :expression-aggregations         true
-                              :expression-literals             true
-                              :expressions                     true
-                              :native-parameters               true
-                              :now                             true
-                              :set-timezone                    true
-                              :standard-deviation-aggregations true
-                              :metadata/key-constraints        false
-                              :database-routing                true}]
+(doseq [[feature supported?] {:basic-aggregations               true
+                              :binning                          true
+                              :database-routing                 true
+                              :expression-aggregations          true
+                              :expression-literals              true
+                              :expressions                      true
+                              :metadata/key-constraints         false
+                              :native-parameters                true
+                              :now                              true
+                              :regex/lookaheads-and-lookbehinds false
+                              :set-timezone                     true
+                              :standard-deviation-aggregations  true}]
   (defmethod driver/database-supports? [:presto-jdbc feature] [_driver _feature _db] supported?))
 
 ;;; Presto API helpers

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -34,23 +34,24 @@
 
 (driver/register! :redshift, :parent #{:postgres})
 
-(doseq [[feature supported?] {:connection-impersonation       true
-                              :describe-fields                true
-                              :describe-fks                   true
-                              :rename                         true
-                              :atomic-renames                 true
-                              :expression-literals            true
-                              :identifiers-with-spaces        false
-                              :uuid-type                      false
-                              :nested-field-columns           false
-                              :test/jvm-timezone-setting      false
-                              :database-routing               true
-                              :metadata/table-existence-check true
-                              :transforms/python              true
-                              :transforms/table               true
-                              :describe-default-expr          false
-                              :describe-is-generated          false
-                              :describe-is-nullable           false}]
+(doseq [[feature supported?] {:atomic-renames                   true
+                              :connection-impersonation         true
+                              :database-routing                 true
+                              :describe-default-expr            false
+                              :describe-fields                  true
+                              :describe-fks                     true
+                              :describe-is-generated            false
+                              :describe-is-nullable             false
+                              :expression-literals              true
+                              :identifiers-with-spaces          false
+                              :metadata/table-existence-check   true
+                              :nested-field-columns             false
+                              :regex/lookaheads-and-lookbehinds false
+                              :rename                           true
+                              :test/jvm-timezone-setting        false
+                              :transforms/python                true
+                              :transforms/table                 true
+                              :uuid-type                        false}]
   (defmethod driver/database-supports? [:redshift feature] [_driver _feat _db] supported?))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/modules/drivers/vertica/src/metabase/driver/vertica.clj
+++ b/modules/drivers/vertica/src/metabase/driver/vertica.clj
@@ -30,17 +30,18 @@
                                       ::sql-jdbc.legacy/use-legacy-classes-for-read-and-set
                                       ::sql.qp.empty-string-is-null/empty-string-is-null})
 
-(doseq [[feature supported?] {:convert-timezone          true
-                              :datetime-diff             true
-                              :expression-literals       true
-                              :now                       true
-                              :identifiers-with-spaces   true
-                              :uuid-type                 true
-                              :percentile-aggregations   false
-                              :test/jvm-timezone-setting false
-                              :database-routing          false
-                              :describe-is-nullable      true
-                              :describe-default-expr     true}]
+(doseq [[feature supported?] {:convert-timezone                 true
+                              :database-routing                 false
+                              :datetime-diff                    true
+                              :describe-default-expr            true
+                              :describe-is-nullable             true
+                              :expression-literals              true
+                              :identifiers-with-spaces          true
+                              :now                              true
+                              :percentile-aggregations          false
+                              :regex/lookaheads-and-lookbehinds false
+                              :test/jvm-timezone-setting        false
+                              :uuid-type                        true}]
   (defmethod driver/database-supports? [:vertica feature] [_driver _feature _db] supported?))
 
 (defmethod driver/db-start-of-week :vertica

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -593,6 +593,11 @@
 
     :regex
 
+    ;; Added in 57.x; whether the driver in question supports lookaheads and lookbehinds in regular expressions; by
+    ;; default this is true if the driver supports `:regex` but can be disabled for drivers where this is not true,
+    ;; like BigQuery.
+    :regex/lookaheads-and-lookbehinds
+
     ;; Does the driver support advanced math expressions such as log, power, ...
     :advanced-math-expressions
 
@@ -848,6 +853,11 @@
   [driver _feature database]
   (and (database-supports? driver :native-parameters database)
        (database-supports? driver :nested-queries database)))
+
+;; by default a driver supports `:regex/lookaheads-and-lookbehinds` if it also supports `:regex` and vice versa
+(defmethod database-supports? [::driver :regex/lookaheads-and-lookbehinds]
+  [driver _feature database]
+  (database-supports? driver :regex database))
 
 (defmulti ^String escape-alias
   "Escape a `column-or-table-alias` string in a way that makes it valid for your database. This method is used for

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -103,13 +103,11 @@
 ;; This is a bit of a lie since the JSON type was introduced for MySQL since 5.7.8.
 ;; And MariaDB doesn't have the JSON type at all, though `JSON` was introduced as an alias for LONGTEXT in 10.2.7.
 ;; But since JSON unfolding will only apply columns with JSON types, this won't cause any problems during sync.
-(defmethod driver/database-supports? [:mysql :nested-field-columns] [_driver _feat db]
+(defmethod driver/database-supports? [:mysql :nested-field-columns]
+  [_driver _feat db]
   (driver.common/json-unfolding-default db))
 
-(doseq [feature [:actions
-                 :actions/custom
-                 :actions/data-editing
-                 :regex/lookaheads-and-lookbehinds]]
+(doseq [feature [:actions :actions/custom :actions/data-editing]]
   (defmethod driver/database-supports? [:mysql feature]
     [driver _feat _db]
     ;; Only supported for MySQL right now. Revise when a child driver is added.
@@ -152,6 +150,11 @@
               (catch Exception e
                 (log/warn e "Failed to check table writable")
                 false)))))
+
+(defmethod driver/database-supports? [:mysql :regex/lookaheads-and-lookbehinds]
+  [driver _feat db]
+  (and (= driver :mysql)
+       (not (mariadb? db))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                             metabase.driver impls                                              |

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -106,7 +106,10 @@
 (defmethod driver/database-supports? [:mysql :nested-field-columns] [_driver _feat db]
   (driver.common/json-unfolding-default db))
 
-(doseq [feature [:actions :actions/custom :actions/data-editing]]
+(doseq [feature [:actions
+                 :actions/custom
+                 :actions/data-editing
+                 :regex/lookaheads-and-lookbehinds]]
   (defmethod driver/database-supports? [:mysql feature]
     [driver _feat _db]
     ;; Only supported for MySQL right now. Revise when a child driver is added.

--- a/src/metabase/lib/drill_thru/column_extract.cljc
+++ b/src/metabase/lib/drill_thru/column_extract.cljc
@@ -12,7 +12,7 @@
   Extra constraints:
 
   - MBQL stages only
-  - Database must support `:regex` feature for the URL and Email extractions to work."
+  - Database must support `:regex/lookaheads-and-lookbehinds` feature for the URL and Email extractions to work."
   (:refer-clojure :exclude [select-keys not-empty])
   (:require
    [medley.core :as m]

--- a/src/metabase/lib/extraction.cljc
+++ b/src/metabase/lib/extraction.cljc
@@ -29,8 +29,8 @@
        :column       column
        :display-name (lib.temporal-bucket/describe-temporal-unit unit)})))
 
-(defn- regex-available? [metadata-providerable]
-  (lib.metadata/database-supports? metadata-providerable :regex))
+(defn- regex-with-lookaheads-and-lookbehinds-available? [metadata-providerable]
+  (lib.metadata/database-supports? metadata-providerable :regex/lookaheads-and-lookbehinds))
 
 (defn- domain-extraction [column]
   {:lib/type     ::extraction
@@ -77,11 +77,12 @@
   (cond
     (lib.types.isa/temporal? column) (column-extract-temporal-units column)
 
-    ;; The URL and email extractions are powered by regular expressions, and not every database supports those.
-    ;; If the target database doesn't support :regex feature, return nil.
-    (not (regex-available? query))   nil
-    (lib.types.isa/email? column)    (email-extractions column)
-    (lib.types.isa/URL? column)      (url-extractions column)))
+    ;; The URL and email extractions are powered by regular expressions that use lookaheads and lookbehinds, and not
+    ;; every database supports those. If the target database doesn't support `:regex/lookaheads-and-lookbehinds`
+    ;; feature, return `nil`/
+    (not (regex-with-lookaheads-and-lookbehinds-available? query)) nil
+    (lib.types.isa/email? column)                                  (email-extractions column)
+    (lib.types.isa/URL? column)                                    (url-extractions column)))
 
 (defmethod lib.metadata.calculation/display-info-method ::extraction
   [_query _stage-number extraction]

--- a/src/metabase/lib/extraction.cljc
+++ b/src/metabase/lib/extraction.cljc
@@ -79,7 +79,7 @@
 
     ;; The URL and email extractions are powered by regular expressions that use lookaheads and lookbehinds, and not
     ;; every database supports those. If the target database doesn't support `:regex/lookaheads-and-lookbehinds`
-    ;; feature, return `nil`/
+    ;; feature, return `nil`.
     (not (regex-with-lookaheads-and-lookbehinds-available? query)) nil
     (lib.types.isa/email? column)                                  (email-extractions column)
     (lib.types.isa/URL? column)                                    (url-extractions column)))

--- a/test/metabase/lib/drill_thru/column_extract_test.cljc
+++ b/test/metabase/lib/drill_thru/column_extract_test.cljc
@@ -321,9 +321,9 @@
 
 (deftest ^:parallel column-extract-url-requires-regex-test
   (let [query-regex    (lib/query (homepage-provider) (meta/table-metadata :people))
-        no-regex       (homepage-provider (meta/updated-metadata-provider update :features disj :regex))
+        no-regex       (homepage-provider (meta/updated-metadata-provider update :features disj :regex/lookaheads-and-lookbehinds))
         query-no-regex (lib/query no-regex (meta/table-metadata :people))]
-    (testing "when the database supports :regex URL extraction is available"
+    (testing "when the database supports `:regex/lookaheads-and-lookbehinds` URL extraction is available"
       (lib.drill-thru.tu/test-drill-application
        {:drill-type     :drill-thru/column-extract
         :click-type     :header
@@ -339,7 +339,7 @@
         :drill-args     ["subdomain"]
         :expected-query {:stages [{:expressions [[:subdomain {:lib/expression-name "Subdomain"}
                                                   exp-homepage]]}]}}))
-    (testing "when the database does not support :regex URL extraction is not available"
+    (testing "when the database does not support `:regex/lookaheads-and-lookbehinds` URL extraction is not available"
       (lib.drill-thru.tu/test-drill-not-returned
        {:drill-type     :drill-thru/column-extract
         :click-type     :header
@@ -349,9 +349,9 @@
 
 (deftest ^:parallel column-extract-email-requires-regex-test
   (let [query-regex    (lib/query meta/metadata-provider (meta/table-metadata :people))
-        no-regex       (meta/updated-metadata-provider update :features disj :regex)
+        no-regex       (meta/updated-metadata-provider update :features disj :regex/lookaheads-and-lookbehinds)
         query-no-regex (lib/query no-regex (meta/table-metadata :people))]
-    (testing "when the database supports :regex email extraction is available"
+    (testing "when the database supports `:regex/lookaheads-and-lookbehinds` email extraction is available"
       (lib.drill-thru.tu/test-drill-application
        {:drill-type     :drill-thru/column-extract
         :click-type     :header
@@ -366,7 +366,7 @@
         :expected-query {:stages [{:expressions [[:domain {:lib/expression-name "Domain"}
                                                   [:field {} (lib.drill-thru.tu/field-key=
                                                               "EMAIL" (meta/id :people :email))]]]}]}}))
-    (testing "when the database does not support :regex email extraction is not available"
+    (testing "when the database does not support `:regex/lookaheads-and-lookbehinds` email extraction is not available"
       (lib.drill-thru.tu/test-drill-not-returned
        {:drill-type     :drill-thru/column-extract
         :click-type     :header

--- a/test/metabase/lib/extraction_test.cljc
+++ b/test/metabase/lib/extraction_test.cljc
@@ -172,7 +172,7 @@
               (->> (lib/returned-columns query-regex)
                    (m/find-first #(= (:name %) "HOMEPAGE"))
                    (lib/column-extractions query-regex)))))
-    (testing "when the database does not support :regex URL extraction is not available"
+    (testing "when the database does not support `:regex/lookaheads-and-lookbehinds` URL extraction is not available"
       (is (empty? (->> (lib/returned-columns query-no-regex)
                        (m/find-first #(= (:name %) "HOMEPAGE"))
                        (lib/column-extractions query-no-regex)))))))

--- a/test/metabase/lib/extraction_test.cljc
+++ b/test/metabase/lib/extraction_test.cljc
@@ -162,9 +162,9 @@
 
 (deftest ^:parallel extracting-from-urls-requires-regex-feature-test
   (let [query-regex    (lib/query (homepage-provider) (meta/table-metadata :people))
-        no-regex       (homepage-provider (meta/updated-metadata-provider update :features disj :regex))
+        no-regex       (homepage-provider (meta/updated-metadata-provider update :features disj :regex/lookaheads-and-lookbehinds))
         query-no-regex (lib/query no-regex (meta/table-metadata :people))]
-    (testing "when the database supports :regex URL extraction is available"
+    (testing "when the database supports `:regex/lookaheads-and-lookbehinds` URL extraction is available"
       (is (=? [{:tag :domain,    :display-name "Domain"}
                {:tag :subdomain, :display-name "Subdomain"}
                {:tag :host,      :display-name "Host"}
@@ -179,15 +179,15 @@
 
 (deftest ^:parallel extracting-from-emails-requires-regex-feature-test
   (let [query-regex    (lib/query meta/metadata-provider (meta/table-metadata :people))
-        no-regex       (meta/updated-metadata-provider update :features disj :regex)
+        no-regex       (meta/updated-metadata-provider update :features disj :regex/lookaheads-and-lookbehinds)
         query-no-regex (lib/query no-regex (meta/table-metadata :people))]
-    (testing "when the database supports :regex email extraction is available"
+    (testing "when the database supports `:regex/lookaheads-and-lookbehinds` email extraction is available"
       (is (=? [{:tag :domain,    :display-name "Domain"}
                {:tag :host,      :display-name "Host"}]
               (->> (lib/returned-columns query-regex)
                    (m/find-first #(= (:name %) "EMAIL"))
                    (lib/column-extractions query-regex)))))
-    (testing "when the database does not support :regex email extraction is not available"
+    (testing "when the database does not support `:regex/lookaheads-and-lookbehinds` email extraction is not available"
       (is (empty? (->> (lib/returned-columns query-no-regex)
                        (m/find-first #(= (:name %) "EMAIL"))
                        (lib/column-extractions query-no-regex)))))))

--- a/test/metabase/lib/filter/desugar/jvm_test.clj
+++ b/test/metabase/lib/filter/desugar/jvm_test.clj
@@ -14,7 +14,7 @@
     "geocities.jp"    "https://www.geocities.jp/some/path/Turbitt?search=foo"
     "jalbum.net"      "https://jalbum.net/some/path/Kirsz?search=foo"
     "usa.gov"         "https://usa.gov/some/path/Curdell?search=foo"
-       ;; Oops, this one captures a subdomain because it can't tell va.gov is supposed to be that short.
+    ;; Oops, this one captures a subdomain because it can't tell va.gov is supposed to be that short.
     "taxes.va.gov"    "http://taxes.va.gov/some/path/Marritt?search=foo"
     "gmpg.org"        "http://log.stuff.gmpg.org/some/path/Cambden?search=foo"
     "hatena.ne.jp"    "http://hatena.ne.jp/"

--- a/test/metabase/lib/test_metadata.cljc
+++ b/test/metabase/lib/test_metadata.cljc
@@ -2966,6 +2966,7 @@
                                   :nested-queries
                                   :now
                                   :regex
+                                  :regex/lookaheads-and-lookbehinds
                                   :right-join
                                   :standard-deviation-aggregations
                                   :temporal-extract}

--- a/test/metabase/query_processor/string_extracts_test.clj
+++ b/test/metabase/query_processor/string_extracts_test.clj
@@ -2,9 +2,10 @@
   (:require
    [clojure.test :refer :all]
    [metabase.driver :as driver]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.query-processor :as qp]
-   [metabase.test :as mt]
-   [metabase.test.data :as data]))
+   [metabase.test :as mt]))
 
 (defn- test-string-extract
   [expr & [filter]]
@@ -13,7 +14,7 @@
         ;; filter clause is optional
         :filter      filter
         ;; To ensure stable ordering
-        :order-by    [[:asc [:field (data/id :venues :id) nil]]]
+        :order-by    [[:asc [:field (mt/id :venues :id) nil]]]
         :limit       1}
        (mt/run-mbql-query venues)
        mt/rows
@@ -37,36 +38,36 @@
 
 (deftest ^:parallel test-upper
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
-    (is (= "RED MEDICINE" (test-string-extract [:upper [:field (data/id :venues :name) nil]])))))
+    (is (= "RED MEDICINE" (test-string-extract [:upper [:field (mt/id :venues :name) nil]])))))
 
 (deftest ^:parallel test-lower
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
-    (is (= "red medicine" (test-string-extract [:lower [:field (data/id :venues :name) nil]])))))
+    (is (= "red medicine" (test-string-extract [:lower [:field (mt/id :venues :name) nil]])))))
 
 (deftest ^:parallel test-substring
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
-    (is (= "Red" (test-string-extract [:substring [:field (data/id :venues :name) nil] 1 3])))
+    (is (= "Red" (test-string-extract [:substring [:field (mt/id :venues :name) nil] 1 3])))
     ;; 0 is normalized 1 to by the normalize/canonicalize processing
-    (is (= "Red" (test-string-extract [:substring [:field (data/id :venues :name) nil] 0 3])))
-    (is (= "ed Medicine" (test-string-extract [:substring [:field (data/id :venues :name) nil] 2])))
-    (is (= "Red Medicin" (test-string-extract [:substring [:field (data/id :venues :name) nil]
-                                               1 [:- [:length [:field (data/id :venues :name) nil]] 1]])))
-    (is (= "ne" (test-string-extract [:substring [:field (data/id :venues :name) nil]
-                                      [:- [:length [:field (data/id :venues :name) nil]] 1]])))))
+    (is (= "Red" (test-string-extract [:substring [:field (mt/id :venues :name) nil] 0 3])))
+    (is (= "ed Medicine" (test-string-extract [:substring [:field (mt/id :venues :name) nil] 2])))
+    (is (= "Red Medicin" (test-string-extract [:substring [:field (mt/id :venues :name) nil]
+                                               1 [:- [:length [:field (mt/id :venues :name) nil]] 1]])))
+    (is (= "ne" (test-string-extract [:substring [:field (mt/id :venues :name) nil]
+                                      [:- [:length [:field (mt/id :venues :name) nil]] 1]])))))
 
 (deftest ^:parallel test-replace
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
-    (is (= "Red Baloon" (test-string-extract [:replace [:field (data/id :venues :name) nil] "Medicine" "Baloon"])))
-    (is (= "Rod Modicino" (test-string-extract [:replace [:field (data/id :venues :name) nil] "e" "o"])))
-    (is (= "Red" (test-string-extract [:replace [:field (data/id :venues :name) nil] " Medicine" ""])))
+    (is (= "Red Baloon" (test-string-extract [:replace [:field (mt/id :venues :name) nil] "Medicine" "Baloon"])))
+    (is (= "Rod Modicino" (test-string-extract [:replace [:field (mt/id :venues :name) nil] "e" "o"])))
+    (is (= "Red" (test-string-extract [:replace [:field (mt/id :venues :name) nil] " Medicine" ""])))
     (is (= "Larry's The Prime Rib" (test-string-extract
-                                    [:replace [:field (data/id :venues :name) nil] "Lawry's" "Larry's"]
-                                    [:= [:field (data/id :venues :name) nil] "Lawry's The Prime Rib"])))))
+                                    [:replace [:field (mt/id :venues :name) nil] "Lawry's" "Larry's"]
+                                    [:= [:field (mt/id :venues :name) nil] "Lawry's The Prime Rib"])))))
 
 (deftest ^:parallel test-coalesce
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (is (= "Red Medicine" (test-string-extract [:coalesce
-                                                [:field (data/id :venues :name) nil]
+                                                [:field (mt/id :venues :name) nil]
                                                 "b"])))))
 
 (deftest ^:parallel test-concat
@@ -98,16 +99,16 @@
 
 (deftest ^:parallel test-regex-match-first
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions :regex)
-    (is (= "Red" (test-string-extract [:regex-match-first [:field (data/id :venues :name) nil] "(.ed+)"])))))
+    (is (= "Red" (test-string-extract [:regex-match-first [:field (mt/id :venues :name) nil] "(.ed+)"])))))
 
 (deftest ^:parallel test-nesting
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
-    (is (= "MED" (test-string-extract [:upper [:substring [:trim [:substring [:field (data/id :venues :name) nil] 4]] 1 3]])))))
+    (is (= "MED" (test-string-extract [:upper [:substring [:trim [:substring [:field (mt/id :venues :name) nil] 4]] 1 3]])))))
 
 (deftest ^:parallel test-breakout
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (is (= ["20th Century Cafefoo" 1]
-           (->> {:expressions  {"test" [:concat [:field (data/id :venues :name) nil] "foo"]}
+           (->> {:expressions  {"test" [:concat [:field (mt/id :venues :name) nil] "foo"]}
                  :breakout     [[:expression "test"]]
                  :aggregation  [[:count]]
                  :limit        1}
@@ -119,8 +120,8 @@
   (mt/test-drivers
     (mt/normal-drivers-with-feature :expressions :regex)
     (is (= "Taylor's" (test-string-extract
-                       [:regex-match-first [:field (data/id :venues :name) nil] "^Taylor's"]
-                       [:= [:field (data/id :venues :name) nil] "Taylor's Prime Steak House"])))))
+                       [:regex-match-first [:field (mt/id :venues :name) nil] "^Taylor's"]
+                       [:= [:field (mt/id :venues :name) nil] "Taylor's Prime Steak House"])))))
 
 (deftest ^:parallel regex-extract-in-explict-join-test
   (testing "Should be able to use regex extra in an explict join (#17790)"
@@ -146,3 +147,25 @@
                      str
                      int str str str str 2.0 2.0 str]
                     (qp/process-query query))))))))))
+
+(deftest ^:parallel domain-extraction-test
+  (testing "Domain extraction should work correctly (#63822, DEV-1190)"
+    (mt/test-drivers (mt/normal-drivers-with-feature :expressions :regex :left-join)
+      (let [mp           (mt/metadata-provider)
+            people       (lib.metadata/table mp (mt/id :people))
+            people-id    (lib.metadata/field mp (mt/id :people :id))
+            people-email (lib.metadata/field mp (mt/id :people :email))
+            query        (-> (lib/query mp people)
+                             (lib/order-by people-id)
+                             (lib/limit 2)
+                             (lib/with-fields [people-id people-email]))
+            extractions  (lib/column-extractions query people-email)
+            _            (is (= #{:domain :host}
+                                (into #{} (map :tag) extractions)))
+            query        (reduce (fn [query extraction]
+                                   (lib/extract query -1 extraction))
+                                 query
+                                 extractions)]
+        (is (= [[1 "borer-hudson@yahoo.com"        "yahoo" "yahoo.com"]
+                [2 "williamson-domenica@yahoo.com" "yahoo" "yahoo.com"]]
+               (mt/formatted-rows [int str str str] (qp/process-query query))))))))


### PR DESCRIPTION
Fixes #63822
Fixes DEV-1190

Extractions like `:domain`, `:host`, `:subdomain`, and `:path` do not work for BigQuery because it does not support lookaheads or lookbehinds in regexes, and as far as I can tell these regexes cannot be written in a functionally equivalent way without using them.

So rather than having these produce invalid queries just don't offer them in the first place for drivers that do not support them.

Pursuant to this I've added a new driver feature flag called `:regex/lookaheads-and-lookbehinds`.

I should note that BigQuery **does** have some native functions that can support some of these extractions, such as [`net.host`](https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/net_functions#nethost) but they don't work on email addresses as far as I can tell and don't fully support what we want anyway; since `:domain` and friends are treated as syntactic sugar by the query processor  supporting custom implementations for BigQuery would be much more work than it would be worth 