### PR TITLE
Metabot measures and segments cleanup and tests

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/entity_details.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/entity_details.clj
@@ -18,21 +18,10 @@
 
 (set! *warn-on-reflection* true)
 
-;; ============================================
-;; Helper functions for Measures and Segments
-;; ============================================
-
-(defn- convert-measure
-  "Convert a measure metadata object to the format expected by the API."
-  [measure-metadata]
-  (select-keys measure-metadata [:id :name :display-name :description :definition]))
-
-(defn- convert-segment
-  "Convert a segment metadata object to the format expected by the API."
-  [segment-metadata]
-  (select-keys segment-metadata [:id :name :display-name :description :definition]))
-
-;; ============================================
+(defn- convert-measure-or-segment
+  "Convert a measure or segment metadata object to the format expected by the API."
+  [metadata]
+  (select-keys metadata [:id :name :display-name :description :definition]))
 
 (defn verified-review?
   "Return true if the most recent ModerationReview for the given item id/type is verified."
@@ -158,7 +147,7 @@
 
        with-segments?
        (assoc :segments (if-let [segments (lib/available-segments metric-query)]
-                          (mapv convert-segment segments)
+                          (mapv convert-measure-or-segment segments)
                           []))))))
 
 (comment
@@ -224,10 +213,10 @@
                                     (not-empty (mapv #(convert-metric % mp options)
                                                      (lib/available-metrics table-query))))
                          :measures (when with-measures?
-                                     (not-empty (mapv convert-measure
+                                     (not-empty (mapv convert-measure-or-segment
                                                       (lib/available-measures table-query))))
                          :segments (when with-segments?
-                                     (not-empty (mapv convert-segment
+                                     (not-empty (mapv convert-measure-or-segment
                                                       (lib/available-segments table-query))))))))))
 
 (defn related-tables
@@ -318,10 +307,10 @@
                      (not-empty (mapv #(convert-metric % metadata-provider options)
                                       (lib/available-metrics card-query))))
           :measures (when with-measures?
-                      (not-empty (mapv convert-measure
+                      (not-empty (mapv convert-measure-or-segment
                                        (lib/available-measures card-query))))
           :segments (when with-segments?
-                      (not-empty (mapv convert-segment
+                      (not-empty (mapv convert-measure-or-segment
                                        (lib/available-segments card-query)))))))))
 
 (defn cards-details

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
@@ -76,11 +76,9 @@
 
 (defn- add-filter
   [query llm-filter]
-  ;; Check if this is a segment filter
   (if-let [segment-id (:segment-id llm-filter)]
-    ;; Use lib/filter with a segment clause
-    (let [segment-clause [:segment {:lib/uuid (str (random-uuid))} segment-id]]
-      (lib/filter query segment-clause))
+    ;; Segment-based filter
+    (lib/filter query (lib.metadata/segment query segment-id))
     ;; Standard field-based filter logic
     (let [{:keys [operation value values]} llm-filter
           expr (filter-bucketed-column llm-filter)
@@ -212,8 +210,7 @@
         query-with-aggregation
         (if-let [measure-id (:measure-id aggregation)]
           ;; Measure-based aggregation
-          (let [measure-clause [:measure {:lib/uuid (str (random-uuid))} measure-id]]
-            (lib/aggregate query measure-clause))
+          (lib/aggregate query (lib.metadata/measure query measure-id))
           ;; Field-based aggregation
           (let [expr (bucketed-column aggregation)
                 agg-expr (case (:function aggregation)

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
@@ -12,11 +12,13 @@
    [metabase-enterprise.metabot-v3.tools.filters :as metabot-v3.tools.filters]
    [metabase-enterprise.metabot-v3.tools.find-outliers :as metabot-v3.tools.find-outliers]
    [metabase-enterprise.metabot-v3.tools.generate-insights :as metabot-v3.tools.generate-insights]
+   [metabase-enterprise.metabot-v3.tools.test-util :as tools.tu]
    [metabase-enterprise.metabot-v3.tools.util :as metabot-v3.tools.u]
    [metabase-enterprise.metabot-v3.util :as metabot-v3.u]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.options :as lib.options]
    [metabase.test :as mt]
    [metabase.util :as u]
    [metabase.util.malli.registry :as mr]
@@ -249,25 +251,25 @@
                                                                 :group_by  breakouts}
                                               :conversation_id conversation-id})
               query-id (-> response :structured_output :query_id)
-              expected-query (mt/$ids :products
-                               {:database (mt/id)
-                                :lib/type :mbql/query
-                                :stages [{:lib/type :mbql.stage/mbql
-                                          :source-table $$products
-                                          :aggregation [[:metric {} metric-id]]
-                                          :breakout [[:field {:temporal-unit :week} %created_at]
-                                                     [:field {:temporal-unit :day} %created_at]]
-                                          :filters [[:> {} [:field {} %id] 50]
-                                                    [:= {} [:field {} %title] "3" "4"]
-                                                    [:!= {} [:field {} %rating] 3 4]
-                                                    [:= {} [:get-month {} [:field {} %created_at]] 4 5 9]
-                                                    [:!= {} [:get-day {} [:field {} %created_at]] 14 15 19]
-                                                    [:= {} [:get-day-of-week {} [:field {} %created_at] :iso] 1 7]
-                                                    [:= {} [:get-year {} [:field {} %created_at]] 2008]]}]})]
+              actual-query (-> response :structured_output :query lib-be/normalize-query)
+              id-col (lib.metadata/field mp (mt/id :products :id))
+              title-col (lib.metadata/field mp (mt/id :products :title))
+              rating-col (lib.metadata/field mp (mt/id :products :rating))
+              created-at-col (lib.metadata/field mp (mt/id :products :created_at))
+              expected-query (-> (lib/query mp (lib.metadata/table mp (mt/id :products)))
+                                 (lib/aggregate (lib.options/ensure-uuid [:metric {} metric-id]))
+                                 (lib/breakout (lib/with-temporal-bucket created-at-col :week))
+                                 (lib/breakout (lib/with-temporal-bucket created-at-col :day))
+                                 (lib/filter (lib/> id-col 50))
+                                 (lib/filter (lib/= title-col "3" "4"))
+                                 (lib/filter (lib/!= rating-col 3 4))
+                                 (lib/filter (lib/= (lib/get-month created-at-col) 4 5 9))
+                                 (lib/filter (lib/!= (lib/get-day created-at-col) 14 15 19))
+                                 (lib/filter (lib/= (lib/get-day-of-week created-at-col :iso) 1 7))
+                                 (lib/filter (lib/= (lib/get-year created-at-col) 2008)))]
           (is (=? {:structured_output
                    {:type "query"
                     :query_id string?
-                    :query expected-query
                     :result_columns
                     [{:field_id (str "q" query-id "-0")
                       :name "CREATED_AT"
@@ -288,7 +290,8 @@
                       :database_type missing-value
                       :semantic_type "score"}]}
                    :conversation_id conversation-id}
-                  (update-in response [:structured_output :query] lib-be/normalize-query))))))))
+                  response))
+          (is (tools.tu/query= expected-query actual-query)))))))
 
 (deftest query-model-test
   (mt/with-premium-features #{:metabot-v3}

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
@@ -287,7 +287,8 @@
                       :database_type missing-value
                       :semantic_type "score"}]}
                    :conversation_id conversation-id}
