### PR TITLE
UXW-2586: Acquire locks before changing data permissions

### DIFF
--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -4,6 +4,7 @@
    [clojure.string :as str]
    [medley.core :as m]
    [metabase.api.common :as api]
+   [metabase.app-db.cluster-lock :as cluster-lock]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.models.interface :as mi]
    [metabase.permissions.published-tables :as published-tables]
@@ -13,6 +14,7 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
+   [metabase.util.malli.schema :as ms]
    [methodical.core :as methodical]
    [toucan2.core :as t2])
   (:import
@@ -24,6 +26,36 @@
   (derive :metabase/model))
 
 (methodical/defmethod t2/table-name :model/DataPermissions [_model] :data_permissions)
+
+(mu/defn- with-cluster-lock-fn
+  [m :- [:map
+         [:group-id ms/PositiveInt]
+         [:db-id ms/PositiveInt]
+         [:perm-type :string]]
+   f :- fn?]
+  (cluster-lock/with-cluster-lock (keyword "data-permissions" (str/join "-"
+                                                                        [(:group-id m)
+                                                                         (:db-id m)
+                                                                         (:perm-type m)]))
+    (f)))
+
+(defmacro with-cluster-lock
+  "Takes a map with `group-id`, `db-id`, and `perm-type`, obtains a cluster lock for that combo, and executes the body"
+  [m & body]
+  `(with-cluster-lock-fn ~m (fn [] ~@body)))
+
+(mu/defn- with-cluster-locks-fn
+  [cluster-locks f]
+  (if (empty? cluster-locks)
+    (f)
+    (with-cluster-lock (first cluster-locks)
+      (with-cluster-locks-fn (rest cluster-locks) f))))
+
+(defmacro with-cluster-locks
+  "Same as `with-cluster-lock`, but takes a sequence of cluster-locks, each of which has a `group-id`, `db-id`, and
+  `perm-type`."
+  [ms & body]
+  `(with-cluster-locks-fn (sort-by :group-id ~ms) (fn [] ~@body)))
 
 (t2/deftransforms :model/DataPermissions
   {:perm_type  mi/transform-keyword
@@ -619,12 +651,15 @@
    db-or-id    :- TheIdable
    perm-type   :- ::permissions.schema/data-permission-type
    value       :- :keyword]
-  (t2/with-transaction [_conn]
-    (let [{:keys [to-insert to-delete]} (build-database-permission group-or-id db-or-id perm-type value)]
-      (when (seq to-delete)
-        (batch-delete-permissions! (map :id to-delete)))
-      (when (seq to-insert)
-        (batch-insert-permissions! to-insert)))))
+  (with-cluster-lock {:db-id     (u/the-id db-or-id)
+                      :perm-type (u/qualified-name perm-type)
+                      :group-id  (u/the-id group-or-id)}
+    (t2/with-transaction [_conn]
+      (let [{:keys [to-insert to-delete]} (build-database-permission group-or-id db-or-id perm-type value)]
+        (when (seq to-delete)
+          (batch-delete-permissions! (map :id to-delete)))
+        (when (seq to-insert)
+          (batch-insert-permissions! to-insert))))))
 
 (defn- lowest-permission-level-in-any-database
   "Given a group and a permission type, returns the lowest permission level for that group in any database, at the DB or table-level.
@@ -855,6 +890,18 @@
                                         new-perms))
              (build-recursive-table-calls group-or-id perm-type table-perms)))))
 
