### PR TITLE
fix: user's input is overwritten by async form reinitializations

### DIFF
--- a/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
@@ -386,7 +386,7 @@ describe("issue 51020", () => {
          * before picker content loads, so no folder is selected and "Everywhere" toggle doesn't appear.
          */
         cy.findByTestId("single-picker-view").should("be.visible");
-        cy.get('[type="search"]').type("foo");
+        cy.findByRole("searchbox").type("foo");
         cy.findByText("Everywhere").click();
         cy.findByText("Foo").click();
       });

--- a/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
@@ -381,9 +381,16 @@ describe("issue 51020", () => {
         .click();
       H.miniPickerBrowseAll().click();
       H.entityPickerModal().within(() => {
-        cy.findByPlaceholderText("Search…").type("foo");
+        /**
+         * Without this wait, typing speed causes flakiness: fast typing switches to search tab
+         * before picker content loads, so no folder is selected and "Everywhere" toggle doesn't appear.
+         */
+        cy.findByTestId("single-picker-view").should("be.visible");
+        cy.get('[type="search"]').type("foo");
+        cy.findByText("Everywhere").click();
         cy.findByText("Foo").click();
       });
+
       cy.findByTestId("run-button").click();
       cy.wait("@dataset");
       cy.button("Save").click();

--- a/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
@@ -394,9 +394,7 @@ describe("issue 51020", () => {
       cy.findByTestId("run-button").click();
       cy.wait("@dataset");
       cy.button("Save").click();
-      H.modal()
-        .findByLabelText("Name")
-        .type("{backspace}{backspace}{backspace}Model 51020");
+      H.modal().findByLabelText("Name").clear().type("Model 51020");
       H.modal().button("Save").click();
       cy.wait("@createCard");
       cy.wait("@getCard");

--- a/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
@@ -323,7 +323,7 @@ describe("issue 51020", () => {
       dropTemporaryTable();
     });
 
-    it("should pass primary key attribute to execute action endpoint when it's populated with click behavior or URL (metabase#51020-1)", () => {
+    it("should pass primary key attribute to execute action endpoint when primary key is called 'id' and it's populated with click behavior or URL (metabase#51020)", () => {
       cy.log(
         "check when primary key parameter is populated with click behavior",
       );
@@ -420,7 +420,7 @@ describe("issue 51020", () => {
       dropTemporaryTable();
     });
 
-    it("should pass primary key attribute to execute action endpoint when it's populated with click behavior or URL (metabase#51020-2)", () => {
+    it("should pass primary key attribute to execute action endpoint when primary key isn't called 'id' and it's populated with click behavior or URL (metabase#51020)", () => {
       cy.log(
         "check when primary key parameter is populated with click behavior",
       );

--- a/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
@@ -323,7 +323,7 @@ describe("issue 51020", () => {
       dropTemporaryTable();
     });
 
-    it("should pass primary key attribute to execute action endpoint when it's populated with click behavior or URL (metabase#51020)", () => {
+    it("should pass primary key attribute to execute action endpoint when it's populated with click behavior or URL (metabase#51020-1)", () => {
       cy.log(
         "check when primary key parameter is populated with click behavior",
       );
@@ -422,7 +422,7 @@ describe("issue 51020", () => {
       dropTemporaryTable();
     });
 
-    it("should pass primary key attribute to execute action endpoint when it's populated with click behavior or URL (metabase#51020)", () => {
+    it("should pass primary key attribute to execute action endpoint when it's populated with click behavior or URL (metabase#51020-2)", () => {
       cy.log(
         "check when primary key parameter is populated with click behavior",
       );

--- a/frontend/src/metabase/common/components/SaveQuestionForm/context.tsx
+++ b/frontend/src/metabase/common/components/SaveQuestionForm/context.tsx
@@ -85,19 +85,9 @@ export const SaveQuestionProvider = ({
       ? currentUser.personal_collection_id
       : userTargetCollection;
 
-  const [hasLoadedRecentItems, setHasLoadedRecentItems] = useState(false);
-  const { data: recentItems, isLoading } = useListRecentsQuery(
-    { context: ["selections"] },
-    { skip: hasLoadedRecentItems },
-  );
-  // We need to stop refetching recent items as the user makes selections in the ui that could cause a refetch
-  // This causes new initial values getting calculated, which combined with Formik's `enableReinitialize`
-  // prop, results in a dirty form getting values replaced within initial state.
-  useEffect(() => {
-    if (!isLoading) {
-      setHasLoadedRecentItems(true);
-    }
-  }, [isLoading]);
+  const { data: recentItems } = useListRecentsQuery({
+    context: ["selections"],
+  });
 
   const lastSelectedEntityModel = useMemo(() => {
     return recentItems?.find(

--- a/frontend/src/metabase/common/components/SaveQuestionForm/context.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/SaveQuestionForm/context.unit.spec.tsx
@@ -1,3 +1,5 @@
+import * as formik from "formik";
+
 import { setupEnterpriseOnlyPlugin } from "__support__/enterprise";
 import {
   defaultAuditInfo,
@@ -6,7 +8,7 @@ import {
   setupRecentViewsAndSelectionsEndpoints,
 } from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
-import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import { render, renderWithProviders, screen, waitFor } from "__support__/ui";
 import Question from "metabase-lib/v1/Question";
 import type { Card } from "metabase-types/api";
 import {
@@ -18,7 +20,11 @@ import {
 } from "metabase-types/api/mocks";
 import { createMockState } from "metabase-types/store/mocks";
 
-import { SaveQuestionProvider, useSaveQuestionContext } from "./context";
+import {
+  FormValuesPatcher,
+  SaveQuestionProvider,
+  useSaveQuestionContext,
+} from "./context";
 
 const TestComponent = () => {
   const { values, saveToDashboard } = useSaveQuestionContext();
@@ -340,5 +346,80 @@ describe("SaveQuestionContext", () => {
         expect(screen.queryByTestId("dashboardId")).not.toBeInTheDocument();
       });
     });
+  });
+});
+
+describe("FormValuesPatcher", () => {
+  const setValuesSpy = jest.fn();
+  const setup = (initialValue: unknown) => {
+    jest.spyOn(formik, "useFormikContext").mockReturnValue({
+      values: initialValue,
+      setValues: setValuesSpy,
+    } as unknown as formik.FormikContextType<unknown>);
+  };
+
+  beforeEach(() => {
+    setValuesSpy.mockClear();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("should patch untouched fields when nextValues change", () => {
+    setup({ name: "initial", count: 1 });
+
+    const { rerender } = render(
+      <FormValuesPatcher nextValues={{ name: "initial", count: 1 }}>
+        <div />
+      </FormValuesPatcher>,
+    );
+
+    rerender(
+      <FormValuesPatcher nextValues={{ name: "updated", count: 99 }}>
+        <div />
+      </FormValuesPatcher>,
+    );
+
+    expect(setValuesSpy).toHaveBeenCalledWith({ name: "updated", count: 99 });
+  });
+
+  it("should preserve user-modified fields when nextValues change", () => {
+    setup({ name: "user typed", count: 1 });
+
+    const { rerender } = render(
+      <FormValuesPatcher nextValues={{ name: "initial", count: 1 }}>
+        <div />
+      </FormValuesPatcher>,
+    );
+
+    rerender(
+      <FormValuesPatcher nextValues={{ name: "updated", count: 99 }}>
+        <div />
+      </FormValuesPatcher>,
+    );
+
+    expect(setValuesSpy).toHaveBeenCalledWith({
+      name: "user typed",
+      count: 99,
+    });
+  });
+
+  it("should not patch anything when nextValues remain unchanged", () => {
+    setup({ name: "initial", count: 1 });
+
+    const { rerender } = render(
+      <FormValuesPatcher nextValues={{ name: "initial", count: 1 }}>
+        <div />
+      </FormValuesPatcher>,
+    );
+
+    rerender(
+      <FormValuesPatcher nextValues={{ name: "initial", count: 1 }}>
+        <div />
+      </FormValuesPatcher>,
+    );
+
+    expect(setValuesSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes [GDGT-1423](https://linear.app/metabase/issue/GDGT-1423/flaky-test-e2e-tests-when-primary-key-is-not-called-id-issue-51020)

### Description
The form is being reinitialized while the user is typing in `SaveModalForm`, but this happens only when network throttling is enabled.

The root cause is that SaveQuestionProvider triggers a request to
`/api/activity/recents?context=selections` and reinitializes the form once the request is finished. As a result, any user input made before the request completes gets overridden by this reinitialization.

#### Solution 1: Do not render the form until all async operations are finished
**Pros:**
- No access to form fields until they are fully ready for editing.

**Cons:**
- Extra complexity to bind all async logic to an `isLoading` prop.
- Requires adding a loader component, which changes UX and needs approval from the UX team.
- The current code allows multiple reinitializations, so we can reliably track only the first one.

#### Solution 2: Patch the form instead of fully reinitializing it when async data is loaded
Instead of a full reinitialization, update only specific fields affected by async data.

**Pros:**
- No need to introduce loaders.
- Supports multiple patches.

**Cons:**
- We need to explicitly know which form values can change asynchronously.
- Every new async-dependent field must be manually added to this control flow.

#### Solution 3: Replace reinitialization with form-wide patching based on changed values
Patch only the values that differ from the initial state, since it doesn't make sense to patch values that aren't changed as user could change them already

**Pros:**
- No overwrites unless it is actually necessary.
- No need to manually track individual fields — all fields are handled automatically.
- Works everywhere (generic solution)

**Cons:**
- Requires additional abstraction


#### Criterias
**UX impact**

- Solution 1 (Loader): ❌ Requires introducing a loader and UX approval.
- Solution 2 (Manual patches): ✅ No UX impact.
- Solution 3 (Auto patches): ✅ No UX impact.

**Maintenance cost**

- Solution 1: ❌ Requires tracking and synchronizing async dependencies.
- Solution 2: ❌ Requires manual tracking of form fields.
- Solution 3: ✅ Automatic handling, no per-field maintenance.

**Adding new async fields**

- Solution 1: ⚠️ Requires extending loading state logic.
- Solution 2: ❌ Each new field must be manually added to patch logic.
- Solution 3: ✅ Works automatically without additional changes.

**User input preservation**

- Solution 1: ❌ User input is blocked until everything is ready.
- Solution 2: ⚠️ Preserved only for explicitly tracked fields.
- Solution 3: ✅ Preserved for all fields.

**Implementation complexity**

- Solution 1: ❌ High complexity due to async orchestration and UX changes.
- Solution 2: ✅ Simple initial implementation.
- Solution 3: ⚠️ Moderate one-time complexity.

#### Conclusion
Solution 3 was selected because its one-time implementation cost eliminates ongoing maintenance overhead. The patching abstraction was intentionally kept local to this form. This allows us to validate the approach over time, observe how it behaves as the form evolves, and gather confidence before considering it as a shared or global solution. This reduces architectural risk while keeping the door open for future generalization if the pattern proves valuable.

### How to verify
Successful stress test run [with network throttling](https://github.com/metabase/metabase/actions/runs/20494628464): 50/50 ✅

### Demo

Before:
https://github.com/user-attachments/assets/a2c88441-2be9-4e41-95a1-bb2fbd70af4c

After:
https://github.com/user-attachments/assets/f99dd7ff-d733-40d7-9caf-f4b8a713522a


### Checklist
- [x] Tests have been added/updated to cover changes in this PR
