### PR TITLE
Support transitive workspace transform execution

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/workspaces/execute.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/execute.clj
@@ -42,7 +42,7 @@
                     :tables  {}}
                    table-mapping)]
     ;; We may need to set other options, like the case insensitivity (driver dependent)
-    (update-in source [:query :stages 0 :native] (fn [%] (macaw/replace-names % remapping {:allow-unused? true})))))
+    (update-in source [:query :stages 0 :native] #(macaw/replace-names % remapping {:allow-unused? true}))))
 
 (defn- remap-mbql-source [_table-mapping _field-map source]
   (throw (ex-info "Remapping MBQL queries is not supported yet" {:source source})))

--- a/enterprise/backend/src/metabase_enterprise/workspaces/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/impl.clj
@@ -84,7 +84,9 @@
                                   :id     isolated_table_id}]))
                          outputs)]
     {:tables          table-map
+     ;; We never want to write to any global tables, so remap on-the-fly if we hit an un-mapped target.
      :target-fallback (fn [[d s t]]
+                        (log/warn "Missing remapping for" {:db d :schema s, :table s})
                         {:db-id d, :schema (:schema workspace), :table (ws.u/isolated-table-name s t), :id nil})
      ;; We won't need the field-map until we support MBQL.
      :fields          nil}))

--- a/enterprise/backend/test/metabase_enterprise/workspaces/execute_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/execute_test.clj
@@ -4,10 +4,8 @@
    [clojure.test :refer :all]
    [metabase-enterprise.transforms.test-util :as transforms.tu]
    [metabase-enterprise.workspaces.common :as ws.common]
-   [metabase-enterprise.workspaces.execute :as ws.execute]
    [metabase-enterprise.workspaces.impl :as ws.impl]
    [metabase-enterprise.workspaces.test-util :as ws.tu]
-   [metabase-enterprise.workspaces.util :as ws.u]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 


### PR DESCRIPTION
References BOT-677 (handles SQL sources, leaving only Python ones)

This allows us to execute graphs of workspace transforms, in the correct order.

We mess up a bit if there are enclosed transforms, as we're not tracking the outputs of those tables, and therefore forget to remap them. We also haven't updated the `workspace/:id/table` API to consider the enclosed transforms either.