### PR TITLE
Underline links in Metabot responses

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/AIMarkdown/AIMarkdown.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/AIMarkdown/AIMarkdown.module.css
@@ -48,6 +48,10 @@
   margin-top: 0.5rem;
 }
 
+.aiMarkdown a {
+  text-decoration: underline !important;
+}
+
 .smartLink {
   color: var(--mb-color-brand);
   font-weight: 700;


### PR DESCRIPTION
The lowest-effort way to fix https://github.com/metabase/metabase/issues/67696. There are probably better ways to do this.

### Description

Describe the overall approach and the problem being solved.

### How to verify

Ask Metabot something that will return a link, like `most visited dashboards`

### Demo

<img width="1352" height="843" alt="image" src="https://github.com/user-attachments/assets/438f7052-75bd-4cab-af30-54231d9e947b" />

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
