### PR TITLE
fix: limit can_run_adhoc_query hydration

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -367,7 +367,8 @@
 
   collections-rest
   {:team "UX West"
-   :api  #{metabase.collections-rest.api}
+   :api  #{metabase.collections-rest.api
+           metabase.collections-rest.init}
    :uses #{api
            app-db
            collections
@@ -382,6 +383,7 @@
            queries
            request
            revisions
+           settings
            upload
            util}}
 

--- a/src/metabase/collections_rest/api.clj
+++ b/src/metabase/collections_rest/api.clj
@@ -13,6 +13,7 @@
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.app-db.core :as mdb]
+   [metabase.collections-rest.settings :as collections-rest.settings]
    [metabase.collections.models.collection :as collection]
    [metabase.collections.models.collection.root :as collection.root]
    [metabase.config.core :as config]
@@ -30,6 +31,7 @@
    [metabase.util :as u]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.i18n :refer [tru]]
+   [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]
@@ -587,18 +589,28 @@
 
 (defn- post-process-card-like
   [{:keys [include-can-run-adhoc-query hydrate-based-on-upload]} rows]
-  (let [hydration (cond-> [:can_write
-                           :can_restore
-                           :can_delete
-                           :dashboard_count
-                           :is_remote_synced
-                           :collection_namespace
-                           [:dashboard :moderation_status]]
-                    include-can-run-adhoc-query (conj :can_run_adhoc_query))]
+  (let [threshold              (collections-rest.settings/can-run-adhoc-query-check-threshold)
+        card-count             (count rows)
+        skip-adhoc-hydration?  (u/prog1 (and include-can-run-adhoc-query
+                                             (pos? threshold)
+                                             (> card-count threshold))
+                                 (when <>
+                                   (log/warnf "Skipping can_run_adhoc_query hydration for %d cards (threshold: %d)"
+                                              card-count threshold)))
+        hydration              (cond-> [:can_write
+                                        :can_restore
+                                        :can_delete
+                                        :dashboard_count
+                                        :is_remote_synced
+                                        :collection_namespace
+                                        [:dashboard :moderation_status]]
+                                 (and include-can-run-adhoc-query
+                                      (not skip-adhoc-hydration?)) (conj :can_run_adhoc_query))]
     (as-> (map post-process-card-row rows) $
       (apply t2/hydrate $ hydration)
       (cond-> $
-        hydrate-based-on-upload upload/model-hydrate-based-on-upload)
+        hydrate-based-on-upload upload/model-hydrate-based-on-upload
+        skip-adhoc-hydration?   (->> (map #(assoc % :can_run_adhoc_query true))))
       (map post-process-card-row-after-hydrate $))))
 
 (defmethod post-process-collection-children :card

--- a/src/metabase/collections_rest/init.clj
+++ b/src/metabase/collections_rest/init.clj
@@ -1,0 +1,3 @@
+(ns metabase.collections-rest.init
+  (:require
+   [metabase.collections-rest.settings]))

--- a/src/metabase/collections_rest/settings.clj
+++ b/src/metabase/collections_rest/settings.clj
@@ -1,0 +1,14 @@
+(ns metabase.collections-rest.settings
+  (:require
+   [metabase.settings.core :refer [defsetting]]
+   [metabase.util.i18n :as i18n]))
+
+(defsetting can-run-adhoc-query-check-threshold
+  (i18n/deferred-tru (str "Maximum number of cards to compute can_run_adhoc_query for. When the number of cards exceeds "
+                          "this threshold, can_run_adhoc_query will return true for all cards without computing actual "
+                          "permissions. Set to 0 to always compute permissions. This only affects how cards are displayed"
+                          " in the query builder and does not affect actual permission enforcement."))
+  :type       :integer
+  :export?    false
+  :default    250
+  :visibility :internal)

--- a/src/metabase/core/init.clj
+++ b/src/metabase/core/init.clj
@@ -20,6 +20,7 @@
    [metabase.channel.init]
    [metabase.classloader.init]
    [metabase.cloud-migration.init]
+   [metabase.collections-rest.init]
    [metabase.comments.init]
    [metabase.config.core :as config]
    [metabase.content-verification.init]

--- a/test/metabase/collections_rest/api_test.clj
+++ b/test/metabase/collections_rest/api_test.clj
@@ -5,6 +5,7 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.collections-rest.api :as api.collection]
+   [metabase.collections-rest.settings :as collections-rest.settings]
    [metabase.collections.models.collection :as collection]
    [metabase.collections.models.collection-test :as collection-test]
    [metabase.collections.test-helpers :refer [without-library]]
@@ -1172,6 +1173,65 @@
                   collection-item (first (filter #(= (:id %) subcoll-id) items))]
               (is (not (contains? dashboard-item :can_run_adhoc_query)))
               (is (not (contains? collection-item :can_run_adhoc_query))))))))))
