### PR TITLE
fix: dirty state tracking of bulk set collections

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/remote_sync/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/core.clj
@@ -66,8 +66,14 @@
     (doseq [collection sync-on
             ;; only publish event when this changed
             :when (not (:is_remote_synced collection))]
-      (events/publish-event! :event/collection-update {:object collection :user-id api/*current-user-id*}))
+      (events/publish-event! :event/collection-update
+                             ;; collection is the model originally loaded set the correct sync state
+                             {:object (assoc collection :is_remote_synced true)
+                              :user-id api/*current-user-id*}))
     (doseq [collection sync-off
             ;; only publish event when this changed
             :when (:is_remote_synced collection)]
-      (events/publish-event! :event/collection-update {:object collection :user-id api/*current-user-id*}))))
+      (events/publish-event! :event/collection-update
+                             ;; collection is the model originally loaded set the correct sync state
+                             {:object (assoc collection :is_remote_synced false)
+                              :user-id api/*current-user-id*}))))

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/core_test.clj
@@ -145,6 +145,7 @@
           (core/bulk-set-remote-sync {coll-id true})
           (is (= 1 (count @published-events)))
           (is (= :event/collection-update (ffirst @published-events)))
+          (is (true? (get-in (first @published-events) [1 :object :is_remote_synced])))
           (is (= coll-id (get-in (first @published-events) [1 :object :id]))))))))
 
 (deftest bulk-set-remote-sync-publishes-event-when-disabling-test
@@ -157,6 +158,7 @@
           (core/bulk-set-remote-sync {coll-id false})
           (is (= 1 (count @published-events)))
           (is (= :event/collection-update (ffirst @published-events)))
+          (is (false? (get-in (first @published-events) [1 :object :is_remote_synced])))
           (is (= coll-id (get-in (first @published-events) [1 :object :id]))))))))
 
 (deftest bulk-set-remote-sync-no-event-when-already-enabled-test


### PR DESCRIPTION
### Description

There is a bug in dirty state tracking for bulk setting remote synced collections where we can't updating the flag value before emitting the event so bulk updated collections are tracking in reverse to what they should be. 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
