### PR TITLE
fix: broken date filter test

### DIFF
--- a/modules/drivers/mongo/test/metabase/driver/mongo/parameters_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/parameters_test.clj
@@ -524,7 +524,7 @@
                                                    :dimension [:field (mt/id :products :created_at) nil]
                                                    :alias "join_alias_Products.created_at"
                                                    :widget-type :date/all-options
-                                                   :default "past6years"}}})]
+                                                   :default "past10years"}}})]
         (is (seq (-> query qp/process-query mt/rows)))))))
 
 (deftest ^:parallel field-filter-single-date-with-alias-test


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-1441/fix-broken-mongo-test-metabasedrivermongoparameters-testfield-filter

### Description

Quick fix for current date dependent test failures.

The test is failing on  `master` branch → https://metaboat.slack.com/archives/C5XHN8GLW/p1767309027380179

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
