### PR TITLE
Fix destroy schema for redshift

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/workspaces/driver/clickhouse.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/driver/clickhouse.clj
@@ -16,9 +16,9 @@
     (jdbc/with-db-transaction [t-conn (sql-jdbc.conn/db->pooled-connection-spec (:id database))]
       (with-open [stmt (.createStatement ^java.sql.Connection (:connection t-conn))]
         (doseq [sql [(format "CREATE DATABASE IF NOT EXISTS `%s`" db-name)
-                     (format "CREATE USER IF NOT EXISTS %s IDENTIFIED BY '%s'"
+                     (format "CREATE USER IF NOT EXISTS `%s` IDENTIFIED BY '%s'"
                              (:user read-user) (:password read-user))
-                     (format "GRANT ALL ON `%s`.* TO %s" db-name (:user read-user))]]
+                     (format "GRANT ALL ON `%s`.* TO `%s`" db-name (:user read-user))]]
           (.addBatch ^java.sql.Statement stmt ^String sql))
         (.executeBatch ^java.sql.Statement stmt)))
     {:schema           db-name
@@ -28,7 +28,7 @@
   [database workspace tables]
   (let [read-user-name (-> workspace :database_details :user)
         sqls           (for [table tables]
-                         (format "GRANT SELECT ON `%s`.`%s` TO %s"
+                         (format "GRANT SELECT ON `%s`.`%s` TO `%s`"
                                  (:schema table)
                                  (:name table)
                                  read-user-name))]
@@ -46,6 +46,6 @@
       (with-open [stmt (.createStatement ^java.sql.Connection (:connection t-conn))]
         (doseq [sql [;; DROP DATABASE cascades to all tables within it
                      (format "DROP DATABASE IF EXISTS `%s`" db-name)
-                     (format "DROP USER IF EXISTS %s" username)]]
+                     (format "DROP USER IF EXISTS `%s`" username)]]
           (.addBatch ^java.sql.Statement stmt ^String sql))
         (.executeBatch ^java.sql.Statement stmt)))))

--- a/enterprise/backend/src/metabase_enterprise/workspaces/driver/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/driver/init.clj
@@ -6,5 +6,6 @@
    [metabase-enterprise.workspaces.driver.clickhouse]
    [metabase-enterprise.workspaces.driver.h2]
    [metabase-enterprise.workspaces.driver.postgres]
+   [metabase-enterprise.workspaces.driver.redshift]
    [metabase-enterprise.workspaces.driver.snowflake]
    [metabase-enterprise.workspaces.driver.sqlserver]))

