### PR TITLE
Fix public powered by metabase footer link

### DIFF
--- a/e2e/test/scenarios/documents/public-documents.cy.spec.ts
+++ b/e2e/test/scenarios/documents/public-documents.cy.spec.ts
@@ -390,7 +390,7 @@ describe("scenarios > documents > public", () => {
       .should("exist")
       .should("be.visible")
       .should("have.attr", "href")
-      .and("contain", "https://www.metabase.com/powered-by-metabase");
+      .and("contain", "https://www.metabase.com/index");
   });
 
   it("should not display footer for premium", () => {

--- a/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
@@ -137,7 +137,7 @@ describe("scenarios > embedding > smoke tests", { tags: "@OSS" }, () => {
         cy.findByRole("contentinfo").within(() => {
           cy.findByRole("link", { name: "Powered by Metabase" })
             .should("have.attr", "href")
-            .and("contain", "https://www.metabase.com/powered-by-metabase");
+            .and("contain", "https://www.metabase.com/index");
         });
 
         cy.log(

--- a/frontend/src/metabase/public/components/EmbedFrame/LogoBadge/LogoBadge.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/LogoBadge/LogoBadge.tsx
@@ -19,7 +19,7 @@ export const LogoBadge = ({ dark }: { dark: boolean }) => {
         [LogoBadgeStyle.dark]: dark,
         [LogoBadgeStyle.light]: !dark,
       })}
-      href={`https://www.metabase.com/powered-by-metabase?utm_medium=referral&utm_source=product&utm_campaign=powered_by_metabase&utm_content=${utmContentValue}`}
+      href={`https://www.metabase.com/index?utm_medium=referral&utm_source=product&utm_campaign=powered_by_metabase&utm_content=${utmContentValue}`}
       target="_blank"
     >
       <span>{t`Powered by`}</span>

--- a/frontend/src/metabase/public/components/EmbedFrame/LogoBadge/LogoBadge.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/LogoBadge/LogoBadge.unit.spec.tsx
@@ -14,7 +14,7 @@ describe("LogoBadge", () => {
 
     expect(screen.getByRole("link")).toHaveProperty(
       "href",
-      "https://www.metabase.com/powered-by-metabase?utm_medium=referral&utm_source=product&utm_campaign=powered_by_metabase&utm_content=embedded_banner_localhost",
+      "https://www.metabase.com/index?utm_medium=referral&utm_source=product&utm_campaign=powered_by_metabase&utm_content=embedded_banner_localhost",
     );
   });
 });


### PR DESCRIPTION
### Description

Currently Powered by Metabase links lead to https://www.metabase.com/powered-by-metabase , which always gets redirected to https://www.metabase.com/index. We've been asked to use index page as default.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Using OSS - Create a public question or document
2. Click on Powered by Metabase footer link
3. You should be redirected to https://www.metabase.com/index


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
