### PR TITLE
Disable progress bar in whitespace linter github actions workflow

### DIFF
--- a/.github/workflows/whitespace.yml
+++ b/.github/workflows/whitespace.yml
@@ -16,5 +16,5 @@ jobs:
     - uses: actions/checkout@v4
     - name: Prepare back-end environment
       uses: ./.github/actions/prepare-backend
-    - run: clojure -T:whitespace-linter lint
+    - run: clojure -T:whitespace-linter lint :whitespace-linter/progress-bar false
       name: Run Whitespace Linter

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
@@ -384,4 +384,3 @@
         options (build-request-options body)
         response (post! url options)]
     (check-response! response body)))
-

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
@@ -384,3 +384,4 @@
         options (build-request-options body)
         response (post! url options)]
     (check-response! response body)))
+


### PR DESCRIPTION
Fixes a minor annoyance: the whitespace linter includes a progress bar by default, which is nice when you're running it interactively in the terminal. But in CI, it prints out every individual progress line, and makes it difficult to quickly see what failed. e.g.

```
Linting 3791 files...

   1/3791     0% [                                                  ]  ETA: 04:02
   2/3791     0% [                                                  ]  ETA: 02:16
   3/3791     0% [                                                  ]  ETA: 01:30
   4/3791     0% [                                                  ]  ETA: 01:20
   8/3791     0% [                                                  ]  ETA: 01:03
   9/3791     0% [                                                  ]  ETA: 00:59
   5/3791     0% [                                                  ]  ETA: 01:49
   6/3791     0% [                                                  ]  ETA: 01:31
  11/3791     0% [                                                  ]  ETA: 00:50
   7/3791     0% [                                                  ]  ETA: 01:18
  10/3791     0% [                                                  ]  ETA: 00:56
  12/3791     0% [                                                  ]  ETA: 00:49
  13/3791     0% [                                                  ]  ETA: 00:46
  14/3791     0% [                                                  ]  ETA: 00:43
  15/3791     0% [                                                  ]  ETA: 00:40
  16/3791     0% [                                                  ]  ETA: 00:37
  ```
  and so on.
  
  It appears there's already an option to disable the progress bar, so this PR simply disables it the github actions workflow.
  
New output:

```
Linting 3791 files...

Linted 3791 files in 14.6 seconds.
Found 1 errors
enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj:387 File should not end in a blank line (:file/no-trailing-blank-lines)
```