### PR TITLE
Several MBQL 4 normalization fixes :wrench:

### DIFF
--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -1934,7 +1934,8 @@
      :breakout     "A join should not have top-level 'inner' query keys like :breakout"
      :aggreggation "A join should not have top-level 'inner' query keys like :aggreggation"
      :expressions  "A join should not have top-level 'inner' query keys like :expressions"
-     :joins        "A join should not have top-level 'inner' query keys like :joins"})])
+     :joins        "A join should not have top-level 'inner' query keys like :joins"
+     :ident        ":ident is deprecated and should not be included in joins"})])
 
 (mr/def ::Joins
   "Schema for a valid sequence of `Join`s. Must be a non-empty sequence, and `:alias`, if specified, must be unique."

--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -1193,6 +1193,7 @@
 
 (defmethod options-style-method :case [_tag] ::options-style.last-unless-empty)
 
+;; `:if` is just an alias for `:case`
 (defclause if
   clauses [:ref ::CaseSubclauses], options (optional [:ref ::CaseOptions]))
 
@@ -1314,8 +1315,10 @@
   (when (helpers/normalized-mbql-clause? x)
     (when-let [[tag & args] x]
       (or (lib.hierarchy/isa? tag ::lib.schema.aggregation/aggregation-clause-tag)
-          ;; Case has the following shape [:case [[cond expr]...] default-expr?]
-          (if (= :case tag)
+          ;; `:case` has the following shape [:case [[cond expr]...] default-expr?]
+          ;;
+          ;; `:if` is an alias for `:case`
+          (if (#{:if :case} tag)
             (or (some aggregation-expression? (ffirst args))
                 (some aggregation-expression? (fnext args)))
             (some aggregation-expression? args))))))

--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -1248,9 +1248,19 @@
 (mr/def ::AggregationArg
   "Schema for the argument to an aggregation clause like `:sum`.
 
-  Strings are allowed as literals here, unlike at the top level as `::Expressions`, so `::FieldOrExpressionDef` is
-  not enough. However, nested aggregations are not allowed here, so we can't use `::ExpressionArg` either. (#66199)"
-  [:or ::FieldOrExpressionDef :string])
+  Nested aggregations are not allowed here, so we can't use `::ExpressionArg` directly. (#66199)
+
+  Unlike `::FieldOrExpressionDef`, raw integers are treated as unwrapped `:field` clauses for backwards compatibility
+  with MBQL 1 and 2, e.g.
+
+    [:sum 1] => [:sum [:field 1 nil]]"
+  [:and
+   [:ref ::FieldOrExpressionDef]
+   [:any
+    {:decode/normalize (fn [x]
+                         (if (pos-int? x)
+                           [:field x nil]
+                           x))}]])
 
 ;; For all of the 'normal' Aggregations below (excluding Metrics) fields are implicit Field IDs
 

--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -503,7 +503,7 @@
 
 (def ^:private datetime-functions
   "Functions that return Date or DateTime values. Should match `::DatetimeExpression`."
-  #{:+ :datetime-add :datetime-subtract :convert-timezone :now :date :datetime :today})
+  #{:+ :datetime-add :datetime-subtract :convert-timezone :now :date :datetime :today :coalesce :case :if})
 
 (mr/def ::NumericExpressionArg
   [:multi
@@ -811,7 +811,7 @@
 
 (mr/def ::DatetimeExpression
   "Schema for the definition of a date function expression."
-  (one-of + datetime-add datetime-subtract convert-timezone now date datetime today))
+  (one-of + datetime-add datetime-subtract convert-timezone now date datetime today coalesce case if))
 
 (defn- compound-filter-schema [tag]
   [:multi

--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -1515,6 +1515,14 @@
 ;;     :type         :dimension,
 ;;     :dimension    [:field 4 nil]
 ;;     :widget-type  :date/all-options}
+(mr/def ::TemplateTag.FieldFilter.Options
+  [:map-of
+   {:decode/normalize (fn [m]
+                        (when (map? m)
+                          (update-keys m lib.schema.common/normalize-keyword)))}
+   :keyword
+   :any])
+
 (mr/def ::TemplateTag.FieldFilter
   "Schema for a field filter template tag."
   [:merge
@@ -1535,7 +1543,7 @@
     [:options
      {:optional    true
       :description "optional map to be appended to filter clause"}
-     [:maybe [:map-of :keyword :any]]]]])
+     [:maybe [:ref ::TemplateTag.FieldFilter.Options]]]]])
 
 ;; Example:
 ;;