-                  response)))))))
+                  (-> response
+                      (update-in [:structured_output :query] mbql.normalize/normalize)))))))))
 
 (deftest query-model-test
   (mt/with-premium-features #{:metabot-v3}

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
@@ -287,8 +287,7 @@
                       :database_type missing-value
                       :semantic_type "score"}]}
                    :conversation_id conversation-id}
-                  (-> response
-                      (update-in [:structured_output :query] mbql.normalize/normalize)))))))))
+                  response)))))))
 
 (deftest query-model-test
   (mt/with-premium-features #{:metabot-v3}

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
@@ -14,7 +14,6 @@
    [metabase-enterprise.metabot-v3.tools.generate-insights :as metabot-v3.tools.generate-insights]
    [metabase-enterprise.metabot-v3.tools.util :as metabot-v3.tools.u]
    [metabase-enterprise.metabot-v3.util :as metabot-v3.u]
-   [metabase.legacy-mbql.normalize :as mbql.normalize]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
@@ -287,7 +286,7 @@
                       :database_type missing-value
                       :semantic_type "score"}]}
                    :conversation_id conversation-id}
-                  response)))))))
+                  (update-in response [:structured_output :query] lib-be/normalize-query))))))))
 
 (deftest query-model-test
   (mt/with-premium-features #{:metabot-v3}

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
@@ -248,24 +248,26 @@
                                                                 :filters   filters
                                                                 :group_by  breakouts}
                                               :conversation_id conversation-id})
