### PR TITLE
Don't auto-redirect to tenants page on new user creation

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/tenants/utils/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/utils/utils.ts
@@ -10,8 +10,8 @@ export const isTenantGroup = (group: Pick<Group, "is_tenant_group">) => {
   return !!group.is_tenant_group;
 };
 
-export const isExternalUser = (user?: Pick<User, "tenant_id">) => {
-  return user?.tenant_id !== null;
+export const isExternalUser = (user?: Pick<User, "tenant_id">): boolean => {
+  return Boolean(user && user.tenant_id !== null);
 };
 
 export const isTenantCollection = (collection: Collection) =>


### PR DESCRIPTION
Closes UXW-2499 (redirection issue)
Closes UXW-2592 (broken test)

### Description

In the `UserSuccessModal`, because user was not defined on first component load, `isExternalUser` was returning true because undefined !==null. Thus, we were always redirecting past the new user creation modal before the user was even loaded.

The fix here is to make sure we have a user at all in the `isExternalUser` helper function

<img width="724" height="292" alt="CleanShot 2025-12-19 at 13 38 11" src="https://github.com/user-attachments/assets/e824fc84-9f1a-4002-9929-42c7029a4003" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
