### PR TITLE
Disable regex lookaheads/lookbehinds for Snowflake driver

### DIFF
--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -76,6 +76,7 @@
                               :now                                    true
                               :database-routing                       true
                               :metadata/table-existence-check         true
+                              :regex/lookaheads-and-lookbehinds       false
                               :transforms/python                      true
                               :transforms/table                       true}]
   (defmethod driver/database-supports? [:snowflake feature] [_driver _feature _db] supported?))


### PR DESCRIPTION
## Summary
- Adds `:regex/lookaheads-and-lookbehinds false` to Snowflake's feature declarations

Snowflake's `REGEXP_SUBSTR` doesn't support regex lookaheads and lookbehinds, which are required for email and URL extractions. This follows the same pattern used for BigQuery, Oracle, Redshift, Athena, ClickHouse, Presto-JDBC, and Vertica in PR #66982.

This was blocking Snowflake driver tests - see Slack discussion with @camsaul, @dsutton, and @jakub in https://metaboat.slack.com/archives/C0669P4AF9N/p1768210125775859.

## Test plan
- Snowflake driver tests should pass (the `email-extractions-test` and `url-extractions-test` will now be skipped for Snowflake)