### PR TITLE
fix: make sure we don't sync unchanged collections

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/remote_sync/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/core.clj
@@ -50,15 +50,19 @@
       (when (seq sync-on)
         (t2/query {:update (t2/table-name :model/Collection)
                    :set {:is_remote_synced true}
-                   :where (into [:or [:in :id (map :id sync-on)]]
-                                (for [collection sync-on]
-                                  [:like :location (str (collections/location-path collection) "%")]))}))
+                   :where [:and
+                           [:= :is_remote_synced false]
+                           (into [:or [:in :id (map :id sync-on)]]
+                                 (for [collection sync-on]
+                                   [:like :location (str (collections/location-path collection) "%")]))]}))
       (when (seq sync-off)
         (t2/query {:update (t2/table-name :model/Collection)
                    :set {:is_remote_synced false}
-                   :where (into [:or [:in :id (map :id sync-off)]]
-                                (for [collection sync-off]
-                                  [:like :location (str (collections/location-path collection) "%")]))}))
+                   :where [:and
+                           [:= :is_remote_synced true]
+                           (into [:or [:in :id (map :id sync-off)]]
+                                 (for [collection sync-off]
+                                   [:like :location (str (collections/location-path collection) "%")]))]}))
       (doseq [collection sync-on]
         (collections/check-non-remote-synced-dependencies collection))
       (doseq [collection sync-off]

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/core_test.clj
@@ -202,3 +202,53 @@
             (is (contains? event-collection-ids coll3-id))
             (is (not (contains? event-collection-ids coll2-id)))
             (is (not (contains? event-collection-ids coll4-id)))))))))
+
+;;; ------------------------------------------- No-Op Optimization Tests -------------------------------------------
+
+(deftest bulk-set-remote-sync-skips-already-enabled-collections-test
+  (testing "bulk-set-remote-sync does not update collections that are already in the target state (enable)"
+    (mt/with-temp [:model/Collection {parent-id :id} {:name "Parent" :location "/" :is_remote_synced true}
+                   :model/Collection {child-id :id} {:name "Child" :location (format "/%d/" parent-id) :is_remote_synced true}]
+      ;; Both collections already have is_remote_synced = true
+      ;; The UPDATE should affect 0 rows because of the WHERE is_remote_synced = false clause
+      (core/bulk-set-remote-sync {parent-id true})
+      ;; Verify collections remain unchanged (the UPDATE was a no-op)
+      (is (true? (:is_remote_synced (t2/select-one :model/Collection :id parent-id))))
+      (is (true? (:is_remote_synced (t2/select-one :model/Collection :id child-id)))))))
+
+(deftest bulk-set-remote-sync-skips-already-disabled-collections-test
+  (testing "bulk-set-remote-sync does not update collections that are already in the target state (disable)"
+    (mt/with-temp [:model/Collection {parent-id :id} {:name "Parent" :location "/" :is_remote_synced false}
+                   :model/Collection {child-id :id} {:name "Child" :location (format "/%d/" parent-id) :is_remote_synced false}]
+      ;; Both collections already have is_remote_synced = false
+      ;; The UPDATE should affect 0 rows because of the WHERE is_remote_synced = true clause
+      (core/bulk-set-remote-sync {parent-id false})
+      ;; Verify collections remain unchanged (the UPDATE was a no-op)
+      (is (false? (:is_remote_synced (t2/select-one :model/Collection :id parent-id))))
+      (is (false? (:is_remote_synced (t2/select-one :model/Collection :id child-id)))))))
+
+(deftest bulk-set-remote-sync-only-updates-changed-descendants-test
+  (testing "bulk-set-remote-sync only updates descendants that need changing"
+    (mt/with-temp [:model/Collection {parent-id :id} {:name "Parent" :location "/" :is_remote_synced false}
+                   :model/Collection {child1-id :id} {:name "Child 1" :location (format "/%d/" parent-id) :is_remote_synced false}
+                   :model/Collection {child2-id :id} {:name "Child 2" :location (format "/%d/" parent-id) :is_remote_synced true}]
+      ;; Parent and Child 1 are false, Child 2 is already true
+      ;; When enabling parent, only parent and child1 should be updated, child2 should be skipped
+      (core/bulk-set-remote-sync {parent-id true})
+      ;; All should now be true
+      (is (true? (:is_remote_synced (t2/select-one :model/Collection :id parent-id))))
+      (is (true? (:is_remote_synced (t2/select-one :model/Collection :id child1-id))))
+      (is (true? (:is_remote_synced (t2/select-one :model/Collection :id child2-id)))))))
+
+(deftest bulk-set-remote-sync-only-updates-changed-descendants-disable-test
+  (testing "bulk-set-remote-sync only updates descendants that need changing (disable)"
+    (mt/with-temp [:model/Collection {parent-id :id} {:name "Parent" :location "/" :is_remote_synced true}
+                   :model/Collection {child1-id :id} {:name "Child 1" :location (format "/%d/" parent-id) :is_remote_synced true}
+                   :model/Collection {child2-id :id} {:name "Child 2" :location (format "/%d/" parent-id) :is_remote_synced false}]
+      ;; Parent and Child 1 are true, Child 2 is already false
+      ;; When disabling parent, only parent and child1 should be updated, child2 should be skipped
+      (core/bulk-set-remote-sync {parent-id false})
+      ;; All should now be false
+      (is (false? (:is_remote_synced (t2/select-one :model/Collection :id parent-id))))
+      (is (false? (:is_remote_synced (t2/select-one :model/Collection :id child1-id))))
+      (is (false? (:is_remote_synced (t2/select-one :model/Collection :id child2-id)))))))


### PR DESCRIPTION
### Description

Fixes a performance issue where we are not checking if a collection's status has changed when it is updated from the remote sync api endpoint which can result in very slow tests for valid remote sync status. 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
