### PR TITLE
updating ClauseStep type, fixing segment and measure editors

### DIFF
--- a/frontend/src/metabase/querying/measures/components/MeasureAggregationPicker/MeasureAggregationPicker.tsx
+++ b/frontend/src/metabase/querying/measures/components/MeasureAggregationPicker/MeasureAggregationPicker.tsx
@@ -4,7 +4,6 @@ import { t } from "ttag";
 import ErrorBoundary from "metabase/ErrorBoundary";
 import { AggregationPicker } from "metabase/common/components/AggregationPicker";
 import { ClauseStep } from "metabase/querying/notebook/components/ClauseStep";
-import { color } from "metabase/ui/utils/colors";
 import * as Lib from "metabase-lib";
 
 const STAGE_INDEX = -1;
@@ -79,7 +78,7 @@ export function MeasureAggregationPicker({
         items={aggregations}
         initialAddText={t`Pick an aggregation function`}
         readOnly={readOnly}
-        color={color("summarize")}
+        color="summarize"
         isLastOpened={false}
         hasAddButton={hasAddButton}
         hasRemoveButton={hasRemoveButton}

--- a/frontend/src/metabase/querying/notebook/components/ClauseStep/ClauseStep.tsx
+++ b/frontend/src/metabase/querying/notebook/components/ClauseStep/ClauseStep.tsx
@@ -7,6 +7,7 @@ import { useMergedRef } from "@mantine/hooks";
 import type { ReactNode, Ref } from "react";
 import { forwardRef, useCallback } from "react";
 
+import type { ColorName } from "metabase/lib/colors/types";
 import { Icon } from "metabase/ui";
 
 import {
@@ -32,7 +33,7 @@ type RenderPopoverOpts<T> = {
 };
 
 export type ClauseStepProps<T> = {
-  color: string;
+  color: ColorName;
   items: T[];
   initialAddText?: string;
   readOnly?: boolean;

--- a/frontend/src/metabase/querying/segments/components/SegmentFilterEditor/SegmentFilterEditor.tsx
+++ b/frontend/src/metabase/querying/segments/components/SegmentFilterEditor/SegmentFilterEditor.tsx
@@ -4,7 +4,6 @@ import { t } from "ttag";
 import ErrorBoundary from "metabase/ErrorBoundary";
 import { FilterPicker } from "metabase/querying/filters/components/FilterPicker";
 import { ClauseStep } from "metabase/querying/notebook/components/ClauseStep";
-import { color } from "metabase/ui/utils/colors";
 import * as Lib from "metabase-lib";
 
 const STAGE_INDEX = -1;
@@ -65,7 +64,7 @@ export function SegmentFilterEditor({
         items={filters}
         initialAddText={t`Add filters to narrow your answer`}
         readOnly={readOnly}
-        color={color("filter")}
+        color="filter"
         isLastOpened={false}
         renderName={renderFilterName}
         renderPopover={({ item: filter, index, onClose }) =>


### PR DESCRIPTION
### Description
The `<ClauseStep>` component now accepts the name of a color, rather than the value. This PR enforces that type while also updating the values provided by the `SegmentFilterEditor` and `MeasureAggregationPicker`

### How to verify
1. Go to the data studio
2. Either through the Library or Data Structure pages, create a new segment
3. The Filter picker should be visible
4. Through the Data Structure page, go to create a measure
5. The Aggregation picker should be visible.

### Demo
<img width="853" height="478" alt="image" src="https://github.com/user-attachments/assets/09a34745-0466-44e6-923e-825329cdce28" />

<img width="864" height="418" alt="image" src="https://github.com/user-attachments/assets/7de785eb-4e3a-4d0f-b3d5-eff9bf53a487" />

