### PR TITLE
fix e2e test that checks that hidden column is not visible in the DataGrid

### DIFF
--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -1917,7 +1917,7 @@ describe("Issue 56913", () => {
   });
 });
 
-describe.skip("issue 45919", () => {
+describe("issue 45919", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();
@@ -1929,7 +1929,8 @@ describe.skip("issue 45919", () => {
     cy.findByTestId("new-model-options")
       .findByText("Use the notebook editor")
       .click();
-    H.entityPickerModal().findByText("People").click();
+    H.popover().findByText("Sample Database").click();
+    H.popover().findByText("People").click();
     H.runButtonOverlay().click();
     H.tableInteractive().should("be.visible");
     cy.findByTestId("dataset-edit-bar").button("Save").click();


### PR DESCRIPTION
Closes #45919
Closes [QUE-418](https://linear.app/metabase/issue/QUE-418/data-models-do-not-update-to-reflect-fields-that-have-been-removed)

### Description
There was a repro test added [here](https://github.com/metabase/metabase/pull/62545) but it was skip. I fixed the test, removed `.skip` and now it passes. The original issue isn't reproducible - this test confirms it.

### How to verify
See https://github.com/metabase/metabase/issues/45919#issuecomment-2396564466

### Demo

https://github.com/user-attachments/assets/c35f8fdb-9626-4a41-bd6b-50c59bbdbe85




### Checklist

- [x] Tests have been added/updated to cover changes in this PR
