### PR TITLE
Add time in click behaviour for hours and minutes

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
@@ -2263,3 +2263,99 @@ describe("issue 64138", () => {
       .last();
   }
 });
+
+describe("issue 58556", () => {
+  const QUESTION = {
+    query: {
+      "source-table": ORDERS_ID,
+      aggregation: [["count"]],
+      breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "hour" }]],
+    },
+    display: "table",
+  };
+
+  const PARAMETER = createMockParameter({
+    id: "date-param",
+    name: "Date",
+    slug: "date",
+    type: "date/all-options",
+  });
+
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+
+    H.createDashboardWithQuestions({
+      questions: [QUESTION],
+      dashboardDetails: {
+        parameters: [PARAMETER],
+      },
+    }).then(({ dashboard }) => {
+      cy.request("GET", `/api/dashboard/${dashboard.id}`).then(
+        ({ body: dashboard }) => {
+          const [dashcard] = dashboard.dashcards;
+
+          cy.request("PUT", `/api/dashboard/${dashboard.id}`, {
+            dashcards: [
+              {
+                ...dashcard,
+                parameter_mappings: [
+                  {
+                    card_id: dashcard.card_id,
+                    parameter_id: PARAMETER.id,
+                    target: [
+                      "dimension",
+                      [
+                        "field",
+                        "CREATED_AT",
+                        {
+                          "base-type": "type/DateTime",
+                          "inherited-temporal-unit": "hour",
+                        },
+                      ],
+                      {
+                        "stage-number": 1,
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          });
+        },
+      );
+
+      H.visitDashboard(dashboard.id);
+    });
+
+    H.editDashboard();
+    H.showDashboardCardActions();
+
+    H.clickBehaviorSidebar().within(() => {
+      cy.findByText("Created At: Hour").click();
+      cy.findByText("Update a dashboard filter").click();
+      cy.findByText("Date").click();
+    });
+
+    H.popover().findByText("Created At: Hour").click();
+    H.sidebar().button("Done").click();
+
+    H.saveDashboard();
+  });
+
+  it("should be possible to add a click action on a time column with hour granularity and have the time be present in the resulting parameter (metabase#58556)", () => {
+    cy.log("click a row");
+    H.dashboardCards()
+      .findByTestId("table-body")
+      .findAllByTestId("link-formatted-text")
+      .eq(0)
+      .click();
+
+    cy.log("ensure the filter contains a time value");
+    cy.location().then((location) => {
+      const url = new URL(location.href);
+      const date = url.searchParams.get("date");
+      cy.wrap(date).should("match", /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/);
+    });
+  });
+});

--- a/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
@@ -2264,7 +2264,7 @@ describe("issue 64138", () => {
   }
 });
 
-describe("issue 58556", () => {
+describe("issue 58556, issue 66277", () => {
   const QUESTION = {
     query: {
       "source-table": ORDERS_ID,
@@ -2330,7 +2330,9 @@ describe("issue 58556", () => {
 
     H.editDashboard();
     H.showDashboardCardActions();
+  });
 
+  it("should be possible to add a click action on a time column with hour granularity and have the time be present in the resulting parameter (metabase#58556)", () => {
     H.clickBehaviorSidebar().within(() => {
       cy.findByText("Created At: Hour").click();
       cy.findByText("Update a dashboard filter").click();
@@ -2341,9 +2343,7 @@ describe("issue 58556", () => {
     H.sidebar().button("Done").click();
 
     H.saveDashboard();
-  });
 
-  it("should be possible to add a click action on a time column with hour granularity and have the time be present in the resulting parameter (metabase#58556)", () => {
     cy.log("click a row");
     H.dashboardCards()
       .findByTestId("table-body")
@@ -2357,5 +2357,35 @@ describe("issue 58556", () => {
       const date = url.searchParams.get("date");
       cy.wrap(date).should("match", /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/);
     });
+  });
+
+  it("should pass hour or minutes to linked questions from click actions (metabase#66277)", () => {
+    H.clickBehaviorSidebar().within(() => {
+      cy.findByText("Created At: Hour").click();
+      cy.findByText("Go to a custom destination").click();
+      cy.findByText("Saved question").click();
+    });
+
+    H.entityPickerModal().findByText("Orders").click();
+
+    H.sidebar().findByText("Created At").scrollIntoView().click();
+
+    H.popover().findByText("Created At: Hour").click();
+    H.sidebar().button("Done").click();
+
+    H.saveDashboard();
+
+    cy.log("click a row");
+    H.dashboardCards()
+      .findByTestId("table-body")
+      .findAllByTestId("link-formatted-text")
+      .eq(0)
+      .click();
+
+    H.queryBuilderFiltersPanel()
+      .findByText(
+        /Created At is .* \d{1,2}:\d{2} (AM|PM) – \d{1,2}:\d{2} (AM|PM)/,
+      )
+      .should("be.visible");
   });
 });

--- a/frontend/src/metabase-lib/v1/parameters/utils/click-behavior.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/click-behavior.ts
@@ -415,7 +415,9 @@ export function formatSourceForTarget(
 
       if (
         typeof sourceDateUnit === "string" &&
-        ["week", "month", "quarter", "year"].includes(sourceDateUnit)
+        ["week", "month", "quarter", "year", "hour", "minute"].includes(
+          sourceDateUnit,
+        )
       ) {
         return formatDateToRangeForParameter(datum.value, sourceDateUnit);
       }
@@ -455,6 +457,9 @@ function formatDateForParameterType(
   } else if (parameterType === "date/quarter-year") {
     return m.format("[Q]Q-YYYY");
   } else if (parameterType === "date/single") {
+    if (unit === "hour" || unit === "minute") {
+      return m.format("YYYY-MM-DDTHH:mm");
+    }
     return m.format("YYYY-MM-DD");
   } else if (parameterType === "date/all-options") {
     return formatDateTimeForParameter(value, unit);

--- a/frontend/src/metabase/lib/formatting/date.tsx
+++ b/frontend/src/metabase/lib/formatting/date.tsx
@@ -770,6 +770,8 @@ export function formatDateTimeForParameter(
     return m.format("[Q]Q-YYYY");
   } else if (unit === "day") {
     return m.format("YYYY-MM-DD");
+  } else if (unit === "hour" || unit === "minute") {
+    return m.format("YYYY-MM-DDTHH:mm");
   } else if (unit) {
     return formatDateToRangeForParameter(value, unit);
   }

--- a/frontend/src/metabase/lib/formatting/date.tsx
+++ b/frontend/src/metabase/lib/formatting/date.tsx
@@ -789,17 +789,27 @@ export function formatDateToRangeForParameter(
   }
 
   const start = m.clone().startOf(unit);
-  const end = m.clone().endOf(unit);
+  const end = getEndOfInterval(start, unit);
 
   if (!start.isValid() || !end.isValid()) {
     return String(value);
   }
 
-  const isSameDay = start.isSame(end, "day");
+  if (unit === "hour" || unit === "minute") {
+    return `${start.format("YYYY-MM-DDTHH:mm")}~${end.format("YYYY-MM-DDTHH:mm")}`;
+  }
 
+  const isSameDay = start.isSame(end, "day");
   return isSameDay
     ? start.format("YYYY-MM-DD")
     : `${start.format("YYYY-MM-DD")}~${end.format("YYYY-MM-DD")}`;
+}
+
+function getEndOfInterval(start: Dayjs, unit: DatetimeUnit | null) {
+  if (unit === "hour" || unit === "minute") {
+    return start.clone().add(1, unit);
+  }
+  return start.clone().endOf(unit);
 }
 
 export function normalizeDateTimeRangeWithUnit(

--- a/frontend/src/metabase/lib/formatting/date.unit.spec.tsx
+++ b/frontend/src/metabase/lib/formatting/date.unit.spec.tsx
@@ -85,7 +85,7 @@ describe("formatDateTimeRangeWithUnit", () => {
 });
 
 describe("formatDateTimeForParameter", () => {
-  const value = "2020-01-01T00:00:00+05:00";
+  const value = "2020-01-01T06:00:00+05:00";
 
   it("should format year", () => {
     expect(formatDateTimeForParameter(value, "year")).toBe(
@@ -111,12 +111,14 @@ describe("formatDateTimeForParameter", () => {
     expect(formatDateTimeForParameter(value, "day")).toBe("2020-01-01");
   });
 
-  it("should format hour as a day", () => {
-    expect(formatDateTimeForParameter(value, "hour")).toBe("2020-01-01");
+  it("should format hour", () => {
+    expect(formatDateTimeForParameter(value, "hour")).toBe("2020-01-01T06:00");
   });
 
   it("should format minute", () => {
-    expect(formatDateTimeForParameter(value, "minute")).toBe("2020-01-01");
+    expect(formatDateTimeForParameter(value, "minute")).toBe(
+      "2020-01-01T06:00",
+    );
   });
 
   it("should format quarter-of-year as a day", () => {


### PR DESCRIPTION
Closes #58556 
Closes #66277

Adds the time component to parameter values for click behavior on dash cards when its hours or minutes.

### To Verify 

1. New Question -> Orders -> Aggregate -> Count of rows -> Break out by Created At: Hour -> Visualize as table -> Save
2. Add this question to a dashboard
3. Add a parameter -> name: Date -> Link to Created At: Hour
4. Add click action on card -> Created At: Hour -> Update dashboard filter -> Date -> Created At: Hour -> Done
5. Save dashboard
6. Click a value in the Created At column

The parameter should contain the hour of the value you clicked