### PR TITLE
perms for moving collections with archived kids

### DIFF
--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -1369,7 +1369,9 @@
   (set
    (for [collection-or-id (cons
                            collection
-                           (t2/select-pks-set :model/Collection :location [:like (str (children-location collection) "%")]))]
+                           (t2/select-pks-set :model/Collection
+                                              :location [:like (str (children-location collection) "%")]
+                                              :archived false))]
      (perms/collection-readwrite-path collection-or-id))))
 
 (mu/defn perms-for-archiving :- [:set perms/PathSchema]

--- a/test/metabase/collections_rest/api_test.clj
+++ b/test/metabase/collections_rest/api_test.clj
@@ -2749,6 +2749,23 @@
                    (mt/user-http-request :rasta :put 403 (str "collection/" (u/the-id collection-a))
                                          {:archived true})))))))))
 
+(deftest archive-collection-with-archived-descendants-test
+  (testing "PUT /api/collection/:id"
+    (testing "I should be allowed to archive a collection if I have perms on it and all non-archived descendants"
+      ;; Create hierarchy A > B > C where C is already archived
+      ;; Grant perms for A and B only
+      ;; User should be able to archive A because C (which they don't have perms on) is archived
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-temp [:model/Collection collection-a {}
+                       :model/Collection collection-b {:location (collection/children-location collection-a)}
+                       :model/Collection _collection-c {:location (collection/children-location collection-b)
+                                                        :archived true}]
+          (doseq [collection [collection-a collection-b]]
+            (perms/grant-collection-readwrite-permissions! (perms/all-users-group) collection))
+          ;; This should succeed because C is archived and excluded from permission checks
+          (is (some? (mt/user-http-request :rasta :put 200 (str "collection/" (u/the-id collection-a))
+                                           {:archived true}))))))))
+
 (deftest move-collection-test
   (testing "PUT /api/collection/:id"
     (testing "Can I *change* the `location` of a Collection? (i.e. move it into a different parent Collection)"
@@ -2817,6 +2834,24 @@
                 (is (= "You don't have permissions to do that."
                        (mt/user-http-request :rasta :put 403 (str "collection/" (u/the-id collection-a))
                                              {:parent_id (u/the-id collection-c)})))))))))))
+
+(deftest move-collection-with-archived-descendants-test
+  (testing "PUT /api/collection/:id"
+    (testing "I should be allowed to move a collection if I have perms on it and all non-archived descendants"
+      ;; Create hierarchy A > B > C, plus destination D, where C is already archived
+      ;; Grant perms for A, B, and D only
+      ;; User should be able to move A into D because C (which they don't have perms on) is archived
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-temp [:model/Collection collection-a {}
+                       :model/Collection collection-b {:location (collection/children-location collection-a)}
+                       :model/Collection _collection-c {:location (collection/children-location collection-b)
+                                                        :archived true}
+                       :model/Collection collection-d {}]
+          (doseq [collection [collection-a collection-b collection-d]]
+            (perms/grant-collection-readwrite-permissions! (perms/all-users-group) collection))
+          ;; This should succeed because C is archived and excluded from permission checks
+          (is (some? (mt/user-http-request :rasta :put 200 (str "collection/" (u/the-id collection-a))
+                                           {:parent_id (u/the-id collection-d)}))))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                            GET /api/collection/graph and PUT /api/collection/graph                             |


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #67418
Previously if you had:

```
A (curate)
  B (curate)
    C (no permissions)
      D (curate)
```

Then if C was archived, you would be unable to move or archive A or B.
