### PR TITLE
fix(sdk-package, sdk-bundle, embed-js): Don't expose `question` in SDK's `entityTypes`

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-package/index.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/index.ts
@@ -128,7 +128,7 @@ export type {
   SqlParameterValues,
 } from "embedding-sdk-bundle/types";
 
-export type { EmbeddingEntityType } from "metabase-types/store/embedding-data-picker";
+export type { ModularEmbeddingEntityType } from "metabase-types/store/embedding-data-picker";
 
 export type { ParameterValues } from "metabase/embedding-sdk/types/dashboard";
 export type { IconName } from "metabase/embedding-sdk/types/icon";

--- a/enterprise/frontend/src/embedding/data-picker/DataSelector/tests/DataSourceSelector.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding/data-picker/DataSelector/tests/DataSourceSelector.unit.spec.tsx
@@ -12,7 +12,7 @@ import { ROOT_COLLECTION } from "metabase/entities/collections";
 import type { Database, SearchModel, Table } from "metabase-types/api";
 import { createMockDatabase, createMockTable } from "metabase-types/api/mocks";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
-import type { EmbeddingEntityType } from "metabase-types/store/embedding-data-picker";
+import type { FullAppEmbeddingEntityType } from "metabase-types/store/embedding-data-picker";
 import {
   createMockSettingsState,
   createMockState,
@@ -47,7 +47,7 @@ interface SetupOpts {
     id: number;
     databaseId: number;
   };
-  entityTypes?: EmbeddingEntityType[];
+  entityTypes?: FullAppEmbeddingEntityType[];
 }
 
 function setup({

--- a/enterprise/frontend/src/embedding/data-picker/DataSelector/tests/DataSourceSelector.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding/data-picker/DataSelector/tests/DataSourceSelector.unit.spec.tsx
@@ -12,7 +12,7 @@ import { ROOT_COLLECTION } from "metabase/entities/collections";
 import type { Database, SearchModel, Table } from "metabase-types/api";
 import { createMockDatabase, createMockTable } from "metabase-types/api/mocks";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
-import type { FullAppEmbeddingEntityType } from "metabase-types/store/embedding-data-picker";
+import type { EmbeddingEntityType } from "metabase-types/store/embedding-data-picker";
 import {
   createMockSettingsState,
   createMockState,
@@ -47,7 +47,7 @@ interface SetupOpts {
     id: number;
     databaseId: number;
   };
-  entityTypes?: FullAppEmbeddingEntityType[];
+  entityTypes?: EmbeddingEntityType[];
 }
 
 function setup({

--- a/enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPicker.tsx
+++ b/enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPicker.tsx
@@ -8,7 +8,7 @@ import { Box, Popover } from "metabase/ui";
 import { getQuestionVirtualTableId } from "metabase-lib/v1/metadata/utils/saved-questions";
 import type { SearchModel, SearchResult, TableId } from "metabase-types/api";
 import { SortDirection, type SortingOptions } from "metabase-types/api/sorting";
-import type { EmbeddingEntityType } from "metabase-types/store/embedding-data-picker";
+import type { ModularEmbeddingEntityType } from "metabase-types/store/embedding-data-picker";
 
 import { SimpleDataPickerView } from "./SimpleDataPickerView";
 
@@ -103,7 +103,7 @@ function sortEntities(
 const compareString = (a: string, b: string) => a.localeCompare(b);
 
 function translateEntityTypesToSearchModels(
-  entityTypes: EmbeddingEntityType[],
+  entityTypes: ModularEmbeddingEntityType[],
 ): SearchModel[] {
   const searchModels: SearchModel[] = [];
 

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/context/types.ts
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/context/types.ts
@@ -18,13 +18,13 @@ import type {
 import type Question from "metabase-lib/v1/Question";
 import type { CardDisplayType, DashboardId } from "metabase-types/api";
 import type { EntityToken } from "metabase-types/api/entity";
-import type { EmbeddingEntityType } from "metabase-types/store/embedding-data-picker";
+import type { ModularEmbeddingEntityType } from "metabase-types/store/embedding-data-picker";
 
 type SdkQuestionConfig = {
   /**
    * An array that specifies which entity types are available in the data picker
    */
-  entityTypes?: EmbeddingEntityType[];
+  entityTypes?: ModularEmbeddingEntityType[];
 
   /**
    * Whether to show the save button.

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/EditableDashboard/EditableDashboard.stories.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/EditableDashboard/EditableDashboard.stories.tsx
@@ -32,12 +32,7 @@ const meta = {
 
     "dataPickerProps.entityTypes": {
       control: "check",
-      options: [
-        "model",
-        "table",
-        "question",
-      ] satisfies SdkQuestionProps["entityTypes"],
-      description: "`question` doesn't have effect on simple data picker",
+      options: ["model", "table"] satisfies SdkQuestionProps["entityTypes"],
     },
 
     // Display options

--- a/frontend/src/metabase-types/store/embed.ts
+++ b/frontend/src/metabase-types/store/embed.ts
@@ -1,6 +1,6 @@
 import type {
   EmbeddingDataPicker,
-  EmbeddingEntityType,
+  FullAppEmbeddingEntityType,
 } from "./embedding-data-picker";
 
 export interface InteractiveEmbeddingOptions {
@@ -19,7 +19,7 @@ export interface InteractiveEmbeddingOptions {
    * There might be a cleaner way to say this is in a search parameter
    * but it's not in the embed reducer, than making this optional.
    */
-  entity_types?: EmbeddingEntityType[];
+  entity_types?: FullAppEmbeddingEntityType[];
 }
 
 type EmptyObject = Record<string, never>;

--- a/frontend/src/metabase-types/store/embedding-data-picker.ts
+++ b/frontend/src/metabase-types/store/embedding-data-picker.ts
@@ -1,5 +1,5 @@
 export interface EmbeddingDataPickerState {
-  entityTypes: FullAppEmbeddingEntityType[];
+  entityTypes: EmbeddingEntityType[];
 }
 
 // Duplicate the type instead, so we see this type name rather than `FullAppEmbeddingEntityType` if we do type EmbeddingEntityType = FullAppEmbeddingEntityType

--- a/frontend/src/metabase-types/store/embedding-data-picker.ts
+++ b/frontend/src/metabase-types/store/embedding-data-picker.ts
@@ -13,12 +13,8 @@ export type EmbeddingEntityType = "model" | "table" | "question";
  */
 export type FullAppEmbeddingEntityType = "model" | "table" | "question";
 
-/**
- * `question` is only applicable to the staged picker, which is rarely used in SDK unless
- * there are 100+ combined tables/models.
- *
- * @internal
- */
+// `question` is only applicable to the staged picker, which is rarely used in SDK unless
+// there are 100+ combined tables/models.
 export type ModularEmbeddingEntityType = "model" | "table";
 
 export type EmbeddingDataPicker = "staged" | "flat";

--- a/frontend/src/metabase-types/store/embedding-data-picker.ts
+++ b/frontend/src/metabase-types/store/embedding-data-picker.ts
@@ -1,6 +1,9 @@
 export interface EmbeddingDataPickerState {
-  entityTypes: EmbeddingEntityType[];
+  entityTypes: FullAppEmbeddingEntityType[];
 }
+
+// Duplicate the type instead, so we see this type name rather than `FullAppEmbeddingEntityType` if we do type EmbeddingEntityType = FullAppEmbeddingEntityType
+export type EmbeddingEntityType = "model" | "table" | "question";
 
 /**
  * `question` only works on multi-stage data picker, not the simple data picker.
@@ -8,6 +11,8 @@ export interface EmbeddingDataPickerState {
  * use cases, but `question` was later added to support users who are used to
  * selecting Saved questions in interactive embedding, so this is special case.
  */
-export type EmbeddingEntityType = "model" | "table" | "question";
+export type FullAppEmbeddingEntityType = "model" | "table" | "question";
+
+export type ModularEmbeddingEntityType = "model" | "table";
 
 export type EmbeddingDataPicker = "staged" | "flat";

--- a/frontend/src/metabase-types/store/embedding-data-picker.ts
+++ b/frontend/src/metabase-types/store/embedding-data-picker.ts
@@ -13,6 +13,12 @@ export type EmbeddingEntityType = "model" | "table" | "question";
  */
 export type FullAppEmbeddingEntityType = "model" | "table" | "question";
 
+/**
+ * `question` is only applicable to the staged picker, which is rarely used in SDK unless
+ * there are 100+ combined tables/models.
+ *
+ * @internal
+ */
 export type ModularEmbeddingEntityType = "model" | "table";
 
 export type EmbeddingDataPicker = "staged" | "flat";

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
@@ -20,7 +20,7 @@ import type { StrictUnion } from "metabase/embedding-sdk/types/utils";
 import type { EmbeddedAnalyticsJsEventSchema } from "metabase-types/analytics/embedded-analytics-js";
 import type { CollectionId } from "metabase-types/api";
 import type { EntityToken } from "metabase-types/api/entity";
-import type { EmbeddingEntityType } from "metabase-types/store/embedding-data-picker";
+import type { ModularEmbeddingEntityType } from "metabase-types/store/embedding-data-picker";
 
 /** Events that the embed.js script listens for */
 export type SdkIframeEmbedTagMessage =
@@ -141,7 +141,7 @@ export interface BrowserEmbedOptions {
   collectionEntityTypes?: CollectionBrowserEntityTypes[];
 
   /** Which entities to show on the question's data picker */
-  dataPickerEntityTypes?: EmbeddingEntityType[];
+  dataPickerEntityTypes?: ModularEmbeddingEntityType[];
 
   /** Whether to show the "New exploration" button. Defaults to true. */
   withNewQuestion?: boolean;

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BrowseNavSection.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BrowseNavSection.unit.spec.tsx
@@ -13,7 +13,7 @@ import {
 } from "__support__/ui";
 import * as domUtils from "metabase/lib/dom";
 import { createMockDatabase, createMockUser } from "metabase-types/api/mocks";
-import type { EmbeddingEntityType } from "metabase-types/store/embedding-data-picker";
+import type { ModularEmbeddingEntityType } from "metabase-types/store/embedding-data-picker";
 import { createMockState } from "metabase-types/store/mocks";
 
 import { BrowseNavSection } from "./BrowseNavSection";
@@ -176,7 +176,7 @@ describe("BrowseNavSection", () => {
 
 interface SetupOpts {
   isEmbeddingIframe?: boolean;
-  entityTypes?: EmbeddingEntityType[];
+  entityTypes?: ModularEmbeddingEntityType[];
   isAdmin?: boolean;
 }
 

--- a/frontend/src/metabase/plugins/oss/embedding.ts
+++ b/frontend/src/metabase/plugins/oss/embedding.ts
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 import type { DataSourceSelectorProps } from "metabase/embedding-sdk/types/components/data-picker";
 import type { TableId } from "metabase-types/api";
 import type { State } from "metabase-types/store";
-import type { EmbeddingEntityType } from "metabase-types/store/embedding-data-picker";
+import type { ModularEmbeddingEntityType } from "metabase-types/store/embedding-data-picker";
 
 export interface SimpleDataPickerProps {
   filterByDatabaseId: number | null;
@@ -11,7 +11,7 @@ export interface SimpleDataPickerProps {
   isInitiallyOpen: boolean;
   triggerElement: ReactNode;
   setSourceTableFn: (tableId: TableId) => void;
-  entityTypes: EmbeddingEntityType[];
+  entityTypes: ModularEmbeddingEntityType[];
 }
 
 const getDefaultPluginEmbedding = () => ({

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/EmbeddingDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/EmbeddingDataPicker.tsx
@@ -8,7 +8,10 @@ import { getMetadata } from "metabase/selectors/metadata";
 import * as Lib from "metabase-lib";
 import { getQuestionIdFromVirtualTableId } from "metabase-lib/v1/metadata/utils/saved-questions";
 import type { CardType, TableId } from "metabase-types/api";
-import type { EmbeddingEntityType } from "metabase-types/store/embedding-data-picker";
+import type {
+  EmbeddingEntityType,
+  ModularEmbeddingEntityType,
+} from "metabase-types/store/embedding-data-picker";
 
 import { DataPickerTarget } from "../DataPickerTarget";
 
@@ -102,7 +105,10 @@ export function EmbeddingDataPicker({
           />
         }
         setSourceTableFn={onChange}
-        entityTypes={simpleDataPickerEntityTypes}
+        entityTypes={
+          // We don't care about the extra entity type `question` for simple data picker
+          simpleDataPickerEntityTypes as ModularEmbeddingEntityType[]
+        }
       />
     );
   }


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #65797
closes EMB-1026

### Backport reason
It's just type change, so safe to be backported to 57 as well.

### Description

We say we could pass `question` to our SDK components via various entity types prop. e.g. https://www.metabase.com/docs/latest/embedding/sdk/api/EmbeddingEntityType.html. Actually, `question` is only applicable sor staged picker, and that means unless our SDK fallback to staged picker which would require users to have more than 100 of combined tables or models, `question` wouldn't be used at all. This aims to remove confusion around the fact that `question` is actually meant for full-app embedding users (aka interactive embeddings)

### How to verify

When using SDK e.g. `InteractiveQuestion`, `entityTypes` would only consist of 2 values, `table` or `model`, not `question`.

### Demo

<img width="932" height="113" alt="image" src="https://github.com/user-attachments/assets/54423309-7d39-4b1f-a8cf-ec4a153ce96c" />

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~ just a type change.
