### PR TITLE
Show embedding picker when logged in as a tenant user

### DIFF
--- a/e2e/test/scenarios/admin-2/tenants.cy.spec.ts
+++ b/e2e/test/scenarios/admin-2/tenants.cy.spec.ts
@@ -928,23 +928,6 @@ describe("tenant users", () => {
       .findByText(GIZMO_FULL_NAME)
       .should("be.visible");
   });
-
-  it("should show the embedding data picker when logged in as a tenant user (metabase#EMB-1144)", () => {
-    cy.log("log in as tenant user");
-    cy.task<string>("signJwt", {
-      payload: GIZMO_USER,
-      secret: JWT_SECRET,
-    }).then((key) =>
-      cy.visit(`/auth/sso?return_to=/question/notebook&jwt=${key}`),
-    );
-
-    cy.log("embedding data picker is shown");
-    cy.findByTestId("embedding-simple-data-picker-trigger").should(
-      "be.visible",
-    );
-    H.popover().contains("Orders").should("be.visible");
-    H.popover().contains("People").should("be.visible");
-  });
 });
 
 type AssertionType = "exist" | "not.exist";

--- a/e2e/test/scenarios/admin-2/tenants.cy.spec.ts
+++ b/e2e/test/scenarios/admin-2/tenants.cy.spec.ts
@@ -786,11 +786,7 @@ describe("tenant users", () => {
       cy.visit(`/auth/sso?return_to=/question/notebook&jwt=${key}`),
     );
 
-    H.miniPickerBrowseAll().click();
-    H.entityPickerModal().within(() => {
-      H.entityPickerModalItem(0, "Databases").click();
-      H.entityPickerModalItem(1, "Products").click();
-    });
+    H.popover().findByText("Products").click();
     cy.button("Visualize").click();
 
     cy.get("[data-column-id=CATEGORY]")
@@ -806,11 +802,7 @@ describe("tenant users", () => {
       cy.visit(`/auth/sso?return_to=/question/notebook&jwt=${key}`),
     );
 
-    H.miniPickerBrowseAll().click();
-    H.entityPickerModal().within(() => {
-      H.entityPickerModalItem(0, "Databases").click();
-      H.entityPickerModalItem(1, "Products").click();
-    });
+    H.popover().findByText("Products").click();
     cy.button("Visualize").click();
 
     cy.get("[data-column-id=CATEGORY]")

--- a/e2e/test/scenarios/admin-2/tenants.cy.spec.ts
+++ b/e2e/test/scenarios/admin-2/tenants.cy.spec.ts
@@ -928,6 +928,23 @@ describe("tenant users", () => {
       .findByText(GIZMO_FULL_NAME)
       .should("be.visible");
   });
+
+  it("should show the embedding data picker when logged in as a tenant user (metabase#EMB-1144)", () => {
+    cy.log("log in as tenant user");
+    cy.task<string>("signJwt", {
+      payload: GIZMO_USER,
+      secret: JWT_SECRET,
+    }).then((key) =>
+      cy.visit(`/auth/sso?return_to=/question/notebook&jwt=${key}`),
+    );
+
+    cy.log("embedding data picker is shown");
+    cy.findByTestId("embedding-simple-data-picker-trigger").should(
+      "be.visible",
+    );
+    H.popover().contains("Orders").should("be.visible");
+    H.popover().contains("People").should("be.visible");
+  });
 });
 
 type AssertionType = "exist" | "not.exist";

