### PR TITLE
Don't close InteractiveQuestion editor on Filters change

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/create-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/create-question.cy.spec.tsx
@@ -101,6 +101,7 @@ describe("scenarios > embedding-sdk > interactive-question > creating a question
     });
 
     getSdkRoot().findByText(expectedQuestionName).should("be.visible");
+    getSdkRoot().findByTestId("visualization-root").should("be.visible");
   });
 
   it("can save a question in a dashboard", () => {

--- a/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
@@ -1,14 +1,10 @@
 const { H } = cy;
 import { InteractiveQuestion } from "@metabase/embedding-sdk-react";
 
-import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { createQuestion } from "e2e/support/helpers";
 import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
 import { mountSdkContent } from "e2e/support/helpers/embedding-sdk-component-testing/component-embedding-sdk-helpers";
 import { signInAsAdminAndEnableEmbeddingSdk } from "e2e/support/helpers/embedding-sdk-testing";
 import { mockAuthProviderAndJwtSignIn } from "e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers";
-
-const { ORDERS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > embedding-sdk > interactive-question", () => {
   beforeEach(() => {
@@ -24,16 +20,6 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
         idAlias: "sqlQuestionId",
       },
     );
-
-    createQuestion({
-      name: "Orders Question",
-      query: {
-        "source-table": ORDERS_ID,
-        limit: 10,
-      },
-    }).then(({ body: question }) => {
-      cy.wrap(question.id).as("ordersQuestionId");
-    });
 
     cy.signOut();
 
@@ -60,29 +46,6 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
         cy.button(">").click();
       });
       H.assertTableRowsCount(4);
-    });
-  });
-
-  it("should stay in editor mode after adding a filter for the first time for an existing saved question (EMB-1077)", () => {
-    cy.get<number>("@ordersQuestionId").then((questionId) => {
-      mountSdkContent(<InteractiveQuestion questionId={questionId} />);
-    });
-
-    getSdkRoot().within(() => {
-      cy.findByTestId("notebook-button").click();
-
-      cy.findByRole("button", { name: "Visualize" }).should("exist");
-
-      cy.findAllByTestId("action-buttons").find(".Icon-filter").click();
-    });
-
-    H.popover().within(() => {
-      cy.findByText("Created At").click();
-      cy.findByText("Previous 7 days").click();
-    });
-
-    getSdkRoot().within(() => {
-      cy.findByRole("button", { name: "Visualize" }).should("exist");
     });
   });
 });

--- a/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
@@ -20,7 +20,6 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
         idAlias: "sqlQuestionId",
       },
     );
-
     cy.signOut();
 
     mockAuthProviderAndJwtSignIn();

--- a/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
@@ -1,10 +1,14 @@
 const { H } = cy;
 import { InteractiveQuestion } from "@metabase/embedding-sdk-react";
 
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { createQuestion } from "e2e/support/helpers";
 import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
 import { mountSdkContent } from "e2e/support/helpers/embedding-sdk-component-testing/component-embedding-sdk-helpers";
 import { signInAsAdminAndEnableEmbeddingSdk } from "e2e/support/helpers/embedding-sdk-testing";
 import { mockAuthProviderAndJwtSignIn } from "e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers";
+
+const { ORDERS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > embedding-sdk > interactive-question", () => {
   beforeEach(() => {
@@ -20,6 +24,17 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
         idAlias: "sqlQuestionId",
       },
     );
+
+    createQuestion({
+      name: "Orders Question",
+      query: {
+        "source-table": ORDERS_ID,
+        limit: 10,
+      },
+    }).then(({ body: question }) => {
+      cy.wrap(question.id).as("ordersQuestionId");
+    });
+
     cy.signOut();
 
     mockAuthProviderAndJwtSignIn();
@@ -45,6 +60,29 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
         cy.button(">").click();
       });
       H.assertTableRowsCount(4);
