### PR TITLE
Avoid persisting non-dashboard settings

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartSettings/DashboardChartSettings/DashboardChartSettings.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings/DashboardChartSettings/DashboardChartSettings.tsx
@@ -3,7 +3,9 @@ import _ from "underscore";
 
 import { useDashboardContext } from "metabase/dashboard/context";
 import { Divider, Flex } from "metabase/ui";
+import { getVisualizationRaw } from "metabase/visualizations";
 import { getClickBehaviorSettings } from "metabase/visualizations/lib/settings";
+import { sanitizeDashcardSettings } from "metabase/visualizations/lib/settings/typed-utils";
 import { getSettingsWidgetsForSeries } from "metabase/visualizations/lib/settings/visualization";
 import type { VisualizationSettings } from "metabase-types/api";
 
@@ -39,9 +41,20 @@ export const DashboardChartSettings = ({
   });
 
   const handleDone = useCallback(() => {
-    onChange?.(chartSettings ?? tempSettings ?? {});
+    const allSettings = chartSettings ?? tempSettings ?? {};
+
+    // Filter out settings with dashboard: false to avoid persisting
+    // settings that are hidden from dashboard UI
+    const visualization = getVisualizationRaw(series);
+    const vizSettingsDefs = visualization?.settings ?? {};
+    const settingsToSave = sanitizeDashcardSettings(
+      allSettings,
+      vizSettingsDefs,
+    );
+
+    onChange?.(settingsToSave);
     onClose?.();
-  }, [chartSettings, onChange, onClose, tempSettings]);
+  }, [chartSettings, onChange, onClose, tempSettings, series]);
 
   const handleResetSettings = useCallback(() => {
     const originalCardSettings = dashcard?.card.visualization_settings;

--- a/frontend/src/metabase/visualizations/lib/settings/typed-utils.ts
+++ b/frontend/src/metabase/visualizations/lib/settings/typed-utils.ts
@@ -71,6 +71,27 @@ export const isSettingHiddenOnDashboards = (
   return vizSettingDefinition.dashboard === false;
 };
 
+/**
+ * Filters out visualization settings that should not be persisted in dashcards.
+ * Settings with `dashboard: false` are hidden from dashboard UI and should not
+ * be saved to avoid overriding the card's settings (like graph.dimensions, graph.metrics).
+ */
+export function sanitizeDashcardSettings(
+  settings: VisualizationSettings,
+  vizSettingsDefs: Record<
+    string,
+    VisualizationSettingDefinition<unknown, unknown>
+  >,
+): VisualizationSettings {
+  return Object.fromEntries(
+    Object.entries(settings).filter(([key]) => {
+      const settingDef = vizSettingsDefs[key];
+      // Keep the setting if it doesn't have dashboard: false
+      return !settingDef || !isSettingHiddenOnDashboards(settingDef);
+    }),
+  );
+}
+
 export function extendCardWithDashcardSettings(
   card: Card | VirtualCard,
   dashcardSettings?: VisualizationSettings,

--- a/frontend/src/metabase/visualizations/lib/settings/typed-utils.ts
+++ b/frontend/src/metabase/visualizations/lib/settings/typed-utils.ts
@@ -83,13 +83,10 @@ export function sanitizeDashcardSettings(
     VisualizationSettingDefinition<unknown, unknown>
   >,
 ): VisualizationSettings {
-  return Object.fromEntries(
-    Object.entries(settings).filter(([key]) => {
-      const settingDef = vizSettingsDefs[key];
-      // Keep the setting if it doesn't have dashboard: false
-      return !settingDef || !isSettingHiddenOnDashboards(settingDef);
-    }),
-  );
+  return _.pick(settings, (_, key) => {
+    const settingDef = vizSettingsDefs[key];
+    return !settingDef || !isSettingHiddenOnDashboards(settingDef);
+  });
 }
 
 export function extendCardWithDashcardSettings(


### PR DESCRIPTION
Fixes [UXW-69](https://linear.app/metabase/issue/UXW-69/dashcard-visualization-settings-should-not-persist-non-dashboard) → #61224 

### Description

This is the up-to-date version of a patch to a bug in 54 that persisted settings even when the viz settings' `dashboard` was set to `false`. Although the reported behavior isn't testable on the current release, it is when porting over the code to the 54 branch (along with the `isSettingHiddenOnDashboards` function). 

Any advice on how to properly address issues like this and/or providing repro steps for verifying the solution will be much appreciated.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
