### PR TITLE
Bring broken dependencies page back

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/DependencyList.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/DependencyList.module.css
@@ -1,4 +1,3 @@
 .main {
   overflow: hidden;
-  align-self: flex-start;
 }

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListHeader/ListHeader.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListHeader/ListHeader.tsx
@@ -12,6 +12,11 @@ import {
 export const ListHeader = memo(function ListHeader() {
   const tabs: PaneHeaderTab[] = [
     {
+      label: t`Broken entities`,
+      to: Urls.brokenDependencies(),
+      icon: "list",
+    },
+    {
       label: t`Unreferenced entities`,
       to: Urls.unreferencedDependencies(),
       icon: "list",

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListSearchBar/FilterOptionsPicker/LocationFilterPicker/LocationFilterPicker.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListSearchBar/FilterOptionsPicker/LocationFilterPicker/LocationFilterPicker.tsx
@@ -16,9 +16,10 @@ export function LocationFilterPicker({
   const handleIncludeInPersonalCollectionsChange = (
     event: ChangeEvent<HTMLInputElement>,
   ) => {
+    const newValue = event.target.checked;
     onParamsChange({
       ...params,
-      includePersonalCollections: event.target.checked,
+      includePersonalCollections: newValue || undefined,
     });
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListSearchBar/FilterOptionsPicker/TypeFilterPicker/TypeFilterPicker.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListSearchBar/FilterOptionsPicker/TypeFilterPicker/TypeFilterPicker.tsx
@@ -37,7 +37,13 @@ export function TypeFilterPicker({
       newValue.includes(groupType),
     );
     setGroupTypes(newGroupTypes);
-    onParamsChange({ ...params, groupTypes: newGroupTypes });
+    onParamsChange({
+      ...params,
+      groupTypes:
+        newGroupTypes.length === availableGroupTypes.length
+          ? undefined
+          : newGroupTypes,
+    });
   };
 
   return (

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListSidebar/SidebarDependentsInfo/SidebarDependentsInfo.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListSidebar/SidebarDependentsInfo/SidebarDependentsInfo.tsx
@@ -29,7 +29,12 @@ export function SidebarDependentsInfo({ node }: SidebarDependentsInfoProps) {
       <Card shadow="none" withBorder>
         <Stack gap="sm" lh="1rem">
           {groups.map((group, groupIndex) => (
-            <Anchor key={groupIndex} component={ForwardRefLink} to={link}>
+            <Anchor
+              key={groupIndex}
+              component={ForwardRefLink}
+              to={link}
+              target="_blank"
+            >
               <Group gap="sm" wrap="nowrap">
                 <Icon name={getDependencyGroupIcon(group.type)} />
                 {getDependentGroupLabel(group)}

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListSidebar/SidebarErrorInfo/SidebarErrorInfo.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListSidebar/SidebarErrorInfo/SidebarErrorInfo.tsx
@@ -1,5 +1,6 @@
 import { CopyButton } from "metabase/common/components/CopyButton";
-import { Box, Card, Group, Stack, Title } from "metabase/ui";
+import { Ellipsified } from "metabase/common/components/Ellipsified";
+import { Card, Group, Stack, Title } from "metabase/ui";
 import type { DependencyError, DependencyErrorType } from "metabase-types/api";
 
 import {
@@ -33,7 +34,7 @@ export function SidebarErrorInfo({ type, errors }: SidebarErrorInfoProps) {
               justify="space-between"
               wrap="nowrap"
             >
-              <Box>{detail}</Box>
+              <Ellipsified>{detail}</Ellipsified>
               <CopyButton value={detail} />
             </Group>
           ))}

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListSidebar/SidebarLocationInfo/SidebarLocationInfo.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListSidebar/SidebarLocationInfo/SidebarLocationInfo.tsx
@@ -26,7 +26,7 @@ export function SidebarLocationInfo({ node }: SidebarLocationInfoProps) {
         {locationInfo.links.map((link, linkIndex) => (
           <Fragment key={linkIndex}>
             {linkIndex > 0 && <Box>/</Box>}
-            <Anchor component={Link} to={link.url}>
+            <Anchor component={Link} to={link.url} target="_blank">
               <Group gap="sm" wrap="nowrap">
                 {linkIndex === 0 && <Icon name={locationInfo.icon} />}
                 {link.label}

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyListPage/DependencyListPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyListPage/DependencyListPage.tsx
@@ -13,6 +13,25 @@ type DependencyListPageProps = {
   location: Location<DependencyListQueryParams>;
 };
 
+export function BrokenDependencyListPage({
+  location,
+}: DependencyListPageProps) {
+  const params = parseParams(location.query);
+  const dispatch = useDispatch();
+
+  const handleParamsChange = (params: Urls.DependencyListParams) => {
+    dispatch(replace(Urls.brokenDependencies(params)));
+  };
+
+  return (
+    <DependencyList
+      mode="broken"
+      params={params}
+      onParamsChange={handleParamsChange}
+    />
+  );
+}
+
 export function UnreferencedDependencyListPage({
   location,
 }: DependencyListPageProps) {

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/routes.tsx
@@ -1,7 +1,10 @@
 import { IndexRedirect, IndexRoute, Route } from "react-router";
 
 import { DependencyGraphPage } from "./pages/DependencyGraphPage";
-import { UnreferencedDependencyListPage } from "./pages/DependencyListPage";
+import {
+  BrokenDependencyListPage,
+  UnreferencedDependencyListPage,
+} from "./pages/DependencyListPage";
 
 export function getDataStudioDependencyRoutes() {
   return <IndexRoute component={DependencyGraphPage} />;
@@ -10,7 +13,8 @@ export function getDataStudioDependencyRoutes() {
 export function getDataStudioTasksRoutes() {
   return (
     <>
-      <IndexRedirect to="unreferenced" />
+      <IndexRedirect to="broken" />
+      <Route path="broken" component={BrokenDependencyListPage} />
       <Route path="unreferenced" component={UnreferencedDependencyListPage} />
     </>
   );


### PR DESCRIPTION
The page was temporary removed for refactoring purposes, now it's back.