-              query-id (-> response :structured_output :query_id)]
+              query-id (-> response :structured_output :query_id)
+              expected-query (mt/$ids :products
+                               {:database (mt/id)
+                                :lib/type :mbql/query
+                                :stages [{:lib/type :mbql.stage/mbql
+                                          :source-table $$products
+                                          :aggregation [[:metric {} metric-id]]
+                                          :breakout [[:field {:temporal-unit :week} %created_at]
+                                                     [:field {:temporal-unit :day} %created_at]]
+                                          :filters [[:> {} [:field {} %id] 50]
+                                                    [:= {} [:field {} %title] "3" "4"]
+                                                    [:!= {} [:field {} %rating] 3 4]
+                                                    [:= {} [:get-month {} [:field {} %created_at]] 4 5 9]
+                                                    [:!= {} [:get-day {} [:field {} %created_at]] 14 15 19]
+                                                    [:= {} [:get-day-of-week {} [:field {} %created_at] :iso] 1 7]
+                                                    [:= {} [:get-year {} [:field {} %created_at]] 2008]]}]})]
           (is (=? {:structured_output
                    {:type "query"
                     :query_id string?
-                    :query {:database (mt/id)
-                            :lib/type :mbql/query
-                            :stages [{:lib/type :mbql.stage/mbql
-                                      :source-table (mt/id :products)
-                                      :aggregation [[:metric {} metric-id]]
-                                      :breakout [[:field {:temporal-unit :week} (mt/id :products :created_at)]
-                                                 [:field {:temporal-unit :day} (mt/id :products :created_at)]]
-                                      :filters [[:> {} [:field {} (mt/id :products :id)] 50]
-                                                [:= {} [:field {} (mt/id :products :title)] "3" "4"]
-                                                [:!= {} [:field {} (mt/id :products :rating)] 3 4]
-                                                [:= {} [:get-month {} [:field {} (mt/id :products :created_at)]] 4 5 9]
-                                                [:!= {} [:get-day {} [:field {} (mt/id :products :created_at)]] 14 15 19]
-                                                [:= {} [:get-day-of-week {} [:field {} (mt/id :products :created_at)] :iso] 1 7]
-                                                [:= {} [:get-year {} [:field {} (mt/id :products :created_at)]] 2008]]}]}
+                    :query expected-query
                     :result_columns
                     [{:field_id (str "q" query-id "-0")
                       :name "CREATED_AT"

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
@@ -253,17 +253,20 @@
           (is (=? {:structured_output
                    {:type "query"
                     :query_id string?
-                    :query (mt/mbql-query products
-                             {:aggregation [[:metric metric-id]]
-                              :breakout [!week.products.created_at !day.products.created_at]
-                              :filter [:and
-                                       [:> [:field %id {}] 50]
-                                       [:= [:field %title {}] "3" "4"]
-                                       [:!= [:field %rating {}] 3 4]
-                                       [:= [:get-month [:field %created_at {}]] 4 5 9]
-                                       [:!= [:get-day [:field %products.created_at {}]] 14 15 19]
-                                       [:= [:get-day-of-week [:field %created_at {}] :iso] 1 7]
-                                       [:= [:get-year [:field %created_at {}]] 2008]]})
+                    :query {:database (mt/id)
+                            :lib/type :mbql/query
+                            :stages [{:lib/type :mbql.stage/mbql
+                                      :source-table (mt/id :products)
+                                      :aggregation [[:metric {} metric-id]]
+                                      :breakout [[:field {:temporal-unit :week} (mt/id :products :created_at)]
+                                                 [:field {:temporal-unit :day} (mt/id :products :created_at)]]
+                                      :filters [[:> {} [:field {} (mt/id :products :id)] 50]
+                                                [:= {} [:field {} (mt/id :products :title)] "3" "4"]
+                                                [:!= {} [:field {} (mt/id :products :rating)] 3 4]
+                                                [:= {} [:get-month {} [:field {} (mt/id :products :created_at)]] 4 5 9]
+                                                [:!= {} [:get-day {} [:field {} (mt/id :products :created_at)]] 14 15 19]
+                                                [:= {} [:get-day-of-week {} [:field {} (mt/id :products :created_at)] :iso] 1 7]
+                                                [:= {} [:get-year {} [:field {} (mt/id :products :created_at)]] 2008]]}]}
                     :result_columns
                     [{:field_id (str "q" query-id "-0")
                       :name "CREATED_AT"
@@ -284,8 +287,7 @@
                       :database_type missing-value
                       :semantic_type "score"}]}
                    :conversation_id conversation-id}
-                  (-> response
-                      (update-in [:structured_output :query] mbql.normalize/normalize)))))))))
+                  response)))))))
 
 (deftest query-model-test
   (mt/with-premium-features #{:metabot-v3}

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/entity_details_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/entity_details_test.clj
@@ -265,12 +265,13 @@
                   output (:structured-output result)]
               (is (nil? (:segments output)))))
 
-          (testing "with_segments: true returns segments key (may be empty if source-table not resolvable)"
+          (testing "with_segments: true includes segments for the table"
             (let [result (entity-details/get-metric-details {:metric-id metric-id
                                                              :with-segments? true})
-                  output (:structured-output result)]
-              ;; The segments key should be present when with-segments? is true
-              (is (contains? output :segments))
-              ;; If segments are found, they should have the expected structure
-              (when-let [segments (seq (:segments output))]
-                (is (= segment-id (:id (first segments))))))))))))
+                  output (:structured-output result)
+                  segments (:segments output)]
+              (is (sequential? segments))
+              (is (= 1 (count segments)))
+              (let [segment (first segments)]
+                (is (= segment-id (:id segment)))
+                (is (= "Large Orders" (:name segment)))))))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/entity_details_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/entity_details_test.clj
@@ -3,6 +3,7 @@
    [clojure.test :refer :all]
    [metabase-enterprise.metabot-v3.tools.entity-details :as entity-details]
    [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]))
 
