### PR TITLE
Add support for content translations for auth embeds

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/content-translations.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/content-translations.cy.spec.tsx
@@ -1,0 +1,78 @@
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { createQuestion } from "e2e/support/helpers";
+import { uploadTranslationDictionaryViaAPI } from "e2e/support/helpers/e2e-content-translation-helpers";
+import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
+import { mountInteractiveQuestion } from "e2e/support/helpers/embedding-sdk-component-testing";
+import {
+  mockAuthProviderAndJwtSignIn,
+  signInAsAdminAndEnableEmbeddingSdk,
+} from "e2e/support/helpers/embedding-sdk-testing";
+import type { Card } from "metabase-types/api";
+
+const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+
+describe("scenarios > embedding-sdk > content-translations", () => {
+  describe("question", () => {
+    const setup = ({ display }: { display?: Card["display"] } = {}) => {
+      signInAsAdminAndEnableEmbeddingSdk();
+
+      createQuestion({
+        name: "Question Embed SDK",
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["max", ["field", ORDERS.QUANTITY, null]]],
+          breakout: [["field", ORDERS.PRODUCT_ID, null]],
+          limit: 2,
+        },
+        display,
+      }).then(({ body: question }) => {
+        cy.wrap(question.id).as("questionId");
+      });
+
+      cy.signOut();
+    };
+
+    describe("content translation", () => {
+      it("should show question content with applied content translation", () => {
+        setup();
+
+        cy.signInAsAdmin();
+
+        uploadTranslationDictionaryViaAPI([
+          {
+            locale: "de",
+            msgid: "Question Embed SDK",
+            msgstr: "Override title für Deutsch",
+          },
+          {
+            locale: "de",
+            msgid: "Product ID",
+            msgstr: "Override Product ID für Deutsch",
+          },
+        ]);
+
+        cy.signOut();
+
+        mockAuthProviderAndJwtSignIn();
+
+        cy.get("@questionId").then(async () => {
+          mountInteractiveQuestion(
+            { title: true },
+            {
+              sdkProviderProps: {
+                locale: "de",
+              },
+            },
+          );
+
+          getSdkRoot().within(() => {
+            cy.findByText("Override title für Deutsch").should("be.visible");
+            cy.findByText("Override Product ID für Deutsch").should(
+              "be.visible",
+            );
+          });
+        });
+      });
+    });
+  });
+});

