### PR TITLE
test(tenants): add e2e for what tenant users should see in core app

### DIFF
--- a/e2e/test/scenarios/embedding/tenant-users-sidecar.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/tenant-users-sidecar.cy.spec.ts
@@ -1,7 +1,18 @@
+import { JWT_SHARED_SECRET } from "e2e/support/helpers/e2e-jwt-helpers";
+
 const { H } = cy;
 
-const JWT_SECRET =
-  "0000000000000000000000000000000000000000000000000000000000000000";
+const loginWithJWT = (user: TenantUser, returnTo: string = "/") => {
+  cy.task<string>("signJwt", {
+    payload: user,
+    secret: JWT_SHARED_SECRET,
+  }).then((key) =>
+    cy.visit(`/auth/sso?return_to=${encodeURIComponent(returnTo)}&jwt=${key}`),
+  );
+};
+
+// !TODO: the backend fix for this has not merged yet, we're assessing the old name for now
+const NAME_OF_COLLECTION_FROM_BE = "Tenant Collection: Gizmos";
 
 interface TenantAttributes {
   CAPS?: string;
@@ -51,22 +62,28 @@ describe("scenarios > sidecar > tenant users", () => {
       "jwt-attribute-lastname": "last_name",
       "jwt-enabled": true,
       "jwt-identity-provider-uri": "localhost:4000",
-      "jwt-shared-secret": JWT_SECRET,
+      "jwt-shared-secret": JWT_SHARED_SECRET,
       "jwt-user-provisioning-enabled?": true,
       "use-tenants": true,
     });
 
     cy.request("POST", "/api/ee/tenant", GIZMO_TENANT);
+
+    H.createSharedTenantCollection("Shared tenant collection 1").then(
+      ({ body }) => {
+        cy.wrap(body.id).as("sharedCollection1Id");
+      },
+    );
+    H.createSharedTenantCollection("Shared tenant collection 2").then(
+      ({ body }) => {
+        cy.wrap(body.id).as("sharedCollection2Id");
+      },
+    );
   });
 
   it("should show the embedding data picker when logged in as a tenant user (metabase#EMB-1144)", () => {
     cy.log("log in as tenant user");
-    cy.task<string>("signJwt", {
-      payload: GIZMO_USER,
-      secret: JWT_SECRET,
-    }).then((key) =>
-      cy.visit(`/auth/sso?return_to=/question/notebook&jwt=${key}`),
-    );
+    loginWithJWT(GIZMO_USER, "/question/notebook");
 
     cy.log("embedding data picker is shown");
     cy.findByTestId("embedding-simple-data-picker-trigger").should(
@@ -74,5 +91,115 @@ describe("scenarios > sidecar > tenant users", () => {
     );
     H.popover().contains("Orders").should("be.visible");
     H.popover().contains("People").should("be.visible");
+  });
+
+  it("tenant users should see a flatten view of collections", () => {
+    loginWithJWT(GIZMO_USER);
+
+    H.navigationSidebar().within(() => {
+      cy.findByText("Collections").should("be.visible");
+      cy.findByText("Shared tenant collection 1").should("be.visible");
+      cy.findByText("Shared tenant collection 2").should("be.visible");
+      cy.findByText("Our data").should("be.visible");
+
+      // No "internal/external" naming or sections
+      cy.findByText(/External collections/).should("not.exist");
+      cy.findByText(/Internal collections/).should("not.exist");
+    });
+  });
+
+  it("the tenant collection should be called 'Our data' and be read only", () => {
+    /*
+      The "Our data" comes from both on the FE and the BE depending on the place it's used.
+      This test checks a few places to make sure everything is working as expected.
+    */
+    loginWithJWT(GIZMO_USER);
+
+    H.navigationSidebar().findByText("Our data").should("be.visible").click();
+    cy.url().should("include", "/collection/");
+
+    // Check the collection name on the collection page, it should be read only
+    cy.findByTestId("collection-name-heading").should(
+      "have.text",
+      NAME_OF_COLLECTION_FROM_BE,
+    );
+    cy.findByTestId("collection-name-heading").should("be.disabled");
+
+    // Check the save modal
+    H.main().findByText("New").click();
+    H.popover().findByText("Question").click();
+    H.popover().findByText("Orders").click();
+    H.main().findByText("Save").click();
+
+    // Check the entity picker modal
+    H.modal()
+      .findByLabelText(/Where do you want to save this/)
+      .should("have.text", NAME_OF_COLLECTION_FROM_BE)
+      .click();
+
+    H.entityPickerModal().findByText("Our data").should("be.visible");
+  });
+
+  it("tenant users should not see the synced collection icons", () => {
+    cy.signInAsAdmin();
+
+    // Setup git sync
+    H.setupGitSync();
+    H.copySyncedCollectionFixture();
+    H.commitToRepo();
+
+    // Make shared tenant collections synced
+    cy.get<number>("@sharedCollection1Id").then((id1) => {
+      cy.get<number>("@sharedCollection2Id").then((id2) => {
+        const collectionsConfig = {
+          [id1]: true,
+          [id2]: true,
+        };
+
+        cy.request("PUT", "/api/ee/remote-sync/settings", {
+          collections: collectionsConfig,
+          "remote-sync-branch": "main",
+          "remote-sync-type": "read-write",
+          "remote-sync-url": H.LOCAL_GIT_PATH + "/.git",
+          "remote-sync-enabled": true,
+        });
+      });
+    });
+
+    cy.signOut();
+
+    loginWithJWT(GIZMO_USER);
+
+    // Check sidebar
+    H.navigationSidebar().within(() => {
+      // Synced collections should show a regular folder icon for tenant users
+      cy.findByText("Shared tenant collection 1")
+        .closest("li")
+        .icon("folder")
+        .should("be.visible");
+
+      cy.findByText("Shared tenant collection 1")
+        .closest("li")
+        .icon("synced_collection")
+        .should("not.exist");
+    });
+
+    // Check picker
+    H.newButton().click();
+    H.popover().findByText("Question").click();
+    H.popover().findByText("Orders").click();
+    H.main().findByText("Save").click();
+    H.modal()
+      .findByLabelText(/Where do you want to save this/)
+      .click();
+
+    H.entityPickerModal().within(() => {
+      cy.findByText("Shared collections").click();
+
+      cy.findByText("Shared tenant collection 1")
+        .closest("a")
+        .icon("folder")
+        .should("be.visible");
+    });
   });
 });


### PR DESCRIPTION
Closes [EMB-1145: add e2e test for what tenant users should see](https://linear.app/metabase/issue/EMB-1145/add-e2e-test-for-what-tenant-users-should-see)


This adds tests for
- the flatten view of tenant users
- no sync collections icon
- `Our data` rename

Note that part of the rename is still open in the [BE PR](https://github.com/metabase/metabase/pull/67086), part is already done as it was on the FE. This PR uses a variable for the name coming from the BE, i'll substitute the variable usage with the correct name in the BE PR if this is merged before that