### PR TITLE
Hide authority level picker in new shared collection modal

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/MainNavSharedCollections/MainNavSharedCollections.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/MainNavSharedCollections/MainNavSharedCollections.tsx
@@ -154,6 +154,7 @@ export const MainNavSharedCollections = () => {
       >
         <CreateCollectionForm
           showCollectionPicker={false}
+          showAuthorityLevelPicker={false}
           onSubmit={handleCreateTenantCollection}
         />
       </Modal>

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/MainNavSharedCollections/MainNavSharedCollections.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/MainNavSharedCollections/MainNavSharedCollections.unit.spec.tsx
@@ -52,6 +52,25 @@ describe("MainNavSharedCollections > create shared tenant collection button", ()
   });
 });
 
+describe("MainNavSharedCollections > new shared collection modal", () => {
+  it("hides the authority level picker when creating a shared tenant collection", async () => {
+    setup({ isAdmin: true });
+    await screen.findByText("External collections");
+
+    const addButton = screen.getByRole("button", { name: /add/i });
+    addButton.click();
+
+    expect(
+      await screen.findByText("New shared collection"),
+    ).toBeInTheDocument();
+
+    // Assert that the Collection type field is not present
+    expect(screen.queryByText(/Collection type/i)).not.toBeInTheDocument();
+    expect(screen.queryByText("Regular")).not.toBeInTheDocument();
+    expect(screen.queryByText("Official")).not.toBeInTheDocument();
+  });
+});
+
 describe("MainNavSharedCollections > section visibility", () => {
   it("shows the section for admins when there are no collections", async () => {
     setup({ isAdmin: true, tenantCollections: [] });

--- a/frontend/src/metabase/collections/components/CreateCollectionForm/CreateCollectionForm.tsx
+++ b/frontend/src/metabase/collections/components/CreateCollectionForm/CreateCollectionForm.tsx
@@ -45,6 +45,7 @@ export interface CreateCollectionFormOwnProps {
   onCancel?: () => void;
   filterPersonalCollections?: FilterItemsInPersonalCollection;
   showCollectionPicker?: boolean;
+  showAuthorityLevelPicker?: boolean;
 }
 
 interface CreateCollectionFormStateProps {
@@ -83,6 +84,7 @@ function CreateCollectionForm({
   onCancel,
   filterPersonalCollections,
   showCollectionPicker = true,
+  showAuthorityLevelPicker = true,
 }: Props) {
   const initialValues = useMemo(
     () => ({
@@ -125,7 +127,7 @@ function CreateCollectionForm({
               savingModel="collection"
             />
           )}
-          <FormAuthorityLevelField />
+          {showAuthorityLevelPicker && <FormAuthorityLevelField />}
           <FormFooter>
             <FormErrorMessage inline />
             {!!onCancel && (

--- a/frontend/src/metabase/collections/components/CreateCollectionForm/tests/premium.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CreateCollectionForm/tests/premium.unit.spec.tsx
@@ -27,4 +27,11 @@ describe("CreateCollectionForm", () => {
     setupPremium({ user: createMockUser({ is_superuser: false }) });
     expect(screen.queryByText("Collection type")).not.toBeInTheDocument();
   });
+
+  it("does not show authority level controls when showAuthorityLevelPicker is false", () => {
+    setupPremium({ showAuthorityLevelPicker: false });
+    expect(screen.queryByText("Collection type")).not.toBeInTheDocument();
+    expect(screen.queryByText("Regular")).not.toBeInTheDocument();
+    expect(screen.queryByText("Official")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/metabase/collections/components/CreateCollectionForm/tests/setup.tsx
+++ b/frontend/src/metabase/collections/components/CreateCollectionForm/tests/setup.tsx
@@ -24,12 +24,14 @@ export interface SetupOpts {
   user?: User;
   tokenFeatures?: TokenFeatures;
   hasEnterprisePlugins?: boolean;
+  showAuthorityLevelPicker?: boolean;
 }
 
 export const setup = ({
   user = createMockUser({ is_superuser: true }),
   tokenFeatures = createMockTokenFeatures(),
   hasEnterprisePlugins = false,
+  showAuthorityLevelPicker,
 }: SetupOpts = {}) => {
   const settings = mockSettings({ "token-features": tokenFeatures });
   const onCancel = jest.fn();
@@ -41,15 +43,21 @@ export const setup = ({
     collections: [],
     rootCollection: ROOT_COLLECTION,
   });
-  renderWithProviders(<CreateCollectionForm onCancel={onCancel} />, {
-    storeInitialState: createMockState({
-      currentUser: user,
-      settings,
-      entities: createMockEntitiesState({
-        collections: [ROOT_COLLECTION],
+  renderWithProviders(
+    <CreateCollectionForm
+      onCancel={onCancel}
+      showAuthorityLevelPicker={showAuthorityLevelPicker}
+    />,
+    {
+      storeInitialState: createMockState({
+        currentUser: user,
+        settings,
+        entities: createMockEntitiesState({
+          collections: [ROOT_COLLECTION],
+        }),
       }),
-    }),
-  });
+    },
+  );
 
   return { onCancel };
 };


### PR DESCRIPTION
Closes EMB-1131

### Description

Hides the collection type picker (regular/official) when creating shared tenant collections in the modal.

### How to verify

- Enable tenants
- Click the add button "Create a shared collection" in the external collection sidebar
- You should not see collection type picker there

### Demo

<img width="1394" height="928" alt="CleanShot 2568-12-17 at 02 49 41@2x" src="https://github.com/user-attachments/assets/763a9edc-03be-45d9-97b6-e36fdce211ff" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