--- a/src/metabase/lib/schema/aggregation.cljc
+++ b/src/metabase/lib/schema/aggregation.cljc
@@ -130,10 +130,13 @@
   "A clause is a valid aggregation if it is an aggregation clause, or it is an expression that transitively contains
   a single aggregation clause."
   [x]
-  (when-let [[tag _opts & args] (and (vector? x) x)]
+  (when-let [[tag _opts & args] (when (vector? x) x)]
+    (println "(pr-str args):" (pr-str args)) ; NOCOMMIT
     (or (lib.hierarchy/isa? tag ::aggregation-clause-tag)
         ;; Case has the following shape [:case opts [[cond expr]...] default-expr?]
-        (if (= :case tag)
+        ;;
+        ;; `:if` is an alias for `:case`
+        (if (#{:case :if} tag)
           (or (some aggregation-expression? (ffirst args))
               (some aggregation-expression? (fnext args)))
           (some aggregation-expression? args)))))

--- a/src/metabase/lib/schema/aggregation.cljc
+++ b/src/metabase/lib/schema/aggregation.cljc
@@ -131,7 +131,6 @@
   a single aggregation clause."
   [x]
   (when-let [[tag _opts & args] (when (vector? x) x)]
-    (println "(pr-str args):" (pr-str args)) ; NOCOMMIT
     (or (lib.hierarchy/isa? tag ::aggregation-clause-tag)
         ;; Case has the following shape [:case opts [[cond expr]...] default-expr?]
         ;;

--- a/src/metabase/lib/schema/expression/string.cljc
+++ b/src/metabase/lib/schema/expression/string.cljc
@@ -28,9 +28,9 @@
   #_regex [:schema [:ref ::expression/string]])
 
 (mbql-clause/define-tuple-mbql-clause :replace :- :type/Text
-  #_str [:schema [:ref ::expression/string]]
-  #_find [:schema :string]
-  #_replace [:schema :string])
+  #_str     [:schema [:ref ::expression/string]]
+  #_find    :string
+  #_replace :string)
 
 (mbql-clause/define-catn-mbql-clause :substring :- :type/Text
   [:str    [:schema [:ref ::expression/string]]]
@@ -39,12 +39,12 @@
 
 (mbql-clause/define-tuple-mbql-clause :split-part :- :type/Text
   #_text      [:schema [:ref ::expression/string]]
-  #_delimiter [:schema [:string {:min 1}]] ;; literal string
+  #_delimiter [:string {:min 1}] ; literal string
   #_position  [:schema [:ref ::expression/positive-integer-or-numeric-expression]])
 
 (mbql-clause/define-tuple-mbql-clause :collate :- :type/Text
   #_str [:schema [:ref ::expression/string]]
-  #_collation [:schema :string])
+  #_collation :string)
 
 (mbql-clause/define-catn-mbql-clause :concat :- :type/Text
   [:args [:repeat {:min 2} [:schema [:ref ::expression/expression]]]])

--- a/src/metabase/lib/schema/join.cljc
+++ b/src/metabase/lib/schema/join.cljc
@@ -131,7 +131,8 @@
      :source-query       "join should not have :source-query; use :stages instead"
      :filter             "join should not have top-level :filters; these should belong to one of the join :stages"
      :filters            "join should not have top-level :filters; these should belong to one of the join :stages"
-     :parameters         "join should not have top-level :parameters; these should belong to one of the join :stages"})
+     :parameters         "join should not have top-level :parameters; these should belong to one of the join :stages"
+     :ident              ":ident is deprecated and should not be included in joins"})
    [:ref ::validate-field-aliases-match-join-alias]])
 
 (mr/def ::joins

--- a/test/metabase/legacy_mbql/normalize_test.cljc
+++ b/test/metabase/legacy_mbql/normalize_test.cljc
@@ -777,9 +777,12 @@
 
 (deftest ^:parallel canonicalize-aggregations-test-11
   (normalize-tests
-   "subclauses of `:aggregation-options` should get canonicalized correctly"
+   "subclauses of `:aggregation-options` should get canonicalized correctly; unwrap :aggregation-options with empty options"
    {{:query {:aggregation [[:aggregation-options [:sum 10] {}]]}}
-    {:query {:aggregation [[:aggregation-options [:sum [:field 10 nil]] {}]]}}}))
+    {:query {:aggregation [[:sum [:field 10 nil]]]}}
+
+    {:query {:aggregation [[:aggregation-options [:sum 10] nil]]}}
+    {:query {:aggregation [[:sum [:field 10 nil]]]}}}))
 
 (deftest ^:parallel canonicalize-aggregations-test-12
   (normalize-tests

--- a/test/metabase/legacy_mbql/schema_test.cljc
+++ b/test/metabase/legacy_mbql/schema_test.cljc
@@ -590,3 +590,7 @@
                    [:= [:expression "Paid" {:base-type :type/Boolean}] true]]]}]
                normalized))
         (is (mr/validate ::mbql.s/DateTimeExpressionArg normalized))))))
