### PR TITLE
fill line series symbol with appropriate color in dark mode

### DIFF
--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -3185,7 +3185,10 @@ describe("Issue 42817", () => {
   });
 
   it("should be possible to drill down into a question with datetime buckets and a native join (metabase#42817)", () => {
-    H.echartsContainer().get("path[fill='#fff']").first().click();
+    H.echartsContainer()
+      .get("path[fill='hsla(0, 0%, 100%, 1.00)']")
+      .first()
+      .click();
 
     H.popover().findByText("See this day by hour").click();
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -626,6 +626,9 @@ const buildEChartsLineAreaSeries = (
   );
 
   const blurOpacity = hasMultipleSeries ? CHART_STYLE.opacity.blur : 1;
+  const lineWidth = seriesSettings["line.size"]
+    ? LINE_SIZE[seriesSettings["line.size"]]
+    : LINE_SIZE.M;
 
   return {
     emphasis: {
@@ -651,10 +654,9 @@ const buildEChartsLineAreaSeries = (
     id: seriesModel.dataKey,
     type: "line",
     lineStyle: {
+      color: seriesModel.color,
       type: seriesSettings["line.style"],
-      width: seriesSettings["line.size"]
-        ? LINE_SIZE[seriesSettings["line.size"]]
-        : LINE_SIZE.M,
+      width: lineWidth,
     },
     yAxisIndex,
     showSymbol: true,
@@ -667,7 +669,10 @@ const buildEChartsLineAreaSeries = (
     stack: stackName,
     areaStyle:
       seriesSettings.display === "area"
-        ? { opacity: CHART_STYLE.opacity.area }
+        ? {
+            opacity: CHART_STYLE.opacity.area,
+            color: seriesModel.color,
+          }
         : undefined,
     encode: {
       y: seriesModel.dataKey,
@@ -686,8 +691,11 @@ const buildEChartsLineAreaSeries = (
     labelLayout: {
       hideOverlap: settings["graph.label_value_frequency"] === "fit",
     },
+    symbol: "circle", // default is "emptyCircle", but it's filled with white, so we need to handle the fill ourselves for dark mode
     itemStyle: {
-      color: seriesModel.color,
+      color: renderingContext.getColor("bg-white"),
+      borderColor: seriesModel.color,
+      borderWidth: lineWidth,
       opacity: isSymbolVisible ? 1 : 0, // Make the symbol invisible to keep it for event trigger for tooltip
     },
   };


### PR DESCRIPTION
Closes [UXW-2042](https://linear.app/metabase/issue/UXW-2042/adjust-circle-color-on-data-points-in-charts)

### Description

The default symbol (aka marker) used by ECharts for line series is "emptyCircle", but it's not actually empty and is filled with white, which is inappropriate for dark mode. This change sets the symbol to "circle" so we can set the fill appropriately for dark mode.

Since `lineStyle` and `areaStyle` seem to inherit `color` from `itemStyle` (which for "emptyCircle" represents the border, while for "circle" it represents the fill), this change sets `color` for `lineStyle` and `areaStyle` explicitly to preserve their current behavior.

### How to verify

Create a line chart in dark mode and verify that the color inside the markers/symbols matches the background.

### Demo

Before, dark mode:
<img width="2810" height="782" alt="image" src="https://github.com/user-attachments/assets/13221b16-b0a0-4efa-bea8-3fbd469e9d32" />

After, dark mode:
<img width="1496" height="503" alt="image" src="https://github.com/user-attachments/assets/ae006343-2e18-4cc7-88a5-b885f6c10f67" />

Before, light mode:
<img width="2812" height="966" alt="image" src="https://github.com/user-attachments/assets/554c1a19-77c2-4eaf-8f46-c1941b8e4c07" />

After, light mode:
<img width="1426" height="490" alt="image" src="https://github.com/user-attachments/assets/71cf2471-8472-43c4-8cb7-9b89b5f68a0a" />

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
