### PR TITLE
Add a delay to the flaky Loki test

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/BarChart/BarChart.stories.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/BarChart/BarChart.stories.tsx
@@ -20,6 +20,9 @@ import { BarChart } from "./BarChart";
 export default {
   title: "viz/BarChart",
   component: BarChart,
+  parameters: {
+    loki: { delay: 500 },
+  },
 };
 
 // @ts-expect-error: incompatible prop types with registerVisualization


### PR DESCRIPTION
Not sure if this is going to help with the flakiness, but it's worth trying.
Context: https://metaboat.slack.com/archives/C084XNEPH6K/p1767650958314219?thread_ts=1766157646.570019&cid=C084XNEPH6K

Closes DEV-1225