### PR TITLE
Replace table with tree table in Library and Jobs pages

### DIFF
--- a/e2e/support/helpers/e2e-data-studio-helpers.ts
+++ b/e2e/support/helpers/e2e-data-studio-helpers.ts
@@ -114,7 +114,8 @@ export const DataStudio = {
     allTableItems: () => libraryPage().findAllByTestId("table-name"),
     tableItem: (name: string) =>
       DataStudio.Library.allTableItems().contains(name),
-    result: (name: string) => libraryPage().findByText(name).closest("tr"),
+    result: (name: string) =>
+      libraryPage().findByText(name).closest('[role="row"]'),
     newButton: () => libraryPage().findByRole("button", { name: /New/ }),
     collectionItem: (name: string) =>
       libraryPage().findAllByTestId("collection-name").contains(name),

--- a/e2e/test/scenarios/data-studio/data-studio-metrics.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-studio-metrics.cy.spec.ts
@@ -97,7 +97,9 @@ describe("scenarios > data studio > library > metrics", () => {
     cy.visit("/data-studio/library");
 
     cy.log("Click on the metric from the collection view");
-    cy.findByRole("table").findByText("Trusted Orders Metric").click();
+    H.DataStudio.Library.libraryPage()
+      .findByText("Trusted Orders Metric")
+      .click();
 
     cy.log("Verify metric overview page displays correct data");
     H.DataStudio.Metrics.overviewPage()
@@ -129,7 +131,9 @@ describe("scenarios > data studio > library > metrics", () => {
     cy.visit("/data-studio/library");
 
     cy.log("Click on the metric from the collection view");
-    cy.findByRole("table").findByText("Trusted Orders Metric").click();
+    H.DataStudio.Library.libraryPage()
+      .findByText("Trusted Orders Metric")
+      .click();
 
     cy.log("Navigate to definition tab");
     H.DataStudio.Metrics.definitionTab().click();
@@ -152,7 +156,9 @@ describe("scenarios > data studio > library > metrics", () => {
     cy.visit("/data-studio/library");
 
     cy.log("Click on the metric from the collection view");
-    cy.findByRole("table").findByText("Trusted Orders Metric").click();
+    H.DataStudio.Library.libraryPage()
+      .findByText("Trusted Orders Metric")
+      .click();
 
     cy.log("Navigate to definition tab");
     H.DataStudio.Metrics.definitionTab().click();
@@ -181,7 +187,9 @@ describe("scenarios > data studio > library > metrics", () => {
     cy.visit("/data-studio/library");
 
     cy.log("Click on the metric from the collection view");
-    cy.findByRole("table").findByText("Trusted Orders Metric").click();
+    H.DataStudio.Library.libraryPage()
+      .findByText("Trusted Orders Metric")
+      .click();
 
     cy.log("Verify metric is loaded before archiving");
     H.DataStudio.Metrics.overviewPage()
@@ -202,7 +210,7 @@ describe("scenarios > data studio > library > metrics", () => {
 
     cy.log("Verify metric is removed from collection view");
     cy.visit("/data-studio/library");
-    cy.findByRole("table")
+    H.DataStudio.Library.libraryPage()
       .findByText("Trusted Orders Metric")
       .should("not.exist");
 
@@ -222,7 +230,7 @@ describe("scenarios > data studio > library > metrics", () => {
 
     cy.log("Verify metric is restored in collection view");
     cy.visit("/data-studio/library");
-    cy.findByRole("table")
+    H.DataStudio.Library.libraryPage()
       .findByText("Trusted Orders Metric")
       .should("be.visible");
   });
@@ -232,7 +240,9 @@ describe("scenarios > data studio > library > metrics", () => {
     cy.visit("/data-studio/library");
 
     cy.log("Click on the metric from the collection view");
-    cy.findByRole("table").findByText("Trusted Orders Metric").click();
+    H.DataStudio.Library.libraryPage()
+      .findByText("Trusted Orders Metric")
+      .click();
 
     cy.log("Verify metric is loaded");
     H.DataStudio.Metrics.overviewPage()
@@ -254,7 +264,9 @@ describe("scenarios > data studio > library > metrics", () => {
     cy.visit("/data-studio/library");
 
     cy.log("Click on the metric from the collection view");
-    cy.findByRole("table").findByText("Trusted Orders Metric").click();
+    H.DataStudio.Library.libraryPage()
+      .findByText("Trusted Orders Metric")
+      .click();
 
     cy.log("Verify metric is loaded");
     H.DataStudio.Metrics.overviewPage()
@@ -294,7 +306,7 @@ describe("scenarios > data studio > library > metrics", () => {
 
     cy.log("Verify both metrics appear in collection view");
     H.DataStudio.nav().findByRole("link", { name: "Library" }).click();
-    cy.findByRole("table").within(() => {
+    H.DataStudio.Library.libraryPage().within(() => {
       cy.findByText("Trusted Orders Metric").should("be.visible");
       cy.findByText("Trusted Orders Metric - Duplicate").should("be.visible");
     });
@@ -305,7 +317,9 @@ describe("scenarios > data studio > library > metrics", () => {
     cy.visit("/data-studio/library");
 
     cy.log("Click on the metric from the collection view");
-    cy.findByRole("table").findByText("Trusted Orders Metric").click();
+    H.DataStudio.Library.libraryPage()
+      .findByText("Trusted Orders Metric")
+      .click();
 
     cy.log("Verify metric is loaded");
     H.DataStudio.Metrics.overviewPage()
@@ -327,7 +341,7 @@ describe("scenarios > data studio > library > metrics", () => {
 
     cy.log("Verify metric is no longer in Metrics collection");
     cy.visit("/data-studio/library");
-    cy.findByRole("table")
+    H.DataStudio.Library.libraryPage()
       .findByText("Trusted Orders Metric")
       .should("not.exist");
   });

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/LibrarySectionLayout.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/LibrarySectionLayout.tsx
@@ -130,7 +130,7 @@ export function LibrarySectionLayout() {
         accessorKey: "updatedAt",
         enableSorting: true,
         sortingFn: "datetime",
-        width: 200,
+        width: "auto",
         cell: ({ getValue }) => {
           const dateValue = getValue() as string | undefined;
           return dateValue ? <DateTime value={dateValue} /> : null;

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/LibrarySectionLayout.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/LibrarySectionLayout.tsx
@@ -1,5 +1,4 @@
-import type { ColumnDef } from "@tanstack/react-table";
-import { type ReactNode, useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { goBack, push } from "react-router-redux";
 import { t } from "ttag";
 
@@ -10,22 +9,23 @@ import { usePageTitle } from "metabase/hooks/use-page-title";
 import { useDispatch } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { PLUGIN_SNIPPET_FOLDERS } from "metabase/plugins";
+import type { TreeTableColumnDef } from "metabase/ui";
 import {
   Button,
   Card,
+  EntityNameCell,
   FixedSizeIcon,
   Flex,
-  Group,
   Icon,
   Menu,
   Stack,
   TextInput,
+  TreeTable,
+  useTreeTableInstance,
 } from "metabase/ui";
 import { CreateLibraryModal } from "metabase-enterprise/data-studio/common/components/CreateLibraryModal";
 import { DataStudioBreadcrumbs } from "metabase-enterprise/data-studio/common/components/DataStudioBreadcrumbs";
 import { PaneHeader } from "metabase-enterprise/data-studio/common/components/PaneHeader";
-import { Table } from "metabase-enterprise/data-studio/common/components/Table";
-import { useTreeFilter } from "metabase-enterprise/data-studio/common/components/Table/useTreeFilter";
 import { ListEmptyState } from "metabase-enterprise/transforms/components/ListEmptyState";
 import { ListLoadingState } from "metabase-enterprise/transforms/components/ListLoadingState";
 import type { Collection, CollectionId } from "metabase-types/api";
@@ -49,7 +49,7 @@ export function LibrarySectionLayout() {
   );
   const [permissionsCollectionId, setPermissionsCollectionId] =
     useState<CollectionId | null>(null);
-  const [searchQuery, setSearchQuery] = useState<string>();
+  const [searchQuery, setSearchQuery] = useState("");
 
   const { data: collections = [], isLoading: isLoadingCollections } =
     useListCollectionsTreeQuery({
@@ -70,14 +70,13 @@ export function LibrarySectionLayout() {
 
   const handleItemSelect = useCallback(
     (item: TreeItem) => {
-      // Casting because these should not be collections, but collection items with
-      // numbers for IDs
+      const entityId = item.data.id as number;
       if (item.model === "metric") {
-        dispatch(push(Urls.dataStudioMetric(item.id as number)));
+        dispatch(push(Urls.dataStudioMetric(entityId)));
       } else if (item.model === "snippet") {
-        dispatch(push(Urls.dataStudioSnippet(item.id as number)));
+        dispatch(push(Urls.dataStudioSnippet(entityId)));
       } else if (item.model === "table") {
-        dispatch(push(Urls.dataStudioTable(item.id as number)));
+        dispatch(push(Urls.dataStudioTable(entityId)));
       }
     },
     [dispatch],
@@ -98,47 +97,50 @@ export function LibrarySectionLayout() {
     error: snippetsError,
   } = useBuildSnippetTree();
 
-  const filteredTree = useTreeFilter({
-    data: [...tablesTree, ...metricsTree, ...snippetTree],
-    searchQuery,
-    searchProps: ["name"],
-  });
+  const combinedTree = useMemo(
+    () => [...tablesTree, ...metricsTree, ...snippetTree],
+    [tablesTree, metricsTree, snippetTree],
+  );
 
   const isLoading = loadingTables || loadingMetrics || loadingSnippets;
   useErrorHandling(tablesError || metricsError || snippetsError);
-  const filterReturnedEmpty = !!searchQuery && filteredTree.length === 0;
-  const showEmptyState = !isLoading && filterReturnedEmpty;
 
-  const libraryColumnDef = useMemo<ColumnDef<TreeItem, ReactNode>[]>(
+  const libraryHasContent = combinedTree.some(
+    (node) => node.children && node.children.length > 0,
+  );
+
+  const libraryColumnDef = useMemo<TreeTableColumnDef<TreeItem>[]>(
     () => [
       {
-        accessorKey: "name",
+        id: "name",
         header: t`Name`,
-        meta: { width: "auto" },
-        cell: ({ getValue, row }) => {
-          const data = row.original;
-          return (
-            <Group data-testid={`${data.model}-name`} gap="sm">
-              {data.icon && <Icon name={data.icon} c="brand" />}
-              {getValue()}
-            </Group>
-          );
-        },
+        enableSorting: true,
+        accessorKey: "name",
+        cell: ({ row }) => (
+          <EntityNameCell
+            data-testid={`${row.original.model}-name`}
+            icon={row.original.icon}
+            name={row.original.name}
+          />
+        ),
       },
       {
-        accessorKey: "updatedAt",
+        id: "updatedAt",
         header: t`Updated At`,
+        accessorKey: "updatedAt",
+        enableSorting: true,
+        sortingFn: "datetime",
+        width: 200,
         cell: ({ getValue }) => {
-          const value = getValue() as string;
-          return value && <DateTime value={value} />;
+          const dateValue = getValue() as string | undefined;
+          return dateValue ? <DateTime value={dateValue} /> : null;
         },
       },
       {
         id: "actions",
-        header: "",
-        size: 24,
-        cell: ({ row: { original } }) => {
-          const { data } = original;
+        width: 48,
+        cell: ({ row }) => {
+          const { data } = row.original;
           if (
             isCollection(data) &&
             data.model === "collection" &&
@@ -167,6 +169,32 @@ export function LibrarySectionLayout() {
     ],
     [],
   );
+
+  const handleRowActivate = useCallback(
+    (row: { original: TreeItem }) => {
+      handleItemSelect(row.original);
+    },
+    [handleItemSelect],
+  );
+
+  const treeTableInstance = useTreeTableInstance({
+    data: combinedTree,
+    columns: libraryColumnDef,
+    getSubRows: (node) => node.children,
+    getNodeId: (node) => node.id,
+    globalFilter: searchQuery,
+    onGlobalFilterChange: setSearchQuery,
+    isFilterable: (node) => node.model !== "collection",
+    defaultExpanded: true,
+    onRowActivate: handleRowActivate,
+  });
+
+  let emptyMessage = null;
+  if (!libraryHasContent) {
+    emptyMessage = t`No tables, metrics, or snippets yet`;
+  } else if (searchQuery) {
+    emptyMessage = t`No results for "${searchQuery}"`;
+  }
 
   return (
     <>
@@ -197,21 +225,21 @@ export function LibrarySectionLayout() {
             <CreateMenu metricCollectionId={metricCollection?.id} />
           </Flex>
           <Card withBorder p={0}>
-            {isLoading && <ListLoadingState />}
-            {showEmptyState && (
-              <ListEmptyState
-                label={
-                  filterReturnedEmpty
-                    ? t`No results for "${searchQuery}"`
-                    : t`No tables, metrics, or snippets yet`
+            {isLoading ? (
+              <ListLoadingState />
+            ) : (
+              <TreeTable
+                instance={treeTableInstance}
+                emptyState={
+                  emptyMessage ? <ListEmptyState label={emptyMessage} /> : null
                 }
-              />
-            )}
-            {!isLoading && !showEmptyState && (
-              <Table
-                data={filteredTree}
-                columns={libraryColumnDef}
-                onSelect={handleItemSelect}
+                onRowClick={(row) => {
+                  if (row.getCanExpand()) {
+                    row.toggleExpanded();
+                  } else {
+                    handleRowActivate(row);
+                  }
+                }}
               />
             )}
           </Card>

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/LibrarySectionLayout.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/LibrarySectionLayout.tsx
@@ -131,6 +131,7 @@ export function LibrarySectionLayout() {
         enableSorting: true,
         sortingFn: "datetime",
         width: "auto",
+        widthPadding: 20,
         cell: ({ getValue }) => {
           const dateValue = getValue() as string | undefined;
           return dateValue ? <DateTime value={dateValue} /> : null;

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/hooks.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/hooks.ts
@@ -45,7 +45,7 @@ export const useBuildTreeForCollection = (
       tree: [
         {
           name: collection.name,
-          id: collection.id,
+          id: `collection:${collection.id}`,
           icon: getIcon({ ...collection, model: "collection" }).name,
           data: { ...collection, model: "collection" },
           model: "collection",
@@ -54,7 +54,7 @@ export const useBuildTreeForCollection = (
             updatedAt: item["last-edit-info"]?.timestamp,
             icon: getIcon({ model: item.model }).name,
             data: item,
-            id: item.id,
+            id: `${item.model}:${item.id}`,
             model: item.model,
           })),
         },

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/types.ts
@@ -7,16 +7,16 @@ import type {
 } from "metabase-types/api";
 
 export type TreeItem = {
+  id: string;
   name: string;
   icon: IconName;
   updatedAt?: string;
   model: CollectionItemModel;
   data: (Collection | Omit<CollectionItem, "getUrl">) & {
     model: CollectionItem["model"];
-    namespace?: CollectionNamespace;
+    namespace?: CollectionNamespace | null;
   };
   children?: TreeItem[];
-  id: number | string;
 };
 
 export const isCollection = (

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/utils.ts
@@ -11,7 +11,7 @@ import type { TreeItem } from "./types";
 
 function createSnippetNode(snippet: NativeQuerySnippet): TreeItem {
   return {
-    id: snippet.id,
+    id: `snippet:${snippet.id}`,
     name: snippet.name,
     icon: "snippet",
     model: "snippet",
@@ -43,7 +43,7 @@ function buildCollectionNode(
   ];
 
   return {
-    id: collection.id,
+    id: `collection:${collection.id}`,
     name: collection.name,
     model: "collection",
     icon: isRoot ? "snippet" : "folder",

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/JobListPage/JobListPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/JobListPage/JobListPage.tsx
@@ -1,6 +1,4 @@
-import { useDebouncedValue } from "@mantine/hooks";
-import type { ColumnDef } from "@tanstack/react-table";
-import { type ReactNode, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { push } from "react-router-redux";
 import { t } from "ttag";
 
@@ -9,12 +7,21 @@ import { ForwardRefLink } from "metabase/common/components/Link";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { useDispatch } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
-import { Button, Card, Flex, Icon, Stack, TextInput } from "metabase/ui";
+import type { TreeTableColumnDef } from "metabase/ui";
+import {
+  Button,
+  Card,
+  Flex,
+  Icon,
+  Stack,
+  TextInput,
+  TreeTable,
+  useTreeTableInstance,
+} from "metabase/ui";
 import { useListTransformJobsQuery } from "metabase-enterprise/api";
 import { DataStudioBreadcrumbs } from "metabase-enterprise/data-studio/common/components/DataStudioBreadcrumbs";
 import { PageContainer } from "metabase-enterprise/data-studio/common/components/PageContainer";
 import { PaneHeader } from "metabase-enterprise/data-studio/common/components/PaneHeader";
-import { Table } from "metabase-enterprise/data-studio/common/components/Table";
 import { ListEmptyState } from "metabase-enterprise/transforms/components/ListEmptyState";
 import { ListLoadingState } from "metabase-enterprise/transforms/components/ListLoadingState";
 import type { TransformJob } from "metabase-types/api";
@@ -22,53 +29,57 @@ import type { TransformJob } from "metabase-types/api";
 export const JobListPage = () => {
   const dispatch = useDispatch();
   const [searchQuery, setSearchQuery] = useState("");
-  const [debouncedSearchQuery] = useDebouncedValue(searchQuery, 300);
 
-  const { data: jobs, error, isLoading } = useListTransformJobsQuery({});
+  const { data: jobs = [], error, isLoading } = useListTransformJobsQuery({});
 
-  const filteredJobs = useMemo(() => {
-    if (!jobs) {
-      return [];
-    }
+  const handleRowActivate = useCallback(
+    (row: { original: TransformJob }) => {
+      dispatch(push(Urls.transformJob(row.original.id)));
+    },
+    [dispatch],
+  );
 
-    if (!debouncedSearchQuery) {
-      return jobs;
-    }
-
-    const query = debouncedSearchQuery.toLowerCase();
-    return jobs.filter((job) => job.name.toLowerCase().includes(query));
-  }, [jobs, debouncedSearchQuery]);
-
-  const handleSelect = (item: TransformJob) => {
-    dispatch(push(Urls.transformJob(item.id)));
-  };
-
-  const jobColumnDef = useMemo<ColumnDef<TransformJob, ReactNode>[]>(
+  const jobColumnDef = useMemo<TreeTableColumnDef<TransformJob>[]>(
     () => [
       {
+        id: "name",
         accessorKey: "name",
         header: t`Name`,
-        meta: {
-          width: "auto",
-        },
       },
       {
+        id: "last_run",
         accessorFn: (job) => job.last_run?.start_time,
         header: t`Last Run`,
-        meta: {
-          width: "auto",
-        },
-        cell: ({ row: { original: job } }) =>
-          job.last_run ? (
+        minWidth: "auto",
+        cell: ({ row }) =>
+          row.original.last_run ? (
             <>
-              {job.last_run.status === "failed" ? t`Failed` : t`Last run`}
-              <DateTime value={job.last_run.start_time} />
+              {row.original.last_run.status === "failed"
+                ? t`Failed`
+                : t`Last run`}{" "}
+              <DateTime value={row.original.last_run.start_time} />
             </>
           ) : null,
       },
     ],
     [],
   );
+
+  const treeTableInstance = useTreeTableInstance({
+    data: jobs,
+    columns: jobColumnDef,
+    getNodeId: (node) => String(node.id),
+    globalFilter: searchQuery,
+    onGlobalFilterChange: setSearchQuery,
+    onRowActivate: handleRowActivate,
+  });
+
+  let emptyMessage = null;
+  if (jobs.length === 0) {
+    emptyMessage = t`No jobs yet`;
+  } else if (searchQuery) {
+    emptyMessage = t`No jobs found`;
+  }
 
   if (error) {
     return <LoadingAndErrorWrapper loading={false} error={error} />;
@@ -101,16 +112,14 @@ export const JobListPage = () => {
         <Flex direction="column" flex={1} mih={0}>
           {isLoading ? (
             <ListLoadingState />
-          ) : filteredJobs.length === 0 ? (
-            <ListEmptyState
-              label={debouncedSearchQuery ? t`No jobs found` : t`No jobs yet`}
-            />
           ) : (
             <Card withBorder p={0}>
-              <Table
-                data={filteredJobs}
-                columns={jobColumnDef}
-                onSelect={handleSelect}
+              <TreeTable
+                instance={treeTableInstance}
+                emptyState={
+                  emptyMessage ? <ListEmptyState label={emptyMessage} /> : null
+                }
+                onRowClick={handleRowActivate}
               />
             </Card>
           )}

--- a/frontend/src/metabase/ui/components/data-display/TreeTable/EntityNameCell/EntityNameCell.tsx
+++ b/frontend/src/metabase/ui/components/data-display/TreeTable/EntityNameCell/EntityNameCell.tsx
@@ -1,3 +1,5 @@
+import { memo } from "react";
+
 import { Ellipsified } from "metabase/common/components/Ellipsified";
 import CS from "metabase/css/core/index.css";
 import type { IconName } from "metabase/ui";
@@ -12,7 +14,7 @@ interface EntityNameCellProps {
   "data-testid"?: string;
 }
 
-export function EntityNameCell({
+export const EntityNameCell = memo(function EntityNameCell({
   icon,
   name,
   iconColor = "brand",
@@ -38,4 +40,4 @@ export function EntityNameCell({
       )}
     </Group>
   );
-}
+});

--- a/frontend/src/metabase/ui/components/data-display/TreeTable/ExpandButton/ExpandButton.tsx
+++ b/frontend/src/metabase/ui/components/data-display/TreeTable/ExpandButton/ExpandButton.tsx
@@ -1,4 +1,5 @@
 import cx from "classnames";
+import { memo } from "react";
 import { t } from "ttag";
 
 import { Center, Icon, Loader } from "metabase/ui";
@@ -7,7 +8,7 @@ import type { ExpandButtonProps } from "../types";
 
 import S from "./ExpandButton.module.css";
 
-export function ExpandButton({
+export const ExpandButton = memo(function ExpandButton({
   canExpand,
   isExpanded,
   isLoading,
@@ -52,4 +53,4 @@ export function ExpandButton({
       />
     </Center>
   );
-}
+});

--- a/frontend/src/metabase/ui/components/data-display/TreeTable/hooks/useColumnSizing.tsx
+++ b/frontend/src/metabase/ui/components/data-display/TreeTable/hooks/useColumnSizing.tsx
@@ -32,7 +32,7 @@ interface UseColumnSizingOptions<TData extends TreeNodeData> {
 export function needsMeasurement<TData extends TreeNodeData>(
   column: TreeTableColumnDef<TData>,
 ): boolean {
-  return column.minWidth === "auto";
+  return column.minWidth === "auto" || column.width === "auto";
 }
 
 function pickTreeRowsToMeasure<TData>(
@@ -94,7 +94,12 @@ export function calculateColumnWidths<TData extends TreeNodeData>(
 
   const fixedWidth = columns
     .filter((col) => col.width != null)
-    .reduce((sum, col) => sum + col.width!, 0);
+    .reduce((sum, col) => {
+      if (col.width === "auto") {
+        return sum + (contentWidths[col.id] ?? MIN_COLUMN_WIDTH);
+      }
+      return sum + col.width;
+    }, 0);
 
   let remainingSpace = containerWidth - fixedWidth;
 
@@ -104,7 +109,11 @@ export function calculateColumnWidths<TData extends TreeNodeData>(
 
   columns.forEach((column) => {
     if (column.width != null) {
-      widths[column.id] = column.width;
+      if (column.width === "auto") {
+        widths[column.id] = contentWidths[column.id] ?? MIN_COLUMN_WIDTH;
+      } else {
+        widths[column.id] = column.width;
+      }
     }
   });
 

--- a/frontend/src/metabase/ui/components/data-display/TreeTable/hooks/useColumnSizing.tsx
+++ b/frontend/src/metabase/ui/components/data-display/TreeTable/hooks/useColumnSizing.tsx
@@ -52,6 +52,15 @@ function pickTreeRowsToMeasure<TData>(
   return result;
 }
 
+function getContentWidth<TData extends TreeNodeData>(
+  column: TreeTableColumnDef<TData>,
+  contentWidths: Record<string, number>,
+): number {
+  const baseWidth = contentWidths[column.id] ?? MIN_COLUMN_WIDTH;
+  const padding = column.widthPadding ?? 0;
+  return baseWidth + padding;
+}
+
 export function getMinConstraint<TData extends TreeNodeData>(
   column: TreeTableColumnDef<TData>,
   colIndex: number,
@@ -61,7 +70,7 @@ export function getMinConstraint<TData extends TreeNodeData>(
 ): number {
   let minConstraint: number;
   if (column.minWidth === "auto") {
-    minConstraint = contentWidths[column.id] ?? MIN_COLUMN_WIDTH;
+    minConstraint = getContentWidth(column, contentWidths);
   } else if (typeof column.minWidth === "number") {
     minConstraint = column.minWidth;
   } else {
@@ -96,9 +105,9 @@ export function calculateColumnWidths<TData extends TreeNodeData>(
     .filter((col) => col.width != null)
     .reduce((sum, col) => {
       if (col.width === "auto") {
-        return sum + (contentWidths[col.id] ?? MIN_COLUMN_WIDTH);
+        return sum + getContentWidth(col, contentWidths);
       }
-      return sum + col.width;
+      return sum + (col.width ?? 0);
     }, 0);
 
   let remainingSpace = containerWidth - fixedWidth;
@@ -110,7 +119,7 @@ export function calculateColumnWidths<TData extends TreeNodeData>(
   columns.forEach((column) => {
     if (column.width != null) {
       if (column.width === "auto") {
-        widths[column.id] = contentWidths[column.id] ?? MIN_COLUMN_WIDTH;
+        widths[column.id] = getContentWidth(column, contentWidths);
       } else {
         widths[column.id] = column.width;
       }

--- a/frontend/src/metabase/ui/components/data-display/TreeTable/hooks/useColumnSizing.unit.spec.ts
+++ b/frontend/src/metabase/ui/components/data-display/TreeTable/hooks/useColumnSizing.unit.spec.ts
@@ -21,6 +21,10 @@ describe("needsMeasurement", () => {
     expect(needsMeasurement(createColumn({ minWidth: "auto" }))).toBe(true);
   });
 
+  it("returns true when width is auto", () => {
+    expect(needsMeasurement(createColumn({ width: "auto" }))).toBe(true);
+  });
+
   it("returns false when minWidth is a number or undefined", () => {
     expect(needsMeasurement(createColumn({ minWidth: 100 }))).toBe(false);
     expect(needsMeasurement(createColumn({}))).toBe(false);
@@ -85,6 +89,29 @@ describe("calculateColumnWidths", () => {
     expect(calculateColumnWidths(columns, 400, {}, 0, 20)).toEqual({
       col1: 300,
       col2: 50,
+    });
+  });
+
+  it("uses content width for width=auto columns without stretching", () => {
+    const columns = [
+      createColumn({ id: "auto", width: "auto" }),
+      createColumn({ id: "stretch" }),
+    ];
+    // auto column uses measured width (150), stretch gets remaining space
+    expect(calculateColumnWidths(columns, 500, { auto: 150 }, 0, 20)).toEqual({
+      auto: 150,
+      stretch: 350,
+    });
+  });
+
+  it("falls back to MIN_COLUMN_WIDTH when width=auto has no measured content", () => {
+    const columns = [
+      createColumn({ id: "auto", width: "auto" }),
+      createColumn({ id: "stretch" }),
+    ];
+    expect(calculateColumnWidths(columns, 500, {}, 0, 20)).toEqual({
+      auto: MIN_COLUMN_WIDTH,
+      stretch: 450,
     });
   });
 });

--- a/frontend/src/metabase/ui/components/data-display/TreeTable/hooks/useColumnSizing.unit.spec.ts
+++ b/frontend/src/metabase/ui/components/data-display/TreeTable/hooks/useColumnSizing.unit.spec.ts
@@ -47,6 +47,15 @@ describe("getMinConstraint", () => {
     // maxDepth=3, indentWidth=20 -> MIN_COLUMN_WIDTH + 60 = 110
     expect(getMinConstraint(column, 0, {}, 3, 20)).toBe(MIN_COLUMN_WIDTH + 60);
   });
+
+  it("includes widthPadding when minWidth is auto", () => {
+    const column = createColumn({
+      id: "name",
+      minWidth: "auto",
+      widthPadding: 16,
+    });
+    expect(getMinConstraint(column, 1, { name: 200 }, 0, 20)).toBe(216);
+  });
 });
 
 describe("calculateColumnWidths", () => {
@@ -112,6 +121,26 @@ describe("calculateColumnWidths", () => {
     expect(calculateColumnWidths(columns, 500, {}, 0, 20)).toEqual({
       auto: MIN_COLUMN_WIDTH,
       stretch: 450,
+    });
+  });
+
+  it("adds widthPadding to width=auto columns", () => {
+    const columns = [
+      createColumn({ id: "auto", width: "auto", widthPadding: 20 }),
+      createColumn({ id: "stretch" }),
+    ];
+    expect(calculateColumnWidths(columns, 500, { auto: 150 }, 0, 20)).toEqual({
+      auto: 170,
+      stretch: 330,
+    });
+  });
+
+  it("adds widthPadding to minWidth=auto columns", () => {
+    const columns = [
+      createColumn({ id: "auto", minWidth: "auto", widthPadding: 20 }),
+    ];
+    expect(calculateColumnWidths(columns, 200, { auto: 150 }, 0, 20)).toEqual({
+      auto: 200,
     });
   });
 });

--- a/frontend/src/metabase/ui/components/data-display/TreeTable/types.ts
+++ b/frontend/src/metabase/ui/components/data-display/TreeTable/types.ts
@@ -31,8 +31,8 @@ export interface TreeNodeData {
 export interface TreeTableColumnSizingDef {
   /** Column ID is required for TreeTable columns. */
   id: string;
-  /** Fixed width in pixels. Column does NOT stretch. */
-  width?: number;
+  /** Fixed width in pixels, or 'auto' (measures content via DOM) */
+  width?: number | "auto";
   /** Minimum width: pixels or 'auto' (measures content via DOM). */
   minWidth?: number | "auto";
   /** Maximum width in pixels. Only applies to stretching columns. */

--- a/frontend/src/metabase/ui/components/data-display/TreeTable/types.ts
+++ b/frontend/src/metabase/ui/components/data-display/TreeTable/types.ts
@@ -37,6 +37,8 @@ export interface TreeTableColumnSizingDef {
   minWidth?: number | "auto";
   /** Maximum width in pixels. Only applies to stretching columns. */
   maxWidth?: number;
+  /** Extra pixels added to measured width. Only applies when width or minWidth is 'auto'. */
+  widthPadding?: number;
 }
 
 /**


### PR DESCRIPTION
### Description

Uses new TreeTable in the Data Studio for library and jobs pages. It does not remove previous Table component which becomes unused because Tasks PR uses it https://github.com/metabase/metabase/pull/66279

Library:
<img width="1723" height="544" alt="Screenshot 2025-12-22 at 3 41 58 PM" src="https://github.com/user-attachments/assets/5256850e-d1b7-4a3e-9949-620e44be0ae9" />

Jobs:
<img width="1728" height="991" alt="Screenshot 2025-12-22 at 3 42 10 PM" src="https://github.com/user-attachments/assets/c3650060-85a7-4612-881c-2d265b0c1b8c" />
