### PR TITLE
Delete invalid `source-card-id`s on native SQL questions

### DIFF
--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -1257,6 +1257,21 @@ databaseChangeLog:
             tableName: pulse
             columnName: disable_links
 
+  - changeSet:
+      id: v58.2026-01-12T22:43:43
+      author: galdre
+      comment: "Clear source_card_id for native queries to prevent cascade deletion (#68080)"
+      changes:
+        - update:
+            tableName: report_card
+            columns:
+              - column:
+                  name: source_card_id
+                  value: null
+            where: query_type = 'native' AND source_card_id IS NOT NULL
+      rollback:
+        # No rollback - we can't know what the original source_card_id values were
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -1275,11 +1275,26 @@ databaseChangeLog:
   - changeSet:
       id: v58.2026-01-13T12:00:00
       author: galdre
-      comment: "Change source_card_id FK from ON DELETE CASCADE to ON DELETE SET NULL (#68080)"
+      comment: "Drop source_card_id FK in preparation for changing to SET NULL (#68080)"
       changes:
         - dropForeignKeyConstraint:
             baseTableName: report_card
             constraintName: fk_report_card_source_card_id_ref_report_card_id
+      rollback:
+        - addForeignKeyConstraint:
+            baseTableName: report_card
+            baseColumnNames: source_card_id
+            referencedTableName: report_card
+            referencedColumnNames: id
+            constraintName: fk_report_card_source_card_id_ref_report_card_id
+            nullable: true
+            deleteCascade: true
+
+  - changeSet:
+      id: v58.2026-01-13T12:00:01
+      author: galdre
+      comment: "Add source_card_id FK with ON DELETE SET NULL (#68080)"
+      changes:
         - addForeignKeyConstraint:
             baseTableName: report_card
             baseColumnNames: source_card_id
@@ -1292,14 +1307,6 @@ databaseChangeLog:
         - dropForeignKeyConstraint:
             baseTableName: report_card
             constraintName: fk_report_card_source_card_id_ref_report_card_id
-        - addForeignKeyConstraint:
-            baseTableName: report_card
-            baseColumnNames: source_card_id
-            referencedTableName: report_card
-            referencedColumnNames: id
-            constraintName: fk_report_card_source_card_id_ref_report_card_id
-            nullable: true
-            deleteCascade: true
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -1257,57 +1257,6 @@ databaseChangeLog:
             tableName: pulse
             columnName: disable_links
 
-  - changeSet:
-      id: v58.2026-01-12T22:43:43
-      author: galdre
-      comment: "Clear source_card_id for native queries to prevent cascade deletion (#68080)"
-      changes:
-        - update:
-            tableName: report_card
-            columns:
-              - column:
-                  name: source_card_id
-                  value: null
-            where: query_type = 'native' AND source_card_id IS NOT NULL
-      rollback:
-        # No rollback - we can't know what the original source_card_id values were
-
-  - changeSet:
-      id: v58.2026-01-13T12:00:00
-      author: galdre
-      comment: "Drop source_card_id FK in preparation for changing to SET NULL (#68080)"
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: report_card
-            constraintName: fk_report_card_source_card_id_ref_report_card_id
-      rollback:
-        - addForeignKeyConstraint:
-            baseTableName: report_card
-            baseColumnNames: source_card_id
-            referencedTableName: report_card
-            referencedColumnNames: id
-            constraintName: fk_report_card_source_card_id_ref_report_card_id
-            nullable: true
-            deleteCascade: true
-
-  - changeSet:
-      id: v58.2026-01-13T12:00:01
-      author: galdre
-      comment: "Add source_card_id FK with ON DELETE SET NULL (#68080)"
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: report_card
-            baseColumnNames: source_card_id
-            referencedTableName: report_card
-            referencedColumnNames: id
-            constraintName: fk_report_card_source_card_id_ref_report_card_id
-            nullable: true
-            onDelete: SET NULL
-      rollback:
-        - dropForeignKeyConstraint:
-            baseTableName: report_card
-            constraintName: fk_report_card_source_card_id_ref_report_card_id
-
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -1272,6 +1272,35 @@ databaseChangeLog:
       rollback:
         # No rollback - we can't know what the original source_card_id values were
 
