### PR TITLE
Fix #61219: Add ability to include personal collection items in search results for admins

### DIFF
--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -441,8 +441,7 @@ describe("command palette", () => {
     cy.realType("asdf");
     H.commandPalette()
       .get("#search-results-metadata")
-      .should("contain", "Search everything")
-      .click();
+      .should("contain", "Search everything");
   });
 
   describe("ee", () => {

--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -435,6 +435,20 @@ describe("command palette", () => {
     });
   });
 
+  it("should allow searching personal collections if no results and user is admin", () => {
+    cy.visit("/");
+    cy.findByRole("button", { name: /search/i }).click();
+    cy.realType("asdf");
+    H.commandPalette()
+      .get("#search-results-metadata")
+      .should("contain", "Search all personal collections")
+      .click();
+
+    cy.findByTestId("filter_items_in_personal_collection-search-filter")
+      .findByRole("switch")
+      .should("be.checked");
+  });
+
   describe("ee", () => {
     beforeEach(() => {
       H.activateToken("bleeding-edge");

--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -441,12 +441,8 @@ describe("command palette", () => {
     cy.realType("asdf");
     H.commandPalette()
       .get("#search-results-metadata")
-      .should("contain", "Search all personal collections")
+      .should("contain", "Search everything")
       .click();
-
-    cy.findByTestId("filter_items_in_personal_collection-search-filter")
-      .findByRole("switch")
-      .should("be.checked");
   });
 
   describe("ee", () => {

--- a/e2e/test/scenarios/search/search-filters.cy.spec.js
+++ b/e2e/test/scenarios/search/search-filters.cy.spec.js
@@ -2,8 +2,10 @@ const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
+  ADMIN_PERSONAL_COLLECTION_ID,
   ADMIN_USER_ID,
   FIRST_COLLECTION_ID,
+  NORMAL_PERSONAL_COLLECTION_ID,
   NORMAL_USER_ID,
   ORDERS_COUNT_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
@@ -999,6 +1001,83 @@ describe("scenarios > search", () => {
 
         expectSearchResultItemNameContent({
           itemNames: [TEST_NATIVE_QUESTION_NAME],
+        });
+      });
+    });
+
+    describe("personal collection filter", () => {
+      beforeEach(() => {
+        cy.log("Create a question in admin's personal collection");
+        H.createQuestion({
+          name: "Admin Personal Question [keyword]",
+          query: { "source-table": ORDERS_ID, limit: 1 },
+          collection_id: ADMIN_PERSONAL_COLLECTION_ID,
+        });
+
+        cy.log("Create a question in normal user's personal collection");
+        cy.signInAsNormalUser();
+        H.createQuestion({
+          name: "Normal User Personal Question [keyword]",
+          query: { "source-table": ORDERS_ID, limit: 1 },
+          collection_id: NORMAL_PERSONAL_COLLECTION_ID,
+        });
+        cy.signInAsAdmin();
+      });
+
+      it("should hydrate personal collection filter", () => {
+        cy.visit("/search?q=keyword&filter_items_in_personal_collection=only");
+        cy.wait("@search");
+
+        cy.findByTestId("filter_items_in_personal_collection-search-filter")
+          .findByRole("switch")
+          .should("be.checked");
+
+        expectSearchResultItemNameContent({
+          itemNames: [
+            "Admin Personal Question [keyword]",
+            "Normal User Personal Question [keyword]",
+          ],
+        });
+      });
+
+      it("should not be exposed to non-admins", () => {
+        cy.signInAsNormalUser();
+        cy.visit("/search?q=keyword&filter_items_in_personal_collection=only");
+        cy.wait("@search");
+        expectSearchResultItemNameContent({
+          itemNames: ["Normal User Personal Question [keyword]"],
+        });
+        cy.findByTestId(
+          "filter_items_in_personal_collection-search-filter",
+        ).should("not.exist");
+      });
+
+      it("should include other users' personal collection items when filter is turned on", () => {
+        cy.visit("/search?q=keyword");
+        cy.wait("@search");
+
+        cy.log("Should only see own personal items when filter is off");
+        expectSearchResultItemNameContent({
+          itemNames: ["Admin Personal Question [keyword]"],
+        });
+
+        cy.log("Turn on personal collection filter");
+        cy.findByTestId("filter_items_in_personal_collection-search-filter")
+          .findByRole("switch")
+          .should("not.be.checked");
+        cy.findByTestId("filter_items_in_personal_collection-search-filter")
+          .click()
+          .findByRole("switch")
+          .should("be.checked");
+
+        cy.url().should("contain", "filter_items_in_personal_collection=only");
+
+        cy.log("Should see own and other users' items when filter is on");
+        expectSearchResultItemNameContent({
+          itemNames: [
+            "Admin Personal Question [keyword]",
+            "Normal User Personal Question [keyword]",
+          ],
         });
       });
     });

--- a/e2e/test/scenarios/search/search-filters.cy.spec.js
+++ b/e2e/test/scenarios/search/search-filters.cy.spec.js
@@ -1025,7 +1025,7 @@ describe("scenarios > search", () => {
       });
 
       it("should hydrate personal collection filter", () => {
-        cy.visit("/search?q=keyword&filter_items_in_personal_collection=only");
+        cy.visit("/search?q=keyword&filter_items_in_personal_collection=all");
         cy.wait("@search");
 
         cy.findByTestId("filter_items_in_personal_collection-search-filter")
@@ -1042,7 +1042,7 @@ describe("scenarios > search", () => {
 
       it("should not be exposed to non-admins", () => {
         cy.signInAsNormalUser();
-        cy.visit("/search?q=keyword&filter_items_in_personal_collection=only");
+        cy.visit("/search?q=keyword&filter_items_in_personal_collection=all");
         cy.wait("@search");
         expectSearchResultItemNameContent({
           itemNames: ["Normal User Personal Question [keyword]"],
@@ -1070,7 +1070,7 @@ describe("scenarios > search", () => {
           .findByRole("switch")
           .should("be.checked");
 
-        cy.url().should("contain", "filter_items_in_personal_collection=only");
+        cy.url().should("contain", "filter_items_in_personal_collection=all");
 
         cy.log("Should see own and other users' items when filter is on");
         expectSearchResultItemNameContent({

--- a/frontend/src/metabase-types/api/search.ts
+++ b/frontend/src/metabase-types/api/search.ts
@@ -129,7 +129,7 @@ export type SearchRequest = {
   table_db_id?: DatabaseId;
   models?: SearchModel[];
   ids?: SearchResultId[];
-  filter_items_in_personal_collection?: "only" | "exclude" | "all";
+  filter_items_in_personal_collection?: "only" | "exclude";
   context?: SearchContext;
   created_at?: string | null;
   created_by?: UserId[] | null;

--- a/frontend/src/metabase-types/api/search.ts
+++ b/frontend/src/metabase-types/api/search.ts
@@ -129,7 +129,7 @@ export type SearchRequest = {
   table_db_id?: DatabaseId;
   models?: SearchModel[];
   ids?: SearchResultId[];
-  filter_items_in_personal_collection?: "only" | "exclude";
+  filter_items_in_personal_collection?: "only" | "exclude" | "all";
   context?: SearchContext;
   created_at?: string | null;
   created_by?: UserId[] | null;

--- a/frontend/src/metabase/common/hooks/use-show-other-users-collections.ts
+++ b/frontend/src/metabase/common/hooks/use-show-other-users-collections.ts
@@ -1,0 +1,16 @@
+import { useSelector } from "metabase/lib/redux";
+import { getUserIsAdmin } from "metabase/selectors/user";
+
+import { useSetting } from "./use-setting";
+
+/**
+ * Hook to determine if other users' collections are shown in the UI.
+ * Returns true if the current user is an admin AND there are other users in the instance.
+ */
+export const useShowOtherUsersCollections = (): boolean => {
+  const isAdmin = useSelector(getUserIsAdmin);
+  const activeUsersCount = useSetting("active-users-count");
+  const areThereOtherUsers = (activeUsersCount ?? 0) > 1;
+
+  return isAdmin && areThereOtherUsers;
+};

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarContainer.tsx
@@ -29,7 +29,6 @@ import {
   getIsTenantUser,
   getUser,
   getUserCanWriteToCollections,
-  getUserIsAdmin,
 } from "metabase/selectors/user";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type { Bookmark, Collection, User } from "metabase-types/api";
@@ -46,7 +45,6 @@ type NavbarModal = "MODAL_NEW_COLLECTION" | null;
 function mapStateToProps(state: State, { databases = [] }: DatabaseProps) {
   return {
     currentUser: getUser(state),
-    isAdmin: getUserIsAdmin(state),
     hasDataAccess: databases.length > 0,
     bookmarks: getOrderedBookmarks(state),
   };
@@ -58,7 +56,6 @@ const mapDispatchToProps = {
 };
 
 interface Props extends MainNavbarProps {
-  isAdmin: boolean;
   currentUser: User;
   databases: Database[];
   selectedItems: SelectedItem[];
@@ -78,7 +75,6 @@ interface DatabaseProps {
 
 function MainNavbarContainer({
   bookmarks,
-  isAdmin,
   selectedItems,
   isOpen,
   currentUser,
@@ -205,7 +201,6 @@ function MainNavbarContainer({
       <MainNavbarView
         {...props}
         bookmarks={bookmarks}
-        isAdmin={isAdmin}
         isOpen={isOpen}
         collections={collectionTree}
         selectedItems={selectedItems}

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
@@ -14,6 +14,7 @@ import CollapseSection from "metabase/common/components/CollapseSection";
 import { Tree } from "metabase/common/components/tree";
 import { useSetting, useUserSetting } from "metabase/common/hooks";
 import { useIsAtHomepageDashboard } from "metabase/common/hooks/use-is-at-homepage-dashboard";
+import { useShowOtherUsersCollections } from "metabase/common/hooks/use-show-other-users-collections";
 import type { CollectionTreeItem } from "metabase/entities/collections";
 import {
   getCanAccessOnboardingPage,
@@ -56,7 +57,6 @@ import { BrowseNavSection } from "./BrowseNavSection";
 import { GettingStartedSection } from "./GettingStartedSection";
 
 type Props = {
-  isAdmin: boolean;
   isOpen: boolean;
   bookmarks: Bookmark[];
   hasDataAccess: boolean;
@@ -79,7 +79,6 @@ type Props = {
 const OTHER_USERS_COLLECTIONS_URL = Urls.otherUsersPersonalCollections();
 
 export function MainNavbarView({
-  isAdmin,
   bookmarks,
   collections,
   selectedItems,
@@ -173,9 +172,7 @@ export function MainNavbarView({
   const canAccessOnboarding = useSelector(getCanAccessOnboardingPage);
   const shouldDisplayGettingStarted = isNewInstance && canAccessOnboarding;
 
-  const activeUsersCount = useSetting("active-users-count");
-  const areThereOtherUsers = (activeUsersCount ?? 0) > 1;
-  const showOtherUsersCollections = isAdmin && areThereOtherUsers;
+  const showOtherUsersCollections = useShowOtherUsersCollections();
 
   const collectionsHeading = showExternalCollectionsSection
     ? t`Internal Collections`

--- a/frontend/src/metabase/palette/components/PaletteResults.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResults.tsx
@@ -6,10 +6,8 @@ import { useKeyPressEvent } from "react-use";
 import { t } from "ttag";
 
 import NoResults from "assets/img/no_results.svg";
-import { useSetting } from "metabase/common/hooks/use-setting/use-setting";
-import { useSelector } from "metabase/lib/redux/hooks";
+import { useShowOtherUsersCollections } from "metabase/common/hooks/use-show-other-users-collections";
 import { trackSearchClick } from "metabase/search/analytics";
-import { getUserIsAdmin } from "metabase/selectors/user";
 import {
   Flex,
   Group,
@@ -43,10 +41,7 @@ const FullSearchCTA = ({
   searchTerm: string;
   onClick: () => void;
 }) => {
-  const activeUsersCount = useSetting("active-users-count");
-  const isAdmin = useSelector(getUserIsAdmin);
-  const areThereOtherUsers = (activeUsersCount ?? 0) > 1;
-  const showOtherUsersCollections = isAdmin && areThereOtherUsers;
+  const showOtherUsersCollections = useShowOtherUsersCollections();
   if (!searchResults.total && !showOtherUsersCollections) {
     return null;
   }

--- a/frontend/src/metabase/palette/components/PaletteResults.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResults.tsx
@@ -6,7 +6,10 @@ import { useKeyPressEvent } from "react-use";
 import { t } from "ttag";
 
 import NoResults from "assets/img/no_results.svg";
+import { useSetting } from "metabase/common/hooks/use-setting/use-setting";
+import { useSelector } from "metabase/lib/redux/hooks";
 import { trackSearchClick } from "metabase/search/analytics";
+import { getUserIsAdmin } from "metabase/selectors/user";
 import {
   Flex,
   Group,
@@ -28,6 +31,55 @@ import { PaletteResultItem } from "./PaletteResultItem";
 import { PaletteResultList } from "./PaletteResultsList";
 
 const PAGE_SIZE = 4;
+
+const FullSearchCTA = ({
+  locationQuery,
+  searchResults,
+  searchTerm,
+  onClick,
+}: {
+  locationQuery: Query;
+  searchResults: SearchResponse;
+  searchTerm: string;
+  onClick: () => void;
+}) => {
+  const activeUsersCount = useSetting("active-users-count");
+  const isAdmin = useSelector(getUserIsAdmin);
+  const areThereOtherUsers = (activeUsersCount ?? 0) > 1;
+  const showOtherUsersCollections = isAdmin && areThereOtherUsers;
+  const promptOtherUsersSearch =
+    !searchResults.total && showOtherUsersCollections;
+
+  return (
+    <Text
+      c="brand"
+      component={Link}
+      fw={700}
+      id="search-results-metadata"
+      to={{
+        pathname: "search",
+        query: {
+          ...locationQuery,
+          q: searchTerm,
+          filter_items_in_personal_collection: promptOtherUsersSearch
+            ? "all"
+            : locationQuery.filter_items_in_personal_collection,
+        },
+      }}
+      className={S.viewAndFilterResults}
+      onClick={onClick}
+    >
+      <Group align="center" gap={rem(4)}>
+        <span>
+          {promptOtherUsersSearch
+            ? t`Search other users' personal collections`
+            : t`View and filter all ${searchResults.total} results`}
+        </span>
+        <Icon name="chevronright" size={12} />
+      </Group>
+    </Text>
+  );
+};
 
 type Props = Omit<StackProps, "children"> & {
   locationQuery: Query;
@@ -112,20 +164,11 @@ export const PaletteResults = ({
                 >
                   {item}
 
-                  {item === t`Results` && searchResults?.data.length && (
-                    <Text
-                      c="brand"
-                      component={Link}
-                      fw={700}
-                      id="search-results-metadata"
-                      to={{
-                        pathname: "search",
-                        query: {
-                          ...locationQuery,
-                          q: searchTerm,
-                        },
-                      }}
-                      className={S.viewAndFilterResults}
+                  {item === t`Results` && searchResults && (
+                    <FullSearchCTA
+                      locationQuery={locationQuery}
+                      searchResults={searchResults}
+                      searchTerm={searchTerm}
                       onClick={() => {
                         query.setVisualState(VisualState.hidden);
 
@@ -140,13 +183,7 @@ export const PaletteResults = ({
                           searchTerm,
                         });
                       }}
-                    >
-                      <Group align="center" gap={rem(4)}>
-                        <span>{t`View and filter all ${searchResults?.total} results`}</span>
-
-                        <Icon name="chevronright" size={12} />
-                      </Group>
-                    </Text>
+                    />
                   )}
                 </Group>
               ) : (

--- a/frontend/src/metabase/palette/components/PaletteResults.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResults.tsx
@@ -60,9 +60,6 @@ const FullSearchCTA = ({
         query: {
           ...locationQuery,
           q: searchTerm,
-          filter_items_in_personal_collection: promptOtherUsersSearch
-            ? "only"
-            : locationQuery.filter_items_in_personal_collection,
         },
       }}
       className={S.viewAndFilterResults}
@@ -71,7 +68,7 @@ const FullSearchCTA = ({
       <Group align="center" gap={rem(4)}>
         <span>
           {promptOtherUsersSearch
-            ? t`Search all personal collections`
+            ? t`Search everything`
             : t`View and filter all ${searchResults.total} results`}
         </span>
         <Icon name="chevronright" size={12} />

--- a/frontend/src/metabase/palette/components/PaletteResults.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResults.tsx
@@ -46,7 +46,7 @@ const FullSearchCTA = ({
     return null;
   }
 
-  const promptOtherUsersSearch =
+  const promptSearchEverything =
     !searchResults.total && showOtherUsersCollections;
 
   return (
@@ -67,7 +67,7 @@ const FullSearchCTA = ({
     >
       <Group align="center" gap={rem(4)}>
         <span>
-          {promptOtherUsersSearch
+          {promptSearchEverything
             ? t`Search everything`
             : t`View and filter all ${searchResults.total} results`}
         </span>

--- a/frontend/src/metabase/palette/components/PaletteResults.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResults.tsx
@@ -47,6 +47,10 @@ const FullSearchCTA = ({
   const isAdmin = useSelector(getUserIsAdmin);
   const areThereOtherUsers = (activeUsersCount ?? 0) > 1;
   const showOtherUsersCollections = isAdmin && areThereOtherUsers;
+  if (!searchResults.total && !showOtherUsersCollections) {
+    return null;
+  }
+
   const promptOtherUsersSearch =
     !searchResults.total && showOtherUsersCollections;
 

--- a/frontend/src/metabase/palette/components/PaletteResults.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResults.tsx
@@ -62,7 +62,7 @@ const FullSearchCTA = ({
           ...locationQuery,
           q: searchTerm,
           filter_items_in_personal_collection: promptOtherUsersSearch
-            ? "all"
+            ? "only"
             : locationQuery.filter_items_in_personal_collection,
         },
       }}

--- a/frontend/src/metabase/palette/components/PaletteResults.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResults.tsx
@@ -72,7 +72,7 @@ const FullSearchCTA = ({
       <Group align="center" gap={rem(4)}>
         <span>
           {promptOtherUsersSearch
-            ? t`Search other users' personal collections`
+            ? t`Search all personal collections`
             : t`View and filter all ${searchResults.total} results`}
         </span>
         <Icon name="chevronright" size={12} />

--- a/frontend/src/metabase/search/components/SearchSidebar/SearchSidebar.tsx
+++ b/frontend/src/metabase/search/components/SearchSidebar/SearchSidebar.tsx
@@ -8,6 +8,7 @@ import { CreatedByFilter } from "metabase/search/components/filters/CreatedByFil
 import { LastEditedAtFilter } from "metabase/search/components/filters/LastEditedAtFilter";
 import { LastEditedByFilter } from "metabase/search/components/filters/LastEditedByFilter";
 import { NativeQueryFilter } from "metabase/search/components/filters/NativeQueryFilter";
+import { PersonalCollectionsFilter } from "metabase/search/components/filters/PersonalCollectionsFilter";
 import { SearchTrashedItemsFilter } from "metabase/search/components/filters/SearchTrashedItemsFilter";
 import { TypeFilter } from "metabase/search/components/filters/TypeFilter";
 import { SearchFilterKeys } from "metabase/search/constants";
@@ -34,6 +35,7 @@ export const SearchSidebar = ({ value, onChange }: SearchSidebarProps) => {
     [SearchFilterKeys.Verified]: PLUGIN_CONTENT_VERIFICATION.VerifiedFilter,
     [SearchFilterKeys.NativeQuery]: NativeQueryFilter,
     [SearchFilterKeys.SearchTrashedItems]: SearchTrashedItemsFilter,
+    [SearchFilterKeys.PersonalCollections]: PersonalCollectionsFilter,
   };
 
   const onOutputChange = (key: FilterTypeKeys, val?: SearchQueryParamValue) => {
@@ -92,6 +94,7 @@ export const SearchSidebar = ({ value, onChange }: SearchSidebarProps) => {
       {getFilter(SearchFilterKeys.Verified)}
       {getFilter(SearchFilterKeys.NativeQuery)}
       {getFilter(SearchFilterKeys.SearchTrashedItems)}
+      {getFilter(SearchFilterKeys.PersonalCollections)}
     </Stack>
   );
 };

--- a/frontend/src/metabase/search/components/SearchSidebar/SearchSidebar.tsx
+++ b/frontend/src/metabase/search/components/SearchSidebar/SearchSidebar.tsx
@@ -1,7 +1,6 @@
 import _ from "underscore";
 
-import { useSetting } from "metabase/common/hooks/use-setting/use-setting";
-import { useSelector } from "metabase/lib/redux/hooks";
+import { useShowOtherUsersCollections } from "metabase/common/hooks/use-show-other-users-collections";
 import { PLUGIN_CONTENT_VERIFICATION } from "metabase/plugins";
 import { DropdownSidebarFilter } from "metabase/search/components/DropdownSidebarFilter";
 import { ToggleSidebarFilter } from "metabase/search/components/ToggleSidebarFilter";
@@ -20,7 +19,6 @@ import type {
   SearchQueryParamValue,
   URLSearchFilterQueryParams,
 } from "metabase/search/types";
-import { getUserIsAdmin } from "metabase/selectors/user";
 import { Stack } from "metabase/ui";
 
 type SearchSidebarProps = {
@@ -83,10 +81,7 @@ export const SearchSidebar = ({ value, onChange }: SearchSidebarProps) => {
     return null;
   };
 
-  const activeUsersCount = useSetting("active-users-count");
-  const isAdmin = useSelector(getUserIsAdmin);
-  const areThereOtherUsers = (activeUsersCount ?? 0) > 1;
-  const showOtherUsersCollections = isAdmin && areThereOtherUsers;
+  const showOtherUsersCollections = useShowOtherUsersCollections();
 
   return (
     <Stack gap="lg">

--- a/frontend/src/metabase/search/components/SearchSidebar/SearchSidebar.tsx
+++ b/frontend/src/metabase/search/components/SearchSidebar/SearchSidebar.tsx
@@ -1,5 +1,7 @@
 import _ from "underscore";
 
+import { useSetting } from "metabase/common/hooks/use-setting/use-setting";
+import { useSelector } from "metabase/lib/redux/hooks";
 import { PLUGIN_CONTENT_VERIFICATION } from "metabase/plugins";
 import { DropdownSidebarFilter } from "metabase/search/components/DropdownSidebarFilter";
 import { ToggleSidebarFilter } from "metabase/search/components/ToggleSidebarFilter";
@@ -18,6 +20,7 @@ import type {
   SearchQueryParamValue,
   URLSearchFilterQueryParams,
 } from "metabase/search/types";
+import { getUserIsAdmin } from "metabase/selectors/user";
 import { Stack } from "metabase/ui";
 
 type SearchSidebarProps = {
@@ -80,6 +83,11 @@ export const SearchSidebar = ({ value, onChange }: SearchSidebarProps) => {
     return null;
   };
 
+  const activeUsersCount = useSetting("active-users-count");
+  const isAdmin = useSelector(getUserIsAdmin);
+  const areThereOtherUsers = (activeUsersCount ?? 0) > 1;
+  const showOtherUsersCollections = isAdmin && areThereOtherUsers;
+
   return (
     <Stack gap="lg">
       {getFilter(SearchFilterKeys.Type)}
@@ -94,7 +102,8 @@ export const SearchSidebar = ({ value, onChange }: SearchSidebarProps) => {
       {getFilter(SearchFilterKeys.Verified)}
       {getFilter(SearchFilterKeys.NativeQuery)}
       {getFilter(SearchFilterKeys.SearchTrashedItems)}
-      {getFilter(SearchFilterKeys.PersonalCollections)}
+      {showOtherUsersCollections &&
+        getFilter(SearchFilterKeys.PersonalCollections)}
     </Stack>
   );
 };

--- a/frontend/src/metabase/search/components/filters/PersonalCollectionsFilter.tsx
+++ b/frontend/src/metabase/search/components/filters/PersonalCollectionsFilter.tsx
@@ -5,6 +5,6 @@ import type { SearchFilterToggle } from "metabase/search/types";
 export const PersonalCollectionsFilter: SearchFilterToggle = {
   label: () => t`Search all personal collections`,
   type: "toggle",
-  fromUrl: (value) => value === "only",
-  toUrl: (value: boolean) => (value ? "only" : null),
+  fromUrl: (value) => value === "all",
+  toUrl: (value: boolean) => (value ? "all" : null),
 };

--- a/frontend/src/metabase/search/components/filters/PersonalCollectionsFilter.tsx
+++ b/frontend/src/metabase/search/components/filters/PersonalCollectionsFilter.tsx
@@ -3,7 +3,7 @@ import { t } from "ttag";
 import type { SearchFilterToggle } from "metabase/search/types";
 
 export const PersonalCollectionsFilter: SearchFilterToggle = {
-  label: () => t`Search personal collections`,
+  label: () => t`Search all personal collections`,
   type: "toggle",
   fromUrl: (value) => value === "only",
   toUrl: (value: boolean) => (value ? "only" : null),

--- a/frontend/src/metabase/search/components/filters/PersonalCollectionsFilter.tsx
+++ b/frontend/src/metabase/search/components/filters/PersonalCollectionsFilter.tsx
@@ -3,8 +3,8 @@ import { t } from "ttag";
 import type { SearchFilterToggle } from "metabase/search/types";
 
 export const PersonalCollectionsFilter: SearchFilterToggle = {
-  label: () => t`Search other users' collections`,
+  label: () => t`Search personal collections`,
   type: "toggle",
-  fromUrl: (value) => value === "all",
-  toUrl: (value: boolean) => (value ? "all" : null),
+  fromUrl: (value) => value === "only",
+  toUrl: (value: boolean) => (value ? "only" : null),
 };

--- a/frontend/src/metabase/search/components/filters/PersonalCollectionsFilter.tsx
+++ b/frontend/src/metabase/search/components/filters/PersonalCollectionsFilter.tsx
@@ -1,0 +1,10 @@
+import { t } from "ttag";
+
+import type { SearchFilterToggle } from "metabase/search/types";
+
+export const PersonalCollectionsFilter: SearchFilterToggle = {
+  label: () => t`Search other users' collections`,
+  type: "toggle",
+  fromUrl: (value) => value === "all",
+  toUrl: (value: boolean) => (value ? "all" : null),
+};

--- a/frontend/src/metabase/search/constants.ts
+++ b/frontend/src/metabase/search/constants.ts
@@ -9,6 +9,7 @@ export const SearchFilterKeys = {
   LastEditedAt: "last_edited_at",
   NativeQuery: "search_native_query",
   SearchTrashedItems: "archived",
+  PersonalCollections: "filter_items_in_personal_collection",
 } as const;
 
 export const enabledSearchTypes: EnabledSearchModel[] = [

--- a/frontend/src/metabase/search/types.ts
+++ b/frontend/src/metabase/search/types.ts
@@ -21,6 +21,7 @@ export type LastEditedAtFilterProps = string | null;
 export type VerifiedFilterProps = true | null;
 export type NativeQueryFilterProps = true | null;
 export type SearchTrashedItemsFilterProps = true | undefined;
+export type PersonalCollectionFilterProps = "all" | undefined;
 
 export type SearchFilterPropTypes = {
   [SearchFilterKeys.Type]: TypeFilterProps;
@@ -31,6 +32,7 @@ export type SearchFilterPropTypes = {
   [SearchFilterKeys.LastEditedAt]: LastEditedAtFilterProps;
   [SearchFilterKeys.NativeQuery]: NativeQueryFilterProps;
   [SearchFilterKeys.SearchTrashedItems]: SearchTrashedItemsFilterProps;
+  [SearchFilterKeys.PersonalCollections]: PersonalCollectionFilterProps;
 };
 
 export type FilterTypeKeys = keyof SearchFilterPropTypes;

--- a/frontend/src/metabase/search/types.ts
+++ b/frontend/src/metabase/search/types.ts
@@ -21,7 +21,7 @@ export type LastEditedAtFilterProps = string | null;
 export type VerifiedFilterProps = true | null;
 export type NativeQueryFilterProps = true | null;
 export type SearchTrashedItemsFilterProps = true | undefined;
-export type PersonalCollectionFilterProps = "all" | undefined;
+export type PersonalCollectionFilterProps = "only" | undefined;
 
 export type SearchFilterPropTypes = {
   [SearchFilterKeys.Type]: TypeFilterProps;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/61219 / UXW-332
Closes [BOT-378](https://linear.app/metabase/issue/BOT-378)

[Most recent slack thread about it](https://metaboat.slack.com/archives/C01LQQ2UW03/p1766415291499899) (tldr exclude other users' items from quick search, add toggle to search page)
[Most relevant slack thread about it](https://metaboat.slack.com/archives/C07SJT1P0ET/p1756439591677859?thread_ts=1755547526.524229&cid=C07SJT1P0ET) (tldr defines ideal toggle)

### Description

* Adds "Search all personal collections" toggle to search page (uses same display logic as "Other users' personal collections" in sidebar).
  * Turning it on sends `filter_items_in_personal_collection=all` to search endpoint. Turning it off omits the param (which is treated as `exclude-others`).
* Adds "Search everything" CTA to command palette when no results and is admin and multiple users (i.e. same display logic as above).

### How to verify

1. Verify no changes for normal users
2. Verify admins now have a toggle to include other users' personal items in search results
3. Verify admins can get to the search page when the command palette has no results

### Demo

https://github.com/user-attachments/assets/4d0818bd-ec72-47e3-9208-b039081dd2dc

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
