### PR TITLE
Show Metabot button on transform creation page

### DIFF
--- a/e2e/test/scenarios/data-studio/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms.cy.spec.ts
@@ -720,6 +720,15 @@ LIMIT
         cy.findByText("Count").should("be.visible");
       });
     });
+
+    it("should show the metabot button", () => {
+      visitTransformListPage();
+      cy.button("Create a transform").click();
+      H.popover().findByText("Query builder").click();
+      cy.findByRole("button", { name: /Chat with Metabot/ }).should(
+        "be.visible",
+      );
+    });
   });
 
   describe("name", () => {

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/NewTransformPage/NewTransformPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/NewTransformPage/NewTransformPage.tsx
@@ -147,6 +147,7 @@ function NewTransformPageBody({
               {t`New transform`}
             </DataStudioBreadcrumbs>
           }
+          showMetabotButton
         />
         <Box
           w="100%"


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-2644/re-add-metabot-button-in-transform-creation-view

### How to verify

1. Data Studio > Transforms > New Transform
2. Metabot icon button should be present on header

### Demo
Before:
<img width="2646" height="1021" alt="image" src="https://github.com/user-attachments/assets/250c3ea5-e119-4f2b-a49e-c4c9d2a0614b" />

After:
<img width="2646" height="1021" alt="image" src="https://github.com/user-attachments/assets/72e63caf-36db-45f2-937a-63caad44e5ad" />


### Checklist

- [X] Tests have been added/updated to cover changes in this PR
