### PR TITLE
Use named exports in query_builder code

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/ai-entity-analysis/components/AIQuestionAnalysisSidebar/AIQuestionAnalysisSidebar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-entity-analysis/components/AIQuestionAnalysisSidebar/AIQuestionAnalysisSidebar.tsx
@@ -5,7 +5,7 @@ import { t } from "ttag";
 import { CopyButton } from "metabase/common/components/CopyButton";
 import { useSelector } from "metabase/lib/redux";
 import type { AIQuestionAnalysisSidebarProps } from "metabase/plugins";
-import SidebarContent from "metabase/query_builder/components/SidebarContent";
+import { SidebarContent } from "metabase/query_builder/components/SidebarContent";
 import { getIsLoadingComplete } from "metabase/query_builder/selectors";
 import { Box } from "metabase/ui";
 import {

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/OverviewVisualization/OverviewVisualization.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/OverviewVisualization/OverviewVisualization.tsx
@@ -7,7 +7,7 @@ import {
 } from "metabase/api";
 import DebouncedFrame from "metabase/common/components/DebouncedFrame";
 import { useSelector } from "metabase/lib/redux";
-import QueryVisualization from "metabase/query_builder/components/QueryVisualization";
+import { QueryVisualization } from "metabase/query_builder/components/QueryVisualization";
 import { getMetadata } from "metabase/selectors/metadata";
 import Question from "metabase-lib/v1/Question";
 import type { Card } from "metabase-types/api";

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonEditorBody/PythonEditorBody.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonEditorBody/PythonEditorBody.tsx
@@ -7,7 +7,7 @@ import { t } from "ttag";
 import { clickableTokens } from "metabase/common/components/CodeMirror";
 import { useDispatch } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
-import RunButtonWithTooltip from "metabase/query_builder/components/RunButtonWithTooltip";
+import { RunButtonWithTooltip } from "metabase/query_builder/components/RunButtonWithTooltip";
 import { Button, Flex, Icon, Stack, Tooltip } from "metabase/ui";
 import { SHARED_LIB_IMPORT_PATH } from "metabase-enterprise/transforms-python/constants";
 

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Visualization.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Visualization.tsx
@@ -14,7 +14,7 @@ import { useSdkSelector } from "embedding-sdk-bundle/store";
 import { getIsGuestEmbed } from "embedding-sdk-bundle/store/selectors";
 import { useLocale } from "metabase/common/hooks/use-locale";
 import CS from "metabase/css/core/index.css";
-import QueryVisualization from "metabase/query_builder/components/QueryVisualization";
+import { QueryVisualization } from "metabase/query_builder/components/QueryVisualization";
 import type Question from "metabase-lib/v1/Question";
 import type { CardDisplayType } from "metabase-types/api";
 

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.tsx
@@ -9,7 +9,7 @@ import type {
 } from "metabase/common/components/Sortable";
 import { Sortable, SortableList } from "metabase/common/components/Sortable";
 import { Form, FormProvider } from "metabase/forms";
-import SidebarContent from "metabase/query_builder/components/SidebarContent";
+import { SidebarContent } from "metabase/query_builder/components/SidebarContent";
 import { Flex, Icon, UnstyledButton } from "metabase/ui";
 import type {
   ActionFormSettings,

--- a/frontend/src/metabase/actions/containers/ActionCreator/InlineActionSettings.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/InlineActionSettings.tsx
@@ -11,7 +11,7 @@ import { useUniqueId } from "metabase/common/hooks/use-unique-id";
 import { Actions } from "metabase/entities/actions/actions";
 import { connect } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
-import SidebarContent from "metabase/query_builder/components/SidebarContent";
+import { SidebarContent } from "metabase/query_builder/components/SidebarContent";
 import { getSetting } from "metabase/selectors/settings";
 import { getUserIsAdmin } from "metabase/selectors/user";
 import { Switch, Tooltip } from "metabase/ui";

--- a/frontend/src/metabase/actions/containers/ActionCreator/InlineDataReference.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/InlineDataReference.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { t } from "ttag";
 
 import Button from "metabase/common/components/Button";
-import DataReference from "metabase/query_builder/components/dataref/DataReference";
+import { DataReference } from "metabase/query_builder/components/dataref/DataReference";
 import { Tooltip } from "metabase/ui";
 
 export const DataReferenceInline = ({

--- a/frontend/src/metabase/common/components/BookmarkToggle/BookmarkToggle.tsx
+++ b/frontend/src/metabase/common/components/BookmarkToggle/BookmarkToggle.tsx
@@ -14,7 +14,7 @@ export interface BookmarkToggleProps extends ActionIconProps {
   onDeleteBookmark: () => void;
 }
 
-const BookmarkToggle = forwardRef(function BookmarkToggle(
+export const BookmarkToggle = forwardRef(function BookmarkToggle(
   {
     isBookmarked,
     onCreateBookmark,
@@ -67,5 +67,3 @@ const BookmarkToggle = forwardRef(function BookmarkToggle(
     </Tooltip>
   );
 });
-
-export { BookmarkToggle };

--- a/frontend/src/metabase/common/components/Modal/Modal.tsx
+++ b/frontend/src/metabase/common/components/Modal/Modal.tsx
@@ -5,9 +5,7 @@ import { useDisableCommandPalette } from "metabase/palette/hooks/useDisableComma
 export type ModalProps = WindowModalProps;
 
 /** @deprecated use Modal from metabase/ui */
-const Modal = ({ isOpen = true, ...props }: ModalProps) => {
+export const Modal = ({ isOpen = true, ...props }: ModalProps) => {
   useDisableCommandPalette({ disabled: isOpen });
   return <WindowModal isOpen={isOpen} {...props} />;
 };
-
-export { Modal };

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -24,12 +24,12 @@ import {
   isVirtualCardId,
 } from "metabase-lib/v1/metadata/utils/saved-questions";
 
-import { DataBucketPicker } from "./DataSelectorDataBucketPicker";
-import { DatabasePicker } from "./DataSelectorDatabasePicker";
-import { DatabaseSchemaPicker } from "./DataSelectorDatabaseSchemaPicker";
-import { FieldPicker } from "./DataSelectorFieldPicker";
-import { SchemaPicker } from "./DataSelectorSchemaPicker";
-import { TablePicker } from "./DataSelectorTablePicker";
+import { DataSelectorDataBucketPicker } from "./DataSelectorDataBucketPicker";
+import { DataSelectorDatabasePicker } from "./DataSelectorDatabasePicker";
+import { DataSelectorDatabaseSchemaPicker } from "./DataSelectorDatabaseSchemaPicker";
+import { DataSelectorFieldPicker } from "./DataSelectorFieldPicker";
+import { DataSelectorSchemaPicker } from "./DataSelectorSchemaPicker";
+import { DataSelectorTablePicker } from "./DataSelectorTablePicker";
 import {
   DatabaseTrigger,
   FieldTrigger,
@@ -911,7 +911,7 @@ export class UnconnectedDataSelector extends Component {
       case DATA_BUCKET_STEP:
         return (
           <Box p="sm">
-            <DataBucketPicker
+            <DataSelectorDataBucketPicker
               dataTypes={getDataTypes({
                 hasModels: this.hasModels(),
                 hasTables: this.props.canSelectTable,
@@ -925,20 +925,26 @@ export class UnconnectedDataSelector extends Component {
         );
       case DATABASE_STEP:
         return combineDatabaseSchemaSteps ? (
-          <DatabaseSchemaPicker {...props} hasBackButton={hasBackButton} />
+          <DataSelectorDatabaseSchemaPicker
+            {...props}
+            hasBackButton={hasBackButton}
+          />
         ) : (
-          <DatabasePicker {...props} />
+          <DataSelectorDatabasePicker {...props} />
         );
       case SCHEMA_STEP:
         return combineDatabaseSchemaSteps ? (
-          <DatabaseSchemaPicker {...props} hasBackButton={hasBackButton} />
+          <DataSelectorDatabaseSchemaPicker
+            {...props}
+            hasBackButton={hasBackButton}
+          />
         ) : (
-          <SchemaPicker {...props} />
+          <DataSelectorSchemaPicker {...props} />
         );
       case TABLE_STEP:
-        return <TablePicker {...props} />;
+        return <DataSelectorTablePicker {...props} />;
       case FIELD_STEP:
-        return <FieldPicker {...props} />;
+        return <DataSelectorFieldPicker {...props} />;
     }
 
     return null;

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -24,12 +24,12 @@ import {
   isVirtualCardId,
 } from "metabase-lib/v1/metadata/utils/saved-questions";
 
-import DataBucketPicker from "./DataSelectorDataBucketPicker";
-import DatabasePicker from "./DataSelectorDatabasePicker";
-import DatabaseSchemaPicker from "./DataSelectorDatabaseSchemaPicker";
-import FieldPicker from "./DataSelectorFieldPicker";
-import SchemaPicker from "./DataSelectorSchemaPicker";
-import TablePicker from "./DataSelectorTablePicker";
+import { DataBucketPicker } from "./DataSelectorDataBucketPicker";
+import { DatabasePicker } from "./DataSelectorDatabasePicker";
+import { DatabaseSchemaPicker } from "./DataSelectorDatabaseSchemaPicker";
+import { FieldPicker } from "./DataSelectorFieldPicker";
+import { SchemaPicker } from "./DataSelectorSchemaPicker";
+import { TablePicker } from "./DataSelectorTablePicker";
 import {
   DatabaseTrigger,
   FieldTrigger,
@@ -37,7 +37,7 @@ import {
   Trigger,
 } from "./TriggerComponents";
 import { CONTAINER_WIDTH, DATA_BUCKET } from "./constants";
-import SavedEntityPicker from "./saved-entity-picker/SavedEntityPicker";
+import { SavedEntityPicker } from "./saved-entity-picker/SavedEntityPicker";
 import { getDataTypes } from "./utils";
 
 // chooses a data source bucket (datasets / raw data (tables) / saved questions)

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDataBucketPicker/DataSelectorDataBucketPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDataBucketPicker/DataSelectorDataBucketPicker.tsx
@@ -70,5 +70,4 @@ const DataBucketListItem = ({
   </SelectList.BaseItem>
 );
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default DataSelectorDataBucketPicker;
+export { DataSelectorDataBucketPicker };

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDataBucketPicker/DataSelectorDataBucketPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDataBucketPicker/DataSelectorDataBucketPicker.tsx
@@ -10,7 +10,7 @@ type DataSelectorDataBucketPickerProps = {
   onChangeDataBucket: (id: DataTypeInfoItem["id"]) => void;
 };
 
-const DataSelectorDataBucketPicker = ({
+export const DataSelectorDataBucketPicker = ({
   dataTypes,
   onChangeDataBucket,
 }: DataSelectorDataBucketPickerProps) => (
@@ -69,5 +69,3 @@ const DataBucketListItem = ({
     </Box>
   </SelectList.BaseItem>
 );
-
-export { DataSelectorDataBucketPicker };

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDataBucketPicker/DataSelectorDataBucketPicker.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDataBucketPicker/DataSelectorDataBucketPicker.unit.spec.tsx
@@ -3,7 +3,7 @@ import { render, screen } from "__support__/ui";
 import type { DataTypeInfoItem } from "../types";
 import { getDataTypes } from "../utils";
 
-import DataSelectorDataBucketPicker from "./DataSelectorDataBucketPicker";
+import { DataSelectorDataBucketPicker } from "./DataSelectorDataBucketPicker";
 
 const setup = (dataTypes: DataTypeInfoItem[]) => {
   return render(

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDataBucketPicker/index.ts
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDataBucketPicker/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./DataSelectorDataBucketPicker";
+export { DataSelectorDataBucketPicker } from "./DataSelectorDataBucketPicker";

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabasePicker/DataSelectorDatabasePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabasePicker/DataSelectorDatabasePicker.tsx
@@ -10,7 +10,7 @@ import { Icon } from "metabase/ui";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type Schema from "metabase-lib/v1/metadata/Schema";
 
-import DataSelectorLoading from "../DataSelectorLoading";
+import { DataSelectorLoading } from "../DataSelectorLoading";
 import { RawDataBackButton } from "../RawDataBackButton";
 
 type DataSelectorDatabasePickerProps = {
@@ -103,5 +103,4 @@ const DataSelectorDatabasePicker = ({
   );
 };
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default DataSelectorDatabasePicker;
+export { DataSelectorDatabasePicker };

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabasePicker/DataSelectorDatabasePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabasePicker/DataSelectorDatabasePicker.tsx
@@ -34,7 +34,7 @@ type Item = {
   database: Database;
 };
 
-const DataSelectorDatabasePicker = ({
+export const DataSelectorDatabasePicker = ({
   databases,
   selectedDatabase,
   onChangeDatabase,
@@ -102,5 +102,3 @@ const DataSelectorDatabasePicker = ({
     />
   );
 };
-
-export { DataSelectorDatabasePicker };

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabasePicker/DataSelectorDatabasePicker.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabasePicker/DataSelectorDatabasePicker.unit.spec.tsx
@@ -7,7 +7,7 @@ import { getMetadata } from "metabase/selectors/metadata";
 import { createMockDatabase } from "metabase-types/api/mocks";
 import { createMockState } from "metabase-types/store/mocks";
 
-import DataSelectorDatabasePicker from "./DataSelectorDatabasePicker";
+import { DataSelectorDatabasePicker } from "./DataSelectorDatabasePicker";
 
 const TEST_DATABASE = createMockDatabase();
 

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabasePicker/index.ts
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabasePicker/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./DataSelectorDatabasePicker";
+export { DataSelectorDatabasePicker } from "./DataSelectorDatabasePicker";

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.tsx
@@ -11,7 +11,7 @@ import { Icon } from "metabase/ui";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type Schema from "metabase-lib/v1/metadata/Schema";
 
-import DataSelectorLoading from "../DataSelectorLoading";
+import { DataSelectorLoading } from "../DataSelectorLoading";
 import { RawDataBackButton } from "../RawDataBackButton";
 
 type DataSelectorDatabaseSchemaPicker = {
@@ -136,5 +136,4 @@ const DataSelectorDatabaseSchemaPicker = ({
   );
 };
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default DataSelectorDatabaseSchemaPicker;
+export { DataSelectorDatabaseSchemaPicker };

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.tsx
@@ -37,7 +37,7 @@ type Section = BaseSection<Item> & {
   active?: boolean;
 };
 
-const DataSelectorDatabaseSchemaPicker = ({
+export const DataSelectorDatabaseSchemaPicker = ({
   databases,
   selectedDatabase,
   selectedSchema,
@@ -135,5 +135,3 @@ const DataSelectorDatabaseSchemaPicker = ({
     />
   );
 };
-
-export { DataSelectorDatabaseSchemaPicker };

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.unit.spec.js
@@ -5,7 +5,7 @@ import { getMetadata } from "metabase/selectors/metadata";
 import { createMockDatabase, createMockSchema } from "metabase-types/api/mocks";
 import { createMockState } from "metabase-types/store/mocks";
 
-import DataSelectorDatabaseSchemaPicker from "./DataSelectorDatabaseSchemaPicker";
+import { DataSelectorDatabaseSchemaPicker } from "./DataSelectorDatabaseSchemaPicker";
 
 const setup = (opts) => {
   const state = createMockState({

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabaseSchemaPicker/index.ts
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabaseSchemaPicker/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./DataSelectorDatabaseSchemaPicker";
+export { DataSelectorDatabaseSchemaPicker } from "./DataSelectorDatabaseSchemaPicker";

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorFieldPicker/DataSelectorFieldPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorFieldPicker/DataSelectorFieldPicker.tsx
@@ -12,7 +12,7 @@ import { Box, DelayGroup, Icon } from "metabase/ui";
 import type Field from "metabase-lib/v1/metadata/Field";
 import type Table from "metabase-lib/v1/metadata/Table";
 
-import DataSelectorLoading from "../DataSelectorLoading";
+import { DataSelectorLoading } from "../DataSelectorLoading";
 import { CONTAINER_WIDTH } from "../constants";
 
 import DataSelectorFieldPickerS from "./DataSelectorFieldPicker.module.css";
@@ -113,5 +113,4 @@ const Header = ({ onBack, selectedTable }: HeaderProps) => (
   </Box>
 );
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default DataSelectorFieldPicker;
+export { DataSelectorFieldPicker };

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorFieldPicker/DataSelectorFieldPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorFieldPicker/DataSelectorFieldPicker.tsx
@@ -38,7 +38,7 @@ type FieldWithName = {
   field: Field;
 };
 
-const DataSelectorFieldPicker = ({
+export const DataSelectorFieldPicker = ({
   isLoading,
   fields,
   selectedTable,
@@ -112,5 +112,3 @@ const Header = ({ onBack, selectedTable }: HeaderProps) => (
     </Box>
   </Box>
 );
-
-export { DataSelectorFieldPicker };

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorFieldPicker/DataSelectorFieldPicker.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorFieldPicker/DataSelectorFieldPicker.unit.spec.tsx
@@ -4,7 +4,7 @@ import { checkNotNull } from "metabase/lib/types";
 import type Table from "metabase-lib/v1/metadata/Table";
 import { ORDERS, createSampleDatabase } from "metabase-types/api/mocks/presets";
 
-import DataSelectorFieldPicker from "./DataSelectorFieldPicker";
+import { DataSelectorFieldPicker } from "./DataSelectorFieldPicker";
 
 const metadata = createMockMetadata({
   databases: [createSampleDatabase()],

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorFieldPicker/index.ts
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorFieldPicker/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./DataSelectorFieldPicker";
+export { DataSelectorFieldPicker } from "./DataSelectorFieldPicker";

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorLoading/DataSelectorLoading.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorLoading/DataSelectorLoading.tsx
@@ -5,7 +5,9 @@ import type { DataSelectorSectionHeaderProps } from "../DataSelectorSectionHeade
 import { DataSelectorSectionHeader } from "../DataSelectorSectionHeader";
 import { CONTAINER_WIDTH } from "../constants";
 
-const DataSelectorLoading = ({ header }: DataSelectorSectionHeaderProps) =>
+export const DataSelectorLoading = ({
+  header,
+}: DataSelectorSectionHeaderProps) =>
   header ? (
     <Box component="section" w={CONTAINER_WIDTH}>
       <DataSelectorSectionHeader header={header} />
@@ -14,5 +16,3 @@ const DataSelectorLoading = ({ header }: DataSelectorSectionHeaderProps) =>
   ) : (
     <LoadingAndErrorWrapper loading />
   );
-
-export { DataSelectorLoading };

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorLoading/DataSelectorLoading.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorLoading/DataSelectorLoading.tsx
@@ -2,7 +2,7 @@ import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErr
 import { Box } from "metabase/ui";
 
 import type { DataSelectorSectionHeaderProps } from "../DataSelectorSectionHeader";
-import DataSelectorSectionHeader from "../DataSelectorSectionHeader";
+import { DataSelectorSectionHeader } from "../DataSelectorSectionHeader";
 import { CONTAINER_WIDTH } from "../constants";
 
 const DataSelectorLoading = ({ header }: DataSelectorSectionHeaderProps) =>
@@ -15,5 +15,4 @@ const DataSelectorLoading = ({ header }: DataSelectorSectionHeaderProps) =>
     <LoadingAndErrorWrapper loading />
   );
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default DataSelectorLoading;
+export { DataSelectorLoading };

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorLoading/index.ts
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorLoading/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./DataSelectorLoading";
+export { DataSelectorLoading } from "./DataSelectorLoading";

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorSchemaPicker/DataSelectorSchemaPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorSchemaPicker/DataSelectorSchemaPicker.tsx
@@ -56,5 +56,4 @@ const DataSelectorSchemaPicker = ({
   );
 };
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default DataSelectorSchemaPicker;
+export { DataSelectorSchemaPicker };

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorSchemaPicker/DataSelectorSchemaPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorSchemaPicker/DataSelectorSchemaPicker.tsx
@@ -18,7 +18,7 @@ type DataSelectorSchemaPickerProps = {
   onChangeSchema: (item: { schema: Schema }) => void;
 };
 
-const DataSelectorSchemaPicker = ({
+export const DataSelectorSchemaPicker = ({
   schemas,
   selectedSchemaId,
   onChangeSchema,
@@ -55,5 +55,3 @@ const DataSelectorSchemaPicker = ({
     </Box>
   );
 };
-
-export { DataSelectorSchemaPicker };

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorSchemaPicker/DataSelectorSchemaPicker.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorSchemaPicker/DataSelectorSchemaPicker.unit.spec.js
@@ -1,6 +1,6 @@
 import { render, screen } from "__support__/ui";
 
-import DataSelectorSchemaPicker from "./DataSelectorSchemaPicker";
+import { DataSelectorSchemaPicker } from "./DataSelectorSchemaPicker";
 
 describe("DataSelectorSchemaPicker", () => {
   it("displays schema name", () => {

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorSchemaPicker/index.ts
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorSchemaPicker/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./DataSelectorSchemaPicker";
+export { DataSelectorSchemaPicker } from "./DataSelectorSchemaPicker";

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorSectionHeader/DataSelectorSectionHeader.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorSectionHeader/DataSelectorSectionHeader.tsx
@@ -18,5 +18,4 @@ const DataSelectorSectionHeader = ({
   </Flex>
 );
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default DataSelectorSectionHeader;
+export { DataSelectorSectionHeader };

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorSectionHeader/DataSelectorSectionHeader.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorSectionHeader/DataSelectorSectionHeader.tsx
@@ -8,7 +8,7 @@ export type DataSelectorSectionHeaderProps = {
   header?: React.ReactElement;
 };
 
-const DataSelectorSectionHeader = ({
+export const DataSelectorSectionHeader = ({
   header,
 }: DataSelectorSectionHeaderProps) => (
   <Flex p="md" align="center" className={DataSelectorSectionHeaderS.Container}>
@@ -17,5 +17,3 @@ const DataSelectorSectionHeader = ({
     </Box>
   </Flex>
 );
-
-export { DataSelectorSectionHeader };

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorSectionHeader/index.ts
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorSectionHeader/index.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./DataSelectorSectionHeader";
+export { DataSelectorSectionHeader } from "./DataSelectorSectionHeader";
 
 export type { DataSelectorSectionHeaderProps } from "./DataSelectorSectionHeader";

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorTablePicker/DataSelectorTablePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorTablePicker/DataSelectorTablePicker.tsx
@@ -20,7 +20,7 @@ import type Database from "metabase-lib/v1/metadata/Database";
 import type Schema from "metabase-lib/v1/metadata/Schema";
 import type Table from "metabase-lib/v1/metadata/Table";
 
-import DataSelectorSectionHeader from "../DataSelectorSectionHeader";
+import { DataSelectorSectionHeader } from "../DataSelectorSectionHeader";
 import { CONTAINER_WIDTH } from "../constants";
 
 type DataSelectorTablePickerProps = {
@@ -206,5 +206,4 @@ const Header = ({
   </Flex>
 );
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default DataSelectorTablePicker;
+export { DataSelectorTablePicker };

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorTablePicker/DataSelectorTablePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorTablePicker/DataSelectorTablePicker.tsx
@@ -49,7 +49,7 @@ type Item = {
   database: Database;
 };
 
-const DataSelectorTablePicker = ({
+export const DataSelectorTablePicker = ({
   schemas,
   tables,
   selectedDatabase,
@@ -205,5 +205,3 @@ const Header = ({
     )}
   </Flex>
 );
-
-export { DataSelectorTablePicker };

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorTablePicker/DataSelectorTablePicker.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorTablePicker/DataSelectorTablePicker.unit.spec.tsx
@@ -6,7 +6,7 @@ import type { Database, InitialSyncStatus } from "metabase-types/api";
 import { createMockDatabase, createMockTable } from "metabase-types/api/mocks";
 import { createMockState } from "metabase-types/store/mocks";
 
-import DataSelectorTablePicker from "./DataSelectorTablePicker";
+import { DataSelectorTablePicker } from "./DataSelectorTablePicker";
 
 const NOT_SYNCED_DB_STATUSES: InitialSyncStatus[] = ["aborted", "incomplete"];
 

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorTablePicker/index.ts
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorTablePicker/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./DataSelectorTablePicker";
+export { DataSelectorTablePicker } from "./DataSelectorTablePicker";

--- a/frontend/src/metabase/query_builder/components/DataSelector/saved-entity-picker/SavedEntityList.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/saved-entity-picker/SavedEntityList.tsx
@@ -96,5 +96,4 @@ const SavedEntityList = ({
   );
 };
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default SavedEntityList;
+export { SavedEntityList };

--- a/frontend/src/metabase/query_builder/components/DataSelector/saved-entity-picker/SavedEntityList.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/saved-entity-picker/SavedEntityList.tsx
@@ -23,7 +23,7 @@ interface SavedEntityListProps {
   onSelect: (tableOrModelId: string) => void;
 }
 
-const SavedEntityList = ({
+export const SavedEntityList = ({
   type,
   selectedId,
   databaseId,
@@ -95,5 +95,3 @@ const SavedEntityList = ({
     </Box>
   );
 };
-
-export { SavedEntityList };

--- a/frontend/src/metabase/query_builder/components/DataSelector/saved-entity-picker/SavedEntityPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/saved-entity-picker/SavedEntityPicker.jsx
@@ -18,7 +18,7 @@ import {
 import { connect } from "metabase/lib/redux";
 import { Box, Icon } from "metabase/ui";
 
-import SavedEntityList from "./SavedEntityList";
+import { SavedEntityList } from "./SavedEntityList";
 import SavedEntityPickerS from "./SavedEntityPicker.module.css";
 import { CARD_INFO } from "./constants";
 
@@ -46,7 +46,7 @@ const ALL_PERSONAL_COLLECTIONS_ROOT = {
   ...PERSONAL_COLLECTIONS,
 };
 
-function SavedEntityPicker({
+function SavedEntityPickerInner({
   type,
   onBack,
   onSelect,
@@ -139,11 +139,11 @@ function SavedEntityPicker({
   );
 }
 
-SavedEntityPicker.propTypes = propTypes;
+SavedEntityPickerInner.propTypes = propTypes;
 
 const mapStateToProps = ({ currentUser }) => ({ currentUser });
 
-export default _.compose(
+export const SavedEntityPicker = _.compose(
   Collections.load({
     id: () => "root",
     entityAlias: "rootCollection",
@@ -153,4 +153,4 @@ export default _.compose(
     query: () => ({ tree: true, "exclude-archived": true }),
   }),
   connect(mapStateToProps),
-)(SavedEntityPicker);
+)(SavedEntityPickerInner);

--- a/frontend/src/metabase/query_builder/components/DataSelector/saved-entity-picker/SavedEntityPicker.unit.spec.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/saved-entity-picker/SavedEntityPicker.unit.spec.jsx
@@ -11,7 +11,7 @@ import {
   createMockCollectionItem,
 } from "metabase-types/api/mocks";
 
-import SavedEntityPicker from "./SavedEntityPicker";
+import { SavedEntityPicker } from "./SavedEntityPicker";
 
 const CURRENT_USER = {
   id: 1,

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditorInner.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditorInner.tsx
@@ -32,11 +32,11 @@ import {
   updateQuestion as updateQuestionAction,
 } from "metabase/query_builder/actions";
 import { getInitialEditorHeight } from "metabase/query_builder/components/NativeQueryEditor/utils";
-import QueryVisualization from "metabase/query_builder/components/QueryVisualization";
-import DataReference from "metabase/query_builder/components/dataref/DataReference";
+import { QueryVisualization } from "metabase/query_builder/components/QueryVisualization";
+import { DataReference } from "metabase/query_builder/components/dataref/DataReference";
 import { SnippetSidebar } from "metabase/query_builder/components/template_tags/SnippetSidebar/SnippetSidebar";
 import { TagEditorSidebar } from "metabase/query_builder/components/template_tags/TagEditorSidebar";
-import ViewSidebar from "metabase/query_builder/components/view/ViewSidebar";
+import { ViewSidebar } from "metabase/query_builder/components/view/ViewSidebar";
 import { MODAL_TYPES } from "metabase/query_builder/constants";
 import {
   getDatasetEditorTab,
@@ -80,8 +80,8 @@ import {
   DatasetEditorSettingsSidebar,
   type ModelSettings,
 } from "./DatasetEditorSettingsSidebar/DatasetEditorSettingsSidebar";
-import DatasetFieldMetadataSidebar from "./DatasetFieldMetadataSidebar";
-import DatasetQueryEditor from "./DatasetQueryEditor";
+import { DatasetFieldMetadataSidebar } from "./DatasetFieldMetadataSidebar";
+import { DatasetQueryEditor } from "./DatasetQueryEditor";
 import { EditorTabs } from "./EditorTabs";
 import { EDITOR_TAB_INDEXES } from "./constants";
 type MetadataDiff = Record<string, Partial<Field>>;

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.jsx
@@ -17,7 +17,7 @@ import {
 } from "metabase/forms";
 import { color } from "metabase/lib/colors";
 import { FIELD_VISIBILITY_TYPES } from "metabase/lib/core";
-import SidebarContent from "metabase/query_builder/components/SidebarContent";
+import { SidebarContent } from "metabase/query_builder/components/SidebarContent";
 import { Box, Radio, Stack, Tabs } from "metabase/ui";
 import ColumnSettings, {
   hasColumnSettingsWidgets,
@@ -32,7 +32,7 @@ import { DatasetFieldMetadataCurrencyPicker } from "./DatasetFieldMetadataCurren
 import { DatasetFieldMetadataFkTargetPicker } from "./DatasetFieldMetadataFkTargetPicker";
 import { DatasetFieldMetadataSemanticTypePicker } from "./DatasetFieldMetadataSemanticTypePicker";
 import DatasetFieldMetadataSidebarS from "./DatasetFieldMetadataSidebar.module.css";
-import MappedFieldPicker from "./MappedFieldPicker";
+import { MappedFieldPicker } from "./MappedFieldPicker";
 
 const propTypes = {
   dataset: PropTypes.object.isRequired,
@@ -90,7 +90,7 @@ const TAB_OPTIONS = [
   },
 ];
 
-function DatasetFieldMetadataSidebar({
+function DatasetFieldMetadataSidebarInner({
   dataset,
   field,
   isLastField,
@@ -371,6 +371,8 @@ function DatasetFieldMetadataSidebar({
   );
 }
 
-DatasetFieldMetadataSidebar.propTypes = propTypes;
+DatasetFieldMetadataSidebarInner.propTypes = propTypes;
 
-export default memo(DatasetFieldMetadataSidebar);
+export const DatasetFieldMetadataSidebar = memo(
+  DatasetFieldMetadataSidebarInner,
+);

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/MappedFieldPicker/MappedFieldPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/MappedFieldPicker/MappedFieldPicker.tsx
@@ -124,5 +124,4 @@ function MappedFieldPicker({
     </>
   );
 }
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default MappedFieldPicker;
+export { MappedFieldPicker };

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/MappedFieldPicker/MappedFieldPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/MappedFieldPicker/MappedFieldPicker.tsx
@@ -23,7 +23,7 @@ type MappedFieldPickerProps = {
   onChange: (value: FieldId | null) => void;
 };
 
-function MappedFieldPicker({
+export function MappedFieldPicker({
   className,
   databaseId = null,
   onChange,
@@ -124,4 +124,3 @@ function MappedFieldPicker({
     </>
   );
 }
-export { MappedFieldPicker };

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/MappedFieldPicker/index.ts
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/MappedFieldPicker/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./MappedFieldPicker";
+export { MappedFieldPicker } from "./MappedFieldPicker";

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/index.ts
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./DatasetFieldMetadataSidebar";
+export { DatasetFieldMetadataSidebar } from "./DatasetFieldMetadataSidebar";

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetQueryEditor.jsx
@@ -29,7 +29,7 @@ const propTypes = {
   onSetDatabaseId: PropTypes.func,
 };
 
-function DatasetQueryEditor({
+function DatasetQueryEditorInner({
   question,
   isActive,
   height,
@@ -97,6 +97,6 @@ function DatasetQueryEditor({
   );
 }
 
-DatasetQueryEditor.propTypes = propTypes;
+DatasetQueryEditorInner.propTypes = propTypes;
 
-export default memo(DatasetQueryEditor);
+export const DatasetQueryEditor = memo(DatasetQueryEditorInner);

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetQueryEditor.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetQueryEditor.unit.spec.tsx
@@ -94,7 +94,7 @@ const setup = async ({
  * would have been used in tests instead of the actual implementation.
  */
 const importDatasetQueryEditor = async () => {
-  const { default: DatasetQueryEditor } = await import(
+  const { DatasetQueryEditor } = await import(
     "metabase/query_builder/components/DatasetEditor/DatasetQueryEditor"
   );
   return DatasetQueryEditor;

--- a/frontend/src/metabase/query_builder/components/ExpandableString.jsx
+++ b/frontend/src/metabase/query_builder/components/ExpandableString.jsx
@@ -6,7 +6,7 @@ import { t } from "ttag";
 
 import CS from "metabase/css/core/index.css";
 
-export default class ExpandableString extends Component {
+export class ExpandableString extends Component {
   constructor(props, context) {
     super(props, context);
     this.toggleExpansion = this.toggleExpansion.bind(this);

--- a/frontend/src/metabase/query_builder/components/LimitInput.tsx
+++ b/frontend/src/metabase/query_builder/components/LimitInput.tsx
@@ -31,5 +31,4 @@ const LimitInput = ({
   />
 );
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default LimitInput;
+export { LimitInput };

--- a/frontend/src/metabase/query_builder/components/LimitInput.tsx
+++ b/frontend/src/metabase/query_builder/components/LimitInput.tsx
@@ -13,7 +13,7 @@ interface LimitInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   medium?: boolean;
 }
 
-const LimitInput = ({
+export const LimitInput = ({
   className,
   small,
   medium,
@@ -30,5 +30,3 @@ const LimitInput = ({
     {...props}
   />
 );
-
-export { LimitInput };

--- a/frontend/src/metabase/query_builder/components/LimitPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/LimitPopover.jsx
@@ -5,7 +5,7 @@ import { t } from "ttag";
 import Radio from "metabase/common/components/Radio";
 import CS from "metabase/css/core/index.css";
 import { formatNumber } from "metabase/lib/formatting";
-import LimitInput from "metabase/query_builder/components/LimitInput";
+import { LimitInput } from "metabase/query_builder/components/LimitInput";
 import { HARD_ROW_LIMIT } from "metabase-lib/v1/queries/utils";
 
 const CustomRowLimit = ({ limit, onChangeLimit, onClose }) => {
@@ -64,4 +64,4 @@ const LimitPopover = ({ limit, onChangeLimit, onClose, className }) => (
   </div>
 );
 
-export default LimitPopover;
+export { LimitPopover };

--- a/frontend/src/metabase/query_builder/components/LimitPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/LimitPopover.jsx
@@ -35,7 +35,7 @@ const CustomRowLimit = ({ limit, onChangeLimit, onClose }) => {
   );
 };
 
-const LimitPopover = ({ limit, onChangeLimit, onClose, className }) => (
+export const LimitPopover = ({ limit, onChangeLimit, onClose, className }) => (
   <div className={cx(className, CS.textBold, CS.textMedium)}>
     <Radio
       vertical
@@ -63,5 +63,3 @@ const LimitPopover = ({ limit, onChangeLimit, onClose, className }) => (
     />
   </div>
 );
-
-export { LimitPopover };

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/DataSourceSelectors/DataSourceSelectors.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/DataSourceSelectors/DataSourceSelectors.jsx
@@ -58,7 +58,7 @@ const PlaceholderPropTypes = {
   editorContext: PropTypes.oneOf(["action", "question"]),
 };
 
-const DataSourceSelectors = ({
+export const DataSourceSelectors = ({
   isNativeEditorOpen,
   query,
   question,
@@ -248,5 +248,3 @@ const Placeholder = ({ query, editorContext }) => {
 };
 
 Placeholder.propTypes = PlaceholderPropTypes;
-
-export { DataSourceSelectors };

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/DataSourceSelectors/DataSourceSelectors.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/DataSourceSelectors/DataSourceSelectors.jsx
@@ -249,4 +249,4 @@ const Placeholder = ({ query, editorContext }) => {
 
 Placeholder.propTypes = PlaceholderPropTypes;
 
-export default DataSourceSelectors;
+export { DataSourceSelectors };

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/DataSourceSelectors/index.ts
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/DataSourceSelectors/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./DataSourceSelectors";
+export { DataSourceSelectors } from "./DataSourceSelectors";

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorRunButton/NativeQueryEditorRunButton.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorRunButton/NativeQueryEditorRunButton.tsx
@@ -1,7 +1,7 @@
 import { t } from "ttag";
 
 import { METAKEY } from "metabase/lib/browser";
-import RunButtonWithTooltip from "metabase/query_builder/components/RunButtonWithTooltip";
+import { RunButtonWithTooltip } from "metabase/query_builder/components/RunButtonWithTooltip";
 import type * as Lib from "metabase-lib";
 
 import S from "./NativeQueryEditorRunButton.module.css";

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorRunButton/NativeQueryEditorRunButton.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorRunButton/NativeQueryEditorRunButton.tsx
@@ -16,7 +16,9 @@ interface NativeQueryEditorRunButtonProps {
   runQuery?: () => void;
 }
 
-const NativeQueryEditorRunButton = (props: NativeQueryEditorRunButtonProps) => {
+export const NativeQueryEditorRunButton = (
+  props: NativeQueryEditorRunButtonProps,
+) => {
   const {
     cancelQuery,
     isResultDirty,
@@ -57,5 +59,3 @@ const NativeQueryEditorRunButton = (props: NativeQueryEditorRunButtonProps) => {
     />
   );
 };
-
-export { NativeQueryEditorRunButton };

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorTopBar/NativeQueryEditorTopBar.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorTopBar/NativeQueryEditorTopBar.tsx
@@ -16,7 +16,7 @@ import type {
 } from "metabase-types/api";
 
 import { ResponsiveParametersList } from "../../ResponsiveParametersList";
-import DataSourceSelectors from "../DataSourceSelectors/DataSourceSelectors";
+import { DataSourceSelectors } from "../DataSourceSelectors/DataSourceSelectors";
 import { NativeQueryEditorActionButtons } from "../NativeQueryEditorActionButtons/NativeQueryEditorActionButtons";
 import { VisibilityToggler } from "../VisibilityToggler/VisibilityToggler";
 import type { SidebarFeatures } from "../types";

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorTopBar/NativeQueryEditorTopBar.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorTopBar/NativeQueryEditorTopBar.tsx
@@ -55,7 +55,7 @@ interface NativeQueryEditorTopBarProps extends PropsWithChildren {
   databaseIsDisabled?: (database: Database) => boolean;
 }
 
-const NativeQueryEditorTopBar = forwardRef<
+export const NativeQueryEditorTopBar = forwardRef<
   HTMLDivElement,
   NativeQueryEditorTopBarProps
 >(function NativeQueryEditorTopBarInner(props, ref) {
@@ -182,5 +182,3 @@ const NativeQueryEditorTopBar = forwardRef<
     </Flex>
   );
 });
-
-export { NativeQueryEditorTopBar };

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/__mocks__/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/__mocks__/NativeQueryEditor.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import CS from "metabase/css/core/index.css";
-import DataSourceSelectors from "metabase/query_builder/components/NativeQueryEditor/DataSourceSelectors";
+import { DataSourceSelectors } from "metabase/query_builder/components/NativeQueryEditor/DataSourceSelectors";
 import { SyncedParametersList } from "metabase/query_builder/components/SyncedParametersList";
 
 export const NativeQueryEditor = ({

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/__mocks__/index.ts
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/__mocks__/index.ts
@@ -1,1 +1,1 @@
-export * from "./NativeQueryEditor";
+export { NativeQueryEditor } from "./NativeQueryEditor";

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/index.ts
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/index.ts
@@ -1,2 +1,2 @@
-export * from "./NativeQueryEditor";
+export { NativeQueryEditor } from "./NativeQueryEditor";
 export { type SelectionRange } from "./types";

--- a/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
@@ -16,14 +16,14 @@ import { Box, Flex, Stack, Text, Title } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import { HARD_ROW_LIMIT } from "metabase-lib/v1/queries/utils";
 
-import RunButtonWithTooltip from "./RunButtonWithTooltip";
+import { RunButtonWithTooltip } from "./RunButtonWithTooltip";
 import { VisualizationError } from "./VisualizationError";
-import VisualizationResult from "./VisualizationResult";
-import Warnings from "./Warnings";
+import { VisualizationResult } from "./VisualizationResult";
+import { Warnings } from "./Warnings";
 
 const SLOW_MESSAGE_TIMEOUT = 4000;
 
-export default function QueryVisualization(props) {
+export function QueryVisualization(props) {
   const {
     className,
     question,

--- a/frontend/src/metabase/query_builder/components/QuestionDownloadPopover/QuestionDownloadPopover.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionDownloadPopover/QuestionDownloadPopover.tsx
@@ -134,6 +134,3 @@ const shouldRender = ({ result }: ShouldRenderDownloadPopoverProps) => {
 
 QuestionDownloadPopover.shouldRender = shouldRender;
 PublicOrEmbeddedQuestionDownloadPopover.shouldRender = shouldRender;
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default QuestionDownloadPopover;

--- a/frontend/src/metabase/query_builder/components/QuestionDownloadPopover/QuestionDownloadPopover.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionDownloadPopover/QuestionDownloadPopover.unit.spec.tsx
@@ -17,7 +17,7 @@ import {
 import { ORDERS_ID, SAMPLE_DB_ID } from "metabase-types/api/mocks/presets";
 import { createMockState } from "metabase-types/store/mocks";
 
-import QuestionDownloadPopover from "./QuestionDownloadPopover";
+import { QuestionDownloadPopover } from "./QuestionDownloadPopover";
 
 const TEST_CARD = createMockCard({
   dataset_query: createMockStructuredDatasetQuery({

--- a/frontend/src/metabase/query_builder/components/QuestionDownloadPopover/index.ts
+++ b/frontend/src/metabase/query_builder/components/QuestionDownloadPopover/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./QuestionDownloadPopover";
+export { QuestionDownloadPopover } from "./QuestionDownloadPopover";

--- a/frontend/src/metabase/query_builder/components/RunButton.tsx
+++ b/frontend/src/metabase/query_builder/components/RunButton.tsx
@@ -81,5 +81,4 @@ const getButtonIcon = (isRunning: boolean, isDirty: boolean) => {
   return "refresh";
 };
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default RunButton;
+export { RunButton };

--- a/frontend/src/metabase/query_builder/components/RunButton.tsx
+++ b/frontend/src/metabase/query_builder/components/RunButton.tsx
@@ -20,7 +20,7 @@ interface RunButtonProps {
   onCancel?: () => void;
 }
 
-const RunButton = forwardRef(function RunButton(
+export const RunButton = forwardRef(function RunButton(
   {
     isRunning,
     isDirty,
@@ -80,5 +80,3 @@ const getButtonIcon = (isRunning: boolean, isDirty: boolean) => {
 
   return "refresh";
 };
-
-export { RunButton };

--- a/frontend/src/metabase/query_builder/components/RunButtonWithTooltip.jsx
+++ b/frontend/src/metabase/query_builder/components/RunButtonWithTooltip.jsx
@@ -4,7 +4,7 @@ import { t } from "ttag";
 import { duration } from "metabase/lib/formatting";
 import { Tooltip } from "metabase/ui";
 
-import RunButton from "./RunButton";
+import { RunButton } from "./RunButton";
 
 const REFRESH_TOOLTIP_THRESHOLD = 30 * 1000; // 30 seconds
 
@@ -19,7 +19,7 @@ const defaultGetTooltip = ({ isDirty, result }) => {
     : null;
 };
 
-export default function RunButtonWithTooltip({
+export function RunButtonWithTooltip({
   getTooltip = defaultGetTooltip,
   ...props
 }) {

--- a/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.tsx
+++ b/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.tsx
@@ -13,7 +13,7 @@ interface SavedQuestionHeaderButtonProps {
   onSave: (name: string) => void;
 }
 
-function SavedQuestionHeaderButton({
+export function SavedQuestionHeaderButton({
   question,
   onSave,
 }: SavedQuestionHeaderButtonProps) {
@@ -47,5 +47,3 @@ function SavedQuestionHeaderButton({
     </Flex>
   );
 }
-
-export { SavedQuestionHeaderButton };

--- a/frontend/src/metabase/query_builder/components/SidebarContent/SidebarContent.tsx
+++ b/frontend/src/metabase/query_builder/components/SidebarContent/SidebarContent.tsx
@@ -11,8 +11,8 @@ import {
   type IconName,
 } from "metabase/ui";
 
-import SidebarHeader from "../SidebarHeader";
-import ViewButton from "../view/ViewButton";
+import { SidebarHeader } from "../SidebarHeader";
+import { ViewButton } from "../view/ViewButton";
 
 import SidebarContentS from "./SidebarContent.module.css";
 
@@ -55,7 +55,7 @@ const SidebarContentRoot = ({ className, children, ...props }: FlexProps) => {
   );
 };
 
-function SidebarContent({
+function SidebarContentInner({
   className,
   title,
   icon,
@@ -102,8 +102,7 @@ const PaneContent = (props: BoxProps & { children: React.ReactNode }) => {
   return <Box px="lg" {...props} />;
 };
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default Object.assign(SidebarContent, {
+export const SidebarContent = Object.assign(SidebarContentInner, {
   Root: SidebarContentRoot,
   Header: SidebarHeader,
   Content: SidebarContentMain,

--- a/frontend/src/metabase/query_builder/components/SidebarContent/index.ts
+++ b/frontend/src/metabase/query_builder/components/SidebarContent/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./SidebarContent";
+export { SidebarContent } from "./SidebarContent";

--- a/frontend/src/metabase/query_builder/components/SidebarHeader/SidebarHeader.tsx
+++ b/frontend/src/metabase/query_builder/components/SidebarHeader/SidebarHeader.tsx
@@ -37,7 +37,7 @@ function getHeaderVariant({
   return "default";
 }
 
-function SidebarHeader({
+export function SidebarHeader({
   className,
   title,
   icon,
@@ -96,6 +96,3 @@ function SidebarHeader({
     </Flex>
   );
 }
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default Object.assign(SidebarHeader);

--- a/frontend/src/metabase/query_builder/components/SidebarHeader/index.ts
+++ b/frontend/src/metabase/query_builder/components/SidebarHeader/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./SidebarHeader";
+export { SidebarHeader } from "./SidebarHeader";

--- a/frontend/src/metabase/query_builder/components/VisualizationResult.jsx
+++ b/frontend/src/metabase/query_builder/components/VisualizationResult.jsx
@@ -27,7 +27,7 @@ const ALLOWED_VISUALIZATION_PROPS = [
   "zoomedRowIndex",
 ];
 
-export default class VisualizationResult extends Component {
+export class VisualizationResult extends Component {
   state = {
     showCreateAlertModal: false,
   };

--- a/frontend/src/metabase/query_builder/components/Warnings.jsx
+++ b/frontend/src/metabase/query_builder/components/Warnings.jsx
@@ -25,4 +25,4 @@ const Warnings = ({ warnings, className = "", size = 16 }) => {
   );
 };
 
-export default Warnings;
+export { Warnings };

--- a/frontend/src/metabase/query_builder/components/Warnings.jsx
+++ b/frontend/src/metabase/query_builder/components/Warnings.jsx
@@ -4,7 +4,7 @@ import cx from "classnames";
 import CS from "metabase/css/core/index.css";
 import { Icon, Tooltip } from "metabase/ui";
 
-const Warnings = ({ warnings, className = "", size = 16 }) => {
+export const Warnings = ({ warnings, className = "", size = 16 }) => {
   if (!warnings || warnings.length === 0) {
     return null;
   }
@@ -24,5 +24,3 @@ const Warnings = ({ warnings, className = "", size = 16 }) => {
     </Tooltip>
   );
 };
-
-export { Warnings };

--- a/frontend/src/metabase/query_builder/components/Warnings.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/Warnings.unit.spec.js
@@ -1,7 +1,7 @@
 import userEvent from "@testing-library/user-event";
 
 import { render, screen } from "__support__/ui";
-import Warnings from "metabase/query_builder/components/Warnings";
+import { Warnings } from "metabase/query_builder/components/Warnings";
 
 describe("Warnings", () => {
   it("should render a warning icon", () => {

--- a/frontend/src/metabase/query_builder/components/dataref/ConnectedTableList.tsx
+++ b/frontend/src/metabase/query_builder/components/dataref/ConnectedTableList.tsx
@@ -37,5 +37,4 @@ const ConnectedTableList = ({
   </NodeListContainer>
 );
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default ConnectedTableList;
+export { ConnectedTableList };

--- a/frontend/src/metabase/query_builder/components/dataref/ConnectedTableList.tsx
+++ b/frontend/src/metabase/query_builder/components/dataref/ConnectedTableList.tsx
@@ -17,7 +17,7 @@ interface ConnectedTableListProps {
   onTableClick: (table: Table) => void;
 }
 
-const ConnectedTableList = ({
+export const ConnectedTableList = ({
   tables,
   onTableClick,
 }: ConnectedTableListProps) => (
@@ -36,5 +36,3 @@ const ConnectedTableList = ({
     ))}
   </NodeListContainer>
 );
-
-export { ConnectedTableList };

--- a/frontend/src/metabase/query_builder/components/dataref/DataReference.jsx
+++ b/frontend/src/metabase/query_builder/components/dataref/DataReference.jsx
@@ -3,10 +3,10 @@ import PropTypes from "prop-types";
 import { useCallback } from "react";
 
 import { DatabasePane } from "./DatabasePane";
-import FieldPane from "./FieldPane";
-import MainPane from "./MainPane";
+import { FieldPane } from "./FieldPane";
+import { MainPane } from "./MainPane";
 import { QuestionPane } from "./QuestionPane";
-import SchemaPane from "./SchemaPane";
+import { SchemaPane } from "./SchemaPane";
 import { TablePane } from "./TablePane";
 
 const PANES = {
@@ -57,4 +57,4 @@ const DataReference = ({
 
 DataReference.propTypes = DataReferencePropTypes;
 
-export default DataReference;
+export { DataReference };

--- a/frontend/src/metabase/query_builder/components/dataref/DataReference.jsx
+++ b/frontend/src/metabase/query_builder/components/dataref/DataReference.jsx
@@ -25,7 +25,7 @@ const DataReferencePropTypes = {
   onBack: PropTypes.func,
 };
 
-const DataReference = ({
+export const DataReference = ({
   dataReferenceStack,
   popDataReferenceStack,
   pushDataReferenceStack,
@@ -56,5 +56,3 @@ const DataReference = ({
 };
 
 DataReference.propTypes = DataReferencePropTypes;
-
-export { DataReference };

--- a/frontend/src/metabase/query_builder/components/dataref/DatabasePane.tsx
+++ b/frontend/src/metabase/query_builder/components/dataref/DatabasePane.tsx
@@ -16,7 +16,7 @@ import type {
   TreeNodeProps,
 } from "metabase/common/components/tree/types";
 import CS from "metabase/css/core/index.css";
-import SidebarContent from "metabase/query_builder/components/SidebarContent";
+import { SidebarContent } from "metabase/query_builder/components/SidebarContent";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type {
   CollectionId,

--- a/frontend/src/metabase/query_builder/components/dataref/FieldPane.tsx
+++ b/frontend/src/metabase/query_builder/components/dataref/FieldPane.tsx
@@ -8,7 +8,7 @@ interface FieldPaneProps {
   field: Field;
 }
 
-const FieldPane = ({ onBack, onClose, field }: FieldPaneProps) => {
+export const FieldPane = ({ onBack, onClose, field }: FieldPaneProps) => {
   return (
     <SidebarContent
       title={field.name}
@@ -27,5 +27,3 @@ const FieldPane = ({ onBack, onClose, field }: FieldPaneProps) => {
     </SidebarContent>
   );
 };
-
-export { FieldPane };

--- a/frontend/src/metabase/query_builder/components/dataref/FieldPane.tsx
+++ b/frontend/src/metabase/query_builder/components/dataref/FieldPane.tsx
@@ -1,5 +1,5 @@
 import { TableColumnInfo } from "metabase/common/components/MetadataInfo/ColumnInfo";
-import SidebarContent from "metabase/query_builder/components/SidebarContent";
+import { SidebarContent } from "metabase/query_builder/components/SidebarContent";
 import type Field from "metabase-lib/v1/metadata/Field";
 
 interface FieldPaneProps {
@@ -28,5 +28,4 @@ const FieldPane = ({ onBack, onClose, field }: FieldPaneProps) => {
   );
 };
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default FieldPane;
+export { FieldPane };

--- a/frontend/src/metabase/query_builder/components/dataref/MainPane.jsx
+++ b/frontend/src/metabase/query_builder/components/dataref/MainPane.jsx
@@ -5,7 +5,7 @@ import { t } from "ttag";
 
 import CS from "metabase/css/core/index.css";
 import { Databases } from "metabase/entities/databases";
-import SidebarContent from "metabase/query_builder/components/SidebarContent";
+import { SidebarContent } from "metabase/query_builder/components/SidebarContent";
 
 import {
   NodeListItemIcon,
@@ -13,7 +13,7 @@ import {
   NodeListItemName,
 } from "./NodeList";
 
-const MainPane = ({ databases, onClose, onItemClick, onBack }) => (
+const MainPaneInner = ({ databases, onClose, onItemClick, onBack }) => (
   <SidebarContent title={t`Data Reference`} onClose={onClose} onBack={onBack}>
     <SidebarContent.Pane>
       <p className={cx(CS.mt2, CS.mb3, CS.textSpaced)}>
@@ -36,11 +36,11 @@ const MainPane = ({ databases, onClose, onItemClick, onBack }) => (
   </SidebarContent>
 );
 
-MainPane.propTypes = {
+MainPaneInner.propTypes = {
   databases: PropTypes.array,
   onClose: PropTypes.func,
   onBack: PropTypes.func,
   onItemClick: PropTypes.func.isRequired,
 };
 
-export default Databases.loadList()(MainPane);
+export const MainPane = Databases.loadList()(MainPaneInner);

--- a/frontend/src/metabase/query_builder/components/dataref/QuestionPane/QuestionPane.tsx
+++ b/frontend/src/metabase/query_builder/components/dataref/QuestionPane/QuestionPane.tsx
@@ -14,7 +14,7 @@ import {
   EmptyDescription,
 } from "metabase/common/components/MetadataInfo/MetadataInfo";
 import { useSelector } from "metabase/lib/redux";
-import SidebarContent from "metabase/query_builder/components/SidebarContent";
+import { SidebarContent } from "metabase/query_builder/components/SidebarContent";
 import { getMetadata } from "metabase/selectors/metadata";
 import { Box, Flex, Icon, type IconName } from "metabase/ui";
 import type Question from "metabase-lib/v1/Question";

--- a/frontend/src/metabase/query_builder/components/dataref/SchemaPane.tsx
+++ b/frontend/src/metabase/query_builder/components/dataref/SchemaPane.tsx
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { msgid, ngettext } from "ttag";
 
 import { Schemas } from "metabase/entities/schemas";
-import SidebarContent from "metabase/query_builder/components/SidebarContent";
+import { SidebarContent } from "metabase/query_builder/components/SidebarContent";
 import type Schema from "metabase-lib/v1/metadata/Schema";
 import type { State } from "metabase-types/store";
 
@@ -23,7 +23,7 @@ interface SchemaPaneProps {
   schema: Schema;
 }
 
-const SchemaPane = ({
+const SchemaPaneInner = ({
   onBack,
   onClose,
   onItemClick,
@@ -68,7 +68,6 @@ const SchemaPane = ({
   );
 };
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default Schemas.load({
+export const SchemaPane = Schemas.load({
   id: (_state: State, props: SchemaPaneProps) => props.schema.id,
-})(SchemaPane);
+})(SchemaPaneInner);

--- a/frontend/src/metabase/query_builder/components/dataref/TableInfoLoader.tsx
+++ b/frontend/src/metabase/query_builder/components/dataref/TableInfoLoader.tsx
@@ -49,7 +49,7 @@ function useDependentTableMetadata({
   return hasFetchedMetadata;
 }
 
-export function TableInfoLoader({
+export function TableInfoLoaderInner({
   table,
   fetchForeignKeys,
   fetchMetadata,
@@ -63,5 +63,7 @@ export function TableInfoLoader({
   return hasFetchedMetadata ? <> {children} </> : null;
 }
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default connect(null, mapDispatchToProps)(TableInfoLoader);
+export const TableInfoLoader = connect(
+  null,
+  mapDispatchToProps,
+)(TableInfoLoaderInner);

--- a/frontend/src/metabase/query_builder/components/dataref/TablePane.tsx
+++ b/frontend/src/metabase/query_builder/components/dataref/TablePane.tsx
@@ -8,8 +8,8 @@ import {
 } from "metabase/common/components/MetadataInfo/MetadataInfo";
 import CS from "metabase/css/core/index.css";
 import { useSelector } from "metabase/lib/redux";
-import SidebarContent from "metabase/query_builder/components/SidebarContent";
-import ConnectedTableList from "metabase/query_builder/components/dataref/ConnectedTableList";
+import { SidebarContent } from "metabase/query_builder/components/SidebarContent";
+import { ConnectedTableList } from "metabase/query_builder/components/dataref/ConnectedTableList";
 import { getMetadata } from "metabase/selectors/metadata";
 import type { ConcreteTableId } from "metabase-types/api";
 
@@ -23,7 +23,7 @@ import {
   NodeListTitle,
   NodeListTitleText,
 } from "./NodeList";
-import TableInfoLoader from "./TableInfoLoader";
+import { TableInfoLoader } from "./TableInfoLoader";
 
 type TableItem = {
   id: ConcreteTableId;

--- a/frontend/src/metabase/query_builder/components/template_tags/SnippetForm/SnippetForm.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/SnippetForm/SnippetForm.tsx
@@ -136,5 +136,6 @@ function SnippetForm({
   );
 }
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default _.compose(SnippetCollections.loadList())(SnippetForm);
+export const SnippetForm = _.compose(SnippetCollections.loadList())(
+  SnippetForm,
+);

--- a/frontend/src/metabase/query_builder/components/template_tags/SnippetForm/SnippetForm.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/SnippetForm/SnippetForm.tsx
@@ -49,7 +49,7 @@ interface SnippetLoaderProps {
 }
 type SnippetFormProps = SnippetFormOwnProps & SnippetLoaderProps;
 
-function SnippetForm({
+function SnippetFormInner({
   snippet,
   snippetCollections,
   isEditing,
@@ -137,5 +137,5 @@ function SnippetForm({
 }
 
 export const SnippetForm = _.compose(SnippetCollections.loadList())(
-  SnippetForm,
+  SnippetFormInner,
 );

--- a/frontend/src/metabase/query_builder/components/template_tags/SnippetForm/index.ts
+++ b/frontend/src/metabase/query_builder/components/template_tags/SnippetForm/index.ts
@@ -1,3 +1,2 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./SnippetForm";
+export { SnippetForm } from "./SnippetForm";
 export type { SnippetFormValues } from "./SnippetForm";

--- a/frontend/src/metabase/query_builder/components/template_tags/SnippetFormModal/SnippetFormModal.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/SnippetFormModal/SnippetFormModal.tsx
@@ -11,7 +11,7 @@ import type {
   UpdateSnippetRequest,
 } from "metabase-types/api";
 
-import SnippetForm, { type SnippetFormValues } from "../SnippetForm";
+import { SnippetForm, type SnippetFormValues } from "../SnippetForm";
 
 type SnippetModalProps = {
   snippet: NativeQuerySnippet | Partial<Omit<NativeQuerySnippet, "id">>;

--- a/frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar/SnippetSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar/SnippetSidebar.jsx
@@ -16,8 +16,8 @@ import {
   PLUGIN_SNIPPET_SIDEBAR_PLUS_MENU_OPTIONS,
   PLUGIN_SNIPPET_SIDEBAR_ROW_RENDERERS,
 } from "metabase/plugins";
-import SidebarContent from "metabase/query_builder/components/SidebarContent";
-import SidebarHeader from "metabase/query_builder/components/SidebarHeader";
+import { SidebarContent } from "metabase/query_builder/components/SidebarContent";
+import { SidebarHeader } from "metabase/query_builder/components/SidebarHeader";
 import { Box, Button, Flex, Icon, Menu } from "metabase/ui";
 
 import { SnippetRow } from "../SnippetRow";

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.tsx
@@ -3,7 +3,7 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import type { EmbeddingParameterVisibility } from "metabase/public/lib/types";
-import SidebarContent from "metabase/query_builder/components/SidebarContent";
+import { SidebarContent } from "metabase/query_builder/components/SidebarContent";
 import { Box, Tabs } from "metabase/ui";
 import type Question from "metabase-lib/v1/Question";
 import type Database from "metabase-lib/v1/metadata/Database";

--- a/frontend/src/metabase/query_builder/components/view/QuestionDisplayToggle/QuestionDisplayToggle.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDisplayToggle/QuestionDisplayToggle.tsx
@@ -12,7 +12,7 @@ export interface QuestionDisplayToggleProps {
   onToggleRawTable: (isShowingRawTable: boolean) => void;
 }
 
-const QuestionDisplayToggle = ({
+export const QuestionDisplayToggle = ({
   className,
   isShowingRawTable,
   onToggleRawTable,
@@ -83,5 +83,3 @@ const QuestionDisplayToggle = ({
     />
   );
 };
-
-export { QuestionDisplayToggle };

--- a/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.tsx
@@ -70,7 +70,7 @@ const mapDispatchToProps = {
   onChangeLimit: setLimit,
 };
 
-function QuestionRowCount({
+function QuestionRowCountInner({
   question,
   result,
   isResultDirty,
@@ -207,7 +207,7 @@ const ConnectedQuestionRowCount = _.compose(
     id: getDatabaseId,
     loadingAndErrorWrapper: false,
   }),
-)(QuestionRowCount);
+)(QuestionRowCountInner);
 
 export type QuestionRowCountOpts = {
   result?: Dataset;

--- a/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.tsx
@@ -14,7 +14,7 @@ import CS from "metabase/css/core/index.css";
 import { Databases } from "metabase/entities/databases";
 import { connect } from "metabase/lib/redux";
 import { setLimit } from "metabase/query_builder/actions";
-import LimitPopover from "metabase/query_builder/components/LimitPopover";
+import { LimitPopover } from "metabase/query_builder/components/LimitPopover";
 import {
   getFirstQueryResult,
   getIsResultDirty,
@@ -218,5 +218,6 @@ function shouldRender({ result, isObjectDetail }: QuestionRowCountOpts) {
   return result?.data && !isObjectDetail;
 }
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default Object.assign(ConnectedQuestionRowCount, { shouldRender });
+export const QuestionRowCount = Object.assign(ConnectedQuestionRowCount, {
+  shouldRender,
+});

--- a/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.unit.spec.tsx
@@ -34,7 +34,7 @@ import {
 } from "metabase-types/api/mocks/presets";
 import { createMockQueryBuilderState } from "metabase-types/store/mocks";
 
-import QuestionRowCount from "./QuestionRowCount";
+import { QuestionRowCount } from "./QuestionRowCount";
 
 type SetupOpts = {
   question: Card | UnsavedCard;

--- a/frontend/src/metabase/query_builder/components/view/QuestionRowCount/index.ts
+++ b/frontend/src/metabase/query_builder/components/view/QuestionRowCount/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./QuestionRowCount";
+export { QuestionRowCount } from "./QuestionRowCount";

--- a/frontend/src/metabase/query_builder/components/view/QuestionTimelineWidget/QuestionTimelineWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionTimelineWidget/QuestionTimelineWidget.tsx
@@ -79,5 +79,4 @@ QuestionTimelineWidget.shouldRender = ({
   return isTimeseries;
 };
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default QuestionTimelineWidget;
+export { QuestionTimelineWidget };

--- a/frontend/src/metabase/query_builder/components/view/QuestionTimelineWidget/QuestionTimelineWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionTimelineWidget/QuestionTimelineWidget.tsx
@@ -41,7 +41,7 @@ function QuestionTimelineAcknowledgement({
   );
 }
 
-const QuestionTimelineWidget = ({
+export const QuestionTimelineWidget = ({
   className,
 }: QuestionTimelineWidgetProps): JSX.Element => {
   const { isShowingTimelineSidebar } = useSelector(getUiControls);
@@ -78,5 +78,3 @@ QuestionTimelineWidget.shouldRender = ({
 }: QuestionTimelineWidgetOpts) => {
   return isTimeseries;
 };
-
-export { QuestionTimelineWidget };

--- a/frontend/src/metabase/query_builder/components/view/QuestionTimelineWidget/index.ts
+++ b/frontend/src/metabase/query_builder/components/view/QuestionTimelineWidget/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./QuestionTimelineWidget";
+export { QuestionTimelineWidget } from "./QuestionTimelineWidget";

--- a/frontend/src/metabase/query_builder/components/view/View/NativeQueryRightSidebar/NativeQueryRightSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View/NativeQueryRightSidebar/NativeQueryRightSidebar.tsx
@@ -2,12 +2,12 @@ import { match } from "ts-pattern";
 
 import { PLUGIN_AI_ENTITY_ANALYSIS } from "metabase/plugins";
 import type { EmbeddingParameterVisibility } from "metabase/public/lib/types";
-import DataReference from "metabase/query_builder/components/dataref/DataReference";
+import { DataReference } from "metabase/query_builder/components/dataref/DataReference";
 import { SnippetSidebar } from "metabase/query_builder/components/template_tags/SnippetSidebar";
 import { TagEditorSidebar } from "metabase/query_builder/components/template_tags/TagEditorSidebar";
 import { QuestionInfoSidebar } from "metabase/query_builder/components/view/sidebars/QuestionInfoSidebar";
 import { QuestionSettingsSidebar } from "metabase/query_builder/components/view/sidebars/QuestionSettingsSidebar";
-import TimelineSidebar from "metabase/query_builder/components/view/sidebars/TimelineSidebar";
+import { TimelineSidebar } from "metabase/query_builder/components/view/sidebars/TimelineSidebar";
 import type Question from "metabase-lib/v1/Question";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type {

--- a/frontend/src/metabase/query_builder/components/view/View/StructuredQueryRightSidebar/StructuredQueryRightSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View/StructuredQueryRightSidebar/StructuredQueryRightSidebar.jsx
@@ -4,7 +4,7 @@ import { PLUGIN_AI_ENTITY_ANALYSIS } from "metabase/plugins";
 import { QuestionInfoSidebar } from "metabase/query_builder/components/view/sidebars/QuestionInfoSidebar";
 import { QuestionSettingsSidebar } from "metabase/query_builder/components/view/sidebars/QuestionSettingsSidebar";
 import { SummarizeSidebar } from "metabase/query_builder/components/view/sidebars/SummarizeSidebar";
-import TimelineSidebar from "metabase/query_builder/components/view/sidebars/TimelineSidebar";
+import { TimelineSidebar } from "metabase/query_builder/components/view/sidebars/TimelineSidebar";
 
 export const StructuredQueryRightSidebar = ({
   deselectTimelineEvents,

--- a/frontend/src/metabase/query_builder/components/view/View/View/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View/View/View.jsx
@@ -28,7 +28,7 @@ import * as Lib from "metabase-lib";
 import { DatasetEditor } from "../../../DatasetEditor";
 import { QueryModals } from "../../../QueryModals";
 import { SavedQuestionIntroModal } from "../../../SavedQuestionIntroModal";
-import ViewSidebar from "../../ViewSidebar";
+import { ViewSidebar } from "../../ViewSidebar";
 import { NotebookContainer } from "../NotebookContainer";
 import { ViewHeaderContainer } from "../ViewHeaderContainer";
 import { ViewLeftSidebarContainer } from "../ViewLeftSidebarContainer";

--- a/frontend/src/metabase/query_builder/components/view/View/ViewHeaderContainer/ViewHeaderContainer.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View/ViewHeaderContainer/ViewHeaderContainer.jsx
@@ -7,7 +7,7 @@ import { Box, Flex, Transition } from "metabase/ui";
 import * as Lib from "metabase-lib";
 
 import { ViewTitleHeader } from "../../ViewHeader";
-import ViewSection, { ViewHeading } from "../../ViewSection";
+import { ViewHeading, ViewSection } from "../../ViewSection";
 
 import ViewHeaderContainerS from "./ViewHeaderContainer.module.css";
 

--- a/frontend/src/metabase/query_builder/components/view/View/ViewMainContainer/ViewMainContainer.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View/ViewMainContainer/ViewMainContainer.tsx
@@ -8,7 +8,7 @@ import type {
   SelectionRange,
   SidebarFeatures,
 } from "metabase/query_builder/components/NativeQueryEditor/types";
-import QueryVisualization from "metabase/query_builder/components/QueryVisualization";
+import { QueryVisualization } from "metabase/query_builder/components/QueryVisualization";
 import { SyncedParametersList } from "metabase/query_builder/components/SyncedParametersList";
 import type { QueryModalType } from "metabase/query_builder/constants";
 import { TimeseriesChrome } from "metabase/querying/filters/components/TimeseriesChrome";

--- a/frontend/src/metabase/query_builder/components/view/ViewButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewButton.tsx
@@ -27,5 +27,4 @@ const ViewButton = ({ className, active, color, ...props }: Props) => {
   );
 };
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default ViewButton;
+export { ViewButton };

--- a/frontend/src/metabase/query_builder/components/view/ViewButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewButton.tsx
@@ -11,7 +11,7 @@ interface Props extends ButtonProps {
 }
 
 // NOTE: some of this is duplicated from NotebookCell.jsx
-const ViewButton = ({ className, active, color, ...props }: Props) => {
+export const ViewButton = ({ className, active, color, ...props }: Props) => {
   return (
     <Button
       classNames={{
@@ -26,5 +26,3 @@ const ViewButton = ({ className, active, color, ...props }: Props) => {
     />
   );
 };
-
-export { ViewButton };

--- a/frontend/src/metabase/query_builder/components/view/ViewFooter/LeftViewFooterButtonGroup.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewFooter/LeftViewFooterButtonGroup.tsx
@@ -11,7 +11,7 @@ import {
   onOpenChartSettings,
   onOpenChartType,
 } from "metabase/query_builder/actions";
-import ViewButton from "metabase/query_builder/components/view/ViewButton";
+import { ViewButton } from "metabase/query_builder/components/view/ViewButton";
 import { getQuestion, getUiControls } from "metabase/query_builder/selectors";
 import { Group } from "metabase/ui";
 import type { QueryBuilderUIControls } from "metabase-types/store";

--- a/frontend/src/metabase/query_builder/components/view/ViewFooter/RightViewFooterButtonGroup.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewFooter/RightViewFooterButtonGroup.tsx
@@ -12,8 +12,8 @@ import { Group } from "metabase/ui";
 
 import { ExecutionTime } from "../ExecutionTime";
 import { QuestionLastUpdated } from "../QuestionLastUpdated/QuestionLastUpdated";
-import QuestionRowCount from "../QuestionRowCount";
-import QuestionTimelineWidget from "../QuestionTimelineWidget";
+import { QuestionRowCount } from "../QuestionRowCount";
+import { QuestionTimelineWidget } from "../QuestionTimelineWidget";
 
 import S from "./RightViewFooterButtonGroup.module.css";
 

--- a/frontend/src/metabase/query_builder/components/view/ViewFooter/ViewFooter.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewFooter/ViewFooter.tsx
@@ -10,7 +10,7 @@ import {
 import { Box, Group } from "metabase/ui";
 import * as Lib from "metabase-lib";
 
-import ViewSection from "../ViewSection";
+import { ViewSection } from "../ViewSection";
 
 import { CenterViewFooterButtonGroup } from "./CenterViewFooterButtonGroup";
 import { LeftViewFooterButtonGroup } from "./LeftViewFooterButtonGroup";

--- a/frontend/src/metabase/query_builder/components/view/ViewFooter/ViewFooterDownloadWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewFooter/ViewFooterDownloadWidget.tsx
@@ -2,7 +2,7 @@ import cx from "classnames";
 
 import CS from "metabase/css/core/index.css";
 import { useSelector } from "metabase/lib/redux";
-import QuestionDownloadPopover from "metabase/query_builder/components/QuestionDownloadPopover";
+import { QuestionDownloadPopover } from "metabase/query_builder/components/QuestionDownloadPopover";
 import {
   getFirstQueryResult,
   getQuestion,

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewTitleHeader.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewTitleHeader.tsx
@@ -10,7 +10,7 @@ import type Question from "metabase-lib/v1/Question";
 import type { Dataset } from "metabase-types/api";
 import type { DatasetEditorTab, QueryBuilderMode } from "metabase-types/store";
 
-import ViewSection from "../ViewSection";
+import { ViewSection } from "../ViewSection";
 
 import ViewTitleHeaderS from "./ViewTitleHeader.module.css";
 import {

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/ExploreResultsLink.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/ExploreResultsLink.tsx
@@ -1,7 +1,7 @@
 import { t } from "ttag";
 
 import Link from "metabase/common/components/Link";
-import ViewButton from "metabase/query_builder/components/view/ViewButton";
+import { ViewButton } from "metabase/query_builder/components/view/ViewButton";
 import type Question from "metabase-lib/v1/Question";
 import { getUrl as ML_getUrl } from "metabase-lib/v1/urls";
 

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionMoreActionsMenu/QuestionMoreActionsMenu.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionMoreActionsMenu/QuestionMoreActionsMenu.tsx
@@ -15,7 +15,7 @@ import {
   turnQuestionIntoModel,
 } from "metabase/query_builder/actions";
 import { trackTurnIntoModelClicked } from "metabase/query_builder/analytics";
-import DatasetMetadataStrengthIndicator from "metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator";
+import { DatasetMetadataStrengthIndicator } from "metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator";
 import { shouldShowQuestionSettingsSidebar } from "metabase/query_builder/components/view/sidebars/QuestionSettingsSidebar";
 import {
   MODAL_TYPES,

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/ViewTitleHeaderRightSide/ViewTitleHeaderRightSide.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/ViewTitleHeaderRightSide/ViewTitleHeaderRightSide.tsx
@@ -10,7 +10,7 @@ import { useSelector } from "metabase/lib/redux";
 import MetabaseSettings from "metabase/lib/settings";
 import { useRegisterShortcut } from "metabase/palette/hooks/useRegisterShortcut";
 import { PLUGIN_AI_ENTITY_ANALYSIS } from "metabase/plugins";
-import RunButtonWithTooltip from "metabase/query_builder/components/RunButtonWithTooltip";
+import { RunButtonWithTooltip } from "metabase/query_builder/components/RunButtonWithTooltip";
 import { canExploreResults } from "metabase/query_builder/components/view/ViewHeader/utils";
 import type { QueryModalType } from "metabase/query_builder/constants";
 import { MODAL_TYPES } from "metabase/query_builder/constants";

--- a/frontend/src/metabase/query_builder/components/view/ViewSection.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewSection.tsx
@@ -15,7 +15,7 @@ export interface ViewSectionProps
   children?: ReactNode;
 }
 
-const ViewSection = ({
+export const ViewSection = ({
   className,
   style,
   children,
@@ -43,5 +43,3 @@ export const ViewSubHeading = ({ children, ...props }: ViewSubHeadingProps) => (
     {children}
   </div>
 );
-
-export { ViewSection };

--- a/frontend/src/metabase/query_builder/components/view/ViewSection.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewSection.tsx
@@ -44,5 +44,4 @@ export const ViewSubHeading = ({ children, ...props }: ViewSubHeadingProps) => (
   </div>
 );
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default ViewSection;
+export { ViewSection };

--- a/frontend/src/metabase/query_builder/components/view/ViewSidebar/ViewSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewSidebar/ViewSidebar.jsx
@@ -35,4 +35,4 @@ ViewSidebar.propTypes = {
   children: PropTypes.node,
 };
 
-export default ViewSidebar;
+export { ViewSidebar };

--- a/frontend/src/metabase/query_builder/components/view/ViewSidebar/ViewSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewSidebar/ViewSidebar.jsx
@@ -5,7 +5,12 @@ import { Box } from "metabase/ui";
 
 import ViewSidebarS from "./ViewSidebar.module.css";
 
-const ViewSidebar = ({ side = "right", width = 400, isOpen, children }) => (
+export const ViewSidebar = ({
+  side = "right",
+  width = 400,
+  isOpen,
+  children,
+}) => (
   // If we passed `width` as prop, it would end up in the final HTML elements.
   // This would ruin the animation, so we pass it as `widthProp`.
   <Box
@@ -34,5 +39,3 @@ ViewSidebar.propTypes = {
   side: PropTypes.oneOf(["left", "right"]),
   children: PropTypes.node,
 };
-
-export { ViewSidebar };

--- a/frontend/src/metabase/query_builder/components/view/ViewSidebar/index.ts
+++ b/frontend/src/metabase/query_builder/components/view/ViewSidebar/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./ViewSidebar";
+export { ViewSidebar } from "./ViewSidebar";

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.tsx
@@ -9,7 +9,7 @@ import {
   onOpenChartType,
   onReplaceAllVisualizationSettings,
 } from "metabase/query_builder/actions";
-import SidebarContent from "metabase/query_builder/components/SidebarContent";
+import { SidebarContent } from "metabase/query_builder/components/SidebarContent";
 import {
   getUiControls,
   getVisualizationSettings,

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar/ChartTypeSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar/ChartTypeSidebar.tsx
@@ -10,7 +10,7 @@ import {
   setUIControls,
   updateQuestion,
 } from "metabase/query_builder/actions";
-import SidebarContent from "metabase/query_builder/components/SidebarContent";
+import { SidebarContent } from "metabase/query_builder/components/SidebarContent";
 import {
   ChartTypeSettings,
   type GetSensibleVisualizationsProps,

--- a/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.tsx
@@ -60,7 +60,7 @@ type Props = {
 
 const TOOLTIP_DELAY = 700;
 
-function DatasetMetadataStrengthIndicator({ dataset, ...props }: Props) {
+export function DatasetMetadataStrengthIndicator({ dataset, ...props }: Props) {
   const rootRef = useRef<HTMLDivElement>(null);
   const isHovering = useHoverDirty(rootRef);
   const resultMetadata = dataset.getResultMetadata();
@@ -98,5 +98,3 @@ function DatasetMetadataStrengthIndicator({ dataset, ...props }: Props) {
     </Box>
   );
 }
-
-export { DatasetMetadataStrengthIndicator };

--- a/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.tsx
@@ -99,5 +99,4 @@ function DatasetMetadataStrengthIndicator({ dataset, ...props }: Props) {
   );
 }
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default DatasetMetadataStrengthIndicator;
+export { DatasetMetadataStrengthIndicator };

--- a/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.unit.spec.js
@@ -1,6 +1,6 @@
 import { render, screen } from "__support__/ui";
 
-import DatasetMetadataStrengthIndicator from "./DatasetMetadataStrengthIndicator";
+import { DatasetMetadataStrengthIndicator } from "./DatasetMetadataStrengthIndicator";
 
 function setup({ resultMetadata } = {}) {
   const mockDataset = {

--- a/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/index.ts
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./DatasetMetadataStrengthIndicator";
+export { DatasetMetadataStrengthIndicator } from "./DatasetMetadataStrengthIndicator";

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.tsx
@@ -2,7 +2,7 @@ import cx from "classnames";
 import { useCallback } from "react";
 import { t } from "ttag";
 
-import SidebarContent from "metabase/query_builder/components/SidebarContent";
+import { SidebarContent } from "metabase/query_builder/components/SidebarContent";
 import type { UpdateQueryHookProps } from "metabase/query_builder/hooks/types";
 import { useDefaultQueryAggregation } from "metabase/query_builder/hooks/use-default-query-aggregation";
 import { Divider } from "metabase/ui";

--- a/frontend/src/metabase/query_builder/components/view/sidebars/TimelineSidebar/TimelineSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/TimelineSidebar/TimelineSidebar.tsx
@@ -2,7 +2,7 @@ import type { Dayjs } from "dayjs";
 import { useCallback } from "react";
 import { t } from "ttag";
 
-import SidebarContent from "metabase/query_builder/components/SidebarContent";
+import { SidebarContent } from "metabase/query_builder/components/SidebarContent";
 import type { QueryModalType } from "metabase/query_builder/constants";
 import { MODAL_TYPES } from "metabase/query_builder/constants";
 import TimelinePanel from "metabase/timelines/questions/containers/TimelinePanel";
@@ -93,5 +93,4 @@ const formatDate = (date: Dayjs) => {
   return date.format("ll");
 };
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default TimelineSidebar;
+export { TimelineSidebar };

--- a/frontend/src/metabase/query_builder/components/view/sidebars/TimelineSidebar/TimelineSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/TimelineSidebar/TimelineSidebar.tsx
@@ -23,7 +23,7 @@ export interface TimelineSidebarProps {
   onClose?: () => void;
 }
 
-const TimelineSidebar = ({
+export const TimelineSidebar = ({
   question,
   timelines,
   visibleTimelineEventIds,
@@ -92,5 +92,3 @@ const formatTitle = (xDomain?: [Dayjs, Dayjs]) => {
 const formatDate = (date: Dayjs) => {
   return date.format("ll");
 };
-
-export { TimelineSidebar };

--- a/frontend/src/metabase/query_builder/components/view/sidebars/TimelineSidebar/index.ts
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/TimelineSidebar/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./TimelineSidebar";
+export { TimelineSidebar } from "./TimelineSidebar";

--- a/frontend/src/metabase/querying/editor/components/QueryEditor/NativeQuerySidebar/NativeQuerySidebar.tsx
+++ b/frontend/src/metabase/querying/editor/components/QueryEditor/NativeQuerySidebar/NativeQuerySidebar.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useMount } from "react-use";
 import { match } from "ts-pattern";
 
-import DataReference from "metabase/query_builder/components/dataref/DataReference";
+import { DataReference } from "metabase/query_builder/components/dataref/DataReference";
 import { SnippetSidebar } from "metabase/query_builder/components/template_tags/SnippetSidebar";
 import { Box } from "metabase/ui";
 import type Question from "metabase-lib/v1/Question";

--- a/frontend/src/metabase/querying/editor/components/QueryEditor/QueryEditorVisualization/QueryEditorVisualization.tsx
+++ b/frontend/src/metabase/querying/editor/components/QueryEditor/QueryEditorVisualization/QueryEditorVisualization.tsx
@@ -1,5 +1,5 @@
 import DebouncedFrame from "metabase/common/components/DebouncedFrame";
-import QueryVisualization from "metabase/query_builder/components/QueryVisualization";
+import { QueryVisualization } from "metabase/query_builder/components/QueryVisualization";
 import type Question from "metabase-lib/v1/Question";
 import type { Dataset, RawSeries } from "metabase-types/api";
 

--- a/frontend/src/metabase/querying/metrics/components/MetricEditor/MetricEditorFooter/MetricEditorFooter.tsx
+++ b/frontend/src/metabase/querying/metrics/components/MetricEditor/MetricEditorFooter/MetricEditorFooter.tsx
@@ -1,5 +1,5 @@
 import DebouncedFrame from "metabase/common/components/DebouncedFrame";
-import QueryVisualization from "metabase/query_builder/components/QueryVisualization";
+import { QueryVisualization } from "metabase/query_builder/components/QueryVisualization";
 import type Question from "metabase-lib/v1/Question";
 import type { Dataset, RawSeries } from "metabase-types/api";
 

--- a/frontend/src/metabase/querying/notebook/components/LimitStep/LimitStep.tsx
+++ b/frontend/src/metabase/querying/notebook/components/LimitStep/LimitStep.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { t } from "ttag";
 
 import CS from "metabase/css/core/index.css";
-import LimitInput from "metabase/query_builder/components/LimitInput";
+import { LimitInput } from "metabase/query_builder/components/LimitInput";
 import * as Lib from "metabase-lib";
 
 import type { NotebookStepProps } from "../../types";

--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/shared/NativeQueryModal.tsx
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/shared/NativeQueryModal.tsx
@@ -13,7 +13,7 @@ import {
 import { isMac } from "metabase/lib/browser";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { NativeQueryEditor } from "metabase/query_builder/components/NativeQueryEditor";
-import DataReference from "metabase/query_builder/components/dataref/DataReference";
+import { DataReference } from "metabase/query_builder/components/dataref/DataReference";
 import { createRawSeries } from "metabase/query_builder/utils";
 import { getMetadata } from "metabase/selectors/metadata";
 import { Box, Button, Flex, Loader, Modal, Stack, Text } from "metabase/ui";

--- a/frontend/src/metabase/ui/components/overlays/HoverCard/index.tsx
+++ b/frontend/src/metabase/ui/components/overlays/HoverCard/index.tsx
@@ -19,6 +19,4 @@ const HoverCardDropdown = function Dropdown(props: HoverCardDropdownProps) {
 HoverCardDropdown.displayName = MantineHoverCardDropdown.displayName;
 MantineHoverCard.Dropdown = HoverCardDropdown;
 
-const HoverCard: typeof MantineHoverCard = MantineHoverCard;
-
-export { HoverCard };
+export const HoverCard: typeof MantineHoverCard = MantineHoverCard;

--- a/frontend/src/metabase/ui/components/overlays/Popover/index.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Popover/index.tsx
@@ -50,7 +50,5 @@ PopoverDropdown.displayName = MantinePopoverDropdown.displayName;
 // @ts-expect-error -- our types are better
 MantinePopover.Dropdown = PopoverDropdown;
 
-const Popover = MantinePopover;
-
-export { Popover };
+export const Popover = MantinePopover;
 export { DEFAULT_POPOVER_Z_INDEX } from "./Popover.config";

--- a/frontend/src/metabase/visualizations/components/ChartSettings/ChartSettingsVisualization/ChartSettingsVisualization.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings/ChartSettingsVisualization/ChartSettingsVisualization.styled.tsx
@@ -2,7 +2,7 @@
 import styled from "@emotion/styled";
 
 import { color } from "metabase/lib/colors";
-import Warnings from "metabase/query_builder/components/Warnings";
+import { Warnings } from "metabase/query_builder/components/Warnings";
 
 export const SectionWarnings = styled(Warnings)`
   color: ${() => color("accent4")};

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
@@ -8,7 +8,7 @@ import EmptyState from "metabase/common/components/EmptyState";
 import CS from "metabase/css/core/index.css";
 import QueryBuilderS from "metabase/css/query_builder.module.css";
 import { displayNameForColumn, formatValue } from "metabase/lib/formatting";
-import ExpandableString from "metabase/query_builder/components/ExpandableString";
+import { ExpandableString } from "metabase/query_builder/components/ExpandableString";
 import type { ClickObject } from "metabase-lib";
 import { findColumnIndexesForColumnSettings } from "metabase-lib/v1/queries/utils/dataset";
 import { TYPE } from "metabase-lib/v1/types/constants";

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
@@ -603,7 +603,7 @@ const PivotTableInner = forwardRef<HTMLDivElement, VisualizationProps>(
   },
 );
 
-const PivotTable = ExplicitSize<
+export const PivotTable = ExplicitSize<
   VisualizationProps & {
     className?: string;
   }
@@ -626,5 +626,3 @@ export default Object.assign(connect(mapStateToProps)(PivotTable), {
   columnSettings,
   isLiveResizable: () => false,
 });
-
-export { PivotTable };


### PR DESCRIPTION
Mostly mechanical.

In some cases moving to named export requires renaming internal components. I followed the following convention using `XInner`
```
// Before:
const Card = () => {
  return <div />
}

export default WithSize(Card);

// After
const CardInner = () => {
  return <div />
}

export const Card = WithSize(CardInner);
```