### PR TITLE
Fix model metadata e2e flake #35711

### DIFF
--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -120,9 +120,10 @@ describe("issue 35711", () => {
   function reorderTaxAndTotalColumns() {
     cy.findAllByTestId("header-cell").eq(4).should("have.text", "Tax");
     cy.findAllByTestId("header-cell").eq(5).should("have.text", "Total");
+    H.tableHeaderColumn("Total").as("totalColumn");
 
     // drag & drop the Total column 80 px to the left to switch it with Tax column
-    H.moveDnDKitElement(H.tableHeaderColumn("Total"), { horizontal: -80 });
+    H.moveDnDKitElementByAlias("@totalColumn", { horizontal: -80 });
 
     cy.findAllByTestId("header-cell").eq(4).should("have.text", "Total");
     cy.findAllByTestId("header-cell").eq(5).should("have.text", "Tax");


### PR DESCRIPTION
Resolves DEV-694 by using an up-to-date helper. The previous helper was deprecated, and it even warns about the DOM issues.

```js
/**
 * @deprecated Use `moveDnDKitElementByAlias` instead.
 * Otherwise, the chain will be broken due to "element was removed from the DOM" error
 */
```

Which is exactly what was causing this test to flake:
```
The test failed because `cy.trigger()` was called on an element that was removed from the DOM due to a page update, causing the command chain to break. 
```

## Stress-test

- [20/20](https://github.com/metabase/metabase/actions/runs/20491948027) ✅ 
- [100/100](https://github.com/metabase/metabase/actions/runs/20492286127) with throttling ✅ 
- [100/100](https://github.com/metabase/metabase/actions/runs/20492278835) without throttling ✅  