### PR TITLE
Metabot NLQ collection picker

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/metabot.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/metabot.clj
@@ -48,8 +48,7 @@
                        [:collection_id {:optional true} [:maybe pos-int?]]]]
   (api/check-superuser)
   (api/check-404 (t2/exists? :model/Metabot :id id))
-  (let [old-metabot (t2/select-one :model/Metabot :id id)
-        metabot-field-updates (dissoc metabot-updates :use_cases)]
+  (let [old-metabot (t2/select-one :model/Metabot :id id)]
     ;; Prevent enabling verified content without the premium feature
     (when (:use_verified_content metabot-updates)
       (premium-features/assert-has-feature :content-verification (tru "Content verification")))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/metabot.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/metabot.clj
@@ -1,7 +1,6 @@
 (ns metabase-enterprise.metabot-v3.api.metabot
   "`/api/ee/metabot-v3/metabot` routes"
   (:require
-   [metabase-enterprise.metabot-v3.config :as metabot-v3.config]
    [metabase-enterprise.metabot-v3.suggested-prompts :as metabot-v3.suggested-prompts]
    [metabase-enterprise.metabot-v3.tools.util :as metabot-v3.tools.u]
    [metabase.api.common :as api]
@@ -49,12 +48,8 @@
                        [:collection_id {:optional true} [:maybe pos-int?]]]]
   (api/check-superuser)
   (api/check-404 (t2/exists? :model/Metabot :id id))
-  (let [old-metabot (t2/select-one :model/Metabot :id id)]
-    ;; Prevent updating collection_id on the primary metabot instance
-    (when (and (contains? metabot-updates :collection_id)
-               (= (:entity_id old-metabot)
-                  (get-in metabot-v3.config/metabot-config [metabot-v3.config/internal-metabot-id :entity-id])))
-      (api/check-400 false "Cannot update collection_id for the primary metabot instance."))
+  (let [old-metabot (t2/select-one :model/Metabot :id id)
+        metabot-field-updates (dissoc metabot-updates :use_cases)]
     ;; Prevent enabling verified content without the premium feature
     (when (:use_verified_content metabot-updates)
       (premium-features/assert-has-feature :content-verification (tru "Content verification")))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/metabot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/metabot_test.clj
@@ -274,24 +274,7 @@
                                                    (format "ee/metabot-v3/metabot/%d" metabot-id)
                                                    {:use_verified_content true}))))))
 
