### PR TITLE
Hopeful fix for the ooms that betterment is running into.

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -87,8 +87,7 @@
   io.github.eerohele/pp                     {#_#_:git/tag "2024-11-13.77"       ; super fast pretty-printing library
                                              :git/sha "ffc4edc482c057cd9412c62f018a41e9140c618b"
                                              :git/url "https://github.com/eerohele/pp"}
-  ;; TODO: replace back to normal artifact
-  io.github.metabase/macaw                  {:mvn/version "0.2.29"}             ; Parse native SQL queries
+  io.github.metabase/macaw                  {:mvn/version "0.2.30"}             ; Parse native SQL queries
   io.netty/netty-codec-http                 {:mvn/version "4.2.9.Final"}        ; override of transitive dep from aws s3
   io.prometheus/simpleclient_hotspot        {:mvn/version "0.16.0"}             ; prometheus jvm collector
   junegunn/grouper                          {:mvn/version "0.1.1"}              ; Batch processing helper

--- a/src/metabase/driver/sql.clj
+++ b/src/metabase/driver/sql.clj
@@ -188,14 +188,14 @@
    query  :- :metabase.lib.schema/native-only-query]
   (let [db-tables (driver-api/tables query)
         db-transforms (driver-api/transforms query)]
-    (->> query
-         driver-api/raw-native-query
-         macaw/parsed-query
-         macaw/query->components
-         :tables
-         (map :component)
-         (into #{} (keep #(->> (normalize-table-spec driver %)
-                               (find-table-or-transform driver db-tables db-transforms)))))))
+    (-> query
+        driver-api/raw-native-query
+        macaw/parsed-query
+        (macaw/query->components {:strip-contexts? true})
+        :tables
+        (->> (map :component))
+        (->> (into #{} (keep #(->> (normalize-table-spec driver %)
+                                   (find-table-or-transform driver db-tables db-transforms))))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                              Dependencies                                                      |


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/[issue_number]

### Description

A macaw pr is adding a new `:strip-contexts?` option to macaw/query->components.  This pr updates metabase to use that new option.  It is currently a noop, but once metabase is using a version of macaw that supports the new option, this should fix the ooms that certain customers are running into.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Get the betterment query from [this slack thread](https://metaboat.slack.com/archives/C010ZSXQY87/p1766183914802339)
2. Load it into the repl in the metabase.driver.sql namespace
3. Run `(-> query macaw/parsed-query (macaw/query->components {:strip-contexts? true}))` to verify that macaw can handle the query now

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
