### PR TITLE
bump databricks timeout to get logging info

### DIFF
--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -81,8 +81,8 @@ runs:
         list-suites: failed
         list-tests: failed
         fail-on-error: false
-    - name: Upload Logs on Failure
-      if: always() && steps.run-test.outcome != 'success' && steps.check-driver.outputs.skip != 'true'
+    - name: Upload Logs When Not Skipped
+      if: always() && steps.check-driver.outputs.skip != 'true'
       uses: actions/upload-artifact@v4
       with:
         name: ${{ format('test-logs-{0}{1}', github.job, (inputs.logs-artifact-suffix == '' || inputs.logs-artifact-suffix == null) && '' || format('-{0}', inputs.logs-artifact-suffix)) }}

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -299,7 +299,7 @@ jobs:
     needs: determine-driver-skips
     if: ${{ !inputs.skip && !(needs.determine-driver-skips.outputs.skip == 'true') }}
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 75
     env:
       CI: 'true'
       DRIVERS: databricks


### PR DESCRIPTION
Bumps Databricks CI timeout from 60 to 75 minutes and uploads test logs on all runs (not just failures).

  Databricks tests have been timing out repeatedly (3 times now), and the timeout combined with tests passing just before the timeout is canceling the log upload step. This means we can't analyze the test duration JSON to understand why tests are slow. Previously, logs were only uploaded on test failure—so even passing-but-slow runs gave us nothing to analyze.

  This PR gives us headroom to:
  1. Get the test logs uploaded successfully
  2. Capture logs even when tests pass (they have 1-day retention)
  3. Analyze which tests are taking longest
  4. Understand why ~half the tests running sequentially with cloud network latency is causing issues

  Test plan

  - Databricks CI completes and uploads test logs
  - Analyze logs to determine root cause of slowness