### PR TITLE
fix dashboard question picker collection icons

### DIFF
--- a/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionPicker.tsx
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionPicker.tsx
@@ -14,13 +14,14 @@ import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { Collections, ROOT_COLLECTION } from "metabase/entities/collections";
 import { getCrumbs } from "metabase/lib/collections";
 import { SEARCH_DEBOUNCE_DURATION } from "metabase/lib/constants";
+import { getIcon } from "metabase/lib/icon";
 import { connect, useDispatch, useSelector } from "metabase/lib/redux";
 import { PLUGIN_COLLECTIONS } from "metabase/plugins";
 import {
   canUserCreateNativeQueries,
   canUserCreateQueries,
 } from "metabase/selectors/user";
-import { Button, Flex, Icon, type IconProps } from "metabase/ui";
+import { Button, Flex, Icon } from "metabase/ui";
 import type { Collection, CollectionId } from "metabase-types/api";
 
 import { QuestionList } from "./QuestionList";
@@ -30,13 +31,11 @@ import { addDashboardQuestion } from "./actions";
 interface QuestionPickerInnerProps {
   onSelect: BaseSelectListItemProps["onSelect"];
   collectionsById: Record<CollectionId, Collection>;
-  getCollectionIcon: (collection: Collection) => IconProps;
 }
 
 function QuestionPickerInner({
   onSelect,
   collectionsById,
-  getCollectionIcon,
 }: QuestionPickerInnerProps) {
   const dispatch = useDispatch();
   const dashboard = useSelector(getDashboard);
@@ -115,7 +114,7 @@ function QuestionPickerInner({
           {collections.length > 0 && (
             <SelectList>
               {collections.map((collection) => {
-                const icon = getCollectionIcon(collection);
+                const icon = getIcon({ ...collection, model: "collection" });
                 const iconColor = PLUGIN_COLLECTIONS.isRegularCollection(
                   collection,
                 )
@@ -167,6 +166,5 @@ export const QuestionPicker = _.compose(
     collectionsById: (
       props.entity || Collections
     ).selectors.getExpandedCollectionsById(state),
-    getCollectionIcon: (props.entity || Collections).objectSelectors.getIcon,
   })),
 )(QuestionPickerInner);

--- a/frontend/src/metabase/lib/icon.ts
+++ b/frontend/src/metabase/lib/icon.ts
@@ -74,7 +74,11 @@ export const getIconBase = (item: ObjectWithModel): IconData => {
     return { name: "group" };
   }
 
-  if (item.model === "collection" && item.is_personal) {
+  if (
+    item.model === "collection" &&
+    item.is_personal &&
+    item.location === "/"
+  ) {
     return { name: "person" };
   }
 

--- a/frontend/src/metabase/lib/icon.unit.spec.ts
+++ b/frontend/src/metabase/lib/icon.unit.spec.ts
@@ -103,7 +103,33 @@ describe("getIcon", () => {
       });
     });
 
-    it("should return the correct icon for a card with anobject detail chart", () => {
+    it("should return the correct icon for a personal collection root", () => {
+      expect(
+        getIcon({ model: "collection", is_personal: true, location: "/" }),
+      ).toEqual({
+        name: "person",
+      });
+    });
+
+    it("should return the correct icon for a nested personal collection", () => {
+      expect(
+        getIcon({
+          model: "collection",
+          is_personal: true,
+          location: "/123/456",
+        }),
+      ).toEqual({
+        name: "folder",
+      });
+    });
+
+    it("should return the correct icon for all personal collections", () => {
+      expect(getIcon({ model: "collection", id: "personal" })).toEqual({
+        name: "group",
+      });
+    });
+
+    it("should return the correct icon for a card with an object detail chart", () => {
       expect(getIcon({ model: "card", display: "object" })).toEqual({
         name: "document",
       });


### PR DESCRIPTION


### Description

Fixes icons for collections in dashboard question picker sidebar. I missed a reference to a now-gone entity getIcon call. This also adds a little more sophistication to choosing icons for personal collections. only the root collection should have a person icon.


Before | After
---|---
<img width="394" height="763" alt="CleanShot 2025-12-17 at 15 40 06" src="https://github.com/user-attachments/assets/0fabec1f-f5ec-40ac-a45a-1b3ba136b508" /> | <img width="399" height="781" alt="CleanShot 2025-12-17 at 15 31 50" src="https://github.com/user-attachments/assets/55221e11-4fae-48a5-9d2f-bfad979a4770" />


- [x] Tests have been added/updated to cover changes in this PR
