### PR TITLE
fix flake unit test

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/metabot/tests/history.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/tests/history.unit.spec.tsx
@@ -28,11 +28,12 @@ describe("metabot > history", () => {
   it("should send conversation history along with future messages", async () => {
     setup();
 
-    mockAgentEndpoint({
+    const { sendResponse } = mockAgentEndpoint({
       textChunks: whoIsYourFavoriteResponse,
-      initialDelay: 50,
+      waitForResponse: true,
     });
     await enterChatMessage("Who is your favorite?");
+    sendResponse();
     expect(
       await screen.findByText("You, but don't tell anyone."),
     ).toBeInTheDocument();

--- a/enterprise/frontend/src/metabase-enterprise/metabot/tests/message.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/tests/message.unit.spec.tsx
@@ -17,9 +17,9 @@ describe("metabot > message", () => {
   it("should properly send chat messages", async () => {
     setup();
 
-    mockAgentEndpoint({
+    const { sendResponse } = mockAgentEndpoint({
       textChunks: whoIsYourFavoriteResponse,
-      initialDelay: 200,
+      waitForResponse: true,
     });
 
     await enterChatMessage("Who is your favorite?", false);
@@ -27,10 +27,12 @@ describe("metabot > message", () => {
 
     await enterChatMessage("Who is your favorite?");
     expect(await responseLoader()).toBeInTheDocument();
+
+    sendResponse();
+
     expect(
       await screen.findByText("You, but don't tell anyone."),
     ).toBeInTheDocument();
-
     expect(await input()).toHaveTextContent("");
     expect(await input()).toHaveFocus();
   });

--- a/enterprise/frontend/src/metabase-enterprise/metabot/tests/message.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/tests/message.unit.spec.tsx
@@ -19,7 +19,7 @@ describe("metabot > message", () => {
 
     mockAgentEndpoint({
       textChunks: whoIsYourFavoriteResponse,
-      initialDelay: 50,
+      initialDelay: 200,
     });
 
     await enterChatMessage("Who is your favorite?", false);


### PR DESCRIPTION
Fixes [this fkaky test](https://app.trunk.io/metabase/flaky-tests/test/ff090e89-4575-5a39-aa7a-ed1abbd5ddb4?repo=metabase%2Fmetabase)

### Description
`findByTestId` polls the DOM roughly every 50 ms. The initial delay is also 50 ms, which creates a race condition. To fix this, I decided to remove the time-based logic and use defer instead.

[Stress-test run](https://github.com/metabase/metabase/actions/runs/20830945826): 57/57 🟢  