### PR TITLE
QUE-2287 settings definitions for a column now respects column remapping. The same for the formatting cell value

### DIFF
--- a/frontend/src/metabase/lib/formatting/value.tsx
+++ b/frontend/src/metabase/lib/formatting/value.tsx
@@ -196,12 +196,7 @@ export function formatValueRaw(
   ) {
     return formatDateTimeWithUnit(value as string | number, "minute", options);
   } else if (typeof value === "string") {
-    // Check if we're looking for a number isNumber(column) and
-    // check that the value string is a valid number
-    // it could be a remap
-    // TODO(eric, 2025-12-23): The second check should probably be in parseNumber(),
-    // but it caused tests to fail so I put it here.
-    if (isNumber(column) && Number.isFinite(Number(value))) {
+    if (isNumber(column)) {
       const number = parseNumber(value);
       if (number != null) {
         return formatNumber(number, options);

--- a/frontend/src/metabase/lib/formatting/value.tsx
+++ b/frontend/src/metabase/lib/formatting/value.tsx
@@ -144,7 +144,7 @@ export function formatValueRaw(
 
   const remapped = getRemappedValue(value as string | number, options);
   if (remapped !== undefined && options.view_as !== "link") {
-    value = remapped;
+    return remapped;
   }
 
   if (value == null) {

--- a/frontend/src/metabase/lib/number.ts
+++ b/frontend/src/metabase/lib/number.ts
@@ -3,14 +3,6 @@ const INTEGER_REGEX = /^[+-]?\d+$/;
 export type NumberValue = number | bigint;
 
 export function parseNumber(value: string): NumberValue | null {
-  // TODO(eric, 2025-12-23): we should check if the string is a valid number
-  // if value === "1j", this function returns 1
-  // I tried it and it broke a number of tests
-  // Example:
-  //   if (!Number.isFinite(Number(value))) {
-  //     return null;
-  //    }
-
   const number = parseFloat(value);
   if (!Number.isFinite(number)) {
     return null;

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -442,19 +442,23 @@ const COMMON_COLUMN_SETTINGS = {
 };
 
 export function getSettingDefinitionsForColumn(series, column) {
+  const effectiveColumn = column.remapped_to_column ?? column;
   const visualization = getVisualizationRaw(series);
   const extraColumnSettings =
     typeof visualization.columnSettings === "function"
-      ? visualization.columnSettings(column)
+      ? visualization.columnSettings(effectiveColumn)
       : visualization.columnSettings || {};
 
-  if (isDate(column) || (column.unit && column.unit !== "default")) {
+  if (
+    isDate(effectiveColumn) ||
+    (effectiveColumn.unit && effectiveColumn.unit !== "default")
+  ) {
     return {
       ...extraColumnSettings,
       ...DATE_COLUMN_SETTINGS,
       ...COMMON_COLUMN_SETTINGS,
     };
-  } else if (isNumber(column) && !isCoordinate(column)) {
+  } else if (isNumber(effectiveColumn) && !isCoordinate(effectiveColumn)) {
     return {
       ...extraColumnSettings,
       ...NUMBER_COLUMN_SETTINGS,


### PR DESCRIPTION
Closes [QUE-2287](https://linear.app/metabase/issue/QUE-2287/custom-mappings-starting-with-an-integer-cause-the-mapping-to-fail)
Closes https://github.com/metabase/metabase/issues/62494
Re-fixes https://github.com/metabase/metabase/issues/17427, https://github.com/metabase/metabase/issues/67338
Re-fixes [UXW-1150](https://linear.app/metabase/issue/UXW-1150/number-format-settings-incorrectly-show-for-remapped-columns)

### Description
This bug is caused by solution here: [UXW-1150](https://linear.app/metabase/issue/UXW-1150/number-format-settings-incorrectly-show-for-remapped-columns). Short idea: try to apply everything we can apply in `formatValueRaw` in `frontend/src/metabase/lib/formatting/value.tsx` even if the column values are remapped. 

But, if a user remaps number column values to something that contains a number (e.g 1 => 1a, 2 => 2a, 3 => 3a) then this line `const number = parseNumber(value);` in `frontend/src/metabase/lib/formatting/value.tsx` will parse remapped value back to original one (because `parseNumber("1b")` returns `1`). And this is exactly what is happening in the current issue. 

My suggestion is to rollback UXW-1150 fix and respects remapped column type when columns settings are building.
This is based on @perivamsi comment in [UXW-1150](https://linear.app/metabase/issue/UXW-1150/number-format-settings-incorrectly-show-for-remapped-columns).

### How to verify

### Demo

https://github.com/user-attachments/assets/2152a394-66ce-49f5-ab3b-232aedc91e26




### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
