### PR TITLE
Workspaces archive shouldn't fail if failed to destroy isolation

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/workspaces/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/api_test.clj
@@ -127,10 +127,8 @@
       (mt/with-dynamic-fn-redefs [ws.isolation/destroy-workspace-isolation!
                                   (fn [_database _workspace]
                                     (throw (ex-info "Simulated cleanup failure" {:test true})))]
-        ;; Archive should still succeed
         (let [response (mt/user-http-request :crowberto :post 200 (str "ee/workspace/" (:id workspace) "/archive"))]
           (is (= {:ok true} response)))
-        ;; Workspace should be archived
         (is (some? (t2/select-one-fn :archived_at :model/Workspace :id (:id workspace)))
             "Workspace should have archived_at set despite cleanup failure")))))
 

--- a/enterprise/backend/test/metabase_enterprise/workspaces/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/api_test.clj
@@ -121,9 +121,9 @@
         (mt/user-http-request :crowberto :post 200 (str "ee/workspace/" (:id workspace) "/archive"))
         (is @called? "destroy-workspace-isolation! should be called when archiving")))))
 
-(deftest ^:parallel archive-workspace-succeeds-when-cleanup-fails-test
+(deftest archive-workspace-succeeds-when-cleanup-fails-test
   (testing "POST /api/ee/workspace/:id/archive succeeds even when destroy-workspace-isolation! fails"
-    (let [workspace (ws.tu/create-ready-ws! "Archive Cleanup Fail Test")]
+    (ws.tu/with-workspaces! [workspace {:name "Archive Cleanup Fail Test"}]
       (mt/with-dynamic-fn-redefs [ws.isolation/destroy-workspace-isolation!
                                   (fn [_database _workspace]
                                     (throw (ex-info "Simulated cleanup failure" {:test true})))]


### PR DESCRIPTION
Middle ground for our discussion about how destroying an isolation can prevent workspaces archive. see https://metaboat.slack.com/archives/C099RKNLP6U/p1766163959457709