### PR TITLE
bump athena to 3.7.0

### DIFF
--- a/modules/drivers/athena/deps.edn
+++ b/modules/drivers/athena/deps.edn
@@ -9,4 +9,4 @@
  ;; https://github.com/metabase/metabase/actions/workflows/athena.yml
  ;; new versions of athena-jdbc appear here:
  ;; https://docs.aws.amazon.com/athena/latest/ug/jdbc-v3-driver.html#jdbc-v3-driver-download-uber-jar
- {com.metabase/athena-jdbc {:mvn/version "3.6.0"}}}
+ {com.metabase/athena-jdbc {:mvn/version "3.7.0"}}}


### PR DESCRIPTION
ran workflow at
https://github.com/metabase/metabase/actions/runs/20439789522/job/58729767910

https://github.com/metabase/metabase/actions/workflows/athena.yml to publish the 3.7.0 version