### PR TITLE
Nicer error msg when trying to pull tenant colls

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
@@ -108,6 +108,9 @@
     (str/includes? (ex-message e) "branch")
     "Branch error: Please check the specified branch exists"
 
+    (some-> e ex-cause ex-message (str/includes? "Can't create a tenant collection without tenants enabled"))
+    "This repository contains tenant collections, but the tenants feature is disabled on your instance."
+
     :else
     (format "Failed to reload from git repository: %s" (ex-message e))))
 


### PR DESCRIPTION
Previously if you tried to pull from a remote sync repository that contained tenant collections you would get an incomprehensible error that didn't explain what was wrong.

[EMB-1104: Update error message when trying to pull Tenant collections with Tenants turned off](https://linear.app/metabase/issue/EMB-1104/update-error-message-when-trying-to-pull-tenant-collections-with)
