### PR TITLE
feat(sdk): resolve tenant collection in collection browser

### DIFF
--- a/frontend/src/embedding-sdk-bundle/components/public/CollectionBrowser/CollectionBrowser.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/CollectionBrowser/CollectionBrowser.tsx
@@ -65,7 +65,7 @@ const ENTITY_NAME_MAP: Partial<
  */
 export type CollectionBrowserProps = {
   /**
-   * The numerical ID of the collection, "personal" for the user's personal collection, or "root" for the root collection. You can find this ID in the URL when accessing a collection in your Metabase instance. For example, the collection ID in `http://localhost:3000/collection/1-my-collection` would be `1`. Defaults to "personal"
+   * The numerical ID of the collection, "personal" for the user's personal collection, "tenant" for the user's tenant collection, or "root" for the root collection. You can find this ID in the URL when accessing a collection in your Metabase instance. For example, the collection ID in `http://localhost:3000/collection/1-my-collection` would be `1`. Defaults to "personal"
    */
   collectionId?: SdkCollectionId;
 

--- a/frontend/src/embedding-sdk-bundle/components/public/CollectionBrowser/CollectionBrowser.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/CollectionBrowser/CollectionBrowser.unit.spec.tsx
@@ -157,7 +157,7 @@ describe("CollectionBrowser", () => {
   it("should resolve collectionId=tenant to user's tenant collection", async () => {
     const tenantCollection = createMockCollection({
       id: 999,
-      name: "Tenant Collection Root",
+      name: "Tenant Collection: Acme Inc",
       archived: false,
       can_write: true,
       description: null,

--- a/frontend/src/embedding-sdk-bundle/store/collections.ts
+++ b/frontend/src/embedding-sdk-bundle/store/collections.ts
@@ -26,7 +26,15 @@ export const getCollectionIdValueFromReference = createSelector(
   ): CollectionId | null => {
     return match(collectionReference)
       .with("personal", () => personalCollectionId as RegularCollectionId)
-      .with("tenant", () => tenantCollectionId as RegularCollectionId)
+      .with("tenant", () => {
+        if (!tenantCollectionId) {
+          throw new Error(
+            "You must be a tenant member to access the tenant collection.",
+          );
+        }
+
+        return tenantCollectionId as RegularCollectionId;
+      })
       .with("root", () => null)
       .with(P.union(P.number, P.string), (id) => id)
       .otherwise(() => {
@@ -56,7 +64,15 @@ export const getCollectionIdSlugFromReference = createSelector(
   ): CollectionId => {
     return match(collectionReference)
       .with("personal", () => personalCollectionId as RegularCollectionId)
-      .with("tenant", () => tenantCollectionId as RegularCollectionId)
+      .with("tenant", () => {
+        if (!tenantCollectionId) {
+          throw new Error(
+            "You must be a tenant member to access the tenant collection.",
+          );
+        }
+
+        return tenantCollectionId as RegularCollectionId;
+      })
       .with("root", () => "root" as const)
       .with(P.union(P.number, P.string), (id) => id)
       .otherwise(() => {

--- a/frontend/src/embedding-sdk-bundle/store/collections.ts
+++ b/frontend/src/embedding-sdk-bundle/store/collections.ts
@@ -1,28 +1,37 @@
 import { createSelector } from "@reduxjs/toolkit";
 import { P, match } from "ts-pattern";
 
-import { getUserPersonalCollectionId } from "metabase/selectors/user";
+import {
+  getUserPersonalCollectionId,
+  getUserTenantCollectionId,
+} from "metabase/selectors/user";
 import type { CollectionId, RegularCollectionId } from "metabase-types/api";
 
 import type { SdkCollectionId } from "../types/collection";
 
 /**
- * Converts "personal" and "root" to the ids accepted by the api
+ * Converts "personal", "tenant", and "root" to the ids accepted by the api
  * For the root collection id, the API expects null.
  */
 export const getCollectionIdValueFromReference = createSelector(
   [
     getUserPersonalCollectionId,
+    getUserTenantCollectionId,
     (_, collectionReference: SdkCollectionId) => collectionReference,
   ],
-  (personalCollectionId, collectionReference): CollectionId | null => {
+  (
+    personalCollectionId,
+    tenantCollectionId,
+    collectionReference,
+  ): CollectionId | null => {
     return match(collectionReference)
       .with("personal", () => personalCollectionId as RegularCollectionId)
+      .with("tenant", () => tenantCollectionId as RegularCollectionId)
       .with("root", () => null)
       .with(P.union(P.number, P.string), (id) => id)
       .otherwise(() => {
         throw new Error(
-          "Invalid collection id, expected `number | string | 'root' | 'personal'`",
+          "Invalid collection id, expected `number | string | 'root' | 'personal' | 'tenant'`",
         );
       });
   },
@@ -37,16 +46,22 @@ export const getCollectionIdValueFromReference = createSelector(
 export const getCollectionIdSlugFromReference = createSelector(
   [
     getUserPersonalCollectionId,
+    getUserTenantCollectionId,
     (_, collectionReference: SdkCollectionId) => collectionReference,
   ],
-  (personalCollectionId, collectionReference): CollectionId => {
+  (
+    personalCollectionId,
+    tenantCollectionId,
+    collectionReference,
+  ): CollectionId => {
     return match(collectionReference)
       .with("personal", () => personalCollectionId as RegularCollectionId)
+      .with("tenant", () => tenantCollectionId as RegularCollectionId)
       .with("root", () => "root" as const)
       .with(P.union(P.number, P.string), (id) => id)
       .otherwise(() => {
         throw new Error(
-          "Invalid collection id, expected `number | string | 'root' | 'personal'`",
+          "Invalid collection id, expected `number | string | 'root' | 'personal' | 'tenant'`",
         );
       });
   },

--- a/frontend/src/embedding-sdk-bundle/types/collection.ts
+++ b/frontend/src/embedding-sdk-bundle/types/collection.ts
@@ -5,7 +5,12 @@ import type { SdkEntityId } from "./entity";
 // "CollectionId" from core app also includes "root" | "users" and "trash", we don't want to include those
 // in public apis of the sdk, as we don't support them
 
-export type SdkCollectionId = number | "personal" | "root" | SdkEntityId;
+export type SdkCollectionId =
+  | number
+  | "personal"
+  | "root"
+  | "tenant"
+  | SdkEntityId;
 
 /**
  * The Collection entity

--- a/frontend/src/metabase/selectors/user.ts
+++ b/frontend/src/metabase/selectors/user.ts
@@ -40,6 +40,11 @@ export const getUserPersonalCollectionId = createSelector(
   (user) => user?.personal_collection_id,
 );
 
+export const getUserTenantCollectionId = createSelector(
+  [getUser],
+  (user) => user?.tenant_collection_id,
+);
+
 export const canUserCreateQueries = createSelector(
   [getUser],
   (user) => user?.permissions?.can_create_queries ?? false,


### PR DESCRIPTION
Closes EMB-1081

### Description

Adds the ability to specify `<CollectionBrowser collectionId="tenant" />` in React SDK, or `<metabase-browser initial-collection="tenant"></metabase-browser>` for EAJS which resolves to the user's tenant collection id.

### How to verify

- Enable tenants
- Make sure at least 1 tenant is created
- Log in the React SDK or EAJS as a tenant user
- Add some content to that tenant's collection
- Display `<CollectionBrowser collectionId="tenant" />`
- It should load the user's tenant collection and show the expected content

### Demo

<img width="1296" height="844" alt="CleanShot 2568-12-17 at 03 54 28@2x" src="https://github.com/user-attachments/assets/9ebb3e96-6f87-4d2b-920d-cadb51cf9728" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
