### PR TITLE
Cleanup docker build caches when building sample apps on CI

### DIFF
--- a/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
+++ b/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
@@ -190,6 +190,9 @@ jobs:
       - name: Prune build cache
         run: docker builder prune -af
 
+      - name: Log free disk space
+        run: df -h /
+
       - name: Run e2e tests for Sample App
         id: run-e2e-tests
         if: ${{ steps.check-sample-app-branch.outputs.sample_app_branch_exists == 'true' }}

--- a/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
+++ b/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
@@ -111,6 +111,7 @@ jobs:
       CYPRESS_CI: true
       SAMPLE_APP_BRANCH_NAME: ${{ needs.get-sample-apps-data.outputs.branch_name }}
       SAMPLE_APP_ENVIRONMENT: ${{ matrix.environment }}
+      DOCKER_BUILDKIT: 0
     permissions:
       id-token: write
 
@@ -186,6 +187,9 @@ jobs:
       - name: Prepare and launch Sample Apps for other test suites
         if: ${{ steps.check-sample-app-branch.outputs.sample_app_branch_exists == 'true' && matrix.test_suite != 'shoppy-e2e' }}
         run: npx tsx ./e2e/runner/embedding-sdk/sample-apps/start-ci.ts ${{ matrix.test_suite }}
+
+      - name: Prune build cache
+        run: docker builder prune -af
 
       - name: Run e2e tests for Sample App
         id: run-e2e-tests

--- a/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
+++ b/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
@@ -111,7 +111,6 @@ jobs:
       CYPRESS_CI: true
       SAMPLE_APP_BRANCH_NAME: ${{ needs.get-sample-apps-data.outputs.branch_name }}
       SAMPLE_APP_ENVIRONMENT: ${{ matrix.environment }}
-      DOCKER_BUILDKIT: 0
     permissions:
       id-token: write
 


### PR DESCRIPTION
Cleanup docker build caches when building sample apps on CI to avoid crash/freeze when not enough of memory.