### PR TITLE
Hide Data Permissions sections that are irrelevant to oss

### DIFF
--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -494,6 +494,8 @@ describe("scenarios > admin > permissions", () => {
   });
 
   it("shows permissions help", () => {
+    // pro-token because some help sections are hidden for OSS
+    H.activateToken("pro-self-hosted");
     cy.visit("/admin/permissions");
 
     // Data permissions w/o `legacy-no-self-service` in graph

--- a/frontend/src/metabase/admin/permissions/components/DataPermissionsHelp/DataPermissionsHelp.tsx
+++ b/frontend/src/metabase/admin/permissions/components/DataPermissionsHelp/DataPermissionsHelp.tsx
@@ -1,7 +1,6 @@
 import { jt, t } from "ttag";
 
 import { PermissionHelpDescription } from "metabase/admin/permissions/components/PermissionHelpDescription";
-import { getLimitedPermissionAvailabilityMessage } from "metabase/admin/permissions/constants/messages";
 import { DataPermissionValue } from "metabase/admin/permissions/types";
 import ExternalLink from "metabase/common/components/ExternalLink";
 import { useDocsUrl } from "metabase/common/hooks";
@@ -40,7 +39,6 @@ export const DataPermissionsHelp = () => {
         <Title order={3}>{t`Data permissions`}</Title>
         <Text my="1rem">{t`People can be members of multiple groups, and Metabase grants them the most permissive level of access across all of a person's groups.`}</Text>
       </Box>
-
       <Accordion
         chevron={<Icon name="chevrondown" size={12} />}
         defaultValue="database-level"
@@ -48,6 +46,7 @@ export const DataPermissionsHelp = () => {
         <Accordion.Item
           value="database-view-data-level"
           data-testid="database-view-data-level"
+          hidden={!isAdvancedPermissionsFeatureEnabled}
         >
           <Accordion.Control>{t`Database ‘View data’ levels`}</Accordion.Control>
           <Accordion.Panel>
@@ -58,22 +57,18 @@ export const DataPermissionsHelp = () => {
                 name={t`Can view`}
                 description={t`The group can view all data for that database.`}
               />
-
               <PermissionHelpDescription
                 icon="permissions_limited"
                 iconColor="warning"
                 name={t`Granular`}
                 description={t`The group can view select schemas and tables. Can be combined with user attributes to enable row and column security to control what data each person can view.`}
               />
-
               <PermissionHelpDescription
-                hasUpgradeNotice={!isAdvancedPermissionsFeatureEnabled}
                 icon="database"
                 iconColor="warning"
                 name={t`Impersonated (Pro)`}
                 description={t`The group can view data based on the database role you specify with a user attribute (manually or via SSO).`}
               />
-
               {shouldShowLegacyNoSelfServiceInfo && (
                 <PermissionHelpDescription
                   icon="eye"
@@ -82,9 +77,7 @@ export const DataPermissionsHelp = () => {
                   description={t`The group can't use the query builder or drill through existing questions. They also can't see the data in the Browse data section. They can still view questions based on this data, if they have permissions to the relevant collection. ‘Blocked‘, ‘Impersonated‘ and ‘Row and column security‘ in another group will override ‘No self-service‘.`}
                 />
               )}
-
               <PermissionHelpDescription
-                hasUpgradeNotice={!isAdvancedPermissionsFeatureEnabled}
                 icon="close"
                 iconColor="danger"
                 name={t`Blocked (Pro)`}
@@ -93,10 +86,10 @@ export const DataPermissionsHelp = () => {
             </Stack>
           </Accordion.Panel>
         </Accordion.Item>
-
         <Accordion.Item
           value="schema-table-level"
           data-testid="schema-table-level"
+          hidden={!isAdvancedPermissionsFeatureEnabled}
         >
           <Accordion.Control>{t`Schema or table ‘View data’ levels`}</Accordion.Control>
           <Accordion.Panel>
@@ -107,7 +100,6 @@ export const DataPermissionsHelp = () => {
                 name={t`Can view`}
                 description={t`The group can view all data for that schema or table.`}
               />
-
               {shouldShowLegacyNoSelfServiceInfo && (
                 <PermissionHelpDescription
                   icon="eye"
@@ -116,17 +108,13 @@ export const DataPermissionsHelp = () => {
                   description={t`"No self-service" works like it does for databases, except here it is scoped to individual schemas or tables.`}
                 />
               )}
-
               <PermissionHelpDescription
-                hasUpgradeNotice={!isAdvancedPermissionsFeatureEnabled}
                 icon="permissions_limited"
                 iconColor="brand"
                 name={t`Row and column security (Pro)`}
                 description={t`Lets you specify row and column-level permissions. Can be set up via user attributes and SSO.`}
               />
-
               <PermissionHelpDescription
-                hasUpgradeNotice={!isAdvancedPermissionsFeatureEnabled}
                 icon="close"
                 iconColor="danger"
                 name={t`Blocked (Pro)`}
@@ -154,7 +142,6 @@ export const DataPermissionsHelp = () => {
             </Stack>
           </Accordion.Panel>
         </Accordion.Item>
-
         <Accordion.Item
           value="create-queries-level"
           data-testid="create-queries-level"
@@ -168,14 +155,12 @@ export const DataPermissionsHelp = () => {
                 name={t`Query builder and native`}
                 description={t`The group can use both the query builder and the native code editor to create questions and models.`}
               />
-
               <PermissionHelpDescription
                 icon="permissions_limited"
                 iconColor="warning"
                 name={t`Query builder only`}
                 description={t`The group can use the query builder to create questions and models.`}
               />
-
               <PermissionHelpDescription
                 icon="permissions_limited"
                 iconColor="warning"
@@ -192,37 +177,32 @@ export const DataPermissionsHelp = () => {
             </Stack>
           </Accordion.Panel>
         </Accordion.Item>
-
-        <Accordion.Item value="others">
+        <Accordion.Item
+          value="others"
+          hidden={!isAdvancedPermissionsFeatureEnabled}
+        >
           <Accordion.Control>{t`Other data permissions`}</Accordion.Control>
           <Accordion.Panel>
             <Stack gap="1rem" py="1rem">
               <Text>
                 {jt`${(
                   <strong key="permission">{t`Download results (Pro):`}</strong>
-                )} The group can download results, up to a maximum number of rows that you set.`}{" "}
-                {!isAdvancedPermissionsFeatureEnabled &&
-                  getLimitedPermissionAvailabilityMessage()}
+                )} The group can download results, up to a maximum number of rows that you set.`}
               </Text>
               <Text>
                 {jt`${(
                   <strong key="permission">{t`Manage Data Model (Pro):`}</strong>
-                )} The group can edit metadata via the “Table metadata” tab in the Admin settings.`}{" "}
-                {!isAdvancedPermissionsFeatureEnabled &&
-                  getLimitedPermissionAvailabilityMessage()}
+                )} The group can edit metadata via the “Table metadata” tab in the Admin settings.`}
               </Text>
               <Text>
                 {jt`${(
                   <strong key="permission">{t`Manage Database (Pro):`}</strong>
-                )} The group can edit database settings for a given database in the “Database” tab of the Admin settings.`}{" "}
-                {!isAdvancedPermissionsFeatureEnabled &&
-                  getLimitedPermissionAvailabilityMessage()}
+                )} The group can edit database settings for a given database in the “Database” tab of the Admin settings.`}
               </Text>
             </Stack>
           </Accordion.Panel>
         </Accordion.Item>
       </Accordion>
-
       <Text component="footer" ta="center" py="1.5rem" fw={600}>
         {jt`${(
           <ExternalLink key="link" href={docsUrl}>{t`Learn more`}</ExternalLink>

--- a/frontend/src/metabase/admin/permissions/components/DataPermissionsHelp/DataPermissionsHelp.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/components/DataPermissionsHelp/DataPermissionsHelp.unit.spec.tsx
@@ -24,29 +24,29 @@ async function setup({ hasAdvancedPermissions = false } = {}) {
 }
 
 describe("DataPermissionsHelp", () => {
-  it("shows link to the plans page on non-enterprise instances", () => {
-    setup({ hasAdvancedPermissions: false });
+  it("shows all the sections to users with advanced permissions", () => {
+    setup({ hasAdvancedPermissions: true });
 
-    screen
-      .queryAllByText("Only available in certain Metabase plans.")
-      .every((element) => {
-        expect(element).toBeInTheDocument();
-      });
-
-    screen.getAllByText("Upgrade to Pro").every((link) => {
-      expect(link).toHaveAttribute(
-        "href",
-        "https://www.metabase.com/upgrade?utm_source=product&utm_medium=upsell&utm_content=admin_permissions&source_plan=oss",
-      );
+    [
+      "Database ‘View data’ levels",
+      "Schema or table ‘View data’ levels",
+      "‘Create queries’ levels",
+      "Other data permissions",
+    ].forEach((text) => {
+      expect(screen.getByText(text)).toBeVisible();
     });
   });
 
-  it("does not show the link to the plans page on enterprise instances", () => {
-    setup({ hasAdvancedPermissions: true });
+  it("hides sections to users without advanced permissions", () => {
+    setup({ hasAdvancedPermissions: false });
+    expect(screen.getByText("‘Create queries’ levels")).toBeInTheDocument();
 
-    expect(
-      screen.queryByText("Only available in certain Metabase plans."),
-    ).not.toBeInTheDocument();
-    expect(screen.queryByText("Upgrade to Pro")).not.toBeInTheDocument();
+    [
+      "Database ‘View data’ levels",
+      "Schema or table ‘View data’ levels",
+      "Other data permissions",
+    ].forEach((text) => {
+      expect(screen.getByText(text)).not.toBeVisible();
+    });
   });
 });

--- a/frontend/src/metabase/admin/permissions/components/PermissionHelpDescription/PermissionHelpDescription.tsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionHelpDescription/PermissionHelpDescription.tsx
@@ -1,11 +1,6 @@
 import type { ReactNode } from "react";
-import { t } from "ttag";
 
-import { getLimitedPermissionAvailabilityMessage } from "metabase/admin/permissions/constants/messages";
-import ExternalLink from "metabase/common/components/ExternalLink";
 import type { ColorName } from "metabase/lib/colors/types";
-import { useSelector } from "metabase/lib/redux";
-import { getUpgradeUrl } from "metabase/selectors/settings";
 import type { IconName } from "metabase/ui";
 import { Flex, Icon, Text, Title } from "metabase/ui";
 
@@ -16,7 +11,6 @@ interface PermissionHelpDescriptionProps {
   description?: ReactNode;
   icon: IconName;
   iconColor: ColorName;
-  hasUpgradeNotice?: boolean;
 }
 
 export const PermissionHelpDescription = ({
@@ -24,12 +18,7 @@ export const PermissionHelpDescription = ({
   description,
   icon,
   iconColor,
-  hasUpgradeNotice,
 }: PermissionHelpDescriptionProps) => {
-  const upgradeUrl = useSelector((state) =>
-    getUpgradeUrl(state, { utm_content: "admin_permissions" }),
-  );
-
   return (
     <div>
       <Flex align="center" mb={4}>
@@ -46,15 +35,6 @@ export const PermissionHelpDescription = ({
         ) : (
           description
         ))}
-
-      {hasUpgradeNotice ? (
-        <>
-          <Text mt="1rem">{getLimitedPermissionAvailabilityMessage()}</Text>{" "}
-          <Text fw="bold">
-            <ExternalLink href={upgradeUrl}>{t`Upgrade to Pro`}</ExternalLink>
-          </Text>
-        </>
-      ) : null}
     </div>
   );
 };

--- a/frontend/src/metabase/admin/permissions/constants/messages.ts
+++ b/frontend/src/metabase/admin/permissions/constants/messages.ts
@@ -27,6 +27,3 @@ export const Messages = {
     return t`Groups with Block data access can't download results`;
   },
 };
-
-export const getLimitedPermissionAvailabilityMessage = () =>
-  t`Only available in certain Metabase plans.`;


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #61324
Data permissions now just shows the `Create queries` section, which was the only section relevant to oss users.

<img width="1512" height="666" alt="Screenshot 2025-12-22 at 6 32 36 PM" src="https://github.com/user-attachments/assets/f050bf43-c27e-4741-9894-67982ec062f2" />
