### PR TITLE
Minor clojure tweaks for metabot measures and segments poc

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/entity_details.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/entity_details.clj
@@ -215,14 +215,13 @@
                          :related_tables related-tables
                          :metrics (when with-metrics?
                                     (not-empty (mapv #(convert-metric % mp options)
-                                                     (lib/available-metrics table-query)))))
-           (cond->
-            with-measures? (assoc :measures (if-let [measures (lib/available-measures table-query)]
-                                              (mapv convert-measure measures)
-                                              []))
-            with-segments? (assoc :segments (if-let [segments (lib/available-segments table-query)]
-                                              (mapv convert-segment segments)
-                                              []))))))))
+                                                     (lib/available-metrics table-query))))
+                         :measures (when with-measures?
+                                     (not-empty (mapv convert-measure
+                                                      (lib/available-measures table-query))))
+                         :segments (when with-segments?
+                                     (not-empty (mapv convert-segment
+                                                      (lib/available-segments table-query))))))))))
 
 (defn related-tables
   "Constructs a list of tables, optionally including their fields, that are related to the given query via foreign key.
@@ -310,14 +309,13 @@
           :related_tables related-tables
           :metrics (when with-metrics?
                      (not-empty (mapv #(convert-metric % metadata-provider options)
-                                      (lib/available-metrics card-query)))))
-         (cond->
-          with-measures? (assoc :measures (if-let [measures (lib/available-measures card-query)]
-                                            (mapv convert-measure measures)
-                                            []))
-          with-segments? (assoc :segments (if-let [segments (lib/available-segments card-query)]
-                                            (mapv convert-segment segments)
-                                            [])))))))
+                                      (lib/available-metrics card-query))))
+          :measures (when with-measures?
+                      (not-empty (mapv convert-measure
+                                       (lib/available-measures card-query))))
+          :segments (when with-segments?
+                      (not-empty (mapv convert-segment
+                                       (lib/available-segments card-query)))))))))
 
 (defn cards-details
   "Get the details of metrics or models as specified by `card-type` and `cards`

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
@@ -10,11 +10,6 @@
    [metabase.lib.util :as lib.util]
    [metabase.util :as u]))
 
-(defn- query->output-format
-  "Convert query to MBQL5 pMBQL format for output."
-  [query]
-  (lib/->pMBQL query))
-
 (defn- apply-filter-bucket
   [column bucket]
   (case bucket
@@ -176,7 +171,7 @@
         returned-cols (lib/returned-columns query)]
     {:type :query
      :query-id query-id
-     :query (query->output-format query)
+     :query query
      :result-columns (into []
                            (map-indexed #(metabot-v3.tools.u/->result-column query %2 %1 query-field-id-prefix))
                            returned-cols)}))
@@ -294,7 +289,7 @@
         returned-cols (lib/returned-columns query)]
     {:type :query
      :query-id query-id
-     :query (query->output-format query)
+     :query query
      :result-columns (into []
                            (map-indexed #(metabot-v3.tools.u/->result-column query %2 %1 query-field-id-prefix))
                            returned-cols)}))
@@ -365,7 +360,7 @@
         returned-cols (lib/returned-columns query)]
     {:type :query
      :query-id query-id
-     :query (query->output-format query)
+     :query query
      :result-columns (into []
                            (map-indexed #(metabot-v3.tools.u/->result-column query %2 %1 query-field-id-prefix))
                            returned-cols)}))
@@ -442,7 +437,7 @@
       {:structured-output
        {:type :query
         :query-id query-id
-        :query (query->output-format query)
+        :query query
         :result-columns (into []
                               (map-indexed #(metabot-v3.tools.u/->result-column query %2 %1 query-field-id-prefix))
                               (lib/returned-columns query))}})


### PR DESCRIPTION
### Description

Minor clojure tweaks for metabot measures and segments poc in #67368

* Handle measures and segments like metrics in table-details and card-details
  Move these into the existing m/assoc-some and handle them in the same way as metrics
* Remove query->output-format
  This was just a wrapper around lib/->pMBQL, but all these queries are already MBQL5 queries

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
