### PR TITLE
Validation for internal group's tenant collection permission should reference all internal users

### DIFF
--- a/e2e/test/scenarios/admin-2/tenants.cy.spec.ts
+++ b/e2e/test/scenarios/admin-2/tenants.cy.spec.ts
@@ -431,6 +431,55 @@ describe("Tenants - management", () => {
     });
   });
 
+  it("should show 'All Internal Users' in permission warning modal for internal groups on tenant collections (EMB-1143)", () => {
+    cy.request("PUT", "/api/setting", { "use-tenants": true });
+
+    cy.request("POST", "/api/permissions/group", {
+      name: "Test Internal Group",
+      is_tenant_group: false,
+    });
+
+    cy.visit("/admin/permissions/tenant-collections/root");
+
+    cy.log("all internal users should have 'View' access");
+    cy.findAllByRole("row")
+      .contains("tr", "All Internal Users")
+      .findByText("View")
+      .should("be.visible");
+
+    cy.log("internal group should have no access");
+    cy.findAllByRole("row")
+      .contains("tr", "Test Internal Group")
+      .findByText("No access")
+      .click();
+
+    cy.log("change internal group to view-only");
+    H.popover().findByText("View").click();
+
+    cy.findAllByRole("row")
+      .contains("tr", "Test Internal Group")
+      .findByText("View")
+      .click();
+
+    cy.log("change internal group back to no access");
+    H.popover().findByText("No access").click();
+
+    H.modal().within(() => {
+      cy.log("title should mention internal users group");
+      cy.findByText(/Revoke access even though "All Internal Users"/).should(
+        "be.visible",
+      );
+
+      cy.log("description should mention internal users group");
+      cy.findByText(
+        /The "All Internal Users" group has a higher level of access/,
+      ).should("be.visible");
+
+      cy.log("should not mention tenant users");
+      cy.contains("Tenant users").should("not.exist");
+    });
+  });
+
   it("should not show send email modal when creating tenant users when SMTP is configured", () => {
     H.setupSMTP();
     cy.request("PUT", "/api/setting", {

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantCollectionPermissionsPage/selectors.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantCollectionPermissionsPage/selectors.tsx
@@ -19,7 +19,11 @@ import {
   getCollectionIcon,
 } from "metabase/entities/collections";
 import { Groups } from "metabase/entities/groups";
-import { getGroupNameLocalized, isAdminGroup } from "metabase/lib/groups";
+import {
+  getGroupNameLocalized,
+  isAdminGroup,
+  isDefaultGroup,
+} from "metabase/lib/groups";
 import { PLUGIN_TENANTS } from "metabase/plugins";
 import type {
   Collection,
@@ -172,7 +176,7 @@ export const getTenantCollectionsPermissionEditor = createSelector(
 
         const defaultGroup = _.find(
           groups,
-          PLUGIN_TENANTS.isExternalUsersGroup,
+          isTenantGroup ? PLUGIN_TENANTS.isExternalUsersGroup : isDefaultGroup,
         );
 
         const defaultGroupPermission = defaultGroup


### PR DESCRIPTION
Closes EMB-1143

### Description

When editing tenant collection permissions, setting an internal group to No access while both All tenant users and All internal users are set to View shows the error: `The "All tenant users" group has a higher level of access than this.`

This is incorrect, because internal groups inherit from All internal users, not All tenant users. The validation logic (and/or error message) is using the wrong inheritance source for internal groups.

### How to verify

- Go to tenant collection permission settings page e.g. `/tenant-collections/root`
- Create an internal group
- Set "All Internal Users" to "View"
- Set the internal group to "No access"
- The modal `The "All Internal Users" group has a higher level of access than this, which will override this setting. You should limit or revoke the "All Internal Users" group's access to this item.` should show up.
- It must mention the internal users group, NOT tenant users group.

### Demo

<img width="1412" height="880" alt="CleanShot 2568-12-18 at 23 49 17@2x" src="https://github.com/user-attachments/assets/f171e606-ddfd-4165-b9dd-62ddefe97d76" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