+(mu/defn- set-table-permissions-internal!
+  "For internal use only - assumes that the cluster lock has already been obtained and sets table permissions."
+  [group-or-id :- TheIdable
+   perm-type   :- ::permissions.schema/data-permission-type
+   table-perms :- [:map-of TheIdable :keyword]]
+  (t2/with-transaction [_conn]
+    (let [{:keys [to-delete to-insert]} (build-table-permissions group-or-id perm-type table-perms)]
+      (when (seq to-delete)
+        (batch-delete-permissions! (map :id to-delete)))
+      (when (seq to-insert)
+        (batch-insert-permissions! to-insert)))))
+
 (mu/defn set-table-permissions!
   "Sets table permissions to specified values for a given group. If a permission value already exists for a specified group and table,
   it will be updated to the new value.
@@ -868,12 +915,15 @@
   [group-or-id :- TheIdable
    perm-type   :- ::permissions.schema/data-permission-type
    table-perms :- [:map-of TheIdable :keyword]]
-  (t2/with-transaction [_conn]
-    (let [{:keys [to-delete to-insert]} (build-table-permissions group-or-id perm-type table-perms)]
-      (when (seq to-delete)
-        (batch-delete-permissions! (map :id to-delete)))
-      (when (seq to-insert)
-        (batch-insert-permissions! to-insert)))))
+  ;; you can't use `set-table-permissions!` with tables from different databases, so this is safe.
+  (let [table-or-id (first (keys table-perms))
+        db-id (if (map? table-or-id)
+                (:db_id table-or-id)
+                (t2/select-one-fn :db_id :model/Table table-or-id))]
+    (with-cluster-lock {:group-id (u/the-id group-or-id)
+                        :perm-type (u/qualified-name perm-type)
+                        :db-id db-id}
+      (set-table-permissions-internal! group-or-id perm-type table-perms))))
 
 (mu/defn set-table-permission!
   "Sets permissions for a single table to the specified value for a given group."
@@ -921,64 +971,70 @@
     (throw (ex-info (tru "Permission type {0} cannot be set on tables." perm-type)
                     {perm-type (permissions.schema/data-permissions perm-type)})))
   (when (seq groups-or-ids)
-    (t2/with-transaction [_conn]
-      (let [group-ids              (map u/the-id groups-or-ids)
-            table                  (if (map? table-or-id)
-                                     table-or-id
-                                     (t2/select-one [:model/Table :id :db_id :schema] :id table-or-id))
-            db-id                  (:db_id table)
-            schema-name            (:schema table)
-            db-level-perms         (t2/select :model/DataPermissions
-                                              {:where
-                                               [:and
-                                                [:= :db_id db-id]
-                                                [:= :table_id nil]
-                                                [:= :perm_type (u/qualified-name perm-type)]
-                                                [:in :group_id group-ids]]})
-            db-level-group-ids     (set (map :group_id db-level-perms))
-            new-perms              (reduce
-                                    (fn [new-perms group-id]
-                                      (let [new-value (or
-                                                       ;; Make sure we set `blocked` data access if we're on EE and *any*
-                                                       ;; other table in the DB has `blocked` or `sandboxed`
-                                                       (and (= perm-type :perms/view-data)
-                                                            (new-table-view-data-permission-level db-id group-id))
-                                                       ;; Otherwise, if all tables in the schema have the same
-                                                       ;; value, use that value for the new table
-                                                       (schema-permission-value db-id group-id schema-name perm-type)
-                                                       ;; Otherwise, use the default value passed in
-                                                       default-value)
-                                            new-perm {:perm_type   perm-type
-                                                      :group_id    group-id
-                                                      :perm_value  new-value
-                                                      :db_id       db-id
-                                                      :table_id    (u/the-id table)
-                                                      :schema_name schema-name}]
-                                        (cond
-                                          ;; Perms that are being added at the table-level for a group currently set at the DB
-                                          ;; level. This should only happen when adding a table to a DB where some existing
-                                          ;; tables are sandboxed, because the DB might have `:unrestricted` DB-level perms which
-                                          ;; need to be split out to table-level perms.
-                                          (and (db-level-group-ids group-id)
-                                               (= new-value :blocked))
-                                          (update new-perms :going-granular conj new-perm)
+    (let [table (if (map? table-or-id)
+                  table-or-id
+                  (t2/select-one [:model/Table :id :db_id :schema] :id table-or-id))
+          db-id (:db_id table)
+          group-ids (map u/the-id groups-or-ids)
+          cluster-locks (mapv (fn [group-id]
+                                {:group-id group-id
+                                 :db-id db-id
+                                 :perm-type (u/qualified-name perm-type)})
+                              group-ids)]
+      (with-cluster-locks cluster-locks
+        (t2/with-transaction [_conn]
+          (let [schema-name            (:schema table)
+                db-level-perms         (t2/select :model/DataPermissions
+                                                  {:where
+                                                   [:and
+                                                    [:= :db_id db-id]
+                                                    [:= :table_id nil]
+                                                    [:= :perm_type (u/qualified-name perm-type)]
+                                                    [:in :group_id group-ids]]})
+                db-level-group-ids     (set (map :group_id db-level-perms))
+                new-perms              (reduce
+                                        (fn [new-perms group-id]
+                                          (let [new-value (or
+                                                           ;; Make sure we set `blocked` data access if we're on EE and *any*
+                                                           ;; other table in the DB has `blocked` or `sandboxed`
+                                                           (and (= perm-type :perms/view-data)
+                                                                (new-table-view-data-permission-level db-id group-id))
+                                                           ;; Otherwise, if all tables in the schema have the same
+                                                           ;; value, use that value for the new table
+                                                           (schema-permission-value db-id group-id schema-name perm-type)
+                                                           ;; Otherwise, use the default value passed in
+                                                           default-value)
+                                                new-perm {:perm_type   perm-type
+                                                          :group_id    group-id
+                                                          :perm_value  new-value
+                                                          :db_id       db-id
+                                                          :table_id    (u/the-id table)
+                                                          :schema_name schema-name}]
+                                            (cond
+                                              ;; Perms that are being added at the table-level for a group currently set at the DB
+                                              ;; level. This should only happen when adding a table to a DB where some existing
+                                              ;; tables are sandboxed, because the DB might have `:unrestricted` DB-level perms which
+                                              ;; need to be split out to table-level perms.
+                                              (and (db-level-group-ids group-id)
+                                                   (= new-value :blocked))
+                                              (update new-perms :going-granular conj new-perm)
 
-                                          ;; Otherwise, we only add a new table-level permission row if existing perms
-                                          ;; are table-level
-                                          (not (db-level-group-ids group-id))
-                                          (update new-perms :simple-perms conj new-perm)
+                                              ;; Otherwise, we only add a new table-level permission row if existing perms
+                                              ;; are table-level
+                                              (not (db-level-group-ids group-id))
+                                              (update new-perms :simple-perms conj new-perm)
 
-                                          :else
-                                          new-perms)))
-                                    {:simple-perms [] :going-granular []}
-                                    group-ids)
-            {:keys [going-granular
-                    simple-perms]} new-perms]
-        ;; These perms might need existing DB-level perms to be broken out to table-level perms
-        (doseq [{:keys [perm_type perm_value group_id]} going-granular]
-          (set-table-permission! group_id table perm_type perm_value))
-        ;; These perms can be inserted raw, and don't require changes to existing perms in the DB
-        (t2/insert! :model/DataPermissions simple-perms)))))
+                                              :else
+                                              new-perms)))
+                                        {:simple-perms [] :going-granular []}
+                                        group-ids)
+                {:keys [going-granular
+                        simple-perms]} new-perms]
+            ;; These perms might need existing DB-level perms to be broken out to table-level perms
+            (doseq [{:keys [perm_type perm_value group_id]} going-granular]
+              (set-table-permissions-internal! group_id perm_type {table perm_value}))
+            ;; These perms can be inserted raw, and don't require changes to existing perms in the DB
+            (t2/insert! :model/DataPermissions simple-perms)))))))
 
 (defenterprise download-perms-level
   "Return the download permission for the query that the given user has. OSS returns :full"

--- a/test/metabase/permissions/models/data_permissions_test.clj
+++ b/test/metabase/permissions/models/data_permissions_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase.api.common :as api]
+   [metabase.app-db.core :as mdb]
    [metabase.app-db.schema-migrations-test.impl :as impl]
    [metabase.permissions-rest.data-permissions.graph :as data-perms.graph]
    [metabase.permissions.models.data-permissions :as data-perms]
