### PR TITLE
Change permission required to view segment

### DIFF
--- a/src/metabase/segments/models/segment.clj
+++ b/src/metabase/segments/models/segment.clj
@@ -76,12 +76,7 @@
 (defmethod mi/can-read? :model/Segment
   ([instance]
    (let [table (:table (t2/hydrate instance :table))]
-     (perms/user-has-permission-for-table?
-      api/*current-user-id*
-      :perms/manage-table-metadata
-      :yes
-      (:db_id table)
-      (u/the-id table))))
+     (mi/can-read? table)))
   ([model pk]
    (mi/can-read? (t2/select-one model pk))))
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #63782
I think this permission makes more sense and is probably what we intended. Note that users without `manage-table-metadata` but with table permission can already read this information from the `/api/query_metadata` endpoint.

[UXW-1756: Non-admins can't see segments in data reference](https://linear.app/metabase/issue/UXW-1756/non-admins-cant-see-segments-in-data-reference)