--- a/enterprise/backend/src/metabase_enterprise/workspaces/driver/postgres.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/driver/postgres.clj
@@ -15,11 +15,11 @@
   [database workspace tables]
   (let [username (-> workspace :database_details :user)
         sqls     (cons
-                  (format "GRANT USAGE ON SCHEMA %s TO %s" (:schema workspace) username)
+                  (format "GRANT USAGE ON SCHEMA \"%s\" TO \"%s\"" (:schema workspace) username)
                   (for [{s :schema, t :name} tables]
                     (if (str/blank? s)
-                      (format "GRANT SELECT ON TABLE \"%s\" TO %s" t username)
-                      (format "GRANT SELECT ON TABLE %s.%s TO %s" s t username))))]
+                      (format "GRANT SELECT ON TABLE \"%s\" TO \"%s\"" t username)
+                      (format "GRANT SELECT ON TABLE \"%s\".\"%s\" TO \"%s\"" s t username))))]
     (jdbc/with-db-transaction [t-conn (sql-jdbc.conn/db->pooled-connection-spec (:id database))]
       (with-open [stmt (.createStatement ^Connection (:connection t-conn))]
         (doseq [sql sqls]
@@ -33,12 +33,12 @@
                      :password (ws.u/random-isolated-password)}]
     (jdbc/with-db-transaction [t-conn (sql-jdbc.conn/db->pooled-connection-spec (:id database))]
       (with-open [stmt (.createStatement ^Connection (:connection t-conn))]
-        (doseq [sql [(format "CREATE SCHEMA %s" schema-name)
-                     (format "CREATE USER %s WITH PASSWORD '%s'" (:user read-user) (:password read-user))
+        (doseq [sql [(format "CREATE SCHEMA \"%s\"" schema-name)
+                     (format "CREATE USER \"%s\" WITH PASSWORD '%s'" (:user read-user) (:password read-user))
                      ;; grant schema access (CREATE to create tables, USAGE to access them)
-                     (format "GRANT ALL PRIVILEGES ON SCHEMA %s TO %s" schema-name (:user read-user))
+                     (format "GRANT ALL PRIVILEGES ON SCHEMA \"%s\" TO \"%s\"" schema-name (:user read-user))
                      ;; grant all privileges on future tables created in this schema (by admin)
-                     (format "ALTER DEFAULT PRIVILEGES IN SCHEMA %s GRANT ALL ON TABLES TO %s" schema-name (:user read-user))]]
+                     (format "ALTER DEFAULT PRIVILEGES IN SCHEMA \"%s\" GRANT ALL ON TABLES TO \"%s\"" schema-name (:user read-user))]]
           (.addBatch ^Statement stmt ^String sql))
         (.executeBatch ^Statement stmt)))
     {:schema           schema-name

--- a/enterprise/backend/src/metabase_enterprise/workspaces/driver/postgres.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/driver/postgres.clj
@@ -58,6 +58,6 @@
         (doseq [sql (cond-> [(format "DROP SCHEMA IF EXISTS \"%s\" CASCADE" schema-name)]
                       (user-exists? t-conn username)
                       (into [(format "DROP OWNED BY \"%s\"" username)
-                             (format "DROP USER \"%s\"" username)]))]
+                             (format "DROP USER IF EXISTS \"%s\"" username)]))]
           (.addBatch ^Statement stmt ^String sql))
         (.executeBatch ^Statement stmt)))))

--- a/enterprise/backend/src/metabase_enterprise/workspaces/driver/redshift.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/driver/redshift.clj
@@ -20,8 +20,7 @@
                    ["SELECT DISTINCT namespace_name FROM svv_relation_privileges
            WHERE identity_name = ? AND identity_type = 'user'"
                     username])
