### PR TITLE
fix: respect time format in exclude date picker filter QUE-2611

### DIFF
--- a/frontend/src/metabase/querying/filters/components/DatePicker/DatePicker.stories.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/DatePicker.stories.tsx
@@ -1,18 +1,45 @@
+import type { Store } from "@reduxjs/toolkit";
 import FakeTimers from "@sinonjs/fake-timers";
 import type { Meta, StoryFn } from "@storybook/react";
 import { userEvent, within } from "@storybook/test";
 import { merge } from "icepick";
 import { type ComponentProps, useEffect } from "react";
 
+import { getStore } from "__support__/entities-store";
+import { mockSettings } from "__support__/settings";
+import { createMockEntitiesState } from "__support__/store";
+import { MetabaseReduxProvider } from "metabase/lib/redux";
+import { publicReducers } from "metabase/reducers-public";
 import { Box, Popover } from "metabase/ui";
+import type { State } from "metabase-types/store";
+import { createMockState } from "metabase-types/store/mocks";
 
 import { DatePicker } from "./DatePicker";
 
 import "metabase/public/components/EmbedFrame/EmbedFrame.module.css";
 
+const storeInitialState = createMockState({
+  settings: mockSettings(),
+  entities: createMockEntitiesState({}),
+});
+const store = getStore(
+  publicReducers,
+  storeInitialState,
+  [],
+) as unknown as Store<State>;
+
+const ReduxDecorator = (Story: StoryFn) => {
+  return (
+    <MetabaseReduxProvider store={store}>
+      <Story />
+    </MetabaseReduxProvider>
+  );
+};
+
 export default {
   title: "Components/Parameters/DatePicker",
   component: DatePicker,
+  decorators: [ReduxDecorator],
 } as Meta<typeof DatePicker>;
 
 let clock: FakeTimers.InstalledClock | undefined;

--- a/frontend/src/metabase/querying/filters/components/DatePicker/ExcludeDatePicker/ExcludeDatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/ExcludeDatePicker/ExcludeDatePicker.tsx
@@ -1,6 +1,7 @@
 import { type FormEvent, type ReactNode, useMemo, useState } from "react";
 import { t } from "ttag";
 
