### PR TITLE
Add effective type to expression when resolving from ref

### DIFF
--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -1474,3 +1474,50 @@ describe("issue QUE-1359", () => {
       });
   });
 });
+
+describe("issue QUE-2567", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+
+    H.createQuestion(
+      {
+        query: {
+          "source-table": ORDERS_ID,
+          expressions: {
+            Foo: [
+              "datetime-add",
+              [
+                "field",
+                ORDERS.CREATED_AT,
+                {
+                  "base-type": "type/DateTime",
+                  "effective-type": "type/DateTime",
+                },
+              ],
+              5,
+              "day",
+            ],
+          },
+        },
+      },
+      { visitQuestion: true },
+    );
+
+    H.filter();
+    H.popover().within(() => {
+      cy.findByText("Foo").click();
+      cy.findByText("Previous 12 months").click();
+    });
+  });
+
+  it("should be possible to edit a datetime filter that is based on a custom expression (QUE-2567)", () => {
+    cy.log("Editing the filter should show the date picker");
+    cy.findByTestId("filter-pill").click();
+    H.popover().within(() => {
+      cy.findByText("Previous").should("be.visible");
+      cy.findByText("Current").should("be.visible");
+      cy.findByText("Next").should("be.visible");
+    });
+  });
+});

--- a/src/metabase/lib/expression.cljc
+++ b/src/metabase/lib/expression.cljc
@@ -92,21 +92,23 @@
   (lib.computed/with-cache-ephemeral* query [:expression-metadata/by-ref stage-number expression-ref-clause
                                              (lib.metadata.calculation/cacheable-options {})]
     (fn []
-      (merge {:lib/type                :metadata/column
+      (let [base-type (lib.metadata.calculation/type-of query stage-number expression-ref-clause)]
+        (merge {:lib/type                :metadata/column
               ;; TODO (Cam 8/7/25) -- is the source UUID of an expression ref supposed to be the ID of the ref, or the ID
               ;; of the expression definition??
-              :lib/source-uuid         (:lib/uuid opts)
-              :name                    expression-name
-              :lib/expression-name     expression-name
-              :lib/source-column-alias expression-name
-              :display-name            (lib.metadata.calculation/display-name query stage-number expression-ref-clause)
-              :base-type               (lib.metadata.calculation/type-of query stage-number expression-ref-clause)
-              :lib/source              :source/expressions}
-             (when-let [unit (lib.temporal-bucket/raw-temporal-bucket expression-ref-clause)]
-               {:metabase.lib.field/temporal-unit unit})
-             (when lib.metadata.calculation/*propagate-binning-and-bucketing*
+                :lib/source-uuid         (:lib/uuid opts)
+                :name                    expression-name
+                :lib/expression-name     expression-name
+                :lib/source-column-alias expression-name
+                :display-name            (lib.metadata.calculation/display-name query stage-number expression-ref-clause)
+                :base-type               base-type
+                :effective-type          (or (:effective-type opts) base-type)
+                :lib/source              :source/expressions}
                (when-let [unit (lib.temporal-bucket/raw-temporal-bucket expression-ref-clause)]
-                 {:inherited-temporal-unit unit}))))))
+                 {:metabase.lib.field/temporal-unit unit})
+               (when lib.metadata.calculation/*propagate-binning-and-bucketing*
+                 (when-let [unit (lib.temporal-bucket/raw-temporal-bucket expression-ref-clause)]
+                   {:inherited-temporal-unit unit})))))))
 
 (defmethod lib.temporal-bucket/available-temporal-buckets-method :expression
   [query stage-number [_expression opts _expr-name, :as expr-clause]]

--- a/src/metabase/lib/types/isa.cljc
+++ b/src/metabase/lib/types/isa.cljc
@@ -44,7 +44,7 @@
 
       :else false)))
 
-(defn effective-type
+(defn column-type
   "Returns the :effective-type of `column`, if set. Otherwise, returns the :base-type."
   [column]
   (or (:effective-type column) (:base-type column)))
@@ -147,12 +147,12 @@
 (defn ^:export date-or-datetime?
   "Is `column` a date or datetime?"
   [column]
-  (clojure.core/isa? (effective-type column) :type/HasDate))
+  (clojure.core/isa? (column-type column) :type/HasDate))
 
 (defn ^:export date-without-time?
   "Is `column` a date without time?"
   [column]
-  (clojure.core/isa? (effective-type column) :type/Date))
+  (clojure.core/isa? (column-type column) :type/Date))
 
 (defn ^:export creation-timestamp?
   "Is `column` a creation timestamp column?"
@@ -177,7 +177,7 @@
 (defn ^:export time?
   "Is `column` a time?"
   [column]
-  (clojure.core/isa? (effective-type column) :type/Time))
+  (clojure.core/isa? (column-type column) :type/Time))
 
 (defn ^:export address?
   "Is `column` an address?"
@@ -260,12 +260,12 @@
 (defn searchable?
   "Is this column one that we should show a search widget for (to search its values) in the QB filter UI? If so, we can
   give it a `has-field-values` value of `:search`."
-  [{:keys [base-type effective-type]}]
+  [column]
   ;; For the time being we will consider something to be "searchable" if it's a text Field since the `starts-with`
   ;; filter that powers the search queries (see [[metabase.parameters.field/search-values]]) doesn't work on anything else
-  (let [column-type (or effective-type base-type)]
-    (or (clojure.core/isa? column-type :type/Text)
-        (clojure.core/isa? column-type :type/TextLike))))
+  (let [col-type (column-type column)]
+    (or (clojure.core/isa? col-type :type/Text)
+        (clojure.core/isa? col-type :type/TextLike))))
 
 (defn valid-filter-for?
   "Given two CLJS `:metadata/columns` returns true if `src-column` is a valid source to use for filtering `dst-column`.

--- a/src/metabase/lib/types/isa.cljc
+++ b/src/metabase/lib/types/isa.cljc
@@ -44,6 +44,11 @@
 
       :else false)))
 
+(defn effective-type
+  "Returns the :effective-type of `column`, if set. Otherwise, returns the :base-type."
+  [column]
+  (or (:effective-type column) (:base-type column)))
+
 (defn ^:export temporal?
   "Is `column` of a temporal type?"
   [column]
@@ -142,12 +147,12 @@
 (defn ^:export date-or-datetime?
   "Is `column` a date or datetime?"
   [column]
-  (clojure.core/isa? (:effective-type column) :type/HasDate))
+  (clojure.core/isa? (effective-type column) :type/HasDate))
 
 (defn ^:export date-without-time?
   "Is `column` a date without time?"
   [column]
-  (clojure.core/isa? (:effective-type column) :type/Date))
+  (clojure.core/isa? (effective-type column) :type/Date))
 
 (defn ^:export creation-timestamp?
   "Is `column` a creation timestamp column?"
@@ -172,7 +177,7 @@
 (defn ^:export time?
   "Is `column` a time?"
   [column]
-  (clojure.core/isa? (:effective-type column) :type/Time))
+  (clojure.core/isa? (effective-type column) :type/Time))
 
 (defn ^:export address?
   "Is `column` an address?"

--- a/test/metabase/lib/types/isa_test.cljc
+++ b/test/metabase/lib/types/isa_test.cljc
@@ -168,3 +168,28 @@
     false :type/Integer  :type/Number    :type/String   :type/Text
     false :type/DateTime :type/Temporal  :type/String   :type/Text
     false :type/String   :type/Text      :type/DateTime :type/Temporal))
+
+(deftest ^:parallel effective-type-fallback-test
+  (are [expected predicate column] (= expected (predicate column))
+    true lib.types.isa/date-or-datetime? {:base-type :type/DateTime}
+    true lib.types.isa/date-or-datetime? {:effective-type :type/DateTime :base-type :type/String}
+
+    true lib.types.isa/date-or-datetime? {:base-type :type/Date}
+    true lib.types.isa/date-or-datetime? {:effective-type :type/Date :base-type :type/String}
+
+    false lib.types.isa/date-or-datetime? {:base-type :type/String}
+    false lib.types.isa/date-or-datetime? {:effective-type :type/Location :base-type :type/String}
+
+    true lib.types.isa/date-without-time? {:base-type :type/Date}
+    true lib.types.isa/date-or-datetime? {:effective-type :type/Date :base-type :type/String}
+
+    false lib.types.isa/date-without-time? {:base-type :type/String}
+    false lib.types.isa/date-without-time? {:base-type :type/DateTime}
+    false lib.types.isa/date-without-time? {:effective-type :type/String :base-type :type/String}
+    false lib.types.isa/date-without-time? {:effective-type :type/DateTime :base-type :type/String}
+
+    true lib.types.isa/time? {:base-type :type/Time}
+    true lib.types.isa/time? {:effective-type :type/Time :base-type :type/String}
+
+    false lib.types.isa/time? {:base-type :type/String}
+    false lib.types.isa/time? {:effective-type :type/String :base-type :type/String}))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #63966
closes https://github.com/metabase/metabase/issues/64353
Closes QUE-2567

The root cause of the issue is that custom expressions do not have a `:effective-type` key set when resolving the metadata from the filter clause.

This makes it so that [`date-or-datetime?`](https://github.com/metabase/metabase/blob/9fa1bdfc2f6f2c3b715b0f5d20c3e8af04bf3cdc/src/metabase/lib/types/isa.cljc#L142-L145) does not return true for expressions that are date or datetime because it only checks `:effective-type`.

This PR fixes the bug by adding an `:effective-type` to the resolved column metadata for the filter clause.

Additionally it also adds a fallback to `:base-type` in `date-or-datetime?` and similar functions.