### PR TITLE
Fix flake #23630

### DIFF
--- a/e2e/test/scenarios/admin-2/people.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/people.cy.spec.js
@@ -631,8 +631,8 @@ describe("scenarios > admin > people", () => {
 
     const { first_name, last_name, email } = TEST_USER;
     const FULL_NAME = `${first_name} ${last_name}`;
-    cy.visit("/admin/people");
 
+    cy.visit("/admin/people");
     clickButton("Invite someone");
 
     // first modal
@@ -642,25 +642,23 @@ describe("scenarios > admin > people", () => {
     clickButton("Create");
 
     // second modal
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText(`${FULL_NAME} has been added`);
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.contains(
-      `We’ve sent an invite to ${email} with instructions to log in. If this user is unable to authenticate then you can reset their password.`,
-    );
-    cy.url().then((url) => {
-      const URL_REGEX = /\/admin\/people\/(?<userId>\d+)\/success/;
-      const { userId } = URL_REGEX.exec(url).groups;
-      assertLinkMatchesUrl(
-        "reset their password.",
-        `/admin/people/${userId}/reset`,
+    H.modal().within(() => {
+      cy.findByText(`${FULL_NAME} has been added`);
+      cy.contains(
+        `We’ve sent an invite to ${email} with instructions to log in. If this user is unable to authenticate then you can reset their password.`,
       );
+      cy.url().then((url) => {
+        const URL_REGEX = /\/admin\/people\/(?<userId>\d+)\/success/;
+        const { userId } = URL_REGEX.exec(url).groups;
+        assertLinkMatchesUrl(
+          "reset their password.",
+          `/admin/people/${userId}/reset`,
+        );
+      });
+      cy.button("Done").click();
     });
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Done").click();
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText(FULL_NAME);
+    cy.findByTestId("admin-people-list-table").should("contain", FULL_NAME);
   });
 });
 


### PR DESCRIPTION
[The related Linear issue](https://linear.app/metabase/issue/UXW-2592/broken-test-e2e-tests-scenarios-admin-people-scenarios-admin-people) was marked as DONE three days ago, but the Trunk analytics is still showing the test as unstable in master. This PR tidies things up a bit (aka can't hurt).

Stress-testing the change shows 50/50 attempts passing ✅ 
https://github.com/metabase/metabase/actions/runs/20433800119/job/58710265185

> [!Note]
> I've added `ci skip` label to avoid wasting CI cycles since this change was independently stress-tested.