### PR TITLE
load schemas when displaying DataSourceCrumbs

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/DataSourceCrumbs.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/DataSourceCrumbs.tsx
@@ -1,6 +1,10 @@
 import type { ReactElement } from "react";
+import _ from "underscore";
 
+import Schema from "metabase/entities/schemas";
+import { getDatabaseId } from "metabase/query_builder/selectors";
 import type Question from "metabase-lib/v1/Question";
+import type { State } from "metabase-types/store";
 
 import { HeadBreadcrumbs } from "../HeaderBreadcrumbs/HeaderBreadcrumbs";
 
@@ -14,12 +18,14 @@ interface Props {
   isObjectDetail?: boolean;
 }
 
-export function DataSourceCrumbs({
-  question,
-  variant,
-  isObjectDetail,
-  ...props
-}: Props) {
+export const DataSourceCrumbs = _.compose(
+  Schema.loadList({
+    query: (state: State) => ({
+      dbId: getDatabaseId(state),
+    }),
+    loadingAndErrorWrapper: false,
+  }),
+)(({ question, variant, isObjectDetail, ...props }: Props) => {
   const parts = getDataSourceParts({
     question,
     subHead: variant === "subhead",
@@ -27,4 +33,4 @@ export function DataSourceCrumbs({
   });
 
   return <HeadBreadcrumbs parts={parts} variant={variant} {...props} />;
-}
+});

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/DataSourceCrumbs.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/DataSourceCrumbs.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from "react";
 import _ from "underscore";
 
-import Schema from "metabase/entities/schemas";
+import { Schemas } from "metabase/entities/schemas";
 import { getDatabaseId } from "metabase/query_builder/selectors";
 import type Question from "metabase-lib/v1/Question";
 import type { State } from "metabase-types/store";
@@ -19,7 +19,7 @@ interface Props {
 }
 
 export const DataSourceCrumbs = _.compose(
-  Schema.loadList({
+  Schemas.loadList({
     query: (state: State) => ({
       dbId: getDatabaseId(state),
     }),


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #66155
### Description
This is kinda gross, but the reason that the schema isn't shown is because we hide schemas when we think only 1 exists in the DB, and we very rarely do calls that say "give me all the schemas for this DB". So when we go to render the Data Source Breadcrumbs, we only know of what we have seen before. If we have other schemas loaded in state, (for example, if you were browsing databases), then we get what we expect.

This change ensures that we load the schemas when rendering the breadcrumbs. Currently, they will pop in... It may be worth while to do this while loading the query builder as a whole, but it's hard to know when it will be relevant or not (saved questions would show collection breadcrumbs, not these).

### How to verify
1. Go to Browse -> Databases -> Select a DB, Schema, then Table
2. You should see the schema in the breadcrumbs
3. Reload the page, they should still be there.

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
