### PR TITLE
docs: serialization API typo 

### DIFF
--- a/docs/installation-and-operation/serialization.md
+++ b/docs/installation-and-operation/serialization.md
@@ -632,53 +632,53 @@ tar -xvf  metabase_data.tgz
 
 1. Send a `curl` request to export data:
 
-```sh
-curl \
-  -H 'x-api-key: YOUR_API_KEY' \
-  -X POST 'https://your-metabase-url/api/ee/serialization/export' \
-  -o metabase_data.tgz
-```
+    ```sh
+    curl \
+      -H 'x-api-key: YOUR_API_KEY' \
+      -X POST 'https://your-metabase-url/api/ee/serialization/export' \
+      -o metabase_data.tgz
+    ```
 
-substituting `YOUR_API_KEY` with your API key and `your-metabase-url` with the URL of your Metabase instance.
+    substituting `YOUR_API_KEY` with your API key and `your-metabase-url` with the URL of your Metabase instance.
 
-> We use `POST`, not `GET`, for the `/export` endpoint.
-
-This command will download the files as a GZIP-compressed Tar file named `metabase_data.tgz`.
+    > We use `POST`, not `GET`, for the `/export` endpoint.
+    
+    This command will download the files as a GZIP-compressed Tar file named `metabase_data.tgz`.
 
 2. Unzip the compressed file:
 
-```sh
-tar -xvf metabase_data.tgz
-```
-
-The extracted directory will be called something like `metabase-yyyy-MM-dd_HH-mm`, with the date and time of the export.
+    ```sh
+    tar -xvf metabase_data.tgz
+    ```
+    
+    The extracted directory will be called something like `metabase-yyyy-MM-dd_HH-mm`, with the date and time of the export.
 
 ### Step 3: Import
 
-1. Compress the directory containing serialized Metabase application data
+1. Compress the directory containing serialized Metabase application data.
 
-Let's say you have your YAML files with Metabase application data in a directory called `metabase_data`. Before importing those files to your target Metabase, you'll need to compress those files.
+    Let's say you have your YAML files with Metabase application data in a directory called `metabase_data`. Before importing those files to your target Metabase, you'll need to compress those files.
+    
+    ```sh
+    tar -czf metabase_data.tgz metabase_data
+    ```
 
-```sh
-tar -czf metabase_data.tgz metabase_data
-```
+2. POST to `/api/ee/serialization/import`.
 
-3. POST to `/api/ee/serialization/import`.
+    From the directory where you've stored your GZIP-compressed file, run:
+    
+    ```sh
+    curl -X POST \
+      -H 'x-api-key: YOUR_API_KEY' \
+      -F 'file=@metabase_data.tgz' \
+      'https://your-metabase-url/api/ee/serialization/import' \
+      -o -
+    ```
 
-From the directory where you've stored your GZIP-compressed file, run:
+    substituting `YOUR_API_KEY` with your API key and `your-metabase-url` with your Metabase instance URL.
+    The `-o -` option will output logs in the terminal.
 
-```sh
-curl -X POST \
-  -H 'x-api-key: YOUR_API_KEY' \
-  -F file=@metabase_data.tgz \
-  'https://your-metabase-url/api/ee/serialization/import' \
-  -o -
-```
-
-substituting `YOUR_API_KEY` with your API key and `your-metabase-url` with your Metabase instance URL.
-The `-o -` option will output logs in the terminal.
-
-> If you import Metabase data into the same Metabase as you exported it from, you will overwrite your existing questions, dashboards, etc. See [How import works](#how-import-works).
+    > If you import Metabase data into the same Metabase as you exported it from, you will overwrite your existing questions, dashboards, etc. See [How import works](#how-import-works).
 
 ## Other uses of serialization
 


### PR DESCRIPTION
https://metaboat.slack.com/archives/C013N8XL286/p1766748019130699

`file=@metabase_data.tgz` should be in quotes. The rest is just fixing list indentation