### PR TITLE
Revert "Upload failed e2e test artifacts for quarantined tests (#67381)"

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -113,7 +113,6 @@ jobs:
         run: node e2e/runner/run_cypress_ci.js snapshot
 
       - name: Run auto-split Cypress tests on ${{ inputs.name }}
-        id: split-e2e
         if: ${{ !inputs.specs }}
         env:
           SPLIT: ${{ inputs.total_chunks }}
@@ -137,7 +136,6 @@ jobs:
         continue-on-error: true
 
       - name: Run Tagged EE Cypress tests on ${{ inputs.name }}
-        id: tagged-e2e
         if: ${{ inputs.specs }}
         shell: bash
         env:
@@ -170,7 +168,7 @@ jobs:
 
       - name: Upload Cypress Artifacts upon failure
         uses: actions/upload-artifact@v4
-        if: steps.split-e2e.outcome == 'failure' || steps.tagged-e2e.outcome == 'failure'
+        if: failure()
         with:
           name: cypress-recording-${{ inputs.name }}-${{ inputs.edition }}
           path: |
@@ -180,11 +178,10 @@ jobs:
 
       - name: Upload Failed Tests
         uses: actions/upload-artifact@v4
-        if: steps.split-e2e.outcome == 'failure' || steps.tagged-e2e.outcome == 'failure'
+        if: failure()
         with:
           name: failed-tests-${{ inputs.name }}-${{ inputs.edition }}
           path: ./cypress/test-results
-          if-no-files-found: ignore
 
       - name: Extract chunk-specific changed timings
         id: extract-timings


### PR DESCRIPTION
This reverts commit 487036f0b146f82b873aef5eee4b279deb5dc122.

For some reason, PRs now do not include Cypress failed test recordings at all. Reverting to prevent disrupting other people's workflows while I try to figure out why this happens.