### PR TITLE
[Metabot] Metabot error boundary

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/Metabot.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/Metabot.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { tinykeys } from "tinykeys";
 import { t } from "ttag";
 
-import EmptyDashboardBot from "assets/img/dashboard-empty.svg?component";
+import MetabotFailure from "assets/img/metabot-failure.svg?component";
 import ErrorBoundary from "metabase/ErrorBoundary";
 import { useSelector } from "metabase/lib/redux";
 import { Sidebar } from "metabase/nav/containers/MainNavbar/MainNavbar.styled";
@@ -27,7 +27,7 @@ const MetabotErrorFallback = ({ onRetry }: { onRetry: () => void }) => {
         justify="center"
         data-testid="metabot-error-fallback"
       >
-        <Box component={EmptyDashboardBot} w="6rem" />
+        <Box component={MetabotFailure} w="6rem" />
         <Text c="text-light" maw="12rem" ta="center">
           {t`Something went wrong.`}
         </Text>
@@ -36,33 +36,6 @@ const MetabotErrorFallback = ({ onRetry }: { onRetry: () => void }) => {
         </Button>
       </Flex>
     </Sidebar>
-  );
-};
-
-const SimulateError = () => {
-  const [shouldThrow, setShouldThrow] = useState(false);
-
-  if (shouldThrow) {
-    throw new Error("Simulated error for testing ErrorBoundary");
-  }
-
-  return (
-    <Button
-      onClick={() => setShouldThrow(true)}
-      variant="subtle"
-      size="xs"
-      c="text-dark"
-      style={{
-        position: "fixed",
-        right: 500,
-        top: 75,
-        width: 300,
-        height: 100,
-        background: "red",
-      }}
-    >
-      🧨🔥 {t`Simulate Error`}
-    </Button>
   );
 };
 
