### PR TITLE
Fix typo in test metadata

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -339,7 +339,7 @@
                  (semantic.tu/upsert-index! (semantic.tu/mock-documents))))
           (is (= 2.0 (mt/metric-value system :metabase-search/semantic-index-size))))))))
 
-(deftest ^:syncronized semantic-search-analytics-test
+(deftest ^:synchronized semantic-search-analytics-test
   (mt/with-premium-features #{:semantic-search}
     (with-open [_ (semantic.tu/open-temp-index!)]
       (semantic.tu/upsert-index! (semantic.tu/mock-documents))


### PR DESCRIPTION
@camsaul found this, but unfortunately it couldn't have caught this typo :(
https://github.com/metabase/metabase/blob/master/.clj-kondo/src/hooks/clojure/test.clj#L29-L59