### PR TITLE
Keep filters header visible when details view is open

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
@@ -993,3 +993,36 @@ describe("Object Detail > public", () => {
     });
   });
 });
+
+describe("issue 66957", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+    H.openOrdersTable();
+  });
+
+  it("filter header should not hide when opening object details (metabase#66957)", () => {
+    H.tableInteractive().findByText("Quantity").click();
+    H.popover().findByText("Filter by this column").click();
+    H.popover().within(() => {
+      cy.findByText("2").click();
+      cy.button("Add filter").click();
+    });
+
+    H.openObjectDetail(5);
+
+    H.queryBuilderFiltersPanel()
+      .should("be.visible")
+      .findByText("Quantity is equal to 2")
+      .click();
+
+    H.popover().within(() => {
+      cy.findByText("3").click();
+      cy.button("Update filter").click();
+    });
+
+    H.queryBuilderFiltersPanel()
+      .findByText("Quantity is equal to 2 selections")
+      .should("be.visible");
+  });
+});

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewTitleHeader.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewTitleHeader.tsx
@@ -207,7 +207,6 @@ export function ViewTitleHeader({
       {QuestionFiltersHeader.shouldRender({
         question,
         queryBuilderMode,
-        isObjectDetail,
       }) && (
         <QuestionFiltersHeader
           expanded={areFiltersExpanded}

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionFiltersHeader/QuestionFiltersHeader.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionFiltersHeader/QuestionFiltersHeader.tsx
@@ -30,20 +30,14 @@ export function QuestionFiltersHeader({
 type RenderCheckOpts = {
   question: Question;
   queryBuilderMode: QueryBuilderMode;
-  isObjectDetail: boolean;
 };
 
-const shouldRender = ({
-  question,
-  queryBuilderMode,
-  isObjectDetail,
-}: RenderCheckOpts) => {
+const shouldRender = ({ question, queryBuilderMode }: RenderCheckOpts) => {
   const { isEditable, isNative } = Lib.queryDisplayInfo(question.query());
   return (
     queryBuilderMode === "view" &&
     !isNative &&
     isEditable &&
-    !isObjectDetail &&
     !question.isArchived()
   );
 };


### PR DESCRIPTION
Closes #66957 

For some reason the filter header was hidden when the details view is open. This could create issues where two filters for the same column could be added.

This PR keeps the filter header visible even when the details view is open.