### PR TITLE
Manage table metadata allows syncing table

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1636,7 +1636,6 @@
            upload
            util
            warehouse-schema
-           warehouses-rest
            xrays}}
 
   warehouses

--- a/src/metabase/warehouse_schema_rest/api/table.clj
+++ b/src/metabase/warehouse_schema_rest/api/table.clj
@@ -33,7 +33,6 @@
    [metabase.util.quick-task :as quick-task]
    [metabase.warehouse-schema.models.table :as table]
    [metabase.warehouse-schema.table :as schema.table]
-   [metabase.warehouses-rest.api :as warehouses]
    [metabase.xrays.core :as xrays]
    [steffan-westcott.clj-otel.api.trace.span :as span]
    [toucan2.core :as t2]))
@@ -500,8 +499,10 @@
   "Trigger a manual update of the schema metadata for this `Table`."
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]]
-  (let [table    (t2/select-one :model/Table :id id)
-        database (warehouses/get-database (:db_id table))]
+  (let [table    (api/check-404 (t2/select-one :model/Table :id id))
+        database (api/check-404 (t2/select-one :model/Database
+                                               :id (:db_id table)
+                                               :router_database_id nil))]
     (api/check-403
      (perms/user-has-permission-for-table?
       api/*current-user-id*

--- a/test/metabase/warehouse_schema_rest/api/table_test.clj
+++ b/test/metabase/warehouse_schema_rest/api/table_test.clj
@@ -1197,6 +1197,40 @@
         (is (true?
              (deref sync-called? timeout :sync-never-called)))))))
 
+(deftest sync-schema-with-manage-table-metadata-permission-test
+  (testing "POST /api/table/:id/sync_schema"
+    (testing "User with manage-table-metadata permission can sync table"
+      (let [sync-called? (promise)
+            timeout (* 10 60)]
+        (mt/with-premium-features #{:audit-app}
+          (mt/with-temp [:model/Database {db-id :id} {:engine "h2", :details (:details (mt/db))}
+                         :model/Table    table       {:db_id db-id :schema "PUBLIC"}]
+            (mt/with-no-data-perms-for-all-users!
+              ;; Grant only manage-table-metadata permission for this table
+              (data-perms/set-table-permission! (perms-group/all-users) (:id table) :perms/manage-table-metadata :yes)
+              (with-redefs [sync/sync-table! (deliver-when-tbl sync-called? table)]
+                (mt/user-http-request :rasta :post 200 (format "table/%d/sync_schema" (u/the-id table)))))))
+        (testing "sync called?"
+          (is (true?
+               (deref sync-called? timeout :sync-never-called))))))))
+
+(deftest sync-schema-mirror-database-test
+  (testing "POST /api/table/:id/sync_schema"
+    (testing "Mirror databases (with router_database_id set) return 404"
+      (mt/with-temp [:model/Database {source-db-id :id} {:engine "h2", :details (:details (mt/db))}
+                     :model/Database {mirror-db-id :id} {:engine "h2"
+                                                         :details (:details (mt/db))
+                                                         :router_database_id source-db-id}
+                     :model/Table    table              {:db_id mirror-db-id :schema "PUBLIC"}]
+        (is (= "Not found."
+               (mt/user-http-request :crowberto :post 404 (format "table/%d/sync_schema" (u/the-id table)))))))))
+
+(deftest ^:parallel sync-schema-nonexistent-table-test
+  (testing "POST /api/table/:id/sync_schema"
+    (testing "Non-existent table returns 404"
+      (is (= "Not found."
+             (mt/user-http-request :crowberto :post 404 (format "table/%d/sync_schema" Integer/MAX_VALUE)))))))
+
 (deftest ^:parallel list-table-filtering-test
   (let [list-tables (fn [& params]
                       (->> (apply mt/user-http-request :crowberto :get 200 "table" params)


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #67838
This is the permission we're correctly checking with the below `api/check-403` but by using `warehouses/get-database` (which, btw, has the MOST confusing possible arguments I've ever seen) we were throwing a 403 if we didn't have read access to the whole database (which checks *create-queries* perms on the entire database).

We still need to exclude mirror databases. In the medium term there might be a better way to do this - maybe we could somehow have two different models, so `(t2/select :model/Database)` would always exclude mirror databases, while `(t2/select :model/DatabaseIncludingMirrorDatabase)` would return them? I dunno.