### PR TITLE
Fix flake + some cleanup in db details permission enforcement API tests

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -733,7 +733,7 @@
 (deftest non-admin-sync-schema-test
   (mt/test-helpers-set-global-values!
     (mt/with-temp [:model/Database {db-id :id} {:engine "h2", :details (:details (mt/db))}]
-      ;; Don't actually run the sync task in this test — just test the API-level permission enforcement
+      ;; Don't actually run the sync task in this test — just test the API-level permission enforcement
       (with-redefs [quick-task/submit-task! (constantly nil)]
         (testing "A non-admin cannot trigger a sync of the DB schema if they do not have DB details permissions"
           (mt/with-all-users-data-perms-graph! {db-id {:details :no}}


### PR DESCRIPTION
I hit a flake [here](https://github.com/metabase/metabase/actions/runs/20661429809/job/59324674283?pr=67656) in `metabase-enterprise.advanced-permissions.common-test/db-operations-test`. There's some sort of H2 lock contention and my hypothesis is that we kick off a database schema sync by calling `POST /database/<db-id>/sync_schema` which leads to permission updates that race with the cleanup step in `mt/with-all-users-data-perms-graph!`.

I've tried to fix this by disabling the actual sync job in this test. We only need to test the API-level permission enforcement which can be done without a real sync.

I've also split this test up into a few different `deftest` forms, each for a different API endpoint, and renamed/made minor edits to some of the surrounding tests for consistency. Also added some extra test assertions for users who lack DB detail permissions. Hopefully nothing here is too controversial.