### PR TITLE
Install clojure for pre-release

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -166,11 +166,8 @@ jobs:
           snowplow: true
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
-      - name: Prepare JDK 21
-        uses: actions/setup-java@v4
-        with:
-          java-version: 21
-          distribution: "temurin"
+      - name: Prepare back-end environment
+        uses: ./.github/actions/prepare-backend
       - name: Prepare Cypress environment
         id: cypress-prep
         uses: ./.github/actions/prepare-cypress


### PR DESCRIPTION
Pre-release script needs clojure cli in order to parse jvm options from deps.edn

This PR ensures that the clojure is installed with `prepare-backend`.


Context: https://metaboat.slack.com/archives/C864UT5CZ/p1765841775680089?thread_ts=1765807285.261709&cid=C864UT5CZ