### PR TITLE
Remove embedding subscriptions email links

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/editable-dashboard.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/editable-dashboard.cy.spec.tsx
@@ -1,6 +1,7 @@
 const { H } = cy;
 import { EditableDashboard } from "@metabase/embedding-sdk-react";
 
+import { WEBMAIL_CONFIG } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ORDERS_BY_YEAR_QUESTION_ID,
@@ -21,6 +22,8 @@ import {
   createMockHeadingDashboardCard,
   createMockParameter,
 } from "metabase-types/api/mocks";
+
+const { WEB_PORT } = WEBMAIL_CONFIG;
 
 const categoryParameter = createMockParameter({
   id: "1b9cd9f1",
@@ -443,6 +446,49 @@ describe("scenarios > embedding-sdk > editable-dashboard", () => {
           H.getDashboardCard(1)
             .findByText(ADDED_QUESTION_NAME_2)
             .should("be.visible");
+        });
+      });
+    });
+  });
+
+  describe("subscriptions", () => {
+    beforeEach(() => {
+      cy.signInAsAdmin();
+      H.setupSMTP();
+      const questionCard: Partial<DashboardCard> = {
+        id: ORDERS_DASHBOARD_DASHCARD_ID,
+        card_id: ORDERS_QUESTION_ID,
+        row: 0,
+        col: 0,
+        size_x: 16,
+        size_y: 8,
+      };
+      H.createDashboard({
+        name: DASHBOARD_NAME,
+        dashcards: [questionCard],
+        parameters: [categoryParameter, textParameter, countParameter],
+      }).then(({ body: dashboard }) => {
+        cy.wrap(dashboard.id).as("dashboardId");
+        cy.wrap(dashboard.entity_id).as("dashboardEntityId");
+      });
+      cy.signOut();
+    });
+
+    it("should not include links to Metabase", () => {
+      cy.get<string>("@dashboardId").then((dashboardId) => {
+        mountSdkContent(
+          <EditableDashboard dashboardId={dashboardId} withSubscriptions />,
+        );
+
+        cy.button("Subscriptions").click();
+        H.clickSend();
+        const emailUrl = `http://localhost:${WEB_PORT}/email`;
+        cy.request("GET", emailUrl).then(({ body }) => {
+          const latest = body.slice(-1)[0];
+          cy.request(`${emailUrl}/${latest.id}/html`).then(({ body }) => {
+            expect(body).to.include("Embedding SDK Test Dashboard");
+            expect(body).not.to.include("href=");
+          });
         });
       });
     });

--- a/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
@@ -811,7 +811,13 @@ describe("scenarios > dashboard > subscriptions", () => {
           H.sendEmailAndVisitIt();
         });
 
-        cy.log("Checks that links should not work");
+        cy.log(
+          "Links should be disabled in modular embedding and modular embedding SDK subscription emails",
+        );
+        cy.findAllByRole("table")
+          .first()
+          .findByText("Orders in a dashboard")
+          .should("exist");
         cy.findAllByRole("link").should("not.exist");
       });
     });

--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -1245,7 +1245,7 @@ databaseChangeLog:
             columns:
               - column:
                   name: disable_links
-                  type: boolean
+                  type: ${boolean.type}
                   remarks: "Whether to disable email subscription links"
                   constraints:
                     nullable: true

--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -1235,6 +1235,25 @@ databaseChangeLog:
             path: instance_analytics_views/tables/v1/h2-tables.sql
             relativeToChangelogFile: true
 
+  - changeSet:
+      id: v58.2025-12-18T16:14:03
+      author: winlost
+      comment: Add disable_links column to pulse table
+      changes:
+        - addColumn:
+            tableName: pulse
+            columns:
+              - column:
+                  name: disable_links
+                  type: boolean
+                  remarks: "Whether to disable email subscription links"
+                  constraints:
+                    nullable: true
+      rollback:
+        - dropColumn:
+            tableName: pulse
+            columnName: disable_links
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -1247,6 +1247,7 @@ databaseChangeLog:
                   name: disable_links
                   type: ${boolean.type}
                   remarks: "Whether to disable email subscription links"
