### PR TITLE
Don't show metrics in the join step

### DIFF
--- a/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
@@ -1446,3 +1446,34 @@ describe("issue #47005", () => {
       .should("be.visible");
   });
 });
+
+describe("issue 66210", () => {
+  const METRIC_NAME = "66210 metric";
+
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+
+    H.createQuestion({
+      name: METRIC_NAME,
+      query: {
+        "source-table": ORDERS_ID,
+        aggregation: [["count"]],
+      },
+      type: "metric",
+    });
+
+    cy.visit("/");
+  });
+
+  it("should not allow you to join on metrics", () => {
+    H.startNewQuestion();
+    H.miniPickerBrowseAll().click();
+    H.entityPickerModalItem(1, METRIC_NAME).should("be.visible");
+    H.entityPickerModalItem(1, "Orders").click();
+    H.join();
+    H.miniPickerBrowseAll().click();
+    H.entityPickerModalTab("Data").click();
+    H.entityPickerModalLevel(1).findByText(METRIC_NAME).should("not.exist");
+  });
+});

--- a/frontend/src/metabase/common/components/Pickers/DataPicker/components/DataPickerModal.tsx
+++ b/frontend/src/metabase/common/components/Pickers/DataPicker/components/DataPickerModal.tsx
@@ -82,7 +82,7 @@ export const DataPickerModal = ({
   onClose,
   shouldDisableItem,
   options,
-  models,
+  models = ["card", "dataset", "metric", "table"],
 }: Props) => {
   options = {
     ...OPTIONS,
@@ -219,19 +219,17 @@ export const DataPickerModal = ({
       computedTabs.push({
         id: "questions-tab",
         displayName: t`Data`,
-        models: [
-          "card" as const,
-          "dataset" as const,
-          "metric" as const,
-          "table" as const,
-        ],
+        models,
         folderModels: ["collection", "dashboard", "schema", "database"],
         icon: "folder",
         extraButtons: [filterButton],
         render: ({ onItemSelect }) => (
           <QuestionPicker
             initialValue={value}
-            models={QUESTION_PICKER_MODELS}
+            models={[
+              ...models,
+              ...(models.includes("card") ? ["dashboard" as const] : []),
+            ]}
             options={options}
             path={questionsPath}
             shouldShowItem={shouldShowItem}


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #66210
### Description
Removes metrics from the data picker in the join step

### How to verify
1. Make sure you have a metric on your instance
2. start a new question and pick a data source
3. Start a join, and look for your metric. It should not be shown.

### Demo
 
https://github.com/user-attachments/assets/3d8fab03-aca3-4106-bcbe-ec10ff5bf411


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
