### PR TITLE
UXW-115 Disables "Export as PDF" button in dashboard share menu while cards are still loading

### DIFF
--- a/frontend/src/metabase/embedding/components/SharingMenu/DashboardSharingMenu.tsx
+++ b/frontend/src/metabase/embedding/components/SharingMenu/DashboardSharingMenu.tsx
@@ -1,6 +1,9 @@
 import { isInstanceAnalyticsCollection } from "metabase/collections/utils";
 import { setSharing as setDashboardSubscriptionSidebarOpen } from "metabase/dashboard/actions";
-import { getIsSharing as getIsDashboardSubscriptionSidebarOpen } from "metabase/dashboard/selectors";
+import {
+  getIsDashCardsRunning,
+  getIsSharing as getIsDashboardSubscriptionSidebarOpen,
+} from "metabase/dashboard/selectors";
 import { GUEST_EMBED_EMBEDDING_TYPE } from "metabase/embedding/constants";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { DashboardSubscriptionMenuItem } from "metabase/notifications/NotificationsActionsMenu/DashboardSubscriptionMenuItem";
@@ -39,6 +42,7 @@ export function DashboardSharingMenu({ dashboard }: { dashboard: Dashboard }) {
     dashboard.collection && isInstanceAnalyticsCollection(dashboard.collection);
 
   const canShare = !isAnalytics;
+  const isDashCardsRunning = useSelector(getIsDashCardsRunning);
 
   if (isArchived) {
     return null;
@@ -51,7 +55,7 @@ export function DashboardSharingMenu({ dashboard }: { dashboard: Dashboard }) {
           onClick={toggleSubscriptionSidebar}
           dashboard={dashboard}
         />
-        <ExportPdfMenuItem dashboard={dashboard} />
+        <ExportPdfMenuItem dashboard={dashboard} loading={isDashCardsRunning} />
         {canShare && (
           <>
             <Menu.Divider />

--- a/frontend/src/metabase/embedding/components/SharingMenu/MenuItems/ExportPdfMenuItem.tsx
+++ b/frontend/src/metabase/embedding/components/SharingMenu/MenuItems/ExportPdfMenuItem.tsx
@@ -25,7 +25,13 @@ const handleClick = async (dashboard: Dashboard, includeBranding: boolean) => {
   });
 };
 
-export const ExportPdfMenuItem = ({ dashboard }: { dashboard: Dashboard }) => {
+export const ExportPdfMenuItem = ({
+  dashboard,
+  loading,
+}: {
+  dashboard: Dashboard;
+  loading?: boolean;
+}) => {
   const isWhitelabeled = useHasTokenFeature("whitelabel");
   const includeBranding = !isWhitelabeled;
 
@@ -34,6 +40,8 @@ export const ExportPdfMenuItem = ({ dashboard }: { dashboard: Dashboard }) => {
       data-testid="dashboard-export-pdf-button"
       leftSection={<Icon name="document" />}
       onClick={() => handleClick(dashboard, includeBranding)}
+      disabled={loading}
+      style={loading ? { cursor: "wait" } : undefined}
     >
       {getExportTabAsPdfButtonText(dashboard.tabs)}
     </Menu.Item>

--- a/frontend/src/metabase/embedding/components/SharingMenu/test/DashboardSharingMenu.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/components/SharingMenu/test/DashboardSharingMenu.unit.spec.tsx
@@ -137,6 +137,33 @@ describe("DashboardSharingMenu", () => {
         expect(screen.getByText("Export tab as PDF")).toBeInTheDocument();
       });
     });
+
+    it("should be disabled if dashcards are still loading", async () => {
+      setupDashboardSharingMenu({
+        dashboardState: {
+          loadingDashCards: {
+            loadingIds: [],
+            loadingStatus: "running",
+            startTime: null,
+            endTime: null,
+          },
+        },
+      });
+      await openMenu();
+      expect(screen.getByTestId("dashboard-export-pdf-button")).toBeDisabled();
+      expect(screen.getByTestId("dashboard-export-pdf-button")).toHaveStyle({
+        cursor: "wait",
+      });
+    });
+
+    it("should be enabled if dashcards are done loading", async () => {
+      setupDashboardSharingMenu({});
+      await openMenu();
+      expect(screen.getByTestId("dashboard-export-pdf-button")).toBeEnabled();
+      expect(screen.getByTestId("dashboard-export-pdf-button")).not.toHaveStyle(
+        { cursor: "wait" },
+      );
+    });
   });
 
   describe("public links", () => {

--- a/frontend/src/metabase/embedding/components/SharingMenu/test/setup.tsx
+++ b/frontend/src/metabase/embedding/components/SharingMenu/test/setup.tsx
@@ -24,7 +24,11 @@ import {
   createMockTokenFeatures,
   createMockUser,
 } from "metabase-types/api/mocks";
-import { createMockState } from "metabase-types/store/mocks";
+import type { DashboardState } from "metabase-types/store/dashboard";
+import {
+  createMockDashboardState,
+  createMockState,
+} from "metabase-types/store/mocks";
 
 import { DashboardSharingMenu } from "../DashboardSharingMenu";
 import { QuestionSharingMenu } from "../QuestionSharingMenu";
@@ -49,6 +53,7 @@ type SettingsProps = {
   canManageSubscriptions?: boolean;
   isEnterprise?: boolean;
   card?: Card;
+  dashboardState?: Partial<DashboardState>;
 };
 
 const setupState = ({
@@ -60,6 +65,7 @@ const setupState = ({
   canManageSubscriptions = false,
   isEnterprise = false,
   card,
+  dashboardState,
 }: SettingsProps) => {
   const tokenFeatures = createMockTokenFeatures({
     advanced_permissions: isEnterprise,
@@ -95,6 +101,7 @@ const setupState = ({
         card,
       },
     } as User,
+    dashboard: createMockDashboardState(dashboardState),
   });
 
   return state;
@@ -110,6 +117,7 @@ export function setupDashboardSharingMenu({
   isEnterprise = false,
   hasPublicLink = false,
   dashboard: dashboardOverrides = {},
+  dashboardState,
 }: {
   dashboard?: Partial<Dashboard>;
   hasPublicLink?: boolean;
@@ -133,6 +141,7 @@ export function setupDashboardSharingMenu({
     isAdmin,
     canManageSubscriptions,
     isEnterprise,
+    dashboardState,
   });
 
   if (isEnterprise) {


### PR DESCRIPTION
Closes #33263 / UXW-115

### Description

Uses `getIsDashCardsRunning` selector to disable "Export as PDF" button while dashcards are loading. 

### How to verify

1. Navigate to a dashboard that loads quickly
2. Open the Sharing menu
3. Verify "Export [tab] as PDF" works the same as before
4. Navigate to a slow-loading dashboard (or just throttle your connection and load the same dashboard again)
5. Verify the "Export [tab] as PDF" menu item is disabled while dashcards are loading but works the same as before once the tab's dashcards are all loaded

### Demo

https://github.com/user-attachments/assets/7481b05f-f209-47a2-ba67-7407eb109887

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