+                  defaultValueBoolean: false
                   constraints:
                     nullable: true
       rollback:

--- a/src/metabase/embedding/util.clj
+++ b/src/metabase/embedding/util.clj
@@ -20,7 +20,7 @@
   (or (has-react-sdk-header? request)
       (has-embedded-analytics-js-header? request)))
 
-(defn modular-embedding-context?
+(defn modular-embedding-or-modular-embedding-sdk-context?
   "Check if the client is in modular embedding context"
   [client]
   (or (= client embedding-sdk-client)

--- a/src/metabase/embedding/util.clj
+++ b/src/metabase/embedding/util.clj
@@ -5,12 +5,12 @@
 (def ^:private embedded-analytics-js-client "embedding-simple")
 
 (defn has-react-sdk-header?
-  "Check if the client has indicated it is from the Embedding SDK for React "
+  "Check if the client has indicated it is from the Embedding SDK for React."
   [request]
   (= (get-in request [:headers "x-metabase-client"]) embedding-sdk-client))
 
 (defn has-embedded-analytics-js-header?
-  "Check if the client has indicated it is from modular embedding"
+  "Check if the client has indicated it is from modular embedding."
   [request]
   (= (get-in request [:headers "x-metabase-client"]) embedded-analytics-js-client))
 
@@ -21,7 +21,7 @@
       (has-embedded-analytics-js-header? request)))
 
 (defn modular-embedding-or-modular-embedding-sdk-context?
-  "Check if the client is in modular embedding context"
+  "Check if the client is in modular embedding context."
   [client]
   (or (= client embedding-sdk-client)
       (= client embedded-analytics-js-client)))

--- a/src/metabase/pulse/api/pulse.clj
+++ b/src/metabase/pulse/api/pulse.clj
@@ -160,7 +160,8 @@
        [:collection_id       {:optional true} [:maybe ms/PositiveInt]]
        [:collection_position {:optional true} [:maybe ms/PositiveInt]]
        [:dashboard_id        {:optional true} [:maybe ms/PositiveInt]]
-       [:parameters          {:optional true} [:maybe [:sequential :map]]]]]
+       [:parameters          {:optional true} [:maybe [:sequential :map]]]]
+   request]
   (perms/check-has-application-permission :subscription false)
   (let [pulse-data {:name                name
                     :creator_id          api/*current-user-id*
@@ -168,7 +169,8 @@
                     :collection_id       collection-id
                     :collection_position collection-position
                     :dashboard_id        dashboard-id
-                    :parameters          parameters}]
+                    :parameters          parameters
+                    :disable_links       (embed.util/modular-embedding-context? (get-in request [:headers "x-metabase-client"]))}]
     (api/create-check :model/Pulse (assoc pulse-data :cards cards))
     (t2/with-transaction [_conn]
       ;; Adding a new pulse at `collection_position` could cause other pulses in this collection to change position,

--- a/src/metabase/pulse/api/pulse.clj
+++ b/src/metabase/pulse/api/pulse.clj
@@ -170,7 +170,7 @@
                     :collection_position collection-position
                     :dashboard_id        dashboard-id
                     :parameters          parameters
-                    :disable_links       (embed.util/modular-embedding-context? (get-in request [:headers "x-metabase-client"]))}]
+                    :disable_links       (embed.util/modular-embedding-or-modular-embedding-sdk-context? (get-in request [:headers "x-metabase-client"]))}]
     (api/create-check :model/Pulse (assoc pulse-data :cards cards))
     (t2/with-transaction [_conn]
       ;; Adding a new pulse at `collection_position` could cause other pulses in this collection to change position,
@@ -459,7 +459,7 @@
   (notification/with-default-options {:notification/sync? true}
     (pulse.send/send-pulse! (-> body
                                 (assoc :creator_id api/*current-user-id*)
-                                (assoc :disable_links (embed.util/modular-embedding-context? (get-in request [:headers "x-metabase-client"]))))))
+                                (assoc :disable_links (embed.util/modular-embedding-or-modular-embedding-sdk-context? (get-in request [:headers "x-metabase-client"]))))))
   {:ok true})
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to

--- a/src/metabase/pulse/api/pulse.clj
+++ b/src/metabase/pulse/api/pulse.clj
@@ -170,7 +170,8 @@
                     :collection_position collection-position
                     :dashboard_id        dashboard-id
                     :parameters          parameters
-                    :disable_links       (embed.util/modular-embedding-or-modular-embedding-sdk-context? (get-in request [:headers "x-metabase-client"]))}]
+                    :disable_links       (embed.util/modular-embedding-or-modular-embedding-sdk-context?
+                                          (get-in request [:headers "x-metabase-client"]))}]
     (api/create-check :model/Pulse (assoc pulse-data :cards cards))
     (t2/with-transaction [_conn]
       ;; Adding a new pulse at `collection_position` could cause other pulses in this collection to change position,
@@ -459,7 +460,9 @@
   (notification/with-default-options {:notification/sync? true}
     (pulse.send/send-pulse! (-> body
                                 (assoc :creator_id api/*current-user-id*)
-                                (assoc :disable_links (embed.util/modular-embedding-or-modular-embedding-sdk-context? (get-in request [:headers "x-metabase-client"]))))))
+                                (assoc :disable_links
+                                       (embed.util/modular-embedding-or-modular-embedding-sdk-context?
+                                        (get-in request [:headers "x-metabase-client"]))))))
   {:ok true})
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to

--- a/src/metabase/pulse/models/pulse.clj
+++ b/src/metabase/pulse/models/pulse.clj
@@ -326,8 +326,8 @@
       (assoc :card (first (:cards notification)))
       (dissoc :cards)
       ;; TODO (Kelvin 2025-12-19) Remove this once we support alerts on modular embedding,
-      ;; as we only currently have `creation_context` column on Subscriptions.
-      (dissoc :creation_context)))
+      ;; as we only currently have `disable_links` column on Subscriptions.
+      (dissoc :disable_links)))
 
 (mu/defn retrieve-alert :- [:maybe (ms/InstanceOf :model/Pulse)]
   "Fetch a single Alert by its `id` value, do the standard hydrations, and put it in the standard `Alert` format."
@@ -545,7 +545,7 @@
                 [:collection_position {:optional true} [:maybe ms/PositiveInt]]
                 [:dashboard_id        {:optional true} [:maybe ms/PositiveInt]]
                 [:parameters          {:optional true} [:maybe [:sequential :map]]]
-                [:creation_context    {:optional true} [:maybe ms/NonBlankString]]]]
+                [:disable_links       {:optional true} [:maybe ms/BooleanValue]]]]
   (let [pulse-id (create-notification-and-add-cards-and-channels! kvs cards channels)]
     ;; return the full Pulse (and record our create event).
     (u/prog1 (retrieve-pulse pulse-id)

--- a/src/metabase/pulse/models/pulse.clj
+++ b/src/metabase/pulse/models/pulse.clj
@@ -324,7 +324,10 @@
   [notification :- (ms/InstanceOf :model/Pulse)]
   (-> notification
       (assoc :card (first (:cards notification)))
-      (dissoc :cards)))
+      (dissoc :cards)
+      ;; TODO (Kelvin 2025-12-19) Remove this once we support alerts on modular embedding,
+      ;; as we only currently have `creation_context` column on Subscriptions.
+      (dissoc :creation_context)))
 
 (mu/defn retrieve-alert :- [:maybe (ms/InstanceOf :model/Pulse)]
   "Fetch a single Alert by its `id` value, do the standard hydrations, and put it in the standard `Alert` format."

--- a/src/metabase/pulse/models/pulse.clj
+++ b/src/metabase/pulse/models/pulse.clj
@@ -541,7 +541,8 @@
                 [:collection_id       {:optional true} [:maybe ms/PositiveInt]]
                 [:collection_position {:optional true} [:maybe ms/PositiveInt]]
                 [:dashboard_id        {:optional true} [:maybe ms/PositiveInt]]
-                [:parameters          {:optional true} [:maybe [:sequential :map]]]]]
+                [:parameters          {:optional true} [:maybe [:sequential :map]]]
+                [:creation_context    {:optional true} [:maybe ms/NonBlankString]]]]
   (let [pulse-id (create-notification-and-add-cards-and-channels! kvs cards channels)]
     ;; return the full Pulse (and record our create event).
     (u/prog1 (retrieve-pulse pulse-id)

--- a/test/metabase/pulse/api/pulse_test.clj
+++ b/test/metabase/pulse/api/pulse_test.clj
@@ -54,7 +54,7 @@
    (select-keys
     pulse
     [:id :name :created_at :updated_at :creator_id :collection_id :collection_position :entity_id :archived
-     :skip_if_empty :dashboard_id :parameters])
+     :skip_if_empty :dashboard_id :parameters :disable_links])
    {:creator  (user-details (t2/select-one 'User :id (:creator_id pulse)))
     :cards    (map pulse-card-details (:cards pulse))
     :channels (map pulse-channel-details (:channels pulse))}))
@@ -164,7 +164,8 @@
    :archived            false
    :dashboard_id        nil
    :entity_id           true
-   :parameters          []})
+   :parameters          []
+   :disable_links       false})
 
 (def ^:private daily-email-channel
   {:enabled       true

--- a/test/metabase/pulse/dashboard_subscription_test.clj
+++ b/test/metabase/pulse/dashboard_subscription_test.clj
@@ -1168,6 +1168,39 @@
                   :channel/email first :message first :content
                   (re-find #"<h1>dashboard description</h1>")))))))
 
+(deftest dashboard-disable-links-test
+  (testing "Dashboard with links disabled"
+    (mt/with-temp [:model/Card                  {card-id :id} {:name          "Test card"
+                                                               :dataset_query {:database (mt/id)
+                                                                               :type     :native
+                                                                               :native   {:query "select * from orders limit 1"}}
+                                                               :display       :table}
+                   :model/Dashboard             {dashboard-id :id} {:name "dashboard subscription with disabled links"}
+                   :model/DashboardCard         {dashboard-card-id :id} {:dashboard_id dashboard-id
+                                                                         :card_id      card-id}
+                   :model/Pulse                 {pulse-id :id} {:name          "Pulse Name"
+                                                                :dashboard_id  dashboard-id
+                                                                :disable_links true}
+                   :model/PulseCard             _ {:pulse_id          pulse-id
+                                                   :card_id           card-id
+                                                   :dashboard_card_id dashboard-card-id}
+                   :model/PulseChannel          {pc-id :id} {:pulse_id pulse-id}
+                   :model/PulseChannelRecipient _ {:user_id          (pulse.test-util/rasta-id)
+                                                   :pulse_channel_id pc-id}]
+      (let [pulse (t2/select-one :model/Pulse pulse-id)
+            has-link? (fn [pulse]
+                        (->> (pulse.test-util/with-captured-channel-send-messages!
+                               (pulse.send/send-pulse! pulse))
+                             :channel/email first :message first :content
+                             (re-find #"href=")
+                             (= "href=")))]
+        (testing "test that disable_links: false will keep links in the email subscription"
+          (is (true? (has-link? (assoc pulse :disable_links false)))))
+        (testing "test that disable_links: nil will disable all links in the email subscription"
+          (is (true? (has-link? (assoc pulse :disable_links nil)))))
+        (testing "test that disable_links: true will disable all links in the email subscription"
+          (is (false? (has-link? pulse))))))))
+
 (deftest attachments-test
   (tests!
    {:card (pulse.test-util/checkins-query-card {})}

--- a/test/metabase/pulse/dashboard_subscription_test.clj
+++ b/test/metabase/pulse/dashboard_subscription_test.clj
@@ -1196,7 +1196,7 @@
                              (= "href=")))]
         (testing "test that disable_links: false will keep links in the email subscription"
           (is (true? (has-link? (assoc pulse :disable_links false)))))
-        (testing "test that disable_links: nil will disable all links in the email subscription"
+        (testing "test that disable_links: nil will keep links in the email subscription"
           (is (true? (has-link? (assoc pulse :disable_links nil)))))
         (testing "test that disable_links: true will disable all links in the email subscription"
           (is (false? (has-link? pulse))))))))

--- a/test/metabase/pulse/models/pulse_test.clj
+++ b/test/metabase/pulse/models/pulse_test.clj
@@ -52,7 +52,8 @@
    :dashboard_id        nil
    :skip_if_empty       false
    :archived            false
-   :parameters          []})
+   :parameters          []
+   :creation_context    nil})
 
 (deftest retrieve-pulse-test
   (testing "this should cover all the basic Pulse attributes"

--- a/test/metabase/pulse/models/pulse_test.clj
+++ b/test/metabase/pulse/models/pulse_test.clj
@@ -53,7 +53,7 @@
    :skip_if_empty       false
    :archived            false
    :parameters          []
-   :disable_links       nil})
+   :disable_links       false})
 
 (deftest retrieve-pulse-test
   (testing "this should cover all the basic Pulse attributes"

--- a/test/metabase/pulse/models/pulse_test.clj
+++ b/test/metabase/pulse/models/pulse_test.clj
@@ -53,7 +53,7 @@
    :skip_if_empty       false
    :archived            false
    :parameters          []
-   :creation_context    nil})
+   :disable_links       nil})
 
 (deftest retrieve-pulse-test
   (testing "this should cover all the basic Pulse attributes"


### PR DESCRIPTION
closes EMB-1140

### Description

We add a new column `creation_context` which is the value from the header `X-Metabase-Client`, so when we run a subscription we can use this value to include `:disable_links: true` to disable all controlled links on subsription emails.

### How to verify
1. Run Metabase with Postgres DB (required for the next flag) with `MB_ANALYTICS_DEV_MODE=true`
1. Run any SMTP server and configure it on Metabase (otherwise, the subscription button won't be visible)
    ```sh
    docker run -d -p 1080:1080 -p 1025:1025 maildev/maildev
    ```
1. Create a subscription in modular embedding, or modular embedding SDK, and normally in Metabase.
1. Check the pulse table, from the sidebar: Database > Internal Metabase Database > Pulse
1. Disable links should be true only when the subscriptions are created from modular embedding or modular embedding SDK.
1. Now test the actual subscription task
1. REPL into the running BE.
    ```sh
    clj -Sdeps '{:deps {reply/reply {:mvn/version "0.5.1"}}}' -M -m reply.main --attach 50605
    ```
1. Open the Pulse table from the previous step and join it with Pulse Channel (not Pulse channel recipient).
1. Send the subscription by going back to the repl.
    ```sh
    (ns metabase.pulse.task.send-pulses)
    ;; take the IDs from the previous step <pulse-id> from "ID" and <pulse-channel-id> from "Pulse Channel -> ID" e.g. (send-pulse!* 1 [2])
    (send-pulse!* <pulse-id> [<pulse-channel-id>])
    ```
1. Checks the email you receive, in case you use maildev from the above command. Go to http://localhost:1080. And see that for subscriptions from modular embedding and modular embedding SDK, there must be no links, but for normal subscription (created in Metabase directly) there should still be links.


### Demo
<img width="520" height="454" alt="image" src="https://github.com/user-attachments/assets/96201627-15a0-42a0-bbef-232161a6fb89" />

#### Emails with links (Metabase)
<img width="667" height="379" alt="image" src="https://github.com/user-attachments/assets/0c1d3c86-d301-4bf9-bad7-552a245413f1" />

#### Modular embedding and modular embedding SDK emails will contain no links
<img width="646" height="337" alt="image" src="https://github.com/user-attachments/assets/40a10b54-9d36-4e36-b868-8e5dc4a9d2ac" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
