### PR TITLE
fix: custom home page settings are not being exported

### DIFF
--- a/src/metabase/appearance/settings.clj
+++ b/src/metabase/appearance/settings.clj
@@ -35,14 +35,16 @@
   :default    false
   :type       :boolean
   :audit      :getter
-  :visibility :public)
+  :visibility :public
+  :export?    true)
 
 (defsetting custom-homepage-dashboard
   (deferred-tru "ID of dashboard to use as a homepage")
   :encryption :no
   :type       :integer
   :visibility :public
-  :audit      :getter)
+  :audit      :getter
+  :export?    true)
 
 (defn- coerce-to-relative-url
   "Get the path of a given URL if the URL contains an origin.

--- a/test_resources/serialization_baseline/settings.yaml
+++ b/test_resources/serialization_baseline/settings.yaml
@@ -12,6 +12,8 @@ available-timezones: null
 breakout-bins-num: null
 custom-formatting: null
 custom-geojson: null
+custom-homepage: null
+custom-homepage-dashboard: null
 custom-geojson-enabled: null
 default-maps-enabled: null
 disable-cors-on-localhost: null


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #38969
Closes https://linear.app/metabase/issue/GDGT-20/custom-homepage-will-not-be-dumped-in-serialization

### Description

Two settings related to custom home page were not marked as ones that should be exported. Adding `export` flag was enough to fix it.

### How to verify

1. Go to `/admin/settings/general` 
2. Enable `Custom homepage` and set any dashboard as the homepage.
3. [Export/serialize](https://www.metabase.com/docs/latest/installation-and-operation/serialization) Metabase instance.
```
curl \
  -H 'x-api-key: api-token' \
  -X POST 'http://localhost:3000/api/ee/serialization/export' \
  -o metabase_data.tgz
```
4. Decompess the file file and check if `settings.yaml` has exported dashboard fields (`custom-homepage` and `custom-homepage-dashboard`).

Additionally turn off custom home page in settings and then import exported settings to see if the custom homepage will be correctly imported.

```
curl -X POST \
  -H 'x-api-key: api-token' \
  -F 'file=@metabase_data.tar.gz' \
  'http://localhost:3000/api/ee/serialization/import' \
  -o -
```

### Checklist

- [x] Export/import features are already covered with tests.
