### PR TITLE
Allow temporal args for `-` in MBQL 4 schema

### DIFF
--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -681,7 +681,7 @@
   more (rest [:ref ::Addable]))
 
 (defclause -
-  x    [:ref ::NumericExpressionArg]
+  x    [:ref ::Addable]
   y    [:ref ::Addable]
   more (rest [:ref ::Addable]))
 

--- a/test/metabase/legacy_mbql/schema_test.cljc
+++ b/test/metabase/legacy_mbql/schema_test.cljc
@@ -647,3 +647,14 @@
                  false]]
                normalized))
         (is (mr/validate schema normalized))))))
+
+(deftest ^:parallel allow-temporal-args-for-minus-test
+  (let [expr       ["-"
+                    ["date" ["now"]]
+                    ["expression" "Last_Date_Active" {"base-type" "type/DateTimeWithLocalTZ"}]]
+        normalized (lib/normalize ::mbql.s/- expr)]
+    (is (= [:-
+            [:date [:now]]
+            [:expression "Last_Date_Active" {:base-type :type/DateTimeWithLocalTZ}]]
+           normalized))
+    (is (mr/validate ::mbql.s/- normalized))))


### PR DESCRIPTION
The MBQL 4 schema didn't let you do 

```clj
[:-
 [:date [:now]]
 [:expression "Last_Date_Active" {:base-type :type/DateTimeWithLocalTZ}]]
 ```
 
(use `:date` as the first arg) which we should allow, because we allow it for `+`