### PR TITLE
Prevent test email from including Metabase links

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1010,6 +1010,7 @@
            collections
            config
            driver
+           embedding
            events
            lib
            models

--- a/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
@@ -796,6 +796,25 @@ describe("scenarios > dashboard > subscriptions", () => {
           .should("not.exist");
       });
     });
+
+    describe("modular embedding", () => {
+      it("should not include links to Metabase", () => {
+        H.visitDashboard(ORDERS_DASHBOARD_ID);
+
+        H.openSharingMenu();
+        H.sharingMenu().findByRole("menuitem", { name: "Embed" }).click();
+        cy.findByRole("button", { name: "Agree and enable" }).click();
+        cy.findByLabelText("Metabase account (SSO)").click();
+        cy.findByLabelText("Allow subscriptions").check().should("be.checked");
+        H.getIframeBody().within(() => {
+          cy.button("Subscriptions").click();
+          H.sendEmailAndVisitIt();
+        });
+
+        cy.log("Checks that links should not work");
+        cy.findAllByRole("link").should("not.exist");
+      });
+    });
   });
 });
 

--- a/frontend/src/metabase/common/components/SendTestPulse/SendTestPulse.jsx
+++ b/frontend/src/metabase/common/components/SendTestPulse/SendTestPulse.jsx
@@ -3,7 +3,6 @@ import { Component } from "react";
 import { t } from "ttag";
 
 import ActionButton from "metabase/common/components/ActionButton";
