### PR TITLE
docs - fix translation docs

### DIFF
--- a/docs/embedding/components.md
+++ b/docs/embedding/components.md
@@ -33,7 +33,8 @@ To render a dashboard:
 - `with-subscriptions` - let people set up [dashboard subscriptions](../dashboards/subscriptions.md). Unlike subscriptions sent from non-embedded dashboards, subscriptions sent from embedded dashboards exclude links to Metabase items, as Metabase assumes the recipient lacks access to the embedded Metabase.
 - `refresh` - auto-refreshes the dashboard. `refresh="60"` will refresh the dashboard every 60 seconds.
 - `hidden-parameters` - list of filter names to hide from the dashboard, like `['productId']`
-- `locale` - see [translations](./translations.md) (only available for guest embeds).
+
+For guest embeds, you can also set a `locale` in your page-level configuration to [translate embedded content](./translations.md).
 
 If you surround your attribute value with double quotes, make sure to use single quotes:
 

--- a/docs/embedding/guest-embedding.md
+++ b/docs/embedding/guest-embedding.md
@@ -143,7 +143,19 @@ You can propagate filter values into the external URL, unless the filter is lock
 
 ## Translating guest embeds
 
-See [Translating embedded questions and dashboards](./translations.md).
+To translate an embed, set the `locale` in `window.metabaseConfig`:
+
+```html
+<script>
+  window.metabaseConfig = {
+    isGuest: true,
+    instanceUrl: "YOUR_METABASE_URL",
+    locale: "es",
+  };
+</script>
+```
+
+The `locale` setting works for all modular embeds (guest and SSO). Metabase will automatically translate UI elements (like menus and buttons). To also translate content like dashboard titles and filter labels, you'll need to upload a translation dictionary. Translation dictionaries only work with guest embeds. See [Translating embedded questions and dashboards](./translations.md).
 
 ## How guest embedding works
 

--- a/docs/embedding/translations.md
+++ b/docs/embedding/translations.md
@@ -18,8 +18,10 @@ To translate an embed's user interface, set the locale in the config:
   window.metabaseConfig = {
     isGuest: true,
     instanceUrl: "YOUR_METABASE_URL",
-    // Sets the language. If you've uploaded a translation dictionary,
-    // Metabase will translate strings for this locale from that dictionary
+    // Translates UI elements to the locale's language.
+    // If you've uploaded a translation dictionary,
+    // Metabase will also translate content strings
+    // to this locale from that dictionary.
     locale: "es"
   };
 </script>

--- a/docs/embedding/translations.md
+++ b/docs/embedding/translations.md
@@ -9,7 +9,27 @@ summary: Upload a translation dictionary to translate questions and dashboards i
 
 For now, translations are only available for [guest embeds](./guest-embedding.md). Translations aren't available for SSO-based modular embedding or full app embedding.
 
-You can upload a translation dictionary to translate strings both in Metabase content (like dashboard titles) and in the data itself (like column names and values).
+## Set a locale to translate UI, and upload a dictionary to translate content
+
+To translate an embed's user interface, set the locale in the config:
+
+```html
+<script>
+  window.metabaseConfig = {
+    isGuest: true,
+    instanceUrl: "YOUR_METABASE_URL",
+    // Sets the language. If you've uploaded a translation dictionary,
+    // Metabase will translate strings for this locale from that dictionary
+    locale: "es"
+  };
+</script>
+
+<metabase-dashboard token="YOUR_JWT_TOKEN"></metabase-dashboard>
+```
+
+Metabase UI elements (like menus) will be translated automatically - you don't need to add translations for them to your dictionary.
+
+If you also want to translate content---item titles, headings, filter labels, etc---you'll need to add a translation dictionary.
 
 ## Add a translation dictionary
 
@@ -29,21 +49,6 @@ To add a translation dictionary:
 Uploading a new dictionary will replace the existing dictionary.
 
 To remove a translation dictionary, upload a blank dictionary.
-
-## Translate content in guest embeds
-
-To translate content in a guest embed using the uploaded dictionary, add the [`locale` parameter](./components.md).
-```
- <metabase-dashboard
-    dashboard-id="1"
-    with-title="false"
-    with-subscriptions="true"
-    drills="true"
-    locale="es"
- </metabase-dashboard>
-```
-
-Metabase UI elements (like button labels) will be translated automatically - you don't need to add translations for them to your dictionary.
 
 ## Example translation dictionary
 

