### PR TITLE
add all .env file except .env.example to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,8 @@
 /*.mv.db
 /*.trace.db
 /.babel_cache
-/.env
+/.env*
+!/.env.example
 /.envrc
 /.lein-env
 /.lein-failures


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-1444/add-env-to-gitignore

### Description

By adding all .env.* files to gitignore (with an exception of .env.example) we're gonna allow people to store different sets of environment variables that can be easily loaded for different local dev needs.