### PR TITLE
Extend CI to autofix OpenAPI schema in PRs

### DIFF
--- a/.github/workflows/openapi-check.yml
+++ b/.github/workflows/openapi-check.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
           fetch-depth: 0
       - name: Setup Node.js 22
         uses: actions/setup-node@v4

--- a/.github/workflows/openapi-check.yml
+++ b/.github/workflows/openapi-check.yml
@@ -13,6 +13,9 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
       - name: Setup Node.js 22
         uses: actions/setup-node@v4
         with:
@@ -21,5 +24,9 @@ jobs:
         uses: ./.github/actions/prepare-backend
       - name: Generate version.properties
         run: ./bin/build.sh :steps [:version]
+      - name: Check and commit OpenAPI changes
+        if: github.event_name == 'pull_request'
+        run: ./bin/openapi-check.sh --auto-commit
       - name: Check OpenAPI specs are up to date
+        if: github.event_name == 'push'
         run: ./bin/openapi-check.sh

--- a/bin/openapi-check.sh
+++ b/bin/openapi-check.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
 
 # Check that resources/openapi/openapi.json matches the current Malli schema definitions
+# Usage: ./bin/openapi-check.sh [--auto-commit]
+#   --auto-commit: Automatically commit and push changes if schema is out of date
 
 set -euo pipefail
+
+AUTO_COMMIT=false
+if [[ "${1:-}" == "--auto-commit" ]]; then
+        AUTO_COMMIT=true
+fi
 
 # Generate the current OpenAPI spec from Malli schemas using write-openapi-spec-to-file!
 # This creates resources/openapi/openapi.json directly
@@ -21,6 +28,17 @@ fi
 
 # Check if there are any differences between generated and committed versions
 if ! git diff --exit-code resources/openapi/openapi.json >/dev/null 2>&1; then
+        if [[ "$AUTO_COMMIT" == "true" ]]; then
+                echo "OpenAPI schema has changed, committing updates..."
+                git config user.name "github-actions[bot]"
+                git config user.email "github-actions[bot]@users.noreply.github.com"
+                git add resources/openapi/openapi.json
+                git commit -m "Update OpenAPI schema"
+                git push
+                echo "OpenAPI schema updated and pushed."
+                exit 0
+        fi
+
         echo "Error: OpenAPI specs are out of date!"
         echo "The schema in resources/openapi/openapi.json does not match the current Malli schema definitions."
         echo ""

--- a/resources/openapi/openapi.json
+++ b/resources/openapi/openapi.json
@@ -36421,7 +36421,20 @@
         "parameters" : [ ],
         "responses" : {
           "2XX" : {
-            "description" : "Successful response"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "properties" : {
+                    "token" : {
+                      "type" : "string"
+                    }
+                  },
+                  "required" : [ "token" ],
+                  "type" : "object"
+                }
+              }
+            },
+            "description" : "map where {:token -> <string>}"
           },
           "4XX" : {
             "description" : "Client error response"

--- a/src/metabase/api/util.clj
+++ b/src/metabase/api/util.clj
@@ -8,13 +8,8 @@
 (set! *warn-on-reflection* true)
 
 ;; TODO (Cam 10/28/25) -- fix this endpoint route to use kebab-case for consistency with the rest of our REST API
-;;
-;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
-;; use our API + we will need it when we make auto-TypeScript-signature generation happen
-;;
-#_{:clj-kondo/ignore [:metabase/validate-defendpoint-route-uses-kebab-case
-                      :metabase/validate-defendpoint-has-response-schema]}
-(api.macros/defendpoint :get "/random_token"
+#_{:clj-kondo/ignore [:metabase/validate-defendpoint-route-uses-kebab-case]}
+(api.macros/defendpoint :get "/random_token" :- [:map [:token :string]]
   "Return a cryptographically secure random 32-byte token, encoded as a hexadecimal string.
    Intended for use when creating a value for `embedding-secret-key`."
   []


### PR DESCRIPTION
### Description

To minimize the friction for keeping OpenAPI spec file up to date, we add automatic commit for changes if such have been found in current branch. This should help in cases where changes haven't been added manually, and even when master somehow ended up in failed state. 

In theory, it would allow us to avoid making this check required.

As a test, I've added a Malli schema for a utility endpoint `/random_token`, and you can see that Github has added a schema for me.