### PR TITLE
docs: Add redirect for interactive embedding quickstart guide

### DIFF
--- a/docs/embedding/full-app-embedding-quick-start-guide.md
+++ b/docs/embedding/full-app-embedding-quick-start-guide.md
@@ -2,6 +2,7 @@
 title: "Full app embedding quickstart"
 redirect_from:
   - /docs/latest/embedding/interactive-embedding-quickstart
+  - /docs/latest/embedding/interactive-embedding-quickstart-guide
 ---
 
 # Full app embedding quickstart

--- a/docs/embedding/full-app-embedding-quick-start-guide.md
+++ b/docs/embedding/full-app-embedding-quick-start-guide.md
@@ -3,6 +3,7 @@ title: "Full app embedding quickstart"
 redirect_from:
   - /docs/latest/embedding/interactive-embedding-quickstart
   - /docs/latest/embedding/interactive-embedding-quickstart-guide
+  - /docs/latest/embedding/interactive-embedding-quick-start-guide
 ---
 
 # Full app embedding quickstart


### PR DESCRIPTION
marketing website is breaking 