@@ -119,7 +92,6 @@ export const MetabotAuthenticated = ({ hide, config }: MetabotProps) => {
   return (
     <ErrorBoundary key={errorBoundaryKey} errorComponent={ErrorFallback}>
       <MetabotChat config={config} />
-      <SimulateError />
     </ErrorBoundary>
   );
 };

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/Metabot.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/Metabot.tsx
@@ -31,7 +31,12 @@ const MetabotErrorFallback = ({ onRetry }: { onRetry: () => void }) => {
         <Text c="text-light" maw="12rem" ta="center">
           {t`Something went wrong.`}
         </Text>
-        <Button variant="subtle" size="compact-lg" onClick={onRetry}>
+        <Button
+          variant="subtle"
+          size="compact-lg"
+          onClick={onRetry}
+          data-testid="metabot-error-retry"
+        >
           {t`Try again`}
         </Button>
       </Flex>
@@ -58,9 +63,7 @@ export const MetabotAuthenticated = ({ hide, config }: MetabotProps) => {
   const { visible, setVisible } = useMetabotAgent(config?.agentId ?? "omnibot");
   const [errorBoundaryKey, setErrorBoundaryKey] = useState(0);
 
-  const handleRetry = () => {
-    setErrorBoundaryKey((prev) => prev + 1);
-  };
+  const handleRetry = () => setErrorBoundaryKey((prev) => prev + 1);
 
   useEffect(() => {
     return tinykeys(window, {

--- a/enterprise/frontend/src/metabase-enterprise/metabot/tests/error-boundary.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/tests/error-boundary.unit.spec.tsx
@@ -1,0 +1,112 @@
+import { combineReducers } from "@reduxjs/toolkit";
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+import { assocIn } from "icepick";
+
+import { setupEnterprisePlugins } from "__support__/enterprise";
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen } from "__support__/ui";
+import {
+  createMockTokenFeatures,
+  createMockUser,
+} from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks";
+
+import { Metabot } from "../components/Metabot";
+import { FIXED_METABOT_IDS } from "../constants";
+import { MetabotProvider } from "../context";
+import { metabotReducer } from "../state";
+import { getMetabotInitialState } from "../state/reducer-utils";
+
+let mockShouldThrow = false;
+
+jest.mock("../components/MetabotChat", () => {
+  const metabotChatModule = jest.requireActual("../components/MetabotChat");
+  return {
+    ...metabotChatModule,
+    MetabotChat: (props: any) => {
+      if (mockShouldThrow) {
+        throw new Error("Test error for ErrorBoundary");
+      }
+      return <metabotChatModule.MetabotChat {...props} />;
+    },
+  };
+});
+
+function setup() {
+  const settings = mockSettings({
+    "token-features": createMockTokenFeatures({
+      metabot_v3: true,
+    }),
+  });
+
+  setupEnterprisePlugins();
+
+  const metabotState = assocIn(
+    getMetabotInitialState(),
+    ["conversations", "omnibot", "visible"],
+    true,
+  );
+
+  fetchMock.get(
+    `path:/api/ee/metabot-v3/metabot/${FIXED_METABOT_IDS.DEFAULT}/prompt-suggestions`,
+    { prompts: [], offset: 0, limit: 3, total: 0 },
+  );
+
+  renderWithProviders(
+    <MetabotProvider>
+      <Metabot />
+    </MetabotProvider>,
+    {
+      storeInitialState: createMockState({
+        settings,
+        currentUser: createMockUser(),
+        plugins: {
+          metabotPlugin: metabotState,
+        },
+      } as any),
+      customReducers: {
+        plugins: combineReducers({
+          metabotPlugin: metabotReducer,
+        }),
+      },
+    },
+  );
+}
+
+describe("metabot error boundary", () => {
+  beforeEach(() => {
+    mockShouldThrow = false;
+  });
+
+  it("should show error fallback and recover when clicking try again", async () => {
+    // prevent large amount of error content to get logged for our expected errors
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    mockShouldThrow = true;
+
+    setup();
+
+    // Error fallback should be shown
+    expect(
+      await screen.findByTestId("metabot-error-fallback"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Something went wrong.")).toBeInTheDocument();
+
+    // MetabotChat should not be visible
+    expect(screen.queryByTestId("metabot-chat")).not.toBeInTheDocument();
+
+    // Allow recovery on next render
+    mockShouldThrow = false;
+
+    await userEvent.click(screen.getByTestId("metabot-error-retry"));
+    expect(await screen.findByTestId("metabot-chat")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("metabot-error-fallback"),
+    ).not.toBeInTheDocument();
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/resources/frontend_client/app/assets/img/metabot-failure.svg
+++ b/resources/frontend_client/app/assets/img/metabot-failure.svg
@@ -1,0 +1,20 @@
+<svg width="96" height="96" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g clip-path="url(#a)">
+    <circle cx="48" cy="48" r="48" fill="#4C5773" fill-opacity=".05"/>
+    <path d="M24 35a4 4 0 0 1 4-4h40a4 4 0 0 1 4 4v26a4 4 0 0 1-4 4H28a4 4 0 0 1-4-4V35Z" fill="#fff"/>
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M23.375 35A4.625 4.625 0 0 1 28 30.375h40A4.625 4.625 0 0 1 72.625 35v26A4.625 4.625 0 0 1 68 65.625H28A4.625 4.625 0 0 1 23.375 61V35ZM28 31.625A3.375 3.375 0 0 0 24.625 35v26A3.375 3.375 0 0 0 28 64.375h40A3.375 3.375 0 0 0 71.375 61V35A3.375 3.375 0 0 0 68 31.625H28Z" fill="#949AAB"/>
+    <path d="M29.5 38a1.5 1.5 0 0 1 1.5-1.5h34a1.5 1.5 0 0 1 1.5 1.5v17a1.5 1.5 0 0 1-1.5 1.5H31a1.5 1.5 0 0 1-1.5-1.5V38Z" fill="#fff"/>
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M28.875 38c0-1.174.951-2.125 2.125-2.125h34c1.174 0 2.125.951 2.125 2.125v17A2.125 2.125 0 0 1 65 57.125H31A2.125 2.125 0 0 1 28.875 55V38ZM31 37.125a.875.875 0 0 0-.875.875v17c0 .483.392.875.875.875h34a.875.875 0 0 0 .875-.875V38a.875.875 0 0 0-.875-.875H31ZM61.071 61.179a.464.464 0 1 0 0-.93.464.464 0 0 0 0 .93Zm0 1.25a1.714 1.714 0 1 0 0-3.429 1.714 1.714 0 0 0 0 3.429ZM65.571 61.179a.464.464 0 1 0 0-.93.464.464 0 0 0 0 .93Zm0 1.25a1.714 1.714 0 1 0 0-3.429 1.714 1.714 0 0 0 0 3.429Z" fill="#949AAB"/>
+    <!-- Left X eye -->
+    <path d="M39.5 42 L42.5 45 M42.5 42 L39.5 45" stroke="#949AAB" stroke-width="1.25" stroke-linecap="round"/>
+    <!-- Right X eye -->
+    <path d="M53.5 42 L56.5 45 M56.5 42 L53.5 45" stroke="#949AAB" stroke-width="1.25" stroke-linecap="round"/>
+    <!-- Squiggly mouth -->
+    <path d="M44 49 Q45.5 47.5 47 49 T50 49 T53 49" stroke="#949AAB" stroke-width="1.25" stroke-linecap="round" fill="none"/>
+  </g>
+  <defs>
+    <clipPath id="a">
+      <path fill="#fff" d="M0 0h96v96H0z"/>
+    </clipPath>
+  </defs>
+</svg>


### PR DESCRIPTION
Closes [BOT-714: Error UI for ErrorBoundary](https://linear.app/metabase/issue/BOT-714/error-ui-for-errorboundary)

### Description

Add an error boundary component to the Metabot chat sidebar to better handle catastrophic FE failures.

### How to verify

- Open the Metabot chat sidebar
- Open the react dev tools + find the component in the component tree + select it
- Simulate a failure for the `<MetabotChat />` component (on right side of the dev tools, in the top section where the name of the component is, click the ! exclamation mark icon)
- It should show the error UI (the retry button doesn't work in this simulated case, but if you modify the code to force an error it does work + i have test cases to ensure this works properly)

### Demo

<img width="2978" height="2134" alt="CleanShot 2026-01-05 at 13 49 31@2x" src="https://github.com/user-attachments/assets/a53066c7-4615-4b2f-bf48-3dda12bec3b7" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
