### PR TITLE
[QP] Reject fuzzy match of join condition LHS to that join's RHS

### DIFF
--- a/src/metabase/query_processor/error_type.clj
+++ b/src/metabase/query_processor/error_type.clj
@@ -83,6 +83,11 @@
   :parent invalid-query
   :show-in-embeds? true)
 
+(deferror dangling-lhs-ref-in-join-condition
+  "The query contains a join condition which refers to a field on the LHS of the join which is no longer available."
+  :parent invalid-query
+  :show-in-embeds? true)
+
 ;;;; ### Server-Side Errors
 
 (deferror server

--- a/src/metabase/query_processor/util/add_alias_info.clj
+++ b/src/metabase/query_processor/util/add_alias_info.clj
@@ -58,6 +58,7 @@
    [metabase.query-processor.middleware.annotate.legacy-helper-fns :as annotate.legacy-helper-fns]
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.util :as u]
+   [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
@@ -389,6 +390,21 @@
                         ::source-alias source-alias
                         ::source-table source-table)))
 
+(defn- cartesian-join-condition-exception
+  "Exception thrown when a join condition contains a field ref to an 'other' field, ie. one whose `:join-alias` is not
+  the containing join clause, but which ends up getting resolved to a column from that join anyway. This can happen
+  due to the fuzzy matching of malformed field refs, which might (for example) find the `ID` column of the join when
+  the original `ID` column it was supposed to refer to has been removed from an upstream question. See #67667.
+
+  Such a join condition compares two columns from the RHS of the join, and is therefore incoherent. It might give an
+  empty result set, a full Cartesian join, or anything in between, depending on exactly what RHS column was resolved."
+  [field-ref]
+  (throw
+   (ex-info
+    (tru "Join condition refers to a column from outside this join, but it was incorrectly resolved to a column from this join.")
+    {:type qp.error-type/dangling-lhs-ref-in-join-condition
+     :ref  field-ref})))
+
 (mu/defn- add-alias-info-to-join-conditions :- ::lib.schema.join/join
   "Add alias info to refs in join `:conditions`. Join `:fields` do not need to be updated since they are only used to
   update parent stage `:fields` as appropriate (which will have already been done by now) and otherwise do not directly
@@ -399,6 +415,11 @@
   (let [parent-stage-path (lib.walk/join-parent-stage-path join-path)
         update-other-ref  (fn [field-ref]
                             (let [col (resolve-field-ref query parent-stage-path field-ref)]
+                              ;; Sanity check - reject an "other" ref resolved to also come from this join!
+                              ;; That creates a broken condition and a Cartesian join.
+                              (when (and (= (:lib/source col) :source/joins)
+                                         (= (:source-alias col) (:alias join)))
+                                (throw (cartesian-join-condition-exception field-ref)))
                               (add-source-to-field-ref query parent-stage-path field-ref col)))
         update-conditions (fn [conditions]
                             ;; the only kind of ref join conditions can have is a `:field` ref


### PR DESCRIPTION
Fixes #67667.

### Description

`lib.equality` has logic to do "fuzzy" matching of field refs with
the corresponding columns. This logic exists to support somewhat
malformed older queries with impoverished field refs. Refs in healthy
recent queries are fully specified and there's nothing ambiguous to
required the fuzzy matching.

The bug #67667 caught a case where this fuzzy matching could find a
column with the same name on the RHS of a join, if the original target
column has disappeared from an upstream query.

This change causes the QP to fail in exactly this case: when a would-be
LHS ref in a join condition ends up pointing at the RHS of the same
join. That would produce a strange join condition like
`LEFT JOIN Orders ON Orders.ID = Orders.PRODUCT_ID`
which produces incoherent results, and could result in a very costly
Cartesian join.

This is a user-level error, since the query is broken and needs repair.

### How to verify

Follow the repro steps on #67667; Q2 will throw this new error with this PR applied.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
