### PR TITLE
Fix the querying team pager duty action

### DIFF
--- a/.github/workflows/querying-team-pagerduty.yml
+++ b/.github/workflows/querying-team-pagerduty.yml
@@ -10,9 +10,15 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     if: |
-      (github.event.label.name == 'Priority: P1' || github.event.label.name == '.Escalation') &&
+      (github.event.label.name == 'Priority:P0' || github.event.label.name == 'Priority:P1' || github.event.label.name == '.Escalation') &&
       contains(github.event.issue.labels.*.name, '.Team/Querying')
     steps:
+      - name: Setting title
+        uses: actions/github-script@v7
+        id: vars
+        with:
+          script: |
+            core.setOutput('issue_title', ${{ toJson(github.event.issue.title) }}.replaceAll(/"/g, '\\"'));
       - name: Trigger PagerDuty Incident
         run: |
           curl -X POST https://events.pagerduty.com/v2/enqueue \
@@ -22,7 +28,7 @@ jobs:
               "event_action": "trigger",
               "dedup_key": "github-issue-${{ github.event.issue.number }}",
               "payload": {
-                "summary": "[${{ github.event.label.name }}] ${{ github.event.issue.title }}",
+                "summary": "[${{ github.event.label.name }}] ${{ steps.vars.outputs.issue_title }}",
                 "source": "GitHub Issues - ${{ github.repository }}",
                 "severity": "critical",
                 "custom_details": {


### PR DESCRIPTION
### Description

Use proper priority labels and escape github issue title

### How to verify

1. Create issue with `.Team/Querying` and `Priority:P1` labels
2. Querying on call should receive pager duty notification