### PR TITLE
bumping deps:

### DIFF
--- a/modules/drivers/databricks/deps.edn
+++ b/modules/drivers/databricks/deps.edn
@@ -2,4 +2,4 @@
  ["src" "resources"]
 
  :deps
- {com.databricks/databricks-jdbc-thin {:mvn/version "3.0.5"}}}
+ {com.databricks/databricks-jdbc-thin {:mvn/version "3.0.7"}}}

--- a/modules/drivers/hive-like/deps.edn
+++ b/modules/drivers/hive-like/deps.edn
@@ -2,4 +2,5 @@
  ["src" "resources"]
 
  :deps
- {org.apache.hive/hive-jdbc$standalone {:mvn/version "4.2.0"}}}
+ {org.apache.hive/hive-jdbc$standalone {:mvn/version "4.2.0"
+                                        :exclusions [org.apache.commons/commons-lang3]}}}

--- a/modules/drivers/snowflake/deps.edn
+++ b/modules/drivers/snowflake/deps.edn
@@ -10,6 +10,7 @@
                                                    org.bouncycastle/bcutil-jdk18on]}
   ;; drop when snowflake update driver to the one without the vulnerabilities
   com.nimbusds/nimbus-jose-jwt      {:mvn/version "10.5"}
+  io.grpc/grpc-netty-shaded         {:mvn/version "1.77.0"}
   org.apache.commons/commons-lang3  {:mvn/version "3.19.0"}
   org.bouncycastle/bcpkix-jdk18on   {:mvn/version "1.81"}
   org.bouncycastle/bcprov-jdk18on   {:mvn/version "1.81"}


### PR DESCRIPTION
- https://github.com/metabase/metabase/security/code-scanning/543 about snowflake's of grpc netty shaded. We already have this version elsewhere so now it matches
- https://github.com/metabase/metabase/security/code-scanning/549 and https://github.com/metabase/metabase/security/code-scanning/557 issue in databricks. We bumped that and now it uses the new coordinate `at.yawk.lz4/lz4-java 1.10.1`
- https://github.com/metabase/metabase/security/code-scanning/496 bump commons-lang3. actually just exclude it from the driver jar so it will be found on parent classpath with coordinate from deps.edn: `{:mvn/version "3.19.0"}`