### PR TITLE
Use top-level-column when calculating breakouts

### DIFF
--- a/src/metabase/lib/drill_thru/pivot.cljc
+++ b/src/metabase/lib/drill_thru/pivot.cljc
@@ -173,9 +173,11 @@
   (get-in drill-thru [:pivots pivot-type]))
 
 (defn- breakouts->filters [query stage-number {:keys [column value] :as _dimension}]
-  (let [resolved-column (lib.drill-thru.common/breakout->resolved-column query stage-number column)]
+  (let [col-for-stage   (or (lib.underlying/top-level-column query column)
+                            column)
+        resolved-column (lib.drill-thru.common/breakout->resolved-column query stage-number col-for-stage)]
     (-> query
-        (lib.breakout/remove-existing-breakouts-for-column stage-number column)
+        (lib.breakout/remove-existing-breakouts-for-column stage-number col-for-stage)
         (lib.filter/filter stage-number (lib.filter/= resolved-column value)))))
 
 ;; Pivot drills are in play when clicking an aggregation cell. Pivoting is applied by:

--- a/test/metabase/lib/drill_thru/pivot_test.cljc
+++ b/test/metabase/lib/drill_thru/pivot_test.cljc
@@ -293,7 +293,6 @@
                         (lib.drill-thru.tu/append-filter-stage "count"))
       :expected-query (-> base-case
                           :expected-query
-                          (assoc-in [:stages 0 :filters 0 2 2] "CREATED_AT")
                           (lib.drill-thru.tu/append-filter-stage-to-test-expectation "count"))})))
 
 (deftest ^:parallel returns-pivot-drill-boolean-column-test


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/67228

### Description

Whereas the last drill-through [bug](https://github.com/metabase/metabase/pull/66907) I fixed was using `top-level-column` even when it returned `nil`, here our code appears not to use it when it should.

When you click for breakouts, the dimension's column comes from the final stage of the query being visualized, but the query needs to create a filter at the top-level stage. This simply modifies `breakouts->filters` to use `top-level-column` if it exists. 

### How to verify

Follow the reproduction steps in the [original issue](https://github.com/metabase/metabase/issues/67228).

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
