### PR TITLE
Fix invalid snowplow schema

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-iframe-embedding.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-iframe-embedding.cy.spec.ts
@@ -330,6 +330,7 @@ describe("scenarios > embedding > Modular embedding", () => {
           component: "metabase-dashboard",
           attributes: {
             dashboardId: ORDERS_DASHBOARD_ID,
+            "with-subscriptions": true,
           },
         },
         {
@@ -373,6 +374,10 @@ describe("scenarios > embedding > Modular embedding", () => {
           true: 0,
         },
         drills: {
+          false: 0,
+          true: 1,
+        },
+        with_subscriptions: {
           false: 0,
           true: 1,
         },

--- a/frontend/src/metabase/lib/analytics.ts
+++ b/frontend/src/metabase/lib/analytics.ts
@@ -23,7 +23,7 @@ const VERSIONS: Record<SchemaType, SchemaVersion> = {
   downloads: "1-0-0",
   embed_flow: "1-0-3",
   embed_share: "1-0-1",
-  embedded_analytics_js: "1-0-0",
+  embedded_analytics_js: "2-0-0",
   embedding_homepage: "1-0-0",
   simple_event: "1-0-0",
   invite: "1-0-1",

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/embedded_analytics_js/jsonschema/1-0-1
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/embedded_analytics_js/jsonschema/1-0-1
@@ -35,7 +35,7 @@
       }
     },
     "dashboard": {
-      "description": "Counts of <metabase-dashboard> component properties.",
+      "description": "Aggregated configuration counts for <metabase-dashboard>",
       "type": [
         "object",
         "null"
@@ -43,7 +43,10 @@
       "properties": {
         "drills": {
           "description": "Counts of dashboards with drills enabled or disabled.",
-          "type": "object",
+          "type": [
+            "object",
+            "null"
+          ],
           "properties": {
             "true": {
               "description": "Number of dashboards with drills enabled.",
@@ -57,11 +60,18 @@
               "minimum": 0,
               "maximum": 2147483647
             }
-          }
+          },
+          "required": [
+            "true",
+            "false"
+          ]
         },
         "with_downloads": {
           "description": "Counts of dashboards with downloads enabled or disabled.",
-          "type": "object",
+          "type": [
+            "object",
+            "null"
+          ],
           "properties": {
             "true": {
               "description": "Number of dashboards with downloads enabled.",
@@ -75,14 +85,21 @@
               "minimum": 0,
               "maximum": 2147483647
             }
-          }
+          },
+          "required": [
+            "true",
+            "false"
+          ]
         },
         "with_title": {
-          "description": "Counts of dashboards with title shown or hidden.",
-          "type": "object",
+          "description": "Counts of dashboards with title visible or hidden.",
+          "type": [
+            "object",
+            "null"
+          ],
           "properties": {
             "true": {
-              "description": "Number of dashboards with title shown.",
+              "description": "Number of dashboards with title visible.",
               "type": "integer",
               "minimum": 0,
               "maximum": 2147483647
@@ -93,11 +110,18 @@
               "minimum": 0,
               "maximum": 2147483647
             }
-          }
+          },
+          "required": [
+            "true",
+            "false"
+          ]
         },
         "with_subscriptions": {
           "description": "Counts of dashboards with subscriptions enabled or disabled.",
-          "type": "object",
+          "type": [
+            "object",
+            "null"
+          ],
           "properties": {
             "true": {
               "description": "Number of dashboards with subscriptions enabled.",
@@ -111,12 +135,16 @@
               "minimum": 0,
               "maximum": 2147483647
             }
-          }
+          },
+          "required": [
+            "true",
+            "false"
+          ]
         }
       }
     },
     "question": {
-      "description": "Counts of <metabase-question> component properties.",
+      "description": "Aggregated configuration counts for <metabase-question>",
       "type": [
         "object",
         "null"
@@ -124,7 +152,10 @@
       "properties": {
         "drills": {
           "description": "Counts of questions with drills enabled or disabled.",
-          "type": "object",
+          "type": [
+            "object",
+            "null"
+          ],
           "properties": {
             "true": {
               "description": "Number of questions with drills enabled.",
@@ -138,11 +169,18 @@
               "minimum": 0,
               "maximum": 2147483647
             }
-          }
+          },
+          "required": [
+            "true",
+            "false"
+          ]
         },
         "with_downloads": {
           "description": "Counts of questions with downloads enabled or disabled.",
-          "type": "object",
+          "type": [
+            "object",
+            "null"
+          ],
           "properties": {
             "true": {
               "description": "Number of questions with downloads enabled.",
@@ -156,14 +194,21 @@
               "minimum": 0,
               "maximum": 2147483647
             }
-          }
+          },
+          "required": [
+            "true",
+            "false"
+          ]
         },
         "with_title": {
-          "description": "Counts of questions with title shown or hidden.",
-          "type": "object",
+          "description": "Counts of questions with title visible or hidden.",
+          "type": [
+            "object",
+            "null"
+          ],
           "properties": {
             "true": {
-              "description": "Number of questions with title shown.",
+              "description": "Number of questions with title visible.",
               "type": "integer",
               "minimum": 0,
               "maximum": 2147483647
@@ -174,11 +219,18 @@
               "minimum": 0,
               "maximum": 2147483647
             }
-          }
+          },
+          "required": [
+            "true",
+            "false"
+          ]
         },
         "is_save_enabled": {
           "description": "Counts of questions with save enabled or disabled.",
-          "type": "object",
+          "type": [
+            "object",
+            "null"
+          ],
           "properties": {
             "true": {
               "description": "Number of questions with save enabled.",
@@ -192,12 +244,16 @@
               "minimum": 0,
               "maximum": 2147483647
             }
-          }
+          },
+          "required": [
+            "true",
+            "false"
+          ]
         }
       }
     },
     "exploration": {
-      "description": "Counts of <metabase-question> component with question-id=\"new\" properties.",
+      "description": "Aggregated configuration counts for <metabase-question> with question-id=\"new\"",
       "type": [
         "object",
         "null"
@@ -205,7 +261,10 @@
       "properties": {
         "is_save_enabled": {
           "description": "Counts of explorations with save enabled or disabled.",
-          "type": "object",
+          "type": [
+            "object",
+            "null"
+          ],
           "properties": {
             "true": {
               "description": "Number of explorations with save enabled.",
@@ -219,12 +278,16 @@
               "minimum": 0,
               "maximum": 2147483647
             }
-          }
+          },
+          "required": [
+            "true",
+            "false"
+          ]
         }
       }
     },
     "browser": {
-      "description": "Counts of <metabase-browser> component properties.",
+      "description": "Aggregated configuration counts for <metabase-browser>",
       "type": [
         "object",
         "null"
@@ -232,7 +295,10 @@
       "properties": {
         "read_only": {
           "description": "Counts of browsers with read-only mode enabled or disabled.",
-          "type": "object",
+          "type": [
+            "object",
+            "null"
+          ],
           "properties": {
             "true": {
               "description": "Number of browsers with read-only mode enabled.",
@@ -246,7 +312,11 @@
               "minimum": 0,
               "maximum": 2147483647
             }
-          }
+          },
+          "required": [
+            "true",
+            "false"
+          ]
         }
       }
     }

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/embedded_analytics_js/jsonschema/2-0-0
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/embedded_analytics_js/jsonschema/2-0-0
@@ -5,7 +5,7 @@
     "vendor": "com.metabase",
     "name": "embedded_analytics_js",
     "format": "jsonschema",
-    "version": "1-0-1"
+    "version": "2-0-0"
   },
   "type": "object",
   "properties": {
@@ -23,7 +23,10 @@
       "properties": {
         "auth_method": {
           "description": "Authentication method used for the modular embedding.",
-          "type": "string",
+          "type": [
+            "string",
+            "null"
+          ],
           "enum": [
             "session",
             "api_key",
@@ -324,5 +327,6 @@
   "required": [
     "event",
     "global"
-  ]
+  ],
+  "additionalProperties": true
 }


### PR DESCRIPTION
Relate to [EMB-1066](https://linear.app/metabase/issue/EMB-1066)

This is a follow-up PR from #66932. We contact our Snowcat Cloud contact and he said the schema is invalid. ~It's fine to modify the schema v1-0-1 in-place because 1-0-1 has not been published yet (1-0-0) has been published.~ This introduces version 2-0-0 and removes 1-0-1 because we never published 1-0-1

### Backport reasons
This needs to go to 58

### Description

Fix the schema by doing 2 things.
1. Make all properties inside each component optional by making them `["object", "null"]`
1. Make all `true` and `false` required.

