### PR TITLE
[Metabot] Avoid showing data reference sidebar if metabot chat is open

### DIFF
--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -13,7 +13,7 @@ import { t } from "ttag";
 
 import { useListCollectionsQuery, useListSnippetsQuery } from "metabase/api";
 import { useSelector } from "metabase/lib/redux";
-import { PLUGIN_REMOTE_SYNC } from "metabase/plugins";
+import { PLUGIN_METABOT, PLUGIN_REMOTE_SYNC } from "metabase/plugins";
 import { SnippetFormModal } from "metabase/query_builder/components/template_tags/SnippetFormModal";
 import type { QueryModalType } from "metabase/query_builder/constants";
 import { useNotebookScreenSize } from "metabase/query_builder/hooks/use-notebook-screen-size";
@@ -193,7 +193,11 @@ export const NativeQueryEditor = forwardRef<
 
   // do not show reference sidebar on small screens automatically
   const screenSize = useNotebookScreenSize();
-  const shouldOpenDataReference = screenSize !== "small";
+  const isMetabotSidebarOpen = useSelector((state) =>
+    PLUGIN_METABOT.getMetabotVisible(state, "omnibot"),
+  );
+  const shouldOpenDataReference =
+    screenSize !== "small" && !isMetabotSidebarOpen;
 
   useMount(() => {
     setIsNativeEditorOpen?.(

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.unit.spec.tsx
@@ -1,0 +1,81 @@
+import { renderWithProviders } from "__support__/ui";
+import { PLUGIN_METABOT } from "metabase/plugins";
+import { useNotebookScreenSize } from "metabase/query_builder/hooks/use-notebook-screen-size";
+
+import { NativeQueryEditor } from "./NativeQueryEditor";
+
+jest.mock("metabase/api", () => {
+  const actual = jest.requireActual("metabase/api");
+
+  return {
+    ...actual,
+    useListCollectionsQuery: jest.fn(() => ({ data: [] })),
+    useListSnippetsQuery: jest.fn(() => ({ data: [] })),
+  };
+});
+
+jest.mock("metabase/query_builder/hooks/use-notebook-screen-size", () => ({
+  useNotebookScreenSize: jest.fn(),
+}));
+
+type UseNotebookScreenSize = ReturnType<typeof useNotebookScreenSize>;
+
+const useNotebookScreenSizeMock = useNotebookScreenSize as jest.MockedFunction<
+  () => UseNotebookScreenSize
+>;
+
+const mockQuestion = {
+  isSaved: () => false,
+} as any;
+
+describe("NativeQueryEditor", () => {
+  const createEditor = (
+    screenSize: Exclude<UseNotebookScreenSize, undefined>,
+    isMetabotSidebarOpen: boolean,
+  ) => {
+    const setIsNativeEditorOpen = jest.fn();
+
+    useNotebookScreenSizeMock.mockReturnValue(screenSize);
+    jest
+      .spyOn(PLUGIN_METABOT, "getMetabotVisible")
+      .mockReturnValue(isMetabotSidebarOpen);
+
+    renderWithProviders(
+      <NativeQueryEditor
+        availableHeight={700}
+        isNativeEditorOpen={false}
+        question={mockQuestion}
+        query={null as any}
+        setDatasetQuery={jest.fn()}
+        setIsNativeEditorOpen={setIsNativeEditorOpen}
+        isInitiallyOpen={false}
+        hasTopBar={false}
+      />,
+    );
+
+    return setIsNativeEditorOpen;
+  };
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    useNotebookScreenSizeMock.mockReset();
+  });
+
+  it("should not open data reference when metabot sidebar is open", () => {
+    const setIsNativeEditorOpen = createEditor("large", true);
+
+    expect(setIsNativeEditorOpen).toHaveBeenCalledWith(false, false);
+  });
+
+  it("should not open data reference on small screens", () => {
+    const setIsNativeEditorOpen = createEditor("small", false);
+
+    expect(setIsNativeEditorOpen).toHaveBeenCalledWith(false, false);
+  });
+
+  it("should open data reference when metabot is closed", () => {
+    const setIsNativeEditorOpen = createEditor("large", false);
+
+    expect(setIsNativeEditorOpen).toHaveBeenCalledWith(false, true);
+  });
+});


### PR DESCRIPTION
Closes [BOT-589](https://linear.app/metabase/issue/BOT-589/new-sql-questions-automatically-open-datareference-sidebar)

# Description

Visiting the SQL editor automatically opens the data reference sidebar, this also happens when Metabot creates or edits a query for you, so this PR prevents showing the sidebar by default is the Metabot sidebar is already open.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR