### PR TITLE
Change Metabase AI price to be based on quantity for whole billing period

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotPurchasePage/MetabotPurchasePage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotPurchasePage/MetabotPurchasePage.unit.spec.tsx
@@ -211,12 +211,12 @@ describe("MetabotPurchasePage", () => {
     await expectStoreUserTrialPage();
 
     const metabase_ai_tier3 = screen.getByRole("radio", {
-      name: /up to 3456 requests\/month/,
+      name: /up to 3456 requests\/year/,
     });
     expect(metabase_ai_tier3).toBeVisible();
     expect(metabase_ai_tier3).toHaveAccessibleName(/\$333\/year/);
     const metabase_ai_tier4 = screen.getByRole("radio", {
-      name: /up to 4567 requests\/month/,
+      name: /up to 4567 requests\/year/,
     });
     expect(metabase_ai_tier4).toBeVisible();
     expect(metabase_ai_tier4).toHaveAccessibleName(/\$444\/year/);

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotPurchasePage/MetabotRadios.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotPurchasePage/MetabotRadios.tsx
@@ -66,8 +66,7 @@ export function MetabotRadios({
               selected={`${quantity}` === selectedQuantity}
               value={`${quantity}`}
               title={name}
-              /* time-based quota limits are always per month, not depending on the billing period: */
-              description={t`up to ${quantity} requests/month`}
+              description={t`up to ${quantity} requests/${billingPeriod}`}
               price={`$${price}/${billingPeriod}`}
             />
           </Fragment>


### PR DESCRIPTION
### Description

We want to communicate per-billing-period quantities with customer, instead of always communicate monthly quantities.  Invoiced totals will stay the same.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Ensure you have a token with the `offer-metabase-ai-tiered` feature, but without the `metabot-v3` feature.
2. Navigate to `/admin/metabot` and see the quantities as per billing period, and not per month.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

Fixes: 2b76c38e1f0a84d9f1b287124485568886ca9bc9
Closes: https://metaboat.slack.com/archives/C07RMUQ0GE5/p1765907134400039