### PR TITLE
Fix search links for actions and segments

### DIFF
--- a/frontend/src/metabase/lib/urls/modelToUrl.ts
+++ b/frontend/src/metabase/lib/urls/modelToUrl.ts
@@ -1,9 +1,12 @@
 import type {
+  CardId,
   CollectionId,
   DatabaseId,
   IndexedEntity,
+  TableId,
 } from "metabase-types/api";
 
+import { action } from "./actions";
 import { browseDatabase } from "./browse";
 import { collection } from "./collections";
 import { dashboard } from "./dashboards";
@@ -23,6 +26,8 @@ export type UrlableModel = {
   };
   database_id?: DatabaseId;
   collection_id?: CollectionId | null;
+  model_id?: CardId | null;
+  table_id?: TableId;
 };
 
 const NOT_FOUND_URL = "/404";
@@ -65,6 +70,16 @@ export function modelToUrl(item: UrlableModel): string {
       return transform(item.id);
     case "indexed-entity":
       return indexedEntity(item as IndexedEntity);
+    case "action":
+      if (item.model_id != null) {
+        return action({ id: item.model_id }, item.id);
+      }
+      return NOT_FOUND_URL;
+    case "segment":
+      if (databaseId != null && item.table_id != null) {
+        return tableRowsQuery(databaseId, item.table_id, undefined, item.id);
+      }
+      return NOT_FOUND_URL;
     default:
       return NOT_FOUND_URL;
   }

--- a/frontend/src/metabase/lib/urls/modelToUrl.unit.spec.ts
+++ b/frontend/src/metabase/lib/urls/modelToUrl.unit.spec.ts
@@ -72,4 +72,27 @@ describe("urls > modelToUrl", () => {
       }),
     ).toBe("/document/123");
   });
+
+  it("should return an action URL for an action", () => {
+    expect(
+      modelToUrl({
+        model: "action",
+        name: "My Cool Action",
+        id: 123,
+        model_id: 456,
+      }),
+    ).toBe("/model/456/detail/actions/123");
+  });
+
+  it("should return a segment URL for a segment", () => {
+    expect(
+      modelToUrl({
+        model: "segment",
+        name: "My Cool Segment",
+        id: 123,
+        database_id: 456,
+        table_id: 789,
+      }),
+    ).toBe("/question#?db=456&table=789&segment=123");
+  });
 });


### PR DESCRIPTION
Closes #67860 

### Description

#66282 removed `getUrl` methods from entities in favor of `modelToUrl`, but `modelToUrl` did not have case statements for actions or segments, leading to broken links in search results (and any additional relevant places `modelToUrl` is used). This PR adds case statements for actions and segments to `modelToUrl`.

### How to verify

1. Create an action, search for it, click on it
2. Create a segment, search for it, click on it (note that the segment may not properly be applied due to #67937)

### Demo

[Loom](https://www.loom.com/share/6fa309b679c74b87a39271a6a6beeb40)

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
