### PR TITLE
Fix #64631: Change "Report an issue" -> "Download diagnostics"

### DIFF
--- a/docs/exploration-and-organization/keyboard-shortcuts.md
+++ b/docs/exploration-and-organization/keyboard-shortcuts.md
@@ -25,7 +25,7 @@ in the top right corner and select **Keyboard shortcuts**.
 | Browse databases         | g > d       |
 | Browse models            | g > m       |
 | Browse metrics           | g > k       |
-| Report an issue          | Ctrl/Cmd+f1 |
+| Download diagnostics     | Ctrl/Cmd+f1 |
 | View shortcuts           | ?           |
 | Open trash               | g > t       |
 | Open personal collection | g > p       |

--- a/e2e/test/scenarios/admin-2/error-reporting.cy.spec.ts
+++ b/e2e/test/scenarios/admin-2/error-reporting.cy.spec.ts
@@ -47,7 +47,7 @@ describe("error reporting modal", () => {
 
     H.commandPaletteButton().click();
     H.commandPaletteInput().type("Error");
-    H.commandPaletteAction(/Report an issue/).click();
+    H.commandPaletteAction(/Download diagnostics/).click();
 
     cy.findByRole("dialog", { name: "Gather diagnostic information" }).should(
       "be.visible",

--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -425,13 +425,13 @@ describe("command palette", () => {
     });
   });
 
-  it("should show the 'Report an issue' command palette item", () => {
+  it("should show the 'Download diagnostics' command palette item", () => {
     cy.visit("/");
     cy.findByRole("button", { name: /search/i }).click();
 
     H.commandPalette().within(() => {
       H.commandPaletteInput().should("exist").type("Issue");
-      cy.findByText("Report an issue").should("be.visible");
+      cy.findByText("Download diagnostics").should("be.visible");
     });
   });
 

--- a/frontend/src/metabase/nav/components/ProfileLink/ProfileLink.tsx
+++ b/frontend/src/metabase/nav/components/ProfileLink/ProfileLink.tsx
@@ -136,7 +136,7 @@ function ProfileLinkInner({
         action: () => dispatch(setOpenModal("help")),
       },
       {
-        title: t`Report an issue`,
+        title: t`Download diagnostics`,
         icon: null,
         action: () => {
           trackErrorDiagnosticModalOpened("profile-menu");

--- a/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
@@ -192,8 +192,8 @@ export const useCommandPaletteBasicActions = ({
     }
 
     actions.push({
-      id: "report-issue",
-      name: t`Report an issue`,
+      id: "download-diagnostics",
+      name: t`Download diagnostics`,
       section: "basic",
       icon: "bug",
       keywords: "bug, issue, problem, error, diagnostic",

--- a/frontend/src/metabase/palette/shortcuts/global.ts
+++ b/frontend/src/metabase/palette/shortcuts/global.ts
@@ -72,9 +72,9 @@ export const globalShortcuts = {
     shortcutGroup: "global" as const,
   },
 
-  "report-issue": {
+  "download-diagnostics": {
     get name() {
-      return t`Report an issue`;
+      return t`Download diagnostics`;
     },
     shortcut: ["$mod+f1"],
     shortcutGroup: "global" as const,


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/64631 / UXW-1988

### Description

Changes "Report an issue" -> "Download diagnostics"

### How to verify

Verify the text for the diagnostics modal triggers say "Download diagnostics" instead of "Report an issue"

### Demo

<img width="216" height="378" alt="Screenshot 2025-12-19 at 4 11 05 PM" src="https://github.com/user-attachments/assets/98a83e5f-a7cc-48da-8f08-5c11e2db4c47" />

<img width="711" height="207" alt="Screenshot 2025-12-19 at 4 11 16 PM" src="https://github.com/user-attachments/assets/3ad6359e-6171-4596-979e-72fe0144d1a3" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
