### PR TITLE
Add a precondition to segment dependency migration in case it was run on 57

### DIFF
--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -1002,6 +1002,13 @@ databaseChangeLog:
       id: v58.2025-11-25T17:04:00
       author: dependencies
       comment: Add dependency_analysis_version to segment table for tracking dependency changes
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            changeSetExecuted:
+              id: v57.2025-11-25T17:04:00
+              author: dependencies
+              changeLogFile: migrations/057_update_migrations.yaml
       changes:
         - addColumn:
             tableName: segment


### PR DESCRIPTION
Currently master is broken if you've run 57 first, because https://github.com/metabase/metabase/pull/66604 included a backport of a migration that was previously merged to master with a 58 ID. This fix adds a precondition so that the migration is skipped if the 57 version has already run.

More context: https://metaboat.slack.com/archives/C09DZ0ASL81/p1765919885965629