### PR TITLE
Admins see personal collections for tenant users

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/MainNavSharedCollections/MainNavSharedCollections.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/MainNavSharedCollections/MainNavSharedCollections.tsx
@@ -11,7 +11,10 @@ import { Tree } from "metabase/common/components/tree";
 import { useSetting } from "metabase/common/hooks";
 import { buildCollectionTree } from "metabase/entities/collections";
 import { useSelector } from "metabase/lib/redux";
-import { tenantSpecificCollections } from "metabase/lib/urls";
+import {
+  tenantSpecificCollections,
+  tenantUsersPersonalCollections,
+} from "metabase/lib/urls";
 import {
   PaddedSidebarLink,
   SidebarHeading,
@@ -142,6 +145,14 @@ export const MainNavSharedCollections = ({
           {isAdmin && (
             <PaddedSidebarLink icon="group" url={tenantSpecificCollections()}>
               {t`Tenant collections`}
+            </PaddedSidebarLink>
+          )}
+          {isAdmin && (
+            <PaddedSidebarLink
+              icon="group"
+              url={tenantUsersPersonalCollections()}
+            >
+              {t`Tenant users' personal collections`}
             </PaddedSidebarLink>
           )}
         </SidebarSection>

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantUsersList/TenantUsersList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantUsersList/TenantUsersList.tsx
@@ -1,0 +1,32 @@
+import { t } from "ttag";
+
+import { CollectionListView } from "metabase/common/components/CollectionListView";
+import { ROOT_COLLECTION } from "metabase/entities/collections/constants";
+import * as Urls from "metabase/lib/urls";
+import type { IconName } from "metabase/ui";
+import { useListTenantsQuery } from "metabase-enterprise/api";
+
+export const TenantUsersList = () => {
+  const { data, isLoading } = useListTenantsQuery({ status: "active" });
+
+  const tenants = data?.data ?? [];
+
+  const crumbs = [
+    {
+      title: ROOT_COLLECTION.name,
+      to: Urls.collection({ id: "root", name: "" }),
+    },
+    { title: t`Tenant users' personal collections` },
+  ];
+
+  const items = tenants.map((tenant) => ({
+    key: tenant.id,
+    name: tenant.name,
+    icon: "group" as const satisfies IconName,
+    link: `/collection/tenant-users/${tenant.id}`,
+  }));
+
+  return (
+    <CollectionListView crumbs={crumbs} loading={isLoading} items={items} />
+  );
+};

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantUsersList/TenantUsersList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantUsersList/TenantUsersList.tsx
@@ -23,7 +23,7 @@ export const TenantUsersList = () => {
     key: tenant.id,
     name: tenant.name,
     icon: "group" as const satisfies IconName,
-    link: `/collection/tenant-users/${tenant.id}`,
+    link: Urls.tenantUsersPersonalCollectionsForTenant(tenant.id),
   }));
 
   return (

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantUsersList/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantUsersList/index.ts
@@ -1,0 +1,1 @@
+export { TenantUsersList } from "./TenantUsersList";

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantUsersPersonalCollectionList/TenantUsersPersonalCollectionList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantUsersPersonalCollectionList/TenantUsersPersonalCollectionList.tsx
@@ -1,0 +1,70 @@
+import { t } from "ttag";
+
+import {
+  STANDARD_USER_LIST_PAGE_SIZE as PAGE_SIZE,
+  useListUsersQuery,
+} from "metabase/api";
+import { CollectionListView } from "metabase/common/components/CollectionListView";
+import { usePagination } from "metabase/common/hooks/use-pagination";
+import { ROOT_COLLECTION } from "metabase/entities/collections/constants";
+import * as Urls from "metabase/lib/urls";
+import type { IconName } from "metabase/ui";
+import { useGetTenantQuery } from "metabase-enterprise/api";
+
+interface TenantUsersPersonalCollectionListProps {
+  params: { tenantId: string };
+}
+
+export const TenantUsersPersonalCollectionList = ({
+  params,
+}: TenantUsersPersonalCollectionListProps) => {
+  const tenantId = parseInt(params.tenantId, 10);
+  const { page, handleNextPage, handlePreviousPage } = usePagination();
+
+  const { data: tenant } = useGetTenantQuery(tenantId);
+  const { data, isLoading } = useListUsersQuery({
+    tenant_id: tenantId,
+    limit: PAGE_SIZE,
+    offset: PAGE_SIZE * page,
+  });
+
+  const users = data?.data ?? [];
+  const total = data?.total;
+
+  const crumbs = [
+    {
+      title: ROOT_COLLECTION.name,
+      to: Urls.collection({ id: "root", name: "" }),
+    },
+    {
+      title: t`Tenant users' personal collections`,
+      to: Urls.tenantUsersPersonalCollections(),
+    },
+    { title: tenant?.name ?? "" },
+  ];
+
+  const items = users
+    .filter((user) => user.personal_collection_id)
+    .map((user) => ({
+      key: user.personal_collection_id,
+      name: user.common_name,
+      icon: "person" as const satisfies IconName,
+      link: `/collection/${user.personal_collection_id}`,
+    }));
+
+  return (
+    <CollectionListView
+      crumbs={crumbs}
+      loading={isLoading}
+      items={items}
+      pagination={{
+        page,
+        pageSize: PAGE_SIZE,
+        total,
+        itemsLength: PAGE_SIZE,
+        onNextPage: handleNextPage,
+        onPreviousPage: handlePreviousPage,
+      }}
+    />
+  );
+};

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantUsersPersonalCollectionList/TenantUsersPersonalCollectionList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantUsersPersonalCollectionList/TenantUsersPersonalCollectionList.tsx
@@ -46,10 +46,13 @@ export const TenantUsersPersonalCollectionList = ({
   const items = users
     .filter((user) => user.personal_collection_id)
     .map((user) => ({
-      key: user.personal_collection_id,
+      key: user.id,
       name: user.common_name,
       icon: "person" as const satisfies IconName,
-      link: `/collection/${user.personal_collection_id}`,
+      link: Urls.collection({
+        id: user.personal_collection_id,
+        name: user.common_name,
+      }),
     }));
 
   return (
@@ -61,7 +64,7 @@ export const TenantUsersPersonalCollectionList = ({
         page,
         pageSize: PAGE_SIZE,
         total,
-        itemsLength: PAGE_SIZE,
+        itemsLength: items.length,
         onNextPage: handleNextPage,
         onPreviousPage: handlePreviousPage,
       }}

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantUsersPersonalCollectionList/TenantUsersPersonalCollectionList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantUsersPersonalCollectionList/TenantUsersPersonalCollectionList.tsx
@@ -1,11 +1,7 @@
 import { t } from "ttag";
 
-import {
-  STANDARD_USER_LIST_PAGE_SIZE as PAGE_SIZE,
-  useListUsersQuery,
-} from "metabase/api";
+import { useListUsersQuery } from "metabase/api";
 import { CollectionListView } from "metabase/common/components/CollectionListView";
-import { usePagination } from "metabase/common/hooks/use-pagination";
 import { ROOT_COLLECTION } from "metabase/entities/collections/constants";
 import * as Urls from "metabase/lib/urls";
 import type { IconName } from "metabase/ui";
@@ -19,17 +15,11 @@ export const TenantUsersPersonalCollectionList = ({
   params,
 }: TenantUsersPersonalCollectionListProps) => {
   const tenantId = parseInt(params.tenantId, 10);
-  const { page, handleNextPage, handlePreviousPage } = usePagination();
 
   const { data: tenant } = useGetTenantQuery(tenantId);
-  const { data, isLoading } = useListUsersQuery({
-    tenant_id: tenantId,
-    limit: PAGE_SIZE,
-    offset: PAGE_SIZE * page,
-  });
+  const { data, isLoading } = useListUsersQuery({ tenant_id: tenantId });
 
   const users = data?.data ?? [];
-  const total = data?.total;
 
   const crumbs = [
     {
@@ -56,18 +46,6 @@ export const TenantUsersPersonalCollectionList = ({
     }));
 
   return (
-    <CollectionListView
-      crumbs={crumbs}
-      loading={isLoading}
-      items={items}
-      pagination={{
-        page,
-        pageSize: PAGE_SIZE,
-        total,
-        itemsLength: items.length,
-        onNextPage: handleNextPage,
-        onPreviousPage: handlePreviousPage,
-      }}
-    />
+    <CollectionListView crumbs={crumbs} loading={isLoading} items={items} />
   );
 };

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantUsersPersonalCollectionList/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantUsersPersonalCollectionList/index.ts
@@ -1,0 +1,1 @@
+export { TenantUsersPersonalCollectionList } from "./TenantUsersPersonalCollectionList";

--- a/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
@@ -46,6 +46,8 @@ import { TenantDisplayName } from "./components/TenantDisplayName";
 import { FormTenantWidget } from "./components/TenantFormWidget";
 import { TenantGroupHintIcon } from "./components/TenantGroupHintIcon";
 import { TenantSpecificCollectionsItemList } from "./components/TenantSpecificCollectionsItemList";
+import { TenantUsersList } from "./components/TenantUsersList";
+import { TenantUsersPersonalCollectionList } from "./components/TenantUsersPersonalCollectionList";
 import { EditTenantModal } from "./containers/EditTenantModal";
 import { NewTenantModal } from "./containers/NewTenantModal";
 import { TenantActivationModal } from "./containers/TenantActivationModal";
@@ -233,6 +235,9 @@ export function initializePlugin() {
     PLUGIN_TENANTS.TenantSpecificCollectionsItemList =
       TenantSpecificCollectionsItemList;
     PLUGIN_TENANTS.TenantCollectionList = TenantCollectionList;
+    PLUGIN_TENANTS.TenantUsersList = TenantUsersList;
+    PLUGIN_TENANTS.TenantUsersPersonalCollectionList =
+      TenantUsersPersonalCollectionList;
 
     // Category 1: UI Components
     PLUGIN_TENANTS.GroupDescription = function GroupDescription({ group }) {

--- a/frontend/src/metabase-types/api/user.ts
+++ b/frontend/src/metabase-types/api/user.ts
@@ -139,6 +139,7 @@ export type ListUsersRequest = {
   group_id?: number;
   include_deactivated?: boolean;
   tenancy?: UserTenancy;
+  tenant_id?: number;
 } & PaginationRequest;
 
 export type ListUsersResponse = {

--- a/frontend/src/metabase/lib/urls/collections.ts
+++ b/frontend/src/metabase/lib/urls/collections.ts
@@ -17,6 +17,9 @@ export const tenantSpecificCollections = () => "/collection/tenant-specific";
 
 export const tenantUsersPersonalCollections = () => "/collection/tenant-users";
 
+export const tenantUsersPersonalCollectionsForTenant = (tenantId: number) =>
+  `/collection/tenant-users/${tenantId}`;
+
 type Collection = Pick<
   BaseCollection,
   "id" | "name" | "originalName" | "personal_owner_id" | "type"

--- a/frontend/src/metabase/lib/urls/collections.ts
+++ b/frontend/src/metabase/lib/urls/collections.ts
@@ -15,6 +15,8 @@ export const otherUsersPersonalCollections = () => "/collection/users";
 
 export const tenantSpecificCollections = () => "/collection/tenant-specific";
 
+export const tenantUsersPersonalCollections = () => "/collection/tenant-users";
+
 type Collection = Pick<
   BaseCollection,
   "id" | "name" | "originalName" | "personal_owner_id" | "type"
@@ -67,7 +69,12 @@ export function isCollectionPath(path: string) {
 }
 
 export function extractCollectionId(slug = ""): CollectionId | undefined {
-  if (slug === "root" || slug === "users" || slug === "tenant-specific") {
+  if (
+    slug === "root" ||
+    slug === "users" ||
+    slug === "tenant-specific" ||
+    slug === "tenant-users"
+  ) {
     return slug;
   }
   return extractEntityId(slug);

--- a/frontend/src/metabase/plugins/oss/tenants.ts
+++ b/frontend/src/metabase/plugins/oss/tenants.ts
@@ -47,6 +47,10 @@ const getDefaultPluginTenants = () => ({
   TenantSpecificCollectionsItemList: (_props: CollectionItemListProps) =>
     null as React.ReactElement | null,
   TenantCollectionList: PluginPlaceholder,
+  TenantUsersList: PluginPlaceholder,
+  TenantUsersPersonalCollectionList: PluginPlaceholder as React.ComponentType<{
+    params: { tenantId: string };
+  }>,
   GroupDescription: (_props: { group: Group }) =>
     null as React.ReactElement | null,
   EditUserStrategyModal: PluginPlaceholder,
@@ -112,6 +116,10 @@ export const PLUGIN_TENANTS: {
     props: CollectionItemListProps,
   ) => React.ReactElement | null;
   TenantCollectionList: React.ComponentType;
+  TenantUsersList: React.ComponentType;
+  TenantUsersPersonalCollectionList: React.ComponentType<{
+    params: { tenantId: string };
+  }>;
   GroupDescription: (props: { group: Group }) => React.ReactElement | null;
   EditUserStrategyModal: (props: {
     onClose: () => void;

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -189,6 +189,14 @@ export const getRoutes = (store) => {
             <IndexRoute component={PLUGIN_TENANTS.TenantCollectionList} />
           </Route>
 
+          <Route path="collection/tenant-users" component={IsAdmin}>
+            <IndexRoute component={PLUGIN_TENANTS.TenantUsersList} />
+            <Route
+              path=":tenantId"
+              component={PLUGIN_TENANTS.TenantUsersPersonalCollectionList}
+            />
+          </Route>
+
           <Route path="collection/:slug" component={CollectionLanding}>
             <ModalRoute path="move" modal={MoveCollectionModal} noWrap />
             <ModalRoute path="archive" modal={ArchiveCollectionModal} noWrap />


### PR DESCRIPTION
Closes EMB-1110
Closes EMB-1111

[EMB-1110: As an Admin, I want to be able to see personal collections of external users](https://linear.app/metabase/issue/EMB-1110/as-an-admin-i-want-to-be-able-to-see-personal-collections-of-external)

This was already implemented on the BE. Claude helped with the FE but I think it seems reasonable.