### PR TITLE
MBQL 4 => MBQL 5 conversion should ignore (drop) invalid expressions

### DIFF
--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -49,6 +49,14 @@
          (and (map? opts)
               (contains? opts :lib/uuid)))))
 
+(defn- denormalized-or-unconverted-clause?
+  "Whether this clause is a not a properly normalized MBQL 5 clause -- usually because it failed normalization because
+  it's invalid, e.g. using an aggregation function like `:sum` inside `:expressions`."
+  [clause]
+  (and (sequential? clause)
+       (not (map-entry? clause))
+       (string? (first clause))))
+
 ;;; TODO (Cam 9/8/25) -- some overlap with [[metabase.lib.dispatch/mbql-clause-type]]
 (defn clause-of-type?
   "Returns truthy if is a clause of `clause-type`, which can be either a keyword (like `:field`) or a set (like
@@ -91,15 +99,21 @@
 (defn top-level-expression-clause
   "Top level expressions must be clauses with :lib/expression-name, so if we get a literal, wrap it in :value."
   [clause a-name]
-  (-> (if (clause? clause)
-        clause
-        [:value {:lib/uuid (str (random-uuid))
-                 :effective-type (lib.schema.expression/type-of clause)}
-         clause])
-      (lib.options/update-options (fn [opts]
-                                    (-> opts
-                                        (assoc :lib/expression-name a-name)
-                                        (dissoc :name :display-name))))))
+  (some-> (cond
+            (clause? clause)
+            clause
+
+            (denormalized-or-unconverted-clause? clause)
+            nil
+
+            :else
+            [:value {:lib/uuid (str (random-uuid))
+                     :effective-type (lib.schema.expression/type-of clause)}
+             clause])
+          (lib.options/update-options (fn [opts]
+                                        (-> opts
+                                            (assoc :lib/expression-name a-name)
+                                            (dissoc :name :display-name))))))
 
 (defmulti custom-name-method
   "Implementation for [[custom-name]]."

--- a/test/metabase/lib/query_test.cljc
+++ b/test/metabase/lib/query_test.cljc
@@ -622,3 +622,18 @@
              :lib/type :mbql/query}
             (lib.query/query (lib.tu/mock-metadata-provider {})
                              {"database" 1, "type" "query", "query" {"source-table" 2}})))))
+
+(deftest ^:parallel discard-invalid-clauses-on-conversion-from-mbql-4-test
+  (testing "Invalid expressions that do not get normalized correctly (e.g. :sum inside :expressions) should get dropped"
+    (mu/disable-enforcement
+      (let [query {"database" 1
+                   "type"     "query"
+                   "query"    {"source-table" 2
+                               "expressions"  {"booking" ["sum" ["field" 3 {"base-type" "type/BigInteger"}]]}}}
+            mp    (lib.tu/mock-metadata-provider {})]
+        (is (= {:lib/type               :mbql/query,
+                :stages                 [{:lib/type :mbql.stage/mbql, :source-table 2}]
+                :database               1
+                :lib.convert/converted? true
+                :lib/metadata           (lib.metadata.cached-provider/cached-metadata-provider mp)}
+               (lib.query/query mp query)))))))


### PR DESCRIPTION
This was previously done in 56, but due to the new MBQL 4 normalization code in 57 the invalid expressions were no longer getting dropped correctly... this PR restores the previous 'robust' behavior