--- a/e2e/test/scenarios/embedding/tenant-users-sidecar.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/tenant-users-sidecar.cy.spec.ts
@@ -1,0 +1,78 @@
+const { H } = cy;
+
+const JWT_SECRET =
+  "0000000000000000000000000000000000000000000000000000000000000000";
+
+interface TenantAttributes {
+  CAPS?: string;
+  color?: string;
+}
+
+interface Tenant {
+  name: string;
+  slug: string;
+  attributes?: TenantAttributes;
+}
+
+interface TenantUser {
+  first_name: string;
+  last_name: string;
+  email: string;
+  "@tenant": string;
+}
+
+const GIZMO_TENANT: Tenant = {
+  name: "Gizmos",
+  slug: "gizmo",
+  attributes: {
+    CAPS: "✨GIZMO✨",
+    color: "cerulean",
+  },
+};
+
+const GIZMO_USER: TenantUser = {
+  first_name: "gizmo",
+  last_name: "user",
+  email: "gizmo.user@email.com",
+  "@tenant": GIZMO_TENANT.slug,
+};
+
+// Tests for when a tenant user is given SSO logins to
+// login to the internal Metabase instances, aka sidecar.
+describe("scenarios > sidecar > tenant users", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    H.activateToken("bleeding-edge");
+
+    cy.request("PUT", "/api/setting", {
+      "jwt-attribute-email": "email",
+      "jwt-attribute-firstname": "first_name",
+      "jwt-attribute-lastname": "last_name",
+      "jwt-enabled": true,
+      "jwt-identity-provider-uri": "localhost:4000",
+      "jwt-shared-secret": JWT_SECRET,
+      "jwt-user-provisioning-enabled?": true,
+      "use-tenants": true,
+    });
+
+    cy.request("POST", "/api/ee/tenant", GIZMO_TENANT);
+  });
+
+  it("should show the embedding data picker when logged in as a tenant user (metabase#EMB-1144)", () => {
+    cy.log("log in as tenant user");
+    cy.task<string>("signJwt", {
+      payload: GIZMO_USER,
+      secret: JWT_SECRET,
+    }).then((key) =>
+      cy.visit(`/auth/sso?return_to=/question/notebook&jwt=${key}`),
+    );
+
+    cy.log("embedding data picker is shown");
+    cy.findByTestId("embedding-simple-data-picker-trigger").should(
+      "be.visible",
+    );
+    H.popover().contains("Orders").should("be.visible");
+    H.popover().contains("People").should("be.visible");
+  });
+});

--- a/enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPicker.tsx
+++ b/enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPicker.tsx
@@ -58,7 +58,12 @@ export function SimpleDataPicker({
       trapFocus
     >
       <Popover.Target>
-        <Box onClick={toggle}>{triggerElement}</Box>
+        <Box
+          onClick={toggle}
+          data-testid="embedding-simple-data-picker-trigger"
+        >
+          {triggerElement}
+        </Box>
       </Popover.Target>
       <Popover.Dropdown>
         <DelayedLoadingAndErrorWrapper loading={isLoading} error={error}>

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
@@ -20,6 +20,7 @@ import type { QueryEditorDatabasePickerItem } from "metabase/querying/editor/typ
 import { loadMetadataForTable } from "metabase/questions/actions";
 import { getIsEmbedding } from "metabase/selectors/embed";
 import { getMetadata } from "metabase/selectors/metadata";
+import { getIsTenantUser } from "metabase/selectors/user";
 import { Icon, TextInput } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import { getQuestionVirtualTableId } from "metabase-lib/v1/metadata/utils/saved-questions";
@@ -78,6 +79,7 @@ export function NotebookDataPicker({
   const dispatch = useDispatch();
   const onChangeRef = useLatest(onChange);
   const isEmbedding = useSelector(getIsEmbedding);
+  const isTenantUser = useSelector(getIsTenantUser);
 
   const handleChange = async (tableId: TableId) => {
     await dispatch(loadMetadataForTable(tableId));
@@ -96,7 +98,9 @@ export function NotebookDataPicker({
     );
   }, [query, stageIndex]);
 
-  if (isEmbedding) {
+  // EMB-1144: force the embedding picker if user is a tenant user.
+  //           this is to support the sidecar use-case where tenant users are given instance logins.
+  if (isEmbedding || isTenantUser) {
     const canSelectTableColumns = table && isRaw && !isDisabled;
     return (
       <NotebookCellItem


### PR DESCRIPTION
Closes EMB-1144

### Description

The internal picker (ModernDataPicker from data studio changes) has issues when used by a tenant user that logs in internally to Metabase. In order to support this "sidecar" use case, we show the embedding picker instead of the mini picker for now.

### How to verify

- Enable tenants
- Create a tenant user and a tenant group for that user
- Allow that tenant group to create queries
- Log in as a tenant user that can create queries
- Create a question
- The data picker should be embedding data picker

### Demo

Logged in as a tenant user

<img width="400" alt="CleanShot 2568-12-19 at 00 40 28@2x" src="https://github.com/user-attachments/assets/bb4ef00d-97c8-49ad-aa31-9a8c4cffadfc" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