--- a/enterprise/backend/src/metabase_enterprise/content_translation/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/routes.clj
@@ -105,12 +105,9 @@
 (api.macros/defendpoint :get "/dictionary" :- DictionaryResponse
   "Fetch the content translation dictionary for authenticated users (auth-based embedding flows)."
   [_route-params
-   {:keys [locale]}]
-  (when-not api/*current-user-id*
-    (throw (ex-info (str (tru "Unauthenticated")) {:status-code 401})))
-  (if locale
-    {:data (ct/get-translations (i18n/normalized-locale-string (str/trim locale)))}
-    (throw (ex-info (str (tru "Locale is required.")) {:status-code 400}))))
+   {:keys [locale]} :- [:map [:locale :string]]]
+  (api/check api/*current-user-id* 401 "Unauthenticated")
+  {:data (ct/get-translations (i18n/normalized-locale-string (str/trim locale)))})
 
 (defn- +require-content-translation [handler]
   (ee.api/+require-premium-feature :content-translation (deferred-tru "Content translation") handler))

--- a/enterprise/backend/src/metabase_enterprise/content_translation/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/routes.clj
@@ -26,6 +26,16 @@
                                     {:locale "ja" :msgid "Sample translation" :msgstr "サンプル翻訳"}
                                     {:locale "ko" :msgid "Sample translation" :msgstr "샘플 번역"}])
 
+(def ^:private Translation
+  [:map
+   [:locale ms/NonBlankString]
+   [:msgid ms/NonBlankString]
+   [:msgstr :string]])
+
+(def ^:private DictionaryResponse
+  [:map
+   [:data [:sequential Translation]]])
+
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
 ;;
@@ -88,6 +98,16 @@
    {:keys [locale]}]
   ;; this will error if bad
   (embedding.jwt/unsign token)
+  (if locale
+    {:data (ct/get-translations (i18n/normalized-locale-string (str/trim locale)))}
+    (throw (ex-info (str (tru "Locale is required.")) {:status-code 400}))))
+
+(api.macros/defendpoint :get "/dictionary" :- DictionaryResponse
+  "Fetch the content translation dictionary for authenticated users (auth-based embedding flows)."
+  [_route-params
+   {:keys [locale]}]
+  (when-not api/*current-user-id*
+    (throw (ex-info (str (tru "Unauthenticated")) {:status-code 401})))
   (if locale
     {:data (ct/get-translations (i18n/normalized-locale-string (str/trim locale)))}
     (throw (ex-info (str (tru "Locale is required.")) {:status-code 400}))))

--- a/enterprise/frontend/src/metabase-enterprise/content_translation/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/content_translation/index.ts
@@ -25,6 +25,13 @@ export function initializePlugin() {
       useTranslateFieldValuesInHoveredObject,
       useTranslateSeries,
       getDictionaryBasePath,
+      setEndpointsForAuthEmbedding: () => {
+        if (contentTranslationEndpoints.getDictionary) {
+          return;
+        }
+
+        contentTranslationEndpoints.getDictionary = getDictionaryBasePath;
+      },
       setEndpointsForStaticEmbedding: (encodedToken: string) => {
         if (contentTranslationEndpoints.getDictionary) {
           return;

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/context/SdkQuestionProvider.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/context/SdkQuestionProvider.tsx
@@ -4,6 +4,7 @@ import { t } from "ttag";
 import { SdkError } from "embedding-sdk-bundle/components/private/PublicComponentWrapper";
 import { useExtractResourceIdFromJwtToken } from "embedding-sdk-bundle/hooks/private/use-extract-resource-id-from-jwt-token";
 import { useLoadQuestion } from "embedding-sdk-bundle/hooks/private/use-load-question";
+import { useSetupContentTranslations } from "embedding-sdk-bundle/hooks/private/use-setup-content-translations";
 import { useSdkDispatch, useSdkSelector } from "embedding-sdk-bundle/store";
 import {
   getError,
@@ -14,7 +15,6 @@ import type { MetabasePluginsConfig } from "embedding-sdk-bundle/types/plugins";
 import { EmbeddingEntityContextProvider } from "metabase/embedding/context";
 import { transformSdkQuestion } from "metabase/embedding-sdk/lib/transform-question";
 import type { MetabasePluginsConfig as InternalMetabasePluginsConfig } from "metabase/embedding-sdk/types/plugins";
-import { PLUGIN_CONTENT_TRANSLATION } from "metabase/plugins";
 import {
   type OnCreateOptions,
   useCreateQuestion,
@@ -75,13 +75,7 @@ export const SdkQuestionProvider = ({
     token: rawToken ?? undefined,
   });
 
-  useEffect(() => {
-    if (isGuestEmbed && token) {
-      PLUGIN_CONTENT_TRANSLATION.setEndpointsForStaticEmbedding(token);
-    } else {
-      PLUGIN_CONTENT_TRANSLATION.setEndpointsForAuthEmbedding();
-    }
-  }, [isGuestEmbed, token]);
+  useSetupContentTranslations({ token });
 
   const isNewQuestion = questionId === "new";
 

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/context/SdkQuestionProvider.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/context/SdkQuestionProvider.tsx
@@ -78,6 +78,8 @@ export const SdkQuestionProvider = ({
   useEffect(() => {
     if (isGuestEmbed && token) {
       PLUGIN_CONTENT_TRANSLATION.setEndpointsForStaticEmbedding(token);
+    } else {
+      PLUGIN_CONTENT_TRANSLATION.setEndpointsForAuthEmbedding();
     }
   }, [isGuestEmbed, token]);
 

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
@@ -196,6 +196,8 @@ const SdkDashboardInner = ({
   useEffect(() => {
     if (isGuestEmbed && token) {
       PLUGIN_CONTENT_TRANSLATION.setEndpointsForStaticEmbedding(token);
+    } else {
+      PLUGIN_CONTENT_TRANSLATION.setEndpointsForAuthEmbedding();
     }
   }, [isGuestEmbed, token]);
 

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
@@ -25,6 +25,7 @@ import {
   type SdkDashboardDisplayProps,
   useSdkDashboardParams,
 } from "embedding-sdk-bundle/hooks/private/use-sdk-dashboard-params";
+import { useSetupContentTranslations } from "embedding-sdk-bundle/hooks/private/use-setup-content-translations";
 import { useSdkDispatch, useSdkSelector } from "embedding-sdk-bundle/store";
 import { getIsGuestEmbed } from "embedding-sdk-bundle/store/selectors";
 import type { MetabaseQuestion } from "embedding-sdk-bundle/types";
@@ -54,7 +55,6 @@ import { EmbeddingEntityContextProvider } from "metabase/embedding/context";
 import type { ParameterValues } from "metabase/embedding-sdk/types/dashboard";
 import { isStaticEmbeddingEntityLoadingError } from "metabase/lib/errors/is-static-embedding-entity-loading-error";
 import { useSelector } from "metabase/lib/redux";
-import { PLUGIN_CONTENT_TRANSLATION } from "metabase/plugins";
 import EmbedFrameS from "metabase/public/components/EmbedFrame/EmbedFrame.module.css";
 import { resetErrorPage, setErrorPage } from "metabase/redux/app";
 import { dismissAllUndo } from "metabase/redux/undo";
@@ -193,13 +193,7 @@ const SdkDashboardInner = ({
     token: rawToken ?? undefined,
   });
 
-  useEffect(() => {
-    if (isGuestEmbed && token) {
-      PLUGIN_CONTENT_TRANSLATION.setEndpointsForStaticEmbedding(token);
-    } else {
-      PLUGIN_CONTENT_TRANSLATION.setEndpointsForAuthEmbedding();
-    }
-  }, [isGuestEmbed, token]);
+  useSetupContentTranslations({ token });
 
   const { handleLoad, handleLoadWithoutCards } = useDashboardLoadHandlers({
     onLoad,

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-setup-content-translations.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-setup-content-translations.ts
@@ -1,0 +1,26 @@
+import { useEffect } from "react";
+
+import { useSdkSelector } from "embedding-sdk-bundle/store";
+import { getIsGuestEmbed } from "embedding-sdk-bundle/store/selectors";
+import type { SdkEntityToken } from "embedding-sdk-bundle/types";
+import { useLocale } from "metabase/common/hooks";
+import { PLUGIN_CONTENT_TRANSLATION } from "metabase/plugins";
+
+export const useSetupContentTranslations = ({
+  token,
+}: {
+  token: SdkEntityToken | null;
+}) => {
+  const { locale } = useLocale();
+  const isGuestEmbed = useSdkSelector(getIsGuestEmbed);
+
+  useEffect(() => {
+    if (locale !== "en") {
+      if (isGuestEmbed && token) {
+        PLUGIN_CONTENT_TRANSLATION.setEndpointsForStaticEmbedding(token);
+      } else {
+        PLUGIN_CONTENT_TRANSLATION.setEndpointsForAuthEmbedding();
+      }
+    }
+  }, [isGuestEmbed, locale, token]);
+};

--- a/frontend/src/metabase/plugins/oss/content-translation.ts
+++ b/frontend/src/metabase/plugins/oss/content-translation.ts
@@ -9,6 +9,7 @@ import type { EntityToken } from "metabase-types/api/entity";
 const getDefaultPluginContentTranslation = () => ({
   isEnabled: false,
   getDictionaryBasePath: null as string | null,
+  setEndpointsForAuthEmbedding: () => {},
   setEndpointsForStaticEmbedding: (_encodedToken: EntityToken) => {},
   ContentTranslationConfiguration: PluginPlaceholder,
   useTranslateContent: <


### PR DESCRIPTION
closes EMB-1164

Add support for content translations for auth embeds: Embed JS and SDK
Previously we had content translations only for Static and Recently added Guest Embeds.
SDK support for Content Translations was done, but enabled only for Guest Embeds. Now we enable it for auth embeds as well.

To achieve it, the new enterprise API endpoint was added.

Also we load content translations ONLY for non-en locale 

How to verify:
- upload a dictionary with a content translations
- embed SDK or Embed JS, pass corresponding locale and check that content is translated
- e2e test also reproduces and validates this