### PR TITLE
Measure expression editor

### DIFF
--- a/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
@@ -2451,7 +2451,7 @@ describe("issue 61010", () => {
 
     H.CustomExpressionEditor.clear().type("[New count]");
     H.popover()
-      .findByText("Unknown Aggregation or Metric: New count")
+      .findByText("Unknown Aggregation, Measure or Metric: New count")
       .should("be.visible");
   });
 });

--- a/e2e/test/scenarios/data-studio/measures/measures-queries.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/measures/measures-queries.cy.spec.ts
@@ -104,7 +104,7 @@ describe("scenarios > data studio > measures > queries", () => {
       });
       verifyNewMeasure({
         tableId: ORDERS_ID,
-        scalarValue: "18,760",
+        scalarValue: "1,510,621.68",
         createQuery: () => {
           MeasureEditor.getAggregationPlaceholder().click();
           H.popover().findByText("Custom Expression").click();
@@ -126,7 +126,7 @@ describe("scenarios > data studio > measures > queries", () => {
       });
       verifyNewMeasure({
         tableId: ORDERS_ID,
-        scalarValue: "18,760",
+        scalarValue: "1,510,621.68",
         createQuery: () => {
           MeasureEditor.getAggregationPlaceholder().click();
           H.popover().findByText("Custom Expression").click();

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -43,6 +43,7 @@ export interface AggregationPickerProps {
   clauseIndex?: number;
   operators: Lib.AggregationOperator[];
   allowCustomExpressions?: boolean;
+  allowMetrics?: boolean;
   onClose?: () => void;
   onQueryChange: (query: Lib.Query) => void;
   onBack?: () => void;

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -90,6 +90,7 @@ export function AggregationPicker({
   clauseIndex,
   operators,
   allowCustomExpressions = false,
+  allowMetrics = true,
   onClose,
   onQueryChange,
   onBack,
@@ -148,11 +149,20 @@ export function AggregationPicker({
     [query, stageIndex, clause, clauseIndex, onQueryChange],
   );
 
+  const availableColumns = useMemo(
+    () => Lib.aggregableColumns(query, stageIndex, clauseIndex),
+    [query, stageIndex, clauseIndex],
+  );
+
+  const availableMetrics = useMemo(
+    () => (allowMetrics ? Lib.availableMetrics(query, stageIndex) : []),
+    [query, stageIndex, allowMetrics],
+  );
+
   const sections = useMemo(() => {
     const sections: Section[] = [];
 
     const measures = Lib.availableMeasures(query, stageIndex);
-    const metrics = Lib.availableMetrics(query, stageIndex);
     const databaseId = Lib.databaseID(query);
     const database = metadata.database(databaseId);
     const supportsCustomExpressions = database?.hasFeature(
@@ -183,11 +193,11 @@ export function AggregationPicker({
       });
     }
 
-    if (metrics.length > 0) {
+    if (availableMetrics.length > 0) {
       sections.push({
         key: "metrics",
         name: t`Metrics`,
-        items: metrics.map((metric) =>
+        items: availableMetrics.map((metric) =>
           getMetricListItem(query, stageIndex, metric, clauseIndex),
         ),
         icon: "metric",
@@ -223,12 +233,8 @@ export function AggregationPicker({
     operators,
     allowCustomExpressions,
     isSearching,
+    availableMetrics,
   ]);
-
-  const availableColumns = useMemo(
-    () => Lib.aggregableColumns(query, stageIndex, clauseIndex),
-    [query, stageIndex, clauseIndex],
-  );
 
   const checkIsItemSelected = useCallback(
     (item: Item) => "selected" in item && item.selected,
@@ -350,6 +356,7 @@ export function AggregationPicker({
         query={query}
         stageIndex={stageIndex}
         availableColumns={availableColumns}
+        availableMetrics={availableMetrics}
         name={displayInfo?.displayName}
         clause={clause}
         withName

--- a/frontend/src/metabase/query_builder/components/expressions/Editor/Editor.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/Editor/Editor.tsx
@@ -49,6 +49,7 @@ type EditorProps = {
   expressionMode: Lib.ExpressionMode;
   expressionIndex?: number;
   availableColumns: Lib.ColumnMetadata[];
+  availableMetrics?: Lib.MetricMetadata[];
   reportTimezone?: string;
   readOnly?: boolean;
   error?: ExpressionError | Error | null;
@@ -74,6 +75,7 @@ export function Editor(props: EditorProps) {
     stageIndex,
     query,
     availableColumns,
+    availableMetrics,
     readOnly,
     error,
     reportTimezone,
@@ -125,6 +127,7 @@ export function Editor(props: EditorProps) {
     query,
     stageIndex,
     availableColumns,
+    availableMetrics,
     metadata,
     extensions: [customTooltip],
   });

--- a/frontend/src/metabase/query_builder/components/expressions/Editor/extensions.ts
+++ b/frontend/src/metabase/query_builder/components/expressions/Editor/extensions.ts
@@ -15,6 +15,7 @@ type Options = {
   query: Lib.Query;
   stageIndex: number;
   availableColumns: Lib.ColumnMetadata[];
+  availableMetrics?: Lib.MetricMetadata[];
   metadata: Metadata;
   extensions?: Extension[];
 };
@@ -38,6 +39,7 @@ export function useExtensions(options: Options): Extension[] {
     query,
     stageIndex,
     availableColumns,
+    availableMetrics,
     metadata,
     extensions: extra = [],
   } = options;
@@ -49,6 +51,7 @@ export function useExtensions(options: Options): Extension[] {
         query,
         stageIndex,
         availableColumns,
+        availableMetrics,
         metadata,
       }),
       expander(),
@@ -57,6 +60,7 @@ export function useExtensions(options: Options): Extension[] {
         stageIndex,
         expressionMode,
         availableColumns,
+        availableMetrics,
         metadata,
       }),
       tooltips({

--- a/frontend/src/metabase/query_builder/components/expressions/Editor/language.ts
+++ b/frontend/src/metabase/query_builder/components/expressions/Editor/language.ts
@@ -23,6 +23,7 @@ type LintOptions = {
   query: Lib.Query;
   stageIndex: number;
   availableColumns: Lib.ColumnMetadata[];
+  availableMetrics?: Lib.MetricMetadata[];
   metadata: Metadata;
 };
 

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget/ExpressionWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget/ExpressionWidget.tsx
@@ -36,6 +36,7 @@ export type ExpressionWidgetProps = {
   header?: ReactNode;
   initialExpressionClause?: DefinedClauseName | null;
   availableColumns: Lib.ColumnMetadata[];
+  availableMetrics?: Lib.MetricMetadata[];
   readOnly?: boolean;
 
   onChangeClause?: (name: string, clause: Lib.ExpressionClause) => void;
@@ -54,6 +55,7 @@ export const ExpressionWidget = (props: ExpressionWidgetProps) => {
     reportTimezone,
     header,
     availableColumns,
+    availableMetrics,
     onChangeClause,
     onClose,
     initialExpressionClause,
@@ -199,6 +201,7 @@ export const ExpressionWidget = (props: ExpressionWidgetProps) => {
         stageIndex={stageIndex}
         expressionIndex={expressionIndex}
         availableColumns={availableColumns}
+        availableMetrics={availableMetrics}
         reportTimezone={reportTimezone}
         shortcuts={shortcuts}
         error={error}

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget/ExpressionWidget.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget/ExpressionWidget.unit.spec.tsx
@@ -128,7 +128,9 @@ describe("ExpressionWidget", () => {
       const doneButton = screen.getByRole("button", { name: "Done" });
       expect(doneButton).toBeDisabled();
 
-      await screen.findByText("Unknown Aggregation or Metric: Imaginary");
+      await screen.findByText(
+        "Unknown Aggregation, Measure or Metric: Imaginary",
+      );
     });
 
     it("should show 'no aggregation found' error if the identifier is recognized as a dimension (metabase#50753)", async () => {

--- a/frontend/src/metabase/querying/expressions/formatter/formatter.ts
+++ b/frontend/src/metabase/querying/expressions/formatter/formatter.ts
@@ -136,6 +136,8 @@ function print(
     return formatColumn(path, options.extra);
   } else if (check.isMetricMetadata(path)) {
     return formatMetric(path, options.extra);
+  } else if (check.isMeasureMetadata(path)) {
+    return formatMeasure(path, options.extra);
   } else if (check.isSegmentMetadata(path)) {
     return formatSegment(path, options.extra);
   } else if (check.isExpressionOperator(path)) {
@@ -206,6 +208,21 @@ function formatMetric(
   assert(query !== undefined, "Expected query");
   assert(typeof stageIndex === "number", "Expected stageIndex");
   assert(Lib.isMetricMetadata(metric), "Expected metric");
+
+  const displayInfo = Lib.displayInfo(query, stageIndex, metric);
+  return formatMetricName(displayInfo.displayName);
+}
+
+function formatMeasure(
+  path: AstPath<Lib.MeasureMetadata>,
+  options: FormatOptions,
+): Doc {
+  const metric = path.node;
+  const { query, stageIndex } = options;
+
+  assert(query !== undefined, "Expected query");
+  assert(typeof stageIndex === "number", "Expected stageIndex");
+  assert(Lib.isMeasureMetadata(metric), "Expected measure");
 
   const displayInfo = Lib.displayInfo(query, stageIndex, metric);
   return formatMetricName(displayInfo.displayName);

--- a/frontend/src/metabase/querying/expressions/formatter/formatter.unit.spec.ts
+++ b/frontend/src/metabase/querying/expressions/formatter/formatter.unit.spec.ts
@@ -9,6 +9,7 @@ import { compileExpression } from "../compile-expression";
 import {
   expressions,
   fields,
+  measures,
   metrics,
   query,
   segments,
@@ -287,6 +288,7 @@ describe("format", () => {
       { result: "[Unknown Field]", parts: fields.orders.TOTAL },
       { result: "[Unknown Segment]", parts: segments.EXPENSIVE_THINGS },
       { result: "[Unknown Metric]", parts: metrics.FOO },
+      { result: "[Unknown Measure]", parts: measures.BAR },
     ])("should format an unknown %s as %s", async ({ result, parts }) => {
       const clause = Lib.expressionClause(parts);
 
@@ -641,6 +643,12 @@ describe("if printWidth = Infinity, it should return the same results as the sin
   it("should format metrics", async () => {
     await all({
       "[Foo Metric]": metrics.FOO,
+    });
+  });
+
+  it("should format measures", async () => {
+    await all({
+      "[Bar Measure]": measures.BAR,
     });
   });
 

--- a/frontend/src/metabase/querying/expressions/formatter/utils.ts
+++ b/frontend/src/metabase/querying/expressions/formatter/utils.ts
@@ -50,6 +50,7 @@ export const pathMatchers = lift({
   isExpressionParts: Lib.isExpressionParts,
   isColumnMetadata: Lib.isColumnMetadata,
   isMetricMetadata: Lib.isMetricMetadata,
+  isMeasureMetadata: Lib.isMeasureMetadata,
   isSegmentMetadata: Lib.isSegmentMetadata,
   isExpressionOperator,
   isDimensionOperator,

--- a/frontend/src/metabase/querying/expressions/identifier.ts
+++ b/frontend/src/metabase/querying/expressions/identifier.ts
@@ -20,6 +20,10 @@ export function formatMetricName(metricName: string) {
   return formatIdentifier(metricName);
 }
 
+export function formatMeasureName(measureName: string) {
+  return formatIdentifier(measureName);
+}
+
 export function formatSegmentName(segmentName: string) {
   return formatIdentifier(segmentName);
 }

--- a/frontend/src/metabase/querying/expressions/resolver.ts
+++ b/frontend/src/metabase/querying/expressions/resolver.ts
@@ -26,6 +26,8 @@ export function resolver(options: Options): Resolver {
 
   const metrics = _.memoize(() => Lib.availableMetrics(query, stageIndex));
   const segments = _.memoize(() => Lib.availableSegments(query, stageIndex));
+  const measures = _.memoize(() => Lib.availableMeasures(query, stageIndex));
+
   const cache = infoCache(options);
 
   return function (type, name, node) {
@@ -33,10 +35,21 @@ export function resolver(options: Options): Resolver {
 
     if (type === "aggregation") {
       // Return metrics
-      const dimension = findByName([...metrics(), ...availableColumns]);
+      const dimension = findByName([
+        ...metrics(),
+        ...measures(),
+        ...availableColumns,
+      ]);
+
       if (!dimension) {
-        throw new CompileError(t`Unknown Aggregation or Metric: ${name}`, node);
-      } else if (!Lib.isMetricMetadata(dimension)) {
+        throw new CompileError(
+          t`Unknown Aggregation, Measure or Metric: ${name}`,
+          node,
+        );
+      } else if (
+        !Lib.isMetricMetadata(dimension) &&
+        !Lib.isMeasureMetadata(dimension)
+      ) {
         // If no metric was found, but there is a matching column,
         // show a more sophisticated error message
         throw new CompileError(
@@ -65,10 +78,12 @@ export function resolver(options: Options): Resolver {
       return dimension;
     }
 
-    // Return columns and, in the case of aggregation expressions, metrics
+    // Return columns and, in the case of aggregation expressions, metrics and measures
     const dimension = findByName([
       ...availableColumns,
-      ...(expressionMode === "aggregation" ? metrics() : []),
+      ...(expressionMode === "aggregation"
+        ? [...metrics(), ...measures()]
+        : []),
     ]);
     if (!dimension) {
       if (expressionMode === "aggregation") {
@@ -83,13 +98,21 @@ export function resolver(options: Options): Resolver {
   };
 }
 
-type Dimension = Lib.SegmentMetadata | Lib.MetricMetadata | Lib.ColumnMetadata;
+type Dimension =
+  | Lib.ColumnMetadata
+  | Lib.MeasureMetadata
+  | Lib.MetricMetadata
+  | Lib.SegmentMetadata;
+
+type DimensionInfo =
+  | Lib.ColumnDisplayInfo
+  | Lib.MeasureDisplayInfo
+  | Lib.MetricDisplayInfo
+  | Lib.SegmentDisplayInfo;
 
 function nameMatcher(
   name: string,
-  info: (
-    dimension: Dimension,
-  ) => Lib.ColumnDisplayInfo | Lib.MetricDisplayInfo | Lib.SegmentDisplayInfo,
+  info: (dimension: Dimension) => DimensionInfo,
 ): (dimensions: Dimension[]) => Dimension | undefined {
   function byName({
     preserveSeparators,
@@ -145,11 +168,8 @@ function equals(caseSensitive: boolean, a: string, b: string) {
 // The cache only lives for the duration of each compile phase,
 // so the query can not change in the meantime.
 function infoCache(options: Options) {
-  const cache = new Map<
-    Dimension,
-    Lib.ColumnDisplayInfo | Lib.MetricDisplayInfo | Lib.SegmentDisplayInfo
-  >();
-  return function (dimension: Dimension) {
+  const cache = new Map<Dimension, DimensionInfo>();
+  return function (dimension: Dimension): DimensionInfo {
     const cached = cache.get(dimension);
     if (cached) {
       return cached;

--- a/frontend/src/metabase/querying/expressions/resolver.ts
+++ b/frontend/src/metabase/querying/expressions/resolver.ts
@@ -19,12 +19,21 @@ type Options = {
   stageIndex: number;
   expressionMode: Lib.ExpressionMode;
   availableColumns: Lib.ColumnMetadata[];
+  availableMetrics?: Lib.MetricMetadata[];
 };
 
 export function resolver(options: Options): Resolver {
-  const { query, stageIndex, expressionMode, availableColumns } = options;
+  const {
+    query,
+    stageIndex,
+    expressionMode,
+    availableColumns,
+    availableMetrics,
+  } = options;
 
-  const metrics = _.memoize(() => Lib.availableMetrics(query, stageIndex));
+  const metrics = _.memoize(
+    () => availableMetrics ?? Lib.availableMetrics(query, stageIndex),
+  );
   const segments = _.memoize(() => Lib.availableSegments(query, stageIndex));
   const measures = _.memoize(() => Lib.availableMeasures(query, stageIndex));
 

--- a/frontend/src/metabase/querying/expressions/resolver.unit.spec.ts
+++ b/frontend/src/metabase/querying/expressions/resolver.unit.spec.ts
@@ -7,6 +7,7 @@ import {
   fields,
   findDimensions,
   findField,
+  measures,
   metrics,
   query,
   queryWithAggregation,
@@ -62,6 +63,12 @@ describe("resolver", () => {
             "Unknown Segment or boolean column: Foo Metric",
           );
         });
+
+        it("should not resolve measures", () => {
+          expect(() => boolean("Bar Measure")).toThrow(
+            "Unknown Segment or boolean column: Bar Measure",
+          );
+        });
       });
 
       describe("type = string", () => {
@@ -103,6 +110,12 @@ describe("resolver", () => {
             "Unknown column: Foo Metric",
           );
         });
+
+        it("should not resolve measures", () => {
+          expect(() => string("Bar Measure")).toThrow(
+            "Unknown column: Bar Measure",
+          );
+        });
       });
 
       describe("type = number", () => {
@@ -134,6 +147,12 @@ describe("resolver", () => {
             "Unknown column: Foo Metric",
           );
         });
+
+        it("should not resolve measures", () => {
+          expect(() => number("Bar Measure")).toThrow(
+            "Unknown column: Bar Measure",
+          );
+        });
       });
 
       describe("type = datetime", () => {
@@ -156,6 +175,12 @@ describe("resolver", () => {
         it("should not resolve metrics", () => {
           expect(() => datetime("Foo Metric")).toThrow(
             "Unknown column: Foo Metric",
+          );
+        });
+
+        it("should resolve measures", () => {
+          expect(() => datetime("Bar Measure")).toThrow(
+            "Unknown column: Bar Measure",
           );
         });
       });
@@ -182,6 +207,12 @@ describe("resolver", () => {
 
         it("should not resolve metrics", () => {
           expect(() => any("Foo Metric")).toThrow("Unknown column: Foo Metric");
+        });
+
+        it("should not resolve measures", () => {
+          expect(() => any("Bar Measure")).toThrow(
+            "Unknown column: Bar Measure",
+          );
         });
       });
 
@@ -212,6 +243,12 @@ describe("resolver", () => {
             "Unknown column: Foo Metric",
           );
         });
+
+        it("should not resolve measures", () => {
+          expect(() => expression("Bar Measure")).toThrow(
+            "Unknown column: Bar Measure",
+          );
+        });
       });
 
       describe("type = aggregation", () => {
@@ -219,7 +256,7 @@ describe("resolver", () => {
 
         it("should not resolve fields", () => {
           expect(() => aggregation("Unknown")).toThrow(
-            "Unknown Aggregation or Metric: Unknown",
+            "Unknown Aggregation, Measure or Metric: Unknown",
           );
           expect(() => aggregation("Created At")).toThrow(
             "No aggregation found in: Created At. Use functions like Sum() or custom Metrics",
@@ -234,19 +271,24 @@ describe("resolver", () => {
 
         it("should not resolve unknown fields", () => {
           expect(() => aggregation("Unknown")).toThrow(
-            "Unknown Aggregation or Metric: Unknown",
+            "Unknown Aggregation, Measure or Metric: Unknown",
           );
         });
 
         it("should not resolve segments", () => {
           expect(() => aggregation("Expensive Things")).toThrow(
-            "Unknown Aggregation or Metric: Expensive Things",
+            "Unknown Aggregation, Measure or Metric: Expensive Things",
           );
         });
 
         it("should resolve metrics", () => {
           expect(aggregation("Foo Metric")).toEqual(metrics.FOO);
           expect(aggregation("foo metric")).toEqual(metrics.FOO);
+        });
+
+        it("should resolve measures", () => {
+          expect(aggregation("Bar Measure")).toEqual(measures.BAR);
+          expect(aggregation("bar measure")).toEqual(measures.BAR);
         });
       });
 
@@ -331,6 +373,12 @@ describe("resolver", () => {
         );
       });
 
+      it("should not resolve measures", () => {
+        expect(() => boolean("Bar Measure")).toThrow(
+          "Unknown Segment or boolean column: Bar Measure",
+        );
+      });
+
       it("should not resolve aggregations", () => {
         expect(() => boolean("Bar Aggregation")).toThrow(
           "Unknown Segment or boolean column: Bar Aggregation",
@@ -369,6 +417,10 @@ describe("resolver", () => {
         expect(string("Foo Metric")).toEqual(metrics.FOO);
       });
 
+      it("should resolve measures", () => {
+        expect(string("Bar Measure")).toEqual(measures.BAR);
+      });
+
       it("should resolve aggregations", () => {
         expect(string("Bar Aggregation")).toEqual(aggregations.BAR_AGGREGATION);
       });
@@ -401,6 +453,10 @@ describe("resolver", () => {
         expect(number("Foo Metric")).toEqual(metrics.FOO);
       });
 
+      it("should resolve measures", () => {
+        expect(number("Bar Measure")).toEqual(measures.BAR);
+      });
+
       it("should resolve aggregations", () => {
         expect(number("Bar Aggregation")).toEqual(aggregations.BAR_AGGREGATION);
       });
@@ -427,6 +483,10 @@ describe("resolver", () => {
 
       it("should resolve metrics", () => {
         expect(datetime("Foo Metric")).toEqual(metrics.FOO);
+      });
+
+      it("should resolve measures", () => {
+        expect(datetime("Bar Measure")).toEqual(measures.BAR);
       });
 
       it("should resolve aggregations", () => {
@@ -464,6 +524,10 @@ describe("resolver", () => {
         expect(any("Foo Metric")).toEqual(metrics.FOO);
       });
 
+      it("should resolve measures", () => {
+        expect(any("Bar Measure")).toEqual(measures.BAR);
+      });
+
       it("should resolve aggregations", () => {
         expect(any("Bar Aggregation")).toEqual(aggregations.BAR_AGGREGATION);
       });
@@ -495,6 +559,10 @@ describe("resolver", () => {
         expect(expression("Foo Metric")).toEqual(metrics.FOO);
       });
 
+      it("should resolve measures", () => {
+        expect(expression("Bar Measure")).toEqual(measures.BAR);
+      });
+
       it("should resolve aggregations", () => {
         expect(expression("Bar Aggregation")).toEqual(
           aggregations.BAR_AGGREGATION,
@@ -507,7 +575,7 @@ describe("resolver", () => {
 
       it("should not resolve fields", () => {
         expect(() => aggregation("Unknown")).toThrow(
-          "Unknown Aggregation or Metric: Unknown",
+          "Unknown Aggregation, Measure or Metric: Unknown",
         );
         expect(() => aggregation("Created At")).toThrow(
           "No aggregation found in: Created At. Use functions like Sum() or custom Metrics",
@@ -522,18 +590,22 @@ describe("resolver", () => {
 
       it("should not resolve unknown fields", () => {
         expect(() => aggregation("Unknown")).toThrow(
-          "Unknown Aggregation or Metric: Unknown",
+          "Unknown Aggregation, Measure or Metric: Unknown",
         );
       });
 
       it("should not resolve segments", () => {
         expect(() => aggregation("Expensive Things")).toThrow(
-          "Unknown Aggregation or Metric: Expensive Things",
+          "Unknown Aggregation, Measure or Metric: Expensive Things",
         );
       });
 
       it("should resolve metrics", () => {
         expect(aggregation("Foo Metric")).toEqual(metrics.FOO);
+      });
+
+      it("should resolve measures", () => {
+        expect(aggregation("Bar Measure")).toEqual(measures.BAR);
       });
 
       it("should resolve aggregations", () => {

--- a/frontend/src/metabase/querying/expressions/suggestions/measures.ts
+++ b/frontend/src/metabase/querying/expressions/suggestions/measures.ts
@@ -1,0 +1,61 @@
+import type { CompletionContext } from "@codemirror/autocomplete";
+
+import * as Lib from "metabase-lib";
+
+import { formatIdentifier } from "../identifier";
+import { tokenAtPos } from "../position";
+
+import { fuzzyMatcher } from "./util";
+
+export type Options = {
+  expressionMode: Lib.ExpressionMode;
+  query: Lib.Query;
+  stageIndex: number;
+};
+
+export function suggestMeasures({
+  expressionMode,
+  query,
+  stageIndex,
+}: Options) {
+  const measures = Lib.availableMeasures(query, stageIndex)?.map((metric) => {
+    const displayInfo = Lib.displayInfo(query, stageIndex, metric);
+    return {
+      type: "measure",
+      displayLabel: displayInfo.longDisplayName,
+      label: formatIdentifier(displayInfo.longDisplayName),
+      icon: "sum" as const,
+    };
+  });
+
+  if (expressionMode !== "aggregation" || measures.length === 0) {
+    return null;
+  }
+
+  const matcher = fuzzyMatcher(measures);
+
+  return function (context: CompletionContext) {
+    const source = context.state.doc.toString();
+    const token = tokenAtPos(source, context.pos);
+
+    if (!token) {
+      return null;
+    }
+
+    const word = token.text.replace(/^\[/, "").replace(/\]$/, "");
+    if (word === "") {
+      return {
+        from: token.start,
+        to: token.end,
+        options: measures,
+        filter: false,
+      };
+    }
+
+    return {
+      from: token.start,
+      to: token.end,
+      options: matcher(token.text),
+    };
+  };
+}

--- a/frontend/src/metabase/querying/expressions/suggestions/measures.unit.spec.ts
+++ b/frontend/src/metabase/querying/expressions/suggestions/measures.unit.spec.ts
@@ -1,0 +1,143 @@
+import { createMockMetadata } from "__support__/metadata";
+import { SAMPLE_DATABASE, createQuery } from "metabase-lib/test-helpers";
+import {
+  createMockField,
+  createMockMeasure,
+  createMockStructuredDatasetQuery,
+  createMockTable,
+} from "metabase-types/api/mocks";
+import { createSampleDatabase } from "metabase-types/api/mocks/presets";
+
+import { complete } from "./__support__";
+import { type Options, suggestMeasures } from "./measures";
+
+describe("suggestMeasures", () => {
+  function setup({ expressionMode = "expression" }: Partial<Options>) {
+    const DATABASE_ID = SAMPLE_DATABASE.id;
+    const TABLE_ID = 1;
+
+    const MEASURE_BAR = createMockMeasure({
+      name: "BAR",
+      table_id: TABLE_ID,
+      definition: createMockStructuredDatasetQuery({
+        database: DATABASE_ID,
+        query: {
+          "source-table": TABLE_ID,
+          aggregation: [["sum", ["field", 11, {}]]],
+        },
+      }),
+    });
+
+    const TABLE = createMockTable({
+      db_id: DATABASE_ID,
+      id: TABLE_ID,
+      fields: [
+        createMockField({
+          id: 10,
+          table_id: TABLE_ID,
+          display_name: "Toucan Sam",
+          base_type: "type/Float",
+        }),
+        createMockField({
+          id: 11,
+          table_id: TABLE_ID,
+          display_name: "Sum",
+          base_type: "type/Float",
+        }),
+        createMockField({
+          id: 12,
+          table_id: TABLE_ID,
+          display_name: "count",
+          base_type: "type/Float",
+        }),
+        createMockField({
+          id: 13,
+          table_id: TABLE_ID,
+          display_name: "text",
+          base_type: "type/Text",
+        }),
+        createMockField({
+          id: 14,
+          table_id: TABLE_ID,
+          display_name: "date",
+          base_type: "type/DateTime",
+        }),
+      ],
+      measures: [MEASURE_BAR],
+    });
+
+    const DATABASE = createSampleDatabase({
+      id: DATABASE_ID,
+      name: "Database",
+      tables: [TABLE],
+    });
+
+    const metadata = createMockMetadata({
+      databases: [DATABASE],
+      tables: [TABLE],
+    });
+
+    const query = createQuery({
+      metadata,
+      query: {
+        database: DATABASE.id,
+        type: "query",
+        query: {
+          "source-table": TABLE.id,
+        },
+      },
+    });
+
+    const source = suggestMeasures({
+      expressionMode,
+      query,
+      stageIndex: -1,
+    });
+
+    return function (doc: string) {
+      return complete(source, doc);
+    };
+  }
+
+  describe("expressionMode = expression", () => {
+    const expressionMode = "expression";
+
+    it("should not suggest measures", () => {
+      const complete = setup({ expressionMode });
+      const results = complete("Ba|");
+      expect(results).toBe(null);
+    });
+  });
+
+  describe("expressionMode = boolean", () => {
+    const expressionMode = "filter";
+
+    it("should not suggest measures", () => {
+      const complete = setup({ expressionMode });
+      const results = complete("Ba|");
+      expect(results).toBe(null);
+    });
+  });
+
+  describe("expressionMode = aggregations", () => {
+    const expressionMode = "aggregation";
+
+    it("should suggest measures", () => {
+      const complete = setup({ expressionMode });
+      const results = complete("BA|");
+      expect(results).toEqual({
+        from: 0,
+        to: 2,
+        options: [
+          {
+            displayLabel: "BAR",
+            icon: "sum",
+            label: "[BAR]",
+            matches: [[0, 1]],
+            type: "measure",
+          },
+        ],
+      });
+    });
+  });
+});

--- a/frontend/src/metabase/querying/expressions/suggestions/metrics.ts
+++ b/frontend/src/metabase/querying/expressions/suggestions/metrics.ts
@@ -11,10 +11,18 @@ export type Options = {
   expressionMode: Lib.ExpressionMode;
   query: Lib.Query;
   stageIndex: number;
+  availableMetrics?: Lib.MetricMetadata[];
 };
 
-export function suggestMetrics({ expressionMode, query, stageIndex }: Options) {
-  const metrics = Lib.availableMetrics(query, stageIndex)?.map((metric) => {
+export function suggestMetrics({
+  expressionMode,
+  query,
+  stageIndex,
+  availableMetrics,
+}: Options) {
+  const metrics = (
+    availableMetrics ?? Lib.availableMetrics(query, stageIndex)
+  )?.map((metric) => {
     const displayInfo = Lib.displayInfo(query, stageIndex, metric);
     return {
       type: "metric",

--- a/frontend/src/metabase/querying/expressions/suggestions/suggest.ts
+++ b/frontend/src/metabase/querying/expressions/suggestions/suggest.ts
@@ -16,6 +16,7 @@ import { suggestAggregations } from "./aggregations";
 import { suggestFields } from "./fields";
 import { suggestFunctions } from "./functions";
 import { suggestLiterals } from "./literals";
+import { suggestMeasures } from "./measures";
 import { suggestMetrics } from "./metrics";
 import { suggestSegments } from "./segments";
 
@@ -30,6 +31,7 @@ export function suggestions(options: SuggestOptions) {
       suggestAggregations(options),
       suggestFields(options),
       suggestMetrics(options),
+      suggestMeasures(options),
       suggestSegments(options),
     ].filter(isNotNull),
   });

--- a/frontend/src/metabase/querying/expressions/suggestions/suggest.ts
+++ b/frontend/src/metabase/querying/expressions/suggestions/suggest.ts
@@ -10,6 +10,7 @@ export type SuggestOptions = {
   metadata: Metadata;
   expressionMode: Lib.ExpressionMode;
   availableColumns: Lib.ColumnMetadata[];
+  availableMetrics?: Lib.MetricMetadata[];
 };
 
 import { suggestAggregations } from "./aggregations";

--- a/frontend/src/metabase/querying/expressions/test/shared.ts
+++ b/frontend/src/metabase/querying/expressions/test/shared.ts
@@ -9,6 +9,7 @@ import {
 import {
   COMMON_DATABASE_FEATURES,
   createMockCard,
+  createMockMeasure,
   createMockSegment,
   createMockStructuredDatasetQuery,
   createMockStructuredQuery,
@@ -61,6 +62,20 @@ const metadata = createMockMetadata({
               type: "metric",
               table_id: ORDERS_ID,
               dataset_query: createMockStructuredDatasetQuery({
+                database: SAMPLE_DB_ID,
+                query: createMockStructuredQuery({
+                  "source-table": ORDERS_ID,
+                  aggregation: [["sum", ["field", ORDERS.TOTAL, {}]]],
+                }),
+              }),
+            }),
+          ],
+          measures: [
+            createMockMeasure({
+              id: getNextId(),
+              name: "Bar Measure",
+              table_id: ORDERS_ID,
+              definition: createMockStructuredDatasetQuery({
                 database: SAMPLE_DB_ID,
                 query: createMockStructuredQuery({
                   "source-table": ORDERS_ID,
@@ -199,6 +214,17 @@ function findMetric(query: Lib.Query, name: string) {
   throw new Error(`Could not find metric: ${name}`);
 }
 
+function findMeasure(query: Lib.Query, name: string) {
+  const measures = Lib.availableMeasures(query, stageIndex);
+  for (const measure of measures) {
+    const info = Lib.displayInfo(query, stageIndex, measure);
+    if (info.displayName === name) {
+      return measure;
+    }
+  }
+  throw new Error(`Could not find measure: ${name}`);
+}
+
 function findAggregation(query: Lib.Query, name: string) {
   if (query !== queryWithAggregation) {
     return null;
@@ -238,6 +264,10 @@ export function findDimensions(query: Lib.Query) {
     FOO: findMetric(query, "Foo Metric"),
   };
 
+  const measures = {
+    BAR: findMeasure(query, "Bar Measure"),
+  };
+
   const aggregations = {
     BAR_AGGREGATION: findAggregation(query, "Bar Aggregation"),
   };
@@ -247,9 +277,11 @@ export function findDimensions(query: Lib.Query) {
     expressions,
     segments,
     metrics,
+    measures,
     aggregations,
   };
 }
-export const { fields, expressions, segments, metrics } = findDimensions(query);
+export const { fields, expressions, segments, metrics, measures } =
+  findDimensions(query);
 
 export const sharedMetadata = metadata;

--- a/frontend/src/metabase/querying/measures/components/MeasureAggregationPicker/MeasureAggregationPicker.tsx
+++ b/frontend/src/metabase/querying/measures/components/MeasureAggregationPicker/MeasureAggregationPicker.tsx
@@ -92,6 +92,7 @@ export function MeasureAggregationPicker({
             clauseIndex={index}
             operators={operators}
             allowCustomExpressions
+            allowMetrics={false}
             onQueryChange={handleQueryChange}
             onClose={onClose}
             readOnly={readOnly}


### PR DESCRIPTION
- Adds measure completions to the expression editor
- Allows measure expressions to be compiled and formatted correctly
- Hides metrics in the Measure aggregation picker and expression editor
