### PR TITLE
Remove transform.workspace_id

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/transforms/models/transform.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/models/transform.clj
@@ -225,7 +225,6 @@
    :skip [:dependency_analysis_version :source_type]
    :transform {:created_at    (serdes/date)
                :creator_id    (serdes/fk :model/User)
-               :workspace_id  (serdes/fk :model/Workspace)
                :collection_id (serdes/fk :model/Collection)
                :source        {:export #(update % :query serdes/export-mbql)
                                :import #(update % :query serdes/import-mbql)}

--- a/enterprise/backend/src/metabase_enterprise/workspaces/models/workspace.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/models/workspace.clj
@@ -3,13 +3,8 @@
    [metabase-enterprise.workspaces.impl :as ws.impl]
    [metabase-enterprise.workspaces.isolation :as ws.isolation]
    [metabase.models.interface :as mi]
-   [metabase.util.json :as json]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
-
-(def ^:private type->grouping "How models are grouped in lists"
-  ;; do not forget to update `entities` if you add stuff here
-  {:transform :transforms})
 
 (methodical/defmethod t2/table-name :model/Workspace [_model] :workspace)
 
@@ -22,41 +17,13 @@
   (derive :metabase/model)
   (derive :hook/timestamped?))
 
-(defn- entities [entity-type ids]
-  (->> (case entity-type
-         :transform
-         (t2/select [:model/Transform
-                     :id :name :description :source :target :source_type :creator_id :collection_id
-                     :created_at :updated_at :transform.workspace_id :wmt.upstream_id
-                     [:upstream.target :upstream]]
-                    :transform.workspace_id [:in ids]
-                    {:left-join [[:workspace_mapping_transform :wmt] [:= :wmt.downstream_id :transform.id]
-                                 [:transform :upstream]              [:= :upstream.id :wmt.upstream_id]]
-                     :order-by [:id]}))
-       (mapv #(-> %
-                  (update :upstream json/decode+kw)
-                  (assoc :type entity-type)))))
-
-(defn- ws-contents [ids]
-  (fn []
-    (->> (mapcat #(entities % ids) (keys type->grouping))
-         (reduce (fn [acc e]
-                   (update-in acc [(:workspace_id e) (type->grouping (:type e))] (fnil conj []) e))
-                 {}))))
-
-(methodical/defmethod t2/batched-hydrate [:model/Workspace :contents]
-  "Batch hydrate `Workspace` contents"
-  [_model k wses]
-  (let [ids (mapv :id wses)]
-    (mi/instances-with-hydrated-data wses k (ws-contents ids) :id {:default {}})))
-
 (defn archive!
   "Archive a workspace. Destroys database isolation resources, revokes access grants, and sets archived_at."
   [workspace]
   (let [database     (t2/select-one :model/Database (:database_id workspace))
         workspace-id (:id workspace)]
     (ws.isolation/destroy-workspace-isolation! database workspace)
-    ;; Mark all inputs as ungranted since the user was dropped
+    ;; Mark all inputs as un-granted since the user was dropped
     (t2/update! :model/WorkspaceInput {:workspace_id workspace-id}
                 {:access_granted false})
     (t2/update! :model/Workspace workspace-id {:archived_at [:now]})))
@@ -73,7 +40,7 @@
                                             (select-keys isolation-result [:schema :database_details])))
         ;; Re-fetch workspace to get updated database_details and schema for granting permissions
         updated-ws       (t2/select-one :model/Workspace workspace-id)]
-    ;; Re-grant read access to source tables (inputs were marked ungranted during archive)
+    ;; Re-grant read access to source tables (inputs were marked un-granted during archive)
     (ws.impl/sync-grant-accesses! updated-ws)))
 
 (defn delete!

--- a/enterprise/backend/test/metabase_enterprise/transforms/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/api_test.clj
@@ -269,18 +269,6 @@
             (is (=? [{:id t2-id}]
                     (mt/user-http-request :crowberto :get 200 "ee/transform" :tag_ids [tag2-id])))))))))
 
-(deftest filter-transforms-by-workspace-test
-  (testing "GET /api/ee/transform filters out workspace transforms by default"
-    (mt/with-premium-features #{:transforms :workspaces}
-      (mt/with-temp [:model/Transform {global-id :id}    {}
-                     :model/Workspace {ws-id :id}        {:name "Test Workspace"}
-                     :model/Transform {ws-transform-id :id} {:workspace_id ws-id}]
-        (testing "by default, only global transforms (workspace_id=null) are returned"
-          (let [transforms (mt/user-http-request :crowberto :get 200 "ee/transform")
-                ids (set (map :id transforms))]
-            (is (contains? ids global-id))
-            (is (not (contains? ids ws-transform-id)))))))))
-
 (deftest filter-transforms-by-type-test
   (testing "should be able to filter transforms by source type"
     (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)

--- a/frontend/src/metabase-types/api/mocks/transform.ts
+++ b/frontend/src/metabase-types/api/mocks/transform.ts
@@ -86,7 +86,6 @@ export function createMockTransform(opts?: Partial<Transform>): Transform {
     target: opts?.target ?? createMockTransformTarget(),
     created_at: "2000-01-01T00:00:00Z",
     updated_at: "2000-01-01T00:00:00Z",
-    workspace_id: null,
     ...opts,
   };
 }

--- a/frontend/src/metabase-types/api/transform.ts
+++ b/frontend/src/metabase-types/api/transform.ts
@@ -23,7 +23,6 @@ export type Transform = {
   tag_ids?: TransformTagId[];
   table?: Table | null;
   last_run?: TransformRun | null;
-  workspace_id?: number | null;
 };
 
 export type SuggestedTransform = Partial<Pick<Transform, "id">> &

--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -3748,6 +3748,50 @@ databaseChangeLog:
             tableName: workspace_input
             columnName: access_granted
 
+  - changeSet:
+      id: v58.2025-12-17T17:54:00
+      author: christruter
+      comment: Drop foreign key constraint from transform.workspace_id to workspace
+      preConditions:
+        - onFail: MARK_RAN
+        - foreignKeyConstraintExists:
+            foreignKeyName: fk_transform_workspace_id
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: transform
+            constraintName: fk_transform_workspace_id
+      rollback:
+        - addForeignKeyConstraint:
+            baseTableName: transform
+            baseColumnNames: workspace_id
+            constraintName: fk_transform_workspace_id
+            referencedTableName: workspace
+            referencedColumnNames: id
+
+  - changeSet:
+      id: v58.2025-12-17T17:54:01
+      author: christruter
+      comment: Drop workspace_id column from transform table
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: transform
+            columnName: workspace_id
+      changes:
+        - dropColumn:
+            tableName: transform
+            columnName: workspace_id
+      rollback:
+        - addColumn:
+            tableName: transform
+            columns:
+              - column:
+                  name: workspace_id
+                  type: int
+                  remarks: Workspace containing this transform
+                  constraints:
+                    nullable: true
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################


### PR DESCRIPTION
References BOT-699

We no longer store Workspace definitions in the `transform` table. Purge some left overs.