-       (map :namespace_name)
-       (remove nil?)))
+       (keep :namespace_name)))
 
 (defmethod isolation/destroy-workspace-isolation! :redshift
   [database workspace]

--- a/enterprise/backend/src/metabase_enterprise/workspaces/driver/redshift.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/driver/redshift.clj
@@ -1,0 +1,47 @@
+(ns metabase-enterprise.workspaces.driver.redshift
+  "Redshift-specific implementations for workspace isolation.
+
+  Redshift differs from PostgreSQL:
+  - DROP OWNED BY is not supported
+  - Must revoke privileges from all granted schemas before dropping user"
+  (:require
+   [clojure.java.jdbc :as jdbc]
+   [metabase-enterprise.workspaces.isolation :as isolation]
+   [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn])
+  (:import
+   (java.sql Connection Statement)))
+
+(set! *warn-on-reflection* true)
+
+(defn- schemas-with-user-grants
+  "Query Redshift to find schemas where the user has been granted privileges."
+  [conn username]
+  (->> (jdbc/query conn
+                   ["SELECT DISTINCT namespace_name FROM svv_relation_privileges
+           WHERE identity_name = ? AND identity_type = 'user'"
+                    username])
+       (map :namespace_name)
+       (remove nil?)))
+
+(defmethod isolation/destroy-workspace-isolation! :redshift
+  [database workspace]
+  (let [schema-name (:schema workspace)
+        username    (-> workspace :database_details :user)]
+    (jdbc/with-db-transaction [t-conn (sql-jdbc.conn/db->pooled-connection-spec (:id database))]
+      (let [granted-schemas (schemas-with-user-grants t-conn username)]
+        (with-open [stmt (.createStatement ^Connection (:connection t-conn))]
+          (doseq [schema granted-schemas]
+            (.addBatch ^Statement stmt
+                       ^String (format "REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA \"%s\" FROM \"%s\""
+                                       schema username))
+            (.addBatch ^Statement stmt
+                       ^String (format "REVOKE ALL PRIVILEGES ON SCHEMA \"%s\" FROM \"%s\""
+                                       schema username)))
+          (.addBatch ^Statement stmt
+                     ^String (format "ALTER DEFAULT PRIVILEGES IN SCHEMA \"%s\" REVOKE ALL ON TABLES FROM \"%s\""
+                                     schema-name username))
+          (.addBatch ^Statement stmt
+                     ^String (format "DROP SCHEMA IF EXISTS \"%s\" CASCADE" schema-name))
+          (.addBatch ^Statement stmt
+                     ^String (format "DROP USER IF EXISTS \"%s\"" username))
+          (.executeBatch ^Statement stmt))))))

--- a/enterprise/backend/test/metabase_enterprise/workspaces/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/e2e_test.clj
@@ -5,6 +5,7 @@
    [metabase-enterprise.transforms.test-util :as transforms.tu]
    [metabase-enterprise.workspaces.common :as ws.common]
    [metabase-enterprise.workspaces.isolation :as ws.isolation]
+   [metabase-enterprise.workspaces.test-util :as ws.tu]
    [metabase.driver :as driver]
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.query-processor.preprocess :as qp.preprocess]
@@ -38,43 +39,41 @@
       (mt/with-model-cleanup [:model/Transform :model/Workspace]
         (mt/with-temp [:model/Transform {transform-id :id} {:name   "Transform 1"
                                                             :source {:type  "query"
-                                                                     :query (mt/native-query (mbql->native (mt/mbql-query orders {:limit 1})))}
+                                                                     :query (mt/native-query (mbql->native (mt/mbql-query orders {:limit 3})))}
                                                             :target {:type "table"
                                                                      :name output-table-name
                                                                      :database (mt/id)
                                                                      :schema (t2/select-one-fn :schema :model/Table (mt/id :orders))}}]
-          (let [workspace          (mt/with-current-user (mt/user->id :crowberto)
-                                     (ws.common/create-workspace! (mt/user->id :crowberto)
-                                                                  {:name        (mt/random-name)
-                                                                   :database_id (mt/id)
-                                                                   :upstream    {:transforms [transform-id]}}))
-                _                  (ws.common/add-to-changeset! (mt/user->id :crowberto) workspace
-                                                                :transform transform-id
-                                                                (t2/select-one :model/Transform transform-id))
-                workspace          (u/poll {:thunk      #(t2/select-one :model/Workspace (:id workspace))
-                                            :done?      #(= :ready (:status %))
-                                            :timeout-ms 5000})
-                isolated-transform (t2/select-one :model/WorkspaceTransform :workspace_id (:id workspace))
-                ;; TODO We need to reimplement granting permission once we've reimplemented graph analysis
-                #_#_executed-transform (execute-workspace-transform! workspace isolated-transform {:run-method :manual})
-                #_#_output-table       (-> executed-transform :object :output-table)]
+          (ws.tu/with-workspaces! [workspace {:name        (mt/random-name)
+                                              :database_id (mt/id)
+                                              :upstream    {:transforms [transform-id]}}]
+            (ws.common/add-to-changeset! (mt/user->id :crowberto) workspace
+                                         :transform transform-id
+                                         (t2/select-one :model/Transform transform-id))
+            (let [_workspace          (u/poll {:thunk      #(t2/select-one :model/Workspace (:id workspace))
+                                               :done?      #(= :ready (:status %))
+                                               :timeout-ms 5000})
+                  isolated-transform (t2/select-one :model/WorkspaceTransform :workspace_id (:id workspace))
+                  #_#_executed-transform (mt/with-current-user (mt/user->id :crowberto)
+                                           (ws.impl/run-transform! workspace isolated-transform))
+                  #_#_output-table       (-> executed-transform :table)]
+              ;; TODO: the table is synced but there are no fields even though the table and fields exist in the db
+              #_(testing "execute the transform with the original query is fine and the output is in an isolated schema"
+                  (u/poll {:thunk     #(t2/select-one :model/Table :name (:name output-table))
+                           :done?      some?
+                           :timeout-ms 1000})
+                  (transforms.tu/wait-for-table (:name output-table) 1000)
+                  (is (str/starts-with? (:schema output-table) "mb__isolation"))
+                  (is (= 1 (count (transforms.tu/table-rows (name output-table))))))
 
-            #_(testing "execute the transform with the original query is fine and the output is in an isolated schema"
-                (u/poll {:thunk     #(t2/select-one :model/Table :name (name output-table))
-                         :done?      some?
-                         :timeout-ms 1000})
-                (transforms.tu/wait-for-table (name output-table) 1000)
-                (is (str/starts-with? (namespace output-table) "mb__isolation"))
-                (is (= 1 (count (transforms.tu/table-rows (name output-table))))))
-
-            (testing "changing the query without granting access will fail"
-              (t2/update! :model/WorkspaceTransform
-                          {:ref_id (:ref_id isolated-transform)}
-                          {:source {:type  "query"
-                                    :query (mt/native-query (mbql->native (mt/mbql-query venues {:limit 1})))}})
-              (is (thrown-with-msg?
-                   Exception
-                   #"ERROR: permission denied for table.*"
-                   (execute-workspace-transform! workspace
-                                                 (t2/select-one :model/WorkspaceTransform :ref_id (:ref_id isolated-transform))
-                                                 {:run-method :manual}))))))))))
+              (testing "changing the query without granting access will fail"
+                (t2/update! :model/WorkspaceTransform
+                            {:ref_id (:ref_id isolated-transform)}
+                            {:source {:type  "query"
+                                      :query (mt/native-query (mbql->native (mt/mbql-query venues {:limit 1})))}})
+                (is (thrown-with-msg?
+                     Exception
+                     #"ERROR: permission denied for table.*"
+                     (execute-workspace-transform! workspace
+                                                   (t2/select-one :model/WorkspaceTransform :ref_id (:ref_id isolated-transform))
+                                                   {:run-method :manual})))))))))))

