### PR TITLE
Fix target-db-id calculation

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/transforms/interface.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/interface.clj
@@ -4,15 +4,6 @@
   [transform]
   (-> transform :source :type keyword))
 
-(defmulti source-db-id
-  "Return the ID of the source database for a given `transform`. The source database is where the data originates from
-  before being transformed and written to the target destination.
-
-  NOTE: Currently returns a single database ID, but we may want to change this to return multiple database IDs in the
-  future since transforms can have multiple input sources."
-  {:added "0.57.0" :arglists '([transform])}
-  transform->transform-type)
-
 (defmulti target-db-id
   "Return the ID of the target database for a given `transform`. The target database is the destination where the
   transformed data will be written. Often this is the same database as the source database."

--- a/enterprise/backend/src/metabase_enterprise/transforms/models/transform.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/models/transform.clj
@@ -54,13 +54,13 @@
   #{:transforms})
 
 (t2/define-before-insert :model/Transform
-  [{:keys [source target collection_id] :as transform}]
+  [{:keys [source collection_id] :as transform}]
   (collection/check-collection-namespace :model/Transform collection_id)
   (when collection_id
     (collection/check-allowed-content :model/Transform collection_id))
   (assoc transform
          :source_type (transforms.util/transform-source-type source)
-         :target_db_id (or (transforms.i/target-db-id transform) (:database target) (:target_db_id transform))))
+         :target_db_id (transforms.i/target-db-id transform)))
 
 (t2/define-before-update :model/Transform
   [{:keys [source target] :as transform}]

--- a/enterprise/backend/src/metabase_enterprise/transforms/query_impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/query_impl.clj
@@ -14,16 +14,12 @@
 
 (set! *warn-on-reflection* true)
 
-(defmethod transforms.i/source-db-id :query
-  [transform]
-  (-> transform :source :query :database))
-
 (defmethod transforms.i/target-db-id :query
   [transform]
   (or (get-in transform [:target :database])
-      (:target_db_id transform)
       ;; Fallback to source. https://github.com/metabase/metabase/pull/67084#discussion_r2630147855
-      (-> transform :source :query :database)))
+      (-> transform :source :query :database)
+      (:target_db_id transform)))
 
 (mr/def ::transform-details
   [:map

--- a/enterprise/backend/src/metabase_enterprise/transforms_python/execute.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms_python/execute.clj
@@ -8,6 +8,7 @@
    [metabase-enterprise.transforms-python.settings :as transforms-python.settings]
    [metabase-enterprise.transforms.core :as transforms]
    [metabase-enterprise.transforms.instrumentation :as transforms.instrumentation]
+   [metabase-enterprise.transforms.interface :as transforms.i]
    [metabase-enterprise.transforms.util :as transforms.util]
    [metabase.app-db.core :as app-db]
    [metabase.driver :as driver]
@@ -354,7 +355,7 @@
   (try
     (let [message-log (empty-message-log)
           {:keys [target] transform-id :id} transform
-          {driver :engine :as db} (t2/select-one :model/Database (:database target))
+          {driver :engine :as db} (t2/select-one :model/Database (transforms.i/target-db-id transform))
           {run-id :id} (transforms.util/try-start-unless-already-running transform-id run-method)]
       (some-> start-promise (deliver [:started run-id]))
       (log! message-log (i18n/tru "Executing Python transform"))

--- a/enterprise/backend/src/metabase_enterprise/transforms_python/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms_python/impl.clj
@@ -8,10 +8,6 @@
   (or (get-in transform [:target :database])
       (:target_db_id transform)))
 
-(defmethod transforms.i/source-db-id :python
-  [transform]
-  (-> transform :source :source-database))
-
 #_{:clj-kondo/ignore [:discouraged-var]}
 (defmethod transforms.i/execute! :python
   [transform options]

--- a/enterprise/backend/src/metabase_enterprise/workspaces/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/common.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.workspaces.common
   (:require
    [clojure.string :as str]
+   [metabase-enterprise.transforms.interface :as transforms.i]
    [metabase-enterprise.workspaces.dag :as ws.dag]
    [metabase-enterprise.workspaces.impl :as ws.impl]
    [metabase-enterprise.workspaces.isolation :as ws.isolation]
@@ -165,7 +166,7 @@
   (ws.u/assert-transform! entity-type)
   ;; Initialize workspace if uninitialized (outside transaction so async task can see committed data)
   (let [workspace (if (= :uninitialized (:status workspace))
-                    (let [target-db-id (get-in body [:target :database])]
+                    (let [target-db-id (transforms.i/target-db-id body)]
                       (api/check-400 target-db-id "Transform must have a target database")
                       (initialize-workspace! workspace target-db-id))
                     workspace)]

--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -3591,8 +3591,9 @@ databaseChangeLog:
             columnName: target_db_id
 
   - changeSet:
-      id: v58.2025-12-15T12:16:17
+      id: v58.2025-12-15T12:16:16
       author: piranha
+      runOnChange: true
       comment: Backfill target_db_id column for existing transforms
       changes:
         - customChange:

--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -3591,7 +3591,7 @@ databaseChangeLog:
             columnName: target_db_id
 
   - changeSet:
-      id: v58.2025-12-15T12:16:16
+      id: v58.2025-12-15T12:16:17
       author: piranha
       comment: Backfill target_db_id column for existing transforms
       changes:

--- a/src/metabase/app_db/custom_migrations.clj
+++ b/src/metabase/app_db/custom_migrations.clj
@@ -1825,9 +1825,11 @@
   (reserve-at-symbol-user-attributes/migrate!))
 
 (define-migration BackfillTransformTargetDbId
-  (let [update! (fn [{:keys [id target]}]
+  (let [update! (fn [{:keys [id source target]}]
                   (let [target-map (json/decode target)
-                        db-id      (get target-map "database")]
+                        source-map (json/decode source)
+                        db-id      (or (get target-map "database")
+                                       (get-in source-map ["query" "database"]))]
                     (when db-id
                       (t2/update! :transform id {:target_db_id db-id}))))]
     (run! update! (t2/reducible-query {:select [:id :target]


### PR DESCRIPTION
This is a patch to fix Workspaces staging.

For master, I think we should just [revert](https://github.com/metabase/metabase/pull/67630) the change for now and review it carefully in 2026.