### PR TITLE
Fix empty cards with no results making dashboard longer than expected

### DIFF
--- a/e2e/test/scenarios/dashboard/visualizer/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/reproductions.cy.spec.ts
@@ -1,5 +1,9 @@
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import type { StructuredQuestionDetails } from "e2e/support/helpers";
+import type {
+  DashboardDetails,
+  StructuredQuestionDetails,
+} from "e2e/support/helpers";
+import type { DashboardCard, Parameter } from "metabase-types/api";
 
 const { H } = cy;
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -162,6 +166,127 @@ describe("issue 61521", () => {
       cy.findByText("0.06").should("not.exist");
       cy.findByText("0.05").should("not.exist");
       cy.findByText("0.04").should("not.exist");
+    });
+  });
+});
+
+describe("issue 65908 (UXW-2293)", () => {
+  const dateParameters: Parameter = {
+    default: "2030-01-01~",
+    id: "d3b78b27",
+    name: "Date Filter",
+    slug: "date_filter",
+    type: "date/all-options",
+  };
+
+  interface CreateDashcardProps {
+    index: number;
+    questionId: number;
+    hideEmptyResults: boolean;
+    withParameterMappings: boolean;
+  }
+  function createDashcard({
+    index,
+    questionId,
+    hideEmptyResults,
+    withParameterMappings,
+  }: CreateDashcardProps): Partial<DashboardCard> {
+    const cardHeightInRows = 10;
+
+    return {
+      col: 0,
+      row: cardHeightInRows * index,
+      size_x: 24,
+      size_y: cardHeightInRows,
+      card_id: questionId,
+      visualization_settings: {
+        "card.hide_empty": hideEmptyResults,
+      },
+      parameter_mappings: withParameterMappings
+        ? [
+            {
+              parameter_id: dateParameters.id,
+              card_id: questionId,
+              target: ["dimension", ["field", ORDERS.CREATED_AT, null]],
+            },
+          ]
+        : undefined,
+    };
+  }
+
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+
+    const dashboardDetails = {
+      name: "Dashboard with empty result cards",
+      parameters: [dateParameters],
+    } satisfies DashboardDetails;
+
+    const questionDetails: StructuredQuestionDetails = {
+      name: "Orders question",
+      query: {
+        "source-table": ORDERS_ID,
+        limit: 5,
+      },
+    };
+
+    H.createDashboardWithQuestions({
+      dashboardDetails,
+      questions: [questionDetails],
+    }).then(({ dashboard, questions }) => {
+      const [question] = questions;
+      H.updateDashboardCards({
+        dashboard_id: dashboard.id,
+        cards: [
+          createDashcard({
+            index: 0,
+            questionId: question.id,
+            hideEmptyResults: true,
+            withParameterMappings: true,
+          }),
+          createDashcard({
+            index: 1,
+            questionId: question.id,
+            hideEmptyResults: true,
+            withParameterMappings: true,
+          }),
+          createDashcard({
+            index: 2,
+            questionId: question.id,
+            hideEmptyResults: true,
+            withParameterMappings: true,
+          }),
+          createDashcard({
+            index: 3,
+            questionId: question.id,
+            hideEmptyResults: false,
+            withParameterMappings: false,
+          }),
+        ],
+      });
+      cy.wrap(dashboard.id).as("dashboardId");
+    });
+  });
+
+  it("should not take into account the height of cards with no results when calculating dashboard height", () => {
+    cy.get("@dashboardId").then((dashboardId: any) => {
+      H.visitDashboard(dashboardId);
+
+      cy.findByDisplayValue("Dashboard with empty result cards").should(
+        "be.visible",
+      );
+
+      H.getDashboardCard().within(() => {
+        cy.findByText("Orders question").should("be.visible");
+        cy.log("Checks for the subtotal value from the first row");
+        cy.findByText("37.65").should("be.visible");
+      });
+
+      cy.findByRole("main").should(($main) => {
+        // 4 cards take about 2000px in height, so only 1 card should definitely take less than 1000px
+        expect($main[0].scrollHeight).to.be.lessThan(1000);
+      });
     });
   });
 });

--- a/frontend/src/metabase/dashboard/components/grid/GridLayout.tsx
+++ b/frontend/src/metabase/dashboard/components/grid/GridLayout.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   type ItemCallback,
   Responsive as ReactGridLayout,
 } from "react-grid-layout";
+import _ from "underscore";
 
 import { useMantineTheme } from "metabase/ui";
 
@@ -117,10 +118,19 @@ export function GridLayout<T extends { id: number | null }>(
     [marginMap, currentBreakpoint],
   );
 
-  const layout = useMemo(
-    () => layouts[currentBreakpoint],
-    [layouts, currentBreakpoint],
-  );
+  const previousLayoutRef = useRef<ReactGridLayout.Layout[]>();
+  const layout = useMemo(() => {
+    const newLayout = layouts[currentBreakpoint];
+    const previousLayout = previousLayoutRef.current;
+    if (previousLayout !== undefined && _.isEqual(newLayout, previousLayout)) {
+      return previousLayout;
+    }
+    return newLayout;
+  }, [layouts, currentBreakpoint]);
+
+  useEffect(() => {
+    previousLayoutRef.current = layout;
+  });
 
   const cols = useMemo(
     () => columnsMap[currentBreakpoint],


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #65908
closes uxw-2293
### Backport reasons
triple backports to get this to 56

### Description

Describe the overall approach and the problem being solved.

### How to verify

Follow this [repro steps](https://github.com/metabase/metabase/issues/65908#issuecomment-3689589249)

You shouldn't be able to scroll on a dashboard with just one visible dashcard

### Demo

#### After (no scroll bar)
<img width="1162" height="734" alt="image" src="https://github.com/user-attachments/assets/ecd94c29-ba8c-464f-8fda-04ce062bff72" />

#### Before (see scroll bar)
<img width="1162" height="734" alt="image" src="https://github.com/user-attachments/assets/3b9f4000-8479-4a98-9237-8c78f81122cc" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