--- a/docs/embedding/translations.md
+++ b/docs/embedding/translations.md
@@ -11,9 +11,9 @@ You can set a locale on all modular embeds (guest and SSO) to translate Metabase
 
 ## Set a locale to translate UI, and upload a dictionary to translate content
 
-To translate an embed's user interface, set the locale in the config. The `locale` setting works for all modular embeds (guest and SSO).
+To translate an embed's user interface, set the locale in the config. The `locale` setting works for all modular embeds (guest and SSO). Metabase UI elements (like menus) will be translated automatically - you don't need to add translations for them to your dictionary.
 
-For guest embeds, set the `locale` in `window.metabaseConfig`:
+For guest and SSO embeds (not the SDK), set the `locale` in `window.metabaseConfig`:
 
 ```html
 <script>
@@ -31,6 +31,10 @@ For guest embeds, set the `locale` in `window.metabaseConfig`:
 <metabase-dashboard token="YOUR_JWT_TOKEN"></metabase-dashboard>
 ```
 
+For guest embeds (and only guest embeds), if you also want to translate content (like item titles, headings, filter labels---even data), you'll need to add a translation dictionary.
+
+### SDK translations
+
 For the SDK, set the `locale` prop on the `MetabaseProvider` component:
 
 ```tsx
@@ -40,10 +44,6 @@ For the SDK, set the `locale` prop on the `MetabaseProvider` component:
 >
 </MetabaseProvider>
 ```
-
-Metabase UI elements (like menus) will be translated automatically - you don't need to add translations for them to your dictionary.
-
-For guest embeds, if you also want to translate content (like item titles, headings, filter labels---even data), you'll need to add a translation dictionary.
 
 ## Add a translation dictionary
 

--- a/docs/embedding/translations.md
+++ b/docs/embedding/translations.md
@@ -1,17 +1,19 @@
 ---
 title: Translate embedded dashboards and questions
-summary: Upload a translation dictionary to translate questions and dashboards into different languages. Only available for guest embeds.
+summary: Upload a translation dictionary to translate questions and dashboards into different languages. Translation dictionaries are only available for guest embeds.
 ---
 
 # Translate embedded dashboards and questions
 
 {% include plans-blockquote.html feature="Translation of embedded content" convert_pro_link_to_embbedding=true %}
 
-For now, translations are only available for [guest embeds](./guest-embedding.md). Translations aren't available for SSO-based modular embedding or full app embedding.
+You can set a locale on all modular embeds (guest and SSO) to translate Metabase's UI. Translation dictionaries, however, are only available for [guest embeds](./guest-embedding.md).
 
 ## Set a locale to translate UI, and upload a dictionary to translate content
 
-To translate an embed's user interface, set the locale in the config:
+To translate an embed's user interface, set the locale in the config. The `locale` setting works for all modular embeds (guest and SSO).
+
+For guest embeds, set the `locale` in `window.metabaseConfig`:
 
 ```html
 <script>
@@ -19,7 +21,7 @@ To translate an embed's user interface, set the locale in the config:
     isGuest: true,
     instanceUrl: "YOUR_METABASE_URL",
     // Translates UI elements to the locale's language.
-    // If you've uploaded a translation dictionary,
+    // For guest embeds, if you've uploaded a translation dictionary,
     // Metabase will also translate content strings
     // to this locale from that dictionary.
     locale: "es"
@@ -27,6 +29,16 @@ To translate an embed's user interface, set the locale in the config:
 </script>
 
 <metabase-dashboard token="YOUR_JWT_TOKEN"></metabase-dashboard>
+```
+
+For the SDK, set the `locale` prop on the `MetabaseProvider` component:
+
+```tsx
+<MetabaseProvider
+  authConfig={authConfig}
+  locale="es"
+>
+</MetabaseProvider>
 ```
 
 Metabase UI elements (like menus) will be translated automatically - you don't need to add translations for them to your dictionary.

--- a/docs/embedding/translations.md
+++ b/docs/embedding/translations.md
@@ -43,7 +43,7 @@ For the SDK, set the `locale` prop on the `MetabaseProvider` component:
 
 Metabase UI elements (like menus) will be translated automatically - you don't need to add translations for them to your dictionary.
 
-If you also want to translate content---item titles, headings, filter labels, etc---you'll need to add a translation dictionary.
+For guest embeds, if you also want to translate content (like item titles, headings, filter labels---even data), you'll need to add a translation dictionary.
 
 ## Add a translation dictionary
 


### PR DESCRIPTION
Clarifies locale should be set in the config, not in the component.