+
+(deftest ^:parallel normalize-unwrapped-field-id-test
+  (is (= [:sum [:field 10 nil]]
+         (lib/normalize ::mbql.s/sum [:sum 10]))))

--- a/test/metabase/legacy_mbql/schema_test.cljc
+++ b/test/metabase/legacy_mbql/schema_test.cljc
@@ -435,3 +435,27 @@
     (is (= [:count]
            (lib/normalize ::mbql.s/Aggregation [:aggregation-options [:count] nil])
            (lib/normalize ::mbql.s/Aggregation [:aggregation-options [:count] {}])))))
+
+(deftest ^:parallel normalize-template-tag-options-test
+  (testing "template tag `:options` should get normalized correctly"
+    (let [normalized (lib/normalize
+                      ::mbql.s/TemplateTag
+                      {"type"         "dimension"
+                       "name"         "owner_name"
+                       "id"           "d14f7964-4de7-4d0a-905c-2d2799e87db7"
+                       "display-name" "Owner Name"
+                       "default"      nil
+                       "dimension"    ["field" 28486 nil]
+                       "widget-type"  "string/contains"
+                       "options"      {"case-sensitive" false}})]
+      (is (= {:default      nil
+              :dimension    [:field 28486 nil]
+              :display-name "Owner Name"
+              :id           "d14f7964-4de7-4d0a-905c-2d2799e87db7"
+              :name         "owner_name"
+              :options      {:case-sensitive false}
+              :type         :dimension
+              :widget-type  :string/contains}
+             normalized))
+      (is (mr/validate ::mbql.s/TemplateTag normalized)))))
+        (is (mr/validate ::mbql.s/Query query))))))

--- a/test/metabase/legacy_mbql/schema_test.cljc
+++ b/test/metabase/legacy_mbql/schema_test.cljc
@@ -424,3 +424,14 @@
             {:name "Min+sec", :display-name "Min+sec"}]
            normalized))
     (is (mr/validate ::mbql.s/Aggregation normalized))))
+
+(deftest ^:parallel normalize-aggregation-options-with-nil-options-test
+  (testing "nil options in :aggregation-options should get normalized to an empty map"
+    (let [normalized (lib/normalize ::mbql.s/aggregation-options [:aggregation-options [:count] nil])]
+      (is (= [:aggregation-options [:count] {}]
+             normalized))
+      (is (mr/validate ::mbql.s/aggregation-options normalized))))
+  (testing "::Aggregation itself should unwrap :aggregation-options with an empty options map"
+    (is (= [:count]
+           (lib/normalize ::mbql.s/Aggregation [:aggregation-options [:count] nil])
+           (lib/normalize ::mbql.s/Aggregation [:aggregation-options [:count] {}])))))

--- a/test/metabase/lib/schema/aggregation_test.cljc
+++ b/test/metabase/lib/schema/aggregation_test.cljc
@@ -1,8 +1,9 @@
 (ns metabase.lib.schema.aggregation-test
   (:require
-   [clojure.test :refer [are deftest testing]]
+   [clojure.test :refer [are deftest is testing]]
    [malli.error :as me]
    [metabase.lib.schema]
+   [metabase.lib.schema.aggregation :as lib.schema.aggregation]
    [metabase.lib.schema.expression :as lib.schema.expression]
    [metabase.util.malli.registry :as mr]))
 
