### PR TITLE
Fix `-{un,}install-merge-drivers` when using a git worktree

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -317,7 +317,7 @@
    :requires [[mage.util :as u]
               [clojure.string :as str]]
    :task (task!
-          (let [git-dir (u/sh "git rev-parse --git-dir")
+          (let [git-dir (u/sh "git rev-parse --git-common-dir")
                 git-config-file (str git-dir "/config")
                 the-include (str "\n"
                                  "[include]\n"
@@ -332,7 +332,7 @@
    :requires [[clojure.string :as str]
               [mage.util :as u]]
    :task (task!
-          (let [git-dir (u/sh "git rev-parse --git-dir")
+          (let [git-dir (u/sh "git rev-parse --git-common-dir")
                 git-config-file (str git-dir "/config")
                 the-include (str "\n"
                                  "[include]\n"


### PR DESCRIPTION
> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform). Also, if you're attempting to fix a translation issue, please submit your changes to our [Crowdin project](https://crowdin.com/project/metabase-i18n) instead of opening a PR.

### Description

We have a precommit hook that always calls `mage -uninstall-merge-drivers`:

https://github.com/metabase/metabase/blob/02f1e7b7971326cea359a71d736c8e88e36200a7/lint-staged.config.cjs#L37

This hook breaks when the current directory is a linked [worktree](https://git-scm.com/docs/git-worktree) and not the main worktree. For example, starting from the main worktree:

```
❯ mage -uninstall-merge-drivers && echo $status
0
❯ git worktree add ../test-worktree
Preparing worktree (new branch 'test-worktree')
Updating files: 100% (16044/16044), done.
HEAD is now at c5f433336a4 add kevinkelleher12 to team.json and github-slack-map.json (#67752)
❯ cd ../test-worktree/ && bin/mage -uninstall-merge-drivers
❯ mage -uninstall-merge-drivers
[INFO] Babashka not found or version doesn't match, installing...
[INFO] Detected platform: macos-aarch64
[INFO] Download URL: https://github.com/babashka/babashka/releases/download/v1.12.212/babashka-1.12.212-macos-aarch64.tar.gz
##################################################################################################### 100.0%
[INFO] Download complete. Extracting archive...
babashka v1.12.212
[SUCCESS] Babashka 1.12.212 successfully installed at /Users/rolodato/source/metabase/test-worktree/bin/bb

Exception:
 {:exception-type java.io.FileNotFoundException, :ex-message /Users/rolodato/source/metabase/metabase/.git/worktrees/test-worktree/config (No such file or directory)}
ex-message :  /Users/rolodato/source/metabase/metabase/.git/worktrees/test-worktree/config (No such file or directory)
```

This happens because the script tries to resolve `$(git rev-parse --git-dir)/config`, but this does not exist on linked worktrees:

```
❯ git rev-parse --git-dir
/Users/rolodato/source/metabase/metabase/.git/worktrees/rolodato-precommit-git-worktree
❯ ls -l $(git rev-parse --git-dir)
total 4640
-rw-r--r--@ 1 rolodato  staff      290 Jan  7 09:12 COMMIT_EDITMSG
-rw-r--r--@ 1 rolodato  staff        6 Jan  7 06:22 commondir
-rw-r--r--@ 1 rolodato  staff      137 Jan  7 06:22 gitdir
-rw-r--r--@ 1 rolodato  staff       48 Jan  7 06:22 HEAD
-rw-r--r--@ 1 rolodato  staff  2352367 Jan  7 09:11 index
drwxr-xr-x@ 3 rolodato  staff       96 Jan  7 06:22 logs/
-rw-r--r--@ 1 rolodato  staff       41 Jan  7 06:22 ORIG_HEAD
drwxr-xr-x@ 2 rolodato  staff       64 Jan  7 06:22 refs/
```

Instead, this should use `git rev-parse --git-common-dir`, which returns the main worktree's `.git` directory:

```
❯ git rev-parse --git-common-dir
/Users/rolodato/source/metabase/metabase/.git
```

And also still works when run in the main worktree:

```
❯ git rev-parse --git-common-dir
.git
```

For reference, from `man git-rev-parse`:

```
       --git-dir
           Show $GIT_DIR if defined. Otherwise show the path to the .git directory. The path shown, when
           relative, is relative to the current working directory.

           If $GIT_DIR is not defined and the current directory is not detected to lie in a Git repository
           or work tree print a message to stderr and exit with nonzero status.

       --git-common-dir
           Show $GIT_COMMON_DIR if defined, else $GIT_DIR.
```

### How to verify

1. Clone this branch in a new git worktree
2. Try to make any commit. Precommit hooks should succeed

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
