### PR TITLE
Reduce number of modules that trigger driver tests

### DIFF
--- a/mage/src/mage/modules.clj
+++ b/mage/src/mage/modules.clj
@@ -77,6 +77,57 @@
       acc
       new-deps))))
 
+(def driver-affecting-overrides
+  "These modules affect drivers when computing, but we want to override and not consider them to affect drivers."
+  '#{analytics
+     api
+     api-keys
+     appearance
+     audit-app
+     auth-identity
+     auth-provider
+     batch-processing
+     channel
+     classloader
+     collections
+     config
+     content-verification
+     dashboards
+     eid-translation
+     embedding
+     enterprise/api
+     enterprise/scim
+     enterprise/serialization
+     enterprise/sso
+     events
+     formatter
+     initialization-status
+     internal-stats
+     login-history
+     notification
+     permissions
+     public-sharing
+     pulse
+     remote-sync
+     request
+     search
+     secrets
+     server
+     session
+     settings
+     setup
+     sso
+     startup
+     system
+     task
+     task-history
+     timeline
+     types
+     users
+     util
+     version
+     view-log})
+
 (defn- affected-modules
   "Set of modules that are direct or indirect dependents of `modules`, and thus are affected by changes to them."
   [deps modules]
@@ -155,7 +206,7 @@
   ([modules]
    (driver-deps-affected? (dependencies) modules))
   ([deps modules]
-   (let [unaffected (unaffected-modules deps modules)]
+   (let [unaffected (unaffected-modules deps (remove driver-affecting-overrides modules))]
      (not (contains? unaffected 'driver)))))
 
 (defn cli-can-skip-driver-tests


### PR DESCRIPTION
Before:

76 modules trigger:

```clojure
mage.modules=> (let [deps (dependencies)
                     all-deps (keys deps)]
                 (reduce (fn [acc module]
                           (if (driver-deps-affected? deps [module])
                             (conj acc module)
                             acc))
                         []
                         all-deps))
[actions analytics analyze api api-keys app-db appearance audit-app auth-identity auth-provider batch-processing cache channel classloader collections config content-verification dashboards database-routing driver driver-api eid-translation embedding events formatter initialization-status internal-stats legacy-mbql lib lib-be logger login-history model-persistence models notification parameters permissions pivot plugins premium-features public-sharing pulse queries query-permissions query-processor remote-sync request search secrets server session settings setup sso startup sync system task task-history tenants timeline types upload users util version view-log warehouse-schema warehouses enterprise/advanced-permissions enterprise/api enterprise/impersonation enterprise/sandbox enterprise/scim enterprise/serialization enterprise/sso]
mage.modules=> (count *1)
76
```

After:

Only 28 modules trigger driver tests:
```clojure
mage.modules=> (let [deps (dependencies)
                     all-deps (keys deps)]
                 (reduce (fn [acc module]
                           (if (driver-deps-affected? deps [module])
                             (conj acc module)
                             acc))
                         []
                         all-deps))
[actions analyze app-db cache database-routing driver driver-api legacy-mbql lib lib-be logger model-persistence models parameters pivot plugins premium-features queries query-permissions query-processor sync tenants upload warehouse-schema warehouses enterprise/advanced-permissions enterprise/impersonation enterprise/sandbox]
mage.modules=> (count *1)
28
```

How does this magic work? Just with an exclusion list:

```clojure
mage.modules=> driver-affecting-overrides
 #{batch-processing timeline eid-translation version
 enterprise/serialization initialization-status session users enterprise/api login-history sso classloader
 enterprise/sso permissions request view-log system api task-history notification task dashboards startup config
 content-verification secrets server formatter events util settings channel search collections remote-sync types
 api-keys setup enterprise/scim audit-app analytics public-sharing pulse embedding auth-identity auth-provider
 appearance internal-stats}
```