### PR TITLE
Extend DSL to create workspace transforms too

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/transforms/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/api.clj
@@ -96,10 +96,7 @@
   [& {:keys [last_run_start_time last_run_statuses tag_ids type]}]
   (api/check-superuser)
   (let [where      (when type [:in :source_type (map #(if (= % "query") "mbql" %) type)])
-        transforms (t2/select :model/Transform (merge
-                                                (when where
-                                                  {:where where})
-                                                {:order-by [[:id :asc]]}))]
+        transforms (t2/select :model/Transform {:where (or where true) :order-by [[:id :asc]]})]
     (into []
           (comp (transforms.util/->date-field-filter-xf [:last_run :start_time] last_run_start_time)
                 (transforms.util/->status-filter-xf [:last_run :status] last_run_statuses)

--- a/enterprise/backend/test/metabase_enterprise/workspaces/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/api_test.clj
@@ -1407,7 +1407,6 @@
                                                                   :database_id   db-1
                                                                   :dataset_query (mt/mbql-query venues)}
                          :model/Transform          {xf6-id :id} {:name        "Not checked out - native with card dep"
-                                                                 :source_type :native
                                                                  :source      {:type  "query"
                                                                                :query (my-native-query
                                                                                        db-1
@@ -1415,6 +1414,7 @@
                                                                                        {"card" card-id})}
                                                                  :target      (random-target db-1)}
                          :model/Transform          {xf7-id :id} {:name   "Using another database"
+                                                                 :source {:type "python"}
                                                                  :target (random-target db-2)}
                          ;; Workspace transforms (mirrored from global1 and global2)
                          :model/WorkspaceTransform _            {:global_id    xf1-id

--- a/enterprise/backend/test/metabase_enterprise/workspaces/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/api_test.clj
@@ -10,6 +10,7 @@
    [metabase-enterprise.transforms.test-util :as transforms.tu :refer [with-transform-cleanup!]]
    [metabase-enterprise.workspaces.dag :as ws.dag]
    [metabase-enterprise.workspaces.execute :as ws.execute]
+   [metabase-enterprise.workspaces.impl :as ws.impl]
    [metabase-enterprise.workspaces.isolation :as ws.isolation]
    [metabase-enterprise.workspaces.test-util :as ws.tu]
    [metabase-enterprise.workspaces.util :as ws.u]
@@ -110,16 +111,15 @@
         ;; todo: check the schema / tables and user are gone
         (is (false? (t2/exists? :model/Workspace workspace-id)))))))
 
-;; TODO (chris 2026/01/08) we need to first add a transform to trigger initialization, or else there is nothing to destroy
-#_(deftest archive-workspace-calls-destroy-isolation-test
-    (testing "POST /api/ee/workspace/:id/archive calls destroy-workspace-isolation!"
-      (let [called?   (atom false)
-            workspace (ws.tu/create-ready-ws! "Archive Isolation Test")]
-        (mt/with-dynamic-fn-redefs [ws.isolation/destroy-workspace-isolation!
-                                    (fn [_database _workspace]
-                                      (reset! called? true))]
-          (mt/user-http-request :crowberto :post 200 (ws-url (:id workspace) "/archive"))
-          (is @called? "destroy-workspace-isolation! should be called when archiving")))))
+(deftest archive-workspace-calls-destroy-isolation-test
+  (testing "POST /api/ee/workspace/:id/archive calls destroy-workspace-isolation!"
+    (let [called?   (atom false)
+          workspace (ws.tu/create-ready-ws! "Archive Isolation Test")]
+      (mt/with-dynamic-fn-redefs [ws.isolation/destroy-workspace-isolation!
+                                  (fn [_database _workspace]
+                                    (reset! called? true))]
+        (mt/user-http-request :crowberto :post 200 (ws-url (:id workspace) "/archive"))
+        (is @called? "destroy-workspace-isolation! should be called when archiving")))))
 
 (deftest archive-workspace-succeeds-when-cleanup-fails-test
   (testing "POST /api/ee/workspace/:id/archive succeeds even when destroy-workspace-isolation! fails"
@@ -142,78 +142,60 @@
         (mt/user-http-request :crowberto :delete 200 (ws-url (:id workspace)))
         (is @called? "destroy-workspace-isolation! should be called when deleting")))))
 
