### PR TITLE
fix: remove binning from sample data question QUE-2665

### DIFF
--- a/resources/sample-content.edn
+++ b/resources/sample-content.edn
@@ -3383,7 +3383,7 @@
    :embedding_params nil,
    :cache_ttl nil,
    :dataset_query
-   "{\"database\":1,\"query\":{\"aggregation\":[[\"count\"]],\"breakout\":[[\"field\",\"Age\",{\"base-type\":\"type/BigInteger\",\"binning\":{\"strategy\":\"num-bins\",\"num-bins\":10}}],[\"field\",18,{\"base-type\":\"type/Text\",\"join-alias\":\"Products\"}]],\"joins\":[{\"alias\":\"Products\",\"condition\":[\"=\",[\"field\",\"PRODUCT_ID\",{\"base-type\":\"type/Integer\"}],[\"field\",8,{\"base-type\":\"type/BigInteger\",\"join-alias\":\"Products\"}]],\"source-table\":3,\"strategy\":\"left-join\"}],\"source-table\":\"card__1\"},\"type\":\"query\"}",
+   "{\"database\":1,\"query\":{\"aggregation\":[[\"count\"]],\"breakout\":[[\"field\",\"Age\",{\"base-type\":\"type/BigInteger\",\"binning\":{\"strategy\":\"num-bins\",\"num-bins\":10}}],[\"field\",18,{\"base-type\":\"type/Text\",\"join-alias\":\"Products\"}]],\"filter\":[\"between\",[\"field\",\"Age\",{\"base-type\":\"type/BigInteger\"}],20,70],\"joins\":[{\"alias\":\"Products\",\"condition\":[\"=\",[\"field\",\"PRODUCT_ID\",{\"base-type\":\"type/Integer\"}],[\"field\",8,{\"base-type\":\"type/BigInteger\",\"join-alias\":\"Products\"}]],\"source-table\":3,\"strategy\":\"left-join\"}],\"source-table\":\"card__1\"},\"type\":\"query\"}",
    :id 4,
    :parameter_mappings "[]",
    :dataset_query_metrics_v2_migration_backup nil,
@@ -4232,7 +4232,7 @@
    :source_card_id 1,
    :table_id 2,
    :result_metadata
-   "[{\"base_type\":\"type/Decimal\",\"description\":\"Age of the customer in years.\",\"display_name\":\"Age\",\"effective_type\":\"type/Decimal\",\"field_ref\":[\"field\",\"Age\",{\"base-type\":\"type/BigInteger\",\"binning\":{\"strategy\":\"num-bins\",\"num-bins\":10,\"min-value\":20,\"max-value\":70,\"bin-width\":5}}],\"name\":\"Age\",\"semantic_type\":\"type/Quantity\"},{\"base_type\":\"type/Float\",\"display_name\":\"Sum of Total\",\"effective_type\":\"type/Float\",\"field_ref\":[\"aggregation\",0],\"name\":\"sum\",\"semantic_type\":\"type/Currency\",\"settings\":{\"currency\":\"USD\"}}]",
+   "[{\"base_type\":\"type/Decimal\",\"description\":\"Age of the customer in years.\",\"display_name\":\"Age\",\"effective_type\":\"type/Decimal\",\"field_ref\":[\"field\",\"Age\",{\"base-type\":\"type/BigInteger\"}],\"name\":\"Age\",\"semantic_type\":\"type/Quantity\"},{\"base_type\":\"type/Float\",\"display_name\":\"Sum of Total\",\"effective_type\":\"type/Float\",\"field_ref\":[\"aggregation\",0],\"name\":\"sum\",\"semantic_type\":\"type/Currency\",\"settings\":{\"currency\":\"USD\"}}]",
    :initially_published_at nil,
    :database_id 1,
    :enable_embedding false,
@@ -4247,7 +4247,7 @@
    :embedding_params nil,
    :cache_ttl nil,
    :dataset_query
-   "{\"database\":1,\"query\":{\"aggregation\":[[\"sum\",[\"field\",\"TOTAL\",{\"base-type\":\"type/Float\"}]]],\"breakout\":[[\"field\",\"Age\",{\"base-type\":\"type/BigInteger\",\"binning\":{\"strategy\":\"num-bins\",\"num-bins\":10}}]],\"source-table\":\"card__1\"},\"type\":\"query\"}",
+   "{\"database\":1,\"query\":{\"aggregation\":[[\"sum\",[\"field\",\"TOTAL\",{\"base-type\":\"type/Float\"}]]],\"breakout\":[[\"field\",\"Age\",{\"base-type\":\"type/BigInteger\",\"binning\":{\"strategy\":\"num-bins\",\"num-bins\":10}}]],\"filter\":[\"between\",[\"field\",\"Age\",{\"base-type\":\"type/BigInteger\"}],20,70],\"source-table\":\"card__1\"},\"type\":\"query\"}",
    :id 28,
    :parameter_mappings "[]",
    :dataset_query_metrics_v2_migration_backup nil,
@@ -4517,7 +4517,7 @@
    :source_card_id 1,
    :table_id 2,
    :result_metadata
