### PR TITLE
Don't water down the table background color

### DIFF
--- a/frontend/src/metabase/visualizations/lib/table_format.js
+++ b/frontend/src/metabase/visualizations/lib/table_format.js
@@ -6,7 +6,7 @@ import Color from "color";
 import { alpha } from "metabase/lib/colors";
 import { getColorScale, getSafeColor } from "metabase/lib/colors/scales";
 
-const CELL_ALPHA = 0.65;
+const CELL_ALPHA = 1;
 const ROW_ALPHA = 0.2;
 const GRADIENT_ALPHA = 0.75;
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #65586
Closes GIT-8503

### Description

We should let users see the exact color they selected.


### Note
I found this 0.65 opacity was introduced in [this PR](https://github.com/metabase/metabase/pull/7644). It stated that [the darkest color was too hard to read](https://github.com/metabase/metabase/pull/7644#issuecomment-390343610).


### How to verify

View a table, and set conditional formatting to any color. You should see the exact color not a toned down version of it.


### Demo
#### Color selected
<img width="383" height="117" alt="image" src="https://github.com/user-attachments/assets/b9235fe4-9adb-45ba-87e8-23fd81d8abf0" />

#### After
<img width="165" height="211" alt="Screenshot 2025-12-26 at 9 37 12 PM" src="https://github.com/user-attachments/assets/9fcaf11b-3d9c-4fe4-be6f-91a5d385200e" />


#### Before
<img width="261" height="246" alt="Screenshot 2025-12-26 at 9 36 52 PM" src="https://github.com/user-attachments/assets/83b15438-519a-409a-bae6-e5d428bec655" />

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