-;; TODO we need to first add a transform to trigger initialization, or else there is nothing to destroy
-#_(deftest ^:synchronized merge-workspace-calls-destroy-isolation-test
-    (testing "POST /api/ee/workspace/:id/merge calls destroy-workspace-isolation!"
-      (let [called?   (atom false)
-            workspace (ws.tu/create-ready-ws! "Merge Isolation Test")]
-        (mt/with-dynamic-fn-redefs [ws.isolation/destroy-workspace-isolation!
-                                    (fn [_database _workspace]
-                                      (reset! called? true))]
-          (mt/user-http-request :crowberto :post 200 (ws-url (:id workspace) "/merge"))
-          (is @called? "destroy-workspace-isolation! should be called when merging")))))
+(deftest ^:synchronized merge-workspace-calls-destroy-isolation-test
+  (testing "POST /api/ee/workspace/:id/merge calls destroy-workspace-isolation!"
+    (let [called?   (atom false)
+          workspace (ws.tu/create-ready-ws! "Merge Isolation Test")]
+      (mt/with-dynamic-fn-redefs [ws.isolation/destroy-workspace-isolation!
+                                  (fn [_database _workspace]
+                                    (reset! called? true))]
+        (mt/user-http-request :crowberto :post 200 (ws-url (:id workspace) "/merge"))
+        (is @called? "destroy-workspace-isolation! should be called when merging")))))
 
-;; TODO update this test to have a transform in the workspace. only non-empty workspaces will ensure isolation
-#_(deftest unarchive-workspace-calls-ensure-isolation-test
-    (testing "POST /api/ee/workspace/:id/unarchive calls ensure-database-isolation!"
-      (let [called?   (atom false)
-            workspace (ws.tu/create-ready-ws! "Unarchive Isolation Test")]
-        (mt/user-http-request :crowberto :post 200 (ws-url (:id workspace) "/archive"))
-        (testing "ensure-database-isolation! should be called when unarchiving"
-          (mt/with-dynamic-fn-redefs [ws.isolation/ensure-database-isolation!
-                                      (fn [_workspace _database]
-                                        (reset! called? true)
-                                        {:schema "test_schema" :database_details {}})]
-            (mt/user-http-request :crowberto :post 200 (ws-url (:id workspace) "/unarchive"))
-            (is @called?))))))
-
-;; TODO update this test to have a transform in the workspace. only non-empty workspaces will grant accesses
-#_(deftest unarchive-workspace-calls-sync-grant-accesses-test
-    (testing "POST /api/ee/workspace/:id/unarchive calls sync-grant-accesses!"
-      (let [called?   (atom false)
-            workspace (ws.tu/create-ready-ws! "Unarchive Grant Test")]
-        (mt/user-http-request :crowberto :post 200 (ws-url (:id workspace) "/archive"))
-        (mt/with-dynamic-fn-redefs [ws.impl/sync-grant-accesses!
-                                    (fn [_workspace]
+(deftest unarchive-workspace-calls-ensure-isolation-test
+  (testing "POST /api/ee/workspace/:id/unarchive calls ensure-database-isolation!"
+    (let [called?   (atom false)
+          workspace (ws.tu/create-ready-ws! "Unarchive Isolation Test")]
+      (mt/user-http-request :crowberto :post 200 (ws-url (:id workspace) "/archive"))
+      (testing "ensure-database-isolation! should be called when unarchiving"
+        (mt/with-dynamic-fn-redefs [ws.isolation/ensure-database-isolation!
+                                    (fn [_workspace _database]
                                       (reset! called? true)
-                                      nil)]
+                                      {:schema "test_schema" :database_details {}})]
           (mt/user-http-request :crowberto :post 200 (ws-url (:id workspace) "/unarchive"))
-          (is @called? "sync-grant-accesses! should be called when unarchiving")))))
+          (is @called?))))))
 
