### PR TITLE
Hide subscription button when dashboard has no data cards on modular embeddings

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-ee/subscriptions/DashboardSubscriptionsButton.tsx
+++ b/enterprise/frontend/src/embedding-sdk-ee/subscriptions/DashboardSubscriptionsButton.tsx
@@ -4,6 +4,7 @@ import type { DashboardSubscriptionsButtonProps } from "embedding-sdk-bundle/com
 import { ToolbarButton } from "metabase/common/components/ToolbarButton";
 import { useHasEmailSetup } from "metabase/common/hooks";
 import { toggleSharing } from "metabase/dashboard/actions";
+import { useDashboardContext } from "metabase/dashboard/context";
 import { useDispatch } from "metabase/lib/redux";
 
 /**
@@ -15,9 +16,18 @@ export const DashboardSubscriptionsButton = (
   const dispatch = useDispatch();
   const handleClick = () => dispatch(toggleSharing());
 
+  const { dashboard } = useDashboardContext();
+
+  /**
+   * Use the same logic as in the core app
+   * @see {@link https://github.com/metabase/metabase/blob/71ed90d16cb7c64946135d404c1a79ef65995f03/frontend/src/metabase/notifications/NotificationsActionsMenu/DashboardSubscriptionMenuItem.tsx#L26-L28}
+   */
+  const hasDataCards = dashboard?.dashcards?.some(
+    (dashCard) => !["text", "heading"].includes(dashCard.card.display),
+  );
   // We decided not to show the subscriptions button if email is not set up
   const hasEmailSetup = useHasEmailSetup();
-  if (!hasEmailSetup) {
+  if (!hasEmailSetup || !hasDataCards) {
     return null;
   }
 

--- a/enterprise/frontend/src/embedding-sdk-ee/subscriptions/DashboardSubscriptionsButton.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk-ee/subscriptions/DashboardSubscriptionsButton.unit.spec.tsx
@@ -2,22 +2,66 @@ import { screen, waitFor } from "@testing-library/react";
 
 import {
   findRequests,
+  setupDashboardEndpoints,
+  setupDashboardQueryMetadataEndpoint,
   setupNotificationChannelsEndpoints,
 } from "__support__/server-mocks";
+import { setupDashcardQueryEndpoints } from "__support__/server-mocks/dashcard";
 import { renderWithProviders } from "__support__/ui";
+import { DashboardContextProvider } from "metabase/dashboard/context";
+import type { DashboardCard } from "metabase-types/api";
+import {
+  createMockCard,
+  createMockDashboard,
+  createMockDashboardCard,
+  createMockDashboardQueryMetadata,
+  createMockDataset,
+  createMockStructuredDatasetQuery,
+} from "metabase-types/api/mocks";
+import {
+  ORDERS_ID,
+  createSampleDatabase,
+} from "metabase-types/api/mocks/presets";
 
 import { DashboardSubscriptionsButton } from "./DashboardSubscriptionsButton";
 
+const tableCard = createMockCard({
+  id: 1,
+  dataset_query: createMockStructuredDatasetQuery({
+    query: { "source-table": ORDERS_ID },
+  }),
+  name: "Here is a card title",
+});
+const tableDashcard = createMockDashboardCard({
+  id: 1,
+  card_id: tableCard.id,
+  card: tableCard,
+});
+
 interface SetupOpts {
+  dashcards?: DashboardCard[];
   emailConfigured?: boolean;
 }
-const setup = (opts: SetupOpts = {}) => {
+const setup = ({
+  emailConfigured,
+  dashcards = [tableDashcard],
+}: SetupOpts = {}) => {
   setupNotificationChannelsEndpoints({
     email: {
-      configured: opts.emailConfigured,
+      configured: emailConfigured,
     },
   });
-  renderWithProviders(<DashboardSubscriptionsButton />);
+
+  const dashboardId = 1;
+  setupDashboardRelatedEndpoints(dashboardId, dashcards);
+  renderWithProviders(
+    <DashboardContextProvider
+      dashboardId={dashboardId}
+      navigateToNewCardFromDashboard={jest.fn()}
+    >
+      <DashboardSubscriptionsButton />
+    </DashboardContextProvider>,
+  );
 };
 
 describe("DashboardSubscriptionsButton", () => {
@@ -27,19 +71,73 @@ describe("DashboardSubscriptionsButton", () => {
     expect(
       await screen.findByRole("button", { name: "Subscriptions" }),
     ).toBeInTheDocument();
-    const gets = await findRequests("GET");
-    expect(gets).toHaveLength(1);
+    const subscriptionChannelInfoRequests =
+      await getSubscriptionChannelInfoRequests();
+    expect(subscriptionChannelInfoRequests).toHaveLength(1);
   });
 
   it("should not render the subscriptions button when email is not configured", async () => {
     setup({ emailConfigured: false });
     // Ensure the API finishes loading, otherwise, the assertion below will always pass because the API hasn't returned yet
     await waitFor(async () => {
-      const gets = await findRequests("GET");
-      expect(gets).toHaveLength(1);
+      expect(await getSubscriptionChannelInfoRequests()).toHaveLength(1);
+    });
+    expect(
+      screen.queryByRole("button", { name: "Subscriptions" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should not render the subscriptions button when there are no data cards on the dashboard even when email is configured", async () => {
+    setup({
+      emailConfigured: true,
+      dashcards: [],
+    });
+
+    // Ensure the API finishes loading, otherwise, the assertion below will always pass because the API hasn't returned yet
+    await waitFor(async () => {
+      expect(await getDashboardRequests()).toHaveLength(1);
     });
     expect(
       screen.queryByRole("button", { name: "Subscriptions" }),
     ).not.toBeInTheDocument();
   });
 });
+
+function setupDashboardRelatedEndpoints(
+  dashboardId: number,
+  dashcards: DashboardCard[],
+) {
+  const dashboard = createMockDashboard({
+    id: dashboardId,
+    name: "Test Dashboard",
+    dashcards,
+  });
+  const database = createSampleDatabase();
+
+  setupDashboardEndpoints(dashboard);
+
+  setupDashboardQueryMetadataEndpoint(
+    dashboard,
+    createMockDashboardQueryMetadata({
+      databases: [database],
+    }),
+  );
+
+  setupDashcardQueryEndpoints(dashboardId, tableDashcard, createMockDataset());
+
+  return dashboardId;
+}
+
+async function getSubscriptionChannelInfoRequests() {
+  const gets = await findRequests("GET");
+  return gets.filter((req) =>
+    req.url.match(new RegExp("/api/pulse/form_input$")),
+  );
+}
+
+async function getDashboardRequests() {
+  const gets = await findRequests("GET");
+  return gets.filter((req) =>
+    req.url.match(new RegExp(`/api/dashboard/\\d+(?!/)`)),
+  );
+}


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #67462
closes EMB-1155

### Description

I missed this logic from the core app. When there's no data cards, we hide the subscription button completely. We need to replicate the same logic on modular embeddings too.

### How to verify
1. Setup SMTP server on Metabase
2. Try to embed either using modular embedding or modular embedding SDK. The former is easier to test.
3. For modular embedding, select a dahsboard, sharing icon > Embed > Select SSO as the auth method. Select "Allow subscriptions", now based on the dashboard you're on. If the dashboard doesn't have any data card, the subscription button would be invisible, if there is at least a single data card, the subscription button would be visible.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
