### PR TITLE
fix(SDK, Embed JS): Hide Static Question topbar from DOM when no children rendered

### DIFF
--- a/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.tsx
@@ -120,6 +120,9 @@ const StaticQuestionInner = (
     );
   };
 
+  const hasResultToolbar = withChartTypeSelector || withDownloads;
+  const hasTopBar = Boolean(title || hasResultToolbar || isGuestEmbed);
+
   return (
     <SdkQuestion
       questionId={questionId ?? null}
@@ -143,18 +146,20 @@ const StaticQuestionInner = (
             h="100%"
             gap="xs"
           >
-            <Stack className={InteractiveQuestionS.TopBar} gap="sm" p="md">
-              {title && <DefaultViewTitle title={title} />}
+            {hasTopBar && (
+              <Stack className={InteractiveQuestionS.TopBar} gap="sm" p="md">
+                {title && <DefaultViewTitle title={title} />}
 
-              {(withChartTypeSelector || withDownloads) && (
-                <ResultToolbar>
-                  {withChartTypeSelector && <SdkQuestion.ChartTypeDropdown />}
-                  {withDownloads && <SdkQuestion.DownloadWidgetDropdown />}
-                </ResultToolbar>
-              )}
+                {hasResultToolbar && (
+                  <ResultToolbar>
+                    {withChartTypeSelector && <SdkQuestion.ChartTypeDropdown />}
+                    {withDownloads && <SdkQuestion.DownloadWidgetDropdown />}
+                  </ResultToolbar>
+                )}
 
-              {isGuestEmbed && <SdkQuestion.SqlParametersList />}
-            </Stack>
+                {isGuestEmbed && <SdkQuestion.SqlParametersList />}
+              </Stack>
+            )}
 
             <Box className={InteractiveQuestionS.Main} w="100%" h="100%">
               <Box className={InteractiveQuestionS.Content}>


### PR DESCRIPTION
Hide Static Question topbar from DOM when no children rendered.
When there is no element with `InteractiveQuestionS.TopBa` class, the `InteractiveQuestionS.Container` properly applies grid template styles to have only the `main` row.

This condition was in the code initially, but it seems was lost during rebasing (???) (see image)
<img width="2986" height="2114" alt="image" src="https://github.com/user-attachments/assets/88506ad7-33b9-49e0-aa18-aced5117f952" />

With the fix
<img width="2124" height="1854" alt="image" src="https://github.com/user-attachments/assets/1c3d698f-5311-4723-82f5-840a70974328" />