-;; TODO rework this test
+(deftest unarchive-workspace-calls-sync-grant-accesses-test
+  (testing "POST /api/ee/workspace/:id/unarchive calls sync-grant-accesses!"
+    (let [called?   (atom false)
+          workspace (ws.tu/create-ready-ws! "Unarchive Grant Test")]
+      (mt/user-http-request :crowberto :post 200 (ws-url (:id workspace) "/archive"))
+      (mt/with-dynamic-fn-redefs [ws.impl/sync-grant-accesses!
+                                  (fn [_workspace]
+                                    (reset! called? true)
+                                    nil)]
+        (mt/user-http-request :crowberto :post 200 (ws-url (:id workspace) "/unarchive"))
+        (is @called? "sync-grant-accesses! should be called when unarchiving")))))
+
 (deftest archive-unarchive-access-granted-test
   (testing "Archive/unarchive properly manages access_granted flags and grants"
     (let [workspace      (ws.tu/create-ready-ws! "Archive Grant Test")
           granted-tables (atom [])]
-      ;; This hack has rotted - since we re-do the analysis now on unarchive, we need to add a tx with a real query
-      (mt/with-temp [:model/WorkspaceTransform t {:workspace_id (:id workspace)}
-                     :model/WorkspaceInput input {:workspace_id   (:id workspace)
-                                                  :db_id          (mt/id)
-                                                  :ref_id         (:ref_id t)
-                                                  :schema         nil
-                                                  :table          "test_table"
-                                                  :access_granted true}]
-        ;; workaround for bad mocking
-        (t2/update! :model/WorkspaceTransform {:ref_id (:ref_id t)} {:target {:type     :table
-                                                                              :database (mt/id)
-                                                                              :name     "output"}})
+      (testing "Archive resets access_granted to false"
+        (mt/user-http-request :crowberto :post 200 (ws-url (:id workspace) "/archive"))
+        (ws.tu/analyze-workspace! (:id workspace))
+        (is (false? (t2/select-one-fn :access_granted :model/WorkspaceInput :workspace_id (:id workspace)))))
 
-        (testing "Archive resets access_granted to false"
-          (mt/user-http-request :crowberto :post 200 (ws-url (:id workspace) "/archive"))
-          (is (false? (t2/select-one-fn :access_granted :model/WorkspaceInput :id (:id input)))))
-
-        (testing "Unarchive re-grants access and sets access_granted to true"
-          (mt/with-dynamic-fn-redefs [ws.isolation/grant-read-access-to-tables!
-                                      (fn [_database _workspace tables]
-                                        (reset! granted-tables tables))]
-            (mt/user-http-request :crowberto :post 200 (ws-url (:id workspace) "/unarchive"))
-            ;; TODO since analysis is now lazy, we have to call this api to force it to happen.
-            ;;      really we should restructure our tests.
-            (mt/user-http-request :crowberto :get 200 (ws-url (:id workspace) "graph"))
-            #_(is (= [{:schema nil :name "test_table"}] @granted-tables)
-                  "grant-read-access-to-tables! should be called with the input tables")
-            #_(is (true? (t2/select-one-fn :access_granted :model/WorkspaceInput :id (:id input)))
-                  "access_granted should be true after unarchive")))))))
+      (testing "Unarchive re-grants access and sets access_granted to true"
+        (mt/with-dynamic-fn-redefs [ws.isolation/grant-read-access-to-tables!
+                                    (fn [_database _workspace tables]
+                                      (reset! granted-tables tables))]
+          (mt/user-http-request :crowberto :post 200 (ws-url (:id workspace) "/unarchive"))
+          (ws.tu/analyze-workspace! (:id workspace))
+          (is (=? [{:schema string? :name "test_table_1"}] @granted-tables)
+              "grant-read-access-to-tables! should be called with the input tables")
+          (is (true? (t2/select-one-fn :access_granted :model/WorkspaceInput :workspace_id (:id workspace)))
+              "access_granted should be true after unarchive"))))))
 
 (deftest merge-workspace-test
   (testing "POST /api/ee/workspace/:id/promote requires superuser"
@@ -1079,7 +1061,6 @@
 
 ;;;; Async workspace creation tests
 
-;; TODO need to add a transform to trigger initialization
 #_(deftest create-workspace-returns-updating-status-test
     (testing "Creating workspace returns status :pending immediately"
       (let [res (mt/user-http-request :crowberto :post 200 "ee/workspace"
@@ -1089,51 +1070,43 @@
         (testing "and then it becomes ready"
           (is (=? {:status :ready} (ws.tu/ws-ready res)))))))
 
-;; TODO need to add a transform to trigger initialization
-#_(deftest workspace-log-endpoint-test
-    (testing "GET /api/ee/workspace/:id/log returns status and log entries"
-      (let [{ws-id :id} (ws.tu/ws-ready (mt/user-http-request :crowberto :post 200 "ee/workspace"
-                                                              {:name "log-test" :database_id (mt/id)}))]
-        (is (=? {:workspace_id      ws-id
-                 :status            "ready"
-                 :updated_at        some?
-                 :last_completed_at some?
-                 :logs              [{:task   "database-isolation"
-                                      :status "success"}
-                                     {:task "workspace-setup"}]}
-                (mt/user-http-request :crowberto :get 200 (ws-url ws-id "/log")))))))
+(deftest workspace-log-endpoint-test
+  (testing "GET /api/ee/workspace/:id/log returns status and log entries"
+    (let [{ws-id :id} (ws.tu/create-ready-ws! "Log tester")]
+      (is (=? {:workspace_id      ws-id
+               :status            "ready"
+               :updated_at        some?
+               :last_completed_at some?
+               :logs              [{:task   "database-isolation"
+                                    :status "success"}
+                                   {:task "workspace-setup"}]}
+              (mt/user-http-request :crowberto :get 200 (ws-url ws-id "/log")))))))
 
 (deftest workspace-log-endpoint-404-test
   (testing "GET /api/ee/workspace/:id/log returns 404 for non-existent workspace"
     (is (= "Not found."
            (mt/user-http-request :crowberto :get 404 "ee/workspace/999999/log")))))
 
-;; TODO need to add a transform to trigger initialization
-#_(deftest workspace-log-entries-created-test
-    (testing "WorkspaceLog entries are created during setup"
-      (let [{ws-id :id} (ws.tu/ws-ready (mt/user-http-request :crowberto :post 200 "ee/workspace"
-                                                              {:name "log-entries-test" :database_id (mt/id)}))]
-        (is (=? [{:task   :database-isolation
-                  :status :success}
-                 {:task   :workspace-setup
-                  :status :success}]
-                (t2/select :model/WorkspaceLog :workspace_id ws-id {:order-by [[:started_at :desc]]}))))))
+(deftest workspace-log-entries-created-test
+  (testing "WorkspaceLog entries are created during setup"
+    (let [{ws-id :id} (ws.tu/create-ready-ws! "Log tester #2")]
+      (is (=? [{:task   :database-isolation
+                :status :success}
+               {:task   :workspace-setup
+                :status :success}]
+              (t2/select :model/WorkspaceLog :workspace_id ws-id {:order-by [[:started_at :desc]]}))))))
 
-;; TODO this test doesn't work yet, because we need to add a transform before it'll do the initialization
-#_(deftest workspace-setup-failure-logs-error-test
-    (testing "Failed workspace setup logs error message"
-      (mt/with-dynamic-fn-redefs [ws.isolation/ensure-database-isolation!
-                                  (fn [& _] (throw (ex-info "Test isolation error" {})))]
-        (let [{ws-id :id} (mt/user-http-request :crowberto :post 200 "ee/workspace"
-                                                {:name "fail-test" :database_id (mt/id)})
-              _           (try (ws.tu/ws-ready ws-id) (catch Exception _))]
-          (Thread/sleep 500)
-          (is (=? [{:task    :database-isolation
-                    :status  :failure
-                    :message "Test isolation error"}
-                   {:task   :workspace-setup
-                    :status :failure}]
-                  (t2/select :model/WorkspaceLog :workspace_id ws-id {:order-by [[:started_at :desc]]})))))))
+(deftest workspace-setup-failure-logs-error-test
+  (testing "Failed workspace setup logs error message"
+    (mt/with-dynamic-fn-redefs [ws.isolation/ensure-database-isolation!
+                                (fn [& _] (throw (ex-info "Test isolation error" {})))]
+      (let [{ws-id :id} (ws.tu/create-ready-ws! "Log tester #3")]
+        (is (=? [{:task    :database-isolation
+                  :status  :failure
+                  :message "Test isolation error"}
+                 {:task   :workspace-setup
+                  :status :failure}]
+                (t2/select :model/WorkspaceLog :workspace_id ws-id {:order-by [[:started_at :desc]]})))))))
 
 ;;; ---------------------------------------- Uninitialized Workspace Tests ----------------------------------------
 

