### PR TITLE
GIT-8461 hide "Visualize another way" button for Sankey charts

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.tsx
@@ -17,6 +17,7 @@ import type { NewParameterOpts } from "metabase/parameters/utils/dashboards";
 import { Box, Icon } from "metabase/ui";
 import { getVisualizationRaw } from "metabase/visualizations";
 import {
+  isDisabledForVisualizer,
   isVisualizerDashboardCard,
   isVisualizerSupportedVisualization,
 } from "metabase/visualizer/utils";
@@ -221,6 +222,7 @@ function DashCardActionsPanelInner({
       !isVisualizerDashboardCard(dashcard) &&
       !isVisualizerSupportedVisualization(dashcard?.card.display) &&
       !isVirtualDashCard(dashcard) &&
+      !isDisabledForVisualizer(dashcard?.card.display) &&
       onEditVisualization
     ) {
       buttons.push(

--- a/frontend/src/metabase/visualizations/types/visualization.ts
+++ b/frontend/src/metabase/visualizations/types/visualization.ts
@@ -335,6 +335,7 @@ export type VisualizationDefinition = {
   disableSettingsConfig?: boolean;
   supportPreviewing?: boolean;
   supportsVisualizer?: boolean;
+  disableVisualizer?: boolean;
 
   minSize: VisualizationGridSize;
   defaultSize: VisualizationGridSize;

--- a/frontend/src/metabase/visualizations/visualizations/SankeyChart/chart-definition.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SankeyChart/chart-definition.ts
@@ -14,6 +14,7 @@ import {
 } from "metabase/visualizations/shared/utils/sizes";
 import type {
   ComputedVisualizationSettings,
+  VisualizationDefinition,
   VisualizationSettingsDefinitions,
 } from "metabase/visualizations/types";
 import { isDate, isDimension, isMetric } from "metabase-lib/v1/types/utils/isa";
@@ -141,14 +142,14 @@ export const SETTINGS_DEFINITIONS = {
   },
 };
 
-export const SANKEY_CHART_DEFINITION = {
+export const SANKEY_CHART_DEFINITION: VisualizationDefinition = {
   getUiName: () => t`Sankey`,
   identifier: "sankey",
   iconName: "sankey",
-  supportsVisualizer: true,
   // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
   noun: t`sankey chart`,
   minSize: getMinSize("sankey"),
+  disableVisualizer: true,
   defaultSize: getDefaultSize("sankey"),
   isSensible: (data: DatasetData) => {
     const { cols, rows } = data;

--- a/frontend/src/metabase/visualizations/visualizations/SankeyChart/chart-definition.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SankeyChart/chart-definition.ts
@@ -145,6 +145,7 @@ export const SANKEY_CHART_DEFINITION = {
   getUiName: () => t`Sankey`,
   identifier: "sankey",
   iconName: "sankey",
+  supportsVisualizer: true,
   // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
   noun: t`sankey chart`,
   minSize: getMinSize("sankey"),

--- a/frontend/src/metabase/visualizer/utils/dashboard-card-supports-visualizer.ts
+++ b/frontend/src/metabase/visualizer/utils/dashboard-card-supports-visualizer.ts
@@ -24,3 +24,13 @@ export function isVisualizerSupportedVisualization(
 
   return visualizations.get(display)?.supportsVisualizer;
 }
+
+export function isDisabledForVisualizer(
+  display: VisualizationDisplay | null | undefined,
+) {
+  if (!display) {
+    return false;
+  }
+
+  return visualizations.get(display)?.disableVisualizer;
+}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/65317
Closes [GIT-8461](https://linear.app/metabase/issue/GIT-8461/confusing-ux-sankey-charts-and-any-other-non-visualizer-chart-changes)

### Description
Added `disableVisualizer` option for `VisualizationDefinition`. Set this option as true for `SANKEY_CHART_DEFINITION`. 

### How to verify
1. Create a question
2. Visualize it with Sankey chart
3. Add this question to a dashboard
4. In edit dashboard mode hover over the card
5. See that there is no "Visualize another way" button

### Demo
Before:

https://github.com/user-attachments/assets/cca72e02-923f-41a7-b660-3ac194323afc

After:

https://github.com/user-attachments/assets/0c6e364c-b002-40ea-80af-570e319a0e49



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
