### PR TITLE
Allow for non-string column names in Python Transform test data

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonEditorResults/ExecutionOutputTable.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonEditorResults/ExecutionOutputTable.tsx
@@ -13,18 +13,22 @@ export function ExecutionOutputTable({
 
   const tableProps = useDataGridInstance<Row, unknown>({
     data: rows,
-    columnsOptions: cols.map((column) => ({
-      id: column.name,
-      name: column.name,
-      accessorFn: (row) => row[column.name],
-      formatter: (value) => {
-        return formatValue(value, {
-          type: "cell",
-          jsx: true,
-          rich: true,
-        });
-      },
-    })),
+    columnsOptions: cols.map((column) => {
+      // Convert name to string since DataFrames can haven non-string column names
+      const name = (column.name ?? "None").toString();
+      return {
+        id: name,
+        name,
+        accessorFn: (row) => row[column.name],
+        formatter: (value) => {
+          return formatValue(value, {
+            type: "cell",
+            jsx: true,
+            rich: true,
+          });
+        },
+      };
+    }),
   });
 
   if (!output || cols.length === 0) {


### PR DESCRIPTION
Closes #67892 

> [!WARNING]
> This PR currently only contains a FE fix, we should really fix this on the BE or in the Python runner.

This PR adds a defensive check to make sure all column names returned from a Python transform are strings.