### PR TITLE
Fix stress-test snapshot conditions

### DIFF
--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -128,10 +128,16 @@ jobs:
       - name: Run Metabase
         run: node e2e/runner/run_cypress_ci.js start
 
-      - name: Generate database snapshots
+      - name: Generate default database snapshot
+        if: inputs.qa_db == false # true boolean, do not use string here!
         run: |
           node e2e/runner/run_cypress_ci.js snapshot \
-            --env grepTags="${{inputs.qa_db && '' || '-@external'}}"
+            --spec "e2e/snapshot-creators/default.cy.snap.js"
+
+      - name: Generate all database snapshots
+        if: inputs.qa_db
+        run: |
+          node e2e/runner/run_cypress_ci.js snapshot
 
       # For all options and fine-grained control, take a look at the documentation
       # https://github.com/cypress-io/cypress/tree/develop/npm/grep


### PR DESCRIPTION
Bug reported in Slack [here](https://metaboat.slack.com/archives/C010L1Z4F9S/p1766160775380029).

The input `qa_db` is true boolean.
However, the previously used fake ternary operator was always resolving to the false branch for some unknown reason. This resulted in the snapshot step always excluding "@external" snapshots, even when `inputs.qa_db` was obviously `true`. Or maybe it did evaluate the input correctly, but GHA treats the empty string as falsy value...

```
${{inputs.qa_db && '' || '-@external'}}
```

To make things more explicit, I've included two distinct snapshot steps:
1. run only the default snapshot
2. run all snapshots

## Test
1. https://github.com/metabase/metabase/actions/runs/20415226009
<img width="583" height="420" alt="image" src="https://github.com/user-attachments/assets/87be91b2-6d74-442c-a191-383d7164dbbc" />

Result:
Only the default snapshot ran
<img width="331" height="80" alt="image" src="https://github.com/user-attachments/assets/5889c102-bd6f-480b-8f0f-0fc5d9f3cc41" />

2. https://github.com/metabase/metabase/actions/runs/20415217544
<img width="550" height="409" alt="image" src="https://github.com/user-attachments/assets/6c91442f-e3f1-4b56-ad1d-0ae9a2e1aee9" />

Result:
Both snapshots ran, and the test that relies on an external Postgres database passed.
<img width="315" height="79" alt="image" src="https://github.com/user-attachments/assets/e80ab6bf-c58b-40e8-b40a-62235a9feac1" />
