### PR TITLE
feat: add table/field/segment support to remote-sync

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2141,7 +2141,6 @@
            metabase-enterprise.remote-sync.init}
    :uses #{analytics
            api
-           app-db
            collections
            events
            models

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1193,6 +1193,7 @@
    :api  #{metabase.remote-sync.core
            metabase.remote-sync.init}
    :uses #{api
+           app-db
            models
            premium-features}}
 

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1283,6 +1283,7 @@
            lib-be
            models
            permissions
+           remote-sync
            search
            util
            xrays}}
@@ -1635,6 +1636,7 @@
            permissions
            premium-features
            query-processor
+           remote-sync
            search
            util
            warehouses}}
@@ -1778,6 +1780,7 @@
            premium-features
            query-permissions
            query-processor
+           remote-sync
            util
            warehouses
            enterprise/impersonation}}

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1193,7 +1193,6 @@
    :api  #{metabase.remote-sync.core
            metabase.remote-sync.init}
    :uses #{api
-           app-db
            models
            premium-features}}
 
@@ -2141,6 +2140,7 @@
            metabase-enterprise.remote-sync.init}
    :uses #{analytics
            api
+           app-db
            collections
            events
            models

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1648,6 +1648,7 @@
    :uses #{analytics
            api
            app-db
+           config
            database-routing
            driver
            events

