### PR TITLE
display setting limit and dont let users enter more than the limit

### DIFF
--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -404,6 +404,8 @@ export const createMockSettings = (
   "embedding-hub-sso-auth-manual-tested": false,
   "notebook-native-preview-sidebar-width": null,
   "query-analysis-enabled": false,
+  "unaggregated-query-row-limit": null,
+  "aggregated-query-row-limit": null,
   "check-for-updates": true,
   "trial-banner-dismissal-timestamp": null,
   "license-token-missing-banner-dismissal-timestamp": [],

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -426,6 +426,7 @@ export type CustomGeoJSONSetting = Record<string, CustomGeoJSONMap>;
 
 interface InstanceSettings {
   "admin-email": string | null;
+  "aggregated-query-row-limit": number | null;
   "email-from-address-override": string | null;
   "email-smtp-host-override": string | null;
   "email-smtp-port-override": 465 | 587 | 2525 | null;
@@ -461,6 +462,7 @@ interface InstanceSettings {
   "site-uuid": string;
   "smtp-override-enabled": boolean;
   "subscription-allowed-domains": string | null;
+  "unaggregated-query-row-limit": number | null;
   "uploads-settings": UploadsSettings;
   "user-visibility": string | null;
   "query-analysis-enabled": boolean;

--- a/frontend/src/metabase/common/utils/get-row-count-message.ts
+++ b/frontend/src/metabase/common/utils/get-row-count-message.ts
@@ -1,7 +1,5 @@
 import { t } from "ttag";
 
-import { HARD_ROW_LIMIT } from "metabase-lib/v1/queries/utils";
-
 import type { NumberFormatter } from "../hooks/use-number-formatter";
 
 import { formatRowCount } from "./format-row-count";
@@ -9,12 +7,13 @@ import { formatRowCount } from "./format-row-count";
 export function getRowCountMessage(
   result: { data: { rows_truncated: number }; row_count: number },
   formatNumber: NumberFormatter,
+  maxRowCount: number,
 ) {
   if (result.data.rows_truncated > 0) {
     return t`Showing first ${formatRowCount(result.row_count, formatNumber)}`;
   }
-  if (result.row_count === HARD_ROW_LIMIT) {
-    return t`Showing first ${formatRowCount(HARD_ROW_LIMIT, formatNumber)}`;
+  if (result.row_count === maxRowCount) {
+    return t`Showing first ${formatRowCount(maxRowCount, formatNumber)}`;
   }
   return t`Showing ${formatRowCount(result.row_count, formatNumber)}`;
 }

--- a/frontend/src/metabase/query_builder/components/LimitPopover.tsx
+++ b/frontend/src/metabase/query_builder/components/LimitPopover.tsx
@@ -29,6 +29,8 @@ const CustomRowLimit = ({
   return (
     <NumberInput
       size="sm"
+      allowDecimal={false}
+      allowNegative={false}
       value={inputValue}
       className={cx({
         [cx(CS.textBrand, CS.borderBrand)]: limit != null && !exceedsMax,

--- a/frontend/src/metabase/query_builder/components/LimitPopover.tsx
+++ b/frontend/src/metabase/query_builder/components/LimitPopover.tsx
@@ -2,10 +2,9 @@ import cx from "classnames";
 import { type KeyboardEvent, useState } from "react";
 import { t } from "ttag";
 
-import { Radio } from "metabase/common/components/Radio";
 import CS from "metabase/css/core/index.css";
 import { formatNumber } from "metabase/lib/formatting";
-import { LimitInput } from "metabase/querying/components/LimitInput";
+import { NumberInput, Radio, Stack } from "metabase/ui";
 import { HARD_ROW_LIMIT } from "metabase-lib/v1/queries/utils";
 
 interface CustomRowLimitProps {
@@ -28,18 +27,16 @@ const CustomRowLimit = ({
   const exceedsMax = !isNaN(numericValue) && numericValue > maxRowLimit;
 
   return (
-    <LimitInput
-      small
+    <NumberInput
+      size="sm"
       value={inputValue}
       className={cx({
         [cx(CS.textBrand, CS.borderBrand)]: limit != null && !exceedsMax,
       })}
-      style={exceedsMax ? { borderColor: "var(--mb-color-error)" } : undefined}
+      error={exceedsMax && t`Value exceeds maximum of ${maxRowLimit}`}
       placeholder={t`Pick a limit`}
-      onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-        setInputValue(e.target.value)
-      }
-      onKeyPress={(e: KeyboardEvent<HTMLInputElement>) => {
+      onChange={(value: number | string) => setInputValue(value.toString())}
+      onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => {
         if (e.nativeEvent.isComposing) {
           return;
         }
@@ -80,31 +77,37 @@ export const LimitPopover = ({
 
   return (
     <div className={cx(className, CS.textBold, CS.textMedium)}>
-      <Radio
-        vertical
+      <Radio.Group
         value={limit == null ? "maximum" : "custom"}
-        options={[
-          {
-            name: t`Show maximum (first ${formatNumber(HARD_ROW_LIMIT)})`,
-            value: "maximum",
-          },
-          {
-            name: (
+        onChange={(value: string) =>
+          value === "maximum"
+            ? onChangeLimit(null)
+            : onChangeLimit(effectiveMaxLimit)
+        }
+      >
+        <Stack>
+          <Radio
+            value="maximum"
+            label={t`Show maximum (first ${formatNumber(effectiveMaxLimit)})`}
+          />
+          <Radio
+            value="custom"
+            label={
               <CustomRowLimit
-                key={limit == null ? "a" : "b"}
                 limit={limit}
                 onChangeLimit={onChangeLimit}
                 onClose={onClose}
                 maxRowLimit={effectiveMaxLimit}
               />
-            ),
-            value: "custom",
-          },
-        ]}
-        onChange={(value: string) =>
-          value === "maximum" ? onChangeLimit(null) : onChangeLimit(2000)
-        }
-      />
+            }
+            styles={{
+              inner: {
+                marginTop: "0.5rem",
+              },
+            }}
+          />
+        </Stack>
+      </Radio.Group>
     </div>
   );
 };

--- a/frontend/src/metabase/query_builder/components/LimitPopover.tsx
+++ b/frontend/src/metabase/query_builder/components/LimitPopover.tsx
@@ -1,5 +1,5 @@
 import cx from "classnames";
-import type { KeyboardEvent } from "react";
+import { type KeyboardEvent, useState } from "react";
 import { t } from "ttag";
 
 import { Radio } from "metabase/common/components/Radio";
@@ -12,31 +12,49 @@ interface CustomRowLimitProps {
   limit: number | null;
   onChangeLimit: (limit: number | null) => void;
   onClose: () => void;
+  maxRowLimit: number;
 }
 
 const CustomRowLimit = ({
   limit,
   onChangeLimit,
   onClose,
+  maxRowLimit,
 }: CustomRowLimitProps) => {
+  const [inputValue, setInputValue] = useState(
+    limit != null ? String(limit) : "",
+  );
+  const numericValue = parseInt(inputValue, 10);
+  const exceedsMax = !isNaN(numericValue) && numericValue > maxRowLimit;
+
   return (
     <LimitInput
       small
-      defaultValue={limit ?? undefined}
-      className={cx({ [cx(CS.textBrand, CS.borderBrand)]: limit != null })}
+      value={inputValue}
+      className={cx({
+        [cx(CS.textBrand, CS.borderBrand)]: limit != null && !exceedsMax,
+      })}
+      style={exceedsMax ? { borderColor: "var(--mb-color-error)" } : undefined}
       placeholder={t`Pick a limit`}
+      onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+        setInputValue(e.target.value)
+      }
       onKeyPress={(e: KeyboardEvent<HTMLInputElement>) => {
         if (e.nativeEvent.isComposing) {
           return;
         }
         if (e.key === "Enter") {
           const value = parseInt(e.currentTarget.value, 10);
-          if (value > 0) {
+          if (value > 0 && value <= maxRowLimit) {
             onChangeLimit(value);
+            onClose?.();
+          } else if (value > maxRowLimit) {
+            // Don't close or submit if value exceeds max
+            return;
           } else {
             onChangeLimit(null);
+            onClose?.();
           }
-          onClose();
         }
       }}
     />
@@ -48,6 +66,7 @@ interface LimitPopoverProps {
   onChangeLimit: (limit: number | null) => void;
   onClose: () => void;
   className?: string;
+  maxRowLimit?: number;
 }
 
 export const LimitPopover = ({
@@ -55,31 +74,37 @@ export const LimitPopover = ({
   onChangeLimit,
   onClose,
   className,
-}: LimitPopoverProps) => (
-  <div className={cx(className, CS.textBold, CS.textMedium)}>
-    <Radio
-      vertical
-      value={limit == null ? "maximum" : "custom"}
-      options={[
-        {
-          name: t`Show maximum (first ${formatNumber(HARD_ROW_LIMIT)})`,
-          value: "maximum",
-        },
-        {
-          name: (
-            <CustomRowLimit
-              key={limit == null ? "a" : "b"}
-              limit={limit}
-              onChangeLimit={onChangeLimit}
-              onClose={onClose}
-            />
-          ),
-          value: "custom",
-        },
-      ]}
-      onChange={(value: string) =>
-        value === "maximum" ? onChangeLimit(null) : onChangeLimit(2000)
-      }
-    />
-  </div>
-);
+  maxRowLimit,
+}: LimitPopoverProps) => {
+  const effectiveMaxLimit = maxRowLimit ?? HARD_ROW_LIMIT;
+
+  return (
+    <div className={cx(className, CS.textBold, CS.textMedium)}>
+      <Radio
+        vertical
+        value={limit == null ? "maximum" : "custom"}
+        options={[
+          {
+            name: t`Show maximum (first ${formatNumber(HARD_ROW_LIMIT)})`,
+            value: "maximum",
+          },
+          {
+            name: (
+              <CustomRowLimit
+                key={limit == null ? "a" : "b"}
+                limit={limit}
+                onChangeLimit={onChangeLimit}
+                onClose={onClose}
+                maxRowLimit={effectiveMaxLimit}
+              />
+            ),
+            value: "custom",
+          },
+        ]}
+        onChange={(value: string) =>
+          value === "maximum" ? onChangeLimit(null) : onChangeLimit(2000)
+        }
+      />
+    </div>
+  );
+};

--- a/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.tsx
@@ -107,11 +107,13 @@ function QuestionRowCountInner({
 
   const message = useMemo(() => {
     if (isNative) {
-      return isResultDirty ? "" : getRowCountMessage(result, formatNumber);
+      return isResultDirty
+        ? ""
+        : getRowCountMessage(result, formatNumber, maxRowLimit);
     }
     return isResultDirty
       ? getLimitMessage(question, result, formatNumber, maxRowLimit)
-      : getRowCountMessage(result, formatNumber);
+      : getRowCountMessage(result, formatNumber, maxRowLimit);
   }, [question, result, isResultDirty, isNative, formatNumber, maxRowLimit]);
 
   const handleLimitChange = (limit: number | null) => {
@@ -205,7 +207,7 @@ function getLimitMessage(
 ): string {
   const limit = Lib.currentLimit(question.query(), -1);
   const isValidLimit =
-    typeof limit === "number" && limit > 0 && limit < maxRowLimit;
+    typeof limit === "number" && limit > 0 && limit <= maxRowLimit;
 
   if (isValidLimit) {
     return t`Show ${formatRowCount(limit, formatNumber)}`;

--- a/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.tsx
@@ -8,6 +8,7 @@ import {
   type NumberFormatter,
   useNumberFormatter,
 } from "metabase/common/hooks/use-number-formatter";
+import { useSetting } from "metabase/common/hooks/use-setting";
 import { formatRowCount } from "metabase/common/utils/format-row-count";
 import { getRowCountMessage } from "metabase/common/utils/get-row-count-message";
 import CS from "metabase/css/core/index.css";
@@ -24,9 +25,11 @@ import { Box, Popover, UnstyledButton } from "metabase/ui";
 import type { Limit } from "metabase-lib";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
-import { HARD_ROW_LIMIT } from "metabase-lib/v1/queries/utils";
 import type { Dataset } from "metabase-types/api";
 import type { State } from "metabase-types/store";
+
+const DEFAULT_UNAGGREGATED_ROW_LIMIT = 2000;
+const DEFAULT_AGGREGATED_ROW_LIMIT = 10000;
 
 import QuestionRowCountS from "./QuestionRowCount.module.css";
 
@@ -70,6 +73,13 @@ const mapDispatchToProps = {
   onChangeLimit: setLimit,
 };
 
+function hasAggregations(question: Question): boolean {
+  const query = question.query();
+  const stageIndex = -1; // last stage
+  const aggregations = Lib.aggregations(query, stageIndex);
+  return aggregations.length > 0;
+}
+
 function QuestionRowCountInner({
   question,
   result,
@@ -81,14 +91,28 @@ function QuestionRowCountInner({
   const [opened, { close, toggle }] = useDisclosure(false);
   const { isEditable, isNative } = Lib.queryDisplayInfo(question.query());
   const formatNumber = useNumberFormatter();
+
+  // Get configured row limits from settings
+  const unaggregatedRowLimit = useSetting("unaggregated-query-row-limit");
+  const aggregatedRowLimit = useSetting("aggregated-query-row-limit");
+
+  // Determine the effective max row limit based on whether the query has aggregations
+  const maxRowLimit = useMemo(() => {
+    const isAggregated = hasAggregations(question);
+    if (isAggregated) {
+      return aggregatedRowLimit ?? DEFAULT_AGGREGATED_ROW_LIMIT;
+    }
+    return unaggregatedRowLimit ?? DEFAULT_UNAGGREGATED_ROW_LIMIT;
+  }, [question, unaggregatedRowLimit, aggregatedRowLimit]);
+
   const message = useMemo(() => {
     if (isNative) {
       return isResultDirty ? "" : getRowCountMessage(result, formatNumber);
     }
     return isResultDirty
-      ? getLimitMessage(question, result, formatNumber)
+      ? getLimitMessage(question, result, formatNumber, maxRowLimit)
       : getRowCountMessage(result, formatNumber);
-  }, [question, result, isResultDirty, isNative, formatNumber]);
+  }, [question, result, isResultDirty, isNative, formatNumber, maxRowLimit]);
 
   const handleLimitChange = (limit: number | null) => {
     onChangeLimit(limit !== null && limit > 0 ? limit : null);
@@ -135,6 +159,7 @@ function QuestionRowCountInner({
           limit={limit}
           onChangeLimit={handleLimitChange}
           onClose={close}
+          maxRowLimit={maxRowLimit}
         />
       </Popover.Dropdown>
     </Popover>
@@ -176,10 +201,11 @@ function getLimitMessage(
   question: Question,
   result: Dataset,
   formatNumber: NumberFormatter,
+  maxRowLimit: number,
 ): string {
   const limit = Lib.currentLimit(question.query(), -1);
   const isValidLimit =
-    typeof limit === "number" && limit > 0 && limit < HARD_ROW_LIMIT;
+    typeof limit === "number" && limit > 0 && limit < maxRowLimit;
 
   if (isValidLimit) {
     return t`Show ${formatRowCount(limit, formatNumber)}`;
@@ -190,11 +216,11 @@ function getLimitMessage(
 
   if (hasValidRowCount) {
     // The query has been altered but we might still have the old result set,
-    // so show that instead of a generic HARD_ROW_LIMIT
+    // so show that instead of a generic maxRowLimit
     return t`Showing ${formatRowCount(result.row_count, formatNumber)}`;
   }
 
-  return t`Showing first ${formatRowCount(HARD_ROW_LIMIT, formatNumber)} rows`;
+  return t`Showing first ${formatRowCount(maxRowLimit, formatNumber)} rows`;
 }
 
 function getDatabaseId(_state: State, { question }: OwnProps & StateProps) {

--- a/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.unit.spec.tsx
@@ -6,12 +6,7 @@ import {
   setupUnauthorizedDatabasesEndpoints,
 } from "__support__/server-mocks";
 import { createMockEntitiesState } from "__support__/store";
-import {
-  fireEvent,
-  renderWithProviders,
-  screen,
-  waitFor,
-} from "__support__/ui";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
 import { formatNumber } from "metabase/lib/formatting";
 import { checkNotNull } from "metabase/lib/types";
 import * as Lib from "metabase-lib";
@@ -21,6 +16,7 @@ import { HARD_ROW_LIMIT } from "metabase-lib/v1/queries/utils";
 import type { Card, Dataset, UnsavedCard } from "metabase-types/api";
 import {
   createMockDataset,
+  type createMockSettings,
   createMockStructuredDatasetQuery,
 } from "metabase-types/api/mocks";
 import {
@@ -32,7 +28,10 @@ import {
   createSavedNativeCard,
   createSavedStructuredCard,
 } from "metabase-types/api/mocks/presets";
-import { createMockQueryBuilderState } from "metabase-types/store/mocks";
+import {
+  createMockQueryBuilderState,
+  createMockSettingsState,
+} from "metabase-types/store/mocks";
 
 import { QuestionRowCount } from "./QuestionRowCount";
 
@@ -41,6 +40,7 @@ type SetupOpts = {
   result?: Dataset;
   isResultDirty?: boolean;
   isReadOnly?: boolean;
+  settings?: Partial<Parameters<typeof createMockSettings>[0]>;
 };
 
 function patchQuestion(question: Question) {
@@ -61,6 +61,7 @@ async function setup({
   result = createMockDataset(),
   isResultDirty = false,
   isReadOnly = false,
+  settings = {},
 }: SetupOpts) {
   const databases = [createSampleDatabase()];
   const metadata = createMockMetadata({
@@ -92,6 +93,7 @@ async function setup({
   renderWithProviders(<QuestionRowCount />, {
     storeInitialState: {
       qb: state,
+      settings: createMockSettingsState(settings),
       entities: createMockEntitiesState({
         databases: isReadOnly ? [] : databases,
         questions: "id" in card ? [card] : [],
@@ -161,8 +163,7 @@ describe("QuestionRowCount", () => {
 
           await userEvent.click(rowCount);
           const input = await screen.findByPlaceholderText("Pick a limit");
-          fireEvent.change(input, { target: { value: "25" } });
-          fireEvent.keyPress(input, { key: "Enter", charCode: 13 });
+          await userEvent.type(input, "25{Enter}");
 
           await waitFor(() => {
             expect(rowCount).toHaveTextContent("Show 25 rows");
@@ -176,8 +177,8 @@ describe("QuestionRowCount", () => {
 
           await userEvent.click(rowCount);
           const input = await screen.findByDisplayValue("25");
-          fireEvent.change(input, { target: { value: "400" } });
-          fireEvent.keyPress(input, { key: "Enter", charCode: 13 });
+          await userEvent.clear(input);
+          await userEvent.type(input, "400{Enter}");
 
           await waitFor(() => {
             expect(rowCount).toHaveTextContent("Show 400 rows");
@@ -215,6 +216,87 @@ describe("QuestionRowCount", () => {
 
           expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
         });
+      });
+    });
+  });
+
+  describe("with custom row limit settings", () => {
+    it("uses unaggregated-query-row-limit for queries without aggregations", async () => {
+      const { rowCount } = await setup({
+        question: createAdHocCard(),
+        result: createMockDataset({ row_count: 500 }),
+        settings: { "unaggregated-query-row-limit": 500 },
+      });
+
+      expect(rowCount).toHaveTextContent(
+        `Showing first ${formatNumber(500)} rows`,
+      );
+    });
+
+    it("uses aggregated-query-row-limit for queries with aggregations", async () => {
+      const { rowCount } = await setup({
+        question: createAdHocCard({
+          dataset_query: createMockStructuredDatasetQuery({
+            database: SAMPLE_DB_ID,
+            query: {
+              "source-table": ORDERS_ID,
+              aggregation: [["count"]],
+            },
+          }),
+        }),
+        result: createMockDataset({ row_count: 5000 }),
+        settings: { "aggregated-query-row-limit": 5000 },
+      });
+
+      expect(rowCount).toHaveTextContent(
+        `Showing first ${formatNumber(5000)} rows`,
+      );
+    });
+
+    it("shows the custom limit in the popover maximum label", async () => {
+      const { rowCount } = await setup({
+        question: createAdHocCard(),
+        settings: { "unaggregated-query-row-limit": 500 },
+      });
+
+      await userEvent.click(rowCount);
+
+      expect(
+        screen.getByRole("radio", {
+          name: `Show maximum (first ${formatNumber(500)})`,
+        }),
+      ).toBeInTheDocument();
+    });
+
+    it("does not allow setting a limit above the configured max", async () => {
+      const { rowCount } = await setup({
+        question: createAdHocCard(),
+        settings: { "unaggregated-query-row-limit": 100 },
+      });
+
+      await userEvent.click(rowCount);
+      const input = await screen.findByPlaceholderText("Pick a limit");
+      await userEvent.type(input, "200{Enter}");
+
+      expect(
+        screen.getByText("Value exceeds maximum of 100"),
+      ).toBeInTheDocument();
+
+      expect(rowCount).toHaveTextContent("Showing 0 rows");
+    });
+
+    it("allows setting a limit at exactly the configured max", async () => {
+      const { rowCount } = await setup({
+        question: createAdHocCard(),
+        settings: { "unaggregated-query-row-limit": 100 },
+      });
+
+      await userEvent.click(rowCount);
+      const input = await screen.findByPlaceholderText("Pick a limit");
+      await userEvent.type(input, "100{Enter}");
+
+      await waitFor(() => {
+        expect(rowCount).toHaveTextContent("Show 100 rows");
       });
     });
   });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/65638

### Description
Updates the QuestionRowCount component to pull in the max rows as defined by the app settings for MB_AGGREGATED_QUERY_ROW_LIMIT and MB_UNAGGREGATED_QUERY_ROW_LIMIT, as well as migrates the LimitPopover to use mantine components for it's Radios and Input.

### How to verify
1. Start metabase with values for MB_AGGREGATED_QUERY_ROW_LIMIT and MB_UNAGGREGATED_QUERY_ROW_LIMIT
2. Notice in the popover it should adjust the message to display the max value
3. If you input a custom value higher than the max, it should show an error
4. Test both aggregated and unaggregated questions


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