--- a/enterprise/backend/test/metabase_enterprise/workspaces/dag_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/dag_test.clj
@@ -1,13 +1,10 @@
 (ns metabase-enterprise.workspaces.dag-test
   (:require
-   [clojure.string :as str]
    [clojure.test :refer :all]
    [flatland.ordered.map :as ordered-map]
    [metabase-enterprise.workspaces.dag :as ws.dag]
    [metabase-enterprise.workspaces.dag-abstract :as dag-abstract]
    [metabase-enterprise.workspaces.test-util :as ws.tu]
-   [metabase.app-db.core :as app-db]
-   [metabase.driver.sql.normalize :as sql.normalize]
    [metabase.test :as mt]
    [metabase.util :as u]
    [toucan2.core :as t2]))
@@ -16,7 +13,7 @@
   :once
   (fn [f]
     (mt/with-premium-features [:dependencies :transforms :workspaces]
-      (mt/with-model-cleanup [:model/Dependency :model/Transform :model/Table]
+      (mt/with-model-cleanup [:model/Dependency :model/Transform :model/Table :model/Workspace]
         (f)))))
 
 ;;;; Example graphs for testing
@@ -31,74 +28,6 @@
    :m13 [:x11 :m12]})
 
 ;;;; Test data helpers
-
-(defn- transform? [kw] (= \x (first (name kw))))
-(defn- table? [kw] (= \t (first (name kw))))
-(defn- kw->id [kw] (parse-long (subs (name kw) 1)))
-
-(defn- create-test-graph!
-  "Create test transforms and tables from shorthand notation, returning id mappings.
-
-   Shorthand uses keywords like :x1, :t2, :m3 where:
-   - :x<n> is a transform
-   - :t<n> is a table (source/generated)
-   - :m<n> is a model (card)
-
-   Returns a map from shorthand id to real database id, e.g. {:x1 123, :t2 456}
-
-   NOTE: Caller should wrap in mt/with-model-cleanup for proper cleanup."
-  [dependencies]
-  (let [schema     (str/replace (str (random-uuid)) "-" "_")
-        all-ids    (set (concat (keys dependencies)
-                                (mapcat val dependencies)))
-        transforms (filter transform? all-ids)
-        driver     (t2/select-one-fn :engine [:model/Database :engine] (mt/id))
-        normalize  #(sql.normalize/normalize-name driver %)
-        tables     (filter table? all-ids)
-        table-ids  (u/for-map [t tables]
-                     [t (t2/insert-returning-pk! :model/Table
-                                                 {:db_id  (mt/id)
-                                                  :schema (some-> schema normalize)
-                                                  :name   (normalize (str "test_table_" (kw->id t)))
-                                                  :active true})])
-        ;; Create transforms that reference their input tables
-        tx-ids     (u/for-map [tx transforms]
-                     (let [parent-tables (->> (get dependencies tx []) (filter table?) (map table-ids))
-                           id            (t2/insert-returning-pk! :model/Transform
-                                                                  {:name   (str "Test " (name tx))
-                                                                   :source {:type  :query
-                                                                            :query (if (seq parent-tables)
-                                                                                     #_{:database (mt/id)
-                                                                                        :type     :query
-                                                                                        :query    {:source-table (first parent-tables)
-                                                                                                   :joins        (for [pt (rest parent-tables)]
-                                                                                                                   {:source-table pt
-                                                                                                                    :condition    [:= 1 1]})}}
-                                                                                     {:database (mt/id)
-                                                                                      :type     :native
-                                                                                      :native   {:query (->> (t2/select-fn-vec #(str (:schema %) "." (:name %))
-                                                                                                                               [:model/Table :schema :name]
-                                                                                                                               :id [:in parent-tables])
-                                                                                                             (str/join ", ")
-                                                                                                             (str "SELECT * FROM "))}}
-                                                                                     {:database (mt/id)
-                                                                                      :type     :native
-                                                                                      :native   {:query "SELECT 1"}})}
-                                                                   :target {:type     "table"
-                                                                            :database (mt/id)
-                                                                            :schema   schema
-                                                                            :name     (str "test_table_" (kw->id tx))}})]
-                       [tx id]))]
-
-    ;; This is a workaround for the dependency between transforms and their output only being inserted on run.
-    (doseq [[tx-kw tx-id] tx-ids]
-      (app-db/update-or-insert! :model/Dependency
-                                {:to_entity_type   "transform"
-                                 :to_entity_id     tx-id
-                                 :from_entity_type "table"
-                                 :from_entity_id   (table-ids (keyword (str "t" (kw->id tx-kw))))}))
-
-    (merge tx-ids table-ids)))
 
 (defn- translate-result
   "Translate result from real IDs back to shorthand notation for easier comparison."
@@ -121,7 +50,7 @@
 (deftest path-induced-subgraph-shorthand-test
   (testing "graph built from shorthand matches abstract solver"
     (let [shorthand   {:x2 [:t1]}
-          id-map      (create-test-graph! (dag-abstract/expand-shorthand shorthand))
+          id-map      (ws.tu/create-global-resources! shorthand)
           gtx         (t2/select-one :model/Transform (id-map :x2))]
       ;; TODO make this nice and declarative too
       (mt/with-temp [:model/Workspace          ws  {:name "Test Workspace", :database_id (mt/id)}
@@ -147,7 +76,7 @@
                        :x3 [:x2, :t8]
                        :x4 [:x3]
                        :x5 [:x2, :x4, :t9]}
-          id-map     (create-test-graph! (dag-abstract/expand-shorthand shorthand))
+          id-map     (ws.tu/create-global-resources! shorthand)
           gtx-2       (t2/select-one :model/Transform (id-map :x2))
           gtx-4       (t2/select-one :model/Transform (id-map :x4))
           fork        (fn [ws gtx]
@@ -240,7 +169,7 @@
           :x4 []
           :x5 []}
          (#'ws.dag/collapse
-          table?
+          ws.tu/table?
           {:x1 [:t1 :t2]
            :t1 [:x2]
            :t2 [:x3]
@@ -252,18 +181,18 @@
            :x5 []}))))
 
 (defn tx->table [kw]
-  (when (transform? kw)
-    (keyword (str "t" (kw->id kw)))))
+  (when (ws.tu/transform? kw)
+    (keyword (str "t" (ws.tu/kw->id kw)))))
 
 (defn- solve-in-memory [init-nodes graph]
-  (let [tx-nodes (filter transform? init-nodes)
+  (let [tx-nodes (filter ws.tu/transform? init-nodes)
         tables   (map tx->table tx-nodes)]
     (#'ws.dag/path-induced-subgraph*
      ;; Include all changeset targets in the init-nodes
      (distinct (into init-nodes tables))
      {:node-parents (dag-abstract/expand-shorthand graph)
-      :table?       table?
-      :table-sort   kw->id
+      :table?       ws.tu/table?
+      :table-sort   ws.tu/kw->id
       :unwrap-table identity})))
 
 (defn- chain->deps [chain]

--- a/enterprise/backend/test/metabase_enterprise/workspaces/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/test_util.clj
@@ -1,15 +1,232 @@
 (ns ^:mb/driver-tests metabase-enterprise.workspaces.test-util
   (:require
+   [clojure.set :as set]
+   [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase-enterprise.workspaces.common :as ws.common]
+   [metabase-enterprise.workspaces.dag-abstract :as dag-abstract]
    [metabase-enterprise.workspaces.isolation :as ws.isolation]
    [metabase-enterprise.workspaces.models.workspace :as ws.model]
+   [metabase.app-db.core :as app-db]
    [metabase.config.core :as config]
+   [metabase.driver.sql.normalize :as sql.normalize]
    [metabase.search.test-util :as search.tu]
    [metabase.test :as mt]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [toucan2.core :as t2]))
+
+;;;; Shorthand notation helpers
+
+(defn transform?
+  "Check if keyword represents a transform (starts with 'x')."
+  [kw]
+  (= \x (first (name kw))))
+
+(defn table?
+  "Check if keyword represents a table (starts with 't')."
+  [kw]
+  (= \t (first (name kw))))
+
+(defn kw->id
+  "Extract numeric id from shorthand keyword (e.g., :x1 -> 1, :t2 -> 2)."
+  [kw]
+  (parse-long (subs (name kw) 1)))
+
+;;;; Building blocks for test resource creation
+
+(defn- build-source-query
+  "Build a native source query referencing the given table IDs."
+  [table-ids]
+  (if (seq table-ids)
+    {:database (mt/id)
+     :type     :native
+     :native   {:query (str "SELECT * FROM "
+                            (->> (t2/select [:model/Table :schema :name] :id [:in table-ids])
+                                 (map #(str (:schema %) "." (:name %)))
+                                 (str/join ", ")))}}
+    {:database (mt/id)
+     :type     :native
+     :native   {:query "SELECT 1"}}))
+
+(defn- build-transform-target
+  "Build target map for a transform."
+  [tx-sym schema]
+  (let [driver    (t2/select-one-fn :engine [:model/Database :engine] (mt/id))
+        normalize #(sql.normalize/normalize-name driver %)]
+    {:type     "table"
+     :database (mt/id)
+     :schema   (some-> schema normalize)
+     :name     (normalize (str "test_table_" (kw->id tx-sym)))}))
+
+(defn create-tables!
+  "Create test tables for the given table symbols. Returns {symbol -> table-id}."
+  [table-syms schema]
+  (let [driver    (t2/select-one-fn :engine [:model/Database :engine] (mt/id))
+        normalize #(sql.normalize/normalize-name driver %)]
+    (into {}
+          (for [t table-syms]
+            [t (t2/insert-returning-pk! :model/Table
+                                        {:db_id  (mt/id)
+                                         :schema (some-> schema normalize)
+                                         :name   (normalize (str "test_table_" (kw->id t)))
+                                         :active true})]))))
+
+(defn create-transform!
+  "Create a global transform with given dependencies. Returns transform ID."
+  [tx-sym deps id-map schema]
+  (let [table-ids (->> deps (filter table?) (map id-map) (filter some?))
+        source    (build-source-query table-ids)
+        target    (build-transform-target tx-sym schema)]
+    (t2/insert-returning-pk! :model/Transform
+                             {:name   (str "Test " (name tx-sym))
+                              :source {:type :query :query source}
+                              :target target})))
+
+(defn add-transform-to-workspace!
+  "Add a transform to a workspace via API. Returns ref-id.
+
+   For checkouts: provide :global-tx (the global transform to checkout)
+   For new transforms: provide :deps and :id-map to build the source
+   If both :global-tx and :deps are provided, the deps override the global source."
+  [ws-id tx-sym {:keys [global-tx deps id-map schema]}]
+  (let [body     (if global-tx
+                   ;; Checkout: use global transform's body (can be overridden with deps)
+                   (cond-> (select-keys global-tx [:name :description :source :target])
+                     deps (assoc :source {:type  :query
+                                          :query (build-source-query
+                                                  (->> deps (filter table?) (map id-map)))}))
+                   ;; New: build from deps
+                   {:name   (str "Test " (name tx-sym))
+                    :source {:type :query :query (build-source-query
+                                                  (->> deps (filter table?) (map id-map)))}
+                    :target (build-transform-target tx-sym schema)})
+        response (mt/user-http-request :crowberto :post 200
+                                       (str "ee/workspace/" ws-id "/transform")
+                                       (cond-> body
+                                         global-tx (assoc :global_id (:id global-tx))))]
+    (:ref_id response)))
+
+;;;; Orchestration functions
+
+(defn create-global-resources!
+  "Create test transforms and tables from shorthand dependency graph.
+   Automatically expands shorthand notation (e.g., :x2 [:x1] becomes :x2 [:t1], :t1 [:x1]).
+   Returns {symbol -> id} for both tables and transforms.
+
+   NOTE: Caller should wrap in mt/with-model-cleanup for proper cleanup."
+  [dependencies]
+  (let [expanded-deps (dag-abstract/expand-shorthand dependencies)
+        schema        (str/replace (str (random-uuid)) "-" "_")
+        all-ids       (set (concat (keys expanded-deps) (mapcat val expanded-deps)))
+        table-syms    (filter table? all-ids)
+        tx-syms       (filter transform? all-ids)
+
+        ;; Create tables first
+        table-ids  (create-tables! table-syms schema)
+
+        ;; Create transforms (they depend on tables)
+        tx-ids     (into {}
+                         (for [tx tx-syms]
+                           [tx (create-transform! tx (get expanded-deps tx []) table-ids schema)]))
+
+        ;; Insert dependencies (usually inserted as side effect of running the transform, but we want to skip that)
+        _          (doseq [[tx-kw tx-id] tx-ids]
+                     (let [output-table-sym (keyword (str "t" (kw->id tx-kw)))]
+                       (when-let [table-id (table-ids output-table-sym)]
+                         (app-db/update-or-insert! :model/Dependency
+                                                   {:to_entity_type   "transform"
+                                                    :to_entity_id     tx-id
+                                                    :from_entity_type "table"
+                                                    :from_entity_id   table-id}))))]
+    (merge table-ids tx-ids)))
+
+(defn- create-workspace-for-test! [props]
+  (let [creator-id (or (:creator_id props) (mt/user->id :crowberto))
+        props      (-> props
+                       (dissoc :creator_id)
+                       (update :database_id #(or % (mt/id))))]
+    (mt/with-current-user creator-id
+      (ws.common/create-workspace! creator-id props))))
+
+(defn create-resources!
+  "Create test resources from shorthand notation for both global and workspace transforms.
+
+   Input: {:global dependencies-graph (shorthand)
+           :workspace {:checkouts ids, :definitions dependencies-graph (shorthand)}}
+
+   Returns: {:workspace-id int
+             :global-map {symbol -> db-id}
+             :workspace-map {symbol -> ref-id}}
+
+   NOTE: Caller should wrap in mt/with-model-cleanup for proper cleanup."
+  [{:keys [global workspace]}]
+  (let [{:keys [checkouts definitions]} workspace
+        checkouts        (set checkouts)
+        schema           (str/replace (str (random-uuid)) "-" "_")
+
+        ;; Expand shorthand to insert intermediate table nodes
+        expanded-global  (dag-abstract/expand-shorthand global)
+        expanded-ws-defs (when definitions (dag-abstract/expand-shorthand definitions))
+
+        ;; Find all tables needed (union of global and workspace)
+        global-tables    (set (filter table? (concat (keys expanded-global)
+                                                     (mapcat val expanded-global))))
+        ws-tables        (when expanded-ws-defs
+                           (set (filter table? (concat (keys expanded-ws-defs)
+                                                       (mapcat val expanded-ws-defs)))))
+        all-tables       (set/union global-tables (or ws-tables #{}))
+
+        ;; Create all tables upfront
+        table-ids        (create-tables! all-tables schema)
+
+        ;; Create global transforms
+        global-tx-syms   (filter transform? (keys expanded-global))
+        global-tx-ids    (into {}
+                               (for [tx global-tx-syms]
+                                 [tx (create-transform! tx (get expanded-global tx []) table-ids schema)]))
+
+        ;; Insert global dependencies
+        _                (doseq [[tx-kw tx-id] global-tx-ids]
+                           (let [output-table-sym (keyword (str "t" (kw->id tx-kw)))]
+                             (when-let [table-id (table-ids output-table-sym)]
+                               (app-db/update-or-insert! :model/Dependency
+                                                         {:to_entity_type   "transform"
+                                                          :to_entity_id     tx-id
+                                                          :from_entity_type "table"
+                                                          :from_entity_id   table-id}))))
+
+        global-map       (merge table-ids global-tx-ids)
+
+        ;; Create workspace
+        ws               (create-workspace-for-test! {:name (str "test-ws-" (random-uuid))})
+        ws-id            (:id ws)
+
+        ;; Determine which workspace transforms to create
+        ws-tx-syms       (distinct (concat
+                                    ;; Checkouts not overridden in definitions
+                                    (filter #(not (contains? (set (keys definitions)) %)) checkouts)
+                                    ;; All transforms from definitions
+                                    (when expanded-ws-defs
+                                      (filter transform? (keys expanded-ws-defs)))))
+
+        ;; Create workspace transforms
+        workspace-map    (into {}
+                               (for [tx ws-tx-syms]
+                                 (let [is-checkout? (contains? checkouts tx)
+                                       in-defs?     (contains? (set (keys definitions)) tx)
+                                       global-tx    (when is-checkout?
+                                                      (t2/select-one :model/Transform (global-map tx)))
+                                       deps         (when (or (not is-checkout?) in-defs?)
+                                                      (get expanded-ws-defs tx []))]
+                                   [tx (add-transform-to-workspace! ws-id tx
+                                                                    {:global-tx global-tx
+                                                                     :deps      deps
+                                                                     :id-map    global-map
+                                                                     :schema    schema})])))]
+    {:workspace-id  ws-id
+     :global-map    global-map
+     :workspace-map workspace-map}))
 
 (defn ws-fixtures!
   "Sets up test fixtures for workspace tests. Must be called at the top level of test namespaces."
@@ -56,14 +273,6 @@
                  ;; some cloud drivers are really slow
                  :timeout-ms (if config/is-dev? 10000 60000)})
         (throw (ex-info "Timeout waiting for workspace to be ready" {:workspace-id ws-id})))))
-
-(defn- create-workspace-for-test! [props]
-  (let [creator-id (or (:creator_id props) (mt/user->id :crowberto))
-        props      (-> props
-                       (dissoc :creator_id)
-                       (update :database_id #(or % (mt/id))))]
-    (mt/with-current-user creator-id
-      (ws.common/create-workspace! creator-id props))))
 
 ;; TODO (chris 2026/01/06) this needs a transform added for it to really be ready
 (defn create-ready-ws!

--- a/enterprise/backend/test/metabase_enterprise/workspaces/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/test_util.clj
@@ -199,7 +199,7 @@
         global-map       (merge table-ids global-tx-ids)
 
         ;; Create workspace
-        ws               (create-workspace-for-test! {:name (str "test-ws-" (random-uuid))})
+        ws               (create-workspace-for-test! {:name (or (:name workspace) (str "test-ws-" (random-uuid)))})
         ws-id            (:id ws)
 
         ;; Determine which workspace transforms to create
@@ -274,11 +274,10 @@
                  :timeout-ms (if config/is-dev? 10000 60000)})
         (throw (ex-info "Timeout waiting for workspace to be ready" {:workspace-id ws-id})))))
 
-;; TODO (chris 2026/01/06) this needs a transform added for it to really be ready
 (defn create-ready-ws!
-  "Create a workspace and wait for it to be ready."
+  "Create a simple workspace and wait for it to be ready."
   [name]
-  (create-workspace-for-test! {:name name}))
+  (ws-ready (:workspace-id (create-resources! {:workspace {:name name, :definitions {:x2 [:t1]}}}))))
 
 (defn do-with-workspaces!
   "Function that sets up workspaces for testing and cleans up afterwards.


### PR DESCRIPTION
We need this to test non-trivial stuff without tears.

For now just use it to fix some of the basic tests we'd disabled.