### PR TITLE
Uxw 734 pie chart legend does not respect querys sort order

### DIFF
--- a/frontend/src/metabase/visualizations/shared/settings/pie.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/pie.ts
@@ -435,6 +435,7 @@ export const getDefaultSortRows = (series: MaybeTranslatedSeries) => {
 
   // Auto-sort only when there's NO explicit order-by in the query
   const hasOrderBy = hasExplicitOrderBy(card.dataset_query);
+
   return !hasOrderBy;
 };
 
@@ -448,6 +449,6 @@ function hasExplicitOrderBy(datasetQuery: DatasetQuery | null): boolean {
     return false;
   }
 
-  const orderBys = Lib.orderBys(question.query(), 0);
+  const orderBys = Lib.orderBys(question.query(), -1);
   return orderBys.length > 0;
 }

--- a/frontend/src/metabase/visualizations/shared/settings/pie.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/pie.ts
@@ -380,7 +380,7 @@ export function getPieRows(
   });
   newPieRows.push(...removedPieRows);
 
-  // Make any slices below mimium slice percentage hidden
+  // Make any slices below minimum slice percentage hidden
   const total = newPieRows.reduce((currTotal, pieRow) => {
     if (pieRow.hidden || !pieRow.enabled) {
       return currTotal;

--- a/frontend/src/metabase/visualizations/shared/settings/pie.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/pie.unit.spec.ts
@@ -1,0 +1,222 @@
+import {
+  createMockCard,
+  createMockColumn,
+  createMockDatasetData,
+  createMockNativeDatasetQuery,
+  createMockStructuredDatasetQuery,
+  createMockStructuredQuery,
+} from "metabase-types/api/mocks";
+
+import { getDefaultSortRows, getPieRows } from "./pie";
+
+const defaultCardArgs = {
+  name: "Test Card",
+  display: "pie",
+  visualization_settings: {},
+} as const;
+
+const data = createMockDatasetData({
+  cols: [
+    createMockColumn({ name: "Category" }),
+    createMockColumn({ name: "Count" }),
+  ],
+  rows: [
+    ["A", 10],
+    ["B", 20],
+    ["C", 15],
+  ],
+});
+
+describe("getDefaultSortRows", () => {
+  it("should return true (auto-sort) when there is no order-by clause", () => {
+    const datasetQuery = createMockStructuredDatasetQuery({
+      query: createMockStructuredQuery({
+        "source-table": 1,
+      }),
+    });
+    const series = [
+      {
+        card: createMockCard({
+          ...defaultCardArgs,
+          dataset_query: datasetQuery,
+        }),
+        data,
+      },
+    ];
+
+    const result = getDefaultSortRows(series);
+
+    expect(result).toBe(true);
+  });
+
+  it("should return false (preserve data order) when there is an explicit order-by clause", () => {
+    const datasetQuery = createMockStructuredDatasetQuery({
+      query: createMockStructuredQuery({
+        "source-table": 1,
+        "order-by": [["asc", ["field", 1, null]]],
+      }),
+    });
+    const series = [
+      {
+        card: createMockCard({
+          ...defaultCardArgs,
+          dataset_query: datasetQuery,
+        }),
+        data,
+      },
+    ];
+
+    const result = getDefaultSortRows(series);
+
+    expect(result).toBe(false);
+  });
+
+  it("should return true (auto-sort) for native queries since we cannot detect order-by", () => {
+    const datasetQuery = createMockNativeDatasetQuery({
+      native: {
+        query: "SELECT category, count FROM table ORDER BY count DESC",
+      },
+    });
+    const series = [
+      {
+        card: createMockCard({
+          ...defaultCardArgs,
+          dataset_query: datasetQuery,
+        }),
+        data,
+      },
+    ];
+
+    const result = getDefaultSortRows(series);
+
+    // Native queries always return true because we can't detect ORDER BY
+    expect(result).toBe(true);
+  });
+
+  it("should return true when dataset_query is undefined", () => {
+    const series = [
+      {
+        card: createMockCard({
+          ...defaultCardArgs,
+          dataset_query: undefined,
+        }),
+        data,
+      },
+    ];
+
+    const result = getDefaultSortRows(series);
+
+    expect(result).toBe(true);
+  });
+});
+
+describe("getPieRows", () => {
+  const formatter = (value: unknown) => String(value);
+
+  describe("sorting behavior based on order-by", () => {
+    it("should auto-sort by metric (descending) when pie.sort_rows is true", () => {
+      const datasetQuery = createMockStructuredDatasetQuery();
+      const series = [
+        {
+          card: createMockCard({
+            ...defaultCardArgs,
+            dataset_query: datasetQuery,
+          }),
+          data,
+        },
+      ];
+
+      const settings = {
+        "pie.dimension": "Category",
+        "pie.metric": "Count",
+        "pie.sort_rows": true,
+        "pie.colors": {},
+        column: () => ({}),
+      };
+
+      const result = getPieRows(series, settings, formatter);
+      expect(result.map((row) => row.key)).toEqual(["B", "C", "A"]);
+    });
+
+    it("should preserve data order when pie.sort_rows is false", () => {
+      const datasetQuery = createMockStructuredDatasetQuery({
+        query: createMockStructuredQuery({
+          "source-table": 1,
+          "order-by": [["asc", ["field", 1, null]]],
+        }),
+      });
+      const series = [
+        {
+          card: createMockCard({
+            ...defaultCardArgs,
+            dataset_query: datasetQuery,
+          }),
+          data,
+        },
+      ];
+
+      const settings = {
+        "pie.dimension": "Category",
+        "pie.metric": "Count",
+        "pie.sort_rows": false,
+        "pie.rows": [], // No saved rows
+        "pie.colors": {},
+        column: () => ({}),
+      };
+
+      const result = getPieRows(series, settings, formatter);
+      expect(result.map((row) => row.key)).toEqual(["A", "B", "C"]);
+    });
+
+    it("should preserve manual sort order when pie.sort_rows is false and pie.rows exist", () => {
+      const datasetQuery = createMockStructuredDatasetQuery({
+        query: createMockStructuredQuery({
+          "source-table": 1,
+          "order-by": [["asc", ["field", 1, null]]],
+        }),
+      });
+      const data = createMockDatasetData({
+        cols: [
+          createMockColumn({ name: "Category" }),
+          createMockColumn({ name: "Count" }),
+        ],
+        rows: [
+          ["A", 10],
+          ["B", 30],
+          ["C", 20],
+        ],
+      });
+      const series = [
+        {
+          card: createMockCard({
+            ...defaultCardArgs,
+            dataset_query: datasetQuery,
+          }),
+          data,
+        },
+      ];
+
+      const settings = {
+        "pie.dimension": "Category",
+        "pie.metric": "Count",
+        "pie.sort_rows": false,
+        "pie.sort_rows_dimension": "Category",
+        "pie.rows": ["C", "B", "A"].map((key) => ({
+          key,
+          name: key,
+          originalName: key,
+          color: "#FF0000",
+          defaultColor: true,
+          enabled: true,
+          hidden: false,
+          isOther: false,
+        })),
+        "pie.colors": {},
+        column: () => ({}),
+      };
+
+      const result = getPieRows(series, settings, formatter);
+      expect(result.map((row) => row.key)).toEqual(["C", "B", "A"]);
+    });
+  });
+});


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> 
closes #63585
Closes https://linear.app/metabase/issue/UXW-734/pie-chart-legend-does-not-respect-querys-sort-order

### Description

When we're dealing with a question that has an explicit ordering set (`ORDER BY` clause), then let's use this order in the pie chart, instead of the auto sort based on the pie size.

We can detect ordering reliably only in case of non-native questions. In case of native question we fallback to the the auto sort by pie size.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> Orders
2. Filtering: Product ID less than 5
3. Summarize: count by Product ID

<img width="1006" height="848" alt="image" src="https://github.com/user-attachments/assets/aad27e87-f3b2-4ce3-aab1-a606610cd710" />


Visualize as pie chart → Pie parts should be sorted by size 

<img width="1668" height="1101" alt="image" src="https://github.com/user-attachments/assets/eeaa42f7-d64c-4547-a37a-3fb686975421" />


5. Go to editor
6. Sort: Product ID

Visualize as pie chart → pie parts should be sorted alphabetically

<img width="1274" height="1171" alt="image" src="https://github.com/user-attachments/assets/135aa3a5-5efa-4c1b-a542-dc487d011aad" />

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