@@ -843,3 +844,31 @@
         (testing "cache disabled, different user"
           (binding [data-perms/*use-perms-cache?* false]
             (is (not (#'data-perms/use-cache? other-user-id)))))))))
+
+(deftest race-conditions-test
+  ;; This test is probabilistic: success doesn't *necessarily* prove we're doing things correctly, but
+  ;; a failure *definitely* indicates that we're not.
+  (when-not (= (mdb/db-type) :h2)
+    ;; using `with-temp` causes the connection to be shared, and the lock mechanism to fail (because both threads are
+    ;; able to obtain the lock simultaneously).
+    (mt/with-model-cleanup [:model/PermissionsGroup :model/Database :model/Table]
+      (let [db-id (t2/insert-returning-pk! :model/Database (mt/with-temp-defaults :model/Database))
+            group-id (t2/insert-returning-pk! :model/PermissionsGroup (mt/with-temp-defaults :model/PermissionsGroup))
+            table-id (t2/insert-returning-pk! :model/Table (merge (mt/with-temp-defaults :model/Table)
+                                                                  {:db_id db-id}))]
+        ;; when testing locally, without a cluster lock this failed 9/10 times. Run it a few times to make sure a lock
+        ;; failure is very likely to result in test failure
+        (dotimes [_ 5]
+          ;; fire off two threads for setting perms
+          (let [f1 (future (data-perms/set-database-permission! group-id db-id :perms/view-data :blocked))
+                f2 (future (data-perms/set-table-permission! group-id table-id :perms/view-data :unrestricted))
+                perm-exists? (fn [& args]
+                               (apply t2/exists? :model/DataPermissions
+                                      :db_id db-id
+                                      :group_id group-id
+                                      :perm_type :perms/view-data
+                                      args))]
+            ;; let both threads finish
+            @f1 @f2
+            (is (not (and (perm-exists? :table_id nil)
+                          (perm-exists? :table_id [:not= nil]))))))))))


### PR DESCRIPTION
Data permission have a read-modify-write cycle:

- we read the existing permissions to see what's currently set
- then we decide what to do (e.g. delete the existing DB level permissions to write a granular table-level permission)
- then we do the write

This has a race condition if multiple Metabase instances are modifying permissions at the same time.

For example, say we have:

Initial state: `{:db_id 1 :table_id nil :perm_value :unrestricted}`

Instance A: set table 1 to :blocked
Instance B: set database to :blocked

T1: A reads state, sees db-level permission, plans to expand to table-level
T2: B reads state, sees db-level permission, plans to replace it
T3: A deletes db-level, inserts table-level rows for all tables
T4: B deletes db-level (no-op), inserts new db-level :blocked

Result (CORRUPT):
```
{:db_id 1 :table_id 1 :perm_value :blocked}      ;; from A
{:db_id 1 :table_id 2 :perm_value :unrestricted} ;; from A
{:db_id 1 :table_id nil :perm_value :blocked}    ;; from B
```

Both db-level AND table-level permissions now exist.

For the permissions API, we take a cluster lock, but sync operations bypassed this cluster lock. This PR creates a lower-level cluster lock per `[database, group, perm-type]` so only one instance/thread can do the read/decide/write cycle for a particular db/group/perm at a time.

**EDIT:** I ended up taking a broader lock, on just `[database, perm-type]`, because `set-new-table-permissions!` would otherwise need to obtain one lock per group in the instance, which is unbounded and could cause serious issues (pretty sure 10k active savepoints wouldn't make Postgres happy). So we trade a bit more contention for just needing one cluster lock in that case instead of `(count groups)`.