+  - changeSet:
+      id: v58.2026-01-13T12:00:00
+      author: galdre
+      comment: "Change source_card_id FK from ON DELETE CASCADE to ON DELETE SET NULL (#68080)"
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: report_card
+            constraintName: fk_report_card_source_card_id_ref_report_card_id
+        - addForeignKeyConstraint:
+            baseTableName: report_card
+            baseColumnNames: source_card_id
+            referencedTableName: report_card
+            referencedColumnNames: id
+            constraintName: fk_report_card_source_card_id_ref_report_card_id
+            nullable: true
+            onDelete: SET NULL
+      rollback:
+        - dropForeignKeyConstraint:
+            baseTableName: report_card
+            constraintName: fk_report_card_source_card_id_ref_report_card_id
+        - addForeignKeyConstraint:
+            baseTableName: report_card
+            baseColumnNames: source_card_id
+            referencedTableName: report_card
+            referencedColumnNames: id
+            constraintName: fk_report_card_source_card_id_ref_report_card_id
+            nullable: true
+            deleteCascade: true
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/059_update_migrations.yaml
+++ b/resources/migrations/059_update_migrations.yaml
@@ -241,7 +241,7 @@ databaseChangeLog:
                   name: result
 
   - changeSet:
-      id: v58.2026-01-12T22:43:43
+      id: v59.2026-01-12T22:43:43
       author: galdre
       comment: "Clear source_card_id for native queries to prevent cascade deletion (#68080)"
       changes:
@@ -256,7 +256,7 @@ databaseChangeLog:
         # No rollback - we can't know what the original source_card_id values were
 
   - changeSet:
-      id: v58.2026-01-13T12:00:00
+      id: v59.2026-01-13T12:00:00
       author: galdre
       comment: "Drop source_card_id FK in preparation for changing to SET NULL (#68080)"
       changes:
@@ -274,7 +274,7 @@ databaseChangeLog:
             deleteCascade: true
 
   - changeSet:
-      id: v58.2026-01-13T12:00:01
+      id: v59.2026-01-13T12:00:01
       author: galdre
       comment: "Add source_card_id FK with ON DELETE SET NULL (#68080)"
       changes:

--- a/resources/migrations/059_update_migrations.yaml
+++ b/resources/migrations/059_update_migrations.yaml
@@ -240,6 +240,57 @@ databaseChangeLog:
               - column:
                   name: result
 