--- a/enterprise/backend/test/metabase_enterprise/workspaces/isolation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/isolation_test.clj
@@ -97,6 +97,11 @@
 
 ;;; Tests
 
+#_(mt/set-test-drivers! #{:redshift})
+
+#_(mt/test-driver :redshift
+    (mt/db))
+
 (deftest destroy-workspace-isolation-test
   (mt/test-drivers (mt/normal-drivers-with-feature :workspace)
     (ws.tu/with-workspaces! [workspace {:name "Test destroy isolation"}]

--- a/enterprise/backend/test/metabase_enterprise/workspaces/isolation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/isolation_test.clj
@@ -97,11 +97,6 @@
 
 ;;; Tests
 
-#_(mt/set-test-drivers! #{:redshift})
-
-#_(mt/test-driver :redshift
-    (mt/db))
-
 (deftest destroy-workspace-isolation-test
   (mt/test-drivers (mt/normal-drivers-with-feature :workspace)
     (ws.tu/with-workspaces! [workspace {:name "Test destroy isolation"}]

--- a/enterprise/backend/test/metabase_enterprise/workspaces/isolation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/isolation_test.clj
@@ -35,7 +35,7 @@
                              ["SELECT 1 FROM information_schema.schemata WHERE schema_name = ?" schema-name])
                  seq boolean)
      :user   (-> (jdbc/query conn-spec
-                             ["SELECT 1 FROM pg_roles WHERE rolname = ?" username])
+                             ["SELECT 1 FROM pg_user WHERE usename = ?" username])
                  seq boolean)}))
 
 (defmethod workspace-isolation-resources-exist? :h2

--- a/enterprise/backend/test/metabase_enterprise/workspaces/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/test_util.clj
@@ -48,7 +48,7 @@
                 (map? ws-or-id) :id)]
     (or (u/poll {:thunk      #(t2/select-one :model/Workspace :id ws-id)
                  :done?      #(not= :pending (:status %))
-                 :timeout-ms 5000})
+                 :timeout-ms 50000})
         (throw (ex-info "Timeout waiting for workspace to be ready" {:workspace-id ws-id})))))
 
 (defn create-workspace-for-test!

--- a/enterprise/backend/test/metabase_enterprise/workspaces/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/test_util.clj
@@ -48,7 +48,8 @@
                 (map? ws-or-id) :id)]
     (or (u/poll {:thunk      #(t2/select-one :model/Workspace :id ws-id)
                  :done?      #(not= :pending (:status %))
-                 :timeout-ms 50000})
+                 ;; some cloud drivers are really slow
+                 :timeout-ms 10000})
         (throw (ex-info "Timeout waiting for workspace to be ready" {:workspace-id ws-id})))))
 
 (defn create-workspace-for-test!

--- a/enterprise/backend/test/metabase_enterprise/workspaces/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/test_util.clj
@@ -48,7 +48,7 @@
                 (map? ws-or-id) :id)]
     (or (u/poll {:thunk      #(t2/select-one :model/Workspace :id ws-id)
                  :done?      #(not= :pending (:status %))
-                 :timeout-ms 500})
+                 :timeout-ms 5000})
         (throw (ex-info "Timeout waiting for workspace to be ready" {:workspace-id ws-id})))))
 
 (defn create-workspace-for-test!

--- a/modules/drivers/redshift/test/metabase/test/data/redshift.clj
+++ b/modules/drivers/redshift/test/metabase/test/data/redshift.clj
@@ -34,6 +34,11 @@
 ;;; need to load this so we can properly override the implementation of `describe-database` below
 (comment metabase.driver.redshift/keep-me)
 
+(def ^:private workspace-isolation-prefix (or
+                                           @(requiring-resolve 'metabase-enterprise.workspaces.util/isolated-prefix)
+                                           ;; OSS might not be able to require it
+                                           "mb__isolation"))
+
 (defmethod driver/database-supports? [:redshift :test/time-type]
   [_driver _feature _database]
   false)
@@ -164,31 +169,72 @@
                               :unknown-error)))]
         (group-by classify schemas)))))
 
