### PR TITLE
Provide Cypress env (CI) for the support file

### DIFF
--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -156,6 +156,9 @@ const defaultConfig = {
   },
   baseUrl: `http://${BACKEND_HOST}:${BACKEND_PORT}`,
   defaultBrowser: process.env.CYPRESS_BROWSER ?? "chrome",
+  env: {
+    CI: isCI,
+  },
   supportFile: "e2e/support/cypress.js",
   chromeWebSecurity: false,
   modifyObstructiveCode: false,


### PR DESCRIPTION
Resolves DEV-1234

Cypress support file needs to know whether we're in the CI environment or no. It does so by reading the Cypress.env() because it cannot directly access NodeJS' `process.env`. This PR ensures that the "CI" environment variable is available to Cypress.

If the fix works, we should start seeing the failed test PR comments again. Context [here](https://metaboat.slack.com/archives/C5XHN8GLW/p1767891581066459).