### PR TITLE
Scalar - column might be undefined

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/Scalar/Scalar.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Scalar/Scalar.tsx
@@ -70,7 +70,7 @@ export class Scalar extends Component<
         {
           data: { cols },
         },
-      ]) => cols[0].name,
+      ]) => cols[0]?.name,
       getHidden: ([
         {
           data: { cols },


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #66798
### Description
Series `DatasetColumns` only come back once the query is complete, so we need to not access `name` if `col[0]` is undefined. Returning undefined is fine here as it's what we're doing anyways when this error appears in `frontend/src/metabase/visualizations/lib/settings.js`

### How to verify
1. Create a scalar question
2. Add that scalar question to a dashboard
3. The dashboard should load without any console messages

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
