### PR TITLE
If the entity id is unknown when calling the export API, throw an error

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/api.clj
@@ -94,6 +94,7 @@
      :log-file      (when (.exists log-file)
                       log-file)
      :report        report
+     :status        (:status-code (ex-data @err))
      :error-message (when @err
                       (u/strip-error @err nil))
      :callback      (fn []
@@ -216,6 +217,7 @@
         {:keys [archive
                 log-file
                 report
+                status
                 error-message
                 callback]} (serialize&pack opts)]
     (analytics/track-event! :snowplow/serialization
@@ -239,7 +241,7 @@
        :headers {"Content-Type"        "application/gzip"
                  "Content-Disposition" (format "attachment; filename=\"%s\"" (.getName ^File archive))}
        :body    (on-response! archive callback)}
-      {:status  500
+      {:status  (or status 500)
        :headers {"Content-Type" "text/plain"}
        :body    (on-response! log-file callback)})))
 

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
@@ -73,7 +73,12 @@
 
 (defn- parse-target [[model-name id :as target]]
   (if (string? id)
-    [model-name (serdes/eid->id model-name id)]
+    (if-let [resolved-id (serdes/eid->id model-name id)]
+      [model-name resolved-id]
+      (throw (ex-info (format "Could not find %s with entity ID: %s" model-name id)
+                      {:status-code 400
+                       :model       model-name
+                       :entity-id   id})))
     target))
 
 (defn- analytics-collection-ids

--- a/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
@@ -157,7 +157,15 @@
                                               :dirname "check" :all_collections false :data_model false :settings false)]
                   (is (= "check/"
                          (with-open [tar (open-tar f)]
-                           (.getName ^TarArchiveEntry (first (u.compress/entries tar))))))))))))
+                           (.getName ^TarArchiveEntry (first (u.compress/entries tar))))))))
+
+              (testing "Invalid entity ID returns an error instead of falling back to root collection"
+                (let [fake-eid "abcdefghijklmnopqrstu"
+                      res      (mt/user-http-request :crowberto :post 400 "ee/serialization/export" {}
+                                                     :collection fake-eid :data_model false :settings false)
+                      log      (slurp (io/input-stream res))]
+                  (is (re-find #"Could not find Collection with entity ID" log))
+                  (is (re-find #"abcdefghijklmnopqrstu" log))))))))
       (testing "We've left no new files, every request is cleaned up"
         ;; if this breaks, check if you consumed every response with io/input-stream
         (is (= known-files


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #61227
### Description

Instead of exporting "Our analytics" when `POST /api/ee/serialization/export` is passed an invalid entity_id, throw a 400 error 

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
