### PR TITLE
ellipisify table names, fix published table link

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/TableCollection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/TableCollection.tsx
@@ -22,7 +22,7 @@ export function TableCollection({ table }: TableCollectionProps) {
           <Box
             className={S.link}
             component={Link}
-            to={Urls.dataStudioCollection(collection.id)}
+            to={Urls.dataStudioLibrary({ expandedIds: [collection.id] })}
             fw="bold"
           >
             {collection.name}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/TableMetadata.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/TableMetadata.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { useId } from "react";
 import { t } from "ttag";
 
+import { Ellipsified } from "metabase/common/components/Ellipsified";
 import Link from "metabase/common/components/Link";
 import { useNumberFormatter } from "metabase/common/hooks/use-number-formatter";
 import { isNullOrUndefined } from "metabase/lib/types";
@@ -94,13 +95,18 @@ function MetadataRow({
 }) {
   const id = useId();
   return (
-    <Group justify="space-between">
-      <Text size="md" c="text-primary" id={id}>
+    <Group justify="space-between" gap="lg" wrap="nowrap">
+      <Text size="md" c="text-primary" id={id} flex="1 0 auto">
         {label}
       </Text>
-      <Text size="md" c="text-primary" aria-labelledby={id}>
+      <Ellipsified
+        size="md"
+        c="text-primary"
+        aria-labelledby={id}
+        tooltipProps={{ maw: "unset" }}
+      >
         {value}
-      </Text>
+      </Ellipsified>
     </Group>
   );
 }

--- a/frontend/src/metabase/lib/urls/data-studio.ts
+++ b/frontend/src/metabase/lib/urls/data-studio.ts
@@ -215,10 +215,6 @@ export function dataStudioGlossary() {
   return `${dataStudio()}/glossary`;
 }
 
-export function dataStudioCollection(collectionId: CollectionId) {
-  return `${dataStudioLibrary()}/collections/${collectionId}`;
-}
-
 export function dataStudioSnippet(snippetId: NativeQuerySnippetId) {
   return `${dataStudioLibrary()}/snippets/${snippetId}`;
 }


### PR DESCRIPTION
### Description
Small clean up PR that fixes a broken link, removes an incorrect url function, and adjusts the MetadataRow component in `TableMetadata`

### How to verify
1. In the Data Studio, publish a table
2. In the Table Section, Click on the link in the `This table has been published` section. You should be brought to the library
3. Go back to the data model page, go to a table with a very long name (easy way to do this is via CSV uploads)
4. The name should appear in the metadata section on a single line, and ellipsified with a tooltip if appropriate.

### Demo

https://github.com/user-attachments/assets/16f3d799-5d23-4071-ad33-21087f9cc6ba

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