+import { useSelector } from "metabase/lib/redux";
 import type {
   DatePickerExtractionUnit,
   DatePickerOperator,
@@ -8,6 +9,7 @@ import type {
   ExcludeDatePickerOperator,
   ExcludeDatePickerValue,
 } from "metabase/querying/filters/types";
+import { getSetting } from "metabase/selectors/settings";
 import type { PopoverBackButtonProps } from "metabase/ui";
 import {
   Box,
@@ -178,8 +180,14 @@ function ExcludeValuePicker({
   readOnly,
 }: ExcludeValuePickerProps) {
   const [values, setValues] = useState(initialValues);
+  const formattingOptions = useSelector((state) =>
+    getSetting(state, "custom-formatting"),
+  );
   const option = useMemo(() => findExcludeUnitOption(unit), [unit]);
-  const groups = useMemo(() => getExcludeValueOptionGroups(unit), [unit]);
+  const groups = useMemo(
+    () => getExcludeValueOptionGroups(unit, formattingOptions["type/Temporal"]),
+    [unit, formattingOptions],
+  );
   const options = groups.flat();
   const isAll = values.length === options.length;
   const isValid = values.length > 0;

--- a/frontend/src/metabase/querying/filters/components/DatePicker/ExcludeDatePicker/ExcludeDatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/ExcludeDatePicker/ExcludeDatePicker.tsx
@@ -1,7 +1,7 @@
 import { type FormEvent, type ReactNode, useMemo, useState } from "react";
 import { t } from "ttag";
 
-import { useSelector } from "metabase/lib/redux";
+import { useSetting } from "metabase/common/hooks";
 import type {
   DatePickerExtractionUnit,
   DatePickerOperator,
@@ -9,7 +9,6 @@ import type {
   ExcludeDatePickerOperator,
   ExcludeDatePickerValue,
 } from "metabase/querying/filters/types";
-import { getSetting } from "metabase/selectors/settings";
 import type { PopoverBackButtonProps } from "metabase/ui";
 import {
   Box,
@@ -180,9 +179,7 @@ function ExcludeValuePicker({
   readOnly,
 }: ExcludeValuePickerProps) {
   const [values, setValues] = useState(initialValues);
-  const formattingOptions = useSelector((state) =>
-    getSetting(state, "custom-formatting"),
-  );
+  const formattingOptions = useSetting("custom-formatting");
   const option = useMemo(() => findExcludeUnitOption(unit), [unit]);
   const groups = useMemo(
     () => getExcludeValueOptionGroups(unit, formattingOptions["type/Temporal"]),

--- a/frontend/src/metabase/querying/filters/components/DatePicker/ExcludeDatePicker/ExcludeDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/ExcludeDatePicker/ExcludeDatePicker.unit.spec.tsx
@@ -237,9 +237,9 @@ describe("ExcludeDatePicker", () => {
       const { onChange } = setup({ timeStyle: "HH:mm" });
 
       await userEvent.click(screen.getByText("Hours of the day…"));
-      ["00:00", "09:00", "17:00"].forEach(async (label) => {
+      for (const label of ["00:00", "09:00", "17:00"]) {
         await userEvent.click(screen.getByLabelText(label));
-      });
+      }
       await userEvent.click(screen.getByRole("button", { name: "Apply" }));
 
       expect(onChange).toHaveBeenCalledWith({

--- a/frontend/src/metabase/querying/filters/components/DatePicker/ExcludeDatePicker/ExcludeDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/ExcludeDatePicker/ExcludeDatePicker.unit.spec.tsx
@@ -214,33 +214,32 @@ describe("ExcludeDatePicker", () => {
 
       await userEvent.click(screen.getByText("Hours of the day…"));
 
-      expect(screen.getByLabelText("12 AM")).toBeInTheDocument();
-      expect(screen.getByLabelText("1 AM")).toBeInTheDocument();
-      expect(screen.getByLabelText("11 AM")).toBeInTheDocument();
-      expect(screen.getByLabelText("12 PM")).toBeInTheDocument();
-      expect(screen.getByLabelText("1 PM")).toBeInTheDocument();
-      expect(screen.getByLabelText("11 PM")).toBeInTheDocument();
+      ["AM", "PM"].forEach((suffix) => {
+        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].forEach((hour) => {
+          expect(
+            screen.getByLabelText(`${hour} ${suffix}`),
+          ).toBeInTheDocument();
+        });
+      });
     });
 
     it("should display hours in 24-hour format when setting is HH:mm", async () => {
       setup({ timeStyle: "HH:mm" });
 
       await userEvent.click(screen.getByText("Hours of the day…"));
-
-      expect(screen.getByLabelText("00:00")).toBeInTheDocument();
-      expect(screen.getByLabelText("01:00")).toBeInTheDocument();
-      expect(screen.getByLabelText("12:00")).toBeInTheDocument();
-      expect(screen.getByLabelText("17:00")).toBeInTheDocument();
-      expect(screen.getByLabelText("23:00")).toBeInTheDocument();
+      Array.from({ length: 24 }).forEach((_, hour) => {
+        const label = hour.toString().padStart(2, "0") + ":00";
+        expect(screen.getByLabelText(label)).toBeInTheDocument();
+      });
     });
 
     it("should exclude hours correctly with 24-hour format", async () => {
       const { onChange } = setup({ timeStyle: "HH:mm" });
 
       await userEvent.click(screen.getByText("Hours of the day…"));
-      await userEvent.click(screen.getByLabelText("00:00"));
-      await userEvent.click(screen.getByLabelText("09:00"));
-      await userEvent.click(screen.getByLabelText("17:00"));
+      ["00:00", "09:00", "17:00"].forEach(async (label) => {
+        await userEvent.click(screen.getByLabelText(label));
+      });
       await userEvent.click(screen.getByRole("button", { name: "Apply" }));
 
       expect(onChange).toHaveBeenCalledWith({

--- a/frontend/src/metabase/querying/filters/components/DatePicker/ExcludeDatePicker/utils.ts
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/ExcludeDatePicker/utils.ts
@@ -9,6 +9,7 @@ import type {
   ExcludeDatePickerOperator,
   ExcludeDatePickerValue,
 } from "metabase/querying/filters/types";
+import type { DateFormattingSettings } from "metabase-types/api/settings";
 
 import { EXCLUDE_OPERATOR_OPTIONS, EXCLUDE_UNIT_OPTIONS } from "./constants";
 import type {
@@ -46,12 +47,15 @@ export function findExcludeUnitOption(
 
 export function getExcludeValueOptionGroups(
   unit: DatePickerExtractionUnit,
+  formattingOptions: DateFormattingSettings | undefined,
 ): ExcludeValueOption[][] {
+  const DEFAULT_TIME_STYLE = "h A";
+  const format = formattingOptions?.time_style ?? DEFAULT_TIME_STYLE;
   switch (unit) {
     case "hour-of-day":
       return [
-        _.range(0, 12).map(getExcludeHourOption),
-        _.range(12, 24).map(getExcludeHourOption),
+        _.range(0, 12).map((value) => getExcludeHourOption(value, format)),
+        _.range(12, 24).map((value) => getExcludeHourOption(value, format)),
       ];
     case "day-of-week":
       return [_.range(1, 8).map(getExcludeDayOption)];
@@ -65,9 +69,12 @@ export function getExcludeValueOptionGroups(
   }
 }
 
-function getExcludeHourOption(hour: number): ExcludeValueOption {
-  const date = dayjs().hour(hour);
-  return { value: hour, label: date.format("h A") };
+function getExcludeHourOption(
+  hour: number,
+  format: string,
+): ExcludeValueOption {
+  const date = dayjs().hour(hour).minute(0).second(0).millisecond(0);
+  return { value: hour, label: date.format(format) };
 }
 
 function getExcludeDayOption(day: number): ExcludeValueOption {

--- a/frontend/src/metabase/querying/filters/components/DatePicker/ExcludeDatePicker/utils.ts
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/ExcludeDatePicker/utils.ts
@@ -18,6 +18,8 @@ import type {
   ExcludeValueOption,
 } from "./types";
 
+const DEFAULT_TIME_STYLE = "h A";
+
 export function getExcludeUnitOptions(
   availableOperators: DatePickerOperator[],
   availableUnits: DatePickerUnit[],
@@ -49,7 +51,6 @@ export function getExcludeValueOptionGroups(
   unit: DatePickerExtractionUnit,
   formattingOptions: DateFormattingSettings | undefined,
 ): ExcludeValueOption[][] {
-  const DEFAULT_TIME_STYLE = "h A";
   const format = formattingOptions?.time_style ?? DEFAULT_TIME_STYLE;
   switch (unit) {
     case "hour-of-day":

--- a/frontend/src/metabase/querying/parameters/components/DateAllOptionsWidget/DateAllOptionsWidget.unit.spec.tsx
+++ b/frontend/src/metabase/querying/parameters/components/DateAllOptionsWidget/DateAllOptionsWidget.unit.spec.tsx
@@ -1,6 +1,6 @@
 import userEvent from "@testing-library/user-event";
 
-import { render, screen, within } from "__support__/ui";
+import { renderWithProviders, screen, within } from "__support__/ui";
 
 import { DateAllOptionsWidget } from "./DateAllOptionsWidget";
 
@@ -10,7 +10,9 @@ type SetupOpts = {
 
 function setup({ value }: SetupOpts = {}) {
   const onChange = jest.fn();
-  render(<DateAllOptionsWidget value={value} onChange={onChange} />);
+  renderWithProviders(
+    <DateAllOptionsWidget value={value} onChange={onChange} />,
+  );
   return { onChange };
 }
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #64269
Closes https://linear.app/metabase/issue/QUE-2611/date-picker-filter-hour-of-the-day-exclusion-does-not-respect-instance

### Description

Describe the overall approach and the problem being solved.

### How to verify

- create a dashboard and a add to it a question
- add Date Picker filter to it and save the dashboard
- add filtering and choose exclude
- default time formatting options (US 12 hour format should be visible)
- now go to to localization settings (`/admin/settings/localization`) and change the time format to 24 hour one
- go back to the dashboard
- 24 hour format should be visible in the exclude time filter

### Demo

https://github.com/user-attachments/assets/f988bf83-b857-47a5-be8a-82a2e230e045

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
