### PR TITLE
Use sentence case for people tab pages in admin settings

### DIFF
--- a/e2e/test/scenarios/admin-2/tenants.cy.spec.ts
+++ b/e2e/test/scenarios/admin-2/tenants.cy.spec.ts
@@ -287,9 +287,7 @@ describe("Tenants - management", () => {
     });
 
     cy.findByRole("navigation", { name: "people-nav" })
-      .findAllByRole("link", { name: /Groups/ })
-      .should("have.length", 2)
-      .first()
+      .findByRole("link", { name: /Internal groups/ })
       .click();
 
     cy.findByTestId("admin-content-table").within(() => {

--- a/e2e/test/scenarios/admin-2/tenants.cy.spec.ts
+++ b/e2e/test/scenarios/admin-2/tenants.cy.spec.ts
@@ -300,7 +300,7 @@ describe("Tenants - management", () => {
     });
 
     cy.findByRole("navigation", { name: "people-nav" })
-      .findAllByRole("link", { name: /Tenant Groups/ })
+      .findAllByRole("link", { name: /Tenant groups/ })
       .click();
 
     cy.findByTestId("admin-content-table").within(() => {
@@ -768,14 +768,14 @@ describe("tenant users", () => {
     H.popover().findByText("Edit user").click();
 
     H.modal().within(() => {
-      cy.findByText("Tenant Groups");
+      cy.findByText("Tenant groups");
       cy.findByText("All tenant users").click();
     });
 
     H.popover().findByText(GROUP_NAME).click();
 
     H.modal().within(() => {
-      cy.findByText("Tenant Groups").click(); // trigger blur
+      cy.findByText("Tenant groups").click(); // trigger blur
       cy.findByText("2 other groups").should("be.visible");
       cy.button("Update").click();
     });
@@ -802,7 +802,7 @@ describe("tenant users", () => {
     H.popover().findByText(GROUP_NAME).click();
 
     H.modal().within(() => {
-      cy.findByText("Tenant Groups").click(); // trigger blur
+      cy.findByText("Tenant groups").click(); // trigger blur
       cy.findByText("2 other groups").should("be.visible");
       cy.button("Create").click();
     });
@@ -917,11 +917,11 @@ const createTenantGroupFromUI = (groupName: string) => {
 
   // FIXME shouldn't be necessary - caused by slow route guard
   cy.findByTestId("admin-layout-sidebar")
-    .findByText(/Tenant Groups/)
+    .findByText(/Tenant groups/)
     .click();
 
   cy.findByTestId("admin-layout-content")
-    .findByRole("heading", { name: /Tenant Groups/ })
+    .findByRole("heading", { name: /Tenant groups/ })
     .should("be.visible");
 
   cy.button("Create a group").click();

--- a/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
@@ -281,7 +281,7 @@ describe("scenarios - embedding hub", () => {
 
       cy.log("the internal prefix should show up on the page");
       H.main()
-        .findAllByText("Internal Users")
+        .findAllByText("Internal users")
         .should("have.length", 2)
         .should("be.visible");
 

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/ExternalGroupDetailApp/ExternalGroupDetailApp.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/ExternalGroupDetailApp/ExternalGroupDetailApp.tsx
@@ -5,5 +5,5 @@ import { GroupDetailApp } from "metabase/admin/people/containers/GroupDetailApp"
 export const ExternalGroupDetailApp = (props: {
   params: { groupId: number };
 }) => {
-  return <GroupDetailApp title={t`Tenant Groups`} {...props} />;
+  return <GroupDetailApp title={t`Tenant groups`} {...props} />;
 };

--- a/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
@@ -241,7 +241,7 @@ export function initializePlugin() {
     };
 
     PLUGIN_TENANTS.getFormGroupsTitle = (isExternal: boolean) => {
-      return isExternal ? t`Tenant Groups` : null;
+      return isExternal ? t`Tenant groups` : null;
     };
 
     // Category 2: Collection namespace utilities

--- a/frontend/src/metabase/admin/people/components/PeopleNav.tsx
+++ b/frontend/src/metabase/admin/people/components/PeopleNav.tsx
@@ -22,13 +22,13 @@ export function PeopleNav() {
         <PeopleNavItem
           path="/admin/people"
           data-testid="nav-item"
-          label={isUsingTenants ? t`Internal Users` : t`People`}
+          label={isUsingTenants ? t`Internal users` : t`People`}
           icon="person"
         />
         <PeopleNavItem
           path="/admin/people/groups"
           data-testid="nav-item"
-          label={isUsingTenants ? t`Internal Groups` : t`Groups`}
+          label={isUsingTenants ? t`Internal groups` : t`Groups`}
           icon="group"
         />
         {isUsingTenants && (
@@ -43,7 +43,7 @@ export function PeopleNav() {
             <PeopleNavItem
               path="/admin/tenants/groups"
               data-testid="nav-item-tenant-groups"
-              label={t`Tenant Groups`}
+              label={t`Tenant groups`}
               icon="group"
             />
             <PeopleNavItem

--- a/frontend/src/metabase/admin/people/containers/AdminPeopleApp/AdminPeopleApp.unit.spec.tsx
+++ b/frontend/src/metabase/admin/people/containers/AdminPeopleApp/AdminPeopleApp.unit.spec.tsx
@@ -64,8 +64,8 @@ describe("AdminPeopleApp", () => {
     it("should render both internal and external people links if tenants is enabled", async () => {
       await setup({ useTenants: true });
 
-      assertNavLink("Internal Users", "/admin/people");
-      assertNavLink("Internal Groups", "/admin/people/groups");
+      assertNavLink("Internal users", "/admin/people");
+      assertNavLink("Internal groups", "/admin/people/groups");
       assertNavLink("Tenants", "/admin/tenants");
       assertNavLink("Tenant users", "/admin/tenants/people");
     });

--- a/frontend/src/metabase/admin/people/containers/GroupsListingApp.tsx
+++ b/frontend/src/metabase/admin/people/containers/GroupsListingApp.tsx
@@ -72,7 +72,7 @@ export const GroupsListingApp = ({
       return t`Groups`;
     }
 
-    return external ? t`Tenant Groups` : t`Internal Groups`;
+    return external ? t`Tenant groups` : t`Internal groups`;
   }, [external, isUsingTenants]);
 
   return (

--- a/frontend/src/metabase/admin/people/containers/PeopleListingApp/PeopleListingApp.tsx
+++ b/frontend/src/metabase/admin/people/containers/PeopleListingApp/PeopleListingApp.tsx
@@ -93,7 +93,7 @@ export function PeopleListingApp({
       return t`People`;
     }
 
-    return external ? t`Tenant users` : t`Internal Users`;
+    return external ? t`Tenant users` : t`Internal users`;
   }, [external, isUsingTenants]);
 
   return (

--- a/frontend/src/metabase/admin/people/containers/PeopleListingApp/PeopleListingApp.unit.spec.tsx
+++ b/frontend/src/metabase/admin/people/containers/PeopleListingApp/PeopleListingApp.unit.spec.tsx
@@ -85,11 +85,11 @@ describe("page title", () => {
     ).toBeInTheDocument();
   });
 
-  it("should show 'Internal Users' when tenants is enabled and viewing internal users", async () => {
+  it("should show 'Internal users' when tenants is enabled and viewing internal users", async () => {
     setup({ useTenants: true, external: false });
 
     expect(
-      await screen.findByRole("heading", { name: "Internal Users", level: 1 }),
+      await screen.findByRole("heading", { name: "Internal users", level: 1 }),
     ).toBeInTheDocument();
   });
 


### PR DESCRIPTION
Updates the admin settings navigation and page title within the "People" tab to use sentence cases.

<img width="486" height="486" alt="CleanShot 2568-12-17 at 03 12 06@2x" src="https://github.com/user-attachments/assets/644089bf-11cc-424e-a18c-8f0bfa1308f9" />
