### PR TITLE
Fix serialization in the presence of xray of usage analytics

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
@@ -179,7 +179,8 @@
                               (seq targeted-tables) (assoc "Table" targeted-tables)
                               ;; Remove analytics cards from extraction - they have stable entity_ids across instances
                               ;; so cards that reference them can still be exported and imported correctly
-                              (contains? by-model "Card") (update "Card" (fn [ids] (vec (remove analytics-card-ids ids)))))
+                              (and analytics-card-ids (contains? by-model "Card"))
+                              (update "Card" (fn [ids] (vec (remove analytics-card-ids ids)))))
             extract-by-ids  (fn [[model ids]]
                               (serdes/extract-all model (merge opts {:collection-set coll-set
                                                                      :where          [:in :id ids]})))

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
@@ -80,8 +80,8 @@
   "Returns a set of collection IDs that are in the 'analytics' namespace (internal analytics collections).
    These collections are intentionally excluded from serialization."
   []
-  (let [analytics-roots (t2/select-pks-set :model/Collection {:where [:= :namespace "analytics"]})]
-    (into analytics-roots
+  (let [analytics-roots (t2/select :model/Collection {:where [:= :namespace "analytics"]})]
+    (into (set (map :id analytics-roots))
           (mapcat collection/descendant-ids)
           analytics-roots)))
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #41946
Closes https://linear.app/metabase/issue/GDGT-21/serialization-breaks-when-theres-an-x-ray-of-a-model-of-internal

Excludes dependencies of usage analytics cards from escape analysis: UA is automatically installed and the entity ids are stable, so we can safely export dependants even if the dependencies are not satisfied.