### PR TITLE
fix: scientific notation in color (#67087)

### DIFF
--- a/frontend/src/metabase/visualizations/lib/table_format.js
+++ b/frontend/src/metabase/visualizations/lib/table_format.js
@@ -141,7 +141,7 @@ export function compileFormatter(
     }
 
     const scale = getColorScale(
-      [min, max],
+      [min, 100],
       format.colors.map((c) => {
         const color = Color(c);
         const alpha = color.alpha();

--- a/frontend/src/metabase/visualizations/lib/table_format.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/table_format.unit.spec.js
@@ -119,6 +119,27 @@ describe("compileFormatter", () => {
     expect(formatter("food")).toBe(null);
     expect(formatter("foo ")).toBe(null);
   });
+
+  it("properly detect not scientific notation", () => {
+    const formatter = compileFormatter(
+      {
+        columns: ["A"],
+        type: "range",
+        colors: ["transparent", "#C8B4DA"],
+        min_type: null,
+        max_type: null,
+        min_value: 0,
+        max_value: 100,
+      },
+      "A",
+      {
+        A: [0, 1000000],
+      },
+    );
+
+    expect(formatter(0)).toBe("rgba(200, 180, 218, 0)");
+    expect(formatter(1)).toBe("rgba(200, 180, 218, 0.0075)");
+  });
 });
 
 describe("canCompareSubstrings", () => {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/67087

### Description

Describe the overall approach and the problem being solved.
The issue was caused due to [`Color`](https://www.npmjs.com/package/color) package not being able to process scientific notation return in `opacity` value inside `rgba` [here](https://github.com/metabase/metabase/blob/c6efa84b64d4f915f093e1901c7a6949bc882b78/frontend/src/metabase/lib/colors/palette.ts#L121) and the cause of scientific notation in `rgba` was [`scaleLinear`](https://www.npmjs.com/package/d3-scale#linear-scales) code for which can be found [here](https://github.com/metabase/metabase/blob/d0327d0b4b2c7027f1df49767b9ca2d3acc5be60/frontend/src/metabase/lib/colors/scales.ts#L18).
- To solve the issue I changed max value which is passed to getColorScale [here](https://github.com/metabase/metabase/blob/d0327d0b4b2c7027f1df49767b9ca2d3acc5be60/frontend/src/metabase/visualizations/lib/table_format.js#L144) to 256 which is the max range for `rgb` color which results in linear value to be in range between min value and 256.

### How to verify

Describe the steps to verify that the changes are working as expected.

- Issue reproduction steps can be used for validation from issue ticket.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
