### PR TITLE
`My Tenant Collection` -> `Our data` in hooks.ts

### DIFF
--- a/frontend/src/metabase/common/components/Pickers/CollectionPicker/hooks.ts
+++ b/frontend/src/metabase/common/components/Pickers/CollectionPicker/hooks.ts
@@ -211,7 +211,7 @@ export const useRootCollectionPickerItems = (
     const userTenantCollectionId = currentUser?.tenant_collection_id;
     if (shouldShowTenantCollections && userTenantCollectionId) {
       collectionItems.push({
-        name: t`My Tenant Collection`,
+        name: t`Our data`,
         id: userTenantCollectionId,
         here: ["collection", "card", "dashboard"],
         description: null,


### PR DESCRIPTION
Note:
This doesn't rename it after you select it, that comes from the BE and will be changed in another open PR, see this thread: https://metaboat.slack.com/archives/C07SHGTH88H/p1766139588001669?thread_ts=1766138679.376749&cid=C07SHGTH88H

Closes https://linear.app/metabase/issue/EMB-1149/rename-my-tenant-collection-in-collection-picker-to-our-data


<img width="1030" height="966" alt="image" src="https://github.com/user-attachments/assets/27a501c7-067b-44af-8cd7-e527ce983c19" />