@@ -157,3 +158,119 @@
                    (count (:fields products-related)))
                 (str "Products related table should have " expected-products-field-count
                      " fields (only its own fields, not implicitly joinable fields)"))))))))
+
+(defn- pmbql-measure-definition
+  "Create an MBQL5 measure definition with a sum aggregation."
+  [table-id field-id]
+  (let [mp (mt/metadata-provider)
+        table (lib.metadata/table mp table-id)
+        query (lib/query mp table)
+        field (lib.metadata/field mp field-id)]
+    (lib/aggregate query (lib/sum field))))
+
+(defn- pmbql-segment-definition
+  "Create an MBQL5 segment definition with a filter."
+  [table-id field-id value]
+  (let [mp (mt/metadata-provider)
+        table (lib.metadata/table mp table-id)
+        query (lib/query mp table)
+        field (lib.metadata/field mp field-id)]
+    (lib/filter query (lib/> field value))))
+
+(deftest get-table-details-with-measures-test
+  (testing "get-table-details returns measures when with_measures is true"
+    (let [measure-def (pmbql-measure-definition (mt/id :orders) (mt/id :orders :total))]
+      (mt/with-temp [:model/Measure {measure-id :id} {:name       "Total Revenue"
+                                                      :table_id   (mt/id :orders)
+                                                      :definition measure-def}]
+        (mt/with-current-user (mt/user->id :crowberto)
+          (testing "with_measures: false (default) does not include measures"
+            (let [result (entity-details/get-table-details {:table-id (mt/id :orders)})
+                  output (:structured-output result)]
+              (is (nil? (:measures output)))))
+
+          (testing "with_measures: true includes measures for the table"
+            (let [result (entity-details/get-table-details {:table-id (mt/id :orders)
+                                                            :with-measures? true})
+                  output (:structured-output result)
+                  measures (:measures output)]
+              (is (sequential? measures))
+              (is (= 1 (count measures)))
+              (let [measure (first measures)]
+                (is (= measure-id (:id measure)))
+                (is (= "Total Revenue" (:name measure)))
+                (is (map? (:definition measure)))))))))))
+
+(deftest get-table-details-with-segments-test
+  (testing "get-table-details returns segments when with_segments is true"
+    (let [segment-def (pmbql-segment-definition (mt/id :orders) (mt/id :orders :total) 100)]
+      (mt/with-temp [:model/Segment {segment-id :id} {:name       "High Value Orders"
+                                                      :table_id   (mt/id :orders)
+                                                      :definition segment-def}]
+        (mt/with-current-user (mt/user->id :crowberto)
+          (testing "with_segments: false (default) does not include segments"
+            (let [result (entity-details/get-table-details {:table-id (mt/id :orders)})
+                  output (:structured-output result)]
+              (is (nil? (:segments output)))))
+
+          (testing "with_segments: true includes segments for the table"
+            (let [result (entity-details/get-table-details {:table-id (mt/id :orders)
+                                                            :with-segments? true})
+                  output (:structured-output result)
+                  segments (:segments output)]
+              (is (sequential? segments))
+              (is (= 1 (count segments)))
+              (let [segment (first segments)]
+                (is (= segment-id (:id segment)))
+                (is (= "High Value Orders" (:name segment)))
+                (is (map? (:definition segment)))))))))))
+
+(deftest get-table-details-measures-scoped-to-table-test
+  (testing "get-table-details only returns measures for the requested table, not other tables"
+    (let [orders-measure-def (pmbql-measure-definition (mt/id :orders) (mt/id :orders :total))
+          products-measure-def (pmbql-measure-definition (mt/id :products) (mt/id :products :price))]
+      (mt/with-temp [:model/Measure {orders-measure-id :id} {:name       "Orders Total"
+                                                             :table_id   (mt/id :orders)
+                                                             :definition orders-measure-def}
+                     :model/Measure {_products-measure-id :id} {:name       "Products Price"
+                                                                :table_id   (mt/id :products)
+                                                                :definition products-measure-def}]
+        (mt/with-current-user (mt/user->id :crowberto)
+          (let [result (entity-details/get-table-details {:table-id (mt/id :orders)
+                                                          :with-measures? true})
+                output (:structured-output result)
+                measures (:measures output)]
+            (is (= 1 (count measures)))
+            (is (= orders-measure-id (:id (first measures))))))))))
+
+(deftest get-metric-details-with-segments-test
+  (testing "get-metric-details returns segments when with_segments is true"
+    ;; Note: lib/available-segments requires the query to have a direct source-table-id.
+    ;; For metrics, this means the underlying card must be based on a table (not another card).
+    (let [mp (mt/metadata-provider)
+          ;; Create a metric query that's directly based on a table
+          metric-query (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+                           (lib/aggregate (lib/sum (lib.metadata/field mp (mt/id :orders :total)))))
+          segment-def (pmbql-segment-definition (mt/id :orders) (mt/id :orders :total) 50)]
+      (mt/with-temp [:model/Card {metric-id :id} {:dataset_query metric-query
+                                                  :database_id   (mt/id)
+                                                  :name          "Total Orders"
+                                                  :type          :metric}
+                     :model/Segment {segment-id :id} {:name       "Large Orders"
+                                                      :table_id   (mt/id :orders)
+                                                      :definition segment-def}]
+        (mt/with-current-user (mt/user->id :crowberto)
+          (testing "with_segments: false (default) does not include segments"
+            (let [result (entity-details/get-metric-details {:metric-id metric-id})
+                  output (:structured-output result)]
+              (is (nil? (:segments output)))))
+
+          (testing "with_segments: true returns segments key (may be empty if source-table not resolvable)"
+            (let [result (entity-details/get-metric-details {:metric-id metric-id
+                                                             :with-segments? true})
+                  output (:structured-output result)]
+              ;; The segments key should be present when with-segments? is true
+              (is (contains? output :segments))
+              ;; If segments are found, they should have the expected structure
+              (when-let [segments (seq (:segments output))]
+                (is (= segment-id (:id (first segments))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/entity_details_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/entity_details_test.clj
@@ -159,7 +159,7 @@
                 (str "Products related table should have " expected-products-field-count
                      " fields (only its own fields, not implicitly joinable fields)"))))))))
 
-(defn- pmbql-measure-definition
+(defn- measure-definition
   "Create an MBQL5 measure definition with a sum aggregation."
   [table-id field-id]
   (let [mp (mt/metadata-provider)
@@ -168,7 +168,7 @@
         field (lib.metadata/field mp field-id)]
     (lib/aggregate query (lib/sum field))))
 
-(defn- pmbql-segment-definition
+(defn- segment-definition
   "Create an MBQL5 segment definition with a filter."
   [table-id field-id value]
   (let [mp (mt/metadata-provider)
@@ -179,7 +179,7 @@
 
 (deftest get-table-details-with-measures-test
   (testing "get-table-details returns measures when with_measures is true"
-    (let [measure-def (pmbql-measure-definition (mt/id :orders) (mt/id :orders :total))]
+    (let [measure-def (measure-definition (mt/id :orders) (mt/id :orders :total))]
       (mt/with-temp [:model/Measure {measure-id :id} {:name       "Total Revenue"
                                                       :table_id   (mt/id :orders)
                                                       :definition measure-def}]
@@ -203,7 +203,7 @@
 
 (deftest get-table-details-with-segments-test
   (testing "get-table-details returns segments when with_segments is true"
-    (let [segment-def (pmbql-segment-definition (mt/id :orders) (mt/id :orders :total) 100)]
+    (let [segment-def (segment-definition (mt/id :orders) (mt/id :orders :total) 100)]
       (mt/with-temp [:model/Segment {segment-id :id} {:name       "High Value Orders"
                                                       :table_id   (mt/id :orders)
                                                       :definition segment-def}]
@@ -227,8 +227,8 @@
 
 (deftest get-table-details-measures-scoped-to-table-test
   (testing "get-table-details only returns measures for the requested table, not other tables"
-    (let [orders-measure-def (pmbql-measure-definition (mt/id :orders) (mt/id :orders :total))
-          products-measure-def (pmbql-measure-definition (mt/id :products) (mt/id :products :price))]
+    (let [orders-measure-def (measure-definition (mt/id :orders) (mt/id :orders :total))
+          products-measure-def (measure-definition (mt/id :products) (mt/id :products :price))]
       (mt/with-temp [:model/Measure {orders-measure-id :id} {:name       "Orders Total"
                                                              :table_id   (mt/id :orders)
                                                              :definition orders-measure-def}
@@ -251,7 +251,7 @@
           ;; Create a metric query that's directly based on a table
           metric-query (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
                            (lib/aggregate (lib/sum (lib.metadata/field mp (mt/id :orders :total)))))
-          segment-def (pmbql-segment-definition (mt/id :orders) (mt/id :orders :total) 50)]
+          segment-def (segment-definition (mt/id :orders) (mt/id :orders :total) 50)]
       (mt/with-temp [:model/Card {metric-id :id} {:dataset_query metric-query
                                                   :database_id   (mt/id)
                                                   :name          "Total Orders"

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/entity_details_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/entity_details_test.clj
@@ -248,7 +248,6 @@
     ;; Note: lib/available-segments requires the query to have a direct source-table-id.
     ;; For metrics, this means the underlying card must be based on a table (not another card).
     (let [mp (mt/metadata-provider)
-          ;; Create a metric query that's directly based on a table
           metric-query (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
                            (lib/aggregate (lib/sum (lib.metadata/field mp (mt/id :orders :total)))))
           segment-def (segment-definition (mt/id :orders) (mt/id :orders :total) 50)]
@@ -265,7 +264,7 @@
                   output (:structured-output result)]
               (is (nil? (:segments output)))))
 
-          (testing "with_segments: true includes segments for the table"
+          (testing "with_segments: true includes segments for the metric"
             (let [result (entity-details/get-metric-details {:metric-id metric-id
                                                              :with-segments? true})
                   output (:structured-output result)

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/filters_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/filters_test.clj
@@ -188,7 +188,7 @@
                                        :query {:database (mt/id)
                                                :lib/type :mbql/query
                                                :stages [{:lib/type :mbql.stage/mbql
-                                                         :source-table model-card-id}]}}}
+                                                         :source-card model-id}]}}}
                   (metabot-v3.tools.filters/query-model
                    {:model-id model-id
                     :filters []
@@ -199,7 +199,7 @@
                                        :query {:database (mt/id)
                                                :lib/type :mbql/query
                                                :stages [{:lib/type :mbql.stage/mbql
-                                                         :source-table model-card-id
+                                                         :source-card model-id
                                                          :aggregation [[:sum {} [:field {} "SUBTOTAL"]]]
                                                          :breakout [[:field {} "PRODUCT_ID"]]
                                                          :filters [[:> {} [:field {} "DISCOUNT"] 3]]}]}}}
@@ -219,7 +219,7 @@
                                        :query {:database (mt/id)
                                                :lib/type :mbql/query
                                                :stages [{:lib/type :mbql.stage/mbql
-                                                         :source-table model-card-id
+                                                         :source-card model-id
                                                          :aggregation [[:min {} [:field {:temporal-unit :hour-of-day} "CREATED_AT"]]
                                                                        [:avg {} [:field {:temporal-unit :hour-of-day} "CREATED_AT"]]
                                                                        [:max {} [:field {:temporal-unit :hour-of-day} "CREATED_AT"]]]
@@ -285,7 +285,7 @@
                                  :query {:database (mt/id)
                                          :lib/type :mbql/query
                                          :stages [{:lib/type :mbql.stage/mbql
-                                                   :source-table model-card-id
+                                                   :source-card model-id
                                                    :filters [[:!= {} [:field {} "USER_ID"] 3 42]]}]}}}
                 input {:model-id model-id
                        :filters [{:field-id (->field-id "User ID")
@@ -377,7 +377,7 @@
                                          :query {:database (mt/id)
                                                  :lib/type :mbql/query
                                                  :stages [{:lib/type :mbql.stage/mbql
-                                                           :source-table table-id}]}}}
+                                                           :source-card model-id}]}}}
                     (metabot-v3.tools.filters/filter-records
                      {:data-source {:table-id table-id}
                       :filters []}))))
@@ -387,7 +387,7 @@
                                          :query {:database (mt/id)
                                                  :lib/type :mbql/query
                                                  :stages [{:lib/type :mbql.stage/mbql
-                                                           :source-table table-id
+                                                           :source-card model-id
                                                            :filters [[:> {} [:field {} "DISCOUNT"] 3]]}]}}}
                     (metabot-v3.tools.filters/filter-records
                      {:data-source {:table-id table-id}

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/filters_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/filters_test.clj
@@ -47,9 +47,10 @@
             (is (=? {:structured-output {:type :query,
                                          :query-id string?
                                          :query {:database (mt/id)
-                                                 :type :query
-                                                 :query {:source-table (mt/id :orders)
-                                                         :aggregation [[:metric metric-id]]}}}}
+                                                 :lib/type :mbql/query
+                                                 :stages [{:lib/type :mbql.stage/mbql
+                                                           :source-table (mt/id :orders)
+                                                           :aggregation [[:metric {} metric-id]]}]}}}
                     (metabot-v3.tools.filters/query-metric
                      {:metric-id metric-id
                       :filters []
@@ -58,21 +59,18 @@
             (is (=? {:structured-output {:type :query,
                                          :query-id string?
                                          :query {:database (mt/id)
-                                                 :type :query
-                                                 :query {:source-table (mt/id :orders)
-                                                         :aggregation [[:metric metric-id]]
-                                                         :breakout [[:field (mt/id :products :category)
-                                                                     {:base-type :type/Text
-                                                                      :source-field (mt/id :orders :product_id)}]]
-                                                         :filter
-                                                         [:and
-                                                          [:= [:field (mt/id :people :state)
-                                                               {:base-type :type/Text
-                                                                :source-field (mt/id :orders :user_id)}]
-                                                           "TX"]
-                                                          [:> [:field (mt/id :orders :discount)
-                                                               {:base-type :type/Float}]
-                                                           3]]}}}}
+                                                 :lib/type :mbql/query
+                                                 :stages [{:lib/type :mbql.stage/mbql
+                                                           :source-table (mt/id :orders)
+                                                           :aggregation [[:metric {} metric-id]]
+                                                           :breakout [[:field {:source-field (mt/id :orders :product_id)}
+                                                                       (mt/id :products :category)]]
+                                                           :filters
+                                                           [[:= {} [:field {:source-field (mt/id :orders :user_id)}
+                                                                    (mt/id :people :state)]
+                                                             "TX"]
+                                                            [:> {} [:field {} (mt/id :orders :discount)]
+                                                             3]]}]}}}
                     (metabot-v3.tools.filters/query-metric
                      {:metric-id metric-id
                       :filters [{:field-id (->field-id ["User" "State"])
@@ -87,23 +85,18 @@
             (is (=? {:structured-output {:type :query,
                                          :query-id string?
                                          :query {:database (mt/id)
-                                                 :type :query
-                                                 :query {:source-table (mt/id :orders)
-                                                         :aggregation [[:metric metric-id]]
-                                                         :filter [:and
-                                                                  [:!=
-                                                                   [:get-week
-                                                                    [:field (mt/id :orders :created_at)
-                                                                     {:base-type :type/DateTimeWithLocalTZ}]
-                                                                    :iso]
-                                                                   1 2 3]
-                                                                  [:=
-                                                                   [:get-month [:field (mt/id :orders :created_at)
-                                                                                {:base-type :type/DateTimeWithLocalTZ}]]
-                                                                   6 7 8]]
-                                                         :breakout [[:field (mt/id :orders :created_at)
-                                                                     {:base-type :type/DateTimeWithLocalTZ
-                                                                      :temporal-unit :week}]]}}}}
+                                                 :lib/type :mbql/query
+                                                 :stages [{:lib/type :mbql.stage/mbql
+                                                           :source-table (mt/id :orders)
+                                                           :aggregation [[:metric {} metric-id]]
+                                                           :filters [[:!= {}
+                                                                      [:get-week {} [:field {} (mt/id :orders :created_at)] :iso]
+                                                                      1 2 3]
+                                                                     [:= {}
+                                                                      [:get-month {} [:field {} (mt/id :orders :created_at)]]
+                                                                      6 7 8]]
+                                                           :breakout [[:field {:temporal-unit :week}
+                                                                       (mt/id :orders :created_at)]]}]}}}
                     (metabot-v3.tools.filters/query-metric
                      {:metric-id metric-id
                       :filters [{:field-id (->field-id "Created At")
@@ -508,8 +501,9 @@
         (is (=? {:structured-output {:type :query
                                      :query-id string?
                                      :query {:database (mt/id)
-                                             :type :query
-                                             :query {:source-table table-id}}}}
+                                             :lib/type :mbql/query
+                                             :stages [{:lib/type :mbql.stage/mbql
+                                                       :source-table table-id}]}}}
                 (metabot-v3.tools.filters/query-datasource
                  {:table-id table-id}))))
 
@@ -517,10 +511,11 @@
         (is (=? {:structured-output {:type :query
                                      :query-id string?
                                      :query {:database (mt/id)
-                                             :type :query
-                                             :query {:source-table table-id
-                                                     :fields [[:field (mt/id :orders :created_at) {:base-type :type/DateTimeWithLocalTZ}]
-                                                              [:field (mt/id :orders :total) {:base-type :type/Float}]]}}}}
+                                             :lib/type :mbql/query
+                                             :stages [{:lib/type :mbql.stage/mbql
+                                                       :source-table table-id
+                                                       :fields [[:field {} (mt/id :orders :created_at)]
+                                                                [:field {} (mt/id :orders :total)]]}]}}}
                 (metabot-v3.tools.filters/query-datasource
                  {:table-id table-id
                   :fields [{:field-id (->field-id "Created At")}
@@ -530,11 +525,11 @@
         (is (=? {:structured-output {:type :query
                                      :query-id string?
                                      :query {:database (mt/id)
-                                             :type :query
-                                             :query {:source-table table-id
-                                                     :filter [:and
-                                                              [:> [:field (mt/id :orders :discount) {:base-type :type/Float}] 3]
-                                                              [:= [:field (mt/id :orders :user_id) {:base-type :type/Integer}] 10]]}}}}
+                                             :lib/type :mbql/query
+                                             :stages [{:lib/type :mbql.stage/mbql
+                                                       :source-table table-id
+                                                       :filters [[:> {} [:field {} (mt/id :orders :discount)] 3]
+                                                                 [:= {} [:field {} (mt/id :orders :user_id)] 10]]}]}}}
                 (metabot-v3.tools.filters/query-datasource
                  {:table-id table-id
                   :filters [{:field-id (->field-id "Discount")
@@ -548,11 +543,12 @@
         (is (=? {:structured-output {:type :query
                                      :query-id string?
                                      :query {:database (mt/id)
-                                             :type :query
-                                             :query {:source-table table-id
-                                                     :aggregation [[:sum [:field (mt/id :orders :subtotal) {:base-type :type/Float}]]
-                                                                   [:avg [:field (mt/id :orders :discount) {:base-type :type/Float}]]]
-                                                     :breakout [[:field (mt/id :orders :product_id) {:base-type :type/Integer}]]}}}}
+                                             :lib/type :mbql/query
+                                             :stages [{:lib/type :mbql.stage/mbql
+                                                       :source-table table-id
+                                                       :aggregation [[:sum {} [:field {} (mt/id :orders :subtotal)]]
+                                                                     [:avg {} [:field {} (mt/id :orders :discount)]]]
+                                                       :breakout [[:field {} (mt/id :orders :product_id)]]}]}}}
                 (metabot-v3.tools.filters/query-datasource
                  {:table-id table-id
                   :aggregations [{:field-id (->field-id "Subtotal")
@@ -565,11 +561,12 @@
         (is (=? {:structured-output {:type :query
                                      :query-id string?
                                      :query {:database (mt/id)
-                                             :type :query
-                                             :query {:source-table table-id
-                                                     :order-by [[:asc [:field (mt/id :orders :created_at) {:base-type :type/DateTimeWithLocalTZ}]]
-                                                                [:desc [:field (mt/id :orders :total) {:base-type :type/Float}]]]
-                                                     :limit 100}}}}
+                                             :lib/type :mbql/query
+                                             :stages [{:lib/type :mbql.stage/mbql
+                                                       :source-table table-id
+                                                       :order-by [[:asc {} [:field {} (mt/id :orders :created_at)]]
+                                                                  [:desc {} [:field {} (mt/id :orders :total)]]]
+                                                       :limit 100}]}}}
                 (metabot-v3.tools.filters/query-datasource
                  {:table-id table-id
                   :order-by [{:field {:field-id (->field-id "Created At")}
@@ -582,12 +579,11 @@
         (is (=? {:structured-output {:type :query
                                      :query-id string?
                                      :query {:database (mt/id)
-                                             :type :query
-                                             :query {:source-table table-id
-                                                     :aggregation [[:count]]
-                                                     :breakout [[:field (mt/id :orders :created_at)
-                                                                 {:base-type :type/DateTimeWithLocalTZ
-                                                                  :temporal-unit :month}]]}}}}
+                                             :lib/type :mbql/query
+                                             :stages [{:lib/type :mbql.stage/mbql
+                                                       :source-table table-id
+                                                       :aggregation [[:count {}]]
+                                                       :breakout [[:field {:temporal-unit :month} (mt/id :orders :created_at)]]}]}}}
                 (metabot-v3.tools.filters/query-datasource
                  {:table-id table-id
                   :aggregations [{:field-id (->field-id "Product ID")

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/filters_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/filters_test.clj
@@ -787,8 +787,7 @@
                   filters (get-in query [:stages 0 :filters])]
               (is (some? (:structured-output result)))
               (is (= :query (get-in result [:structured-output :type])))
-              ;; Check that a segment filter is present
-              (is (some #(and (vector? %) (= :segment (first %))) filters)))))))))
+              (is (=? [[:segment {} mock-segment-id]] filters)))))))))
 
 (deftest query-datasource-with-measure-aggregation-test
   (let [mp (mt/metadata-provider)

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/filters_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/filters_test.clj
@@ -177,7 +177,6 @@
     (mt/with-current-user (mt/user->id :crowberto)
       (let [model-details (-> (metabot-v3.tools.entity-details/get-table-details {:model-id model-id})
                               :structured-output)
-            model-card-id (str "card__" model-id)
             ->field-id #(u/prog1 (-> model-details :fields (by-name %) :field_id)
                           (when-not <>
                             (throw (ex-info (str "Column " % " not found") {:column %}))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/test_util.clj
@@ -1,0 +1,9 @@
+(ns metabase-enterprise.metabot-v3.tools.test-util
+  (:require
+   [metabase.lib.core :as lib]))
+
+(defn query=
+  "Compare two queries for equality, ignoring lib/uuids."
+  [expected actual]
+  (= (lib/remove-lib-uuids expected)
+     (lib/remove-lib-uuids actual)))


### PR DESCRIPTION
Cleanup, tests and misc follow-up work for https://github.com/metabase/metabase/pull/67368

* Uses metabase lib for adding segment-based filters and measure-based aggregations to queries
* Switches aggregation & filter tests to assert on MBQL5 queries, which we're now returning directly (that change is on the base PR)
* Adds a number of BE tests for measures and segments
* Some other misc pieces of cleanup/organization

I _believe_ the e2e failure is an underlying issue on the measures feature branch since it's unrelated to metabot. I think this PR can be merged into Thomas's with it failing and then we can rebase on master once measures is merged.