-import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { cleanPulse } from "metabase/lib/pulse";
 
 export default class SendTestPulse extends Component {
@@ -21,9 +20,6 @@ export default class SendTestPulse extends Component {
   onTestPulseChannel = () => {
     const { pulse, channel, channelSpecs, testPulse } = this.props;
     const channelPulse = { ...pulse, channels: [channel] };
-    if (isEmbeddingSdk()) {
-      channelPulse.disable_links = true;
-    }
     const cleanedPulse = cleanPulse(channelPulse, channelSpecs);
 
     return testPulse(cleanedPulse);

--- a/frontend/src/metabase/common/components/SendTestPulse/SendTestPulse.jsx
+++ b/frontend/src/metabase/common/components/SendTestPulse/SendTestPulse.jsx
@@ -3,6 +3,7 @@ import { Component } from "react";
 import { t } from "ttag";
 
 import ActionButton from "metabase/common/components/ActionButton";
+import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { cleanPulse } from "metabase/lib/pulse";
 
 export default class SendTestPulse extends Component {
@@ -20,6 +21,9 @@ export default class SendTestPulse extends Component {
   onTestPulseChannel = () => {
     const { pulse, channel, channelSpecs, testPulse } = this.props;
     const channelPulse = { ...pulse, channels: [channel] };
+    if (isEmbeddingSdk()) {
+      channelPulse.disable_links = true;
+    }
     const cleanedPulse = cleanPulse(channelPulse, channelSpecs);
 
     return testPulse(cleanedPulse);

--- a/src/metabase/channel/email/dashboard_subscription.hbs
+++ b/src/metabase/channel/email/dashboard_subscription.hbs
@@ -4,6 +4,11 @@
       <tr>
         <td>
           <div class="container" style="background-color: white; max-width: 555px; border-radius: 24px; margin: 0 auto; padding: 30px;">
+            {{#if payload.disable_links}}
+              the link is disabled
+            {{else}}
+              the link isn't disabled
+            {{/if}}
             {{#if context.include_branding}}
               <a href="https://www.metabase.com?utm_source=product&utm_medium=export&utm_campaign=exports_branding&utm_content=dashboard_subscription">
                 <div style="text-align: right; height: 28px; margin-bottom: 16px; color: {{payload.style.color_text_dark}};">

--- a/src/metabase/channel/email/dashboard_subscription.hbs
+++ b/src/metabase/channel/email/dashboard_subscription.hbs
@@ -55,8 +55,8 @@
               <hr>
             {{/unless}}
             {{{computed.dashboard_content}}}
-            <hr>
             {{#unless payload.disable_links}}
+              <hr>
               <div class="footer" style="font-size: 11px; width: max-content; margin: 0 auto">
                 Sent from <a href="{{context.site_url}}" style="color: {{context.application_color}}">{{context.site_url}}</a>.
                 {{#if computed.management_url}}

--- a/src/metabase/channel/email/dashboard_subscription.hbs
+++ b/src/metabase/channel/email/dashboard_subscription.hbs
@@ -4,13 +4,8 @@
       <tr>
         <td>
           <div class="container" style="background-color: white; max-width: 555px; border-radius: 24px; margin: 0 auto; padding: 30px;">
-            {{#if payload.disable_links}}
-              the link is disabled
-            {{else}}
-              the link isn't disabled
-            {{/if}}
             {{#if context.include_branding}}
-              <a href="https://www.metabase.com?utm_source=product&utm_medium=export&utm_campaign=exports_branding&utm_content=dashboard_subscription">
+              <a {{#unless payload.disable_links}}href="https://www.metabase.com?utm_source=product&utm_medium=export&utm_campaign=exports_branding&utm_content=dashboard_subscription"{{/unless}}>
                 <div style="text-align: right; height: 28px; margin-bottom: 16px; color: {{payload.style.color_text_dark}};">
                   <span style="font-size: 12px; vertical-align: middle;">Made with</span>
                   <img width="22.4" height="28" src="{{context.application_logo_url}}" style="vertical-align: middle; margin-inline: 4px;"/>
@@ -24,7 +19,7 @@
                   <img class="icon" style="padding-top: 4px; padding-right: 16px; width: 100%; height: auto; max-width: 20px" src="cid:{{computed.icon_cid}}"/>
                 </td>
                 <td>
-                  <a class="title" href="{{{dashboard-url payload.dashboard.id payload.parameters}}}" style="font-size: 20px; font-weight: 700; padding-bottom: 4px;">
+                  <a class="title" {{#unless payload.disable_links}}href="{{{dashboard-url payload.dashboard.id payload.parameters}}}"{{/unless}} style="font-size: 20px; font-weight: 700; padding-bottom: 4px;">
                     {{payload.dashboard.name}}
                   </a>
                 </td>
@@ -61,12 +56,14 @@
             {{/unless}}
             {{{computed.dashboard_content}}}
             <hr>
-            <div class="footer" style="font-size: 11px; width: max-content; margin: 0 auto">
-              Sent from <a href="{{context.site_url}}" style="color: {{context.application_color}}">{{context.site_url}}</a>.
-              {{#if computed.management_url}}
-                <a href="{{computed.management_url}}" style="color: {{context.application_color}}">{{computed.management_text}}</a>
-              {{/if}}
-            </div>
+            {{#unless payload.disable_links}}
+              <div class="footer" style="font-size: 11px; width: max-content; margin: 0 auto">
+                Sent from <a href="{{context.site_url}}" style="color: {{context.application_color}}">{{context.site_url}}</a>.
+                {{#if computed.management_url}}
+                  <a href="{{computed.management_url}}" style="color: {{context.application_color}}">{{computed.management_text}}</a>
+                {{/if}}
+              </div>
+            {{/unless}}
           </div>
         </td>
       </tr>

--- a/src/metabase/channel/impl/email.clj
+++ b/src/metabase/channel/impl/email.clj
@@ -255,7 +255,7 @@
          html-contents]     (reduce
                              (fn [[merged-attachments result-attachments html-contents] part]
                                (let [{:keys [attachments content]} (render-part timezone part {:channel.render/include-title? true
-                                                                                               :channel.render/disable-links? (:disable_links dashboard_subscription)})
+                                                                                               :channel.render/disable-links? (boolean (:disable_links dashboard_subscription))})
                                      result-attachment             (email.result-attachment/result-attachment part)]
                                  [(merge merged-attachments attachments)
                                   (into result-attachments result-attachment)

--- a/src/metabase/channel/impl/email.clj
+++ b/src/metabase/channel/impl/email.clj
@@ -254,7 +254,8 @@
          result-attachments
          html-contents]     (reduce
                              (fn [[merged-attachments result-attachments html-contents] part]
-                               (let [{:keys [attachments content]} (render-part timezone part {:channel.render/include-title? true})
+                               (let [{:keys [attachments content]} (render-part timezone part {:channel.render/include-title? true
+                                                                                               :channel.render/disable-links? (:disable_links dashboard_subscription)})
                                      result-attachment             (email.result-attachment/result-attachment part)]
                                  [(merge merged-attachments attachments)
                                   (into result-attachments result-attachment)

--- a/src/metabase/channel/render/card.clj
+++ b/src/metabase/channel/render/card.clj
@@ -25,6 +25,7 @@
    [:channel.render/include-buttons?           {:description "default: false", :optional true} :boolean]
    [:channel.render/include-title?             {:description "default: false", :optional true} :boolean]
    [:channel.render/include-description?       {:description "default: false", :optional true} :boolean]
+   [:channel.render/disable-links?             {:description "default: false", :optional true} :boolean]
    [:channel.render/include-inline-parameters? {:description "default: false", :optional true} :boolean]])
 
 (defn- card-href
@@ -51,10 +52,11 @@
                       [:tr
                        [:td {:style (style/style {:padding :0
                                                   :margin  :0})}
-                        [:a {:style  (style/style (style/header-style))
-                             :href   title-href
-                             :target "_blank"
-                             :rel    "noopener noreferrer"}
+                        [:a (cond-> {:style  (style/style (style/header-style))
+                                     :target "_blank"
+                                     :rel    "noopener noreferrer"}
+                              (not (:channel.render/disable-links? options))
+                              (assoc :href title-href))
                          (h card-name)]]
                        [:td {:style (style/style {:text-align :right})}
                         (when (:channel.render/include-buttons? options)
@@ -200,13 +202,14 @@
                         ;; Provide a horizontal scrollbar for tables that overflow container width.
                         ;; Surrounding <p> element prevents buggy behavior when dragging scrollbar.
                         [:div
-                         [:a {:href        attachment-href
-                              :target      "_blank"
-                              :rel         "noopener noreferrer"
-                              :style       (style/style
-                                            (style/section-style)
-                                            {:display         :block
-                                             :text-decoration :none})}
+                         [:a (cond-> {:target      "_blank"
+                                      :rel         "noopener noreferrer"
+                                      :style       (style/style
+                                                    (style/section-style)
+                                                    {:display         :block
+                                                     :text-decoration :none})}
+                               (not (:channel.render/disable-links? options))
+                               (assoc :href attachment-href))
                           title
                           description
                           (when (seq inline-parameters)

--- a/src/metabase/embedding/util.clj
+++ b/src/metabase/embedding/util.clj
@@ -19,3 +19,9 @@
   [request]
   (or (has-react-sdk-header? request)
       (has-embedded-analytics-js-header? request)))
+
+(defn modular-embedding-context?
+  "Check if the client is in modular embedding context"
+  [client]
+  (or (= client embedding-sdk-client)
+      (= client embedded-analytics-js-client)))

--- a/src/metabase/notification/payload/impl/dashboard.clj
+++ b/src/metabase/notification/payload/impl/dashboard.clj
@@ -42,7 +42,8 @@
                                 :color_text_light  channel.render/color-text-light
                                 :color_text_medium channel.render/color-text-medium}
        :parameters             parameters
-       :dashboard_subscription dashboard_subscription})))
+       :dashboard_subscription dashboard_subscription
+       :disable_links          (:disable_links dashboard_subscription)})))
 
 (mu/defmethod notification.payload/skip-reason :notification/dashboard
   [{:keys [payload] :as _noti-payload}]

--- a/src/metabase/pulse/api/pulse.clj
+++ b/src/metabase/pulse/api/pulse.clj
@@ -442,7 +442,8 @@
                                          [:disable_links       {:default false} [:maybe :boolean]]
                                          [:collection_id       {:optional true} [:maybe ms/PositiveInt]]
                                          [:collection_position {:optional true} [:maybe ms/PositiveInt]]
-                                         [:dashboard_id        {:optional true} [:maybe ms/PositiveInt]]]]
+                                         [:dashboard_id        {:optional true} [:maybe ms/PositiveInt]]]
+   request]
   ;; Check permissions on cards that exist. Placeholders and iframes don't matter.
   (check-card-read-permissions
    (remove (fn [{:keys [id display]}]
@@ -453,7 +454,9 @@
   (doseq [channel channels]
     (pulse-channel/validate-email-domains channel))
   (notification/with-default-options {:notification/sync? true}
-    (pulse.send/send-pulse! (assoc body :creator_id api/*current-user-id*)))
+    (pulse.send/send-pulse! (-> body
+                                (assoc :creator_id api/*current-user-id*)
+                                (assoc :creation_context (get-in request [:headers "x-metabase-client"])))))
   {:ok true})
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to

--- a/src/metabase/pulse/api/pulse.clj
+++ b/src/metabase/pulse/api/pulse.clj
@@ -18,6 +18,7 @@
    [metabase.classloader.core :as classloader]
    [metabase.collections.models.collection :as collection]
    [metabase.config.core :as config]
+   [metabase.embedding.util :as embed.util]
    [metabase.events.core :as events]
    [metabase.models.interface :as mi]
    [metabase.notification.core :as notification]
@@ -456,7 +457,7 @@
   (notification/with-default-options {:notification/sync? true}
     (pulse.send/send-pulse! (-> body
                                 (assoc :creator_id api/*current-user-id*)
-                                (assoc :creation_context (get-in request [:headers "x-metabase-client"])))))
+                                (assoc :disable_links (embed.util/modular-embedding-context? (get-in request [:headers "x-metabase-client"]))))))
   {:ok true})
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to

--- a/src/metabase/pulse/api/pulse.clj
+++ b/src/metabase/pulse/api/pulse.clj
@@ -439,6 +439,7 @@
                                          [:cards               [:+ models.pulse/CoercibleToCardRef]]
                                          [:channels            [:+ :map]]
                                          [:skip_if_empty       {:default false} [:maybe :boolean]]
+                                         [:disable_links       {:default false} [:maybe :boolean]]
                                          [:collection_id       {:optional true} [:maybe ms/PositiveInt]]
                                          [:collection_position {:optional true} [:maybe ms/PositiveInt]]
                                          [:dashboard_id        {:optional true} [:maybe ms/PositiveInt]]]]

--- a/src/metabase/pulse/send.clj
+++ b/src/metabase/pulse/send.clj
@@ -67,6 +67,7 @@
                               :dashboard_id                     (:id dashboard)
                               :parameters                       (:parameters pulse)
                               :skip_if_empty                    (:skip_if_empty pulse)
+                              :disable_links                    (:disable_links pulse)
                               :dashboard_subscription_dashcards (map
                                                                  #(merge {:card_id (:id %)
                                                                           :dashboard_card_id (:dashboard_card_id %)}

--- a/src/metabase/pulse/send.clj
+++ b/src/metabase/pulse/send.clj
@@ -1,7 +1,6 @@
 (ns metabase.pulse.send
   "Code related to sending Pulses (Alerts or Dashboard Subscriptions)."
   (:require
-   [metabase.embedding.util :as embed.util]
    [metabase.models.interface :as mi]
    [metabase.pulse.models.pulse :as models.pulse]
    [metabase.util.cron :as u.cron]
@@ -68,7 +67,7 @@
                               :dashboard_id                     (:id dashboard)
                               :parameters                       (:parameters pulse)
                               :skip_if_empty                    (:skip_if_empty pulse)
-                              :disable_links                    (embed.util/modular-embedding-context? (:creation_context pulse))
+                              :disable_links                    (:disable_links pulse)
                               :dashboard_subscription_dashcards (map
                                                                  #(merge {:card_id (:id %)
                                                                           :dashboard_card_id (:dashboard_card_id %)}

--- a/src/metabase/pulse/send.clj
+++ b/src/metabase/pulse/send.clj
@@ -1,6 +1,7 @@
 (ns metabase.pulse.send
   "Code related to sending Pulses (Alerts or Dashboard Subscriptions)."
   (:require
+   [metabase.embedding.util :as embed.util]
    [metabase.models.interface :as mi]
    [metabase.pulse.models.pulse :as models.pulse]
    [metabase.util.cron :as u.cron]
@@ -67,7 +68,7 @@
                               :dashboard_id                     (:id dashboard)
                               :parameters                       (:parameters pulse)
                               :skip_if_empty                    (:skip_if_empty pulse)
-                              :disable_links                    (:disable_links pulse)
+                              :disable_links                    (embed.util/modular-embedding-context? (:creation_context pulse))
                               :dashboard_subscription_dashcards (map
                                                                  #(merge {:card_id (:id %)
                                                                           :dashboard_card_id (:dashboard_card_id %)}


### PR DESCRIPTION
closes EMB-1139
.

### Description

When calling `/api/pulse/test` endpoint on the modular embedding and modular embedding SDK, we will pass `disable_links: true` and that will be used to disable links in subscription emails.

Markdown links are not removed as it's complicated to detect which one are Metabase links while parsing markdown.

The footer is also removed as it contains links to Metabase.

### How to verify
1. Run any SMTP server e.g.
    ```sh
    docker run -d -p 1080:1080 -p 1025:1025 maildev/maildev
    ```
1. Set up SMTP
1. Test modular embedding: Go to any dashboard > sharing icon > Embed > select any auth except "guest" > check "Allow subscriptions"
2. Test modular embedding SDK (StaticDashboard, InteractiveDashboard, EditableDashboard)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
