### PR TITLE
Fix issues in the llms.txt generation workflow

### DIFF
--- a/.github/workflows/llms-txt-generate.yml
+++ b/.github/workflows/llms-txt-generate.yml
@@ -45,13 +45,16 @@ jobs:
           # Extract version number (e.g., v0.57.0 -> 0.57.0)
           VERSION_NUM="${VERSION#v}"
 
-          # Extract patch version (last number)
-          PATCH_VERSION=$(echo "$VERSION_NUM" | cut -d. -f3)
+          # Count dots to determine version type
+          # Metabase format: v0.MAJOR.MINOR (3 segments) or v0.MAJOR.MINOR.PATCH (4 segments)
+          DOT_COUNT=$(echo "$VERSION_NUM" | tr -cd '.' | wc -c | tr -d ' ')
 
-          # Only proceed if this is a minor or major release (patch version is 0)
+          # Only proceed if this is a minor or major release (3 segments)
+          # Examples of minor/major releases: v0.57.8, v0.59.0
+          # Skip for patch releases (4 segments): v0.57.8.1
           # Note: This is a safety check even though the workflow should only be called
           # for minor/major releases, just in case the workflow is dispatched manually.
-          if [ "$PATCH_VERSION" != "0" ]; then
+          if [ "$DOT_COUNT" -eq 3 ]; then
             echo "⏭️  This is a patch release ($VERSION). Skipping llms.txt generation."
             echo "should_generate=false" >> $GITHUB_OUTPUT
           else
@@ -180,6 +183,7 @@ jobs:
 
       - name: Auto approve PR
         if: steps.create_pr.outputs.pull-request-number != ''
+        working-directory: metabase
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -187,6 +191,7 @@ jobs:
 
       - name: Auto merge PR
         if: steps.create_pr.outputs.pull-request-number != ''
+        working-directory: metabase
         env:
           GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
         run: |


### PR DESCRIPTION
In https://github.com/metabase/metabase/pull/67737, I made a couple of errors in the workflow which made the automatic generation fails:

1. The workflow misinterprets the version: we can have both minor and patch releases:

Minor releases: v0.57.0, v0.58.0 (format: v0.MAJOR.MINOR)
Patch releases: v0.57.0.1, v0.57.0.2 (format: v0.MAJOR.MINOR.PATCH)

We need to account for this when determining version numbers.

2. The auto-approve and auto-merge steps are missing working directories, so `gh pr` command fails.

### How to verify

- Go to https://github.com/metabase/metabase/actions/workflows/llms-txt-generate.yml
- Select "Use workflow from" to be "fix-llms-generation-workflow", i.e. use this branch
- Set the version to `v0.59.5` just to pass the validation check
- Set the target to an existing throwaway test branch e.g. `your-name/llms-test-jan-10` that you'd like to test to. Make sure you pushed that branch to remote at least once.
- It should complete successfully (see [this example Actions Run](https://github.com/metabase/metabase/actions/runs/20862429171) that works) and creates an example PR such as https://github.com/metabase/metabase/pull/68021

### Demo

Auto approve and auto merge works now

<img width="1780" height="496" alt="CleanShot 2569-01-10 at 02 01 01@2x" src="https://github.com/user-attachments/assets/b05bb015-6dfd-45f7-b632-8c22046f5dc3" />
