### PR TITLE
Re-enable Python transform tests for BigQuery and Snowflake

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -148,11 +148,10 @@ jobs:
               :only-tags [:mb/driver-tests]
               :exclude-tags [:mb/transforms-python-test]
               :fail-fast? true
-# DS 2025-09-26 temporarily disabled while we diagnose flakes
-#          - name: Transforms Python Tests
-#            test-args: >-
-#              :only-tags [:mb/transforms-python-test]
-#            needs-python-runner: true
+          - name: Transforms Python Tests
+            test-args: >-
+              :only-tags [:mb/transforms-python-test]
+            needs-python-runner: true
     env:
       CI: 'true'
       DRIVERS: bigquery-cloud-sdk
@@ -1275,12 +1274,10 @@ jobs:
               :only-tags [:mb/driver-tests]
               :exclude-tags [:mb/transforms-python-test]
               :fail-fast? true
-
-# DS 2025-09-26 temporarily disabled while we diagnose flakes
-#          - name: Transforms Python Tests
-#            test-args: >-
-#              :only-tags [:mb/transforms-python-test]
-#            needs-python-runner: true
+          - name: Transforms Python Tests
+            test-args: >-
+              :only-tags [:mb/transforms-python-test]
+            needs-python-runner: true
     env:
       CI: 'true'
       DRIVERS: snowflake


### PR DESCRIPTION
These tests were temporarily disabled on 2025-09-26 due to flakes. Re-enabling them now to restore full test coverage. This was before we had the same quarantine support we do now.

Worked on #69566 to fix issues that haven been introduced recently and have not been caught due to lack of snowflake/bigquery coverage.

Will monitor and if they still flake regularily will quarantine/disable/investigate again.
