### PR TITLE
Remove deprecated `moveDnDKitElement` helper

### DIFF
--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -368,8 +368,8 @@ export const moveDnDKitElementByAlias = (
       button: 0,
     })
     .wait(200);
-  cy.get(alias)
-    .trigger("pointerup", horizontal, vertical, {
+  cy.document()
+    .trigger("pointerup", {
       force: true,
       isPrimary: true,
       button: 0,

--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -383,7 +383,7 @@ export const moveDnDKitElementByAlias = (
     })
     .wait(200);
 
-  onBeforeDragEnd?.();
+  onBeforeDragEnd();
 
   cy.document()
     .trigger("pointerup", {

--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -307,6 +307,15 @@ export const moveColumnDown = (column, distance) => {
     .trigger("mouseup", 0, distance * 50, { force: true });
 };
 
+/**
+ * Moves an element within a dnd-kit sortable list from one position to another.
+ *
+ * @param {string | RegExp} dataTestId - The data-testid pattern to match list elements
+ * @param {Object} options
+ * @param {number} options.startIndex - The index of the element to drag
+ * @param {number} options.dropIndex - The index where the element should be dropped
+ * @param {Function} [options.onBeforeDragEnd] - Optional callback executed before releasing the drag
+ */
 export const moveDnDKitListElement = (
   dataTestId,
   { startIndex, dropIndex, onBeforeDragEnd = () => {} } = {},
@@ -319,29 +328,34 @@ export const moveDnDKitListElement = (
     return { clientX: x + width / 2, clientY: y + height / 2 };
   };
 
-  cy.findAllByTestId(selector)
-    .then(($all) => {
-      const dragEl = $all.get(startIndex);
-      const dropEl = $all.get(dropIndex);
-      const dragPoint = getCenter(dragEl);
-      const dropPoint = getCenter(dropEl);
+  cy.findAllByTestId(selector).then(($all) => {
+    const dragEl = $all.get(startIndex);
+    const dropEl = $all.get(dropIndex);
+    const dragPoint = getCenter(dragEl);
+    const dropPoint = getCenter(dropEl);
 
-      return { dragPoint, dropPoint, dragEl };
-    })
-    .then(({ dragPoint, dropPoint, dragEl }) => {
-      cy.wrap(dragEl).as("dragElement");
+    cy.wrap(dragEl).as("dragElement");
 
-      moveDnDKitElementByAlias("@dragElement", {
-        vertical: dropPoint.clientY - dragPoint.clientY,
-        horizontal: dropPoint.clientX - dragPoint.clientX,
-        onBeforeDragEnd,
-      });
+    moveDnDKitElementByAlias("@dragElement", {
+      vertical: dropPoint.clientY - dragPoint.clientY,
+      horizontal: dropPoint.clientX - dragPoint.clientX,
+      onBeforeDragEnd,
     });
+  });
 };
 
+/**
+ * Moves a dnd-kit draggable element by a specified offset using a Cypress alias.
+ *
+ * @param {string} alias - The Cypress alias for the element to drag (e.g., "@dragElement")
+ * @param {Object} options
+ * @param {number} [options.horizontal=0] - Horizontal distance to move in pixels
+ * @param {number} [options.vertical=0] - Vertical distance to move in pixels
+ * @param {Function} [options.onBeforeDragEnd] - Optional callback executed before releasing the drag
+ */
 export const moveDnDKitElementByAlias = (
   alias,
-  { horizontal = 0, vertical = 0 } = {},
+  { horizontal = 0, vertical = 0, onBeforeDragEnd = () => {} } = {},
 ) => {
   // This function queries alias before triggering every event to avoid running into "element was removed from the DOM"
   // error caused by node remounting https://on.cypress.io/element-has-detached-from-dom
@@ -368,6 +382,9 @@ export const moveDnDKitElementByAlias = (
       button: 0,
     })
     .wait(200);
+
+  onBeforeDragEnd?.();
+
   cy.document()
     .trigger("pointerup", {
       force: true,

--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -307,41 +307,6 @@ export const moveColumnDown = (column, distance) => {
     .trigger("mouseup", 0, distance * 50, { force: true });
 };
 
-/**
- * @deprecated Use `moveDnDKitElementByAlias` instead.
- * Otherwise, the chain will be broken due to "element was removed from the DOM" error
- */
-export const moveDnDKitElement = (
-  element,
-  { horizontal = 0, vertical = 0, onBeforeDragEnd = () => {} } = {},
-) => {
-  element
-    .trigger("pointerdown", 0, 0, {
-      force: true,
-      isPrimary: true,
-      button: 0,
-    })
-    .wait(200)
-    // This initial move needs to be greater than the activation constraint
-    // of the pointer sensor
-    .trigger("pointermove", 20, 20, {
-      force: true,
-      isPrimary: true,
-      button: 0,
-    })
-    .wait(200)
-    .trigger("pointermove", horizontal, vertical, {
-      force: true,
-      isPrimary: true,
-      button: 0,
-    })
-    .wait(200);
-
-  onBeforeDragEnd?.();
-
-  cy.document().trigger("pointerup").wait(200);
-};
-
 export const moveDnDKitListElement = (
   dataTestId,
   { startIndex, dropIndex, onBeforeDragEnd = () => {} } = {},
@@ -364,7 +329,9 @@ export const moveDnDKitListElement = (
       return { dragPoint, dropPoint, dragEl };
     })
     .then(({ dragPoint, dropPoint, dragEl }) => {
-      moveDnDKitElement(cy.wrap(dragEl), {
+      cy.wrap(dragEl).as("dragElement");
+
+      moveDnDKitElementByAlias("@dragElement", {
         vertical: dropPoint.clientY - dragPoint.clientY,
         horizontal: dropPoint.clientX - dragPoint.clientX,
         onBeforeDragEnd,

--- a/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
+++ b/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
@@ -1254,7 +1254,8 @@ describe("scenarios > admin > datamodel", () => {
           .findByDisplayValue("database")
           .should("be.checked");
 
-        H.moveDnDKitElement(TableSection.getSortableField("ID"), {
+        TableSection.getSortableField("ID").as("dragElement");
+        H.moveDnDKitElementByAlias("@dragElement", {
           vertical: 50,
         });
         cy.wait("@updateFieldOrder");
@@ -1298,7 +1299,8 @@ describe("scenarios > admin > datamodel", () => {
           .findByDisplayValue("database")
           .should("be.checked");
 
-        H.moveDnDKitElement(TableSection.getSortableField("ID"), {
+        TableSection.getSortableField("ID").as("dragElement");
+        H.moveDnDKitElementByAlias("@dragElement", {
           vertical: 50,
         });
         cy.wait("@updateFieldOrder");
@@ -1337,7 +1339,8 @@ describe("scenarios > admin > datamodel", () => {
         });
 
         cy.log("should allow drag & drop afterwards (metabase#56482)"); // extra sanity check
-        H.moveDnDKitElement(TableSection.getSortableField("ID"), {
+        TableSection.getSortableField("ID").as("dragElement");
+        H.moveDnDKitElementByAlias("@dragElement", {
           vertical: 50,
         });
         cy.wait("@updateFieldOrder");
@@ -3437,7 +3440,8 @@ describe("scenarios > admin > datamodel", () => {
       verifyAndCloseToast("Failed to update field order");
 
       cy.log("custom field order");
-      H.moveDnDKitElement(TableSection.getSortableField("ID"), {
+      TableSection.getSortableField("ID").as("dragElement");
+      H.moveDnDKitElementByAlias("@dragElement", {
         vertical: 50,
       });
       verifyAndCloseToast("Failed to update field order");
@@ -3581,7 +3585,8 @@ describe("scenarios > admin > datamodel", () => {
         .should("be.checked");
 
       cy.log("custom field order");
-      H.moveDnDKitElement(TableSection.getSortableField("ID"), {
+      TableSection.getSortableField("ID").as("dragElement");
+      H.moveDnDKitElementByAlias("@dragElement", {
         vertical: 50,
       });
       verifyToastAndUndo("Field order updated");

--- a/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
@@ -2058,13 +2058,12 @@ describe("scenarios > question > custom column > aggregation", () => {
     H.openNotebook();
 
     cy.log("Move the second Count to be the first");
-    H.moveDnDKitElement(
-      H.getNotebookStep("summarize")
-        .findAllByText("Count")
-        .should("have.length", 2)
-        .last(),
-      { horizontal: -400 },
-    );
+    H.getNotebookStep("summarize")
+      .findAllByText("Count")
+      .should("have.length", 2)
+      .last()
+      .as("dragElement");
+    H.moveDnDKitElementByAlias("@dragElement", { horizontal: -400 });
 
     cy.log("The values should not have changed, but the order should have");
     H.visualize();
@@ -2526,13 +2525,12 @@ describe("scenarios > question > custom column > aggregation", () => {
         "Swapping the aggregation clauses should not change the results, but the column order will be different",
       );
       H.openNotebook();
-      H.moveDnDKitElement(
-        H.getNotebookStep("summarize")
-          .findAllByText("Count")
-          .should("have.length", 2)
-          .last(),
-        { horizontal: -400 },
-      );
+      H.getNotebookStep("summarize")
+        .findAllByText("Count")
+        .should("have.length", 2)
+        .last()
+        .as("dragElement");
+      H.moveDnDKitElementByAlias("@dragElement", { horizontal: -400 });
 
       H.visualize();
       H.assertTableData({

--- a/e2e/test/scenarios/dashboard-cards/visualization-options.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/visualization-options.cy.spec.js
@@ -91,7 +91,8 @@ describe("scenarios > dashboard cards > visualization options", () => {
     H.getDashboardCard().realHover();
     cy.findByLabelText("Show visualization options").click();
     cy.findByTestId("chartsettings-sidebar").within(() => {
-      H.moveDnDKitElement(H.getDraggableElements().contains("ID"), {
+      H.getDraggableElements().contains("ID").as("dragElement");
+      H.moveDnDKitElementByAlias("@dragElement", {
         vertical: 100,
       });
       const idButton = () =>

--- a/e2e/test/scenarios/data-studio/data-model/datamodel-data-studio.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-model/datamodel-data-studio.cy.spec.ts
@@ -1346,7 +1346,8 @@ describe("scenarios > data studio > datamodel", () => {
           .findByDisplayValue("database")
           .should("be.checked");
 
-        H.moveDnDKitElement(TableSection.getSortableField("ID"), {
+        TableSection.getSortableField("ID").as("dragElement");
+        H.moveDnDKitElementByAlias("@dragElement", {
           vertical: 50,
         });
         cy.wait("@updateFieldOrder");
@@ -1390,7 +1391,8 @@ describe("scenarios > data studio > datamodel", () => {
           .findByDisplayValue("database")
           .should("be.checked");
 
-        H.moveDnDKitElement(TableSection.getSortableField("ID"), {
+        TableSection.getSortableField("ID").as("dragElement");
+        H.moveDnDKitElementByAlias("@dragElement", {
           vertical: 50,
         });
         cy.wait("@updateFieldOrder");
@@ -1429,7 +1431,8 @@ describe("scenarios > data studio > datamodel", () => {
         });
 
         cy.log("should allow drag & drop afterwards (metabase#56482)"); // extra sanity check
-        H.moveDnDKitElement(TableSection.getSortableField("ID"), {
+        TableSection.getSortableField("ID").as("dragElement");
+        H.moveDnDKitElementByAlias("@dragElement", {
           vertical: 50,
         });
         cy.wait("@updateFieldOrder");
@@ -3570,7 +3573,8 @@ describe("scenarios > data studio > datamodel", () => {
       verifyAndCloseToast("Failed to update field order");
 
       cy.log("custom field order");
-      H.moveDnDKitElement(TableSection.getSortableField("ID"), {
+      TableSection.getSortableField("ID").as("dragElement");
+      H.moveDnDKitElementByAlias("@dragElement", {
         vertical: 50,
       });
       verifyAndCloseToast("Failed to update field order");
@@ -3716,7 +3720,8 @@ describe("scenarios > data studio > datamodel", () => {
         .should("be.checked");
 
       cy.log("custom field order");
-      H.moveDnDKitElement(TableSection.getSortableField("ID"), {
+      TableSection.getSortableField("ID").as("dragElement");
+      H.moveDnDKitElementByAlias("@dragElement", {
         vertical: 50,
       });
       verifyToastAndUndo("Field order updated");

--- a/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
@@ -37,7 +37,8 @@ describe("issue 9357", () => {
       );
 
       // Drag the firstparameter to last position
-      H.moveDnDKitElement(H.filterWidget().findAllByRole("listitem").first(), {
+      H.filterWidget().findAllByRole("listitem").first().as("dragElement");
+      H.moveDnDKitElementByAlias("@dragElement", {
         vertical: 50,
       });
 
@@ -1180,7 +1181,8 @@ describe("issue 31606", () => {
     cy.findAllByRole("radio", { name: "Search box" }).first().click();
     H.filterWidget().first().click();
 
-    H.moveDnDKitElement(H.popover().findByText("Add filter"), {
+    H.popover().findByText("Add filter").as("dragElement");
+    H.moveDnDKitElementByAlias("@dragElement", {
       horizontal: 300,
     });
 

--- a/e2e/test/scenarios/organization/helpers/bookmark-helpers.ts
+++ b/e2e/test/scenarios/organization/helpers/bookmark-helpers.ts
@@ -2,7 +2,7 @@ import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   createQuestion,
-  moveDnDKitElement,
+  moveDnDKitElementByAlias,
   navigationSidebar,
 } from "e2e/support/helpers";
 
@@ -49,11 +49,10 @@ export const moveBookmark = (
     putAlias = "reorderBookmarks",
   } = {},
 ) => {
-  moveDnDKitElement(
-    navigationSidebar()
-      .findByRole("section", { name: "Bookmarks" })
-      .findByText(name),
-    { vertical: verticalDistance },
-  );
+  navigationSidebar()
+    .findByRole("section", { name: "Bookmarks" })
+    .findByText(name)
+    .as("dragElement");
+  moveDnDKitElementByAlias("@dragElement", { vertical: verticalDistance });
   cy.wait(`@${putAlias}`);
 };

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -619,7 +619,8 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
 
   it("should be able to drag-n-drop query clauses", () => {
     function moveElement({ name, horizontal, vertical, index }) {
-      H.moveDnDKitElement(cy.findByText(name), {
+      cy.findByText(name).as("dragElement");
+      H.moveDnDKitElementByAlias("@dragElement", {
         horizontal,
         vertical,
       });
@@ -658,7 +659,8 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     }) {
       H.getNotebookStep(type).findByText(name).click();
       H.popover().within(() => {
-        H.moveDnDKitElement(cy.findByText("Is"), {
+        cy.findByText("Is").as("dragElement");
+        H.moveDnDKitElementByAlias("@dragElement", {
           horizontal,
           vertical,
         });

--- a/e2e/test/scenarios/question/settings.cy.spec.js
+++ b/e2e/test/scenarios/question/settings.cy.spec.js
@@ -90,7 +90,7 @@ describe("scenarios > question > settings", () => {
 
       getSidebarColumns().eq("5").as("total").contains("Total");
 
-      H.moveDnDKitElement(cy.get("@total"), { vertical: -100 });
+      H.moveDnDKitElementByAlias("@total", { vertical: -100 });
 
       getSidebarColumns().eq("3").should("contain.text", "Total");
 
@@ -104,7 +104,7 @@ describe("scenarios > question > settings", () => {
         expect($el.scrollTop).to.eql(0);
       });
 
-      H.moveDnDKitElement(cy.get("@title"), { vertical: 15 });
+      H.moveDnDKitElementByAlias("@title", { vertical: 15 });
 
       cy.findByTestId("chartsettings-list-container").should(([$el]) => {
         expect($el.scrollTop).to.be.greaterThan(0);
@@ -159,7 +159,7 @@ describe("scenarios > question > settings", () => {
         .contains(/Products? → Category/);
 
       // Drag and drop this column between "Tax" and "Discount" (index 5 in @sidebarColumns array)
-      H.moveDnDKitElement(cy.get("@prod-category"), { vertical: -360 });
+      H.moveDnDKitElementByAlias("@prod-category", { vertical: -360 });
 
       refreshResultsInHeader();
 
@@ -188,7 +188,7 @@ describe("scenarios > question > settings", () => {
       findColumnAtIndex("User → Address", -1).as("user-address");
 
       // Move it one place up
-      H.moveDnDKitElement(cy.get("@user-address"), { vertical: -100 });
+      H.moveDnDKitElementByAlias("@user-address", { vertical: -100 });
 
       findColumnAtIndex("User → Address", -3);
 

--- a/e2e/test/scenarios/visualizations-charts/bar_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/bar_chart.cy.spec.js
@@ -135,7 +135,8 @@ describe("scenarios > visualizations > bar chart", () => {
     });
 
     it("should allow you to show/hide and reorder columns", () => {
-      H.moveDnDKitElement(H.getDraggableElements().eq(0), { vertical: 100 });
+      H.getDraggableElements().eq(0).as("dragElement");
+      H.moveDnDKitElementByAlias("@dragElement", { vertical: 100 });
 
       cy.findAllByTestId("legend-item").eq(0).should("contain.text", "Gadget");
       cy.findAllByTestId("legend-item").eq(1).should("contain.text", "Gizmo");
@@ -174,7 +175,8 @@ describe("scenarios > visualizations > bar chart", () => {
     });
 
     it("should gracefully handle removing filtered items, and adding new items to the end of the list", () => {
-      H.moveDnDKitElement(H.getDraggableElements().first(), { vertical: 100 });
+      H.getDraggableElements().first().as("dragElement");
+      H.moveDnDKitElementByAlias("@dragElement", { vertical: 100 });
 
       H.getDraggableElements().eq(1).icon("close").click({ force: true }); // Hide Gizmo
 
@@ -953,8 +955,10 @@ describe("scenarios > visualizations > bar chart", () => {
         .should("have.length", 5);
 
       // Test can move series in/out of "Other" series
-      H.moveDnDKitElement(H.getDraggableElements().eq(3), { vertical: 150 }); // Move AZ into "Other"
-      H.moveDnDKitElement(H.getDraggableElements().eq(6), { vertical: -150 }); // Move CT out of "Other"
+      H.getDraggableElements().eq(3).as("AZ");
+      H.moveDnDKitElementByAlias("@AZ", { vertical: 150 }); // Move AZ into "Other"
+      H.getDraggableElements().eq(6).as("CT");
+      H.moveDnDKitElementByAlias("@CT", { vertical: -150 }); // Move CT out of "Other"
 
       H.queryBuilderMain()
         .findAllByTestId("legend-item")

--- a/e2e/test/scenarios/visualizations-charts/funnel.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/funnel.cy.spec.js
@@ -38,7 +38,8 @@ describe("scenarios > visualizations > funnel chart", () => {
           .first()
           .should("have.text", name);
 
-        H.moveDnDKitElement(H.getDraggableElements().first(), {
+        H.getDraggableElements().first().as("dragElement");
+        H.moveDnDKitElementByAlias("dragElement", {
           vertical: 100,
         });
 
@@ -66,7 +67,8 @@ describe("scenarios > visualizations > funnel chart", () => {
   });
 
   it("should handle row items being filterd out and returned gracefully", () => {
-    H.moveDnDKitElement(H.getDraggableElements().first(), { vertical: 100 });
+    H.getDraggableElements().first().as("dragElement");
+    H.moveDnDKitElementByAlias("@dragElement", { vertical: 100 });
 
     H.getDraggableElements()
       .eq(1)

--- a/e2e/test/scenarios/visualizations-charts/funnel.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/funnel.cy.spec.js
@@ -39,7 +39,7 @@ describe("scenarios > visualizations > funnel chart", () => {
           .should("have.text", name);
 
         H.getDraggableElements().first().as("dragElement");
-        H.moveDnDKitElementByAlias("dragElement", {
+        H.moveDnDKitElementByAlias("@dragElement", {
           vertical: 100,
         });
 

--- a/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
@@ -554,7 +554,8 @@ describe("scenarios > visualizations > line chart", () => {
       cy.log("Drag and drop the first y-axis field to the last position");
       cy.findAllByTestId("chart-setting-select").then((initial) => {
         cy.findByTestId("chart-settings-widget-graph.metrics").within(() => {
-          H.moveDnDKitElement(cy.findAllByTestId("drag-handle").first(), {
+          cy.findAllByTestId("drag-handle").first().as("dragElement");
+          H.moveDnDKitElementByAlias("@dragElement", {
             vertical: 50,
           });
         });

--- a/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
@@ -219,7 +219,8 @@ describe("scenarios > visualizations > pie chart", () => {
 
     cy.findByDisplayValue("Widget").type("{selectall}Woooget").realPress("Tab");
 
-    H.moveDnDKitElement(H.getDraggableElements().contains("Woooget"), {
+    H.getDraggableElements().contains("Woooget").as("dragElement");
+    H.moveDnDKitElementByAlias("@dragElement", {
       vertical: 100,
     });
 
@@ -241,7 +242,8 @@ describe("scenarios > visualizations > pie chart", () => {
 
     cy.findByTestId("Gadget-settings-button").click();
     cy.findByDisplayValue("Gadget").type("{selectall}Katget").realPress("Tab");
-    H.moveDnDKitElement(H.getDraggableElements().contains("Katget"), {
+    H.getDraggableElements().contains("Katget").as("dragElement");
+    H.moveDnDKitElementByAlias("@dragElement", {
       vertical: 30,
     });
 

--- a/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.ts
@@ -87,7 +87,8 @@ describe("issue 45255", () => {
 
     // Can reorder (empty)
     H.getDraggableElements().eq(2).should("have.text", "(empty)");
-    H.moveDnDKitElement(H.getDraggableElements().first(), { vertical: 100 });
+    H.getDraggableElements().first().as("dragElement");
+    H.moveDnDKitElementByAlias("@dragElement", { vertical: 100 });
     H.getDraggableElements().eq(1).should("have.text", "(empty)");
 
     // Has (empty) in the chart

--- a/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
@@ -584,7 +584,7 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
         .eq("7")
         .as("stateItem")
         .should("have.text", "State");
-      H.moveDnDKitElement(cy.get("@stateItem"), { vertical: -300 });
+      H.moveDnDKitElementByAlias("@stateItem", { vertical: -300 });
     });
 
     H.openObjectDetail(0);

--- a/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
@@ -1091,17 +1091,21 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
 
     it("should persist column sizes in visualization settings", () => {
       H.visitQuestionAdhoc({ dataset_query: testQuery, display: "pivot" });
-      const leftHeaderColHandle = () =>
-        cy.findAllByTestId("pivot-table-resize-handle").first();
-      const totalHeaderColHandle = () =>
-        // eslint-disable-next-line no-unsafe-element-filtering
-        cy.findAllByTestId("pivot-table-resize-handle").last();
 
-      H.moveDnDKitElement(leftHeaderColHandle(), {
+      cy.findAllByTestId("pivot-table-resize-handle")
+        .first()
+        .as("leftHeaderColHandle");
+      // eslint-disable-next-line no-unsafe-element-filtering
+      cy.findAllByTestId("pivot-table-resize-handle")
+        .last()
+        .as("totalHeaderColHandle");
+
+      H.moveDnDKitElementByAlias("@leftHeaderColHandle", {
         horizontal: -100,
         vertical: 0,
       });
-      H.moveDnDKitElement(totalHeaderColHandle(), {
+
+      H.moveDnDKitElementByAlias("@totalHeaderColHandle", {
         horizontal: 100,
         vertical: 0,
       });

--- a/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
@@ -183,7 +183,8 @@ describe("scenarios > visualizations > table", () => {
     cy.findByTestId("sidebar-left").findByText("Done").click();
 
     headerCells().eq(3).should("contain.text", "TOTAL");
-    H.moveDnDKitElement(H.tableHeaderColumn("TOTAL"), { horizontal: -220 });
+    H.tableHeaderColumn("TOTAL").as("dragElement");
+    H.moveDnDKitElementByAlias("@dragElement", { horizontal: -220 });
     headerCells().eq(1).should("contain.text", "TOTAL");
 
     H.tableHeaderClick("QUANTITY");
@@ -210,7 +211,8 @@ describe("scenarios > visualizations > table", () => {
     H.tableHeaderColumn("first_column").invoke("outerWidth").as("firstWidth");
     H.tableHeaderColumn("second_column").invoke("outerWidth").as("secondWidth");
 
-    H.moveDnDKitElement(H.tableHeaderColumn("first_column"), {
+    H.tableHeaderColumn("first_column").as("dragElement");
+    H.moveDnDKitElementByAlias("@dragElement", {
       horizontal: 100,
     });
 
@@ -928,7 +930,8 @@ describe("scenarios > visualizations > table > conditional formatting", () => {
         .first()
         .should("contain.text", "is less than 20");
 
-      H.moveDnDKitElement(cy.findAllByTestId("formatting-rule-preview").eq(2), {
+      cy.findAllByTestId("formatting-rule-preview").eq(2).as("dragElement");
+      H.moveDnDKitElementByAlias("@dragElement", {
         vertical: -300,
       });
 

--- a/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
@@ -543,7 +543,8 @@ describe("issue 25250", () => {
     cy.findByText("Product ID").should("be.visible");
 
     H.openVizSettingsSidebar();
-    H.moveDnDKitElement(H.getDraggableElements().contains("Product ID"), {
+    H.getDraggableElements().contains("Product ID").as("dragElement");
+    H.moveDnDKitElementByAlias("@dragElement", {
       vertical: -100,
     });
     H.getDraggableElements().eq(0).should("contain", "Product ID");


### PR DESCRIPTION
There's been a new(er) wave of flakes caused by this deprecated helper. This PR should resolve DEV-1211 (one of the newest flakes caused by it).

It's perfectly clear what the solution is - replace it with the helper suggested in the deprecation notice.
It worked like a charm in #67522

