### PR TITLE
Check that the number was parsed correctly

### DIFF
--- a/frontend/src/metabase/lib/formatting/value.tsx
+++ b/frontend/src/metabase/lib/formatting/value.tsx
@@ -196,7 +196,12 @@ export function formatValueRaw(
   ) {
     return formatDateTimeWithUnit(value as string | number, "minute", options);
   } else if (typeof value === "string") {
-    if (isNumber(column)) {
+    // Check if we're looking for a number isNumber(column) and
+    // check that the value string is a valid number
+    // it could be a remap
+    // TODO(eric, 2025-12-23): The second check should probably be in parseNumber(),
+    // but it caused tests to fail so I put it here.
+    if (isNumber(column) && Number.isFinite(Number(value))) {
       const number = parseNumber(value);
       if (number != null) {
         return formatNumber(number, options);

--- a/frontend/src/metabase/lib/formatting/value.tsx
+++ b/frontend/src/metabase/lib/formatting/value.tsx
@@ -202,7 +202,7 @@ export function formatValueRaw(
         return options.collapseNewlines ? removeNewLines(value) : value;
       }
       const number = parseNumber(value);
-      if (number != null && value.trim() === "" + number) {
+      if (number != null) {
         return formatNumber(number, options);
       }
     }

--- a/frontend/src/metabase/lib/formatting/value.tsx
+++ b/frontend/src/metabase/lib/formatting/value.tsx
@@ -39,14 +39,6 @@ const MARKDOWN_RENDERERS = {
   ),
 };
 
-function isNumeric(x: string): boolean {
-  // This works by coercing x to a number (with +), then comparing them equal.
-  // If x is not a number, then +x will return NaN, which is not equal to NaN.
-  // example: isNumeric("1") => true
-  // example: isNumeric("1j") => false
-  return +x === +x;
-}
-
 export function formatValue(value: unknown, _options: OptionsType = {}) {
   let { prefix, suffix, ...options } = _options;
   // avoid rendering <ExternalLink> if we have click_behavior set
@@ -205,12 +197,9 @@ export function formatValueRaw(
     return formatDateTimeWithUnit(value as string | number, "minute", options);
   } else if (typeof value === "string") {
     if (isNumber(column)) {
-      // check if the string contains a number only
-      if (isNumeric(value)) {
-        const number = parseNumber(value);
-        if (number != null) {
-          return formatNumber(number, options);
-        }
+      const number = parseNumber(value);
+      if (number != null) {
+        return formatNumber(number, options);
       }
     }
     if (options.view_as === "image") {

--- a/frontend/src/metabase/lib/formatting/value.tsx
+++ b/frontend/src/metabase/lib/formatting/value.tsx
@@ -198,7 +198,7 @@ export function formatValueRaw(
   } else if (typeof value === "string") {
     if (isNumber(column)) {
       const number = parseNumber(value);
-      if (number != null) {
+      if (number != null && value.trim() === "" + number) {
         return formatNumber(number, options);
       }
     }

--- a/frontend/src/metabase/lib/formatting/value.tsx
+++ b/frontend/src/metabase/lib/formatting/value.tsx
@@ -197,6 +197,10 @@ export function formatValueRaw(
     return formatDateTimeWithUnit(value as string | number, "minute", options);
   } else if (typeof value === "string") {
     if (isNumber(column)) {
+      if (remapped !== undefined) {
+        // Value was remapped - treat as string, don't parse it!
+        return options.collapseNewlines ? removeNewLines(value) : value;
+      }
       const number = parseNumber(value);
       if (number != null && value.trim() === "" + number) {
         return formatNumber(number, options);

--- a/frontend/src/metabase/lib/formatting/value.tsx
+++ b/frontend/src/metabase/lib/formatting/value.tsx
@@ -39,6 +39,14 @@ const MARKDOWN_RENDERERS = {
   ),
 };
 
+function isNumeric(x: string): boolean {
+  // This works by coercing x to a number (with +), then comparing them equal.
+  // If x is not a number, then +x will return NaN, which is not equal to NaN.
+  // example: isNumeric("1") => true
+  // example: isNumeric("1j") => false
+  return +x === +x;
+}
+
 export function formatValue(value: unknown, _options: OptionsType = {}) {
   let { prefix, suffix, ...options } = _options;
   // avoid rendering <ExternalLink> if we have click_behavior set
@@ -197,13 +205,12 @@ export function formatValueRaw(
     return formatDateTimeWithUnit(value as string | number, "minute", options);
   } else if (typeof value === "string") {
     if (isNumber(column)) {
-      if (remapped !== undefined) {
-        // Value was remapped - treat as string, don't parse it!
-        return options.collapseNewlines ? removeNewLines(value) : value;
-      }
-      const number = parseNumber(value);
-      if (number != null) {
-        return formatNumber(number, options);
+      // check if the string contains a number only
+      if (isNumeric(value)) {
+        const number = parseNumber(value);
+        if (number != null) {
+          return formatNumber(number, options);
+        }
       }
     }
     if (options.view_as === "image") {

--- a/frontend/src/metabase/lib/formatting/value.unit.spec.tsx
+++ b/frontend/src/metabase/lib/formatting/value.unit.spec.tsx
@@ -112,6 +112,7 @@ describe("formatValue", () => {
       setup(2, { column, scale: 100 });
       expect(screen.getByText("200")).toBeInTheDocument();
     });
+
     it("should correctly parse string with initial digit", () => {
       const column = createMockColumn({
         base_type: "type/Float",
@@ -130,6 +131,7 @@ describe("formatValue", () => {
       setup(2, { column, scale: 100 });
       expect(screen.getByText("200")).toBeInTheDocument();
     });
+
     it("should correctly parse string with big integer", () => {
       const column = createMockColumn({
         base_type: "type/Float",

--- a/frontend/src/metabase/lib/formatting/value.unit.spec.tsx
+++ b/frontend/src/metabase/lib/formatting/value.unit.spec.tsx
@@ -112,9 +112,6 @@ describe("formatValue", () => {
       setup(2, { column, scale: 100 });
       expect(screen.getByText("200")).toBeInTheDocument();
     });
-  });
-
-  describe("remapped column", () => {
     it("should correctly parse string with initial digit", () => {
       const column = createMockColumn({
         base_type: "type/Float",
@@ -133,9 +130,6 @@ describe("formatValue", () => {
       setup(2, { column, scale: 100 });
       expect(screen.getByText("200")).toBeInTheDocument();
     });
-  });
-
-  describe("remapped column", () => {
     it("should correctly parse string with big integer", () => {
       const column = createMockColumn({
         base_type: "type/Float",

--- a/frontend/src/metabase/lib/formatting/value.unit.spec.tsx
+++ b/frontend/src/metabase/lib/formatting/value.unit.spec.tsx
@@ -114,6 +114,27 @@ describe("formatValue", () => {
     });
   });
 
+  describe("remapped column", () => {
+    it("should apply formatting settings", () => {
+      const column = createMockColumn({
+        base_type: "type/Float",
+        remapped_to_column: createMockColumn({
+          base_type: "type/Text",
+        }),
+        remapping: new Map([
+          [1, "1j"],
+          [2, "2"],
+          [3, "Three"],
+        ]),
+      } as any);
+      setup(1, { column, scale: 100 });
+      expect(screen.getByText("1j")).toBeInTheDocument();
+
+      setup(2, { column, scale: 100 });
+      expect(screen.getByText("200")).toBeInTheDocument();
+    });
+  });
+
   describe("collapseNewlines", () => {
     it("should collapse newlines in plain text when collapseNewlines is true", () => {
       const result = formatValue("Line 1\nLine 2\nLine 3", {

--- a/frontend/src/metabase/lib/formatting/value.unit.spec.tsx
+++ b/frontend/src/metabase/lib/formatting/value.unit.spec.tsx
@@ -115,7 +115,7 @@ describe("formatValue", () => {
   });
 
   describe("remapped column", () => {
-    it("should apply formatting settings", () => {
+    it("should correctly parse string with initial digit", () => {
       const column = createMockColumn({
         base_type: "type/Float",
         remapped_to_column: createMockColumn({
@@ -129,6 +129,29 @@ describe("formatValue", () => {
       } as any);
       setup(1, { column, scale: 100 });
       expect(screen.getByText("1j")).toBeInTheDocument();
+
+      setup(2, { column, scale: 100 });
+      expect(screen.getByText("200")).toBeInTheDocument();
+    });
+  });
+
+  describe("remapped column", () => {
+    it("should correctly parse string with big integer", () => {
+      const column = createMockColumn({
+        base_type: "type/Float",
+        remapped_to_column: createMockColumn({
+          base_type: "type/Text",
+        }),
+        remapping: new Map([
+          [1, "4000000000000000000"], // bigger than 9,007,199,254,740,991 to trigger BigInt branch
+          [2, "2"],
+          [3, "Three"],
+        ]),
+      } as any);
+      setup(1, { column, scale: 100 });
+      expect(
+        screen.getByText("400,000,000,000,000,000,000"),
+      ).toBeInTheDocument();
 
       setup(2, { column, scale: 100 });
       expect(screen.getByText("200")).toBeInTheDocument();

--- a/frontend/src/metabase/lib/number.ts
+++ b/frontend/src/metabase/lib/number.ts
@@ -3,9 +3,13 @@ const INTEGER_REGEX = /^[+-]?\d+$/;
 export type NumberValue = number | bigint;
 
 export function parseNumber(value: string): NumberValue | null {
-  if (!Number.isFinite(Number(value))) {
-    return null;
-  }
+  // TODO(eric, 2025-12-23): we should check if the string is a valid number
+  // if value === "1j", this function returns 1
+  // I tried it and it broke a number of tests
+  // Example:
+  //   if (!Number.isFinite(Number(value))) {
+  //     return null;
+  //    }
 
   const number = parseFloat(value);
   if (!Number.isFinite(number)) {

--- a/frontend/src/metabase/lib/number.ts
+++ b/frontend/src/metabase/lib/number.ts
@@ -3,6 +3,10 @@ const INTEGER_REGEX = /^[+-]?\d+$/;
 export type NumberValue = number | bigint;
 
 export function parseNumber(value: string): NumberValue | null {
+  if (!Number.isFinite(Number(value))) {
+    return null;
+  }
+
   const number = parseFloat(value);
   if (!Number.isFinite(number)) {
     return null;


### PR DESCRIPTION

Closes https://github.com/metabase/metabase/issues/67338

### Description

When we try to display a number, it could be remapped (internal) to a string. And that string might look like `"1jjj"`. If we blindly try to parse it as a number (parseFloat()), it will return `1`, leaving off the jjj. 

This fix checks whether the numeric column was remapped. If it is remapped, don't try to parse it.

### How to verify

1. go to settings->table metadata->feedback table->Rating column
2. change "display values" to custom mapping
3. Change 1 to 1j
4. now go to the feedback table, sort by rating, and see the rating column, the remapping should be there.