-        (testing "should prevent updating collection_id on primary metabot instance"
-          (let [metabot-id (metabot-v3.config/normalize-metabot-id metabot-v3.config/internal-metabot-id)]
-            (is (= "Cannot update collection_id for the primary metabot instance."
-                   (mt/user-http-request :crowberto :put 400
-
-                                         (format "ee/metabot-v3/metabot/%d" metabot-id)
-                                         {:collection_id collection-id-1})))
-            ;; Verify the collection_id was not updated
-            (let [unchanged-metabot (t2/select-one :model/Metabot :id metabot-id)]
-              (is (= nil (:collection_id unchanged-metabot))))
-
-            ;; Verify that updating other fields still works
-            (with-redefs [metabot-v3.suggested-prompts/generate-sample-prompts (constantly nil)]
-              (let [response (mt/user-http-request :crowberto :put 200
-                                                   (format "ee/metabot-v3/metabot/%d" metabot-id)
-                                                   {:use_verified_content true})]
-                (is (true? (:use_verified_content response)))
-                (is (= nil (:collection_id response)))))))))))
+))))))))
 
 (deftest metabot-prompt-regeneration-on-config-change-test
   (mt/dataset test-data

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/metabot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/metabot_test.clj
@@ -3,7 +3,6 @@
    [clojure.set :as set]
    [clojure.test :refer :all]
    [metabase-enterprise.metabot-v3.client :as metabot-v3.client]
-   [metabase-enterprise.metabot-v3.config :as metabot-v3.config]
    [metabase-enterprise.metabot-v3.suggested-prompts :as metabot-v3.suggested-prompts]
    [metabase.collections.models.collection :as collection]
    [metabase.lib.core :as lib]

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/metabot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/metabot_test.clj
@@ -272,9 +272,7 @@
             (is (= "Content verification is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/"
                    (:message (mt/user-http-request :crowberto :put 402
                                                    (format "ee/metabot-v3/metabot/%d" metabot-id)
-                                                   {:use_verified_content true}))))))
-
-))))))))
+                                                   {:use_verified_content true}))))))))))
 
 (deftest metabot-prompt-regeneration-on-config-change-test
   (mt/dataset test-data

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/client_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/client_test.clj
@@ -115,7 +115,7 @@
         metabot-eid (get-in metabot-v3.config/metabot-config [metabot-v3.config/internal-metabot-id
                                                               :entity-id])]
     ;; Ensure internal metabot is set to the root collection for generating prompts
-    (t2/update! :model/Metabot {:collection_id nil} :entity_id metabot-eid)
+    (t2/update! :model/Metabot :entity_id metabot-eid {:collection_id nil})
     (mt/with-temp [:model/Card c {:type :metric
                                   :dataset_query (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
                                                      (lib/aggregate

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/client_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/client_test.clj
@@ -123,26 +123,26 @@
                                                        (lib/aggregate
                                                         (lib/count (lib.metadata/field mp (mt/id :orders :total)))))
                                     ;; Set large view count to ensure metric is picked in `generate-sample-prompts`.
-                                    :view_count 1000}])
-      ;; Add column with type/* to metric result_metadata
-      (t2/update! :model/Card :id (:id c)
-                  {:result_metadata (conj (:result_metadata (t2/select-one :model/Card :id (:id c)))
-                                          {:database_type "point"
-                                           :base_type :type/*
-                                           :effective_type :type/*
-                                           :name "dummy"})})
-      (testing "No exception is thrown when type/* column is present it result_metadata"
-        (is (= :not-thrown
-               (try
-                 ;; Override calls to ai service as we are interested in no exception being thrown
-                 ;; prior to those calls.
-                 (with-redefs [metabot-v3.client/post! (constantly {:status 200
-                                                                    :body {:table_questions []
-                                                                           :metric_questions []}})]
-                   (let [metabot-id (t2/select-one-fn :id :model/Metabot :entity_id metabot-eid)]
-                     (metabot-v3.suggested-prompts/generate-sample-prompts metabot-id)
-                     :not-thrown))
-                 (catch Exception e
-                   e)))))
+                                    :view_count 1000}]
+        ;; Add column with type/* to metric result_metadata
+        (t2/update! :model/Card :id (:id c)
+                    {:result_metadata (conj (:result_metadata (t2/select-one :model/Card :id (:id c)))
+                                            {:database_type "point"
+                                             :base_type :type/*
+                                             :effective_type :type/*
+                                             :name "dummy"})})
+        (testing "No exception is thrown when type/* column is present it result_metadata"
+          (is (= :not-thrown
+                 (try
+                   ;; Override calls to ai service as we are interested in no exception being thrown
+                   ;; prior to those calls.
+                   (with-redefs [metabot-v3.client/post! (constantly {:status 200
+                                                                      :body {:table_questions []
+                                                                             :metric_questions []}})]
+                     (let [metabot-id (t2/select-one-fn :id :model/Metabot :entity_id metabot-eid)]
+                       (metabot-v3.suggested-prompts/generate-sample-prompts metabot-id)
+                       :not-thrown))
+                   (catch Exception e
+                     e))))))
       (finally
         (t2/update! :model/Metabot :entity_id metabot-eid {:collection_id original-collection-id})))))

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminPage.tsx
@@ -93,9 +93,14 @@ export function MetabotAdminPage() {
 
           <MetabotVerifiedContentConfigurationPane metabot={metabot} />
 
-          {isEmbedMetabot && (
-            <MetabotCollectionConfigurationPane metabot={metabot} />
-          )}
+          <MetabotCollectionConfigurationPane
+            metabot={metabot}
+            title={
+              isEmbedMetabot
+                ? undefined
+                : t`Collection for natural language querying`
+            }
+          />
 
           <MetabotPromptSuggestionPane metabot={metabot} />
         </SettingsSection>
@@ -186,8 +191,10 @@ function MetabotVerifiedContentConfigurationPane({
 
 function MetabotCollectionConfigurationPane({
   metabot,
+  title,
 }: {
   metabot: MetabotInfo;
+  title?: string;
 }) {
   const metabotId = metabot.id;
   const metabotName = metabot.name;
@@ -230,13 +237,12 @@ function MetabotCollectionConfigurationPane({
     }
   };
 
+  const defaultTitle = c("{0} is the name of an AI assistant")
+    .t`Collection ${metabotName} can use`;
+
   return (
     <Box>
-      <SettingHeader
-        id="allow-metabot"
-        title={c("{0} is the name of an AI assistant")
-          .t`Collection ${metabotName} can use`}
-      />
+      <SettingHeader id="allow-metabot" title={title ?? defaultTitle} />
       <CollectionInfo collection={collection} />
       <Flex gap="md" mt="md">
         <Button onClick={open} leftSection={isUpdating && <Loader size="xs" />}>

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminPage.unit.spec.tsx
@@ -130,12 +130,12 @@ describe("MetabotAdminPage", () => {
     expect(screen.getByText("Embedded Metabot")).toBeInTheDocument();
   });
 
-  it("should not be able to select a collection for default metabot", async () => {
+  it("should show collection picker for default metabot with NLQ title", async () => {
     await setup();
     expect(await screen.findByText("Configure Metabot")).toBeInTheDocument();
     expect(
-      screen.queryByText("Collection Metabot can use"),
-    ).not.toBeInTheDocument();
+      screen.getByText("Collection for natural language querying"),
+    ).toBeInTheDocument();
   });
 
   it("should render a selected collection for embedded metabot", async () => {

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.ts
@@ -1,9 +1,7 @@
 import { createSelector } from "@reduxjs/toolkit";
 import _ from "underscore";
 
-import * as Urls from "metabase/lib/urls";
 import { getIsEmbedding } from "metabase/selectors/embed";
-import { getLocation } from "metabase/selectors/routing";
 import type { TransformId } from "metabase-types/api";
 
 import {
@@ -33,15 +31,6 @@ export const getActiveMetabotAgentIds = createSelector(
 
 export const getMetabotId = createSelector(getIsEmbedding, (isEmbedding) =>
   isEmbedding ? FIXED_METABOT_IDS.EMBEDDED : FIXED_METABOT_IDS.DEFAULT,
-);
-
-export const getUseCase = createSelector(
-  getLocation,
-  (location): "transforms" | "omnibot" => {
-    return location.pathname.startsWith(Urls.transformList())
-      ? "transforms"
-      : "omnibot";
-  },
 );
 
 export const getDebugMode = createSelector(
@@ -209,15 +198,13 @@ export const getProfileOverride = createSelector(
 export const getAgentRequestMetadata = createSelector(
   getHistory,
   getMetabotRequestState,
-  getUseCase,
   getProfileOverride,
-  (history, state, useCase, profileOverride) => ({
+  (history, state, profileOverride) => ({
     state,
     // NOTE: need end to end support for ids on messages as BE will error if ids are present
     history: history.map((h) =>
       h.id && h.id.startsWith(`msg_`) ? _.omit(h, "id") : h,
     ),
-    use_case: useCase,
     ...(profileOverride ? { profile_id: profileOverride } : {}),
   }),
 );


### PR DESCRIPTION
Updated, simpler version of https://github.com/metabase/metabase/pull/66791 which doesn't use `use_cases`, due to simpler product approach agreed on this week.

* Adds a collection picker back to the internal metabot config page, specifically for NLQ
* Accesses the `profile_id` in the search tool and enforces the collection restriction only if the profile is `nlq`
* Restricts search to the configured `collection_id` for embedded metabot, to support an option in the future of allowing embedded metabot to use the search tool