### PR TITLE
tweak tree table column widths

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/LibrarySectionLayout.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/LibrarySectionLayout.tsx
@@ -135,7 +135,7 @@ export function LibrarySectionLayout() {
         header: t`Name`,
         enableSorting: true,
         accessorKey: "name",
-        minWidth: 400,
+        minWidth: 200,
         cell: ({ row }) => (
           <EntityNameCell
             data-testid={`${row.original.model}-name`}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/LibrarySectionLayout.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/LibrarySectionLayout.tsx
@@ -135,7 +135,7 @@ export function LibrarySectionLayout() {
         header: t`Name`,
         enableSorting: true,
         accessorKey: "name",
-        minWidth: 600,
+        minWidth: 400,
         cell: ({ row }) => (
           <EntityNameCell
             data-testid={`${row.original.model}-name`}

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListBody/ErrorsCell/ErrorsCell.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListBody/ErrorsCell/ErrorsCell.tsx
@@ -20,7 +20,7 @@ export function ErrorsCell({ node }: ErrorsCellProps) {
     : errorsInfo.label;
 
   return (
-    <Ellipsified tooltip={fullText}>
+    <Ellipsified tooltip={fullText} tooltipProps={{ openDelay: 300 }}>
       <span>{errorsInfo.label}</span>{" "}
       {errorsInfo.detail && <strong>{errorsInfo.detail}</strong>}
     </Ellipsified>

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListBody/LocationCell/LocationCell.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListBody/LocationCell/LocationCell.tsx
@@ -21,7 +21,7 @@ export function LocationCell({ node }: LocationCellProps) {
   return (
     <Flex align="center" gap="sm" miw={0}>
       {icon && <FixedSizeIcon name={icon} />}
-      <Ellipsified>{path}</Ellipsified>
+      <Ellipsified tooltipProps={{ openDelay: 300 }}>{path}</Ellipsified>
     </Flex>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListBody/NameCell/NameCell.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListBody/NameCell/NameCell.tsx
@@ -15,7 +15,7 @@ export function NameCell({ node }: NameCellProps) {
   return (
     <Flex align="center" gap="sm" miw={0}>
       {icon && <FixedSizeIcon name={icon} />}
-      <Ellipsified>{label}</Ellipsified>
+      <Ellipsified tooltipProps={{ openDelay: 300 }}>{label}</Ellipsified>
     </Flex>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListBody/utils.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListBody/utils.tsx
@@ -17,8 +17,7 @@ function getNodeNameColumn(): TreeTableColumnDef<DependencyNode> {
   return {
     id: "name",
     header: t`Name`,
-    minWidth: "auto",
-    maxAutoWidth: 400,
+    minWidth: 100,
     accessorFn: (node) => getNodeLabel(node),
     cell: ({ row }) => {
       const node = row.original;
@@ -31,8 +30,7 @@ function getNodeLocationColumn(): TreeTableColumnDef<DependencyNode> {
   return {
     id: "location",
     header: t`Location`,
-    minWidth: "auto",
-    maxAutoWidth: 400,
+    minWidth: 100,
     accessorFn: (node) => {
       const location = getNodeLocationInfo(node);
       const links = location?.links ?? [];
@@ -49,8 +47,7 @@ function getNodeErrorsColumn(): TreeTableColumnDef<DependencyNode> {
   return {
     id: "error",
     header: t`Errors`,
-    minWidth: "auto",
-    maxAutoWidth: 400,
+    minWidth: 100,
     accessorFn: (node) => node.errors?.length ?? 0,
     cell: ({ row }) => {
       const node = row.original;
@@ -67,7 +64,7 @@ function getNodeDependentsCountColumn(): TreeTableColumnDef<DependencyNode> {
   return {
     id: "dependents-count",
     header: t`Downstream dependents`,
-    width: "auto",
+    minWidth: 100,
     accessorFn: (node) => getNodeDependentsCount(node),
     cell: ({ row }) => {
       const node = row.original;

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListBody/utils.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListBody/utils.tsx
@@ -18,6 +18,7 @@ function getNodeNameColumn(): TreeTableColumnDef<DependencyNode> {
     id: "name",
     header: t`Name`,
     minWidth: "auto",
+    maxAutoWidth: 400,
     accessorFn: (node) => getNodeLabel(node),
     cell: ({ row }) => {
       const node = row.original;
@@ -31,6 +32,7 @@ function getNodeLocationColumn(): TreeTableColumnDef<DependencyNode> {
     id: "location",
     header: t`Location`,
     minWidth: "auto",
+    maxAutoWidth: 400,
     accessorFn: (node) => {
       const location = getNodeLocationInfo(node);
       const links = location?.links ?? [];
@@ -48,6 +50,7 @@ function getNodeErrorsColumn(): TreeTableColumnDef<DependencyNode> {
     id: "error",
     header: t`Errors`,
     minWidth: "auto",
+    maxAutoWidth: 400,
     accessorFn: (node) => node.errors?.length ?? 0,
     cell: ({ row }) => {
       const node = row.original;

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/JobListPage/JobListPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/JobListPage/JobListPage.tsx
@@ -3,6 +3,7 @@ import { push } from "react-router-redux";
 import { t } from "ttag";
 
 import DateTime from "metabase/common/components/DateTime";
+import { Ellipsified } from "metabase/common/components/Ellipsified";
 import { ForwardRefLink } from "metabase/common/components/Link";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { useDispatch } from "metabase/lib/redux";
@@ -45,20 +46,22 @@ export const JobListPage = () => {
         id: "name",
         accessorKey: "name",
         header: t`Name`,
+        minWidth: 120,
+        cell: ({ row }) => <Ellipsified>{row.original.name}</Ellipsified>,
       },
       {
         id: "last_run",
         accessorFn: (job) => job.last_run?.start_time,
         header: t`Last Run`,
-        minWidth: "auto",
+        minWidth: 120,
         cell: ({ row }) =>
           row.original.last_run ? (
-            <>
+            <Ellipsified>
               {row.original.last_run.status === "failed"
                 ? t`Failed`
                 : t`Last run`}{" "}
               <DateTime value={row.original.last_run.start_time} />
-            </>
+            </Ellipsified>
           ) : null,
       },
     ],

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformListPage/TransformListPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformListPage/TransformListPage.tsx
@@ -136,6 +136,7 @@ export const TransformListPage = ({ location }: WithRouterProps) => {
         accessorKey: "name",
         header: t`Name`,
         minWidth: 320,
+        maxAutoWidth: 800,
         enableSorting: true,
         cell: ({ row }) => (
           <EntityNameCell
@@ -165,6 +166,7 @@ export const TransformListPage = ({ location }: WithRouterProps) => {
         accessorFn: (node) => node.target?.name ?? "",
         header: t`Output table`,
         minWidth: 240,
+        maxAutoWidth: 800,
         enableSorting: true,
         cell: ({ row }) =>
           row.original.target?.name ? (

--- a/frontend/src/metabase/ui/components/data-display/SortableHeaderPill/SortableHeaderPill.module.css
+++ b/frontend/src/metabase/ui/components/data-display/SortableHeaderPill/SortableHeaderPill.module.css
@@ -2,7 +2,9 @@
   display: flex;
   align-items: center;
   gap: 0.25rem;
+  min-width: 0;
   padding: 0.25rem 0.625em;
+  overflow: hidden;
   font-weight: 700;
   color: var(--mb-color-brand);
   white-space: nowrap;

--- a/frontend/src/metabase/ui/components/data-display/TreeTable/TreeTableHeader/TreeTableHeader.module.css
+++ b/frontend/src/metabase/ui/components/data-display/TreeTable/TreeTableHeader/TreeTableHeader.module.css
@@ -6,11 +6,11 @@
   z-index: 1;
   flex-shrink: 0;
   font-size: 12.5px;
-  background-color: var(--mb-color-background-primary);
 }
 
 .headerRow {
   border-bottom: 1px solid var(--mb-color-border);
+  background-color: var(--mb-color-background-primary);
 }
 
 .cell {

--- a/frontend/src/metabase/ui/components/data-display/TreeTable/hooks/useColumnSizing.tsx
+++ b/frontend/src/metabase/ui/components/data-display/TreeTable/hooks/useColumnSizing.tsx
@@ -108,7 +108,11 @@ function getContentWidth<TData extends TreeNodeData>(
 ): number {
   const baseWidth = contentWidths[column.id] ?? MIN_COLUMN_WIDTH;
   const padding = column.widthPadding ?? 0;
-  return baseWidth + padding;
+  let width = baseWidth + padding;
+  if (column.maxAutoWidth != null) {
+    width = Math.min(width, column.maxAutoWidth);
+  }
+  return width;
 }
 
 export function getMinConstraint<TData extends TreeNodeData>(
@@ -156,7 +160,11 @@ export function calculateColumnWidths<TData extends TreeNodeData>(
     .filter((col) => col.width != null)
     .reduce((sum, col) => {
       if (col.width === "auto") {
-        return sum + getContentWidth(col, contentWidths);
+        let width = getContentWidth(col, contentWidths);
+        if (col.maxWidth != null) {
+          width = Math.min(width, col.maxWidth);
+        }
+        return sum + width;
       }
       return sum + (col.width ?? 0);
     }, 0);
@@ -172,7 +180,11 @@ export function calculateColumnWidths<TData extends TreeNodeData>(
   columns.forEach((column) => {
     if (column.width != null) {
       if (column.width === "auto") {
-        widths[column.id] = getContentWidth(column, contentWidths);
+        let width = getContentWidth(column, contentWidths);
+        if (column.maxWidth != null) {
+          width = Math.min(width, column.maxWidth);
+        }
+        widths[column.id] = width;
       } else {
         widths[column.id] = column.width;
       }

--- a/frontend/src/metabase/ui/components/data-display/TreeTable/hooks/useColumnSizing.unit.spec.ts
+++ b/frontend/src/metabase/ui/components/data-display/TreeTable/hooks/useColumnSizing.unit.spec.ts
@@ -147,4 +147,33 @@ describe("calculateColumnWidths", () => {
       auto: 200,
     });
   });
+
+  it("maxAutoWidth caps measured content width", () => {
+    const columns = [
+      createColumn({ id: "auto", width: "auto", maxAutoWidth: 100 }),
+      createColumn({ id: "stretch" }),
+    ];
+    // Content is 300 but maxAutoWidth caps it at 100
+    expect(calculateColumnWidths(columns, 500, { auto: 300 }, 0, 20)).toEqual({
+      auto: 100,
+      stretch: 400,
+    });
+    // Content smaller than cap uses actual content width
+    expect(calculateColumnWidths(columns, 500, { auto: 80 }, 0, 20)).toEqual({
+      auto: 80,
+      stretch: 420,
+    });
+  });
+
+  it("maxAutoWidth caps minimum but column can stretch beyond it if there is extra space", () => {
+    const columns = [
+      createColumn({ id: "col", minWidth: "auto", maxAutoWidth: 100 }),
+      createColumn({ id: "fixed", width: 100 }),
+    ];
+    // Content is 300, maxAutoWidth caps minimum at 100, but column stretches to 400
+    expect(calculateColumnWidths(columns, 500, { col: 300 }, 0, 20)).toEqual({
+      col: 400,
+      fixed: 100,
+    });
+  });
 });

--- a/frontend/src/metabase/ui/components/data-display/TreeTable/types.ts
+++ b/frontend/src/metabase/ui/components/data-display/TreeTable/types.ts
@@ -37,6 +37,24 @@ export interface TreeTableColumnSizingDef {
   minWidth?: number | "auto";
   /** Maximum width in pixels. Only applies to stretching columns. */
   maxWidth?: number;
+  /**
+   * Maximum width for auto-measured content. Caps the measured content width,
+   * not the final rendered width. Only applies when `width` or `minWidth` is 'auto'.
+   *
+   * Use this to prevent extremely long content from creating oversized columns,
+   * while still allowing the column to stretch if the table has extra space.
+   *
+   * @example
+   * // Stretchable column with capped minimum (recommended pattern)
+   * { minWidth: "auto", maxAutoWidth: 480 }
+   * // → Minimum is min(content, 480px), stretches to fill available space
+   *
+   * @example
+   * // With absolute maximum
+   * { minWidth: "auto", maxAutoWidth: 480, maxWidth: 800 }
+   * // → Stretches between min(content, 480px) and 800px
+   */
+  maxAutoWidth?: number;
   /** Extra pixels added to measured width. Only applies when width or minWidth is 'auto'. */
   widthPadding?: number;
 }


### PR DESCRIPTION
### Description

Let tasks tables shrink a lot more to avoid having horizontal scroll unless width is too narrow.
Also add `maxAutoWidth` setting that lets you use column auto width for nice layout but limit auto width to some reasonable value if there are huge outliers that lead to huge horizontal scroll. Adds ellipsification for the Jobs page.

### Demo

https://www.loom.com/share/24fed19dc42f42e0ac07ab9e240bc936

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
