### PR TITLE
Flatten multi-arity operators

### DIFF
--- a/src/metabase/lib/normalize.cljc
+++ b/src/metabase/lib/normalize.cljc
@@ -1,9 +1,10 @@
 (ns metabase.lib.normalize
-  (:refer-clojure :exclude [some])
+  (:refer-clojure :exclude [mapv some])
   (:require
    [malli.core :as mc]
    [malli.error :as me]
    [malli.transform :as mtx]
+   [medley.core :as m]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.mbql-clause :as lib.schema.mbql-clause]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
@@ -13,7 +14,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [some]]))
+   [metabase.util.performance :refer [mapv some]]))
 
 (defn- lib-type [x]
   (when (map? x)
@@ -65,6 +66,107 @@
                  (log/debugf "Building :normalize coercer for schema %s" (pr-str schema))
                  (mc/coercer schema (mtx/transformer mtx/default-value-transformer {:name :normalize}) respond raise)))))
 
+;;; ---------------------------------- Pre-normalization expression flattening ----------------------------------
+;;; Flatten deeply nested expressions before Malli validation to avoid excessive memory allocation.
+;;; Nested :case/:if/:and/:or/:coalesce/:+/:*/:concat expressions are semantically equivalent when flattened.
+
+(defn- clause-tag
+  "Get the tag of a clause as keyword. Handles both keyword and string tags. Returns nil if not a clause."
+  [x]
+  (when (vector? x)
+    (let [tag (get x 0)]
+      (cond
+        (keyword? tag) tag
+        (string? tag)  (keyword tag)
+        :else          nil))))
+
+(defn- clause-opts-and-args
+  "Parse a clause into [opts args-vector]. Handles both pMBQL [tag opts & args] and legacy [tag & args]."
+  [clause]
+  (if (map? (get clause 1))
+    [(get clause 1) (subvec clause 2)]
+    [nil (subvec clause 1)]))
+
+(declare flatten-expressions)
+
+(defn- flatten-case
+  "Flatten a :case or :if clause by merging nested case/if from the default branch.
+  Structure: [tag opts? [[pred1 expr1] ...] default?]"
+  [clause]
+  (let [tag           (clause-tag clause)
+        [opts [pairs default & _more]] (clause-opts-and-args clause)
+        pairs'        (mapv (fn [[pred expr]]
+                              [(flatten-expressions pred) (flatten-expressions expr)])
+                            pairs)
+        default'      (some-> default flatten-expressions)
+        [nested-opts nested-args] (when (= tag (clause-tag default'))
+                                    (clause-opts-and-args default'))
+        ;; Preserve opts from outer clause, or use nested opts if outer had none
+        merged-opts   (or opts nested-opts)]
+    (if nested-args
+      ;; Flatten: merge nested case/if branches
+      (let [[nested-pairs nested-default & _] nested-args]
+        (cond-> (if merged-opts [tag merged-opts] [tag])
+          true                     (conj (into pairs' nested-pairs))
+          (some? nested-default)   (conj nested-default)))
+      ;; No flattening needed
+      (cond-> (if opts [tag opts] [tag])
+        true             (conj pairs')
+        (some? default') (conj default')))))
+
+(defn- flatten-variadic
+  "Flatten a variadic clause (:and, :or, :coalesce) by merging nested clauses of the same type.
+  Structure: [tag opts? & args]"
+  [clause]
+  (let [tag        (clause-tag clause)
+        [opts args] (clause-opts-and-args clause)]
+    (into (if opts [tag opts] [tag])
+          (mapcat (fn [arg]
+                    (let [arg' (flatten-expressions arg)]
+                      (if (= (clause-tag arg') tag)
+                        ;; Same tag: splice in the nested args
+                        (second (clause-opts-and-args arg'))
+                        [arg']))))
+          args)))
+
+(defn- flatten-clause
+  "Flatten a single clause, recursing into its arguments."
+  [clause]
+  (case (clause-tag clause)
+    (:case :if)
+    (flatten-case clause)
+
+    (:and :or :coalesce :+ :* :concat)
+    (flatten-variadic clause)
+
+    ;; Other clause: just recurse into args
+    (let [tag        (clause-tag clause)
+          [opts args] (clause-opts-and-args clause)]
+      (into (if opts [tag opts] [tag]) (map flatten-expressions) args))))
+
+(defn- flatten-expressions
+  "Walk x and flatten nested expressions. Handles pre-normalized input (string or keyword tags)."
+  [x]
+  (cond
+    (clause-tag x)
+    (flatten-clause x)
+
+    (map? x)
+    (reduce-kv (fn [m k v]
+                 (let [v' (flatten-expressions v)]
+                   (if (identical? v v')
+                     m
+                     (assoc m k v'))))
+               x
+               x)
+
+    (vector? x)
+    (let [x' (mapv flatten-expressions x)]
+      (if (= x x') x x'))
+
+    :else
+    x))
+
 (defn normalize
   "Ensure some part of an MBQL query `x`, e.g. a clause or map, is in the right shape after coming in from JavaScript or
   deserialized JSON (from the app DB or a REST API request). This is intended for things that are already in a
@@ -89,6 +191,14 @@
 
   ([schema x {:keys [throw?], :or {throw? false}, :as _options}]
    (let [schema (or schema (infer-schema x))
+         ;; Only flatten within :query/:stages, not in :parameters, :native :params, etc.
+         x      (if (map? x)
+                  (-> x
+                      (m/update-existing :stages flatten-expressions)
+                      (m/update-existing "stages" flatten-expressions)
+                      (m/update-existing :query flatten-expressions)
+                      (m/update-existing "query" flatten-expressions))
+                  (flatten-expressions x))
          thunk  (^:once fn* []
                   ((coercer schema) x))]
      (if throw?

--- a/src/metabase/lib/schema.cljc
+++ b/src/metabase/lib/schema.cljc
@@ -232,6 +232,8 @@
       ;; reliable way to differentiate them since it gets populated by the QP.
       (merge (select-keys stage [:qp/stage-is-from-source-card :qp/stage-had-source-card]))))
 
+;;; NOTE: If you add expression-containing keys here, also update [[metabase.lib.normalize/flatten-stage]]
+;;; which pre-processes these keys before Malli validation to avoid OOM with deeply nested expressions.
 (mr/def ::stage.mbql
   [:and
    [:merge

--- a/src/metabase/lib/schema/join.cljc
+++ b/src/metabase/lib/schema/join.cljc
@@ -112,6 +112,8 @@
                 (= (:join-alias opts) join-alias))
               fields)))])
 
+;;; NOTE: If you add expression-containing keys here, also update [[metabase.lib.normalize/flatten-join]]
+;;; which pre-processes these keys before Malli validation to avoid OOM with deeply nested expressions.
 (mr/def ::join
   [:and
    [:map

--- a/test/metabase/lib/fe_util_test.cljc
+++ b/test/metabase/lib/fe_util_test.cljc
@@ -336,6 +336,7 @@
                              string-field
                              "default"]}
 
+                     ;; Nested case in default is flattened during normalization, so use flat structure
                      {:lib/type :mbql/expression-parts
                       :operator :upper
                       :options {}
@@ -344,12 +345,9 @@
                               :options {}
                               :args [boolean-field
                                      string-field
-                                     {:lib/type :mbql/expression-parts
-                                      :operator :case
-                                      :options {}
-                                      :args [boolean-field
-                                             string-field
-                                             "default"]}]}]}
+                                     boolean-field
+                                     string-field
+                                     "default"]}]}
 
                      {:lib/type :mbql/expression-parts
                       :operator :upper

--- a/test/metabase/lib/normalize_test.cljc
+++ b/test/metabase/lib/normalize_test.cljc
@@ -231,107 +231,107 @@
      result)))
 
 (deftest ^:parallel flatten-case-test
-  (testing "nested :case in default branch is flattened"
-    (is (= [:case {} [[[:= {} 1 1] "a"] [[:= {} 2 2] "b"]] "c"]
-           (normalize-and-strip-uuids
-            [:case {} [[[:= {} 1 1] "a"]] [:case {} [[[:= {} 2 2] "b"]] "c"]]))))
-  (testing "nested :if in default branch is flattened"
-    (is (= [:if {} [[[:= {} 1 1] "a"] [[:= {} 2 2] "b"]] "c"]
-           (normalize-and-strip-uuids
-            [:if {} [[[:= {} 1 1] "a"]] [:if {} [[[:= {} 2 2] "b"]] "c"]]))))
-  (testing "deeply nested case is fully flattened"
-    (is (= [:case {} [[[:= {} 1 1] "a"] [[:= {} 2 2] "b"] [[:= {} 3 3] "c"]] "d"]
-           (normalize-and-strip-uuids
-            [:case {} [[[:= {} 1 1] "a"]]
-             [:case {} [[[:= {} 2 2] "b"]]
-              [:case {} [[[:= {} 3 3] "c"]] "d"]]]))))
-  (testing "string tags are handled"
-    (is (= [:case {} [[[:= {} 1 1] "a"] [[:= {} 2 2] "b"]] "c"]
-           (normalize-and-strip-uuids
-            ["case" {} [[["=" {} 1 1] "a"]] ["case" {} [[["=" {} 2 2] "b"]] "c"]])))))
+  (are [expected input] (= expected (normalize-and-strip-uuids input))
+    ;; nested :case in default branch is flattened
+    [:case {} [[[:= {} 1 1] "a"] [[:= {} 2 2] "b"]] "c"]
+    [:case {} [[[:= {} 1 1] "a"]] [:case {} [[[:= {} 2 2] "b"]] "c"]]
+
+    ;; nested :if in default branch is flattened
+    [:if {} [[[:= {} 1 1] "a"] [[:= {} 2 2] "b"]] "c"]
+    [:if {} [[[:= {} 1 1] "a"]] [:if {} [[[:= {} 2 2] "b"]] "c"]]
+
+    ;; deeply nested case is fully flattened
+    [:case {} [[[:= {} 1 1] "a"] [[:= {} 2 2] "b"] [[:= {} 3 3] "c"]] "d"]
+    [:case {} [[[:= {} 1 1] "a"]]
+     [:case {} [[[:= {} 2 2] "b"]]
+      [:case {} [[[:= {} 3 3] "c"]] "d"]]]
+
+    ;; string tags are handled
+    [:case {} [[[:= {} 1 1] "a"] [[:= {} 2 2] "b"]] "c"]
+    ["case" {} [[["=" {} 1 1] "a"]] ["case" {} [[["=" {} 2 2] "b"]] "c"]]))
 
 (deftest ^:parallel flatten-and-test
-  (testing "nested :and is flattened"
-    (is (= [:and {} [:= {} 1 1] [:= {} 2 2] [:= {} 3 3]]
-           (normalize-and-strip-uuids
-            [:and {} [:= {} 1 1] [:and {} [:= {} 2 2] [:= {} 3 3]]]))))
-  (testing "deeply nested :and is fully flattened"
-    (is (= [:and {} [:= {} 1 1] [:= {} 2 2] [:= {} 3 3] [:= {} 4 4]]
-           (normalize-and-strip-uuids
-            [:and {} [:= {} 1 1] [:and {} [:= {} 2 2] [:and {} [:= {} 3 3] [:= {} 4 4]]]]))))
-  (testing "string tags are handled"
-    (is (= [:and {} [:= {} 1 1] [:= {} 2 2] [:= {} 3 3]]
-           (normalize-and-strip-uuids
-            ["and" {} ["=" {} 1 1] ["and" {} ["=" {} 2 2] ["=" {} 3 3]]])))))
+  (are [expected input] (= expected (normalize-and-strip-uuids input))
+    ;; nested :and is flattened
+    [:and {} [:= {} 1 1] [:= {} 2 2] [:= {} 3 3]]
+    [:and {} [:= {} 1 1] [:and {} [:= {} 2 2] [:= {} 3 3]]]
+
+    ;; deeply nested :and is fully flattened
+    [:and {} [:= {} 1 1] [:= {} 2 2] [:= {} 3 3] [:= {} 4 4]]
+    [:and {} [:= {} 1 1] [:and {} [:= {} 2 2] [:and {} [:= {} 3 3] [:= {} 4 4]]]]
+
+    ;; string tags are handled
+    [:and {} [:= {} 1 1] [:= {} 2 2] [:= {} 3 3]]
+    ["and" {} ["=" {} 1 1] ["and" {} ["=" {} 2 2] ["=" {} 3 3]]]))
 
 (deftest ^:parallel flatten-or-test
-  (testing "nested :or is flattened"
-    (is (= [:or {} [:= {} 1 1] [:= {} 2 2] [:= {} 3 3]]
-           (normalize-and-strip-uuids
-            [:or {} [:= {} 1 1] [:or {} [:= {} 2 2] [:= {} 3 3]]]))))
-  (testing "deeply nested :or is fully flattened"
-    (is (= [:or {} [:= {} 1 1] [:= {} 2 2] [:= {} 3 3] [:= {} 4 4]]
-           (normalize-and-strip-uuids
-            [:or {} [:= {} 1 1] [:or {} [:= {} 2 2] [:or {} [:= {} 3 3] [:= {} 4 4]]]])))))
+  (are [expected input] (= expected (normalize-and-strip-uuids input))
+    ;; nested :or is flattened
+    [:or {} [:= {} 1 1] [:= {} 2 2] [:= {} 3 3]]
+    [:or {} [:= {} 1 1] [:or {} [:= {} 2 2] [:= {} 3 3]]]
+
+    ;; deeply nested :or is fully flattened
+    [:or {} [:= {} 1 1] [:= {} 2 2] [:= {} 3 3] [:= {} 4 4]]
+    [:or {} [:= {} 1 1] [:or {} [:= {} 2 2] [:or {} [:= {} 3 3] [:= {} 4 4]]]]))
 
 (deftest ^:parallel flatten-coalesce-test
-  (testing "nested :coalesce is flattened"
-    (is (= [:coalesce {} [:field {} 1] [:field {} 2] [:field {} 3]]
-           (normalize-and-strip-uuids
-            [:coalesce {} [:field {} 1] [:coalesce {} [:field {} 2] [:field {} 3]]]))))
-  (testing "deeply nested :coalesce is fully flattened"
-    (is (= [:coalesce {} [:field {} 1] [:field {} 2] [:field {} 3] "default"]
-           (normalize-and-strip-uuids
-            [:coalesce {} [:field {} 1]
-             [:coalesce {} [:field {} 2]
-              [:coalesce {} [:field {} 3] "default"]]])))))
+  (are [expected input] (= expected (normalize-and-strip-uuids input))
+    ;; nested :coalesce is flattened
+    [:coalesce {} [:field {} 1] [:field {} 2] [:field {} 3]]
+    [:coalesce {} [:field {} 1] [:coalesce {} [:field {} 2] [:field {} 3]]]
+
+    ;; deeply nested :coalesce is fully flattened
+    [:coalesce {} [:field {} 1] [:field {} 2] [:field {} 3] "default"]
+    [:coalesce {} [:field {} 1]
+     [:coalesce {} [:field {} 2]
+      [:coalesce {} [:field {} 3] "default"]]]))
 
 (deftest ^:parallel flatten-plus-test
-  (testing "nested :+ is flattened"
-    (is (= [:+ {} 1 2 3]
-           (normalize-and-strip-uuids
-            [:+ {} 1 [:+ {} 2 3]]))))
-  (testing "deeply nested :+ is fully flattened"
-    (is (= [:+ {} 1 2 3 4]
-           (normalize-and-strip-uuids
-            [:+ {} 1 [:+ {} 2 [:+ {} 3 4]]])))))
+  (are [expected input] (= expected (normalize-and-strip-uuids input))
+    ;; nested :+ is flattened
+    [:+ {} 1 2 3]
+    [:+ {} 1 [:+ {} 2 3]]
+
+    ;; deeply nested :+ is fully flattened
+    [:+ {} 1 2 3 4]
+    [:+ {} 1 [:+ {} 2 [:+ {} 3 4]]]))
 
 (deftest ^:parallel flatten-multiply-test
-  (testing "nested :* is flattened"
-    (is (= [:* {} 1 2 3]
-           (normalize-and-strip-uuids
-            [:* {} 1 [:* {} 2 3]]))))
-  (testing "deeply nested :* is fully flattened"
-    (is (= [:* {} 1 2 3 4]
-           (normalize-and-strip-uuids
-            [:* {} 1 [:* {} 2 [:* {} 3 4]]])))))
+  (are [expected input] (= expected (normalize-and-strip-uuids input))
+    ;; nested :* is flattened
+    [:* {} 1 2 3]
+    [:* {} 1 [:* {} 2 3]]
+
+    ;; deeply nested :* is fully flattened
+    [:* {} 1 2 3 4]
+    [:* {} 1 [:* {} 2 [:* {} 3 4]]]))
 
 (deftest ^:parallel flatten-concat-test
-  (testing "nested :concat is flattened"
-    (is (= [:concat {} "a" "b" "c"]
-           (normalize-and-strip-uuids
-            [:concat {} "a" [:concat {} "b" "c"]]))))
-  (testing "deeply nested :concat is fully flattened"
-    (is (= [:concat {} "a" "b" "c" "d"]
-           (normalize-and-strip-uuids
-            [:concat {} "a" [:concat {} "b" [:concat {} "c" "d"]]])))))
+  (are [expected input] (= expected (normalize-and-strip-uuids input))
+    ;; nested :concat is flattened
+    [:concat {} "a" "b" "c"]
+    [:concat {} "a" [:concat {} "b" "c"]]
+
+    ;; deeply nested :concat is fully flattened
+    [:concat {} "a" "b" "c" "d"]
+    [:concat {} "a" [:concat {} "b" [:concat {} "c" "d"]]]))
 
 (deftest ^:parallel no-flatten-non-associative-test
-  (testing ":- is not flattened (not associative)"
-    (is (= [:- {} 1 [:- {} 2 3]]
-           (normalize-and-strip-uuids
-            [:- {} 1 [:- {} 2 3]]))))
-  (testing ":/ is not flattened (not associative)"
-    (is (= [:/ {} 1 [:/ {} 2 3]]
-           (normalize-and-strip-uuids
-            [:/ {} 1 [:/ {} 2 3]])))))
+  (are [expected input] (= expected (normalize-and-strip-uuids input))
+    ;; :- is not flattened (not associative)
+    [:- {} 1 [:- {} 2 3]]
+    [:- {} 1 [:- {} 2 3]]
+
+    ;; :/ is not flattened (not associative)
+    [:/ {} 1 [:/ {} 2 3]]
+    [:/ {} 1 [:/ {} 2 3]]))
 
 (deftest ^:parallel flatten-mixed-operators-test
-  (testing "different operators are not flattened together"
-    (is (= [:and {} [:= {} 1 1] [:or {} [:= {} 2 2] [:= {} 3 3]]]
-           (normalize-and-strip-uuids
-            [:and {} [:= {} 1 1] [:or {} [:= {} 2 2] [:= {} 3 3]]]))))
-  (testing "flattening happens at each level independently"
-    (is (= [:and {} [:= {} 1 1] [:= {} 2 2] [:or {} [:= {} 3 3] [:= {} 4 4] [:= {} 5 5]]]
-           (normalize-and-strip-uuids
-            [:and {} [:= {} 1 1] [:and {} [:= {} 2 2] [:or {} [:= {} 3 3] [:or {} [:= {} 4 4] [:= {} 5 5]]]]])))))
+  (are [expected input] (= expected (normalize-and-strip-uuids input))
+    ;; different operators are not flattened together
+    [:and {} [:= {} 1 1] [:or {} [:= {} 2 2] [:= {} 3 3]]]
+    [:and {} [:= {} 1 1] [:or {} [:= {} 2 2] [:= {} 3 3]]]
+
+    ;; flattening happens at each level independently
+    [:and {} [:= {} 1 1] [:= {} 2 2] [:or {} [:= {} 3 3] [:= {} 4 4] [:= {} 5 5]]]
+    [:and {} [:= {} 1 1] [:and {} [:= {} 2 2] [:or {} [:= {} 3 3] [:or {} [:= {} 4 4] [:= {} 5 5]]]]]))

--- a/test/metabase/lib/normalize_test.cljc
+++ b/test/metabase/lib/normalize_test.cljc
@@ -335,3 +335,18 @@
     ;; flattening happens at each level independently
     [:and {} [:= {} 1 1] [:= {} 2 2] [:or {} [:= {} 3 3] [:= {} 4 4] [:= {} 5 5]]]
     [:and {} [:= {} 1 1] [:and {} [:= {} 2 2] [:or {} [:= {} 3 3] [:or {} [:= {} 4 4] [:= {} 5 5]]]]]))
+
+(deftest ^:parallel flatten-legacy-native-query-test
+  (testing "legacy queries with native :query string should not throw"
+    (is (= {:type     :native
+            :database 1
+            :native   {:query "SELECT * FROM orders"}}
+           (lib.normalize/normalize
+            {:type     :native
+             :database 1
+             :native   {:query "SELECT * FROM orders"}}))))
+  (testing "NativeQuery schema normalization with :query string"
+    ;; This is the structure used by metabase.test.data/native-query
+    (is (= {:query "SELECT * FROM orders"}
+           (lib.normalize/normalize :metabase.legacy-mbql.schema/NativeQuery
+                                    {:query "SELECT * FROM orders"})))))


### PR DESCRIPTION
Malli schema checks consume extreme amounts of memory on deeply nested expressions. This change optimizes a common class of cases by removing the nesting. The concrete queries from our customers consume significantly less memory after this change.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
