### PR TITLE
Fix bad normalization for the `:text` function in MBQL 4

### DIFF
--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -61,7 +61,7 @@
   [:fn
    {:error/message "Valid MBQL clause"
     :decode/normalize normalize-mbql-clause}
-   helpers/mbql-clause?])
+   helpers/normalized-mbql-clause?])
 
 (mr/def ::options-style
   "For convenience of converting back and forth between MBQL 5, from now on we can record info about the options style
@@ -315,7 +315,7 @@
    [:fn
     {:error/message    ":expression should not have empty opts"
      :decode/normalize (fn [x]
-                         (when (helpers/mbql-clause? x)
+                         (when (helpers/possibly-unnormalized-mbql-clause? x)
                            (if (and (= (count x) 3)
                                     (empty? (last x)))
                              (pop (vec x)) ; remove nil/empty options maps.
@@ -357,8 +357,8 @@
 
 (defn- normalize-field [x]
   (case (cond
-          (pos-int? x)             ::raw-int
-          (helpers/mbql-clause? x) (helpers/actual-clause-tag x))
+          (pos-int? x)                                   ::raw-int
+          (helpers/possibly-unnormalized-mbql-clause? x) (helpers/actual-clause-tag x))
     ::raw-int         [:field x nil]
     :field-id         (let [[_tag id] x]
                         ;; sometimes the old FE code was dumb and passed in `:field-literal` wrapped inside` `:field-id`
@@ -442,7 +442,7 @@
    [:fn
     {:error/message    ":aggregation should not have empty opts"
      :decode/normalize (fn [x]
-                         (when (helpers/mbql-clause? x)
+                         (when (helpers/possibly-unnormalized-mbql-clause? x)
                            (if (and (= (count x) 3)
                                     (empty? (last x)))
                              (pop (vec x)) ; remove nil/empty options maps.
@@ -629,7 +629,7 @@
   replacement :string)
 
 (defclause text
-  x :any)
+  x [:ref ::ExpressionArg])
 
 ;; Relax the arg types to ExpressionArg for concat since many DBs allow to concatenate non-string types. This also
 ;; aligns with the corresponding MLv2 schema and with the reference docs we publish.
@@ -1300,9 +1300,9 @@
   "A clause is a valid aggregation if it is an aggregation clause, or it is an expression that transitively contains
   a single aggregation clause.
 
-  (This is mostly copied from [[metabase.lib.schema.aggregation/aggregation-expression?]]"
+  (This is mostly copied from [[metabase.lib.schema.aggregation/aggregation-expression?]])"
   [x]
-  (when (vector? x)
+  (when (helpers/normalized-mbql-clause? x)
     (when-let [[tag & args] x]
       (or (lib.hierarchy/isa? tag ::lib.schema.aggregation/aggregation-clause-tag)
           ;; Case has the following shape [:case [[cond expr]...] default-expr?]
@@ -1330,6 +1330,7 @@
 
 (defclause* aggregation-options
   [:and
+   ;; this schema normalizes the MBQL 3 (?) `:named` clause to `:aggregation-options`
    [:schema
     {:decode/normalize (fn [x]
                          ;; [:named <subclase> <name>] was the MBQL 3 (?) version of `:aggregation-options`
@@ -1341,6 +1342,7 @@
                              [:aggregation-options subclause {(if use-as-display-name? :display-name :name) display-name}])
                            x))}
     :any]
+   ;; this schema is the schema for `:aggregation-options` itself
    (helpers/clause
     :aggregation-options
     "aggregation" [:ref ::UnnamedAggregation]

--- a/src/metabase/legacy_mbql/schema/helpers.cljc
+++ b/src/metabase/legacy_mbql/schema/helpers.cljc
@@ -26,14 +26,18 @@
       (lib.util/format "Schema for a valid MBQL 4 %s clause." clause-name)
       schema)))
 
-(defn mbql-clause?
-  "True if `x` is an MBQL clause (a sequence with a keyword as its first arg).
-
-  Deprecated: Use [[metabase.lib.core/clause?]] going forward."
+(defn possibly-unnormalized-mbql-clause?
+  "True if `x` is a (possibly not-yet-normalized) MBQL 4 clause (a sequence with a keyword as its first arg)."
   [x]
   (and (sequential? x)
        (not (map-entry? x))
        ((some-fn simple-keyword? string?) (first x))))
+
+(defn normalized-mbql-clause?
+  "True if `x` is a **normalized** MBQL 4 clause."
+  [x]
+  (and (vector? x)
+       (simple-keyword? (first x))))
 
 (defn normalize-keyword
   "Like [[lib.schema.common/normalize-keyword]] but also converts the keyword to lower-kebabcase (this is needed in
@@ -43,15 +47,13 @@
   (some-> x lib.schema.common/memoized-kebab-key))
 
 (defn is-clause?
-  "If `x` is an MBQL clause, and an instance of clauses defined by keyword(s) `k-or-ks`?
+  "If `x` is an MBQL 4 clause, and an instance of clauses defined by keyword(s) `k-or-ks`?
 
     (is-clause? :count [:count 10])        ; -> true
-    (is-clause? #{:+ :- :* :/} [:+ 10 20]) ; -> true
-
-  Deprecated: use [[metabase.lib.core/clause-of-type?]] going forward."
+    (is-clause? #{:+ :- :* :/} [:+ 10 20]) ; -> true"
   [k-or-ks x]
   (and
-   (mbql-clause? x)
+   (possibly-unnormalized-mbql-clause? x)
    (let [k (normalize-keyword (first x))]
      (if (coll? k-or-ks)
        ((set k-or-ks) k)
@@ -94,7 +96,7 @@
   "Actual tag of the clause, even if it's one of the MBQL 3 tags removed in MBQL 4. In most cases you want to
   use [[effective-clause-tag]] instead."
   [a-clause]
-  (when (mbql-clause? a-clause)
+  (when (possibly-unnormalized-mbql-clause? a-clause)
     (normalize-keyword (first a-clause))))
 
 (defn effective-clause-tag

--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -41,7 +41,7 @@
 
 ;;; TODO (Cam 9/8/25) -- overlapping functionality with [[metabase.lib.schema.common/is-clause?]]
 (defn clause?
-  "Returns true if this is a clause."
+  "Returns true if this is a **normalized** MBQL 5 clause."
   [clause]
   (and (vector? clause)
        (keyword? (first clause))

--- a/test/metabase/legacy_mbql/schema_test.cljc
+++ b/test/metabase/legacy_mbql/schema_test.cljc
@@ -351,3 +351,76 @@
            "dimension"    ["field" 298221 nil]
            "widget-type"  "category/="
            "default"      nil}))))
+
+(deftest ^:parallel normalize-text-clause-test
+  (is (= [:text
+          [:floor
+           [:/ [:avg [:field 11476 {:base-type :type/Integer}]] 60]]]
+         (lib/normalize ::mbql.s/ExpressionArg ["text" ["floor" ["/" ["avg" ["field" 11476 {"base-type" "type/Integer"}]] 60]]]))))
+
+(deftest ^:parallel normalize-hairball-aggregation-expression-test
+  (let [expr ["aggregation-options"
+              ["concat"
+               ["text" ["floor" ["/" ["avg" ["field" 11476 {"base-type" "type/Integer"}]] 60]]]
+               ":"
+               ["substring"
+                ["concat"
+                 "0"
+                 ["text"
+                  ["floor"
+                   ["-"
+                    ["avg" ["field" 11476 {"base-type" "type/Integer"}]]
+                    ["*" ["floor" ["/" ["avg" ["field" 11476 {"base-type" "type/Integer"}]] 60]] 60]]]]]
+                ["-"
+                 ["+"
+                  1
+                  ["length"
+                   ["concat"
+                    "0"
+                    ["text"
+                     ["floor"
+                      ["-"
+                       ["avg" ["field" 11476 {"base-type" "type/Integer"}]]
+                       ["*" ["floor" ["/" ["avg" ["field" 11476 {"base-type" "type/Integer"}]] 60]] 60]]]]]]]
+                 2]
+                2]]
+              {"name" "Min+sec", "display-name" "Min+sec"}]
+        normalized (lib/normalize ::mbql.s/Aggregation expr)]
+    (is (= [:aggregation-options
+            [:concat
+             [:text
+              [:floor
+               [:/ [:avg [:field 11476 {:base-type :type/Integer}]] 60]]]
+             ":"
+             [:substring
+              [:concat
+               "0"
+               [:text
+                [:floor
+                 [:-
+                  [:avg [:field 11476 {:base-type :type/Integer}]]
+                  [:*
+                   [:floor
+                    [:/ [:avg [:field 11476 {:base-type :type/Integer}]] 60]]
+                   60]]]]]
+              [:-
+               [:+
+                1
+                [:length
+                 [:concat
+                  "0"
+                  [:text
+                   [:floor
+                    [:-
+                     [:avg [:field 11476 {:base-type :type/Integer}]]
+                     [:*
+                      [:floor
+                       [:/
+                        [:avg [:field 11476 {:base-type :type/Integer}]]
+                        60]]
+                      60]]]]]]]
+               2]
+              2]]
+            {:name "Min+sec", :display-name "Min+sec"}]
+           normalized))
+    (is (mr/validate ::mbql.s/Aggregation normalized))))


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/67027