### PR TITLE
fix saved question intro modal layout

### DIFF
--- a/frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.tsx
+++ b/frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.tsx
@@ -3,7 +3,7 @@ import { t } from "ttag";
 import EmptyMetric from "assets/img/empty-states/qbnewb-metric.svg";
 import EmptyModel from "assets/img/empty-states/qbnewb-model.svg";
 import EmptyQuestion from "assets/img/empty-states/qbnewq-question.svg";
-import { Box, Button, Modal, Stack, Text } from "metabase/ui";
+import { Box, Button, Modal, Stack, Text, Title } from "metabase/ui";
 import type Question from "metabase-lib/v1/Question";
 
 interface Props {
@@ -60,14 +60,14 @@ export const SavedQuestionIntroModal = ({
       <Modal.Overlay />
       <Modal.Content p="xl" ta="center">
         <Modal.Header maw={contentWidth} mx="auto" my="md">
-          <Stack align="center">
+          <Stack align="center" w="100%">
             <Box w="6rem">
               <img
                 src={image}
                 alt={t`Saved entity modal empty state illustration`}
               />
             </Box>
-            <Modal.Title>{title}</Modal.Title>
+            <Title order={3}>{title}</Title>
           </Stack>
         </Modal.Header>
         <Modal.Body maw={contentWidth} mx="auto" my="md">


### PR DESCRIPTION
### Description

Before
<img width="610" height="468" alt="Screenshot 2025-12-30 at 10 07 51 PM" src="https://github.com/user-attachments/assets/6ccd68ef-371e-49f9-873a-687cc6cfd004" />

After
<img width="657" height="486" alt="Screenshot 2025-12-30 at 10 07 33 PM" src="https://github.com/user-attachments/assets/13ad2030-5d04-432f-b507-2eb7a87e92c2" />


