### PR TITLE
UXW-64 Fix table cell formatting for temporal breakout by week

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/table-column-settings.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table-column-settings.cy.spec.js
@@ -936,6 +936,63 @@ describe("scenarios > visualizations > table column settings", () => {
         cy.findByTestId("TAX-hide-button").should("exist");
       });
   });
+
+  it("should respect date_style column setting for week temporal unit", () => {
+    const questionWithWeekBreakout = {
+      display: "table",
+      query: {
+        "source-table": ORDERS_ID,
+        aggregation: [["count"]],
+        breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "week" }]],
+        limit: 5,
+      },
+    };
+
+    H.createQuestion(questionWithWeekBreakout, { visitQuestion: true });
+
+    // Open visualization settings
+    H.openVizSettingsSidebar();
+
+    // Click on the "Created At: Week" column to open its settings
+    H.leftSidebar().findByTestId("Created At: Week-settings-button").click();
+
+    // Change date style to M/D/YYYY
+    H.popover().findByText("Date style").click();
+    H.popover()
+      .findByText(/^1\/31\/2018/)
+      .click();
+
+    // Verify the formatting changed to numeric style
+    H.tableInteractiveBody().within(() => {
+      cy.findAllByTestId("cell-data")
+        .first()
+        .invoke("text")
+        .should("match", /\d+\/\d+\/\d{4} – \d+\/\d+\/\d{4}/); // Format like "1/1/2025 - 1/7/2025"
+    });
+
+    // Change date style to YYYY/M/D
+    H.popover().findByText("Date style").click();
+    H.popover()
+      .findByText(/^2018\/1\/31/)
+      .click();
+
+    // Verify the formatting changed to day-first numeric style
+    H.tableInteractiveBody().within(() => {
+      cy.findAllByTestId("cell-data")
+        .first()
+        .invoke("text")
+        .should("match", /\d{4}\/\d+\/\d+ – \d{4}\/\d+\/\d+/); // Format like "2025/1/1 - 2025/1/7"
+    });
+
+    H.popover().findByText("YYYY.M.D").click();
+    // Verify separator formatting changed
+    H.tableInteractiveBody().within(() => {
+      cy.findAllByTestId("cell-data")
+        .first()
+        .invoke("text")
+        .should("match", /\d{4}\.\d+\.\d+ – \d{4}\.\d+\.\d+/); // Format like "2025.1.1 - 2025.1.7"
+    });
+  });
 });
 
 const showColumn = (column) => {

--- a/frontend/src/metabase/lib/formatting/date.tsx
+++ b/frontend/src/metabase/lib/formatting/date.tsx
@@ -845,125 +845,134 @@ function getWeekFormatSpecsWithDateStyle(
   dateStyle: string,
   dateSeparator: string = "/",
 ): DateRangeFormatSpec[] {
-  const sep = dateSeparator;
   const M = DATE_RANGE_MONTH_PLACEHOLDER;
   const D = "D";
   const Y = "YYYY";
 
   // Handle numeric date formats (M/D/YYYY, D/M/YYYY, YYYY/M/D)
-  if (dateStyle.includes("/")) {
-    if (dateStyle === "M/D/YYYY") {
-      return [
-        {
-          same: "month",
-          format: [`M${sep}D`, `D, ${Y}`],
-          removedYearFormat: [`M${sep}D`, D],
-          tests: {
-            verbose: {
-              output: "1/1–7, 2017",
-              input: ["2017-01-01", "2017-01-07"],
-            },
+  if (dateStyle === "M/D/YYYY") {
+    return [
+      {
+        same: "month",
+        format: [`M${dateSeparator}D`, `D, ${Y}`],
+        removedYearFormat: [`M${dateSeparator}D`, D],
+        tests: {
+          verbose: {
+            output: "1/1–7, 2017",
+            input: ["2017-01-01", "2017-01-07"],
           },
         },
-        {
-          same: "year",
-          format: [`M${sep}D`, `M${sep}D, ${Y}`],
-          removedYearFormat: [`M${sep}D`, `M${sep}D`],
-          dashPad: " ",
-          tests: {
-            verbose: {
-              output: "1/1 – 5/14, 2017",
-              input: ["2017-01-01", "2017-05-14"],
-            },
+      },
+      {
+        same: "year",
+        format: [`M${dateSeparator}D`, `M${dateSeparator}D, ${Y}`],
+        removedYearFormat: [`M${dateSeparator}D`, `M${dateSeparator}D`],
+        dashPad: " ",
+        tests: {
+          verbose: {
+            output: "1/1 – 5/14, 2017",
+            input: ["2017-01-01", "2017-05-14"],
           },
         },
-        {
-          same: null,
-          format: [`M${sep}D${sep}${Y}`, `M${sep}D${sep}${Y}`],
-          dashPad: " ",
-          tests: {
-            verbose: {
-              output: "1/1/2017 – 2/4/2018",
-              input: ["2017-01-01", "2018-02-04"],
-            },
+      },
+      {
+        same: null,
+        format: [
+          `M${dateSeparator}D${dateSeparator}${Y}`,
+          `M${dateSeparator}D${dateSeparator}${Y}`,
+        ],
+        dashPad: " ",
+        tests: {
+          verbose: {
+            output: "1/1/2017 – 2/4/2018",
+            input: ["2017-01-01", "2018-02-04"],
           },
         },
-      ];
-    } else if (dateStyle === "D/M/YYYY") {
-      return [
-        {
-          same: "month",
-          format: [`D${sep}M`, `D, ${Y}`],
-          removedYearFormat: [`D${sep}M`, D],
-          tests: {
-            verbose: {
-              output: "1/1–7, 2017",
-              input: ["2017-01-01", "2017-01-07"],
-            },
+      },
+    ];
+  } else if (dateStyle === "D/M/YYYY") {
+    return [
+      {
+        same: "month",
+        format: [`D${dateSeparator}M`, `D, ${Y}`],
+        removedYearFormat: [`D${dateSeparator}M`, D],
+        tests: {
+          verbose: {
+            output: "1/1–7, 2017",
+            input: ["2017-01-01", "2017-01-07"],
           },
         },
-        {
-          same: "year",
-          format: [`D${sep}M`, `D${sep}M, ${Y}`],
-          removedYearFormat: [`D${sep}M`, `D${sep}M`],
-          dashPad: " ",
-          tests: {
-            verbose: {
-              output: "1/1 – 14/5, 2017",
-              input: ["2017-01-01", "2017-05-14"],
-            },
+      },
+      {
+        same: "year",
+        format: [`D${dateSeparator}M`, `D${dateSeparator}M, ${Y}`],
+        removedYearFormat: [`D${dateSeparator}M`, `D${dateSeparator}M`],
+        dashPad: " ",
+        tests: {
+          verbose: {
+            output: "1/1 – 14/5, 2017",
+            input: ["2017-01-01", "2017-05-14"],
           },
         },
-        {
-          same: null,
-          format: [`D${sep}M${sep}${Y}`, `D${sep}M${sep}${Y}`],
-          dashPad: " ",
-          tests: {
-            verbose: {
-              output: "1/1/2017 – 4/2/2018",
-              input: ["2017-01-01", "2018-02-04"],
-            },
+      },
+      {
+        same: null,
+        format: [
+          `D${dateSeparator}M${dateSeparator}${Y}`,
+          `D${dateSeparator}M${dateSeparator}${Y}`,
+        ],
+        dashPad: " ",
+        tests: {
+          verbose: {
+            output: "1/1/2017 – 4/2/2018",
+            input: ["2017-01-01", "2018-02-04"],
           },
         },
-      ];
-    } else if (dateStyle === "YYYY/M/D") {
-      return [
-        {
-          same: "month",
-          format: [`${Y}${sep}M${sep}D`, D],
-          removedYearFormat: [`M${sep}D`, D],
-          tests: {
-            verbose: {
-              output: "2017/1/1–7",
-              input: ["2017-01-01", "2017-01-07"],
-            },
+      },
+    ];
+  } else if (dateStyle === "YYYY/M/D") {
+    return [
+      {
+        same: "month",
+        format: [`${Y}${dateSeparator}M${dateSeparator}D`, D],
+        removedYearFormat: [`M${dateSeparator}D`, D],
+        tests: {
+          verbose: {
+            output: "2017/1/1–7",
+            input: ["2017-01-01", "2017-01-07"],
           },
         },
-        {
-          same: "year",
-          format: [`${Y}${sep}M${sep}D`, `M${sep}D`],
-          removedYearFormat: [`M${sep}D`, `M${sep}D`],
-          dashPad: " ",
-          tests: {
-            verbose: {
-              output: "2017/1/1 – 5/14",
-              input: ["2017-01-01", "2017-05-14"],
-            },
+      },
+      {
+        same: "year",
+        format: [
+          `${Y}${dateSeparator}M${dateSeparator}D`,
+          `M${dateSeparator}D`,
+        ],
+        removedYearFormat: [`M${dateSeparator}D`, `M${dateSeparator}D`],
+        dashPad: " ",
+        tests: {
+          verbose: {
+            output: "2017/1/1 – 5/14",
+            input: ["2017-01-01", "2017-05-14"],
           },
         },
-        {
-          same: null,
-          format: [`${Y}${sep}M${sep}D`, `${Y}${sep}M${sep}D`],
-          dashPad: " ",
-          tests: {
-            verbose: {
-              output: "2017/1/1 – 2018/2/4",
-              input: ["2017-01-01", "2018-02-04"],
-            },
+      },
+      {
+        same: null,
+        format: [
+          `${Y}${dateSeparator}M${dateSeparator}D`,
+          `${Y}${dateSeparator}M${dateSeparator}D`,
+        ],
+        dashPad: " ",
+        tests: {
+          verbose: {
+            output: "2017/1/1 – 2018/2/4",
+            input: ["2017-01-01", "2018-02-04"],
           },
         },
-      ];
-    }
+      },
+    ];
   }
 
   // Handle text-based date formats

--- a/frontend/src/metabase/lib/formatting/date.tsx
+++ b/frontend/src/metabase/lib/formatting/date.tsx
@@ -837,6 +837,184 @@ export function normalizeDateTimeRangeWithUnit(
   return [shiftedStart, shiftedEnd, shift];
 }
 
+/**
+ * Generates custom format specs for week ranges based on date_style setting.
+ * This allows week ranges to respect user's preferred date format (numeric vs text, component order, etc.)
+ */
+function getWeekFormatSpecsWithDateStyle(
+  dateStyle: string,
+  dateSeparator: string = "/",
+): DateRangeFormatSpec[] {
+  const sep = dateSeparator;
+  const M = DATE_RANGE_MONTH_PLACEHOLDER;
+  const D = "D";
+  const Y = "YYYY";
+
+  // Handle numeric date formats (M/D/YYYY, D/M/YYYY, YYYY/M/D)
+  if (dateStyle.includes("/")) {
+    if (dateStyle === "M/D/YYYY") {
+      return [
+        {
+          same: "month",
+          format: [`M${sep}D`, `D, ${Y}`],
+          removedYearFormat: [`M${sep}D`, D],
+          tests: {
+            verbose: {
+              output: "1/1–7, 2017",
+              input: ["2017-01-01", "2017-01-07"],
+            },
+          },
+        },
+        {
+          same: "year",
+          format: [`M${sep}D`, `M${sep}D, ${Y}`],
+          removedYearFormat: [`M${sep}D`, `M${sep}D`],
+          dashPad: " ",
+          tests: {
+            verbose: {
+              output: "1/1 – 5/14, 2017",
+              input: ["2017-01-01", "2017-05-14"],
+            },
+          },
+        },
+        {
+          same: null,
+          format: [`M${sep}D${sep}${Y}`, `M${sep}D${sep}${Y}`],
+          dashPad: " ",
+          tests: {
+            verbose: {
+              output: "1/1/2017 – 2/4/2018",
+              input: ["2017-01-01", "2018-02-04"],
+            },
+          },
+        },
+      ];
+    } else if (dateStyle === "D/M/YYYY") {
+      return [
+        {
+          same: "month",
+          format: [`D${sep}M`, `D, ${Y}`],
+          removedYearFormat: [`D${sep}M`, D],
+          tests: {
+            verbose: {
+              output: "1/1–7, 2017",
+              input: ["2017-01-01", "2017-01-07"],
+            },
+          },
+        },
+        {
+          same: "year",
+          format: [`D${sep}M`, `D${sep}M, ${Y}`],
+          removedYearFormat: [`D${sep}M`, `D${sep}M`],
+          dashPad: " ",
+          tests: {
+            verbose: {
+              output: "1/1 – 14/5, 2017",
+              input: ["2017-01-01", "2017-05-14"],
+            },
+          },
+        },
+        {
+          same: null,
+          format: [`D${sep}M${sep}${Y}`, `D${sep}M${sep}${Y}`],
+          dashPad: " ",
+          tests: {
+            verbose: {
+              output: "1/1/2017 – 4/2/2018",
+              input: ["2017-01-01", "2018-02-04"],
+            },
+          },
+        },
+      ];
+    } else if (dateStyle === "YYYY/M/D") {
+      return [
+        {
+          same: "month",
+          format: [`${Y}${sep}M${sep}D`, D],
+          removedYearFormat: [`M${sep}D`, D],
+          tests: {
+            verbose: {
+              output: "2017/1/1–7",
+              input: ["2017-01-01", "2017-01-07"],
+            },
+          },
+        },
+        {
+          same: "year",
+          format: [`${Y}${sep}M${sep}D`, `M${sep}D`],
+          removedYearFormat: [`M${sep}D`, `M${sep}D`],
+          dashPad: " ",
+          tests: {
+            verbose: {
+              output: "2017/1/1 – 5/14",
+              input: ["2017-01-01", "2017-05-14"],
+            },
+          },
+        },
+        {
+          same: null,
+          format: [`${Y}${sep}M${sep}D`, `${Y}${sep}M${sep}D`],
+          dashPad: " ",
+          tests: {
+            verbose: {
+              output: "2017/1/1 – 2018/2/4",
+              input: ["2017-01-01", "2018-02-04"],
+            },
+          },
+        },
+      ];
+    }
+  }
+
+  // Handle text-based date formats
+  if (dateStyle === "D MMMM, YYYY") {
+    // Day-first text format
+    const MD = `D ${M}`;
+    const MDY = `D ${M}, ${Y}`;
+    const DY = `D, ${Y}`;
+
+    return [
+      {
+        same: "month",
+        format: [MD, DY],
+        removedYearFormat: [MD, D],
+        tests: {
+          verbose: {
+            output: "1 January–7, 2017",
+            input: ["2017-01-01", "2017-01-07"],
+          },
+        },
+      },
+      {
+        same: "year",
+        format: [MD, MDY],
+        removedYearFormat: [MD, MD],
+        dashPad: " ",
+        tests: {
+          verbose: {
+            output: "1 January – 14 May, 2017",
+            input: ["2017-01-01", "2017-05-14"],
+          },
+        },
+      },
+      {
+        same: null,
+        format: [MDY, MDY],
+        dashPad: " ",
+        tests: {
+          verbose: {
+            output: "1 January, 2017 – 4 February, 2018",
+            input: ["2017-01-01", "2018-02-04"],
+          },
+        },
+      },
+    ];
+  }
+
+  // Default to the existing week specs for MMMM D, YYYY and dddd, MMMM D, YYYY
+  return DATE_RANGE_FORMAT_SPECS.week;
+}
+
 /** This formats a time with unit as a date range */
 export function formatDateTimeRangeWithUnit(
   values: [DateVal] | [DateVal, DateVal],
@@ -859,7 +1037,17 @@ export function formatDateTimeRangeWithUnit(
     options.type === "tooltip" ? "MMMM" : getMonthFormat(options);
   const condensed = options.compact || options.type === "tooltip";
 
-  const specs = DATE_RANGE_FORMAT_SPECS[unit];
+  let specs = DATE_RANGE_FORMAT_SPECS[unit];
+
+  // Use custom format specs for week unit when date_style is provided
+  if (unit === "week" && options.date_style && options.type === "cell") {
+    const customSpecs = getWeekFormatSpecsWithDateStyle(
+      options.date_style as string,
+      (options.date_separator as string) || "/",
+    );
+    specs = customSpecs;
+  }
+
   const defaultSpec = specs.find((spec) => spec.same === null);
   const matchSpec =
     specs.find((spec) => start.isSame(end, spec.same)) ?? defaultSpec;

--- a/frontend/src/metabase/lib/formatting/date.unit.spec.tsx
+++ b/frontend/src/metabase/lib/formatting/date.unit.spec.tsx
@@ -84,6 +84,75 @@ describe("formatDateTimeRangeWithUnit", () => {
   }
 });
 
+describe("formatDateTimeRangeWithUnit with date_style", () => {
+  it("should format M/D/YYYY style in cells", () => {
+    const input: [string] = ["2017-01-01"]; // Week: 2017-01-01 to 2017-01-07
+    const options = { type: "cell" as const, date_style: "M/D/YYYY" };
+
+    expect(formatDateTimeRangeWithUnit(input, "week", options)).toBe(
+      "1/1/2017 – 1/7/2017",
+    );
+  });
+
+  it("should format D/M/YYYY style in cells", () => {
+    const input: [string] = ["2017-01-01"]; // Week: 2017-01-01 to 2017-01-07
+    const options = { type: "cell" as const, date_style: "D/M/YYYY" };
+
+    expect(formatDateTimeRangeWithUnit(input, "week", options)).toBe(
+      "1/1/2017 – 7/1/2017",
+    );
+  });
+
+  it("should format YYYY/M/D style in cells", () => {
+    const input: [string] = ["2017-01-01"]; // Week: 2017-01-01 to 2017-01-07
+    const options = { type: "cell" as const, date_style: "YYYY/M/D" };
+
+    expect(formatDateTimeRangeWithUnit(input, "week", options)).toBe(
+      "2017/1/1 – 2017/1/7",
+    );
+  });
+
+  it("should format D MMMM, YYYY style in cells", () => {
+    const input: [string] = ["2017-01-01"]; // Week: 2017-01-01 to 2017-01-07
+    const options = { type: "cell" as const, date_style: "D MMMM, YYYY" };
+
+    expect(formatDateTimeRangeWithUnit(input, "week", options)).toBe(
+      "1 January, 2017 – 7 January, 2017",
+    );
+  });
+
+  it("should format week across months with M/D/YYYY in cells", () => {
+    const input: [string] = ["2017-01-29"]; // Week: 2017-01-29 to 2017-02-04
+    const options = { type: "cell" as const, date_style: "M/D/YYYY" };
+
+    expect(formatDateTimeRangeWithUnit(input, "week", options)).toBe(
+      "1/29/2017 – 2/4/2017",
+    );
+  });
+
+  it("should format week across years with M/D/YYYY in cells", () => {
+    const input: [string] = ["2017-12-31"]; // Week: 2017-12-31 to 2018-01-06
+    const options = { type: "cell" as const, date_style: "M/D/YYYY" };
+
+    expect(formatDateTimeRangeWithUnit(input, "week", options)).toBe(
+      "12/31/2017 – 1/6/2018",
+    );
+  });
+
+  it("should respect custom separator with M/D/YYYY style", () => {
+    const input: [string] = ["2017-01-01"]; // Week: 2017-01-01 to 2017-01-07
+    const options = {
+      type: "cell" as const,
+      date_style: "M/D/YYYY",
+      date_separator: "-",
+    };
+
+    expect(formatDateTimeRangeWithUnit(input, "week", options)).toBe(
+      "1-1-2017 – 1-7-2017",
+    );
+  });
+});
+
 describe("formatDateTimeForParameter", () => {
   const value = "2020-01-01T06:00:00+05:00";
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/22359 / UXW-64

### Description

This fixes date value formatting for breakout "by week"

### How to verify

1. Go to Sample Database -> Orders -> Summarize -> Created At by week
2. Go to Visualization -> Table
3. Click the gear icon next to Created At
4. Change the date style, and observe that the values in the "Created At: Week" are displayed in selected format and separator

### Demo


https://github.com/user-attachments/assets/c6f26cd4-2db2-4079-a929-e8b4ed741da6



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
