### PR TITLE
fix: use "All tenant users" group for tenant users in popover and modal

### DIFF
--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.tsx
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.tsx
@@ -386,7 +386,7 @@ export const getGroupsDataPermissionEditor: GetGroupsDataPermissionEditorSelecto
       const sortedGroups = groups.flat();
 
       const defaultGroup = _.find(sortedGroups, isDefaultGroup);
-      const externalUsersGroup = _.find(
+      const allTenantUsersGroup = _.find(
         sortedGroups,
         PLUGIN_TENANTS.isExternalUsersGroup,
       );
@@ -400,11 +400,15 @@ export const getGroupsDataPermissionEditor: GetGroupsDataPermissionEditorSelecto
 
       const entities = sortedGroups.map((group) => {
         const isAdmin = isAdminGroup(group);
-        const isExternal =
-          !!externalUsersGroup && PLUGIN_TENANTS.isExternalUsersGroup(group);
+
+        const isAllTenantUsersGroup =
+          !!allTenantUsersGroup && PLUGIN_TENANTS.isExternalUsersGroup(group);
 
         const isTenantGroup = PLUGIN_TENANTS.isTenantGroup(group);
         let groupPermissions;
+
+        const shouldUseAllExternalUsersGroup =
+          !!allTenantUsersGroup && (isAllTenantUsersGroup || isTenantGroup);
 
         if (tableId != null) {
           groupPermissions = buildFieldsPermissions(
@@ -415,10 +419,10 @@ export const getGroupsDataPermissionEditor: GetGroupsDataPermissionEditorSelecto
             },
             group.id,
             isAdmin,
-            isExternal,
+            isAllTenantUsersGroup,
             permissions,
             originalPermissions,
-            isExternal ? externalUsersGroup : defaultGroup,
+            shouldUseAllExternalUsersGroup ? allTenantUsersGroup : defaultGroup,
             database,
           );
         } else if (schemaName != null) {
@@ -429,10 +433,10 @@ export const getGroupsDataPermissionEditor: GetGroupsDataPermissionEditorSelecto
             },
             group.id,
             isAdmin,
-            isExternal,
+            isAllTenantUsersGroup,
             permissions,
             originalPermissions,
-            isExternal ? externalUsersGroup : defaultGroup,
+            shouldUseAllExternalUsersGroup ? allTenantUsersGroup : defaultGroup,
             database,
           );
         } else if (databaseId != null) {
@@ -442,10 +446,10 @@ export const getGroupsDataPermissionEditor: GetGroupsDataPermissionEditorSelecto
             },
             group.id,
             isAdmin,
-            isExternal,
+            isAllTenantUsersGroup,
             permissions,
             originalPermissions,
-            isExternal ? externalUsersGroup : defaultGroup,
+            shouldUseAllExternalUsersGroup ? allTenantUsersGroup : defaultGroup,
             database,
             "database",
           );

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.tsx
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.tsx
@@ -408,7 +408,7 @@ export const getGroupsDataPermissionEditor: GetGroupsDataPermissionEditorSelecto
         let groupPermissions;
 
         const shouldUseAllExternalUsersGroup =
-          !!allTenantUsersGroup && (isAllTenantUsersGroup || isTenantGroup);
+          isAllTenantUsersGroup || isTenantGroup;
 
         if (tableId != null) {
           groupPermissions = buildFieldsPermissions(

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.tsx
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.tsx
@@ -408,7 +408,7 @@ export const getGroupsDataPermissionEditor: GetGroupsDataPermissionEditorSelecto
         let groupPermissions;
 
         const shouldUseAllExternalUsersGroup =
-          isAllTenantUsersGroup || isTenantGroup;
+          !!allTenantUsersGroup && (isAllTenantUsersGroup || isTenantGroup);
 
         if (tableId != null) {
           groupPermissions = buildFieldsPermissions(


### PR DESCRIPTION
Fix https://linear.app/metabase/issue/UXW-2624/tenant-group-permission-popover-references-all-internal-users


## How to reproduce:
You'll need to enable tenants, create a tenant group and go to data permissions


<img width="932" height="763" alt="image" src="https://github.com/user-attachments/assets/49d7d6a5-e2ac-49ec-84fd-e18cf7ea2dd2" />
