### PR TITLE
(chore): Bump netty version in bigquery-cloud-sdk deps to 4.2.9.Final

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/deps.edn
+++ b/modules/drivers/bigquery-cloud-sdk/deps.edn
@@ -18,5 +18,5 @@
   ;; was 1.71.0. bumping to 77
   io.grpc/grpc-netty-shaded              {:mvn/version "1.77.0"}
   ;; matches those in athena
-  io.netty/netty-common                  {:mvn/version "4.2.7.Final"}
-  io.netty/netty-buffer                  {:mvn/version "4.2.7.Final"}}}
+  io.netty/netty-common                  {:mvn/version "4.2.9.Final"}
+  io.netty/netty-buffer                  {:mvn/version "4.2.9.Final"}}}


### PR DESCRIPTION
> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform). Also, if you're attempting to fix a translation issue, please submit your changes to our [Crowdin project](https://crowdin.com/project/metabase-i18n) instead of opening a PR.

Closes #67626 

### Description

This PR updates one Netty dependency to `4.2.9.Final`. The primary motivation is to align dependency versions with current upstream releases and to minimize noise from automated vulnerability/container scanners, which frequently flag the older Netty version.

### How to verify

Please verify via CI and integration test runs, as I was not able to test these changes locally.

General steps:
1. Ensure build passes and integration tests are green.
2. Check that key flows involving drivers and HTTP continue to work as expected (e.g., new question on Sample Dataset, DB connections using drivers that depend on Netty).
3. Scan the built artifacts with your preferred tool to confirm that the new Netty version (`4.1.129.Final`) is present and there are no old or duplicated Netty dependencies.

### Demo

_N/A (no UI or visible feature changes; routine dependency bump)._

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR  
  (Integration tests and CI coverage are strongly recommended for this update, since local testing was not possible.)

### Note
Contributor License Agreement has been sent via Google Forms right before opening this PR.