### PR TITLE
Fix translations workflow permissions

### DIFF
--- a/.github/workflows/translation-update.yml
+++ b/.github/workflows/translation-update.yml
@@ -15,8 +15,8 @@ jobs:
       BRANCH_NAME: update-translations-${{ github.run_id }}
       CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
       CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_TOKEN }}
-      GITHUB_TOKEN: ${{ github.token }}
-      GH_TOKEN: ${{ github.token }}
+      GITHUB_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+      GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
@@ -107,7 +107,7 @@ jobs:
       - name: Auto approve PR
         uses: juliangruber/approve-pull-request-action@v1
         with:
-          github-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+          github-token: ${{ github.token }}
           number: ${{ steps.create_pr.outputs.pr_number }}
 
       - name: Enable Pull Request Automerge


### PR DESCRIPTION
Closes UXW-2657

### Description

The problem here is we need 2 users for an auto-approved workflow
1. the metabase automation user must open the PR
2. the github generated user must approve the PR

The tricky bit is for some reason the user that checks out the repo ends up being the one, in the CLI, that opens the PR