+  - changeSet:
+      id: v58.2026-01-12T22:43:43
+      author: galdre
+      comment: "Clear source_card_id for native queries to prevent cascade deletion (#68080)"
+      changes:
+        - update:
+            tableName: report_card
+            columns:
+              - column:
+                  name: source_card_id
+                  value: null
+            where: query_type = 'native' AND source_card_id IS NOT NULL
+      rollback:
+        # No rollback - we can't know what the original source_card_id values were
+
+  - changeSet:
+      id: v58.2026-01-13T12:00:00
+      author: galdre
+      comment: "Drop source_card_id FK in preparation for changing to SET NULL (#68080)"
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: report_card
+            constraintName: fk_report_card_source_card_id_ref_report_card_id
+      rollback:
+        - addForeignKeyConstraint:
+            baseTableName: report_card
+            baseColumnNames: source_card_id
+            referencedTableName: report_card
+            referencedColumnNames: id
+            constraintName: fk_report_card_source_card_id_ref_report_card_id
+            nullable: true
+            deleteCascade: true
+
+  - changeSet:
+      id: v58.2026-01-13T12:00:01
+      author: galdre
+      comment: "Add source_card_id FK with ON DELETE SET NULL (#68080)"
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: report_card
+            baseColumnNames: source_card_id
+            referencedTableName: report_card
+            referencedColumnNames: id
+            constraintName: fk_report_card_source_card_id_ref_report_card_id
+            nullable: true
+            onDelete: SET NULL
+      rollback:
+        - dropForeignKeyConstraint:
+            baseTableName: report_card
+            constraintName: fk_report_card_source_card_id_ref_report_card_id
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -425,7 +425,10 @@
 
 (mu/defn- assert-valid-type
   "Check that the card is a valid model if being saved as one. Throw an exception if not."
-  [{query :dataset_query, card-type :type, :as _card} :- [:maybe ::queries.schema/card]]
+  [{query :dataset_query, card-type :type, source-card :source_card_id, :as _card} :- [:maybe ::queries.schema/card]]
+  (assert (not (and (query/query-is-native? query)
+                    (some? source-card)))
+          "A native SQL question cannot have a source card.")
   (when (= (keyword card-type) :model)
     (let [template-tag-types (into #{}
                                    (map :type)

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -633,7 +633,7 @@
         (parameter-card/upsert-or-delete-from-parameters! "card" id (:parameters changes)))
       ;; additional checks (Enterprise Edition only)
       (pre-update-check-sandbox-constraints card changes)
-      (assert-valid-type (merge old-card-info changes)))))
+      (assert-valid-type card))))
 
 (defn- add-query-description-to-metric-card
   "Add `:query_description` key to returned card.
@@ -824,8 +824,9 @@
         (apply-dashboard-question-updates changes)
         (m/update-existing :dataset_query lib-be/normalize-query)
         (populate-result-metadata changes verified-result-metadata?)
-        (pre-update changes)
+        ;; populate-query-fields must run before pre-update in case source_card_id should be nilled
         populate-query-fields
+        (pre-update changes)
         maybe-populate-initially-published-at)))
 
 ;; Cards don't normally get deleted (they get archived instead) so this mostly affects tests

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -346,9 +346,7 @@
               (map? query)
               (not mi/*deserializing?*))
      (merge
-      ;; Always set source_card_id even if it's nilling out.
-      ;; This ensures that when a question is converted from model-based to native SQL,
-      ;; the source_card_id is cleared, preventing cascade deletion when the model is deleted (#68080).
+      ;; This used to be conditional on not nilling source-card-id, changed due to #68080.
       {:source_card_id (source-card-id query)}
       (when-let [{:keys [database-id table-id]} (query/query->database-and-table-ids query)]
         ;; TODO -- not sure `query_type` is actually used for anything important anyway

--- a/test/metabase/dashboards_rest/api_test.clj
+++ b/test/metabase/dashboards_rest/api_test.clj
@@ -4793,12 +4793,14 @@
                   :tables     [{:id (str "card__" card-id-1)}]
                   :databases  [{:id (mt/id) :engine string?}]}
                  (query-metadata))))
+         ;; After delete, card-id-2 still exists on the dashboard but its source is gone.
+         ;; The source table can't be resolved, but the database should still be present.
          #(testing "After delete"
             (is (=? {:cards      empty?
                      :fields     empty?
                      :dashboards empty?
                      :tables     empty?
-                     :databases  empty?}
+                     :databases [{:id (mt/id) :engine string?}]}
                     (query-metadata)))))))))
 
 (deftest dashboard-query-metadata-no-tables-test

--- a/test/metabase/queries/models/card_test.clj
+++ b/test/metabase/queries/models/card_test.clj
@@ -1057,6 +1057,45 @@
           (is (= (mt/id :venues) (:table_id updated-card)))
           (is (= :query (:query_type updated-card))))))))
 
+(deftest source-card-id-cleared-on-conversion-to-native-test
+  (testing "source_card_id should be set to nil when a model-based question is converted to native SQL (#68080)"
+    (mt/with-temp [:model/Card model {:name          "Test Model"
+                                      :type          :model
+                                      :dataset_query (mt/mbql-query venues)}
+                   :model/Card question {:name          "Test Question"
+                                         :dataset_query {:database (mt/id)
+                                                         :type     :query
+                                                         :query    {:source-table (str "card__" (:id model))}}}]
+      (let [question-id (:id question)
+            model-id    (:id model)]
+        (testing "source_card_id is initially set to the model's ID"
+          (is (= model-id (:source_card_id (t2/select-one :model/Card :id question-id)))))
+        (testing "source_card_id is cleared when converting to native SQL"
+          (t2/update! :model/Card question-id
+                      {:dataset_query {:database (mt/id)
+                                       :type     :native
+                                       :native   {:query "SELECT * FROM venues"}}})
+          (is (nil? (:source_card_id (t2/select-one :model/Card :id question-id))))))))
+  (testing "deleting a model should not cascade delete questions that were converted to native SQL"
+    (mt/with-temp [:model/Card model {:name          "Test Model"
+                                      :type          :model
+                                      :dataset_query (mt/mbql-query venues)}
+                   :model/Card question {:name          "Test Question"
+                                         :dataset_query {:database (mt/id)
+                                                         :type     :query
+                                                         :query    {:source-table (str "card__" (:id model))}}}]
+      (let [question-id (:id question)
+            model-id    (:id model)]
+        (t2/update! :model/Card question-id
+                    {:dataset_query {:database (mt/id)
+                                     :type     :native
+                                     :native   {:query "SELECT * FROM venues"}}})
+        (t2/delete! :model/Card model-id)
+        (testing "model should be deleted"
+          (is (not (t2/exists? :model/Card :id model-id))))
+        (testing "converted question should survive"
+          (is (t2/exists? :model/Card :id question-id)))))))
+
 (deftest before-update-embedding-timestamp-test
   (testing "maybe-populate-initially-published-at is called"
     (mt/with-temp [:model/Card {card-id :id} {:enable_embedding false}]

--- a/test/metabase/queries/models/card_test.clj
+++ b/test/metabase/queries/models/card_test.clj
@@ -1096,6 +1096,16 @@
         (testing "converted question should survive"
           (is (t2/exists? :model/Card :id question-id)))))))
 
+(deftest assert-no-source-card-id-for-native-query-test
+  (testing "assertion fires if native query has source_card_id set"
+    (with-redefs [card/populate-query-fields identity]
+      (is (thrown-with-msg? Exception #"Assert failed"
+                            (t2/insert! :model/Card
+                                        {:name "Bad Card"
+                                         :dataset_query (mt/native-query {:query "SELECT 1"})
+                                         :source_card_id 999
+                                         :database_id (mt/id)}))))))
+
 (deftest before-update-embedding-timestamp-test
   (testing "maybe-populate-initially-published-at is called"
     (mt/with-temp [:model/Card {card-id :id} {:enable_embedding false}]

--- a/test/metabase/queries_rest/api/card_test.clj
+++ b/test/metabase/queries_rest/api/card_test.clj
@@ -3881,9 +3881,14 @@
                     :databases [{:id (mt/id) :engine string?}]}
                    (query-metadata 200 card-id)))))
          #(testing "After delete"
-            (doseq [card-id [card-id-1 card-id-2]]
+            ;; card-id-1 is deleted, so it should return 404
               (is (= "Not found."
-                     (query-metadata 404 card-id))))))))))
+                   (query-metadata 404 card-id-1)))
+            ;; card-id-2 still exists but its source is gone, so it should return empty metadata
+            (is (=? {:fields empty?
+                     :tables empty?
+                     :databases [{:id (mt/id) :engine string?}]}
+                    (query-metadata 200 card-id-2)))))))))
 
 (deftest card-query-metadata-no-tables-test
   (testing "Don't throw an error if users doesn't have access to any tables #44043"

--- a/test/metabase/queries_rest/api/card_test.clj
+++ b/test/metabase/queries_rest/api/card_test.clj
@@ -3882,7 +3882,7 @@
                    (query-metadata 200 card-id)))))
          #(testing "After delete"
             ;; card-id-1 is deleted, so it should return 404
-              (is (= "Not found."
+            (is (= "Not found."
                    (query-metadata 404 card-id-1)))
             ;; card-id-2 still exists but its source is gone, so it should return empty metadata
             (is (=? {:fields empty?

--- a/test/metabase/query_processor/api_test.clj
+++ b/test/metabase/query_processor/api_test.clj
@@ -1042,12 +1042,18 @@
                     :databases [{:id (mt/id) :engine string?}]}
                    (query-metadata 200 card-id)))))
          #(testing "After delete"
-            (doseq [card-id [card-id-1 card-id-2]]
+            ;; card-id-1 is deleted, so querying it as a source returns empty tables
               (is (=?
                    {:fields    empty?
                     :tables    empty?
                     :databases [{:id (mt/id) :engine string?}]}
-                   (query-metadata 200 card-id))))))))))
+                 (query-metadata 200 card-id-1)))
+            ;; card-id-2 still exists, so querying it as a source still works
+            (is (=?
+                 {:fields empty?
+                  :tables [{:id (str "card__" card-id-2)}]
+                  :databases [{:id (mt/id) :engine string?}]}
+                 (query-metadata 200 card-id-2)))))))))
 
 (deftest published-table-does-not-grant-database-access-oss-test
   (testing "POST /api/dataset in OSS: published table access does NOT grant database access"

--- a/test/metabase/query_processor/api_test.clj
+++ b/test/metabase/query_processor/api_test.clj
@@ -1043,15 +1043,15 @@
                    (query-metadata 200 card-id)))))
          #(testing "After delete"
             ;; card-id-1 is deleted, so querying it as a source returns empty tables
-              (is (=?
-                   {:fields    empty?
-                    :tables    empty?
-                    :databases [{:id (mt/id) :engine string?}]}
+            (is (=?
+                 {:fields    empty?
+                  :tables    empty?
+                  :databases [{:id (mt/id) :engine string?}]}
                  (query-metadata 200 card-id-1)))
             ;; card-id-2 still exists, so querying it as a source still works
             (is (=?
-                 {:fields empty?
-                  :tables [{:id (str "card__" card-id-2)}]
+                 {:fields    empty?
+                  :tables    [{:id (str "card__" card-id-2)}]
                   :databases [{:id (mt/id) :engine string?}]}
                  (query-metadata 200 card-id-2)))))))))
 

--- a/test/metabase/search/appdb/index_test.clj
+++ b/test/metabase/search/appdb/index_test.clj
@@ -548,7 +548,7 @@
    "metabase_database" #{"action" "measure" "metabase_table" "model_index_value" "report_card" "segment"}
    "metabase_table"    #{"action" "measure" "model_index_value" "report_card" "segment"}
    "document"          #{"action" "model_index_value" "report_card"}
-   "report_card"       #{"action" "model_index_value" "report_card"}
+   "report_card"       #{"action" "model_index_value"}
    "report_dashboard"  #{"action" "model_index_value" "report_card"}})
 
 (deftest search-model-cascade-test

--- a/test/metabase/warehouse_schema_rest/api/table_test.clj
+++ b/test/metabase/warehouse_schema_rest/api/table_test.clj
@@ -843,8 +843,13 @@
                        :type              "question"}
                       (query-metadata 200 card-id)))))
          #(testing "After delete"
-            (doseq [card-id [card-id-1 card-id-2]]
-              (is (empty? (query-metadata 204 card-id))))))))))
+            ;; card-id-1 is deleted, so it returns 204 empty
+            (is (empty? (query-metadata 204 card-id-1)))
+            ;; card-id-2 still exists, so it returns 200 with metadata
+            (is (=? {:db_id (mt/id)
+                     :id (str "card__" card-id-2)
+                     :type "question"}
+                    (query-metadata 200 card-id-2)))))))))
 
 (deftest ^:parallel include-date-dimensions-in-nested-query-test
   (testing "GET /api/table/:id/query_metadata"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/68080

### Description

When a user creates a question based on a model, `source_card_id` is set to the model's ID. If that question is later converted to native SQL, `source_card_id` doesn't get cleared. This means that deleting the model will cause the question to be deleted even though they no longer have any relationship to one another.

The code fix won't help anyone who has already got incorrect data, so we have a migration to correct the inconsistent data. I added an assertion to the t2 hook to catch this at dev time in the future. And ultimately, the delete cascade seems overkill, so there's a migration to replace that with SET NULL instead.

### How to verify

Easy reproduction steps in original issue.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
