### PR TITLE
Consolidate outlines in main sidebar nav

### DIFF
--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarItems.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarItems.styled.tsx
@@ -54,6 +54,11 @@ export const NodeRoot = styled(TreeNode.Root)<NodeRootProps>`
   padding-left: ${(props) => props.depth}rem;
   border-radius: 4px;
 
+  &:focus-within {
+    outline: 2px solid var(--mb-color-focus);
+    outline-offset: -2px;
+  }
+
   ${ExpandToggleButton} {
     ${(props) => props.isSelected && activeColorCSS}
   }
@@ -106,10 +111,20 @@ export const FullWidthButton = styled.button<{ isSelected: boolean }>`
       color: var(--mb-color-brand);
     }
   }
+
+  &:focus,
+  &:focus-visible {
+    outline: none;
+  }
 `;
 
 export const FullWidthLink = styled(Link)`
   ${itemContentStyle}
+
+  &:focus,
+  &:focus-visible {
+    outline: none !important;
+  }
 `;
 
 const ITEM_NAME_LENGTH_TOOLTIP_THRESHOLD = 35;


### PR DESCRIPTION
Resolves #44674

## Summary

- Move focus outline from inner interactive elements (link/button) to the parent NodeRoot container in the sidebar navigation
- This ensures the focus outline matches the shape of the sidebar item rather than just the inner content area

I was guided by what @fraserdrops said in the original issue:
> I would argue that the real issue is that the highlighted area doesn't match the clickable area.

### Demo

Before
![Kapture 2025-12-19 at 16 05 03](https://github.com/user-attachments/assets/74513f1d-168d-421d-9a4e-3a2eda6a5e7b)

Now
![Kapture 2025-12-19 at 16 00 04](https://github.com/user-attachments/assets/2dfe31ee-0f13-45cc-b463-5285f8eab3b9)

Notice the double outline that appears in this particular element. Not sure if that's acceptable trade-off compared to the double outline everywhere else.
<img width="313" height="54" alt="image" src="https://github.com/user-attachments/assets/513ec361-649f-44ac-9421-bf58eec82cbb" />

