### PR TITLE
Improve Redshift sync performance by filtering PK subquery by schema

### DIFF
--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -164,7 +164,10 @@
                                      [:= :tc.constraint_name :kc.constraint_name]
                                      [:= :tc.table_schema :kc.table_schema]
                                      [:= :tc.table_name :kc.table_name]]]
-                             :where [:= :tc.constraint_type [:inline "PRIMARY KEY"]]}
+                             ;; Filter PK subquery by schema to avoid scanning all schemas
+                             :where [:and
+                                     [:= :tc.constraint_type [:inline "PRIMARY KEY"]]
+                                     (when schema-names [:in :tc.table_schema (map u/lower-case-en schema-names)])]}
                             :pk]
                            [:and
                             [:= :c.table_schema :pk.table_schema]


### PR DESCRIPTION
The `describe-fields-sql` query joins with a subquery that looks up
primary keys from information_schema tables. Previously, this subquery
scanned ALL schemas in the database to find PKs, then the outer query
filtered down to the target schema(s).

With many orphaned test isolation schemas (200+), this caused each
sync-fields operation to take 30-45 seconds instead of ~1 second.

This change adds the same schema filter to the PK subquery, so it only
fetches PKs for the schemas being synced. When schema-names is nil
(full database sync), the original behavior is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
