### PR TITLE
Drop transform.target_db_id if present

### DIFF
--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -1235,8 +1235,6 @@ databaseChangeLog:
             path: instance_analytics_views/tables/v1/h2-tables.sql
             relativeToChangelogFile: true
 
-# >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
-
   - changeSet:
       id: v58.2025-12-18T16:14:03
       author: winlost
@@ -1256,6 +1254,21 @@ databaseChangeLog:
         - dropColumn:
             tableName: pulse
             columnName: disable_links
+
+  - changeSet:
+      id: v58.2026-01-05T00:00:00
+      author: christruter
+      comment: Drop transform.target_db_id column if present (cleanup after https://github.com/metabase/metabase/pull/67630)
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: transform
+            columnName: target_db_id
+      changes:
+        - dropColumn:
+            tableName: transform
+            columnName: target_db_id
+      rollback:
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -1269,6 +1269,8 @@ databaseChangeLog:
             tableName: transform
             columnName: target_db_id
       rollback:
+        # The column should not have existed yet - do not recreate on rollback
+        - empty: {}
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 


### PR DESCRIPTION
Cleanup migration after [reverting](https://github.com/metabase/metabase/pull/67630) the [original PR](https://github.com/metabase/metabase/pull/66953) that added this column.
Environments that already ran the migration before the revert now have a dangling column.

This migration conditionally drops it if present, and no-ops otherwise.

Examples of people tripping over this: [slack thread](https://metaboat.slack.com/archives/C096T8NED1S/p1767618707951049)
