### PR TITLE
Fix EmbedJS/SDK dashboard styles to properly display the EmbedJS branding footer

### DIFF
--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboardStyleWrapper.module.css
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboardStyleWrapper.module.css
@@ -1,0 +1,4 @@
+.SdkDashboardStyleWrapper {
+  min-height: 100vh;
+  background-color: var(--mb-color-bg-dashboard);
+}

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboardStyleWrapper.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboardStyleWrapper.tsx
@@ -6,6 +6,8 @@ import CS from "metabase/css/core/index.css";
 import { useDashboardContext } from "metabase/dashboard/context";
 import { Flex } from "metabase/ui";
 
+import SdkDashboardStyleWrapperS from "./SdkDashboardStyleWrapper.module.css";
+
 export const SdkDashboardStyledWrapper = forwardRef(
   function SdkDashboardStyledWrapperInner(
     { className, style, children }: PropsWithChildren<CommonStylingProps>,
@@ -16,12 +18,12 @@ export const SdkDashboardStyledWrapper = forwardRef(
         direction="column"
         justify="flex-start"
         align="stretch"
-        className={cx(className, CS.overflowAuto)}
-        style={{
-          minHeight: "100vh",
-          backgroundColor: "var(--mb-color-bg-dashboard)",
-          ...style,
-        }}
+        className={cx(
+          className,
+          SdkDashboardStyleWrapperS.SdkDashboardStyleWrapper,
+          CS.overflowAuto,
+        )}
+        style={style}
         ref={fullscreenRef}
       >
         {children}

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboardStyleWrapper.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboardStyleWrapper.tsx
@@ -18,7 +18,7 @@ export const SdkDashboardStyledWrapper = forwardRef(
         align="stretch"
         className={cx(className, CS.overflowAuto)}
         style={{
-          minHeight: "100vh",
+          height: "100%",
           backgroundColor: "var(--mb-color-bg-dashboard)",
           ...style,
         }}

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboardStyleWrapper.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboardStyleWrapper.tsx
@@ -4,7 +4,6 @@ import { type PropsWithChildren, forwardRef } from "react";
 import type { CommonStylingProps } from "embedding-sdk-bundle/types/props";
 import CS from "metabase/css/core/index.css";
 import { useDashboardContext } from "metabase/dashboard/context";
-import { isEmbeddingEajs } from "metabase/embedding-sdk/config";
 import { Flex } from "metabase/ui";
 
 export const SdkDashboardStyledWrapper = forwardRef(
@@ -19,9 +18,7 @@ export const SdkDashboardStyledWrapper = forwardRef(
         align="stretch"
         className={cx(className, CS.overflowAuto)}
         style={{
-          minHeight: isEmbeddingEajs()
-            ? "100%" // to respect grid-template-columns styles in SdkIframeEmbedRoute
-            : "100vh",
+          minHeight: "100vh",
           backgroundColor: "var(--mb-color-bg-dashboard)",
           ...style,
         }}

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboardStyleWrapper.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboardStyleWrapper.tsx
@@ -18,7 +18,7 @@ export const SdkDashboardStyledWrapper = forwardRef(
         align="stretch"
         className={cx(className, CS.overflowAuto)}
         style={{
-          height: "100%",
+          minHeight: "100%",
           backgroundColor: "var(--mb-color-bg-dashboard)",
           ...style,
         }}

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboardStyleWrapper.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboardStyleWrapper.tsx
@@ -4,6 +4,7 @@ import { type PropsWithChildren, forwardRef } from "react";
 import type { CommonStylingProps } from "embedding-sdk-bundle/types/props";
 import CS from "metabase/css/core/index.css";
 import { useDashboardContext } from "metabase/dashboard/context";
+import { isEmbeddingEajs } from "metabase/embedding-sdk/config";
 import { Flex } from "metabase/ui";
 
 export const SdkDashboardStyledWrapper = forwardRef(
@@ -18,7 +19,9 @@ export const SdkDashboardStyledWrapper = forwardRef(
         align="stretch"
         className={cx(className, CS.overflowAuto)}
         style={{
-          minHeight: "100%",
+          minHeight: isEmbeddingEajs()
+            ? "100%" // to respect grid-template-columns styles in SdkIframeEmbedRoute
+            : "100vh",
           backgroundColor: "var(--mb-color-bg-dashboard)",
           ...style,
         }}

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.module.css
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.module.css
@@ -8,3 +8,8 @@
 .Container:has(.BrandingFooter) {
   grid-template-rows: 1fr auto;
 }
+
+.Dashboard {
+  height: 100%;
+  min-height: unset;
+}

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.module.css
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.module.css
@@ -1,0 +1,10 @@
+.Container {
+  display: grid;
+  width: 100%;
+  grid-template-columns: 1fr;
+  grid-template-rows: 1fr;
+}
+
+.Container:has(.BrandingFooter) {
+  grid-template-rows: 1fr auto;
+}

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
@@ -37,6 +37,7 @@ import {
   SdkIframeExistingUserSessionInProductionError,
   SdkIframeInvalidLicenseError,
 } from "./SdkIframeError";
+import { DASHBOARD_STYLES } from "./constants";
 
 const onSettingsChanged = (settings: SdkIframeEmbedSettings) => {
   // Tell the SDK whether to use the existing user session or not.
@@ -174,6 +175,7 @@ const SdkIframeEmbedView = ({
               withDownloads={settings.withDownloads}
               initialParameters={settings.initialParameters}
               hiddenParameters={settings.hiddenParameters}
+              style={DASHBOARD_STYLES}
             />
           );
         },
@@ -197,6 +199,7 @@ const SdkIframeEmbedView = ({
             hiddenParameters={settings.hiddenParameters}
             drillThroughQuestionHeight="100%"
             drillThroughQuestionProps={{ isSaveEnabled: false }}
+            style={DASHBOARD_STYLES}
           />
         ),
       )

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
@@ -31,6 +31,7 @@ import { useSdkIframeEmbedEventBus } from "../hooks/use-sdk-iframe-embed-event-b
 import type { SdkIframeEmbedSettings } from "../types/embed";
 
 import { MetabaseBrowser } from "./MetabaseBrowser";
+import SdkIframeEmbedRouteS from "./SdkIframeEmbedRoute.module.css";
 import {
   SdkIframeApiKeyInProductionError,
   SdkIframeExistingUserSessionInProductionError,
@@ -99,11 +100,8 @@ export const SdkIframeEmbedRoute = () => {
     >
       <Stack
         mih="100vh"
+        className={SdkIframeEmbedRouteS.Container}
         style={{
-          display: "grid",
-          width: "100%",
-          gridTemplateColumns: "1fr",
-          gridTemplateRows: "1fr auto",
           backgroundColor: adjustedTheme?.colors?.background,
         }}
       >
@@ -285,7 +283,9 @@ const EmbedBrandingFooter = () => {
   }
 
   return (
-    <PublicComponentStylesWrapper>
+    <PublicComponentStylesWrapper
+      className={SdkIframeEmbedRouteS.BrandingFooter}
+    >
       <EmbeddingFooter variant="default" hasEmbedBranding />
     </PublicComponentStylesWrapper>
   );

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
@@ -37,7 +37,6 @@ import {
   SdkIframeExistingUserSessionInProductionError,
   SdkIframeInvalidLicenseError,
 } from "./SdkIframeError";
-import { DASHBOARD_STYLES } from "./constants";
 
 const onSettingsChanged = (settings: SdkIframeEmbedSettings) => {
   // Tell the SDK whether to use the existing user session or not.
@@ -170,12 +169,12 @@ const SdkIframeEmbedView = ({
           return (
             <StaticDashboard
               key={rerenderKey}
+              className={SdkIframeEmbedRouteS.Dashboard}
               {...entityProps}
               withTitle={settings.withTitle}
               withDownloads={settings.withDownloads}
               initialParameters={settings.initialParameters}
               hiddenParameters={settings.hiddenParameters}
-              style={DASHBOARD_STYLES}
             />
           );
         },
@@ -190,6 +189,7 @@ const SdkIframeEmbedView = ({
         (settings) => (
           <InteractiveDashboard
             key={rerenderKey}
+            className={SdkIframeEmbedRouteS.Dashboard}
             dashboardId={settings.dashboardId ?? null}
             token={settings.token}
             withTitle={settings.withTitle}
@@ -199,7 +199,6 @@ const SdkIframeEmbedView = ({
             hiddenParameters={settings.hiddenParameters}
             drillThroughQuestionHeight="100%"
             drillThroughQuestionProps={{ isSaveEnabled: false }}
-            style={DASHBOARD_STYLES}
           />
         ),
       )

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/components/constants.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/components/constants.ts
@@ -1,4 +1,0 @@
-export const DASHBOARD_STYLES = {
-  height: "100%",
-  minHeight: "unset",
-};

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/components/constants.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/components/constants.ts
@@ -1,0 +1,4 @@
+export const DASHBOARD_STYLES = {
+  height: "100%",
+  minHeight: "unset",
+};


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #68118
Fix EmbedJS/SDK dashboard styles to properly display the EmbedJS branding footer

Fixes https://linear.app/metabase/issue/EMB-1187/metabase-58-embed-js-oss-footer-banner-is-visible-only-after-scroll

We had `min-height: 100vw` for Dashboard in SDK/EmbedJS and for EmbedJS it causes issues because it's parent (in an iframe) has  mih="100vh" and grid-template rows `1fr auto` so with `100vh` it behaves wrong.

The fix sets only for Embed JS `min-hight: 100%` to fill the available space according to `1fr`. 
Also PR fixes the empty bottom gap when a footer is not rendered.

<img width="2698" height="2692" alt="image" src="https://github.com/user-attachments/assets/25028571-28fd-4881-b29b-0d07ed3a0ee6" />

How to test:
- comment `return null` in `frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx` at line 282
- in OSS version locally, open Embed JS Wizard => dashboard.
- ensure that footer with `metabase logo` visible IF content of a dashboard is less than a page height.
- ensure that footer with `metabase logo` is still scrollable if content of a dashboard is larger in height than a page height

Check case when Embed JS dashboard is added on a page