+(defn- classify-isolation-schemas
+  "Classifies workspace isolation schemas by age using a single query. Returns a map:
+   {:expired  schemas older than threshold (safe to delete)
+    :recent   schemas created within threshold (might be from parallel test)}"
+  [^java.sql.Connection conn schemas]
+  (if (empty? schemas)
+    {}
+    (let [threshold    (t/minus (t/instant) (t/hours hours-before-expired-threshold))
+          schema-list  (str/join "," (map #(str "'" % "'") schemas))
+          ;; Use pg_class_info joined with pg_namespace to get oldest object creation time per schema
+          sql          (str "SELECT TRIM(n.nspname) as schema_name, MIN(c.relcreationtime) as oldest "
+                            "FROM pg_class_info c "
+                            "JOIN pg_namespace n ON c.relnamespace = n.oid "
+                            "WHERE TRIM(n.nspname) IN (" schema-list ") "
+                            "GROUP BY n.nspname")
+          schema->time (with-open [stmt (.createStatement conn)
+                                   rset (.executeQuery stmt sql)]
+                         (loop [result {}]
+                           (if (.next rset)
+                             (recur (assoc result
+                                           (.getString rset "schema_name")
+                                           (.getTimestamp rset "oldest")))
+                             result)))]
+      (group-by (fn [schema-name]
+                  (if-let [oldest (get schema->time schema-name)]
+                    (if (t/before? (.toInstant oldest) threshold)
+                      :expired
+                      :recent)
+                    ;; Schema not in pg_class_info means no objects - treat as expired
+                    :expired))
+                schemas))))
+
 (defn- delete-old-schemas!
   "Remove unneeded schemas from redshift. Local databases are thrown away after a test run. Shared cloud instances do
   not have this luxury. Test runs can create schemas where models are persisted and nothing cleans these up, leading
-  to redshift clusters hitting the max number of tables allowed."
+  to redshift clusters hitting the max number of tables allowed.
+
+  Also cleans up workspace isolation schemas (mb__isolation_*) and their associated users that may have been
+  left behind by workspace tests. Only deletes isolation schemas older than [[hours-before-expired-threshold]]
+  to avoid interfering with parallel test runs."
   [^java.sql.Connection conn]
-  (let [{old-convention   :old
-         caches-with-info :cache}    (reduce (fn [acc s]
-                                               (cond (sql.tu.unique-prefix/old-dataset-name? s)
-                                                     (update acc :old conj s)
-                                                     (str/starts-with? s "metabase_cache_")
-                                                     (update acc :cache conj s)
-                                                     :else acc))
-                                             {:old [] :cache []}
-                                             (fetch-schemas conn))
+  (let [isolation-pattern (str workspace-isolation-prefix "_")
+        {old-convention   :old
+         caches-with-info :cache
+         isolation        :isolation} (reduce (fn [acc s]
+                                                (cond (sql.tu.unique-prefix/old-dataset-name? s)
+                                                      (update acc :old conj s)
+                                                      (str/starts-with? s "metabase_cache_")
+                                                      (update acc :cache conj s)
+                                                      (str/starts-with? s isolation-pattern)
+                                                      (update acc :isolation conj s)
+                                                      :else acc))
+                                              {:old [] :cache [] :isolation []}
+                                              (fetch-schemas conn))
         {:keys [expired
                 old-style-cache
-                lacking-created-at]} (classify-cache-schemas conn caches-with-info)
-        drop-sql                     (fn [schema-name] (format "DROP SCHEMA IF EXISTS \"%s\" CASCADE;"
-                                                               schema-name))]
-    ;; don't delete unknown-error and recent.
+                lacking-created-at]}      (classify-cache-schemas conn caches-with-info)
+        {expired-isolation :expired}      #p (classify-isolation-schemas conn isolation)
+        drop-sql                          (fn [schema-name] (format "DROP SCHEMA IF EXISTS \"%s\" CASCADE;" schema-name))]
     (with-open [stmt (.createStatement conn)]
+      ;; Drop schemas first
       (doseq [[collection fmt-str] [[old-convention "Dropping old data schema: %s"]
                                     [expired "Dropping expired cache schema: %s"]
                                     [lacking-created-at "Dropping cache without created-at info: %s"]
-                                    [old-style-cache "Dropping old cache schema without `cache_info` table: %s"]]
+                                    [old-style-cache "Dropping old cache schema without `cache_info` table: %s"]
+                                    [expired-isolation "Dropping expired workspace isolation schema: %s"]]
               schema               collection]
         (log/infof fmt-str schema)
         (.execute stmt (drop-sql schema))))))

