### PR TITLE
Change `guest embeds disabled` tooltip to display a link to admin settings

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
@@ -73,6 +73,8 @@ describe(suiteTitle, () => {
 
       visitNewEmbedPage({ waitForResource: false });
 
+      cy.url().should("not.match", /\/admin\/embedding\/guest/);
+
       getEmbedSidebar().within(() => {
         cy.findByTestId("guest-embeds-disabled-info-icon").should("be.visible");
         cy.findByTestId("guest-embeds-disabled-info-icon").click();
@@ -81,6 +83,17 @@ describe(suiteTitle, () => {
       H.hovercard()
         .findByText(/Disabled, enable guest embeds in/)
         .should("exist");
+
+      H.hovercard()
+        .findByText(/admin settings/)
+        .click();
+
+      cy.findAllByTestId(/(sdk-setting-card|guest-embeds-setting-card)/)
+        .first()
+        .within(() => {
+          cy.url().should("match", /\/admin\/embedding\/guest/);
+          cy.findByText("Enable guest embeds").should("be.visible");
+        });
     });
 
     it("hides the `guest embeds disabled` icon + tooltip when guest embeds enabled", () => {

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
@@ -81,7 +81,7 @@ describe(suiteTitle, () => {
       });
 
       H.hovercard()
-        .findByText(/Disabled, enable guest embeds in/)
+        .findByText(/You can enable guest embeds in/)
         .should("exist");
 
       H.hovercard()

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
@@ -22,7 +22,9 @@ describe(suiteTitle, () => {
     cy.signInAsAdmin();
     H.activateToken("bleeding-edge");
     H.enableTracking();
+
     H.updateSetting("enable-embedding-simple", true);
+    H.updateSetting("enable-embedding-static", true);
 
     cy.intercept("GET", "/api/dashboard/*").as("dashboard");
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");
@@ -61,6 +63,35 @@ describe(suiteTitle, () => {
 
         cy.log("dashboard card is visible");
         cy.findByText("Orders").should("be.visible");
+      });
+    });
+
+    it("shows the `guest embeds disabled` icon + tooltip when guest embeds disabled", () => {
+      H.updateSetting("enable-embedding-static", false);
+
+      H.visitQuestion(ORDERS_COUNT_QUESTION_ID);
+
+      visitNewEmbedPage({ waitForResource: false });
+
+      getEmbedSidebar().within(() => {
+        cy.findByTestId("guest-embeds-disabled-info-icon").should("be.visible");
+        cy.findByTestId("guest-embeds-disabled-info-icon").click();
+      });
+
+      H.hovercard()
+        .findByText(/Disabled, enable guest embeds in/)
+        .should("exist");
+    });
+
+    it("hides the `guest embeds disabled` icon + tooltip when guest embeds enabled", () => {
+      H.updateSetting("enable-embedding-static", true);
+
+      H.visitQuestion(ORDERS_COUNT_QUESTION_ID);
+
+      visitNewEmbedPage({ waitForResource: false });
+
+      getEmbedSidebar().within(() => {
+        cy.findByTestId("guest-embeds-disabled-info-icon").should("not.exist");
       });
     });
 

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Authentication/AuthenticationSection.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Authentication/AuthenticationSection.tsx
@@ -1,14 +1,17 @@
 import type { ReactNode } from "react";
-import { t } from "ttag";
+import { Link } from "react-router";
+import { c, t } from "ttag";
 
-import { TooltipWarning } from "metabase/embedding/embedding-iframe-sdk-setup/components/Common/TooltipWarning";
 import { useSdkIframeEmbedSetupContext } from "metabase/embedding/embedding-iframe-sdk-setup/context";
 import {
   DEFAULT_EXPERIENCE,
   useHandleExperienceChange,
 } from "metabase/embedding/embedding-iframe-sdk-setup/hooks/use-handle-experience-change";
 import { getAuthTypeForSettings } from "metabase/embedding/embedding-iframe-sdk-setup/utils/get-auth-type-for-settings";
-import { Card, Radio, Stack, Text } from "metabase/ui";
+import { useDispatch } from "metabase/lib/redux";
+import { isEEBuild } from "metabase/lib/utils";
+import { closeModal } from "metabase/redux/ui";
+import { Card, Flex, HoverCard, Icon, Radio, Stack, Text } from "metabase/ui";
 
 export const AuthenticationSection = () => {
   const {
@@ -79,16 +82,45 @@ const WithGuestEmbedsDisabledWarning = ({
 }: {
   children: (data: { disabled: boolean }) => ReactNode;
 }) => {
+  const dispatch = useDispatch();
+
   const { isGuestEmbedsEnabled } = useSdkIframeEmbedSetupContext();
 
-  const disabled = !isGuestEmbedsEnabled;
+  // We show the icon only in the EE build. For the OSS build we show the EnableEmbeddingCard
+  const showIcon = isEEBuild();
 
   return (
-    <TooltipWarning
-      tooltip={t`Disabled in the admin settings`}
-      disabled={disabled}
-    >
-      {children}
-    </TooltipWarning>
+    <Flex align="center" gap="xs">
+      {children({ disabled: !isGuestEmbedsEnabled })}
+
+      <HoverCard>
+        {showIcon && !isGuestEmbedsEnabled && (
+          <HoverCard.Target>
+            <Icon
+              data-testid="guest-embeds-disabled-info-icon"
+              name="info"
+              size={14}
+              c="text-secondary"
+            />
+          </HoverCard.Target>
+        )}
+
+        <HoverCard.Dropdown p="sm">
+          <Text>{c(
+            "{0} is a link to guest embeds settings page with text 'admin settings'",
+          ).jt`Disabled, enable guest embeds in ${(
+            <Link
+              key="admin-settings-link"
+              to="/admin/embedding/guest"
+              onClick={() => dispatch(closeModal())}
+            >
+              <Text display="inline" c="text-brand" fw="bold">{c(
+                "is a link in a sentence 'Disabled, enable guest embeds in admin settings'",
+              ).t`admin settings`}</Text>
+            </Link>
+          )}`}</Text>
+        </HoverCard.Dropdown>
+      </HoverCard>
+    </Flex>
   );
 };

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Authentication/AuthenticationSection.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Authentication/AuthenticationSection.tsx
@@ -108,14 +108,14 @@ const WithGuestEmbedsDisabledWarning = ({
         <HoverCard.Dropdown p="sm">
           <Text>{c(
             "{0} is a link to guest embeds settings page with text 'admin settings'",
-          ).jt`Disabled, enable guest embeds in ${(
+          ).jt`You can enable guest embeds in ${(
             <Link
               key="admin-settings-link"
               to="/admin/embedding/guest"
               onClick={() => dispatch(closeModal())}
             >
               <Text display="inline" c="text-brand" fw="bold">{c(
-                "is a link in a sentence 'Disabled, enable guest embeds in admin settings'",
+                "is a link in a sentence 'You can enable guest embeds in admin settings'",
               ).t`admin settings`}</Text>
             </Link>
           )}`}</Text>


### PR DESCRIPTION
Change `guest embeds disabled` tooltip to display a link to admin settings.
The icon + tooltip is displayed only in EE build, in OSS we already allow to enable it in place via a Enable Guest Embeds card.

Closes: https://linear.app/metabase/issue/EMB-1159/add-link-to-admin-settings-when-guest-embed-is-disabled

<img width="810" height="380" alt="image" src="https://github.com/user-attachments/assets/289daa84-fbf3-4d11-a0dd-2210e46baa45" />

How to verify:
- in EE build, in admin settings disable guest embeds.
- open the Embed JS wizard, check the icon.
- click the link - the modal should be closed
- if a  current path is different to `/admin/embeds/guest` - should be navigated to `/admin/embeds/guest` 
- enable guest embeds
- open the wizard again
- there should be no icon as guest embeds enabled