### PR TITLE
Test coercion strategy

### DIFF
--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -1498,6 +1498,7 @@ describe("issue QUE-2567", () => {
               5,
               "day",
             ],
+            Bar: ["datetime", "2025-12-24"],
           },
         },
       },
@@ -1509,11 +1510,27 @@ describe("issue QUE-2567", () => {
       cy.findByText("Foo").click();
       cy.findByText("Previous 12 months").click();
     });
+
+    H.filter();
+    H.popover().within(() => {
+      cy.findByText("Bar").click();
+      cy.findByText("Previous 12 months").click();
+    });
   });
 
   it("should be possible to edit a datetime filter that is based on a custom expression (QUE-2567)", () => {
     cy.log("Editing the filter should show the date picker");
-    cy.findByTestId("filter-pill").click();
+    cy.findAllByTestId("filter-pill").should("have.length", 2).eq(0).click();
+    H.popover().within(() => {
+      cy.findByText("Previous").should("be.visible");
+      cy.findByText("Current").should("be.visible");
+      cy.findByText("Next").should("be.visible");
+    });
+
+    cy.log(
+      "Editing the filter should show the date picker for coerced datetime",
+    );
+    cy.findAllByTestId("filter-pill").should("have.length", 2).eq(1).click();
     H.popover().within(() => {
       cy.findByText("Previous").should("be.visible");
       cy.findByText("Current").should("be.visible");

--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -1538,3 +1538,31 @@ describe("issue QUE-2567", () => {
     });
   });
 });
+
+describe("issue QUE-2567 (bis)", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    cy.request("PUT", `/api/field/${ORDERS.QUANTITY}`, {
+      coercion_strategy: "Coercion/UNIXSeconds->DateTime",
+      semantic_type: null,
+    });
+    H.openOrdersTable();
+
+    H.filter();
+    H.popover().within(() => {
+      cy.findByText("Quantity").click();
+      cy.findByText("Previous 12 months").click();
+    });
+  });
+
+  it("should open the datetime filter for coerced columns", () => {
+    cy.log("Editing the filter should show the date picker");
+    cy.findByTestId("filter-pill").click();
+    H.popover().within(() => {
+      cy.findByText("Previous").should("be.visible");
+      cy.findByText("Current").should("be.visible");
+      cy.findByText("Next").should("be.visible");
+    });
+  });
+});

--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -86,7 +86,7 @@
   [expression typ]
   (isa?
    (or (and (clause? expression)
-            ((some-fn :metabase.lib.field/original-effective-type :base-type) (lib.options/options expression)))
+            ((some-fn :metabase.lib.field/original-effective-type :effective-type :base-type) (lib.options/options expression)))
        (lib.schema.expression/type-of expression))
    typ))
 

--- a/test/metabase/lib/filter_test.cljc
+++ b/test/metabase/lib/filter_test.cljc
@@ -926,7 +926,7 @@
   (let [query (lib/native-query meta/metadata-provider "SELECT * FROM ORDERS;")]
     (is (= "Created At is Jan 1 – Dec 31, 2023"
            (lib/display-name query [:= {:lib/uuid "79e513f8-af80-4c15-96b6-e72eff7f37cc"}
-                                    [:field {:effective-type :type/Integer
+                                    [:field {:effective-type :type/DateTime
                                              :base-type      :type/DateTime
                                              :temporal-unit  :year
                                              :lib/uuid       "1fe5dc66-54af-4368-9e4a-1e64a1fbe484"}


### PR DESCRIPTION
Adds a test for coerced columns as a follow up to #67064

I also uncovered another bug: when using datetime filters on coerced fields, the filter opens always as the custom expression editor. This is because `original-isa?` does not take into account the `:effective-type` of the field, and just checks against the base type.

This PR fixes that.

For example, when coercing `Quantity` to a datetime:

### Before
<img width="719" height="493" alt="Screenshot 2025-12-24 at 14 44 22" src="https://github.com/user-attachments/assets/1e9b1edc-1ba9-4df2-a46a-5b382b2a3db1" />


### After
<img width="417" height="341" alt="Screenshot 2025-12-24 at 14 47 08" src="https://github.com/user-attachments/assets/34ef136f-458f-46e3-a898-d31a66873e2c" />

