### PR TITLE
Typesafe `c` and `bg` props

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/dependencies/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/types.ts
@@ -1,3 +1,4 @@
+import type { ColorName } from "metabase/lib/colors/types";
 import type { IconName } from "metabase/ui";
 import type { DependencyGroupType } from "metabase-types/api";
 
@@ -5,7 +6,7 @@ export type NodeId = string;
 
 export type DependencyGroupTypeInfo = {
   label: string;
-  color: string;
+  color: ColorName;
 };
 
 export type NodeLink = {

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/ResultToolbar/ResultToolbar.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/ResultToolbar/ResultToolbar.tsx
@@ -13,8 +13,10 @@ export const ResultToolbar = ({
   <Group
     justify="space-between"
     p="sm"
-    bg="var(--mb-color-bg-sdk-question-toolbar)"
-    style={{ borderRadius: "0.5rem" }}
+    style={{
+      borderRadius: "0.5rem",
+      backgroundColor: "var(--mb-color-bg-sdk-question-toolbar)",
+    }}
     data-testid={dataTestId}
   >
     {children}

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.tsx
@@ -235,7 +235,9 @@ export const SdkQuestionDefaultView = ({
                         <Divider
                           mx="xs"
                           orientation="vertical"
-                          color="var(--mb-color-border) !important"
+                          style={{
+                            color: "var(--mb-color-border) !important",
+                          }}
                         />
                       )}
                     </>

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkUsageProblem/SdkUsageProblemBanner.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkUsageProblem/SdkUsageProblemBanner.tsx
@@ -81,11 +81,16 @@ export const SdkUsageProblemBanner = ({
         >
           <Stack gap="sm">
             <Flex w="100%" justify="space-between">
-              <Text fw="bold" size="md" c={unthemedTextDark} ff={fontFamily}>
+              <Text
+                fw="bold"
+                size="md"
+                style={{ color: unthemedTextDark }}
+                ff={fontFamily}
+              >
                 {title}
               </Text>
             </Flex>
-            <Text c={unthemedTextDark} ff={fontFamily} fz="sm">
+            <Text style={{ color: unthemedTextDark }} ff={fontFamily} fz="sm">
               {problem.message}
             </Text>
 

--- a/frontend/src/embedding-sdk-bundle/components/public/SdkQuestion/SdkQuestion-themed.stories.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/SdkQuestion/SdkQuestion-themed.stories.tsx
@@ -33,7 +33,7 @@ const Wrapper = ({
   theme: MetabaseTheme;
 }) => (
   <ComponentProvider theme={theme} authConfig={storybookSdkAuthDefaultConfig}>
-    <Box p="xl" bg={theme.colors?.background}>
+    <Box p="xl" bg="background-primary">
       {children}
     </Box>
   </ComponentProvider>

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboardStyleWrapper.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboardStyleWrapper.tsx
@@ -13,13 +13,13 @@ export const SdkDashboardStyledWrapper = forwardRef(
   ) {
     return (
       <Flex
-        bg="bg-dashboard"
         direction="column"
         justify="flex-start"
         align="stretch"
         className={cx(className, CS.overflowAuto)}
         style={{
           minHeight: "100vh",
+          backgroundColor: "var(--mb-color-bg-dashboard)",
           ...style,
         }}
         ref={fullscreenRef}

--- a/frontend/src/metabase/actions/containers/ActionPicker/ActionPicker.styled.tsx
+++ b/frontend/src/metabase/actions/containers/ActionPicker/ActionPicker.styled.tsx
@@ -6,7 +6,6 @@ import styled from "@emotion/styled";
 import Button from "metabase/common/components/Button";
 import CollapseSection from "metabase/common/components/CollapseSection";
 import UnstyledEmptyState from "metabase/common/components/EmptyState";
-import { alpha } from "metabase/lib/colors";
 
 export const ModelCollapseSection = styled(CollapseSection)`
   margin-bottom: var(--mantine-spacing-sm);
@@ -27,14 +26,14 @@ export const ActionItem = styled.li<{ isSelected?: boolean }>`
   border-radius: var(--mantine-spacing-xs);
   cursor: pointer;
 
-  ${({ isSelected, theme }) =>
+  ${({ isSelected }) =>
     isSelected &&
     css`
-      background-color: ${alpha(theme.fn.themeColor("brand"), 0.2)};
+      background-color: var(--mb-color-background-brand);
     `}
 
   &:hover {
-    background-color: ${() => alpha("brand", 0.35)};
+    background-color: var(--mb-color-background-hover);
   }
 `;
 

--- a/frontend/src/metabase/admin/datamodel/components/SegmentItem.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/SegmentItem.tsx
@@ -23,12 +23,12 @@ export const SegmentItem = ({ segment, onRetire }: Props) => {
           <Link to={Urls.dataModelSegment(segment.id)}>
             <Group display="inline-flex" gap="sm" wrap="nowrap">
               <Box
-                color="text-medium"
+                color="text-secondary"
                 component={Icon}
                 flex="0 0 auto"
                 name="segment"
               />
-              <Box c="text-dark" fw="bold">
+              <Box c="text-primary" fw="bold">
                 {segment.name}
               </Box>
             </Group>

--- a/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.styled.tsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.styled.tsx
@@ -1,6 +1,4 @@
 // eslint-disable-next-line no-restricted-imports
-import type { Theme } from "@emotion/react";
-// eslint-disable-next-line no-restricted-imports
 import styled from "@emotion/styled";
 import { forwardRef } from "react";
 
@@ -9,15 +7,15 @@ import Label from "metabase/common/components/type/Label";
 import { Icon, type IconProps } from "metabase/ui";
 import { color } from "metabase/ui/utils/colors";
 
-const getTableBorder = (theme: Theme) =>
-  `1px solid color-mix(in srgb, ${theme.fn.themeColor("border")}, transparent 50%)`;
+const getTableBorder = () =>
+  `1px solid color-mix(in srgb, var(--mb-color-border), transparent 50%)`;
 
 // background with 1px of border color at the bottom
 // to work properly with sticky positioning
-const getHeaderBackground = (theme: Theme) =>
+const getHeaderBackground = () =>
   `linear-gradient(
     to top,
-    color-mix(in srgb, ${theme.fn.themeColor("border")} 50%, ${theme.fn.themeColor("background-primary")} 50%) 1px,
+    color-mix(in srgb, var(--mb-color-border) 50%, var(--mb-color-background-primary) 50%) 1px,
     var(--mb-color-background-primary) 1px,
     var(--mb-color-background-primary) 100%
   )`;
@@ -51,7 +49,7 @@ export const PermissionsTableCell = styled.td`
       right: 0;
       top: 0;
       height: 100%;
-      border-right: ${({ theme }) => getTableBorder(theme)};
+      border-right: ${() => getTableBorder()};
       content: " ";
     }
   }
@@ -63,11 +61,11 @@ export const PermissionTableHeaderCell = styled(
   position: sticky;
   top: 0;
   border: none;
-  background: ${({ theme }) => getHeaderBackground(theme)};
+  background: ${() => getHeaderBackground()};
   z-index: 1;
 
   &:first-of-type {
-    background: ${({ theme }) => getHeaderBackground(theme)};
+    background: ${() => getHeaderBackground()};
     z-index: 2;
 
     &:after {
@@ -77,7 +75,7 @@ export const PermissionTableHeaderCell = styled(
 `;
 
 export const PermissionsTableRow = styled.tr`
-  border-bottom: ${({ theme }) => getTableBorder(theme)};
+  border-bottom: ${() => getTableBorder()};
 `;
 
 export const EntityNameLink = styled(Link)`

--- a/frontend/src/metabase/browse/components/BrowseContainer.styled.tsx
+++ b/frontend/src/metabase/browse/components/BrowseContainer.styled.tsx
@@ -25,7 +25,6 @@ export const BrowseHeader = styled.div`
   display: flex;
   flex-direction: column;
   padding: 1rem 2.5rem 3rem 2.5rem;
-  color: ${({ theme }) => theme.fn.themeColor("dark")};
 `;
 
 export const BrowseMain = styled.div`

--- a/frontend/src/metabase/common/components/Button/Button.styled.tsx
+++ b/frontend/src/metabase/common/components/Button/Button.styled.tsx
@@ -3,10 +3,7 @@ import { css } from "@emotion/react";
 // eslint-disable-next-line no-restricted-imports
 import styled from "@emotion/styled";
 
-import { alpha } from "metabase/lib/colors";
-
 interface ButtonRootProps {
-  purple?: boolean;
   onlyText?: boolean;
   light?: boolean;
 }
@@ -21,20 +18,6 @@ export const ButtonRoot = styled.button<ButtonRootProps>`
       transition: none;
     }
   }
-
-  ${({ purple, theme }) =>
-    purple &&
-    css`
-      color: var(--mb-color-text-primary-inverse);
-      background-color: var(--mb-color-filter);
-      border: 1px solid var(--mb-color-filter);
-
-      &:hover {
-        color: var(--mb-color-text-primary-inverse);
-        background-color: ${alpha(theme.fn.themeColor("filter"), 0.88)};
-        border-color: ${alpha(theme.fn.themeColor("filter"), 0.88)};
-      }
-    `}
 
   ${({ onlyText }) =>
     onlyText &&

--- a/frontend/src/metabase/common/components/Button/Button.tsx
+++ b/frontend/src/metabase/common/components/Button/Button.tsx
@@ -78,7 +78,6 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   warning?: boolean;
   cancel?: boolean;
   white?: boolean;
-  purple?: boolean;
 
   disabled?: boolean;
   round?: boolean;
@@ -128,7 +127,6 @@ const BaseButton = forwardRef(function BaseButton(
         },
         className,
       )}
-      purple={props.purple}
     >
       <ButtonContent iconVertical={iconVertical}>
         {icon && typeof icon === "string" ? (

--- a/frontend/src/metabase/common/components/Card/Card.tsx
+++ b/frontend/src/metabase/common/components/Card/Card.tsx
@@ -22,11 +22,11 @@ const Card = styled.div<CardProps>`
   border-radius: var(--mantine-radius-md);
   box-shadow: 0 7px 20px var(--mb-color-shadow);
   line-height: 24px;
-  ${({ hoverable, theme }) =>
+  ${({ hoverable }) =>
     hoverable &&
     css`
       &:hover {
-        box-shadow: 0 10px 22px ${theme.fn.themeColor("shadow")};
+        box-shadow: 0 10px 22px var(--mb-color-shadow);
       }
     `};
   ${(props) =>

--- a/frontend/src/metabase/common/components/ColorPill/ColorPill.tsx
+++ b/frontend/src/metabase/common/components/ColorPill/ColorPill.tsx
@@ -3,6 +3,7 @@ import type { HTMLAttributes, MouseEvent } from "react";
 import { useCallback } from "react";
 
 import CS from "metabase/css/core/index.css";
+import type { ColorName } from "metabase/lib/colors/types";
 import { Box, Center } from "metabase/ui";
 
 import ColorPillS from "./ColorPill.module.css";
@@ -14,7 +15,7 @@ export type ColorPillAttributes = Omit<
 >;
 
 export interface ColorPillProps extends ColorPillAttributes {
-  color: string;
+  color: ColorName | string;
   isAuto?: boolean;
   isSelected?: boolean;
   onSelect?: (newColor: string) => void;
@@ -61,6 +62,7 @@ export const ColorPill = ({
         className,
       )}
     >
+      {/* @ts-expect-error color pill needs access to arbitrary color values */}
       <Box bg={color} w="100%" h="100%" style={{ borderRadius: "50%" }}></Box>
     </Center>
   );

--- a/frontend/src/metabase/common/components/ColorRange/ColorRange.tsx
+++ b/frontend/src/metabase/common/components/ColorRange/ColorRange.tsx
@@ -53,6 +53,7 @@ export const ColorRange = forwardRef(function ColorRange(
     >
       {_.range(0, sections).map((section) => (
         <>
+          {/* @ts-expect-error color range needs access to arbitrary color values */}
           <Box key={section} flex="1" bg={scale(section)} />
         </>
       ))}

--- a/frontend/src/metabase/common/components/TabButton/TabButton.tsx
+++ b/frontend/src/metabase/common/components/TabButton/TabButton.tsx
@@ -1,6 +1,6 @@
 import type { UniqueIdentifier } from "@dnd-kit/core";
 // eslint-disable-next-line no-restricted-imports
-import { type Theme, css } from "@emotion/react";
+import { css } from "@emotion/react";
 // eslint-disable-next-line no-restricted-imports
 import styled from "@emotion/styled";
 import type {
@@ -23,7 +23,6 @@ import { t } from "ttag";
 
 import ControlledPopoverWithTrigger from "metabase/common/components/PopoverWithTrigger/ControlledPopoverWithTrigger";
 import { useTranslateContent } from "metabase/i18n/hooks";
-import { lighten } from "metabase/lib/colors";
 
 import type { TabContextType } from "../Tab";
 import {
@@ -195,9 +194,8 @@ export interface RenameableTabButtonProps
 }
 
 // These styles need to be here instead of .styled to avoid circular dependency
-const getBorderStyle = (theme: Theme) => css`
-  border: 1px solid var(--mb-color-brand);
-  box-shadow: 0px 0px 0px 1px ${lighten(theme.fn.themeColor("brand"), 0.28)};
+const getBorderStyle = () => css`
+  box-shadow: 0px 0px 2px 1px var(--mb-color-brand);
 `;
 export const RenameableTabButtonStyled = styled(_TabButton)<{
   isRenaming: boolean;
@@ -205,10 +203,9 @@ export const RenameableTabButtonStyled = styled(_TabButton)<{
   canRename: boolean;
 }>`
   ${TabButtonInputWrapper} {
-    ${(props) => props.isRenaming && getBorderStyle(props.theme)}
+    ${(props) => props.isRenaming && getBorderStyle()}
     :hover {
-      ${(props) =>
-        props.canRename && props.isSelected && getBorderStyle(props.theme)}
+      ${(props) => props.canRename && props.isSelected && getBorderStyle()}
     }
   }
 `;

--- a/frontend/src/metabase/css/core/colors.stories.tsx
+++ b/frontend/src/metabase/css/core/colors.stories.tsx
@@ -55,7 +55,7 @@ export function Default() {
         return (
           <Card
             // @ts-expect-error story file
-            bg={colorName}
+            bg={`var(${colorName})`}
             key={colorName}
             withBorder
             style={{

--- a/frontend/src/metabase/css/core/colors.stories.tsx
+++ b/frontend/src/metabase/css/core/colors.stories.tsx
@@ -54,13 +54,15 @@ export function Default() {
       {COLOR_NAMES.map((colorName) => {
         return (
           <Card
-            bg={`var(${colorName})`}
+            // @ts-expect-error story file
+            bg={colorName}
             key={colorName}
             withBorder
             style={{
               flexBasis: "24%",
             }}
           >
+            {/* @ts-expect-error story file */}
             <Text c="black">{colorName}</Text>
           </Card>
         );

--- a/frontend/src/metabase/dashboard/components/grid/GridLayout.tsx
+++ b/frontend/src/metabase/dashboard/components/grid/GridLayout.tsx
@@ -4,7 +4,6 @@ import {
   Responsive as ReactGridLayout,
 } from "react-grid-layout";
 
-import { colors } from "metabase/lib/colors";
 import { useMantineTheme } from "metabase/ui";
 
 import "react-grid-layout/css/styles.css";
@@ -187,7 +186,8 @@ export function GridLayout<T extends { id: number | null }>(
         // We cannot use CSS variables here, as the svg data in background-image
         // lives a separate style tree from the rest of the app.
         cellStrokeColor:
-          theme.other?.dashboard?.gridBorderColor ?? colors["border"],
+          theme.other?.dashboard?.gridBorderColor ??
+          theme.fn.themeColor("border"),
       }),
     [cellSize, gridWidth, margin, cols, theme],
   );

--- a/frontend/src/metabase/dashboard/components/grid/GridLayout.tsx
+++ b/frontend/src/metabase/dashboard/components/grid/GridLayout.tsx
@@ -4,6 +4,7 @@ import {
   Responsive as ReactGridLayout,
 } from "react-grid-layout";
 
+import { colors } from "metabase/lib/colors";
 import { useMantineTheme } from "metabase/ui";
 
 import "react-grid-layout/css/styles.css";
@@ -186,8 +187,7 @@ export function GridLayout<T extends { id: number | null }>(
         // We cannot use CSS variables here, as the svg data in background-image
         // lives a separate style tree from the rest of the app.
         cellStrokeColor:
-          theme.other?.dashboard?.gridBorderColor ??
-          theme.fn.themeColor("border"),
+          theme.other?.dashboard?.gridBorderColor ?? colors["border"],
       }),
     [cellSize, gridWidth, margin, cols, theme],
   );

--- a/frontend/src/metabase/dashboard/containers/XrayIcon.tsx
+++ b/frontend/src/metabase/dashboard/containers/XrayIcon.tsx
@@ -1,17 +1,5 @@
-import { Icon, useMantineTheme } from "metabase/ui";
+import { Icon } from "metabase/ui";
 
 export const XrayIcon = () => {
-  const theme = useMantineTheme();
-
-  return (
-    <Icon
-      name="bolt"
-      size={24}
-      style={{
-        // we don't have access to this color in css
-        // TODO: replace this color with one from palette
-        color: theme.fn.themeColor("accent4"),
-      }}
-    />
-  );
+  return <Icon name="bolt" size={24} c="accent4" />;
 };

--- a/frontend/src/metabase/databases/components/DatabaseForm/container-styles.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseForm/container-styles.tsx
@@ -50,7 +50,14 @@ function GridContainer({
 
 function Backdrop({ children }: { children: React.ReactNode }) {
   return (
-    <Box p="lg" bg="background-light" bdrs="md" mb="lg" display="grid" pb={0}>
+    <Box
+      p="lg"
+      bg="background-secondary"
+      bdrs="md"
+      mb="lg"
+      display="grid"
+      pb={0}
+    >
       {children}
     </Box>
   );

--- a/frontend/src/metabase/documents/components/Editor/shared/MenuComponents.tsx
+++ b/frontend/src/metabase/documents/components/Editor/shared/MenuComponents.tsx
@@ -87,7 +87,7 @@ export const SearchResultsFooter = ({
     {...rest}
   >
     <Group gap="sm" wrap="nowrap" align="center">
-      <Icon name="search" size={16} color="inherit" />
+      <Icon name="search" size={16} c="inherit" />
       <Text size="md" lh="lg" c="inherit">{t`Browse all`}</Text>
     </Group>
   </UnstyledButton>
@@ -106,7 +106,7 @@ export const CreateNewQuestionFooter = ({
     {...rest}
   >
     <Group gap="sm" wrap="nowrap" align="center">
-      <Icon name="add" size={16} color="inherit" />
+      <Icon name="add" size={16} c="inherit" />
       <Text size="md" lh="lg" c="inherit">{t`New chart`}</Text>
     </Group>
   </UnstyledButton>
@@ -120,7 +120,7 @@ export const MetabotFooter = ({ isSelected, onClick }: ExtraItemProps) => (
     aria-selected={isSelected}
   >
     <Group gap="sm" wrap="nowrap" align="center">
-      <Icon name="metabot" size={16} color="inherit" />
+      <Icon name="metabot" size={16} c="inherit" />
       <Stack gap={2}>
         <Text size="md" lh="lg" c="inherit">{t`Ask Metabot`}</Text>
         <Text size="sm" c="text-tertiary" lh="md">

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/EmbedPreviewLoadingOverlay.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/EmbedPreviewLoadingOverlay.tsx
@@ -18,7 +18,7 @@ export const EmbedPreviewLoadingOverlay = ({
   return (
     <Box
       pos="absolute"
-      style={{ backgroundColor: bg ?? "background-primary" }}
+      style={{ backgroundColor: bg ?? "var(--mb-color-background-primary)" }}
       inset={0}
     >
       <Center h="100%" w="100%" mx="auto">

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/EmbedPreviewLoadingOverlay.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/EmbedPreviewLoadingOverlay.tsx
@@ -16,7 +16,11 @@ export const EmbedPreviewLoadingOverlay = ({
   }
 
   return (
-    <Box pos="absolute" bg={bg ?? "background-primary"} inset={0}>
+    <Box
+      pos="absolute"
+      style={{ backgroundColor: bg ?? "background-primary" }}
+      inset={0}
+    >
       <Center h="100%" w="100%" mx="auto">
         <Loader data-testid="preview-loading-indicator" />
       </Center>

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeEmbedPreview.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeEmbedPreview.tsx
@@ -147,7 +147,7 @@ const SdkIframeEmbedPreviewInner = () => {
     <Card
       className={S.EmbedPreviewIframe}
       id="iframe-embed-container"
-      bg={theme?.colors?.background}
+      bg="background-primary"
       h="100%"
       ref={containerRef}
       pos="relative"

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeEmbedPreview.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeEmbedPreview.tsx
@@ -147,7 +147,7 @@ const SdkIframeEmbedPreviewInner = () => {
     <Card
       className={S.EmbedPreviewIframe}
       id="iframe-embed-container"
-      bg="background-primary"
+      style={{ backgroundColor: theme?.colors?.background }}
       h="100%"
       ref={containerRef}
       pos="relative"

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
@@ -99,7 +99,7 @@ export const SdkIframeEmbedRoute = () => {
     >
       <Stack
         mih="100vh"
-        bg={adjustedTheme?.colors?.background}
+        bg="background-primary"
         style={{
           display: "grid",
           width: "100%",

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
@@ -99,12 +99,12 @@ export const SdkIframeEmbedRoute = () => {
     >
       <Stack
         mih="100vh"
-        bg="background-primary"
         style={{
           display: "grid",
           width: "100%",
           gridTemplateColumns: "1fr",
           gridTemplateRows: "1fr auto",
+          backgroundColor: adjustedTheme?.colors?.background,
         }}
       >
         <SdkIframeEmbedView settings={embedSettings} />

--- a/frontend/src/metabase/list-view/components/ListView/ColumnValue.tsx
+++ b/frontend/src/metabase/list-view/components/ListView/ColumnValue.tsx
@@ -171,13 +171,7 @@ export function ColumnValue({
     case isProduct(column):
     case isSource(column):
       return (
-        <Ellipsified
-          size="sm"
-          truncate
-          fw="bold"
-          style={style}
-          c={style?.color || "text-primary"}
-        >
+        <Ellipsified size="sm" truncate fw="bold">
           {value}
         </Ellipsified>
       );
@@ -301,12 +295,7 @@ export function ColumnValue({
   }
 
   return (
-    <Ellipsified
-      size="sm"
-      truncate
-      style={style}
-      c={style?.color || "text-primary"}
-    >
+    <Ellipsified size="sm" truncate>
       {value}
     </Ellipsified>
   );

--- a/frontend/src/metabase/list-view/components/ListView/ColumnValue.tsx
+++ b/frontend/src/metabase/list-view/components/ListView/ColumnValue.tsx
@@ -171,7 +171,13 @@ export function ColumnValue({
     case isProduct(column):
     case isSource(column):
       return (
-        <Ellipsified size="sm" truncate fw="bold">
+        <Ellipsified
+          size="sm"
+          truncate
+          fw="bold"
+          style={style}
+          c={style?.color ? undefined : "text-primary"}
+        >
           {value}
         </Ellipsified>
       );
@@ -295,7 +301,12 @@ export function ColumnValue({
   }
 
   return (
-    <Ellipsified size="sm" truncate>
+    <Ellipsified
+      size="sm"
+      truncate
+      style={style}
+      c={style?.color ? undefined : "text-primary"}
+    >
       {value}
     </Ellipsified>
   );

--- a/frontend/src/metabase/list-view/components/ListView/ListViewItem.tsx
+++ b/frontend/src/metabase/list-view/components/ListView/ListViewItem.tsx
@@ -86,10 +86,6 @@ export function ListViewItem({
             column={titleColumn}
             settings={settings}
             rawValue={row[cols.indexOf(titleColumn as DatasetColumn)]}
-            // style={{
-            //   fontWeight: "bold",
-            //   color: "var(--mb-color-text-primary)",
-            // }}
           />
         )}
       </Flex>

--- a/frontend/src/metabase/list-view/components/ListView/ListViewItem.tsx
+++ b/frontend/src/metabase/list-view/components/ListView/ListViewItem.tsx
@@ -60,6 +60,7 @@ export function ListViewItem({
             backgroundColor: getIconBackground(entityIconColor),
           }}
         >
+          {/* @ts-expect-error viz components may be passed arbitrary color values */}
           <Icon name={entityIcon as IconName} c={entityIconColor} />
         </Box>
       )}
@@ -85,10 +86,10 @@ export function ListViewItem({
             column={titleColumn}
             settings={settings}
             rawValue={row[cols.indexOf(titleColumn as DatasetColumn)]}
-            style={{
-              fontWeight: "bold",
-              color: "var(--mb-color-text-primary)",
-            }}
+            // style={{
+            //   fontWeight: "bold",
+            //   color: "var(--mb-color-text-primary)",
+            // }}
           />
         )}
       </Flex>

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardView.stories.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardView.stories.tsx
@@ -461,6 +461,7 @@ function ScrollDecorator(Story: StoryFn) {
 
 function DarkBackgroundDecorator(Story: StoryFn) {
   return (
+    // @ts-expect-error story file
     <Box bg="#434e56" mih="100vh">
       <Story />
     </Box>
@@ -469,6 +470,7 @@ function DarkBackgroundDecorator(Story: StoryFn) {
 
 function LightBackgroundDecorator(Story: StoryFn) {
   return (
+    // @ts-expect-error story file
     <Box bg="#ddd" mih="100vh">
       <Story />
     </Box>

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardView.stories.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardView.stories.tsx
@@ -461,8 +461,7 @@ function ScrollDecorator(Story: StoryFn) {
 
 function DarkBackgroundDecorator(Story: StoryFn) {
   return (
-    // @ts-expect-error story file
-    <Box bg="#434e56" mih="100vh">
+    <Box style={{ backgroundColor: "#434e56" }} mih="100vh">
       <Story />
     </Box>
   );
@@ -470,8 +469,7 @@ function DarkBackgroundDecorator(Story: StoryFn) {
 
 function LightBackgroundDecorator(Story: StoryFn) {
   return (
-    // @ts-expect-error story file
-    <Box bg="#ddd" mih="100vh">
+    <Box style={{ backgroundColor: "#ddd" }} mih="100vh">
       <Story />
     </Box>
   );

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/EditorTabs/EditorTabs.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/EditorTabs/EditorTabs.tsx
@@ -2,8 +2,7 @@ import cx from "classnames";
 import type { CSSProperties } from "react";
 import { t } from "ttag";
 
-import { alpha, darken } from "metabase/lib/colors";
-import { Icon, useMantineTheme } from "metabase/ui";
+import { Icon } from "metabase/ui";
 import type { DatasetEditorTab } from "metabase-types/store";
 
 import EditorTabsS from "./EditorTabs.module.css";
@@ -21,18 +20,14 @@ export function EditorTabs({
   disabledColumns,
   onChange,
 }: Props) {
-  const theme = useMantineTheme();
-
   return (
     <ul
       className={EditorTabsS.TabBar}
       style={
         {
-          "--active-tab-color": darken(theme.fn.themeColor("brand")),
-          "--inactive-tab-color": alpha(
-            darken(theme.fn.themeColor("brand")),
-            0.3,
-          ),
+          "--active-tab-color": "var(--mb-color-brand-dark)",
+          "--inactive-tab-color":
+            "color-mix(in srgb, var(--mb-color-brand-dark), transparent 30%)",
         } as CSSProperties
       }
     >

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/EditorTabs/EditorTabs.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/EditorTabs/EditorTabs.tsx
@@ -27,7 +27,7 @@ export function EditorTabs({
         {
           "--active-tab-color": "var(--mb-color-brand-dark)",
           "--inactive-tab-color":
-            "color-mix(in srgb, var(--mb-color-brand-dark), transparent 30%)",
+            "color-mix(in srgb, var(--mb-color-brand-dark) 30%, transparent )",
         } as CSSProperties
       }
     >

--- a/frontend/src/metabase/query_builder/components/view/ViewButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewButton.tsx
@@ -2,7 +2,6 @@ import cx from "classnames";
 import type { CSSProperties } from "react";
 
 import Button, { type ButtonProps } from "metabase/common/components/Button";
-import { useMantineTheme } from "metabase/ui";
 
 import S from "./ViewButton.module.css";
 
@@ -13,8 +12,6 @@ interface Props extends ButtonProps {
 
 // NOTE: some of this is duplicated from NotebookCell.jsx
 const ViewButton = ({ className, active, color, ...props }: Props) => {
-  const theme = useMantineTheme();
-
   return (
     <Button
       classNames={{
@@ -22,7 +19,7 @@ const ViewButton = ({ className, active, color, ...props }: Props) => {
       }}
       style={
         {
-          "--view-button-color": color ?? theme.fn.themeColor("brand"),
+          "--view-button-color": color ?? "var(--mb-color-brand)",
         } as CSSProperties
       }
       {...props}

--- a/frontend/src/metabase/search/components/SearchUserPicker/SearchUserPicker.styled.tsx
+++ b/frontend/src/metabase/search/components/SearchUserPicker/SearchUserPicker.styled.tsx
@@ -32,15 +32,13 @@ export const SearchUserSelectBox = styled(Stack)`
 export const SelectedUserButton = styled(Button)<
   ButtonProps & HTMLAttributes<HTMLButtonElement>
 >`
-  ${({ theme }) => {
-    const primaryColor = theme.fn.themeColor("brand");
-
+  ${() => {
     return css`
-      background-color: color-mix(in srgb, ${primaryColor}, white 88%);
+      background-color: var(--mb-color-brand-lighter) !important;
       border: 0;
 
       &:hover {
-        background-color: color-mix(in srgb, ${primaryColor}, white 60%);
+        background-color: var(--mb-color-brand-light) !important;
       }
     `;
   }}

--- a/frontend/src/metabase/ui/components/icons/Icon/Icon.tsx
+++ b/frontend/src/metabase/ui/components/icons/Icon/Icon.tsx
@@ -22,7 +22,7 @@ export type IconProps = Omit<SVGAttributes<SVGSVGElement>, "color"> &
     tooltipPosition?: FloatingPosition;
     onClick?: (event: MouseEvent<HTMLImageElement | SVGElement>) => void;
     className?: string;
-    color?: ColorName | string;
+    color?: ColorName;
   };
 
 export const Icon = forwardRef<SVGSVGElement, IconProps>(function Icon(

--- a/frontend/src/metabase/ui/components/theme/ThemeProvider/ThemeProvider.tsx
+++ b/frontend/src/metabase/ui/components/theme/ThemeProvider/ThemeProvider.tsx
@@ -75,37 +75,12 @@ const ThemeProviderInner = (props: ThemeProviderProps) => {
         },
       },
       fn: {
-        themeColor: (
-          color: ColorName,
-          shade?: number,
-          primaryFallback: boolean = true,
-          useSplittedShade: boolean = true,
-        ) => {
-          if (typeof color === "string" && color.includes(".")) {
-            const [splitterColor, _splittedShade] = color.split(".");
-            const splittedShade = parseInt(_splittedShade, 10);
-
-            if (
-              splitterColor in theme.colors &&
-              splittedShade >= 0 &&
-              splittedShade < 10
-            ) {
-              return theme.colors[splitterColor as ColorName][
-                typeof shade === "number" && !useSplittedShade
-                  ? shade
-                  : splittedShade
-              ];
-            }
-          }
-
-          const _shade =
-            typeof shade === "number" ? shade : (theme.primaryShade as number);
+        themeColor: (color: ColorName): string => {
+          const { primaryShade, primaryColor } = theme;
 
           return color in theme.colors
-            ? theme.colors[color][_shade]
-            : primaryFallback
-              ? theme.colors[theme.primaryColor as ColorName][_shade]
-              : color;
+            ? theme.colors[color][primaryShade as number]
+            : theme.colors[primaryColor as ColorName][primaryShade as number];
         },
       },
     } as MantineTheme;

--- a/frontend/src/metabase/ui/components/theme/ThemeProvider/ThemeProvider.tsx
+++ b/frontend/src/metabase/ui/components/theme/ThemeProvider/ThemeProvider.tsx
@@ -29,6 +29,7 @@ import {
   setUserColorSchemeAfterUpdate,
 } from "metabase/lib/color-scheme";
 import { mutateColors } from "metabase/lib/colors/colors";
+import type { ColorName } from "metabase/lib/colors/types";
 import MetabaseSettings from "metabase/lib/settings";
 import type { DisplayTheme } from "metabase/public/lib/types";
 
@@ -75,7 +76,7 @@ const ThemeProviderInner = (props: ThemeProviderProps) => {
       },
       fn: {
         themeColor: (
-          color: string,
+          color: ColorName,
           shade?: number,
           primaryFallback: boolean = true,
           useSplittedShade: boolean = true,
@@ -89,7 +90,7 @@ const ThemeProviderInner = (props: ThemeProviderProps) => {
               splittedShade >= 0 &&
               splittedShade < 10
             ) {
-              return theme.colors[splitterColor][
+              return theme.colors[splitterColor as ColorName][
                 typeof shade === "number" && !useSplittedShade
                   ? shade
                   : splittedShade
@@ -103,7 +104,7 @@ const ThemeProviderInner = (props: ThemeProviderProps) => {
           return color in theme.colors
             ? theme.colors[color][_shade]
             : primaryFallback
-              ? theme.colors[theme.primaryColor][_shade]
+              ? theme.colors[theme.primaryColor as ColorName][_shade]
               : color;
         },
       },

--- a/frontend/src/metabase/ui/utils/colors.ts
+++ b/frontend/src/metabase/ui/utils/colors.ts
@@ -1,8 +1,7 @@
-import type { MantineTheme } from "@mantine/core";
+import type { MantineColorsTuple } from "@mantine/core";
 
 import { colorConfig } from "metabase/lib/colors";
 import type { ColorName } from "metabase/lib/colors/types";
-type ColorShades = MantineTheme["colors"]["dark"];
 
 export const ALL_COLOR_NAMES = Object.keys(colorConfig);
 
@@ -23,7 +22,7 @@ const ORIGINAL_COLORS = [
   "teal",
 ] as const;
 
-export function getColorShades(colorName: string): ColorShades {
+export function getColorShades(colorName: string): MantineColorsTuple {
   // yes this is silly, but it makes typescript so happy
   return [
     colorName,
@@ -41,7 +40,7 @@ export function getColorShades(colorName: string): ColorShades {
 
 export function getThemeColors(
   colorScheme: "light" | "dark",
-): Record<string, ColorShades> {
+): Record<string, MantineColorsTuple> {
   return {
     ...Object.fromEntries(
       ORIGINAL_COLORS.map((name) => [name, getColorShades("transparent")]),

--- a/frontend/src/metabase/visualizations/components/ChartTooltip/KeyValuePairChartTooltip/KeyValuePairChartTooltip.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip/KeyValuePairChartTooltip/KeyValuePairChartTooltip.styled.tsx
@@ -32,7 +32,7 @@ export const TableCell = styled.td`
 `;
 
 export const TableFooter = styled.tfoot`
-  ${({ theme }) => getTooltipSeparatorStyle(theme)}
+  ${() => getTooltipSeparatorStyle()}
 
   &:before {
     ${tableRowSpacingStyle}

--- a/frontend/src/metabase/visualizations/components/ChartTooltip/StackedDataTooltip/StackedDataTooltip.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip/StackedDataTooltip/StackedDataTooltip.styled.tsx
@@ -1,9 +1,7 @@
 // eslint-disable-next-line no-restricted-imports
-import { type Theme, css } from "@emotion/react";
+import { css } from "@emotion/react";
 // eslint-disable-next-line no-restricted-imports
 import styled from "@emotion/styled";
-
-import { darken } from "metabase/lib/colors";
 
 // Should be applied to :before or :after pseudo-elements to add a spacing between table sections such as header, body or footer
 export const tableRowSpacingStyle = css`
@@ -34,13 +32,12 @@ export const DataPointTableHeader = styled.thead<DataPointTableHeaderProps>`
   }
 `;
 
-export const getTooltipSeparatorStyle = (theme: Theme) => css`
-  border-top: 1px solid
-    ${darken(theme.fn.themeColor("background-tertiary-inverse"), 0.55)};
+export const getTooltipSeparatorStyle = () => css`
+  border-top: 1px solid var(--mb-color-background-secondary-inverse);
 `;
 
 export const DataPointTableBody = styled.tbody`
-  ${({ theme }) => getTooltipSeparatorStyle(theme)}
+  ${() => getTooltipSeparatorStyle()}
 
   &:before {
     ${tableRowSpacingStyle}

--- a/frontend/src/metabase/visualizations/components/legend/LegendCaption/LegendCaption.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendCaption/LegendCaption.styled.tsx
@@ -2,7 +2,6 @@
 import styled from "@emotion/styled";
 import { forwardRef } from "react";
 
-import { lighten } from "metabase/lib/colors";
 import { Box, type BoxProps, Icon, type IconProps } from "metabase/ui";
 
 import { LegendLabel as BaseLegendLabel } from "../LegendLabel";
@@ -44,7 +43,7 @@ export const LegendDescriptionIcon = styled(
     );
   }),
 )`
-  color: ${({ theme }) => lighten(theme.fn?.themeColor("text-tertiary"), 0.1)};
+  color: var(--mb-color-text-tertiary);
   margin: 0 0.25rem;
 
   &:hover {

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting/RuleBackground.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting/RuleBackground.tsx
@@ -16,5 +16,6 @@ export const RuleBackground = ({
   rule.type === "range" ? (
     <ColorRange colors={rule.colors} className={className} style={style} />
   ) : rule.type === "single" ? (
+    // @ts-expect-error viz settings need to accept hex color values
     <Box className={className} style={style} bg={rule.color} />
   ) : null;

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/PreviousValueComparison/VariationPercent.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/PreviousValueComparison/VariationPercent.tsx
@@ -26,7 +26,7 @@ export const VariationPercent = ({
   const { changeArrowIconName, changeColor } = comparison;
 
   return (
-    <Flex align="center" maw="100%" c={changeColor ?? color}>
+    <Flex align="center" maw="100%" style={{ color: changeColor ?? color }}>
       {changeArrowIconName && (
         <VariationIcon name={changeArrowIconName} size={iconSize} />
       )}

--- a/frontend/src/types/mantine.d.ts
+++ b/frontend/src/types/mantine.d.ts
@@ -1,4 +1,7 @@
+import type { MantineColorsTuple } from "@mantine/core";
+
 import type { EmbeddingThemeOptions } from "metabase/embedding-sdk/theme/private";
+import type { ColorName } from "metabase/lib/colors/types";
 import type { ColorSettings } from "metabase-types/api/settings";
 
 interface _EmotionCompatibilityTheme {
@@ -18,4 +21,11 @@ declare module "@mantine/core" {
     updateColorSettings: (settings: ColorSettings) => void;
   }
   export interface MantineTheme extends _EmotionCompatibilityTheme {}
+
+  export interface MantineThemeColorsOverride {
+    colors: Record<
+      ColorName | "inherit" | "transparent" | "currentColor" | "none" | "unset",
+      MantineColorsTuple
+    >;
+  }
 }

--- a/frontend/test/__support__/storybook.tsx
+++ b/frontend/test/__support__/storybook.tsx
@@ -116,6 +116,7 @@ export const SdkVisualizationStory = ({
   theme,
 }: IsomorphicVisualizationStoryProps & { theme?: MetabaseTheme }) => {
   return (
+    // @ts-expect-error story file
     <Box w={1000} h={600} bg={theme?.colors?.background}>
       <VisualizationWrapper>
         <SdkThemeProvider theme={theme}>


### PR DESCRIPTION
### Description
Makes the `c` and `bg` props typesafe, requiring a valid `ColorName`, as well as removing most usages of the `theme.fn.themeColor` function (ideally we can remove this in the near future)

### How to verify
Green CI, and embedding use cases should continue to work as expected.

## Call outs:
There are a few places where some colors have technically changed. I expect the only one folks will really notice is the edit buttons on the metadata editor are darker now:
<img width="434" height="88" alt="image" src="https://github.com/user-attachments/assets/770aef48-69d9-4141-9a99-5c9bf5d41ba3" />

### The info icon for dashcards when it's being shown:
before:
<img width="580" height="450" alt="image" src="https://github.com/user-attachments/assets/a082b69a-9c04-4140-9ffc-6b0f46528c7e" />

after:
<img width="318" height="191" alt="image" src="https://github.com/user-attachments/assets/5da22a8a-4ca0-47a6-9ca2-117d072a767f" />

### The hover states for our beloved Action Library:
before:
<img width="297" height="200" alt="image" src="https://github.com/user-attachments/assets/6fb9950f-e763-41bf-a3fb-6c8cea548a79" />

after:
<img width="369" height="408" alt="image" src="https://github.com/user-attachments/assets/66620604-c0b7-4d69-afde-9f558ca37c77" />

### Tabs in dashboards changed slightly when being renamed or hovered when active:
before:
<img width="169" height="76" alt="image" src="https://github.com/user-attachments/assets/d1b5534e-813a-440e-9308-ec3f65d2a7ef" />

after:
<img width="204" height="63" alt="image" src="https://github.com/user-attachments/assets/5124ac13-5980-4c25-b64c-751f13b0e0eb" />

### Row Chart tooltips with stacked viz (the line between the total and the table):
before:
<img width="481" height="481" alt="image" src="https://github.com/user-attachments/assets/b68a7f74-410f-4d9b-a443-153a35d0d227" />

after:
<img width="643" height="501" alt="image" src="https://github.com/user-attachments/assets/a5af1705-35ad-4102-bb4c-3203859ba456" />

