### PR TITLE
Handle unroutable token checks

### DIFF
--- a/src/metabase/premium_features/token_check.clj
+++ b/src/metabase/premium_features/token_check.clj
@@ -161,7 +161,11 @@
           (http/get {:query-params     (merge (stats-for-token-request)
                                               {:site-uuid  site-uuid
                                                :mb-version (:tag config/mb-version-info)})
-                     :throw-exceptions false})))
+                     :throw-exceptions   false
+                     ;; socket is data transfer, connection is handshake and create connection timeout
+                     :socket-timeout     5000     ;; in milliseconds
+                     :connection-timeout 2000     ;; in milliseconds
+                     })))
 
 (defn- fetch-token-and-parse-body
   [token base-url site-uuid]


### PR DESCRIPTION
closes https://github.com/metabase/metabase/issues/67697

We have a grace periods and circuit breakers for token checks. But one issue is that if the token check doesn't throw an error we can't catch it.

An easy way to see this is to use a local network address that won't respond like 192.168.random.random (i used 192.168.40.40) then see the behavior. Without the timeouts, the threads all just get stuck here and the page never loads. With timeouts, you'll see a few stutters until the circuit breaker steps in, at which point you have a non-enterprise version.

https://www.loom.com/share/6ae056dc126b48c9abe8a7ad9366fd05