### PR TITLE
Reenable deactivated tenants when autoprovisioning

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/providers/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/providers/jwt.clj
@@ -134,10 +134,14 @@
     ;; Authentication succeeded - check account creation policy
     ;; TODO(edpaget): 2025/11/11 this should return an error condition instead of throwing
     :else
-    (do (when-not (and (:user request) (get-in request [:user :is_active]))
-          (sso-utils/check-user-provisioning :jwt))
-        ;; If the user was deactivated but user provisioning is allowed reactive the user
-        (next-method provider (assoc-in request [:user-data :is_active] true)))))
+    (let [provisioning-enabled? (sso-settings/jwt-user-provisioning-enabled?)]
+      (when-not (and (:user request) (get-in request [:user :is_active]))
+        (sso-utils/check-user-provisioning :jwt))
+      ;; If the user was deactivated but user provisioning is allowed reactive the user
+      ;; Pass provisioning status for tenant reactivation logic
+      (next-method provider (-> request
+                                (assoc-in [:user-data :is_active] true)
+                                (assoc :user-provisioning-enabled? provisioning-enabled?))))))
 
 (defn- group-names->ids
   "Translate a user's group names to a set of MB group IDs using the configured mappings"

--- a/enterprise/backend/src/metabase_enterprise/tenants/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/tenants/api.clj
@@ -81,7 +81,8 @@
    [:attributes {:optional true} [:maybe tenant/Attributes]]
    [:is_active {:optional true} [:maybe ms/BooleanValue]]])
 
-(mu/defn- update-tenant!
+(mu/defn update-tenant!
+  "Updates a tenant, publishing any necessary events after doing so"
   [tenant-id :- ms/PositiveInt
    {:keys [is_active] :as tenant} :- UpdateTenantArguments]
   (when (false? is_active)

--- a/enterprise/backend/src/metabase_enterprise/tenants/auth_provider.clj
+++ b/enterprise/backend/src/metabase_enterprise/tenants/auth_provider.clj
@@ -37,26 +37,37 @@
                        :user/tenant-slug (t2/select-one-fn :slug :model/Tenant :id tenant_id)
                        :tenant-slug/tenant-id (:id existing-tenant)
                        :tenant-slug/slug (:slug existing-tenant)
-                       :status-code 403}))
-
-      (and existing-tenant
-           (not (:is_active existing-tenant)))
-      (throw (ex-info "Tenant is not active"
-                      {:tenant-slug/tenant-id (:id existing-tenant)
-                       :tenant-slug/slug (:slug existing-tenant)
-                       :tenant-slug/is-active (:is_active existing-tenant)
                        :status-code 403})))))
 
 (defn- validate-with-tenants-disabled! [{:keys [user tenant-slug]}]
   (when (or (:tenant_id user) (not-empty tenant-slug))
     (throw (ex-info "Tenants and tenant users are disabled." {:status-code 403}))))
 
+(defn- reactivate-tenant!
+  "Reactivate a disabled tenant and any users that were deactivated along with it."
+  [{tenant-id :id}]
+  (api.tenants/update-tenant! tenant-id {:is_active true}))
+
+(defn- maybe-reactivate-tenant!
+  "If the tenant is disabled and user provisioning is enabled,
+   reactivate the tenant. Otherwise throw an error if the tenant is disabled."
+  [existing-tenant user-provisioning-enabled?]
+  (when (and existing-tenant (not (:is_active existing-tenant)))
+    (if user-provisioning-enabled?
+      (reactivate-tenant! existing-tenant)
+      (throw (ex-info "Tenant is not active"
+                      {:tenant-slug/tenant-id (:id existing-tenant)
+                       :tenant-slug/slug (:slug existing-tenant)
+                       :tenant-slug/is-active (:is_active existing-tenant)
+                       :status-code 403})))))
+
 (defn- create-tenant-if-not-exists!
-  [{:as request :keys [user tenant-slug]} existing-tenant]
+  [{:as request :keys [user tenant-slug user-provisioning-enabled?]} existing-tenant]
   (if-not (setting/get :use-tenants)
     (do (validate-with-tenants-disabled! request)
         request)
     (do (validate-user-and-tenant-slug! user existing-tenant (boolean tenant-slug))
+        (maybe-reactivate-tenant! existing-tenant user-provisioning-enabled?)
         (cond-> request
           (boolean tenant-slug)
           (assoc-in [:user-data :tenant_id]


### PR DESCRIPTION
Previously even when autoprovisioning was on, you could not log into a deactivated tenant (either as a new user or an existing user with that tenant).

This changes the behavior to be more consistent. Just as a deactivated user can log in when provisioning is on (and their user gets reactivated), a deactivated tenant's users can still log in, but doing so reactivates the tenant.
