### PR TITLE
Add documentation button to tenants list page

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/tenants/TenantsDocsButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/TenantsDocsButton.tsx
@@ -1,0 +1,29 @@
+import { t } from "ttag";
+
+import ExternalLink from "metabase/common/components/ExternalLink";
+import { useDocsUrl } from "metabase/common/hooks";
+import { ActionIcon, Icon, Tooltip } from "metabase/ui";
+
+export const TenantsDocsButton = () => {
+  // eslint-disable-next-line no-unconditional-metabase-links-render -- admin
+  const { url } = useDocsUrl("embedding/tenants");
+
+  if (!url) {
+    return null;
+  }
+
+  return (
+    <ExternalLink href={url}>
+      <Tooltip label={t`View documentation`}>
+        <ActionIcon
+          size="lg"
+          variant="outline"
+          c="text-primary"
+          bd="1px solid var(--mb-color-border)"
+        >
+          <Icon name="reference" />
+        </ActionIcon>
+      </Tooltip>
+    </ExternalLink>
+  );
+};

--- a/enterprise/frontend/src/metabase-enterprise/tenants/TenantsDocsButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/TenantsDocsButton.tsx
@@ -5,7 +5,7 @@ import { useDocsUrl } from "metabase/common/hooks";
 import { ActionIcon, Icon, Tooltip } from "metabase/ui";
 
 export const TenantsDocsButton = () => {
-  // eslint-disable-next-line no-unconditional-metabase-links-render -- admin
+  // eslint-disable-next-line no-unconditional-metabase-links-render -- we can always show links in admin panels, showMetabaseLinks doesn't apply
   const { url } = useDocsUrl("embedding/tenants");
 
   if (!url) {

--- a/enterprise/frontend/src/metabase-enterprise/tenants/containers/TenantsListingApp.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/containers/TenantsListingApp.tsx
@@ -13,6 +13,7 @@ import { Box, Group, Tabs, Title } from "metabase/ui";
 import { useListTenantsQuery } from "metabase-enterprise/api";
 
 import { EditUserStrategySettingsButton } from "../EditUserStrategySettingsButton";
+import { TenantsDocsButton } from "../TenantsDocsButton";
 import { TenantsListing } from "../components/TenantsListing";
 
 import S from "./TenantsListingApp.module.css";
@@ -63,6 +64,7 @@ export const TenantsListingApp = ({
         <Title order={1}>{t`Tenants`}</Title>
 
         <Group gap="sm">
+          <TenantsDocsButton />
           <EditUserStrategySettingsButton page="tenants" />
         </Group>
       </Group>

--- a/enterprise/frontend/src/metabase-enterprise/tenants/containers/TenantsListingApp.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/containers/TenantsListingApp.unit.spec.tsx
@@ -1,0 +1,83 @@
+import { setupEnterprisePlugins } from "__support__/enterprise";
+import { setupTenantEntpoints } from "__support__/server-mocks";
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen } from "__support__/ui";
+import type { Tenant } from "metabase-types/api";
+import {
+  createMockTenant,
+  createMockTokenFeatures,
+  createMockUser,
+} from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks";
+
+import { TenantsListingApp } from "./TenantsListingApp";
+
+const setup = ({
+  tenants = [],
+  isAdmin = true,
+}: {
+  tenants?: Tenant[];
+  isAdmin?: boolean;
+} = {}) => {
+  const settings = mockSettings({
+    "token-features": createMockTokenFeatures({ tenants: true }),
+  });
+
+  setupEnterprisePlugins();
+  setupTenantEntpoints(tenants);
+
+  const currentUser = createMockUser({ is_superuser: isAdmin });
+
+  renderWithProviders(<TenantsListingApp>{null}</TenantsListingApp>, {
+    storeInitialState: createMockState({
+      settings,
+      currentUser,
+    }),
+  });
+};
+
+describe("TenantsListingApp", () => {
+  it("shows tenant documentation button", async () => {
+    setup();
+
+    const docLinks = await screen.findAllByRole("link");
+    const docButton = docLinks.find((link) =>
+      link.getAttribute("href")?.includes("embedding/tenants"),
+    );
+    expect(docButton).toBeInTheDocument();
+    expect(docButton).toHaveAttribute("target", "_blank");
+  });
+
+  it("shows edit user strategy button for admins", async () => {
+    setup({ isAdmin: true });
+
+    const gearIcon = await screen.findByLabelText("gear icon");
+    expect(gearIcon).toBeInTheDocument();
+  });
+
+  it("shows empty state when there are no tenants", async () => {
+    setup({ tenants: [] });
+
+    expect(
+      await screen.findByText(/Create your first tenant to start adding/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows tenants list when tenants exist", async () => {
+    setup({
+      tenants: [
+        createMockTenant({ id: 1, name: "Tenant One", slug: "tenant-one" }),
+        createMockTenant({ id: 2, name: "Tenant Two", slug: "tenant-two" }),
+      ],
+    });
+
+    expect(await screen.findByText("Tenant One")).toBeInTheDocument();
+    expect(await screen.findByText("Tenant Two")).toBeInTheDocument();
+  });
+
+  it("shows new tenant button for admins", async () => {
+    setup({ isAdmin: true, tenants: [createMockTenant()] });
+
+    expect(await screen.findByText("New tenant")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes EMB-1075

Adds a documentation button to the tenants list page in admin settings that links to the tenants documentation. Makes it easier for users to discover and access the tenants documentation directly from the Tenants admin page.

### Demo

<img width="1854" height="798" alt="CleanShot 2569-01-08 at 05 50 53@2x" src="https://github.com/user-attachments/assets/52e724de-8d12-44cc-bf12-b43d39bf6406" />

### Tests

- Added unit tests covering the TenantsListingApp page (including the new documentation button)