### PR TITLE
Enable codespell for `modules/drivers`

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -18,3 +18,4 @@ jobs:
           path: >-
             docs
             enterprise
+            modules/drivers

--- a/mage/src/mage/codespell.clj
+++ b/mage/src/mage/codespell.clj
@@ -12,7 +12,7 @@
    #_"e2e"
    "enterprise"
    #_"frontend"
-   #_"modules/drivers"
+   "modules/drivers"
    #_"src"
    #_"test"])
 

--- a/modules/drivers/athena/src/metabase/driver/athena.clj
+++ b/modules/drivers/athena/src/metabase/driver/athena.clj
@@ -407,7 +407,7 @@
       (when (not (str/blank? remarks))
         {:field-comment remarks})))))
 
-;; Not all tables in the Data Catalog are guaranted to be compatible with Athena
+;; Not all tables in the Data Catalog are guaranteed to be compatible with Athena
 ;; If an exception is thrown, log and throw an error
 
 (defn- table-has-nested-fields? [columns]
@@ -447,10 +447,10 @@
           (describe-table-fields-with-nested-fields database schema table-name)
           (describe-table-fields-without-nested-fields driver schema table-name columns)))
       (catch Throwable e
-        (log/errorf e "Error retreiving fields for DB %s.%s" schema table-name)
+        (log/errorf e "Error retrieving fields for DB %s.%s" schema table-name)
         (throw e)))))
 
-;; Becuse describe-table-fields might fail, we catch the error here and return an empty set of columns
+;; Because describe-table-fields might fail, we catch the error here and return an empty set of columns
 
 (defmethod driver/describe-table :athena
   [driver {{:keys [catalog dbname]} :details, :as database} table]

--- a/modules/drivers/athena/test/metabase/driver/athena_test.clj
+++ b/modules/drivers/athena/test/metabase/driver/athena_test.clj
@@ -252,7 +252,7 @@
                             :limit        1}
                  :info     {:executed-by 1000
                             :query-hash  (byte-array [1 2 3 4])}}]
