### PR TITLE
UXW-2597 fix row bar charts' tooltip

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/RowChart/utils/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/utils/events.ts
@@ -55,12 +55,7 @@ const getMetricColumnData = (
   });
 };
 
-const getColumnData = (
-  columns: ColumnDescriptor[],
-  datum: GroupedDatum,
-  rawRows: RowValues[],
-  seriesIndex: number,
-) => {
+const getColumnData = (columns: ColumnDescriptor[], rawRows: RowValues[]) => {
   return columns
     .map((columnDescriptor) => {
       const { column, index } = columnDescriptor;
@@ -75,7 +70,7 @@ const getColumnData = (
 
         value = formatNullable(metricSum);
       } else {
-        value = datum.rawRows[seriesIndex][index];
+        value = rawRows[0]?.[index];
       }
 
       return value != null
@@ -91,8 +86,7 @@ const getColumnData = (
 
 const getColumnsData = (
   chartColumns: CartesianChartColumns,
-  series: Series<GroupedDatum, unknown>,
-  seriesIndex: number,
+  series: Series<GroupedDatum>,
   datum: GroupedDatum,
   datasetColumns: DatasetColumn[],
   visualizationSettings: VisualizationSettings,
@@ -133,9 +127,7 @@ const getColumnsData = (
     datasetColumns,
   );
 
-  data.push(
-    ...getColumnData(otherColumnsDescriptors, datum, rawRows, seriesIndex),
-  );
+  data.push(...getColumnData(otherColumnsDescriptors, rawRows));
   return data;
 };
 
@@ -145,11 +137,10 @@ export const getClickData = (
   chartColumns: CartesianChartColumns,
   datasetColumns: DatasetColumn[],
 ): ClickObject => {
-  const { series, seriesIndex, datum } = bar;
+  const { series, datum } = bar;
   const data = getColumnsData(
     chartColumns,
     series,
-    seriesIndex,
     datum,
     datasetColumns,
     visualizationSettings,
@@ -314,7 +305,6 @@ export const getHoverData = (
     const data = getColumnsData(
       chartColumns,
       bar.series,
-      bar.seriesIndex,
       bar.datum,
       datasetColumns,
       settings,

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/utils/events.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/utils/events.unit.spec.ts
@@ -187,6 +187,117 @@ describe("events utils", () => {
       expect(tooltipModel).not.toBeDefined();
     });
 
+    it("handles breakout where datum has fewer rawRows than seriesIndex (UXW-2597)", () => {
+      // Simulates: SELECT 'Production' as stage, 'App1' as application, 'Finished' as status, 2000000 as x
+      //            UNION SELECT 'Development', 'App2', 'Finished', 2000000
+      // Each dimension value has only one breakout value, but series are created for all breakout values
+      const dataWithSparseBreakout: GroupedDatum[] = [
+        {
+          dimensionValue: "Production",
+          metrics: { x: 2000000 },
+          isClickable: true,
+          rawRows: [["Production", "App1", "Finished", 2000000]],
+          breakout: {
+            App1: {
+              metrics: { x: 2000000 },
+              rawRows: [["Production", "App1", "Finished", 2000000]],
+            },
+          },
+        },
+        {
+          dimensionValue: "Development",
+          metrics: { x: 2000000 },
+          isClickable: true,
+          rawRows: [["Development", "App2", "Finished", 2000000]],
+          breakout: {
+            App2: {
+              metrics: { x: 2000000 },
+              rawRows: [["Development", "App2", "Finished", 2000000]],
+            },
+          },
+        },
+      ];
+
+      const datasetColumns = [
+        createMockColumn({ name: "stage", display_name: "Stage" }),
+        createMockColumn({ name: "application", display_name: "Application" }),
+        createMockColumn({ name: "status", display_name: "Status" }),
+        createMockNumericColumn({ name: "x", display_name: "X" }),
+      ];
+
+      const columnsMap = {
+        stage: datasetColumns[0],
+        application: datasetColumns[1],
+        status: datasetColumns[2],
+        x: datasetColumns[3],
+      };
+
+      const chartColumns: BreakoutChartColumns = {
+        dimension: { index: 0, column: columnsMap.stage },
+        breakout: { index: 1, column: columnsMap.application },
+        metric: { index: 3, column: columnsMap.x },
+      };
+
+      const seriesApp1: Series<GroupedDatum, SeriesInfo> = {
+        seriesKey: "App1",
+        seriesName: "App1",
+        seriesInfo: {
+          metricColumn: columnsMap.x,
+          dimensionColumn: columnsMap.stage,
+          breakoutValue: "App1",
+        },
+        xAccessor: (datum: GroupedDatum) => datum.metrics["x"],
+        yAccessor: SERIES_Y_ACCESSOR,
+      };
+
+      const seriesApp2: Series<GroupedDatum, SeriesInfo> = {
+        seriesKey: "App2",
+        seriesName: "App2",
+        seriesInfo: {
+          metricColumn: columnsMap.x,
+          dimensionColumn: columnsMap.stage,
+          breakoutValue: "App2",
+        },
+        xAccessor: (datum: GroupedDatum) => datum.metrics["x"],
+        yAccessor: SERIES_Y_ACCESSOR,
+      };
+
+      const seriesColors = {
+        App1: "#509EE3",
+        App2: "#88BF4D",
+      };
+
+      // Hover on Development/App2 bar - seriesIndex is 1 but datum.rawRows.length is 1
+      const barData: BarData<GroupedDatum> = {
+        isNegative: false,
+        xStartValue: 0,
+        xEndValue: 2000000,
+        yValue: "Development",
+        datum: dataWithSparseBreakout[1],
+        datumIndex: 1,
+        series: seriesApp2,
+        seriesIndex: 1, // Second series, but datum only has 1 rawRow
+      };
+
+      // Should not throw and should return correct status value from breakout-specific rawRows
+      const tooltipData = getHoverData(
+        barData,
+        { "graph.dimensions": ["stage", "application"] },
+        chartColumns,
+        datasetColumns,
+        [seriesApp1, seriesApp2],
+        seriesColors,
+      );
+
+      expect(tooltipData.data).toBeDefined();
+      expect(
+        tooltipData.data?.find(({ col }) => col?.name === "status")?.value,
+      ).toBe("Finished");
+      expect(
+        tooltipData.data?.find(({ col }) => col?.name === "x")?.value,
+      ).toBe(2000000);
+    });
+
     it("does handle data with breakout correctly (metabase#64931)", () => {
       const dataWithBreakout: GroupedDatum[] = [
         {


### PR DESCRIPTION
Closes [UXW-2597](https://linear.app/metabase/issue/UXW-2597/tooltips-break-on-row-charts-when-using-two-columns-on-y-axis-but)
Closes https://github.com/metabase/metabase/issues/67110
Relates https://github.com/metabase/metabase/pull/49530

### Description
**Problem**: `seriesIndex` represents which series (metric or breakout value) is being displayed, not an index into the raw data rows. When a datum has fewer raw rows than the series index, accessing rawRows[seriesIndex] causes an out-of-bounds error.

**Solution**: Use `rawRows[0]` instead of `datum.rawRows[seriesIndex]`. The `rawRows` parameter is already correctly scoped to the relevant rows for the current series (via breakout-specific rows in `getColumnsData`), so we just need the first row to get non-metric column values.

### How to verify
1. New > SQL query
2. `select 'Production' as stage, 'App1' as application, 'Finished' as status, 2000000 as x 
union
(select 'Development', 'App2', 'Finished', 2000000)`
3. Run query
4. Change viz type to "Row"
5. Open viz settings
6. Set Y-Axis to "STAGE"
7. Click "Add series breakout" and select "APPLICATION"
8. Set  X-Axis to "X"
9. Hover on the bottom row, it should show a tooltip
10. (optional) Re-verify https://github.com/metabase/metabase/pull/49530

### Demo
Before:

https://github.com/user-attachments/assets/15d6b9be-1652-4423-ba6e-f062ec86f42e

After:

https://github.com/user-attachments/assets/a6af3ee9-8987-4221-959e-2c2dce5a5882



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