+    });
+  });
+
+  it("should stay in editor mode after adding a filter for the first time for an existing saved question (EMB-1077)", () => {
+    cy.get<number>("@ordersQuestionId").then((questionId) => {
+      mountSdkContent(<InteractiveQuestion questionId={questionId} />);
+    });
+
+    getSdkRoot().within(() => {
+      cy.findByTestId("notebook-button").click();
+
+      cy.findByRole("button", { name: "Visualize" }).should("exist");
+
+      cy.findAllByTestId("action-buttons").find(".Icon-filter").click();
+    });
+
+    H.popover().within(() => {
+      cy.findByText("Created At").click();
+      cy.findByText("Previous 7 days").click();
+    });
+
+    getSdkRoot().within(() => {
+      cy.findByRole("button", { name: "Visualize" }).should("exist");
     });
   });
 });

--- a/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
@@ -632,4 +632,29 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
       expect(interception.response?.statusCode).to.equal(200);
     });
   });
+
+  it("should stay in editor mode after adding a filter for the first time for an existing saved question (EMB-1077)", () => {
+    cy.get<string>("@questionId").then((questionId) => {
+      mountSdkContent(<InteractiveQuestion questionId={questionId} />);
+    });
+
+    getSdkRoot().within(() => {
+      cy.findByTestId("notebook-button").click();
+
+      cy.findByRole("button", { name: "Visualize" }).should("exist");
+
+      cy.findByTestId("step-data-0-0").within(() => {
+        cy.findAllByTestId("action-buttons").find(".Icon-filter").click();
+      });
+    });
+
+    H.popover().within(() => {
+      cy.findByText("Created At").click();
+      cy.findByText("Previous 7 days").click();
+    });
+
+    getSdkRoot().within(() => {
+      cy.findByRole("button", { name: "Visualize" }).should("exist");
+    });
+  });
 });

--- a/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
@@ -657,4 +657,83 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
       cy.findByRole("button", { name: "Visualize" }).should("exist");
     });
   });
+
+  it("should close the editor after modifying and saving an existing question in-place", () => {
+    cy.get<number>("@questionId").then((questionId) => {
+      mountSdkContent(
+        <InteractiveQuestion questionId={questionId} isSaveEnabled />,
+      );
+    });
+
+    getSdkRoot().within(() => {
+      cy.findByTestId("visualization-root").should("be.visible");
+      cy.findByTestId("notebook-button").click();
+
+      cy.findByTestId("step-data-0-0").within(() => {
+        cy.findAllByTestId("action-buttons").find(".Icon-filter").click();
+      });
+    });
+
+    H.popover().findByText("Product ID").click();
+    H.popover().within(() => {
+      cy.findByPlaceholderText("Enter an ID").type("1");
+      cy.findByText("Add filter").click();
+    });
+
+    getSdkRoot().within(() => {
+      cy.findByText("Back to visualization").should("be.visible");
+      cy.findByRole("button", { name: "Save" }).click();
+    });
+
+    H.modal().within(() => {
+      cy.findByText(/Replace original question/).click();
+      cy.findByRole("button", { name: "Save" }).click();
+    });
+
+    getSdkRoot().within(() => {
+      cy.findByText("Back to visualization").should("not.exist");
+      cy.findByTestId("visualization-root").should("be.visible");
+    });
+  });
+
+  it("should close the editor after modifying and saving an existing question as a new question", () => {
+    cy.get<number>("@questionId").then((questionId) => {
+      mountSdkContent(
+        <InteractiveQuestion questionId={questionId} isSaveEnabled />,
+      );
+    });
+
+    getSdkRoot().within(() => {
+      cy.findByTestId("visualization-root").should("be.visible");
+      cy.findByTestId("notebook-button").click();
+
+      cy.findByTestId("step-data-0-0").within(() => {
+        cy.findAllByTestId("action-buttons").find(".Icon-filter").click();
+      });
+    });
+
+    H.popover().findByText("Product ID").click();
+    H.popover().within(() => {
+      cy.findByPlaceholderText("Enter an ID").type("1");
+      cy.findByText("Add filter").click();
+    });
+
+    getSdkRoot().within(() => {
+      cy.findByText("Back to visualization").should("be.visible");
+      cy.findByRole("button", { name: "Save" }).click();
+    });
+
+    H.modal().within(() => {
+      cy.findByText("Save as new question").click();
+      cy.findByPlaceholderText("What is the name of your question?")
+        .clear()
+        .type("Orders Copy");
+      cy.findByRole("button", { name: "Save" }).click();
+    });
+
+    getSdkRoot().within(() => {
+      cy.findByText("Back to visualization").should("not.exist");
+      cy.findByTestId("visualization-root").should("be.visible");
+    });
+  });
 });

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.tsx
@@ -2,6 +2,7 @@ import { useDisclosure } from "@mantine/hooks";
 import cx from "classnames";
 import type { ReactElement } from "react";
 import { useEffect, useMemo } from "react";
