### PR TITLE
Clarify permissions model for suggested prompts generation

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/task/suggested_prompts_generator.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/task/suggested_prompts_generator.clj
@@ -6,6 +6,7 @@
    [metabase-enterprise.metabot-v3.config :as metabot-v3.config]
    [metabase-enterprise.metabot-v3.suggested-prompts :as metabot-v3.suggested-prompts]
    [metabase.premium-features.core :as premium-features]
+   [metabase.request.core :as request]
    [metabase.task.core :as task]
    [metabase.util.log :as log]
    [toucan2.core :as t2])
@@ -22,16 +23,19 @@
 (defn- maybe-generate-suggested-prompts! []
   (try
     (when (premium-features/has-feature? :metabot-v3)
-      (let [metabot-eid (get-in metabot-v3.config/metabot-config
-                                [metabot-v3.config/internal-metabot-id :entity-id])
-            metabot-id (t2/select-one-pk :model/Metabot :entity_id metabot-eid)
-            suggested-prompts-cnt (t2/count :model/MetabotPrompt :metabot_id metabot-id)]
-        (if (zero? suggested-prompts-cnt)
-          (do
-            (log/info "No suggested prompts found. Generating suggested prompts.")
-            (metabot-v3.suggested-prompts/generate-sample-prompts metabot-id)
-            (log/info "Suggested prompts generated successfully."))
-          (log/info "Suggested prompts are present. Not generating."))))
+      ;; Run as admin since this is a system task generating prompts for all content in scope.
+      ;; Users will only see prompts for content they have access to (filtered at query time).
+      (request/as-admin
+        (let [metabot-eid (get-in metabot-v3.config/metabot-config
+                                  [metabot-v3.config/internal-metabot-id :entity-id])
+              metabot-id (t2/select-one-pk :model/Metabot :entity_id metabot-eid)
+              suggested-prompts-cnt (t2/count :model/MetabotPrompt :metabot_id metabot-id)]
+          (if (zero? suggested-prompts-cnt)
+            (do
+              (log/info "No suggested prompts found. Generating suggested prompts.")
+              (metabot-v3.suggested-prompts/generate-sample-prompts metabot-id)
+              (log/info "Suggested prompts generated successfully."))
+            (log/info "Suggested prompts are present. Not generating.")))))
     (catch Exception e
       (log/errorf "Suggested prompts generation failed: %s" (.getMessage e)))))
 

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/metabot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/metabot_test.clj
@@ -7,6 +7,8 @@
    [metabase.collections.models.collection :as collection]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.permissions.core :as perms]
+   [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 
@@ -368,3 +370,48 @@
                         current-ids (set (map :id current-prompts))]
                     (is (= baseline-ids current-ids))
                     (is (= "baseline prompt" (:prompt (first current-prompts))))))))))))))
