### PR TITLE
Add document metrics to Snowplow analytics

### DIFF
--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -713,7 +713,8 @@
     [:questions_with_params           (get-in stats [:stats :question :questions :with_params] 0)     #{"questions"}]
     [:segments                        (get-in stats [:stats :segment :segments] 0)                    #{"segments"}]
     [:tables                          (get-in stats [:stats :table :tables] 0)                        #{"tables"}]
-    [:users                           (get-in stats [:stats :user :users :total] 0)                   #{"users"}]]))
+    [:users                           (get-in stats [:stats :user :users :total] 0)                   #{"users"}]
+    [:documents                       (get-in stats [:stats :document :documents :total] 0)           #{"documents"}]]))
 
 (defn- whitelabeling-in-use?
   "Are any whitelabeling settings set to values other than their default?"


### PR DESCRIPTION
## Summary

Document metrics were being collected and included in legacy stats but were missing from Snowplow metrics, which are consumed by the dbt pipeline.

## Changes

This fix adds the `:documents` metric to Snowplow analytics:
- Total number of documents
- Tagged with #{"documents"}
- Follows the same pattern as other metrics like segments and tables

## Testing

- [x] Code formatted with cljfmt
- [x] Pre-commit hooks passed
- [x] Follows existing patterns in the codebase