### PR TITLE
prevent tenant users from editing their dedicated tenant collection

### DIFF
--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionCaption.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionCaption.tsx
@@ -1,11 +1,13 @@
 import { useCallback } from "react";
 import { t } from "ttag";
 
+import { getCurrentUser } from "metabase/admin/datamodel/selectors";
 import {
   isEditableCollection,
   isInstanceAnalyticsCollection,
   isRootTrashCollection,
 } from "metabase/collections/utils";
+import { useSelector } from "metabase/lib/redux";
 import {
   PLUGIN_COLLECTIONS,
   PLUGIN_COLLECTION_COMPONENTS,
@@ -29,7 +31,8 @@ export const CollectionCaption = ({
   collection,
   onUpdateCollection,
 }: CollectionCaptionProps): JSX.Element => {
-  const isEditable = isEditableCollection(collection);
+  const currentUser = useSelector(getCurrentUser);
+  const isEditable = isEditableCollection(collection, { currentUser });
   const hasDescription = Boolean(collection.description);
 
   const handleChangeName = useCallback(

--- a/frontend/src/metabase/collections/utils.ts
+++ b/frontend/src/metabase/collections/utils.ts
@@ -9,6 +9,7 @@ import {
   type CollectionItem,
   type CollectionItemModel,
   type CollectionType,
+  type User,
   isBaseEntityID,
 } from "metabase-types/api";
 
@@ -44,6 +45,19 @@ export function isDedicatedTenantCollectionRoot(
   return collection.type === "tenant-specific-root-collection";
 }
 
+export function isDedicatedTenantCollectionOfUser({
+  user,
+  collection,
+}: {
+  user: User;
+  collection: Collection;
+}): boolean {
+  return (
+    user.tenant_collection_id !== null &&
+    user.tenant_collection_id === collection.id
+  );
+}
+
 export function isPersonalCollection(
   collection: Pick<Collection, "is_personal">,
 ) {
@@ -68,13 +82,17 @@ export function isPublicCollection(
   return !isPersonalCollection(collection);
 }
 
-export function isEditableCollection(collection: Collection) {
+export function isEditableCollection(
+  collection: Collection,
+  { currentUser }: { currentUser: User },
+) {
   return (
     collection.can_write &&
     !isRootCollection(collection) &&
     !isRootPersonalCollection(collection) &&
     !isTrashedCollection(collection) &&
-    !isLibraryCollection(collection)
+    !isLibraryCollection(collection) &&
+    !isDedicatedTenantCollectionOfUser({ user: currentUser, collection })
   );
 }
 


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/EMB-1141/rename-my-tenant-collection-and-make-it-read-only


## How to verify:
- login as a tenant user
- open their dedicated tenant collection
The title and description should not be editable, not that the name you see on the page may still wrong as that's changed in https://github.com/metabase/metabase/pull/67086
The name on the sidebar was already renamed to `Our data` on the FE in another PR.