### PR TITLE
add series limit to row chart

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/rows.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/rows.cy.spec.js
@@ -1,5 +1,6 @@
 import _ from "underscore";
 
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { H } = cy;
@@ -153,5 +154,65 @@ describe("scenarios > visualizations > rows", () => {
         .invoke("width")
         .should("be.gt", 500);
     });
+  });
+
+  it("should display an error message when there are more series than the chart supports", () => {
+    H.visitQuestionAdhoc({
+      display: "row",
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        type: "query",
+        query: {
+          "source-table": PRODUCTS_ID,
+          aggregation: [["count"]],
+          breakout: [
+            ["field", PRODUCTS.CREATED_AT, { "temporal-unit": "year" }],
+            ["field", PRODUCTS.TITLE, null],
+          ],
+        },
+      },
+      visualization_settings: {
+        "graph.dimensions": ["CREATED_AT", "TITLE"],
+        "graph.metrics": ["count"],
+      },
+    });
+
+    H.main().findByText(
+      "This chart type doesn't support more than 100 series of data.",
+    );
+  });
+
+  it("should show error when adding high-cardinality breakout via UI (metabase#64086)", () => {
+    const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+
+    H.visitQuestionAdhoc({
+      display: "row",
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        type: "query",
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"]],
+          breakout: [
+            ["field", ORDERS.CREATED_AT, { "temporal-unit": "minute" }],
+            ["field", ORDERS.ID, null],
+          ],
+        },
+      },
+      visualization_settings: {
+        "graph.dimensions": ["CREATED_AT"],
+        "graph.metrics": ["count"],
+      },
+    });
+
+    H.openVizSettingsSidebar();
+    H.leftSidebar().within(() => {
+      cy.findByText("Data").click();
+      cy.findByText("Add series breakout").click();
+    });
+
+    H.main().findByText(
+      "This chart type doesn't support more than 100 series of data.",
+    );
   });
 });

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -12,6 +12,7 @@ import { dimensionIsNumeric } from "metabase/visualizations/lib/numeric";
 import { columnSettings } from "metabase/visualizations/lib/settings/column";
 import { seriesSetting } from "metabase/visualizations/lib/settings/series";
 import { getOptionFromColumn } from "metabase/visualizations/lib/settings/utils";
+import { getBreakoutCardinality } from "metabase/visualizations/lib/settings/validation";
 import { dimensionIsTimeseries } from "metabase/visualizations/lib/timeseries";
 import { MAX_SERIES, columnsAreValid } from "metabase/visualizations/lib/utils";
 import {
@@ -164,11 +165,13 @@ export const GRAPH_DATA_SETTINGS = {
         truncateAfter: 10,
       };
     },
