### PR TITLE
Remove the "Groups" heading from the invite popover

### DIFF
--- a/frontend/src/metabase/admin/people/components/MembershipSelect/MembershipSelect.module.css
+++ b/frontend/src/metabase/admin/people/components/MembershipSelect/MembershipSelect.module.css
@@ -28,13 +28,6 @@
   cursor: not-allowed;
 }
 
-.membershipSelectHeader {
-  padding: 0.75rem 1.5rem 0.5rem 1.5rem;
-  font-size: 12px;
-  font-weight: 800;
-  color: var(--mb-color-filter);
-}
-
 .membershipActionsContainer {
   padding-left: 1rem;
   display: flex;

--- a/frontend/src/metabase/admin/people/components/MembershipSelect/MembershipSelect.module.css
+++ b/frontend/src/metabase/admin/people/components/MembershipSelect/MembershipSelect.module.css
@@ -1,18 +1,11 @@
-.membershipSelectContainer {
-  padding: 0.5rem 0;
-  width: 300px;
-  max-height: 600px;
-}
-
 .membershipSelectItem {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  cursor: pointer;
   padding: 0.5rem 1.5rem;
   background-color: var(--mb-color-bg-white);
   color: var(--mb-color-text-medium);
-  font-weight: 700;
+  font-weight: bold;
 
   &:hover {
     color: var(--mb-color-text-white);
@@ -22,15 +15,4 @@
       color: var(--mb-color-text-white) !important;
     }
   }
-}
-
-.membershipSelectItemDisabled {
-  cursor: not-allowed;
-}
-
-.membershipActionsContainer {
-  padding-left: 1rem;
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
 }

--- a/frontend/src/metabase/admin/people/components/MembershipSelect/MembershipSelect.tsx
+++ b/frontend/src/metabase/admin/people/components/MembershipSelect/MembershipSelect.tsx
@@ -1,6 +1,4 @@
 import { useDisclosure } from "@mantine/hooks";
-import cx from "classnames";
-import { Fragment } from "react";
 import { t } from "ttag";
 
 import {
@@ -10,7 +8,7 @@ import {
 } from "metabase/lib/groups";
 import { isNotNull } from "metabase/lib/types";
 import { PLUGIN_GROUP_MANAGERS, PLUGIN_TENANTS } from "metabase/plugins";
-import { Box, Flex, Icon, Popover } from "metabase/ui";
+import { Box, Divider, Flex, Icon, Popover } from "metabase/ui";
 import type { GroupInfo, Member } from "metabase-types/api";
 
 import { GroupSummary } from "../GroupSummary";
@@ -30,11 +28,7 @@ const getGroupSections = (groups: GroupInfo[]) => {
       !PLUGIN_TENANTS.isExternalUsersGroup(group),
   );
 
-  if (pinnedGroups.length > 0) {
-    return [{ groups: pinnedGroups }, { groups: regularGroups }];
-  }
-
-  return [{ groups: regularGroups }];
+  return { pinnedGroups, regularGroups };
 };
 
 type Memberships = Map<GroupInfo["id"], Partial<Member>>;
