### PR TITLE
Fix broken python test

### DIFF
--- a/e2e/test/scenarios/data-studio/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms.cy.spec.ts
@@ -235,7 +235,7 @@ describe("scenarios > admin > transforms", () => {
         });
 
         cy.findByTestId("python-data-picker")
-          .findByText("Select a database")
+          .findByText("Writable Postgres12")
           .click();
 
         cy.log("Unsupported databases should be disabled");

--- a/e2e/test/scenarios/data-studio/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms.cy.spec.ts
@@ -606,7 +606,13 @@ LIMIT
     it("should not be possible to create a sql transform from a table from an unsupported database", () => {
       visitTransformListPage();
       cy.button("Create a transform").click();
+
       H.popover().findByText("SQL query").click();
+
+      cy.findByTestId("gui-builder-data")
+        .findByText("Writable Postgres12")
+        .click();
+
       H.popover()
         .findByRole("option", { name: "Sample Database" })
         .should("have.attr", "aria-disabled", "true")


### PR DESCRIPTION
The database is selected automatically if it is the only valid one. This is breaking the test which expects the selector to have no value set.
The test was sometime succeeding however, since the auto-selection can take time.

This PR changes the tests to correctly assume the auto-selection has taken place already.

- `should not be possible to create a sql transform from a table from an unsupported database`
  - [stress test (throttling)](https://github.com/metabase/metabase/actions/runs/20585008922)
  - [stress test (no throttling)](https://github.com/metabase/metabase/actions/runs/20585028967)
- `should be possible to create and run a Python transform`
  - [stress test (throttling)](https://github.com/metabase/metabase/actions/runs/20585039163)
  - [stress test (no throttling)](https://github.com/metabase/metabase/actions/runs/20585046818)