### PR TITLE
Add debug logging to the OOM path

### DIFF
--- a/src/metabase/search/ingestion.clj
+++ b/src/metabase/search/ingestion.clj
@@ -101,6 +101,9 @@
           input (if fields
                   (select-keys record fields)
                   record)]
+      (when (= :has-temporal-dim attr-key)
+        (log/debugf "Executing function attr %s for model=%s id=%s name=%s"
+                    attr-key (:model record) (:id record) (:name record)))
       (f input))
     (catch Exception e
       (log/warn e "Function execution failed for attribute" attr-key)


### PR DESCRIPTION
### Description

Adds debug logging to pinpoint the card triggering the OOM in the mealsuite instance.