### PR TITLE
Make "All internal users" sentence-cased in permission editor

### DIFF
--- a/e2e/test/scenarios/admin-2/tenants.cy.spec.ts
+++ b/e2e/test/scenarios/admin-2/tenants.cy.spec.ts
@@ -322,7 +322,7 @@ describe("Tenants - management", () => {
       .click();
 
     cy.findByTestId("admin-content-table").within(() => {
-      cy.findByRole("link", { name: /All Internal Users/ }).should(
+      cy.findByRole("link", { name: /All internal users/ }).should(
         "be.visible",
       );
       cy.findByRole("link", { name: /All tenant users/ }).should("not.exist");
@@ -333,7 +333,7 @@ describe("Tenants - management", () => {
       .click();
 
     cy.findByTestId("admin-content-table").within(() => {
-      cy.findByRole("link", { name: /All Internal Users/ }).should("not.exist");
+      cy.findByRole("link", { name: /All internal users/ }).should("not.exist");
       cy.findByRole("row", {
         name: `group-${ALL_EXTERNAL_USERS_GROUP_ID}-row`,
       }).within(() => {
@@ -416,7 +416,7 @@ describe("Tenants - management", () => {
     hasGlobeIcon(EXTERNAL_USER_GROUP_NAME);
     hasGlobeIcon(TENANT_GROUP_NAME);
     lacksGlobeIcon("Administrators");
-    lacksGlobeIcon("All Internal Users");
+    lacksGlobeIcon("All internal users");
   });
 
   it("should show 'All tenant users' in permission warning tooltip for tenant groups (UXW-2474)", () => {
@@ -453,16 +453,16 @@ describe("Tenants - management", () => {
         .findByLabelText("warning icon")
         .realHover();
 
-      // Tooltip must reference "All tenant users" not "All Internal Users"
+      // Tooltip must reference "All tenant users" not "All internal users"
       H.tooltip().should(
         "contain",
         'The "All tenant users" group has a higher level of access',
       );
-      H.tooltip().should("not.contain", "All Internal Users");
+      H.tooltip().should("not.contain", "All internal users");
     });
   });
 
-  it("should show 'All Internal Users' in permission warning modal for internal groups on tenant collections (EMB-1143)", () => {
+  it("should show 'All internal users' in permission warning modal for internal groups on tenant collections (EMB-1143)", () => {
     cy.request("PUT", "/api/setting", { "use-tenants": true });
 
     cy.request("POST", "/api/permissions/group", {
@@ -474,7 +474,7 @@ describe("Tenants - management", () => {
 
     cy.log("all internal users should have 'View' access");
     cy.findAllByRole("row")
-      .contains("tr", "All Internal Users")
+      .contains("tr", "All internal users")
       .findByText("View")
       .should("be.visible");
 
@@ -497,13 +497,13 @@ describe("Tenants - management", () => {
 
     H.modal().within(() => {
       cy.log("title should mention internal users group");
-      cy.findByText(/Revoke access even though "All Internal Users"/).should(
+      cy.findByText(/Revoke access even though "All internal users"/).should(
         "be.visible",
       );
 
       cy.log("description should mention internal users group");
       cy.findByText(
-        /The "All Internal Users" group has a higher level of access/,
+        /The "All internal users" group has a higher level of access/,
       ).should("be.visible");
 
       cy.log("should not mention tenant users");

--- a/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/common.unit.spec.tsx
@@ -65,7 +65,7 @@ describe("Admin > CollectionPermissionsPage", () => {
         await screen.findByText("Permissions for Nested One"),
       ).toBeVisible();
       expect(await screen.findByText("Administrators")).toBeVisible();
-      expect(await screen.findByText("All Internal Users")).toBeVisible();
+      expect(await screen.findByText("All internal users")).toBeVisible();
       expect(await screen.findByText("Other Users")).toBeVisible();
 
       // 1 groups has write, 1 has read, 1 has none

--- a/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/enterprise.unit.spec.tsx
@@ -53,7 +53,7 @@ describe("Admin > CollectionPermissionsPage (enterprise)", () => {
       });
 
       await assertCollectionAccessForGroup("Administrators", "Curate");
-      await assertCollectionAccessForGroup("All Internal Users", "View");
+      await assertCollectionAccessForGroup("All internal users", "View");
       await assertCollectionAccessForGroup("Other Users", "View");
       await assertCollectionAccessForGroup("All tenant users", "No access");
       await assertCollectionAccessIsDisabled("All tenant users");
@@ -69,7 +69,7 @@ describe("Admin > CollectionPermissionsPage (enterprise)", () => {
       });
 
       await assertCollectionAccessForGroup("Administrators", "Curate");
-      await assertCollectionAccessForGroup("All Internal Users", "Curate");
+      await assertCollectionAccessForGroup("All internal users", "Curate");
       await assertCollectionAccessForGroup("Other Users", "View");
       await assertCollectionAccessForGroup("All Tenant users", "No access");
       await assertCollectionAccessIsDisabled("All Tenant users");
@@ -110,7 +110,7 @@ describe("Admin > CollectionPermissionsPage (enterprise)", () => {
       });
 
       await assertCollectionAccessForGroup("Administrators", "View");
-      await assertCollectionAccessForGroup("All Internal Users", "View");
+      await assertCollectionAccessForGroup("All internal users", "View");
       await assertCollectionAccessForGroup("Other Users", "View");
 
       await userEvent.click(await getCollectionPermissionCell("Other Users"));
@@ -129,7 +129,7 @@ describe("Admin > CollectionPermissionsPage (enterprise)", () => {
       });
 
       await assertCollectionAccessForGroup("Administrators", "View");
-      await assertCollectionAccessForGroup("All Internal Users", "View");
+      await assertCollectionAccessForGroup("All internal users", "View");
       await assertCollectionAccessForGroup("Other Users", "View");
       await assertCollectionAccessIsDisabled("Administrators");
 

--- a/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/setup.tsx
+++ b/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/setup.tsx
@@ -72,7 +72,7 @@ export const defaultRootCollection = createMockCollection({
 export const defaultPermissionGroups: GroupInfo[] = [
   {
     id: 1,
-    name: "All Internal Users",
+    name: "All internal users",
     member_count: 40,
     magic_group_type: "all-internal-users",
   },

--- a/frontend/src/metabase/admin/permissions/test/DatabasesPermissionsPage/DatabasesPermissionsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/test/DatabasesPermissionsPage/DatabasesPermissionsPage.unit.spec.tsx
@@ -29,7 +29,7 @@ const TEST_DATABASE = createSampleDatabase();
 const TEST_GROUPS = [
   createMockGroup({
     id: 1,
-    name: "All Internal Users",
+    name: "All internal users",
     magic_group_type: "all-internal-users",
   }),
   createMockGroup({ id: 2, name: "Administrators", magic_group_type: "admin" }),

--- a/frontend/src/metabase/admin/permissions/test/GroupsPermissionsPage/GroupsPermissionsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/test/GroupsPermissionsPage/GroupsPermissionsPage.unit.spec.tsx
@@ -29,7 +29,7 @@ const TEST_GROUPS = [
   createMockGroup({ id: 2, name: "Administrators", magic_group_type: "admin" }),
   createMockGroup({
     id: 1,
-    name: "All Internal Users",
+    name: "All internal users",
     magic_group_type: "all-internal-users",
   }),
 ];

--- a/src/metabase/permissions_rest/api.clj
+++ b/src/metabase/permissions_rest/api.clj
@@ -137,7 +137,7 @@
                (some? query)  (sql.helpers/where query))))
 
 (defn- maybe-fix-name
-  "With Tenants enabled, we refer to the `all-internal-users` group as \"All Internal Users\", but
+  "With Tenants enabled, we refer to the `all-internal-users` group as \"All internal users\", but
    if Tenants is disabled we should call it \"All Users\".
 
   Actually changing the name brings a whole host of problems, and we very rarely actually present the names of
@@ -147,7 +147,7 @@
   (update group :name (fn [n]
                         (if (and (= magic_group_type perms/all-users-magic-group-type)
                                  using-tenants?)
-                          "All Internal Users"
+                          "All internal users"
                           n))))
 
 (defn- maybe-fix-names

--- a/test/metabase/permissions_rest/api_test.clj
+++ b/test/metabase/permissions_rest/api_test.clj
@@ -587,9 +587,9 @@
         (testing "When disabled, 'All tenant users' is not visible"
           (is (nil? (get-magic-group "all-external-users")))))
       (mt/with-temporary-setting-values [use-tenants true]
-        (testing "When enabled, 'All Users' is 'All Internal Users'"
+        (testing "When enabled, 'All Users' is 'All internal users'"
           (is (=? {:magic_group_type "all-internal-users"
-                   :name "All Internal Users"}
+                   :name "All internal users"}
                   (get-magic-group "all-internal-users"))))
         (testing "When enabled, 'All tenant users' is visible"
           (is (=? {:magic_group_type "all-external-users"


### PR DESCRIPTION
Closes EMB-1147

Makes "All internal users" sentence-cased in permission editor.