### PR TITLE
[Metabot] Update Metabot icon

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotQueryBuilder/MetabotQueryBuilder.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotQueryBuilder/MetabotQueryBuilder.tsx
@@ -6,6 +6,7 @@ import { isMatching } from "ts-pattern";
 import { t } from "ttag";
 import _ from "underscore";
 
+import { MetabotLogo } from "metabase/common/components/MetabotLogo";
 import { useDispatch } from "metabase/lib/redux";
 import { useRouter } from "metabase/router";
 import {
@@ -166,7 +167,7 @@ export const MetabotQueryBuilder = () => {
     <Box className={S.page}>
       <Box className={S.centeredContainer}>
         <Box className={S.greeting}>
-          <Icon name="metabot" className={S.greetingIcon} c="brand" />
+          <MetabotLogo className={S.greetingIcon} />
           <Text fz={{ base: "xl", sm: 32 }} fw={600} c="text-dark">
             {title}
           </Text>


### PR DESCRIPTION
### Description

We were using the smaller metabot icon in a place where the larger once should have been used.

**Before:**
<img width="3442" height="2078" alt="image (17)" src="https://github.com/user-attachments/assets/4255c58f-2a44-422e-8db8-f16602d4c7b5" />

**After:**
<img width="2984" height="2120" alt="CleanShot 2026-01-05 at 12 38 22@2x" src="https://github.com/user-attachments/assets/255359d1-714f-45e7-b7bf-37825fd57cb5" />