### PR TITLE
docs(tenants): update `tenant` to `@tenant`

### DIFF
--- a/docs/people-and-groups/assigning-users-to-tenants.md
+++ b/docs/people-and-groups/assigning-users-to-tenants.md
@@ -18,7 +18,7 @@ If you're running a multi-tenant application, you can assign users to tenants ba
 
 When a user logs in with JWT:
 
-1. Metabase reads the tenant identifier from the JWT claim. By default, this is the `tenant` key.
+1. Metabase reads the tenant identifier from the JWT claim. By default, this is the `@tenant` key.
 2. If the tenant doesn't exist, Metabase automatically creates it
 3. New users are automatically assigned to the tenant from their JWT
 
@@ -29,7 +29,7 @@ When a user logs in with JWT:
   "email": "user@example.com",
   "first_name": "Jane",
   "last_name": "Doe",
-  "tenant": "acme-corp"
+  "@tenant": "acme-corp"
 }
 ```
 
@@ -46,7 +46,7 @@ If a user attempts to log in with mismatched tenant information, they will recei
 
 # Configuring the tenant claim
 
-By default, Metabase looks for a `tenant` key in your JWT. You can customize this:
+By default, Metabase looks for a `@tenant` key in your JWT. You can customize this:
 
 1. Go to **Admin** > **Settings** > **Authentication** > **JWT** > **User attribute configuration**
 2. Change the **Tenant assignment attribute** key to your preferred identifier.

--- a/docs/people-and-groups/authenticating-with-jwt.md
+++ b/docs/people-and-groups/authenticating-with-jwt.md
@@ -42,7 +42,7 @@ These are additional settings you can fill in to pass user attributes to Metabas
 - **First name attribute:** the key to retrieve each JWT user's first name.
 - **Last name attribute:** if you guessed that this is the key to retrieve each JWT user's last name, well then you have been paying attention.
 - **Group assignment attribute:** the key to retrieve each JWT user's group assignments.
-- **Tenant attribute:** the key to retrieve each JWT user's tenant. Default is `tenant`. See [Assigning tenant users to tenants](./assigning-users-to-tenants.md).
+- **Tenant attribute:** the key to retrieve each JWT user's tenant. Default is `@tenant`. See [Assigning tenant users to tenants](./assigning-users-to-tenants.md).
 
 You can send additional user attributes to Metabase by adding the attributes as key/value pairs to your JWT. These attributes will be synced on every login.
 


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-2580/update-tenant-jwt-docs-to-use-tenant-claim

We renamed "tenant" to `@tenant` but we didn't change the docs