+
+(deftest can-run-adhoc-query-threshold-exceeded-test
+  (testing "GET /api/collection/:id/items with include_can_run_adhoc_query=true"
+    (testing "When card count exceeds threshold, can_run_adhoc_query returns true (skips permission check)"
+      (let [card-query {:database (mt/id)
+                        :type     :query
+                        :query    {:source-table (mt/id :venues)}}]
+        (mt/with-no-data-perms-for-all-users!
+          (mt/with-temp [:model/Collection {collection-id :id} {}
+                         :model/Card _ {:collection_id collection-id :dataset_query card-query}
+                         :model/Card _ {:collection_id collection-id :dataset_query card-query}
+                         :model/Card _ {:collection_id collection-id :dataset_query card-query}]
+            (mt/with-temporary-setting-values [collections-rest.settings/can-run-adhoc-query-check-threshold 2]
+              (let [items (:data (mt/user-http-request :rasta :get 200
+                                                       (str "collection/" collection-id "/items")
+                                                       :include_can_run_adhoc_query true))]
+                ;; With 3 cards and threshold of 2, all cards should have can_run_adhoc_query=true
+                ;; even though user doesn't have data permissions (computation was skipped)
+                (is (= 3 (count items)))
+                (is (every? #(true? (:can_run_adhoc_query %)) items))))))))))
+
+(deftest can-run-adhoc-query-threshold-not-exceeded-test
+  (testing "GET /api/collection/:id/items with include_can_run_adhoc_query=true"
+    (testing "When card count is at or below threshold, normal hydration occurs (returns false without perms)"
+      (let [card-query {:database (mt/id)
+                        :type     :query
+                        :query    {:source-table (mt/id :venues)}}]
+        (mt/with-no-data-perms-for-all-users!
+          (mt/with-temp [:model/Collection {collection-id :id} {}
+                         :model/Card _ {:collection_id collection-id :dataset_query card-query}
+                         :model/Card _ {:collection_id collection-id :dataset_query card-query}]
+            (mt/with-temporary-setting-values [collections-rest.settings/can-run-adhoc-query-check-threshold 5]
+              (let [items (:data (mt/user-http-request :rasta :get 200
+                                                       (str "collection/" collection-id "/items")
+                                                       :include_can_run_adhoc_query true))]
+                ;; With 2 cards and threshold of 5, actual permission check occurs
+                ;; User doesn't have data permissions, so all should be false
+                (is (= 2 (count items)))
+                (is (every? #(false? (:can_run_adhoc_query %)) items))))))))))
+
+(deftest can-run-adhoc-query-threshold-disabled-test
+  (testing "GET /api/collection/:id/items with include_can_run_adhoc_query=true"
+    (testing "When threshold is 0, always compute permissions regardless of card count"
+      (let [card-query {:database (mt/id)
+                        :type     :query
+                        :query    {:source-table (mt/id :venues)}}]
+        (mt/with-no-data-perms-for-all-users!
+          (mt/with-temp [:model/Collection {collection-id :id} {}
+                         :model/Card _ {:collection_id collection-id :dataset_query card-query}
+                         :model/Card _ {:collection_id collection-id :dataset_query card-query}
+                         :model/Card _ {:collection_id collection-id :dataset_query card-query}]
+            (mt/with-temporary-setting-values [collections-rest.settings/can-run-adhoc-query-check-threshold 0]
+              (let [items (:data (mt/user-http-request :rasta :get 200
+                                                       (str "collection/" collection-id "/items")
+                                                       :include_can_run_adhoc_query true))]
+                ;; With threshold of 0, hydration should always occur
+                ;; User doesn't have data permissions, so all should be false
+                (is (= 3 (count items)))
+                (is (every? #(false? (:can_run_adhoc_query %)) items))))))))))
 
 (deftest collection-items-include-datasets-test
   (testing "GET /api/collection/:id/items"


### PR DESCRIPTION
Closes #68009

### Description

We can't hydrate unbounded collections of cards with the can_run_adhoc_query hydration since it linearly adds db queries to the request. Users with > 10000k can have severe CPU/memory issues processing this.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
