### PR TITLE
Fix opening an info sidebar when native _variables_ sidebar was already opened

### DIFF
--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
@@ -933,3 +933,44 @@ describe("issue 66745", () => {
     });
   });
 });
+
+describe("issue 51717", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("should open question info sidebar when variables sidebar is already open (metabase#51717)", () => {
+    H.createNativeQuestion(
+      {
+        name: "42",
+        native: { query: "select 42" },
+      },
+      { visitQuestion: true },
+    );
+
+    cy.findByTestId("visibility-toggler")
+      .findByText(/open editor/i)
+      .click();
+
+    cy.log("Open variables sidebar");
+    cy.findByTestId("native-query-editor-action-buttons")
+      .should("be.visible")
+      .findByLabelText("Variables")
+      .click();
+    cy.findByTestId("sidebar-right")
+      .should("be.visible")
+      .and("contain", "Variables and parameters");
+
+    cy.log("Info sidebar is opened");
+    H.openQuestionInfoSidesheet();
+    cy.findByTestId("sidesheet")
+      .as("infoSidebar")
+      .should("be.visible")
+      .and("contain", "Info");
+
+    cy.log("Make sure info sidebar is interactive (on top of the stack)");
+    cy.get("@infoSidebar").findByRole("tab", { name: "History" }).click();
+    cy.get("@infoSidebar").should("contain", "You created this");
+  });
+});

--- a/frontend/src/metabase/query_builder/components/view/NativeVariablesButton/NativeVariablesButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/NativeVariablesButton/NativeVariablesButton.tsx
@@ -23,6 +23,7 @@ export const NativeVariablesButton = ({
     <Tooltip label={t`Variables`}>
       <Box
         component="a"
+        aria-label={`Variables`}
         h={size}
         className={cx(className, NativeVariablesButtonS.ButtonRoot, {
           [NativeVariablesButtonS.isSelected]: isShowingTemplateTagsEditor,

--- a/frontend/src/metabase/query_builder/components/view/NativeVariablesButton/NativeVariablesButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/NativeVariablesButton/NativeVariablesButton.tsx
@@ -23,7 +23,7 @@ export const NativeVariablesButton = ({
     <Tooltip label={t`Variables`}>
       <Box
         component="a"
-        aria-label={`Variables`}
+        aria-label={t`Variables`}
         h={size}
         className={cx(className, NativeVariablesButtonS.ButtonRoot, {
           [NativeVariablesButtonS.isSelected]: isShowingTemplateTagsEditor,

--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -270,6 +270,7 @@ export const uiControls = handleActions(
     [onOpenQuestionInfo]: (state) =>
       setUIControls(state, {
         ...UI_CONTROLS_SIDEBAR_DEFAULTS,
+        ...CLOSED_NATIVE_EDITOR_SIDEBARS,
         isShowingQuestionInfoSidebar: true,
         queryBuilderMode: "view",
       }),


### PR DESCRIPTION
Fixes #51717

## Demo
![Kapture 2025-12-18 at 16 03 35](https://github.com/user-attachments/assets/cc52a48f-8653-449b-997a-f13c2f33ab21)


- [x] Tests have been added/updated to cover changes in this PR