### PR TITLE
Re-introduce: Upload failed e2e test artifacts for quarantined tests

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -113,6 +113,7 @@ jobs:
         run: node e2e/runner/run_cypress_ci.js snapshot
 
       - name: Run auto-split Cypress tests on ${{ inputs.name }}
+        id: split-e2e
         if: ${{ !inputs.specs }}
         env:
           SPLIT: ${{ inputs.total_chunks }}
@@ -136,6 +137,7 @@ jobs:
         continue-on-error: true
 
       - name: Run Tagged EE Cypress tests on ${{ inputs.name }}
+        id: tagged-e2e
         if: ${{ inputs.specs }}
         shell: bash
         env:
@@ -168,7 +170,7 @@ jobs:
 
       - name: Upload Cypress Artifacts upon failure
         uses: actions/upload-artifact@v4
-        if: failure()
+        if: steps.split-e2e.outcome == 'failure' || steps.tagged-e2e.outcome == 'failure'
         with:
           name: cypress-recording-${{ inputs.name }}-${{ inputs.edition }}
           path: |
@@ -178,10 +180,11 @@ jobs:
 
       - name: Upload Failed Tests
         uses: actions/upload-artifact@v4
-        if: failure()
+        if: steps.split-e2e.outcome == 'failure' || steps.tagged-e2e.outcome == 'failure'
         with:
           name: failed-tests-${{ inputs.name }}-${{ inputs.edition }}
           path: ./cypress/test-results
+          if-no-files-found: ignore
 
       - name: Extract chunk-specific changed timings
         id: extract-timings

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -170,7 +170,8 @@ jobs:
 
       - name: Upload Cypress Artifacts upon failure
         uses: actions/upload-artifact@v4
-        if: steps.split-e2e.outcome == 'failure' || steps.tagged-e2e.outcome == 'failure'
+        if: |
+          !cancelled() && (steps.split-e2e.outcome == 'failure' || steps.tagged-e2e.outcome == 'failure')
         with:
           name: cypress-recording-${{ inputs.name }}-${{ inputs.edition }}
           path: |
@@ -180,7 +181,8 @@ jobs:
 
       - name: Upload Failed Tests
         uses: actions/upload-artifact@v4
-        if: steps.split-e2e.outcome == 'failure' || steps.tagged-e2e.outcome == 'failure'
+        if: |
+          !cancelled() && (steps.split-e2e.outcome == 'failure' || steps.tagged-e2e.outcome == 'failure')
         with:
           name: failed-tests-${{ inputs.name }}-${{ inputs.edition }}
           path: ./cypress/test-results


### PR DESCRIPTION
The original syntax I used in [487036f](https://github.com/metabase/metabase/commit/487036f0b146f82b873aef5eee4b279deb5dc122) was correct but it never got the change to evaluate because the whole step was being skipped.

old
```yml
if: steps.split-e2e.outcome == 'failure' || steps.tagged-e2e.outcome == 'failure'`
```

After some debug test runs, I realized what's going on, and the solution to this problem is clearer now. We need to make sure the step runs unless cancelled. This gives the expression a chance to actually evaluate.

new
```yml
if: |
  !cancelled() && (steps.split-e2e.outcome == 'failure' || steps.tagged-e2e.outcome == 'failure')
```

### Tests

This [debug run](https://github.com/metabase/metabase/actions/runs/20580901246/job/59107982691) is the confirmation that the solution works
<img width="668" height="343" alt="image" src="https://github.com/user-attachments/assets/5c5bfc39-9acb-43bd-89f0-e772c7f2ed05" />

