### PR TITLE
Reduce the "Attributes" font size in a user form

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/components/LoginAttributesWidget/LoginAttributesWidget.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/components/LoginAttributesWidget/LoginAttributesWidget.tsx
@@ -82,7 +82,7 @@ export const LoginAttributesWidget = ({
       <Accordion mt="xl">
         <Accordion.Item value="login-attributes">
           <Accordion.Control>
-            <Text fz="lg">{title}</Text>
+            <Text fz="md">{title}</Text>
           </Accordion.Control>
           <Accordion.Panel>
             <Box pt="md">


### PR DESCRIPTION
Resolves #65297.

"Attributes" font size is now aligned with the other form labels. The outstanding issue (outside the scope of this fix) is that the accordion is still larger than the text input fields. There's a separate linear issue for it: https://linear.app/metabase/issue/DSN-95/align-accordion-and-input-field-sizing-in-forms

![Kapture 2025-12-17 at 16 58 34](https://github.com/user-attachments/assets/004000a7-e26c-4ff2-b9ca-f4d830e01de5)
