### PR TITLE
QOL tweak with color() function

### DIFF
--- a/frontend/src/metabase/common/components/Badge/Badge.styled.tsx
+++ b/frontend/src/metabase/common/components/Badge/Badge.styled.tsx
@@ -8,7 +8,7 @@ import type { LinkProps } from "metabase/common/components/Link";
 import Link from "metabase/common/components/Link";
 import { doNotForwardProps } from "metabase/common/utils/doNotForwardProps";
 import { Icon } from "metabase/ui";
-import { color } from "metabase/ui/utils/colors";
+import { maybeColor } from "metabase/ui/utils/colors";
 
 interface RawMaybeLinkProps {
   to?: string;
@@ -29,7 +29,7 @@ export function RawMaybeLink({
 
 const hoverStyle = (props: RawMaybeLinkProps) => css`
   cursor: pointer;
-  ${props.activeColor ? `color: ${color(props.activeColor)};` : ""}
+  ${props.activeColor ? `color: ${maybeColor(props.activeColor)};` : ""}
 `;
 
 export const MaybeLink = styled(RawMaybeLink)`
@@ -38,7 +38,7 @@ export const MaybeLink = styled(RawMaybeLink)`
   font-size: 0.875em;
   font-weight: bold;
   ${(props) =>
-    props.inactiveColor ? `color: ${color(props.inactiveColor)};` : ""}
+    props.inactiveColor ? `color: ${maybeColor(props.inactiveColor)};` : ""}
   min-width: ${(props) => (props.isSingleLine ? 0 : "")};
 
   :hover {

--- a/frontend/src/metabase/common/components/SelectList/SelectListItem.styled.tsx
+++ b/frontend/src/metabase/common/components/SelectList/SelectListItem.styled.tsx
@@ -5,7 +5,7 @@ import styled from "@emotion/styled";
 
 import type { ColorName } from "metabase/lib/colors/types";
 import { Icon, Text, type TextProps } from "metabase/ui";
-import { color } from "metabase/ui/utils/colors";
+import { maybeColor } from "metabase/ui/utils/colors";
 
 export const ItemTitle = styled(Text)<TextProps>`
   margin: 0;
@@ -13,7 +13,7 @@ export const ItemTitle = styled(Text)<TextProps>`
 ` as unknown as typeof Text;
 
 export const ItemIcon = styled(Icon)<{ color?: ColorName | string | null }>`
-  color: ${(props) => color(props.color ?? "text-light")};
+  color: ${(props) => maybeColor(props.color ?? "text-light")};
   justify-self: end;
 `;
 

--- a/frontend/src/metabase/list-view/components/ListView/styling.ts
+++ b/frontend/src/metabase/list-view/components/ListView/styling.ts
@@ -1,5 +1,5 @@
 import type { IconName } from "metabase/ui";
-import { color } from "metabase/ui/utils/colors";
+import { color, maybeColor } from "metabase/ui/utils/colors";
 
 export const ENTITY_ICONS = {
   "entity/UserTable": "person",
@@ -44,7 +44,7 @@ export function getIconBackground(iconColor?: string) {
   }
 
   return iconColor !== color("text-primary")
-    ? `color-mix(in srgb, ${color(iconColor)}, transparent 88%)`
+    ? `color-mix(in srgb, ${maybeColor(iconColor)}, transparent 88%)`
     : "var(--mb-color-white)";
 }
 
@@ -57,7 +57,7 @@ const CATEGORY_COLORS = [
   "accent5",
   "accent6",
   "accent7",
-];
+] as const;
 
 // Get a consistent color for a category value based on its hash
 export const getCategoryColor = (categoryValue: any, columnName: string) => {

--- a/frontend/src/metabase/ui/components/feedback/Alert/Alert.config.tsx
+++ b/frontend/src/metabase/ui/components/feedback/Alert/Alert.config.tsx
@@ -14,14 +14,12 @@ export const alertOverrides: MantineThemeOverride["components"] = {
       title: AlertStyles.title,
     },
     vars: (_theme, props) => {
-      if (
-        isColorName(props.color) &&
-        isColorName(`background-${props.color}`)
-      ) {
+      const bgColor = `background-${props.color}`;
+      if (isColorName(props.color) && isColorName(bgColor)) {
         return {
           root: {
             "--alert-color": color(props.color),
-            "--alert-bg": color(`background-${props.color}`),
+            "--alert-bg": color(bgColor),
           },
         };
       } else {

--- a/frontend/src/metabase/ui/utils/colors.ts
+++ b/frontend/src/metabase/ui/utils/colors.ts
@@ -60,13 +60,19 @@ export function getThemeColors(
  * @param colorName
  * @returns string referencing a css variable
  */
-export function color(colorName: ColorName | string): string {
-  if (isColorName(colorName)) {
-    return `var(--mb-color-${colorName})`;
-  }
-  return colorName;
+export function color(colorName: ColorName): string {
+  return `var(--mb-color-${colorName})`;
 }
 
 export const isColorName = (name?: string | null): name is ColorName => {
   return !!name && allColorNames.includes(name);
+};
+
+/**
+ * Prefer to use `color()` instead.
+ * Only use `maybeColor()` if you can't be sure you're going to have a `ColorName` as input,
+ * e.g. the value comes from an endpoint, upstream type-checking is too loose, etc.
+ */
+export const maybeColor = (maybeColorName: ColorName | string): string => {
+  return isColorName(maybeColorName) ? color(maybeColorName) : maybeColorName;
 };


### PR DESCRIPTION
### Description

ℹ️  **TLDR** ℹ️ 
Improves type-checking with color function, removes unnecessary .includes() calls

**The why**
We have a color util which is used a lot of places and called a lot of times. It has 2 problems that are easily fixed:

1. **Problem 1:** It doesn't enforce at compile-time that you're passing in a valid color name. So you could pass in like `color("asdf")` and it'd be fine with it, yield invalid css.
2. **Problem 2:** Every time it's called, it checks a big array to see if you passed in a valid color name, even though 99% of the places it's used, we can check that at compile-time.

**The fix**
For the 99% of cases where we can check at compile-time, we remove `| string` from `ColorName | string`, which means we can also remove the includes() call.

For the 1% we can't, we continue to use the type guard, and it works the same as before.

### How to verify

Functionality-wise, nothing should change.

DX-wise, you should get better IDE hints, and `color()` will now complain if you accidentally put in an invalid color name.

<img width="435" height="294" alt="Screenshot 2025-12-16 at 5 19 55 PM" src="https://github.com/user-attachments/assets/d00cba71-73a7-4c57-8b32-8ae3fd9d74c0" />
<br/>
<br/>
<img width="290" height="180" alt="Screenshot 2025-12-16 at 5 17 47 PM" src="https://github.com/user-attachments/assets/e8568b04-d5cd-43da-a9ba-e0db38461d09" />
