### PR TITLE
fix: saving question with network throttling flake

### DIFF
--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -297,6 +297,7 @@ export function saveQuestion(
     idAlias = "questionId",
     shouldReplaceOriginalQuestion = false,
     shouldSaveAsNewQuestion = false,
+    waitForInitialName = false,
   } = {},
   pickEntityOptions = null,
 ) {
@@ -318,7 +319,17 @@ export function saveQuestion(
 
   cy.findByTestId("save-question-modal").within(() => {
     if (name) {
-      cy.findByLabelText("Name").clear().type(name);
+      if (waitForInitialName) {
+        /**
+         * we need to wait until the form finally initialize. Otherwise, the initialization will could the value.
+         */
+        cy.findByLabelText("Name")
+          .should("not.have.value", "")
+          .clear()
+          .type(name);
+      } else {
+        cy.findByLabelText("Name").clear().type(name);
+      }
     }
 
     if (pickEntityOptions) {

--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -304,13 +304,13 @@ export function saveQuestion(
   cy.intercept("POST", "/api/card").as("saveQuestion");
   if (waitForRecents) {
     cy.intercept("GET", "/api/activity/recents?context=selections*").as(
-      "saveQuestion_recents",
+      "saveQuestionRecents",
     );
   }
   cy.findByTestId("qb-header").button("Save").click();
   if (waitForRecents) {
     // Wait for recents API to complete before typing to avoid form reinitialization race condition
-    cy.wait("@saveQuestion_recents");
+    cy.wait("@saveQuestionRecents");
   }
   if (shouldReplaceOriginalQuestion) {
     modal().within(() => {

--- a/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
@@ -389,7 +389,10 @@ describe("issue 51020", () => {
       cy.button("Save").click();
       H.modal()
         .findByLabelText("Name")
-        .should("have.value", "Foo")
+        /**
+         * we need to wait until the form finally initialize. Otherwise, the initialization will could the value.
+         */
+        .should("not.have.value", "")
         .clear()
         .type("Model 51020");
       H.modal().button("Save").click();
@@ -401,10 +404,14 @@ describe("issue 51020", () => {
       H.miniPickerBrowseAll().click();
       H.entityPickerModalTab("Data").click();
       H.entityPickerModalItem(1, "Model 51020").click();
-      H.saveQuestion("Question 51020", undefined, {
-        tab: "Browse",
-        path: ["Our analytics"],
-      });
+      H.saveQuestion(
+        "Question 51020",
+        { waitForInitialName: true },
+        {
+          tab: "Browse",
+          path: ["Our analytics"],
+        },
+      );
 
       setupDashboard({
         modelName: "Model 51020",

--- a/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
@@ -389,7 +389,9 @@ describe("issue 51020", () => {
       cy.button("Save").click();
       H.modal()
         .findByLabelText("Name")
-        .type("{backspace}{backspace}{backspace}Model 51020");
+        .should("have.value", "Foo")
+        .clear()
+        .type("Model 51020");
       H.modal().button("Save").click();
       cy.wait("@createCard");
       cy.wait("@getCard");
@@ -415,7 +417,7 @@ describe("issue 51020", () => {
       dropTemporaryTable();
     });
 
-    it("should pass primary key attribute to execute action endpoint when it's populated with click behavior or URL (metabase#51020)", () => {
+    it("should pass primary key attribute to execute action endpoint when it's populated with click behavior or URL x(metabase#51020)", () => {
       cy.log(
         "check when primary key parameter is populated with click behavior",
       );

--- a/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
@@ -398,8 +398,9 @@ describe("issue 51020", () => {
       cy.findByTestId("run-button").click();
       cy.wait("@dataset");
       /**
-       * we need to "wait" until first recent_selections is completed, then after
-       * clicking "Save button" there will be another one we must wait for.
+       * we need to wait for the recent_selections twice as two requests are made in this test:
+       * 1. Somewhere before this line
+       * 2. After clicking on the "Save" button. - this is a must to wait as it re-initializes the form and interferes with typing
        */
       cy.wait("@recents_selections");
       cy.button("Save").click();
@@ -434,7 +435,7 @@ describe("issue 51020", () => {
       dropTemporaryTable();
     });
 
-    it("should pass primary key attribute to execute action endpoint when it's populated with click behavior or URL (metabase#51020)", () => {
+    it("should pass primary key attribute to execute action endpoint when it's populated with click behavior or URL x(metabase#51020)", () => {
       cy.log(
         "check when primary key parameter is populated with click behavior",
       );

--- a/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
@@ -431,7 +431,7 @@ describe("issue 51020", () => {
       dropTemporaryTable();
     });
 
-    it("should pass primary key attribute to execute action endpoint when it's populated with click behavior or URL x(metabase#51020)", () => {
+    it("should pass primary key attribute to execute action endpoint when it's populated with click behavior or URL (metabase#51020)", () => {
       cy.log(
         "check when primary key parameter is populated with click behavior",
       );


### PR DESCRIPTION
> [!WARNING]
> There is alternative solution here: https://github.com/metabase/metabase/pull/67525

Closes GDGT-1423

### Description
The were two issues in the test:
1. fast typing in `EntityPickerModal` switches to search tab before picker content loads, so no folder is selected and "Everywhere" toggle doesn't appear and search happens in "Our analytic" folder. That means it isn't able to find the Foo table.
2. the form reinitialization and typing at the same time in `SaveModalForm` only when network throttling is enabled. I found the main reason: `SaveQuestionProvider` runs `/api/activity/recents?context=selections` and reinitializes the form once the request is finished. That means any changes in any input are overridden by this reinititalization. This leads to saving a model and then a question with wrong name.

### How to verify
Successful stress test run [with network throttling](https://github.com/metabase/metabase/actions/runs/20475136429)

Recorded this weird behaviour:
https://github.com/user-attachments/assets/c39efc1e-06bf-4ba2-96fc-e8802f66fb7f

