### PR TITLE
Use collection in breadcrumbs for nested questions

### DIFF
--- a/e2e/support/helpers/e2e-bi-basics-helpers.js
+++ b/e2e/support/helpers/e2e-bi-basics-helpers.js
@@ -79,21 +79,7 @@ export function assertQueryBuilderRowCount(count) {
  * @param {string} lhsSampleColumn join's LHS sample column name
  * @param {string} rhsSampleColumn join's RHS sample column name
  */
-export function assertJoinValid({
-  lhsTable,
-  rhsTable,
-  lhsSampleColumn,
-  rhsSampleColumn,
-}) {
-  // Ensure the QB shows `${lhsTable} + ${rhsTable}` in the header
-  // The check is optional for cases when a table name isn't clear (e.g. a multi-stage ad-hoc question)
-  if (lhsTable && rhsTable) {
-    cy.findByTestId("question-table-badges").within(() => {
-      cy.findByText(lhsTable).should("be.visible");
-      cy.findByText(rhsTable).should("be.visible");
-    });
-  }
-
+export function assertJoinValid({ lhsSampleColumn, rhsSampleColumn }) {
   // Ensure the results have columns from both tables
   queryBuilderMain().within(() => {
     tableHeaderColumn(lhsSampleColumn).should("be.visible");

--- a/e2e/test/scenarios/joins/joins-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/joins/joins-reproductions.cy.spec.js
@@ -91,10 +91,8 @@ describe("issue 12928", () => {
 
     H.visualize();
 
-    cy.get("@joinedQuestionId").then((joinedQuestionId) => {
+    cy.get("@joinedQuestionId").then(() => {
       H.assertJoinValid({
-        lhsTable: SOURCE_QUESTION_NAME,
-        rhsTable: JOINED_QUESTION_NAME,
         lhsSampleColumn: "Products → Category",
         rhsSampleColumn: `${JOINED_QUESTION_NAME} - Products → Category → Category`,
       });

--- a/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
@@ -1414,3 +1414,35 @@ describe("issue 13347", () => {
     });
   });
 });
+
+describe("issue #47005", () => {
+  beforeEach(() => {
+    H.restore();
+    H.restore("postgres-12");
+    cy.signInAsNormalUser();
+
+    H.createQuestion({
+      name: "Question A",
+      query: {
+        "source-table": ORDERS_ID,
+      },
+    }).then(({ body: question }) => {
+      H.createQuestion(
+        {
+          name: "Question B",
+          query: {
+            "source-table": "card__" + question.id,
+          },
+        },
+        { visitQuestion: true },
+      );
+    });
+  });
+
+  it("should show the collection of the base question in breadcrumbs (metabase#47005)", () => {
+    cy.findAllByTestId("head-crumbs-container")
+      .filter(":contains(Question A)")
+      .findByText("Our analytics")
+      .should("be.visible");
+  });
+});

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/SourceQuestionBreadcrumbs.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/SourceQuestionBreadcrumbs.tsx
@@ -7,7 +7,6 @@ import * as Lib from "metabase-lib";
 import Question from "metabase-lib/v1/Question";
 import { getQuestionIdFromVirtualTableId } from "metabase-lib/v1/metadata/utils/saved-questions";
 
-import { DataSourceCrumbs } from "./DataSourceCrumbs";
 import { SourceModelBreadcrumbs } from "./SourceModelBreadcrumbs";
 
 interface Props {
@@ -37,15 +36,11 @@ export function SourceQuestionBreadcrumbs({
     return null;
   }
 
-  if (sourceQuestion.type() === "model" || sourceQuestion.type() === "metric") {
-    return (
-      <SourceModelBreadcrumbs
-        question={sourceQuestion}
-        variant={variant}
-        {...props}
-      />
-    );
-  }
-
-  return <DataSourceCrumbs question={question} variant={variant} {...props} />;
+  return (
+    <SourceModelBreadcrumbs
+      question={sourceQuestion}
+      variant={variant}
+      {...props}
+    />
+  );
 }


### PR DESCRIPTION
Closes #47005 

Uses the collection name in the breadcrumbs for nested questions rather than the database.

# To verify 

1. New question
2. Choose saved question as a data source
3. Save this new question
4. There is a link to the base questions' collection in the breadcrumbs