### PR TITLE
Adding e2e repro for drill through entity keys

### DIFF
--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -1991,3 +1991,46 @@ describe("issue 50915", () => {
       .should("be.visible");
   });
 });
+
+describe("issue 38747", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("should allow you to drill through with entity qualified ids", () => {
+    cy.visit("/model/new");
+    cy.findByRole("link", { name: /notebook editor/ }).click();
+
+    H.miniPickerBrowseAll().click();
+    H.entityPickerModalItem(0, "Databases").click();
+    H.entityPickerModalItem(1, "Products").click();
+    H.runButtonInOverlay().click();
+
+    // Wait for the query to run so we can click the columns "button"
+    // ... It's actually a list item, so we can't check to see if it's
+    // actually disabled in any sane way
+    H.tableInteractive().should("exist");
+
+    H.datasetEditBar().findByText("Columns").click();
+    cy.findAllByTestId("model-column-header-content")
+      .contains("Vendor")
+      .click();
+
+    cy.findByPlaceholderText("Select a semantic type").click();
+    H.popover().findByText("Entity Key").click();
+    H.datasetEditBar().button("Save").click();
+
+    H.modal().button("Save").click();
+
+    cy.findByRole("gridcell", { name: "Nolan-Wolff" }).click();
+
+    // Assert that we're at an adhoc question with aproprate filters
+    cy.location("pathname").should("equal", "/question");
+    cy.findByTestId("filter-pill").should(
+      "contain.text",
+      "Vendor is Nolan-Wolff",
+    );
+    H.tableInteractive().should("have.attr", "data-rows-count", "1");
+  });
+});


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #38747
### Description
PR adds a repro for an issue that is not reproducible in 57 at the moment: [QUE-281: Clicking on entity qualified id on the content model takes nowhere and spins forever](https://linear.app/metabase/issue/QUE-281/clicking-on-entity-qualified-id-on-the-content-model-takes-nowhere-and)

### How to verify
CI should be green

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
