### PR TITLE
Increase the unreturned cxn timeout for appdb

### DIFF
--- a/src/metabase/app_db/connection_pool_setup.clj
+++ b/src/metabase/app_db/connection_pool_setup.clj
@@ -135,7 +135,20 @@
    "maxPoolSize"
    (or (config/config-int :mb-application-db-max-connection-pool-size)
        ;; 15 is the c3p0 default but it's always nice to be explicit in case that changes
-       15)})
+       15)
+
+   "unreturnedConnectionTimeout"
+   (or (config/config-int :mb-application-db-unreturned-connection-timeout)
+       ;; we set an unreturnedConnectionTimeout for data warehouses, via
+       ;; `(driver.settings/jdbc-data-warehouse-unreturned-connection-timeout-seconds)`, which defaults to the same
+       ;; 5 minute value as the query timeout. But for the application DB this is not nearly so safe, as we don't
+       ;; have a fixed maximum possible time a query could take, and e.g. `copy-to-h2` can easily take more than this.
+       ;;
+       ;; Let's default to 1 hour. Note that as discussed at
+       ;; https://www.mchange.com/projects/c3p0/#unreturnedConnectionTimeout
+       ;; this is a *backstop*; as it says there, "it's better to be neurotic about closing your Connections in
+       ;; the first place."
+       3600)})
 
 (mu/defn connection-pool-data-source :- (ms/InstanceOfClass PoolBackedDataSource)
   "Create a connection pool [[javax.sql.DataSource]] from an unpooled [[javax.sql.DataSource]] `data-source`. If


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #67470
For the data warehouses we can safely set a fixed
unreturnedConnectionTimeout to a fairly low number (5 minute default) because we also have a default maximum query length for data warehouses, which can't be exceeded anywhere. This is the default, without this PR.

For the application DB though, this isn't safe, as operations against it can legitimately hold connections for extended periods - for example, dump-to-h2 on large databases streams data for as long as it takes to copy all rows.

Bumping this to 1 hour by default (configurable via `MB_APPLICATION_DB_UNRETURNED_CONNECTION_TIMEOUT`).