### PR TITLE
fix zoom resets on resize

### DIFF
--- a/frontend/src/metabase/visualizations/components/LeafletMap.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletMap.jsx
@@ -84,54 +84,76 @@ export default class LeafletMap extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { bounds, settings, zoomControl } = this.props;
+    const { bounds, settings, zoomControl, zoom, lat, lng } = this.props;
 
-    if (zoomControl === false) {
-      this.map.removeControl(this.map.zoomControl);
-    } else {
-      this.map.addControl(this.map.zoomControl);
+    if (prevProps.zoomControl !== zoomControl) {
+      if (zoomControl === false) {
+        this.map.zoomControl?.remove();
+      } else if (this.map.zoomControl) {
+        this.map.zoomControl.addTo(this.map);
+      }
     }
 
-    if (
-      !prevProps ||
-      prevProps.points !== this.props.points ||
-      prevProps.width !== this.props.width ||
-      prevProps.height !== this.props.height
-    ) {
-      this.map.invalidateSize();
+    const isInitialUpdate = !prevProps;
+    const pointsChanged = prevProps && prevProps.points !== this.props.points;
+    const dimensionsChanged =
+      prevProps &&
+      (prevProps.width !== this.props.width ||
+        prevProps.height !== this.props.height);
 
-      if (
-        settings["map.center_latitude"] != null ||
-        settings["map.center_longitude"] != null ||
-        settings["map.zoom"] != null
-      ) {
+    if (!isInitialUpdate && !pointsChanged && !dimensionsChanged) {
+      return;
+    }
+
+    this.map.invalidateSize();
+
+    const hasSavedView =
+      settings["map.center_latitude"] != null ||
+      settings["map.center_longitude"] != null ||
+      settings["map.zoom"] != null;
+
+    // Pure resize (no data change): preserve user's current view
+    if (!isInitialUpdate && !pointsChanged && dimensionsChanged) {
+      if (zoom != null) {
+        const currentCenter = this.map.getCenter();
         this.map.setView(
-          [settings["map.center_latitude"], settings["map.center_longitude"]],
-          settings["map.zoom"],
+          [lat ?? currentCenter.lat, lng ?? currentCenter.lng],
+          zoom,
         );
-        return;
       }
+      // Don't reset to saved settings or recalculate on pure resize
+      return;
+    }
 
-      if (shouldRecalculateZoom(prevProps?.points, this.props.points)) {
-        // compute ideal lat and lon zoom separately and use the lesser zoom to ensure the bounds are visible
-        const latZoom = this.map.getBoundsZoom(
-          L.latLngBounds([
-            [bounds.getSouth(), 0],
-            [bounds.getNorth(), 0],
-          ]),
-        );
-        const lonZoom = this.map.getBoundsZoom(
-          L.latLngBounds([
-            [0, bounds.getWest()],
-            [0, bounds.getEast()],
-          ]),
-        );
-        const zoom = Math.min(latZoom, lonZoom);
-        // NOTE: unclear why calling `fitBounds` twice is sometimes required to get it to work
-        this.map.fitBounds(bounds);
-        this.map.setZoom(zoom);
-        this.map.fitBounds(bounds);
-      }
+    // Initial update or data changed: apply saved settings if available
+    if (hasSavedView) {
+      this.map.setView(
+        [settings["map.center_latitude"], settings["map.center_longitude"]],
+        settings["map.zoom"],
+      );
+      return;
+    }
+
+    // No saved view: fit to data bounds
+    if (shouldRecalculateZoom(prevProps?.points, this.props.points)) {
+      // compute ideal lat and lon zoom separately and use the lesser zoom to ensure the bounds are visible
+      const latZoom = this.map.getBoundsZoom(
+        L.latLngBounds([
+          [bounds.getSouth(), 0],
+          [bounds.getNorth(), 0],
+        ]),
+      );
+      const lonZoom = this.map.getBoundsZoom(
+        L.latLngBounds([
+          [0, bounds.getWest()],
+          [0, bounds.getEast()],
+        ]),
+      );
+      const zoom = Math.min(latZoom, lonZoom);
+      // NOTE: unclear why calling `fitBounds` twice is sometimes required to get it to work
+      this.map.fitBounds(bounds);
+      this.map.setZoom(zoom);
+      this.map.fitBounds(bounds);
     }
   }
 

--- a/frontend/src/metabase/visualizations/components/PinMap.jsx
+++ b/frontend/src/metabase/visualizations/components/PinMap.jsx
@@ -233,7 +233,7 @@ export default class PinMap extends Component {
             binWidth={binWidth}
             binHeight={binHeight}
             onFiltering={(filtering) => this.setState({ filtering })}
-            zoomControl={!isEditing}
+            zoomControl={!(isDashboard && isEditing)}
             onHoverChange={
               isDashboard && isEditing ? null : mapProps.onHoverChange
             }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/11211

### Description

Fixes any resizing on the pin map resets zoom/pan back to the saved default view. Also fixes missing zoom buttons in query builder caused by https://github.com/metabase/metabase/pull/64174

### Demo

Loom: https://www.loom.com/share/916c13c4cc7d4ec78c19ea7f7ab9972d

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
