### PR TITLE
Allow customizing filters values for subscriptions on modular embedding

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/subscriptions.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/subscriptions.cy.spec.tsx
@@ -5,6 +5,7 @@ import {
   StaticDashboard,
 } from "@metabase/embedding-sdk-react";
 
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ORDERS_DASHBOARD_DASHCARD_ID,
   ORDERS_QUESTION_ID,
@@ -14,11 +15,21 @@ import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
 import { mountSdkContent } from "e2e/support/helpers/embedding-sdk-component-testing";
 import { signInAsAdminAndEnableEmbeddingSdk } from "e2e/support/helpers/embedding-sdk-testing";
 import { mockAuthProviderAndJwtSignIn } from "e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers";
+import type { DashboardParameterMapping } from "metabase-types/api";
+
+const { PRODUCTS } = SAMPLE_DATABASE;
 
 describe("scenarios > embedding-sdk > subscriptions", () => {
   beforeEach(() => {
     signInAsAdminAndEnableEmbeddingSdk();
 
+    const parameter = {
+      id: "1b9cd9f1",
+      name: "Category",
+      slug: "category",
+      type: "string/=",
+      sectionId: "string",
+    };
     const textCard = getTextCardDetails({ col: 16, text: "Test text card" });
     const questionCard = {
       id: ORDERS_DASHBOARD_DASHCARD_ID,
@@ -30,11 +41,19 @@ describe("scenarios > embedding-sdk > subscriptions", () => {
       visualization_settings: {
         "card.title": "Test question card",
       },
+      parameter_mappings: [
+        {
+          parameter_id: parameter.id,
+          card_id: ORDERS_QUESTION_ID,
+          target: ["dimension", ["field", PRODUCTS.CATEGORY, null]],
+        } satisfies DashboardParameterMapping,
+      ],
     };
 
     createDashboard({
       name: "Embedding SDK Test Dashboard",
       dashcards: [questionCard, textCard],
+      parameters: [parameter],
     }).then(({ body: dashboard }) => {
       cy.wrap(dashboard.id).as("dashboardId");
       cy.wrap(dashboard.entity_id).as("dashboardEntityId");
@@ -66,6 +85,11 @@ describe("scenarios > embedding-sdk > subscriptions", () => {
         cy.icon("subscription").click();
         cy.findByText("Email this dashboard").should("be.visible");
 
+        cy.log("can customize filter values");
+        cy.findByRole("heading", {
+          name: "Set filter values for when this gets sent",
+        }).should("be.visible");
+
         cy.findByRole("button", { name: "Done" }).click();
         cy.wait("@createPulse");
 
@@ -91,6 +115,11 @@ describe("scenarios > embedding-sdk > subscriptions", () => {
         cy.icon("subscription").click();
         cy.findByText("Email this dashboard").should("be.visible");
 
+        cy.log("can customize filter values");
+        cy.findByRole("heading", {
+          name: "Set filter values for when this gets sent",
+        }).should("be.visible");
+
         cy.findByRole("button", { name: "Done" }).click();
         cy.wait("@createPulse");
 
@@ -115,6 +144,11 @@ describe("scenarios > embedding-sdk > subscriptions", () => {
         cy.findByText("Embedding SDK Test Dashboard").should("be.visible");
         cy.icon("subscription").click();
         cy.findByText("Email this dashboard").should("be.visible");
+
+        cy.log("can customize filter values");
+        cy.findByRole("heading", {
+          name: "Set filter values for when this gets sent",
+        }).should("be.visible");
 
         cy.findByRole("button", { name: "Done" }).click();
         cy.wait("@createPulse");

--- a/enterprise/frontend/src/metabase-enterprise/sdk-plugins.ts
+++ b/enterprise/frontend/src/metabase-enterprise/sdk-plugins.ts
@@ -12,6 +12,7 @@ import { initializePlugin as initializeContentTranslation } from "./content_tran
 import { initializePlugin as initializeEmbedding } from "./embedding";
 import { initializePlugin as initializeEmbeddingSdk } from "./embedding-sdk";
 import { initializePlugin as initializeMetabot } from "./metabot";
+import { initializePlugin as initializeSharing } from "./sharing";
 import { initializePlugin as initializeTenants } from "./tenants";
 import { initializePlugin as initializeWhitelabelPlugin } from "./whitelabel";
 import { initializePlugin as initializeWhitelabelOverridePlugin } from "./whitelabel/sdk-overrides";
@@ -29,6 +30,7 @@ export function initializePlugins() {
   initializeWhitelabelOverridePlugin?.();
   initializeContentTranslation?.();
   initializeSubscriptions();
+  initializeSharing();
 }
 
 // "SDK EE-plugins", that are specific to the embedding sdk.


### PR DESCRIPTION
closes EMB-1148

### Backport reasons
Backport to get this to 58.
### Description

In modular embedding (SDK), we have a different set of enterprise plugins separately from the core app, so any feature we want to include in the embeddings needs to be included in this SDK plugin (used for both modular embedding and modular embedding SDK) file.

### How to verify

The new tests should pass

### Demo

#### After
<img width="453" height="752" alt="image" src="https://github.com/user-attachments/assets/f31e4bd0-e8de-46bd-9bf8-4c97955f8f1a" />

#### Before
<img width="461" height="785" alt="image" src="https://github.com/user-attachments/assets/77a30d27-ae81-453b-8427-c0f227ff500c" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
