### PR TITLE
Block official collections in shared collections and its subcollections

### DIFF
--- a/e2e/test/scenarios/collections/collection-picker-tenants.cy.spec.ts
+++ b/e2e/test/scenarios/collections/collection-picker-tenants.cy.spec.ts
@@ -22,7 +22,7 @@ describe("scenarios > collections > collection picker with tenants", () => {
     H.updateSetting("use-tenants", true);
   });
 
-  it("should block official collections in shared collections and its sub-collections", () => {
+  it("should not allow marking collections as official in shared collections and its sub-collections", () => {
     createSharedCollection("Test Shared Collection").then((response) => {
       const sharedCollectionId = response.body.id;
 

--- a/e2e/test/scenarios/collections/collection-picker-tenants.cy.spec.ts
+++ b/e2e/test/scenarios/collections/collection-picker-tenants.cy.spec.ts
@@ -1,0 +1,215 @@
+const { H } = cy;
+
+const TENANT_NAMESPACE = "shared-tenant-collection";
+
+/**
+ * Create a collection in the shared-tenant-collection namespace.
+ * Collections with this namespace are shared collections.
+ */
+function createSharedCollection(name: string, parentId?: number) {
+  return cy.request("POST", "/api/collection", {
+    name,
+    namespace: TENANT_NAMESPACE,
+    parent_id: parentId ?? null,
+  });
+}
+
+describe("scenarios > collections > collection picker with tenants", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    H.activateToken("bleeding-edge");
+    H.updateSetting("use-tenants", true);
+  });
+
+  it("should block official collections in shared collections and its sub-collections", () => {
+    createSharedCollection("Test Shared Collection").then((response) => {
+      const sharedCollectionId = response.body.id;
+
+      cy.log("Navigate to the shared collection");
+      H.visitCollection(sharedCollectionId);
+
+      cy.log("Verify collection loaded");
+      cy.findByTestId("collection-name-heading").should(
+        "have.text",
+        "Test Shared Collection",
+      );
+
+      cy.log("Click on the three dots menu and verify cannot mark as official");
+      H.openCollectionMenu();
+
+      H.popover().within(() => {
+        cy.log("Should not have 'Make collection official' option");
+        cy.findByText("Make collection official").should("not.exist");
+        cy.findByText("Remove Official badge").should("not.exist");
+      });
+
+      // Close the popover
+      cy.findByTestId("app-bar").click();
+
+      cy.log("Click 'Create a new collection' button");
+      cy.findByTestId("collection-menu")
+        .findByLabelText("Create a new collection")
+        .click();
+
+      cy.findByTestId("new-collection-modal").within(() => {
+        cy.log("Should not see 'Collection type' picker");
+        cy.findByText(/Collection type/i).should("not.exist");
+        cy.findByText("Regular").should("not.exist");
+        cy.findByText("Official").should("not.exist");
+
+        cy.log("Verify we're creating inside the shared collection");
+        cy.findByTestId("collection-picker-button").should(
+          "contain",
+          "Test Shared Collection",
+        );
+
+        cy.log("Edge case: Change target collection to a normal collection");
+        cy.findByTestId("collection-picker-button").click();
+      });
+
+      H.entityPickerModal().within(() => {
+        cy.log("Select 'Our analytics' (a normal collection)");
+        H.entityPickerModalTab("Collections").click();
+        cy.findByText("Our analytics").click();
+        cy.button("Select").click();
+      });
+
+      cy.findByTestId("new-collection-modal").within(() => {
+        cy.log("Wait for collection picker to update to 'Our analytics'");
+        cy.findByTestId("collection-picker-button").should(
+          "contain",
+          "Our analytics",
+        );
+
+        cy.log("Should now see 'Collection type' picker");
+        cy.findByText(/Collection type/i).should("exist");
+        cy.findByText("Regular").should("exist");
+        cy.findByText("Official").should("exist");
+
+        cy.log("Close modal without creating");
+        cy.findByLabelText("Close").click();
+      });
+    });
+  });
+
+  it("should block official collections in sub-collections of shared collections", () => {
+    createSharedCollection("Shared Parent Collection").then((response) => {
+      const sharedParentId = response.body.id;
+
+      createSharedCollection("Shared Sub Collection", sharedParentId).then(
+        (subResponse) => {
+          const sharedSubCollectionId = subResponse.body.id;
+
+          cy.log("Navigate to the sub-collection");
+          H.visitCollection(sharedSubCollectionId);
+
+          cy.log("Verify sub-collection loaded");
+          cy.findByTestId("collection-name-heading").should(
+            "have.text",
+            "Shared Sub Collection",
+          );
+
+          cy.log("Open collection menu");
+          H.openCollectionMenu();
+
+          H.popover().within(() => {
+            cy.log("Should not have 'Make collection official' option");
+            cy.findByText("Make collection official").should("not.exist");
+            cy.findByText("Remove Official badge").should("not.exist");
+          });
+
+          // Close the popover
+          cy.findByTestId("app-bar").click();
+
+          cy.log("Create a new sub-sub-collection");
+          cy.findByTestId("collection-menu")
+            .findByLabelText("Create a new collection")
+            .click();
+
+          cy.findByTestId("new-collection-modal").within(() => {
+            cy.log("Should not see 'Collection type' picker");
+            cy.findByText(/Collection type/i).should("not.exist");
+            cy.findByText("Regular").should("not.exist");
+            cy.findByText("Official").should("not.exist");
+          });
+        },
+      );
+    });
+  });
+
+  it("should hide collection type picker when switching from normal to shared collection in create modal", () => {
+    createSharedCollection("Target Shared Collection");
+
+    cy.log("Start creating a new collection from root");
+    cy.visit("/collection/root");
+    H.startNewCollectionFromSidebar();
+
+    cy.findByTestId("new-collection-modal").within(() => {
+      cy.log("Initially should see collection type picker");
+      cy.findByText(/Collection type/i).should("exist");
+
+      cy.log("Click collection picker to change target");
+      cy.findByTestId("collection-picker-button").click();
+    });
+
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Collections").click();
+      cy.log("Navigate to Shared collections");
+      cy.findByText("Shared collections").click();
+      cy.findByText("Target Shared Collection").click();
+      cy.button("Select").click();
+    });
+
+    cy.findByTestId("new-collection-modal").within(() => {
+      cy.log("Should no longer see collection type picker");
+      cy.findByText(/Collection type/i).should("not.exist");
+      cy.findByText("Regular").should("not.exist");
+      cy.findByText("Official").should("not.exist");
+    });
+  });
+
+  it("should show collection type picker when switching from shared to normal collection in create modal", () => {
+    createSharedCollection("Shared Collection for Switching").then(
+      (response) => {
+        const sharedCollectionId = response.body.id;
+
+        cy.log("Navigate inside shared collection");
+        H.visitCollection(sharedCollectionId);
+
+        cy.log("Start creating a sub-collection");
+        cy.findByTestId("collection-menu")
+          .findByLabelText("Create a new collection")
+          .click();
+
+        cy.findByTestId("new-collection-modal").within(() => {
+          cy.log("Should not see collection type picker initially");
+          cy.findByText(/Collection type/i).should("not.exist");
+
+          cy.log("Click collection picker to change target");
+          cy.findByTestId("collection-picker-button").click();
+        });
+
+        H.entityPickerModal().within(() => {
+          H.entityPickerModalTab("Collections").click();
+          cy.log("Select 'Our analytics' (normal collection)");
+          cy.findByText("Our analytics").click();
+          cy.button("Select").click();
+        });
+
+        cy.findByTestId("new-collection-modal").within(() => {
+          cy.log("Wait for collection picker to update to 'Our analytics'");
+          cy.findByTestId("collection-picker-button").should(
+            "contain",
+            "Our analytics",
+          );
+
+          cy.log("Should now see collection type picker");
+          cy.findByText(/Collection type/i).should("exist");
+          cy.findByText("Regular").should("exist");
+          cy.findByText("Official").should("exist");
+        });
+      },
+    );
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/collections/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/collections/index.tsx
@@ -8,6 +8,8 @@ import { Icon, Menu } from "metabase/ui";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 import type { Collection } from "metabase-types/api";
 
+import { isTenantCollection } from "../tenants/utils/utils";
+
 import { CollectionAuthorityLevelDisplay } from "./components/CollectionAuthorityLevelDisplay";
 import { CollectionAuthorityLevelIcon } from "./components/CollectionAuthorityLevelIcon";
 import { CollectionInstanceAnalyticsIcon } from "./components/CollectionInstanceAnalyticsIcon";
@@ -45,6 +47,11 @@ export function initializePlugin() {
       collection: Collection,
       onUpdate: (collection: Collection, values: Partial<Collection>) => void,
     ) => {
+      // Shared tenant collections cannot be marked as official
+      if (isTenantCollection(collection)) {
+        return [];
+      }
+
       if (isRegularCollection(collection)) {
         return [
           <Menu.Item

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/MainNavSharedCollections/MainNavSharedCollections.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/MainNavSharedCollections/MainNavSharedCollections.unit.spec.tsx
@@ -74,6 +74,9 @@ describe("MainNavSharedCollections > new shared collection modal", () => {
     setup({ isAdmin: true, canWriteToSharedCollectionRoot: true });
     await screen.findByText("External collections");
 
+    // Mock the initial collection fetch that CreateCollectionForm makes
+    fetchMock.get("path:/api/collection/1", MOCK_TENANT_COLLECTIONS[0]);
+
     const addButton = screen.getByRole("button", { name: /add/i });
     addButton.click();
 

--- a/enterprise/frontend/src/metabase-enterprise/tenants/utils/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/utils/utils.ts
@@ -14,5 +14,6 @@ export const isExternalUser = (user?: Pick<User, "tenant_id">): boolean => {
   return Boolean(user && user.tenant_id !== null);
 };
 
-export const isTenantCollection = (collection: Collection) =>
-  collection.namespace === "shared-tenant-collection";
+export const isTenantCollection = (
+  collection: Partial<Pick<Collection, "namespace">>,
+) => collection.namespace === "shared-tenant-collection";

--- a/frontend/src/metabase/collections/components/CollectionMenu/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionMenu/tests/enterprise.unit.spec.tsx
@@ -44,4 +44,43 @@ describe("CollectionMenu", () => {
     await userEvent.click(getIcon("ellipsis"));
     expect(screen.queryByText("Edit permissions")).not.toBeInTheDocument();
   });
+
+  it("should not be able to make shared tenant collections official", async () => {
+    setupEnterprise({
+      collection: createMockCollection({
+        can_write: true,
+        namespace: "shared-tenant-collection",
+      }),
+      isAdmin: true,
+      tokenFeatures: createMockTokenFeatures({
+        tenants: true,
+        official_collections: true,
+      }),
+    });
+
+    await userEvent.click(getIcon("ellipsis"));
+
+    expect(
+      screen.queryByText("Make collection official"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should not be able to remove official badge from shared tenant collections", async () => {
+    setupEnterprise({
+      collection: createMockCollection({
+        can_write: true,
+        namespace: "shared-tenant-collection",
+        authority_level: "official",
+      }),
+      isAdmin: true,
+      tokenFeatures: createMockTokenFeatures({
+        tenants: true,
+        official_collections: true,
+      }),
+    });
+
+    await userEvent.click(getIcon("ellipsis"));
+
+    expect(screen.queryByText("Remove Official badge")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/metabase/collections/components/CreateCollectionForm/CreateCollectionForm.tsx
+++ b/frontend/src/metabase/collections/components/CreateCollectionForm/CreateCollectionForm.tsx
@@ -87,7 +87,6 @@ function CreateCollectionForm({
   showCollectionPicker = true,
   showAuthorityLevelPicker = true,
 }: Props) {
-  // Used to get the namespace of a collection
   const { data: initialCollection } = useGetCollectionQuery(
     initialCollectionId != null ? { id: initialCollectionId } : skipToken,
   );
@@ -109,46 +108,55 @@ function CreateCollectionForm({
       validationSchema={COLLECTION_SCHEMA}
       onSubmit={onSubmit}
     >
-      {({ dirty, setFieldValue, values }) => (
-        <Form>
-          <FormInput
-            name="name"
-            title={t`Name`}
-            placeholder={t`My new fantastic collection`}
-            data-autofocus
-          />
-          <FormTextArea
-            name="description"
-            title={t`Description`}
-            placeholder={t`It's optional but oh, so helpful`}
-            nullable
-            optional
-          />
-          {showCollectionPicker && (
-            <FormCollectionPicker
-              name="parent_id"
-              setNamespace={(namespace) =>
-                setFieldValue("namespace", namespace)
-              }
-              title={t`Collection it's saved in`}
-              filterPersonalCollections={filterPersonalCollections}
-              entityType="collection"
-              savingModel="collection"
+      {({ dirty, setFieldValue, values }) => {
+        // Populate the namespace for initial collection.
+        // Otherwise, use the value from the collection picker.
+        const namespace =
+          values.parent_id === initialCollectionId
+            ? initialCollection?.namespace
+            : values.namespace;
+
+        return (
+          <Form>
+            <FormInput
+              name="name"
+              title={t`Name`}
+              placeholder={t`My new fantastic collection`}
+              data-autofocus
             />
-          )}
-          {showAuthorityLevelPicker &&
-            values.namespace !== "shared-tenant-collection" && (
-              <FormAuthorityLevelField />
+            <FormTextArea
+              name="description"
+              title={t`Description`}
+              placeholder={t`It's optional but oh, so helpful`}
+              nullable
+              optional
+            />
+            {showCollectionPicker && (
+              <FormCollectionPicker
+                name="parent_id"
+                setNamespace={(namespace) =>
+                  setFieldValue("namespace", namespace)
+                }
+                title={t`Collection it's saved in`}
+                filterPersonalCollections={filterPersonalCollections}
+                entityType="collection"
+                savingModel="collection"
+              />
             )}
-          <FormFooter>
-            <FormErrorMessage inline />
-            {!!onCancel && (
-              <Button type="button" onClick={onCancel}>{t`Cancel`}</Button>
-            )}
-            <FormSubmitButton title={t`Create`} disabled={!dirty} primary />
-          </FormFooter>
-        </Form>
-      )}
+            {showAuthorityLevelPicker &&
+              namespace !== "shared-tenant-collection" && (
+                <FormAuthorityLevelField />
+              )}
+            <FormFooter>
+              <FormErrorMessage inline />
+              {!!onCancel && (
+                <Button type="button" onClick={onCancel}>{t`Cancel`}</Button>
+              )}
+              <FormSubmitButton title={t`Create`} disabled={!dirty} primary />
+            </FormFooter>
+          </Form>
+        );
+      }}
     </FormProvider>
   );
 }

--- a/frontend/src/metabase/collections/components/CreateCollectionForm/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CreateCollectionForm/tests/enterprise.unit.spec.tsx
@@ -16,7 +16,7 @@ describe("CreateCollectionForm", () => {
         tenants: true,
         official_collections: true,
       }),
-      enterprisePlugins: ["collections"],
+      enterprisePlugins: ["collections", "tenants"],
       parentCollectionNamespace: "shared-tenant-collection",
     });
 
@@ -33,7 +33,7 @@ describe("CreateCollectionForm", () => {
         tenants: true,
         official_collections: true,
       }),
-      enterprisePlugins: ["collections"],
+      enterprisePlugins: ["collections", "tenants"],
       parentCollectionNamespace: null,
     });
 

--- a/frontend/src/metabase/collections/components/CreateCollectionForm/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CreateCollectionForm/tests/enterprise.unit.spec.tsx
@@ -1,4 +1,5 @@
-import { screen } from "__support__/ui";
+import { screen, waitFor } from "__support__/ui";
+import { createMockTokenFeatures } from "metabase-types/api/mocks";
 
 import { setup } from "./setup";
 
@@ -6,5 +7,37 @@ describe("CreateCollectionForm", () => {
   it("does not show authority level controls", () => {
     setup();
     expect(screen.queryByText("Collection type")).not.toBeInTheDocument();
+  });
+
+  it("hides authority level picker when initial parent is a shared tenant collection", async () => {
+    setup({
+      showAuthorityLevelPicker: true,
+      tokenFeatures: createMockTokenFeatures({
+        tenants: true,
+        official_collections: true,
+      }),
+      enterprisePlugins: ["collections"],
+      initialParentNamespace: "shared-tenant-collection",
+    });
+
+    // Wait for the authority level picker to disappear after collection data loads
+    await waitFor(() => {
+      expect(screen.queryByText("Collection type")).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows authority level picker when initial parent is a regular collection", () => {
+    setup({
+      showAuthorityLevelPicker: true,
+      tokenFeatures: createMockTokenFeatures({
+        tenants: true,
+        official_collections: true,
+      }),
+      enterprisePlugins: ["collections"],
+      initialParentNamespace: null,
+    });
+
+    // The authority level picker should be visible
+    expect(screen.getByText("Collection type")).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/collections/components/CreateCollectionForm/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CreateCollectionForm/tests/enterprise.unit.spec.tsx
@@ -17,7 +17,7 @@ describe("CreateCollectionForm", () => {
         official_collections: true,
       }),
       enterprisePlugins: ["collections"],
-      initialParentNamespace: "shared-tenant-collection",
+      parentCollectionNamespace: "shared-tenant-collection",
     });
 
     // Wait for the authority level picker to disappear after collection data loads
@@ -34,7 +34,7 @@ describe("CreateCollectionForm", () => {
         official_collections: true,
       }),
       enterprisePlugins: ["collections"],
-      initialParentNamespace: null,
+      parentCollectionNamespace: null,
     });
 
     // The authority level picker should be visible

--- a/frontend/src/metabase/collections/components/CreateCollectionForm/tests/setup.tsx
+++ b/frontend/src/metabase/collections/components/CreateCollectionForm/tests/setup.tsx
@@ -7,7 +7,11 @@ import {
 import { mockSettings } from "__support__/settings";
 import { createMockEntitiesState } from "__support__/store";
 import { renderWithProviders } from "__support__/ui";
-import type { TokenFeatures, User } from "metabase-types/api";
+import type {
+  CollectionNamespace,
+  TokenFeatures,
+  User,
+} from "metabase-types/api";
 import {
   createMockCollection,
   createMockTokenFeatures,
@@ -28,7 +32,7 @@ export interface SetupOpts {
   tokenFeatures?: TokenFeatures;
   showAuthorityLevelPicker?: boolean;
   enterprisePlugins?: Parameters<typeof setupEnterpriseOnlyPlugin>[0][];
-  initialParentNamespace?: string | null;
+  parentCollectionNamespace?: CollectionNamespace | null;
 }
 
 export const setup = ({
@@ -36,24 +40,23 @@ export const setup = ({
   tokenFeatures = createMockTokenFeatures(),
   showAuthorityLevelPicker,
   enterprisePlugins,
-  initialParentNamespace,
+  parentCollectionNamespace,
 }: SetupOpts = {}) => {
   const settings = mockSettings({ "token-features": tokenFeatures });
   const onCancel = jest.fn();
 
   // Create a parent collection with the specified namespace if provided
-  const parentCollection =
-    initialParentNamespace !== undefined
-      ? createMockCollection({
-          id: 1,
-          name: "Parent Collection",
-          namespace: initialParentNamespace,
-          can_write: true,
-        })
-      : ROOT_COLLECTION;
+  const parentCollection = parentCollectionNamespace
+    ? createMockCollection({
+        id: 1,
+        name: "Parent Collection",
+        namespace: parentCollectionNamespace,
+        can_write: true,
+      })
+    : ROOT_COLLECTION;
 
   const collections =
-    initialParentNamespace !== undefined
+    parentCollectionNamespace !== undefined
       ? [ROOT_COLLECTION, parentCollection]
       : [ROOT_COLLECTION];
 
@@ -61,7 +64,8 @@ export const setup = ({
     enterprisePlugins.forEach(setupEnterpriseOnlyPlugin);
   }
   setupCollectionsEndpoints({
-    collections: initialParentNamespace !== undefined ? [parentCollection] : [],
+    collections:
+      parentCollectionNamespace !== undefined ? [parentCollection] : [],
     rootCollection: ROOT_COLLECTION,
   });
 
@@ -74,7 +78,7 @@ export const setup = ({
     <CreateCollectionForm
       onCancel={onCancel}
       showAuthorityLevelPicker={showAuthorityLevelPicker}
-      collectionId={initialParentNamespace !== undefined ? 1 : undefined}
+      collectionId={parentCollectionNamespace !== undefined ? 1 : undefined}
     />,
     {
       storeInitialState: createMockState({

--- a/frontend/src/metabase/collections/components/CreateCollectionForm/tests/setup.tsx
+++ b/frontend/src/metabase/collections/components/CreateCollectionForm/tests/setup.tsx
@@ -1,6 +1,9 @@
 /* istanbul ignore file */
 import { setupEnterpriseOnlyPlugin } from "__support__/enterprise";
-import { setupCollectionsEndpoints } from "__support__/server-mocks";
+import {
+  setupCollectionByIdEndpoint,
+  setupCollectionsEndpoints,
+} from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
 import { createMockEntitiesState } from "__support__/store";
 import { renderWithProviders } from "__support__/ui";
@@ -25,6 +28,7 @@ export interface SetupOpts {
   tokenFeatures?: TokenFeatures;
   showAuthorityLevelPicker?: boolean;
   enterprisePlugins?: Parameters<typeof setupEnterpriseOnlyPlugin>[0][];
+  initialParentNamespace?: string | null;
 }
 
 export const setup = ({
@@ -32,28 +36,52 @@ export const setup = ({
   tokenFeatures = createMockTokenFeatures(),
   showAuthorityLevelPicker,
   enterprisePlugins,
+  initialParentNamespace,
 }: SetupOpts = {}) => {
   const settings = mockSettings({ "token-features": tokenFeatures });
   const onCancel = jest.fn();
+
+  // Create a parent collection with the specified namespace if provided
+  const parentCollection =
+    initialParentNamespace !== undefined
+      ? createMockCollection({
+          id: 1,
+          name: "Parent Collection",
+          namespace: initialParentNamespace,
+          can_write: true,
+        })
+      : ROOT_COLLECTION;
+
+  const collections =
+    initialParentNamespace !== undefined
+      ? [ROOT_COLLECTION, parentCollection]
+      : [ROOT_COLLECTION];
 
   if (enterprisePlugins) {
     enterprisePlugins.forEach(setupEnterpriseOnlyPlugin);
   }
   setupCollectionsEndpoints({
-    collections: [],
+    collections: initialParentNamespace !== undefined ? [parentCollection] : [],
     rootCollection: ROOT_COLLECTION,
   });
+
+  // Mock individual collection fetches
+  setupCollectionByIdEndpoint({
+    collections,
+  });
+
   renderWithProviders(
     <CreateCollectionForm
       onCancel={onCancel}
       showAuthorityLevelPicker={showAuthorityLevelPicker}
+      collectionId={initialParentNamespace !== undefined ? 1 : undefined}
     />,
     {
       storeInitialState: createMockState({
         currentUser: user,
         settings,
         entities: createMockEntitiesState({
-          collections: [ROOT_COLLECTION],
+          collections,
         }),
       }),
     },

--- a/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
+++ b/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
@@ -156,10 +156,7 @@ function FormCollectionPicker({
 
   const handleChange = useCallback(
     ({ id, namespace }: CollectionPickerItem) => {
-      if (namespace) {
-        setNamespace?.(namespace);
-      }
-
+      setNamespace?.(namespace ?? undefined);
       setCollectionNamespace(namespace ?? null);
       setValue(canonicalCollectionId(id));
       setIsPickerOpen(false);

--- a/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
+++ b/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
@@ -42,7 +42,7 @@ interface FormCollectionPickerProps extends HTMLAttributes<HTMLDivElement> {
   filterPersonalCollections?: FilterItemsInPersonalCollection;
   entityType?: EntityType;
   collectionPickerModalProps?: Partial<CollectionPickerModalProps>;
-  setNamespace?: (namespace: string | undefined) => void;
+  onCollectionSelect?: (collection: CollectionPickerItem) => void;
   /**
    * When set to "collection", allows saving to namespace root collections
    * (like tenant root). When null/undefined, namespace roots are disabled.
@@ -84,7 +84,6 @@ function FormCollectionPicker({
   className,
   style,
   name,
-  setNamespace,
   title,
   placeholder = t`Select a collection`,
   type = "collections",
@@ -92,6 +91,7 @@ function FormCollectionPicker({
   entityType,
   collectionPickerModalProps,
   savingModel,
+  onCollectionSelect,
 }: FormCollectionPickerProps) {
   const id = useUniqueId();
 
@@ -155,13 +155,13 @@ function FormCollectionPicker({
   );
 
   const handleChange = useCallback(
-    ({ id, namespace }: CollectionPickerItem) => {
-      setNamespace?.(namespace ?? undefined);
-      setCollectionNamespace(namespace ?? null);
-      setValue(canonicalCollectionId(id));
+    (collection: CollectionPickerItem) => {
+      onCollectionSelect?.(collection);
+      setCollectionNamespace(collection.namespace ?? null);
+      setValue(canonicalCollectionId(collection.id));
       setIsPickerOpen(false);
     },
-    [setValue, setNamespace, setCollectionNamespace],
+    [onCollectionSelect, setValue],
   );
 
   return (

--- a/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
+++ b/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
@@ -156,9 +156,11 @@ function FormCollectionPicker({
 
   const handleChange = useCallback(
     ({ id, namespace }: CollectionPickerItem) => {
-      const normalizedNamespace = namespace ?? null;
-      setNamespace?.(normalizedNamespace);
-      setCollectionNamespace(normalizedNamespace);
+      if (namespace) {
+        setNamespace?.(namespace);
+      }
+
+      setCollectionNamespace(namespace ?? null);
       setValue(canonicalCollectionId(id));
       setIsPickerOpen(false);
     },

--- a/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
+++ b/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
@@ -156,11 +156,9 @@ function FormCollectionPicker({
 
   const handleChange = useCallback(
     ({ id, namespace }: CollectionPickerItem) => {
-      if (namespace) {
-        setNamespace?.(namespace);
-        setCollectionNamespace(namespace);
-      }
-      setCollectionNamespace(namespace ?? null);
+      const normalizedNamespace = namespace ?? null;
+      setNamespace?.(normalizedNamespace);
+      setCollectionNamespace(normalizedNamespace);
       setValue(canonicalCollectionId(id));
       setIsPickerOpen(false);
     },

--- a/frontend/src/metabase/plugins/oss/tenants.ts
+++ b/frontend/src/metabase/plugins/oss/tenants.ts
@@ -32,7 +32,8 @@ const getDefaultPluginTenants = () => ({
   isExternalUsersGroup: (_group: Pick<Group, "magic_group_type">) => false,
   isTenantGroup: (_group: Pick<Group, "is_tenant_group">) => false,
   isExternalUser: (_user?: Pick<User, "tenant_id">) => false,
-  isTenantCollection: (_collection: Collection) => false,
+  isTenantCollection: (_collection: Partial<Pick<Collection, "namespace">>) =>
+    false,
   PeopleNav: null as React.ReactElement | null,
   ReactivateExternalUserButton: ({ user: _user }: { user: User }) =>
     null as React.ReactElement | null,

--- a/frontend/src/metabase/plugins/oss/tenants.ts
+++ b/frontend/src/metabase/plugins/oss/tenants.ts
@@ -92,7 +92,9 @@ export const PLUGIN_TENANTS: {
   isExternalUsersGroup: (group: Pick<Group, "magic_group_type">) => boolean;
   isTenantGroup: (group: Pick<Group, "is_tenant_group">) => boolean;
   isExternalUser: (user?: Pick<User, "tenant_id">) => boolean;
-  isTenantCollection: (collection: Collection) => boolean;
+  isTenantCollection: (
+    collection: Partial<Pick<Collection, "namespace">>,
+  ) => boolean;
   PeopleNav: React.ReactElement | null;
   ReactivateExternalUserButton: (props: {
     user: User;


### PR DESCRIPTION
Closes UXW-2617

### Description

Shared collections no longer show the collection type picker (Regular/Official toggle) when being created, but it is still possible to 1) mark an existing shared collection as official and 2) to create official sub-collections under a shared collection.

This PR changes the collection behavior so that shared collections and any sub-collections of a shared collection cannot be marked as official.

### How to verify

- Enable tenants
- Create a shared collection
- Go inside the newly created shared collection
- Click on the three dots. You should not be able to mark shared collections as official.
- Click "Create a new collection" icon button to create a sub-collection
- _You should not see the "Collection type" picker in the modal._

Edge case, continuing from the above step:

- Change the target collection using the collection picker to a normal collection (not tenant collection)
- _You should see the "Collection type" picker in the modal now._

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
