### PR TITLE
Reinforce 'rename column' e2e helper

### DIFF
--- a/e2e/support/helpers/e2e-models-metadata-helpers.js
+++ b/e2e/support/helpers/e2e-models-metadata-helpers.js
@@ -48,8 +48,9 @@ export function renameColumn(oldName, newName) {
   tableInteractive()
     .findAllByTestId("header-cell")
     .contains(newName)
-    .scrollIntoView()
-    .should("be.visible");
+    .as("column")
+    .scrollIntoView();
+  cy.get("@column").should("be.visible");
 }
 
 export function setColumnType(oldType, newType) {

--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -1155,12 +1155,15 @@ describe("issue 36161", () => {
   });
 
   it("should allow to override metadata for custom columns (metabase#36161)", () => {
-    H.visitModel(ORDERS_MODEL_ID);
-    cy.wait("@dataset");
+    cy.log("Go straight to model query definition");
+    cy.visit(`/model/${ORDERS_MODEL_ID}/query`);
+    H.tableInteractiveBody().should("be.visible").and("contain", "37.65");
 
-    H.openQuestionActions("Edit query definition");
+    cy.log("Deselect all columns (except for ID)");
     H.getNotebookStep("data").button("Pick columns").click();
     H.popover().findByText("Select all").click();
+
+    cy.log("Add two custom columns based on the ID");
     H.getNotebookStep("data").button("Custom column").click();
     H.enterCustomColumnDetails({ formula: "[ID]", name: "ID2" });
     H.popover().button("Done").click();
@@ -1169,6 +1172,8 @@ describe("issue 36161", () => {
     H.popover().button("Done").click();
     H.runButtonOverlay().click();
     cy.wait("@dataset");
+
+    cy.log("Rename custom columns");
     cy.findByTestId("editor-tabs-columns-name").click();
     H.openColumnOptions("ID2");
     H.renameColumn("ID2", "ID2 custom");
@@ -1176,6 +1181,7 @@ describe("issue 36161", () => {
     H.renameColumn("ID3", "ID3 custom");
     H.saveMetadataChanges();
 
+    cy.log("Assert that the renamed columns appear in filter options");
     H.openNotebook();
     H.getNotebookStep("data").button("Filter").click();
     H.popover().within(() => {


### PR DESCRIPTION
Resolves DEV-786

The error from Trunk (that I also ran into)
```
The test failed because the element was removed from the DOM during a `cy.should()` check, causing the command to fail due to the element no longer being attached.
```

Before this change:
- [1 failed out of 50 attempts](https://github.com/metabase/metabase/actions/runs/20510255904/job/58930412287#step:12:93)
- [63 failed out of 100 attempts](https://github.com/metabase/metabase/actions/runs/20510401675/job/58930742696)

After the change
- [3 failed out of 100](https://github.com/metabase/metabase/actions/runs/20510810247/job/58931624962)

And the most important thing, these failures are different from the original cause, which means this PR solves it.

For the record, those three failures are:
```
CypressError: Timed out retrying after 5000ms: `cy.wait()` timed out waiting `5000ms` for the 1st request to the route: `modelQuery79`. No request ever occurred.
```
This is most likely due to resources getting depleted in a runner because they happened quite late on attempts 89, 95, and 98.

### Update

In order to further reduce flakiness, I've replaced `H.visitModel()` with going straight to the model's query definition page. No more waiting for the request. This helped because these are the newest results:

- [100/100 passes](https://github.com/metabase/metabase/actions/runs/20511789169) (with throttling enabled) ✅ 
- [1 failed out of 100](https://github.com/metabase/metabase/actions/runs/20511790263) probably due to the runner choking