### PR TITLE
Highlight people tab on admin tenant pages

### DIFF
--- a/e2e/test/scenarios/admin-2/tenants.cy.spec.ts
+++ b/e2e/test/scenarios/admin-2/tenants.cy.spec.ts
@@ -80,7 +80,7 @@ describe("Tenants - management OSS", { tags: "@OSS" }, () => {
   });
 
   it("should not show the popup to enable multi tenancy", () => {
-    cy.visit("/admin/tenants");
+    cy.visit("/admin/people/tenants");
     cy.location("pathname").should("eq", "/admin/people");
 
     cy.findByRole("link", { name: /gear/ }).should("not.exist");
@@ -99,7 +99,7 @@ describe("Tenants - management", () => {
   it("should disable the feature if the token feature is not enabled", () => {
     H.deleteToken();
 
-    cy.visit("/admin/tenants");
+    cy.visit("/admin/people/tenants");
     cy.location("pathname").should("eq", "/admin/people");
 
     cy.findByRole("link", { name: /gear/ }).should("not.exist");
@@ -107,10 +107,10 @@ describe("Tenants - management", () => {
 
   it("should allow users to enable multi tenancy, and create / manage tenants and tenant users", () => {
     // We expect this to redirect to /admin/people
-    cy.visit("/admin/tenants");
+    cy.visit("/admin/people/tenants");
 
     cy.location("pathname").should("eq", "/admin/people");
-    cy.visit("/admin/tenants");
+    cy.visit("/admin/people/tenants");
 
     cy.findByRole("navigation", { name: "people-nav" })
       .findByRole("link", { name: /Groups/ })
@@ -581,7 +581,7 @@ describe("Tenants - management", () => {
 
     createTenants();
 
-    cy.visit("admin/tenants/people");
+    cy.visit("admin/people/tenants/people");
 
     cy.findByRole("link", { name: /Tenant users/ }).click();
     cy.button("Create tenant user").click();
@@ -669,7 +669,7 @@ describe("Tenants - management", () => {
 
     cy.log("check that tenant attributes propagate to users");
 
-    cy.visit("/admin/tenants/people");
+    cy.visit("/admin/people/tenants/people");
     cy.findByTestId("nav-item-external-users").findByText("Tenant users", 1000);
     cy.findByTestId("admin-people-list-table").within(() => {
       cy.findByText(`${GIZMO_USER.first_name} ${GIZMO_USER.last_name}`).should(
@@ -761,7 +761,7 @@ describe("tenant users", () => {
   });
 
   it("should disable users on a tenant when disabling the tenant", () => {
-    cy.visit("/admin/tenants/people");
+    cy.visit("/admin/people/tenants/people");
 
     cy.findAllByRole("row")
       .contains("tr", "donthickey user")
@@ -1045,7 +1045,7 @@ const createTenants = () => {
 
 const createTenantGroupFromUI = (groupName: string) => {
   cy.intercept("POST", "/api/permissions/group").as("createGroup");
-  cy.visit("/admin/tenants/groups");
+  cy.visit("/admin/people/tenants/groups");
 
   // FIXME shouldn't be necessary - caused by slow route guard
   cy.findByTestId("admin-layout-sidebar")

--- a/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
@@ -326,7 +326,7 @@ describe("scenarios - embedding hub", () => {
         .scrollIntoView()
         .should("be.visible")
         .closest("a")
-        .should("have.attr", "href", "/admin/tenants");
+        .should("have.attr", "href", "/admin/people/tenants");
     });
   });
 });

--- a/e2e/test/scenarios/embedding/modular-embedding-settings.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/modular-embedding-settings.cy.spec.ts
@@ -27,6 +27,6 @@ describe("scenarios > modular embedding settings", { tags: "@EE" }, () => {
       .scrollIntoView()
       .should("be.visible")
       .closest("a")
-      .should("have.attr", "href", "/admin/tenants");
+      .should("have.attr", "href", "/admin/people/tenants");
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/index.js
@@ -26,7 +26,7 @@ export function initializePlugin() {
         to={
           isInternalUser(user)
             ? `/admin/people/${user.id}/unsubscribe`
-            : `/admin/tenants/people/${user.id}/unsubscribe`
+            : `/admin/people/tenants/people/${user.id}/unsubscribe`
         }
         key="unsubscribe"
       >

--- a/enterprise/frontend/src/metabase-enterprise/tenants/EditUserStrategyModal/EditUserStrategyModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/EditUserStrategyModal/EditUserStrategyModal.tsx
@@ -91,7 +91,7 @@ export const EditUserStrategyModal = ({
       // This ensures `createTenantsRouteGuard` sees the updated setting.
       await refetch();
 
-      dispatch(push("/admin/tenants"));
+      dispatch(push("/admin/people/tenants"));
     }
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantsListingEmptyState.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantsListingEmptyState.tsx
@@ -16,10 +16,10 @@ export const TenantsListingEmptyState = ({
         ).jt`Create your first tenant to start adding ${(
           <Anchor
             component={Link}
-            to="/admin/tenants/people"
+            to="/admin/people/tenants/people"
             key="external-users-link"
           >{t`external users`}</Anchor>
-        )} to it, and organize these users into ${(<Anchor component={Link} to="/admin/tenants/groups" key="tenant-groups-link">{t`groups`}</Anchor>)} to assign ${(
+        )} to it, and organize these users into ${(<Anchor component={Link} to="/admin/people/tenants/groups" key="tenant-groups-link">{t`groups`}</Anchor>)} to assign ${(
           <Anchor
             component={Link}
             to="/admin/permissions"

--- a/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
@@ -2,7 +2,6 @@ import { Fragment } from "react";
 import { IndexRedirect, IndexRoute, Route } from "react-router";
 import { t } from "ttag";
 
-import { AdminPeopleApp } from "metabase/admin/people/containers/AdminPeopleApp";
 import { EditUserModal } from "metabase/admin/people/containers/EditUserModal";
 import { NewUserModal } from "metabase/admin/people/containers/NewUserModal";
 import { UserActivationModal } from "metabase/admin/people/containers/UserActivationModal";
@@ -147,75 +146,73 @@ export function initializePlugin() {
 
     PLUGIN_TENANTS.tenantsRoutes = (
       <>
-        <Route component={AdminPeopleApp}>
-          <IndexRoute component={TenantsListingApp} />
-          <Route path="" component={TenantsListingApp}>
-            <ModalRoute path="new" modal={NewTenantModal} noWrap />
-            <ModalRoute
-              path="user-strategy"
-              modal={EditUserStrategyModal}
-              noWrap
-            />
-          </Route>
-          <Route path="groups">
-            <IndexRoute component={ExternalGroupsListingApp} />
-            <Route path=":groupId" component={ExternalGroupDetailApp} />
-          </Route>
-          <Route path="people" component={ExternalPeopleListingApp}>
-            <ModalRoute
-              path="new"
-              modal={(props) => <NewUserModal {...props} external />}
-              noWrap
-            />
-            <Route path=":userId">
-              <IndexRedirect to="/admin/tenants/people" />
-              <ModalRoute
-                path="edit"
-                // @ts-expect-error - params prop can't be infered
-                modal={(props) => <EditUserModal {...props} external />}
-                noWrap
-              />
-              <ModalRoute
-                path="deactivate"
-                // @ts-expect-error - params prop can't be infered
-                modal={UserActivationModal}
-                noWrap
-              />
-              <ModalRoute
-                path="reactivate"
-                // @ts-expect-error - params prop can't be infered
-                modal={UserActivationModal}
-                noWrap
-              />
-              {/* @ts-expect-error - params prop can't be infered */}
-              <ModalRoute path="success" modal={UserSuccessModal} noWrap />
-              {/* @ts-expect-error - params prop can't be infered */}
-              <ModalRoute path="reset" modal={UserPasswordResetModal} noWrap />
-              {PLUGIN_ADMIN_USER_MENU_ROUTES.map((getRoutes, index) => (
-                <Fragment key={index}>{getRoutes()}</Fragment>
-              ))}
-            </Route>
-          </Route>
-          <Route path=":tenantId" component={TenantsListingApp}>
+        <IndexRoute component={TenantsListingApp} />
+        <Route path="" component={TenantsListingApp}>
+          <ModalRoute path="new" modal={NewTenantModal} noWrap />
+          <ModalRoute
+            path="user-strategy"
+            modal={EditUserStrategyModal}
+            noWrap
+          />
+        </Route>
+        <Route path="groups">
+          <IndexRoute component={ExternalGroupsListingApp} />
+          <Route path=":groupId" component={ExternalGroupDetailApp} />
+        </Route>
+        <Route path="people" component={ExternalPeopleListingApp}>
+          <ModalRoute
+            path="new"
+            modal={(props) => <NewUserModal {...props} external />}
+            noWrap
+          />
+          <Route path=":userId">
+            <IndexRedirect to="/admin/people/tenants/people" />
             <ModalRoute
               path="edit"
               // @ts-expect-error - params prop can't be infered
-              modal={EditTenantModal}
+              modal={(props) => <EditUserModal {...props} external />}
               noWrap
             />
             <ModalRoute
               path="deactivate"
               // @ts-expect-error - params prop can't be infered
-              modal={TenantActivationModal}
+              modal={UserActivationModal}
               noWrap
             />
             <ModalRoute
               path="reactivate"
               // @ts-expect-error - params prop can't be infered
-              modal={TenantActivationModal}
+              modal={UserActivationModal}
               noWrap
             />
+            {/* @ts-expect-error - params prop can't be infered */}
+            <ModalRoute path="success" modal={UserSuccessModal} noWrap />
+            {/* @ts-expect-error - params prop can't be infered */}
+            <ModalRoute path="reset" modal={UserPasswordResetModal} noWrap />
+            {PLUGIN_ADMIN_USER_MENU_ROUTES.map((getRoutes, index) => (
+              <Fragment key={index}>{getRoutes()}</Fragment>
+            ))}
           </Route>
+        </Route>
+        <Route path=":tenantId" component={TenantsListingApp}>
+          <ModalRoute
+            path="edit"
+            // @ts-expect-error - params prop can't be infered
+            modal={EditTenantModal}
+            noWrap
+          />
+          <ModalRoute
+            path="deactivate"
+            // @ts-expect-error - params prop can't be infered
+            modal={TenantActivationModal}
+            noWrap
+          />
+          <ModalRoute
+            path="reactivate"
+            // @ts-expect-error - params prop can't be infered
+            modal={TenantActivationModal}
+            noWrap
+          />
         </Route>
       </>
     );

--- a/enterprise/frontend/src/metabase-enterprise/urls.ts
+++ b/enterprise/frontend/src/metabase-enterprise/urls.ts
@@ -29,21 +29,21 @@ export function newMetabotConversation({ prompt }: { prompt: string }) {
 }
 
 export function newTenant() {
-  return `/admin/tenants/new`;
+  return `/admin/people/tenants/new`;
 }
 
 export function editTenant(tenantId: Tenant["id"]) {
-  return `/admin/tenants/${tenantId}/edit`;
+  return `/admin/people/tenants/${tenantId}/edit`;
 }
 
 export function deactivateTenant(tenantId: Tenant["id"]) {
-  return `/admin/tenants/${tenantId}/deactivate`;
+  return `/admin/people/tenants/${tenantId}/deactivate`;
 }
 
 export function reactivateTenant(tenantId: Tenant["id"]) {
-  return `/admin/tenants/${tenantId}/reactivate`;
+  return `/admin/people/tenants/${tenantId}/reactivate`;
 }
 
 export function editUserStrategy(page: "people" | "tenants") {
-  return `/admin/${page}/user-strategy`;
+  return `/admin/people${page === "tenants" ? "/tenants" : ""}/user-strategy`;
 }

--- a/frontend/src/metabase/admin/components/RelatedSettingsSection/constants.ts
+++ b/frontend/src/metabase/admin/components/RelatedSettingsSection/constants.ts
@@ -53,7 +53,7 @@ export const getModularEmbeddingRelatedSettingItems = ({
             icon: "globe" as const,
             name: t`Tenants`,
             to: isUsingTenants
-              ? "/admin/tenants"
+              ? "/admin/people/tenants"
               : "/admin/people/user-strategy",
           },
         ]

--- a/frontend/src/metabase/admin/people/components/GroupsListing.tsx
+++ b/frontend/src/metabase/admin/people/components/GroupsListing.tsx
@@ -247,7 +247,7 @@ function GroupRow({
   const isTenantGroup = PLUGIN_TENANTS.isTenantGroup(group);
 
   const membersLink = isTenantGroup
-    ? `/admin/tenants/groups/${group.id}`
+    ? `/admin/people/tenants/groups/${group.id}`
     : `/admin/people/groups/${group.id}`;
 
   return editing ? (

--- a/frontend/src/metabase/admin/people/components/PeopleNav.tsx
+++ b/frontend/src/metabase/admin/people/components/PeopleNav.tsx
@@ -35,19 +35,19 @@ export function PeopleNav() {
           <>
             <Divider my="sm" />
             <PeopleNavItem
-              path="/admin/tenants"
+              path="/admin/people/tenants"
               data-testid="nav-item-tenants"
               label={t`Tenants`}
               icon="globe"
             />
             <PeopleNavItem
-              path="/admin/tenants/groups"
+              path="/admin/people/tenants/groups"
               data-testid="nav-item-tenant-groups"
               label={t`Tenant groups`}
               icon="group"
             />
             <PeopleNavItem
-              path="/admin/tenants/people"
+              path="/admin/people/tenants/people"
               data-testid="nav-item-external-users"
               label={t`Tenant users`}
               icon="person"

--- a/frontend/src/metabase/admin/people/containers/AdminPeopleApp/AdminPeopleApp.unit.spec.tsx
+++ b/frontend/src/metabase/admin/people/containers/AdminPeopleApp/AdminPeopleApp.unit.spec.tsx
@@ -66,8 +66,8 @@ describe("AdminPeopleApp", () => {
 
       assertNavLink("Internal users", "/admin/people");
       assertNavLink("Internal groups", "/admin/people/groups");
-      assertNavLink("Tenants", "/admin/tenants");
-      assertNavLink("Tenant users", "/admin/tenants/people");
+      assertNavLink("Tenants", "/admin/people/tenants");
+      assertNavLink("Tenant users", "/admin/people/tenants/people");
     });
   });
 

--- a/frontend/src/metabase/admin/people/containers/UserSuccessModal.tsx
+++ b/frontend/src/metabase/admin/people/containers/UserSuccessModal.tsx
@@ -40,7 +40,9 @@ export function UserSuccessModal({ params }: UserSuccessModalProps) {
 
   const handleClose = () => {
     dispatch(
-      isExternalUser ? push("/admin/tenants/people") : push("/admin/people"),
+      isExternalUser
+        ? push("/admin/people/tenants/people")
+        : push("/admin/people"),
     );
   };
 
@@ -52,7 +54,7 @@ export function UserSuccessModal({ params }: UserSuccessModalProps) {
 
   useEffect(() => {
     if (isExternalUser && !temporaryPassword) {
-      dispatch(replace("/admin/tenants/people"));
+      dispatch(replace("/admin/people/tenants/people"));
     }
   }, [isExternalUser, temporaryPassword, dispatch]);
 

--- a/frontend/src/metabase/admin/routes.jsx
+++ b/frontend/src/metabase/admin/routes.jsx
@@ -129,6 +129,11 @@ const getRoutes = (store, CanAccessSettings, IsAdmin) => (
             <Route path=":groupId" component={GroupDetailApp} />
           </Route>
 
+          {/* Tenants */}
+          <Route path="tenants" component={createTenantsRouteGuard()}>
+            {PLUGIN_TENANTS.tenantsRoutes}
+          </Route>
+
           <Route path="" component={PeopleListingApp}>
             <ModalRoute path="new" modal={NewUserModal} noWrap />
             {PLUGIN_TENANTS.userStrategyRoute}
@@ -213,11 +218,6 @@ const getRoutes = (store, CanAccessSettings, IsAdmin) => (
       {/* PERMISSIONS */}
       <Route path="permissions" component={IsAdmin}>
         {getAdminPermissionsRoutes(store)}
-      </Route>
-
-      {/* Tenants */}
-      <Route path="tenants" component={createTenantsRouteGuard()}>
-        {PLUGIN_TENANTS.tenantsRoutes}
       </Route>
 
       {/* PERFORMANCE */}

--- a/frontend/src/metabase/lib/urls/admin.ts
+++ b/frontend/src/metabase/lib/urls/admin.ts
@@ -13,37 +13,37 @@ export function newUser() {
   return `/admin/people/new`;
 }
 export function newTenantUser() {
-  return "/admin/tenants/people/new";
+  return "/admin/people/tenants/people/new";
 }
 
 export function editUser(user: BaseUser) {
   return isInternalUser(user)
     ? `/admin/people/${user.id}/edit`
-    : `/admin/tenants/people/${user.id}/edit`;
+    : `/admin/people/tenants/people/${user.id}/edit`;
 }
 
 export function resetPassword(user: BaseUser) {
   return isInternalUser(user)
     ? `/admin/people/${user.id}/reset`
-    : `/admin/tenants/people/${user.id}/reset`;
+    : `/admin/people/tenants/people/${user.id}/reset`;
 }
 
 export function newUserSuccess(user: BaseUser) {
   return isInternalUser(user)
     ? `/admin/people/${user.id}/success`
-    : `/admin/tenants/people/${user.id}/success`;
+    : `/admin/people/tenants/people/${user.id}/success`;
 }
 
 export function deactivateUser(user: BaseUser) {
   return isInternalUser(user)
     ? `/admin/people/${user.id}/deactivate`
-    : `/admin/tenants/people/${user.id}/deactivate`;
+    : `/admin/people/tenants/people/${user.id}/deactivate`;
 }
 
 export function reactivateUser(user: BaseUser) {
   return isInternalUser(user)
     ? `/admin/people/${user.id}/reactivate`
-    : `/admin/tenants/people/${user.id}/reactivate`;
+    : `/admin/people/tenants/people/${user.id}/reactivate`;
 }
 
 // TODO: move to EE urls


### PR DESCRIPTION
Closes [EMB-1170](https://linear.app/metabase/issue/EMB-1170/people-tab-not-highlighted-on-tenant-admin-pages)

### Description

The problem was that the People tab is highlighted when the URL path begins with "admin/people", but the Tenants pages began with "admin/tenants". This change reroutes Tenants pages from "admin/tenants" to "admin/people/tenants".

### How to verify

1. Go to Admin -> People -> Tenants
2. Verify the People tab is highlighted at the top of the screen

### Demo

Before:
<img width="3500" height="1340" alt="image" src="https://github.com/user-attachments/assets/dd29d90a-efc8-48bb-9bf0-f69586e502a6" />

After:
<img width="755" height="285" alt="image" src="https://github.com/user-attachments/assets/46549868-fe34-4f13-b590-8579d2b77051" />

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