+
+(deftest prompt-suggestions-collection-permissions-test
+  (testing "GET /api/ee/metabot-v3/metabot/:id/prompt-suggestions respects collection permissions"
+    (mt/dataset test-data
+      (mt/with-premium-features #{:metabot-v3}
+        (let [model-query {:type :query, :database (mt/id), :query {:source-table (mt/id :products)}}]
+          (mt/with-temp [:model/Collection {accessible-coll-id :id} {:name "Accessible Collection"}
+                         :model/Collection {restricted-coll-id :id} {:name "Restricted Collection"}
+                         :model/Card {accessible-card-id :id} {:name "Accessible Model"
+                                                               :type :model
+                                                               :collection_id accessible-coll-id
+                                                               :dataset_query model-query}
+                         :model/Card {restricted-card-id :id} {:name "Restricted Model"
+                                                               :type :model :collection_id restricted-coll-id
+                                                               :dataset_query model-query}
+                         :model/Metabot {metabot-id :id} {:name "Test Metabot"}
+                         :model/MetabotPrompt _ {:metabot_id metabot-id
+                                                 :prompt "Accessible prompt"
+                                                 :model :model
+                                                 :card_id accessible-card-id}
+                         :model/MetabotPrompt _ {:metabot_id metabot-id
+                                                 :prompt "Restricted prompt"
+                                                 :model :model
+                                                 :card_id restricted-card-id}
+                         :model/PermissionsGroup {group-id :id} {:name "Test Group"}
+                         :model/PermissionsGroupMembership _ {:group_id group-id
+                                                              :user_id (mt/user->id :rasta)}]
+            ;; Revoke default All Users access to restricted collection
+            (perms/revoke-collection-permissions! (perms-group/all-users) restricted-coll-id)
+
+            (testing "admin sees all prompts"
+              (let [response (mt/user-http-request :crowberto :get 200
+                                                   (format "ee/metabot-v3/metabot/%d/prompt-suggestions" metabot-id))
+                    prompts (set (map :prompt (:prompts response)))]
+                (is (= 2 (:total response)))
+                (is (contains? prompts "Accessible prompt"))
+                (is (contains? prompts "Restricted prompt"))))
+
+            (testing "non-admin user only sees prompts for cards in accessible collections"
+              (let [response (mt/user-http-request :rasta :get 200
+                                                   (format "ee/metabot-v3/metabot/%d/prompt-suggestions" metabot-id))
+                    prompts (set (map :prompt (:prompts response)))]
+                (is (= 1 (:total response)))
+                (is (contains? prompts "Accessible prompt"))
+                (is (not (contains? prompts "Restricted prompt")))))))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/metabot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/metabot_test.clj
@@ -375,7 +375,8 @@
   (testing "GET /api/ee/metabot-v3/metabot/:id/prompt-suggestions respects collection permissions"
     (mt/dataset test-data
       (mt/with-premium-features #{:metabot-v3}
-        (let [model-query {:type :query, :database (mt/id), :query {:source-table (mt/id :products)}}]
+        (let [mp (mt/metadata-provider)
+              model-query (lib/query mp (lib.metadata/table mp (mt/id :products)))]
           (mt/with-temp [:model/Collection {accessible-coll-id :id} {:name "Accessible Collection"}
                          :model/Collection {restricted-coll-id :id} {:name "Restricted Collection"}
                          :model/Card {accessible-card-id :id} {:name "Accessible Model"

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/metabot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/metabot_test.clj
@@ -383,7 +383,8 @@
                                                                :collection_id accessible-coll-id
                                                                :dataset_query model-query}
                          :model/Card {restricted-card-id :id} {:name "Restricted Model"
-                                                               :type :model :collection_id restricted-coll-id
+                                                               :type :model
+                                                               :collection_id restricted-coll-id
                                                                :dataset_query model-query}
                          :model/Metabot {metabot-id :id} {:name "Test Metabot"}
                          :model/MetabotPrompt _ {:metabot_id metabot-id
@@ -393,10 +394,7 @@
                          :model/MetabotPrompt _ {:metabot_id metabot-id
                                                  :prompt "Restricted prompt"
                                                  :model :model
-                                                 :card_id restricted-card-id}
-                         :model/PermissionsGroup {group-id :id} {:name "Test Group"}
-                         :model/PermissionsGroupMembership _ {:group_id group-id
-                                                              :user_id (mt/user->id :rasta)}]
+                                                 :card_id restricted-card-id}]
             ;; Revoke default All Users access to restricted collection
             (perms/revoke-collection-permissions! (perms-group/all-users) restricted-coll-id)
 

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/task/suggested_prompts_generator_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/task/suggested_prompts_generator_test.clj
@@ -8,13 +8,11 @@
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
-   [metabase.premium-features.core :as premium-features]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 
 (deftest suggested-prompts-generator-test
-  (when (and (premium-features/has-feature? :metabot-v3)
-             (premium-features/has-feature? :content-verification))
+  (mt/with-premium-features #{:metabot-v3 :content-verification}
     (mt/with-empty-h2-app-db!
       (let [original-metabot (t2/select-one :model/Metabot
                                             :entity_id (get-in metabot-v3.config/metabot-config
@@ -31,7 +29,7 @@
               :dataset_query query}]
             (with-redefs [metabot-v3.client/generate-example-questions
                           (fn [input]
-                          ;; Return fake prompts if we have cards, empty otherwise
+                            ;; Return fake prompts if we have cards, empty otherwise
                             (if (or (seq (:metrics input)) (seq (:tables input)))
                               {:table_questions [{:questions ["What is the total for this model?"
                                                               "How many items are in this model?"]}]

--- a/src/metabase/request/session.clj
+++ b/src/metabase/request/session.clj
@@ -78,7 +78,7 @@
    thunk))
 
 (defmacro as-admin
-  "Execude code in body as an admin user."
+  "Execute code in body as an admin user."
   {:style/indent 0}
   [& body]
   `(do-as-admin (^:once fn* [] ~@body)))


### PR DESCRIPTION
* Runs suggested prompts generation with admin perms to prevent errors in https://linear.app/metabase/issue/BOT-764
* Fixes `suggested-prompts-generator-test` to use `mt/with-premium-features` so that it runs correctly
* Adds a new test for enforcing collection permissions when fetching prompt suggestions