### PR TITLE
Wait for recent dashboards being loaded before we load a resource in Embed JS wizard

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
@@ -23,7 +23,9 @@ export const getEmbedSidebar = () =>
 export const getRecentItemCards = () =>
   cy.findAllByTestId("embed-recent-item-card");
 
-export const visitNewEmbedPage = () => {
+export const visitNewEmbedPage = (
+  { waitForResource } = { waitForResource: true },
+) => {
   cy.intercept("GET", "/api/dashboard/*").as("dashboard");
 
   cy.visit("/admin/embedding");
@@ -42,9 +44,14 @@ export const visitNewEmbedPage = () => {
       embedModalEnableEmbedding();
     }
 
-    cy.wait("@dashboard");
+    if (waitForResource) {
+      cy.wait("@dashboard");
 
-    cy.get("[data-iframe-loaded]", { timeout: 20000 }).should("have.length", 1);
+      cy.get("[data-iframe-loaded]", { timeout: 20000 }).should(
+        "have.length",
+        1,
+      );
+    }
   });
 };
 

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
@@ -214,6 +214,21 @@ describe(suiteTitle, () => {
     cy.findByTestId("preview-loading-indicator").should("not.exist");
   });
 
+  it("should respect slow loading of recent dashboard and avoid recent conditions", () => {
+    cy.intercept("GET", "/api/activity/recents*", (req) => {
+      req.on("response", (res) => {
+        res.setThrottle(0.3); // Slow down the response
+      });
+    }).as("getRecents");
+
+    visitNewEmbedPage();
+
+    H.getSimpleEmbedIframeContent().within(() => {
+      cy.findByText("Person overview").should("not.exist");
+      cy.findByText("Orders in a dashboard").should("be.visible");
+    });
+  });
+
   it("shows Metabot experience when selected", () => {
     visitNewEmbedPage();
 

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
@@ -214,7 +214,7 @@ describe(suiteTitle, () => {
     cy.findByTestId("preview-loading-indicator").should("not.exist");
   });
 
-  it("should respect slow loading of recent dashboard and avoid recent conditions", () => {
+  it("should respect slow loading of recent dashboars and wait till loading complete", () => {
     cy.intercept("GET", "/api/activity/recents*", (req) => {
       req.on("response", (res) => {
         res.setThrottle(0.3); // Slow down the response

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/analytics.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/analytics.ts
@@ -228,7 +228,7 @@ const buildEventDetailsPartsForSettings = (
 
     const value = settings[optionKey];
 
-    if (value === undefined) {
+    if (value === undefined || value === null) {
       continue;
     }
 

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/LegacyStaticEmbeddingModal.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/LegacyStaticEmbeddingModal.tsx
@@ -11,8 +11,8 @@ import type { Card, Dashboard, DashboardId } from "metabase-types/api";
 
 export type LegacyStaticEmbeddingModalProps = {
   experience: SdkIframeEmbedSetupExperience;
-  dashboardId?: DashboardId;
-  questionId?: string | number;
+  dashboardId?: DashboardId | null;
+  questionId?: string | number | null;
   parentInitialState: SdkIframeEmbedSetupModalInitialState | undefined;
 };
 

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeEmbedSetupModal.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeEmbedSetupModal.tsx
@@ -47,6 +47,7 @@ export const SdkIframeEmbedSetupContent = () => {
     handleNext,
     handleBack,
     canGoBack,
+    isLoading,
     resource,
     settings,
   } = useSdkIframeEmbedSetupContext();
@@ -71,6 +72,8 @@ export const SdkIframeEmbedSetupContent = () => {
   const allowPreviewAndNavigation = isSimpleEmbedFeatureAvailable
     ? isSimpleEmbeddingEnabled && isSimpleEmbeddingTermsAccepted
     : isGuestEmbedsEnabled && isGuestEmbedsTermsAccepted;
+
+  const isMissingResource = !isLoading && !resource;
 
   const nextStepButton = match(currentStep)
     .with("get-code", () => (
@@ -148,7 +151,7 @@ export const SdkIframeEmbedSetupContent = () => {
 
           <SdkIframeGuestEmbedStatusBar />
 
-          {allowPreviewAndNavigation ? (
+          {allowPreviewAndNavigation && !isMissingResource ? (
             <SdkIframeEmbedPreview />
           ) : (
             <Card h="100%">

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeEmbedSetupModal.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeEmbedSetupModal.tsx
@@ -12,6 +12,7 @@ import CS from "metabase/css/core/index.css";
 import { SdkIframeGuestEmbedStatusBar } from "metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeGuestEmbedStatusBar";
 import { SdkIframeStepHeader } from "metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeStepHeader";
 import { EMBED_STEPS } from "metabase/embedding/embedding-iframe-sdk-setup/constants";
+import { isQuestionOrDashboardSettings } from "metabase/embedding/embedding-iframe-sdk-setup/utils/is-question-or-dashboard-settings";
 import { useDispatch } from "metabase/lib/redux";
 import type { SdkIframeEmbedSetupModalProps } from "metabase/plugins";
 import { closeModal } from "metabase/redux/ui";
@@ -48,6 +49,7 @@ export const SdkIframeEmbedSetupContent = () => {
     handleBack,
     canGoBack,
     isLoading,
+    experience,
     resource,
     settings,
   } = useSdkIframeEmbedSetupContext();
@@ -73,7 +75,13 @@ export const SdkIframeEmbedSetupContent = () => {
     ? isSimpleEmbeddingEnabled && isSimpleEmbeddingTermsAccepted
     : isGuestEmbedsEnabled && isGuestEmbedsTermsAccepted;
 
-  const isMissingResource = !isLoading && (!resource || resource.archived);
+  const isQuestionOrDashboard = isQuestionOrDashboardSettings(
+    experience,
+    settings,
+  );
+
+  const isMissingResource =
+    isQuestionOrDashboard && !isLoading && (!resource || resource.archived);
 
   const nextStepButton = match(currentStep)
     .with("get-code", () => (

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeEmbedSetupModal.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeEmbedSetupModal.tsx
@@ -73,7 +73,7 @@ export const SdkIframeEmbedSetupContent = () => {
     ? isSimpleEmbeddingEnabled && isSimpleEmbeddingTermsAccepted
     : isGuestEmbedsEnabled && isGuestEmbedsTermsAccepted;
 
-  const isMissingResource = !isLoading && !resource;
+  const isMissingResource = !isLoading && (!resource || resource.archived);
 
   const nextStepButton = match(currentStep)
     .with("get-code", () => (

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeEmbedSetupProvider.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeEmbedSetupProvider.tsx
@@ -182,6 +182,7 @@ export const SdkIframeEmbedSetupProvider = ({
     isError,
     isLoading,
     isFetching,
+    isRecentsLoading,
     settings,
     defaultSettings,
     replaceSettings,

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/constants.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/constants.ts
@@ -96,6 +96,9 @@ export const EMBED_STEPS: EmbedStepConfig[] = [
   },
 ];
 
+/** If the activity log of the user is completely empty, we fallback to this dashboard. */
+export const EMBED_FALLBACK_DASHBOARD_ID = 1;
+
 /** If the activity log of the user is completely empty, we fallback to this question. */
 export const EMBED_FALLBACK_QUESTION_ID = 1;
 

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/constants.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/constants.ts
@@ -96,9 +96,6 @@ export const EMBED_STEPS: EmbedStepConfig[] = [
   },
 ];
 
-/** If the activity log of the user is completely empty, we fallback to this dashboard. */
-export const EMBED_FALLBACK_DASHBOARD_ID = 1;
-
 /** If the activity log of the user is completely empty, we fallback to this question. */
 export const EMBED_FALLBACK_QUESTION_ID = 1;
 

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/context.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/context.ts
@@ -47,6 +47,7 @@ export interface SdkIframeEmbedSetupContextType {
   isError: boolean;
   isLoading: boolean;
   isFetching: boolean;
+  isRecentsLoading: boolean;
 
   // Embed settings
   settings: SdkIframeEmbedSetupSettings;

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-get-current-resource.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-get-current-resource.ts
@@ -33,8 +33,8 @@ export const useGetCurrentResource = ({
   questionId,
 }: {
   experience: SdkIframeEmbedSetupExperience;
-  dashboardId?: DashboardId;
-  questionId?: string | number;
+  dashboardId?: DashboardId | null;
+  questionId?: string | number | null;
 }) => {
   const dispatch = useDispatch();
 

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-handle-experience-change.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-handle-experience-change.ts
@@ -4,12 +4,10 @@ import _ from "underscore";
 
 import { useSetting } from "metabase/common/hooks";
 import { ALLOWED_EMBED_SETTING_KEYS_MAP } from "metabase/embedding/embedding-iframe-sdk/constants";
-import {
-  EMBED_FALLBACK_DASHBOARD_ID,
-  EMBED_FALLBACK_QUESTION_ID,
-} from "metabase/embedding/embedding-iframe-sdk-setup/constants";
+import { EMBED_FALLBACK_QUESTION_ID } from "metabase/embedding/embedding-iframe-sdk-setup/constants";
 import { useSdkIframeEmbedSetupContext } from "metabase/embedding/embedding-iframe-sdk-setup/context";
 import type { SdkIframeEmbedSetupExperience } from "metabase/embedding/embedding-iframe-sdk-setup/types";
+import { determineDashboardId } from "metabase/embedding/embedding-iframe-sdk-setup/utils/determine-dashboard-id";
 import { getDefaultSdkIframeEmbedSettings } from "metabase/embedding/embedding-iframe-sdk-setup/utils/get-default-sdk-iframe-embed-setting";
 
 export const DEFAULT_EXPERIENCE = "dashboard";
@@ -19,6 +17,7 @@ export const useHandleExperienceChange = () => {
     isSimpleEmbedFeatureAvailable,
     isGuestEmbedsEnabled,
     isSsoEnabledAndConfigured,
+    isRecentsLoading,
     settings,
     replaceSettings,
     recentDashboards,
@@ -41,12 +40,12 @@ export const useHandleExperienceChange = () => {
           "chart",
           () => recentQuestions[0]?.id ?? EMBED_FALLBACK_QUESTION_ID,
         )
-        .with(
-          "dashboard",
-          () =>
-            recentDashboards[0]?.id ??
-            exampleDashboardId ??
-            EMBED_FALLBACK_DASHBOARD_ID,
+        .with("dashboard", () =>
+          determineDashboardId({
+            isRecentsLoading,
+            recentDashboards,
+            exampleDashboardId,
+          }),
         )
         .with(P.union("exploration", "browser", "metabot"), () => 0) // resource id does not apply
         .exhaustive();
@@ -72,6 +71,7 @@ export const useHandleExperienceChange = () => {
       isSsoEnabledAndConfigured,
       isSimpleEmbedFeatureAvailable,
       recentDashboards,
+      isRecentsLoading,
       recentQuestions,
       replaceSettings,
       settings,

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-handle-experience-change.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-handle-experience-change.ts
@@ -2,11 +2,9 @@ import { useCallback } from "react";
 import { P, match } from "ts-pattern";
 import _ from "underscore";
 
+import { useSetting } from "metabase/common/hooks";
 import { ALLOWED_EMBED_SETTING_KEYS_MAP } from "metabase/embedding/embedding-iframe-sdk/constants";
-import {
-  EMBED_FALLBACK_DASHBOARD_ID,
-  EMBED_FALLBACK_QUESTION_ID,
-} from "metabase/embedding/embedding-iframe-sdk-setup/constants";
+import { EMBED_FALLBACK_QUESTION_ID } from "metabase/embedding/embedding-iframe-sdk-setup/constants";
 import { useSdkIframeEmbedSetupContext } from "metabase/embedding/embedding-iframe-sdk-setup/context";
 import type { SdkIframeEmbedSetupExperience } from "metabase/embedding/embedding-iframe-sdk-setup/types";
 import { getDefaultSdkIframeEmbedSettings } from "metabase/embedding/embedding-iframe-sdk-setup/utils/get-default-sdk-iframe-embed-setting";
@@ -24,6 +22,8 @@ export const useHandleExperienceChange = () => {
     recentQuestions,
   } = useSdkIframeEmbedSetupContext();
 
+  const exampleDashboardId = useSetting("example-dashboard-id");
+
   const handleEmbedExperienceChange = useCallback(
     (experience: SdkIframeEmbedSetupExperience) => {
       const persistedSettings = _.pick(
@@ -40,7 +40,7 @@ export const useHandleExperienceChange = () => {
         )
         .with(
           "dashboard",
-          () => recentDashboards[0]?.id ?? EMBED_FALLBACK_DASHBOARD_ID,
+          () => recentDashboards[0]?.id ?? exampleDashboardId ?? null,
         )
         .with(P.union("exploration", "browser", "metabot"), () => 0) // resource id does not apply
         .exhaustive();
@@ -69,6 +69,7 @@ export const useHandleExperienceChange = () => {
       recentQuestions,
       replaceSettings,
       settings,
+      exampleDashboardId,
     ],
   );
 

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-handle-experience-change.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-handle-experience-change.ts
@@ -4,7 +4,10 @@ import _ from "underscore";
 
 import { useSetting } from "metabase/common/hooks";
 import { ALLOWED_EMBED_SETTING_KEYS_MAP } from "metabase/embedding/embedding-iframe-sdk/constants";
-import { EMBED_FALLBACK_QUESTION_ID } from "metabase/embedding/embedding-iframe-sdk-setup/constants";
+import {
+  EMBED_FALLBACK_DASHBOARD_ID,
+  EMBED_FALLBACK_QUESTION_ID,
+} from "metabase/embedding/embedding-iframe-sdk-setup/constants";
 import { useSdkIframeEmbedSetupContext } from "metabase/embedding/embedding-iframe-sdk-setup/context";
 import type { SdkIframeEmbedSetupExperience } from "metabase/embedding/embedding-iframe-sdk-setup/types";
 import { getDefaultSdkIframeEmbedSettings } from "metabase/embedding/embedding-iframe-sdk-setup/utils/get-default-sdk-iframe-embed-setting";
@@ -40,7 +43,10 @@ export const useHandleExperienceChange = () => {
         )
         .with(
           "dashboard",
-          () => recentDashboards[0]?.id ?? exampleDashboardId ?? null,
+          () =>
+            recentDashboards[0]?.id ??
+            exampleDashboardId ??
+            EMBED_FALLBACK_DASHBOARD_ID,
         )
         .with(P.union("exploration", "browser", "metabot"), () => 0) // resource id does not apply
         .exhaustive();

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-sdk-iframe-embed-settings.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-sdk-iframe-embed-settings.ts
@@ -121,7 +121,9 @@ export const useSdkIframeEmbedSettings = ({
       .otherwise((initialState) =>
         getDefaultSdkIframeEmbedSettings({
           experience: "dashboard",
-          resourceId: recentDashboards[0]?.id ?? EMBED_FALLBACK_DASHBOARD_ID,
+          resourceId: isRecentsLoading
+            ? null
+            : (recentDashboards[0]?.id ?? EMBED_FALLBACK_DASHBOARD_ID),
           isSimpleEmbedFeatureAvailable,
           isGuestEmbedsEnabled,
           isSsoEnabledAndConfigured,
@@ -135,6 +137,7 @@ export const useSdkIframeEmbedSettings = ({
     isGuestEmbedsEnabled,
     isSsoEnabledAndConfigured,
     recentDashboards,
+    isRecentsLoading,
   ]);
 
   const [rawSettings, setRawSettings] = useState<SdkIframeEmbedSetupSettings>();

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-sdk-iframe-embed-settings.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-sdk-iframe-embed-settings.ts
@@ -3,10 +3,7 @@ import { P, match } from "ts-pattern";
 import _ from "underscore";
 
 import { useSetting, useUserSetting } from "metabase/common/hooks";
-import {
-  EMBED_FALLBACK_DASHBOARD_ID,
-  USER_SETTINGS_DEBOUNCE_MS,
-} from "metabase/embedding/embedding-iframe-sdk-setup/constants";
+import { USER_SETTINGS_DEBOUNCE_MS } from "metabase/embedding/embedding-iframe-sdk-setup/constants";
 import type {
   SdkIframeEmbedSetupRecentItem,
   SdkIframeEmbedSetupSettings,
@@ -125,9 +122,7 @@ export const useSdkIframeEmbedSettings = ({
           experience: "dashboard",
           resourceId: isRecentsLoading
             ? null
-            : (recentDashboards[0]?.id ??
-              exampleDashboardId ??
-              EMBED_FALLBACK_DASHBOARD_ID),
+            : (recentDashboards[0]?.id ?? exampleDashboardId ?? null),
           isSimpleEmbedFeatureAvailable,
           isGuestEmbedsEnabled,
           isSsoEnabledAndConfigured,

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-sdk-iframe-embed-settings.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-sdk-iframe-embed-settings.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { P, match } from "ts-pattern";
 import _ from "underscore";
 
-import { useUserSetting } from "metabase/common/hooks";
+import { useSetting, useUserSetting } from "metabase/common/hooks";
 import {
   EMBED_FALLBACK_DASHBOARD_ID,
   USER_SETTINGS_DEBOUNCE_MS,
@@ -90,6 +90,8 @@ export const useSdkIframeEmbedSettings = ({
     isSimpleEmbedFeatureAvailable,
   });
 
+  const exampleDashboardId = useSetting("example-dashboard-id");
+
   const defaultSettings = useMemo(() => {
     return match(initialState)
       .with(
@@ -123,7 +125,9 @@ export const useSdkIframeEmbedSettings = ({
           experience: "dashboard",
           resourceId: isRecentsLoading
             ? null
-            : (recentDashboards[0]?.id ?? EMBED_FALLBACK_DASHBOARD_ID),
+            : (recentDashboards[0]?.id ??
+              exampleDashboardId ??
+              EMBED_FALLBACK_DASHBOARD_ID),
           isSimpleEmbedFeatureAvailable,
           isGuestEmbedsEnabled,
           isSsoEnabledAndConfigured,
@@ -136,6 +140,7 @@ export const useSdkIframeEmbedSettings = ({
     isSimpleEmbedFeatureAvailable,
     isGuestEmbedsEnabled,
     isSsoEnabledAndConfigured,
+    exampleDashboardId,
     recentDashboards,
     isRecentsLoading,
   ]);

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-sdk-iframe-embed-settings.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-sdk-iframe-embed-settings.ts
@@ -3,14 +3,12 @@ import { P, match } from "ts-pattern";
 import _ from "underscore";
 
 import { useSetting, useUserSetting } from "metabase/common/hooks";
-import {
-  EMBED_FALLBACK_DASHBOARD_ID,
-  USER_SETTINGS_DEBOUNCE_MS,
-} from "metabase/embedding/embedding-iframe-sdk-setup/constants";
+import { USER_SETTINGS_DEBOUNCE_MS } from "metabase/embedding/embedding-iframe-sdk-setup/constants";
 import type {
   SdkIframeEmbedSetupRecentItem,
   SdkIframeEmbedSetupSettings,
 } from "metabase/embedding/embedding-iframe-sdk-setup/types";
+import { determineDashboardId } from "metabase/embedding/embedding-iframe-sdk-setup/utils/determine-dashboard-id";
 import type { SdkIframeEmbedSetupModalInitialState } from "metabase/plugins";
 
 import { getAdjustedSdkIframeEmbedSetting } from "../utils/get-adjusted-sdk-iframe-embed-setting";
@@ -123,11 +121,11 @@ export const useSdkIframeEmbedSettings = ({
       .otherwise((initialState) =>
         getDefaultSdkIframeEmbedSettings({
           experience: "dashboard",
-          resourceId: isRecentsLoading
-            ? null
-            : (recentDashboards[0]?.id ??
-              exampleDashboardId ??
-              EMBED_FALLBACK_DASHBOARD_ID),
+          resourceId: determineDashboardId({
+            isRecentsLoading,
+            recentDashboards,
+            exampleDashboardId,
+          }),
           isSimpleEmbedFeatureAvailable,
           isGuestEmbedsEnabled,
           isSsoEnabledAndConfigured,

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-sdk-iframe-embed-settings.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-sdk-iframe-embed-settings.ts
@@ -3,7 +3,10 @@ import { P, match } from "ts-pattern";
 import _ from "underscore";
 
 import { useSetting, useUserSetting } from "metabase/common/hooks";
-import { USER_SETTINGS_DEBOUNCE_MS } from "metabase/embedding/embedding-iframe-sdk-setup/constants";
+import {
+  EMBED_FALLBACK_DASHBOARD_ID,
+  USER_SETTINGS_DEBOUNCE_MS,
+} from "metabase/embedding/embedding-iframe-sdk-setup/constants";
 import type {
   SdkIframeEmbedSetupRecentItem,
   SdkIframeEmbedSetupSettings,
@@ -122,7 +125,9 @@ export const useSdkIframeEmbedSettings = ({
           experience: "dashboard",
           resourceId: isRecentsLoading
             ? null
-            : (recentDashboards[0]?.id ?? exampleDashboardId ?? null),
+            : (recentDashboards[0]?.id ??
+              exampleDashboardId ??
+              EMBED_FALLBACK_DASHBOARD_ID),
           isSimpleEmbedFeatureAvailable,
           isGuestEmbedsEnabled,
           isSsoEnabledAndConfigured,

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/determine-dashboard-id.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/determine-dashboard-id.ts
@@ -1,0 +1,18 @@
+import { EMBED_FALLBACK_DASHBOARD_ID } from "metabase/embedding/embedding-iframe-sdk-setup/constants";
+import type { SdkIframeEmbedSetupRecentItem } from "metabase/embedding/embedding-iframe-sdk-setup/types";
+import type { DashboardId } from "metabase-types/api";
+
+export const determineDashboardId = ({
+  isRecentsLoading,
+  recentDashboards,
+  exampleDashboardId,
+}: {
+  isRecentsLoading: boolean;
+  recentDashboards: SdkIframeEmbedSetupRecentItem[];
+  exampleDashboardId: DashboardId | null;
+}) =>
+  isRecentsLoading
+    ? null
+    : (recentDashboards[0]?.id ??
+      exampleDashboardId ??
+      EMBED_FALLBACK_DASHBOARD_ID);

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-default-sdk-iframe-embed-setting.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-default-sdk-iframe-embed-setting.ts
@@ -27,7 +27,7 @@ export const getDefaultSdkIframeEmbedSettings = ({
   useExistingUserSession,
 }: {
   experience: SdkIframeEmbedSetupExperience;
-  resourceId: SdkDashboardId | SdkQuestionId;
+  resourceId: SdkDashboardId | SdkQuestionId | null;
   isSimpleEmbedFeatureAvailable: boolean;
   isGuestEmbedsEnabled: boolean;
   isSsoEnabledAndConfigured: boolean;

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
@@ -68,7 +68,7 @@ export type SdkIframeEmbedReportAnalytics = {
 // --- Embed Option Interfaces ---
 
 export type DashboardEmbedOptions = StrictUnion<
-  { dashboardId: number | string } | { token: string }
+  { dashboardId: number | string | null } | { token: string }
 > & {
   componentName: "metabase-dashboard";
 
@@ -87,7 +87,7 @@ export type DashboardEmbedOptions = StrictUnion<
 };
 
 export type QuestionEmbedOptions = StrictUnion<
-  { questionId: number | string } | { token: string }
+  { questionId: number | string | null } | { token: string }
 > & {
   componentName: "metabase-question";
 


### PR DESCRIPTION
closes emb-1137

Wait for recent dashboards being loaded before we load a resource in Embed JS wizard.

This fixes the issue when:
- we start loading recent dashboards
- we don't wait for them to be loaded and fallback to `EMBED_FALLBACK_DASHBOARD_ID`, that is started its loading
- then, depending on what is faster, a recent dashboard or EMBED_FALLBACK_DASHBOARD is loaded and displayed.

The fix sets dashboardId to `null` while a recent dashboard is loading, so we don't load a dashboard as well and wait until the `recent` dashboards are loaded first, then we properly handle the `recentDashboards[0]?.id ?? EMBED_FALLBACK_DASHBOARD_ID` logic

How to reproduce:
- we need to slowdown `http://localhost:3000/api/activity/recents?context=selections&context=views` request so it will take longer than a resource loading for EMBED_FALLBACK_DASHBOARD_ID. I reproduced it directly in Cypress by using cy.intercept. Also setting throttling in the `network` tab and reloading a page multiple times may reproduce the issue.
- then when we load the Embed JS wizard from Admin UI, in some cases we don't wait for recent dashboards being loaded and show the default dashboard id (locally it has id 1).


How to verify:
- also slowdown `recents` request.
- open Embed JS from Admin UI
- in all cases we should not load a resurce until the `recent` request is done, so we load a proper resource.