### PR TITLE
Use formatting settings for date parameters

### DIFF
--- a/frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx
+++ b/frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx
@@ -1,6 +1,7 @@
 import { t } from "ttag";
 
 import { Ellipsified } from "metabase/common/components/Ellipsified";
+import { useSetting } from "metabase/common/hooks";
 import { ParameterFieldWidgetValue } from "metabase/parameters/components/widgets/ParameterFieldWidget/ParameterFieldWidgetValue/ParameterFieldWidgetValue";
 import { formatParameterValue } from "metabase/parameters/utils/formatting";
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
@@ -41,6 +42,8 @@ function FormattedParameterValue({
   placeholder,
   isPopoverOpen = false,
 }: FormattedParameterValueProps) {
+  const formattingSettings = useSetting("custom-formatting");
+
   if (parameterHasNoDisplayValue(value)) {
     return placeholder;
   }
@@ -75,10 +78,16 @@ function FormattedParameterValue({
     }
 
     if (label) {
-      return <span>{formatParameterValue(label, parameter)}</span>;
+      return (
+        <span>
+          {formatParameterValue(label, parameter, formattingSettings)}
+        </span>
+      );
     }
 
-    return <span>{formatParameterValue(value, parameter)}</span>;
+    return (
+      <span>{formatParameterValue(value, parameter, formattingSettings)}</span>
+    );
   };
 
   if (isStringParameter(parameter)) {

--- a/frontend/src/metabase/parameters/utils/date-formatting.ts
+++ b/frontend/src/metabase/parameters/utils/date-formatting.ts
@@ -1,10 +1,11 @@
 import { getDateFilterDisplayName } from "metabase/querying/filters/utils/dates";
 import { deserializeDateParameterValue } from "metabase/querying/parameters/utils/parsing";
-import type { Parameter } from "metabase-types/api";
+import type { DateFormattingSettings, Parameter } from "metabase-types/api";
 
 export function formatDateValue(
   parameter: Parameter,
   value: string,
+  formattingSettings?: DateFormattingSettings,
 ): string | null {
   const filter = deserializeDateParameterValue(value);
   if (filter == null) {
@@ -13,5 +14,6 @@ export function formatDateValue(
 
   return getDateFilterDisplayName(filter, {
     withPrefix: parameter.type !== "date/single",
+    formattingSettings,
   });
 }

--- a/frontend/src/metabase/parameters/utils/formatting.ts
+++ b/frontend/src/metabase/parameters/utils/formatting.ts
@@ -14,7 +14,11 @@ import {
   isFieldFilterParameter,
   isTemporalUnitParameter,
 } from "metabase-lib/v1/parameters/utils/parameter-type";
-import type { ParameterValue, RowValue } from "metabase-types/api";
+import type {
+  FormattingSettings,
+  ParameterValue,
+  RowValue,
+} from "metabase-types/api";
 
 import { formatDateValue } from "./date-formatting";
 
@@ -41,6 +45,7 @@ function formatWithInferredType(value: any, parameter: UiParameter) {
 export function formatParameterValue(
   rawValue: string | number | number[] | ParameterValue,
   parameter: UiParameter,
+  formattingSettings?: FormattingSettings,
 ) {
   if (Array.isArray(rawValue) && rawValue.length > 1) {
     return renderNumberOfSelections(rawValue.length);
@@ -49,7 +54,11 @@ export function formatParameterValue(
   const value: RowValue = Array.isArray(rawValue) ? rawValue[0] : rawValue;
 
   if (isDateParameter(parameter)) {
-    return formatDateValue(parameter, String(value));
+    return formatDateValue(
+      parameter,
+      String(value),
+      formattingSettings?.["type/Temporal"],
+    );
   }
 
   if (isTemporalUnitParameter(parameter)) {

--- a/frontend/src/metabase/parameters/utils/formatting.unit.spec.ts
+++ b/frontend/src/metabase/parameters/utils/formatting.unit.spec.ts
@@ -37,7 +37,7 @@ const categoryField = checkNotNull(metadata.field(PRODUCTS.CATEGORY));
 const remappedField = checkNotNull(metadata.field(REMAPPED_FIELD_ID));
 
 describe("metabase/parameters/utils/formatting", () => {
-  describe("formatParameterValue", () => {
+  describe("formatParameterValue without settings", () => {
     const cases = [
       {
         type: "date/single",
@@ -188,5 +188,102 @@ describe("metabase/parameters/utils/formatting", () => {
       });
       expect(formatParameterValue(123456789, parameter)).toEqual("A");
     });
+  });
+
+  describe("formatParameterValue with settings", () => {
+    const cases = [
+      {
+        type: "date/single",
+        value: "2018-01-01",
+        expected: "1 January, 2018",
+      },
+      {
+        type: "date/single",
+        value: "2018-01-01T12:30:00",
+        expected: "1 January, 2018 12:30 pm",
+      },
+      {
+        type: "date/range",
+        value: "1995-01-01~1995-01-10",
+        expected: "1 January, 1995 - 10 January, 1995",
+      },
+      {
+        type: "date/range",
+        value: "2018-01-01T12:30:00~2018-01-10",
+        expected: "1 January, 2018 12:30 pm - 10 January, 2018 12:00 am",
+      },
+      {
+        type: "date/range",
+        value: "2018-01-01~2018-01-10T08:15:00",
+        expected: "1 January, 2018 12:00 am - 10 January, 2018 08:15 am",
+      },
+      {
+        type: "date/range",
+        value: "2018-01-01T12:30:00~2018-01-10T08:15:00",
+        expected: "1 January, 2018 12:30 pm - 10 January, 2018 08:15 am",
+      },
+      {
+        type: "date/all-options",
+        value: "2018-01-01",
+        expected: "On 1 January, 2018",
+      },
+      {
+        type: "date/month-year",
+        value: "2018-01",
+        expected: "January 2018",
+      },
+      {
+        type: "date/quarter-year",
+        value: "Q1-2018",
+        expected: "Q1 2018",
+      },
+      {
+        type: "date/relative",
+        value: "past30days",
+        expected: "Previous 30 days",
+      },
+      {
+        type: "date/month-year",
+        value: "thisday",
+        expected: "Today",
+      },
+      {
+        type: "date/month-year",
+        value: "thisweek",
+        expected: "This week",
+      },
+      {
+        type: "date/month-year",
+        value: "past1days",
+        expected: "Yesterday",
+      },
+      {
+        type: "date/month-year",
+        value: "past1weeks",
+        expected: "Previous week",
+      },
+      {
+        type: "date/month-year",
+        value: "2023-10-02~2023-10-24",
+        expected: "2 October, 2023 - 24 October, 2023",
+      },
+    ];
+
+    const formattingSettings = {
+      "type/Temporal": {
+        date_style: "D MMMM, YYYY",
+        time_style: "hh:mm a",
+      },
+    };
+
+    test.each(cases)(
+      "should format $type parameter",
+      ({ value, expected, ...parameterProps }) => {
+        const parameter = createMockUiParameter(parameterProps);
+        expect(
+          formatParameterValue(value, parameter, formattingSettings),
+        ).toEqual(expected);
+      },
+    );
   });
 });

--- a/frontend/src/metabase/parameters/utils/formatting.unit.spec.ts
+++ b/frontend/src/metabase/parameters/utils/formatting.unit.spec.ts
@@ -62,12 +62,12 @@ describe("metabase/parameters/utils/formatting", () => {
       {
         type: "date/range",
         value: "2018-01-01~2018-01-10T08:15:00",
-        expected: "January 1, 2018 12:00 AM - January 10, 2018 08:15 AM",
+        expected: "January 1, 2018 12:00 AM - January 10, 2018 8:15 AM",
       },
       {
         type: "date/range",
         value: "2018-01-01T12:30:00~2018-01-10T08:15:00",
-        expected: "January 1, 2018 12:30 PM - January 10, 2018 08:15 AM",
+        expected: "January 1, 2018 12:30 PM - January 10, 2018 8:15 AM",
       },
       {
         type: "date/all-options",

--- a/frontend/src/metabase/querying/filters/types.ts
+++ b/frontend/src/metabase/querying/filters/types.ts
@@ -1,4 +1,5 @@
 import type * as Lib from "metabase-lib";
+import type { DateFormattingSettings } from "metabase-types/api";
 
 import type {
   DATE_PICKER_DIRECTIONS,
@@ -106,6 +107,7 @@ export type DateFilterValue =
 export type DateFilterDisplayOpts = {
   // whether to include `On` prefix for a single date filter
   withPrefix?: boolean;
+  formattingSettings?: DateFormattingSettings;
 };
 
 export type BooleanFilterValue = "true" | "false" | "is-null" | "not-null";

--- a/frontend/src/metabase/querying/filters/utils/dates.ts
+++ b/frontend/src/metabase/querying/filters/utils/dates.ts
@@ -2,6 +2,7 @@ import dayjs from "dayjs";
 import { match } from "ts-pattern";
 import { c, msgid, ngettext, t } from "ttag";
 
+import { DEFAULT_TIME_STYLE } from "metabase/lib/formatting/datetime-utils";
 import {
   DATE_PICKER_EXTRACTION_UNITS,
   DATE_PICKER_OPERATORS,
@@ -23,6 +24,7 @@ import type {
 } from "metabase/querying/filters/types";
 import type { ExcludeDateFilterUnit } from "metabase-lib";
 import * as Lib from "metabase-lib";
+import type { DateFormattingSettings } from "metabase-types/api";
 
 export function isDatePickerOperator(
   operator: string,
@@ -248,13 +250,13 @@ function getQuarterYearFilterClause(
 
 export function getDateFilterDisplayName(
   value: DateFilterValue,
-  { withPrefix }: DateFilterDisplayOpts = {},
+  { withPrefix, formattingSettings }: DateFilterDisplayOpts = {},
 ) {
   return match(value)
     .with(
       { type: "specific", operator: "=" },
       ({ values: [date], hasTime }) => {
-        const dateText = formatDate(date, hasTime);
+        const dateText = formatDate(date, hasTime, formattingSettings);
         return withPrefix
           ? c("On a date. Example: On Jan 20.").t`On ${dateText}`
           : dateText;
@@ -264,20 +266,20 @@ export function getDateFilterDisplayName(
       { type: "specific", operator: "<" },
       ({ values: [date], hasTime }) => {
         return c("Before a date. Example: Before Jan 20.")
-          .t`Before ${formatDate(date, hasTime)}`;
+          .t`Before ${formatDate(date, hasTime, formattingSettings)}`;
       },
     )
     .with(
       { type: "specific", operator: ">" },
       ({ values: [date], hasTime }) => {
         return c("After a date. Example: After Jan 20.")
-          .t`After ${formatDate(date, hasTime)}`;
+          .t`After ${formatDate(date, hasTime, formattingSettings)}`;
       },
     )
     .with(
       { type: "specific", operator: "between" },
       ({ values: [startDate, endDate], hasTime }) => {
-        return `${formatDate(startDate, hasTime)} - ${formatDate(endDate, hasTime)}`;
+        return `${formatDate(startDate, hasTime, formattingSettings)} - ${formatDate(endDate, hasTime, formattingSettings)}`;
       },
     )
     .with(
@@ -322,8 +324,17 @@ export function getDateFilterDisplayName(
     .exhaustive();
 }
 
-export function formatDate(date: Date, hasTime: boolean) {
-  return hasTime ? dayjs(date).format("LL hh:mm A") : dayjs(date).format("LL");
+export function formatDate(
+  date: Date,
+  hasTime: boolean,
+  formattingSettings: DateFormattingSettings = {
+    date_style: "LL", // fall back to local date format
+    time_style: DEFAULT_TIME_STYLE,
+  },
+) {
+  const { date_style, time_style } = formattingSettings;
+  const format = hasTime ? `${date_style} ${time_style}` : date_style;
+  return dayjs(date).format(format);
 }
 
 function formatMonth(month: number, year: number) {


### PR DESCRIPTION
Closes #65462 

The parameter widget on dashboards does not respect the instance's settings for date/time formatting.

This PR changes that so that it does.

### To verify

- Go to admin -> Localization and set a custom date format
- Go to Examples -> E-commerce insights
- Add a date filter and make sure to pick a specific date range
- The filter pill should show the dates in the date format you picked in the admin settings

<img width="573" height="115" alt="Screenshot 2026-01-07 at 15 18 07" src="https://github.com/user-attachments/assets/4c10f312-431d-48a5-bb77-b92f4091f10c" />

<img width="577" height="166" alt="Screenshot 2026-01-07 at 15 17 49" src="https://github.com/user-attachments/assets/37c86e9e-668f-4f69-a704-9174caded086" />


