### PR TITLE
Add transform metrics to anonymous stats ping

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/analytics/stats.clj
+++ b/enterprise/backend/src/metabase_enterprise/analytics/stats.clj
@@ -1,5 +1,6 @@
 (ns metabase-enterprise.analytics.stats
   (:require
+   [java-time.api :as t]
    [metabase-enterprise.advanced-config.settings :as advanced-config.settings]
    [metabase-enterprise.scim.core :as scim]
    [metabase-enterprise.semantic-search.core :as semantic-search]
@@ -32,3 +33,12 @@
    {:name      :semantic-search
     :available (premium-features/enable-semantic-search?)
     :enabled   (semantic-search/supported?)}])
+
+(defenterprise ee-transform-metrics
+  "Returns transform usage metrics for the Snowplow stats ping."
+  :feature :transforms
+  []
+  (let [one-day-ago (t/minus (t/offset-date-time) (t/days 1))]
+    {:transforms               (t2/count :model/Transform)
+     :transform_runs_last_24h  (t2/count :model/TransformRun
+                                         :start_time [:>= one-day-ago])}))

--- a/enterprise/backend/src/metabase_enterprise/analytics/stats.clj
+++ b/enterprise/backend/src/metabase_enterprise/analytics/stats.clj
@@ -36,7 +36,7 @@
 
 (defenterprise ee-transform-metrics
   "Returns transform usage metrics for the Snowplow stats ping."
-  :feature :transforms
+  :feature :none
   []
   (let [one-day-ago (t/minus (t/offset-date-time) (t/days 1))]
     {:transforms               (t2/count :model/Transform)

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -664,20 +664,22 @@
   []
   (let [one-day-ago (->one-day-ago)
         total-translation-count (:total (get-translation-count))]
-    {:models                          (t2/count :model/Card :type :model :archived false)
-     :new_embedded_dashboards         (t2/count :model/Dashboard
-                                                :enable_embedding true
-                                                :archived false
-                                                :created_at [:>= one-day-ago])
-     :new_users_last_24h              (t2/count :model/User
-                                                :is_active true
-                                                :date_joined [:>= one-day-ago])
-     :pivot_tables                    (t2/count :model/Card :display :pivot :archived false)
-     :query_executions_last_24h       (t2/count :model/QueryExecution :started_at [:>= one-day-ago])
-     :entity_id_translations_last_24h total-translation-count
-     :scim_users_last_24h             (t2/count :model/User :sso_source :scim
-                                                :is_active true
-                                                :date_joined [:>= one-day-ago])}))
+    (merge
+     {:models                          (t2/count :model/Card :type :model :archived false)
+      :new_embedded_dashboards         (t2/count :model/Dashboard
+                                                 :enable_embedding true
+                                                 :archived false
+                                                 :created_at [:>= one-day-ago])
+      :new_users_last_24h              (t2/count :model/User
+                                                 :is_active true
+                                                 :date_joined [:>= one-day-ago])
+      :pivot_tables                    (t2/count :model/Card :display :pivot :archived false)
+      :query_executions_last_24h       (t2/count :model/QueryExecution :started_at [:>= one-day-ago])
+      :entity_id_translations_last_24h total-translation-count
+      :scim_users_last_24h             (t2/count :model/User :sso_source :scim
+                                                 :is_active true
+                                                 :date_joined [:>= one-day-ago])}
+     (ee-transform-metrics))))
 
 (mu/defn- snowplow-metrics
   [stats metric-info :- [:map
@@ -686,7 +688,9 @@
                          [:new_users_last_24h :int]
                          [:pivot_tables :int]
                          [:query_executions_last_24h :int]
-                         [:entity_id_translations_last_24h :int]]]
+                         [:entity_id_translations_last_24h :int]
+                         [:transforms :int]
+                         [:transform_runs_last_24h :int]]]
   (mapv
    (fn [[k v tags]]
      (assert (every? string? tags) "Tags must be strings in snowplow metrics.")
@@ -725,6 +729,8 @@
     [:questions_with_params           (get-in stats [:stats :question :questions :with_params] 0)     #{"questions"}]
     [:segments                        (get-in stats [:stats :segment :segments] 0)                    #{"segments"}]
     [:tables                          (get-in stats [:stats :table :tables] 0)                        #{"tables"}]
+    [:transform_runs_last_24h         (:transform_runs_last_24h metric-info 0)                        #{"transforms"}]
+    [:transforms                      (:transforms metric-info 0)                                     #{"transforms"}]
     [:users                           (get-in stats [:stats :user :users :total] 0)                   #{"users"}]]))
 
 (defn- whitelabeling-in-use?

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -647,6 +647,18 @@
      :values (mapv (fn [[k v]] {:group k :value v}) eid-translations-24h)
      :tags ["embedding"]}]))
 
+(defn- ee-transform-metrics'
+  "OSS fallback for transform metrics. Returns zeros since transforms are an enterprise feature."
+  []
+  {:transforms               0
+   :transform_runs_last_24h  0})
+
+(defenterprise ee-transform-metrics
+  "Returns transform usage metrics for the Snowplow stats ping."
+  metabase-enterprise.analytics.stats
+  []
+  (ee-transform-metrics'))
+
 (defn- ->snowplow-metric-info
   "Collects Snowplow metrics data that is not in the legacy stats format. Also clears entity id translation count."
   []

--- a/test/metabase/analytics/stats_test.clj
+++ b/test/metabase/analytics/stats_test.clj
@@ -639,3 +639,9 @@
         (is (=? {:documents {:total 2
                              :archived 1}}
                 (#'stats/document-metrics)))))))
+
+(deftest transform-metrics-test
+  (testing "ee-transform-metrics should return zeros for OSS"
+    (mt/with-empty-h2-app-db!
+      (is (= {:transforms 0, :transform_runs_last_24h 0}
+             (stats/ee-transform-metrics))))))


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-1443/add-transform-metrics-to-anonymous-usage-stats-ping

adds `transforms` and `transform_runs_last_24h` metrics to snowplow anonymous stats