### PR TITLE
fix: don't unset remote-sync settings on api req

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
@@ -221,6 +221,8 @@
                                                                        [:= :rso.model_id :c.id]]]
                                                                :where [:= :location "/"]})
                                                     (map #(str "collections/" (:entity_id %))))
+                    _ (prn models)
+                    _ (prn top-level-removed-prefixes)
                     written-version (source/store! models top-level-removed-prefixes snapshot task-id message)]
                 (remote-sync.task/set-version! task-id written-version))
               (t2/update! :model/RemoteSyncObject {:status "synced" :status_changed_at sync-timestamp})))

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
@@ -221,8 +221,6 @@
                                                                        [:= :rso.model_id :c.id]]]
                                                                :where [:= :location "/"]})
                                                     (map #(str "collections/" (:entity_id %))))
-                    _ (prn models)
-                    _ (prn top-level-removed-prefixes)
                     written-version (source/store! models top-level-removed-prefixes snapshot task-id message)]
                 (remote-sync.task/set-version! task-id written-version))
               (t2/update! :model/RemoteSyncObject {:status "synced" :status_changed_at sync-timestamp})))

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/settings.clj
@@ -122,8 +122,8 @@
 
   Throws ExceptionInfo if the git settings are invalid or if unable to connect to the repository."
   [{:keys [remote-sync-url remote-sync-token] :as settings}]
-
-  (if (str/blank? remote-sync-url)
+  (if (and (contains? settings :remote-sync-url)
+           (str/blank? remote-sync-url))
     (t2/with-transaction [_conn]
       (setting/set! :remote-sync-url nil)
       (setting/set! :remote-sync-token nil)
@@ -134,5 +134,6 @@
           _ (check-git-settings! (assoc settings :remote-sync-token token-to-check))]
       (t2/with-transaction [_conn]
         (doseq [k [:remote-sync-url :remote-sync-token :remote-sync-type :remote-sync-branch :remote-sync-auto-import]]
-          (when (not (and (= k :remote-sync-token) obfuscated?))
+          (when (and (contains? settings k)
+                     (not (and (= k :remote-sync-token) obfuscated?)))
             (setting/set! k (k settings))))))))

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/api_test.clj
@@ -779,3 +779,55 @@
           (is (= #{["main" "main-ref"] ["develop" "develop-ref"] ["feature-branch" "feature-branch-ref"]}
                  (set (source.p/branches mock-source))))
           (is (= 1 @export-calls)))))))
+
+;;; ------------------------------------------- Token Preservation Tests -------------------------------------------
+
+(deftest settings-preserves-token-when-switching-to-read-only-test
+  (testing "PUT /api/ee/remote-sync/settings preserves token when switching from read-write to read-only"
+    (let [mock-source (test-helpers/create-mock-source)]
+      (with-redefs [settings/check-git-settings! (constantly nil)
+                    source/source-from-settings (constantly mock-source)]
+        (mt/with-temporary-setting-values [remote-sync-url "https://github.com/test/repo.git"
+                                           remote-sync-token "secret-token-value"
+                                           remote-sync-branch "main"
+                                           remote-sync-type :read-write]
+          (let [{:keys [task_id] :as resp} (mt/user-http-request :crowberto :put 200 "ee/remote-sync/settings"
+                                                                 {:remote-sync-type :read-only})]
+            (wait-for-task-completion task_id)
+            (is (= {:success true :task_id task_id} resp))
+            (is (= :read-only (settings/remote-sync-type)))
+            (is (= "secret-token-value" (settings/remote-sync-token))
+                "Token should be preserved when not included in request")))))))
+
+(deftest settings-preserves-token-when-changing-branch-test
+  (testing "PUT /api/ee/remote-sync/settings preserves token when changing branch"
+    (let [mock-source (test-helpers/create-mock-source)]
+      (with-redefs [settings/check-git-settings! (constantly nil)
+                    source/source-from-settings (constantly mock-source)]
+        (mt/with-temporary-setting-values [remote-sync-url "https://github.com/test/repo.git"
+                                           remote-sync-token "secret-token-value"
+                                           remote-sync-branch "main"
+                                           remote-sync-type :read-write]
+          (let [{:as resp :keys [task_id]} (mt/user-http-request :crowberto :put 200 "ee/remote-sync/settings"
+                                                                 {:remote-sync-branch "develop"})]
+            (wait-for-task-completion task_id)
+            (is (=? {:success true} resp))
+            (is (= "develop" (settings/remote-sync-branch)))
+            (is (= "secret-token-value" (settings/remote-sync-token))
+                "Token should be preserved when not included in request")))))))
+
+(deftest settings-clears-token-when-explicitly-nil-test
+  (testing "PUT /api/ee/remote-sync/settings clears token when explicitly set to nil"
+    (let [mock-source (test-helpers/create-mock-source)]
+      (with-redefs [settings/check-git-settings! (constantly nil)
+                    source/source-from-settings (constantly mock-source)]
+        (mt/with-temporary-setting-values [remote-sync-url "https://github.com/test/repo.git"
+                                           remote-sync-token "secret-token-value"
+                                           remote-sync-branch "main"
+                                           remote-sync-type :read-write]
+          (let [{:as resp :keys [task_id]} (mt/user-http-request :crowberto :put 200 "ee/remote-sync/settings"
+                                                                 {:remote-sync-token nil})]
+            (wait-for-task-completion task_id)
+            (is (=? {:success true} resp))
+            (is (nil? (settings/remote-sync-token))
+                "Token should be cleared when explicitly set to nil")))))))

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
@@ -278,7 +278,7 @@
     (let [existing-synced-ids (t2/select-pks-set :model/Collection :is_remote_synced true)]
       (try
         (when (seq existing-synced-ids)
-          (t2/update! :model/Collection {:is_remote_synced false} :id [:in existing-synced-ids]))
+          (t2/update! :model/Collection :id [:in existing-synced-ids] {:is_remote_synced false}))
         (mt/dataset test-data
           (mt/with-temporary-setting-values [remote-sync-type :read-write]
             (let [task-id (t2/insert-returning-pk! :model/RemoteSyncTask {:sync_task_type "export" :initiated_by (mt/user->id :rasta)})]
@@ -299,7 +299,7 @@
                       (is (= 0.3 (:progress (first @progress-calls)))))))))))
         (finally
           (when (seq existing-synced-ids)
-            (t2/update! :model/Collection {:is_remote_synced true} :id [:in existing-synced-ids])))))))
+            (t2/update! :model/Collection :id [:in existing-synced-ids] {:is_remote_synced true})))))))
 
 (deftest import!-resets-remote-sync-object-table-test
   (testing "import! deletes and recreates RemoteSyncObject table with synced status"


### PR DESCRIPTION
### Description

...if request is partial. Fixes an issue where the token could be unset when switching between read-write and read-only modes.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
