### PR TITLE
Hide external collections sidebar for internal users without tenant collection accesses

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/MainNavSharedCollections/MainNavSharedCollections.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/MainNavSharedCollections/MainNavSharedCollections.unit.spec.tsx
@@ -21,13 +21,33 @@ const setup = ({
   isAdmin = false,
   tenantCollections = MOCK_TENANT_COLLECTIONS,
   currentUser = createMockUser({ is_superuser: isAdmin }),
+  rootCollectionCanWrite = false,
 }: {
   isAdmin?: boolean;
   tenantCollections?: Collection[];
   currentUser?: ReturnType<typeof createMockUser>;
+  rootCollectionCanWrite?: boolean;
 } = {}) => {
   const settings = mockSettings({ "use-tenants": true });
   setupCollectionsEndpoints({ collections: tenantCollections });
+
+  // Mock the root shared collection endpoint
+  fetchMock.get(
+    "path:/api/collection/root",
+    (url) => {
+      const urlObj = new URL(url, "http://localhost");
+      if (urlObj.searchParams.get("namespace") === "shared-tenant-collection") {
+        return createMockCollection({
+          id: "root",
+          name: "Root shared collection",
+          namespace: "shared-tenant-collection",
+          can_write: rootCollectionCanWrite,
+        });
+      }
+      return 404;
+    },
+    { overwriteRoutes: false },
+  );
 
   renderWithProviders(<MainNavSharedCollections />, {
     storeInitialState: createMockState({ settings, currentUser }),
@@ -81,8 +101,42 @@ describe("MainNavSharedCollections > section visibility", () => {
     // Tree endpoint returns an empty array as it is filtered by permissions
     fetchMock.get("path:/api/collection/tree", () => []);
 
+    // Root collection endpoint - user cannot write
+    fetchMock.get("path:/api/collection/root", (url) => {
+      const urlObj = new URL(url, "http://localhost");
+      if (urlObj.searchParams.get("namespace") === "shared-tenant-collection") {
+        return createMockCollection({
+          id: "root",
+          name: "Root shared collection",
+          namespace: "shared-tenant-collection",
+          can_write: false,
+        });
+      }
+      return 404;
+    });
+
     renderWithProviders(<MainNavSharedCollections />, {
       storeInitialState: createMockState({ settings, currentUser }),
+    });
+
+    expect(screen.queryByText("External collections")).not.toBeInTheDocument();
+  });
+
+  it("shows the section for non-admins when they can create shared collections (curate permission on root tenant collection)", async () => {
+    setup({
+      isAdmin: false,
+      tenantCollections: [],
+      rootCollectionCanWrite: true,
+    });
+
+    expect(await screen.findByText("External collections")).toBeInTheDocument();
+  });
+
+  it("hides the section for non-admins when they cannot create shared collections and have no visible collections", () => {
+    setup({
+      isAdmin: false,
+      tenantCollections: [],
+      rootCollectionCanWrite: false,
     });
 
     expect(screen.queryByText("External collections")).not.toBeInTheDocument();


### PR DESCRIPTION
Closes EMB-1133

### Description

Hides the "External Collections" sidebar section only if they don't have access to any shared collections and also don't have curate permissions on root tenant collection (i.e. they can't create shared collections).

### How to verify

- Enable tenants.
- Create a shared collection
- Go to "Settings > Permissions > Tenant Collections"
- Create a non-admin internal user
- On **another browser**, login as a non-admin user, and assign that user to a group. You can create one if you haven't already.
- Setting "curate" permissions on "Root shared collection" should enable the plus icon on the non-admin user
- Setting "view" permission on the shared collection should show the "External collections" section
- Setting "no access" permission on the shared collection should hide the "External collections" section

### Demo

This is how you set the curate permission on root shared collections:

<img width="500" src="https://github.com/user-attachments/assets/7fff7e78-ced3-4210-a343-9813b6c80d79" />

Without the curate permission on root shared collection:

<img width="500" src="https://github.com/user-attachments/assets/683238f9-fef5-4bd0-9731-6f46728bf897" />

With the curate permission on root shared collection:

<img width="500" src="https://github.com/user-attachments/assets/ee5bea32-cda1-4469-93b7-e5ac2f4f3fb2" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
