### PR TITLE
Show border on segment name editable content in new segment page header

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data-studio/segments/components/NewSegmentHeader/NewSegmentHeader.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/segments/components/NewSegmentHeader/NewSegmentHeader.tsx
@@ -31,7 +31,7 @@ export function NewSegmentHeader({
           initialValue=""
           isOptional
           maxLength={SEGMENT_NAME_MAX_LENGTH}
-          onChange={onNameChange}
+          onContentChange={onNameChange}
           placeholder={t`New segment`}
         />
       }

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/segments/components/NewSegmentHeader/NewSegmentHeader.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/segments/components/NewSegmentHeader/NewSegmentHeader.tsx
@@ -1,8 +1,10 @@
 import type { ReactNode } from "react";
 import { t } from "ttag";
 
-import EditableText from "metabase/common/components/EditableText";
-import { PaneHeader } from "metabase-enterprise/data-studio/common/components/PaneHeader";
+import {
+  PaneHeader,
+  PaneHeaderInput,
+} from "metabase-enterprise/data-studio/common/components/PaneHeader";
 
 import { SegmentMoreMenu } from "../SegmentMoreMenu";
 
@@ -25,15 +27,12 @@ export function NewSegmentHeader({
     <PaneHeader
       data-testid="segment-pane-header"
       title={
-        <EditableText
+        <PaneHeaderInput
           initialValue=""
-          placeholder={t`New segment`}
+          isOptional
           maxLength={SEGMENT_NAME_MAX_LENGTH}
-          p={0}
-          fw="bold"
-          fz="h3"
-          lh="h3"
-          onContentChange={onNameChange}
+          onChange={onNameChange}
+          placeholder={t`New segment`}
         />
       }
       menu={previewUrl && <SegmentMoreMenu previewUrl={previewUrl} />}


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-2656/clarify-new-segment-name-field-and-description-ux

### Description

Just needed to use PaneHeaderInput instead of EditableText just like we do in Transforms code.

### How to verify

1. Data Studio > Data Structure > Table > Segments > New segment
2. Notice a border is displayed around the segment name input

### Demo
Before:
<img width="1575" height="777" alt="image" src="https://github.com/user-attachments/assets/9a5d93e1-8ab7-4fa1-9cbe-86bdea52917a" />

After:
<img width="1575" height="777" alt="image" src="https://github.com/user-attachments/assets/b28065bf-38bc-4115-8936-860b3c1a8893" />

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
