### PR TITLE
Stop preserving the sql/native preview panel open/closed state

### DIFF
--- a/.clj-kondo/src/hooks/metabase/settings/models/setting.clj
+++ b/.clj-kondo/src/hooks/metabase/settings/models/setting.clj
@@ -97,7 +97,6 @@
      metabot-get-prompt-templates-url
      metabot-prompt-generator-token-limit
      multi-setting-read-only
-     notebook-native-preview-shown
      notebook-native-preview-sidebar-width
      notification-link-base-url
      num-metabot-choices

--- a/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
@@ -19,8 +19,7 @@ describe("scenarios > question > notebook > native query preview sidebar", () =>
     );
   });
 
-  it("should not an show empty sidebar when no data source is selected", () => {
-    H.activateToken("pro-self-hosted");
+  it("should not show empty sidebar when no data source is selected", () => {
     cy.intercept("POST", "/api/dataset/native").as("nativeDataset");
     H.openReviewsTable({ mode: "notebook", limit: 1 });
     cy.findByLabelText("View SQL").click();
@@ -37,13 +36,20 @@ describe("scenarios > question > notebook > native query preview sidebar", () =>
     cy.findByTestId("native-query-preview-sidebar").should("not.exist");
   });
 
-  it("smoke test: should show the preview sidebar, update it, persist it and close it", () => {
+  it("smoke test: should show the preview sidebar, update it, and close it", () => {
     const defaultRowLimit = 1048575;
     const queryLimit = 2;
 
     cy.intercept("POST", "/api/dataset/native").as("nativeDataset");
 
     H.openReviewsTable({ mode: "notebook", limit: queryLimit });
+    cy.findByLabelText("View SQL").click();
+    cy.findByTestId("native-query-preview-sidebar").should("be.visible");
+
+    cy.log("Refreshing the page does not persist the sidebar state");
+    cy.reload();
+    cy.findByTestId("native-query-preview-sidebar").should("not.exist");
+
     cy.findByLabelText("View SQL").click();
     cy.wait("@nativeDataset");
     cy.findByTestId("native-query-preview-sidebar").within(() => {
@@ -54,18 +60,6 @@ describe("scenarios > question > notebook > native query preview sidebar", () =>
         .and("contain", queryLimit);
       cy.button("Convert this question to SQL").should("exist");
     });
-
-    cy.log(
-      "Sidebar state should be persisted when navigating away from the notebook",
-    );
-    H.visualize();
-    cy.findAllByTestId("header-cell").should("contain", "Rating");
-    cy.findByTestId("native-query-preview-sidebar")
-      .should("exist")
-      .and("not.be.visible");
-
-    H.openNotebook();
-    cy.findByTestId("native-query-preview-sidebar").should("be.visible");
 
     cy.log("Modifying GUI query should update the SQL preview");
     cy.findByTestId("step-limit-0-0").icon("close").click({ force: true });
@@ -103,9 +97,6 @@ describe("scenarios > question > notebook > native query preview sidebar", () =>
       cy.findByLabelText("View SQL").click();
       cy.location("pathname").should("eq", "/question/notebook");
 
-      cy.log("user setting should not be updated on small screens");
-      cy.get("@updatePreviewStateSpy").should("not.have.been.called");
-
       cy.log(
         "It shouldn't be possible to click on any of the notebook elements",
       );
@@ -128,60 +119,12 @@ describe("scenarios > question > notebook > native query preview sidebar", () =>
     },
   );
 
-  it("should disregard user setting on small screens when navigating (metabase#48170)", () => {
+  it("resizing to the small window should close the native preview (metabase#48170)", () => {
     H.openReviewsTable({ mode: "notebook", limit: 1 });
-
-    cy.get("@updatePreviewStateSpy").should("have.callCount", 0);
-    cy.findByLabelText("View SQL").click(); // set setting to true
-    cy.get("@updatePreviewStateSpy").should("have.callCount", 1);
-    cy.findByTestId("native-query-preview-sidebar").should("be.visible");
-
-    cy.visit("/model/new");
-    cy.findByTestId("new-model-options").should("be.visible");
-
-    resizeScreen("small");
-
-    H.openReviewsTable({ mode: "notebook", limit: 1 });
-    cy.findByTestId("native-query-preview-sidebar").should("not.exist");
-  });
-
-  it("should disregard user setting on small screens when resizing (metabase#48170)", () => {
-    H.openReviewsTable({ mode: "notebook", limit: 1 });
-
-    cy.get("@updatePreviewStateSpy").should("have.callCount", 0);
-    cy.findByLabelText("View SQL").click(); // set setting to true
-    cy.get("@updatePreviewStateSpy").should("have.callCount", 1);
-    cy.findByTestId("native-query-preview-sidebar").should("be.visible");
-
-    cy.log(
-      "resizing from large to small screen, setting: open, ui state: open",
-    );
-    resizeScreen("small");
-    cy.findByTestId("native-query-preview-sidebar").should("not.exist");
-
     cy.findByLabelText("View SQL").click();
     cy.findByTestId("native-query-preview-sidebar").should("be.visible");
 
-    cy.log(
-      "resizing from small to large screen, setting: open, ui state: closed",
-    );
-    cy.findByLabelText("Hide SQL").click();
-    cy.findByTestId("native-query-preview-sidebar").should("not.exist");
-    resizeScreen("large");
-    cy.findByTestId("native-query-preview-sidebar").should("be.visible");
-
-    cy.log(
-      "resizing from small to large screen, setting: closed, ui state: open",
-    );
-    cy.get("@updatePreviewStateSpy").should("have.callCount", 1);
-    cy.findByLabelText("Hide SQL").click(); // set setting to false
-    cy.get("@updatePreviewStateSpy").should("have.callCount", 2);
-    cy.findByTestId("native-query-preview-sidebar").should("not.exist");
     resizeScreen("small");
-    cy.findByLabelText("View SQL").click();
-    cy.get("@updatePreviewStateSpy").should("have.callCount", 2);
-    cy.findByTestId("native-query-preview-sidebar").should("be.visible");
-    resizeScreen("large");
     cy.findByTestId("native-query-preview-sidebar").should("not.exist");
   });
 
@@ -200,14 +143,12 @@ describe("scenarios > question > notebook > native query preview sidebar", () =>
 
     cy.intercept("POST", "/api/dataset/query_metadata").as("metadata");
     cy.intercept("GET", "/api/session/properties").as("sessionProperties");
-    cy.intercept("PUT", "/api/setting/notebook-native-preview-shown").as(
-      "updatePreviewState",
-    );
+    cy.intercept("POST", "/api/dataset/native").as("nativeDataset");
 
     H.openReviewsTable({ mode: "notebook", limit: 1 });
     cy.wait("@metadata");
     cy.findByLabelText("View SQL").click();
-    cy.wait(["@updatePreviewState", "@sessionProperties"]);
+    cy.wait(["@nativeDataset", "@sessionProperties"]);
 
     cy.log(
       "It should not be possible to shrink the sidebar below its min (initial) width",
@@ -233,6 +174,7 @@ describe("scenarios > question > notebook > native query preview sidebar", () =>
     cy.signInAsAdmin();
     H.visitQuestion(ORDERS_COUNT_QUESTION_ID);
     H.openNotebook();
+    cy.findByLabelText("View SQL").click();
     cy.findByTestId("native-query-preview-sidebar")
       .should("be.visible")
       .then(($sidebar) => {
@@ -362,7 +304,8 @@ describe(
       cy.get("[data-testid=cell-data]").should("contain", "Small Marble Shoes");
 
       cy.log("The generated query should be valid (metabase#38181)");
-      H.openNotebook(); // SQL sidebar state was persisted so it's already open now
+      H.openNotebook();
+      cy.findByLabelText("View native query").click();
       cy.findByTestId("native-query-preview-sidebar").within(() => {
         cy.findByText("Native query for this question").should("exist");
         H.NativeEditor.get()

--- a/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
@@ -119,15 +119,6 @@ describe("scenarios > question > notebook > native query preview sidebar", () =>
     },
   );
 
-  it("resizing to the small window should close the native preview (metabase#48170)", () => {
-    H.openReviewsTable({ mode: "notebook", limit: 1 });
-    cy.findByLabelText("View SQL").click();
-    cy.findByTestId("native-query-preview-sidebar").should("be.visible");
-
-    resizeScreen("small");
-    cy.findByTestId("native-query-preview-sidebar").should("not.exist");
-  });
-
   it("sidebar should be resizable", () => {
     const toleranceDelta = 0.5;
 
@@ -466,15 +457,4 @@ function resizeSidebar(amountX: number, cb: ResizeSidebarCallback) {
       cb(initialSidebarWidth, sidebarWidth);
     });
   });
-}
-
-function resizeScreen(size: "small" | "large") {
-  const width = size === "small" ? 800 : 1280;
-  cy.viewport(width, 800);
-
-  // We need to wait for react to re-render but nothing really changes on the screen
-  // when changing viewport size, so it's hard to detect when it happens.
-  // Let's dummy-interact with the app to make sure it re-rendered.
-  cy.findByLabelText("Settings menu").click(); // open menu
-  cy.findByLabelText("Settings menu").click(); // close menu
 }

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -391,7 +391,6 @@ export const createMockSettings = (
   "setup-license-active-at-setup": false,
   "embedding-hub-test-embed-snippet-created": false,
   "embedding-hub-production-embed-snippet-created": false,
-  "notebook-native-preview-shown": false,
   "notebook-native-preview-sidebar-width": null,
   "query-analysis-enabled": false,
   "check-for-updates": true,

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -571,7 +571,6 @@ export type UserSettings = {
   "dismissed-browse-models-banner"?: boolean;
   "dismissed-custom-dashboard-toast"?: boolean;
   "last-used-native-database-id"?: number | null;
-  "notebook-native-preview-shown"?: boolean;
   "notebook-native-preview-sidebar-width"?: number | null;
   "expand-browse-in-nav"?: boolean;
   "expand-bookmarks-in-nav"?: boolean;

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -9,7 +9,6 @@ import { isNotNull } from "metabase/lib/types";
 import * as Urls from "metabase/lib/urls";
 import {
   getIsEditingInDashboard,
-  getIsNotebookNativePreviewShown,
   getNotebookNativePreviewSidebarWidth,
 } from "metabase/query_builder/selectors";
 import { loadMetadataForCard } from "metabase/questions/actions";
@@ -375,8 +374,6 @@ async function handleQBInit(
 
   const objectId = params?.objectId || queryParams?.objectId;
 
-  uiControls.isShowingNotebookNativePreview =
-    getIsNotebookNativePreviewShown(getState());
   uiControls.notebookNativePreviewSidebarWidth =
     getNotebookNativePreviewSidebarWidth(getState());
 

--- a/frontend/src/metabase/query_builder/actions/ui.ts
+++ b/frontend/src/metabase/query_builder/actions/ui.ts
@@ -102,12 +102,6 @@ export const navigateBackToDashboard = createAction(NAVIGATE_BACK_TO_DASHBOARD);
 export const CLOSE_QB = "metabase/qb/CLOSE_QB";
 export const closeQB = createAction(CLOSE_QB);
 
-export const setNotebookNativePreviewState = (isShown: boolean) =>
-  updateUserSetting({
-    key: "notebook-native-preview-shown",
-    value: isShown,
-  });
-
 export const setDidFirstNonTableChartRender = (card: Card) => {
   trackFirstNonTableChartGenerated(card);
   return updateSetting({

--- a/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
@@ -10,10 +10,7 @@ import {
   setUIControls,
 } from "metabase/query_builder/actions";
 import { useNotebookScreenSize } from "metabase/query_builder/hooks/use-notebook-screen-size";
-import {
-  getIsNotebookNativePreviewShown,
-  getUiControls,
-} from "metabase/query_builder/selectors";
+import { getUiControls } from "metabase/query_builder/selectors";
 import {
   Notebook,
   type NotebookProps,
@@ -84,24 +81,6 @@ export const NotebookContainer = ({
   };
 
   const screenSize = useNotebookScreenSize();
-  const isNotebookNativePreviewShown = useSelector(
-    getIsNotebookNativePreviewShown,
-  );
-
-  useEffect(() => {
-    if (screenSize === "small") {
-      dispatch(setUIControls({ isShowingNotebookNativePreview: false }));
-    } else if (screenSize === "large") {
-      const currentSettingValue = isNotebookNativePreviewShown;
-
-      dispatch(
-        setUIControls({
-          isShowingNotebookNativePreview: currentSettingValue,
-        }),
-      );
-    }
-  }, [dispatch, isNotebookNativePreviewShown, screenSize]);
-
   const transformStyle = isOpen ? "translateY(0)" : "translateY(-100%)";
 
   const Handle = forwardRef<

--- a/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
@@ -83,14 +83,6 @@ export const NotebookContainer = ({
   const screenSize = useNotebookScreenSize();
   const transformStyle = isOpen ? "translateY(0)" : "translateY(-100%)";
 
-  useEffect(() => {
-    // If someone resizes to a small window with the native preview previously open,
-    // we want to close it because it obscures the notebook view
-    if (screenSize === "small" && isShowingNotebookNativePreview === true) {
-      dispatch(setUIControls({ isShowingNotebookNativePreview: false }));
-    }
-  }, [dispatch, isShowingNotebookNativePreview, screenSize]);
-
   const Handle = forwardRef<
     HTMLDivElement,
     Partial<ResizableBoxProps> & {

--- a/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
@@ -83,6 +83,14 @@ export const NotebookContainer = ({
   const screenSize = useNotebookScreenSize();
   const transformStyle = isOpen ? "translateY(0)" : "translateY(-100%)";
 
+  useEffect(() => {
+    // If someone resizes to a small window with the native preview previously open,
+    // we want to close it because it obscures the notebook view
+    if (screenSize === "small" && isShowingNotebookNativePreview === true) {
+      dispatch(setUIControls({ isShowingNotebookNativePreview: false }));
+    }
+  }, [dispatch, isShowingNotebookNativePreview, screenSize]);
+
   const Handle = forwardRef<
     HTMLDivElement,
     Partial<ResizableBoxProps> & {

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/ToggleNativeQueryPreview/ToggleNativeQueryPreview.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/ToggleNativeQueryPreview/ToggleNativeQueryPreview.tsx
@@ -2,12 +2,8 @@ import { t } from "ttag";
 
 import { getEngineNativeType } from "metabase/lib/engine";
 import { useDispatch, useSelector } from "metabase/lib/redux";
-import {
-  setNotebookNativePreviewState,
-  setUIControls,
-} from "metabase/query_builder/actions";
+import { setUIControls } from "metabase/query_builder/actions";
 import { trackNotebookNativePreviewShown } from "metabase/query_builder/analytics";
-import { useNotebookScreenSize } from "metabase/query_builder/hooks/use-notebook-screen-size";
 import { getUiControls } from "metabase/query_builder/selectors";
 import { Button, Icon } from "metabase/ui";
 import type Question from "metabase-lib/v1/Question";
@@ -45,8 +41,6 @@ export const ToggleNativeQueryPreview = ({
     isShowingNotebookNativePreview,
   }: { isShowingNotebookNativePreview: boolean } = useSelector(getUiControls);
 
-  const screenSize = useNotebookScreenSize();
-
   const engineType = getEngineNativeType(question.database()?.engine);
   const buttonText = isShowingNotebookNativePreview
     ? BUTTON_CLOSE_TEXT[engineType]
@@ -58,11 +52,6 @@ export const ToggleNativeQueryPreview = ({
         isShowingNotebookNativePreview: !isShowingNotebookNativePreview,
       }),
     );
-
-    // the setting is intentionally remembered only for large screens
-    if (screenSize === "large") {
-      dispatch(setNotebookNativePreviewState(!isShowingNotebookNativePreview));
-    }
 
     trackNotebookNativePreviewShown(question, !isShowingNotebookNativePreview);
   };

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -1088,9 +1088,6 @@ export const getSubmittableQuestion = (state, question) => {
   return submittableQuestion;
 };
 
-export const getIsNotebookNativePreviewShown = (state) =>
-  getSetting(state, "notebook-native-preview-shown");
-
 export const getNotebookNativePreviewSidebarWidth = (state) =>
   getSetting(state, "notebook-native-preview-sidebar-width");
 

--- a/src/metabase/users/settings.clj
+++ b/src/metabase/users/settings.clj
@@ -47,13 +47,6 @@
   :default    false
   :audit      :never)
 
-(defsetting notebook-native-preview-shown
-  (deferred-tru "User preference for the state of the native query preview in the notebook.")
-  :user-local :only
-  :visibility :authenticated
-  :type       :boolean
-  :default    false)
-
 (defsetting notebook-native-preview-sidebar-width
   (deferred-tru "Last user set sidebar width for the native query preview in the notebook.")
   :user-local :only


### PR DESCRIPTION
Resolves #65818
Resolves #67143

This pull request removes the user setting that persisted the open/closed state of the native query preview sidebar in the notebook editor. The sidebar's visibility is now managed entirely in the UI state (not persisted per user), simplifying the logic for showing or hiding the sidebar and cleaning up related code and tests.

tl;dr
1. opening a notebook editor will *always* start from a closed native preview sidebar
2. state is now managed exclusively by Redux (sidebar state might be preserved until the page reload, but it is not persisted on the backend)

> [!Important]
> We're changing a previous behavior where, if a native preview sidebar was open and we're resizing the window to something small, the sidebar was automatically closed. This PR changes that behavior. i.e. There is no special resize handling anymore. Whatever the (Redux) state of the sidebar is, it will stay like that no matter the window size.

---
Key changes include:

**Removal of persisted user setting for native preview sidebar:**

- Deleted the `notebook-native-preview-shown` user setting from backend definitions and mocks, so the sidebar open/closed state is no longer stored per user. [[1]](diffhunk://#diff-c4e5bdf0c47454bfd9a9b0e0655384b1e8f731d34dc532e07de493b673d4f886L50-L56) [[2]](diffhunk://#diff-0f42a9fe4a0f5da00914e5b4d631a3cd1dc592675805aba830f63c9f8a7e0722L100) [[3]](diffhunk://#diff-4c4718483c004efa812bea1b34f68adecf469419a0cb458109505e30d3ded6dfL394) [[4]](diffhunk://#diff-38a91baa5226c636d59fb05a5529b66f2d66b03bcc95cf3c945f88601bc7e44dL574)

**Frontend logic and selector cleanup:**

- Removed all usage of the `notebook-native-preview-shown` setting in selectors, actions, and initialization logic (`getIsNotebookNativePreviewShown`, `setNotebookNativePreviewState`, and related code). The sidebar state is now managed only in UI controls. [[1]](diffhunk://#diff-19880c5baad1b4f45b5c4bfe18f199882566ca35dfcbe3d545bb7924701e5e16L12) [[2]](diffhunk://#diff-19880c5baad1b4f45b5c4bfe18f199882566ca35dfcbe3d545bb7924701e5e16L378-L379) [[3]](diffhunk://#diff-e7adc96f472139312659082ce781960ed5911f7741b5ef1569d12a3bd2d91dc4L105-L110) [[4]](diffhunk://#diff-2fc40467e8370b516c4ce51320cd4d159278808493231640527a65f51d06e65aL1091-L1093)
- Updated components to use only UI state for sidebar visibility, removing references to the deleted setting and simplifying the effect logic for screen size changes. [[1]](diffhunk://#diff-f5aa0f65e76aee920d8ee677d54df9fad372ca1c1db95e8d0afd3a9aa46a6d36L13-R13) [[2]](diffhunk://#diff-f5aa0f65e76aee920d8ee677d54df9fad372ca1c1db95e8d0afd3a9aa46a6d36L87-R92) [[3]](diffhunk://#diff-7c1aa4c8c68a67ee3c887386f15f56c2380a84a19c85dd220850878b4dc16a35L5-L10) [[4]](diffhunk://#diff-7c1aa4c8c68a67ee3c887386f15f56c2380a84a19c85dd220850878b4dc16a35L48-L49) [[5]](diffhunk://#diff-7c1aa4c8c68a67ee3c887386f15f56c2380a84a19c85dd220850878b4dc16a35L62-L66)