### PR TITLE
Fix sample app e2e tests silently failing when containers don't start

### DIFF
--- a/e2e/runner/embedding-sdk/sample-apps/helpers/start-containers.ts
+++ b/e2e/runner/embedding-sdk/sample-apps/helpers/start-containers.ts
@@ -34,8 +34,9 @@ export async function startContainers({
     await Promise.all(healthcheckPromises);
 
     shell(getLogsCommand(appName));
-  } catch {
+  } catch (err) {
     shell(getLogsCommand(appName));
     shell(dockerDownCommand, { cwd, env });
+    throw err;
   }
 }


### PR DESCRIPTION
The catch block in startContainers was swallowing errors - it would
log and tear down containers but never re-throw. This meant when
health checks failed, the script would print "All done!" and exit 0,
then Cypress would run and fail with a confusing "could not verify
server is running" error.

Now we re-throw after cleanup so the actual failure is surfaced.
