### PR TITLE
use named exports in admin folder

### DIFF
--- a/frontend/src/metabase/admin/admin.js
+++ b/frontend/src/metabase/admin/admin.js
@@ -2,13 +2,13 @@
 
 import { appReducer as app } from "metabase/admin/app/reducers";
 import { databasesReducer as databases } from "metabase/admin/databases/database";
-import datamodel from "metabase/admin/datamodel/datamodel";
-import people from "metabase/admin/people/people";
-import permissions from "metabase/admin/permissions/permissions";
-import settings from "metabase/admin/settings/settings";
+import { datamodel } from "metabase/admin/datamodel/datamodel";
+import { people } from "metabase/admin/people/people";
+import { permissions } from "metabase/admin/permissions/permissions";
+import { settings } from "metabase/admin/settings/settings";
 import { combineReducers } from "metabase/lib/redux";
 
-export default combineReducers({
+const admin = combineReducers({
   app,
   databases,
   datamodel,
@@ -16,3 +16,5 @@ export default combineReducers({
   permissions,
   settings,
 });
+
+export { admin };

--- a/frontend/src/metabase/admin/admin.js
+++ b/frontend/src/metabase/admin/admin.js
@@ -8,7 +8,7 @@ import { permissions } from "metabase/admin/permissions/permissions";
 import { settings } from "metabase/admin/settings/settings";
 import { combineReducers } from "metabase/lib/redux";
 
-const admin = combineReducers({
+export const admin = combineReducers({
   app,
   databases,
   datamodel,
@@ -16,5 +16,3 @@ const admin = combineReducers({
   permissions,
   settings,
 });
-
-export { admin };

--- a/frontend/src/metabase/admin/datamodel/components/revisions/QueryDiff.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/revisions/QueryDiff.jsx
@@ -4,7 +4,7 @@ import { Component } from "react";
 import { QueryDefinition } from "metabase/admin/datamodel/components/QueryDefinition";
 import CS from "metabase/css/core/index.css";
 
-export default class QueryDiff extends Component {
+export class QueryDiff extends Component {
   static propTypes = {
     diff: PropTypes.object.isRequired,
     tableId: PropTypes.number.isRequired,

--- a/frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx
@@ -8,9 +8,9 @@ import { t } from "ttag";
 import UserAvatar from "metabase/common/components/UserAvatar";
 import CS from "metabase/css/core/index.css";
 
-import RevisionDiff from "./RevisionDiff";
+import { RevisionDiff } from "./RevisionDiff";
 
-export default class Revision extends Component {
+export class Revision extends Component {
   static propTypes = {
     objectName: PropTypes.string.isRequired,
     revision: PropTypes.object.isRequired,

--- a/frontend/src/metabase/admin/datamodel/components/revisions/RevisionDiff.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/revisions/RevisionDiff.jsx
@@ -4,11 +4,11 @@ import { Component } from "react";
 
 import CS from "metabase/css/core/index.css";
 
-import QueryDiff from "./QueryDiff";
+import { QueryDiff } from "./QueryDiff";
 import { EditIcon, ErrorIcon, SuccessIcon } from "./RevisionDiff.styled";
-import TextDiff from "./TextDiff";
+import { TextDiff } from "./TextDiff";
 
-export default class RevisionDiff extends Component {
+export class RevisionDiff extends Component {
   static propTypes = {
     property: PropTypes.string.isRequired,
     diff: PropTypes.object.isRequired,

--- a/frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx
@@ -10,9 +10,9 @@ import CS from "metabase/css/core/index.css";
 import { assignUserColors } from "metabase/lib/formatting";
 import * as Urls from "metabase/lib/urls";
 
-import Revision from "./Revision";
+import { Revision } from "./Revision";
 
-export default class RevisionHistory extends Component {
+export class RevisionHistory extends Component {
   static propTypes = {
     segment: PropTypes.object,
     revisions: PropTypes.array,

--- a/frontend/src/metabase/admin/datamodel/components/revisions/TextDiff.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/revisions/TextDiff.jsx
@@ -4,7 +4,7 @@ import { diffWords } from "diff";
 import PropTypes from "prop-types";
 import { Component } from "react";
 
-export default class TextDiff extends Component {
+export class TextDiff extends Component {
   static propTypes = {
     diff: PropTypes.object.isRequired,
   };

--- a/frontend/src/metabase/admin/datamodel/containers/RevisionHistoryApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/RevisionHistoryApp.jsx
@@ -6,7 +6,7 @@ import { Segments } from "metabase/entities/segments";
 import { Tables } from "metabase/entities/tables";
 import { connect } from "metabase/lib/redux";
 
-import RevisionHistory from "../components/revisions/RevisionHistory";
+import { RevisionHistory } from "../components/revisions/RevisionHistory";
 import { fetchSegmentRevisions } from "../datamodel";
 import { getCurrentUser, getRevisions } from "../selectors";
 
@@ -29,7 +29,9 @@ class RevisionHistoryApp extends Component {
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(RevisionHistoryApp);
+const RevisionHistoryAppConnected = connect(mapStateToProps, mapDispatchToProps)(RevisionHistoryApp);
+
+export { RevisionHistoryAppConnected as RevisionHistoryApp };
 
 class SegmentRevisionHistoryInner extends Component {
   render() {

--- a/frontend/src/metabase/admin/datamodel/containers/RevisionHistoryApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/RevisionHistoryApp.jsx
@@ -29,7 +29,10 @@ class RevisionHistoryApp extends Component {
   }
 }
 
-const RevisionHistoryAppConnected = connect(mapStateToProps, mapDispatchToProps)(RevisionHistoryApp);
+const RevisionHistoryAppConnected = connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(RevisionHistoryApp);
 
 export { RevisionHistoryAppConnected as RevisionHistoryApp };
 

--- a/frontend/src/metabase/admin/datamodel/containers/RevisionHistoryApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/RevisionHistoryApp.jsx
@@ -18,7 +18,7 @@ const mapStateToProps = (state, props) => ({
 
 const mapDispatchToProps = { fetchSegmentRevisions };
 
-class RevisionHistoryApp extends Component {
+class RevisionHistoryAppInner extends Component {
   componentDidMount() {
     const { id } = this.props;
     this.props.fetchSegmentRevisions(id);
@@ -29,12 +29,10 @@ class RevisionHistoryApp extends Component {
   }
 }
 
-const RevisionHistoryAppConnected = connect(
+export const RevisionHistoryApp = connect(
   mapStateToProps,
   mapDispatchToProps,
-)(RevisionHistoryApp);
-
-export { RevisionHistoryAppConnected as RevisionHistoryApp };
+)(RevisionHistoryAppInner);
 
 class SegmentRevisionHistoryInner extends Component {
   render() {

--- a/frontend/src/metabase/admin/datamodel/containers/SegmentApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/SegmentApp.jsx
@@ -113,7 +113,7 @@ const CreateSegmentForm = ({
   );
 };
 
-const SegmentApp = (props) => {
+const SegmentAppInner = (props) => {
   if (props.params.id) {
     return <UpdateSegmentForm {...props} />;
   }
@@ -121,9 +121,7 @@ const SegmentApp = (props) => {
   return <CreateSegmentForm {...props} />;
 };
 
-const SegmentAppConnected = connect(
+export const SegmentApp = connect(
   mapStateToProps,
   mapDispatchToProps,
-)(SegmentApp);
-
-export { SegmentAppConnected as SegmentApp };
+)(SegmentAppInner);

--- a/frontend/src/metabase/admin/datamodel/containers/SegmentApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/SegmentApp.jsx
@@ -121,4 +121,6 @@ const SegmentApp = (props) => {
   return <CreateSegmentForm {...props} />;
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(SegmentApp);
+const SegmentAppConnected = connect(mapStateToProps, mapDispatchToProps)(SegmentApp);
+
+export { SegmentAppConnected as SegmentApp };

--- a/frontend/src/metabase/admin/datamodel/containers/SegmentApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/SegmentApp.jsx
@@ -121,6 +121,9 @@ const SegmentApp = (props) => {
   return <CreateSegmentForm {...props} />;
 };
 
-const SegmentAppConnected = connect(mapStateToProps, mapDispatchToProps)(SegmentApp);
+const SegmentAppConnected = connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(SegmentApp);
 
 export { SegmentAppConnected as SegmentApp };

--- a/frontend/src/metabase/admin/datamodel/containers/SegmentApp.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/containers/SegmentApp.unit.spec.tsx
@@ -24,7 +24,7 @@ import { checkNotNull } from "metabase/lib/types";
 import { createMockCollection } from "metabase-types/api/mocks";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
 
-import SegmentApp from "./SegmentApp";
+import { SegmentApp } from "./SegmentApp";
 
 const TestHome = () => <div />;
 

--- a/frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx
@@ -63,12 +63,10 @@ class SegmentListAppInner extends Component {
   }
 }
 
-const SegmentListApp = _.compose(
+export const SegmentListApp = _.compose(
   Segments.loadList(),
   FilteredToUrlTable("segments"),
   connect((state, props) => ({ isAdmin: getUserIsAdmin(state) }), {
     setArchived: Segments.actions.setArchived,
   }),
 )(SegmentListAppInner);
-
-export { SegmentListApp };

--- a/frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx
@@ -71,4 +71,4 @@ const SegmentListApp = _.compose(
   }),
 )(SegmentListAppInner);
 
-export default SegmentListApp;
+export { SegmentListApp };

--- a/frontend/src/metabase/admin/datamodel/datamodel.js
+++ b/frontend/src/metabase/admin/datamodel/datamodel.js
@@ -38,6 +38,4 @@ const revisions = handleActions(
   null,
 );
 
-const datamodel = combineReducers({ previewSummary, revisions });
-
-export { datamodel };
+export const datamodel = combineReducers({ previewSummary, revisions });

--- a/frontend/src/metabase/admin/datamodel/datamodel.js
+++ b/frontend/src/metabase/admin/datamodel/datamodel.js
@@ -38,4 +38,6 @@ const revisions = handleActions(
   null,
 );
 
-export default combineReducers({ previewSummary, revisions });
+const datamodel = combineReducers({ previewSummary, revisions });
+
+export { datamodel };

--- a/frontend/src/metabase/admin/people/people.js
+++ b/frontend/src/metabase/admin/people/people.js
@@ -30,6 +30,4 @@ const temporaryPasswords = handleActions(
   {},
 );
 
-const people = combineReducers({ temporaryPasswords });
-
-export { people };
+export const people = combineReducers({ temporaryPasswords });

--- a/frontend/src/metabase/admin/people/people.js
+++ b/frontend/src/metabase/admin/people/people.js
@@ -30,4 +30,6 @@ const temporaryPasswords = handleActions(
   {},
 );
 
-export default combineReducers({ temporaryPasswords });
+const people = combineReducers({ temporaryPasswords });
+
+export { people };

--- a/frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx
@@ -103,4 +103,4 @@ const PermissionsConfirm = ({ diff }) => (
   </div>
 );
 
-export default PermissionsConfirm;
+export { PermissionsConfirm };

--- a/frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx
@@ -40,7 +40,7 @@ const TableAccessChange = ({ tables, verb, colorClassName }) => {
   );
 };
 
-const PermissionsConfirm = ({ diff }) => (
+export const PermissionsConfirm = ({ diff }) => (
   <div>
     {Object.values(diff.groups).map((group, groupIndex) =>
       Object.values(group.databases).map((database, databaseIndex) => (
@@ -102,5 +102,3 @@ const PermissionsConfirm = ({ diff }) => (
     )}
   </div>
 );
-
-export { PermissionsConfirm };

--- a/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsEditBar.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsEditBar.jsx
@@ -7,7 +7,7 @@ import Button from "metabase/common/components/Button";
 import { ConfirmModal } from "metabase/common/components/ConfirmModal";
 import EditBar from "metabase/common/components/EditBar";
 
-import PermissionsConfirm from "../PermissionsConfirm";
+import { PermissionsConfirm } from "../PermissionsConfirm";
 
 const propTypes = {
   diff: PropTypes.object,

--- a/frontend/src/metabase/admin/permissions/pages/DatabasePermissionsPage/DatabasesPermissionsPage.jsx
+++ b/frontend/src/metabase/admin/permissions/pages/DatabasePermissionsPage/DatabasesPermissionsPage.jsx
@@ -182,7 +182,7 @@ function DatabasesPermissionsPageInner({
   );
 }
 
-DatabasesPermissionsPage.propTypes = propTypes;
+DatabasesPermissionsPageInner.propTypes = propTypes;
 
 export const DatabasesPermissionsPage = _.compose(
   connect(mapStateToProps, mapDispatchToProps),

--- a/frontend/src/metabase/admin/permissions/pages/DatabasePermissionsPage/DatabasesPermissionsPage.jsx
+++ b/frontend/src/metabase/admin/permissions/pages/DatabasePermissionsPage/DatabasesPermissionsPage.jsx
@@ -72,7 +72,7 @@ const propTypes = {
   sidebarError: PropTypes.string,
 };
 
-function DatabasesPermissionsPage({
+function DatabasesPermissionsPageInner({
   sidebar,
   params,
   children,
@@ -184,6 +184,6 @@ function DatabasesPermissionsPage({
 
 DatabasesPermissionsPage.propTypes = propTypes;
 
-export default _.compose(connect(mapStateToProps, mapDispatchToProps))(
-  DatabasesPermissionsPage,
-);
+export const DatabasesPermissionsPage = _.compose(
+  connect(mapStateToProps, mapDispatchToProps),
+)(DatabasesPermissionsPageInner);

--- a/frontend/src/metabase/admin/permissions/pages/GroupDataPermissionsPage/GroupsPermissionsPage.jsx
+++ b/frontend/src/metabase/admin/permissions/pages/GroupDataPermissionsPage/GroupsPermissionsPage.jsx
@@ -202,7 +202,7 @@ function GroupsPermissionsPageInner({
   );
 }
 
-GroupsPermissionsPage.propTypes = propTypes;
+GroupsPermissionsPageInner.propTypes = propTypes;
 
 export const GroupsPermissionsPage = _.compose(
   connect(mapStateToProps, mapDispatchToProps),

--- a/frontend/src/metabase/admin/permissions/pages/GroupDataPermissionsPage/GroupsPermissionsPage.jsx
+++ b/frontend/src/metabase/admin/permissions/pages/GroupDataPermissionsPage/GroupsPermissionsPage.jsx
@@ -75,7 +75,7 @@ const propTypes = {
   editorError: PropTypes.string,
 };
 
-function GroupsPermissionsPage({
+function GroupsPermissionsPageInner({
   sidebar,
   params,
   children,
@@ -204,6 +204,6 @@ function GroupsPermissionsPage({
 
 GroupsPermissionsPage.propTypes = propTypes;
 
-export default _.compose(connect(mapStateToProps, mapDispatchToProps))(
-  GroupsPermissionsPage,
-);
+export const GroupsPermissionsPage = _.compose(
+  connect(mapStateToProps, mapDispatchToProps),
+)(GroupsPermissionsPageInner);

--- a/frontend/src/metabase/admin/permissions/permissions.js
+++ b/frontend/src/metabase/admin/permissions/permissions.js
@@ -671,7 +671,7 @@ const hasRevisionChanged = handleActions(
   },
 );
 
-export default combineReducers({
+export const permissions = combineReducers({
   saveError,
   dataPermissions,
   originalDataPermissions,

--- a/frontend/src/metabase/admin/permissions/routes.jsx
+++ b/frontend/src/metabase/admin/permissions/routes.jsx
@@ -11,8 +11,8 @@ import {
 
 import { CollectionPermissionsPage } from "./pages/CollectionPermissionsPage/CollectionPermissionsPage";
 import DataPermissionsPage from "./pages/DataPermissionsPage";
-import DatabasesPermissionsPage from "./pages/DatabasePermissionsPage/DatabasesPermissionsPage";
-import GroupsPermissionsPage from "./pages/GroupDataPermissionsPage/GroupsPermissionsPage";
+import { DatabasesPermissionsPage } from "./pages/DatabasePermissionsPage/DatabasesPermissionsPage";
+import { GroupsPermissionsPage } from "./pages/GroupDataPermissionsPage/GroupsPermissionsPage";
 
 const getRoutes = () => (
   <Route>
@@ -47,4 +47,4 @@ const getRoutes = () => (
   </Route>
 );
 
-export default getRoutes;
+export { getRoutes };

--- a/frontend/src/metabase/admin/permissions/test/DatabasesPermissionsPage/DatabasesPermissionsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/test/DatabasesPermissionsPage/DatabasesPermissionsPage.unit.spec.tsx
@@ -16,7 +16,7 @@ import {
 } from "__support__/ui";
 import { delay } from "__support__/utils";
 import DataPermissionsPage from "metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage";
-import DatabasesPermissionsPage from "metabase/admin/permissions/pages/DatabasePermissionsPage/DatabasesPermissionsPage";
+import { DatabasesPermissionsPage } from "metabase/admin/permissions/pages/DatabasePermissionsPage/DatabasesPermissionsPage";
 import { BEFORE_UNLOAD_UNSAVED_MESSAGE } from "metabase/common/hooks/use-before-unload";
 import { PLUGIN_ADMIN_PERMISSIONS_TABLE_GROUP_ROUTES } from "metabase/plugins";
 import { createMockGroup } from "metabase-types/api/mocks/group";

--- a/frontend/src/metabase/admin/permissions/test/GroupsPermissionsPage/GroupsPermissionsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/test/GroupsPermissionsPage/GroupsPermissionsPage.unit.spec.tsx
@@ -15,7 +15,7 @@ import {
 } from "__support__/ui";
 import { delay } from "__support__/utils";
 import DataPermissionsPage from "metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage";
-import GroupsPermissionsPage from "metabase/admin/permissions/pages/GroupDataPermissionsPage/GroupsPermissionsPage";
+import { GroupsPermissionsPage } from "metabase/admin/permissions/pages/GroupDataPermissionsPage/GroupsPermissionsPage";
 import { BEFORE_UNLOAD_UNSAVED_MESSAGE } from "metabase/common/hooks/use-before-unload";
 import { PLUGIN_ADMIN_PERMISSIONS_TABLE_ROUTES } from "metabase/plugins";
 import { createMockGroup } from "metabase-types/api/mocks/group";

--- a/frontend/src/metabase/admin/routes.jsx
+++ b/frontend/src/metabase/admin/routes.jsx
@@ -6,9 +6,9 @@ import AdminApp from "metabase/admin/app/components/AdminApp";
 import { DatabaseEditApp } from "metabase/admin/databases/containers/DatabaseEditApp";
 import { DatabaseListApp } from "metabase/admin/databases/containers/DatabaseListApp";
 import { DatabasePage } from "metabase/admin/databases/containers/DatabasePage";
-import RevisionHistoryApp from "metabase/admin/datamodel/containers/RevisionHistoryApp";
-import SegmentApp from "metabase/admin/datamodel/containers/SegmentApp";
-import SegmentListApp from "metabase/admin/datamodel/containers/SegmentListApp";
+import { RevisionHistoryApp } from "metabase/admin/datamodel/containers/RevisionHistoryApp";
+import { SegmentApp } from "metabase/admin/datamodel/containers/SegmentApp";
+import { SegmentListApp } from "metabase/admin/datamodel/containers/SegmentListApp";
 import { AdminEmbeddingApp } from "metabase/admin/embedding/containers/AdminEmbeddingApp";
 import { AdminPeopleApp } from "metabase/admin/people/containers/AdminPeopleApp";
 import { EditUserModal } from "metabase/admin/people/containers/EditUserModal";
@@ -20,7 +20,7 @@ import { UserActivationModal } from "metabase/admin/people/containers/UserActiva
 import { UserPasswordResetModal } from "metabase/admin/people/containers/UserPasswordResetModal";
 import { UserSuccessModal } from "metabase/admin/people/containers/UserSuccessModal";
 import { PerformanceApp } from "metabase/admin/performance/components/PerformanceApp";
-import getAdminPermissionsRoutes from "metabase/admin/permissions/routes";
+import { getRoutes as getAdminPermissionsRoutes } from "metabase/admin/permissions/routes";
 import {
   EmbeddingSecuritySettings,
   EmbeddingSettings,
@@ -320,4 +320,4 @@ const getRoutes = (store, CanAccessSettings, IsAdmin) => {
   );
 };
 
-export default getRoutes;
+export { getRoutes };

--- a/frontend/src/metabase/admin/routes.jsx
+++ b/frontend/src/metabase/admin/routes.jsx
@@ -63,7 +63,7 @@ import {
   createTenantsRouteGuard,
 } from "./utils";
 
-const getRoutes = (store, CanAccessSettings, IsAdmin) => {
+export const getRoutes = (store, CanAccessSettings, IsAdmin) => {
   const hasSimpleEmbedding = getTokenFeature(
     store.getState(),
     "embedding_simple",
@@ -319,5 +319,3 @@ const getRoutes = (store, CanAccessSettings, IsAdmin) => {
     </Route>
   );
 };
-
-export { getRoutes };

--- a/frontend/src/metabase/admin/settings/settings.js
+++ b/frontend/src/metabase/admin/settings/settings.js
@@ -77,13 +77,13 @@ export const updateSettings = createThunkAction(
 );
 
 // REDUCERS
-const settings = handleActions(
+const settingsReducer = handleActions(
   {
     [REFRESH_SETTINGS_LIST]: { next: (state, { payload }) => payload },
   },
   [],
 );
 
-export default combineReducers({
-  settings,
+export const settings = combineReducers({
+  settingsReducer,
 });

--- a/frontend/src/metabase/reducers-main.ts
+++ b/frontend/src/metabase/reducers-main.ts
@@ -2,7 +2,7 @@
 
 import { combineReducers } from "@reduxjs/toolkit";
 
-import admin from "metabase/admin/admin";
+import { admin } from "metabase/admin/admin";
 import * as pulse from "metabase/notifications/pulse/reducers";
 import { PLUGIN_REDUCERS } from "metabase/plugins";
 import * as qb from "metabase/query_builder/reducers";

--- a/frontend/src/metabase/reference/segments/SegmentRevisions.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentRevisions.jsx
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import { Component } from "react";
 import { t } from "ttag";
 
-import Revision from "metabase/admin/datamodel/components/revisions/Revision";
+import { Revision } from "metabase/admin/datamodel/components/revisions/Revision";
 import EmptyState from "metabase/common/components/EmptyState";
 import S from "metabase/common/components/List/List.module.css";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -3,7 +3,7 @@ import { IndexRedirect, IndexRoute, Redirect, Route } from "react-router";
 import App from "metabase/App.tsx";
 import getAccountRoutes from "metabase/account/routes";
 import CollectionPermissionsModal from "metabase/admin/permissions/components/CollectionPermissionsModal/CollectionPermissionsModal";
-import getAdminRoutes from "metabase/admin/routes";
+import { getRoutes as getAdminRoutes } from "metabase/admin/routes";
 import { ForgotPassword } from "metabase/auth/components/ForgotPassword";
 import { Login } from "metabase/auth/components/Login";
 import { Logout } from "metabase/auth/components/Logout";


### PR DESCRIPTION
Mostly mechanical.

In some cases moving to named export requires renaming internal components. I followed the following convention using `XInner`

```
// Before:
const Card = () => {
  return <div />
}

export default WithSize(Card);

// After
const CardInner = () => {
  return <div />
}

export const Card = WithSize(CardInner);
```