### PR TITLE
Prevent black background loaded with light full-app embedding

### DIFF
--- a/resources/frontend_client/index_template.html
+++ b/resources/frontend_client/index_template.html
@@ -17,10 +17,6 @@
     <meta name="base-href" content="{{{baseHref}}}" />
     <meta name="uri" content="{{{uri}}}" />
 
-    {{#hasColorSchemeMetaTag}}
-    <meta name="color-scheme" content="light dark" />
-    {{/hasColorSchemeMetaTag}}
-
     {{{embedCode}}}
 
     <title>{{{applicationName}}}</title>

--- a/src/metabase/server/routes/index.clj
+++ b/src/metabase/server/routes/index.clj
@@ -79,7 +79,7 @@
         (throw (Exception. message e))))))
 
 (defn- template-parameters
-  [entrypoint-name embeddable? {:keys [uri params nonce]}]
+  [embeddable? {:keys [uri params nonce]}]
   (let [{:keys [anon-tracking-enabled google-auth-client-id], :as public-settings} (setting/user-readable-values-map #{:public})
         ;; We disable `locale` parameter on static embeds/public links (metabase#50313)
         should-load-locale-params? (not embeddable?)]
@@ -101,15 +101,12 @@
      :baseHref               (hiccup.util/escape-html (base-href))
      :embedCode              (when embeddable? (embed/head uri))
      :enableGoogleAuth       (boolean google-auth-client-id)
-     :enableAnonTracking     (boolean anon-tracking-enabled)
-     ;; (metabase#65533) color-scheme meta tag breaks Modular embedding because it has a transparent background.
-     ;; (metabase#66585) Also omit for static/public embedding to preserve legacy behavior for transparent iframes.
-     :hasColorSchemeMetaTag  (not (contains? #{"embed-sdk" "embed" "public"} entrypoint-name))}))
+     :enableAnonTracking     (boolean anon-tracking-enabled)}))
 
 (defn- load-entrypoint-template [entrypoint-name embeddable? opts]
   (load-template
    (str "frontend_client/" entrypoint-name ".html")
-   (template-parameters entrypoint-name embeddable? opts)))
+   (template-parameters embeddable? opts)))
 
 (defn- load-init-template []
   (load-template

--- a/test/metabase/server/routes/index_test.clj
+++ b/test/metabase/server/routes/index_test.clj
@@ -76,12 +76,12 @@
 
 (deftest load-entrypoint-template-contains-user-locale
   (binding [i18n/*user-locale* "es"]
-    (is (= "es" (:language (#'index/template-parameters "index" false {})))))
+    (is (= "es" (:language (#'index/template-parameters false {})))))
   (binding [i18n/*user-locale* "en"]
-    (is (= "en" (:language (#'index/template-parameters "index" false {})))))
+    (is (= "en" (:language (#'index/template-parameters false {})))))
   (mt/with-temporary-setting-values [site-locale "es"]
     ;; site locale is used as the default
-    (is (= "es" (:language (#'index/template-parameters "index" false {}))))
+    (is (= "es" (:language (#'index/template-parameters false {}))))
     ;; but we can override with the user locale
     (binding [i18n/*user-locale* "fr"]
-      (is (= "fr" (:language (#'index/template-parameters "index" false {})))))))
+      (is (= "fr" (:language (#'index/template-parameters false {})))))))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #66544
closes EMB-1103

### Backport reasons
Since fixes mentioned below go back to 57, we need to double backport.

### Description

This happens because we started to set `color-sheme` to `light-dark` in https://github.com/metabase/metabase/pull/64324. This seems to create more problems down the line.

- https://github.com/metabase/metabase/pull/66753
- https://github.com/metabase/metabase/pull/66662
- https://github.com/metabase/metabase/pull/65534

So, [we agreed](https://metaboat.slack.com/archives/C063Q3F1HPF/p1766678513710849?thread_ts=1766677861.982509&cid=C063Q3F1HPF) that the proper way to deal with this is to revert #64324, and if users can set their desired `color-scheme` on the iframe when needed.

### How to verify

1. Set your device theme mode to automatic (not sure if it's needed, but this is what I and Alberto who originally reported the issue set)
1. Embed full-app embedding. If you're running this PR, there should be no black background flash anymore.

### Demo
#### After

https://github.com/user-attachments/assets/dd1be06e-cee8-4887-928e-de2b2db52010



#### Before
https://github.com/user-attachments/assets/51a0200f-8474-498d-8a3f-7bd425bd0576



### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
