### PR TITLE
Run only the default snapshot for pre-release

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -186,8 +186,14 @@ jobs:
       - name: Run Metabase
         run: node e2e/runner/run_cypress_ci.js start
 
+      # For now we only need the default snapshots for pre-release checks.
+      # If we decide to include tests that rely on the external QA databases, we should:
+      #   1. remove the --spec ... line
+      #   2. add postgres, mysql, and mongo to the prepare-containers step
       - name: Make app db snapshot
-        run: node e2e/runner/run_cypress_ci.js snapshot
+        run: |
+          node e2e/runner/run_cypress_ci.js snapshot \
+            --spec "e2e/snapshot-creators/default.cy.snap.js"
 
       - name: Run a few important OSS Cypress tests as sanity check
         if: ${{ matrix.edition == 'oss' }}


### PR DESCRIPTION
https://github.com/metabase/metabase/actions/runs/20267445215/job/58194458921 failed because snapshots running for qa databases, and we don't have those Docker containers up for this job.

Since we don't need them, I have adjusted the snapshot step to only run the default snapshots. There's a comment what to do if we change our mind and want to run external database checks in the future.