+import { usePrevious } from "react-use";
 import { t } from "ttag";
 
 import {
@@ -114,16 +115,18 @@ export const SdkQuestionDefaultView = ({
     return isNative;
   }, [question]);
 
+  const prevOriginalId = usePrevious(originalId);
+
   useEffect(() => {
     if (isNewQuestion && !isQuestionSaved) {
       // When switching to new question, open the notebook editor
       openEditor();
-    } else if (!isNewQuestion) {
-      // When no longer in a notebook editor, switch back to visualization.
-      // When a question is saved, also switch back to visualization.
+    } else if (prevOriginalId === "new" && !isNewQuestion) {
+      // Only close editor when transitioning from a new question to an existing one
+      // (e.g., after saving or switching questions), not on every render
       closeEditor();
     }
-  }, [isNewQuestion, isQuestionSaved, openEditor, closeEditor]);
+  }, [prevOriginalId, isNewQuestion, isQuestionSaved, openEditor, closeEditor]);
 
   // When visualizing a question for the first time, there is no query result yet.
   const isQueryResultLoading =

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.tsx
@@ -89,6 +89,7 @@ export const SdkQuestionDefaultView = ({
     withDownloads,
     onReset,
     onNavigateBack,
+    queryQuestion,
   } = useSdkQuestionContext();
 
   const { isBreadcrumbEnabled, reportLocation } = useSdkBreadcrumbs();
@@ -125,6 +126,10 @@ export const SdkQuestionDefaultView = ({
       closeEditor();
     } else if (!prevIsQuestionSaved && isQuestionSaved) {
       closeEditor();
+
+      if (!queryResults) {
+        void queryQuestion();
+      }
     }
   }, [
     prevOriginalId,
@@ -133,6 +138,8 @@ export const SdkQuestionDefaultView = ({
     isQuestionSaved,
     openEditor,
     closeEditor,
+    queryResults,
+    queryQuestion,
   ]);
 
   // When visualizing a question for the first time, there is no query result yet.

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.tsx
@@ -116,17 +116,24 @@ export const SdkQuestionDefaultView = ({
   }, [question]);
 
   const prevOriginalId = usePrevious(originalId);
+  const prevIsQuestionSaved = usePrevious(isQuestionSaved);
 
   useEffect(() => {
     if (isNewQuestion && !isQuestionSaved) {
-      // When switching to new question, open the notebook editor
       openEditor();
     } else if (prevOriginalId === "new" && !isNewQuestion) {
-      // Only close editor when transitioning from a new question to an existing one
-      // (e.g., after saving or switching questions), not on every render
+      closeEditor();
+    } else if (!prevIsQuestionSaved && isQuestionSaved) {
       closeEditor();
     }
-  }, [prevOriginalId, isNewQuestion, isQuestionSaved, openEditor, closeEditor]);
+  }, [
+    prevOriginalId,
+    prevIsQuestionSaved,
+    isNewQuestion,
+    isQuestionSaved,
+    openEditor,
+    closeEditor,
+  ]);
 
   // When visualizing a question for the first time, there is no query result yet.
   const isQueryResultLoading =

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-existing-question-editor-sync.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-existing-question-editor-sync.ts
@@ -1,0 +1,40 @@
+import { useEffect } from "react";
+import { usePrevious } from "react-use";
+
+interface UseExistingQuestionEditorSyncOptions {
+  enabled: boolean;
+  originalId: string | number | null | undefined;
+  isQuestionSaved: boolean | undefined;
+  closeEditor: () => void;
+}
+
+export function useExistingQuestionEditorSync({
+  enabled,
+  originalId,
+  isQuestionSaved,
+  closeEditor,
+}: UseExistingQuestionEditorSyncOptions) {
+  const prevOriginalId = usePrevious(originalId);
+  const prevIsQuestionSaved = usePrevious(isQuestionSaved);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    const isTransitionToExistingQuestion =
+      prevOriginalId === "new" && originalId !== "new";
+    const isTransitionToSaved = !prevIsQuestionSaved && isQuestionSaved;
+
+    if (isTransitionToExistingQuestion || isTransitionToSaved) {
+      closeEditor();
+    }
+  }, [
+    prevOriginalId,
+    prevIsQuestionSaved,
+    enabled,
+    isQuestionSaved,
+    closeEditor,
+    originalId,
+  ]);
+}

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-existing-question-editor-sync.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-existing-question-editor-sync.ts
@@ -8,6 +8,11 @@ interface UseExistingQuestionEditorSyncOptions {
   closeEditor: () => void;
 }
 
