### PR TITLE
Fix flake in model test

### DIFF
--- a/e2e/test/scenarios/models/reproductions.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.js
@@ -509,25 +509,25 @@ describe("filtering based on the remapped column name should result in a correct
       H.visitQuestion(id);
 
       // Turn the question into a model
-      cy.request("PUT", `/api/card/${id}`, { type: "model" });
+      cy.request("PUT", `/api/card/${id}`, { type: "model" }).then(() => {
+        // Let's go straight to the model metadata editor
+        cy.visit(`/model/${id}/columns`);
+        cy.findByText("Database column this maps to").should("be.visible");
 
-      // Let's go straight to the model metadata editor
-      cy.visit(`/model/${id}/columns`);
-      cy.findByText("Database column this maps to").should("be.visible");
+        // The first column `ID` is automatically selected
+        H.mapColumnTo({ table: "Orders", column: "ID" });
+        cy.findByText("ALIAS_CREATED_AT").click();
 
-      // The first column `ID` is automatically selected
-      H.mapColumnTo({ table: "Orders", column: "ID" });
-      cy.findByText("ALIAS_CREATED_AT").click();
+        H.mapColumnTo({ table: "Orders", column: "Created At" });
 
-      H.mapColumnTo({ table: "Orders", column: "Created At" });
+        // Make sure the column name updated before saving
+        cy.findByDisplayValue("Created At");
 
-      // Make sure the column name updated before saving
-      cy.findByDisplayValue("Created At");
+        cy.button("Save changes").click();
+        cy.wait("@updateModel");
 
-      cy.button("Save changes").click();
-      cy.wait("@updateModel");
-
-      H.visitModel(id);
+        H.visitModel(id);
+      });
     });
   });
 

--- a/e2e/test/scenarios/models/reproductions.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.js
@@ -505,29 +505,26 @@ describe("filtering based on the remapped column name should result in a correct
           'select 1 as "ID", current_timestamp::datetime as "ALIAS_CREATED_AT"',
       },
     }).then(({ body: { id } }) => {
-      // Visit the question to first load metadata
-      H.visitQuestion(id);
-
       // Turn the question into a model
-      cy.request("PUT", `/api/card/${id}`, { type: "model" }).then(() => {
-        // Let's go straight to the model metadata editor
-        cy.visit(`/model/${id}/columns`);
-        cy.findByText("Database column this maps to").should("be.visible");
+      cy.request("PUT", `/api/card/${id}`, { type: "model" });
 
-        // The first column `ID` is automatically selected
-        H.mapColumnTo({ table: "Orders", column: "ID" });
-        cy.findByText("ALIAS_CREATED_AT").click();
+      // Let's go straight to the model metadata editor
+      cy.visit(`/model/${id}/columns`);
+      cy.findByText("Database column this maps to").should("be.visible");
 
-        H.mapColumnTo({ table: "Orders", column: "Created At" });
+      // The first column `ID` is automatically selected
+      H.mapColumnTo({ table: "Orders", column: "ID" });
+      cy.findByText("ALIAS_CREATED_AT").click();
 
-        // Make sure the column name updated before saving
-        cy.findByDisplayValue("Created At");
+      H.mapColumnTo({ table: "Orders", column: "Created At" });
 
-        cy.button("Save changes").click();
-        cy.wait("@updateModel");
+      // Make sure the column name updated before saving
+      cy.findByDisplayValue("Created At");
 
-        H.visitModel(id);
-      });
+      cy.button("Save changes").click();
+      cy.wait("@updateModel");
+
+      H.visitModel(id);
     });
   });
 


### PR DESCRIPTION
Resolves QUE-2810

Fix flake in beforeEach hook of model test

[stress test (throttling)](https://github.com/metabase/metabase/actions/runs/20569015756)
[stress test (no throttling)](https://github.com/metabase/metabase/actions/runs/20585103249)

The unthrottled stress test succeeds but the throttled one fails with what seems to be an error related to the throttling more than the actual test:

```
Route: {
  "method": "GET",
  "url": "**"
}

Error: Socket closed before finished writing response
    at <embedded>:2743:51372
    at tryCatcher (/home/runner/.cache/Cypress/14.5.3/Cypress/resources/app/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/home/runner/.cache/Cypress/14.5.3/Cypress/resources/app/node_modules/bluebird/js/release/promise.js:512:31)
    at Promise._settlePromise (/home/runner/.cache/Cypress/14.5.3/Cypress/resources/app/node_modules/bluebird/js/release/promise.js:569:18)
    at Promise._settlePromise0 (/home/runner/.cache/Cypress/14.5.3/Cypress/resources/app/node_modules/bluebird/js/release/promise.js:614:10)
    at Promise._settlePromises (/home/runner/.cache/Cypress/14.5.3/Cypress/resources/app/node_modules/bluebird/js/release/promise.js:694:18)
    at _drainQueueStep (/home/runner/.cache/Cypress/14.5.3/Cypress/resources/app/node_modules/bluebird/js/release/async.js:138:12)
    at _drainQueue (/home/runner/.cache/Cypress/14.5.3/Cypress/resources/app/node_modules/bluebird/js/release/async.js:131:9)
    at Async._drainQueues (/home/runner/.cache/Cypress/14.5.3/Cypress/resources/app/node_modules/bluebird/js/release/async.js:147:5)
    at Immediate._onImmediate (/home/runner/.cache/Cypress/14.5.3/Cypress/resources/app/node_modules/bluebird/js/release/async.js:17:14)
    at process.processImmediate (node:internal/timers:483:21)
```

The only intercept for `"**"` I can find is related to the stress test [throttling](https://github.com/metabase/metabase/blob/master/e2e/support/cypress.js#L176-L183).