--- a/e2e/test/scenarios/data-studio/data-model/data-studio-bulk-table.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-model/data-studio-bulk-table.cy.spec.ts
@@ -35,7 +35,7 @@ describe("bulk table operations", () => {
     );
     cy.intercept(
       "GET",
-      `/api/database/${WRITABLE_DB_ID}/schema/public?include_hidden=true&include_editable_data_model=true`,
+      `/api/database/${WRITABLE_DB_ID}/schema/public?include_hidden=true`,
     ).as("getSchema");
     cy.intercept("POST", "/api/ee/data-studio/table/publish-tables").as(
       "publishTables",

--- a/e2e/test/scenarios/data-studio/data-model/datamodel-data-studio.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-model/datamodel-data-studio.cy.spec.ts
@@ -36,7 +36,7 @@ describe("scenarios > data studio > datamodel", () => {
     cy.signInAsAdmin();
     H.activateToken("bleeding-edge");
 
-    cy.intercept("GET", "/api/database?*").as("databases");
+    cy.intercept("GET", "/api/database").as("databases");
     cy.intercept("GET", "/api/database/*/schemas?*").as("schemas");
     cy.intercept("GET", "/api/table/*/query_metadata*").as("metadata");
     cy.intercept("GET", "/api/database/*/schema/*").as("schema");

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
@@ -3,22 +3,28 @@
    [metabase.api.common :as api]
    [metabase.permissions.core :as perms]
    [metabase.premium-features.core :as premium-features :refer [defenterprise]]
+   [metabase.remote-sync.core :as remote-sync]
    [metabase.util :as u]
    [metabase.warehouses.models.database :as database]
    [toucan2.core :as t2]))
 
 (defenterprise current-user-can-write-field?
-  "Enterprise version. Returns a boolean whether the current user can write the given field."
+  "Enterprise version. Returns a boolean whether the current user can write the given field.
+   Checks both that the user has manage-table-metadata permission and that the parent table
+   is editable (not in a remote-synced collection in read-only mode)."
   :feature :advanced-permissions
   [instance]
-  (let [db-id (or (get-in instance [:table :db_id])
-                  (database/table-id->database-id (:table_id instance)))]
-    (perms/user-has-permission-for-table?
-     api/*current-user-id*
-     :perms/manage-table-metadata
-     :yes
-     db-id
-     (:table_id instance))))
+  (let [table (or (:table instance)
+                  (t2/select-one :model/Table :id (:table_id instance)))]
+    (and (remote-sync/table-editable? table)
+         (let [db-id (or (:db_id table)
+                         (database/table-id->database-id (:table_id instance)))]
+           (perms/user-has-permission-for-table?
+            api/*current-user-id*
+            :perms/manage-table-metadata
+            :yes
+            db-id
+            (:table_id instance))))))
 
 (defenterprise current-user-can-manage-schema-metadata?
   "Enterprise version. Returns a boolean whether the current user has permission to edit table metadata for any tables
@@ -43,15 +49,17 @@
    db-id))
 
 (defenterprise current-user-can-write-table?
-  "Enterprise version."
+  "Enterprise version. Checks both that the user has manage-table-metadata permission and
+   that the table is editable (not in a remote-synced collection in read-only mode)."
   :feature :advanced-permissions
   [table]
-  (perms/user-has-permission-for-table?
-   api/*current-user-id*
-   :perms/manage-table-metadata
-   :yes
-   (:db_id table)
-   (:id table)))
+  (and (remote-sync/table-editable? table)
+       (perms/user-has-permission-for-table?
+        api/*current-user-id*
+        :perms/manage-table-metadata
+        :yes
+        (:db_id table)
+        (:id table))))
 
 (defn with-advanced-permissions
   "Adds to `user` a set of boolean flags indicating whether or not current user has access to advanced permissions.

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/core.clj
@@ -32,6 +32,27 @@
   (or (= (settings/remote-sync-type) :read-write)
       (not (collections/remote-synced-collection? collection))))
 
+(defenterprise table-editable?
+  "Determines if a table's metadata should be editable.
+
+  Takes a table to check for editability.
+
+  Returns true if the table is editable, false otherwise. Returns false if:
+  - remote-sync-type is :read-only AND
+  - table is published AND
+  - table is in a remote-synced collection
+
+  Always returns true on OSS.
+
+  If the table has a pre-hydrated :collection key, uses that to avoid an extra query."
+  :feature :none
+  [table]
+  (or (= (settings/remote-sync-type) :read-write)
+      (not (:is_published table))
+      ;; Use pre-hydrated :collection if available, otherwise fall back to :collection_id
+      (not (collections/remote-synced-collection? (or (:collection table)
+                                                      (:collection_id table))))))
+
 (mu/defn bulk-set-remote-sync :- :nil
   "Sets remote sync to true/false on one or collections in a single transaction. Checks that the remote sync state
   afterwards is consistent in terms of dependency rules. Collections are provided as a map of collection-id -> sync state."

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/events.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/events.clj
@@ -151,22 +151,22 @@
 
 ;; Standard model change handlers
 
-(defmodel-change-handler card
+(defmodel-change-handler :card
   {:model-type   "Card"
    :event-prefix :event/card
    :log-name     "card"})
 
-(defmodel-change-handler dashboard
+(defmodel-change-handler :dashboard
   {:model-type   "Dashboard"
    :event-prefix :event/dashboard
    :log-name     "dashboard"})
 
-(defmodel-change-handler document
+(defmodel-change-handler :document
   {:model-type   "Document"
    :event-prefix :event/document
    :log-name     "document"})
 
-(defmodel-change-handler snippet
+(defmodel-change-handler :snippet
   {:model-type   "NativeQuerySnippet"
    :event-prefix :event/snippet
    :log-name     "snippet"})
@@ -222,7 +222,7 @@
         (log/infof "Collection %s type changed from remote-synced, marking as removed" (:id object))
         (create-or-update-remote-sync-object-entry! "Collection" (:id object) "removed" user-id)))))
 
-(defmodel-change-handler timeline
+(defmodel-change-handler :timeline
   {:model-type   "Timeline"
    :event-prefix :event/timeline
    :log-name     "timeline"})
@@ -248,7 +248,7 @@
      (when-let [table (t2/select-one :model/Table :id table_id)]
        (published-table-in-remote-synced-collection? table)))))
 
-(defmodel-change-handler table
+(defmodel-change-handler :table
   {:model-type   "Table"
    :event-prefix :event/table
    :log-name     "table"
@@ -257,7 +257,7 @@
 
 ;; Segment events - track segments in published tables in remote-synced collections
 
-(defmodel-change-handler segment
+(defmodel-change-handler :segment
   {:model-type   "Segment"
    :event-prefix :event/segment
    :log-name     "segment"
@@ -265,7 +265,7 @@
 
 ;; Field events - track fields in published tables in remote-synced collections
 
-(defmodel-change-handler field
+(defmodel-change-handler :field
   {:model-type   "Field"
    :event-prefix :event/field
    :log-name     "field"

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
@@ -40,24 +40,68 @@
   "Populates the remote-sync-object table with imported entities. Deletes all existing RemoteSyncObject records and
   inserts new ones for each imported entity, marking them as 'synced' with the given timestamp.
 
-  Takes a timestamp instant and a map of imported entities grouped by model name, where each model maps to a set of
-  entity IDs that were imported."
-  [timestamp imported-entities-by-model]
+  Takes a timestamp instant, a map of imported entities grouped by model name (for standard models with entity_id),
+  and separate path collections for Table and Field models which use name-based identity."
+  [timestamp imported-entities-by-model table-paths field-paths]
   (t2/delete! :model/RemoteSyncObject)
-  (let [inserts (->> imported-entities-by-model
-                     (mapcat (fn [[model entity-ids]]
-                               (let [fields (model-fields-for-sync model)
-                                     model-kw (keyword "model" model)]
-                                 (t2/select (into [model-kw] fields) :entity_id [:in entity-ids]))))
-                     (map (fn [{:keys [id name collection_id display] :as model}]
-                            {:model_type (clojure.core/name (t2/model model))
-                             :model_id id
-                             :model_name name
-                             :model_collection_id collection_id
-                             :model_display (some-> display clojure.core/name)
-                             :status "synced"
-                             :status_changed_at timestamp})))]
-    (t2/insert! :model/RemoteSyncObject inserts)))
+  (let [;; Standard models use entity_id UUIDs (including Segment)
+        standard-inserts (->> imported-entities-by-model
+                              (mapcat (fn [[model entity-ids]]
+                                        (when (seq entity-ids)
+                                          (let [fields (model-fields-for-sync model)
+                                                model-kw (keyword "model" model)]
+                                            (t2/select (into [model-kw] fields) :entity_id [:in entity-ids])))))
+                              (map (fn [{:keys [id name collection_id display] :as model}]
+                                     {:model_type (clojure.core/name (t2/model model))
+                                      :model_id id
+                                      :model_name name
+                                      :model_collection_id collection_id
+                                      :model_display (some-> display clojure.core/name)
+                                      :status "synced"
+                                      :status_changed_at timestamp})))
+        ;; Tables: batch lookup using join - include name and collection_id
+        table-inserts (when (seq table-paths)
+                        (->> (t2/query {:select [:t.id :t.name :t.collection_id]
+                                        :from [[:metabase_table :t]]
+                                        :join [[:metabase_database :db] [:= :db.id :t.db_id]]
+                                        :where (into [:or]
+                                                     (for [{:keys [db_name schema table_name]} table-paths]
+                                                       [:and
+                                                        [:= :db.name db_name]
+                                                        (if schema [:= :t.schema schema] [:is :t.schema nil])
+                                                        [:= :t.name table_name]]))})
+                             (map (fn [{:keys [id name collection_id]}]
+                                    {:model_type "Table"
+                                     :model_id id
+                                     :model_name name
+                                     :model_collection_id collection_id
+                                     :model_display nil
+                                     :status "synced"
+                                     :status_changed_at timestamp}))))
+        ;; Fields: batch lookup using join through table - include name and collection_id from table
+        field-inserts (when (seq field-paths)
+                        (->> (t2/query {:select [:f.id :f.name [:t.collection_id :collection_id]]
+                                        :from [[:metabase_field :f]]
+                                        :join [[:metabase_table :t] [:= :t.id :f.table_id]
+                                               [:metabase_database :db] [:= :db.id :t.db_id]]
+                                        :where (into [:or]
+                                                     (for [{:keys [db_name schema table_name field_name]} field-paths]
+                                                       [:and
+                                                        [:= :db.name db_name]
+                                                        (if schema [:= :t.schema schema] [:is :t.schema nil])
+                                                        [:= :t.name table_name]
+                                                        [:= :f.name field_name]]))})
+                             (map (fn [{:keys [id name collection_id]}]
+                                    {:model_type "Field"
+                                     :model_id id
+                                     :model_name name
+                                     :model_collection_id collection_id
+                                     :model_display nil
+                                     :status "synced"
+                                     :status_changed_at timestamp}))))
+        all-inserts (concat standard-inserts table-inserts field-inserts)]
+    (when (seq all-inserts)
+      (t2/insert! :model/RemoteSyncObject all-inserts))))
 
 (defn- remove-unsynced!
   "Deletes any remote sync content that was NOT part of the import.
@@ -153,20 +197,42 @@
                       :version (source.p/version snapshot)
                       :message (format "Skipping import: snapshot version %s matches last imported version" snapshot-version)}
               (log/infof (:message <>)))
-            (let [ingestable-snapshot (->> (source.p/->ingestable snapshot {:path-filters [#"collections/.*"]})
+            (let [ingestable-snapshot (->> (source.p/->ingestable snapshot {:path-filters [#"collections/.*" #"databases/.*"]})
                                            (source.ingestable/wrap-progress-ingestable task-id 0.7))
                   load-result (serdes/with-cache
                                 (serialization/load-metabase! ingestable-snapshot))
-                  imported-entities-by-model (->> (:seen load-result)
-                                                  (map last) ; Get the last element of each path (the entity itself)
+                  seen-paths (:seen load-result)
+                  data-model-models #{"Table" "Field"}
+                  ;; For standard models (Collection, Card, Segment, etc.), extract entity_id as before
+                  imported-entities-by-model (->> seen-paths
+                                                  (remove #(data-model-models (:model (last %))))
+                                                  (map last)
                                                   (group-by :model)
                                                   (map (fn [[model entities]]
                                                          [model (set (map :id entities))]))
-                                                  (into {}))]
+                                                  (into {}))
+                  ;; For Tables, capture full path for unique identification
+                  ;; Path format: [{:model "Database" :id db-name} {:model "Schema" :id schema}? {:model "Table" :id table-name}]
+                  table-paths (->> seen-paths
+                                   (filter #(= "Table" (:model (last %))))
+                                   (map (fn [path]
+                                          {:db_name    (-> path first :id)
+                                           :schema     (when (= 3 (count path)) (-> path second :id))
+                                           :table_name (-> path last :id)})))
+                  ;; For Fields, path format includes Table
+                  ;; [{:model "Database"} {:model "Schema"}? {:model "Table"} {:model "Field" :id field-name}]
+                  field-paths (->> seen-paths
+                                   (filter #(= "Field" (:model (last %))))
+                                   (map (fn [path]
+                                          (let [table-idx (dec (count path))]
+                                            {:db_name    (-> path first :id)
+                                             :schema     (when (> (count path) 3) (-> path second :id))
+                                             :table_name (-> path (nth (dec table-idx)) :id)
+                                             :field_name (-> path last :id)}))))]
               (remote-sync.task/update-progress! task-id 0.8)
               (t2/with-transaction [_conn]
                 (remove-unsynced! (all-top-level-remote-synced-collections) imported-entities-by-model)
-                (sync-objects! sync-timestamp imported-entities-by-model)
+                (sync-objects! sync-timestamp imported-entities-by-model table-paths field-paths)
                 (when (and (nil? (collection/remote-synced-collection)) (= :read-write (settings/remote-sync-type)))
                   (collection/create-remote-synced-collection!)))
               (remote-sync.task/update-progress! task-id 0.95)
@@ -221,8 +287,45 @@
                                                                        [:= :rso.model_id :c.id]]]
                                                                :where [:= :location "/"]})
                                                     (map #(str "collections/" (:entity_id %))))
-                    written-version (source/store! models top-level-removed-prefixes snapshot task-id message)]
+                    ;; Add removed table paths - join to get db_name + schema in one query
+                    removed-table-paths (->> (t2/query {:select [[:t.name :table_name] :t.schema [:db.name :db_name]]
+                                                        :from [[:metabase_table :t]]
+                                                        :join [[:remote_sync_object :rso]
+                                                               [:and [:= :rso.model_type [:inline "Table"]]
+                                                                [:= :rso.status [:inline "removed"]]
+                                                                [:= :rso.model_id :t.id]]
+                                                               [:metabase_database :db]
+                                                               [:= :db.id :t.db_id]]})
+                                             (map (fn [{:keys [table_name schema db_name]}]
+                                                    (str/join "/" (cond-> ["databases" db_name]
+                                                                    schema (conj "schemas" schema)
+                                                                    true   (conj "tables" table_name))))))
+                    ;; Add removed segment paths - join to get all path components in one query
+                    ;; Segments use entity_id for path construction
+                    removed-segment-paths (->> (t2/query {:select [:s.entity_id
+                                                                   [:t.name :table_name]
+                                                                   :t.schema
+                                                                   [:db.name :db_name]]
+                                                          :from [[:segment :s]]
+                                                          :join [[:remote_sync_object :rso]
+                                                                 [:and [:= :rso.model_type [:inline "Segment"]]
+                                                                  [:= :rso.status [:inline "removed"]]
+                                                                  [:= :rso.model_id :s.id]]
+                                                                 [:metabase_table :t] [:= :t.id :s.table_id]
+                                                                 [:metabase_database :db] [:= :db.id :t.db_id]]})
+                                               (map (fn [{:keys [entity_id table_name schema db_name]}]
+                                                      (str/join "/" (cond-> ["databases" db_name]
+                                                                      schema (conj "schemas" schema)
+                                                                      true   (conj "tables" table_name "segments" entity_id))))))
+                    all-delete-prefixes (concat top-level-removed-prefixes
+                                                removed-table-paths
+                                                removed-segment-paths)
+                    written-version (source/store! models all-delete-prefixes snapshot task-id message)]
                 (remote-sync.task/set-version! task-id written-version))
+              ;; Delete removed Table/Field/Segment entries (they've been deleted from remote)
+              (t2/delete! :model/RemoteSyncObject
+                          :model_type [:in ["Table" "Field" "Segment"]]
+                          :status "removed")
               (t2/update! :model/RemoteSyncObject {:status "synced" :status_changed_at sync-timestamp})))
           {:status :success
            :version (source.p/version snapshot)}

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/models/remote_sync_object.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/models/remote_sync_object.clj
@@ -1,4 +1,52 @@
 (ns metabase-enterprise.remote-sync.models.remote-sync-object
+  "Model and queries for tracking remote-synced objects and their dirty state.
+
+   ## Adding a New Model to Dirty-State Tracking
+
+   To add a new model to the dirty-state queries (so it appears in the UI
+   when checking for unsynchronized changes), add an entry to [[synced-model-configs]]:
+
+   ```clojure
+   :your_table_name {:model-type \"YourModel\"    ; String stored in RemoteSyncObject.model_type
+                     :model-label \"yourmodel\"}  ; String returned in API results
+   ```
+
+   ### Required Configuration Keys
+
+   - `:model-type` - String used in RemoteSyncObject.model_type column (e.g. \"Card\", \"Dashboard\")
+   - `:model-label` - String label returned in query results (e.g. \"card\", \"dashboard\")
+
+   ### Optional Configuration Keys
+
+   - `:has-description` (default true) - Set to false if model lacks a description column
+   - `:has-authority-level` (default false) - Set to true if model has authority_level column
+   - `:has-updated-at` (default true) - Set to false if model lacks updated_at column
+   - `:extra-columns` - Vector of extra columns to include, e.g. `[:display :query_type]`
+   - `:table-join` - If model gets collection_id through another table, specify that table keyword
+   - `:collection-id-source` - How to get collection_id:
+     - `:direct` (default) - Model has its own collection_id column
+     - `:self` - Use the model's id as collection_id (for Collection model itself)
+     - `:via-table` - Join through `:table-join` table to get collection_id
+
+   ### Example: Model with Direct collection_id
+
+   Most models have a direct collection_id column:
+
+   ```clojure
+   :action {:model-type \"Action\"
+            :model-label \"action\"}
+   ```
+
+   ### Example: Model Needing Table Join
+
+   Some models (like Field, Segment) relate to collections through their parent table:
+
+   ```clojure
+   :dimension {:model-type \"Dimension\"
+               :model-label \"dimension\"
+               :table-join :metabase_field
+               :collection-id-source :via-table}
+   ```"
   (:require
    [clojure.set :as set]
    [methodical.core :as methodical]
@@ -10,18 +58,134 @@
 
 (derive :model/RemoteSyncObject :metabase/model)
 
+;;; ------------------------------------------------ Model Configuration ------------------------------------------------
+
+(def ^:private synced-model-configs
+  "Configuration for models tracked in remote-sync dirty state.
+   See namespace docstring for full documentation on adding new models."
+  {:collection           {:model-type           "Collection"
+                          :model-label          "collection"
+                          :has-authority-level  true
+                          :has-description      false
+                          :has-updated-at       false
+                          :collection-id-source :self}
+   :report_card          {:model-type    "Card"
+                          :model-label   "card"
+                          :extra-columns [:display :query_type]}
+   :document             {:model-type      "Document"
+                          :model-label     "document"
+                          :has-description false}
+   :report_dashboard     {:model-type  "Dashboard"
+                          :model-label "dashboard"}
+   :native_query_snippet {:model-type      "NativeQuerySnippet"
+                          :model-label     "snippet"
+                          :has-description false}
+   :timeline             {:model-type  "Timeline"
+                          :model-label "timeline"}
+   :metabase_table       {:model-type  "Table"
+                          :model-label "table"}
+   :metabase_field       {:model-type           "Field"
+                          :model-label          "field"
+                          :table-join           :metabase_table
+                          :collection-id-source :via-table}
+   :segment              {:model-type           "Segment"
+                          :model-label          "segment"
+                          :table-join           :metabase_table
+                          :collection-id-source :via-table}})
+
+;;; -------------------------------------------- Select Clause Generation ----------------------------------------------
+
+(defn- build-select-clause
+  "Build HoneySQL select clause for a model based on its config.
+   Generates the standard set of columns needed for dirty-state queries."
+  [table-key {:keys [model-label has-description has-authority-level has-updated-at
+                     collection-id-source extra-columns]
+              :or   {has-description      true
+                     has-authority-level  false
+                     has-updated-at       true
+                     collection-id-source :direct
+                     extra-columns        []}}]
+  (let [tbl (name table-key)
+        col #(keyword (str tbl "." (name %)))
+        extra-set (set extra-columns)]
+    (vec
+     (concat
+      ;; Standard columns all models have
+      [(col :id)
+       (col :name)
+       (col :created_at)]
+      ;; Authority level (only Collection has this)
+      [(if has-authority-level (col :authority_level) [nil :authority_level])]
+      ;; Collection ID - varies by source
+      [(case collection-id-source
+         :self     [(col :id) :collection_id]
+         :direct   (col :collection_id)
+         :via-table [:metabase_table.collection_id :collection_id])]
+      ;; Extra columns (display, query_type) - nil if not present
+      [(if (extra-set :display) (col :display) [nil :display])]
+      [(if (extra-set :query_type) (col :query_type) [nil :query_type])]
+      ;; Description
+      [(if has-description (col :description) [nil :description])]
+      ;; Updated at, model label, and sync status
+      [(if has-updated-at (col :updated_at) [nil :updated_at])
+       [[:inline model-label] :model]
+       [:rs_obj.status :sync_status]]))))
+
+;;; --------------------------------------------- Derived Configuration ------------------------------------------------
+
+(def ^:private synced-models
+  "Map of table keyword to model type string.
+   Derived from [[synced-model-configs]]."
+  (into {} (map (fn [[k v]] [k (:model-type v)]) synced-model-configs)))
+
+(def ^:private items-select
+  "Map of table keyword to HoneySQL select clause.
+   Derived from [[synced-model-configs]]."
+  (into {} (map (fn [[k v]] [k (build-select-clause k v)]) synced-model-configs)))
+
+(def ^:private models-requiring-table-join
+  "Set of table keywords that need to join through metabase_table to get collection_id.
+   Derived from [[synced-model-configs]]."
+  (set (keep (fn [[k v]] (when (:table-join v) k)) synced-model-configs)))
+
+;;; ------------------------------------------------ Query Building ----------------------------------------------------
+
+(defn- build-dirty-union-all
+  "Builds a HoneySQL UNION ALL query that returns all dirty objects across all synced model types.
+   Each model gets a SELECT that joins with remote_sync_object and filters for non-synced status."
+  [select-options]
+  (let [queries (mapv (fn [[table entity-type]]
+                        (let [id-col    (keyword (str (name table) ".id"))
+                              base-join [[:remote_sync_object :rs_obj]
+                                         [:and
+                                          [:= :rs_obj.model_id id-col]
+                                          [:= :rs_obj.model_type [:inline entity-type]]]]
+                              ;; Add table join for models that need it (Field, Segment)
+                              full-join (if (models-requiring-table-join table)
+                                          (into base-join
+                                                [[:metabase_table :metabase_table]
+                                                 [:= (keyword (str (name table) ".table_id")) :metabase_table.id]])
+                                          base-join)]
+                          {:select     (select-options table)
+                           :from       [table]
+                           :inner-join full-join
+                           :where      [:not= :status "synced"]}))
+                      synced-models)]
+    {:union-all queries}))
+
+;;; ------------------------------------------------- Public API -------------------------------------------------------
+
+
 (defn dirty-global?
   "Checks if any collection has changes since the last sync.
-
-  Returns true if any remote-synced object has a status other than 'synced', false otherwise."
+   Returns true if any remote-synced object has a status other than 'synced', false otherwise."
   []
   (t2/exists? :model/RemoteSyncObject :status [:not= "synced"]))
 
 (defn dirty-for-global
   "Gets all models in any collection that are dirty with their sync status.
-
-  Returns a sequence of model maps that have changed since the last remote sync, including details about their
-  current state and sync status."
+   Returns a sequence of model maps that have changed since the last remote sync,
+   including details about their current state and sync status."
   []
   (->> (t2/select :model/RemoteSyncObject :status [:not= "synced"])
        (map #(-> %

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/models/remote_sync_object.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/models/remote_sync_object.clj
@@ -87,9 +87,11 @@
    :metabase_field       {:model-type           "Field"
                           :model-label          "field"
                           :table-join           :metabase_table
+                          :extra-columns        [:table_id :table_name]
                           :collection-id-source :via-table}
    :segment              {:model-type           "Segment"
                           :model-label          "segment"
+                          :extra-columns        [:table_id :table_name]
                           :table-join           :metabase_table
                           :collection-id-source :via-table}})
 
@@ -99,7 +101,7 @@
   "Build HoneySQL select clause for a model based on its config.
    Generates the standard set of columns needed for dirty-state queries."
   [table-key {:keys [model-label has-description has-authority-level has-updated-at
-                     collection-id-source extra-columns]
+                     collection-id-source table-join extra-columns]
               :or   {has-description      true
                      has-authority-level  false
                      has-updated-at       true
@@ -124,6 +126,8 @@
       ;; Extra columns (display, query_type) - nil if not present
       [(if (extra-set :display) (col :display) [nil :display])]
       [(if (extra-set :query_type) (col :query_type) [nil :query_type])]
+      [(if (extra-set :table_id) (col :table_id) [[:cast nil :int] :table_id])]
+      [(if (extra-set :table_name) [:metabase_table.name :table_name] [nil :table_name])]
       ;; Description
       [(if has-description (col :description) [nil :description])]
       ;; Updated at, model label, and sync status

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/models/remote_sync_object.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/models/remote_sync_object.clj
@@ -1,55 +1,11 @@
 (ns metabase-enterprise.remote-sync.models.remote-sync-object
   "Model and queries for tracking remote-synced objects and their dirty state.
 
-   ## Adding a New Model to Dirty-State Tracking
-
-   To add a new model to the dirty-state queries (so it appears in the UI
-   when checking for unsynchronized changes), add an entry to [[synced-model-configs]]:
-
-   ```clojure
-   :your_table_name {:model-type \"YourModel\"    ; String stored in RemoteSyncObject.model_type
-                     :model-label \"yourmodel\"}  ; String returned in API results
-   ```
-
-   ### Required Configuration Keys
-
-   - `:model-type` - String used in RemoteSyncObject.model_type column (e.g. \"Card\", \"Dashboard\")
-   - `:model-label` - String label returned in query results (e.g. \"card\", \"dashboard\")
-
-   ### Optional Configuration Keys
-
-   - `:has-description` (default true) - Set to false if model lacks a description column
-   - `:has-authority-level` (default false) - Set to true if model has authority_level column
-   - `:has-updated-at` (default true) - Set to false if model lacks updated_at column
-   - `:extra-columns` - Vector of extra columns to include, e.g. `[:display :query_type]`
-   - `:table-join` - If model gets collection_id through another table, specify that table keyword
-   - `:collection-id-source` - How to get collection_id:
-     - `:direct` (default) - Model has its own collection_id column
-     - `:self` - Use the model's id as collection_id (for Collection model itself)
-     - `:via-table` - Join through `:table-join` table to get collection_id
-
-   ### Example: Model with Direct collection_id
-
-   Most models have a direct collection_id column:
-
-   ```clojure
-   :action {:model-type \"Action\"
-            :model-label \"action\"}
-   ```
-
-   ### Example: Model Needing Table Join
-
-   Some models (like Field, Segment) relate to collections through their parent table:
-
-   ```clojure
-   :dimension {:model-type \"Dimension\"
-               :model-label \"dimension\"
-               :table-join :metabase_field
-               :collection-id-source :via-table}
-   ```"
+   The RemoteSyncObject table stores denormalized information about objects that are
+   tracked for remote synchronization. This includes the object's name, collection_id,
+   and for Field/Segment/Table models, parent table information."
   (:require
    [clojure.set :as set]
-   [metabase.app-db.core :as mdb]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
@@ -59,134 +15,7 @@
 
 (derive :model/RemoteSyncObject :metabase/model)
 
-;;; ------------------------------------------------ Model Configuration ------------------------------------------------
-
-(def ^:private synced-model-configs
-  "Configuration for models tracked in remote-sync dirty state.
-   See namespace docstring for full documentation on adding new models."
-  {:collection           {:model-type           "Collection"
-                          :model-label          "collection"
-                          :has-authority-level  true
-                          :has-description      false
-                          :has-updated-at       false
-                          :collection-id-source :self}
-   :report_card          {:model-type    "Card"
-                          :model-label   "card"
-                          :extra-columns [:display :query_type]}
-   :document             {:model-type      "Document"
-                          :model-label     "document"
-                          :has-description false}
-   :report_dashboard     {:model-type  "Dashboard"
-                          :model-label "dashboard"}
-   :native_query_snippet {:model-type      "NativeQuerySnippet"
-                          :model-label     "snippet"
-                          :has-description false}
-   :timeline             {:model-type  "Timeline"
-                          :model-label "timeline"}
-   :metabase_table       {:model-type  "Table"
-                          :model-label "table"}
-   :metabase_field       {:model-type           "Field"
-                          :model-label          "field"
-                          :table-join           :metabase_table
-                          :extra-columns        [:table_id :table_name]
-                          :collection-id-source :via-table}
-   :segment              {:model-type           "Segment"
-                          :model-label          "segment"
-                          :extra-columns        [:table_id :table_name]
-                          :table-join           :metabase_table
-                          :collection-id-source :via-table}})
-
-;;; -------------------------------------------- Select Clause Generation ----------------------------------------------
-
-(defn- null-integer-column
-  "Return a HoneySQL expression for a NULL integer value that works across databases.
-   MySQL requires CAST(NULL AS SIGNED), while PostgreSQL/H2 use CAST(NULL AS INTEGER)."
-  [alias]
-  (let [int-type (if (= :mysql (mdb/db-type)) :signed :integer)]
-    [[:cast nil int-type] alias]))
-
-(defn- build-select-clause
-  "Build HoneySQL select clause for a model based on its config.
-   Generates the standard set of columns needed for dirty-state queries."
-  [table-key {:keys [model-label has-description has-authority-level has-updated-at
-                     collection-id-source extra-columns]
-              :or   {has-description      true
-                     has-authority-level  false
-                     has-updated-at       true
-                     collection-id-source :direct
-                     extra-columns        []}}]
-  (let [tbl (name table-key)
-        col #(keyword (str tbl "." (name %)))
-        extra-set (set extra-columns)]
-    (vec
-     (concat
-      ;; Standard columns all models have
-      [(col :id)
-       (col :name)
-       (col :created_at)]
-      ;; Authority level (only Collection has this)
-      [(if has-authority-level (col :authority_level) [nil :authority_level])]
-      ;; Collection ID - varies by source
-      [(case collection-id-source
-         :self     [(col :id) :collection_id]
-         :direct   (col :collection_id)
-         :via-table [:metabase_table.collection_id :collection_id])]
-      ;; Extra columns (display, query_type) - nil if not present
-      [(if (extra-set :display) (col :display) [nil :display])]
-      [(if (extra-set :query_type) (col :query_type) [nil :query_type])]
-      [(if (extra-set :table_id) (col :table_id) (null-integer-column :table_id))]
-      [(if (extra-set :table_name) [:metabase_table.name :table_name] [nil :table_name])]
-      ;; Description
-      [(if has-description (col :description) [nil :description])]
-      ;; Updated at, model label, and sync status
-      [(if has-updated-at (col :updated_at) [nil :updated_at])
-       [[:inline model-label] :model]
-       [:rs_obj.status :sync_status]]))))
-
-;;; --------------------------------------------- Derived Configuration ------------------------------------------------
-
-(def ^:private synced-models
-  "Map of table keyword to model type string.
-   Derived from [[synced-model-configs]]."
-  (into {} (map (fn [[k v]] [k (:model-type v)]) synced-model-configs)))
-
-(def ^:private items-select
-  "Map of table keyword to HoneySQL select clause.
-   Derived from [[synced-model-configs]]."
-  (into {} (map (fn [[k v]] [k (build-select-clause k v)]) synced-model-configs)))
-
-(def ^:private models-requiring-table-join
-  "Set of table keywords that need to join through metabase_table to get collection_id.
-   Derived from [[synced-model-configs]]."
-  (set (keep (fn [[k v]] (when (:table-join v) k)) synced-model-configs)))
-
-;;; ------------------------------------------------ Query Building ----------------------------------------------------
-
-(defn- build-dirty-union-all
-  "Builds a HoneySQL UNION ALL query that returns all dirty objects across all synced model types.
-   Each model gets a SELECT that joins with remote_sync_object and filters for non-synced status."
-  [select-options]
-  (let [queries (mapv (fn [[table entity-type]]
-                        (let [id-col    (keyword (str (name table) ".id"))
-                              base-join [[:remote_sync_object :rs_obj]
-                                         [:and
-                                          [:= :rs_obj.model_id id-col]
-                                          [:= :rs_obj.model_type [:inline entity-type]]]]
-                              ;; Add table join for models that need it (Field, Segment)
-                              full-join (if (models-requiring-table-join table)
-                                          (into base-join
-                                                [[:metabase_table :metabase_table]
-                                                 [:= (keyword (str (name table) ".table_id")) :metabase_table.id]])
-                                          base-join)]
-                          {:select     (select-options table)
-                           :from       [table]
-                           :inner-join full-join
-                           :where      [:not= :status "synced"]}))
-                      synced-models)]
-    {:union-all queries}))
-
 ;;; ------------------------------------------------- Public API -------------------------------------------------------
-
 
 (defn dirty-global?
   "Checks if any collection has changes since the last sync.
@@ -201,11 +30,13 @@
   []
   (->> (t2/select :model/RemoteSyncObject :status [:not= "synced"])
        (map #(-> %
-                 (dissoc :id)
+                 (dissoc :id :status_changed_at)
                  (set/rename-keys {:model_id :id
                                    :model_name :name
                                    :model_type :model
                                    :model_collection_id :collection_id
                                    :model_display :display
+                                   :model_table_id :table_id
+                                   :model_table_name :table_name
                                    :status :sync_status})))
        (into [])))

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/models/remote_sync_object.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/models/remote_sync_object.clj
@@ -6,6 +6,7 @@
    and for Field/Segment/Table models, parent table information."
   (:require
    [clojure.set :as set]
+   [metabase.util :as u]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
@@ -19,14 +20,14 @@
 
 (defn dirty-global?
   "Checks if any collection has changes since the last sync.
-   Returns true if any remote-synced object has a status other than 'synced', false otherwise."
+  Returns true if any remote-synced object has a status other than 'synced', false otherwise."
   []
   (t2/exists? :model/RemoteSyncObject :status [:not= "synced"]))
 
 (defn dirty-for-global
   "Gets all models in any collection that are dirty with their sync status.
-   Returns a sequence of model maps that have changed since the last remote sync,
-   including details about their current state and sync status."
+  Returns a sequence of model maps that have changed since the last remote sync,
+  including details about their current state and sync status."
   []
   (->> (t2/select :model/RemoteSyncObject :status [:not= "synced"])
        (map #(-> %
@@ -38,5 +39,6 @@
                                    :model_display :display
                                    :model_table_id :table_id
                                    :model_table_name :table_name
-                                   :status :sync_status})))
+                                   :status :sync_status})
+                 (update :model u/lower-case-en)))
        (into [])))

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/schema.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/schema.clj
@@ -41,7 +41,9 @@
    [:authority_level {:optional true} [:maybe :string]]
    [:display {:optional true} [:maybe :string]]
    [:query_type {:optional true} [:maybe :string]]
-   [:description {:optional true} [:maybe :string]]])
+   [:description {:optional true} [:maybe :string]]
+   [:table_id {:optional true} [:maybe pos-int?]]
+   [:table_name {:optional true} [:maybe :string]]])
 
 ;;; ------------------------------------------- API Response Schemas -------------------------------------------
 

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
@@ -178,10 +178,11 @@
             coll-set        (get by-model "Collection")
             ;; When targets are specified, also include Tables found via descendants
             ;; (published tables in target collections). These are extracted by ID, not all.
-            targeted-tables (when (seq targets) (get by-model "Table"))
+            targeted-data-model (when (seq targets)
+                                  (select-keys by-model serdes.models/data-model-in-collection))
             by-model        (cond-> (select-keys by-model models)
                               ;; Add Tables back if they were found in descendants
-                              (seq targeted-tables) (assoc "Table" targeted-tables)
+                              (seq targeted-data-model) (merge targeted-data-model)
                               ;; Remove analytics cards from extraction - they have stable entity_ids across instances
                               ;; so cards that reference them can still be exported and imported correctly
                               (and analytics-card-ids (contains? by-model "Card"))

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
@@ -11,6 +11,13 @@
    "Table"
    "Channel"])
 
+(def data-model-in-collection
+  "Data model types that can be found in collections (via published tables).
+   These are extracted by ID when discovered via descendants, even if no-data-model is set."
+  ["Table"
+   "Field"
+   "Segment"])
+
 (def content
   "Content model types"
   ["Action"

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/events_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/events_test.clj
@@ -1039,9 +1039,9 @@
                 (first table-entries))))))
   (testing "unpublished tables are not tracked when collection becomes remote-synced"
     (mt/with-temp [:model/Collection collection {:name "Soon Remote-Sync"}
-                   :model/Table table {:name "Test Table"
-                                       :is_published false
-                                       :collection_id (:id collection)}]
+                   :model/Table _ {:name "Test Table"
+                                   :is_published false
+                                   :collection_id (:id collection)}]
       (t2/delete! :model/RemoteSyncObject)
       ;; Make collection remote-synced
       (events/publish-event! :event/collection-update

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/events_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/events_test.clj
@@ -973,6 +973,9 @@
       ;; First, create an entry with status "synced" directly
       (t2/insert! :model/RemoteSyncObject {:model_type "Table"
                                            :model_id (:id table)
+                                           :model_name "Test Table"
+                                           :model_table_id (:id table)
+                                           :model_table_name "Test Table"
                                            :status "synced"
                                            :status_changed_at (t/offset-date-time)})
       (let [initial-entry (t2/select-one :model/RemoteSyncObject :model_type "Table" :model_id (:id table))]
@@ -995,6 +998,9 @@
       ;; First, create an entry with status "synced" directly
       (t2/insert! :model/RemoteSyncObject {:model_type "Table"
                                            :model_id (:id table)
+                                           :model_name "Test Table"
+                                           :model_table_id (:id table)
+                                           :model_table_name "Test Table"
                                            :status "synced"
                                            :status_changed_at (t/offset-date-time)})
       (let [initial-entry (t2/select-one :model/RemoteSyncObject :model_type "Table" :model_id (:id table))]
@@ -1205,6 +1211,9 @@
       ;; First create a synced entry
       (t2/insert! :model/RemoteSyncObject {:model_type "Segment"
                                            :model_id (:id segment)
+                                           :model_name "Test Segment"
+                                           :model_table_id (:id table)
+                                           :model_table_name "Test Table"
                                            :status "synced"
                                            :status_changed_at (t/offset-date-time)})
       (let [initial-entry (t2/select-one :model/RemoteSyncObject :model_type "Segment" :model_id (:id segment))]
@@ -1289,6 +1298,9 @@
       ;; First create a synced entry
       (t2/insert! :model/RemoteSyncObject {:model_type "Field"
                                            :model_id (:id field)
+                                           :model_name "test_field"
+                                           :model_table_id (:id table)
+                                           :model_table_name "Test Table"
                                            :status "synced"
                                            :status_changed_at (t/offset-date-time)})
       (let [initial-entry (t2/select-one :model/RemoteSyncObject :model_type "Field" :model_id (:id field))]

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
@@ -888,4 +888,3 @@
                             :model_id table-id
                             :status "synced")
                 "Table with schema should be tracked in RemoteSyncObject")))))))
-

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
@@ -810,11 +810,10 @@
         (mt/with-temp [:model/Database {db-id :id} {:name "test-db"}
                        :model/Table {table-id :id} {:name "test-table" :db_id db-id}
                        :model/Field {field-id :id} {:name "test-field" :table_id table-id :base_type :type/Text}
-                       :model/Collection {coll-id :id}
-                       {:name "Test Collection"
-                        :is_remote_synced true
-                        :entity_id "test-collection-1xxxx"
-                        :location "/"}]
+                       :model/Collection _ {:name "Test Collection"
+                                            :is_remote_synced true
+                                            :entity_id "test-collection-1xxxx"
+                                            :location "/"}]
           (let [test-files {"main" {"collections/test-collection-1xxxx-_/test-collection-1xxxx.yaml"
                                     (test-helpers/generate-collection-yaml "test-collection-1xxxx" "Test Collection")
                                     "databases/test-db/tables/test-table/fields/test-field.yaml"
@@ -836,11 +835,10 @@
         (mt/with-temp [:model/Database {db-id :id} {:name "test-db"}
                        :model/Table {table-id :id} {:name "test-table" :db_id db-id}
                        :model/Field {field-id :id} {:name "test-field" :table_id table-id :base_type :type/Integer}
-                       :model/Collection {coll-id :id}
-                       {:name "Test Collection"
-                        :is_remote_synced true
-                        :entity_id "test-collection-1xxxx"
-                        :location "/"}
+                       :model/Collection _ {:name "Test Collection"
+                                            :is_remote_synced true
+                                            :entity_id "test-collection-1xxxx"
+                                            :location "/"}
                        :model/Segment {segment-id :id}
                        {:name "Test Segment"
                         :table_id table-id
@@ -873,11 +871,10 @@
       (let [task-id (t2/insert-returning-pk! :model/RemoteSyncTask {:sync_task_type "import" :initiated_by (mt/user->id :rasta)})]
         (mt/with-temp [:model/Database {db-id :id} {:name "test-db"}
                        :model/Table {table-id :id} {:name "test-table" :db_id db-id :schema "PUBLIC"}
-                       :model/Collection {coll-id :id}
-                       {:name "Test Collection"
-                        :is_remote_synced true
-                        :entity_id "test-collection-1xxxx"
-                        :location "/"}]
+                       :model/Collection _ {:name "Test Collection"
+                                            :is_remote_synced true
+                                            :entity_id "test-collection-1xxxx"
+                                            :location "/"}]
           (let [test-files {"main" {"collections/test-collection-1xxxx-_/test-collection-1xxxx.yaml"
                                     (test-helpers/generate-collection-yaml "test-collection-1xxxx" "Test Collection")
                                     "databases/test-db/schemas/PUBLIC/tables/test-table/test-table.yaml"

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/models/remote_sync_object_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/models/remote_sync_object_test.clj
@@ -373,7 +373,7 @@
         (let [item (first dirty-items)]
           (is (= (:id table) (:id item)))
           (is (= "Test Table" (:name item)))
-          (is (= "Table" (:model item)))
+          (is (= "table" (:model item)))
           (is (= "pending" (:sync_status item)))
           ;; For tables, table_id and table_name refer to themselves
           (is (= (:id table) (:table_id item)))
@@ -404,7 +404,7 @@
         (let [item (first dirty-items)]
           (is (= (:id field) (:id item)))
           (is (= "test_field" (:name item)))
-          (is (= "Field" (:model item)))
+          (is (= "field" (:model item)))
           (is (= "update" (:sync_status item)))
           ;; collection_id should come from the parent table
           (is (= (:id collection) (:collection_id item)))
@@ -442,7 +442,7 @@
         (let [item (first dirty-items)]
           (is (= (:id segment) (:id item)))
           (is (= "Test Segment" (:name item)))
-          (is (= "Segment" (:model item)))
+          (is (= "segment" (:model item)))
           (is (= "create" (:sync_status item)))
           ;; collection_id should come from the parent table
           (is (= (:id collection) (:collection_id item)))
@@ -534,4 +534,4 @@
       (let [dirty-items (rs-object/dirty-for-global)
             models (set (map :model dirty-items))]
         (is (= 8 (count dirty-items)))
-        (is (= #{"Collection" "Card" "Dashboard" "Document" "NativeQuerySnippet" "Table" "Field" "Segment"} models))))))
+        (is (= #{"collection" "card" "dashboard" "document" "nativequerysnippet" "table" "field" "segment"} models))))))

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/test_helpers.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/test_helpers.clj
@@ -318,3 +318,196 @@ width: fixed
 (def clean-remote-sync-state
   "Fixture to make sure sync state is clean"
   (t/compose-fixtures clean-object clean-task-table))
+
+(defn generate-table-yaml
+  "Generates YAML content for a table.
+
+  Args:
+    table-name: The name of the table (used as entity_id).
+    db-name: The name of the database containing this table.
+
+  Returns:
+    A string containing the YAML representation of the table."
+  [table-name db-name & {:keys [schema is-published description]
+                         :or {is-published true
+                              description nil}}]
+  (format "name: %s
+description: %s
+entity_type: entity/GenericTable
+active: true
+display_name: %s
+visibility_type: null
+schema: %s
+points_of_interest: null
+caveats: null
+show_in_getting_started: false
+field_order: database
+initial_sync_status: complete
+is_upload: false
+database_require_filter: false
+is_defective_duplicate: false
+is_writable: false
+data_authority: unconfigured
+data_source: null
+owner_email: null
+owner_user_id: null
+is_published: %s
+created_at: '2024-08-28T09:46:18.671622Z'
+archived_at: null
+deactivated_at: null
+data_layer: null
+db_id: %s
+collection_id: null
+serdes/meta:
+- id: %s
+  model: Database
+%s- id: %s
+  model: Table
+"
+          table-name
+          (or description "null")
+          (str/replace (u/upper-case-en table-name) #"_" " ")
+          (or schema "null")
+          is-published
+          db-name
+          db-name
+          (if schema (format "- id: %s\n  model: Schema\n" schema) "")
+          table-name))
+
+(defn generate-field-yaml
+  "Generates YAML content for a field.
+
+  Args:
+    field-name: The name of the field (used as entity_id).
+    table-name: The name of the table containing this field.
+    db-name: The name of the database containing this field.
+
+  Returns:
+    A string containing the YAML representation of the field."
+  [field-name table-name db-name & {:keys [schema base-type description database-type]
+                                    :or {base-type "type/Text"
+                                         database-type "VARCHAR"
+                                         description nil}}]
+  (format "name: %s
+display_name: %s
+description: %s
+created_at: '2024-08-28T09:46:18.671622Z'
+active: true
+visibility_type: normal
+table_id:
+- %s
+- %s
+- %s
+database_type: %s
+base_type: %s
+effective_type: null
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
+coercion_strategy: null
+preview_display: true
+position: 1
+custom_position: 0
+database_position: 0
+has_field_values: null
+settings: null
+caveats: null
+points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: %s
+  model: Database
+%s- id: %s
+  model: Table
+- id: %s
+  model: Field
+database_default: null
+database_indexed: null
+database_is_generated: null
+database_is_nullable: null
+database_is_pk: null
+database_partitioned: null
+"
+          field-name
+          (str/replace (u/upper-case-en field-name) #"_" " ")
+          (or description "null")
+          db-name
+          (or schema "null")
+          table-name
+          database-type
+          base-type
+          db-name
+          (if schema (format "- id: %s\n  model: Schema\n" schema) "")
+          table-name
+          field-name))
+
+(defn generate-segment-yaml
+  "Generates YAML content for a segment.
+
+  Args:
+    segment-name: The name of the segment (used as entity_id).
+    table-name: The name of the table containing this segment.
+    db-name: The name of the database containing this segment.
+    filter-field-name: The name of the field to use in the filter clause.
+
+  Returns:
+    A string containing the YAML representation of the segment."
+  [segment-name table-name db-name & {:keys [schema description entity-id filter-field-name]
+                                      :or {description "Test segment"
+                                           filter-field-name "Some Field"}}]
+  (let [eid (or entity-id segment-name)]
+    (format "archived: false
+caveats: null
+created_at: '2024-08-28T09:46:18.671622Z'
+creator_id: rasta@metabase.com
+definition:
+  database: %s
+  query:
+    filter:
+    - <
+    - - field
+      - - %s
+        - %s
+        - %s
+        - %s
+      - null
+    - 18
+    source-table:
+    - %s
+    - %s
+    - %s
+  type: query
+description: %s
+entity_id: %s
+name: %s
+points_of_interest: null
+show_in_getting_started: false
+table_id:
+- %s
+- %s
+- %s
+serdes/meta:
+- id: %s
+  label: %s
+  model: Segment
+"
+            db-name
+            db-name
+            (or schema "null")
+            table-name
+            filter-field-name
+            db-name
+            (or schema "null")
+            table-name
+            description
+            eid
+            segment-name
+            db-name
+            (or schema "null")
+            table-name
+            eid
+            (str/replace (u/lower-case-en segment-name) #"\s+" "_"))))

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/CreateMenu.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/CreateMenu.tsx
@@ -18,8 +18,10 @@ import { PublishTableModal } from "./PublishTableModal";
 
 export const CreateMenu = ({
   metricCollectionId,
+  canWriteToMetricCollection,
 }: {
   metricCollectionId?: CollectionId;
+  canWriteToMetricCollection?: boolean;
 }) => {
   const dispatch = useDispatch();
   const [modal, setModal] = useState<"snippet-folder" | "publish-table">();
@@ -29,7 +31,8 @@ export const CreateMenu = ({
   const hasNativeWrite = useSelector(canUserCreateNativeQueries);
   const hasDataAccess = useSelector(canUserCreateQueries);
 
-  const canCreateMetric = hasDataAccess && metricCollectionId;
+  const canCreateMetric =
+    hasDataAccess && metricCollectionId && canWriteToMetricCollection;
 
   const menuItems = [
     isAdmin && (

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/LibrarySectionLayout.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/LibrarySectionLayout.tsx
@@ -77,23 +77,32 @@ export function LibrarySectionLayout() {
     useSetting("remote-sync-enabled"),
   );
 
-  const libraryCollection = collections.find(isLibraryCollection);
+  const libraryCollection = useMemo(
+    () => collections.find(isLibraryCollection),
+    [collections],
+  );
 
-  const tableCollection =
-    libraryCollection &&
-    getAccessibleCollection(
-      libraryCollection,
-      "library-data",
-      isInstanceRemoteSyncEnabled,
-    );
+  const tableCollection = useMemo(
+    () =>
+      libraryCollection &&
+      getAccessibleCollection(
+        libraryCollection,
+        "library-data",
+        isInstanceRemoteSyncEnabled,
+      ),
+    [libraryCollection, isInstanceRemoteSyncEnabled],
+  );
 
-  const metricCollection =
-    libraryCollection &&
-    getAccessibleCollection(
-      libraryCollection,
-      "library-metrics",
-      isInstanceRemoteSyncEnabled,
-    );
+  const metricCollection = useMemo(
+    () =>
+      libraryCollection &&
+      getAccessibleCollection(
+        libraryCollection,
+        "library-metrics",
+        isInstanceRemoteSyncEnabled,
+      ),
+    [libraryCollection, isInstanceRemoteSyncEnabled],
+  );
 
   const handleItemSelect = useCallback(
     (item: TreeItem) => {
@@ -132,8 +141,10 @@ export function LibrarySectionLayout() {
   const isLoading = loadingTables || loadingMetrics || loadingSnippets;
   useErrorHandling(tablesError || metricsError || snippetsError);
 
-  const libraryHasContent = combinedTree.some(
-    (node) => node.children && node.children.length > 0,
+  const libraryHasContent = useMemo(
+    () =>
+      combinedTree.some((node) => node.children && node.children.length > 0),
+    [combinedTree],
   );
 
   const libraryColumnDef = useMemo<TreeTableColumnDef<TreeItem>[]>(

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/LibrarySectionLayout.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/LibrarySectionLayout.tsx
@@ -6,6 +6,7 @@ import _ from "underscore";
 import { useListCollectionsTreeQuery } from "metabase/api";
 import { isLibraryCollection } from "metabase/collections/utils";
 import DateTime from "metabase/common/components/DateTime";
+import { useSetting } from "metabase/common/hooks";
 import { usePageTitle } from "metabase/hooks/use-page-title";
 import { useDispatch } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
@@ -40,7 +41,7 @@ import {
   useErrorHandling,
 } from "./hooks";
 import { type TreeItem, isCollection } from "./types";
-import { getWritableCollection } from "./utils";
+import { getAccessibleCollection } from "./utils";
 
 export function LibrarySectionLayout() {
   usePageTitle(t`Library`);
@@ -72,15 +73,27 @@ export function LibrarySectionLayout() {
       "include-library": true,
     });
 
+  const isInstanceRemoteSyncEnabled = Boolean(
+    useSetting("remote-sync-enabled"),
+  );
+
   const libraryCollection = collections.find(isLibraryCollection);
 
   const tableCollection =
     libraryCollection &&
-    getWritableCollection(libraryCollection, "library-data");
+    getAccessibleCollection(
+      libraryCollection,
+      "library-data",
+      isInstanceRemoteSyncEnabled,
+    );
 
   const metricCollection =
     libraryCollection &&
-    getWritableCollection(libraryCollection, "library-metrics");
+    getAccessibleCollection(
+      libraryCollection,
+      "library-metrics",
+      isInstanceRemoteSyncEnabled,
+    );
 
   const handleItemSelect = useCallback(
     (item: TreeItem) => {
@@ -238,7 +251,10 @@ export function LibrarySectionLayout() {
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
             />
-            <CreateMenu metricCollectionId={metricCollection?.id} />
+            <CreateMenu
+              metricCollectionId={metricCollection?.id}
+              canWriteToMetricCollection={metricCollection?.can_write}
+            />
           </Flex>
           <Card withBorder p={0}>
             {isLoading ? (

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/utils.ts
@@ -83,3 +83,25 @@ export function getWritableCollection(
   );
   return collection?.can_write ? collection : undefined;
 }
+
+export function getAccessibleCollection(
+  rootCollection: Collection,
+  type: CollectionType,
+  isInstanceRemoteSyncEnabled: boolean,
+) {
+  const collection = rootCollection.children?.find(
+    (collection) => collection.type === type,
+  );
+  if (!collection) {
+    return undefined;
+  }
+
+  // If instance remote-sync is enabled AND this collection has remote-sync enabled,
+  // show it even if read-only. Otherwise, only show writable collections.
+  const isCollectionRemoteSynced =
+    isInstanceRemoteSyncEnabled && collection.is_remote_synced;
+  if (isCollectionRemoteSynced) {
+    return collection;
+  }
+  return collection.can_write ? collection : undefined;
+}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/utils.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/utils.unit.spec.ts
@@ -1,0 +1,203 @@
+import { createMockCollection } from "metabase-types/api/mocks";
+
+import { getAccessibleCollection, getWritableCollection } from "./utils";
+
+describe("getWritableCollection", () => {
+  it("returns collection when can_write is true", () => {
+    const childCollection = createMockCollection({
+      id: 2,
+      type: "library-data",
+      can_write: true,
+    });
+    const rootCollection = createMockCollection({
+      id: 1,
+      children: [childCollection],
+    });
+
+    const result = getWritableCollection(rootCollection, "library-data");
+
+    expect(result).toEqual(childCollection);
+  });
+
+  it("returns undefined when can_write is false", () => {
+    const childCollection = createMockCollection({
+      id: 2,
+      type: "library-data",
+      can_write: false,
+    });
+    const rootCollection = createMockCollection({
+      id: 1,
+      children: [childCollection],
+    });
+
+    const result = getWritableCollection(rootCollection, "library-data");
+
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when collection type does not exist", () => {
+    const childCollection = createMockCollection({
+      id: 2,
+      type: "library-metrics",
+      can_write: true,
+    });
+    const rootCollection = createMockCollection({
+      id: 1,
+      children: [childCollection],
+    });
+
+    const result = getWritableCollection(rootCollection, "library-data");
+
+    expect(result).toBeUndefined();
+  });
+});
+
+describe("getAccessibleCollection", () => {
+  describe("when instance remote-sync is disabled", () => {
+    const isInstanceRemoteSyncEnabled = false;
+
+    it("returns collection when can_write is true", () => {
+      const childCollection = createMockCollection({
+        id: 2,
+        type: "library-data",
+        can_write: true,
+        is_remote_synced: false,
+      });
+      const rootCollection = createMockCollection({
+        id: 1,
+        children: [childCollection],
+      });
+
+      const result = getAccessibleCollection(
+        rootCollection,
+        "library-data",
+        isInstanceRemoteSyncEnabled,
+      );
+
+      expect(result).toEqual(childCollection);
+    });
+
+    it("returns undefined when can_write is false even if collection is remote synced", () => {
+      const childCollection = createMockCollection({
+        id: 2,
+        type: "library-data",
+        can_write: false,
+        is_remote_synced: true,
+      });
+      const rootCollection = createMockCollection({
+        id: 1,
+        children: [childCollection],
+      });
+
+      const result = getAccessibleCollection(
+        rootCollection,
+        "library-data",
+        isInstanceRemoteSyncEnabled,
+      );
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("when instance remote-sync is enabled", () => {
+    const isInstanceRemoteSyncEnabled = true;
+
+    it("returns collection when can_write is true (regardless of is_remote_synced)", () => {
+      const childCollection = createMockCollection({
+        id: 2,
+        type: "library-data",
+        can_write: true,
+        is_remote_synced: false,
+      });
+      const rootCollection = createMockCollection({
+        id: 1,
+        children: [childCollection],
+      });
+
+      const result = getAccessibleCollection(
+        rootCollection,
+        "library-data",
+        isInstanceRemoteSyncEnabled,
+      );
+
+      expect(result).toEqual(childCollection);
+    });
+
+    it("returns collection when can_write is false but collection is remote synced", () => {
+      const childCollection = createMockCollection({
+        id: 2,
+        type: "library-data",
+        can_write: false,
+        is_remote_synced: true,
+      });
+      const rootCollection = createMockCollection({
+        id: 1,
+        children: [childCollection],
+      });
+
+      const result = getAccessibleCollection(
+        rootCollection,
+        "library-data",
+        isInstanceRemoteSyncEnabled,
+      );
+
+      expect(result).toEqual(childCollection);
+    });
+
+    it("returns undefined when can_write is false and collection is not remote synced", () => {
+      const childCollection = createMockCollection({
+        id: 2,
+        type: "library-data",
+        can_write: false,
+        is_remote_synced: false,
+      });
+      const rootCollection = createMockCollection({
+        id: 1,
+        children: [childCollection],
+      });
+
+      const result = getAccessibleCollection(
+        rootCollection,
+        "library-data",
+        isInstanceRemoteSyncEnabled,
+      );
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  it("returns undefined when collection type does not exist", () => {
+    const childCollection = createMockCollection({
+      id: 2,
+      type: "library-metrics",
+      can_write: true,
+    });
+    const rootCollection = createMockCollection({
+      id: 1,
+      children: [childCollection],
+    });
+
+    const result = getAccessibleCollection(
+      rootCollection,
+      "library-data",
+      true,
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when root collection has no children", () => {
+    const rootCollection = createMockCollection({
+      id: 1,
+      children: undefined,
+    });
+
+    const result = getAccessibleCollection(
+      rootCollection,
+      "library-data",
+      true,
+    );
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/common/hooks/use-load-table-with-metadata/use-load-table-with-metadata.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/common/hooks/use-load-table-with-metadata/use-load-table-with-metadata.ts
@@ -23,18 +23,12 @@ export function useLoadTableWithMetadata(
     isLoading,
     error,
   } = useGetTableQueryMetadataQuery(
-    tableId != null
-      ? { id: tableId, include_editable_data_model: true }
-      : skipToken,
+    tableId != null ? { id: tableId } : skipToken,
   );
 
   useEffect(() => {
     if (includeForeignTables && table) {
-      dispatch(
-        fetchForeignTablesMetadata(table, {
-          include_editable_data_model: true,
-        }),
-      );
+      dispatch(fetchForeignTablesMetadata(table));
     }
   }, [dispatch, table, includeForeignTables]);
 

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/SearchNew.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/SearchNew.tsx
@@ -115,10 +115,9 @@ export function SearchNew({
   });
   const { data: databases, isLoading: isLoadingDatabases } =
     useListDatabasesQuery();
-  const { isExpanded: getIsExpanded, toggle } = useExpandedState(
-    {
-      defaultExpanded: true,
-    },
+  const { isExpanded, toggle } = useExpandedState(
+    {},
+    { defaultExpanded: true },
   );
 
   const allowedDatabaseIds = useMemo(

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/SearchNew.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/SearchNew.tsx
@@ -114,9 +114,8 @@ export function SearchNew({
     "unused-only": filters.unusedOnly === true ? true : undefined,
   });
   const { data: databases, isLoading: isLoadingDatabases } =
-    useListDatabasesQuery({ include_editable_data_model: true });
-  const { isExpanded, toggle } = useExpandedState(
-    {},
+    useListDatabasesQuery();
+  const { isExpanded: getIsExpanded, toggle } = useExpandedState(
     {
       defaultExpanded: true,
     },

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/hooks/useTableLoader.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/hooks/useTableLoader.ts
@@ -43,10 +43,7 @@ export function useTableLoader() {
   const [isInitialLoading, setIsInitialLoading] = useState(true);
 
   const getDatabases = useCallback(async () => {
-    const response = await fetchDatabases(
-      { include_editable_data_model: true },
-      true,
-    );
+    const response = await fetchDatabases({}, true);
     if (databasesRef.current.isError) {
       // Do not refetch when this call failed previously.
       // This is to prevent infinite data-loading loop as RTK query does not cache error responses.
@@ -77,7 +74,6 @@ export function useTableLoader() {
         id: databaseId,
         schema: schemaName,
         include_hidden: true,
-        include_editable_data_model: true,
       };
 
       if (
@@ -115,7 +111,6 @@ export function useTableLoader() {
       const newArgs = {
         id: databaseId,
         include_hidden: true,
-        include_editable_data_model: true,
       };
 
       if (

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/pages/DataModel/DataModel.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/pages/DataModel/DataModel.tsx
@@ -83,7 +83,7 @@ function DataModelContent({ params }: Props) {
     data: databasesData,
     error: databasesError,
     isLoading: isLoadingDatabases,
-  } = useListDatabasesQuery({ include_editable_data_model: true });
+  } = useListDatabasesQuery();
   const databaseExists = databasesData?.data?.some(
     (database) => database.id === databaseId,
   );

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/segments/pages/NewSegmentPage/NewSegmentPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/segments/pages/NewSegmentPage/NewSegmentPage.tsx
@@ -40,7 +40,7 @@ export function NewSegmentPage({
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [definition, setDefinition] = useState<DatasetQuery | null>(null);
-  const [hasSaved, setHasSaved] = useState(false);
+  const [savedSegment, setSavedSegment] = useState<Segment | null>(null);
 
   const isInitialized = useRef(false);
 
@@ -54,7 +54,8 @@ export function NewSegmentPage({
   const { query, filters } = useSegmentQuery(definition, metadata);
 
   const isDirty =
-    name.trim().length > 0 || description.length > 0 || filters.length > 0;
+    !savedSegment &&
+    (name.trim().length > 0 || description.length > 0 || filters.length > 0);
   const isValid = name.trim().length > 0 && filters.length > 0;
   const previewUrl =
     filters.length > 0 ? getDatasetQueryPreviewUrl(definition) : undefined;
@@ -79,9 +80,8 @@ export function NewSegmentPage({
     if (error) {
       sendErrorToast(t`Failed to create segment`);
     } else if (segment) {
-      setHasSaved(true);
+      setSavedSegment(segment);
       sendSuccessToast(t`Segment created`);
-      dispatch(push(getSuccessUrl(segment)));
     }
   }, [
     table,
@@ -90,11 +90,15 @@ export function NewSegmentPage({
     description,
     isValid,
     createSegment,
-    dispatch,
-    getSuccessUrl,
     sendSuccessToast,
     sendErrorToast,
   ]);
+
+  useEffect(() => {
+    if (savedSegment) {
+      dispatch(push(getSuccessUrl(savedSegment)));
+    }
+  }, [savedSegment, dispatch, getSuccessUrl]);
 
   return (
     <PageContainer data-testid="new-segment-page" gap="xl">
@@ -121,10 +125,7 @@ export function NewSegmentPage({
         onQueryChange={setQuery}
         onDescriptionChange={setDescription}
       />
-      <LeaveRouteConfirmModal
-        route={route}
-        isEnabled={isDirty && !isSaving && !hasSaved}
-      />
+      <LeaveRouteConfirmModal route={route} isEnabled={isDirty && !isSaving} />
     </PageContainer>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/segments/pages/NewSegmentPage/NewSegmentPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/segments/pages/NewSegmentPage/NewSegmentPage.tsx
@@ -40,6 +40,7 @@ export function NewSegmentPage({
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [definition, setDefinition] = useState<DatasetQuery | null>(null);
+  const [hasSaved, setHasSaved] = useState(false);
 
   const isInitialized = useRef(false);
 
@@ -78,6 +79,7 @@ export function NewSegmentPage({
     if (error) {
       sendErrorToast(t`Failed to create segment`);
     } else if (segment) {
+      setHasSaved(true);
       sendSuccessToast(t`Segment created`);
       dispatch(push(getSuccessUrl(segment)));
     }
@@ -119,7 +121,10 @@ export function NewSegmentPage({
         onQueryChange={setQuery}
         onDescriptionChange={setDescription}
       />
-      <LeaveRouteConfirmModal route={route} isEnabled={isDirty && !isSaving} />
+      <LeaveRouteConfirmModal
+        route={route}
+        isEnabled={isDirty && !isSaving && !hasSaved}
+      />
     </PageContainer>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/segments/pages/NewSegmentPage/NewSegmentPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/segments/pages/NewSegmentPage/NewSegmentPage.unit.spec.tsx
@@ -252,4 +252,35 @@ describe("NewSegmentPage", () => {
       screen.queryByText("Add filters to narrow your answer"),
     ).not.toBeInTheDocument();
   });
+
+  it("does not show discard changes modal after successful save", async () => {
+    const createdSegment = createMockSegment({
+      id: 123,
+      name: "High Value Orders",
+      table_id: TEST_TABLE.id,
+    });
+
+    fetchMock.post("path:/api/segment", createdSegment);
+
+    const { history, successUrl } = setup();
+
+    await userEvent.type(
+      screen.getByPlaceholderText("New segment"),
+      "High Value Orders",
+    );
+
+    await addFilter();
+
+    const saveButton = screen.getByRole("button", { name: "Save" });
+    await userEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(history?.getCurrentLocation().pathname).toBe(
+        `${successUrl}/${createdSegment.id}`,
+      );
+    });
+
+    // The "Discard your changes?" modal should NOT appear after a successful save
+    expect(screen.queryByText("Discard your changes?")).not.toBeInTheDocument();
+  });
 });

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/ChangesLists/AllChangesView.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/ChangesLists/AllChangesView.tsx
@@ -182,7 +182,7 @@ export const AllChangesView = ({ entities, title }: AllChangesViewProps) => {
                     p="sm"
                     gap="sm"
                     mb={hasItems ? "0.75rem" : 0}
-                    bg="bg-light"
+                    bg="background-secondary"
                     bdrs="md"
                   >
                     <Icon

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/ChangesLists/AllChangesView.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/ChangesLists/AllChangesView.tsx
@@ -234,7 +234,7 @@ export const AllChangesView = ({ entities, title }: AllChangesViewProps) => {
                               mt="0.75rem"
                               style={{
                                 borderLeft:
-                                  "2px solid var(--mb-color-border-light)",
+                                  "2px solid var(--mb-color-border-subtle)",
                               }}
                             >
                               {tableGroup.children.map((child) => (

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/ChangesLists/EntityLink.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/ChangesLists/EntityLink.tsx
@@ -27,10 +27,8 @@ interface EntityLinkProps {
 
 export const EntityLink = ({ entity }: EntityLinkProps) => {
   const entityIcon = useMemo(() => {
-    // Handle models that aren't in IconModel (like "field")
-    const customIcon = SYNC_ENTITY_ICON_MAP[entity.model];
-    if (customIcon) {
-      return { name: customIcon };
+    if (entity.model === "field") {
+      return { name: "field" };
     }
 
     return getIcon({

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/ChangesLists/EntityLink.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/ChangesLists/EntityLink.tsx
@@ -1,24 +1,44 @@
 import { useMemo } from "react";
 
-import { getIcon } from "metabase/lib/icon";
+import { type IconModel, getIcon } from "metabase/lib/icon";
 import { modelToUrl } from "metabase/lib/urls";
+import type { IconName } from "metabase/ui";
 import { Anchor, Group, Icon } from "metabase/ui";
-import type { RemoteSyncEntity } from "metabase-types/api";
+import type {
+  RemoteSyncEntity,
+  RemoteSyncEntityModel,
+} from "metabase-types/api";
 
 import { getSyncStatusColor, getSyncStatusIcon } from "../../utils";
 
 import S from "./EntityLink.module.css";
+
+/**
+ * Map of sync entity models to their icon names.
+ * Used for models not covered by the standard getIcon function.
+ */
+const SYNC_ENTITY_ICON_MAP: Partial<Record<RemoteSyncEntityModel, IconName>> = {
+  field: "field",
+};
 
 interface EntityLinkProps {
   entity: RemoteSyncEntity;
 }
 
 export const EntityLink = ({ entity }: EntityLinkProps) => {
-  const entityIcon = getIcon({
-    model: entity.model,
-    id: entity.id,
-    display: entity.display,
-  });
+  const entityIcon = useMemo(() => {
+    // Handle models that aren't in IconModel (like "field")
+    const customIcon = SYNC_ENTITY_ICON_MAP[entity.model];
+    if (customIcon) {
+      return { name: customIcon };
+    }
+
+    return getIcon({
+      model: entity.model as IconModel,
+      id: entity.id,
+      display: entity.display,
+    });
+  }, [entity]);
 
   const url = useMemo(() => modelToUrl(entity), [entity]);
   if (url == null) {

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/ChangesLists/EntityLink.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/ChangesLists/EntityLink.tsx
@@ -1,32 +1,20 @@
 import { useMemo } from "react";
 
-import { type IconModel, getIcon } from "metabase/lib/icon";
+import { type IconData, type IconModel, getIcon } from "metabase/lib/icon";
 import { modelToUrl } from "metabase/lib/urls";
-import type { IconName } from "metabase/ui";
 import { Anchor, Group, Icon } from "metabase/ui";
-import type {
-  RemoteSyncEntity,
-  RemoteSyncEntityModel,
-} from "metabase-types/api";
+import type { RemoteSyncEntity } from "metabase-types/api";
 
 import { getSyncStatusColor, getSyncStatusIcon } from "../../utils";
 
 import S from "./EntityLink.module.css";
-
-/**
- * Map of sync entity models to their icon names.
- * Used for models not covered by the standard getIcon function.
- */
-const SYNC_ENTITY_ICON_MAP: Partial<Record<RemoteSyncEntityModel, IconName>> = {
-  field: "field",
-};
 
 interface EntityLinkProps {
   entity: RemoteSyncEntity;
 }
 
 export const EntityLink = ({ entity }: EntityLinkProps) => {
-  const entityIcon = useMemo(() => {
+  const entityIcon = useMemo((): IconData => {
     if (entity.model === "field") {
       return { name: "field" };
     }

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/GitSyncControls/BranchDropdown.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/GitSyncControls/BranchDropdown.unit.spec.tsx
@@ -1,6 +1,7 @@
 import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 
+import { setupRemoteSyncBranchesEndpoint } from "__support__/server-mocks";
 import { renderWithProviders, screen, waitFor } from "__support__/ui";
 import { Combobox, useCombobox } from "metabase/ui";
 
@@ -33,9 +34,7 @@ function WrapperComponent({
 }
 
 const setupEndpoints = () => {
-  fetchMock.get("path:/api/ee/remote-sync/branches", {
-    items: ["main", "develop", "feature-1"],
-  });
+  setupRemoteSyncBranchesEndpoint(["main", "develop", "feature-1"]);
   fetchMock.post("path:/api/ee/remote-sync/create-branch", {});
 };
 

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/hooks/use-has-library-dirty-changes.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/hooks/use-has-library-dirty-changes.ts
@@ -10,7 +10,8 @@ import { useRemoteSyncDirtyState } from "./use-remote-sync-dirty-state";
 
 export function useHasLibraryDirtyChanges(): boolean {
   const { isVisible: isGitSyncVisible } = useGitSyncVisible();
-  const { hasDirtyInCollectionTree, isDirty } = useRemoteSyncDirtyState();
+  const { hasDirtyInCollectionTree, isDirty, hasRemovedItems } =
+    useRemoteSyncDirtyState();
 
   const { data: collections = [] } = useListCollectionsTreeQuery(
     {
@@ -22,6 +23,11 @@ export function useHasLibraryDirtyChanges(): boolean {
   );
 
   return useMemo(() => {
+    // Always show dirty if there are removed items
+    if (hasRemovedItems) {
+      return true;
+    }
+
     if (!isDirty) {
       return false;
     }
@@ -43,5 +49,5 @@ export function useHasLibraryDirtyChanges(): boolean {
     );
 
     return hasDirtyInCollectionTree(numericIds);
-  }, [collections, isDirty, hasDirtyInCollectionTree]);
+  }, [collections, isDirty, hasRemovedItems, hasDirtyInCollectionTree]);
 }

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/hooks/use-has-library-dirty-changes.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/hooks/use-has-library-dirty-changes.unit.spec.ts
@@ -1,41 +1,20 @@
-import fetchMock from "fetch-mock";
-
+import { setupEnterprisePlugins } from "__support__/enterprise";
+import {
+  setupCollectionsEndpoints,
+  setupPropertiesEndpoints,
+  setupRemoteSyncDirtyEndpoint,
+  setupSettingsEndpoints,
+} from "__support__/server-mocks";
+import { mockSettings } from "__support__/settings";
 import { renderHookWithProviders, waitFor } from "__support__/ui";
-import type { Collection } from "metabase-types/api";
-import { createMockCollection } from "metabase-types/api/mocks";
-
-// Mock isLibraryCollection to return true for collections with type "library"
-jest.mock("metabase/collections/utils", () => ({
-  ...jest.requireActual("metabase/collections/utils"),
-  isLibraryCollection: (collection: { type: string | null }) =>
-    collection?.type === "library",
-}));
-
-// Mock useRemoteSyncDirtyState
-const mockHasDirtyInCollectionTree = jest.fn(
-  (_collectionIds: Set<number>) => false,
-);
-const mockIsDirty = jest.fn(() => false);
-const mockHasRemovedItems = jest.fn(() => false);
-jest.mock("./use-remote-sync-dirty-state", () => ({
-  useRemoteSyncDirtyState: () => ({
-    hasDirtyInCollectionTree: mockHasDirtyInCollectionTree,
-    isDirty: mockIsDirty(),
-    hasRemovedItems: mockHasRemovedItems(),
-  }),
-}));
-
-// Mock useGitSyncVisible
-const mockUseGitSyncVisible = jest.fn<
-  { isVisible: boolean; currentBranch: string | null },
-  []
->(() => ({
-  isVisible: true,
-  currentBranch: "main",
-}));
-jest.mock("./use-git-sync-visible", () => ({
-  useGitSyncVisible: () => mockUseGitSyncVisible(),
-}));
+import type { Collection, RemoteSyncEntity } from "metabase-types/api";
+import {
+  createMockCollection,
+  createMockSettings,
+  createMockTokenFeatures,
+  createMockUser,
+} from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks";
 
 import { useHasLibraryDirtyChanges } from "./use-has-library-dirty-changes";
 
@@ -59,32 +38,85 @@ const createRegularCollection = (
     ...overrides,
   });
 
-const setupCollectionsEndpoint = (collections: Collection[]) => {
-  fetchMock.get("path:/api/collection/tree", collections);
+const createMockDirtyEntity = (
+  overrides: Partial<RemoteSyncEntity> = {},
+): RemoteSyncEntity => ({
+  id: 1,
+  name: "Test Entity",
+  description: null,
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: null,
+  model: "card",
+  sync_status: "update",
+  collection_id: 1,
+  ...overrides,
+});
+
+interface SetupOptions {
+  isGitSyncVisible?: boolean;
+  collections?: Collection[];
+  dirty?: RemoteSyncEntity[];
+}
+
+/**
+ * Compute changedCollections map from dirty entities.
+ * This mirrors what the backend does - marking collections that contain dirty entities.
+ */
+const computeChangedCollections = (
+  dirty: RemoteSyncEntity[],
+): Record<number, boolean> => {
+  const changedCollections: Record<number, boolean> = {};
+  for (const entity of dirty) {
+    if (entity.collection_id != null) {
+      changedCollections[entity.collection_id] = true;
+    }
+  }
+  return changedCollections;
 };
 
-const setup = () => {
-  return renderHookWithProviders(() => useHasLibraryDirtyChanges(), {});
+const setup = ({
+  isGitSyncVisible = true,
+  collections = [],
+  dirty = [],
+}: SetupOptions = {}) => {
+  setupEnterprisePlugins();
+
+  const tokenFeatures = createMockTokenFeatures({ data_studio: true });
+  const settings = createMockSettings({
+    "remote-sync-enabled": isGitSyncVisible,
+    "remote-sync-branch": isGitSyncVisible ? "main" : null,
+    "remote-sync-type": "read-write",
+    "token-features": tokenFeatures,
+  });
+
+  const changedCollections = computeChangedCollections(dirty);
+
+  setupPropertiesEndpoints(settings);
+  setupSettingsEndpoints([]);
+  setupRemoteSyncDirtyEndpoint({ dirty, changedCollections });
+  setupCollectionsEndpoints({ collections });
+
+  const storeInitialState = createMockState({
+    currentUser: createMockUser({ is_superuser: true }),
+    settings: mockSettings({
+      "remote-sync-enabled": isGitSyncVisible,
+      "remote-sync-branch": isGitSyncVisible ? "main" : null,
+      "remote-sync-type": "read-write",
+      "token-features": tokenFeatures,
+    }),
+  });
+
+  return renderHookWithProviders(() => useHasLibraryDirtyChanges(), {
+    storeInitialState,
+  });
 };
 
 describe("useHasLibraryDirtyChanges", () => {
-  beforeEach(() => {
-    fetchMock.removeRoutes();
-    fetchMock.clearHistory();
-    mockUseGitSyncVisible.mockReturnValue({
-      isVisible: true,
-      currentBranch: "main",
-    });
-    mockIsDirty.mockReturnValue(false);
-    mockHasDirtyInCollectionTree.mockReturnValue(false);
-    mockHasRemovedItems.mockReturnValue(false);
-  });
-
   it("returns false when no dirty changes exist", async () => {
-    setupCollectionsEndpoint([createLibraryCollection()]);
-    mockIsDirty.mockReturnValue(false);
-
-    const { result } = setup();
+    const { result } = setup({
+      collections: [createLibraryCollection()],
+      dirty: [],
+    });
 
     await waitFor(() => {
       expect(result.current).toBe(false);
@@ -92,14 +124,13 @@ describe("useHasLibraryDirtyChanges", () => {
   });
 
   it("returns false when dirty changes exist but not in Library collections", async () => {
-    setupCollectionsEndpoint([
-      createLibraryCollection({ id: 1 }),
-      createRegularCollection({ id: 2 }),
-    ]);
-    mockIsDirty.mockReturnValue(true);
-    mockHasDirtyInCollectionTree.mockReturnValue(false);
-
-    const { result } = setup();
+    const { result } = setup({
+      collections: [
+        createLibraryCollection({ id: 1 }),
+        createRegularCollection({ id: 2 }),
+      ],
+      dirty: [createMockDirtyEntity({ collection_id: 2 })],
+    });
 
     await waitFor(() => {
       expect(result.current).toBe(false);
@@ -107,43 +138,21 @@ describe("useHasLibraryDirtyChanges", () => {
   });
 
   it("returns true when Library collection has dirty items", async () => {
-    setupCollectionsEndpoint([createLibraryCollection({ id: 1 })]);
-    mockIsDirty.mockReturnValue(true);
-    // When hasDirtyInCollectionTree is called with the library IDs, return true
-    mockHasDirtyInCollectionTree.mockReturnValue(true);
-
-    const { result } = setup();
+    const { result } = setup({
+      collections: [createLibraryCollection({ id: 1 })],
+      dirty: [createMockDirtyEntity({ collection_id: 1 })],
+    });
 
     await waitFor(() => {
       expect(result.current).toBe(true);
     });
   });
 
-  it("calls hasDirtyInCollectionTree when Library exists and isDirty", async () => {
-    setupCollectionsEndpoint([createLibraryCollection({ id: 42 })]);
-    mockIsDirty.mockReturnValue(true);
-    mockHasDirtyInCollectionTree.mockReturnValue(false);
-
-    const { result } = setup();
-
-    await waitFor(() => {
-      expect(result.current).toBe(false);
-    });
-
-    // Verify hasDirtyInCollectionTree was called with a Set
-    expect(mockHasDirtyInCollectionTree).toHaveBeenCalled();
-    const calledWith = mockHasDirtyInCollectionTree.mock.calls[0]?.[0];
-    expect(calledWith).toBeInstanceOf(Set);
-    // The Set should contain numeric IDs (exact IDs depend on buildCollectionTree transformation)
-    expect(calledWith?.size).toBeGreaterThan(0);
-  });
-
   it("returns false when no Library collection exists", async () => {
-    setupCollectionsEndpoint([createRegularCollection()]);
-    mockIsDirty.mockReturnValue(true);
-    mockHasDirtyInCollectionTree.mockReturnValue(true);
-
-    const { result } = setup();
+    const { result } = setup({
+      collections: [createRegularCollection()],
+      dirty: [createMockDirtyEntity({ collection_id: 2 })],
+    });
 
     await waitFor(() => {
       expect(result.current).toBe(false);
@@ -151,12 +160,10 @@ describe("useHasLibraryDirtyChanges", () => {
   });
 
   it("returns true when there are removed items even if no other dirty changes", async () => {
-    setupCollectionsEndpoint([createLibraryCollection()]);
-    mockIsDirty.mockReturnValue(false);
-    mockHasRemovedItems.mockReturnValue(true);
-    mockHasDirtyInCollectionTree.mockReturnValue(false);
-
-    const { result } = setup();
+    const { result } = setup({
+      collections: [createLibraryCollection()],
+      dirty: [createMockDirtyEntity({ sync_status: "removed" })],
+    });
 
     await waitFor(() => {
       expect(result.current).toBe(true);
@@ -164,10 +171,10 @@ describe("useHasLibraryDirtyChanges", () => {
   });
 
   it("returns true when there are removed items even without Library collection", async () => {
-    setupCollectionsEndpoint([createRegularCollection()]);
-    mockHasRemovedItems.mockReturnValue(true);
-
-    const { result } = setup();
+    const { result } = setup({
+      collections: [createRegularCollection()],
+      dirty: [createMockDirtyEntity({ sync_status: "removed" })],
+    });
 
     await waitFor(() => {
       expect(result.current).toBe(true);
@@ -175,18 +182,12 @@ describe("useHasLibraryDirtyChanges", () => {
   });
 
   it("returns false when git sync is not visible", async () => {
-    setupCollectionsEndpoint([createLibraryCollection()]);
-    mockUseGitSyncVisible.mockReturnValue({
-      isVisible: false,
-      currentBranch: null,
+    const { result } = setup({
+      isGitSyncVisible: false,
+      collections: [createLibraryCollection()],
+      dirty: [createMockDirtyEntity({ collection_id: 1 })],
     });
-    mockIsDirty.mockReturnValue(true);
-    mockHasDirtyInCollectionTree.mockReturnValue(true);
 
-    const { result } = setup();
-
-    // When git sync is not visible, collections query is skipped,
-    // so no library collection will be found
     await waitFor(() => {
       expect(result.current).toBe(false);
     });

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/hooks/use-has-library-dirty-changes.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/hooks/use-has-library-dirty-changes.unit.spec.ts
@@ -16,10 +16,12 @@ const mockHasDirtyInCollectionTree = jest.fn(
   (_collectionIds: Set<number>) => false,
 );
 const mockIsDirty = jest.fn(() => false);
+const mockHasRemovedItems = jest.fn(() => false);
 jest.mock("./use-remote-sync-dirty-state", () => ({
   useRemoteSyncDirtyState: () => ({
     hasDirtyInCollectionTree: mockHasDirtyInCollectionTree,
     isDirty: mockIsDirty(),
+    hasRemovedItems: mockHasRemovedItems(),
   }),
 }));
 
@@ -75,6 +77,7 @@ describe("useHasLibraryDirtyChanges", () => {
     });
     mockIsDirty.mockReturnValue(false);
     mockHasDirtyInCollectionTree.mockReturnValue(false);
+    mockHasRemovedItems.mockReturnValue(false);
   });
 
   it("returns false when no dirty changes exist", async () => {
@@ -144,6 +147,30 @@ describe("useHasLibraryDirtyChanges", () => {
 
     await waitFor(() => {
       expect(result.current).toBe(false);
+    });
+  });
+
+  it("returns true when there are removed items even if no other dirty changes", async () => {
+    setupCollectionsEndpoint([createLibraryCollection()]);
+    mockIsDirty.mockReturnValue(false);
+    mockHasRemovedItems.mockReturnValue(true);
+    mockHasDirtyInCollectionTree.mockReturnValue(false);
+
+    const { result } = setup();
+
+    await waitFor(() => {
+      expect(result.current).toBe(true);
+    });
+  });
+
+  it("returns true when there are removed items even without Library collection", async () => {
+    setupCollectionsEndpoint([createRegularCollection()]);
+    mockHasRemovedItems.mockReturnValue(true);
+
+    const { result } = setup();
+
+    await waitFor(() => {
+      expect(result.current).toBe(true);
     });
   });
 

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/hooks/use-has-library-dirty-changes.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/hooks/use-has-library-dirty-changes.unit.spec.ts
@@ -43,9 +43,6 @@ const createMockDirtyEntity = (
 ): RemoteSyncEntity => ({
   id: 1,
   name: "Test Entity",
-  description: null,
-  created_at: "2024-01-01T00:00:00Z",
-  updated_at: null,
   model: "card",
   sync_status: "update",
   collection_id: 1,

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/hooks/use-remote-sync-dirty-state.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/hooks/use-remote-sync-dirty-state.ts
@@ -13,6 +13,8 @@ export interface RemoteSyncDirtyState {
   changedCollections: Record<number, boolean>;
   /** Whether any dirty changes exist globally */
   isDirty: boolean;
+  /** Whether any entities have "removed" status */
+  hasRemovedItems: boolean;
   /** Whether data is loading */
   isLoading: boolean;
   /** Check if a specific collection has dirty items */
@@ -45,6 +47,10 @@ export function useRemoteSyncDirtyState(): RemoteSyncDirtyState {
     [dirtyData?.changedCollections],
   );
   const isDirty = dirty.length > 0;
+  const hasRemovedItems = useMemo(
+    () => dirty.some((entity) => entity.sync_status === "removed"),
+    [dirty],
+  );
 
   const isCollectionDirty = useCallback(
     (collectionId: number | string | undefined) => {
@@ -93,6 +99,7 @@ export function useRemoteSyncDirtyState(): RemoteSyncDirtyState {
     dirty,
     changedCollections,
     isDirty,
+    hasRemovedItems,
     isLoading,
     isCollectionDirty,
     hasAnyCollectionDirty,

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/hooks/use-remote-sync-dirty-state.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/hooks/use-remote-sync-dirty-state.unit.spec.ts
@@ -16,9 +16,6 @@ const createMockDirtyEntity = (
 ): RemoteSyncEntity => ({
   id: 1,
   name: "Test Entity",
-  description: null,
-  created_at: "2024-01-01T00:00:00Z",
-  updated_at: null,
   model: "card",
   sync_status: "update",
   collection_id: 1,

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/hooks/use-remote-sync-dirty-state.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/hooks/use-remote-sync-dirty-state.unit.spec.ts
@@ -247,6 +247,48 @@ describe("useRemoteSyncDirtyState", () => {
     });
   });
 
+  describe("hasRemovedItems", () => {
+    it("returns false when no entities have removed status", async () => {
+      const { result } = setup({
+        dirty: [
+          createMockDirtyEntity({ sync_status: "update" }),
+          createMockDirtyEntity({ id: 2, sync_status: "create" }),
+        ],
+      });
+
+      await waitFor(() => {
+        expect(result.current.dirty.length).toBeGreaterThan(0);
+      });
+
+      expect(result.current.hasRemovedItems).toBe(false);
+    });
+
+    it("returns true when any entity has removed status", async () => {
+      const { result } = setup({
+        dirty: [
+          createMockDirtyEntity({ sync_status: "update" }),
+          createMockDirtyEntity({ id: 2, sync_status: "removed" }),
+        ],
+      });
+
+      await waitFor(() => {
+        expect(result.current.dirty.length).toBeGreaterThan(0);
+      });
+
+      expect(result.current.hasRemovedItems).toBe(true);
+    });
+
+    it("returns false when dirty list is empty", async () => {
+      const { result } = setup({ dirty: [] });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.hasRemovedItems).toBe(false);
+    });
+  });
+
   describe("when git sync is not visible", () => {
     it("returns empty dirty state", async () => {
       const { result } = setup({
@@ -258,6 +300,7 @@ describe("useRemoteSyncDirtyState", () => {
         expect(result.current.dirty).toEqual([]);
       });
       expect(result.current.isDirty).toBe(false);
+      expect(result.current.hasRemovedItems).toBe(false);
     });
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/hooks/use-remote-sync-dirty-state.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/hooks/use-remote-sync-dirty-state.unit.spec.ts
@@ -1,67 +1,80 @@
-import fetchMock from "fetch-mock";
-
+import {
+  setupPropertiesEndpoints,
+  setupRemoteSyncDirtyEndpoint,
+  setupSettingsEndpoints,
+} from "__support__/server-mocks";
+import { mockSettings } from "__support__/settings";
 import { renderHookWithProviders, waitFor } from "__support__/ui";
-
-// Mock the useGitSyncVisible hook before importing useRemoteSyncDirtyState
-const mockUseGitSyncVisible = jest.fn(() => ({
-  isVisible: true,
-  currentBranch: "main",
-}));
-jest.mock("./use-git-sync-visible", () => ({
-  useGitSyncVisible: () => mockUseGitSyncVisible(),
-}));
+import type { RemoteSyncEntity } from "metabase-types/api";
+import { createMockSettings, createMockUser } from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks";
 
 import { useRemoteSyncDirtyState } from "./use-remote-sync-dirty-state";
 
-const createMockDirtyEntity = (overrides: Record<string, unknown> = {}) => ({
+const createMockDirtyEntity = (
+  overrides: Partial<RemoteSyncEntity> = {},
+): RemoteSyncEntity => ({
   id: 1,
   name: "Test Entity",
   description: null,
   created_at: "2024-01-01T00:00:00Z",
   updated_at: null,
-  model: "card" as const,
-  sync_status: "update" as const,
+  model: "card",
+  sync_status: "update",
   collection_id: 1,
   ...overrides,
 });
 
-const setupEndpoints = ({
-  dirty = [],
-  changedCollections = {},
-}: {
-  dirty?: Array<ReturnType<typeof createMockDirtyEntity>>;
-  changedCollections?: Record<number, boolean>;
-} = {}) => {
-  fetchMock.get("path:/api/ee/remote-sync/dirty", {
-    dirty,
-    changedCollections,
-  });
+/**
+ * Compute changedCollections map from dirty entities.
+ * This mirrors what the backend does - marking collections that contain dirty entities.
+ */
+const computeChangedCollections = (
+  dirty: RemoteSyncEntity[],
+): Record<number, boolean> => {
+  const changedCollections: Record<number, boolean> = {};
+  for (const entity of dirty) {
+    if (entity.collection_id != null) {
+      changedCollections[entity.collection_id] = true;
+    }
+  }
+  return changedCollections;
 };
 
 const setup = ({
   isGitSyncVisible = true,
   dirty = [],
-  changedCollections = {},
 }: {
   isGitSyncVisible?: boolean;
-  dirty?: Array<ReturnType<typeof createMockDirtyEntity>>;
-  changedCollections?: Record<number, boolean>;
+  dirty?: RemoteSyncEntity[];
 } = {}) => {
-  mockUseGitSyncVisible.mockReturnValue({
-    isVisible: isGitSyncVisible,
-    currentBranch: "main",
+  const settings = createMockSettings({
+    "remote-sync-enabled": isGitSyncVisible,
+    "remote-sync-branch": isGitSyncVisible ? "main" : null,
+    "remote-sync-type": "read-write",
   });
-  setupEndpoints({ dirty, changedCollections });
 
-  return renderHookWithProviders(() => useRemoteSyncDirtyState(), {});
+  const changedCollections = computeChangedCollections(dirty);
+
+  setupPropertiesEndpoints(settings);
+  setupSettingsEndpoints([]);
+  setupRemoteSyncDirtyEndpoint({ dirty, changedCollections });
+
+  const storeInitialState = createMockState({
+    currentUser: createMockUser({ is_superuser: true }),
+    settings: mockSettings({
+      "remote-sync-enabled": isGitSyncVisible,
+      "remote-sync-branch": isGitSyncVisible ? "main" : null,
+      "remote-sync-type": "read-write",
+    }),
+  });
+
+  return renderHookWithProviders(() => useRemoteSyncDirtyState(), {
+    storeInitialState,
+  });
 };
 
 describe("useRemoteSyncDirtyState", () => {
-  beforeEach(() => {
-    fetchMock.removeRoutes();
-    fetchMock.clearHistory();
-  });
-
   describe("isDirty", () => {
     it("returns false when no dirty entities exist", async () => {
       const { result } = setup({ dirty: [] });
@@ -84,7 +97,6 @@ describe("useRemoteSyncDirtyState", () => {
 
   describe("isCollectionDirty", () => {
     it("returns false for collection without dirty items", async () => {
-      // changedCollections is built from dirty entities' collection_id
       const { result } = setup({
         dirty: [createMockDirtyEntity({ collection_id: 1 })],
       });
@@ -97,7 +109,6 @@ describe("useRemoteSyncDirtyState", () => {
     });
 
     it("returns true for collection with dirty items", async () => {
-      // changedCollections is built from dirty entities' collection_id
       const { result } = setup({
         dirty: [createMockDirtyEntity({ collection_id: 1 })],
       });
@@ -110,7 +121,6 @@ describe("useRemoteSyncDirtyState", () => {
     });
 
     it("returns false for non-numeric collection id", async () => {
-      // changedCollections is built from dirty entities' collection_id
       const { result } = setup({
         dirty: [createMockDirtyEntity({ collection_id: 1 })],
       });
@@ -126,12 +136,10 @@ describe("useRemoteSyncDirtyState", () => {
 
   describe("hasAnyCollectionDirty", () => {
     it("returns false when no collections in set are dirty", async () => {
-      // changedCollections is built from dirty entities' collection_id
       const { result } = setup({
         dirty: [createMockDirtyEntity({ collection_id: 1 })],
       });
 
-      // Wait for data to be populated
       await waitFor(() => {
         expect(result.current.dirty.length).toBeGreaterThan(0);
       });
@@ -140,7 +148,6 @@ describe("useRemoteSyncDirtyState", () => {
     });
 
     it("returns true when any collection in set is dirty", async () => {
-      // changedCollections is built from dirty entities' collection_id
       const { result } = setup({
         dirty: [
           createMockDirtyEntity({ id: 1, collection_id: 1 }),
@@ -148,7 +155,6 @@ describe("useRemoteSyncDirtyState", () => {
         ],
       });
 
-      // Wait for data to be populated
       await waitFor(() => {
         expect(result.current.dirty.length).toBeGreaterThan(0);
       });
@@ -157,12 +163,10 @@ describe("useRemoteSyncDirtyState", () => {
     });
 
     it("works with array input", async () => {
-      // changedCollections is built from dirty entities' collection_id
       const { result } = setup({
         dirty: [createMockDirtyEntity({ collection_id: 1 })],
       });
 
-      // Wait for data to be populated
       await waitFor(() => {
         expect(result.current.dirty.length).toBeGreaterThan(0);
       });
@@ -173,12 +177,10 @@ describe("useRemoteSyncDirtyState", () => {
 
   describe("hasDirtyInCollectionTree", () => {
     it("returns false when no collections in tree are dirty", async () => {
-      // changedCollections is built from dirty entities' collection_id
       const { result } = setup({
         dirty: [createMockDirtyEntity({ collection_id: 100 })],
       });
 
-      // Wait for data to be populated
       await waitFor(() => {
         expect(result.current.dirty.length).toBeGreaterThan(0);
       });
@@ -189,12 +191,10 @@ describe("useRemoteSyncDirtyState", () => {
     });
 
     it("returns true when a collection in tree has dirty children", async () => {
-      // changedCollections is built from dirty entities' collection_id
       const { result } = setup({
         dirty: [createMockDirtyEntity({ collection_id: 2 })],
       });
 
-      // Wait for data to be populated
       await waitFor(() => {
         expect(result.current.dirty.length).toBeGreaterThan(0);
       });
@@ -210,12 +210,11 @@ describe("useRemoteSyncDirtyState", () => {
           createMockDirtyEntity({
             id: 2,
             model: "collection",
-            collection_id: null,
+            collection_id: undefined,
           }),
         ],
       });
 
-      // Wait for dirty to be populated
       await waitFor(() => {
         expect(result.current.dirty.length).toBeGreaterThan(0);
       });
@@ -231,12 +230,11 @@ describe("useRemoteSyncDirtyState", () => {
           createMockDirtyEntity({
             id: 100,
             model: "collection",
-            collection_id: null,
+            collection_id: undefined,
           }),
         ],
       });
 
-      // Wait for dirty to be populated
       await waitFor(() => {
         expect(result.current.dirty.length).toBeGreaterThan(0);
       });

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/middleware/remote-sync-listener-middleware.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/middleware/remote-sync-listener-middleware.ts
@@ -345,7 +345,6 @@ remoteSyncListenerMiddleware.startListening({
   matcher: isAnyOf(
     segmentApi.endpoints.createSegment.matchFulfilled,
     segmentApi.endpoints.updateSegment.matchFulfilled,
-    segmentApi.endpoints.deleteSegment.matchFulfilled,
   ),
   effect: async (_action, { dispatch }) => {
     invalidateRemoteSyncTags(dispatch);

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/middleware/remote-sync-listener-middleware.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/middleware/remote-sync-listener-middleware.ts
@@ -6,11 +6,15 @@ import { cardApi } from "metabase/api/card";
 import { collectionApi } from "metabase/api/collection";
 import { dashboardApi } from "metabase/api/dashboard";
 import { documentApi } from "metabase/api/document";
+import { fieldApi } from "metabase/api/field";
+import { segmentApi } from "metabase/api/segment";
+import { tableApi as coreTableApi } from "metabase/api/table";
 import { tag } from "metabase/api/tags";
 import { timelineApi } from "metabase/api/timeline";
 import { timelineEventApi } from "metabase/api/timeline-event";
 import { getCollectionFromCollectionsTree } from "metabase/selectors/collection";
 import { remoteSyncApi } from "metabase-enterprise/api/remote-sync";
+import { tableApi as enterpriseTableApi } from "metabase-enterprise/api/table";
 import type {
   Card,
   CardId,
@@ -295,6 +299,53 @@ remoteSyncListenerMiddleware.startListening({
     timelineEventApi.endpoints.createTimelineEvent.matchFulfilled,
     timelineEventApi.endpoints.updateTimelineEvent.matchFulfilled,
     timelineEventApi.endpoints.deleteTimelineEvent.matchFulfilled,
+  ),
+  effect: async (_action, { dispatch }) => {
+    invalidateRemoteSyncTags(dispatch);
+  },
+});
+
+// Enterprise table mutations (publish/unpublish/edit)
+remoteSyncListenerMiddleware.startListening({
+  matcher: isAnyOf(
+    enterpriseTableApi.endpoints.publishTables.matchFulfilled,
+    enterpriseTableApi.endpoints.unpublishTables.matchFulfilled,
+    enterpriseTableApi.endpoints.editTables.matchFulfilled,
+  ),
+  effect: async (_action, { dispatch }) => {
+    invalidateRemoteSyncTags(dispatch);
+  },
+});
+
+// Core table mutations (metadata edits)
+remoteSyncListenerMiddleware.startListening({
+  matcher: isAnyOf(
+    coreTableApi.endpoints.updateTable.matchFulfilled,
+    coreTableApi.endpoints.updateTableFieldsOrder.matchFulfilled,
+  ),
+  effect: async (_action, { dispatch }) => {
+    invalidateRemoteSyncTags(dispatch);
+  },
+});
+
+// Field mutations
+remoteSyncListenerMiddleware.startListening({
+  matcher: isAnyOf(
+    fieldApi.endpoints.updateField.matchFulfilled,
+    fieldApi.endpoints.createFieldDimension.matchFulfilled,
+    fieldApi.endpoints.deleteFieldDimension.matchFulfilled,
+  ),
+  effect: async (_action, { dispatch }) => {
+    invalidateRemoteSyncTags(dispatch);
+  },
+});
+
+// Segment mutations
+remoteSyncListenerMiddleware.startListening({
+  matcher: isAnyOf(
+    segmentApi.endpoints.createSegment.matchFulfilled,
+    segmentApi.endpoints.updateSegment.matchFulfilled,
+    segmentApi.endpoints.deleteSegment.matchFulfilled,
   ),
   effect: async (_action, { dispatch }) => {
     invalidateRemoteSyncTags(dispatch);

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/utils.ts
@@ -5,6 +5,8 @@ import type { IconName } from "metabase/ui";
 import type {
   Collection,
   CollectionId,
+  RemoteSyncEntity,
+  RemoteSyncEntityModel,
   RemoteSyncEntityStatus,
 } from "metabase-types/api";
 
@@ -175,4 +177,35 @@ export const getCollectionPathSegments = (
 
   segments.push({ id: collection.id, name: collection.name });
   return segments;
+};
+
+/**
+ * Models that are children of tables (get their collection from a parent table)
+ */
+const TABLE_CHILD_MODELS: RemoteSyncEntityModel[] = ["field", "segment"];
+
+/**
+ * Check if a model type is a child of a table (field or segment)
+ */
+export const isTableChildModel = (
+  model: RemoteSyncEntityModel,
+): model is "field" | "segment" => {
+  return TABLE_CHILD_MODELS.includes(model);
+};
+
+export type TableInfo = {
+  id: number;
+  name: string;
+};
+
+/**
+ * Get parent table info from an entity if it's a table child model
+ */
+export const getParentTableInfo = (
+  entity: RemoteSyncEntity,
+): TableInfo | null => {
+  if (isTableChildModel(entity.model) && entity.table_id && entity.table_name) {
+    return { id: entity.table_id, name: entity.table_name };
+  }
+  return null;
 };

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/utils.ts
@@ -5,7 +5,6 @@ import type { IconName } from "metabase/ui";
 import type {
   Collection,
   CollectionId,
-  RemoteSyncEntity,
   RemoteSyncEntityModel,
   RemoteSyncEntityStatus,
 } from "metabase-types/api";
@@ -182,30 +181,14 @@ export const getCollectionPathSegments = (
 /**
  * Models that are children of tables (get their collection from a parent table)
  */
-const TABLE_CHILD_MODELS: RemoteSyncEntityModel[] = ["field", "segment"];
+const TABLE_CHILD_MODELS: Set<RemoteSyncEntityModel> = new Set([
+  "field",
+  "segment",
+]);
 
 /**
  * Check if a model type is a child of a table (field or segment)
  */
-export const isTableChildModel = (
-  model: RemoteSyncEntityModel,
-): model is "field" | "segment" => {
-  return TABLE_CHILD_MODELS.includes(model);
-};
-
-export type TableInfo = {
-  id: number;
-  name: string;
-};
-
-/**
- * Get parent table info from an entity if it's a table child model
- */
-export const getParentTableInfo = (
-  entity: RemoteSyncEntity,
-): TableInfo | null => {
-  if (isTableChildModel(entity.model) && entity.table_id && entity.table_name) {
-    return { id: entity.table_id, name: entity.table_name };
-  }
-  return null;
+export const isTableChildModel = (model: RemoteSyncEntityModel): boolean => {
+  return TABLE_CHILD_MODELS.has(model);
 };

--- a/frontend/src/metabase-types/api/remote-sync.ts
+++ b/frontend/src/metabase-types/api/remote-sync.ts
@@ -9,7 +9,10 @@ export type RemoteSyncEntityModel =
   | "dashboard"
   | "collection"
   | "document"
-  | "snippet";
+  | "snippet"
+  | "table"
+  | "field"
+  | "segment";
 
 export type RemoteSyncEntityStatus =
   | "create"
@@ -25,6 +28,11 @@ export type RemoteSyncEntity = {
   collection_id?: number;
   display?: CardDisplayType;
   sync_status: RemoteSyncEntityStatus;
+  authority_level?: string | null;
+  /** Parent table ID for field and segment models */
+  table_id?: number;
+  /** Parent table name for field and segment models */
+  table_name?: string;
 };
 
 export type RemoteSyncChangesResponse = {

--- a/frontend/test/__support__/server-mocks/remote-sync.ts
+++ b/frontend/test/__support__/server-mocks/remote-sync.ts
@@ -39,7 +39,7 @@ export const setupRemoteSyncBranchesEndpoint = (
 /**
  * Setup the remote-sync current-task endpoint
  */
-export const setupRemoteSyncCurrentTaskEndpoint = (
+const setupRemoteSyncCurrentTaskEndpoint = (
   status: "idle" | "running" | "completed" = "idle",
 ) => {
   fetchMock.removeRoute("remote-sync-current-task");
@@ -67,6 +67,5 @@ export const setupRemoteSyncEndpoints = ({
   setupRemoteSyncCurrentTaskEndpoint("idle");
   fetchMock.post("path:/api/ee/remote-sync/import", {});
   fetchMock.post("path:/api/ee/remote-sync/create-branch", {});
-  fetchMock.get("path:/api/ee/remote-sync/current-task", { status: "idle" });
   fetchMock.put("path:/api/ee/remote-sync/settings", { success: true });
 };

--- a/frontend/test/__support__/server-mocks/remote-sync.ts
+++ b/frontend/test/__support__/server-mocks/remote-sync.ts
@@ -2,6 +2,57 @@ import fetchMock from "fetch-mock";
 
 import type { RemoteSyncEntity } from "metabase-types/api";
 
+export interface RemoteSyncDirtyResponse {
+  dirty: RemoteSyncEntity[];
+  changedCollections: Record<number, boolean>;
+}
+
+/**
+ * Setup the remote-sync dirty endpoint
+ */
+export const setupRemoteSyncDirtyEndpoint = ({
+  dirty = [],
+  changedCollections = {},
+}: Partial<RemoteSyncDirtyResponse> = {}) => {
+  fetchMock.removeRoute("remote-sync-dirty");
+  fetchMock.get(
+    "path:/api/ee/remote-sync/dirty",
+    { dirty, changedCollections },
+    { name: "remote-sync-dirty" },
+  );
+};
+
+/**
+ * Setup the remote-sync branches endpoint
+ */
+export const setupRemoteSyncBranchesEndpoint = (
+  branches: string[] = ["main", "develop"],
+) => {
+  fetchMock.removeRoute("remote-sync-branches");
+  fetchMock.get(
+    "path:/api/ee/remote-sync/branches",
+    { items: branches },
+    { name: "remote-sync-branches" },
+  );
+};
+
+/**
+ * Setup the remote-sync current-task endpoint
+ */
+export const setupRemoteSyncCurrentTaskEndpoint = (
+  status: "idle" | "running" | "completed" = "idle",
+) => {
+  fetchMock.removeRoute("remote-sync-current-task");
+  fetchMock.get(
+    "path:/api/ee/remote-sync/current-task",
+    { status },
+    { name: "remote-sync-current-task" },
+  );
+};
+
+/**
+ * Setup all remote-sync endpoints at once
+ */
 export const setupRemoteSyncEndpoints = ({
   branches = ["main", "develop"],
   dirty = [],
@@ -11,14 +62,11 @@ export const setupRemoteSyncEndpoints = ({
   dirty?: RemoteSyncEntity[];
   changedCollections?: Record<number, boolean>;
 } = {}) => {
-  fetchMock.get("path:/api/ee/remote-sync/branches", { items: branches });
-  fetchMock.get("path:/api/ee/remote-sync/dirty", {
-    dirty,
-    changedCollections,
-  });
+  setupRemoteSyncBranchesEndpoint(branches);
+  setupRemoteSyncDirtyEndpoint({ dirty, changedCollections });
+  setupRemoteSyncCurrentTaskEndpoint("idle");
   fetchMock.post("path:/api/ee/remote-sync/import", {});
   fetchMock.post("path:/api/ee/remote-sync/create-branch", {});
   fetchMock.get("path:/api/ee/remote-sync/current-task", { status: "idle" });
-
   fetchMock.put("path:/api/ee/remote-sync/settings", { success: true });
 };

--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -1235,6 +1235,36 @@ databaseChangeLog:
             path: instance_analytics_views/tables/v1/h2-tables.sql
             relativeToChangelogFile: true
 
+  - changeSet:
+      id: v58.2025-12-30T22:48:02
+      author: edpaget
+      comment: Add remote_sync_object.model_table_id for parent table reference
+      changes:
+        - addColumn:
+            tableName: remote_sync_object
+            columns:
+              - column:
+                  name: model_table_id
+                  type: int
+                  remarks: Parent table ID for Field/Segment/Table models
+                  constraints:
+                    nullable: true
+
+  - changeSet:
+      id: v58.2025-12-30T22:48:03
+      author: edpaget
+      comment: Add remote_sync_object.model_table_name for parent table name
+      changes:
+        - addColumn:
+            tableName: remote_sync_object
+            columns:
+              - column:
+                  name: model_table_name
+                  type: varchar(255)
+                  remarks: Parent table name for Field/Segment/Table models
+                  constraints:
+                    nullable: true
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
   - changeSet:

--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -1236,6 +1236,26 @@ databaseChangeLog:
             relativeToChangelogFile: true
 
   - changeSet:
+      id: v58.2025-12-18T16:14:03
+      author: winlost
+      comment: Add disable_links column to pulse table
+      changes:
+        - addColumn:
+            tableName: pulse
+            columns:
+              - column:
+                  name: disable_links
+                  type: ${boolean.type}
+                  remarks: "Whether to disable email subscription links"
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: true
+      rollback:
+        - dropColumn:
+            tableName: pulse
+            columnName: disable_links
+
+  - changeSet:
       id: v58.2025-12-30T22:48:02
       author: edpaget
       comment: Add remote_sync_object.model_table_id for parent table reference
@@ -1264,28 +1284,6 @@ databaseChangeLog:
                   remarks: Parent table name for Field/Segment/Table models
                   constraints:
                     nullable: true
-
-# >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
-
-  - changeSet:
-      id: v58.2025-12-18T16:14:03
-      author: winlost
-      comment: Add disable_links column to pulse table
-      changes:
-        - addColumn:
-            tableName: pulse
-            columns:
-              - column:
-                  name: disable_links
-                  type: ${boolean.type}
-                  remarks: "Whether to disable email subscription links"
-                  defaultValueBoolean: false
-                  constraints:
-                    nullable: true
-      rollback:
-        - dropColumn:
-            tableName: pulse
-            columnName: disable_links
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/src/metabase/events/schema.clj
+++ b/src/metabase/events/schema.clj
@@ -185,6 +185,17 @@
    [:user-id  pos-int?]
    [:object [:fn #(t2/instance-of? :model/Table %)]]])
 
+;; table write events
+
+(mr/def ::table
+  [:map {:closed true}
+   [:user-id [:maybe pos-int?]]
+   [:object [:fn #(t2/instance-of? :model/Table %)]]])
+
+(mr/def :event/table-create ::table)
+(mr/def :event/table-update ::table)
+(mr/def :event/table-delete ::table)
+
 (mr/def ::permission-failure
   [:map {:closed true}
    [:user-id [:maybe pos-int?]]

--- a/src/metabase/events/schema.clj
+++ b/src/metabase/events/schema.clj
@@ -234,3 +234,14 @@
 (mr/def :event/snippet-create ::snippet)
 (mr/def :event/snippet-update ::snippet)
 (mr/def :event/snippet-delete ::snippet)
+
+;; field events
+
+(mr/def ::field
+  [:map {:closed true}
+   [:user-id [:maybe pos-int?]]
+   [:object [:fn #(t2/instance-of? :model/Field %)]]])
+
+(mr/def :event/field-create ::field)
+(mr/def :event/field-update ::field)
+(mr/def :event/field-delete ::field)

--- a/src/metabase/remote_sync/core.clj
+++ b/src/metabase/remote_sync/core.clj
@@ -9,3 +9,12 @@
   metabase-enterprise.remote-sync.core
   [_collection]
   true)
+
+(defenterprise table-editable?
+  "Returns if a table's metadata can be edited. Takes a table to check.
+
+  Returns false if the table is published, in a remote-synced collection, and remote-sync-type is :read-only.
+  Always true on OSS."
+  metabase-enterprise.remote-sync.core
+  [_table]
+  true)

--- a/src/metabase/segments/models/segment.clj
+++ b/src/metabase/segments/models/segment.clj
@@ -10,6 +10,7 @@
    [metabase.models.interface :as mi]
    [metabase.models.serialization :as serdes]
    [metabase.permissions.core :as perms]
+   [metabase.remote-sync.core :as remote-sync]
    [metabase.search.core :as search]
    [metabase.segments.schema :as segments.schema]
    [metabase.util :as u]
@@ -70,9 +71,7 @@
 (doto :model/Segment
   (derive :metabase/model)
   (derive :hook/timestamped?)
-  (derive :hook/entity-id)
-  (derive ::mi/write-policy.superuser)
-  (derive ::mi/create-policy.superuser))
+  (derive :hook/entity-id))
 
 (defmethod mi/can-read? :model/Segment
   ([instance]
@@ -85,6 +84,63 @@
       (u/the-id table))))
   ([model pk]
    (mi/can-read? (t2/select-one model pk))))
+
+;; Segments can be written by superusers, but only if the parent table is editable
+;; (not in a remote-synced collection in read-only mode).
+(defmethod mi/can-write? :model/Segment
+  ([instance]
+   (let [table (or (:table instance)
+                   (t2/select-one :model/Table :id (:table_id instance)))]
+     (and (mi/superuser?)
+          (remote-sync/table-editable? table))))
+  ([model pk]
+   (mi/can-write? (t2/select-one model pk))))
+
+;; Segments can be created by superusers, but only if the parent table is editable
+;; (not in a remote-synced collection in read-only mode).
+(defmethod mi/can-create? :model/Segment
+  [_model instance]
+  (let [table (or (:table instance)
+                  (t2/select-one :model/Table :id (:table_id instance)))]
+    (and (mi/superuser?)
+         (remote-sync/table-editable? table))))
+
+(methodical/defmethod t2/batched-hydrate [:model/Segment :can_write]
+  "Batched hydration for :can_write on segments. First hydrates :table for all segments,
+   then pre-fetches collection is_remote_synced values for those tables, and calls can-write?
+   on each segment. This avoids N+1 queries when checking permissions for multiple segments."
+  [_model k segments]
+  (let [segments-with-tables (t2/hydrate (remove nil? segments) :table)
+        ;; Get all unique collection IDs from the hydrated tables
+        collection-ids (->> segments-with-tables
+                            (keep (comp :collection_id :table))
+                            distinct)
+        ;; Batch fetch is_remote_synced for all collections
+        collection-synced-map (if (seq collection-ids)
+                                (into {}
+                                      (map (juxt :id :is_remote_synced))
+                                      (t2/select :model/Collection :id [:in collection-ids]))
+                                {})
+        ;; Associate collection info with each segment's table
+        segments-with-collection (for [segment segments-with-tables
+                                       :let [table (:table segment)
+                                             coll-id (:collection_id table)]]
+                                   (if (and table coll-id)
+                                     (assoc-in segment [:table :collection]
+                                               {:id coll-id
+                                                :is_remote_synced (get collection-synced-map coll-id false)})
+                                     segment))]
+    (mi/instances-with-hydrated-data
+     segments k
+     #(u/index-by :id mi/can-write? segments-with-collection)
+     :id
+     {:default false})))
+
+(t2/define-before-update :model/Segment [segment]
+  ;; throw an Exception if someone tries to update creator_id
+  (when (contains? (t2/changes segment) :creator_id)
+    (throw (UnsupportedOperationException. (tru "You cannot update the creator_id of a Segment."))))
+  segment)
 
 (defn- migrated-segment-definition
   [{:keys [definition], table-id :table_id}]

--- a/src/metabase/segments/models/segment.clj
+++ b/src/metabase/segments/models/segment.clj
@@ -136,12 +136,6 @@
      :id
      {:default false})))
 
-(t2/define-before-update :model/Segment [segment]
-  ;; throw an Exception if someone tries to update creator_id
-  (when (contains? (t2/changes segment) :creator_id)
-    (throw (UnsupportedOperationException. (tru "You cannot update the creator_id of a Segment."))))
-  segment)
-
 (defn- migrated-segment-definition
   [{:keys [definition], table-id :table_id}]
   (let [database-id (t2/select-one-fn :db_id :model/Table :id table-id)]

--- a/src/metabase/warehouse_schema/models/field.clj
+++ b/src/metabase/warehouse_schema/models/field.clj
@@ -12,6 +12,7 @@
    [metabase.models.interface :as mi]
    [metabase.models.serialization :as serdes]
    [metabase.premium-features.core :refer [defenterprise]]
+   [metabase.remote-sync.core :as remote-sync]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
@@ -192,16 +193,52 @@
    (mi/can-query? (t2/select-one model pk))))
 
 (defenterprise current-user-can-write-field?
-  "OSS implementation. Returns a boolean whether the current user can write the given field."
+  "OSS implementation. Returns a boolean whether the current user can write the given field.
+   Checks both that the user is a superuser and that the parent table is editable (not in a
+   remote-synced collection in read-only mode)."
   metabase-enterprise.advanced-permissions.common
-  [_instance]
-  (mi/superuser?))
+  [instance]
+  (let [table (or (:table instance)
+                  (t2/select-one :model/Table :id (:table_id instance)))]
+    (and (remote-sync/table-editable? table)
+         (mi/superuser?))))
 
 (defmethod mi/can-write? :model/Field
   ([instance]
    (current-user-can-write-field? instance))
   ([model pk]
    (mi/can-write? (t2/select-one model pk))))
+
+(methodical/defmethod t2/batched-hydrate [:model/Field :can_write]
+  "Batched hydration for :can_write on fields. First hydrates :table for all fields,
+   then pre-fetches collection is_remote_synced values for those tables, and calls can-write?
+   on each field. This avoids N+1 queries when checking permissions for multiple fields."
+  [_model k fields]
+  (let [fields-with-tables (t2/hydrate (remove nil? fields) :table)
+        ;; Get all unique collection IDs from the hydrated tables
+        collection-ids (->> fields-with-tables
+                            (keep (comp :collection_id :table))
+                            distinct)
+        ;; Batch fetch is_remote_synced for all collections
+        collection-synced-map (if (seq collection-ids)
+                                (into {}
+                                      (map (juxt :id :is_remote_synced))
+                                      (t2/select :model/Collection :id [:in collection-ids]))
+                                {})
+        ;; Associate collection info with each field's table
+        fields-with-collection (for [field fields-with-tables
+                                     :let [table (:table field)
+                                           coll-id (:collection_id table)]]
+                                 (if (and table coll-id)
+                                   (assoc-in field [:table :collection]
+                                             {:id coll-id
+                                              :is_remote_synced (get collection-synced-map coll-id false)})
+                                   field))]
+    (mi/instances-with-hydrated-data
+     fields k
+     #(u/index-by :id mi/can-write? fields-with-collection)
+     :id
+     {:default false})))
 
 (defmethod serdes/hash-fields :model/Field
   [_field]

--- a/src/metabase/warehouse_schema/models/table.clj
+++ b/src/metabase/warehouse_schema/models/table.clj
@@ -487,10 +487,13 @@
   (cond-> [[{:model "Database" :id db_id}]]
     collection_id (conj [{:model "Collection" :id collection_id}])))
 
-(defmethod serdes/descendants "Table" [_model-name id _opts]
+(defmethod serdes/descendants "Table" [_model-name id {:keys [skip-archived]}]
   (let [fields   (into {} (for [field-id (t2/select-pks-set :model/Field {:where [:= :table_id id]})]
                             {["Field" field-id] {"Table" id}}))
-        segments (into {} (for [segment-id (t2/select-pks-set :model/Segment {:where [:= :table_id id]})]
+        segments (into {} (for [segment-id (t2/select-pks-set :model/Segment
+                                                              {:where [:and
+                                                                       [:= :table_id id]
+                                                                       (when skip-archived [:not :archived])]})]
                             {["Segment" segment-id] {"Table" id}}))]
     (merge fields segments)))
 

--- a/src/metabase/warehouse_schema/models/table.clj
+++ b/src/metabase/warehouse_schema/models/table.clj
@@ -487,6 +487,13 @@
   (cond-> [[{:model "Database" :id db_id}]]
     collection_id (conj [{:model "Collection" :id collection_id}])))
 
+(defmethod serdes/descendants "Table" [_model-name id _opts]
+  (let [fields   (into {} (for [field-id (t2/select-pks-set :model/Field {:where [:= :table_id id]})]
+                            {["Field" field-id] {"Table" id}}))
+        segments (into {} (for [segment-id (t2/select-pks-set :model/Segment {:where [:= :table_id id]})]
+                            {["Segment" segment-id] {"Table" id}}))]
+    (merge fields segments)))
+
 (defmethod serdes/generate-path "Table" [_ table]
   (let [db-name (t2/select-one-fn :name :model/Database :id (:db_id table))]
     (filterv some? [{:model "Database" :id db-name}

--- a/src/metabase/warehouse_schema/models/table.clj
+++ b/src/metabase/warehouse_schema/models/table.clj
@@ -10,6 +10,7 @@
    [metabase.models.serialization :as serdes]
    [metabase.permissions.core :as perms]
    [metabase.premium-features.core :refer [defenterprise]]
+   [metabase.remote-sync.core :as remote-sync]
    [metabase.search.spec :as search.spec]
    [metabase.util :as u]
    [metabase.util.log :as log]
@@ -297,10 +298,13 @@
    (mi/can-query? (t2/select-one :model/Table pk))))
 
 (defenterprise current-user-can-write-table?
-  "OSS implementation. Returns a boolean whether the current user can write the given field."
+  "OSS implementation. Returns a boolean whether the current user can write the given table.
+   Checks both that the user is a superuser and that the table is editable (not in a remote-synced
+   collection in read-only mode)."
   metabase-enterprise.advanced-permissions.common
-  [_instance]
-  (mi/superuser?))
+  [instance]
+  (and (remote-sync/table-editable? instance)
+       (mi/superuser?)))
 
 (defmethod mi/can-write? :model/Table
   ;; Check if user can modify this table's metadata.
@@ -309,6 +313,32 @@
    (current-user-can-write-table? instance))
   ([_ pk]
    (mi/can-write? (t2/select-one :model/Table pk))))
+
+(methodical/defmethod t2/batched-hydrate [:model/Table :can_write]
+  "Batched hydration for :can_write on tables. Pre-fetches collection is_remote_synced values
+   to avoid N+1 queries when checking remote-sync permissions for multiple tables."
+  [_model k tables]
+  (let [;; Get all unique collection IDs (excluding nil)
+        collection-ids (->> tables
+                            (keep :collection_id)
+                            distinct)
+        ;; Batch fetch is_remote_synced for all collections
+        collection-synced-map (if (seq collection-ids)
+                                (into {}
+                                      (map (juxt :id :is_remote_synced))
+                                      (t2/select :model/Collection :id [:in collection-ids]))
+                                {})
+        ;; Associate collection info with each table so table-editable? doesn't need to query
+        tables-with-collection (for [table tables]
+                                 (if-let [coll-id (:collection_id table)]
+                                   (assoc table :collection {:id coll-id
+                                                             :is_remote_synced (get collection-synced-map coll-id false)})
+                                   table))]
+    (mi/instances-with-hydrated-data
+     tables k
+     #(u/index-by :id mi/can-write? tables-with-collection)
+     :id
+     {:default false})))
 
 ;;; ------------------------------------------------ SQL Permissions ------------------------------------------------
 

--- a/src/metabase/warehouse_schema_rest/api/field.clj
+++ b/src/metabase/warehouse_schema_rest/api/field.clj
@@ -4,6 +4,7 @@
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.app-db.core :as app-db]
+   [metabase.events.core :as events]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.models.interface :as mi]
    [metabase.parameters.field :as parameters.field]
@@ -185,6 +186,7 @@
     (u/prog1 (-> (t2/select-one :model/Field :id id)
                  (t2/hydrate :dimensions :has_field_values)
                  (field/hydrate-target-with-write-perms))
+      (events/publish-event! :event/field-update {:object <> :user-id api/*current-user-id*})
       (when (not= effective-type (:effective_type field))
         (analytics/track-event! :snowplow/simple_event {:event "field_effective_type_change" :target_id id})
         (quick-task/submit-task! (fn [] (sync/refingerprint-field! <>)))))))

--- a/src/metabase/warehouse_schema_rest/api/table.clj
+++ b/src/metabase/warehouse_schema_rest/api/table.clj
@@ -6,6 +6,7 @@
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.app-db.core :as app-db]
+   [metabase.config.core :as config]
    [metabase.database-routing.core :as database-routing]
    [metabase.driver.settings :as driver.settings]
    [metabase.driver.util :as driver.u]
@@ -233,10 +234,12 @@
           newly-unhidden (when (and (contains? body :visibility_type) (nil? visibility_type))
                            (into [] (filter (comp some? :visibility_type)) existing-tables))]
       (sync-unhidden-tables newly-unhidden)
-      ;; Publish update events for remote sync tracking
-      (doseq [table updated-tables]
-        (events/publish-event! :event/table-update {:object  table
-                                                    :user-id api/*current-user-id*}))
+      ;; Publish update events for remote sync tracking, only when ee extensions are available to provide
+      ;; a handler for these events
+      (config/ee-available?
+       (doseq [table updated-tables]
+         (events/publish-event! :event/table-update {:object  table
+                                                     :user-id api/*current-user-id*})))
       updated-tables)))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to

--- a/src/metabase/warehouse_schema_rest/api/table.clj
+++ b/src/metabase/warehouse_schema_rest/api/table.clj
@@ -236,10 +236,10 @@
       (sync-unhidden-tables newly-unhidden)
       ;; Publish update events for remote sync tracking, only when ee extensions are available to provide
       ;; a handler for these events
-      (config/ee-available?
-       (doseq [table updated-tables]
-         (events/publish-event! :event/table-update {:object  table
-                                                     :user-id api/*current-user-id*})))
+      (when config/ee-available?
+        (doseq [table updated-tables]
+          (events/publish-event! :event/table-update {:object  table
+                                                      :user-id api/*current-user-id*})))
       updated-tables)))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to

--- a/src/metabase/warehouse_schema_rest/api/table.clj
+++ b/src/metabase/warehouse_schema_rest/api/table.clj
@@ -233,6 +233,10 @@
           newly-unhidden (when (and (contains? body :visibility_type) (nil? visibility_type))
                            (into [] (filter (comp some? :visibility_type)) existing-tables))]
       (sync-unhidden-tables newly-unhidden)
+      ;; Publish update events for remote sync tracking
+      (doseq [table updated-tables]
+        (events/publish-event! :event/table-update {:object  table
+                                                    :user-id api/*current-user-id*}))
       updated-tables)))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to

--- a/test/metabase/warehouse_schema/models/table_test.clj
+++ b/test/metabase/warehouse_schema/models/table_test.clj
@@ -664,3 +664,21 @@
         (let [hydrated (t2/hydrate table :can_query)]
           (is (contains? hydrated :can_query))
           (is (boolean? (:can_query hydrated))))))))
+
+(deftest serdes-descendants-includes-fields-and-segments-test
+  (testing "Table descendants includes Fields and Segments"
+    (mt/with-temp [:model/Database {db-id :id}      {:name "Test DB"}
+                   :model/Table    {table-id :id}   {:name "Test Table" :db_id db-id}
+                   :model/Field    {field1-id :id}  {:name "Field 1" :table_id table-id :base_type :type/Integer}
+                   :model/Field    {field2-id :id}  {:name "Field 2" :table_id table-id :base_type :type/Text}
+                   :model/Segment  {segment-id :id} {:name "Test Segment" :table_id table-id :definition {}}]
+      (let [descendants (serdes/descendants "Table" table-id {})]
+        (testing "Fields are included"
+          (is (contains? descendants ["Field" field1-id]))
+          (is (contains? descendants ["Field" field2-id])))
+        (testing "Segments are included"
+          (is (contains? descendants ["Segment" segment-id]))))))
+  (testing "Table with no fields or segments returns empty map"
+    (mt/with-temp [:model/Database {db-id :id}    {:name "Test DB"}
+                   :model/Table    {table-id :id} {:name "Empty Table" :db_id db-id}]
+      (is (= {} (serdes/descendants "Table" table-id {}))))))

--- a/test/metabase/warehouse_schema/models/table_test.clj
+++ b/test/metabase/warehouse_schema/models/table_test.clj
@@ -682,3 +682,27 @@
     (mt/with-temp [:model/Database {db-id :id}    {:name "Test DB"}
                    :model/Table    {table-id :id} {:name "Empty Table" :db_id db-id}]
       (is (= {} (serdes/descendants "Table" table-id {}))))))
+
+(deftest serdes-descendants-skip-archived-segments-test
+  (testing "Table descendants respects skip-archived option for Segments"
+    (mt/with-temp [:model/Database {db-id :id}           {:name "Test DB"}
+                   :model/Table    {table-id :id}        {:name "Test Table" :db_id db-id}
+                   :model/Field    {field-id :id}        {:name "Test Field" :table_id table-id :base_type :type/Integer}
+                   :model/Segment  {active-seg-id :id}   {:name "Active Segment" :table_id table-id :definition {} :archived false}
+                   :model/Segment  {archived-seg-id :id} {:name "Archived Segment" :table_id table-id :definition {} :archived true}]
+      (testing "archived segments are excluded when skip-archived: true"
+        (let [descendants (serdes/descendants "Table" table-id {:skip-archived true})]
+          (is (contains? descendants ["Field" field-id])
+              "Fields are still included")
+          (is (contains? descendants ["Segment" active-seg-id])
+              "Active segments are included")
+          (is (not (contains? descendants ["Segment" archived-seg-id]))
+              "Archived segments are excluded")))
+      (testing "archived segments are included when skip-archived: false"
+        (let [descendants (serdes/descendants "Table" table-id {:skip-archived false})]
+          (is (contains? descendants ["Segment" active-seg-id]))
+          (is (contains? descendants ["Segment" archived-seg-id]))))
+      (testing "archived segments are included when skip-archived is not specified"
+        (let [descendants (serdes/descendants "Table" table-id {})]
+          (is (contains? descendants ["Segment" active-seg-id]))
+          (is (contains? descendants ["Segment" archived-seg-id])))))))


### PR DESCRIPTION
### Description

Fully support remote-sync for data studio and make it easier to extend support for remote-sync to other models in the future. 

1. Supports serializing tables with their fields and segments via remote sync if they are published to a remote-synced collection. 
2. Supports dirty state tracking of tables, fields, and segments. 
3. Refetches dirty state when tables, fields, and segments are created/updated/deleted in the data studio
4. Make sure the data studio still displays content when remote-sync is in read-only mode
5. enforce that tables, fields, and segments published to remote-synced collections are not editable when remote-sync is in read-only mode. 
6. Deletes, tables, fields, and segments from the remote-sync repo when they are removed or archived. 

This also creates two small abstractions to make it easier to add new models (like measures) to remote-sync when they are ready. The remote-sync.events models adds a `defmodel-change-handler` macro that setups handlers for -create, -update, -delete, events models can publish that the dirty state tracking will follow. 

Right now the UI does not change when the data studio is in read-only mode, but all create/edit operations correctly return 403 if you try to modify things. I have a follow up branch to support disabling UI elements. 

### Checklist

- [x] Support archived flag filtering for removed segements
- [x] Figure out why the library isn't marked as dirty when a table is unpublished
- [x] Tests have been added/updated to cover changes in this PR