--- a/modules/drivers/redshift/test/metabase/test/data/redshift.clj
+++ b/modules/drivers/redshift/test/metabase/test/data/redshift.clj
@@ -225,9 +225,9 @@
                                               (fetch-schemas conn))
         {:keys [expired
                 old-style-cache
-                lacking-created-at]}      (classify-cache-schemas conn caches-with-info)
-        {expired-isolation :expired}      #p (classify-isolation-schemas conn isolation)
-        drop-sql                          (fn [schema-name] (format "DROP SCHEMA IF EXISTS \"%s\" CASCADE;" schema-name))]
+                lacking-created-at]}  (classify-cache-schemas conn caches-with-info)
+        {expired-isolation :expired}  (classify-isolation-schemas conn isolation)
+        drop-sql                      (fn [schema-name] (format "DROP SCHEMA IF EXISTS \"%s\" CASCADE;" schema-name))]
     (with-open [stmt (.createStatement conn)]
       ;; Drop schemas first
       (doseq [[collection fmt-str] [[old-convention "Dropping old data schema: %s"]


### PR DESCRIPTION
- There was a bug in destroying isolation for redshift when the workspaces has content similar to https://github.com/metabase/metabase/pull/67076 so this fixes it
- Add hook in test so that when deleting a workspace we attempt to destroy isolation
- Second guardrail is to clean up expired isolated schemas