-      (testing "Baseline: Query strarts with remark"
+      (testing "Baseline: Query starts with remark"
         (mt/with-metadata-provider (mock-provider true)
           (let [result (query->native! query)]
             (is (string? result))

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -325,7 +325,7 @@
   "_PARTITIONTIME")
 
 (def ^:private partitioned-date-field-name
-  "This is also a pseudo-column, similiar to [[partitioned-time-field-name]].
+  "This is also a pseudo-column, similar to [[partitioned-time-field-name]].
   In fact _PARTITIONDATE is _PARTITIONTIME truncated to DATE.
   See https://cloud.google.com/bigquery/docs/querying-partitioned-tables#query_an_ingestion-time_partitioned_table"
   "_PARTITIONDATE")
@@ -555,7 +555,7 @@
 ;;;     - Execution passes to `execute-bigquery`
 ;;; 3. `execute-bigquery`
 ;;;     - Makes the initial query and checks `cancel-chan` in case the browser cancels execution.
-;;;     - Either throws approriate exceptions or takes the initial page `TableResult` to the next step.
+;;;     - Either throws appropriate exceptions or takes the initial page `TableResult` to the next step.
 ;;;     - Execution passes to `execute-bigquery`
 ;;; 4. `bigquery-execute-response`
 ;;;     - Builds `cols` metadata response.
@@ -824,7 +824,7 @@
   * any associated Table instances will be updated to have schema set (to the dataset-id value)
   * the Database model itself will be updated to persist this change to db-details back to the app DB
 
-  Returns the passed `database` parameter with the aformentioned changes having been made and persisted."
+  Returns the passed `database` parameter with the aforementioned changes having been made and persisted."
   [database dataset-id]
   (let [db-id (u/the-id database)]
     (log/infof "DB %s had hardcoded dataset-id; changing to an inclusion pattern and updating table schemas"
@@ -854,7 +854,7 @@
   (when-not (empty? (filter some? ((juxt :auth-code :client-id :client-secret) details)))
     (log/errorf (str "Database ID %d, which was migrated from the legacy :bigquery driver to :bigquery-cloud-sdk, has"
                      " one or more OAuth style authentication scheme parameters saved to db-details, which cannot"
-                     " be automatically migrated to the newer driver (since it *requires* service-account-json intead);"
+                     " be automatically migrated to the newer driver (since it *requires* service-account-json instead);"
                      " this database must therefore be updated by an administrator (by adding a service-account-json)"
                      " before sync and queries will work again")
                 (u/the-id database)))

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
@@ -854,7 +854,7 @@
 (defn- adjust-order-by-clause
   [[dir [_clause _id-or-name opts :as clause]]]
   [dir
-   ;; Following code ensures that only selected columns (with exception of those comming from different source than
+   ;; Following code ensures that only selected columns (with exception of those coming from different source than
    ;; this source table and having no binning and no bucketing) are forced to use aliases.
    ;;
    ;; This solves Bigquery's inability to use expression from group by in order by.

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
@@ -311,7 +311,7 @@
             (throw (ex-info error-message {:metabase.util/no-auto-retry? true}))))))))
 
 (defn- tabledef->prepared-rows
-  "Convert `table-definition` to a format approprate for passing to `insert-data!`."
+  "Convert `table-definition` to a format appropriate for passing to `insert-data!`."
   [{:keys [field-definitions rows]}]
   {:pre [(every? map? field-definitions) (sequential? rows) (seq rows)]}
   (let [field-names (map :field-name field-definitions)]
@@ -323,7 +323,7 @@
   (let [table-name (normalize-name table-name)]
     (create-table! dataset-id table-name field-definitions)
     (when (seq (:rows tabledef))
-      ;; retry the `insert-data!` step up to 5 times because it seens to fail silently a lot. Since each row is given a
+      ;; retry the `insert-data!` step up to 5 times because it seems to fail silently a lot. Since each row is given a
       ;; unique key it shouldn't result in duplicates.
       (loop [num-retries 5]
         (let [^Throwable e (try

--- a/modules/drivers/databricks/src/metabase/driver/databricks.clj
+++ b/modules/drivers/databricks/src/metabase/driver/databricks.clj
@@ -390,7 +390,7 @@
   (set-parameter-to-local-date-time driver prepared-statement index object))
 
 ;;
-;; `set-parameter` is implmented also for LocalTime and OffsetTime, even though Databricks does not support time types.
+;; `set-parameter` is implemented also for LocalTime and OffsetTime, even though Databricks does not support time types.
 ;; It enables creation of `attempted-murders` dataset, hence making the driver compatible with more of existing tests.
 ;;
 

--- a/modules/drivers/druid-jdbc/test/metabase/driver/druid_jdbc/nested_field_columns_test.clj
+++ b/modules/drivers/druid-jdbc/test/metabase/driver/druid_jdbc/nested_field_columns_test.clj
@@ -155,7 +155,7 @@
                 (testing "yet json_unfolding is enabled by default at the field level"
                   (is (true? (:json_unfolding (get-field)))))
                 (testing "nested fields are added automatically when json unfolding is enabled for the field,
-                            and json unfolding is alread enabled for the DB"
+                            and json unfolding is already enabled for the DB"
                   (set-json-unfolding-for-field! false)
                   (set-json-unfolding-for-db! true)
                   (set-json-unfolding-for-field! true)

--- a/modules/drivers/druid/src/metabase/driver/druid/execute.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/execute.clj
@@ -99,7 +99,7 @@
            k))))))
 
 (defn- result-metadata [col-names]
-  ;; rename any occurances of `:timestamp___int` to `:timestamp` in the results so the user doesn't know about
+  ;; rename any occurrences of `:timestamp___int` to `:timestamp` in the results so the user doesn't know about
   ;; our behind-the-scenes conversion and apply any other post-processing on the value such as parsing some
   ;; units to int and rounding up approximate cardinality values.
   (let [fixed-col-names (for [col-name col-names]

--- a/modules/drivers/druid/src/metabase/driver/druid/js.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/js.clj
@@ -38,7 +38,7 @@
        " }"))
 
 (defn- arithmetic-operator
-  "Interpose artihmetic `operator` between `args`, and wrap the entire expression in parens."
+  "Interpose arithmetic `operator` between `args`, and wrap the entire expression in parens."
   ^String [operator & args]
   (parens (str/join (str " " (name operator) " ")
                     (map ->js args))))

--- a/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
@@ -351,7 +351,7 @@
 
 (defmulti ^:private filter-clause->intervals
   "Generate query intervals as appropriate from a `filter-clause` containing a temporal `:field`. `:intervals` are
-  specified seperately from other things we think of as filter clauses in Druid. For temporal filter clauses, this
+  specified separately from other things we think of as filter clauses in Druid. For temporal filter clauses, this
   returns a sequence of min/max datetime tuples; like `[#t 2019-01-01 #t 2019-10-01]`; for irrelevant filter
   clauses, the methods are skipped entirely."
   {:arglists '([filter-clause])}
@@ -1042,7 +1042,7 @@
       [:field (id :guard pos-int?) _opts]
       (driver-api/temporal? (driver-api/field (driver-api/metadata-provider) id)))))
 
-;; Handle order by timstamp field
+;; Handle order by timestamp field
 (defmethod handle-order-by ::grouped-timeseries
   [_ {[[direction field]] :order-by} druid-query]
   (let [can-sort? (if (temporal-field? field)
@@ -1089,7 +1089,7 @@
    (fn
      ([druid-query]
       ;; If you specify nil or empty `:columns` Druid will just return all of the ones available. In cases where
-      ;; we don't want anything to be returned in one or the other, we'll ask for a `:___dummy` column intead.
+      ;; we don't want anything to be returned in one or the other, we'll ask for a `:___dummy` column instead.
       ;; Druid happily returns `nil` for the column in every row, and it will get auto-filtered out of the results
       ;; so the User will never see it.
       (update-in druid-query [:query :columns] #(or (seq %) [:___dummy])))

--- a/modules/drivers/mongo/src/metabase/driver/mongo.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo.clj
@@ -180,7 +180,7 @@
   "Sequence of stages repeated in _search_ phase of [[describe-table-pipeline]]
     for [[describe-table-query-depth]] times.
 
-    Each repetion $unwinds documents having `val` of type \"object\", so those are __swapped__ for sequence
+    Each repetition $unwinds documents having `val` of type \"object\", so those are __swapped__ for sequence
     of their children.
 
     Documents with non-object val are left untouched.

--- a/modules/drivers/mongo/src/metabase/driver/mongo/operators.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/operators.clj
@@ -6,7 +6,7 @@
    TODO: We should consider removing this namespace completely. Having it just adds need for maintaining list of
          operators monger provides. We could use keywords instead. Conversion code currently handles
          transformation of those into strings during transformations to document. More importantly -- we are already
-         using keywords in lot of places in [[metabase.driver.mongo.query-processor]]. Try seraching it for `:\\$``
+         using keywords in lot of places in [[metabase.driver.mongo.query-processor]]. Try searching it for `:\\$``
          regex.
 
    TODO should be addressed during follow-up of monger removal."

--- a/modules/drivers/mongo/src/metabase/driver/mongo/parameters.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/parameters.clj
@@ -89,7 +89,7 @@
 ;; Field filter value is either params/no-value (handled in `substitute-param`, a map with `:type` and `:value`, or a
 ;; sequence of those maps.
 (defn- substitute-one-field-filter [{field :field, alias :alias, {param-type :type, value :value} :value, :as field-filter}]
-  ;; convert relative dates to approprate date range representations
+  ;; convert relative dates to appropriate date range representations
   (cond
     (params.dates/not-single-date-type? param-type)
     (substitute-one-field-filter-date-range field-filter)

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -1273,9 +1273,9 @@ function(bin) {
            [(str \$ aggr-name) (assoc aggregations-seen aggr-expr aggr-name)])
 
          :else
-         (reduce (fn [[ges as] arg]
+         (reduce (fn [[ges as] arg] ; codespell:ignore
                    (let [[ge as] (extract-aggregations arg parent-name as)]
-                     [(conj ges ge) as]))
+                     [(conj ges ge) as])) ; codespell:ignore
                  [[op] aggregations-seen]
                  args)))
      [aggr-expr aggregations-seen])))

--- a/modules/drivers/mongo/src/metabase/driver/mongo/util.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/util.clj
@@ -54,7 +54,7 @@
 
 ;; https://mongodb.github.io/mongo-java-driver/4.11/apidocs/mongodb-driver-sync/com/mongodb/client/MongoCollection.html#listIndexes()
 (defn list-indexes
-  "Return vector of Documets describing indexes."
+  "Return vector of Documents describing indexes."
   [^MongoCollection coll & {:as opts}]
   (mongo.conversion/from-document (.listIndexes coll) opts))
 

--- a/modules/drivers/mongo/test/metabase/driver/mongo/parameters_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/parameters_test.clj
@@ -58,7 +58,7 @@
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #"missing required parameters: #\{:x\}"
                             (substitute nil [(param :x)]))))
-    (testing "params preceeded or followed by strings should get combined into a single string"
+    (testing "params preceded or followed by strings should get combined into a single string"
       (is (= "2100"
              (substitute {:x 100} ["2" (param :x)]))
           "\"2{{x}}\" with x = 100 should be replaced with string \"2100\""))

--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -298,7 +298,7 @@
             (is (true? (t2/select-one-fn :database_indexed :model/Field (mt/id :singly-index :indexed))))
             (is (false? (t2/select-one-fn :database_indexed :model/Field (mt/id :singly-index :not-indexed)))))
 
-          (testing "compount index"
+          (testing "compound index"
             (mongo.connection/with-mongo-database [db (mt/db)]
               (mongo.util/create-index (mongo.util/collection db "compound-index") (array-map "first" 1 "second" 1)))
             (sync/sync-database! (mt/db))
@@ -1011,9 +1011,9 @@
 
   Forward bindings become delays of results of functions used in mongo's describe-table:
 
-  - `dbfields`     : reuslt of [[mongo/fetch-dbfields]],
-  - `ftree`        : reuslt of [[mongo/dbfields->ftree]],
-  - `nested-fields`: reuslt of [[mongo/ftree->nested-fields]]."
+  - `dbfields`     : result of [[mongo/fetch-dbfields]],
+  - `ftree`        : result of [[mongo/dbfields->ftree]],
+  - `nested-fields`: result of [[mongo/ftree->nested-fields]]."
   [documents & body]
   `(do-with-describe-table-for-sample ~documents (fn [~'dbfields ~'ftree ~'nested-fields] ~@body)))
 

--- a/modules/drivers/oracle/src/metabase/driver/oracle.clj
+++ b/modules/drivers/oracle/src/metabase/driver/oracle.clj
@@ -621,7 +621,7 @@
 (defmethod sql-jdbc.sync/excluded-schemas :oracle
   [_]
   #{"ANONYMOUS"
-    ;; TODO - are there othere APEX tables we want to skip? Maybe we should make this a pattern instead? (#"^APEX_")
+    ;; TODO - are there other APEX tables we want to skip? Maybe we should make this a pattern instead? (#"^APEX_")
     "APEX_040200"
     "APPQOSSYS"
     "AUDSYS"

--- a/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
+++ b/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
@@ -27,7 +27,7 @@
    [metabase.sync.util :as sync-util]
    [metabase.test :as mt]
    [metabase.test.data.dataset-definitions :as defs]
-   [metabase.test.data.env :as te]
+   [metabase.test.data.env :as te] ; codespell:ignore
    [metabase.test.data.interface :as tx]
    [metabase.test.data.oracle :as oracle.tx]
    [metabase.test.data.sql :as sql.tx]
@@ -440,7 +440,7 @@
                                   tx/*database-name-override* "test-data"
                                   ;; Only run the embedded test with the :oracle driver. For example, run it with :h2
                                   ;; results in errors because of column name formatting.
-                                  te/*test-drivers* (constantly #{:oracle})]
+                                  te/*test-drivers* (constantly #{:oracle})] ; codespell:ignore te
                           (testing " and execute a query correctly"
                             (qp-test.order-by-test/order-by-test))))))))))))
       (log/warn (u/format-color 'yellow
@@ -549,7 +549,7 @@
   (mt/test-driver :oracle
     (mt/dataset date-cols-with-datetime-values
       (testing "Oracle's DATE columns are mapped to type/DateTime (#49440)"
-        (testing "Filtering by datetime retuns expected results"
+        (testing "Filtering by datetime returns expected results"
           (let [query (mt/mbql-query dates_with_time
                         {:filter [:= [:field %date_with_time {:base-type :type/DateTime}] "2024-11-05T12:12:12"]})]
             (mt/with-native-query-testing-context query

--- a/modules/drivers/redshift/test/metabase/test/data/redshift.clj
+++ b/modules/drivers/redshift/test/metabase/test/data/redshift.clj
@@ -98,7 +98,7 @@
 (defmethod sql.tx/qualified-name-components :redshift [& args]
   (apply tx/single-db-qualified-name-components (unique-session-schema) args))
 
-;; don't use the Postgres implementation of `drop-db-ddl-statements` because it adds an extra statment to kill all
+;; don't use the Postgres implementation of `drop-db-ddl-statements` because it adds an extra statement to kill all
 ;; open connections to that DB, which doesn't work with Redshift
 (defmethod ddl/drop-db-ddl-statements :redshift
   [& args]

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -449,7 +449,7 @@
   "Same as snowflake's `datediff`, but accurate to the millisecond for sub-day units."
   [unit x y]
   (let [milliseconds [:datediff [:raw "milliseconds"] x y]]
-    ;; millseconds needs to be cast to float because division rounds incorrectly with large integers
+    ;; milliseconds needs to be cast to float because division rounds incorrectly with large integers
     [:trunc (h2x// (h2x/cast :float milliseconds)
                    (case unit :hour 3600000 :minute 60000 :second 1000))]))
 

--- a/modules/drivers/sqlite/src/metabase/driver/sqlite.clj
+++ b/modules/drivers/sqlite/src/metabase/driver/sqlite.clj
@@ -108,7 +108,7 @@
     [#"CLOB"      :type/Text]
     [#"BLOB"      :type/*]
     [#"REAL"      :type/Float]
-    [#"DOUB"      :type/Float]
+    [#"DOUB"      :type/Float] ; codespell:ignore
     [#"FLOA"      :type/Float]
     [#"NUMERIC"   :type/Float]
     [#"DECIMAL"   :type/Decimal]

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -159,7 +159,7 @@
        ;; Wait up to 10 seconds for connection success. If we get no response by then, consider the connection failed
        :loginTimeout       10
        ;; apparently specifying `domain` with the official SQLServer driver is done like `user:domain\user` as opposed
-       ;; to specifying them seperately as with jTDS see also:
+       ;; to specifying them separately as with jTDS see also:
        ;; https://social.technet.microsoft.com/Forums/sqlserver/en-US/bc1373f5-cb40-479d-9770-da1221a0bc95/connecting-to-sql-server-in-a-different-domain-using-jdbc-driver?forum=sqldataaccess
        :user               (str (when domain (str domain "\\"))
                                 user)
@@ -287,7 +287,7 @@
   [_driver _unit expr]
   (date-part :dayofyear expr))
 
-;; Subtract the number of days needed to bring us to the first day of the week, then convert to back to orignal type
+;; Subtract the number of days needed to bring us to the first day of the week, then convert to back to original type
 (defn- trunc-week
   [expr]
   (let [original-type (if (= "datetimeoffset" (h2x/type-info->db-type (h2x/type-info expr)))
@@ -849,7 +849,7 @@
                  (not (in-join-source-query? path))
                  (in-source-query? path)))]
     (driver-api/replace inner-query
-      ;; remove order by and then recurse in case we need to do more tranformations at another level
+      ;; remove order by and then recurse in case we need to do more transformations at another level
       (m :guard (partial remove-order-by? &parents))
       (fix-order-bys (dissoc m :order-by))
 
@@ -981,7 +981,7 @@
 (defmethod sql.qp/->integer :sqlserver
   [driver value]
   ;; value can be either string or float
-  ;; if it's a float, coversion to float does nothing
+  ;; if it's a float, conversion to float does nothing
   ;; if it's a string, we can't round, so we need to convert to float first
   (h2x/maybe-cast (sql.qp/integer-dbtype driver)
                   [:round (sql.qp/->float driver value) 0]))

--- a/modules/drivers/starburst/src/metabase/driver/starburst.clj
+++ b/modules/drivers/starburst/src/metabase/driver/starburst.clj
@@ -659,7 +659,7 @@
          (t/zone-offset 0))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
-;;; |                                          SQL Statment Operations                                               |
+;;; |                                          SQL Statement Operations                                              |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 ; Metabase tests require a specific error when an invalid number of parameters are passed

--- a/modules/drivers/vertica/src/metabase/driver/vertica.clj
+++ b/modules/drivers/vertica/src/metabase/driver/vertica.clj
@@ -279,7 +279,7 @@
 
 (defmethod sql.qp/add-interval-honeysql-form :vertica
   [_ hsql-form amount unit]
-  ;; using `timestampadd` instead of `+ (INTERVAL)` because vertica add inteval for month, or year
+  ;; using `timestampadd` instead of `+ (INTERVAL)` because vertica add interval for month, or year
   ;; by adding the equivalent number of days, not adding the unit compoinent.
   ;; For example `select date '2004-02-02' + interval '1 year' will return `2005-02-01` because it's adding
   ;; 365 days under the hood and 2004 is a leap year. Whereas other dbs will return `2006-02-02`.


### PR DESCRIPTION
This PR fixes typos in modules/drivers.
Luckily, all these typos were related to docstrings and comments so all fixes are generally safe.

It also enables codespell GitHub action for this folder.