### PR TITLE
Upload failed e2e test artifacts for quarantined tests

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -182,7 +182,7 @@ jobs:
         with:
           name: failed-tests-${{ inputs.name }}-${{ inputs.edition }}
           path: ./cypress/test-results
-        if-no-files-found: ignore
+          if-no-files-found: ignore
 
       - name: Extract chunk-specific changed timings
         id: extract-timings

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -113,6 +113,7 @@ jobs:
         run: node e2e/runner/run_cypress_ci.js snapshot
 
       - name: Run auto-split Cypress tests on ${{ inputs.name }}
+        id: split-e2e
         if: ${{ !inputs.specs }}
         env:
           SPLIT: ${{ inputs.total_chunks }}
@@ -136,6 +137,7 @@ jobs:
         continue-on-error: true
 
       - name: Run Tagged EE Cypress tests on ${{ inputs.name }}
+        id: tagged-e2e
         if: ${{ inputs.specs }}
         shell: bash
         env:
@@ -168,7 +170,7 @@ jobs:
 
       - name: Upload Cypress Artifacts upon failure
         uses: actions/upload-artifact@v4
-        if: always()
+        if: steps.split-e2e.outcome == 'failure' || steps.tagged-e2e.outcome == 'failure'
         with:
           name: cypress-recording-${{ inputs.name }}-${{ inputs.edition }}
           path: |
@@ -178,7 +180,7 @@ jobs:
 
       - name: Upload Failed Tests
         uses: actions/upload-artifact@v4
-        if: always()
+        if: steps.split-e2e.outcome == 'failure' || steps.tagged-e2e.outcome == 'failure'
         with:
           name: failed-tests-${{ inputs.name }}-${{ inputs.edition }}
           path: ./cypress/test-results

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -168,7 +168,7 @@ jobs:
 
       - name: Upload Cypress Artifacts upon failure
         uses: actions/upload-artifact@v4
-        if: failure()
+        if: always()
         with:
           name: cypress-recording-${{ inputs.name }}-${{ inputs.edition }}
           path: |
@@ -178,10 +178,11 @@ jobs:
 
       - name: Upload Failed Tests
         uses: actions/upload-artifact@v4
-        if: failure()
+        if: always()
         with:
           name: failed-tests-${{ inputs.name }}-${{ inputs.edition }}
           path: ./cypress/test-results
+        if-no-files-found: ignore
 
       - name: Extract chunk-specific changed timings
         id: extract-timings


### PR DESCRIPTION
Ever since we enabled Trunk quarantine, I can no longer access the failed test recordings in the run summary. We were uploading them on `failure()` but that doesn't work anymore. Trunk overrides the exit code and the job will be marked as passing.

This makes it super hard and inconvenient when you want to debug flaky tests. I need to see what exactly happened in CI in order to replicate it locally (and eventually solve the flake).

The proposed solution in this PR should bring back the test recordings and the test logs even for quarantined tests.