### PR TITLE
Optimize Redshift describe-database by pushing schema filter to SQL

### DIFF
--- a/src/metabase/driver/sync.clj
+++ b/src/metabase/driver/sync.clj
@@ -80,3 +80,21 @@
   ([inclusion-patterns exclusion-patterns schema-name]
    (let [filter-fn (schema-patterns->filter-fn inclusion-patterns exclusion-patterns)]
      (filter-fn schema-name))))
+
+(defn inclusion-patterns->literal-schema-names
+  "Given inclusion patterns string (comma-separated), returns a set of literal schema names if ALL patterns
+  are simple literals (no wildcards or regex metacharacters). Returns nil if any pattern contains wildcards
+  or if patterns is nil/blank.
+
+  This is useful for pushing schema filters down into SQL queries when possible.
+
+  Examples:
+    \"public,test_schema\" => #{\"public\" \"test_schema\"}
+    \"public,test*\"       => nil (contains wildcard)
+    nil                    => nil"
+  [inclusion-patterns]
+  (when-not (str/blank? inclusion-patterns)
+    (let [schemas (map str/trim (str/split inclusion-patterns #","))]
+      ;; Only return schemas if none contain wildcards or regex metacharacters
+      (when (every? #(not (re-find #"[*?\\]" %)) schemas)
+        (set schemas)))))


### PR DESCRIPTION
When schema inclusion patterns are simple literals (no wildcards), push
the filter down into the SQL query rather than filtering client-side.
This dramatically improves performance when there are many schemas in
the database that we don't care about (e.g., orphaned test isolation
schemas).

Changes:
- Add `inclusion-patterns->literal-schema-names` to driver.sync namespace
  to extract literal schema names when no wildcards are present
- Convert `get-tables-sql` from def to defn that accepts optional schema
  names and generates parameterized IN clause
- Use parameterized queries (?) to avoid SQL injection


-------
Details:

# Redshift CI Performance Optimization

## The Problem

The Redshift CI tests were timing out at the 60-minute limit. Log analysis showed:

- Total test time: ~56 minutes for 440 tests
- Multiple `sync-fields` operations taking 8-46 seconds each

The CI environment has 200+ orphaned test isolation schemas in the Redshift database. Each test run creates a unique schema like `2024_12_18_abc123_schema`, and over time these accumulate.

## Root Cause: `describe-database` Fetches ALL Tables

The original `get-tables-sql` was a static constant:

```clojure
(def ^:private get-tables-sql
  [(str/join "\n"
    ["select c.relname as name, n.nspname as schema, ..."
     "from pg_catalog.pg_namespace n, pg_catalog.pg_class c"
     "left join pg_catalog.pg_description d on ..."
     "where c.relnamespace = n.oid"
     "  and n.nspname !~ '^information_schema|catalog_history|pg_|metabase_cache_'"
     "  and c.relkind in ('r', 'p', 'v', 'f', 'm')"
     "  ..."
     "union all"
     "select tablename as name, schemaname as schema, ..."
     "from svv_external_tables t"
     "where schemaname !~ '^information_schema|catalog_history|pg_|metabase_cache_'"
     "  ..."])])
```

Then `describe-database-tables` filtered client-side:

```clojure
(defn- describe-database-tables [database]
  (let [[inclusion-patterns exclusion-patterns] (driver.s/db-details->schema-filter-patterns database)
        syncable? (fn [schema] ...)]
    (eduction
     (comp (filter (comp syncable? :schema))  ;; Client-side filtering!
           (map #(dissoc % :type)))
     (sql-jdbc.execute/reducible-query database get-tables-sql))))
```

**The inefficiency:** With 200+ schemas, Redshift must:

1. Scan `pg_catalog.pg_class` and `pg_namespace` for ALL tables across ALL schemas
2. Join with `pg_description` for comments on ALL those tables
3. Execute `has_schema_privilege` and `has_table_privilege` checks for ALL tables
4. Transfer potentially thousands of rows over the network
5. Only then does Clojure filter down to the 2 schemas we actually care about

---

## What We Changed

### 1. New helper: `inclusion-patterns->literal-schema-names`

Added to `src/metabase/driver/sync.clj`:

```clojure
(defn inclusion-patterns->literal-schema-names
  "Given inclusion patterns string (comma-separated), returns a set of literal schema names
  if ALL patterns are simple literals (no wildcards or regex metacharacters).
  Returns nil if any pattern contains wildcards or if patterns is nil/blank."
  [inclusion-patterns]
  (when-not (str/blank? inclusion-patterns)
    (let [schemas (map str/trim (str/split inclusion-patterns #","))]
      (when (every? #(not (re-find #"[*?\\]" %)) schemas)
        (set schemas)))))
```

**Examples:**

| Input | Output | Notes |
|-------|--------|-------|
| `"public,test_schema"` | `#{"public" "test_schema"}` | Literal names, can push to SQL |
| `"public,test*"` | `nil` | Contains wildcard, cannot push to SQL |
| `nil` | `nil` | No patterns |

### 2. Converted `get-tables-sql` from `def` to `defn`

```clojure
(defn- get-tables-sql
  "Returns a SQL query vector for fetching tables. When `schema-names` is provided,
  adds a WHERE clause to filter by those schemas."
  [schema-names]
  (let [schema-names-seq (seq schema-names)
        ;; Generate placeholders like (?, ?, ?) for parameterized query
        placeholders (when schema-names-seq
                       (str "(" (str/join ", " (repeat (count schema-names-seq) "?")) ")"))
        schema-filter (when schema-names-seq
                        (str " and n.nspname in " placeholders))
        external-schema-filter (when schema-names-seq
                                 (str " and schemaname in " placeholders))
        base-query (str/join "\n" [...])]
    ;; Return [sql-string, param1, param2, ...]
    ;; Parameters duplicated for both UNION branches
    (if schema-names-seq
      (into [base-query] (concat schema-names-seq schema-names-seq))
      [base-query])))
```

**Key design decisions:**

- **Parameterized queries** (`?` placeholders) to prevent SQL injection
- **Parameters appear twice** because the query has `UNION ALL` — once for regular tables, once for external tables
- **Returns original query when no schemas** — preserves existing behavior for users without filters

### 3. Updated `describe-database-tables` to use the optimization

```clojure
(defn- describe-database-tables [database]
  (let [[inclusion-patterns exclusion-patterns] (driver.s/db-details->schema-filter-patterns database)
        ;; NEW: Extract literal schema names if possible
        literal-schema-names (driver.s/inclusion-patterns->literal-schema-names inclusion-patterns)
        syncable? (fn [schema] ...)]
    (eduction
     (comp (filter (comp syncable? :schema))  ;; Still kept as safety net
           (map #(dissoc % :type)))
     ;; NEW: Pass schema names to generate filtered SQL
     (sql-jdbc.execute/reducible-query database (get-tables-sql literal-schema-names)))))
```

---

## How This Addresses the Problem

### For CI Tests

The Redshift test configuration uses inclusion patterns like:

```
"spectrum,2024_12_18_abc123_schema"
```

These are literal names (no wildcards), so:

1. `inclusion-patterns->literal-schema-names` returns `#{"spectrum" "2024_12_18_abc123_schema"}`

2. `get-tables-sql` generates:

```sql
SELECT c.relname as name, n.nspname as schema, ...
FROM pg_catalog.pg_namespace n, pg_catalog.pg_class c
LEFT JOIN pg_catalog.pg_description d ON ...
WHERE c.relnamespace = n.oid
  AND n.nspname !~ '^information_schema|catalog_history|pg_|metabase_cache_'
  AND c.relkind in ('r', 'p', 'v', 'f', 'm')
  AND pg_catalog.has_schema_privilege(n.oid, 'USAGE')
  AND (pg_catalog.has_table_privilege(c.oid,'SELECT')
       OR pg_catalog.has_any_column_privilege(c.oid,'SELECT'))
  AND n.nspname IN (?, ?)  -- ← NEW FILTER
UNION ALL
SELECT tablename as name, schemaname as schema, ...
FROM svv_external_tables t
WHERE schemaname !~ '^information_schema|catalog_history|pg_|metabase_cache_'
  AND pg_catalog.has_schema_privilege(t.schemaname, 'USAGE')
  AND schemaname IN (?, ?)  -- ← NEW FILTER
```

3. **Parameters:** `["spectrum", "2024_12_18_abc123_schema", "spectrum", "2024_12_18_abc123_schema"]`

### Performance Impact

| Aspect | Before | After |
|--------|--------|-------|
| Schemas scanned | 200+ | 2 |
| Tables returned | Thousands | ~dozen |
| Network transfer | Large | Minimal |
| Privilege checks | All tables | Only filtered tables |

The database now uses indexes on `nspname`/`schemaname` to efficiently locate only the schemas we need, avoiding full catalog scans.

---

## Why This Should Work (Unlike the Failed PK Optimization)

We previously tried filtering the PK subquery in `describe-fields-sql` (on this PR: https://github.com/metabase/metabase/pull/67184), but it made tests *slower* (368s vs 232s). That failed because:

- It was a subquery inside a `LEFT JOIN` (complex query structure)
- Adding `IN (?, ?)` may have confused Redshift's query planner
- The subquery was already optimized for constraint lookups

**This optimization should work because:**

- It's a simple top-level `WHERE` clause on the driving table
- `pg_namespace.nspname` is indexed
- The filter reduces the dataset before any joins occur
- Less complex query structure for the optimizer

---

## Fallback Behavior

If patterns contain wildcards (e.g., `test*,dev*`):

1. `inclusion-patterns->literal-schema-names` returns `nil`
2. `get-tables-sql(nil)` returns the original unfiltered query
3. Client-side filtering still works as before

This ensures backward compatibility for users with wildcard patterns.
