### PR TITLE
fix: allow newb modal image and content to be centered at awkward screen resolution sizes

### DIFF
--- a/frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.module.css
+++ b/frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.module.css
@@ -1,0 +1,6 @@
+.ModalTitle {
+  max-width: 100%;
+  text-align: center;
+  white-space: normal;
+  word-break: break-word;
+}

--- a/frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.tsx
+++ b/frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.tsx
@@ -3,8 +3,10 @@ import { t } from "ttag";
 import EmptyMetric from "assets/img/empty-states/qbnewb-metric.svg";
 import EmptyModel from "assets/img/empty-states/qbnewb-model.svg";
 import EmptyQuestion from "assets/img/empty-states/qbnewq-question.svg";
-import { Box, Button, Modal, Stack, Text } from "metabase/ui";
+import { Box, Button, Center, Modal, Stack, Text } from "metabase/ui";
 import type Question from "metabase-lib/v1/Question";
+
+import SavedQuestionIntroModalS from "./SavedQuestionIntroModal.module.css";
 
 interface Props {
   isShowingNewbModal: boolean;
@@ -60,24 +62,22 @@ export const SavedQuestionIntroModal = ({
       <Modal.Overlay />
       <Modal.Content p="xl" ta="center">
         <Modal.Header maw={contentWidth} mx="auto" my="md">
-          <Stack align="center" justify="center" style={{ width: "100%" }}>
-            <Box w="6rem">
-              <img
-                src={image}
-                alt={t`Saved entity modal empty state illustration`}
-              />
-            </Box>
-            <Modal.Title
-              style={{
-                maxWidth: "100%",
-                textAlign: "center",
-                whiteSpace: "normal",
-                wordBreak: "break-word",
-              }}
-            >
-              {title}
-            </Modal.Title>
-          </Stack>
+          <Center w="100%">
+            <Stack align="center">
+              <Box w="6rem">
+                <img
+                  src={image}
+                  alt={t`Saved entity modal empty state illustration`}
+                />
+              </Box>
+              <Modal.Title
+                mx="auto"
+                className={SavedQuestionIntroModalS.ModalTitle}
+              >
+                {title}
+              </Modal.Title>
+            </Stack>
+          </Center>
         </Modal.Header>
         <Modal.Body maw={contentWidth} mx="auto" my="md">
           <Text mb="lg">{message}</Text>

--- a/frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.tsx
+++ b/frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.tsx
@@ -60,14 +60,23 @@ export const SavedQuestionIntroModal = ({
       <Modal.Overlay />
       <Modal.Content p="xl" ta="center">
         <Modal.Header maw={contentWidth} mx="auto" my="md">
-          <Stack align="center">
+          <Stack align="center" justify="center" style={{ width: "100%" }}>
             <Box w="6rem">
               <img
                 src={image}
                 alt={t`Saved entity modal empty state illustration`}
               />
             </Box>
-            <Modal.Title>{title}</Modal.Title>
+            <Modal.Title
+              style={{
+                maxWidth: "100%",
+                textAlign: "center",
+                whiteSpace: "normal",
+                wordBreak: "break-word",
+              }}
+            >
+              {title}
+            </Modal.Title>
           </Stack>
         </Modal.Header>
         <Modal.Body maw={contentWidth} mx="auto" my="md">


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/67466

### Description

This fixes an issue where the {title, image} in the new model modal was overflowing instead of being centered.
The modal header now allows titles to wrap across multiple lines and keeps the image centered, preventing overflow and improving first-time UX.

### How to verify

1. Launch new metabase instance where you've not touched a single model
2. Go to examples section of the Modals
3. Click into one and see the modal pop up.
OR

**FORCED RENDER:**
1. Go to metabase/frontend/src/metabase/query_builder/components/view/View.jsx and comment out line 242-248, and right below it, paste:
```bash
        <SavedQuestionIntroModal
          question={question}
          isShowingNewbModal={true}
          onClose={() => closeQbNewbModal()}
        />
````
2. Open up any modal from the metabase console and see the modal pop-up

### Demo
<img width="846" height="713" alt="Screenshot from 2025-12-24 03-21-56" src="https://github.com/user-attachments/assets/2356e1c7-028c-4830-9799-3dd4b7c159ca" />

<img width="236" height="635" alt="Screenshot from 2025-12-24 03-21-35" src="https://github.com/user-attachments/assets/ad0f417f-a766-43c1-924c-f491784116fb" />

<img width="345" height="628" alt="Screenshot from 2025-12-24 03-21-20" src="https://github.com/user-attachments/assets/e7cf71e3-1f44-423c-8167-7cb089db24cc" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
