### PR TITLE
Add a tooltip message if model persistence is unsupported for a database

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/model_persistence/components/ModelCacheControl/ModelCacheControl.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/model_persistence/components/ModelCacheControl/ModelCacheControl.tsx
@@ -1,5 +1,6 @@
 import { t } from "ttag";
 
+import { hasFeature } from "metabase/admin/databases/utils";
 import {
   skipToken,
   useGetDatabaseQuery,
@@ -10,6 +11,30 @@ import { DelayedLoadingAndErrorWrapper } from "metabase/common/components/Loadin
 import { Switch, Tooltip } from "metabase/ui";
 import type Question from "metabase-lib/v1/Question";
 import type { ModelCacheRefreshStatus } from "metabase-types/api";
+
+function getTooltipLabel({
+  userCanPersist,
+  isModelPersistenceSupported,
+  isModelPersistenceEnabled,
+}: {
+  userCanPersist: boolean;
+  isModelPersistenceSupported: boolean;
+  isModelPersistenceEnabled: boolean;
+}): string | null {
+  if (!userCanPersist) {
+    return t`You don't have permission to modify model persistence`;
+  }
+
+  if (!isModelPersistenceSupported) {
+    return t`Model persistence is not supported for this database`;
+  }
+
+  if (!isModelPersistenceEnabled) {
+    return t`Model persistence is disabled for this database`;
+  }
+
+  return null;
+}
 
 export function ModelCacheToggle({
   persistedModel,
@@ -37,21 +62,20 @@ export function ModelCacheToggle({
   const isPersisted = persistedModel && persistedModel.state !== "off";
   const modelId = model.id();
   const userCanPersist = model.canManageDB();
-  const canPersistDatabase = database?.settings?.["persist-models-enabled"];
-  const databaseSupportsPersistence =
-    database?.features?.includes("persist-models");
+  const isModelPersistenceEnabled =
+    database?.settings?.["persist-models-enabled"] ?? false;
 
-  if (!userCanPersist || !databaseSupportsPersistence || !canPersistDatabase) {
-    let tooltipLabel;
+  const isModelPersistenceSupported = database
+    ? hasFeature(database, "persist-models")
+    : false;
 
-    if (!userCanPersist) {
-      tooltipLabel = t`You don't have permission to modify model persistence`;
-    } else if (!databaseSupportsPersistence) {
-      tooltipLabel = t`Model persistence is not supported for this database`;
-    } else {
-      tooltipLabel = t`Model persistence is disabled for this database`;
-    }
+  const tooltipLabel = getTooltipLabel({
+    userCanPersist,
+    isModelPersistenceSupported,
+    isModelPersistenceEnabled,
+  });
 
+  if (tooltipLabel) {
     return (
       <Tooltip label={tooltipLabel}>
         {/* need this div so that disabled input doesn't swallow pointer events */}

--- a/enterprise/frontend/src/metabase-enterprise/model_persistence/components/ModelCacheControl/ModelCacheControl.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/model_persistence/components/ModelCacheControl/ModelCacheControl.tsx
@@ -38,11 +38,19 @@ export function ModelCacheToggle({
   const modelId = model.id();
   const userCanPersist = model.canManageDB();
   const canPersistDatabase = database?.settings?.["persist-models-enabled"];
+  const databaseSupportsPersistence =
+    database?.features?.includes("persist-models");
 
-  if (!canPersistDatabase || !userCanPersist) {
-    const tooltipLabel = !canPersistDatabase
-      ? t`Model persistence is disabled for this database`
-      : t`You don't have permission to modify model persistence`;
+  if (!userCanPersist || !databaseSupportsPersistence || !canPersistDatabase) {
+    let tooltipLabel;
+
+    if (!userCanPersist) {
+      tooltipLabel = t`You don't have permission to modify model persistence`;
+    } else if (!databaseSupportsPersistence) {
+      tooltipLabel = t`Model persistence is not supported for this database`;
+    } else {
+      tooltipLabel = t`Model persistence is disabled for this database`;
+    }
 
     return (
       <Tooltip label={tooltipLabel}>

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionSettingsSidebar/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionSettingsSidebar/tests/enterprise.unit.spec.tsx
@@ -1,3 +1,5 @@
+import userEvent from "@testing-library/user-event";
+
 import { screen } from "__support__/ui";
 import type { TokenFeatures } from "metabase-types/api";
 import {
@@ -78,6 +80,46 @@ describe("QuestionSettingsSidebar", () => {
       expect(await screen.findByText("Persist model data")).toHaveAttribute(
         "data-disabled",
         "true",
+      );
+    });
+
+    it("should show 'not supported' message when database driver doesn't support persistence", async () => {
+      await setupEnterprise(
+        {
+          card: model,
+          dbHasModelPersistence: false,
+          dbSupportsModelPersistence: false,
+        },
+        { cache_granular_controls: true },
+      );
+
+      const toggle = await screen.findByText("Persist model data");
+      expect(toggle).toHaveAttribute("data-disabled", "true");
+
+      await userEvent.hover(toggle);
+
+      expect(await screen.findByRole("tooltip")).toHaveTextContent(
+        "Model persistence is not supported for this database",
+      );
+    });
+
+    it("should show 'disabled' message when database supports but has persistence disabled", async () => {
+      await setupEnterprise(
+        {
+          card: model,
+          dbHasModelPersistence: false,
+          dbSupportsModelPersistence: true,
+        },
+        { cache_granular_controls: true },
+      );
+
+      const toggle = await screen.findByText("Persist model data");
+      expect(toggle).toHaveAttribute("data-disabled", "true");
+
+      await userEvent.hover(toggle);
+
+      expect(await screen.findByRole("tooltip")).toHaveTextContent(
+        "Model persistence is disabled for this database",
       );
     });
   });

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionSettingsSidebar/tests/setup.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionSettingsSidebar/tests/setup.tsx
@@ -56,7 +56,9 @@ export const setup = async ({
       settings: { "persist-models-enabled": dbHasModelPersistence },
       features: dbSupportsModelPersistence
         ? COMMON_DATABASE_FEATURES
-        : COMMON_DATABASE_FEATURES?.filter((f) => f !== "persist-models"),
+        : COMMON_DATABASE_FEATURES.filter(
+            (feature) => feature !== "persist-models",
+          ),
     }),
   );
 

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionSettingsSidebar/tests/setup.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionSettingsSidebar/tests/setup.tsx
@@ -14,6 +14,7 @@ import { checkNotNull } from "metabase/lib/types";
 import { getMetadata } from "metabase/selectors/metadata";
 import type { Card, Settings } from "metabase-types/api";
 import {
+  COMMON_DATABASE_FEATURES,
   createMockCard,
   createMockSettings,
   createMockTokenFeatures,
@@ -50,20 +51,14 @@ export const setup = async ({
     }),
   ]);
 
-  const database = createSampleDatabase({
-    settings: {
-      "persist-models-enabled": dbHasModelPersistence,
-    },
-  });
-
-  // If database doesn't support model persistence, remove the persist-models feature
-  if (!dbSupportsModelPersistence) {
-    database.features = database.features?.filter(
-      (f) => f !== "persist-models",
-    );
-  }
-
-  setupDatabaseEndpoints(database);
+  setupDatabaseEndpoints(
+    createSampleDatabase({
+      settings: { "persist-models-enabled": dbHasModelPersistence },
+      features: dbSupportsModelPersistence
+        ? COMMON_DATABASE_FEATURES
+        : COMMON_DATABASE_FEATURES?.filter((f) => f !== "persist-models"),
+    }),
+  );
 
   const state = createMockState({
     currentUser,


### PR DESCRIPTION
Closes #63712
Closes QUE-2515

### Description

Shows "Model persistence is not supported for this database" tooltip message if model persistence isn't supported.

### How to verify

1. Create a model on a DB that doesn't support persistence
2. From the model go to Model Settings
3. See we display a grey toggle for enabling persistence
4. On hover, the tooltip should indicate that persistence is **not supported** for that database

### Demo

If not supported

<img width="744" height="328" alt="CleanShot 2568-12-27 at 00 49 43@2x" src="https://github.com/user-attachments/assets/79cb0174-0d0f-4196-aaef-2c4590d2eda9" />

If disabled

<img width="762" height="434" alt="CleanShot 2568-12-27 at 00 50 46@2x" src="https://github.com/user-attachments/assets/c805ed4a-9189-42d4-87af-cf6498afac9f" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
