### PR TITLE
Fix typo in a group membership endpoint

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/group_manager_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/group_manager_test.clj
@@ -199,12 +199,12 @@
             (testing "non-admin user can only view groups that are manager of"
               (is (= #{(:id group)} (membership->groups-ids (get-membership user 200))))))
 
-          (testing "admin cant be group manager"
+          (testing "admin can't be group manager"
             (mt/with-temp [:model/User                       new-user {:is_superuser true}
                            :model/PermissionsGroupMembership _        {:user_id          (:id new-user)
                                                                        :group_id         (:id group)
                                                                        :is_group_manager false}]
-              (is (= "Admin cant be a group manager."
+              (is (= "Admin can't be a group manager."
                      (mt/user-http-request user :post 400 "permissions/membership"
                                            {:group_id         (:id group)
                                             :user_id          (:id new-user)

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/group_manager_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/group_manager_test.clj
@@ -199,12 +199,12 @@
             (testing "non-admin user can only view groups that are manager of"
               (is (= #{(:id group)} (membership->groups-ids (get-membership user 200))))))
 
-          (testing "admin can't be group manager"
+          (testing "admin cannot be group manager"
             (mt/with-temp [:model/User                       new-user {:is_superuser true}
                            :model/PermissionsGroupMembership _        {:user_id          (:id new-user)
                                                                        :group_id         (:id group)
                                                                        :is_group_manager false}]
-              (is (= "Admin can't be a group manager."
+              (is (= "Admin cannot be a group manager."
                      (mt/user-http-request user :post 400 "permissions/membership"
                                            {:group_id         (:id group)
                                             :user_id          (:id new-user)

--- a/src/metabase/permissions_rest/api.clj
+++ b/src/metabase/permissions_rest/api.clj
@@ -317,7 +317,7 @@
       (perms/check-advanced-permissions-enabled :group-manager)
       (api/check
        (t2/exists? :model/User :id user_id :is_superuser false)
-       [400 (tru "Admin can''t be a group manager.")]))
+       [400 (tru "Admin cannot be a group manager.")]))
     (perms/add-user-to-group! user_id group_id is_group_manager)
     ;; TODO - it's a bit silly to return the entire list of members for the group, just return the newly created one and
     ;; let the frontend add it as appropriate
@@ -344,7 +344,7 @@
     (perms/check-manager-of-group (:group_id old))
     (api/check
      (t2/exists? :model/User :id (:user_id old) :is_superuser false)
-     [400 (tru "Admin can''t be a group manager.")])
+     [400 (tru "Admin cannot be a group manager.")])
     (t2/update! :model/PermissionsGroupMembership (:id old)
                 {:is_group_manager is_group_manager})
     (t2/select-one :model/PermissionsGroupMembership :id (:id old))))

--- a/src/metabase/permissions_rest/api.clj
+++ b/src/metabase/permissions_rest/api.clj
@@ -317,7 +317,7 @@
       (perms/check-advanced-permissions-enabled :group-manager)
       (api/check
        (t2/exists? :model/User :id user_id :is_superuser false)
-       [400 (tru "Admin cant be a group manager.")]))
+       [400 (tru "Admin can''t be a group manager.")]))
     (perms/add-user-to-group! user_id group_id is_group_manager)
     ;; TODO - it's a bit silly to return the entire list of members for the group, just return the newly created one and
     ;; let the frontend add it as appropriate
@@ -344,7 +344,7 @@
     (perms/check-manager-of-group (:group_id old))
     (api/check
      (t2/exists? :model/User :id (:user_id old) :is_superuser false)
-     [400 (tru "Admin cant be a group manager.")])
+     [400 (tru "Admin can''t be a group manager.")])
     (t2/update! :model/PermissionsGroupMembership (:id old)
                 {:is_group_manager is_group_manager})
     (t2/select-one :model/PermissionsGroupMembership :id (:id old))))


### PR DESCRIPTION
This PR fixes a typo in an error message returned by a (group) membership endpoint.