-    getHidden: (_series, settings, extra) => {
-      const seriesCount = extra.transformedSeries?.length ?? 0;
-      return (
-        settings["graph.dimensions"]?.length < 2 || seriesCount > MAX_SERIES
-      );
+    getHidden: (rawSeries, settings) => {
+      const { cols, rows } = rawSeries?.[0]?.data ?? {};
+      if (!cols || !rows) {
+        return true;
+      }
+      const cardinality = getBreakoutCardinality(cols, rows, settings);
+      return cardinality == null || cardinality > MAX_SERIES;
     },
     dashboard: false,
     readDependencies: [

--- a/frontend/src/metabase/visualizations/shared/utils/data.ts
+++ b/frontend/src/metabase/visualizations/shared/utils/data.ts
@@ -173,20 +173,20 @@ const getBreakoutDistinctValues = (
   data: DatasetData,
   breakout: ColumnDescriptor,
   columnFormatter: ColumnFormatter,
-) => {
+): string[] => {
   const formattedDistinctValues: string[] = [];
   const usedRawValues = new Set<RowValue>();
 
-  data.rows.forEach((row) => {
+  for (const row of data.rows) {
     const rawValue = row[breakout.index];
 
     if (usedRawValues.has(rawValue)) {
-      return;
+      continue;
     }
 
     usedRawValues.add(rawValue);
     formattedDistinctValues.push(columnFormatter(rawValue, breakout.column));
-  });
+  }
 
   return formattedDistinctValues;
 };

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
@@ -1,12 +1,5 @@
 import type { EChartsType } from "echarts/core";
-import {
-  type MouseEvent,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { type MouseEvent, useCallback, useMemo, useRef, useState } from "react";
 import React from "react";
 import { useSet } from "react-use";
 
@@ -28,7 +21,7 @@ import { useChartEvents } from "metabase/visualizations/visualizations/Cartesian
 
 import { useChartDebug } from "./use-chart-debug";
 import { useModelsAndOption } from "./use-models-and-option";
-import { getGridSizeAdjustedSettings, validateChartModel } from "./utils";
+import { getGridSizeAdjustedSettings } from "./utils";
 
 const HIDE_X_AXIS_LABEL_WIDTH_THRESHOLD = 360;
 const HIDE_Y_AXIS_LABEL_WIDTH_THRESHOLD = 200;
@@ -99,10 +92,6 @@ function _CartesianChart(props: VisualizationProps) {
     [chartModel, showAllLegendItems],
   );
   const hasLegend = legendItems.length > 0;
-
-  useEffect(() => {
-    validateChartModel(chartModel);
-  }, [chartModel]);
 
   const handleInit = useCallback((chart: EChartsType) => {
     chartRef.current = chart;

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/chart-definition-legacy.js
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/chart-definition-legacy.js
@@ -4,6 +4,7 @@ import { NULL_DISPLAY_VALUE } from "metabase/lib/constants";
 import { formatValue } from "metabase/lib/formatting";
 import { isEmpty } from "metabase/lib/validate";
 import { getComputedSettingsForSeries } from "metabase/visualizations/lib/settings/visualization";
+import { MAX_SERIES } from "metabase/visualizations/lib/utils";
 
 // TODO: this series transformation is used only for the visualization settings computation which is excessive.
 // Replace this with defining settings models per visualization type which will contain all necessary info
@@ -68,6 +69,10 @@ function transformSingleSeries(s, series, seriesIndex) {
       if (!seriesRows) {
         breakoutRowsByValue.set(seriesValue, (seriesRows = []));
         breakoutValues.push(seriesValue);
+
+        if (breakoutValues.length > MAX_SERIES) {
+          return [s];
+        }
       }
 
       const newRow = rowColumnIndexes.map((columnIndex) => row[columnIndex]);

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/chart-definition.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/chart-definition.ts
@@ -13,6 +13,7 @@ import {
   TOOLTIP_SETTINGS,
 } from "metabase/visualizations/lib/settings/graph";
 import {
+  validateBreakoutSeriesCount,
   validateChartDataSettings,
   validateDatasetRows,
   validateStacking,
@@ -50,6 +51,7 @@ export const getCartesianChartDefinition = (
 
     checkRenderable(series, settings) {
       validateDatasetRows(series);
+      validateBreakoutSeriesCount(series, settings);
       validateChartDataSettings(settings);
       validateStacking(settings);
     },

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/utils.ts
@@ -1,9 +1,7 @@
 import type { EChartsCoreOption } from "echarts/core";
-import { t } from "ttag";
 
 import { isNotNull } from "metabase/lib/types";
 import type {
-  BaseCartesianChartModel,
   DataKey,
   SeriesModel,
 } from "metabase/visualizations/echarts/cartesian/model/types";
@@ -53,16 +51,6 @@ export const getGridSizeAdjustedSettings = (
   }
 
   return newSettings;
-};
-
-export const MAX_SERIES = 100;
-
-export const validateChartModel = (chartModel: BaseCartesianChartModel) => {
-  if (chartModel.seriesModels.length > MAX_SERIES) {
-    throw new Error(
-      t`This chart type doesn't support more than ${MAX_SERIES} series of data.`,
-    );
-  }
 };
 
 export const getHoveredSeriesDataKey = (

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
@@ -14,11 +14,14 @@ import { getChartGoal } from "metabase/visualizations/lib/settings/goal";
 import { GRAPH_DATA_SETTINGS } from "metabase/visualizations/lib/settings/graph";
 import { getStackOffset } from "metabase/visualizations/lib/settings/stacking";
 import {
+  getBreakoutCardinality,
+  validateBreakoutSeriesCount,
   validateChartDataSettings,
   validateDatasetRows,
   validateStacking,
 } from "metabase/visualizations/lib/settings/validation";
 import { getComputedSettingsForSeries } from "metabase/visualizations/lib/settings/visualization";
+import { MAX_SERIES } from "metabase/visualizations/lib/utils";
 import type { RowChartProps } from "metabase/visualizations/shared/components/RowChart";
 import { RowChart } from "metabase/visualizations/shared/components/RowChart";
 import type { BarData } from "metabase/visualizations/shared/components/RowChart/types";
@@ -39,6 +42,7 @@ import {
   getMinSize,
 } from "metabase/visualizations/shared/utils/sizes";
 import type {
+  ComputedVisualizationSettings,
   RemappingHydratedChartData,
   VisualizationProps,
 } from "metabase/visualizations/types";
@@ -372,39 +376,46 @@ RowChartVisualization.settings["graph.dimensions"] = {
  */
 RowChartVisualization.transformSeries = (originalMultipleSeries: any) => {
   const [series] = originalMultipleSeries;
-  const settings: any = getComputedSettingsForSeries(originalMultipleSeries);
+  const settings: ComputedVisualizationSettings = getComputedSettingsForSeries(
+    originalMultipleSeries,
+  );
   const { card, data } = series;
 
-  if (series.card._transformed || !hasValidColumnsSelected(settings, data)) {
+  if (card._transformed || !hasValidColumnsSelected(settings, data)) {
+    return originalMultipleSeries;
+  }
+
+  const cardinality = getBreakoutCardinality(data.cols, data.rows, settings);
+  if (cardinality != null && cardinality > MAX_SERIES) {
     return originalMultipleSeries;
   }
 
   const chartColumns = getCartesianChartColumns(data.cols, settings);
-
-  const computedSeries = getSeries(
+  const seriesDefinitions = getSeries(
     data,
     chartColumns,
     getColumnValueFormatter(),
-  ).map((series) => {
-    const seriesCard = {
-      ...card,
-      name: series.seriesName,
-      _seriesKey: series.seriesKey,
-      _transformed: true,
-    };
+  );
 
-    const newData = {
+  const transformedSeries = seriesDefinitions.map((seriesDef) => ({
+    card: {
+      ...card,
+      name: seriesDef.seriesName,
+      _seriesKey: seriesDef.seriesKey,
+      _transformed: true,
+    },
+    data: {
       ...data,
       cols: [
-        series.seriesInfo?.dimensionColumn,
-        series.seriesInfo?.metricColumn,
+        seriesDef.seriesInfo?.dimensionColumn,
+        seriesDef.seriesInfo?.metricColumn,
       ],
-    };
+    },
+  }));
 
-    return { card: seriesCard, data: newData };
-  });
-
-  return computedSeries.length > 0 ? computedSeries : originalMultipleSeries;
+  return transformedSeries.length > 0
+    ? transformedSeries
+    : originalMultipleSeries;
 };
 
 RowChartVisualization.checkRenderable = (
@@ -412,6 +423,7 @@ RowChartVisualization.checkRenderable = (
   settings: VisualizationSettings,
 ) => {
   validateDatasetRows(series);
+  validateBreakoutSeriesCount(series, settings);
   validateChartDataSettings(settings);
   validateStacking(settings);
 };


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/64086

### Description

Cartesian (line/area/bar) charts have limit to 100 breakout series. When you add a second x-axis dimension it breaks out the series into N series per value of the breakout column. The Row chart on the other hand did not have the limit which allowed to create charts with 10k series that would crash on many machines:
<img width="1721" height="989" alt="Screenshot 2025-12-30 at 2 59 40 PM" src="https://github.com/user-attachments/assets/627ef10d-342d-4831-a550-545543c4f278" />

It is reasonable to introduce the same limit of 100 breakout series to Row charts as well. To reduce freezes when users add high-cardinality breakout dimensions `transformSeries` also got updated to not even compute transformed series when there are >100 breakout values.

### How to verify

- New question -> Orders -> Count group by Created At [minute], and ID
- Set x-axis to Created At, y-axis to Count
- Ensure when you try to add ID as a second x-axis dimension it shows an error in Row and Line/Area/Bar charts

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
