### PR TITLE
Split Redshift driver tests into 3 partitions to avoid CI timeouts

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -983,7 +983,7 @@ jobs:
               :only-tags [:mb/driver-tests]
               :exclude-tags '[:mb/upload-tests :mb/transforms-python-test]'
               :fail-fast? true
-              :partition/total 2
+              :partition/total 3
               :partition/index 0
           - name: Redshift (Excluding Upload Tests) Part 2
             skip: false
@@ -991,8 +991,16 @@ jobs:
               :only-tags [:mb/driver-tests]
               :exclude-tags '[:mb/upload-tests :mb/transforms-python-test]'
               :fail-fast? true
-              :partition/total 2
+              :partition/total 3
               :partition/index 1
+          - name: Redshift (Excluding Upload Tests) Part 3
+            skip: false
+            test-args: >-
+              :only-tags [:mb/driver-tests]
+              :exclude-tags '[:mb/upload-tests :mb/transforms-python-test]'
+              :fail-fast? true
+              :partition/total 3
+              :partition/index 2
           - name: Redshift Transforms Python Tests
             skip: false
             test-args: >-


### PR DESCRIPTION
Redshift tests have been hitting the 60-minute CI timeout and getting cancelled. This splits the driver tests from 2 to 3 parallel partitions, reducing per-job workload by ~33%.

Each partition runs on a separate GitHub runner with its own JVM and unique test schema (via site-uuid), so test isolation is maintained. This follows the same pattern used when tests were split from 1 to 2 partitions in November 2025.
