### PR TITLE
Fix workspaces driver linter warnings

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -1176,10 +1176,10 @@
 (defn- ws-has-role-binding?
   "Check if a policy already has a binding for the given role and member."
   [^Policy policy ^String role ^String member]
-  (clojure.core/some (fn [^Binding binding]
-                       (and (= (.getRole binding) role)
-                            (clojure.core/some #(= % member) (.getMembersList binding))))
-                     (.getBindingsList policy)))
+  (some (fn [^Binding binding]
+          (and (= (.getRole binding) role)
+               (some #(= % member) (.getMembersList binding))))
+        (.getBindingsList policy)))
 
 (defn- ws-grant-impersonation-permission!
   "Grant the main service account permission to impersonate the workspace service account."
@@ -1310,10 +1310,10 @@
 (defn- ws-has-acl-entry?
   "Check if an ACL list already has an entry for the given entity and role."
   [acl-list ^Acl$User entity ^Acl$Role role]
-  (clojure.core/some (fn [^Acl acl]
-                       (and (= (.getEntity acl) entity)
-                            (= (.getRole acl) role)))
-                     acl-list))
+  (some (fn [^Acl acl]
+          (and (= (.getEntity acl) entity)
+               (= (.getRole acl) role)))
+        acl-list))
 
 (defn- ws-grant-dataset-acl!
   "Grant an ACL role on a dataset to a service account."

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -1,5 +1,5 @@
 (ns metabase.driver.h2
-  (:refer-clojure :exclude [some every?])
+  (:refer-clojure :exclude [some every? get-in])
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.math.combinatorics :as math.combo]
@@ -27,7 +27,7 @@
    [metabase.util.i18n :refer [deferred-tru tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [every? some]])
+   [metabase.util.performance :refer [every? get-in some]])
   (:import
    (java.sql Clob Connection ResultSet ResultSetMetaData SQLException Statement)
    (java.time OffsetTime)


### PR DESCRIPTION
Not sure why we were explicitly using clojure.core/some, so cut a PR to see if CI catches anything.