-   "[{\"base_type\":\"type/Decimal\",\"description\":\"Age of the customer in years.\",\"display_name\":\"Age\",\"effective_type\":\"type/Decimal\",\"field_ref\":[\"field\",\"Age\",{\"base-type\":\"type/BigInteger\",\"binning\":{\"strategy\":\"num-bins\",\"num-bins\":10,\"min-value\":20,\"max-value\":70,\"bin-width\":5}}],\"name\":\"Age\",\"semantic_type\":\"type/Quantity\"},{\"base_type\":\"type/Text\",\"coercion_strategy\":null,\"description\":\"The channel through which we acquired this user. Valid values include: Affiliate, Facebook, Google, Organic and Twitter\",\"display_name\":\"User → Source\",\"effective_type\":\"type/Text\",\"field_ref\":[\"field\",30,{\"base-type\":\"type/Text\",\"source-field\":11}],\"fk_target_field_id\":null,\"id\":30,\"name\":\"SOURCE\",\"semantic_type\":\"type/Source\",\"settings\":null,\"visibility_type\":\"normal\"},{\"base_type\":\"type/BigInteger\",\"display_name\":\"Count\",\"effective_type\":\"type/BigInteger\",\"field_ref\":[\"aggregation\",0],\"name\":\"count\",\"semantic_type\":\"type/Quantity\"}]",
+   "[{\"base_type\":\"type/Decimal\",\"description\":\"Age of the customer in years.\",\"display_name\":\"Age\",\"effective_type\":\"type/Decimal\",\"field_ref\":[\"field\",\"Age\",{\"base-type\":\"type/BigInteger\"}],\"name\":\"Age\",\"semantic_type\":\"type/Quantity\"},{\"base_type\":\"type/Text\",\"coercion_strategy\":null,\"description\":\"The channel through which we acquired this user. Valid values include: Affiliate, Facebook, Google, Organic and Twitter\",\"display_name\":\"User → Source\",\"effective_type\":\"type/Text\",\"field_ref\":[\"field\",30,{\"base-type\":\"type/Text\",\"source-field\":11}],\"fk_target_field_id\":null,\"id\":30,\"name\":\"SOURCE\",\"semantic_type\":\"type/Source\",\"settings\":null,\"visibility_type\":\"normal\"},{\"base_type\":\"type/BigInteger\",\"display_name\":\"Count\",\"effective_type\":\"type/BigInteger\",\"field_ref\":[\"aggregation\",0],\"name\":\"count\",\"semantic_type\":\"type/Quantity\"}]",
    :initially_published_at nil,
    :database_id 1,
    :enable_embedding false,
@@ -4532,7 +4532,7 @@
    :embedding_params nil,
    :cache_ttl nil,
    :dataset_query
-   "{\"database\":1,\"query\":{\"aggregation\":[[\"count\"]],\"breakout\":[[\"field\",\"Age\",{\"base-type\":\"type/BigInteger\",\"binning\":{\"strategy\":\"num-bins\",\"num-bins\":10}}],[\"field\",30,{\"base-type\":\"type/Text\",\"source-field\":11}]],\"joins\":[{\"alias\":\"Products\",\"condition\":[\"=\",[\"field\",\"PRODUCT_ID\",{\"base-type\":\"type/Integer\"}],[\"field\",8,{\"base-type\":\"type/BigInteger\",\"join-alias\":\"Products\"}]],\"source-table\":3,\"strategy\":\"left-join\"}],\"source-table\":\"card__1\"},\"type\":\"query\"}",
+   "{\"database\":1,\"query\":{\"aggregation\":[[\"count\"]],\"breakout\":[[\"field\",\"Age\",{\"base-type\":\"type/BigInteger\",\"binning\":{\"strategy\":\"num-bins\",\"num-bins\":10}}],[\"field\",30,{\"base-type\":\"type/Text\",\"source-field\":11}]],\"filter\":[\"between\",[\"field\",\"Age\",{\"base-type\":\"type/BigInteger\"}],20,70],\"joins\":[{\"alias\":\"Products\",\"condition\":[\"=\",[\"field\",\"PRODUCT_ID\",{\"base-type\":\"type/Integer\"}],[\"field\",8,{\"base-type\":\"type/BigInteger\",\"join-alias\":\"Products\"}]],\"source-table\":3,\"strategy\":\"left-join\"}],\"source-table\":\"card__1\"},\"type\":\"query\"}",
    :id 36,
    :parameter_mappings "[]",
    :dataset_query_metrics_v2_migration_backup nil,


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #64391
Closes https://linear.app/metabase/issue/QUE-2665/unable-to-bin-field-on-sample-question-product-category-orders-per-age

### Description

Age, a custom computed column, doesn't support binning because of lack of min-max values.

<img width="596" height="310" alt="image" src="https://github.com/user-attachments/assets/ffa3e612-3874-4181-82d4-ccbe7a04f172" />


Adding explicit filter on the age field adds missing min max values that binning requires.


### How to verify

Describe the steps to verify that the changes are working as expected.

1. Open following sample questions to see if they're not broken.
- Orders by source per age group
- Revenue per age group
- Product category orders per age group

### Demo

Orders by source per age group
![CleanShot 2025-12-23 at 18 47 52@2x](https://github.com/user-attachments/assets/ffb03c04-9d1c-4fc9-9674-fd2084c6991b)

Product category orders per age group
![CleanShot 2025-12-23 at 18 58 21@2x](https://github.com/user-attachments/assets/a9f19719-e290-4c60-9512-8bf927ab9318)

Revenue per age group
<img width="3004" height="1576" alt="18126_9fb05518e22389a644b646ef755b0ab2703d500eff912b8bab647ee16f1157ab" src="https://github.com/user-attachments/assets/9bbcba7a-64ab-4691-9fac-fb55707113a2" />


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
