### PR TITLE
UXW-2444 support opening Document cards in a new tab

### DIFF
--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -431,3 +431,20 @@ export const goToAuthOverviewPage = () => {
     .findByText("Overview") // auth overview page
     .click();
 };
+
+/**
+ * This function exists to work around custom dynamic anchor creation.
+ * @see https://github.com/metabase/metabase/blob/master/frontend/src/metabase/lib/dom.js#L301-L312
+ *
+ * WARNING: For the assertions to work, ensure that a click event occurs on an anchor element afterwards.
+ */
+export const onNextAnchorClick = (callback) => {
+  cy.window().then((window) => {
+    const originalClick = window.HTMLAnchorElement.prototype.click;
+
+    window.HTMLAnchorElement.prototype.click = function () {
+      callback(this);
+      window.HTMLAnchorElement.prototype.click = originalClick;
+    };
+  });
+};

--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -1021,7 +1021,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
 
       H.saveDashboard({ waitMs: 250 });
 
-      onNextAnchorClick((anchor) => {
+      H.onNextAnchorClick((anchor) => {
         expect(anchor).to.have.attr("href", URL);
         expect(anchor).to.have.attr("rel", "noopener");
         expect(anchor).to.have.attr("target", "_blank");
@@ -1078,7 +1078,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
         cy.button("Add filter").click();
       });
 
-      onNextAnchorClick((anchor) => {
+      H.onNextAnchorClick((anchor) => {
         expect(anchor).to.have.attr("href", URL_WITH_FILLED_PARAMS);
         expect(anchor).to.have.attr("rel", "noopener");
         expect(anchor).to.have.attr("target", "_blank");
@@ -1641,7 +1641,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
           cy.findByPlaceholderText("Search the list").type("Dell Adams");
           cy.button("Update filter").click();
         });
-        onNextAnchorClick((anchor) => {
+        H.onNextAnchorClick((anchor) => {
           expect(anchor).to.have.attr("href", URL_WITH_FILLED_PARAMS);
           expect(anchor).to.have.attr("rel", "noopener");
           expect(anchor).to.have.attr("target", "_blank");
@@ -1813,7 +1813,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
         cy.findByPlaceholderText("Search the list").type("Dell Adams");
         cy.button("Add filter").click();
       });
-      onNextAnchorClick((anchor) => {
+      H.onNextAnchorClick((anchor) => {
         expect(anchor).to.have.attr("href", URL_WITH_FILLED_PARAMS);
         expect(anchor).to.have.attr("rel", "noopener");
         expect(anchor).to.have.attr("target", "_blank");
@@ -2752,23 +2752,6 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       .should("be.visible");
   });
 });
-
-/**
- * This function exists to work around custom dynamic anchor creation.
- * @see https://github.com/metabase/metabase/blob/master/frontend/src/metabase/lib/dom.js#L301-L312
- *
- * WARNING: For the assertions to work, ensure that a click event occurs on an anchor element afterwards.
- */
-const onNextAnchorClick = (callback) => {
-  cy.window().then((window) => {
-    const originalClick = window.HTMLAnchorElement.prototype.click;
-
-    window.HTMLAnchorElement.prototype.click = function () {
-      callback(this);
-      window.HTMLAnchorElement.prototype.click = originalClick;
-    };
-  });
-};
 
 const clickLineChartPoint = () => {
   // eslint-disable-next-line no-unsafe-element-filtering

--- a/frontend/src/metabase/documents/actions.ts
+++ b/frontend/src/metabase/documents/actions.ts
@@ -1,6 +1,7 @@
 import { push } from "react-router-redux";
 
 import { NAVIGATE_TO_NEW_CARD } from "metabase/dashboard/actions";
+import { openUrl } from "metabase/redux/app";
 import type { Document } from "metabase-types/api";
 import type { Dispatch } from "metabase-types/store";
 
@@ -22,5 +23,5 @@ export const navigateToCardFromDocument =
       });
     }
 
-    dispatch(push(url));
+    dispatch(openUrl(url));
   };


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/66448 / UXW-2444

### Description

This adds support for clicking on Chart title or drill-thru with Ctrl/Meta key which opens a new question in a separate tab.


### Demo

https://www.loom.com/share/18f8f17120774312907d98464cb2c8cf

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
