### PR TITLE
Allow to overwrite id only for native models

### DIFF
--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -1,5 +1,6 @@
 const { H } = cy;
 
+import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   FIRST_COLLECTION_ID,
@@ -11,7 +12,13 @@ import type {
   NativeQuestionDetails,
   StructuredQuestionDetails,
 } from "e2e/support/helpers";
-import type { CardId, FieldReference } from "metabase-types/api";
+import { DataPermissionValue } from "metabase/admin/permissions/types";
+import type {
+  CardId,
+  FieldReference,
+  GroupPermissions,
+  NativePermissions,
+} from "metabase-types/api";
 
 const {
   ORDERS,
@@ -2001,5 +2008,96 @@ describe("issue 38747", () => {
       "Vendor is Nolan-Wolff",
     );
     H.tableInteractive().should("have.attr", "data-rows-count", "1");
+  });
+});
+
+describe("issue 67680", () => {
+  function setTablePermissions(createQueriesPermission: NativePermissions) {
+    const permissions: GroupPermissions = {
+      [SAMPLE_DB_ID]: {
+        "view-data": {
+          public: {
+            [ORDERS_ID]: DataPermissionValue.BLOCKED,
+            [PRODUCTS_ID]: DataPermissionValue.UNRESTRICTED,
+          },
+        },
+        "create-queries": createQueriesPermission,
+      },
+    };
+    cy.updatePermissionsGraph({
+      [USER_GROUPS.ALL_USERS_GROUP]: permissions,
+      [USER_GROUPS.DATA_GROUP]: permissions,
+      [USER_GROUPS.COLLECTION_GROUP]: permissions,
+    });
+  }
+
+  function setTablePermissionsWithCreateQueries() {
+    setTablePermissions(DataPermissionValue.QUERY_BUILDER);
+  }
+
+  function setTablePermissionsWithoutCreateQueries() {
+    setTablePermissions(DataPermissionValue.NO);
+  }
+
+  function updateModelSourceTableWithResultMetadata() {
+    H.visitModel(ORDERS_MODEL_ID);
+    H.openQuestionActions("Edit query definition");
+    H.getNotebookStep("data").findByText("Orders").click();
+    H.popover().findByText("Products").click();
+    H.runButtonInOverlay().click();
+    H.tableInteractiveHeader().findByText("Category").should("be.visible");
+    H.saveMetadataChanges();
+  }
+
+  function updateModelSourceTableWithoutResultMetadata() {
+    H.visitModel(ORDERS_MODEL_ID);
+    H.openQuestionActions("Edit query definition");
+    H.getNotebookStep("data").findByText("Orders").click();
+    H.popover().findByText("Products").click();
+    H.saveMetadataChanges();
+  }
+
+  function verifyNormalUserCanAccessModel() {
+    cy.signInAsNormalUser();
+    H.visitModel(ORDERS_MODEL_ID);
+    H.assertQueryBuilderRowCount(200);
+  }
+
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    H.activateToken("pro-self-hosted");
+  });
+
+  describe("when the user has create queries permission", () => {
+    beforeEach(() => {
+      setTablePermissionsWithCreateQueries();
+    });
+
+    it("should not override column ids for a mbql model when it is saved with result_metadata (metabase#67680)", () => {
+      updateModelSourceTableWithResultMetadata();
+      verifyNormalUserCanAccessModel();
+    });
+
+    it("should not override column ids for a mbql model when it is saved without result_metadata (metabase#67680)", () => {
+      updateModelSourceTableWithoutResultMetadata();
+      verifyNormalUserCanAccessModel();
+    });
+  });
+
+  describe("when the user does not have create queries permission", () => {
+    beforeEach(() => {
+      setTablePermissionsWithoutCreateQueries();
+    });
+
+    it("should not override column ids for a mbql model when it is saved with result_metadata (metabase#67680)", () => {
+      updateModelSourceTableWithResultMetadata();
+      verifyNormalUserCanAccessModel();
+    });
+
+    it("should not override column ids for a mbql model when it is saved without result_metadata (metabase#67680)", () => {
+      updateModelSourceTableWithoutResultMetadata();
+      verifyNormalUserCanAccessModel();
+    });
   });
 });

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditorInner.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditorInner.tsx
@@ -418,10 +418,10 @@ const _DatasetEditorInner = (props: DatasetEditorInnerProps) => {
     (changes: { id: number } & Partial<DatasetColumn>) => {
       const mappedField = metadata?.field?.(changes.id)?.getPlainObject();
       const inheritedProperties =
-        mappedField && getWritableColumnProperties(mappedField);
+        mappedField && getWritableColumnProperties(mappedField, isNative);
       return mappedField ? merge(inheritedProperties, changes) : changes;
     },
-    [metadata],
+    [metadata, isNative],
   );
 
   const onFieldMetadataChange = useCallback(

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -119,72 +119,6 @@ export const getQueryBuilderMode = createSelector(
   (uiControls) => uiControls.queryBuilderMode,
 );
 
-const getCardResultMetadata = createSelector(
-  [getCard],
-  (card) => card?.result_metadata,
-);
-
-const getModelMetadataDiff = createSelector(
-  [getCardResultMetadata, getMetadataDiff, getQueryBuilderMode],
-  (resultMetadata, metadataDiff, queryBuilderMode) => {
-    if (!resultMetadata || queryBuilderMode !== "dataset") {
-      return metadataDiff;
-    }
-
-    return {
-      ...metadataDiff,
-      ...Object.fromEntries(
-        resultMetadata.map((column) => [
-          column.name,
-          {
-            ...getWritableColumnProperties(column),
-            ...metadataDiff[column.name],
-          },
-        ]),
-      ),
-    };
-  },
-);
-
-export const getQueryResults = createSelector(
-  [getRawQueryResults, getModelMetadataDiff],
-  (queryResults, metadataDiff) => {
-    if (!Array.isArray(queryResults) || !queryResults.length) {
-      return null;
-    }
-
-    const [result] = queryResults;
-    if (result.error || !result?.data?.results_metadata) {
-      return queryResults;
-    }
-    const { cols, results_metadata } = result.data;
-
-    function applyMetadataDiff(column) {
-      const columnDiff = metadataDiff[column.name];
-      return columnDiff ? merge(column, columnDiff) : column;
-    }
-
-    return [
-      {
-        ...result,
-        data: {
-          ...result.data,
-          cols: cols.map(applyMetadataDiff),
-          results_metadata: {
-            ...results_metadata,
-            columns: results_metadata.columns.map(applyMetadataDiff),
-          },
-        },
-      },
-    ];
-  },
-);
-
-export const getFirstQueryResult = createSelector(
-  [getQueryResults],
-  (results) => (Array.isArray(results) ? results[0] : null),
-);
-
 export const getQueryStartTime = (state) => state.qb.queryStartTime;
 
 export const getDatabaseId = createSelector(
@@ -218,34 +152,6 @@ export const getParameters = createSelector(
 const getLastRunDatasetQuery = createSelector(
   [getLastRunCard],
   (card) => card && card.dataset_query,
-);
-
-const getLastRunParameters = createSelector(
-  [getFirstQueryResult],
-  (queryResult) =>
-    (queryResult &&
-      queryResult.json_query &&
-      queryResult.json_query.parameters) ||
-    [],
-);
-const getLastRunParameterValues = createSelector(
-  [getLastRunParameters],
-  (parameters) => parameters.map((parameter) => parameter.value),
-);
-const getNextRunParameterValues = createSelector(
-  [getParameters],
-  (parameters) =>
-    parameters.map((parameter) =>
-      // parameters are "normalized" immediately before a query run, so in order
-      // to compare current parameters to previously-used parameters we need
-      // to run parameters through this normalization function
-      normalizeParameterValue(parameter.type, parameter.value),
-    ),
-);
-
-export const getNextRunParameters = createSelector(
-  [getParameters],
-  (parameters) => normalizeParameters(parameters),
 );
 
 export const getPreviousQueryBuilderMode = createSelector(
@@ -307,6 +213,109 @@ export const getQuestion = createSelector(
     const { isEditable } = Lib.queryDisplayInfo(composedQuestion.query());
     return isEditable ? composedQuestion : question;
   },
+);
+
+/**
+ * Returns whether the current question is a native query
+ */
+export const getIsNative = createSelector(
+  [getQuestion],
+  (question) => question && Lib.queryDisplayInfo(question.query()).isNative,
+);
+
+const getCardResultMetadata = createSelector(
+  [getCard],
+  (card) => card?.result_metadata,
+);
+
+const getModelMetadataDiff = createSelector(
+  [getCardResultMetadata, getMetadataDiff, getQueryBuilderMode, getIsNative],
+  (resultMetadata, metadataDiff, queryBuilderMode, isNative) => {
+    if (!resultMetadata || queryBuilderMode !== "dataset") {
+      return metadataDiff;
+    }
+
+    return {
+      ...metadataDiff,
+      ...Object.fromEntries(
+        resultMetadata.map((column) => [
+          column.name,
+          {
+            ...getWritableColumnProperties(column, isNative),
+            ...metadataDiff[column.name],
+          },
+        ]),
+      ),
+    };
+  },
+);
+
+export const getQueryResults = createSelector(
+  [getRawQueryResults, getModelMetadataDiff],
+  (queryResults, metadataDiff) => {
+    if (!Array.isArray(queryResults) || !queryResults.length) {
+      return null;
+    }
+
+    const [result] = queryResults;
+    if (result.error || !result?.data?.results_metadata) {
+      return queryResults;
+    }
+    const { cols, results_metadata } = result.data;
+
+    function applyMetadataDiff(column) {
+      const columnDiff = metadataDiff[column.name];
+      return columnDiff ? merge(column, columnDiff) : column;
+    }
+
+    return [
+      {
+        ...result,
+        data: {
+          ...result.data,
+          cols: cols.map(applyMetadataDiff),
+          results_metadata: {
+            ...results_metadata,
+            columns: results_metadata.columns.map(applyMetadataDiff),
+          },
+        },
+      },
+    ];
+  },
+);
+
+export const getFirstQueryResult = createSelector(
+  [getQueryResults],
+  (results) => (Array.isArray(results) ? results[0] : null),
+);
+
+const getLastRunParameters = createSelector(
+  [getFirstQueryResult],
+  (queryResult) =>
+    (queryResult &&
+      queryResult.json_query &&
+      queryResult.json_query.parameters) ||
+    [],
+);
+
+const getLastRunParameterValues = createSelector(
+  [getLastRunParameters],
+  (parameters) => parameters.map((parameter) => parameter.value),
+);
+const getNextRunParameterValues = createSelector(
+  [getParameters],
+  (parameters) =>
+    parameters.map((parameter) =>
+      // parameters are "normalized" immediately before a query run, so in order
+      // to compare current parameters to previously-used parameters we need
+      // to run parameters through this normalization function
+      normalizeParameterValue(parameter.type, parameter.value),
+    ),
+);
+
+export const getNextRunParameters = createSelector(
+  [getParameters],
+  (parameters) => normalizeParameters(parameters),
 );
 
 export const getTableId = createSelector([getQuestion], (question) => {
@@ -707,14 +716,6 @@ export const getTransformedVisualization = createSelector(
 export const getVisualizationSettings = createSelector(
   [getTransformedSeries],
   (series) => series && getComputedSettingsForSeries(series),
-);
-
-/**
- * Returns whether the current question is a native query
- */
-export const getIsNative = createSelector(
-  [getQuestion],
-  (question) => question && Lib.queryDisplayInfo(question.query()).isNative,
 );
 
 /**

--- a/frontend/src/metabase/query_builder/utils/index.ts
+++ b/frontend/src/metabase/query_builder/utils/index.ts
@@ -166,8 +166,7 @@ export const createRawSeries = (options: {
   );
 };
 
-const WRITABLE_COLUMN_PROPERTIES = [
-  "id",
+const WRITABLE_MBQL_COLUMN_PROPERTIES = [
   "display_name",
   "description",
   "semantic_type",
@@ -176,6 +175,16 @@ const WRITABLE_COLUMN_PROPERTIES = [
   "settings",
 ];
 
-export function getWritableColumnProperties(column: Field) {
-  return _.pick(column, WRITABLE_COLUMN_PROPERTIES);
+const WRITABLE_NATIVE_COLUMN_PROPERTIES = [
+  "id",
+  ...WRITABLE_MBQL_COLUMN_PROPERTIES,
+];
+
+export function getWritableColumnProperties(column: Field, isNative: boolean) {
+  return _.pick(
+    column,
+    isNative
+      ? WRITABLE_NATIVE_COLUMN_PROPERTIES
+      : WRITABLE_MBQL_COLUMN_PROPERTIES,
+  );
 }

--- a/src/metabase/lib/card.cljc
+++ b/src/metabase/lib/card.cljc
@@ -200,20 +200,20 @@
   metadata, the types returned should be authoritative. But things like semantic_type, display_name, and description
   can be merged on top.
 
-  Returns `:id` only if `native?` is true. This is because we allow to override the `:id` for native models only."
-  [native? :- :boolean]
+  Returns `:id` for native models only."
+  [native-model? :- :boolean]
   (cond-> [:description :display-name :semantic-type :fk-target-field-id :settings :visibility-type :lib/source-display-name]
-    native? (conj :id)))
+    native-model? (conj :id)))
 
 ;;; TODO (Cam 6/13/25) -- duplicated/overlapping responsibility with [[metabase.lib.field/previous-stage-metadata]] as
 ;;; well as [[metabase.lib.metadata.result-metadata/merge-model-metadata]] -- find a way to deduplicate these
 (mu/defn merge-model-metadata :- [:sequential ::lib.schema.metadata/column]
   "Merge metadata from source model metadata into result cols.
 
-  Overrides `:id` only if `native?` is true. This is because we allow to override the `:id` for native models only."
-  [result-cols :- [:maybe [:sequential ::lib.schema.metadata/column]]
-   model-cols  :- [:maybe [:sequential ::lib.schema.metadata/column]]
-   native?     :- :boolean]
+  Overrides `:id` for native models only."
+  [result-cols   :- [:maybe [:sequential ::lib.schema.metadata/column]]
+   model-cols    :- [:maybe [:sequential ::lib.schema.metadata/column]]
+   native-model? :- :boolean]
   (cond
     (and (seq result-cols)
          (empty? model-cols))
@@ -233,7 +233,7 @@
                ;; not because the calculated one e.g. 'Sum of ____' is going to be better than '____'
                (when-not (= (:lib/source result-col) :source/aggregations)
                  (when-let [model-col (get name->model-col (:name result-col))]
-                   (let [model-col     (u/select-non-nil-keys model-col (model-preserved-keys native?))
+                   (let [model-col     (u/select-non-nil-keys model-col (model-preserved-keys native-model?))
                          temporal-unit (lib.temporal-bucket/raw-temporal-bucket result-col)
                          binning       (lib.binning/binning result-col)
                          semantic-type ((some-fn model-col result-col) :semantic-type)]

--- a/src/metabase/lib/card.cljc
+++ b/src/metabase/lib/card.cljc
@@ -255,7 +255,8 @@
             model-cols    (when model-card
                             (card-cols* metadata-providerable model-card))
             native-model? (when model-card
-                            (-> (card->underlying-query metadata-providerable model-card) lib.util/native-stage? -1))]
+                            (-> (card->underlying-query metadata-providerable model-card)
+                                (lib.util/native-stage? -1)))]
         (not-empty
          (into []
                ;; do not truncate the desired column aliases coming back in card metadata, if the query returns a

--- a/src/metabase/lib/card.cljc
+++ b/src/metabase/lib/card.cljc
@@ -159,6 +159,23 @@
                  (select-keys metadata-provider-col [:active]))))
             saved-metadata-cols))))
 
+(mu/defn card->underlying-query :- ::lib.schema/query
+  "Given a `card` return the underlying query that would be run if executing the Card directly. This is different from
+
+    (lib/query mp (lib.metadata/card mp card-id))
+
+  in that this creates a query based on the Card's `:dataset-query` (attaching `:result-metadata` to the last stage)
+  rather than a query that has an empty stage with a `:source-card`.
+
+  This is useful in cases where we want to splice in a Card's query directly (e.g., sanboxing) or for parameter
+  calculation purposes."
+  [metadata-providerable :- ::lib.schema.metadata/metadata-providerable
+   card                  :- ::lib.schema.metadata/card]
+  (let [mp                                                            (lib.metadata/->metadata-provider metadata-providerable)
+        {card-query :dataset-query, result-metadata :result-metadata} card]
+    (cond-> (lib.query/query mp card-query)
+      result-metadata (lib.util/update-query-stage -1 assoc :lib/stage-metadata (lib.normalize/->normalized-stage-metadata result-metadata)))))
+
 (mu/defn- card-cols* :- [:maybe [:sequential ::lib.schema.metadata/column]]
   [metadata-providerable :- ::lib.schema.metadata/metadata-providerable
    card                  :- ::lib.schema.metadata/card]
@@ -167,8 +184,8 @@
                       (not-empty (infer-returned-columns metadata-providerable card)))]
     (->card-metadata-columns metadata-providerable card cols)))
 
-(mu/defn- source-model-cols :- [:maybe [:sequential ::lib.schema.metadata/column]]
-  "If `card` itself has a source card that is a Model, return that Model's columns."
+(mu/defn- source-model-card :- [:maybe ::lib.schema.metadata/card]
+  "If `card` itself has a source card that is a Model, return that source card."
   [metadata-providerable :- ::lib.schema.metadata/metadata-providerable
    card                  :- ::lib.schema.metadata/card]
   (when-let [card-query (some->> (:dataset-query card) not-empty (lib.query/query metadata-providerable))]
@@ -176,21 +193,27 @@
       (when-not (= source-card-id (:id card))
         (let [source-card (lib.metadata/card metadata-providerable source-card-id)]
           (when (= (:type source-card) :model)
-            (card-cols* metadata-providerable source-card)))))))
+            source-card))))))
 
-(def ^:private model-preserved-keys
+(mu/defn- model-preserved-keys :- [:sequential :keyword]
   "Keys that can survive merging metadata from the database onto metadata computed from the query. When merging
   metadata, the types returned should be authoritative. But things like semantic_type, display_name, and description
-  can be merged on top."
-  [:id :description :display-name :semantic-type :fk-target-field-id :settings :visibility-type
-   :lib/source-display-name])
+  can be merged on top.
+
+  Returns `:id` only if `native?` is true. This is because we allow to override the :id for native models only."
+  [native? :- :boolean]
+  (cond-> [:description :display-name :semantic-type :fk-target-field-id :settings :visibility-type :lib/source-display-name]
+    native? (conj :id)))
 
 ;;; TODO (Cam 6/13/25) -- duplicated/overlapping responsibility with [[metabase.lib.field/previous-stage-metadata]] as
 ;;; well as [[metabase.lib.metadata.result-metadata/merge-model-metadata]] -- find a way to deduplicate these
 (mu/defn merge-model-metadata :- [:sequential ::lib.schema.metadata/column]
-  "Merge metadata from source model metadata into result cols."
+  "Merge metadata from source model metadata into result cols.
+
+  Overrides `:id` only if `native?` is true. This is because we allow to override the id for native models only."
   [result-cols :- [:maybe [:sequential ::lib.schema.metadata/column]]
-   model-cols  :- [:maybe [:sequential ::lib.schema.metadata/column]]]
+   model-cols  :- [:maybe [:sequential ::lib.schema.metadata/column]]
+   native?     :- :boolean]
   (cond
     (and (seq result-cols)
          (empty? model-cols))
@@ -210,7 +233,7 @@
                ;; not because the calculated one e.g. 'Sum of ____' is going to be better than '____'
                (when-not (= (:lib/source result-col) :source/aggregations)
                  (when-let [model-col (get name->model-col (:name result-col))]
-                   (let [model-col     (u/select-non-nil-keys model-col model-preserved-keys)
+                   (let [model-col     (u/select-non-nil-keys model-col (model-preserved-keys native?))
                          temporal-unit (lib.temporal-bucket/raw-temporal-bucket result-col)
                          binning       (lib.binning/binning result-col)
                          semantic-type ((some-fn model-col result-col) :semantic-type)]
@@ -225,10 +248,14 @@
    card                  :- ::lib.schema.metadata/card]
   (when-not (contains? *card-metadata-columns-card-ids* (:id card))
     (binding [*card-metadata-columns-card-ids* (conj *card-metadata-columns-card-ids* (:id card))]
-      (let [result-cols (card-cols* metadata-providerable card)
+      (let [result-cols   (card-cols* metadata-providerable card)
             ;; don't pull in metadata from parent model if we ourself are a model
-            model-cols  (when-not (= (:type card) :model)
-                          (source-model-cols metadata-providerable card))]
+            model-card    (when-not (= (:type card) :model)
+                            (source-model-card metadata-providerable card))
+            model-cols    (when model-card
+                            (card-cols* metadata-providerable model-card))
+            native-model? (when model-card
+                            (-> (card->underlying-query metadata-providerable model-card) lib.util/native-stage? -1))]
         (not-empty
          (into []
                ;; do not truncate the desired column aliases coming back in card metadata, if the query returns a
@@ -236,7 +263,7 @@
                ;; See [[metabase.lib.card-test/propagate-crazy-long-identifiers-from-card-metadata-test]]
                (lib.field.util/add-source-and-desired-aliases-xform metadata-providerable (lib.util.unique-name-generator/non-truncating-unique-name-generator))
                (cond-> result-cols
-                 (seq model-cols) (merge-model-metadata model-cols))))))))
+                 (seq model-cols) (merge-model-metadata model-cols native-model?))))))))
 
 (mu/defn saved-question-metadata :- ::maybe-columns
   "Metadata associated with a Saved Question with `card-id`."
@@ -279,20 +306,3 @@
   "Is the query's source-card a model?"
   [query :- ::lib.schema/query]
   (= (source-card-type query) :model))
-
-(mu/defn card->underlying-query :- ::lib.schema/query
-  "Given a `card` return the underlying query that would be run if executing the Card directly. This is different from
-
-    (lib/query mp (lib.metadata/card mp card-id))
-
-  in that this creates a query based on the Card's `:dataset-query` (attaching `:result-metadata` to the last stage)
-  rather than a query that has an empty stage with a `:source-card`.
-
-  This is useful in cases where we want to splice in a Card's query directly (e.g., sanboxing) or for parameter
-  calculation purposes."
-  [metadata-providerable :- ::lib.schema.metadata/metadata-providerable
-   card                  :- ::lib.schema.metadata/card]
-  (let [mp                                                            (lib.metadata/->metadata-provider metadata-providerable)
-        {card-query :dataset-query, result-metadata :result-metadata} card]
-    (cond-> (lib.query/query mp card-query)
-      result-metadata (lib.util/update-query-stage -1 assoc :lib/stage-metadata (lib.normalize/->normalized-stage-metadata result-metadata)))))

--- a/src/metabase/lib/card.cljc
+++ b/src/metabase/lib/card.cljc
@@ -200,7 +200,7 @@
   metadata, the types returned should be authoritative. But things like semantic_type, display_name, and description
   can be merged on top.
 
-  Returns `:id` only if `native?` is true. This is because we allow to override the :id for native models only."
+  Returns `:id` only if `native?` is true. This is because we allow to override the `:id` for native models only."
   [native? :- :boolean]
   (cond-> [:description :display-name :semantic-type :fk-target-field-id :settings :visibility-type :lib/source-display-name]
     native? (conj :id)))
@@ -210,7 +210,7 @@
 (mu/defn merge-model-metadata :- [:sequential ::lib.schema.metadata/column]
   "Merge metadata from source model metadata into result cols.
 
-  Overrides `:id` only if `native?` is true. This is because we allow to override the id for native models only."
+  Overrides `:id` only if `native?` is true. This is because we allow to override the `:id` for native models only."
   [result-cols :- [:maybe [:sequential ::lib.schema.metadata/column]]
    model-cols  :- [:maybe [:sequential ::lib.schema.metadata/column]]
    native?     :- :boolean]

--- a/src/metabase/lib/metadata/result_metadata.cljc
+++ b/src/metabase/lib/metadata/result_metadata.cljc
@@ -383,6 +383,7 @@
     (if-not (seq model-metadata)
       cols ; If not a model, nothing to change
       (let [last-stage (lib.util/query-stage query -1)
+            ;; Assumption: we're in a call path in which fetch-source-query has added this field
             native-model? (if (contains? last-stage :source-query/native-model?)
                             (:source-query/native-model? last-stage)
                             false)]

--- a/src/metabase/lib/metadata/result_metadata.cljc
+++ b/src/metabase/lib/metadata/result_metadata.cljc
@@ -381,7 +381,7 @@
                                 (lib.card/->card-metadata-columns query))]
     (cond-> cols
       (seq model-metadata)
-      ;; TODO (Alex P 1/6/26) -- we need to pass in `native?` here.
+      ;; TODO (Alex P 1/6/26) -- we need to pass in `native-model?` here.
       (lib.card/merge-model-metadata model-metadata true))))
 
 (defn- add-source-and-desired-aliases [query cols]

--- a/src/metabase/lib/metadata/result_metadata.cljc
+++ b/src/metabase/lib/metadata/result_metadata.cljc
@@ -383,10 +383,13 @@
     (if-not (seq model-metadata)
       cols ; If not a model, nothing to change
       (let [last-stage (lib.util/query-stage query -1)
-            ;; Assumption: we're in a call path in which fetch-source-query has added this field
+            ;; Assumption: we're in a call path in which fetch-source-query has added this field.
+            ;; Fallback: for direct model queries (e.g. viewing a native model), fetch-source-query
+            ;; doesn't run because there's no :source-card to resolve. In that case, check if the
+            ;; query stage itself is native.
             native-model? (if (contains? last-stage :source-query/native-model?)
                             (:source-query/native-model? last-stage)
-                            false)]
+                            (lib.util/native-stage? last-stage))]
         (lib.card/merge-model-metadata cols model-metadata native-model?)))))
 
 (defn- add-source-and-desired-aliases [query cols]

--- a/src/metabase/lib/metadata/result_metadata.cljc
+++ b/src/metabase/lib/metadata/result_metadata.cljc
@@ -381,7 +381,8 @@
                                 (lib.card/->card-metadata-columns query))]
     (cond-> cols
       (seq model-metadata)
-      (lib.card/merge-model-metadata model-metadata))))
+      ;; TODO (Alex P 1/6/26) -- we need to pass in `native?` here.
+      (lib.card/merge-model-metadata model-metadata true))))
 
 (defn- add-source-and-desired-aliases [query cols]
   (into []

--- a/src/metabase/lib/metadata/result_metadata.cljc
+++ b/src/metabase/lib/metadata/result_metadata.cljc
@@ -387,8 +387,7 @@
             native-model? (if card
                             (-> (lib.card/card->underlying-query query card)
                                 (lib.util/native-stage? -1))
-                            ;; fallback if no card found: check if current query is native
-                            (lib.util/native-stage? query -1))]
+                            false)]
         (lib.card/merge-model-metadata cols model-metadata native-model?)))))
 
 (defn- add-source-and-desired-aliases [query cols]

--- a/src/metabase/queries/models/card/metadata.clj
+++ b/src/metabase/queries/models/card/metadata.clj
@@ -192,8 +192,10 @@ saved later when it is ready."
   (let [model?         (= (:type card) :model)
         model-metadata (when model? (:result_metadata card))
         ;; If this is a model, include that model metadata so QP will infer correctly overridden metadata.
+        ;; Also include :card-id for the model so downstream code can look it up
         query          (cond-> query
-                         model-metadata (update :info merge {:metadata/model-metadata model-metadata}))]
+                         model-metadata (update :info merge {:metadata/model-metadata model-metadata
+                                                             :card-id (:id card)}))]
     (infer-metadata query)))
 
 ;; TODO: Refactor this to use idents rather than names, so it's more robust.

--- a/src/metabase/queries/models/card/metadata.clj
+++ b/src/metabase/queries/models/card/metadata.clj
@@ -192,10 +192,8 @@ saved later when it is ready."
   (let [model?         (= (:type card) :model)
         model-metadata (when model? (:result_metadata card))
         ;; If this is a model, include that model metadata so QP will infer correctly overridden metadata.
-        ;; Also include :card-id for the model so downstream code can look it up
         query          (cond-> query
-                         model-metadata (update :info merge {:metadata/model-metadata model-metadata
-                                                             :card-id (:id card)}))]
+                         model-metadata (update :info merge {:metadata/model-metadata model-metadata}))]
     (infer-metadata query)))
 
 ;; TODO: Refactor this to use idents rather than names, so it's more robust.

--- a/src/metabase/query_processor/middleware/fetch_source_query.clj
+++ b/src/metabase/query_processor/middleware/fetch_source_query.clj
@@ -120,22 +120,22 @@
                        (tru "Card {0}" (:source-card stage)))
         ;; This will throw if there's a cycle
         (dep/topo-sort <>)))
-    (let [card         (card query (:source-card stage))
-          card-stages  (get-in card [:dataset-query :stages])
+    (let [card          (card query (:source-card stage))
+          card-stages   (get-in card [:dataset-query :stages])
           model?        (= (:type card) :model)
-          native-model? (and model?
-                             (-> (lib.card/card->underlying-query query card)
-                                 (lib.util/native-stage? -1)))
+          native-model? (when model?
+                          (-> (lib.card/card->underlying-query query card)
+                              (lib.util/native-stage? -1)))
           ;; TODO this information WAS used
           ;; by [[metabase.query-processor.middleware.annotate/col-info-for-field-clause*]] which doesn't exist anymore
           ;; -- do we still need it? -- Cam
           stage'        (-> stage
-                             ;; these keys are used by the [[metabase.query-processor.middleware.annotate]] middleware to
-                             ;; decide whether to "flow" the Card's metadata or not (whether to use it preferentially over
-                             ;; the metadata associated with Fields themselves)
+                            ;; these keys are used by the [[metabase.query-processor.middleware.annotate]] middleware to
+                            ;; decide whether to "flow" the Card's metadata or not (whether to use it preferentially over
+                            ;; the metadata associated with Fields themselves)
                             (assoc :qp/stage-had-source-card (:id card)
-                                   :source-query/model? model?
-                                   :source-query/native-model? native-model?)
+                                   :source-query/model? model?)
+                            (cond-> model? (assoc :source-query/native-model? native-model?))
                             (dissoc :source-card))]
       (into (vec card-stages) [stage']))))
 

--- a/src/metabase/query_processor/middleware/fetch_source_query.clj
+++ b/src/metabase/query_processor/middleware/fetch_source_query.clj
@@ -122,15 +122,20 @@
         (dep/topo-sort <>)))
     (let [card         (card query (:source-card stage))
           card-stages  (get-in card [:dataset-query :stages])
+          model?        (= (:type card) :model)
+          native-model? (and model?
+                             (-> (lib.card/card->underlying-query query card)
+                                 (lib.util/native-stage? -1)))
           ;; TODO this information WAS used
           ;; by [[metabase.query-processor.middleware.annotate/col-info-for-field-clause*]] which doesn't exist anymore
           ;; -- do we still need it? -- Cam
           stage'        (-> stage
-                            ;; these keys are used by the [[metabase.query-processor.middleware.annotate]] middleware to
-                            ;; decide whether to "flow" the Card's metadata or not (whether to use it preferentially over
-                            ;; the metadata associated with Fields themselves)
+                             ;; these keys are used by the [[metabase.query-processor.middleware.annotate]] middleware to
+                             ;; decide whether to "flow" the Card's metadata or not (whether to use it preferentially over
+                             ;; the metadata associated with Fields themselves)
                             (assoc :qp/stage-had-source-card (:id card)
-                                   :source-query/model?      (= (:type card) :model))
+                                   :source-query/model? model?
+                                   :source-query/native-model? native-model?)
                             (dissoc :source-card))]
       (into (vec card-stages) [stage']))))
 

--- a/test/metabase/lib/card_test.cljc
+++ b/test/metabase/lib/card_test.cljc
@@ -460,12 +460,12 @@
                                      (lib/expression query "ID" 1)
                                      (lib/with-fields query [(lib/expression-ref query "ID")]))))))))))))))))))
 
-(deftest ^:parallel source-model-cols-test
-  (testing "source-model-cols should not fail in FE usage where Card metadata may not have a query"
+(deftest ^:parallel source-model-card-test
+  (testing "source-model-card should not fail in FE usage where Card metadata may not have a query"
     (let [mp (lib.tu/mock-metadata-provider
               meta/metadata-provider
               {:cards [{:id 1, :name "Card 1", :database-id (meta/id)}]})]
-      (is (nil? (#'lib.card/source-model-cols mp (lib.metadata/card mp 1)))))))
+      (is (nil? (#'lib.card/source-model-card mp (lib.metadata/card mp 1)))))))
 
 (deftest ^:parallel do-not-include-join-aliases-in-original-display-names-test
   (let [query (lib.tu.mocks-31368/query-with-legacy-source-card true)]

--- a/test/metabase/lib/metadata/result_metadata_test.cljc
+++ b/test/metabase/lib/metadata/result_metadata_test.cljc
@@ -966,6 +966,49 @@
                    {:name "PRICE",       :description "user description", :display-name "user display name", :semantic-type :type/Quantity}]
                   (result-metadata/returned-columns query))))))))
 
+(deftest ^:parallel model-metadata-id-preservation-test
+  (testing "Model metadata :id handling based on query type (#67680)"
+    (testing "MBQL query: stale :id from model metadata should be ignored"
+      ;; When a model's source table changes, result_metadata may have stale :id values
+      ;; pointing to the old table. These should NOT override the :id from query analysis.
+      (let [query                     (lib/query meta/metadata-provider
+                                                 {:database (meta/id)
+                                                  :type     :query
+                                                  :query    {:source-table (meta/id :venues)}})
+            ;; Get the real columns to use as a base
+            real-cols                 (result-metadata/returned-columns query)
+            real-id                   (:id (first real-cols))
+            ;; Create "stale" model metadata with wrong :id values (pointing to ORDERS instead of VENUES)
+            stale-model-metadata      (for [col real-cols]
+                                        {:name          (:name col)
+                                         :display_name  (:display-name col)
+                                         :base_type     (:base-type col)
+                                         :semantic_type (:semantic-type col)
+                                         :id            (meta/id :orders :id)
+                                         :table_id      (meta/id :orders)})
+            ;; Add stale metadata to query
+            query-with-stale-metadata (assoc-in query [:info :metadata/model-metadata] stale-model-metadata)
+            result-cols               (result-metadata/returned-columns query-with-stale-metadata)]
+        (is (= real-id (:id (first result-cols)))
+            "MBQL models should use :id from query analysis, not stale model metadata")))
+    (testing "Native query: :id from model metadata should be preserved"
+      ;; Native queries have no field references to analyze, so user-mapped :id values
+      ;; from model metadata are the only source of field linkage and must be preserved.
+      (let [native-query         (lib/query meta/metadata-provider
+                                            {:database (meta/id)
+                                             :type     :native
+                                             :native   {:query "SELECT * FROM venues"}})
+            ;; User-mapped model metadata with explicit :id values
+            user-mapped-metadata [{:name         "ID"
+                                   :display_name "Venue ID"
+                                   :base_type    :type/BigInteger
+                                   :id           (meta/id :venues :id)
+                                   :table_id     (meta/id :venues)}]
+            query-with-metadata  (assoc-in native-query [:info :metadata/model-metadata] user-mapped-metadata)
+            result-cols          (result-metadata/returned-columns query-with-metadata)]
+        (is (= (meta/id :venues :id) (:id (first result-cols)))
+            "Native models should preserve :id from model metadata (user mappings)")))))
+
 (deftest ^:parallel propagate-binning-test
   (testing "Test this stuff the same way this stuff is tested in the Cypress e2e notebook tests"
     (let [mp (lib.tu/mock-metadata-provider

--- a/test/metabase/lib/metadata/result_metadata_test.cljc
+++ b/test/metabase/lib/metadata/result_metadata_test.cljc
@@ -994,10 +994,7 @@
     (testing "Native query: :id from model metadata should be preserved"
       ;; Native queries have no field references to analyze, so user-mapped :id values
       ;; from model metadata are the only source of field linkage and must be preserved.
-      (let [native-query         (lib/query meta/metadata-provider
-                                            {:database (meta/id)
-                                             :type     :native
-                                             :native   {:query "SELECT * FROM venues"}})
+      (let [native-query         (lib/native-query meta/metadata-provider "SELECT * FROM venues")
             ;; User-mapped model metadata with explicit :id values
             user-mapped-metadata [{:name         "ID"
                                    :display_name "Venue ID"


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/67680

Allow to override `:id` in `:result_metadata` for native models only. This is already the case for the UI, but internally we allowed `:id` overrides for MBQL models as well. This results in a case where there is a column with a stale `:id` pointing to a field in a table that the user might not have access to. 