### PR TITLE
Fix flaky "shows a static dashboard using drills" e2e

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/embed-options.cy.spec.ts
@@ -224,7 +224,10 @@ describe("scenarios > embedding > sdk iframe embed options passthrough", () => {
       cy.get('[aria-label="Download as PDF"]').should("be.visible");
 
       cy.log("4. clicking on the column value should not show the popover");
-      cy.findAllByText("37.65").first().should("be.visible").click();
+      cy.findAllByText("37.65").first().should("be.visible");
+
+      cy.findAllByText("37.65").first().click();
+
       cy.findByText(/Filter by this value/).should("not.exist");
     });
   });


### PR DESCRIPTION
Fix flaky "shows a static dashboard using drills" e2e.

Error message:
```
We initially found matching element(s), but while waiting for them to become actionable, they disappeared from the page. Common situations why this happens:
  - Your JS framework re-rendered asynchronously
  - Your app code reacted to an event firing and removed the element

You can typically solve this by breaking up a chain. For example, rewrite:

> `cy.get('button').click().click()`

to

> `cy.get('button').as('btn').click()`
> `cy.get('@btn').click()`
```

As Cypress shows in error, splitting `.click` call fixes it it seems. At least after this change i was not able to reproduce it.