### PR TITLE
Fix adding two DIFFERENT implicit joins with the SAME generated alias

### DIFF
--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -227,7 +227,7 @@
   [query _stage-number {[{:keys [source-table source-card], :as _first-stage}] :stages, :as _join} _style]
   (or
    (when source-table
-     (:display-name (lib.metadata/table query source-table)))
+     ((some-fn :display-name :name) (lib.metadata/table query source-table)))
    (when source-card
      (if-let [card-metadata (lib.metadata/card query source-card)]
        (lib.metadata.calculation/display-name query 0 card-metadata)

--- a/src/metabase/query_processor/middleware/add_implicit_joins.clj
+++ b/src/metabase/query_processor/middleware/add_implicit_joins.clj
@@ -125,10 +125,14 @@
                                       [:field (opts :guard (every-pred :source-field (complement :join-alias))) (id :guard integer?)]
                                       (field-opts->fk-field-info metadata-providerable opts))))
                             distinct
-                            not-empty)]
-    (into []
-          (distinct)
-          (fk-field-infos->joins metadata-providerable fk-field-infos))))
+                            not-empty)
+        joins          (into []
+                             (distinct)
+                             (fk-field-infos->joins metadata-providerable fk-field-infos))
+        unique-name-fn (lib/non-truncating-unique-name-generator)]
+    (mapv (fn [join]
+            (update join :alias unique-name-fn))
+          joins)))
 
 (mu/defn- visible-joins :- [:sequential ::lib.schema.join/join]
   "Set of all joins that are visible in the current level of the query or in a nested source query."

--- a/test/metabase/query_processor/middleware/add_implicit_joins_test.clj
+++ b/test/metabase/query_processor/middleware/add_implicit_joins_test.clj
@@ -1162,6 +1162,14 @@
           query       (lib/query mp (lib.metadata/card mp 1))]
       (is (=? {:stages [{:joins [{:alias "B"}
                                  {:alias "C"}]}
-                        {:joins [{:alias "D__via__D_ID"}
-                                 {:alias "D__via__D_ID_2"}]}]}
+                        {:joins [{:alias      "D__via__D_ID"
+                                  :conditions [[:=
+                                                {}
+                                                [:field {} "B__D_ID"]
+                                                [:field {:join-alias "D__via__D_ID"} 40]]]}
+                                 {:alias      "D__via__D_ID_2"
+                                  :conditions [[:=
+                                                {}
+                                                [:field {} "C__D_ID"]
+                                                [:field {:join-alias "D__via__D_ID_2"} 40]]]}]}]}
               (qp.preprocess/preprocess query))))))

--- a/test/metabase/query_processor/middleware/add_implicit_joins_test.clj
+++ b/test/metabase/query_processor/middleware/add_implicit_joins_test.clj
@@ -1125,3 +1125,43 @@
                         {}
                         {}]}
               preprocessed)))))
+
+;; before the fix this failed with
+;;
+;; Error preprocessing query in #'metabase.query-processor.middleware.add-implicit-joins/add-implicit-joins:
+;; Cannot find matching FK Table ID for FK Field 31 nil
+(deftest ^:parallel conflicting-implicit-joins-with-same-generated-alias-test
+  (testing "If two DIFFERENT implicit joins need to be added that would have the same generated alias, deduplicate them"
+    (let [mp          (-> (lib.tu/mock-metadata-provider
+                           {:database meta/database
+                            :tables   [{:id 1, :name "A"}
+                                       {:id 2, :name "B"}
+                                       {:id 3, :name "C"}
+                                       {:id 4, :name "D"}]
+                            :fields   [{:id 10, :table-id 1, :name "ID", :semantic-type :type/PK}
+                                       {:id 11, :table-id 1, :name "B_ID", :fk-target-field-id 20, :semantic-type :type/FK}
+                                       {:id 12, :table-id 1, :name "C_ID", :fk-target-field-id 30, :semantic-type :type/FK}
+                                       {:id 20, :table-id 2, :name "ID", :semantic-type :type/PK}
+                                       {:id 21, :table-id 2, :name "D_ID", :fk-target-field-id 40, :semantic-type :type/FK}
+                                       {:id 30, :table-id 3, :name "ID", :semantic-type :type/PK}
+                                       {:id 31, :table-id 3, :name "D_ID", :fk-target-field-id 40, :semantic-type :type/FK}
+                                       {:id 40, :table-id 4, :name "ID", :semantic-type :type/PK}
+                                       {:id 41, :table-id 4, :name "NAME"}]})
+                          (lib.tu/remap-metadata-provider 21 41)
+                          (lib.tu/remap-metadata-provider 31 41))
+          model-query (-> (lib/query mp (lib.metadata/table mp 1))
+                          (lib/join (lib.metadata/table mp 2))
+                          (lib/join (lib.metadata/table mp 3)))
+          mp          (lib.tu/mock-metadata-provider
+                       mp
+                       {:cards [{:id            1
+                                 :type          :model
+                                 :name          "A + B + C"
+                                 :display-name  "A + B + C"
+                                 :dataset-query model-query}]})
+          query       (lib/query mp (lib.metadata/card mp 1))]
+      (is (=? {:stages [{:joins [{:alias "B"}
+                                 {:alias "C"}]}
+                        {:joins [{:alias "D__via__D_ID"}
+                                 {:alias "D__via__D_ID_2"}]}]}
+              (qp.preprocess/preprocess query))))))


### PR DESCRIPTION
Discovered while investigating #66843

You can repro this in the 57 branch by attempting to create a model joining Accounts + Analytics Events + Invoices from the Sample database, then starting a new query from that model:

<img width="1245" height="395" alt="image" src="https://github.com/user-attachments/assets/4e953c72-3bb3-4525-9d7b-531782032f57" />

We try to add implicit joins to `Account` for both `Analytics Events` **and** `Invoices`, and they both get the same generated join alias `ACCOUNT__via__ACCOUNT_ID` even tho they are both different joins... we deduplicated them only by `:alias` and the query broke.

The fix is to deduplicate the generated join aliases so we include both.