@@ -65,7 +59,7 @@ export const MembershipSelect = ({
   const [popoverOpened, { open: openPopover, toggle: togglePopover }] =
     useDisclosure();
   const selectedGroupIds = Array.from(memberships.keys());
-  const groupSections = getGroupSections(groups);
+  const { pinnedGroups, regularGroups } = getGroupSections(groups);
 
   const handleToggleMembership = (groupId: number) => {
     if (memberships.has(groupId)) {
@@ -80,6 +74,54 @@ export const MembershipSelect = ({
     membershipData: Partial<Member>,
   ) => {
     onChange(groupId, membershipData);
+  };
+
+  const renderGroup = (group: GroupInfo) => {
+    const isDisabled =
+      (isAdminGroup(group) && isCurrentUser) ||
+      isDefaultGroup(group) ||
+      PLUGIN_TENANTS.isExternalUsersGroup(group);
+    const isMember = memberships.has(group.id);
+    const canEditMembershipType =
+      isMember &&
+      !isUserAdmin &&
+      !isDisabled &&
+      !PLUGIN_TENANTS.isTenantGroup(group) &&
+      !isAdminGroup(group);
+
+    return (
+      <li
+        className={S.membershipSelectItem}
+        key={group.id}
+        aria-label={group.name}
+        onClick={() =>
+          isDisabled ? undefined : handleToggleMembership(group.id)
+        }
+        style={{ cursor: isDisabled ? "not-allowed" : "pointer" }}
+      >
+        <span>{getGroupNameLocalized(group)}</span>
+        <Flex pl="md" align="center" justify="end">
+          {canEditMembershipType && (
+            <PLUGIN_GROUP_MANAGERS.UserTypeToggle
+              tooltipPlacement="bottom"
+              isManager={memberships.get(group.id)?.is_group_manager}
+              onChange={(is_group_manager: boolean) =>
+                handleChangeMembership(group.id, {
+                  is_group_manager,
+                })
+              }
+            />
+          )}
+          <span
+            style={{
+              visibility: isMember ? "visible" : "hidden",
+            }}
+          >
+            <Icon name="check" />
+          </span>
+        </Flex>
+      </li>
+    );
   };
 
   return (
@@ -105,71 +147,30 @@ export const MembershipSelect = ({
           <Icon c="text-light" name="chevrondown" size={10} />
         </Flex>
       </Popover.Target>
-      <Popover.Dropdown>
+      <Popover.Dropdown w="300px" mah="600px" py="sm">
         {groups.length === 0 && (
           <Box component="span" p="sm">
             {emptyListMessage}
           </Box>
         )}
-        {groups.length > 0 && (
-          <ul className={S.membershipSelectContainer}>
-            {groupSections.map((section, index) => (
-              <Fragment key={index}>
-                {section.groups.map((group) => {
-                  const isDisabled =
-                    (isAdminGroup(group) && isCurrentUser) ||
-                    isDefaultGroup(group) ||
-                    PLUGIN_TENANTS.isExternalUsersGroup(group);
-                  const isMember = memberships.has(group.id);
-                  const canEditMembershipType =
-                    isMember &&
-                    !isUserAdmin &&
-                    !isDisabled &&
-                    !PLUGIN_TENANTS.isTenantGroup(group) &&
-                    !isAdminGroup(group);
 
-                  return (
-                    <li
-                      className={cx(S.membershipSelectItem, {
-                        [S.membershipSelectItemDisabled]: isDisabled,
-                      })}
-                      key={group.id}
-                      aria-label={group.name}
-                      onClick={() =>
-                        isDisabled
-                          ? undefined
-                          : handleToggleMembership(group.id)
-                      }
-                    >
-                      <span>{getGroupNameLocalized(group)}</span>
-                      <div className={S.membershipActionsContainer}>
-                        {canEditMembershipType && (
-                          <PLUGIN_GROUP_MANAGERS.UserTypeToggle
-                            tooltipPlacement="bottom"
-                            isManager={
-                              memberships.get(group.id)?.is_group_manager
-                            }
-                            onChange={(is_group_manager: boolean) =>
-                              handleChangeMembership(group.id, {
-                                is_group_manager,
-                              })
-                            }
-                          />
-                        )}
-                        <span
-                          style={{
-                            visibility: isMember ? "visible" : "hidden",
-                          }}
-                        >
-                          <Icon name="check" />
-                        </span>
-                      </div>
-                    </li>
-                  );
-                })}
-              </Fragment>
-            ))}
+        {pinnedGroups.length > 0 && (
+          <ul>
+            {pinnedGroups.map((group) => {
+              return renderGroup(group);
+            })}
           </ul>
+        )}
+
+        {regularGroups.length > 0 && (
+          <>
+            <Divider my="sm" />
+            <ul>
+              {regularGroups.map((group) => {
+                return renderGroup(group);
+              })}
+            </ul>
+          </>
         )}
       </Popover.Dropdown>
     </Popover>

--- a/frontend/src/metabase/admin/people/components/MembershipSelect/MembershipSelect.tsx
+++ b/frontend/src/metabase/admin/people/components/MembershipSelect/MembershipSelect.tsx
@@ -17,7 +17,7 @@ import { GroupSummary } from "../GroupSummary";
 
 import S from "./MembershipSelect.module.css";
 
-const getGroupSections = (groups: GroupInfo[], groupsTitle = t`Groups`) => {
+const getGroupSections = (groups: GroupInfo[]) => {
   const defaultGroup = groups.find(
     (g) => isDefaultGroup(g) || PLUGIN_TENANTS.isExternalUsersGroup(g),
   );
@@ -31,10 +31,7 @@ const getGroupSections = (groups: GroupInfo[], groupsTitle = t`Groups`) => {
   );
 
   if (pinnedGroups.length > 0) {
-    return [
-      { groups: pinnedGroups },
-      { groups: regularGroups, header: groupsTitle },
-    ];
+    return [{ groups: pinnedGroups }, { groups: regularGroups }];
   }
 
   return [{ groups: regularGroups }];
@@ -52,7 +49,6 @@ interface MembershipSelectProps {
   onRemove: (groupId: number) => void;
   onChange: (groupId: number, membershipData: Partial<Member>) => void;
   isConfirmModalOpen?: boolean;
-  groupsTitle?: string;
 }
 
 export const MembershipSelect = ({
@@ -64,13 +60,12 @@ export const MembershipSelect = ({
   isCurrentUser = false,
   isUserAdmin = false,
   emptyListMessage = t`No groups`,
-  groupsTitle = t`Groups`,
   isConfirmModalOpen,
 }: MembershipSelectProps) => {
   const [popoverOpened, { open: openPopover, toggle: togglePopover }] =
     useDisclosure();
   const selectedGroupIds = Array.from(memberships.keys());
-  const groupSections = getGroupSections(groups, groupsTitle);
+  const groupSections = getGroupSections(groups);
 
   const handleToggleMembership = (groupId: number) => {
     if (memberships.has(groupId)) {
@@ -120,9 +115,6 @@ export const MembershipSelect = ({
           <ul className={S.membershipSelectContainer}>
             {groupSections.map((section, index) => (
               <Fragment key={index}>
-                {section.header && (
-                  <li className={S.membershipSelectHeader}>{section.header}</li>
-                )}
                 {section.groups.map((group) => {
                   const isDisabled =
                     (isAdminGroup(group) && isCurrentUser) ||

--- a/frontend/src/metabase/admin/people/components/MembershipSelect/MembershipSelect.tsx
+++ b/frontend/src/metabase/admin/people/components/MembershipSelect/MembershipSelect.tsx
@@ -88,7 +88,7 @@ export const MembershipSelect = ({
       // prevent clicks on the confirm modal from closing this popover
       closeOnClickOutside={!isConfirmModalOpen}
       onChange={togglePopover}
-      position="bottom-end"
+      position="bottom-start"
     >
       <Popover.Target>
         <Flex

--- a/frontend/src/metabase/forms/components/FormGroupsWidget/FormGroupsWidget.tsx
+++ b/frontend/src/metabase/forms/components/FormGroupsWidget/FormGroupsWidget.tsx
@@ -107,7 +107,6 @@ export const FormGroupsWidget = ({
         onAdd={handleAdd}
         onRemove={handleRemove}
         onChange={handleChange}
-        groupsTitle={title}
         isUserAdmin={isUserAdmin}
       />
     </FormField>


### PR DESCRIPTION
Resolves #65296 by removing the "Groups" heading from the popover altogether. [Slack context](https://metaboat.slack.com/archives/C01LQQ2UW03/p1766077669113999).

This PR also includes the commit from @thegeekybaniya from his PR #65923. That PR didn't resolve the issue at hand, but it had a good instinct to re-position the popover position. I'm also including it here because the CI cannot run for external contributors.

### Before
Note how the popover was jumping all over the place because of the weird position. Kudos to @thegeekybaniya for fixing that part.
![Kapture 2025-12-18 at 22 33 19](https://github.com/user-attachments/assets/c883ff98-a7b5-4122-92b8-e719ecf90452)


### Now
![Kapture 2025-12-18 at 22 28 50](https://github.com/user-attachments/assets/c057930f-2df0-4c9d-9553-76ab0947e799)
