### PR TITLE
fix: hide editing toggle for unsupported engines

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/table-editing/admin/AdminDatabaseTableEditingSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/admin/AdminDatabaseTableEditingSection.tsx
@@ -27,14 +27,16 @@ enum DisabledReasonKey {
   MissingDriverFeature = "driver-feature-missing",
   NoWriteableTable = "permissions/no-writable-table",
   SyncInProgress = "database-metadata/sync-in-progress",
-  DatabaseEmtpy = "database-metadata/not-populated",
+  DatabaseEmpty = "database-metadata/not-populated",
 }
 
 const VISIBLE_REASONS: string[] = [
   DisabledReasonKey.NoWriteableTable,
   DisabledReasonKey.SyncInProgress,
-  DisabledReasonKey.DatabaseEmtpy,
+  DisabledReasonKey.DatabaseEmpty,
 ];
+
+const ALLOWED_ENGINES_FOR_TABLE_EDITING = ["postgres", "mysql"];
 
 export function AdminDatabaseTableEditingSection({
   database,
@@ -69,6 +71,11 @@ export function AdminDatabaseTableEditingSection({
     }
   };
 
+  // Only Postgres and MySQL support table data editing
+  const allowedToEnableTableEditing =
+    database.engine &&
+    ALLOWED_ENGINES_FOR_TABLE_EDITING.includes(database.engine);
+
   const dataEditingSetting =
     settingsAvailable?.[DATABASE_TABLE_EDITING_SETTING];
 
@@ -83,7 +90,11 @@ export function AdminDatabaseTableEditingSection({
   const shouldShowSection =
     !firstDisabledReason || VISIBLE_REASONS.includes(firstDisabledReason.key);
 
-  if (!dataEditingSetting || !shouldShowSection) {
+  if (
+    !dataEditingSetting ||
+    !shouldShowSection ||
+    !allowedToEnableTableEditing
+  ) {
     return null;
   }
 

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/admin/AdminDatabaseTableEditingSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/admin/AdminDatabaseTableEditingSection.tsx
@@ -8,6 +8,7 @@ import {
 } from "metabase/admin/databases/components/DatabaseFeatureComponents";
 import { DatabaseInfoSection } from "metabase/admin/databases/components/DatabaseInfoSection";
 import Toggle from "metabase/common/components/Toggle";
+import { ALLOWED_ENGINES_FOR_TABLE_EDITING } from "metabase/databases/constants";
 import { trackSimpleEvent } from "metabase/lib/analytics";
 import { getResponseErrorMessage } from "metabase/lib/errors";
 import { Box, Flex } from "metabase/ui";
@@ -35,8 +36,6 @@ const VISIBLE_REASONS: string[] = [
   DisabledReasonKey.SyncInProgress,
   DisabledReasonKey.DatabaseEmpty,
 ];
-
-const ALLOWED_ENGINES_FOR_TABLE_EDITING = ["postgres", "mysql"];
 
 export function AdminDatabaseTableEditingSection({
   database,

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/admin/AdminDatabaseTableEditingSection.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/admin/AdminDatabaseTableEditingSection.unit.spec.tsx
@@ -25,11 +25,21 @@ const setup = (options: {
 };
 
 describe("AdminDatabaseTableEditingSection", () => {
-  it("should render for supported engines", () => {
-    setup({ engine: "postgres" });
+  it.each(["postgres", "mysql"])(
+    "should render for supported engine: %s",
+    (engine) => {
+      setup({ engine });
+      expect(
+        screen.getByTestId("database-table-editing-section"),
+      ).toBeInTheDocument();
+    },
+  );
+
+  it("should hide section for unsupported engines", () => {
+    setup({ engine: "h2" });
     expect(
-      screen.getByTestId("database-table-editing-section"),
-    ).toBeInTheDocument();
+      screen.queryByTestId("database-table-editing-section"),
+    ).not.toBeInTheDocument();
   });
 
   it("should render disabled toggle for specific disabled reasons", () => {

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/admin/AdminDatabaseTableEditingSection.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/admin/AdminDatabaseTableEditingSection.unit.spec.tsx
@@ -6,16 +6,18 @@ import { DATABASE_TABLE_EDITING_SETTING } from "../settings";
 
 import { AdminDatabaseTableEditingSection } from "./AdminDatabaseTableEditingSection";
 
-const setup = (
-  setting: DatabaseLocalSettingAvailability = { enabled: true },
-) => {
-  const mockDatabase = createMockDatabase();
+const setup = (options: {
+  driverSetting?: DatabaseLocalSettingAvailability;
+  engine?: string;
+}) => {
+  const { driverSetting = { enabled: true }, engine = "h2" } = options;
+  const mockDatabase = createMockDatabase({ engine });
 
   return renderWithProviders(
     <AdminDatabaseTableEditingSection
       database={mockDatabase}
       settingsAvailable={{
-        [DATABASE_TABLE_EDITING_SETTING]: setting,
+        [DATABASE_TABLE_EDITING_SETTING]: driverSetting,
       }}
       updateDatabase={() => Promise.resolve()}
     />,
@@ -24,9 +26,7 @@ const setup = (
 
 describe("AdminDatabaseTableEditingSection", () => {
   it("should render for supported engines", () => {
-    setup({
-      enabled: true,
-    });
+    setup({ engine: "postgres" });
     expect(
       screen.getByTestId("database-table-editing-section"),
     ).toBeInTheDocument();
@@ -34,13 +34,16 @@ describe("AdminDatabaseTableEditingSection", () => {
 
   it("should render disabled toggle for specific disabled reasons", () => {
     setup({
-      enabled: false,
-      reasons: [
-        {
-          key: "permissions/no-writable-table",
-          message: "Database connection is read-only",
-        },
-      ],
+      driverSetting: {
+        enabled: false,
+        reasons: [
+          {
+            key: "permissions/no-writable-table",
+            message: "Database connection is read-only",
+          },
+        ],
+      },
+      engine: "postgres",
     });
 
     expect(
@@ -55,13 +58,16 @@ describe("AdminDatabaseTableEditingSection", () => {
 
   it("should hide section for other disabled reasons", () => {
     setup({
-      enabled: false,
-      reasons: [
-        {
-          key: "driver-feature-missing",
-          message: "The driver does not support table editing",
-        },
-      ],
+      driverSetting: {
+        enabled: false,
+        reasons: [
+          {
+            key: "driver-feature-missing",
+            message: "The driver does not support table editing",
+          },
+        ],
+      },
+      engine: "mysql",
     });
 
     expect(

--- a/frontend/src/metabase/databases/constants.tsx
+++ b/frontend/src/metabase/databases/constants.tsx
@@ -39,6 +39,12 @@ export const ELEVATED_ENGINES = [
   "snowflake",
 ];
 
+// Although some drivers like MongoDB or H2 have table editing capabilities,
+// they were not thoroughly tested and verified.
+// We want to, for now at least, allow users to turn on table editing
+// just for PostgreSQL and MySQL databases.
+export const ALLOWED_ENGINES_FOR_TABLE_EDITING = ["postgres", "mysql"];
+
 export const ENGINE_LOGO: Record<string, string> = {
   athena: "athena.svg",
   bigquery: "bigquery.svg",


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #65901
Closes https://linear.app/metabase/issue/GDGT-1243/disable-option-to-edit-table-data-for-any-db-that-is-not-mysql-or

### Description

Although some drivers like MongoDB or H2 have table editing capabilities, they were not thoroughly tested and verified. We want to, for now at least, allow users to turn on table editing just for PostgreSQL and MySQL databases. 

The conclusion from discussion was that it's enough to turn off the possibility toggle editing in the UI and leave drivers themselves, as is. That's why a new reason to turn of editing was not introduced.

Adding a separate reason in the UI breaks many drivers which support editing, but are not supported and fully verified and tested by us. Doing this change in the UI has much less blast radius and is inline with the discussions and product requirements.
- https://github.com/metabase/metabase/actions/runs/20572390572?pr=67564
- https://github.com/metabase/metabase/pull/67564/changes/7116b107a8866c2257f32493799c34e92bb61c71

### How to verify

Go to unsupported DB, like H2. It should have the table editing section hidden.
Supported DB, like PostgreSQL, should have the section visible and enabled. 

<img width="2346" height="2512" alt="41154" src="https://github.com/user-attachments/assets/f1191428-bbbe-4346-9c43-d52f5f102787" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
