### PR TITLE
Stabilize Flaky Data Model test

### DIFF
--- a/e2e/test/scenarios/data-studio/data-model/datamodel-data-studio.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-model/datamodel-data-studio.cy.spec.ts
@@ -102,8 +102,12 @@ describe("scenarios > data studio > datamodel", () => {
       );
 
       H.DataModel.get().within(() => {
+        cy.findByText("Table details").should("be.visible");
         cy.findByText("Field details").should("be.visible");
-        cy.findByText("Not found.").should("be.visible");
+        cy.findByText("Not found.")
+          .should("exist")
+          .scrollIntoView()
+          .should("be.visible");
       });
     });
 


### PR DESCRIPTION
### Description

This flake can't be reproduced locally, but from what I can see in CI, we're just not scrolling the correct element into view

<img width="821" height="517" alt="CleanShot 2026-01-05 at 11 50 52" src="https://github.com/user-attachments/assets/ab7351a5-861d-4fd2-95e8-4ad76696de45" />

[stress test](https://github.com/metabase/metabase/actions/runs/20725828233)
