### PR TITLE
don't show synced collections icon for tenant users

### DIFF
--- a/enterprise/frontend/src/embedding/data-picker/saved-entity-picker/SavedEntityPicker.jsx
+++ b/enterprise/frontend/src/embedding/data-picker/saved-entity-picker/SavedEntityPicker.jsx
@@ -112,7 +112,7 @@ function InnerSavedEntityPicker({
 
     return [
       ...(rootCollection ? [getOurAnalyticsCollection(rootCollection)] : []),
-      ...buildCollectionTree(preparedCollections, modelFilter),
+      ...buildCollectionTree(preparedCollections, { modelFilter }),
     ];
   }, [collections, rootCollection, currentUser, type]);
 

--- a/enterprise/frontend/src/metabase-enterprise/collections/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/collections/utils.ts
@@ -54,7 +54,10 @@ export function isSyncedCollection(
   return collection.is_remote_synced === true;
 }
 
-export const getIcon = (item: ObjectWithModel): IconData => {
+export const getIcon = (
+  item: ObjectWithModel,
+  { isTenantUser = false }: { isTenantUser?: boolean } = {},
+): IconData => {
   const collectionType = getCollectionType({
     type: (item.type as CollectionType) || item.collection_type,
   }).type;
@@ -65,7 +68,8 @@ export const getIcon = (item: ObjectWithModel): IconData => {
   }
 
   if (item.model === "collection") {
-    if (item.is_remote_synced) {
+    // tenant users see the normal icon, they don't know what a synced collection is
+    if (item.is_remote_synced && !isTenantUser) {
       return {
         name: REMOTE_SYNC_COLLECTION.icon,
       };

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/nav/components/NavbarLibrarySection/NavbarLibrarySection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/nav/components/NavbarLibrarySection/NavbarLibrarySection.tsx
@@ -34,7 +34,9 @@ export function NavbarLibrarySection({
     if (!libraryCollection) {
       return [];
     }
-    const tree = buildCollectionTree([libraryCollection], () => true);
+    const tree = buildCollectionTree([libraryCollection], {
+      modelFilter: () => true,
+    });
     if (tree.length === 0) {
       return [];
     }

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionCaption.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionCaption.tsx
@@ -6,10 +6,12 @@ import {
   isInstanceAnalyticsCollection,
   isRootTrashCollection,
 } from "metabase/collections/utils";
+import { useSelector } from "metabase/lib/redux";
 import {
   PLUGIN_COLLECTIONS,
   PLUGIN_COLLECTION_COMPONENTS,
 } from "metabase/plugins";
+import { getIsTenantUser } from "metabase/selectors/user";
 import { Icon } from "metabase/ui";
 import type { Collection } from "metabase-types/api";
 
@@ -83,6 +85,8 @@ export const CollectionCaption = ({
 };
 
 const CollectionCaptionIcon = ({ collection }: { collection: Collection }) => {
+  const isTenantUser = useSelector(getIsTenantUser);
+
   if (isInstanceAnalyticsCollection(collection)) {
     return (
       <PLUGIN_COLLECTION_COMPONENTS.CollectionInstanceAnalyticsIcon
@@ -94,7 +98,8 @@ const CollectionCaptionIcon = ({ collection }: { collection: Collection }) => {
     );
   }
 
-  if (PLUGIN_COLLECTIONS.isSyncedCollection(collection)) {
+  if (PLUGIN_COLLECTIONS.isSyncedCollection(collection) && !isTenantUser) {
+    // external users should see the normal icon, they should not know about what synced collections are
     return <Icon name="synced_collection" size={24} c="brand" />;
   }
 

--- a/frontend/src/metabase/common/components/EntityPicker/components/ItemList/ItemList.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/ItemList/ItemList.tsx
@@ -3,8 +3,10 @@ import { useMemo } from "react";
 import { t } from "ttag";
 
 import { VirtualizedList } from "metabase/common/components/VirtualizedList";
+import { useSelector } from "metabase/lib/redux";
 import { PLUGIN_MODERATION } from "metabase/plugins";
 import { LoadingAndErrorWrapper } from "metabase/public/containers/PublicAction/PublicAction.styled";
+import { getIsTenantUser } from "metabase/selectors/user";
 import {
   Box,
   type BoxProps,
@@ -56,6 +58,7 @@ export const ItemList = <
   navLinkProps,
   containerProps = { pb: "xs" },
 }: ItemListProps<Id, Model, Item>) => {
+  const isTenantUser = useSelector(getIsTenantUser);
   const filteredItems =
     items && shouldShowItem ? items.filter(shouldShowItem) : items;
   const activeItemIndex = useMemo(() => {
@@ -94,7 +97,10 @@ export const ItemList = <
     >
       {filteredItems.map((item: Item) => {
         const isSelected = isSelectedItem(item, selectedItem);
-        const icon = getEntityPickerIcon(item, isSelected && isCurrentLevel);
+        const icon = getEntityPickerIcon(item, {
+          isSelected: isSelected && isCurrentLevel,
+          isTenantUser,
+        });
         const isDisabled = shouldDisableItem?.(item);
 
         return (

--- a/frontend/src/metabase/common/components/EntityPicker/utils.ts
+++ b/frontend/src/metabase/common/components/EntityPicker/utils.ts
@@ -21,9 +21,15 @@ import type {
 
 export const getEntityPickerIcon = <Id, Model extends string>(
   item: TypeWithModel<Id, Model>,
-  isSelected?: boolean,
+  {
+    isSelected,
+    isTenantUser,
+  }: {
+    isSelected?: boolean;
+    isTenantUser?: boolean;
+  } = {},
 ) => {
-  const icon = getIcon(item as ObjectWithModel);
+  const icon = getIcon(item as ObjectWithModel, { isTenantUser });
 
   if (["person", "group"].includes(icon.name)) {
     // should inherit color

--- a/frontend/src/metabase/entities/collections/utils.ts
+++ b/frontend/src/metabase/entities/collections/utils.ts
@@ -19,7 +19,7 @@ export function normalizedCollection(collection: Collection) {
 
 export function getCollectionIcon(
   collection: Partial<Collection>,
-  { tooltip = "default" } = {},
+  { tooltip = "default", isTenantUser = false } = {},
 ): {
   name: IconName;
   color?: string;
@@ -37,7 +37,8 @@ export function getCollectionIcon(
     return { name: "person" };
   }
 
-  if (isSyncedCollection(collection)) {
+  if (isSyncedCollection(collection) && !isTenantUser) {
+    // tenant users see the normal icon, they don't know what a synced collection is
     return { name: "synced_collection" };
   }
 
@@ -81,7 +82,13 @@ export interface CollectionTreeItem extends Collection {
 
 export function buildCollectionTree(
   collections: Collection[] = [],
-  modelFilter?: (model: CollectionContentModel) => boolean,
+  {
+    modelFilter,
+    isTenantUser = false,
+  }: {
+    modelFilter?: (model: CollectionContentModel) => boolean;
+    isTenantUser?: boolean;
+  } = {},
 ): CollectionTreeItem[] {
   return collections.flatMap((collection) => {
     const isPersonalRoot = collection.id === PERSONAL_COLLECTIONS.id;
@@ -98,7 +105,7 @@ export function buildCollectionTree(
     const children = !isRootTrashCollection(collection)
       ? buildCollectionTree(
           collection.children?.filter((child) => !child.archived) || [],
-          modelFilter,
+          { modelFilter, isTenantUser },
         )
       : [];
 
@@ -109,7 +116,7 @@ export function buildCollectionTree(
     return {
       ...collection,
       schemaName: collection.originalName || collection.name,
-      icon: getCollectionIcon(collection),
+      icon: getCollectionIcon(collection, { isTenantUser }),
       children,
     };
   });

--- a/frontend/src/metabase/entities/collections/utils.unit.spec.ts
+++ b/frontend/src/metabase/entities/collections/utils.unit.spec.ts
@@ -110,10 +110,9 @@ describe("entities > collections > utils", () => {
           children: [child],
         });
 
-        const transformed = buildCollectionTree(
-          [collection],
-          (model) => model === "dataset",
-        );
+        const transformed = buildCollectionTree([collection], {
+          modelFilter: (model) => model === "dataset",
+        });
 
         expect(transformed).toMatchObject([
           {
@@ -160,7 +159,7 @@ describe("entities > collections > utils", () => {
 
         const transformed = buildCollectionTree(
           [collectionWithDatasets, collectionWithCards],
-          (model) => model === "dataset",
+          { modelFilter: (model) => model === "dataset" },
         );
 
         expect(transformed).toMatchObject([
@@ -210,10 +209,9 @@ describe("entities > collections > utils", () => {
           ],
         });
 
-        const collectionTree = buildCollectionTree(
-          [collection],
-          (model) => model === "card",
-        );
+        const collectionTree = buildCollectionTree([collection], {
+          modelFilter: (model) => model === "card",
+        });
 
         expect(collectionTree).toMatchObject([
           {
@@ -251,10 +249,9 @@ describe("entities > collections > utils", () => {
           ],
         });
 
-        const collectionTree = buildCollectionTree(
-          [collection],
-          (model) => model === "card",
-        );
+        const collectionTree = buildCollectionTree([collection], {
+          modelFilter: (model) => model === "card",
+        });
 
         expect(collectionTree).toEqual([]);
       });

--- a/frontend/src/metabase/lib/icon.ts
+++ b/frontend/src/metabase/lib/icon.ts
@@ -101,9 +101,12 @@ export const getIconBase = (item: ObjectWithModel): IconData => {
  * relies mainly on the `model` property to determine the icon to return
  * also handle special collection icons and visualization types for cards
  */
-export const getIcon = (item: ObjectWithModel): IconData => {
+export const getIcon = (
+  item: ObjectWithModel,
+  { isTenantUser = false }: { isTenantUser?: boolean } = {},
+): IconData => {
   if (PLUGIN_COLLECTIONS) {
-    return PLUGIN_COLLECTIONS.getIcon(item);
+    return PLUGIN_COLLECTIONS.getIcon(item, { isTenantUser });
   }
   return getIconBase(item);
 };

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarContainer.tsx
@@ -26,6 +26,7 @@ import { connect, useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { PLUGIN_TENANTS } from "metabase/plugins";
 import {
+  getIsTenantUser,
   getUser,
   getUserCanWriteToCollections,
   getUserIsAdmin,
@@ -94,6 +95,7 @@ function MainNavbarContainer({
 }: Props) {
   const [modal, setModal] = useState<NavbarModal>(null);
   const canWriteToCollections = useSelector(getUserCanWriteToCollections);
+  const isTenantUser = useSelector(getIsTenantUser);
 
   const {
     data: trashCollection,
@@ -131,12 +133,12 @@ function MainNavbarContainer({
     preparedCollections.push(...userPersonalCollections);
     preparedCollections.push(...displayableCollections);
 
-    const tree = buildCollectionTree(preparedCollections);
+    const tree = buildCollectionTree(preparedCollections, { isTenantUser });
     if (trashCollection) {
       const trash: CollectionTreeItem = {
         ...trashCollection,
         id: "trash",
-        icon: getCollectionIcon(trashCollection),
+        icon: getCollectionIcon(trashCollection, { isTenantUser }),
         children: [],
       };
       tree.push(trash);
@@ -145,14 +147,14 @@ function MainNavbarContainer({
     if (rootCollection) {
       const root: CollectionTreeItem = {
         ...rootCollection,
-        icon: getCollectionIcon(rootCollection),
+        icon: getCollectionIcon(rootCollection, { isTenantUser }),
         children: [],
       };
       return [root, ...tree];
     } else {
       return tree;
     }
-  }, [rootCollection, trashCollection, collections, currentUser]);
+  }, [rootCollection, trashCollection, collections, currentUser, isTenantUser]);
 
   const reorderBookmarks = useCallback(
     async ({ newIndex, oldIndex }: { newIndex: number; oldIndex: number }) => {

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarCollectionLink.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarCollectionLink.tsx
@@ -9,8 +9,10 @@ import type {
   TreeNodeProps,
 } from "metabase/common/components/tree/types";
 import { getCollectionIcon } from "metabase/entities/collections/utils";
+import { useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { PLUGIN_COLLECTIONS } from "metabase/plugins";
+import { getIsTenantUser } from "metabase/selectors/user";
 import type { Collection } from "metabase-types/api";
 
 import {
@@ -50,6 +52,7 @@ const SidebarCollectionLink = forwardRef<HTMLLIElement, Props>(
   ) {
     const wasHovered = usePrevious(isHovered);
     const timeoutId = useRef<number>();
+    const isTenantUser = useSelector(getIsTenantUser);
 
     useEffect(() => {
       const justHovered = !wasHovered && isHovered;
@@ -84,7 +87,7 @@ const SidebarCollectionLink = forwardRef<HTMLLIElement, Props>(
       [isExpanded, hasChildren, onToggleExpand],
     );
 
-    const icon = getCollectionIcon(collection);
+    const icon = getCollectionIcon(collection, { isTenantUser });
     const isRegularCollection = PLUGIN_COLLECTIONS.isRegularCollection(
       collection as unknown as Collection,
     );

--- a/frontend/src/metabase/plugins/oss/collections.ts
+++ b/frontend/src/metabase/plugins/oss/collections.ts
@@ -76,7 +76,10 @@ const getDefaultPluginCollections = () => ({
     _collection: Collection,
     _onUpdate: (collection: Collection, values: Partial<Collection>) => void,
   ): React.ReactNode[] => [],
-  getIcon: getIconBase,
+  getIcon: (
+    item: Parameters<typeof getIconBase>[0],
+    _opts?: { isTenantUser?: boolean },
+  ) => getIconBase(item),
   filterOutItemsFromInstanceAnalytics: <Item extends ItemWithCollection>(
     items: Item[],
   ) => items as Item[],

--- a/frontend/src/metabase/query_builder/components/DataSelector/saved-entity-picker/SavedEntityPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/saved-entity-picker/SavedEntityPicker.jsx
@@ -89,7 +89,7 @@ function SavedEntityPicker({
 
     return [
       ...(rootCollection ? [getOurAnalyticsCollection(rootCollection)] : []),
-      ...buildCollectionTree(preparedCollections, modelFilter),
+      ...buildCollectionTree(preparedCollections, { modelFilter }),
     ];
   }, [collections, rootCollection, currentUser, type]);
 


### PR DESCRIPTION
closes https://linear.app/metabase/issue/EMB-1142/tenant-users-should-not-see-the-synced-collection-icon


How to verify:
- enable tenants
- create a couple of shared collections
- enable remote sync and sync the shared collections so that the tenant users would have seen the special icon

Check both:
- sidebar
- picker for saving a question (it's a different icon component)

Demo:

Admins see:
<img width="864" height="627" alt="image" src="https://github.com/user-attachments/assets/6137be52-b536-460d-8af8-6312aa940a43" />
<img width="1049" height="934" alt="image" src="https://github.com/user-attachments/assets/ce23bcc1-534e-42ca-be26-edd73eecb1e7" />


Tenant users see:
<img width="801" height="592" alt="image" src="https://github.com/user-attachments/assets/e578432a-90c2-46a1-80ad-bfbd11bd4f88" />
<img width="1070" height="652" alt="image" src="https://github.com/user-attachments/assets/7e10232a-e21b-4b61-8302-fdeb6e203a82" />
