### PR TITLE
Let users with data model perm access data studio

### DIFF
--- a/e2e/test/scenarios/data-studio/data-model/datamodel-data-studio.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-model/datamodel-data-studio.cy.spec.ts
@@ -1059,9 +1059,7 @@ describe("scenarios > data studio > datamodel", () => {
         cy.findByText("New description").should("be.visible");
       });
 
-      // Skipped because data studio is not available with data model permissions only.
-      // Unskip once the new datamodel page is available in that case.
-      it.skip("should allow changing the table name with data model permissions only", () => {
+      it("should allow changing the table name with data model permissions only", () => {
         H.activateToken("pro-self-hosted");
         setDataModelPermissions({ tableIds: [ORDERS_ID] });
 
@@ -1137,9 +1135,7 @@ describe("scenarios > data studio > datamodel", () => {
         );
       });
 
-      // Skipped because data studio is not available with data model permissions only.
-      // Unskip once the new datamodel page is available in that case.
-      it.skip("should allow changing the field name with data model permissions only", () => {
+      it("should allow changing the field name with data model permissions only", () => {
         H.activateToken("pro-self-hosted");
         setDataModelPermissions({ tableIds: [ORDERS_ID] });
         cy.signIn("none");
@@ -1532,9 +1528,7 @@ describe("scenarios > data studio > datamodel", () => {
         );
       });
 
-      // Skipped because data studio is not available with data model permissions only.
-      // Unskip once the new datamodel page is available in that case.
-      it.skip("should allow changing the field name with data model permissions only", () => {
+      it("should allow changing the field name with data model permissions only", () => {
         H.activateToken("pro-self-hosted");
         setDataModelPermissions({ tableIds: [ORDERS_ID] });
         cy.signIn("none");
@@ -1982,9 +1976,7 @@ describe("scenarios > data studio > datamodel", () => {
           cy.findByLabelText("Left column").should("contain.text", "User ID");
         });
 
-        // Skipped because data studio is not available with data model permissions only.
-        // Unskip once the new datamodel page is available in that case.
-        it.skip("should allow to change the field foreign key target with no permissions to Reviews table", () => {
+        it("should allow to change the field foreign key target with no permissions to Reviews table", () => {
           H.activateToken("pro-self-hosted");
           setDataModelPermissions({
             tableIds: [ORDERS_ID, PRODUCTS_ID, PEOPLE_ID],
@@ -2041,9 +2033,7 @@ describe("scenarios > data studio > datamodel", () => {
           cy.findByLabelText("Left column").should("contain.text", "User ID");
         });
 
-        // Skipped because data studio is not available with data model permissions only.
-        // Unskip once the new datamodel page is available in that case.
-        it.skip("should not allow setting foreign key target for inaccessible tables", () => {
+        it("should not allow setting foreign key target for inaccessible tables", () => {
           H.activateToken("pro-self-hosted");
           setDataModelPermissions({ tableIds: [REVIEWS_ID] });
 
@@ -2660,9 +2650,7 @@ describe("scenarios > data studio > datamodel", () => {
             .and("have.value", "Title");
         });
 
-        // Skipped because data studio is not available with data model permissions only.
-        // Unskip once the new datamodel page is available in that case.
-        it.skip("should allow to change foreign key target for accessible tables", () => {
+        it("should allow to change foreign key target for accessible tables", () => {
           H.activateToken("pro-self-hosted");
           setDataModelPermissions({
             tableIds: [ORDERS_ID, REVIEWS_ID, PRODUCTS_ID],
@@ -2878,9 +2866,7 @@ describe("scenarios > data studio > datamodel", () => {
           });
         });
 
-        // Skipped because data studio is not available with data model permissions only.
-        // Unskip once the new datamodel page is available in that case.
-        it.skip("should show a proper error message when using custom mapping", () => {
+        it("should show a proper error message when using custom mapping", () => {
           H.activateToken("pro-self-hosted");
           setDataModelPermissions({ tableIds: [REVIEWS_ID] });
 

--- a/e2e/test/scenarios/data-studio/data-model/datamodel-data-studio.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-model/datamodel-data-studio.cy.spec.ts
@@ -1060,7 +1060,6 @@ describe("scenarios > data studio > datamodel", () => {
       });
 
       it("should allow changing the table name with data model permissions only", () => {
-        H.activateToken("pro-self-hosted");
         setDataModelPermissions({ tableIds: [ORDERS_ID] });
 
         cy.signIn("none");
@@ -1136,7 +1135,6 @@ describe("scenarios > data studio > datamodel", () => {
       });
 
       it("should allow changing the field name with data model permissions only", () => {
-        H.activateToken("pro-self-hosted");
         setDataModelPermissions({ tableIds: [ORDERS_ID] });
         cy.signIn("none");
         H.DataModel.visitDataStudio({
@@ -1529,7 +1527,6 @@ describe("scenarios > data studio > datamodel", () => {
       });
 
       it("should allow changing the field name with data model permissions only", () => {
-        H.activateToken("pro-self-hosted");
         setDataModelPermissions({ tableIds: [ORDERS_ID] });
         cy.signIn("none");
         H.DataModel.visitDataStudio({
@@ -1977,7 +1974,6 @@ describe("scenarios > data studio > datamodel", () => {
         });
 
         it("should allow to change the field foreign key target with no permissions to Reviews table", () => {
-          H.activateToken("pro-self-hosted");
           setDataModelPermissions({
             tableIds: [ORDERS_ID, PRODUCTS_ID, PEOPLE_ID],
           });
@@ -2034,7 +2030,6 @@ describe("scenarios > data studio > datamodel", () => {
         });
 
         it("should not allow setting foreign key target for inaccessible tables", () => {
-          H.activateToken("pro-self-hosted");
           setDataModelPermissions({ tableIds: [REVIEWS_ID] });
 
           cy.signIn("none");
@@ -2651,7 +2646,6 @@ describe("scenarios > data studio > datamodel", () => {
         });
 
         it("should allow to change foreign key target for accessible tables", () => {
-          H.activateToken("pro-self-hosted");
           setDataModelPermissions({
             tableIds: [ORDERS_ID, REVIEWS_ID, PRODUCTS_ID],
           });
@@ -2867,7 +2861,6 @@ describe("scenarios > data studio > datamodel", () => {
         });
 
         it("should show a proper error message when using custom mapping", () => {
-          H.activateToken("pro-self-hosted");
           setDataModelPermissions({ tableIds: [REVIEWS_ID] });
 
           cy.signIn("none");

--- a/e2e/test/scenarios/data-studio/data-model/segments-data-studio.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-model/segments-data-studio.cy.spec.ts
@@ -11,680 +11,685 @@ const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID, PEOPLE, PEOPLE_ID } =
   SAMPLE_DATABASE;
 const { ALL_USERS_GROUP } = USER_GROUPS;
 
-describe("scenarios > data studio > data model > segments", () => {
-  beforeEach(() => {
-    H.restore();
-    cy.signInAsAdmin();
-    H.activateToken("bleeding-edge");
+describe(
+  "scenarios > data studio > data model > segments",
+  { tags: "@EE" },
+  () => {
+    beforeEach(() => {
+      H.restore();
+      cy.signInAsAdmin();
+      H.activateToken("bleeding-edge");
 
-    cy.intercept("POST", "/api/segment").as("createSegment");
-    cy.intercept("PUT", "/api/segment/*").as("updateSegment");
-    cy.intercept("GET", "/api/table/*/query_metadata*").as("metadata");
-  });
-
-  describe("Segment list", () => {
-    it("should show empty state and navigation when no segments exist", () => {
-      visitDataStudioSegments(ORDERS_ID);
-
-      cy.log("verify empty state");
-      SegmentList.getEmptyState().scrollIntoView().should("be.visible");
-      SegmentList.get()
-        .findByText("Create a segment to filter rows in this table.")
-        .should("be.visible");
-
-      cy.log("verify new segment link and navigation");
-      SegmentList.getNewSegmentLink().scrollIntoView().click();
-
-      cy.url().should("include", `${getSegmentsBaseUrl(ORDERS_ID)}/new`);
+      cy.intercept("POST", "/api/segment").as("createSegment");
+      cy.intercept("PUT", "/api/segment/*").as("updateSegment");
+      cy.intercept("DELETE", "/api/segment/*").as("deleteSegment");
+      cy.intercept("GET", "/api/table/*/query_metadata*").as("metadata");
     });
 
-    it("should display segments and allow navigation to edit page", () => {
-      createTestSegment({
-        name: "High Value Orders",
-        filter: [">", ["field", ORDERS.TOTAL, null], 100],
+    describe("Segment list", () => {
+      it("should show empty state and navigation when no segments exist", () => {
+        visitDataStudioSegments(ORDERS_ID);
+
+        cy.log("verify empty state");
+        SegmentList.getEmptyState().scrollIntoView().should("be.visible");
+        SegmentList.get()
+          .findByText("Create a segment to filter rows in this table.")
+          .should("be.visible");
+
+        cy.log("verify new segment link and navigation");
+        SegmentList.getNewSegmentLink().scrollIntoView().click();
+
+        cy.url().should("include", `${getSegmentsBaseUrl(ORDERS_ID)}/new`);
       });
-      visitDataStudioSegments(ORDERS_ID);
 
-      cy.log("verify segment in list with filter description");
-      SegmentList.getSegment("High Value Orders")
-        .scrollIntoView()
-        .should("be.visible");
-      SegmentList.get()
-        .findByTestId("list-item-description")
-        .should("contain", "Filtered by Total is greater than 100");
+      it("should display segments and allow navigation to edit page", () => {
+        createTestSegment({
+          name: "High Value Orders",
+          filter: [">", ["field", ORDERS.TOTAL, null], 100],
+        });
+        visitDataStudioSegments(ORDERS_ID);
 
-      cy.log("navigate to edit page");
-      SegmentList.getSegment("High Value Orders").click();
-      cy.get<number>("@segmentId").then((segmentId) => {
+        cy.log("verify segment in list with filter description");
+        SegmentList.getSegment("High Value Orders")
+          .scrollIntoView()
+          .should("be.visible");
+        SegmentList.get()
+          .findByTestId("list-item-description")
+          .should("contain", "Filtered by Total is greater than 100");
+
+        cy.log("navigate to edit page");
+        SegmentList.getSegment("High Value Orders").click();
+        cy.get<number>("@segmentId").then((segmentId) => {
+          cy.url().should(
+            "include",
+            `${getSegmentsBaseUrl(ORDERS_ID)}/${segmentId}`,
+          );
+        });
+      });
+
+      it("should navigate between Fields and Segments tabs", () => {
+        visitDataStudioTable(ORDERS_ID);
+
+        cy.log("verify both tabs visible");
+        cy.findByRole("tab", { name: /Fields/i }).scrollIntoView();
+        cy.findByRole("tab", { name: /Segments/i }).should("be.visible");
+
+        cy.log("navigate to segments tab");
+        cy.findByRole("tab", { name: /Segments/i }).click();
         cy.url().should(
           "include",
-          `${getSegmentsBaseUrl(ORDERS_ID)}/${segmentId}`,
+          `/data-studio/data/database/${SAMPLE_DB_ID}/schema/${SAMPLE_DB_SCHEMA_ID}/table/${ORDERS_ID}/segments`,
         );
-      });
-    });
+        SegmentList.getEmptyState().scrollIntoView().should("be.visible");
 
-    it("should navigate between Fields and Segments tabs", () => {
-      visitDataStudioTable(ORDERS_ID);
-
-      cy.log("verify both tabs visible");
-      cy.findByRole("tab", { name: /Fields/i }).scrollIntoView();
-      cy.findByRole("tab", { name: /Segments/i }).should("be.visible");
-
-      cy.log("navigate to segments tab");
-      cy.findByRole("tab", { name: /Segments/i }).click();
-      cy.url().should(
-        "include",
-        `/data-studio/data/database/${SAMPLE_DB_ID}/schema/${SAMPLE_DB_SCHEMA_ID}/table/${ORDERS_ID}/segments`,
-      );
-      SegmentList.getEmptyState().scrollIntoView().should("be.visible");
-
-      cy.log("verify tab selection preserved on refresh");
-      cy.reload();
-      cy.wait("@metadata");
-      cy.findByRole("tab", { name: /Segments/i })
-        .scrollIntoView()
-        .should("have.attr", "aria-selected", "true");
-
-      cy.log("navigate back to fields tab");
-      cy.findByRole("tab", { name: /Fields/i }).click();
-      cy.url().should("include", "/field");
-    });
-  });
-
-  describe("Segment creation", () => {
-    it("should create a segment with filters and verify across features", () => {
-      visitDataStudioSegments(ORDERS_ID);
-
-      cy.log("navigate to new segment page");
-      SegmentList.getNewSegmentLink().scrollIntoView().click();
-
-      cy.log("fill in segment name");
-      SegmentEditor.getNameInput().type("Premium Orders");
-
-      cy.log("add filter");
-      SegmentEditor.getFilterPlaceholder().click();
-      H.popover().findByText("Total").click();
-      H.selectFilterOperator("Greater than");
-      H.popover().within(() => {
-        cy.findByLabelText("Filter value").type("100");
-        cy.button("Add filter").click();
-      });
-
-      cy.log("verify filter was added");
-      SegmentEditor.get()
-        .findByText(/Total is greater than 100/i)
-        .should("exist");
-
-      cy.log("save segment");
-      SegmentEditor.getSaveButton().click();
-      cy.wait("@createSegment");
-
-      cy.log("verify redirect to edit page and toast");
-      H.undoToast().should("contain.text", "Segment created");
-      cy.url().should(
-        "match",
-        new RegExp(
-          `${getSegmentsBaseUrl(ORDERS_ID).replace(/\//g, "\\/")}\/\\d+$`,
-        ),
-      );
-
-      cy.log("verify segment in query builder");
-      verifySegmentInQueryBuilder("Premium Orders");
-    });
-
-    it("should add filter and show preview in menu", () => {
-      visitDataStudioSegments(PRODUCTS_ID);
-
-      SegmentList.getNewSegmentLink().scrollIntoView().click();
-
-      SegmentEditor.getFilterPlaceholder().click();
-      H.popover().findByText("Price").click();
-      H.selectFilterOperator("Less than");
-      H.popover().within(() => {
-        cy.findByLabelText("Filter value").type("50");
-        cy.button("Add filter").click();
-      });
-
-      cy.log("verify filter was added");
-      SegmentEditor.get()
-        .findByText(/Price is less than 50/i)
-        .should("exist");
-
-      cy.log("verify preview is available in menu");
-      SegmentEditor.getActionsButton().click();
-      H.popover().findByText("Preview").should("be.visible");
-    });
-  });
-
-  describe("Segment editing", () => {
-    it("should display and update existing segment", () => {
-      createTestSegment({
-        name: "Test Segment",
-        description: "Test description",
-      });
-      cy.get<number>("@segmentId").then((segmentId) => {
-        visitDataModelSegment(ORDERS_ID, segmentId);
-      });
-
-      cy.log("verify existing data displayed");
-      SegmentEditor.get()
-        .findByDisplayValue("Test Segment")
-        .should("be.visible");
-      SegmentEditor.getDescriptionInput().should(
-        "have.value",
-        "Test description",
-      );
-
-      cy.log("update segment name (saves immediately on blur/enter)");
-      SegmentEditor.get()
-        .findByDisplayValue("Test Segment")
-        .click()
-        .type(" Updated{enter}");
-      cy.wait("@updateSegment");
-
-      cy.log("verify toast for name update");
-      H.undoToast().should("contain.text", "Segment name updated");
-
-      cy.log("update description");
-      SegmentEditor.getDescriptionInput().clear().type("Updated description");
-      SegmentEditor.getSaveButton().click();
-      cy.wait("@updateSegment");
-
-      cy.log("verify updated segment in query builder");
-      verifySegmentInQueryBuilder("Test Segment Updated");
-    });
-
-    it("should navigate back to segments tab via breadcrumb", () => {
-      createTestSegment({ name: "Breadcrumb Test Segment" });
-      cy.get<number>("@segmentId").then((segmentId) => {
-        visitDataModelSegment(ORDERS_ID, segmentId);
-      });
-
-      SegmentEditor.getBreadcrumb("Orders").click();
-
-      cy.url().should(
-        "include",
-        `/data-studio/data/database/${SAMPLE_DB_ID}/schema/${SAMPLE_DB_SCHEMA_ID}/table/${ORDERS_ID}/segments`,
-      );
-      cy.findByRole("tab", { name: /Segments/i })
-        .scrollIntoView()
-        .should("have.attr", "aria-selected", "true");
-    });
-  });
-
-  describe("Segment deletion", () => {
-    it("should remove segment via more menu", () => {
-      createTestSegment({ name: "Segment to Delete" });
-      cy.get<number>("@segmentId").then((segmentId) => {
-        visitDataModelSegment(ORDERS_ID, segmentId);
-      });
-
-      cy.log("delete via more menu");
-      SegmentEditor.getActionsButton().click();
-      H.popover().findByText("Remove segment").click();
-      H.modal().button("Remove").click();
-      cy.wait("@updateSegment");
-
-      cy.log("verify redirect to list and removal");
-      H.undoToast().should("contain.text", "Segment removed");
-      cy.url().should(
-        "include",
-        `/data-studio/data/database/${SAMPLE_DB_ID}/schema/${SAMPLE_DB_SCHEMA_ID}/table/${ORDERS_ID}/segments`,
-      );
-      SegmentList.get()
-        .findByText("Segment to Delete", { timeout: 1000 })
-        .should("not.exist");
-
-      cy.log("verify segment removed from query builder");
-      verifySegmentNotInQueryBuilder("Segment to Delete");
-    });
-  });
-
-  describe("Unsaved changes", () => {
-    it("should show leave confirmation with unsaved changes", () => {
-      visitDataStudioSegments(ORDERS_ID);
-
-      SegmentList.getNewSegmentLink().scrollIntoView().click();
-      SegmentEditor.getNameInput().type("Unsaved Segment");
-
-      cy.log("attempt to navigate away");
-      SegmentEditor.getBreadcrumb("Orders").click();
-
-      cy.log("verify confirmation modal");
-      H.modal().within(() => {
-        cy.findByText("Discard your changes?").should("be.visible");
-        cy.button("Cancel").click();
-      });
-
-      cy.log("verify still on editor");
-      SegmentEditor.get().findByText("Unsaved Segment").should("be.visible");
-    });
-  });
-
-  describe("Segment with implicit joins", () => {
-    it("should create a segment with implicit join filter", () => {
-      visitDataStudioSegments(ORDERS_ID);
-
-      cy.log("navigate to new segment page");
-      SegmentList.getNewSegmentLink().scrollIntoView().click();
-
-      cy.log("fill in segment name");
-      SegmentEditor.getNameInput().type("Widget Orders");
-
-      cy.log("add filter via implicit join");
-      SegmentEditor.getFilterPlaceholder().click();
-      H.popover().within(() => {
-        cy.findByText("Product").click();
-        cy.findByText("Category").click();
-        cy.findByText("Widget").click();
-        cy.button("Add filter").click();
-      });
-
-      cy.log("verify filter was added and save");
-      SegmentEditor.get()
-        .findByText(/Product → Category is Widget/i)
-        .should("exist");
-      SegmentEditor.getSaveButton().click();
-      cy.wait("@createSegment");
-
-      cy.log("verify redirected to edit page with segment name");
-      SegmentEditor.get().should("be.visible");
-      SegmentEditor.get()
-        .findByDisplayValue("Widget Orders")
-        .should("be.visible");
-
-      cy.log("verify segment works in query builder");
-      verifySegmentInQueryBuilder("Widget Orders");
-    });
-  });
-
-  describe("Segment field values modes", () => {
-    it("should display list values when creating segment filter on Category field", () => {
-      cy.request("PUT", `/api/field/${PRODUCTS.CATEGORY}`, {
-        has_field_values: "list",
-      });
-
-      visitDataStudioSegments(PRODUCTS_ID);
-      SegmentList.getNewSegmentLink().scrollIntoView().click();
-
-      cy.log("open filter picker for Category");
-      SegmentEditor.getFilterPlaceholder().click();
-      H.popover().findByText("Category").click();
-
-      cy.log("verify list mode UI");
-      H.popover().within(() => {
-        cy.findByPlaceholderText("Search the list").should("be.visible");
-        cy.findByText("Widget").should("be.visible");
-        cy.findByText("Gadget").should("be.visible");
-        cy.findByText("Gizmo").should("be.visible");
-        cy.findByText("Doohickey").should("be.visible");
-      });
-    });
-
-    it("should display search input when creating segment filter on Email field", () => {
-      cy.request("PUT", `/api/field/${PEOPLE.EMAIL}`, {
-        has_field_values: "search",
-      });
-
-      visitDataStudioSegments(PEOPLE_ID);
-      SegmentList.getNewSegmentLink().scrollIntoView().click();
-
-      cy.log("open filter picker for Email");
-      SegmentEditor.getFilterPlaceholder().click();
-      H.popover().findByText("Email").click();
-
-      cy.log("verify search mode UI and search for email");
-      H.popover().within(() => {
-        cy.findByRole("combobox").should("be.visible");
-        cy.findByRole("combobox").type("borer-hudson@yahoo.com");
-      });
-      cy.findByRole("listbox")
-        .findByText("borer-hudson@yahoo.com")
-        .should("be.visible");
-    });
-
-    it("should display list values for implicit join field", () => {
-      cy.request("PUT", `/api/field/${PRODUCTS.CATEGORY}`, {
-        has_field_values: "list",
-      });
-
-      visitDataStudioSegments(ORDERS_ID);
-      SegmentList.getNewSegmentLink().scrollIntoView().click();
-
-      cy.log("fill in segment name");
-      SegmentEditor.getNameInput().type("Gadget Orders");
-
-      cy.log("open filter picker for Product → Category via implicit join");
-      SegmentEditor.getFilterPlaceholder().click();
-      H.popover().within(() => {
-        cy.findByText("Product").click();
-        cy.findByText("Category").click();
-      });
-
-      cy.log("verify list values are hydrated for FK table field");
-      H.popover().within(() => {
-        cy.findByPlaceholderText("Search the list").should("be.visible");
-        cy.findByText("Widget").should("be.visible");
-        cy.findByText("Gadget").should("be.visible");
-        cy.findByText("Gizmo").should("be.visible");
-        cy.findByText("Doohickey").should("be.visible");
-        cy.findByText("Gadget").click();
-        cy.button("Add filter").click();
-      });
-
-      cy.log("verify filter was added and save segment");
-      SegmentEditor.get()
-        .findByText(/Product → Category is Gadget/i)
-        .should("exist");
-      SegmentEditor.getSaveButton().click();
-      cy.wait("@createSegment");
-
-      cy.log("verify segment created");
-      H.undoToast().should("contain.text", "Segment created");
-      SegmentEditor.get()
-        .findByDisplayValue("Gadget Orders")
-        .should("be.visible");
-    });
-
-    it("should not show segments from FK tables in the filter picker", () => {
-      cy.log("create segment on Products table");
-      H.createSegment({
-        name: "Expensive Products",
-        table_id: PRODUCTS_ID,
-        definition: {
-          type: "query",
-          database: SAMPLE_DB_ID,
-          query: {
-            "source-table": PRODUCTS_ID,
-            filter: [">", ["field", PRODUCTS.PRICE, null], 50],
-          },
-        },
-      });
-
-      cy.log("navigate to create segment on Orders table");
-      visitDataStudioSegments(ORDERS_ID);
-      SegmentList.getNewSegmentLink().scrollIntoView().click();
-
-      cy.log("open filter picker and expand Product table");
-      SegmentEditor.getFilterPlaceholder().click();
-      H.popover().findByText("Product").click();
-
-      cy.log("verify Category field is visible but Products segment is not");
-      H.popover().findByText("Category").should("be.visible");
-      H.popover().findByText("Expensive Products").should("not.exist");
-    });
-  });
-
-  describe("Segment dependencies", () => {
-    it("should create and use a segment based on another segment", () => {
-      cy.log("create base segment");
-      createTestSegment({
-        name: "High Value Orders",
-        filter: [">", ["field", ORDERS.TOTAL, null], 100],
-      });
-
-      cy.get<number>("@segmentId").then((baseSegmentId) => {
-        cy.log("create segment based on segment");
-        H.createSegment({
-          name: "High Value Recent Orders",
-          table_id: ORDERS_ID,
-          definition: {
-            type: "query",
-            database: SAMPLE_DB_ID,
-            query: {
-              "source-table": ORDERS_ID,
-              filter: [
-                "and",
-                ["segment", baseSegmentId],
-                [">", ["field", ORDERS.CREATED_AT, null], "2020-01-01"],
-              ],
-            },
-          },
-        });
-      });
-
-      cy.log("verify both segments appear in query builder");
-      verifySegmentInQueryBuilder("High Value Orders");
-      H.openTable({ table: ORDERS_ID, mode: "notebook" });
-      H.getNotebookStep("data").button("Filter").click();
-      H.popover().findByText("High Value Recent Orders").should("be.visible");
-
-      cy.log("verify dependent segment works");
-      H.popover().findByText("High Value Recent Orders").click();
-      H.visualize();
-      H.tableInteractive().should("be.visible");
-    });
-  });
-
-  describe("Segment cycles", () => {
-    it.skip("should prevent creating segment cycles", () => {
-      cy.log("create Segment A");
-      H.createSegment({
-        name: "Segment A",
-        table_id: ORDERS_ID,
-        definition: {
-          type: "query",
-          database: SAMPLE_DB_ID,
-          query: {
-            "source-table": ORDERS_ID,
-            filter: [">", ["field", ORDERS.TOTAL, null], 50],
-          },
-        },
-      }).then(({ body: segmentA }) => {
-        cy.log("create Segment B that depends on A");
-        H.createSegment({
-          name: "Segment B",
-          table_id: ORDERS_ID,
-          definition: {
-            type: "query",
-            database: SAMPLE_DB_ID,
-            query: {
-              "source-table": ORDERS_ID,
-              filter: ["segment", segmentA.id],
-            },
-          },
-        });
-
-        cy.log("edit Segment A via UI and try to add Segment B as filter");
-        visitDataModelSegment(ORDERS_ID, segmentA.id);
+        cy.log("verify tab selection preserved on refresh");
+        cy.reload();
         cy.wait("@metadata");
+        cy.findByRole("tab", { name: /Segments/i })
+          .scrollIntoView()
+          .should("have.attr", "aria-selected", "true");
 
-        SegmentEditor.get().icon("add").click();
-        H.popover().findByText("Segment B").click();
+        cy.log("navigate back to fields tab");
+        cy.findByRole("tab", { name: /Fields/i }).click();
+        cy.url().should("include", "/field");
+      });
+    });
 
-        cy.log("try to save and verify error");
+    describe("Segment creation", () => {
+      it("should create a segment with filters and verify across features", () => {
+        visitDataStudioSegments(ORDERS_ID);
+
+        cy.log("navigate to new segment page");
+        SegmentList.getNewSegmentLink().scrollIntoView().click();
+
+        cy.log("fill in segment name");
+        SegmentEditor.getNameInput().type("Premium Orders");
+
+        cy.log("add filter");
+        SegmentEditor.getFilterPlaceholder().click();
+        H.popover().findByText("Total").click();
+        H.selectFilterOperator("Greater than");
+        H.popover().within(() => {
+          cy.findByLabelText("Filter value").type("100");
+          cy.button("Add filter").click();
+        });
+
+        cy.log("verify filter was added");
+        SegmentEditor.get()
+          .findByText(/Total is greater than 100/i)
+          .should("exist");
+
+        cy.log("save segment");
         SegmentEditor.getSaveButton().click();
-        cy.wait("@updateSegment");
-        H.undoToast().should(
-          "contain.text",
-          "Unable to save segments with circular dependencies",
-        );
-      });
-    });
-  });
+        cy.wait("@createSegment");
 
-  describe("Revision history", () => {
-    it("should display revision history with changes to name, description, and filter", () => {
-      createTestSegment({
-        name: "Original Name",
-        description: "Original description",
-        filter: ["<", ["field", ORDERS.TOTAL, null], 50],
-      });
-      cy.get<number>("@segmentId").then((segmentId) => {
-        cy.log("update segment name");
-        cy.request("PUT", `/api/segment/${segmentId}`, {
-          name: "Updated Name",
-          description: "Original description",
-          revision_message: "Updated from Data Studio",
-          definition: {
-            type: "query",
-            database: SAMPLE_DB_ID,
-            query: {
-              "source-table": ORDERS_ID,
-              filter: ["<", ["field", ORDERS.TOTAL, null], 50],
-            },
-          },
-        });
-
-        cy.log("update segment description");
-        cy.request("PUT", `/api/segment/${segmentId}`, {
-          name: "Updated Name",
-          description: "Updated description",
-          revision_message: "Updated from Data Studio",
-          definition: {
-            type: "query",
-            database: SAMPLE_DB_ID,
-            query: {
-              "source-table": ORDERS_ID,
-              filter: ["<", ["field", ORDERS.TOTAL, null], 50],
-            },
-          },
-        });
-
-        cy.log("update segment filter");
-        cy.request("PUT", `/api/segment/${segmentId}`, {
-          name: "Updated Name",
-          description: "Updated description",
-          revision_message: "Updated from Data Studio",
-          definition: {
-            type: "query",
-            database: SAMPLE_DB_ID,
-            query: {
-              "source-table": ORDERS_ID,
-              filter: [">", ["field", ORDERS.TOTAL, null], 100],
-            },
-          },
-        });
-
-        cy.wait(1000);
-
-        visitDataModelSegment(ORDERS_ID, segmentId);
-      });
-
-      cy.log("navigate to revision history tab");
-      SegmentEditor.getRevisionHistoryTab().click();
-
-      cy.log("verify URL");
-      cy.get<number>("@segmentId").then((segmentId) => {
+        cy.log("verify redirect to edit page and toast");
+        H.undoToast().should("contain.text", "Segment created");
         cy.url().should(
-          "include",
-          `${getSegmentsBaseUrl(ORDERS_ID)}/${segmentId}/revisions`,
+          "match",
+          new RegExp(
+            `${getSegmentsBaseUrl(ORDERS_ID).replace(/\//g, "\\/")}\/\\d+$`,
+          ),
         );
+
+        cy.log("verify segment in query builder");
+        verifySegmentInQueryBuilder("Premium Orders");
       });
 
-      cy.log("verify revision history entries");
-      SegmentRevisionHistory.get().within(() => {
-        cy.findByText(/created this segment/i)
-          .scrollIntoView()
-          .should("be.visible");
-        cy.findByText(/changed the filter definition/i)
-          .scrollIntoView()
-          .should("be.visible");
-        cy.findByText(/updated the description/i)
-          .scrollIntoView()
-          .should("be.visible");
-        cy.findByText(/renamed the segment/i)
-          .scrollIntoView()
-          .should("be.visible");
-      });
-    });
-  });
+      it("should add filter and show preview in menu", () => {
+        visitDataStudioSegments(PRODUCTS_ID);
 
-  describe("Dependencies", () => {
-    it("should display dependency graph for a segment", () => {
-      createTestSegment({ name: "Dependencies Test Segment" });
-      cy.get<number>("@segmentId").then((segmentId) => {
-        visitDataModelSegment(ORDERS_ID, segmentId);
-      });
+        SegmentList.getNewSegmentLink().scrollIntoView().click();
 
-      cy.log("navigate to dependencies tab");
-      SegmentEditor.getDependenciesTab().click();
+        SegmentEditor.getFilterPlaceholder().click();
+        H.popover().findByText("Price").click();
+        H.selectFilterOperator("Less than");
+        H.popover().within(() => {
+          cy.findByLabelText("Filter value").type("50");
+          cy.button("Add filter").click();
+        });
 
-      cy.log("verify URL and dependency graph display");
-      cy.get<number>("@segmentId").then((segmentId) => {
-        cy.url().should(
-          "include",
-          `${getSegmentsBaseUrl(ORDERS_ID)}/${segmentId}/dependencies`,
-        );
-      });
-      H.DependencyGraph.graph().should("be.visible");
-      H.DependencyGraph.graph()
-        .findByText("Dependencies Test Segment")
-        .should("be.visible");
-    });
-  });
-
-  describe("Readonly access with data model permissions", () => {
-    it("should show segments in list but hide New segment button for non-admin", () => {
-      createTestSegment({ name: "Readonly Test Segment" });
-
-      H.activateToken("pro-self-hosted");
-      setDataModelPermissions({ tableIds: [ORDERS_ID] });
-      cy.signIn("none");
-
-      cy.log("verify segment is visible in list");
-      visitDataStudioSegments(ORDERS_ID);
-      SegmentList.getSegment("Readonly Test Segment")
-        .scrollIntoView()
-        .should("be.visible");
-
-      cy.log("verify New segment button is not visible");
-      SegmentList.get()
-        .findByRole("link", { name: /New segment/i })
-        .should("not.exist");
-
-      cy.log("verify direct navigation to new segment page is blocked");
-      cy.visit(
-        `/data-studio/data/database/${SAMPLE_DB_ID}/schema/${SAMPLE_DB_SCHEMA_ID}/table/${ORDERS_ID}/segments/new`,
-      );
-      H.main()
-        .findByText("Sorry, you don’t have permission to see that.")
-        .should("be.visible");
-    });
-
-    it("should display segment detail in readonly mode for non-admin", () => {
-      createTestSegment({
-        name: "Readonly Detail Segment",
-        description: "Test description for readonly",
-      });
-
-      cy.get<number>("@segmentId").then((segmentId) => {
-        H.activateToken("pro-self-hosted");
-        setDataModelPermissions({ tableIds: [ORDERS_ID] });
-        cy.signIn("none");
-
-        visitDataModelSegment(ORDERS_ID, segmentId);
-
-        cy.log("verify segment name input is disabled");
+        cy.log("verify filter was added");
         SegmentEditor.get()
-          .findByDisplayValue("Readonly Detail Segment")
-          .should("be.disabled");
+          .findByText(/Price is less than 50/i)
+          .should("exist");
 
-        cy.log("verify description input is readonly");
-        SegmentEditor.getDescriptionInput().should("have.attr", "readonly");
-
-        cy.log("verify Save button is not visible");
-        SegmentEditor.get()
-          .findByRole("button", { name: /Save/i })
-          .should("not.exist");
-
-        cy.log("verify Remove segment option is hidden in actions menu");
+        cy.log("verify preview is available in menu");
         SegmentEditor.getActionsButton().click();
         H.popover().findByText("Preview").should("be.visible");
-        H.popover().findByText("Remove segment").should("not.exist");
-        cy.realPress("Escape");
+      });
+    });
 
-        cy.log("verify revision history is still accessible");
+    describe("Segment editing", () => {
+      it("should display and update existing segment", () => {
+        createTestSegment({
+          name: "Test Segment",
+          description: "Test description",
+        });
+        cy.get<number>("@segmentId").then((segmentId) => {
+          visitDataModelSegment(ORDERS_ID, segmentId);
+        });
+
+        cy.log("verify existing data displayed");
+        SegmentEditor.get()
+          .findByDisplayValue("Test Segment")
+          .should("be.visible");
+        SegmentEditor.getDescriptionInput().should(
+          "have.value",
+          "Test description",
+        );
+
+        cy.log("update segment name (saves immediately on blur/enter)");
+        SegmentEditor.get()
+          .findByDisplayValue("Test Segment")
+          .click()
+          .type(" Updated{enter}");
+        cy.wait("@updateSegment");
+
+        cy.log("verify toast for name update");
+        H.undoToast().should("contain.text", "Segment name updated");
+
+        cy.log("update description");
+        SegmentEditor.getDescriptionInput().clear().type("Updated description");
+        SegmentEditor.getSaveButton().click();
+        cy.wait("@updateSegment");
+
+        cy.log("verify updated segment in query builder");
+        verifySegmentInQueryBuilder("Test Segment Updated");
+      });
+
+      it("should navigate back to segments tab via breadcrumb", () => {
+        createTestSegment({ name: "Breadcrumb Test Segment" });
+        cy.get<number>("@segmentId").then((segmentId) => {
+          visitDataModelSegment(ORDERS_ID, segmentId);
+        });
+
+        SegmentEditor.getBreadcrumb("Orders").click();
+
+        cy.url().should(
+          "include",
+          `/data-studio/data/database/${SAMPLE_DB_ID}/schema/${SAMPLE_DB_SCHEMA_ID}/table/${ORDERS_ID}/segments`,
+        );
+        cy.findByRole("tab", { name: /Segments/i })
+          .scrollIntoView()
+          .should("have.attr", "aria-selected", "true");
+      });
+    });
+
+    describe("Segment deletion", () => {
+      it("should remove segment via more menu", () => {
+        createTestSegment({ name: "Segment to Delete" });
+        cy.get<number>("@segmentId").then((segmentId) => {
+          visitDataModelSegment(ORDERS_ID, segmentId);
+        });
+
+        cy.log("delete via more menu");
+        SegmentEditor.getActionsButton().click();
+        H.popover().findByText("Remove segment").click();
+        H.modal().button("Remove").click();
+        cy.wait("@deleteSegment");
+
+        cy.log("verify redirect to list and removal");
+        H.undoToast().should("contain.text", "Segment removed");
+        cy.url().should(
+          "include",
+          `/data-studio/data/database/${SAMPLE_DB_ID}/schema/${SAMPLE_DB_SCHEMA_ID}/table/${ORDERS_ID}/segments`,
+        );
+        SegmentList.get()
+          .findByText("Segment to Delete", { timeout: 1000 })
+          .should("not.exist");
+
+        cy.log("verify segment removed from query builder");
+        verifySegmentNotInQueryBuilder("Segment to Delete");
+      });
+    });
+
+    describe("Unsaved changes", () => {
+      it("should show leave confirmation with unsaved changes", () => {
+        visitDataStudioSegments(ORDERS_ID);
+
+        SegmentList.getNewSegmentLink().scrollIntoView().click();
+        SegmentEditor.getNameInput().type("Unsaved Segment");
+
+        cy.log("attempt to navigate away");
+        SegmentEditor.getBreadcrumb("Orders").click();
+
+        cy.log("verify confirmation modal");
+        H.modal().within(() => {
+          cy.findByText("Discard your changes?").should("be.visible");
+          cy.button("Cancel").click();
+        });
+
+        cy.log("verify still on editor");
+        SegmentEditor.get().findByText("Unsaved Segment").should("be.visible");
+      });
+    });
+
+    describe("Segment with implicit joins", () => {
+      it("should create a segment with implicit join filter", () => {
+        visitDataStudioSegments(ORDERS_ID);
+
+        cy.log("navigate to new segment page");
+        SegmentList.getNewSegmentLink().scrollIntoView().click();
+
+        cy.log("fill in segment name");
+        SegmentEditor.getNameInput().type("Widget Orders");
+
+        cy.log("add filter via implicit join");
+        SegmentEditor.getFilterPlaceholder().click();
+        H.popover().within(() => {
+          cy.findByText("Product").click();
+          cy.findByText("Category").click();
+          cy.findByText("Widget").click();
+          cy.button("Add filter").click();
+        });
+
+        cy.log("verify filter was added and save");
+        SegmentEditor.get()
+          .findByText(/Product → Category is Widget/i)
+          .should("exist");
+        SegmentEditor.getSaveButton().click();
+        cy.wait("@createSegment");
+
+        cy.log("verify redirected to edit page with segment name");
+        SegmentEditor.get().should("be.visible");
+        SegmentEditor.get()
+          .findByDisplayValue("Widget Orders")
+          .should("be.visible");
+
+        cy.log("verify segment works in query builder");
+        verifySegmentInQueryBuilder("Widget Orders");
+      });
+    });
+
+    describe("Segment field values modes", () => {
+      it("should display list values when creating segment filter on Category field", () => {
+        cy.request("PUT", `/api/field/${PRODUCTS.CATEGORY}`, {
+          has_field_values: "list",
+        });
+
+        visitDataStudioSegments(PRODUCTS_ID);
+        SegmentList.getNewSegmentLink().scrollIntoView().click();
+
+        cy.log("open filter picker for Category");
+        SegmentEditor.getFilterPlaceholder().click();
+        H.popover().findByText("Category").click();
+
+        cy.log("verify list mode UI");
+        H.popover().within(() => {
+          cy.findByPlaceholderText("Search the list").should("be.visible");
+          cy.findByText("Widget").should("be.visible");
+          cy.findByText("Gadget").should("be.visible");
+          cy.findByText("Gizmo").should("be.visible");
+          cy.findByText("Doohickey").should("be.visible");
+        });
+      });
+
+      it("should display search input when creating segment filter on Email field", () => {
+        cy.request("PUT", `/api/field/${PEOPLE.EMAIL}`, {
+          has_field_values: "search",
+        });
+
+        visitDataStudioSegments(PEOPLE_ID);
+        SegmentList.getNewSegmentLink().scrollIntoView().click();
+
+        cy.log("open filter picker for Email");
+        SegmentEditor.getFilterPlaceholder().click();
+        H.popover().findByText("Email").click();
+
+        cy.log("verify search mode UI and search for email");
+        H.popover().within(() => {
+          cy.findByRole("combobox").should("be.visible");
+          cy.findByRole("combobox").type("borer-hudson@yahoo.com");
+        });
+        cy.findByRole("listbox")
+          .findByText("borer-hudson@yahoo.com")
+          .should("be.visible");
+      });
+
+      it("should display list values for implicit join field", () => {
+        cy.request("PUT", `/api/field/${PRODUCTS.CATEGORY}`, {
+          has_field_values: "list",
+        });
+
+        visitDataStudioSegments(ORDERS_ID);
+        SegmentList.getNewSegmentLink().scrollIntoView().click();
+
+        cy.log("fill in segment name");
+        SegmentEditor.getNameInput().type("Gadget Orders");
+
+        cy.log("open filter picker for Product → Category via implicit join");
+        SegmentEditor.getFilterPlaceholder().click();
+        H.popover().within(() => {
+          cy.findByText("Product").click();
+          cy.findByText("Category").click();
+        });
+
+        cy.log("verify list values are hydrated for FK table field");
+        H.popover().within(() => {
+          cy.findByPlaceholderText("Search the list").should("be.visible");
+          cy.findByText("Widget").should("be.visible");
+          cy.findByText("Gadget").should("be.visible");
+          cy.findByText("Gizmo").should("be.visible");
+          cy.findByText("Doohickey").should("be.visible");
+          cy.findByText("Gadget").click();
+          cy.button("Add filter").click();
+        });
+
+        cy.log("verify filter was added and save segment");
+        SegmentEditor.get()
+          .findByText(/Product → Category is Gadget/i)
+          .should("exist");
+        SegmentEditor.getSaveButton().click();
+        cy.wait("@createSegment");
+
+        cy.log("verify segment created");
+        H.undoToast().should("contain.text", "Segment created");
+        SegmentEditor.get()
+          .findByDisplayValue("Gadget Orders")
+          .should("be.visible");
+      });
+
+      it("should not show segments from FK tables in the filter picker", () => {
+        cy.log("create segment on Products table");
+        H.createSegment({
+          name: "Expensive Products",
+          table_id: PRODUCTS_ID,
+          definition: {
+            type: "query",
+            database: SAMPLE_DB_ID,
+            query: {
+              "source-table": PRODUCTS_ID,
+              filter: [">", ["field", PRODUCTS.PRICE, null], 50],
+            },
+          },
+        });
+
+        cy.log("navigate to create segment on Orders table");
+        visitDataStudioSegments(ORDERS_ID);
+        SegmentList.getNewSegmentLink().scrollIntoView().click();
+
+        cy.log("open filter picker and expand Product table");
+        SegmentEditor.getFilterPlaceholder().click();
+        H.popover().findByText("Product").click();
+
+        cy.log("verify Category field is visible but Products segment is not");
+        H.popover().findByText("Category").should("be.visible");
+        H.popover().findByText("Expensive Products").should("not.exist");
+      });
+    });
+
+    describe("Segment dependencies", () => {
+      it("should create and use a segment based on another segment", () => {
+        cy.log("create base segment");
+        createTestSegment({
+          name: "High Value Orders",
+          filter: [">", ["field", ORDERS.TOTAL, null], 100],
+        });
+
+        cy.get<number>("@segmentId").then((baseSegmentId) => {
+          cy.log("create segment based on segment");
+          H.createSegment({
+            name: "High Value Recent Orders",
+            table_id: ORDERS_ID,
+            definition: {
+              type: "query",
+              database: SAMPLE_DB_ID,
+              query: {
+                "source-table": ORDERS_ID,
+                filter: [
+                  "and",
+                  ["segment", baseSegmentId],
+                  [">", ["field", ORDERS.CREATED_AT, null], "2020-01-01"],
+                ],
+              },
+            },
+          });
+        });
+
+        cy.log("verify both segments appear in query builder");
+        verifySegmentInQueryBuilder("High Value Orders");
+        H.openTable({ table: ORDERS_ID, mode: "notebook" });
+        H.getNotebookStep("data").button("Filter").click();
+        H.popover().findByText("High Value Recent Orders").should("be.visible");
+
+        cy.log("verify dependent segment works");
+        H.popover().findByText("High Value Recent Orders").click();
+        H.visualize();
+        H.tableInteractive().should("be.visible");
+      });
+    });
+
+    describe("Segment cycles", () => {
+      it.skip("should prevent creating segment cycles", () => {
+        cy.log("create Segment A");
+        H.createSegment({
+          name: "Segment A",
+          table_id: ORDERS_ID,
+          definition: {
+            type: "query",
+            database: SAMPLE_DB_ID,
+            query: {
+              "source-table": ORDERS_ID,
+              filter: [">", ["field", ORDERS.TOTAL, null], 50],
+            },
+          },
+        }).then(({ body: segmentA }) => {
+          cy.log("create Segment B that depends on A");
+          H.createSegment({
+            name: "Segment B",
+            table_id: ORDERS_ID,
+            definition: {
+              type: "query",
+              database: SAMPLE_DB_ID,
+              query: {
+                "source-table": ORDERS_ID,
+                filter: ["segment", segmentA.id],
+              },
+            },
+          });
+
+          cy.log("edit Segment A via UI and try to add Segment B as filter");
+          visitDataModelSegment(ORDERS_ID, segmentA.id);
+          cy.wait("@metadata");
+
+          SegmentEditor.get().icon("add").click();
+          H.popover().findByText("Segment B").click();
+
+          cy.log("try to save and verify error");
+          SegmentEditor.getSaveButton().click();
+          cy.wait("@updateSegment");
+          H.undoToast().should(
+            "contain.text",
+            "Unable to save segments with circular dependencies",
+          );
+        });
+      });
+    });
+
+    describe("Revision history", () => {
+      it("should display revision history with changes to name, description, and filter", () => {
+        createTestSegment({
+          name: "Original Name",
+          description: "Original description",
+          filter: ["<", ["field", ORDERS.TOTAL, null], 50],
+        });
+        cy.get<number>("@segmentId").then((segmentId) => {
+          cy.log("update segment name");
+          cy.request("PUT", `/api/segment/${segmentId}`, {
+            name: "Updated Name",
+            description: "Original description",
+            revision_message: "Updated from Data Studio",
+            definition: {
+              type: "query",
+              database: SAMPLE_DB_ID,
+              query: {
+                "source-table": ORDERS_ID,
+                filter: ["<", ["field", ORDERS.TOTAL, null], 50],
+              },
+            },
+          });
+
+          cy.log("update segment description");
+          cy.request("PUT", `/api/segment/${segmentId}`, {
+            name: "Updated Name",
+            description: "Updated description",
+            revision_message: "Updated from Data Studio",
+            definition: {
+              type: "query",
+              database: SAMPLE_DB_ID,
+              query: {
+                "source-table": ORDERS_ID,
+                filter: ["<", ["field", ORDERS.TOTAL, null], 50],
+              },
+            },
+          });
+
+          cy.log("update segment filter");
+          cy.request("PUT", `/api/segment/${segmentId}`, {
+            name: "Updated Name",
+            description: "Updated description",
+            revision_message: "Updated from Data Studio",
+            definition: {
+              type: "query",
+              database: SAMPLE_DB_ID,
+              query: {
+                "source-table": ORDERS_ID,
+                filter: [">", ["field", ORDERS.TOTAL, null], 100],
+              },
+            },
+          });
+
+          cy.wait(1000);
+
+          visitDataModelSegment(ORDERS_ID, segmentId);
+        });
+
+        cy.log("navigate to revision history tab");
         SegmentEditor.getRevisionHistoryTab().click();
+
+        cy.log("verify URL");
+        cy.get<number>("@segmentId").then((segmentId) => {
+          cy.url().should(
+            "include",
+            `${getSegmentsBaseUrl(ORDERS_ID)}/${segmentId}/revisions`,
+          );
+        });
+
+        cy.log("verify revision history entries");
         SegmentRevisionHistory.get().within(() => {
           cy.findByText(/created this segment/i)
+            .scrollIntoView()
+            .should("be.visible");
+          cy.findByText(/made multiple changes/i)
+            .scrollIntoView()
+            .should("be.visible");
+          cy.findByText(/updated the description/i)
             .scrollIntoView()
             .should("be.visible");
         });
       });
     });
-  });
-});
+
+    describe("Dependencies", () => {
+      it("should display dependency graph for a segment", () => {
+        createTestSegment({ name: "Dependencies Test Segment" });
+        cy.get<number>("@segmentId").then((segmentId) => {
+          visitDataModelSegment(ORDERS_ID, segmentId);
+        });
+
+        cy.log("navigate to dependencies tab");
+        SegmentEditor.getDependenciesTab().click();
+
+        cy.log("verify URL and dependency graph display");
+        cy.get<number>("@segmentId").then((segmentId) => {
+          cy.url().should(
+            "include",
+            `${getSegmentsBaseUrl(ORDERS_ID)}/${segmentId}/dependencies`,
+          );
+        });
+        H.DependencyGraph.graph().should("be.visible");
+        H.DependencyGraph.graph()
+          .findByText("Dependencies Test Segment")
+          .should("be.visible");
+      });
+    });
+
+    describe("Readonly access with data model permissions", () => {
+      it("should show segments in list but hide New segment button for non-admin", () => {
+        createTestSegment({ name: "Readonly Test Segment" });
+
+        setDataModelPermissions({ tableIds: [ORDERS_ID] });
+        cy.signIn("none");
+
+        cy.log("verify segment is visible in list");
+        visitDataStudioSegments(ORDERS_ID);
+        SegmentList.getSegment("Readonly Test Segment")
+          .scrollIntoView()
+          .should("be.visible");
+
+        cy.log("verify New segment button is not visible");
+        SegmentList.get()
+          .findByRole("link", { name: /New segment/i })
+          .should("not.exist");
+
+        cy.log("verify direct navigation to new segment page is blocked");
+        cy.visit(
+          `/data-studio/data/database/${SAMPLE_DB_ID}/schema/${SAMPLE_DB_SCHEMA_ID}/table/${ORDERS_ID}/segments/new`,
+        );
+        H.main()
+          .findByText("Sorry, you don't have permission to see that.")
+          .should("be.visible");
+      });
+
+      it("should display segment detail in readonly mode for non-admin", () => {
+        createTestSegment({
+          name: "Readonly Detail Segment",
+          description: "Test description for readonly",
+        });
+
+        cy.get<number>("@segmentId").then((segmentId) => {
+          setDataModelPermissions({ tableIds: [ORDERS_ID] });
+          cy.signIn("none");
+
+          visitDataModelSegment(ORDERS_ID, segmentId);
+
+          cy.log("verify segment name input is disabled");
+          SegmentEditor.get()
+            .findByDisplayValue("Readonly Detail Segment")
+            .should("be.disabled");
+
+          cy.log("verify description is displayed as plain text");
+          SegmentEditor.get()
+            .findByText("Description")
+            .should("be.visible");
+          SegmentEditor.get()
+            .findByText("Test description for readonly")
+            .should("be.visible");
+
+          cy.log("verify Save button is not visible");
+          SegmentEditor.get()
+            .findByRole("button", { name: /Save/i })
+            .should("not.exist");
+
+          cy.log("verify Remove segment option is hidden in actions menu");
+          SegmentEditor.getActionsButton().click();
+          H.popover().findByText("Preview").should("be.visible");
+          H.popover().findByText("Remove segment").should("not.exist");
+          cy.realPress("Escape");
+
+          cy.log("verify revision history is still accessible");
+          SegmentEditor.getRevisionHistoryTab().click();
+          SegmentRevisionHistory.get().within(() => {
+            cy.findByText(/created this segment/i)
+              .scrollIntoView()
+              .should("be.visible");
+          });
+        });
+      });
+    });
+  },
+);
 
 function visitDataStudioTable(tableId: number) {
   H.DataModel.visitDataStudio({

--- a/e2e/test/scenarios/data-studio/data-model/segments-data-studio.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-model/segments-data-studio.cy.spec.ts
@@ -660,9 +660,7 @@ describe(
             .should("be.disabled");
 
           cy.log("verify description is displayed as plain text");
-          SegmentEditor.get()
-            .findByText("Description")
-            .should("be.visible");
+          SegmentEditor.get().findByText("Description").should("be.visible");
           SegmentEditor.get()
             .findByText("Test description for readonly")
             .should("be.visible");

--- a/e2e/test/scenarios/data-studio/data-model/segments-data-studio.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-model/segments-data-studio.cy.spec.ts
@@ -227,7 +227,6 @@ describe(
         SegmentEditor.getActionsButton().click();
         H.popover().findByText("Remove segment").click();
         H.modal().button("Remove").click();
-        cy.wait("@deleteSegment");
 
         cy.log("verify redirect to list and removal");
         H.undoToast().should("contain.text", "Segment removed");
@@ -581,7 +580,7 @@ describe(
           cy.findByText(/created this segment/i)
             .scrollIntoView()
             .should("be.visible");
-          cy.findByText(/made multiple changes/i)
+          cy.findByText("Total is greater than 100")
             .scrollIntoView()
             .should("be.visible");
           cy.findByText(/updated the description/i)
@@ -638,7 +637,7 @@ describe(
           `/data-studio/data/database/${SAMPLE_DB_ID}/schema/${SAMPLE_DB_SCHEMA_ID}/table/${ORDERS_ID}/segments/new`,
         );
         H.main()
-          .findByText("Sorry, you don't have permission to see that.")
+          .findByText("Sorry, you don’t have permission to see that.")
           .should("be.visible");
       });
 

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/LibrarySectionLayout.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/LibrarySectionLayout.tsx
@@ -6,9 +6,10 @@ import { useListCollectionsTreeQuery } from "metabase/api";
 import { isLibraryCollection } from "metabase/collections/utils";
 import DateTime from "metabase/common/components/DateTime";
 import { usePageTitle } from "metabase/hooks/use-page-title";
-import { useDispatch } from "metabase/lib/redux";
+import { useDispatch, useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { PLUGIN_SNIPPET_FOLDERS } from "metabase/plugins";
+import { getUserIsAdmin } from "metabase/selectors/user";
 import type { TreeTableColumnDef } from "metabase/ui";
 import {
   Button,
@@ -275,6 +276,12 @@ const RootSnippetsCollectionMenu = ({
 }: {
   setPermissionsCollectionId: (id: CollectionId) => void;
 }) => {
+  const isAdmin = useSelector(getUserIsAdmin);
+
+  if (!isAdmin) {
+    return null;
+  }
+
   return (
     <Menu position="bottom-end">
       <Menu.Target>

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/EntityList/EntityList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/EntityList/EntityList.tsx
@@ -15,8 +15,8 @@ type EntityListProps<T> = {
   items: T[];
   title: string;
   emptyState: EntityListEmptyState;
-  newButtonLabel: string;
-  newButtonUrl: string;
+  newButtonLabel?: string;
+  newButtonUrl?: string;
   renderItem: (item: T) => ReactNode;
 };
 
@@ -32,9 +32,11 @@ export function EntityList<T>({
     <Stack gap="md">
       <Group justify="space-between" wrap="nowrap">
         <Title order={4}>{title}</Title>
-        <Button component={ForwardRefLink} to={newButtonUrl} variant="filled">
-          {newButtonLabel}
-        </Button>
+        {newButtonLabel && newButtonUrl && (
+          <Button component={ForwardRefLink} to={newButtonUrl} variant="filled">
+            {newButtonLabel}
+          </Button>
+        )}
       </Group>
 
       {items.length === 0 ? (

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/PaneHeader/PaneHeader.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/PaneHeader/PaneHeader.tsx
@@ -92,6 +92,7 @@ type PaneHeaderInputProps = {
   placeholder?: string;
   maxLength?: number;
   isOptional?: boolean;
+  readOnly?: boolean;
   "data-testid"?: string;
   onChange?: (value: string) => void;
   onContentChange?: (value: string) => void;
@@ -103,6 +104,7 @@ export function PaneHeaderInput({
   maxLength,
   "data-testid": dataTestId,
   isOptional,
+  readOnly = false,
   onChange,
   onContentChange,
 }: PaneHeaderInputProps) {
@@ -118,6 +120,7 @@ export function PaneHeaderInput({
       px={isOptional ? "xs" : undefined}
       bd={isOptional ? "1px solid var(--mb-color-border)" : undefined}
       isOptional={isOptional}
+      isDisabled={readOnly}
       data-testid={dataTestId}
       onChange={onChange}
       onContentChange={onContentChange}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/SegmentList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/SegmentList.tsx
@@ -2,7 +2,9 @@ import { t } from "ttag";
 
 import EmptyState from "metabase/common/components/EmptyState";
 import { ForwardRefLink } from "metabase/common/components/Link";
+import { useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
+import { getUserCanWriteSegments } from "metabase/selectors/user";
 import { Button, Group, Icon, Stack } from "metabase/ui";
 import type { Table } from "metabase-types/api";
 
@@ -13,6 +15,7 @@ type SegmentListProps = {
 };
 
 export function SegmentList({ table }: SegmentListProps) {
+  const canCreateSegment = useSelector(getUserCanWriteSegments);
   const segments = table.segments ?? [];
   const getSegmentHref = (segmentId: number) =>
     Urls.dataStudioDataModelSegment({
@@ -24,21 +27,23 @@ export function SegmentList({ table }: SegmentListProps) {
 
   return (
     <Stack gap="md" data-testid="table-segments-page">
-      <Group gap="md" justify="flex-start" wrap="nowrap">
-        <Button
-          component={ForwardRefLink}
-          to={Urls.newDataStudioDataModelSegment({
-            databaseId: table.db_id,
-            schemaName: table.schema,
-            tableId: table.id,
-          })}
-          h={32}
-          px="sm"
-          py="xs"
-          size="xs"
-          leftSection={<Icon name="add" />}
-        >{t`New segment`}</Button>
-      </Group>
+      {canCreateSegment && (
+        <Group gap="md" justify="flex-start" wrap="nowrap">
+          <Button
+            component={ForwardRefLink}
+            to={Urls.newDataStudioDataModelSegment({
+              databaseId: table.db_id,
+              schemaName: table.schema,
+              tableId: table.id,
+            })}
+            h={32}
+            px="sm"
+            py="xs"
+            size="xs"
+            leftSection={<Icon name="add" />}
+          >{t`New segment`}</Button>
+        </Group>
+      )}
 
       {segments.length === 0 ? (
         <EmptyState

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/SegmentList.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/SegmentList.unit.spec.tsx
@@ -2,7 +2,11 @@ import { Route } from "react-router";
 
 import { renderWithProviders, screen } from "__support__/ui";
 import type { Segment, Table } from "metabase-types/api";
-import { createMockSegment, createMockTable } from "metabase-types/api/mocks";
+import {
+  createMockSegment,
+  createMockTable,
+  createMockUser,
+} from "metabase-types/api/mocks";
 
 import { SegmentList } from "./SegmentList";
 
@@ -22,7 +26,12 @@ function setup({ segments = [], table = {} }: SetupOpts = {}) {
 
   renderWithProviders(
     <Route path="/" component={() => <SegmentList table={mockTable} />} />,
-    { withRouter: true },
+    {
+      withRouter: true,
+      storeInitialState: {
+        currentUser: createMockUser({ is_superuser: true }),
+      },
+    },
   );
 }
 

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/SegmentList.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/SegmentList.unit.spec.tsx
@@ -13,9 +13,10 @@ import { SegmentList } from "./SegmentList";
 type SetupOpts = {
   segments?: Segment[];
   table?: Partial<Table>;
+  isAdmin?: boolean;
 };
 
-function setup({ segments = [], table = {} }: SetupOpts = {}) {
+function setup({ segments = [], table = {}, isAdmin = true }: SetupOpts = {}) {
   const mockTable = createMockTable({
     id: 1,
     db_id: 1,
@@ -29,7 +30,7 @@ function setup({ segments = [], table = {} }: SetupOpts = {}) {
     {
       withRouter: true,
       storeInitialState: {
-        currentUser: createMockUser({ is_superuser: true }),
+        currentUser: createMockUser({ is_superuser: isAdmin }),
       },
     },
   );
@@ -46,6 +47,15 @@ describe("SegmentList", () => {
     expect(
       screen.getByRole("link", { name: /New segment/i }),
     ).toBeInTheDocument();
+  });
+
+  it("should not render 'New segment' button when user cannot create segments", () => {
+    setup({ segments: [], isAdmin: false });
+
+    expect(screen.getByText("No segments yet")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /New segment/i }),
+    ).not.toBeInTheDocument();
   });
 
   it("should render segment items", () => {

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/TableAttributesEditBulk.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/TableAttributesEditBulk.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { t } from "ttag";
 
+import { useSelector } from "metabase/lib/redux";
 import {
   DataSourceInput,
   EntityTypeInput,
@@ -8,6 +9,7 @@ import {
   UserInput,
 } from "metabase/metadata/components";
 import { useMetadataToasts } from "metabase/metadata/hooks";
+import { getUserIsAdmin } from "metabase/selectors/user";
 import { Box, Button, Group, Icon, Stack, Title } from "metabase/ui";
 import { useEditTablesMutation } from "metabase-enterprise/api";
 import { CreateLibraryModal } from "metabase-enterprise/data-studio/common/components/CreateLibraryModal";
@@ -36,6 +38,7 @@ export function TableAttributesEditBulk({
   hasLibrary,
   onUpdate,
 }: TableAttributesEditBulkProps) {
+  const isAdmin = useSelector(getUserIsAdmin);
   const {
     selectedDatabases,
     selectedSchemas,
@@ -155,15 +158,17 @@ export function TableAttributesEditBulk({
 
         <Box px="lg">
           <Group gap="sm">
-            <Button
-              flex={1}
-              p="sm"
-              leftSection={<Icon name="publish" />}
-              onClick={() => setModalType(hasLibrary ? "publish" : "library")}
-            >
-              {t`Publish`}
-            </Button>
-            {hasLibrary && (
+            {isAdmin && (
+              <Button
+                flex={1}
+                p="sm"
+                leftSection={<Icon name="publish" />}
+                onClick={() => setModalType(hasLibrary ? "publish" : "library")}
+              >
+                {t`Publish`}
+              </Button>
+            )}
+            {isAdmin && hasLibrary && (
               <Button
                 flex={1}
                 p="sm"

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/TableSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/TableSection.tsx
@@ -8,7 +8,7 @@ import {
 } from "metabase/api";
 import EmptyState from "metabase/common/components/EmptyState";
 import { ForwardRefLink } from "metabase/common/components/Link";
-import { useDispatch } from "metabase/lib/redux";
+import { useDispatch, useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import type { DataStudioTableMetadataTab } from "metabase/lib/urls/data-studio";
 import { dependencyGraph } from "metabase/lib/urls/dependencies";
@@ -21,6 +21,7 @@ import { TableFieldList } from "metabase/metadata/components/TableFieldList";
 import { TableSortableFieldList } from "metabase/metadata/components/TableSortableFieldList";
 import { useMetadataToasts } from "metabase/metadata/hooks";
 import { getRawTableFieldId } from "metabase/metadata/utils/field";
+import { getUserIsAdmin } from "metabase/selectors/user";
 import {
   Box,
   Button,
@@ -61,6 +62,7 @@ const TableSectionBase = ({
   hasLibrary,
   onSyncOptionsClick,
 }: Props) => {
+  const isAdmin = useSelector(getUserIsAdmin);
   const [updateTable] = useUpdateTableMutation();
   const [updateTableSorting, { isLoading: isUpdatingSorting }] =
     useUpdateTableMutation();
@@ -213,16 +215,18 @@ const TableSectionBase = ({
       </Box>
 
       <Group justify="stretch" gap="sm">
-        <Button
-          flex="1"
-          p="sm"
-          leftSection={
-            <Icon name={table.is_published ? "unpublish" : "publish"} />
-          }
-          onClick={handlePublishToggle}
-        >
-          {table.is_published ? t`Unpublish` : t`Publish`}
-        </Button>
+        {isAdmin && (
+          <Button
+            flex="1"
+            p="sm"
+            leftSection={
+              <Icon name={table.is_published ? "unpublish" : "publish"} />
+            }
+            onClick={handlePublishToggle}
+          >
+            {table.is_published ? t`Unpublish` : t`Publish`}
+          </Button>
+        )}
         <Button
           flex="1"
           leftSection={<Icon name="settings" />}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/TableSection.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/TableSection.unit.spec.tsx
@@ -22,12 +22,14 @@ type SetupOpts = {
   params?: RouteParams;
   activeTab?: DataStudioTableMetadataTab;
   segments?: Segment[];
+  isAdmin?: boolean;
 };
 
 function setup({
   table = createMockTable(),
   activeTab = "field",
   segments,
+  isAdmin = true,
 }: SetupOpts = {}) {
   const onSyncOptionsClick = jest.fn();
 
@@ -52,7 +54,12 @@ function setup({
         />
       )}
     />,
-    { withRouter: true },
+    {
+      withRouter: true,
+      storeInitialState: {
+        currentUser: createMockUser({ is_superuser: isAdmin }),
+      },
+    },
   );
 
   return { onSyncOptionsClick };
@@ -69,6 +76,17 @@ describe("TableSection", () => {
       "href",
       `/question#?db=${table.db_id}&table=${table.id}`,
     );
+  });
+
+  it("should not render publish button for non-admin users", () => {
+    setup({ isAdmin: false });
+
+    expect(
+      screen.queryByRole("button", { name: /Publish/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Unpublish/i }),
+    ).not.toBeInTheDocument();
   });
 
   describe("tabs", () => {

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/pages/DataModel/DataModel.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/pages/DataModel/DataModel.tsx
@@ -9,6 +9,7 @@ import {
 } from "metabase/api";
 import { ForwardRefLink } from "metabase/common/components/Link";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
+import { isCypressActive } from "metabase/env";
 import * as Urls from "metabase/lib/urls";
 import {
   FieldSection,
@@ -149,7 +150,10 @@ function DataModelContent({ params }: Props) {
   );
 
   const scrollToPanel = useCallback((el: HTMLDivElement | null) => {
-    el?.scrollIntoView({ behavior: "smooth", inline: "end" });
+    el?.scrollIntoView({
+      behavior: isCypressActive ? "instant" : "smooth",
+      inline: "end",
+    });
   }, []);
 
   if (databasesData?.data?.length === 0) {

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/pages/DataModel/DataModel.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/pages/DataModel/DataModel.unit.spec.tsx
@@ -40,6 +40,7 @@ import {
   createMockFieldValues,
   createMockSegment,
   createMockTable,
+  createMockUser,
   createMockUserListResult,
 } from "metabase-types/api/mocks";
 import {
@@ -280,6 +281,9 @@ async function setup({
     {
       withRouter: true,
       initialRoute: initialRoute ?? Urls.dataStudioData(params),
+      storeInitialState: {
+        currentUser: createMockUser({ is_superuser: true }),
+      },
     },
   );
 

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/routes.tsx
@@ -1,6 +1,7 @@
 import { IndexRoute, Redirect, Route } from "react-router";
 
 import { PLUGIN_DEPENDENCIES } from "metabase/plugins";
+import { IsAdmin } from "metabase/route-guards";
 import { DataModelMeasureDependenciesPage } from "metabase-enterprise/data-studio/measures/pages/DataModelMeasureDependenciesPage";
 import { DataModelMeasureDetailPage } from "metabase-enterprise/data-studio/measures/pages/DataModelMeasureDetailPage";
 import { DataModelMeasureRevisionHistoryPage } from "metabase-enterprise/data-studio/measures/pages/DataModelMeasureRevisionHistoryPage";
@@ -28,8 +29,10 @@ export function getDataStudioMetadataRoutes() {
       />
       <Route
         path="database/:databaseId/schema/:schemaId/table/:tableId/segments/new"
-        component={DataModelNewSegmentPage}
-      />
+        component={IsAdmin}
+      >
+        <IndexRoute component={DataModelNewSegmentPage} />
+      </Route>
       <Route
         path="database/:databaseId/schema/:schemaId/table/:tableId/segments/:segmentId"
         component={DataModelSegmentDetailPage}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/segments/components/SegmentEditor/SegmentEditor.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/segments/components/SegmentEditor/SegmentEditor.tsx
@@ -1,7 +1,7 @@
 import { t } from "ttag";
 
 import { SegmentFilterEditor } from "metabase/querying/segments";
-import { Card, Stack, TextInput } from "metabase/ui";
+import { Card, Stack, Text, TextInput } from "metabase/ui";
 import type * as Lib from "metabase-lib";
 
 import S from "./SegmentEditor.module.css";
@@ -9,6 +9,7 @@ import S from "./SegmentEditor.module.css";
 type SegmentEditorProps = {
   query: Lib.Query | undefined;
   description: string;
+  readOnly?: boolean;
   onQueryChange: (query: Lib.Query) => void;
   onDescriptionChange: (description: string) => void;
 };
@@ -16,6 +17,7 @@ type SegmentEditorProps = {
 export function SegmentEditor({
   query,
   description,
+  readOnly = false,
   onQueryChange,
   onDescriptionChange,
 }: SegmentEditorProps) {
@@ -23,18 +25,30 @@ export function SegmentEditor({
     <Card withBorder p="xl">
       <Stack flex={1} gap="xl" p={0} className={S.scrollable}>
         {query && (
-          <SegmentFilterEditor query={query} onChange={onQueryChange} />
+          <SegmentFilterEditor
+            query={query}
+            onChange={onQueryChange}
+            readOnly={readOnly}
+          />
         )}
-        <TextInput
-          label={t`Give it a description`}
-          placeholder={t`Only if it really needs it`}
-          value={description}
-          onChange={(e) => onDescriptionChange(e.target.value)}
-          maw={400}
-          classNames={{
-            label: S.descriptionLabel,
-          }}
-        />
+        {!readOnly && (
+          <TextInput
+            label={t`Give it a description`}
+            placeholder={t`Only if it really needs it`}
+            value={description}
+            onChange={(e) => onDescriptionChange(e.target.value)}
+            maw={400}
+            classNames={{
+              label: S.descriptionLabel,
+            }}
+          />
+        )}
+        {readOnly && description && (
+          <Stack gap="sm">
+            <Text fw="bold">{t`Description`}</Text>
+            <Text c="text-secondary">{description}</Text>
+          </Stack>
+        )}
       </Stack>
     </Card>
   );

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/segments/components/SegmentHeader/SegmentHeader.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/segments/components/SegmentHeader/SegmentHeader.tsx
@@ -20,8 +20,9 @@ type SegmentHeaderProps = {
   segment: Segment;
   tabUrls: SegmentTabUrls;
   previewUrl?: string;
-  onRemove: () => void;
+  onRemove?: () => void;
   onNameChange?: (name: string) => void;
+  readOnly?: boolean;
   breadcrumbs?: ReactNode;
   actions?: ReactNode;
 };
@@ -32,6 +33,7 @@ export function SegmentHeader({
   previewUrl,
   onRemove,
   onNameChange,
+  readOnly = false,
   breadcrumbs,
   actions,
 }: SegmentHeaderProps) {
@@ -40,7 +42,11 @@ export function SegmentHeader({
       <PaneHeader
         data-testid="segment-pane-header"
         title={
-          <SegmentNameInput segment={segment} onNameChange={onNameChange} />
+          <SegmentNameInput
+            segment={segment}
+            onNameChange={onNameChange}
+            readOnly={readOnly}
+          />
         }
         icon="segment"
         menu={<SegmentMoreMenu previewUrl={previewUrl} onRemove={onRemove} />}
@@ -55,13 +61,22 @@ export function SegmentHeader({
 type SegmentNameInputProps = {
   segment: Segment;
   onNameChange?: (name: string) => void;
+  readOnly?: boolean;
 };
 
-function SegmentNameInput({ segment, onNameChange }: SegmentNameInputProps) {
+function SegmentNameInput({
+  segment,
+  onNameChange,
+  readOnly = false,
+}: SegmentNameInputProps) {
   const [updateSegment] = useUpdateSegmentMutation();
   const { sendSuccessToast, sendErrorToast } = useMetadataToasts();
 
   const handleChange = async (newName: string) => {
+    if (readOnly) {
+      return;
+    }
+
     onNameChange?.(newName);
 
     if (newName === segment.name) {
@@ -88,6 +103,7 @@ function SegmentNameInput({ segment, onNameChange }: SegmentNameInputProps) {
       maxLength={SEGMENT_NAME_MAX_LENGTH}
       onChange={handleChange}
       onContentChange={onNameChange}
+      readOnly={readOnly}
     />
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/segments/pages/SegmentDetailPage/SegmentDetailPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/segments/pages/SegmentDetailPage/SegmentDetailPage.tsx
@@ -8,6 +8,7 @@ import { LeaveRouteConfirmModal } from "metabase/common/components/LeaveConfirmM
 import { useSelector } from "metabase/lib/redux";
 import { useMetadataToasts } from "metabase/metadata/hooks";
 import { getMetadata } from "metabase/selectors/metadata";
+import { getUserCanWriteSegments } from "metabase/selectors/user";
 import { Button, Group } from "metabase/ui";
 import { PageContainer } from "metabase-enterprise/data-studio/common/components/PageContainer";
 import { getDatasetQueryPreviewUrl } from "metabase-enterprise/data-studio/common/utils/get-dataset-query-preview-url";
@@ -34,6 +35,7 @@ export function SegmentDetailPage({
   breadcrumbs,
   onRemove,
 }: SegmentDetailPageProps) {
+  const canEditSegments = useSelector(getUserCanWriteSegments);
   const metadata = useSelector(getMetadata);
   const { sendSuccessToast, sendErrorToast } = useMetadataToasts();
 
@@ -99,9 +101,11 @@ export function SegmentDetailPage({
         segment={segment}
         tabUrls={tabUrls}
         previewUrl={previewUrl}
-        onRemove={onRemove}
+        onRemove={canEditSegments ? onRemove : undefined}
+        readOnly={!canEditSegments}
         breadcrumbs={breadcrumbs}
         actions={
+          canEditSegments &&
           isDirty && (
             <Group gap="sm">
               <Button onClick={handleReset}>{t`Cancel`}</Button>
@@ -120,14 +124,17 @@ export function SegmentDetailPage({
       <SegmentEditor
         query={query}
         description={description}
+        readOnly={!canEditSegments}
         onQueryChange={setQuery}
         onDescriptionChange={setDescription}
       />
-      <LeaveRouteConfirmModal
-        key={segment.id}
-        route={route}
-        isEnabled={isDirty && !isSaving}
-      />
+      {canEditSegments && (
+        <LeaveRouteConfirmModal
+          key={segment.id}
+          route={route}
+          isEnabled={isDirty && !isSaving}
+        />
+      )}
     </PageContainer>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/tables/pages/TableSegmentsPage/TableSegments.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/tables/pages/TableSegmentsPage/TableSegments.tsx
@@ -1,6 +1,8 @@
 import { t } from "ttag";
 
+import { useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
+import { getUserCanWriteSegments } from "metabase/selectors/user";
 import { Flex } from "metabase/ui";
 import type { Table } from "metabase-types/api";
 
@@ -14,6 +16,7 @@ type TableSegmentsProps = {
 };
 
 export function TableSegments({ table }: TableSegmentsProps) {
+  const canWriteSegments = useSelector(getUserCanWriteSegments);
   const segments = table.segments ?? [];
 
   return (
@@ -26,8 +29,12 @@ export function TableSegments({ table }: TableSegmentsProps) {
           title: t`No segments yet`,
           message: t`Create a segment to filter rows in this table.`,
         }}
-        newButtonLabel={t`New segment`}
-        newButtonUrl={Urls.dataStudioPublishedTableSegmentNew(table.id)}
+        newButtonLabel={canWriteSegments ? t`New segment` : undefined}
+        newButtonUrl={
+          canWriteSegments
+            ? Urls.dataStudioPublishedTableSegmentNew(table.id)
+            : undefined
+        }
         renderItem={(segment) => (
           <EntityListItem
             key={segment.id}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/tables/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/tables/routes.tsx
@@ -1,6 +1,7 @@
 import { IndexRoute, Route } from "react-router";
 
 import { PLUGIN_DEPENDENCIES } from "metabase/plugins";
+import { IsAdmin } from "metabase/route-guards";
 import { PublishedTableMeasureDependenciesPage } from "metabase-enterprise/data-studio/measures/pages/PublishedTableMeasureDependenciesPage";
 import { PublishedTableMeasureDetailPage } from "metabase-enterprise/data-studio/measures/pages/PublishedTableMeasureDetailPage";
 import { PublishedTableMeasureRevisionHistoryPage } from "metabase-enterprise/data-studio/measures/pages/PublishedTableMeasureRevisionHistoryPage";
@@ -23,10 +24,9 @@ export function getDataStudioTableRoutes() {
       <Route path=":tableId/fields" component={TableFieldsPage} />
       <Route path=":tableId/fields/:fieldId" component={TableFieldsPage} />
       <Route path=":tableId/segments" component={TableSegmentsPage} />
-      <Route
-        path=":tableId/segments/new"
-        component={PublishedTableNewSegmentPage}
-      />
+      <Route path=":tableId/segments/new" component={IsAdmin}>
+        <IndexRoute component={PublishedTableNewSegmentPage} />
+      </Route>
       <Route
         path=":tableId/segments/:segmentId"
         component={PublishedTableSegmentDetailPage}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/utils.ts
@@ -3,6 +3,7 @@ import { match } from "ts-pattern";
 
 import { skipToken, useListCollectionItemsQuery } from "metabase/api";
 import type { LibraryCollectionType } from "metabase/plugins";
+import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
 import { getIsEmbeddingIframe } from "metabase/selectors/embed";
 import { getUserIsAdmin } from "metabase/selectors/user";
 import { useGetLibraryCollectionQuery } from "metabase-enterprise/api";
@@ -15,7 +16,13 @@ import type { State } from "metabase-types/store";
 
 // Must be in sync with CanAccessDataStudio in frontend/src/metabase/route-guards.tsx
 export function canAccessDataStudio(state: State) {
-  return getUserIsAdmin(state) && !getIsEmbeddingIframe(state);
+  if (getIsEmbeddingIframe(state)) {
+    return false;
+  }
+  return (
+    getUserIsAdmin(state) ||
+    PLUGIN_FEATURE_LEVEL_PERMISSIONS.canAccessDataModel(state)
+  );
 }
 
 export function getLibraryCollectionType(

--- a/frontend/src/metabase/admin/datamodel/components/SegmentItem.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/SegmentItem.tsx
@@ -10,14 +10,30 @@ import S from "./SegmentItem.module.css";
 
 interface Props {
   segment: Segment;
-  onRetire: () => void;
+  onRetire?: () => void;
 }
 
 export const SegmentItem = ({ segment, onRetire }: Props) => {
+  const canEdit = !!onRetire;
+
   return (
     <tr>
       <Box component="td" className={S.cell} p="sm">
-        <Link to={Urls.dataModelSegment(segment.id)}>
+        {canEdit ? (
+          <Link to={Urls.dataModelSegment(segment.id)}>
+            <Group display="inline-flex" gap="sm" wrap="nowrap">
+              <Box
+                color="text-medium"
+                component={Icon}
+                flex="0 0 auto"
+                name="segment"
+              />
+              <Box c="text-dark" fw="bold">
+                {segment.name}
+              </Box>
+            </Group>
+          </Link>
+        ) : (
           <Group display="inline-flex" gap="sm" wrap="nowrap">
             <Box
               color="text-medium"
@@ -29,7 +45,7 @@ export const SegmentItem = ({ segment, onRetire }: Props) => {
               {segment.name}
             </Box>
           </Group>
-        </Link>
+        )}
       </Box>
 
       <Box component="td" className={S.cell} maw={500} p="sm">
@@ -40,11 +56,13 @@ export const SegmentItem = ({ segment, onRetire }: Props) => {
         {segment.definition_description}
       </Box>
 
-      <Box component="td" className={S.cell} p="sm">
-        <Flex justify="center">
-          <SegmentActionSelect object={segment} onRetire={onRetire} />
-        </Flex>
-      </Box>
+      {onRetire && (
+        <Box component="td" className={S.cell} p="sm">
+          <Flex justify="center">
+            <SegmentActionSelect object={segment} onRetire={onRetire} />
+          </Flex>
+        </Box>
+      )}
     </tr>
   );
 };

--- a/frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx
@@ -13,10 +13,11 @@ import CS from "metabase/css/core/index.css";
 import { Segments } from "metabase/entities/segments";
 import { connect } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
+import { getUserCanWriteSegments } from "metabase/selectors/user";
 
 class SegmentListAppInner extends Component {
   render() {
-    const { segments, tableSelector, setArchived } = this.props;
+    const { segments, tableSelector, setArchived, isAdmin } = this.props;
 
     return (
       <div
@@ -25,9 +26,11 @@ class SegmentListAppInner extends Component {
       >
         <div className={cx(CS.flex, CS.py2)}>
           {tableSelector}
-          <Link to={Urls.newDataModelSegment()} className={CS.mlAuto}>
-            <Button primary>{t`New segment`}</Button>
-          </Link>
+          {isAdmin && (
+            <Link to={Urls.newDataModelSegment()} className={CS.mlAuto}>
+              <Button primary>{t`New segment`}</Button>
+            </Link>
+          )}
         </div>
         <table className={AdminS.AdminTable}>
           <thead className={CS.textBold}>
@@ -35,14 +38,16 @@ class SegmentListAppInner extends Component {
               <th style={{ minWidth: "320px" }}>{t`Name`}</th>
               <th>{t`Table`}</th>
               <th className={CS.full}>{t`Definition`}</th>
-              <th>{t`Actions`}</th>
+              {isAdmin && <th>{t`Actions`}</th>}
             </tr>
           </thead>
           <tbody>
             {segments.map((segment) => (
               <SegmentItem
                 key={segment.id}
-                onRetire={() => setArchived(segment, true)}
+                onRetire={
+                  isAdmin ? () => setArchived(segment, true) : undefined
+                }
                 segment={segment}
               />
             ))}
@@ -61,7 +66,9 @@ class SegmentListAppInner extends Component {
 const SegmentListApp = _.compose(
   Segments.loadList(),
   FilteredToUrlTable("segments"),
-  connect(null, { setArchived: Segments.actions.setArchived }),
+  connect((state) => ({ isAdmin: getUserCanWriteSegments(state) }), {
+    setArchived: Segments.actions.setArchived,
+  }),
 )(SegmentListAppInner);
 
 export default SegmentListApp;

--- a/frontend/src/metabase/admin/routes.jsx
+++ b/frontend/src/metabase/admin/routes.jsx
@@ -101,8 +101,12 @@ const getRoutes = (store, CanAccessSettings, IsAdmin) => (
           />
           <Route component={DataModelV1}>
             <Route path="segments" component={SegmentListApp} />
-            <Route path="segment/create" component={SegmentApp} />
-            <Route path="segment/:id" component={SegmentApp} />
+            <Route path="segment/create" component={IsAdmin}>
+              <IndexRoute component={SegmentApp} />
+            </Route>
+            <Route path="segment/:id" component={IsAdmin}>
+              <IndexRoute component={SegmentApp} />
+            </Route>
             <Route
               path="segment/:id/revisions"
               component={RevisionHistoryApp}

--- a/frontend/src/metabase/querying/notebook/components/ClauseStep/ClausePopover.tsx
+++ b/frontend/src/metabase/querying/notebook/components/ClauseStep/ClausePopover.tsx
@@ -8,12 +8,16 @@ import S from "./ClausePopover.module.css";
 
 interface ClausePopoverProps {
   isInitiallyOpen?: boolean;
+  disabled?: boolean;
   renderItem: (open: () => void, hasPopover?: boolean) => JSX.Element | string;
   renderPopover: (close: () => void) => JSX.Element | null;
 }
 
+const noop = () => {};
+
 export function ClausePopover({
   isInitiallyOpen = false,
+  disabled = false,
   renderItem,
   renderPopover,
 }: ClausePopoverProps) {
@@ -39,7 +43,7 @@ export function ClausePopover({
   }, [active]);
 
   const content = renderPopover(handleClose);
-  const hasPopover = content !== null;
+  const hasPopover = content !== null && !disabled;
 
   return (
     <PreventPopoverExitProvider>
@@ -52,7 +56,9 @@ export function ClausePopover({
         classNames={{ dropdown: S.dropdown }}
         disabled={!hasPopover}
       >
-        <Popover.Target>{renderItem(handleOpen, hasPopover)}</Popover.Target>
+        <Popover.Target>
+          {renderItem(disabled ? noop : handleOpen, hasPopover)}
+        </Popover.Target>
         <Popover.Dropdown data-testid="clause-popover">
           <Box className={S.dropdownContent} data-testid="popover-content">
             {content}

--- a/frontend/src/metabase/querying/notebook/components/ClauseStep/ClauseStep.tsx
+++ b/frontend/src/metabase/querying/notebook/components/ClauseStep/ClauseStep.tsx
@@ -105,6 +105,7 @@ export const ClauseStep = <T,>({
         {items.map((item, index) => (
           <ClausePopover
             key={index}
+            disabled={readOnly}
             renderItem={(onOpen, hasPopover) =>
               renderItem({ item, index, onOpen, hasPopover })
             }

--- a/frontend/src/metabase/querying/segments/components/SegmentFilterEditor/SegmentFilterEditor.tsx
+++ b/frontend/src/metabase/querying/segments/components/SegmentFilterEditor/SegmentFilterEditor.tsx
@@ -68,17 +68,18 @@ export function SegmentFilterEditor({
         color={color("filter")}
         isLastOpened={false}
         renderName={renderFilterName}
-        renderPopover={({ item: filter, index, onClose }) => (
-          <FilterPicker
-            query={query}
-            stageIndex={STAGE_INDEX}
-            filter={filter}
-            filterIndex={index}
-            onSelect={(newFilter) => handleSelectFilter(filter, newFilter)}
-            onClose={onClose}
-            readOnly={readOnly}
-          />
-        )}
+        renderPopover={({ item: filter, index, onClose }) =>
+          readOnly ? null : (
+            <FilterPicker
+              query={query}
+              stageIndex={STAGE_INDEX}
+              filter={filter}
+              filterIndex={index}
+              onSelect={(newFilter) => handleSelectFilter(filter, newFilter)}
+              onClose={onClose}
+            />
+          )
+        }
         onReorder={handleReorderFilter}
         onRemove={handleRemoveFilter}
       />

--- a/frontend/src/metabase/route-guards.tsx
+++ b/frontend/src/metabase/route-guards.tsx
@@ -5,6 +5,7 @@ import { getAdminPaths } from "metabase/admin/app/selectors";
 import { isSameOrSiteUrlOrigin } from "metabase/lib/dom";
 import { MetabaseReduxContext } from "metabase/lib/redux";
 import {
+  PLUGIN_DATA_STUDIO,
   PLUGIN_FEATURE_LEVEL_PERMISSIONS,
   PLUGIN_TRANSFORMS,
 } from "metabase/plugins";
@@ -101,6 +102,16 @@ const UserCanAccessDataModel = connectedReduxRedirect<Props, State>({
   context: MetabaseReduxContext,
 });
 
+const UserCanAccessDataStudio = connectedReduxRedirect<Props, State>({
+  wrapperDisplayName: "UserCanAccessDataStudio",
+  redirectPath: "/unauthorized",
+  allowRedirectBack: false,
+  authenticatedSelector: (state) =>
+    PLUGIN_DATA_STUDIO.canAccessDataStudio(state),
+  redirectAction: routerActions.replace,
+  context: MetabaseReduxContext,
+});
+
 const UserCanAccessTransforms = connectedReduxRedirect<Props, State>({
   wrapperDisplayName: "UserCanAccessTransforms",
   redirectPath: "/unauthorized",
@@ -133,7 +144,7 @@ export const CanAccessOnboarding = UserCanAccessOnboarding(
 // Must be in sync with canAccessDataStudio in enterprise/frontend/src/metabase-enterprise/data-studio/utils.ts
 export const CanAccessDataStudio = MetabaseIsSetup(
   UserIsAuthenticated(
-    UserIsAdmin(AvailableInEmbedding(({ children }) => children)),
+    UserCanAccessDataStudio(AvailableInEmbedding(({ children }) => children)),
   ),
 );
 

--- a/frontend/src/metabase/selectors/user.ts
+++ b/frontend/src/metabase/selectors/user.ts
@@ -64,3 +64,5 @@ export const getIsTenantUser = createSelector(
   [getUser],
   (user) => user?.tenant_id != null,
 );
+
+export const getUserCanWriteSegments = getUserIsAdmin;


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-2603/give-access-to-data-studio-based-on-table-metadata-permissions

### Description

Lets non-admin users with "Manage table metadata" permission edit table metadata in the data studio.

### How to verify

As a non-admin user with Manage table metadata permission ensure you can edit table metadata in the data studio

### Demo

https://www.loom.com/share/5244f00e5fc442bfbaa122fd8819bf7d

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
