### PR TITLE
Temporary update master after 58 beta

### DIFF
--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -383,28 +383,16 @@ jobs:
         run: |
           echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
 
-          TAG=$(jq -r --null-input \
-            --arg branch "${{ inputs.branch }}" \
-            --arg masterTag "${{ steps.compute-tag.outputs.masterTag }}" '
-            {
-              "master": $masterTag,
-              "release-x.51.x": "51-stable",
-              "release-x.52.x": "52-stable",
-              "release-x.53.x": "53-stable",
-              "release-x.54.x": "54-stable",
-              "release-x.55.x": "55-stable",
-              "release-x.56.x": "56-stable"
-            }[$branch]'
-          )
-
+          TAG="${{ steps.compute-tag.outputs.masterTag }}"
           echo "Resolved npm tag: $TAG"
           npm publish --tag "$TAG"
 
-      - name: Add `latest` tag to the latest release branch (`release-x.55.x`) deployment
-        if: ${{ inputs.branch == 'release-x.56.x' }}
-        working-directory: sdk
-        run: |
-          npm dist-tag add @metabase/embedding-sdk-react@${{ env.sdk_version }} latest
+      # ⚠️ This step should only be executed on the latest stable (gold) release branch.
+      # Only uncomment this when the new release branch becomes stable (gold).
+      # - name: Add `latest` tag to the latest release branch (`release-x.55.x`) deployment
+      #   working-directory: sdk
+      #   run: |
+      #     npm dist-tag add @metabase/embedding-sdk-react@${{ env.sdk_version }} latest
 
   git-tag:
     needs: [publish-npm, determine-sdk-version]

--- a/enterprise/frontend/src/embedding-sdk-package/package.template.json
+++ b/enterprise/frontend/src/embedding-sdk-package/package.template.json
@@ -1,6 +1,6 @@
 {
   "name": "@metabase/embedding-sdk-react",
-  "version": "0.57.0-alpha.3",
+  "version": "0.59.0-alpha",
   "description": "Metabase Embedding SDK for React",
   "bin": "./dist/cli.js",
   "repository": {
@@ -22,9 +22,7 @@
   },
   "typesVersions": {
     "*": {
-      "next": [
-        "./dist/next.d.ts"
-      ]
+      "next": ["./dist/next.d.ts"]
     }
   },
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
> [!note]
> We won't need this change the next time we cut a release branch. Master branch change should only be done [after we turn our release branch stable (gold)](https://www.notion.so/metabase/Embedding-Checklist-What-to-do-after-cutting-a-new-release-branch-20269354c90180808329eab86e59f20d?v=c66c072c05924c33a675ff18dbf04371&source=copy_link#2cb69354c9018081af4ccbe7bbdaf975)

This is a temporary PR to update master to match the current release process. Since we've been adding changes to the [release branch directly](https://github.com/metabase/metabase/pull/65781). Master was also forgotten to be updated as per our [checklist](https://www.notion.so/metabase/Embedding-Checklist-What-to-do-after-cutting-a-new-release-branch-20269354c90180808329eab86e59f20d?v=c66c072c05924c33a675ff18dbf04371) (I have added a [step](https://www.notion.so/metabase/Embedding-Checklist-What-to-do-after-cutting-a-new-release-branch-20269354c90180808329eab86e59f20d?v=c66c072c05924c33a675ff18dbf04371&source=copy_link#2cb69354c9018081af4ccbe7bbdaf975) for that now)
