### PR TITLE
chore: Fix safe typos in enterprise/ folder

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit_app/analytics_dev.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/analytics_dev.clj
@@ -104,7 +104,7 @@
   "Transform YAML from dev format to canonical format.
 
   Replaces user email with canonical creator_id.
-  For the Database entitiy, strips down to minimal required fields and sets is_audit to true."
+  For the Database entity, strips down to minimal required fields and sets is_audit to true."
   [file-name yaml-data user-email]
   (let [transformed (walk/postwalk
                      (fn [node]

--- a/enterprise/backend/src/metabase_enterprise/cache/config.clj
+++ b/enterprise/backend/src/metabase_enterprise/cache/config.clj
@@ -6,7 +6,7 @@
   "States of `persisted_info` records which can be refreshed."
   :feature :cache-granular-controls
   []
-  ;; meant to be the same as the oss version except that "off" is deleteable rather than refreshable
+  ;; meant to be the same as the oss version except that "off" is deletable rather than refreshable
   #{"refreshing" "creating" "persisted" "error"})
 
 (defenterprise prunable-states

--- a/enterprise/backend/src/metabase_enterprise/cache/task/refresh_cache_configs.clj
+++ b/enterprise/backend/src/metabase_enterprise/cache/task/refresh_cache_configs.clj
@@ -104,7 +104,7 @@
                            "dashboard" [:= :qe.dashboard_id model_id])
                          [:<= :qc.updated_at rerun-cutoff]
                          ;; This is a safety check so that we don't scan all of query_execution -- if a query
-                         ;; has not been excuted at all in the last month (including cache hits) we won't bother
+                         ;; has not been executed at all in the last month (including cache hits) we won't bother
                          ;; refreshing it again.
                          [:>= :qe.started_at (duration-ago {:duration 30 :unit "days"})]
                          [:= :qe.error nil]
@@ -180,7 +180,7 @@
             [:= :qe.error nil]
             [:= :qe.is_sandboxed false]
             ;; Was the query executed at least once in the last month?
-            ;; This is a safety check so that we don't scan all of query_execution -- if a query has not been excuted at
+            ;; This is a safety check so that we don't scan all of query_execution -- if a query has not been executed at
             ;; all in the last month (including cache hits) we won't bother refreshing it again.
             [:>= :qe.started_at (duration-ago {:duration 30 :unit "days"})]]
    :order-by [[:qe.started_at :desc]]

--- a/enterprise/backend/src/metabase_enterprise/data_studio/api/table.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_studio/api/table.clj
@@ -274,7 +274,7 @@
 (api.macros/defendpoint :post "/sync-schema" :- :nil
   "Batch version of /table/:id/sync_schema. Takes an abstract table selection as /table/edit does.
   - Currently checks policy before returning (so you might receive a 4xx on e.g. AuthZ policy failure)
-  - The sync itself is however, asyncronous. This call may return before all tables synced."
+  - The sync itself is however, asynchronous. This call may return before all tables synced."
   [_
    _
    body :- ::table-selectors]

--- a/enterprise/backend/src/metabase_enterprise/dependencies/task/backfill.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/task/backfill.clj
@@ -36,7 +36,7 @@
   "The list of models to backfill.
 
   This is not the same as deps.dependency-types/models, because tables shouldn't be backfilled.  Instead, links
-  involing tables are found via analysis of the other side of the relation."
+  involving tables are found via analysis of the other side of the relation."
   [:model/Card
    :model/Transform
    :model/NativeQuerySnippet

--- a/enterprise/backend/src/metabase_enterprise/gsheets/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/gsheets/api.clj
@@ -62,7 +62,7 @@
 ;; We need to sync the attached datawarehouse to make sure that the data from the Google Drive folder is available to
 ;; the user in Metabase. Once the gdrive connection's status is set to 'active' by HM, they will call MB's
 ;; `api/notify/db/attached_datawarehouse` endpoint to trigger a sync. The data from the Google Drive folder is already
-;; availiable in the attached datawarehouse, and when MB finishes the sync (and puts an item into :model/TaskHistory
+;; available in the attached datawarehouse, and when MB finishes the sync (and puts an item into :model/TaskHistory
 ;; saying so), the user can start using their Google Sheets data in Metabase.
 ;;
 ;; ## Why do we check for multiple gdrive connections in the delete endpoint? We check for multiple gdrive connections

--- a/enterprise/backend/src/metabase_enterprise/impersonation/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/impersonation/util.clj
@@ -24,7 +24,7 @@
 (defenterprise impersonated-user?
   "Returns a boolean if the current user is in a group that has a connection impersonation in place for any database.
   Note: this function does not check whether the impersonation is *enforced* for the current user, since another group's
-  permissions may supercede it. Will throw an error if [[api/*current-user-id*]] is not bound."
+  permissions may supersede it. Will throw an error if [[api/*current-user-id*]] is not bound."
   :feature :advanced-permissions
   []
   (boolean

--- a/enterprise/backend/src/metabase_enterprise/permission_debug/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/permission_debug/impl.clj
@@ -43,7 +43,7 @@
   [:enum :card/read :card/query :card/download-data])
 
 (def DebuggerArguments
-  "Arguements for the Debugger function. The model type being operated on is infered by the requested action type"
+  "Arguments for the Debugger function. The model type being operated on is inferred by the requested action type"
   [:map
    [:user-id pos-int?]
    [:model-id :string]
@@ -98,8 +98,8 @@
 
 (mu/defn- merge-permission-check :- DebuggerSchema
   "Merges n permissions responses with right most wins semantics. model-type and model-id must match across
-  permissions respones. If the decision is denied that should that precendence over limited which should be
-  prefered over allowed when merging."
+  permissions responses. If the decision is denied that should take precedence over limited which should be
+  preferred over allowed when merging."
   [& responses :- [:sequential DebuggerSchema]]
   (when (seq responses)
     (let [first-response (first responses)

--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/gtap.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/gtap.clj
@@ -67,7 +67,7 @@
 (api.macros/defendpoint :put "/:id"
   "Update a GTAP entry. The only things you're allowed to update for a GTAP are the Card being used (`card_id`) or the
   parameter mappings; changing `table_id` or `group_id` would effectively be deleting this entry and creating a new
-  one. If that's what you want to do, do so explicity with appropriate calls to the `DELETE` and `POST` endpoints."
+  one. If that's what you want to do, do so explicitly with appropriate calls to the `DELETE` and `POST` endpoints."
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]
    _query-params

--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/table.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/table.clj
@@ -99,7 +99,7 @@
                       :metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/:id/query_metadata"
   "This endpoint essentially acts as a wrapper for the OSS version of this route. When a user has sandboxed permissions
-  that only gives them access to a subset of columns for a given table, those inaccessable columns should also be
+  that only gives them access to a subset of columns for a given table, those inaccessible columns should also be
   excluded from what is show in the query builder. When the user has full permissions (or no permissions) this route
   doesn't add/change anything from the OSS version. See the docs on the OSS version of the endpoint for more
   information."

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
@@ -27,7 +27,7 @@
                              :table_id table-id)]
     (when sandboxes
       (sandboxing/assert-one-sandbox-per-table sandboxes)
-      ;; there shold be only one gtap per table and we only need one table here
+      ;; there should be only one gtap per table and we only need one table here
       ;; see docs in [[metabase.permissions.models.permissions]] for more info
       (t2/hydrate (first sandboxes) :card))))
 

--- a/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/sandboxing.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/sandboxing.clj
@@ -164,7 +164,7 @@
     ;; log the query at this point, it's useful for some purposes
     (log/debugf "Fetched query from Card %s:\n%s" card-id (u/cprint-to-str (select-keys query [:stages :parameters])))
     (cond-> query
-      ;; This will be applied, if still appropriate, by the peristence middleware
+      ;; This will be applied, if still appropriate, by the persistence middleware
       persisted?
       (assoc :persisted-info/native
              (qp.persisted/persisted-info-native-query

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -617,7 +617,7 @@
   [index embedding search-context scorers]
   ;; The purpose of this query is just to project the coalesced hybrid columns with standard names so the scorers know
   ;; what to call them (e.g. :model rather than [:coalesced :v.model :t.model]). Likewise, the :search_index alias
-  ;; allows us to re-use scoring expressions between the appdb and semantic backends without adjusting column names.
+  ;; allows us to reuse scoring expressions between the appdb and semantic backends without adjusting column names.
   ;;
   ;; We flatten the nested CTEs because PostgreSQL doesn't support nested WITH clauses.
   ;; The hybrid-query contains nested :with clauses from semantic-search-query and keyword-search-query,

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -617,7 +617,7 @@
   [index embedding search-context scorers]
   ;; The purpose of this query is just to project the coalesced hybrid columns with standard names so the scorers know
   ;; what to call them (e.g. :model rather than [:coalesced :v.model :t.model]). Likewise, the :search_index alias
-  ;; allows us to reuse scoring expressions between the appdb and semantic backends without adjusting column names.
+  ;; allows us to re-use scoring expressions between the appdb and semantic backends without adjusting column names.
   ;;
   ;; We flatten the nested CTEs because PostgreSQL doesn't support nested WITH clauses.
   ;; The hybrid-query contains nested :with clauses from semantic-search-query and keyword-search-query,

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
@@ -174,7 +174,7 @@
             (serdes/load-one! ingested local-or-nil)
             ctx
             (catch Exception e
-              ;; ugly mapv here to convered #ordered/map into normal map so it's readable in the logs
+              ;; ugly mapv here to convert #ordered/map into normal map so it's readable in the logs
               (throw (ex-info (format "Failed to load into database for %s" (serdes/log-path-str path))
                               (path-error-data ::load-failure expanding path)
                               e)))))))))

--- a/enterprise/backend/src/metabase_enterprise/sso/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/settings.clj
@@ -1,5 +1,5 @@
 (ns metabase-enterprise.sso.settings
-  "Namesapce for defining settings used by the SSO backends. This is separate as both the functions needed to support
+  "Namespace for defining settings used by the SSO backends. This is separate as both the functions needed to support
   the SSO backends and the generic routing code used to determine which SSO backend to use need this
   information. Separating out this information creates a better dependency graph and avoids circular dependencies."
   (:require

--- a/enterprise/backend/src/metabase_enterprise/transforms/jobs.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/jobs.clj
@@ -125,7 +125,7 @@
 
 (def ^:private job-key "metabase-enterprise.transforms.jobs.timeout-job")
 
-(task/defjob  ^{:doc "Times out transform jobs when necesssary."
+(task/defjob  ^{:doc "Times out transform jobs when necessary."
                 org.quartz.DisallowConcurrentExecution true}
   TimeoutOldRuns [_ctx]
   (transforms.job-run/timeout-old-runs! (transforms.settings/transform-timeout) :minute))

--- a/enterprise/backend/test/metabase_enterprise/action_v2/validation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/action_v2/validation_test.clj
@@ -5,8 +5,6 @@
 
  ;; Test field definitions
 
-(defn requried [field] (assoc field :database_required true))
-
 (def float-field
   {:name "price" :base_type :type/Float :database_required false})
 

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/application_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/application_test.clj
@@ -17,7 +17,7 @@
           (is (= "You don't have permissions to do that."
                  (mt/user-http-request :rasta :get 403 "ee/advanced-permissions/application/graph"))))
 
-        (testing "return application permissions for groups that has application permisions"
+        (testing "return application permissions for groups that has application permissions"
           (let [graph  (mt/user-http-request :crowberto :get 200 "ee/advanced-permissions/application/graph")
                 groups (:groups graph)]
             (is (int? (:revision graph)))

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/group_manager_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/group_manager_test.clj
@@ -1,5 +1,5 @@
 (ns metabase-enterprise.advanced-permissions.api.group-manager-test
-  "Permisisons tests for API that needs to be enforced by Group Manager permisisons."
+  "Permissions tests for API that needs to be enforced by Group Manager permissions."
   (:require
    [clojure.set :refer [subset?]]
    [clojure.test :refer :all]

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/monitoring_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/monitoring_test.clj
@@ -1,5 +1,5 @@
 (ns metabase-enterprise.advanced-permissions.api.monitoring-test
-  "Permisisons tests for API that needs to be enforced by Application Permissions of type `:monitoring`."
+  "Permissions tests for API that needs to be enforced by Application Permissions of type `:monitoring`."
   (:require
    [clojure.test :refer :all]
    [metabase.permissions.models.permissions :as perms]

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/setting_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/setting_test.clj
@@ -1,5 +1,5 @@
 (ns metabase-enterprise.advanced-permissions.api.setting-test
-  "Permisisons tests for API that needs to be enforced by Application Permissions to access Admin/Setting pages."
+  "Permissions tests for API that needs to be enforced by Application Permissions to access Admin/Setting pages."
   (:require
    [clojure.test :refer :all]
    [metabase.channel.email :as email]

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/subscription_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/subscription_test.clj
@@ -1,5 +1,5 @@
 (ns metabase-enterprise.advanced-permissions.api.subscription-test
-  "Permisisons tests for API that needs to be enforced by Application Permissions to create and edit alerts/subscriptions."
+  "Permissions tests for API that needs to be enforced by Application Permissions to create and edit alerts/subscriptions."
   (:require
    [clojure.test :refer :all]
    [metabase.permissions.core :as perms]

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -26,7 +26,7 @@
       (letfn [(user-permissions [user]
                 (-> (mt/user-http-request user :get 200 "user/current")
                     :permissions))]
-        (testing "admins should have full advanced permisions"
+        (testing "admins should have full advanced permissions"
           (is (=? {:can_access_setting        true
                    :can_access_subscription   true
                    :can_access_monitoring     true

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/group_manager_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/group_manager_test.clj
@@ -64,7 +64,7 @@
                     :is_group_manager false}}
                  (user-group-memberships user))))))
 
-    (testing "Should be able to promote an existing user to Group manger"
+    (testing "Should be able to promote an existing user to Group manager"
       (mt/with-user-in-groups
         [group {:name "Group"}
          user  [group]]

--- a/enterprise/backend/test/metabase_enterprise/audit_app/audit_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/audit_test.clj
@@ -128,7 +128,7 @@
              (#'task.sync-databases/sync-and-analyze-database! "job-context"))))
       (is (= '("metabase.task.update-field-values.trigger.13371337")
              (get-audit-db-trigger-keys))
-          "no sync occured even when called directly for audit db."))))
+          "no sync occurred even when called directly for audit db."))))
 
 (deftest no-backfill-occurs-when-loading-analytics-content-test
   (mt/with-model-cleanup [:model/Collection]

--- a/enterprise/backend/test/metabase_enterprise/audit_app/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/permissions_test.clj
@@ -36,7 +36,7 @@
       (is (= "complete" (t2/select-one-fn :initial_sync_status :model/Database :id audit/audit-db-id))
           "The sync status should be completed by this point. (In test it is synchronous!)")
       (mt/with-test-user :crowberto
-        (testing "A query using a saved audit model as the source table runs succesfully"
+        (testing "A query using a saved audit model as the source table runs successfully"
           (let [audit-card (t2/select-one :model/Card :database_id audit/audit-db-id :type :model)]
             (is (partial=
                  {:status :completed}

--- a/enterprise/backend/test/metabase_enterprise/cache/config_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cache/config_test.clj
@@ -148,7 +148,7 @@
                                  (unpersist! [_ _database persisted-info]
                                    (swap! called-on conj (u/the-id persisted-info))))
                 queued-for-deletion (into #{} (map :id) (#'task.persist-refresh/deletable-models))]
-            (testing "Query finds deletabable, and off persisted infos"
+            (testing "Query finds deletable, and off persisted infos"
               ;; use superset, because orphaned PersistedInfo records from other tests might also be deletable
               (is (set/superset? queued-for-deletion (set (map u/the-id deletable-persisted-infos)))))
               ;; we manually pass in the deletable ones to not catch others in a running instance
@@ -173,7 +173,7 @@
                                  (unpersist! [_ _database persisted-info]
                                    (swap! called-on conj (u/the-id persisted-info))))
                 queued-for-deletion (into #{} (map :id) (#'task.persist-refresh/deletable-models))]
-            (testing "Query finds only state='deletabable' persisted info, and not state='off'"
+            (testing "Query finds only state='deletable' persisted info, and not state='off'"
               (is (contains? queued-for-deletion (u/the-id pdeletable)))
               (is (not (contains? queued-for-deletion (u/the-id poff)))))
               ;; we manually pass in the deletable ones to not catch others in a running instance

--- a/enterprise/backend/test/metabase_enterprise/cache/config_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cache/config_test.clj
@@ -151,7 +151,7 @@
             (testing "Query finds deletabable, and off persisted infos"
               ;; use superset, because orphaned PersistedInfo records from other tests might also be deletable
               (is (set/superset? queued-for-deletion (set (map u/the-id deletable-persisted-infos)))))
-              ;; we manually pass in the deleteable ones to not catch others in a running instance
+              ;; we manually pass in the deletable ones to not catch others in a running instance
             (testing "Both deletables are pruned by prune-deletables!"
               (#'task.persist-refresh/prune-deletables! test-refresher deletable-persisted-infos)
               (is (= (set (map u/the-id deletable-persisted-infos)) @called-on))
@@ -176,7 +176,7 @@
             (testing "Query finds only state='deletabable' persisted info, and not state='off'"
               (is (contains? queued-for-deletion (u/the-id pdeletable)))
               (is (not (contains? queued-for-deletion (u/the-id poff)))))
-              ;; we manually pass in the deleteable ones to not catch others in a running instance
+              ;; we manually pass in the deletable ones to not catch others in a running instance
             (testing "Only state='deletable' is pruned by prune-deletables!, and not state='off'"
               (#'task.persist-refresh/prune-deletables! test-refresher [pdeletable poff])
               (is (contains? @called-on (u/the-id pdeletable)))

--- a/enterprise/backend/test/metabase_enterprise/content_verification/api/moderation_review_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_verification/api/moderation_review_test.clj
@@ -73,7 +73,7 @@
               ;; manually inserted many
 
               (is (> (review-count) moderation-review/max-moderation-reviews))
-              (moderate! "verified" "lookin good")
+              (moderate! "verified" "looking good")
               ;; api ensures we never have more than our limit
 
               (is (<= (review-count) moderation-review/max-moderation-reviews)))

--- a/enterprise/backend/test/metabase_enterprise/content_verification/api/moderation_review_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_verification/api/moderation_review_test.clj
@@ -73,7 +73,7 @@
               ;; manually inserted many
 
               (is (> (review-count) moderation-review/max-moderation-reviews))
-              (moderate! "verified" "looking good")
+              (moderate! "verified" "lookin' good")
               ;; api ensures we never have more than our limit
 
               (is (<= (review-count) moderation-review/max-moderation-reviews)))

--- a/enterprise/backend/test/metabase_enterprise/dependencies/metadata_provider_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/metadata_provider_test.clj
@@ -110,7 +110,7 @@
                                 (lib/remove-clause (first (lib/breakouts upstream)))
                                 (lib/breakout (lib/with-temporal-bucket (meta/field-metadata :orders :created-at) :day))
                                 (replace-query card1)))
-      ;; NOTE: Theses lines are important: this is what would happen to all the dependents returned by the graph.
+      ;; NOTE: These lines are important: this is what would happen to all the dependents returned by the graph.
       ;; There's no update (`nil`) but it still includes the downstream stuff in the scope of the
       ;; OverrideMetadataProvider.
       (deps.mp/add-override mp :card 2 nil)

--- a/enterprise/backend/test/metabase_enterprise/email/messages_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/email/messages_test.clj
@@ -14,7 +14,7 @@
     (mt/with-user-in-groups [group {:name "New Group"}
                              user [group]]
       (perms/grant-application-permissions! group :monitoring)
-      (testing "Users with monitoring but no `manage-database` permission do not recieve"
+      (testing "Users with monitoring but no `manage-database` permission do not receive"
         (mt/with-premium-features #{:advanced-permissions}
           (is (= (set (#'messages/all-admin-recipients))
                  (set (#'messages/admin-or-ee-monitoring-details-emails db-id))))))

--- a/enterprise/backend/test/metabase_enterprise/impersonation/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/api_test.clj
@@ -1,5 +1,5 @@
 (ns metabase-enterprise.impersonation.api-test
-  "Tests for creating and updating Connection Impersonation configs via the permisisons API"
+  "Tests for creating and updating Connection Impersonation configs via the permissions API"
   (:require
    [clojure.test :refer :all]
    [metabase.permissions-rest.data-permissions.graph :as data-perms.graph]

--- a/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
@@ -50,11 +50,11 @@
              (impersonation.driver/connection-impersonation-role (mt/db))))))))
 
 (deftest connection-impersonation-role-test-4
-  (testing "Returns nil if the permissions in another group supercede the impersonation"
+  (testing "Returns nil if the permissions in another group supersede the impersonation"
     (impersonation.util-test/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
                                                    :attributes     {"impersonation_attr" "impersonation_role"}}
       ;; `with-impersonations!` creates a new group and revokes data perms in `all users`, so if we re-grant data perms
-      ;; for all users, it should supercede the impersonation policy in the new group
+      ;; for all users, it should supersede the impersonation policy in the new group
       (mt/with-full-data-perms-for-all-users!
         (is (nil? (impersonation.driver/connection-impersonation-role (mt/db))))))))
 
@@ -398,7 +398,7 @@
     (mt/with-premium-features #{:advanced-permissions}
       (let [venues-table (sql.tx/qualify-and-quote driver/*driver* "test-data" "venues")
             role-a (u/lower-case-en (mt/random-name))
-            ;; todo: this relies on the impersonation user being the login credential. This is not necessarilly true
+            ;; todo: this relies on the impersonation user being the login credential. This is not necessarily true
             ;; on sqlserver. see #60672
             impersonation-user (impersonation-default-user driver/*driver*)
             details (:details (mt/db))]
@@ -615,7 +615,7 @@
                (mt/run-mbql-query venues
                  {:aggregation [[:count]]})))
 
-          ;; Non-impersonated user should stil be able to query the table
+          ;; Non-impersonated user should still be able to query the table
           (request/as-admin
             (is (= [100]
                    (mt/first-row

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api_test.clj
@@ -125,7 +125,7 @@
                   (testing "request to ai-service was canceled"
                     (is (< 20 @cnt) "Stopped writing when channel closed")
                     ;; see `metabase.server.streaming-response-test/canceling-chan-is-working-test` for explanation,
-                    ;; reducing flakyness here
+                    ;; reducing flakiness here
                     (is (some? @canceled)))))))))
       (finally
         (.stop ai-server)))))

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/api_test.clj
@@ -543,7 +543,7 @@
       (is (= "Invalid Repository URL format" (:error response))))))
 
 (deftest settings-cannot-change-with-dirty-data
-  (testing "PUT /api/ee/remote-sync/settings doesn't allow loosing dirty data"
+  (testing "PUT /api/ee/remote-sync/settings doesn't allow losing dirty data"
     (with-redefs [remote-sync.object/dirty-global? (constantly true)
                   settings/check-and-update-remote-settings! #(throw (Exception. "Should not be called"))]
       (mt/with-temporary-setting-values [remote-sync-url "https://github.com/test/repo.git"

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/source/git_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/source/git_test.clj
@@ -228,7 +228,7 @@
                    (git/list-files (assoc remote :version "master"))))
             (is (= ["Update 1" "Initial commit"] (map :message (git/log (assoc remote :branch "master")))))))
 
-        (testing "If no root fils are touched, they all stay as-is"
+        (testing "If no root files are touched, they all stay as-is"
           (source.p/write-files! (source.p/snapshot master) "Update 2" [{:path (str thirddir-path "path.txt") :content "Only third dir content"}])
           (is (= [(str otherdir-path "path.txt")
                   (str otherdir-path "path2.txt")

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/field_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/field_test.clj
@@ -127,7 +127,7 @@
       (testing (str "Searching via the query builder needs to use a GTAP when the user has segmented permissions. "
                     "This tests out a field search on a table with segmented permissions")
         ;; Rasta Toucan is only allowed to see Venues that are in the "Mexican" category [category_id = 50]. So
-        ;; searching whould only include venues in that category
+        ;; searching should only include venues in that category
         (let [url (format "field/%s/search/%s" (mt/id :venues :name) (mt/id :venues :name))]
           (is (= [["Gordo Taqueria"]
                   ["Tacos Villa Corona"]

--- a/enterprise/backend/test/metabase_enterprise/scim/v2/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/scim/v2/api_test.clj
@@ -110,7 +110,7 @@
                 :meta     {:resourceType "User"}}
                response)))))
 
-    (testing "404 is returned when fetching a non-existant user"
+    (testing "404 is returned when fetching a non-existent user"
       (scim-client :get 404 (format "ee/scim/v2/Users/%s" (random-uuid))))))
 
 (deftest list-users-test
@@ -141,7 +141,7 @@
         (is (= 1 (get response :totalResults)))
         (is (= 1 (count (get response :Resources))))))
 
-    (testing "Fetch non-existant user by email"
+    (testing "Fetch non-existent user by email"
       (let [response (scim-client :get 200 (format "ee/scim/v2/Users?filter=%s"
                                                    (codec/url-encode "userName eq \"newuser@metabase.com\"")))]
         (is (malli= scim-api/SCIMUserList response))
@@ -382,7 +382,7 @@
                   (is (= 1 (get response :totalResults)))
                   (is (= 1 (count (get response :Resources))))))
 
-              (testing "Fetch non-existant group by name"
+              (testing "Fetch non-existent group by name"
                 (let [response (scim-client :get 200 (format "ee/scim/v2/Groups?filter=%s"
                                                              (codec/url-encode "displayName eq \"Fake Group\"")))]
                   (is (malli= scim-api/SCIMUserList response))
@@ -410,7 +410,7 @@
                     :meta        {:resourceType "Group"}}
                    response)))))
 
-        (testing "404 is returned when fetching a non-existant group"
+        (testing "404 is returned when fetching a non-existent group"
           (scim-client :get 404 (format "ee/scim/v2/Groups/%s" (random-uuid))))
 
         (testing "404 is returned when fetching the Admin or All Users group"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/gate_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/gate_test.clj
@@ -347,7 +347,7 @@
                     (mt/metric-value system :metabase-search/semantic-gate-write-ms)))
             (is (== 2 (mt/metric-value system :metabase-search/semantic-gate-write-documents)))
             (is (== 2 (mt/metric-value system :metabase-search/semantic-gate-write-modified))))
-          (testing ":metabase-search/semantic-gate-write-modified is not increased if documets are gated"
+          (testing ":metabase-search/semantic-gate-write-modified is not increased if documents are gated"
             (sut pgvector index-metadata docs)
             (is (== 4 (mt/metric-value system :metabase-search/semantic-gate-write-documents)))
             (is (== 2 (mt/metric-value system :metabase-search/semantic-gate-write-modified))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_embedding_test.clj
@@ -10,7 +10,7 @@
 (def ^:private test-long-model-name "some-really-really-really-really-really-long-model-name-that-will-exceed-the-limit")
 (def ^:private test-vector-dimensions 1024)
 
-;; Postgres truncates indentifier names to 63 bytes (+ 1 byte for a terminating NULL). Ensure that names do not exceed the limit
+;; Postgres truncates identifier names to 63 bytes (+ 1 byte for a terminating NULL). Ensure that names do not exceed the limit
 (deftest ^:parallel index-embedding-name-length-test
   (mt/with-premium-features #{:semantic-search}
     (testing "Truncates if name would be longer than the 63 byte Postgres limit"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -377,7 +377,7 @@
   The processing is triggered by means :hook/search-index which :model/Card (and others) derive.
 
   As of 2025-09-10, processing triggered by insertion, combined with manual gating of documents that callers
-  of this fn do, would result in duplicate processing and deletion of those entitities from index
+  of this fn do, would result in duplicate processing and deletion of those entities from index
   due to [[search.ingestion/bulk-ingest!]].
 
   For details see the https://metaboat.slack.com/archives/C07SJT1P0ET/p1757452434713309?thread_ts=1757410361.879029&cid=C07SJT1P0ET"

--- a/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
@@ -202,7 +202,7 @@
                 (let [res (-> (mt/user-http-request :crowberto :post 200 "ee/serialization/export"
                                                     :collection (:id coll) :data_model false :settings false)
                               io/input-stream)
-                    ;; we're going to re-use it for import, so a copy is necessary
+                    ;; we're going to reuse it for import, so a copy is necessary
                       ba  (#'api.serialization/ba-copy res)]
                   (testing "We get only our data and a log file in an archive"
                     (is (= 12

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -422,7 +422,7 @@
                                                                                  :value_field [:field (:id field1s) nil]}}]}]
 
               (testing "make sure we insert ParameterCard when insert Dashboard/Card"
-                ;; one for parameter on card card2s, and one for parmeter on dashboard dash1s
+                ;; one for parameter on card card2s, and one for parameter on dashboard dash1s
                 (is (= 2 (t2/count :model/ParameterCard))))
 
               (testing "extract and store"

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
@@ -255,7 +255,7 @@
                                                     :last_name  "Toucan"
                                                     :extra      "keypairs"
                                                     :are        "also present"
-                                                       ;; registerd claims should not be synced as login attributes
+                                                       ;; registered claims should not be synced as login attributes
                                                     :iss        "issuer"
                                                     :exp        (+ (buddy-util/now) 3600)
                                                     :iat        (buddy-util/now)}

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -717,7 +717,7 @@
                               (get-in response [:headers "Location"])))))))))))))))
 
 (deftest sso-subpath-e2e-test
-  (testing "Redirect URL should correcly append the site-url when the redirect is a relative path (#28650)"
+  (testing "Redirect URL should correctly append the site-url when the redirect is a relative path (#28650)"
     (with-other-sso-types-disabled!
       (with-saml-default-setup!
         (doseq [redirect-url ["/collection/root"

--- a/enterprise/frontend/src/embedding-sdk-package/components/private/ComponentWrapper/ComponentWrapper.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/components/private/ComponentWrapper/ComponentWrapper.tsx
@@ -43,7 +43,7 @@ type Props<TComponentProps> = {
 
 const NOT_STARTED_LOADING_WAIT_TIMEOUT = 1000;
 
-// When the ComponentWrapper is rendered without being wrapped withing the MetabaseProvider,
+// When the ComponentWrapper is rendered without being wrapped within the MetabaseProvider,
 // the SDK bundle loading is not triggered.
 // We wait for 1 second and if the loading state is still not set or Initial - we set the NotStartedLoading error
 const NotStartedLoadingTrigger = () => {

--- a/enterprise/frontend/src/embedding/data-picker/DataSelector/tests/DataSelector.unit.spec.js
+++ b/enterprise/frontend/src/embedding/data-picker/DataSelector/tests/DataSelector.unit.spec.js
@@ -270,7 +270,7 @@ describe("DataSelector", () => {
   it("should expand schemas after viewing tables on a single-schema db", async () => {
     // This is the same and the previous test except that it first opens/closes
     // the multi-schema db. This left some lingering traces in component state
-    // which caused a bug tha that the previous test didn't catch.
+    // which caused a bug that the previous test didn't catch.
     render(
       <DataSelector
         steps={["DATABASE", "SCHEMA", "TABLE"]}

--- a/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/process-stream.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/process-stream.unit.spec.ts
@@ -83,7 +83,7 @@ describe("processChatResponse", () => {
     ).rejects.toBeTruthy();
   });
 
-  it("should error if a tool result is returned without a preceeding tool call", async () => {
+  it("should error if a tool result is returned without a preceding tool call", async () => {
     const mockStream = createMockReadableStream([
       `a:{"toolCallId":"x","result":""}`,
       `d:{"finishReason":"stop","usage":{"promptTokens":4916,"completionTokens":8}}`,

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveConnectionModal.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveConnectionModal.unit.spec.tsx
@@ -69,7 +69,7 @@ describe("Google Drive > Connect / Disconnect modal", () => {
     expect(await screen.findByText("Import Google Sheets")).toBeInTheDocument();
   });
 
-  it("should show service acocunt email", async () => {
+  it("should show service account email", async () => {
     setup({
       status: "not-connected",
     });

--- a/enterprise/frontend/src/metabase-enterprise/license/components/LicenseAndBillingSettings/LicenseAndBillingSettings.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/license/components/LicenseAndBillingSettings/LicenseAndBillingSettings.unit.spec.tsx
@@ -211,7 +211,7 @@ describe("LicenseAndBilling", () => {
         format: "unsupported-format",
         display: "value",
       };
-      // mocking some future diplay that doesn't exist yet
+      // mocking some future display that doesn't exist yet
       const unsupportedDisplay: any = {
         name: "Unsupported display",
         value: "Unsupported display",

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotQueryBuilder/MetabotQueryBuilder.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotQueryBuilder/MetabotQueryBuilder.tsx
@@ -147,7 +147,7 @@ export const MetabotQueryBuilder = () => {
             setVisible(true);
           } else {
             cancelRequest();
-            resetConversation(); // clear any parital response and reset profile
+            resetConversation(); // clear any partial response and reset profile
           }
         }
         return true;

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/actions.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/actions.ts
@@ -398,7 +398,7 @@ export const sendAgentRequest = createAsyncThunk<
             (tc) => tc.state === "call",
           ),
           history: [...getHistory(getState(), agentId), ...response.history],
-          // state object comes at the end, so we may not have recieved it
+          // state object comes at the end, so we may not have received it
           // so fallback to the state used when the request was issued
           state: Object.keys(state).length === 0 ? request.state : state,
         });

--- a/enterprise/frontend/src/metabase-enterprise/metabot/tests/errors.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/tests/errors.unit.spec.tsx
@@ -71,7 +71,7 @@ describe("metabot > errors", () => {
     expect(await input()).toHaveTextContent("");
   });
 
-  it("should remove previous error messages and prompt when submiting next prompt", async () => {
+  it("should remove previous error messages and prompt when submitting next prompt", async () => {
     setup();
     fetchMock.post(`path:/api/ee/metabot-v3/agent-streaming`, 500);
 

--- a/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
@@ -169,7 +169,7 @@ export function initializePlugin() {
             <IndexRedirect to="/admin/people/tenants/people" />
             <ModalRoute
               path="edit"
-              // @ts-expect-error - params prop can't be infered
+              // @ts-expect-error - params prop can't be inferred
               modal={(props) => <EditUserModal {...props} external />}
               noWrap
             />

--- a/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
@@ -175,19 +175,19 @@ export function initializePlugin() {
             />
             <ModalRoute
               path="deactivate"
-              // @ts-expect-error - params prop can't be infered
+              // @ts-expect-error - params prop can't be inferred
               modal={UserActivationModal}
               noWrap
             />
             <ModalRoute
               path="reactivate"
-              // @ts-expect-error - params prop can't be infered
+              // @ts-expect-error - params prop can't be inferred
               modal={UserActivationModal}
               noWrap
             />
-            {/* @ts-expect-error - params prop can't be infered */}
+            {/* @ts-expect-error - params prop can't be inferred */}
             <ModalRoute path="success" modal={UserSuccessModal} noWrap />
-            {/* @ts-expect-error - params prop can't be infered */}
+            {/* @ts-expect-error - params prop can't be inferred */}
             <ModalRoute path="reset" modal={UserPasswordResetModal} noWrap />
             {PLUGIN_ADMIN_USER_MENU_ROUTES.map((getRoutes, index) => (
               <Fragment key={index}>{getRoutes()}</Fragment>
@@ -197,19 +197,19 @@ export function initializePlugin() {
         <Route path=":tenantId" component={TenantsListingApp}>
           <ModalRoute
             path="edit"
-            // @ts-expect-error - params prop can't be infered
+            // @ts-expect-error - params prop can't be inferred
             modal={EditTenantModal}
             noWrap
           />
           <ModalRoute
             path="deactivate"
-            // @ts-expect-error - params prop can't be infered
+            // @ts-expect-error - params prop can't be inferred
             modal={TenantActivationModal}
             noWrap
           />
           <ModalRoute
             path="reactivate"
-            // @ts-expect-error - params prop can't be infered
+            // @ts-expect-error - params prop can't be inferred
             modal={TenantActivationModal}
             noWrap
           />

--- a/enterprise/frontend/src/metabase-enterprise/user_provisioning/components/UserProvisioning.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/user_provisioning/components/UserProvisioning.tsx
@@ -65,9 +65,9 @@ export const UserProvisioning = () => {
   const isScimEnabled = !!settingValues?.["scim-enabled"];
   const isScimInitialized = !!maskedTokenRequest.data;
 
-  // since the request to enable scim and create the first token are seperate requests, it's possible
-  // that the token request failed or wasn't issued due to some interuption (network issue, instance down, etc.)
-  // we can detect this case by seing the scim is enabled without any token after all requests for token have settled
+  // since the request to enable scim and create the first token are separate requests, it's possible
+  // that the token request failed or wasn't issued due to some interruption (network issue, instance down, etc.)
+  // we can detect this case by seeing the scim is enabled without any token after all requests for token have settled
   // this is later used to show an error message based on this token not being found + encourage the user to go through
   // the regenerate flow to get a new unmasked token
   const isScimIncorrectlyIniailized = Boolean(

--- a/test/metabase/model_persistence/task/persist_refresh_test.clj
+++ b/test/metabase/model_persistence/task/persist_refresh_test.clj
@@ -205,7 +205,7 @@
                                  (is false "refresh! called on a model that should not be refreshed"))
                                (unpersist! [_ _database persisted-info]
                                  (swap! called-on conj (u/the-id persisted-info))))]
-          (testing "Query finds deletabable, archived, and unmodeled persisted infos"
+          (testing "Query finds deletable, archived, and unmodeled persisted infos"
             (let [queued-for-deletion (into #{} (map :id) (#'task.persist-refresh/deletable-models))]
               (doseq [deletable-persisted [deletable punmodeled parchived]]
                 (is (contains? queued-for-deletion (u/the-id deletable-persisted))))))

--- a/test/metabase/queries_rest/api/card_test.clj
+++ b/test/metabase/queries_rest/api/card_test.clj
@@ -1470,7 +1470,7 @@
                                                            :moderator_id        (mt/user->id :rasta)
                                                            :most_recent         true
                                                            :status              "verified"
-                                                           :text                "looking good"}]
+                                                           :text                "lookin' good"}]
               (is (= [(clean (assoc review :user {:id true}))]
                      (->> (mt/user-http-request :rasta :get 200 (str "card/" (u/the-id card)))
                           mt/boolean-ids-and-timestamps
@@ -2722,7 +2722,7 @@
                                      :moderator_id        (mt/user->id :crowberto)
                                      :most_recent         true
                                      :status              "verified"
-                                     :text                "looking good"}]))
+                                     :text                "lookin' good"}]))
          ~@body))]
     (letfn [(verified? [card]
               (-> card (t2/hydrate [:moderation_reviews :moderator_details])
@@ -4342,7 +4342,7 @@
                                                       :moderator_id        (mt/user->id :rasta)
                                                       :most_recent         true
                                                       :status              "verified"
-                                                      :text                "lookin good"}]
+                                                      :text                "lookin' good"}]
     (is (= {:name "My Dashboard"
             :id dash-id
             :moderation_status "verified"}

--- a/test/metabase/queries_rest/api/card_test.clj
+++ b/test/metabase/queries_rest/api/card_test.clj
@@ -1470,7 +1470,7 @@
                                                            :moderator_id        (mt/user->id :rasta)
                                                            :most_recent         true
                                                            :status              "verified"
-                                                           :text                "lookin good"}]
+                                                           :text                "looking good"}]
               (is (= [(clean (assoc review :user {:id true}))]
                      (->> (mt/user-http-request :rasta :get 200 (str "card/" (u/the-id card)))
                           mt/boolean-ids-and-timestamps
@@ -2722,7 +2722,7 @@
                                      :moderator_id        (mt/user->id :crowberto)
                                      :most_recent         true
                                      :status              "verified"
-                                     :text                "lookin good"}]))
+                                     :text                "looking good"}]))
          ~@body))]
     (letfn [(verified? [card]
               (-> card (t2/hydrate [:moderation_reviews :moderator_details])


### PR DESCRIPTION
Comments, docstrings, test names, etc