### PR TITLE
Extra remapped fields

### DIFF
--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -972,6 +972,9 @@
                                                   (assoc :type :question))
                                                 (m/update-existing :dataset_query lib-be/normalize-query))
          {:keys [metadata metadata-future]} (card.metadata/maybe-async-result-metadata
+                                             ;; 1. This function is called when storing metadata.
+                                             ;; 2. The metadata for storage shouldn't have remaps.
+                                             ;; 3. Setting this keyword will keep the remapped fields out of the metadata.
                                              {:query     (assoc-in (:dataset_query card-data) [:middleware :disable-remaps?] true)
                                               :metadata  result_metadata
                                               :entity-id (:entity_id card-data)

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -972,7 +972,7 @@
                                                   (assoc :type :question))
                                                 (m/update-existing :dataset_query lib-be/normalize-query))
          {:keys [metadata metadata-future]} (card.metadata/maybe-async-result-metadata
-                                             {:query     (:dataset_query card-data)
+                                             {:query     (assoc-in (:dataset_query card-data) [:middleware :disable-remaps?] true)
                                               :metadata  result_metadata
                                               :entity-id (:entity_id card-data)
                                               :model?    (model? card-data)})

--- a/src/metabase/queries/models/card/metadata.clj
+++ b/src/metabase/queries/models/card/metadata.clj
@@ -177,6 +177,9 @@ saved later when it is ready."
   (not-empty (request/with-current-user nil
                (u/ignore-exceptions
                  (qp.preprocess/query->expected-cols
+                  ;; 1. This function is called when storing metadata.
+                  ;; 2. The metadata for storage shouldn't have remaps.
+                  ;; 3. Setting this keyword will keep the remapped fields out of the metadata.
                   (assoc-in query [:middleware :disable-remaps?] true))))))
 
 (defn infer-metadata-with-model-overrides

--- a/src/metabase/queries/models/card/metadata.clj
+++ b/src/metabase/queries/models/card/metadata.clj
@@ -176,7 +176,8 @@ saved later when it is ready."
   [query]
   (not-empty (request/with-current-user nil
                (u/ignore-exceptions
-                 (qp.preprocess/query->expected-cols query)))))
+                 (qp.preprocess/query->expected-cols
+                  (assoc-in query [:middleware :disable-remaps?] true))))))
 
 (defn infer-metadata-with-model-overrides
   "Does a fresh [[infer-metadata]] for the provided query.

--- a/test/metabase/queries/models/card_test.clj
+++ b/test/metabase/queries/models/card_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [java-time.api :as t]
+   [metabase.api.common :as api]
    [metabase.audit-app.impl :as audit]
    [metabase.config.core :as config]
    [metabase.lib.convert :as lib.convert]
@@ -1294,3 +1295,30 @@
       (t2/save! card')
       (is (= :question
              (t2/select-one-fn :type :model/Card :id (:id card)))))))
+
+(deftest create-card-no-remaps
+  (mt/with-current-user (mt/user->id :crowberto)
+    (mt/with-temp [:model/Dimension _ {:field_id                (mt/id :orders :user_id)
+                                       :name                    "User ID"
+                                       :human_readable_field_id (mt/id :people :name)
+                                       :type                    :external}
+                   :model/Dimension _ {:field_id                (mt/id :orders :product_id)
+                                       :name                    "Product ID"
+                                       :human_readable_field_id (mt/id :products :title)
+                                       :type                    :external}]
+      (let [mp (mt/metadata-provider)
+            query (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+            card (card/create-card! {:database_id (mt/id),
+                                     :display :table,
+                                     :visualization_settings {},
+                                     :type :model
+                                     :name "orders model"
+                                     :dataset_query query}
+                                    @api/*current-user*)]
+        (try
+          (is (= 9
+                 (count (:result_metadata card))))
+          (finally
+            (t2/delete! :model/Card (:id card))))))))
+
+

--- a/test/metabase/queries/models/card_test.clj
+++ b/test/metabase/queries/models/card_test.clj
@@ -1320,5 +1320,3 @@
                  (count (:result_metadata card))))
           (finally
             (t2/delete! :model/Card (:id card))))))))
-
-


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/67128

### Description

When saving metadata for a query to report_card, we should disable remaps.