@@ -53,7 +54,7 @@
 
 (deftest ^:parallel arithmetic-expression-test
   (testing "valid"
-    (are [clause] (not (me/humanize (mr/explain :metabase.lib.schema.aggregation/aggregation clause)))
+    (are [clause] (not (me/humanize (mr/explain ::lib.schema.aggregation/aggregation clause)))
       ;; DIY average
       [:/ {:lib/uuid "00000000-0000-0000-0000-000000000000"}
        [:sum {:lib/uuid "00000000-0000-0000-0000-000000000000"}
@@ -81,7 +82,7 @@
          [:field {:lib/uuid "00000000-0000-0000-0000-000000000000"} 1]]
         -1]]))
   (testing "invalid - no aggregation inside"
-    (are [clause] (me/humanize (mr/explain :metabase.lib.schema.aggregation/aggregation clause))
+    (are [clause] (me/humanize (mr/explain ::lib.schema.aggregation/aggregation clause))
       [:get-day {:lib/uuid "00000000-0000-0000-0000-000000000000"}
        [:now {:lib/uuid "00000000-0000-0000-0000-000000000000"}]]
       [:+ {:lib/uuid "00000000-0000-0000-0000-000000000000"} 7 8]
@@ -109,6 +110,46 @@
             :let  [ag [:/ {:lib/uuid "00000000-0000-0000-0000-000000000000"} x y]]]
       (testing (pr-str ag)
         (are [schema x] (not (me/humanize (mr/explain schema x)))
-          :metabase.lib.schema.expression/number        ag
-          :metabase.lib.schema.aggregation/aggregation  ag
-          :metabase.lib.schema.aggregation/aggregations [ag])))))
+          ::lib.schema.expression/number        ag
+          ::lib.schema.aggregation/aggregation  ag
+          ::lib.schema.aggregation/aggregations [ag])))))
+
+(deftest ^:parallel case-and-if-should-be-considered-valid-aggregations-test
+  (doseq [clause [:if :case]]
+    (testing (str clause " should be allowed as an aggregation expression if it contains an aggregation")
+      (let [expr [:if
+                  {:lib/uuid "9cbbbcf5-6861-4cf2-8509-a531e53d01a8"}
+                  [[[:=
+                     {:lib/uuid "56deb1b8-5bea-4c26-9bbc-6f7d2787ea73"}
+                     [:field
+                      {:base-type :type/Float, :lib/uuid "8bd17b68-8b66-4d63-abde-5d73377e3173"}
+                      781]
+                     0]
+                    0]]
+                  [:/
+                   {:lib/uuid "96c97774-74b1-4e20-8df5-5a23ae7c9a07"}
+                   [:+
+                    {:lib/uuid "9ee6e40e-5882-4b80-bac7-8d83a71498f4"}
+                    [:sum-where
+                     {:lib/uuid "41fa466e-d61e-40b1-b213-5e2e25a6586e"}
+                     [:field
+                      {:base-type :type/Float, :lib/uuid "6004e6ce-a6b0-4205-b018-a967c91e1582"}
+                      755]
+                     [:=
+                      {:lib/uuid "de25f409-3982-4e24-a4d5-bbc6f739adc5"}
+                      [:expression {:base-type :type/Boolean, :lib/uuid "742fcdce-9b3b-48ed-ae93-72a48560b32f"} "Refund"]
+                      true]]
+                    1]
+                   [:+
+                    {:lib/uuid "6d83c61c-55ed-4444-9a04-77bc20608de4"}
+                    [:sum-where
+                     {:lib/uuid "94dae912-8d9a-405d-aef4-f3686fd156c8"}
+                     [:field
+                      {:base-type :type/Float, :lib/uuid "2e3d5468-1633-4ec3-beeb-521f5fb2be80"}
+                      781]
+                     [:=
+                      {:lib/uuid "3c117b80-4e0e-4305-89d3-6a9dd6a51871"}
+                      [:expression {:base-type :type/Boolean, :lib/uuid "5f460efe-d0b3-4d09-ba85-29724fab6fee"} "Paid"]
+                      true]]
+                    1]]]]
+        (is (mr/validate ::lib.schema.aggregation/aggregation expr))))))


### PR DESCRIPTION
- `[:aggregation-options <ag> nil]` => `[:aggregation-options <ag> {}]`
   - Add a bonus normalization step so `[:aggregation-options <ag> {}]` automatically gets unwrapped to `<ag>`
- Fix normalization of template tag `:options` maps not converting string keys into keywords
- Allow raw literals like `0.5` as expression definitions in MBQL 4
- Properly handle aggregations expressions that contain `:if` (alias for `:case`)
- Allow `:coalesce`, `:if`, and `:case` as datetime exprs in MBQL 4