### PR TITLE
Use snake_case for MetabotCodeEdit and MetabotCodeEditorBufferContext fields

### DIFF
--- a/e2e/test/scenarios/metabot/native-sql-generation.cy.spec.ts
+++ b/e2e/test/scenarios/metabot/native-sql-generation.cy.spec.ts
@@ -66,7 +66,7 @@ describe("Native SQL generation", () => {
           expect(codeEditor).to.exist;
           expect(codeEditor.buffers).to.have.length(1);
           expect(codeEditor.buffers[0].source.language).to.eq("sql");
-          expect(codeEditor.buffers[0].source.databaseId).to.eq(1); // Sample Database
+          expect(codeEditor.buffers[0].source.database_id).to.eq(1); // Sample Database
         });
 
         // should auto-close input and show diff with accept/reject buttons
@@ -234,7 +234,7 @@ describe("Native SQL generation", () => {
 
 // Response helpers
 const mockCodeEditResponse = (sql: string) =>
-  `2:{"type":"code_edit","version":1,"value":{"bufferId":"qb","mode":"rewrite","value":"${sql}"}}
+  `2:{"type":"code_edit","version":1,"value":{"buffer_id":"qb","mode":"rewrite","value":"${sql}"}}
 d:{"finishReason":"stop","usage":{"promptTokens":100,"completionTokens":10}}`;
 
 const mockTextOnlyResponse = (text: string) =>

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotInlineSQLPrompt/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotInlineSQLPrompt/utils.ts
@@ -37,7 +37,7 @@ export function extractMetabotBufferContext(
     id: bufferId,
     source: {
       language: "sql",
-      databaseId,
+      database_id: databaseId,
     },
     cursor: {
       line: cursorLine.number,

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
@@ -250,11 +250,11 @@ export const metabot = createSlice({
       state,
       { payload: codeEdit }: PayloadAction<MetabotCodeEdit>,
     ) => {
-      state.reactions.suggestedCodeEdits[codeEdit.bufferId] = codeEdit;
+      state.reactions.suggestedCodeEdits[codeEdit.buffer_id] = codeEdit;
     },
     removeSuggestedCodeEdit: (
       state,
-      action: PayloadAction<MetabotCodeEdit["bufferId"]>,
+      action: PayloadAction<MetabotCodeEdit["buffer_id"]>,
     ) => {
       delete state.reactions.suggestedCodeEdits[action.payload];
     },

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/types.ts
@@ -96,7 +96,7 @@ export type MetabotSuggestedTransform = SuggestedTransform & {
 export type MetabotReactionsState = {
   navigateToPath: string | null;
   suggestedCodeEdits: Partial<
-    Record<MetabotCodeEdit["bufferId"], MetabotCodeEdit>
+    Record<MetabotCodeEdit["buffer_id"], MetabotCodeEdit>
   >;
   suggestedTransforms: MetabotSuggestedTransform[];
 };

--- a/frontend/src/metabase-types/api/metabot.ts
+++ b/frontend/src/metabase-types/api/metabot.ts
@@ -25,7 +25,7 @@ export type MetabotCodeEditorBufferContext = {
   id: string;
   source: Record<string, unknown> & {
     language: "sql";
-    databaseId: number | null;
+    database_id: number | null;
   };
   cursor: { line: number; column: number };
   selection?: {
@@ -162,7 +162,7 @@ export type MetabotEntityInfo =
   | MetabotTransformInfo;
 
 export type MetabotCodeEdit = {
-  bufferId: string;
+  buffer_id: string;
   mode: "rewrite";
   value: string;
   active?: boolean;


### PR DESCRIPTION
### Description

AI-service PR: https://github.com/metabase/ai-service/pull/568

Use snake_case for MetabotCodeEdit and MetabotCodeEditorBufferContext fields for consistency with other types shared between metabase and ai-service.

https://github.com/metabase/ai-service/pull/559#discussion_r2627074346

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New SQL query -> Sample Dataset
2. Cmd + ;
3. Ask metabot to generate a query

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
