### PR TITLE
Fix MB in an iframe running on a subpath

### DIFF
--- a/frontend/src/metabase/common/hooks/is-route-in-sync.ts
+++ b/frontend/src/metabase/common/hooks/is-route-in-sync.ts
@@ -4,6 +4,9 @@ import { getPathnameWithoutSubPath, isWithinIframe } from "metabase/lib/dom";
  * Returns whether the current route is in sync with the given pathname,
  * only if we're in an iframe context.
  *
+ * This has been implemented as part of a fix for metabase#65500
+ * to prevent iframes navigated through postMessage from getting stuck in an error state
+ *
  * @param pathname the current path name
  * @returns whether the routes are in sync, if we're in an iframe context
  */
@@ -11,8 +14,8 @@ export function isRouteInSync(pathname: string): boolean {
   const isRouteInSync =
     getPathnameWithoutSubPath(window.location.pathname) === pathname;
 
-  if (isWithinIframe() && !isRouteInSync) {
-    return false;
+  if (isWithinIframe()) {
+    return isRouteInSync;
   }
 
   return true;

--- a/frontend/src/metabase/common/hooks/is-route-in-sync.ts
+++ b/frontend/src/metabase/common/hooks/is-route-in-sync.ts
@@ -1,0 +1,19 @@
+import { getPathnameWithoutSubPath, isWithinIframe } from "metabase/lib/dom";
+
+/**
+ * Returns whether the current route is in sync with the given pathname,
+ * only if we're in an iframe context.
+ *
+ * @param pathname the current path name
+ * @returns whether the routes are in sync, if we're in an iframe context
+ */
+export function isRouteInSync(pathname: string): boolean {
+  const isRouteInSync =
+    getPathnameWithoutSubPath(window.location.pathname) === pathname;
+
+  if (isWithinIframe() && !isRouteInSync) {
+    return false;
+  }
+
+  return true;
+}

--- a/frontend/src/metabase/common/hooks/is-route-in-sync.unit.spec.ts
+++ b/frontend/src/metabase/common/hooks/is-route-in-sync.unit.spec.ts
@@ -1,8 +1,18 @@
+import MetabaseSettings from "metabase/lib/settings";
+
 import { isRouteInSync } from "./is-route-in-sync";
 
 describe("isRouteInSync", () => {
+  beforeAll(() => {
+    MetabaseSettings.set("site-url", "http://localhost:3000");
+  });
+
   beforeEach(() => {
     delete (window as any).overrideIsWithinIframe;
+  });
+
+  afterAll(() => {
+    MetabaseSettings.set("site-url", undefined as any);
   });
 
   describe("in an iframe", () => {

--- a/frontend/src/metabase/common/hooks/is-route-in-sync.unit.spec.ts
+++ b/frontend/src/metabase/common/hooks/is-route-in-sync.unit.spec.ts
@@ -1,0 +1,43 @@
+import { isRouteInSync } from "./is-route-in-sync";
+
+describe("isRouteInSync", () => {
+  beforeEach(() => {
+    delete (window as any).overrideIsWithinIframe;
+  });
+
+  describe("in an iframe", () => {
+    beforeEach(() => {
+      (window as any).overrideIsWithinIframe = true;
+    });
+
+    it("should return true when the current pathname matches the location pathname", () => {
+      window.history.pushState({}, "", "/some/path");
+      const result = isRouteInSync("/some/path");
+
+      expect(result).toBe(true);
+    });
+
+    it("should return false when the current pathname does not match the location pathname", () => {
+      window.history.pushState({}, "", "/some/other-path");
+      const result = isRouteInSync("/some/path");
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("not in an iframe", () => {
+    it("should return true when the current pathname matches the location pathname", () => {
+      window.history.pushState({}, "", "/some/path");
+      const result = isRouteInSync("/some/path");
+
+      expect(result).toBe(true);
+    });
+
+    it("should return true too when the current pathname does not match the location pathname, to preserve existing behavior", () => {
+      window.history.pushState({}, "", "/some/other-path");
+      const result = isRouteInSync("/some/path");
+
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
@@ -162,6 +162,8 @@ export const DashboardApp = ({
   const { autoScrollToDashcardId, reportAutoScrolledToDashcard } =
     useAutoScrollToDashcard(location);
 
+  // Prevent rendering the dashboard app if the route is out of sync
+  // metabase#65500
   if (!isRouteInSync(location.pathname)) {
     return null;
   }

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
@@ -5,6 +5,7 @@ import type { Route, WithRouterProps } from "react-router";
 import { replace } from "react-router-redux";
 
 import ErrorBoundary from "metabase/ErrorBoundary";
+import { isRouteInSync } from "metabase/common/hooks/is-route-in-sync";
 import { useFavicon } from "metabase/common/hooks/use-favicon";
 import CS from "metabase/css/core/index.css";
 import {
@@ -32,7 +33,6 @@ import {
   usePageTitleWithLoadingTime,
 } from "metabase/hooks/use-page-title";
 import { parseHashOptions, stringifyHashOptions } from "metabase/lib/browser";
-import { getPathnameWithoutSubPath, isWithinIframe } from "metabase/lib/dom";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { setErrorPage } from "metabase/redux/app";
@@ -162,11 +162,8 @@ export const DashboardApp = ({
   const { autoScrollToDashcardId, reportAutoScrolledToDashcard } =
     useAutoScrollToDashcard(location);
 
-  const isRouteInSync =
-    getPathnameWithoutSubPath(window.location.pathname) === location.pathname;
-
-  if (isWithinIframe() && !isRouteInSync) {
-    return null; // Don't render until route syncs (metabase#65500)
+  if (!isRouteInSync(location.pathname)) {
+    return null;
   }
 
   return (

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
@@ -32,7 +32,7 @@ import {
   usePageTitleWithLoadingTime,
 } from "metabase/hooks/use-page-title";
 import { parseHashOptions, stringifyHashOptions } from "metabase/lib/browser";
-import { isWithinIframe } from "metabase/lib/dom";
+import { getPathnameWithoutSubPath, isWithinIframe } from "metabase/lib/dom";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { setErrorPage } from "metabase/redux/app";
@@ -162,7 +162,9 @@ export const DashboardApp = ({
   const { autoScrollToDashcardId, reportAutoScrolledToDashcard } =
     useAutoScrollToDashcard(location);
 
-  const isRouteInSync = window.location.pathname === location.pathname;
+  const isRouteInSync =
+    getPathnameWithoutSubPath(window.location.pathname) === location.pathname;
+
   if (isWithinIframe() && !isRouteInSync) {
     return null; // Don't render until route syncs (metabase#65500)
   }

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.unit.spec.tsx
@@ -16,6 +16,7 @@ import {
   setupTableEndpoints,
 } from "__support__/server-mocks";
 import { setupNotificationChannelsEndpoints } from "__support__/server-mocks/pulse";
+import { mockSettings } from "__support__/settings";
 import { createMockEntitiesState } from "__support__/store";
 import {
   act,
@@ -109,6 +110,7 @@ async function setup({ dashboard }: Options = {}) {
         entities: createMockEntitiesState({
           databases: [TEST_DATABASE_WITH_ACTIONS],
         }),
+        settings: mockSettings({ "site-url": "http://localhost:3000" }),
       },
     },
   );

--- a/frontend/src/metabase/lib/dom.js
+++ b/frontend/src/metabase/lib/dom.js
@@ -224,13 +224,7 @@ export function constrainToScreen(element, direction, padding) {
 }
 
 export function getSitePath() {
-  const siteUrl = MetabaseSettings.get("site-url");
-
-  if (!siteUrl) {
-    return "/";
-  }
-
-  return new URL(siteUrl).pathname.toLowerCase();
+  return new URL(MetabaseSettings.get("site-url")).pathname.toLowerCase();
 }
 
 function isMetabaseUrl(url) {

--- a/frontend/src/metabase/lib/dom.js
+++ b/frontend/src/metabase/lib/dom.js
@@ -402,7 +402,13 @@ const getLocation = (url) => {
   }
 };
 
-function getPathnameWithoutSubPath(pathname) {
+/**
+ * Returns the pathname without the site subpath, if any
+ *
+ * @param {string} pathname the pathname
+ * @returns the pathname without it subpath, if any
+ */
+export function getPathnameWithoutSubPath(pathname) {
   const pathnameSections = pathname.split("/");
   const sitePathSections = getSitePath().split("/");
 

--- a/frontend/src/metabase/lib/dom.js
+++ b/frontend/src/metabase/lib/dom.js
@@ -224,7 +224,13 @@ export function constrainToScreen(element, direction, padding) {
 }
 
 export function getSitePath() {
-  return new URL(MetabaseSettings.get("site-url")).pathname.toLowerCase();
+  const siteUrl = MetabaseSettings.get("site-url");
+
+  if (!siteUrl) {
+    return "/";
+  }
+
+  return new URL(siteUrl).pathname.toLowerCase();
 }
 
 function isMetabaseUrl(url) {

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.tsx
@@ -331,6 +331,8 @@ function QueryBuilderInner(props: QueryBuilderInnerProps) {
   const handleSave = useSaveQuestion({ scheduleCallback });
 
   useMount(() => {
+    // Prevent initializing the query builder if the route is out of sync
+    // metabase#65500
     if (!isRouteInSync(location.pathname)) {
       return;
     }

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.tsx
@@ -17,7 +17,7 @@ import { useWebNotification } from "metabase/common/hooks/use-web-notification";
 import { Bookmarks } from "metabase/entities/bookmarks";
 import { Timelines } from "metabase/entities/timelines";
 import { usePageTitleWithLoadingTime } from "metabase/hooks/use-page-title";
-import { isWithinIframe } from "metabase/lib/dom";
+import { getPathnameWithoutSubPath, isWithinIframe } from "metabase/lib/dom";
 import { connect, useSelector } from "metabase/lib/redux";
 import { closeNavbar } from "metabase/redux/app";
 import { getIsNavbarOpen } from "metabase/selectors/app";
@@ -331,9 +331,11 @@ function QueryBuilderInner(props: QueryBuilderInnerProps) {
   const handleSave = useSaveQuestion({ scheduleCallback });
 
   useMount(() => {
-    const isRouteInSync = window.location.pathname === location.pathname;
+    const isRouteInSync =
+      getPathnameWithoutSubPath(window.location.pathname) === location.pathname;
+
     if (isWithinIframe() && !isRouteInSync) {
-      return null; // Don't initialize query builder until route syncs (metabase#65500)
+      return; // Don't initialize query builder until route syncs (metabase#65500)
     }
     initializeQB(location, params);
   });

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.tsx
@@ -9,6 +9,7 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import { LeaveRouteConfirmModal } from "metabase/common/components/LeaveConfirmModal";
+import { isRouteInSync } from "metabase/common/hooks/is-route-in-sync";
 import { useCallbackEffect } from "metabase/common/hooks/use-callback-effect";
 import { useFavicon } from "metabase/common/hooks/use-favicon";
 import { useForceUpdate } from "metabase/common/hooks/use-force-update";
@@ -17,7 +18,6 @@ import { useWebNotification } from "metabase/common/hooks/use-web-notification";
 import { Bookmarks } from "metabase/entities/bookmarks";
 import { Timelines } from "metabase/entities/timelines";
 import { usePageTitleWithLoadingTime } from "metabase/hooks/use-page-title";
-import { getPathnameWithoutSubPath, isWithinIframe } from "metabase/lib/dom";
 import { connect, useSelector } from "metabase/lib/redux";
 import { closeNavbar } from "metabase/redux/app";
 import { getIsNavbarOpen } from "metabase/selectors/app";
@@ -331,12 +331,10 @@ function QueryBuilderInner(props: QueryBuilderInnerProps) {
   const handleSave = useSaveQuestion({ scheduleCallback });
 
   useMount(() => {
-    const isRouteInSync =
-      getPathnameWithoutSubPath(window.location.pathname) === location.pathname;
-
-    if (isWithinIframe() && !isRouteInSync) {
-      return; // Don't initialize query builder until route syncs (metabase#65500)
+    if (!isRouteInSync(location.pathname)) {
+      return;
     }
+
     initializeQB(location, params);
   });
 

--- a/frontend/src/metabase/query_builder/containers/test-utils.tsx
+++ b/frontend/src/metabase/query_builder/containers/test-utils.tsx
@@ -24,6 +24,7 @@ import {
   setupSearchEndpoints,
   setupTimelinesEndpoints,
 } from "__support__/server-mocks";
+import { mockSettings } from "__support__/settings";
 import {
   renderWithProviders,
   screen,
@@ -315,6 +316,7 @@ export const setup = async ({
             can_create_native_queries: true,
           }),
         }),
+        settings: mockSettings({ "site-url": "http://localhost:3000" }),
       }),
     },
   );


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #67642
Closes [EMB-1162: Iframes might break when Metabase is in a sub path](https://linear.app/metabase/issue/EMB-1162/iframes-might-break-when-metabase-is-in-a-sub-path)

### Description

When running Metabase through a proxy, the querybuilder and the dashboard app would not initialize because of the fix made in #65662. This is now fixed by stripping any potential subpath before the check.

### How to verify

1. Run Metabase through a proxy
2. Open an interactive embedding, it should work, for both questions and dashboards)


No automated tests unfortunately, spinning up a proxy within Cypress is too cumbersome at the moment.