### PR TITLE
`Tenant Collections` -> `Shared collections` in permissions page

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantCollectionPermissionsPage/selectors.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantCollectionPermissionsPage/selectors.tsx
@@ -93,7 +93,7 @@ export const getTenantCollectionsSidebar = createSelector(
   (collectionsTree, collectionId): CollectionSidebarType => {
     return {
       selectedId: collectionId,
-      title: t`Tenant Collections`,
+      title: t`Shared collections`,
       entityGroups: [collectionsTree || []],
       filterPlaceholder: t`Search for a collection`,
     };

--- a/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
@@ -126,7 +126,7 @@ export function initializePlugin() {
 
     // Register tenant collection permissions tab and routes
     PLUGIN_ADMIN_PERMISSIONS_TABS.tabs.push({
-      name: t`Tenant Collections`,
+      name: t`Shared collections`,
       value: "tenant-collections",
     });
 

--- a/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/common.unit.spec.tsx
@@ -225,7 +225,7 @@ describe("Admin > CollectionPermissionsPage", () => {
     setup();
 
     expect(
-      screen.queryByRole("radio", { name: "Tenant Collections" }),
+      screen.queryByRole("radio", { name: "Shared collections" }),
     ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/enterprise.unit.spec.tsx
@@ -16,7 +16,7 @@ import {
 const tokenFeatures = { tenants: true, audit_app: true };
 
 describe("Admin > CollectionPermissionsPage (enterprise)", () => {
-  describe("Tenant Collections Tab", () => {
+  describe("Shared collections Tab", () => {
     it("shows the tab when tenants are enabled", async () => {
       setup({
         tokenFeatures,
@@ -25,7 +25,7 @@ describe("Admin > CollectionPermissionsPage (enterprise)", () => {
       });
 
       expect(
-        await screen.findByRole("radio", { name: "Tenant Collections" }),
+        await screen.findByRole("radio", { name: "Shared collections" }),
       ).toBeInTheDocument();
     });
 
@@ -37,7 +37,7 @@ describe("Admin > CollectionPermissionsPage (enterprise)", () => {
       });
 
       expect(
-        screen.queryByRole("radio", { name: "Tenant Collections" }),
+        screen.queryByRole("radio", { name: "Shared collections" }),
       ).not.toBeInTheDocument();
     });
   });


### PR DESCRIPTION

Closes https://linear.app/metabase/issue/UXW-2626/rename-tenant-collections-tab-to-shared-collections

<img width="570" height="434" alt="image" src="https://github.com/user-attachments/assets/853f9b30-2df4-45d9-bf01-fefec41db28c" />
