### PR TITLE
fix: text selection inside card embed when interacting with card embeds

### DIFF
--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedNode.module.css
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedNode.module.css
@@ -33,6 +33,11 @@
   -ms-user-select: none;
 }
 
+/* Firefox doesn't respect `user-select: none` when inside a contenteditable element. */
+.cardEmbed *:not(input, textarea)::selection {
+  background: transparent;
+}
+
 .questionHeader {
   padding: 0.5rem 1rem;
 }


### PR DESCRIPTION
Closes [UXW-2168](https://linear.app/metabase/issue/UXW-2168/on-firefox-not-on-chrome-whenever-i-try-to-do-anything-with-the-chart)

### Description

On firefox, selecting card embed inside of a document causes text selection inside of the embed. This PR fixes it by disabling ::selection color on non-input elements inside. Original fix with `user-select: none;` does not work on Firefox because Firefox doesn't respect it when inside of contenteditable container (see https://jsfiddle.net/yj7m6ure/2/). [Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1927275)

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New document
2. /chart
3. Add a chart to the document
4. Cmd+A or click anywhere on the card

### Demo

Before: 
<img width="1840" height="1105" alt="image" src="https://github.com/user-attachments/assets/76edbc83-faba-4e98-82f8-fb06336629a6" />

After:
<img width="1840" height="1105" alt="image" src="https://github.com/user-attachments/assets/a789ca13-27b0-4e17-8fdd-08acf6666f96" />

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
