### PR TITLE
Fix check-openapi-specs

### DIFF
--- a/resources/openapi/openapi.json
+++ b/resources/openapi/openapi.json
@@ -30097,6 +30097,66 @@
         "tags" : [ "/api/preview_embed" ]
       }
     },
+    "/api/preview_embed/card/{token}/params/{param-key}/values" : {
+      "get" : {
+        "description" : "Embedded version of api.card filter values endpoint.",
+        "parameters" : [ {
+          "in" : "path",
+          "name" : "token",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "in" : "path",
+          "name" : "param-key",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "2XX" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "properties" : {
+                    "has_more_values" : {
+                      "type" : "boolean"
+                    },
+                    "values" : {
+                      "items" : {
+                        "anyOf" : [ {
+                          "prefixItems" : [ { }, {
+                            "type" : "string"
+                          } ],
+                          "type" : "array"
+                        }, {
+                          "prefixItems" : [ { } ],
+                          "type" : "array"
+                        } ]
+                      },
+                      "type" : "array"
+                    }
+                  },
+                  "required" : [ "has_more_values", "values" ],
+                  "type" : "object"
+                }
+              }
+            },
+            "description" : "map where {:has_more_values -> <boolean>, :values -> <sequence of vector with exactly 2 items of type: anything, string, or vector with exactly 1 items of type: anything>}"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
+        "summary" : "GET /api/preview_embed/card/{token}/params/{param-key}/values",
+        "tags" : [ "/api/preview_embed" ]
+      }
+    },
     "/api/preview_embed/card/{token}/query" : {
       "get" : {
         "description" : "Fetch the query results for a Card you're considering embedding by passing a JWT `token`.",


### PR DESCRIPTION
OpenAPI specs were out-of-date, preventing this check from succeeding on PRs that did not change the API.

References: https://github.com/metabase/metabase/actions/runs/20347428135/job/58463226792?pr=67191#step:6:56