### PR TITLE
Add repro for "Discarding changes after Schedule was edited does not reset the form"

### DIFF
--- a/e2e/test/scenarios/admin/admin-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/admin/admin-reproductions.cy.spec.js
@@ -254,3 +254,30 @@ describe("(metabase#46714)", () => {
     );
   });
 });
+
+describe("issue 45890", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    H.activateToken("bleeding-edge");
+
+    cy.visit("/admin/performance/databases");
+    H.main().within(() => {
+      cy.findByLabelText(/Edit policy for database 'Sample Database'/)
+        .findByText("No caching")
+        .click();
+
+      cy.findByText("Schedule").click();
+
+      cy.button("Save changes").click();
+    });
+  });
+
+  it("should correctly reset caching schedule form when discarding changes", () => {
+    H.main().findByLabelText("Frequency").click();
+    H.popover().findByText("weekly").click();
+
+    H.main().button("Discard changes").click();
+    H.main().findByLabelText("Frequency").should("have.value", "hourly");
+  });
+});


### PR DESCRIPTION
Closes #45890 

This was fixed by the redesigned form in v57, this PR just adds a repro.