### PR TITLE
fix: dropdown menu in create/edit record on database table

### DIFF
--- a/docs/data-modeling/editable-tables.md
+++ b/docs/data-modeling/editable-tables.md
@@ -17,7 +17,6 @@ Currently, editable tables are available for the following databases:
 
 - PostgreSQL
 - MySQL
-- Metabase Sample Database
 
 ## Setting up editable tables
 

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/inputs/TableActionInputSearchableSelect.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/inputs/TableActionInputSearchableSelect.tsx
@@ -174,7 +174,7 @@ export const TableActionInputSearchableSelect = ({
       </Combobox.Target>
 
       <Combobox.Dropdown mah="none" miw={250}>
-        <Box p="0.5rem" pb="0" bg="white" pos="sticky" top={0}>
+        <Box p="0.5rem" pb="0" bg="background" pos="sticky" top={0}>
           <TextInput
             value={search}
             onChange={(event) => setSearch(event.currentTarget.value)}


### PR DESCRIPTION
Closes [UXW-2369](https://linear.app/metabase/issue/UXW-2369/dropdown-menu-in-createedit-record-on-database-table)

### Description

Background was set to white instead of a var.

### How to verify

1. Enable editable tables for some db (either by temporarily allowing h2 [here](https://github.com/metabase/metabase/blob/d1a55ddff153f4123be68c6bebfc6d662caceef3/frontend/src/metabase/databases/constants.tsx#L46) or by connecting a supported source)
3. Go to any table
2. Edit any record

### Demo

Before:
<img width="1840" height="1105" alt="image" src="https://github.com/user-attachments/assets/fb5301ab-3d45-4734-9e64-d018017af25a" />

After:
<img width="1840" height="1105" alt="image" src="https://github.com/user-attachments/assets/c76b3e85-533b-4b15-aaf3-46228a6bfdd3" />


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
