### PR TITLE
Use actual metadata in a Notebook in Embedding SDK/Embed JS

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/create-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/create-question.cy.spec.tsx
@@ -12,7 +12,6 @@ import {
   createQuestion,
   entityPickerModal,
   entityPickerModalTab,
-  miniPicker,
   modal,
   popover,
 } from "e2e/support/helpers";

--- a/e2e/test-component/scenarios/embedding-sdk/create-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/create-question.cy.spec.tsx
@@ -12,6 +12,7 @@ import {
   createQuestion,
   entityPickerModal,
   entityPickerModalTab,
+  miniPicker,
   modal,
   popover,
 } from "e2e/support/helpers";
@@ -286,6 +287,39 @@ describe("scenarios > embedding-sdk > interactive-question > creating a question
 
       // The question title's header should be updated.
       getSdkRoot().contains("My Orders");
+    });
+  });
+
+  it("should show columns from joined table when there is no FK relationship (metabase#EMB-1102)", () => {
+    cy.signOut();
+    mockAuthProviderAndJwtSignIn();
+
+    mountSdkContent(
+      <Flex p="xl">
+        <InteractiveQuestion questionId="new" />
+      </Flex>,
+    );
+
+    popover().within(() => {
+      cy.findByText("Orders").click();
+    });
+
+    getSdkRoot().within(() => {
+      cy.button("Join data").click();
+    });
+
+    popover().within(() => {
+      cy.findByText("Reviews").click();
+    });
+
+    popover().within(() => {
+      cy.findByText("ID").click();
+    });
+
+    popover().within(() => {
+      cy.findByText("Product ID").should("be.visible");
+      cy.findByText("Reviewer").should("be.visible");
+      cy.findByText("Custom Expression").should("be.visible");
     });
   });
 });

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Editor.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Editor.tsx
@@ -8,9 +8,10 @@ import {
   isQuestionRunnable,
 } from "metabase/query_builder/utils/question";
 import { Notebook as QBNotebook } from "metabase/querying/notebook/components/Notebook";
+import { getMetadata } from "metabase/selectors/metadata";
 import { getSetting } from "metabase/selectors/settings";
 import { ScrollArea } from "metabase/ui";
-import type Question from "metabase-lib/v1/Question";
+import Question from "metabase-lib/v1/Question";
 
 /**
  * @interface
@@ -40,8 +41,22 @@ export const Editor = ({
   // Loads databases and metadata so we can show notebook steps for the selected data source
   useDatabaseListQuery();
 
-  const { question, originalQuestion, updateQuestion, queryQuestion } =
-    useSdkQuestionContext();
+  const {
+    question: rawQuestion,
+    originalQuestion,
+    updateQuestion,
+    queryQuestion,
+  } = useSdkQuestionContext();
+
+  const metadata = useSelector(getMetadata);
+
+  const question = useMemo(() => {
+    if (!rawQuestion) {
+      return rawQuestion;
+    }
+
+    return new Question(rawQuestion?.card(), metadata);
+  }, [rawQuestion, metadata]);
 
   const isDirty = useMemo(() => {
     return isQuestionDirty(question, originalQuestion);


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #66610
Use actual metadata in a Notebook in Embedding SDK/Embed JS

This fixes https://linear.app/metabase/issue/EMB-1102/no-fields-to-join-when-a-table-doesnt-have-a-fk-set-up-embedjs

Original issue:

> When there's no relation between tables, at the Table Metadata layer, you can't join between tables when using EmbedJS exploration.

To Reproduce bug: 
- Run 57.5
- Settings > Embedding > Modular > New embed > Exploration
- Create a GUI question from Accounts table from the Sample database
- Try to join with the Analytics Events table, no suggestion will show up

To validate bug:
- Settings > Embedding > Modular > New embed > Exploration
- Create a GUI question from Accounts table from the Sample database
- Try to join with the Analytics Events table, columns to select should be shown

The fix:
We work wrong with Question in SDK, we store the whole question in a state, though a question should be stored, instead a card or metadata should be stored, and a question composed from it in places where it should be used.
Such a refactoring is a complex task, so the current fix ensures that we use the latest `metadata` that is feched deeply inside the Notebook Editor for a joined table.
