### PR TITLE
Default to base-type when it differs from effective type

### DIFF
--- a/src/metabase/query_processor/middleware/wrap_value_literals.clj
+++ b/src/metabase/query_processor/middleware/wrap_value_literals.clj
@@ -231,7 +231,11 @@
   (lib.util.match/match-lite clause
     ;; two literals
     [(tag :guard #{:= :!= :< :> :<= :>=}) opts (x :guard raw-value?) (y :guard raw-value?)]
-    [tag opts x y]
+    (let [x-type (lib.schema.expression/type-of x)
+          y-type (lib.schema.expression/type-of y)]
+      [tag opts
+       (add-type-info x {:base-type x-type :effective-type x-type})
+       (add-type-info y {:base-type y-type :effective-type x-type})])
 
     ;; field and literal
     [(tag :guard #{:= :!= :< :> :<= :>=}) opts field (x :guard raw-value?)]

--- a/src/metabase/query_processor/middleware/wrap_value_literals.clj
+++ b/src/metabase/query_processor/middleware/wrap_value_literals.clj
@@ -44,8 +44,9 @@
   (merge
    (when (lib.util/clause-of-type? clause :field)
      (type-info-from-col (lib.walk/apply-f-for-stage-at-path lib/metadata query path clause)))
-   (let [expr-type (lib.walk/apply-f-for-stage-at-path lib/type-of query path clause)]
-     {:base-type      expr-type
+   (let [expr-type (lib.walk/apply-f-for-stage-at-path lib/type-of query path clause)
+         [_ {:keys [base-type]}] clause]
+     {:base-type      (or base-type expr-type)
       :effective-type expr-type})))
 
 ;; TODO -- parsing the temporal string literals should be moved into `auto-parse-filter-values`, it's really a

--- a/src/metabase/query_processor/middleware/wrap_value_literals.clj
+++ b/src/metabase/query_processor/middleware/wrap_value_literals.clj
@@ -229,6 +229,11 @@
 (defn- wrap-value-literals-in-clause
   [query path clause]
   (lib.util.match/match-lite clause
+    ;; two literals
+    [(tag :guard #{:= :!= :< :> :<= :>=}) opts (x :guard raw-value?) (y :guard raw-value?)]
+    [tag opts x y]
+
+    ;; field and literal
     [(tag :guard #{:= :!= :< :> :<= :>=}) opts field (x :guard raw-value?)]
     [tag opts field (add-type-info x (*type-info* query path field))]
 

--- a/src/metabase/query_processor/middleware/wrap_value_literals.clj
+++ b/src/metabase/query_processor/middleware/wrap_value_literals.clj
@@ -235,7 +235,7 @@
           y-type (lib.schema.expression/type-of y)]
       [tag opts
        (add-type-info x {:base-type x-type :effective-type x-type})
-       (add-type-info y {:base-type y-type :effective-type x-type})])
+       (add-type-info y {:base-type y-type :effective-type y-type})])
 
     ;; field and literal
     [(tag :guard #{:= :!= :< :> :<= :>=}) opts field (x :guard raw-value?)]

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -1049,7 +1049,7 @@
                      (is (=? {:data {:rows [["Rasta" "good bird" "sad bird" "toucan"]]}}
                              (qp/process-query query))))))))))))))
 
-(deftest ^:parallel filtering-on-enum-from-source-bad-effective-type-test
+(deftest filtering-on-enum-from-source-bad-effective-type-test
   (mt/test-driver
     :postgres
     (do-with-enums-db!

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -1049,7 +1049,7 @@
                      (is (=? {:data {:rows [["Rasta" "good bird" "sad bird" "toucan"]]}}
                              (qp/process-query query))))))))))))))
 
-(deftest filtering-on-enum-from-source-bad-effective-type-test
+(deftest ^:parallel filtering-on-enum-from-source-bad-effective-type-test
   (mt/test-driver
     :postgres
     (do-with-enums-db!

--- a/test/metabase/query_processor/filter_test.clj
+++ b/test/metabase/query_processor/filter_test.clj
@@ -148,6 +148,18 @@
                   {:filter   [:!= false false]
                    :order-by [[:asc $id]]}))))))))
 
+(deftest ^:parallel comparison-test-8
+  (mt/test-drivers (mt/normal-drivers)
+    (mt/dataset places-cam-likes
+      (testing "Can we use != with literals on both sides, with a cast"
+        (is (= []
+               (mt/formatted-rows
+                [int str ->bool]
+                :format-nil-values
+                (mt/run-mbql-query places
+                  {:filter   [:!= 0 "0"]
+                   :order-by [[:asc $id]]}))))))))
+
 (deftest ^:parallel between-test
   (mt/test-drivers (mt/normal-drivers)
     (testing ":between filter, single subclause (neither :and nor :or)"

--- a/test/metabase/query_processor/filter_test.clj
+++ b/test/metabase/query_processor/filter_test.clj
@@ -151,13 +151,13 @@
 (deftest ^:parallel comparison-test-8
   (mt/test-drivers (mt/normal-drivers)
     (mt/dataset places-cam-likes
-      (testing "Can we use != with literals on both sides, with a cast"
+      (testing "Can we use != with literals on both sides, 0 != 0"
         (is (= []
                (mt/formatted-rows
                 [int str ->bool]
                 :format-nil-values
                 (mt/run-mbql-query places
-                  {:filter   [:!= 0 "0"]
+                  {:filter   [:!= 0 0]
                    :order-by [[:asc $id]]}))))))))
 
 (deftest ^:parallel between-test


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/67440

### Description

Customer had an incompatible effective_type (:type/Text) for a base-type :type/PostgresEnum field. This defaults to using base-type when it's there, like we used to do in 56.