### PR TITLE
include API keys when copying DBs

### DIFF
--- a/src/metabase/cmd/copy.clj
+++ b/src/metabase/cmd/copy.clj
@@ -107,6 +107,8 @@
     :model/AuditLog
     :model/RecentViews
     :model/UserParameterValue
+    ;; v49+
+    :model/ApiKey
     ;; 51+
     :model/Notification
     :model/NotificationSubscription


### PR DESCRIPTION
[UXW-2690: Instance restored from a H2 snapshot is missing API keys](https://linear.app/metabase/issue/UXW-2690/instance-restored-from-a-h2-snapshot-is-missing-api-keys)

Closes #67976