### PR TITLE
fix: remote-sync origin url errors

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/remote_sync/source/git.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/source/git.clj
@@ -67,7 +67,7 @@
   "Fetches updates from the remote git repository.
 
   Takes a git-source map containing a :git Git instance and optional :token for authentication. Returns the result
-  of the git fetch operation.
+  of the git fetch operation. Uses the 'origin' remote which is configured by ensure-origin-configured!.
 
   Throws ExceptionInfo if the fetch operation fails."
   [{:keys [^Git git] :as git-source}]
@@ -76,37 +76,54 @@
     (u/prog1 (call-remote-command (.fetch git) git-source))
     (log/info "Successfully fetched repository")))
 
-(defn- repo-path [{:keys [^String url ^String token]}]
-  (io/file (System/getProperty "java.io.tmpdir") "metabase-git" (-> (str/join ":" [url token]) buddy-hash/sha1 codecs/bytes->hex)))
+(defn- repo-path [{:keys [^String remote-url ^String token]}]
+  (io/file (System/getProperty "java.io.tmpdir") "metabase-git" (-> (str/join ":" [remote-url token]) buddy-hash/sha1 codecs/bytes->hex)))
 
 (defn- clone-repository!
   "Clones a git repository to a temporary directory using JGit.
 
-  Takes a map with :url (the git repository URL) and optional :token (authentication token for private
+  Takes a map with :remote-url (the git repository URL) and optional :token (authentication token for private
   repositories). Returns a Git instance for the cloned repository. If the repository already exists in the temp
   directory and is valid, returns the existing repository after fetching.
 
   Throws ExceptionInfo if cloning fails due to network issues, invalid URL, authentication failure, etc."
-  [repo-path {:keys [^String url ^String token]}]
-  (log/info "Cloning repository" {:url url :repo-path repo-path})
+  [repo-path {:keys [^String remote-url ^String token]}]
+  (log/info "Cloning repository" {:url remote-url :repo-path repo-path})
   (io/make-parents repo-path)
   (try
     (u/prog1 (call-remote-command (-> (Git/cloneRepository)
                                       (.setDirectory repo-path)
-                                      (.setURI url)
+                                      (.setURI remote-url)
                                       (.setBare true)) {:token token})
       (log/info "Successfully cloned repository" {:repo-path repo-path}))
     (catch Exception e
       (throw (ex-info (format "Failed to clone git repository: %s" (ex-message e))
-                      {:url       url
+                      {:url       remote-url
                        :repo-path repo-path
                        :error     (.getMessage e)} e)))))
 
-(defn- open-jgit [^File repo-path args]
+(defn- ensure-origin-configured!
+  "Ensures the 'origin' remote is configured with the correct URL.
+
+  This fixes issues where the origin remote may be missing or have an incorrect URL
+  (e.g., after repository corruption or configuration changes). If the URL doesn't
+  match, it's updated and saved."
+  [^Git git ^String url]
+  (let [config (.getConfig (.getRepository git))
+        current-url (.getString config "remote" "origin" "url")]
+    (when (not= url current-url)
+      (log/info "Configuring origin remote" {:current current-url :new url})
+      (.setString config "remote" "origin" "url" url)
+      (.setString config "remote" "origin" "fetch" "+refs/heads/*:refs/heads/*")
+      (.save config))))
+
+(defn- open-jgit [^File repo-path {:keys [remote-url] :as args}]
   (if (.exists repo-path)
-    (do
-      (log/debugf "Opening existing at %" repo-path)
-      (Git/open repo-path))
+    (let [git (do
+                (log/debugf "Opening existing at %" repo-path)
+                (Git/open repo-path))]
+      (ensure-origin-configured! git remote-url)
+      git)
     (clone-repository! repo-path args)))
 
 (defn commit-sha
@@ -175,7 +192,7 @@
   "Pushes a local branch to the remote repository.
 
   Takes a git-source map containing a :git Git instance, :branch, and optional :token for
-  authentication.
+  authentication. Uses the 'origin' remote which is configured by ensure-origin-configured!.
 
   Returns the push response from JGit. Throws ExceptionInfo if the push operation fails or returns a
   non-OK/UP_TO_DATE status."
@@ -183,7 +200,6 @@
   (let [branch-name (qualify-branch branch)
         push-response (call-remote-command
                        (-> (.push git)
-                           (.setRemote "origin")
                            (.setRefSpecs (doto (java.util.ArrayList.)
                                            (.add (RefSpec. (str branch-name ":" branch-name))))))
                        git-source)
@@ -301,6 +317,7 @@
   "Retrieves all branch names from the remote repository.
 
   Takes a source map containing a :git Git instance and optional :token for authentication.
+  Uses the 'origin' remote which is configured by ensure-origin-configured!.
 
   Returns a sorted sequence of branch name strings (without 'refs/heads/' prefix)."
   [{:keys [^Git git] :as source}]
@@ -402,14 +419,14 @@
 
 (def ^:private jgit (atom {}))
 
-(defn- get-jgit [^File path {:keys [url token] :as args}]
+(defn- get-jgit [^File path {:keys [remote-url token] :as args}]
   (if-let [obj (get @jgit (.getPath path))]
     obj
-    (get (swap! jgit assoc (.getPath path) (u/prog1 (open-jgit path {:url   url
-                                                                     :token token})
+    (get (swap! jgit assoc (.getPath path) (u/prog1 (open-jgit path {:remote-url remote-url
+                                                                     :token      token})
                                              (when-not (has-data? (assoc args :git <>))
                                                (FileUtils/deleteDirectory path)
-                                               (throw (ex-info "Cannot connect to uninitialized repository" {:url url})))))
+                                               (throw (ex-info "Cannot connect to uninitialized repository" {:url remote-url})))))
          (.getPath path))))
 
 (defn git-source
@@ -420,5 +437,5 @@
 
   Returns a GitSource record implementing the Source protocol."
   [url branch token]
-  (->GitSource (get-jgit (repo-path {:url url :token token}) {:url url :token token})
+  (->GitSource (get-jgit (repo-path {:remote-url url :token token}) {:remote-url url :token token})
                url branch token))

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/source/git_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/source/git_test.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.remote-sync.source.git-test
   (:require
    [clojure.java.io :as io]
+   [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase-enterprise.remote-sync.source.git :as git]
    [metabase-enterprise.remote-sync.source.protocol :as source.p]
@@ -445,7 +446,7 @@
             repaired-url (.getString repaired-config "remote" "origin" "url")]
         (is (not= corrupted-url repaired-url)
             "Origin URL should no longer be the corrupted URL")
-        (is (clojure.string/includes? repaired-url remote-dir)
+        (is (str/includes? repaired-url remote-dir)
             "Origin URL should point to the remote directory")))))
 
 (deftest ensure-origin-configured-sets-fetch-refspec-test

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/source/git_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/source/git_test.clj
@@ -86,7 +86,7 @@
                        (.toURI)
                        (.toURL)
                        (.toExternalForm))
-        local-repo (#'git/get-jgit (#'git/repo-path {:url remote-url}) {:url remote-url})]
+        local-repo (#'git/get-jgit (#'git/repo-path {:remote-url remote-url}) {:remote-url remote-url})]
     (git/->GitSource local-repo remote-url branch nil)))
 
 (defn- init-source!
@@ -417,3 +417,67 @@
         (let [files (set (source.p/list-files (source.p/snapshot master)))]
           (is (= #{"master.txt"} files)
               "Files should remain unchanged"))))))
+
+(deftest ensure-origin-configured-sets-origin-after-clone-test
+  (mt/with-temp-dir [remote-dir nil]
+    (let [[source _remote] (init-source! "master" remote-dir
+                                         :files {"master.txt" "File in master"})
+          ^Git local-git (:git source)
+          config (.getConfig (.getRepository local-git))
+          origin-url (.getString config "remote" "origin" "url")]
+      (is (some? origin-url) "Origin URL should be set after clone"))))
+
+(deftest ensure-origin-configured-repairs-corrupted-url-test
+  (mt/with-temp-dir [remote-dir nil]
+    (let [[source remote] (init-source! "master" remote-dir
+                                        :files {"master.txt" "File in master"})
+          ^Git local-git (:git source)
+          config (.getConfig (.getRepository local-git))
+          corrupted-url "https://wrong-url.example.com/repo.git"]
+      (.setString config "remote" "origin" "url" corrupted-url)
+      (.save config)
+      (is (= corrupted-url (.getString config "remote" "origin" "url"))
+          "Origin URL should be corrupted")
+      (reset! @#'git/jgit {})
+      (let [repaired-source (->source! "master" remote)
+            ^Git repaired-git (:git repaired-source)
+            repaired-config (.getConfig (.getRepository repaired-git))
+            repaired-url (.getString repaired-config "remote" "origin" "url")]
+        (is (not= corrupted-url repaired-url)
+            "Origin URL should no longer be the corrupted URL")
+        (is (clojure.string/includes? repaired-url remote-dir)
+            "Origin URL should point to the remote directory")))))
+
+(deftest ensure-origin-configured-sets-fetch-refspec-test
+  (mt/with-temp-dir [remote-dir nil]
+    (let [[source remote] (init-source! "master" remote-dir
+                                        :files {"master.txt" "File in master"})
+          ^Git local-git (:git source)
+          config (.getConfig (.getRepository local-git))]
+      (.setString config "remote" "origin" "url" "https://wrong-url.example.com/repo.git")
+      (.unset config "remote" "origin" "fetch")
+      (.save config)
+      (reset! @#'git/jgit {})
+      (let [repaired-source (->source! "master" remote)
+            ^Git repaired-git (:git repaired-source)
+            repaired-config (.getConfig (.getRepository repaired-git))]
+        (is (= "+refs/heads/*:refs/heads/*"
+               (.getString repaired-config "remote" "origin" "fetch"))
+            "Origin fetch refspec should be set after repair")))))
+
+(deftest ensure-origin-configured-allows-fetch-after-repair-test
+  (mt/with-temp-dir [remote-dir nil]
+    (let [[source remote] (init-source! "master" remote-dir
+                                        :files {"master.txt" "File in master"})
+          ^Git local-git (:git source)
+          config (.getConfig (.getRepository local-git))]
+      (.setString config "remote" "origin" "url" "https://wrong-url.example.com/repo.git")
+      (.save config)
+      (reset! @#'git/jgit {})
+      (let [repaired-source (->source! "master" remote)]
+        (git-working-add! remote "new-file.txt" "New content")
+        (git-working-commit! remote "Add new file")
+        (git/fetch! repaired-source)
+        (is (= ["Add new file" "Initial commit"]
+               (map :message (git/log repaired-source)))
+            "Should be able to fetch after origin repair")))))


### PR DESCRIPTION
### Description

Fixes issues where the tmp directory for the remote-sync repo can get into a bad state where it doesn't have an origin URL. This calls a function that explicitly sets our desired origin URL and updates all calls to use the more specific :remote-url keyword rather than inconsistently using :url vs :remote-url.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