+/**
+ * Manages editor state for existing questions (originalId !== "new").
+ * - Closes the editor when transitioning from a new question to an existing one
+ * - Closes the editor when an existing question finishes loading
+ */
 export function useExistingQuestionEditorSync({
   enabled,
   originalId,

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-existing-question-editor-sync.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-existing-question-editor-sync.ts
@@ -20,7 +20,7 @@ export function useExistingQuestionEditorSync({
   closeEditor,
 }: UseExistingQuestionEditorSyncOptions) {
   const prevOriginalId = usePrevious(originalId);
-  const prevIsQuestionSaved = usePrevious(isQuestionSaved);
+  const isPrevQuestionSaved = usePrevious(isQuestionSaved);
 
   useEffect(() => {
     if (!enabled) {
@@ -29,14 +29,14 @@ export function useExistingQuestionEditorSync({
 
     const isTransitionToExistingQuestion =
       prevOriginalId === "new" && originalId !== "new";
-    const isTransitionToSaved = !prevIsQuestionSaved && isQuestionSaved;
+    const isTransitionToSaved = !isPrevQuestionSaved && isQuestionSaved;
 
     if (isTransitionToExistingQuestion || isTransitionToSaved) {
       closeEditor();
     }
   }, [
     prevOriginalId,
-    prevIsQuestionSaved,
+    isPrevQuestionSaved,
     enabled,
     isQuestionSaved,
     closeEditor,

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-new-question-editor-sync.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-new-question-editor-sync.ts
@@ -11,8 +11,11 @@ interface UseNewQuestionEditorSyncOptions {
 }
 
 /**
- * Handles editor state for new questions.
- * Opens editor automatically and runs query after saving.
+ * Manages editor state for new questions
+ * - Opens the editor automatically when the question is unsaved
+ * - Closes the editor when the question is saved
+ * - Runs the query after saving if no results are available yet
+ *   (handles the case when user saves without visualizing first)
  */
 export function useNewQuestionEditorSync({
   enabled,

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-new-question-editor-sync.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-new-question-editor-sync.ts
@@ -1,0 +1,48 @@
+import { useEffect, useRef } from "react";
+import { usePrevious } from "react-use";
+
+interface UseNewQuestionEditorSyncOptions {
+  enabled: boolean;
+  isQuestionSaved: boolean | undefined;
+  queryResults: unknown;
+  queryQuestion: () => Promise<unknown>;
+  openEditor: () => void;
+  closeEditor: () => void;
+}
+
+/**
+ * Handles editor state for new questions.
+ * Opens editor automatically and runs query after saving.
+ */
+export function useNewQuestionEditorSync({
+  enabled,
+  isQuestionSaved,
+  queryResults,
+  queryQuestion,
+  openEditor,
+  closeEditor,
+}: UseNewQuestionEditorSyncOptions) {
+  const isPrevQuestionSaved = usePrevious(isQuestionSaved);
+
+  const queryResultsRef = useRef(queryResults);
+  const queryQuestionRef = useRef(queryQuestion);
+
+  queryResultsRef.current = queryResults;
+  queryQuestionRef.current = queryQuestion;
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    if (!isQuestionSaved) {
+      openEditor();
+    } else if (isPrevQuestionSaved === false) {
+      closeEditor();
+
+      if (!queryResultsRef.current) {
+        queryQuestionRef.current();
+      }
+    }
+  }, [enabled, isQuestionSaved, isPrevQuestionSaved, openEditor, closeEditor]);
+}

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-new-question-editor-sync.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-new-question-editor-sync.ts
@@ -1,5 +1,5 @@
-import { useEffect, useRef } from "react";
-import { usePrevious } from "react-use";
+import { useEffect } from "react";
+import { useLatest, usePrevious } from "react-use";
 
 interface UseNewQuestionEditorSyncOptions {
   enabled: boolean;
@@ -26,26 +26,32 @@ export function useNewQuestionEditorSync({
   closeEditor,
 }: UseNewQuestionEditorSyncOptions) {
   const isPrevQuestionSaved = usePrevious(isQuestionSaved);
-
-  const queryResultsRef = useRef(queryResults);
-  const queryQuestionRef = useRef(queryQuestion);
-
-  queryResultsRef.current = queryResults;
-  queryQuestionRef.current = queryQuestion;
+  const queryResultsRef = useLatest(queryResults);
+  const queryQuestionRef = useLatest(queryQuestion);
 
   useEffect(() => {
     if (!enabled) {
       return;
     }
 
+    const isTransitionToSaved = !isPrevQuestionSaved && isQuestionSaved;
+
     if (!isQuestionSaved) {
       openEditor();
-    } else if (isPrevQuestionSaved === false) {
+    } else if (isTransitionToSaved) {
       closeEditor();
 
       if (!queryResultsRef.current) {
         queryQuestionRef.current();
       }
     }
-  }, [enabled, isQuestionSaved, isPrevQuestionSaved, openEditor, closeEditor]);
+  }, [
+    enabled,
+    isQuestionSaved,
+    isPrevQuestionSaved,
+    openEditor,
+    closeEditor,
+    queryResultsRef,
+    queryQuestionRef,
+  ]);
 }

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-question-editor-sync.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-question-editor-sync.ts
@@ -1,6 +1,7 @@
 import { useDisclosure } from "@mantine/hooks";
-import { useEffect, useRef } from "react";
-import { usePrevious } from "react-use";
+
+import { useExistingQuestionEditorSync } from "./use-existing-question-editor-sync";
+import { useNewQuestionEditorSync } from "./use-new-question-editor-sync";
 
 interface UseQuestionEditorSyncOptions {
   originalId: string | number | null | undefined;
@@ -30,66 +31,21 @@ export function useQuestionEditorSync({
     { close: closeEditor, toggle: toggleEditor, open: openEditor },
   ] = useDisclosure(isNewQuestion && !isQuestionSaved);
 
-  const prevOriginalId = usePrevious(originalId);
-  const prevIsQuestionSaved = usePrevious(isQuestionSaved);
-
-  // Use refs to avoid triggering effect when these change
-  const queryResultsRef = useRef(queryResults);
-  const queryQuestionRef = useRef(queryQuestion);
-
-  queryResultsRef.current = queryResults;
-  queryQuestionRef.current = queryQuestion;
-
-  // Track when user switches to a different question (vs saving current one).
-  // This distinguishes between:
-  // - Save: originalId stays same (or changes from "new" to real ID via prop)
-  // - Switch: originalId changes to a different question's ID
-  const isSwitchingQuestionsRef = useRef(false);
-
-  const didQuestionIdChange =
-    prevOriginalId !== undefined && prevOriginalId !== originalId;
-
-  if (didQuestionIdChange) {
-    isSwitchingQuestionsRef.current = true;
-  }
-
-  useEffect(() => {
-    // Open editor for new unsaved questions
-    if (isNewQuestion && !isQuestionSaved) {
-      openEditor();
-      return;
-    }
-
-    // Close editor when transitioning from new question to existing
-    if (prevOriginalId === "new" && !isNewQuestion) {
-      closeEditor();
-      return;
-    }
-
-    // Handle question becoming saved (either via save action or loading existing)
-    if (!prevIsQuestionSaved && isQuestionSaved) {
-      closeEditor();
-
-      // Run query only when saving (not when switching/loading a different question).
-      // When saving, isSwitchingQuestionsRef is false because originalId doesn't change.
-      // When switching, isSwitchingQuestionsRef is true because originalId changes.
-      const isSaveAction =
-        prevIsQuestionSaved === false && !isSwitchingQuestionsRef.current;
-
-      if (isNewQuestion && isSaveAction && !queryResultsRef.current) {
-        queryQuestionRef.current();
-      }
-
-      isSwitchingQuestionsRef.current = false;
-    }
-  }, [
-    prevOriginalId,
-    prevIsQuestionSaved,
-    isNewQuestion,
+  useNewQuestionEditorSync({
+    enabled: isNewQuestion,
     isQuestionSaved,
+    queryResults,
+    queryQuestion,
     openEditor,
     closeEditor,
-  ]);
+  });
+
+  useExistingQuestionEditorSync({
+    enabled: !isNewQuestion,
+    originalId,
+    isQuestionSaved,
+    closeEditor,
+  });
 
   return {
     isEditorOpen,

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-question-editor-sync.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-question-editor-sync.ts
@@ -11,12 +11,10 @@ interface UseQuestionEditorSyncOptions {
 }
 
 /**
- * Manages the editor open/close state and query execution for SDK questions.
+ * Synchronizes the notebook editor open/close state with the question lifecycle.
  *
- * Handles three main scenarios:
- * 1. New question: Opens editor automatically
- * 2. Question saved: Closes editor and runs query if results aren't available
- * 3. Question switched: Closes editor without running query (SDK handles loading)
+ * The hook manages automatic editor state transitions based on whether the user
+ * is working with a new question or an existing one:
  */
 export function useQuestionEditorSync({
   originalId,

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-question-editor-sync.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-question-editor-sync.ts
@@ -1,0 +1,60 @@
+import { useDisclosure } from "@mantine/hooks";
+import { useEffect, useRef } from "react";
+import { usePrevious } from "react-use";
+
+interface UseQuestionEditorSyncOptions {
+  originalId: string | number | null | undefined;
+  isQuestionSaved: boolean | undefined;
+  queryResults: unknown;
+  queryQuestion: () => Promise<unknown>;
+}
+
+export function useQuestionEditorSync({
+  originalId,
+  isQuestionSaved,
+  queryResults,
+  queryQuestion,
+}: UseQuestionEditorSyncOptions) {
+  const isNewQuestion = originalId === "new";
+
+  const [
+    isEditorOpen,
+    { close: closeEditor, toggle: toggleEditor, open: openEditor },
+  ] = useDisclosure(isNewQuestion && !isQuestionSaved);
+
+  const prevOriginalId = usePrevious(originalId);
+  const prevIsQuestionSaved = usePrevious(isQuestionSaved);
+
+  const queryResultsRef = useRef(queryResults);
+  const queryQuestionRef = useRef(queryQuestion);
+  queryResultsRef.current = queryResults;
+  queryQuestionRef.current = queryQuestion;
+
+  useEffect(() => {
+    if (isNewQuestion && !isQuestionSaved) {
+      openEditor();
+    } else if (prevOriginalId === "new" && !isNewQuestion) {
+      closeEditor();
+    } else if (!prevIsQuestionSaved && isQuestionSaved) {
+      closeEditor();
+
+      if (!queryResultsRef.current) {
+        queryQuestionRef.current();
+      }
+    }
+  }, [
+    prevOriginalId,
+    prevIsQuestionSaved,
+    isNewQuestion,
+    isQuestionSaved,
+    openEditor,
+    closeEditor,
+  ]);
+
+  return {
+    isEditorOpen,
+    openEditor,
+    closeEditor,
+    toggleEditor,
+  };
+}

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-question-editor-sync.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-question-editor-sync.ts
@@ -35,7 +35,8 @@ export function useQuestionEditorSync({
       openEditor();
     } else if (prevOriginalId === "new" && !isNewQuestion) {
       closeEditor();
-    } else if (!prevIsQuestionSaved && isQuestionSaved) {
+    } else if (prevIsQuestionSaved === false && isQuestionSaved) {
+      // Only trigger when transitioning from unsaved to saved (not on initial load)
       closeEditor();
 
       if (!queryResultsRef.current) {

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-question-editor-sync.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-question-editor-sync.ts
@@ -76,7 +76,7 @@ export function useQuestionEditorSync({
       const isSaveAction =
         prevIsQuestionSaved === false && !isSwitchingQuestionsRef.current;
 
-      if (isSaveAction && !queryResultsRef.current) {
+      if (isNewQuestion && isSaveAction && !queryResultsRef.current) {
         queryQuestionRef.current();
       }
 

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-question-editor-sync.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-question-editor-sync.ts
@@ -9,6 +9,14 @@ interface UseQuestionEditorSyncOptions {
   queryQuestion: () => Promise<unknown>;
 }
 
+/**
+ * Manages the editor open/close state and query execution for SDK questions.
+ *
+ * Handles three main scenarios:
+ * 1. New question: Opens editor automatically
+ * 2. Question saved: Closes editor and runs query if results aren't available
+ * 3. Question switched: Closes editor without running query (SDK handles loading)
+ */
 export function useQuestionEditorSync({
   originalId,
   isQuestionSaved,
@@ -25,43 +33,60 @@ export function useQuestionEditorSync({
   const prevOriginalId = usePrevious(originalId);
   const prevIsQuestionSaved = usePrevious(isQuestionSaved);
 
+  // Use refs to avoid triggering effect when these change
   const queryResultsRef = useRef(queryResults);
   const queryQuestionRef = useRef(queryQuestion);
+
   queryResultsRef.current = queryResults;
   queryQuestionRef.current = queryQuestion;
 
-  // Track whether we're in a "switching" state to avoid running query after switch
-  const isSwitchingRef = useRef(false);
+  // Track when user switches to a different question (vs saving current one).
+  // This distinguishes between:
+  // - Save: originalId stays same (or changes from "new" to real ID via prop)
+  // - Switch: originalId changes to a different question's ID
+  const isSwitchingQuestionsRef = useRef(false);
 
-  // Detect when originalId changes (switching questions)
-  if (prevOriginalId !== undefined && prevOriginalId !== originalId) {
-    isSwitchingRef.current = true;
+  const didQuestionIdChange =
+    prevOriginalId !== undefined && prevOriginalId !== originalId;
+
+  if (didQuestionIdChange) {
+    isSwitchingQuestionsRef.current = true;
   }
 
   useEffect(() => {
+    // Open editor for new unsaved questions
     if (isNewQuestion && !isQuestionSaved) {
       openEditor();
-    } else if (prevOriginalId === "new" && !isNewQuestion) {
+      return;
+    }
+
+    // Close editor when transitioning from new question to existing
+    if (prevOriginalId === "new" && !isNewQuestion) {
       closeEditor();
-    } else if (!prevIsQuestionSaved && isQuestionSaved) {
+      return;
+    }
+
+    // Handle question becoming saved (either via save action or loading existing)
+    if (!prevIsQuestionSaved && isQuestionSaved) {
       closeEditor();
 
-      // Only run query when saving, not when switching to a different question
-      const wasSave = prevIsQuestionSaved === false && !isSwitchingRef.current;
+      // Run query only when saving (not when switching/loading a different question).
+      // When saving, isSwitchingQuestionsRef is false because originalId doesn't change.
+      // When switching, isSwitchingQuestionsRef is true because originalId changes.
+      const isSaveAction =
+        prevIsQuestionSaved === false && !isSwitchingQuestionsRef.current;
 
-      if (wasSave && !queryResultsRef.current) {
+      if (isSaveAction && !queryResultsRef.current) {
         queryQuestionRef.current();
       }
 
-      // Reset switching state after processing
-      isSwitchingRef.current = false;
+      isSwitchingQuestionsRef.current = false;
     }
   }, [
     prevOriginalId,
     prevIsQuestionSaved,
     isNewQuestion,
     isQuestionSaved,
-    originalId,
     openEditor,
     closeEditor,
   ]);

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-question-editor-sync.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-question-editor-sync.ts
@@ -30,24 +30,38 @@ export function useQuestionEditorSync({
   queryResultsRef.current = queryResults;
   queryQuestionRef.current = queryQuestion;
 
+  // Track whether we're in a "switching" state to avoid running query after switch
+  const isSwitchingRef = useRef(false);
+
+  // Detect when originalId changes (switching questions)
+  if (prevOriginalId !== undefined && prevOriginalId !== originalId) {
+    isSwitchingRef.current = true;
+  }
+
   useEffect(() => {
     if (isNewQuestion && !isQuestionSaved) {
       openEditor();
     } else if (prevOriginalId === "new" && !isNewQuestion) {
       closeEditor();
-    } else if (prevIsQuestionSaved === false && isQuestionSaved) {
-      // Only trigger when transitioning from unsaved to saved (not on initial load)
+    } else if (!prevIsQuestionSaved && isQuestionSaved) {
       closeEditor();
 
-      if (!queryResultsRef.current) {
+      // Only run query when saving, not when switching to a different question
+      const wasSave = prevIsQuestionSaved === false && !isSwitchingRef.current;
+
+      if (wasSave && !queryResultsRef.current) {
         queryQuestionRef.current();
       }
+
+      // Reset switching state after processing
+      isSwitchingRef.current = false;
     }
   }, [
     prevOriginalId,
     prevIsQuestionSaved,
     isNewQuestion,
     isQuestionSaved,
+    originalId,
     openEditor,
     closeEditor,
   ]);


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #66461
Fixes https://linear.app/metabase/issue/EMB-1077/sdk-interactive-question-always-shows-results-when-you-set-the-first

The PR fixes the issue when the editor of the InteractiveQuestion component is closed after filters are added to it.

To Reproduce
- In Embed JS select `SSO` method and select `chart`.
- Click `edit` button to opne Editor.
- Add a filter `created at` with any value
- Editor is closed

To Verify
- In Embed JS select `SSO` method and select `chart`.
- Click `edit` button to opne Editor.
- Add a filter `created at` with any value
- Editor is should not be closed