### PR TITLE
Report FK target fields as ID fields

### DIFF
--- a/e2e/test/scenarios/permissions/data-model-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/data-model-permissions.cy.spec.js
@@ -126,6 +126,28 @@ describe("scenarios > admin > permissions", () => {
       .should("have.attr", "placeholder", "Field access denied")
       .and("have.value", "");
   });
+
+  it("shows FK target correctly when target is not a PK field (metabase#35199)", () => {
+    // Set up an FK relationship to a non-PK field
+    // First, create the FK relationship: ORDERS.QUANTITY -> PRODUCTS.RATING (non-PK)
+    cy.request("PUT", `/api/field/${ORDERS.QUANTITY}`, {
+      semantic_type: "type/FK",
+      fk_target_field_id: SAMPLE_DATABASE.PRODUCTS.RATING,
+    });
+
+    // Visit the data model page for the FK field
+    H.DataModel.visit({
+      databaseId: SAMPLE_DB_ID,
+      schemaId: SAMPLE_DB_SCHEMA_ID,
+      tableId: ORDERS_ID,
+      fieldId: ORDERS.QUANTITY,
+    });
+
+    // The FK target picker should show the target field name, not "Field access denied"
+    H.DataModel.FieldSection.getSemanticTypeFkTarget()
+      .should("not.have.attr", "placeholder", "Field access denied")
+      .should("have.value", "Products → Rating");
+  });
 });
 
 function savePermissionsGraph() {

--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -1331,6 +1331,40 @@ databaseChangeLog:
             tableName: pulse
             columnName: disable_links
 
+  # Add index on fk_target_field_id for faster lookup of FK targets (#35199)
+  - changeSet:
+      id: v58.2025-12-29T16:00:00
+      author: metamben
+      dbms: postgresql
+      comment: Add partial index on metabase_field.fk_target_field_id for faster FK target lookup
+      changes:
+        - sql:
+            sql: >-
+              CREATE INDEX idx_metabase_field_fk_target_field_id
+              ON metabase_field (fk_target_field_id)
+              WHERE fk_target_field_id IS NOT NULL;
+      rollback:
+        - dropIndex:
+            tableName: metabase_field
+            indexName: idx_metabase_field_fk_target_field_id
+
+  - changeSet:
+      id: v58.2025-12-29T16:00:01
+      author: metamben
+      dbms: mysql,mariadb,h2
+      comment: Add index on metabase_field.fk_target_field_id for faster FK target lookup
+      changes:
+        - createIndex:
+            tableName: metabase_field
+            indexName: idx_metabase_field_fk_target_field_id
+            columns:
+              - column:
+                  name: fk_target_field_id
+      rollback:
+        - dropIndex:
+            tableName: metabase_field
+            indexName: idx_metabase_field_fk_target_field_id
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/warehouses/models/database.clj
+++ b/src/metabase/warehouses/models/database.clj
@@ -485,7 +485,7 @@
    :id
    {:default []}))
 
-(defn pk-fields
+(defn id-fields
   "Return all `Fields` that are valid FK targets for this `database`.
    This includes PK fields and fields that are currently FK targets.
 

--- a/src/metabase/warehouses_rest/api.clj
+++ b/src/metabase/warehouses_rest/api.clj
@@ -809,7 +809,7 @@
                                            [api/read-check mi/can-read?])]
     (db-perm-check (get-database id {:include-editable-data-model? true}))
     (sort-by (comp u/lower-case-en :name :table)
-             (filter field-perm-check (-> (database/pk-fields {:id id})
+             (filter field-perm-check (-> (database/id-fields {:id id})
                                           (t2/hydrate :table))))))
 
 ;;; ----------------------------------------------- POST /api/database -----------------------------------------------

--- a/test/metabase/warehouses/models/database_test.clj
+++ b/test/metabase/warehouses/models/database_test.clj
@@ -880,7 +880,7 @@
                                    :semantic_type :type/FK
                                    :fk_target_field_id nationality-id  ; FK to non-PK field!
                                    :base_type :type/Integer}]
-      (let [result-fields (database/pk-fields {:id db-id})
+      (let [result-fields (database/id-fields {:id db-id})
             result-field-ids (set (map :id result-fields))]
         (testing "includes PK fields"
           (is (contains? result-field-ids country-pk-id))
@@ -888,7 +888,7 @@
         (testing "includes non-PK FK target field"
           (is (contains? result-field-ids nationality-id))))))
 
-  (testing "pk-fields excludes inactive fields"
+  (testing "id-fields excludes inactive fields"
     (mt/with-temp [:model/Database {db-id :id} {}
                    :model/Table {table-id :id} {:db_id db-id}
                    :model/Field {active-pk-id :id} {:table_id table-id
@@ -901,6 +901,6 @@
                                                        :semantic_type :type/PK
                                                        :base_type :type/Integer
                                                        :active false}]
-      (let [result-fields (database/pk-fields {:id db-id})]
+      (let [result-fields (database/id-fields {:id db-id})]
         (is (= #{active-pk-id}
                (set (map :id result-fields))))))))


### PR DESCRIPTION
Closes #35199

### Description

The real solution would probably be adding a `:type/UniqueKey` semantic type and listing those along with PKs as ID fields, but that's a bigger change. This PR  considers all FK targets ID fields and returns those too. The drawback of this approach is that a join is needed and the ID/uniqueness property is implicit and possibly wrong.

### How to verify

The repo steps should not result in an error message.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
