### PR TITLE
fix: cancelling remote sync tasks dismisses modal

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/SyncProgressModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/SyncProgressModal.tsx
@@ -35,6 +35,9 @@ export function SyncProgressModal({
 
     await cancelRemoteSyncCurrentTask()
       .unwrap()
+      .then(() => {
+        onDismiss();
+      })
       .catch((error: any) => {
         let message = t`Failed to cancel sync`;
 
@@ -61,7 +64,11 @@ export function SyncProgressModal({
           <Text>{t`An error occurred during sync.`}</Text>
           {errorMessage && <Text>{errorMessage}</Text>}
           <Group justify="flex-end">
-            <Button onClick={onDismiss} variant="filled">{t`Close`}</Button>
+            <Button
+              data-testid="sync-error-close-button"
+              onClick={onDismiss}
+              variant="filled"
+            >{t`Close`}</Button>
           </Group>
         </Stack>
       </Modal>

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/SyncProgressModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/SyncProgressModal.tsx
@@ -1,5 +1,6 @@
 import { t } from "ttag";
 
+import { ActionButton } from "metabase/common/components/ActionButton";
 import { useToast } from "metabase/common/hooks";
 import { useSelector } from "metabase/lib/redux";
 import { getUserIsAdmin } from "metabase/selectors/user";
@@ -24,37 +25,33 @@ export function SyncProgressModal({
 }: SyncProgressModalProps) {
   const canCancel = useSelector(getUserIsAdmin);
 
-  const [cancelRemoteSyncCurrentTask, { isLoading: isCancelling }] =
+  const [cancelRemoteSyncCurrentTask] =
     useCancelRemoteSyncCurrentTaskMutation();
   const [sendToast] = useToast();
 
   const onCancel = async () => {
-    if (!canCancel) {
-      return;
-    }
+    try {
+      await cancelRemoteSyncCurrentTask().unwrap();
+      onDismiss();
+    } catch (error: any) {
+      let message = t`Failed to cancel sync`;
 
-    await cancelRemoteSyncCurrentTask()
-      .unwrap()
-      .then(() => {
-        onDismiss();
-      })
-      .catch((error: any) => {
-        let message = t`Failed to cancel sync`;
+      if (typeof error?.data === "string") {
+        message += `: ${error.data}`;
+      }
 
-        if (typeof error?.data === "string") {
-          message += `: ${error.data}`;
-        }
-
-        sendToast({
-          message,
-          icon: "warning",
-          toastColor: "error",
-        });
-
-        if (message.match(/no active task/i)) {
-          onDismiss();
-        }
+      sendToast({
+        message,
+        icon: "warning",
+        toastColor: "error",
       });
+
+      if (message.match(/no active task/i)) {
+        onDismiss();
+      }
+
+      throw error;
+    }
   };
 
   if (isError) {
@@ -75,7 +72,7 @@ export function SyncProgressModal({
     );
   }
 
-  const { title, progressLabel } = getModalContent(taskType, isCancelling);
+  const { title, progressLabel } = getModalContent(taskType);
 
   return (
     <Modal
@@ -91,9 +88,14 @@ export function SyncProgressModal({
         <Text size="sm">
           {t`Please wait until this finishes before editing content.`}
         </Text>
-        {!isCancelling && canCancel && (
+        {canCancel && (
           <Group justify="flex-end">
-            <Button onClick={onCancel}>{t`Cancel`}</Button>
+            <ActionButton
+              actionFn={onCancel}
+              normalText={t`Cancel`}
+              activeText={t`Cancelling…`}
+              failedText={t`Cancel`}
+            />
           </Group>
         )}
       </Stack>
@@ -103,15 +105,7 @@ export function SyncProgressModal({
 
 const getModalContent = (
   taskType: RemoteSyncTaskType,
-  isCancelling?: boolean,
 ): { title: string; progressLabel: string } => {
-  if (isCancelling) {
-    return {
-      title: t`Cancelling`,
-      progressLabel: "",
-    };
-  }
-
   if (taskType === "import") {
     return {
       title: t`Pulling from Git`,

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/SyncProgressModal.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/SyncProgressModal.unit.spec.tsx
@@ -1,0 +1,222 @@
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import { createMockUser } from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks";
+
+import { SyncProgressModal } from "./SyncProgressModal";
+
+const setupCancelEndpoint = (
+  response: { status?: number; body?: any } = {},
+) => {
+  const { status = 200, body = {} } = response;
+
+  if (status === 200) {
+    fetchMock.post("path:/api/ee/remote-sync/current-task/cancel", body);
+  } else {
+    fetchMock.post("path:/api/ee/remote-sync/current-task/cancel", {
+      status,
+      body,
+    });
+  }
+};
+
+const setup = ({
+  taskType = "import" as const,
+  progress = 0.5,
+  isError = false,
+  errorMessage = "",
+  isAdmin = true,
+  onDismiss = jest.fn(),
+  cancelResponse,
+}: {
+  taskType?: "import" | "export";
+  progress?: number;
+  isError?: boolean;
+  errorMessage?: string;
+  isAdmin?: boolean;
+  onDismiss?: jest.Mock;
+  cancelResponse?: { status?: number; body?: any };
+} = {}) => {
+  if (cancelResponse) {
+    setupCancelEndpoint(cancelResponse);
+  }
+
+  return {
+    onDismiss,
+    ...renderWithProviders(
+      <SyncProgressModal
+        taskType={taskType}
+        progress={progress}
+        isError={isError}
+        errorMessage={errorMessage}
+        onDismiss={onDismiss}
+      />,
+      {
+        storeInitialState: createMockState({
+          currentUser: createMockUser({ is_superuser: isAdmin }),
+        }),
+      },
+    ),
+  };
+};
+
+describe("SyncProgressModal", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("progress state", () => {
+    it("should show import progress modal for import task", () => {
+      setup({ taskType: "import" });
+
+      expect(screen.getByText("Pulling from Git")).toBeInTheDocument();
+      expect(screen.getByText("Importing content…")).toBeInTheDocument();
+    });
+
+    it("should show export progress modal for export task", () => {
+      setup({ taskType: "export" });
+
+      expect(screen.getByText("Pushing to Git")).toBeInTheDocument();
+      expect(screen.getByText("Exporting content…")).toBeInTheDocument();
+    });
+
+    it("should show progress bar with correct value", () => {
+      setup({ progress: 0.75 });
+
+      const progressBar = screen.getByRole("progressbar");
+      expect(progressBar).toHaveAttribute("aria-valuenow", "75");
+    });
+
+    it("should show cancel button when user is admin", () => {
+      setup({ isAdmin: true, cancelResponse: { status: 200 } });
+
+      expect(
+        screen.getByRole("button", { name: "Cancel" }),
+      ).toBeInTheDocument();
+    });
+
+    it("should not show cancel button when user is not admin", () => {
+      setup({ isAdmin: false });
+
+      expect(
+        screen.queryByRole("button", { name: "Cancel" }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("error state", () => {
+    it("should show error modal with message", () => {
+      setup({ isError: true, errorMessage: "Connection timeout" });
+
+      expect(screen.getByText("Sync failed")).toBeInTheDocument();
+      expect(
+        screen.getByText("An error occurred during sync."),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Connection timeout")).toBeInTheDocument();
+    });
+
+    it("should show close button in error state", () => {
+      setup({ isError: true });
+
+      expect(screen.getByText("Close")).toBeInTheDocument();
+    });
+
+    it("should call onDismiss when close button is clicked in error state", async () => {
+      const onDismiss = jest.fn();
+      setup({ isError: true, onDismiss });
+
+      await userEvent.click(screen.getByTestId("sync-error-close-button"));
+
+      expect(onDismiss).toHaveBeenCalled();
+    });
+  });
+
+  describe("cancel functionality", () => {
+    it("should call onDismiss when cancel succeeds", async () => {
+      const onDismiss = jest.fn();
+      setup({ isAdmin: true, onDismiss, cancelResponse: { status: 200 } });
+
+      await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+      await waitFor(() => {
+        expect(
+          fetchMock.callHistory.done(
+            "path:/api/ee/remote-sync/current-task/cancel",
+          ),
+        ).toBe(true);
+      });
+
+      await waitFor(() => {
+        expect(onDismiss).toHaveBeenCalled();
+      });
+    });
+
+    it("should show error toast when cancel fails", async () => {
+      const onDismiss = jest.fn();
+      setup({
+        isAdmin: true,
+        onDismiss,
+        cancelResponse: { status: 500, body: "Server error" },
+      });
+
+      await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+      await waitFor(() => {
+        expect(
+          fetchMock.callHistory.done(
+            "path:/api/ee/remote-sync/current-task/cancel",
+          ),
+        ).toBe(true);
+      });
+
+      // onDismiss should NOT be called on error (unless it's "no active task")
+      expect(onDismiss).not.toHaveBeenCalled();
+    });
+
+    it("should call onDismiss when cancel fails with 'no active task' message", async () => {
+      const onDismiss = jest.fn();
+      setup({
+        isAdmin: true,
+        onDismiss,
+        cancelResponse: { status: 400, body: "No active task to cancel" },
+      });
+
+      await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+      await waitFor(() => {
+        expect(
+          fetchMock.callHistory.done(
+            "path:/api/ee/remote-sync/current-task/cancel",
+          ),
+        ).toBe(true);
+      });
+
+      await waitFor(() => {
+        expect(onDismiss).toHaveBeenCalled();
+      });
+    });
+
+    it("should show 'Cancelling' state while cancel is in progress", async () => {
+      // Create a delayed response to test the loading state
+      fetchMock.post(
+        "path:/api/ee/remote-sync/current-task/cancel",
+        new Promise((resolve) => setTimeout(() => resolve({}), 100)),
+      );
+
+      setup({ isAdmin: true });
+
+      await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+      await waitFor(() => {
+        expect(screen.getByText("Cancelling")).toBeInTheDocument();
+      });
+
+      // Cancel button should be hidden while cancelling
+      expect(
+        screen.queryByRole("button", { name: "Cancel" }),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/test/__support__/server-mocks/remote-sync.ts
+++ b/frontend/test/__support__/server-mocks/remote-sync.ts
@@ -86,6 +86,29 @@ export const setupRemoteSyncImportEndpoint = ({
 };
 
 /**
+ * Setup the remote-sync cancel task endpoint
+ */
+export const setupRemoteSyncCancelTaskEndpoint = ({
+  status = 200,
+  body = {},
+  delay = 0,
+}: { status?: number; body?: any; delay?: number } = {}) => {
+  fetchMock.removeRoute("remote-sync-cancel-task");
+  if (status === 200) {
+    fetchMock.post("path:/api/ee/remote-sync/current-task/cancel", body, {
+      name: "remote-sync-cancel-task",
+      delay,
+    });
+  } else {
+    fetchMock.post(
+      "path:/api/ee/remote-sync/current-task/cancel",
+      { status, body },
+      { name: "remote-sync-cancel-task", delay },
+    );
+  }
+};
+
+/**
  * Setup all remote-sync endpoints at once
  */
 export const setupRemoteSyncEndpoints = ({


### PR DESCRIPTION
### Description

Previously we didn't close this modal until the task reached a 'cancelled' state which could take several seconds.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
