### PR TITLE
Broken & unreferenced entities - add pagination, expose tables

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1987,6 +1987,7 @@
            premium-features
            queries
            query-processor
+           request
            revisions
            settings
            task

--- a/e2e/test/scenarios/dependencies/dependency-unreferenced-list.cy.spec.ts
+++ b/e2e/test/scenarios/dependencies/dependency-unreferenced-list.cy.spec.ts
@@ -168,18 +168,8 @@ describe("scenarios > dependencies > unreferenced list", () => {
     });
 
     it("should filter by location", () => {
-      createEntities({ withPersonalCollection: true });
+      createEntities();
       H.DataStudio.Tasks.visitUnreferencedEntities();
-      checkList({
-        visibleEntities: [
-          MODEL_FOR_MODEL_DATA_SOURCE,
-          SNIPPET_FOR_NATIVE_QUESTION_CARD_TAG,
-        ],
-        hiddenEntities: [MODEL_FOR_METRIC_DATA_SOURCE],
-      });
-
-      H.DataStudio.Tasks.filterButton().click();
-      H.popover().findByText("Include items in personal collections").click();
       checkList({
         visibleEntities: [
           MODEL_FOR_MODEL_DATA_SOURCE,
@@ -188,6 +178,7 @@ describe("scenarios > dependencies > unreferenced list", () => {
         ],
       });
 
+      H.DataStudio.Tasks.filterButton().click();
       H.popover().findByText("Include items in personal collections").click();
       checkList({
         visibleEntities: [
@@ -195,6 +186,15 @@ describe("scenarios > dependencies > unreferenced list", () => {
           SNIPPET_FOR_NATIVE_QUESTION_CARD_TAG,
         ],
         hiddenEntities: [MODEL_FOR_METRIC_DATA_SOURCE],
+      });
+
+      H.popover().findByText("Include items in personal collections").click();
+      checkList({
+        visibleEntities: [
+          MODEL_FOR_MODEL_DATA_SOURCE,
+          MODEL_FOR_METRIC_DATA_SOURCE,
+          SNIPPET_FOR_NATIVE_QUESTION_CARD_TAG,
+        ],
       });
     });
   });
@@ -259,9 +259,8 @@ describe("scenarios > dependencies > unreferenced list", () => {
 
 function createEntities({
   withReferences = false,
-  withPersonalCollection = false,
-}: { withReferences?: boolean; withPersonalCollection?: boolean } = {}) {
-  createModelContent({ withReferences, withPersonalCollection });
+}: { withReferences?: boolean } = {}) {
+  createModelContent({ withReferences });
   createSegmentContent({ withReferences });
   createMetricContent({ withReferences });
   createSnippetContent({ withReferences });
@@ -269,10 +268,8 @@ function createEntities({
 
 function createModelContent({
   withReferences = false,
-  withPersonalCollection = false,
 }: {
   withReferences?: boolean;
-  withPersonalCollection?: boolean;
 }) {
   createModelWithTableDataSource({
     name: MODEL_FOR_QUESTION_DATA_SOURCE,
@@ -302,9 +299,7 @@ function createModelContent({
   createModelWithTableDataSource({
     name: MODEL_FOR_METRIC_DATA_SOURCE,
     tableId: ORDERS_ID,
-    collectionId: withPersonalCollection
-      ? ADMIN_PERSONAL_COLLECTION_ID
-      : undefined,
+    collectionId: ADMIN_PERSONAL_COLLECTION_ID,
   }).then(({ body: model }) => {
     if (withReferences) {
       createMetricWithModelDataSource({

--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -24,6 +24,7 @@
    [metabase.native-query-snippets.core :as native-query-snippets]
    [metabase.permissions.core :as perms]
    [metabase.queries.schema :as queries.schema]
+   [metabase.request.core :as request]
    [metabase.revisions.core :as revisions]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.malli :as mu]
@@ -660,9 +661,7 @@
                                   [:sequential (ms/enum-decode-keyword lib.schema.metadata/card-types)]]]
    [:query {:optional true} :string]
    [:archived {:optional true} :boolean]
-   [:include_personal_collections {:optional true} :boolean]
-   [:offset {:optional true} nat-int?]
-   [:limit {:optional true} ms/PositiveInt]])
+   [:include_personal_collections {:optional true} :boolean]])
 
 (def ^:private unreferenced-items-response
   [:map
@@ -693,10 +692,10 @@
    {:keys [types card_types query archived include_personal_collections offset limit]
     :or {types (vec deps.dependency-types/dependency-types)
          card_types (vec lib.schema.metadata/card-types)
-         include_personal_collections false
-         offset 0
-         limit 50}} :- unreferenced-items-args]
-  (let [include-archived-items (if archived :all :exclude)
+         include_personal_collections false}} :- unreferenced-items-args]
+  (let [offset (or (request/offset) 0)
+        limit (or (request/limit) 50)
+        include-archived-items (if archived :all :exclude)
         graph-opts {:include-archived-items include-archived-items}
         selected-types (cond->> (if (sequential? types) types [types])
                          ;; Sandboxes don't support query filtering, so exclude them when a query is provided
@@ -736,9 +735,7 @@
                                   [:sequential (ms/enum-decode-keyword lib.schema.metadata/card-types)]]]
    [:query {:optional true} :string]
    [:archived {:optional true} :boolean]
-   [:include_personal_collections {:optional true} :boolean]
-   [:offset {:optional true} nat-int?]
-   [:limit {:optional true} ms/PositiveInt]])
+   [:include_personal_collections {:optional true} :boolean]])
 
 (def ^:private broken-items-response
   [:map
@@ -768,10 +765,10 @@
    {:keys [types card_types query archived include_personal_collections offset limit]
     :or {types (vec deps.dependency-types/dependency-types)
          card_types (vec lib.schema.metadata/card-types)
-         include_personal_collections false
-         offset 0
-         limit 50}} :- broken-items-args]
-  (let [include-archived-items (if archived :all :exclude)
+         include_personal_collections false}} :- broken-items-args]
+  (let [offset (or (request/offset) 0)
+        limit (or (request/limit) 50)
+        include-archived-items (if archived :all :exclude)
         graph-opts {:include-archived-items include-archived-items}
         selected-types (cond->> (if (sequential? types) types [types])
                          ;; Sandboxes don't support query filtering, so exclude them when a query is provided

--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -689,7 +689,7 @@
    - `offset`: Applied offset
    - `limit`: Applied limit"
   [_route-params
-   {:keys [types card_types query archived include_personal_collections offset limit]
+   {:keys [types card_types query archived include_personal_collections]
     :or {types (vec deps.dependency-types/dependency-types)
          card_types (vec lib.schema.metadata/card-types)
          include_personal_collections false}} :- unreferenced-items-args]
@@ -762,7 +762,7 @@
    - `offset`: Applied offset
    - `limit`: Applied limit"
   [_route-params
-   {:keys [types card_types query archived include_personal_collections offset limit]
+   {:keys [types card_types query archived include_personal_collections]
     :or {types (vec deps.dependency-types/dependency-types)
          card_types (vec lib.schema.metadata/card-types)
          include_personal_collections false}} :- broken-items-args]

--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -692,8 +692,8 @@
                            selected-types)
         union-query {:union-all union-queries}
         all-ids (->> (t2/query (assoc union-query :order-by [[:sort_key :asc]]
-                                                  :limit limit
-                                                  :offset offset))
+                                      :limit limit
+                                      :offset offset))
                      (map (fn [{:keys [entity_id entity_type]}]
                             [(keyword entity_type) entity_id])))
         downstream-graph (graph/cached-graph (readable-graph-dependents graph-opts))
@@ -805,8 +805,8 @@
                            selected-types)
         union-query {:union-all union-queries}
         all-ids (->> (t2/query (assoc union-query :order-by [[:sort_key :asc]]
-                                                  :limit limit
-                                                  :offset offset))
+                                      :limit limit
+                                      :offset offset))
                      (map (fn [{:keys [entity_id entity_type]}]
                             [(keyword entity_type) entity_id])))
         downstream-graph (graph/cached-graph (readable-graph-dependents graph-opts))
@@ -814,10 +814,10 @@
                              :from [[union-query :subquery]]})
                   first
                   :total)]
-    {:data   (expanded-nodes downstream-graph all-ids {:include-errors? true}
+    {:data   (expanded-nodes downstream-graph all-ids {:include-errors? true})
      :limit  limit
      :offset offset
-     :total  total})))
+     :total  total}))
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/ee/dependencies` routes."

--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -683,7 +683,7 @@
    - `offset`: Default 0
    - `limit`: Default 50
 
-   Returns a a map with:
+   Returns a map with:
    - `data`: List of unreferenced items, each with `:id`, `:type`, and `:data` fields
    - `total`: Total count of matched items
    - `offset`: Applied offset

--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -756,7 +756,7 @@
    - `offset`: Default 0
    - `limit`: Default 50
 
-   Returns a a map with:
+   Returns a map with:
    - `data`: List of broken items, each with `:id`, `:type`, `:data`, and `:error`s fields
    - `total`: Total count of matched items
    - `offset`: Applied offset

--- a/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
@@ -1340,21 +1340,20 @@
 (deftest ^:sequential unreferenced-pagination-test
   (testing "GET /api/ee/dependencies/unreferenced - should paginate results"
     (mt/with-premium-features #{:dependencies}
-      (let [mp (mt/metadata-provider)]
-        (mt/with-temp [:model/Table {table1-id :id} {:name "Table 1 - unreftest"}
-                       :model/Table {table2-id :id} {:name "Table 2 - unreftest"}
-                       :model/Table {table3-id :id} {:name "Table 3 - unreftest"}]
-          (while (#'dependencies.backfill/backfill-dependencies!))
-          (is (=? {:data   [{:id table1-id} {:id table2-id}]
-                   :total  3
-                   :offset 0
-                   :limit  2}
-                  (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=table&query=unreftest&offset=0&limit=2")))
-          (is (=? {:data   [{:id table3-id}]
-                   :total  3
-                   :offset 2
-                   :limit  2}
-                  (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=table&query=unreftest&offset=2&limit=2"))))))))
+      (mt/with-temp [:model/Table {table1-id :id} {:name "Table 1 - unreftest"}
+                     :model/Table {table2-id :id} {:name "Table 2 - unreftest"}
+                     :model/Table {table3-id :id} {:name "Table 3 - unreftest"}]
+        (while (#'dependencies.backfill/backfill-dependencies!))
+        (is (=? {:data   [{:id table1-id} {:id table2-id}]
+                 :total  3
+                 :offset 0
+                 :limit  2}
+                (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=table&query=unreftest&offset=0&limit=2")))
+        (is (=? {:data   [{:id table3-id}]
+                 :total  3
+                 :offset 2
+                 :limit  2}
+                (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=table&query=unreftest&offset=2&limit=2")))))))
 
 (deftest ^:sequential broken-questions-test
   (testing "GET /api/ee/dependencies/broken - only broken questions are returned"

--- a/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
@@ -1337,6 +1337,25 @@
             (is (contains? table-ids inactive-table-id))
             (is (contains? table-ids hidden-table-id))))))))
 
+(deftest ^:sequential unreferenced-pagination-test
+  (testing "GET /api/ee/dependencies/unreferenced - should paginate results"
+    (mt/with-premium-features #{:dependencies}
+      (let [mp (mt/metadata-provider)]
+        (mt/with-temp [:model/Table {table1-id :id} {:name "Table 1 - unreftest"}
+                       :model/Table {table2-id :id} {:name "Table 2 - unreftest"}
+                       :model/Table {table3-id :id} {:name "Table 3 - unreftest"}]
+          (while (#'dependencies.backfill/backfill-dependencies!))
+          (is (=? {:data   [{:id table1-id} {:id table2-id}]
+                   :total  3
+                   :offset 0
+                   :limit  2}
+                  (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=table&query=unreftest&offset=0&limit=2"))
+              (is (=? {:data   [{:id table3-id}]
+                       :total  3
+                       :offset 2
+                       :limit  2}
+                      (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=table&query=unreftest&offset=2&limit=2")))))))))
+
 (deftest ^:sequential broken-questions-test
   (testing "GET /api/ee/dependencies/broken - only broken questions are returned"
     (mt/with-premium-features #{:dependencies}

--- a/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
@@ -1033,9 +1033,9 @@
                                                                                (lib/query mp))}]
           (while (#'dependencies.backfill/backfill-dependencies!))
           (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=card&card_types=question&query=unreftest")]
-            (is (=? [{:id unreffed-card-id
-                      :type "card"
-                      :data {:name "Unreferenced Card - unreftest"}}]
+            (is (=? {:data [{:id unreffed-card-id
+                             :type "card"
+                             :data {:name "Unreferenced Card - unreftest"}}]}
                     response))))))))
 
 (deftest ^:sequential unreferenced-tables-test
@@ -1049,9 +1049,9 @@
                                           :dataset_query (lib/query mp (lib.metadata/table mp referenced-table-id))}]
           (while (#'dependencies.backfill/backfill-dependencies!))
           (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=table&query=unreftest")]
-            (is (=? [{:id unreffed-table-id
-                      :type "table"
-                      :data {:name "Unreferenced Table - unreftest"}}]
+            (is (=? {:data [{:id unreffed-table-id
+                             :type "table"
+                             :data {:name "Unreferenced Table - unreftest"}}]}
                     response))))))))
 
 (deftest ^:sequential unreferenced-transforms-test
@@ -1079,9 +1079,9 @@
                                            :transform-id referenced-transform-id}})
           (while (#'dependencies.backfill/backfill-dependencies!))
           (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=transform&query=unreftest")]
-            (is (=? [{:id unreffed-transform-id
-                      :type "transform"
-                      :data {:name "Unreferenced Transform - unreftest"}}]
+            (is (=? {:data [{:id unreffed-transform-id
+                             :type "transform"
+                             :data {:name "Unreferenced Transform - unreftest"}}]}
                     response))))))))
 
 (deftest ^:sequential unreferenced-snippets-test
@@ -1104,9 +1104,9 @@
                                               :dataset_query native-query}]
               (while (#'dependencies.backfill/backfill-dependencies!))
               (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=snippet&query=unreftest")]
-                (is (=? [{:id unreffed-snippet-id
-                          :type "snippet"
-                          :data {:name "Unreferenced Snippet - unreftest"}}]
+                (is (=? {:data   [{:id unreffed-snippet-id
+                                   :type "snippet"
+                                   :data {:name "Unreferenced Snippet - unreftest"}}]}
                         response))))))))))
 
 (deftest ^:sequential unreferenced-dashboards-test
@@ -1124,9 +1124,9 @@
                                         :content_type "application/json+vnd.prose-mirror"}]
         (while (#'dependencies.backfill/backfill-dependencies!))
         (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=dashboard&query=unreftest")]
-          (is (=? [{:id unreffed-dashboard-id
-                    :type "dashboard"
-                    :data {:name "Unreferenced Dashboard - unreftest"}}]
+          (is (=? {:data [{:id unreffed-dashboard-id
+                           :type "dashboard"
+                           :data {:name "Unreferenced Dashboard - unreftest"}}]}
                   response)))))))
 
 (deftest ^:sequential unreferenced-documents-test
@@ -1142,9 +1142,9 @@
                                                                  :content_type "application/json+vnd.prose-mirror"}]
         (while (#'dependencies.backfill/backfill-dependencies!))
         (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=document&query=unreftest")]
-          (is (=? [{:id unreffed-document-id
-                    :type "document"
-                    :data {:name "Unreferenced Document - unreftest"}}]
+          (is (=? {:data [{:id unreffed-document-id
+                           :type "document"
+                           :data {:name "Unreferenced Document - unreftest"}}]}
                   response)))))))
 
 (deftest ^:sequential unreferenced-sandboxes-test
@@ -1161,9 +1161,9 @@
                                                         :card_id sandbox-card-id}]
           (while (#'dependencies.backfill/backfill-dependencies!))
           (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=sandbox")]
-            (is (=? [{:id sandbox-id
-                      :type "sandbox"
-                      :data {:table {:name "PRODUCTS"}}}]
+            (is (=? {:data [{:id sandbox-id
+                             :type "sandbox"
+                             :data {:table {:name "PRODUCTS"}}}]}
                     response))))))))
 
 (deftest ^:sequential unreferenced-card-types-test
@@ -1180,28 +1180,28 @@
           (while (#'dependencies.backfill/backfill-dependencies!))
           (testing "filtering by model only"
             (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=card&card_types=model&query=cardtype")]
-              (is (=? [{:id unreffed-model-id
-                        :type "card"
-                        :data {:name "A - Unreferenced Model - cardtype"
-                               :type "model"}}]
+              (is (=? {:data [{:id unreffed-model-id
+                               :type "card"
+                               :data {:name "A - Unreferenced Model - cardtype"
+                                      :type "model"}}]}
                       response))))
           (testing "filtering by metric only"
             (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=card&card_types=metric&query=cardtype")]
-              (is (=? [{:id unreffed-metric-id
-                        :type "card"
-                        :data {:name "B - Unreferenced Metric - cardtype"
-                               :type "metric"}}]
+              (is (=? {:data [{:id unreffed-metric-id
+                               :type "card"
+                               :data {:name "B - Unreferenced Metric - cardtype"
+                                      :type "metric"}}]}
                       response))))
           (testing "filtering by model and metric as the default card types"
             (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=card&query=cardtype")]
-              (is (=? [{:id unreffed-model-id
-                        :type "card"
-                        :data {:name "A - Unreferenced Model - cardtype"
-                               :type "model"}}
-                       {:id unreffed-metric-id
-                        :type "card"
-                        :data {:name "B - Unreferenced Metric - cardtype"
-                               :type "metric"}}]
+              (is (=? {:data [{:id unreffed-model-id
+                               :type "card"
+                               :data {:name "A - Unreferenced Model - cardtype"
+                                      :type "model"}}
+                              {:id unreffed-metric-id
+                               :type "card"
+                               :data {:name "B - Unreferenced Metric - cardtype"
+                                      :type "metric"}}]}
                       response)))))))))
 
 (deftest ^:sequential unreferenced-archived-card-test
@@ -1219,12 +1219,12 @@
           (while (#'dependencies.backfill/backfill-dependencies!))
           (testing "archived=false (default) excludes archived card"
             (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=card&card_types=question&query=archivedtest")
-                  card-ids (set (map :id response))]
+                  card-ids (set (map :id (:data response)))]
               (is (contains? card-ids unreffed-card-id))
               (is (not (contains? card-ids archived-card-id)))))
           (testing "archived=true includes archived card"
             (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=card&card_types=question&query=archivedtest&archived=true")
-                  card-ids (set (map :id response))]
+                  card-ids (set (map :id (:data response)))]
               (is (contains? card-ids unreffed-card-id))
               (is (contains? card-ids archived-card-id)))))))))
 
@@ -1237,12 +1237,12 @@
         (while (#'dependencies.backfill/backfill-dependencies!))
         (testing "archived=false (default) excludes archived dashboard"
           (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=dashboard&query=archivedtest")
-                dashboard-ids (set (map :id response))]
+                dashboard-ids (set (map :id (:data response)))]
             (is (contains? dashboard-ids unreffed-dashboard-id))
             (is (not (contains? dashboard-ids archived-dashboard-id)))))
         (testing "archived=true includes archived dashboard"
           (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=dashboard&query=archivedtest&archived=true")
-                dashboard-ids (set (map :id response))]
+                dashboard-ids (set (map :id (:data response)))]
             (is (contains? dashboard-ids unreffed-dashboard-id))
             (is (contains? dashboard-ids archived-dashboard-id))))))))
 
@@ -1255,12 +1255,12 @@
         (while (#'dependencies.backfill/backfill-dependencies!))
         (testing "archived=false (default) excludes archived document"
           (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=document&query=archivedtest")
-                document-ids (set (map :id response))]
+                document-ids (set (map :id (:data response)))]
             (is (contains? document-ids unreffed-document-id))
             (is (not (contains? document-ids archived-document-id)))))
         (testing "archived=true includes archived document"
           (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=document&query=archivedtest&archived=true")
-                document-ids (set (map :id response))]
+                document-ids (set (map :id (:data response)))]
             (is (contains? document-ids unreffed-document-id))
             (is (contains? document-ids archived-document-id))))))))
 
@@ -1275,12 +1275,12 @@
         (while (#'dependencies.backfill/backfill-dependencies!))
         (testing "archived=false (default) excludes archived snippet"
           (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=snippet&query=archivedtest")
-                snippet-ids (set (map :id response))]
+                snippet-ids (set (map :id (:data response)))]
             (is (contains? snippet-ids unreffed-snippet-id))
             (is (not (contains? snippet-ids archived-snippet-id)))))
         (testing "archived=true includes archived snippet"
           (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=snippet&query=archivedtest&archived=true")
-                snippet-ids (set (map :id response))]
+                snippet-ids (set (map :id (:data response)))]
             (is (contains? snippet-ids unreffed-snippet-id))
             (is (contains? snippet-ids archived-snippet-id))))))))
 
@@ -1301,12 +1301,12 @@
           (while (#'dependencies.backfill/backfill-dependencies!))
           (testing "archived=false (default) excludes archived segment"
             (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=segment&query=archivedtest")
-                  segment-ids (set (map :id response))]
+                  segment-ids (set (map :id (:data response)))]
               (is (contains? segment-ids unreffed-segment-id))
               (is (not (contains? segment-ids archived-segment-id)))))
           (testing "archived=true includes archived segment"
             (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=segment&query=archivedtest&archived=true")
-                  segment-ids (set (map :id response))]
+                  segment-ids (set (map :id (:data response)))]
               (is (contains? segment-ids unreffed-segment-id))
               (is (contains? segment-ids archived-segment-id)))))))))
 
@@ -1326,13 +1326,13 @@
         (while (#'dependencies.backfill/backfill-dependencies!))
         (testing "archived=false (default) excludes inactive and hidden tables"
           (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=table&query=archivedtest")
-                table-ids (set (map :id response))]
+                table-ids (set (map :id (:data response)))]
             (is (contains? table-ids active-table-id))
             (is (not (contains? table-ids inactive-table-id)))
             (is (not (contains? table-ids hidden-table-id)))))
         (testing "archived=true includes inactive and hidden tables"
           (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=table&query=archivedtest&archived=true")
-                table-ids (set (map :id response))]
+                table-ids (set (map :id (:data response)))]
             (is (contains? table-ids active-table-id))
             (is (contains? table-ids inactive-table-id))
             (is (contains? table-ids hidden-table-id))))))))
@@ -1350,9 +1350,9 @@
                                                          :dataset_query (lib/native-query mp "not a query")}]
           (while (> (dependencies.findings/analyze-batch! :card 50) 0))
           (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/broken?types=card&card_types=question&query=brokentest")]
-            (is (=? [{:id broken-card-id
-                      :type "card"
-                      :data {:name "Broken Card - brokentest"}}]
+            (is (=? {:data [{:id broken-card-id
+                             :type "card"
+                             :data {:name "Broken Card - brokentest"}}]}
                     response))))))))
 
 (deftest ^:sequential broken-transforms-test
@@ -1372,9 +1372,9 @@
                                                     :name "referenced_transform_table"}}]
           (while (> (dependencies.findings/analyze-batch! :transform 50) 0))
           (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/broken?types=transform&query=brokentest")]
-            (is (=? [{:id broken-transform-id
-                      :type "transform"
-                      :data {:name "Broken Transform - brokentest"}}]
+            (is (=? {:data [{:id broken-transform-id
+                             :type "transform"
+                             :data {:name "Broken Transform - brokentest"}}]}
                     response))))))))
 
 (deftest ^:sequential broken-card-types-test
@@ -1390,28 +1390,28 @@
           (while (> (dependencies.findings/analyze-batch! :card 50) 0))
           (testing "filtering by model only"
             (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/broken?types=card&card_types=model&query=cardtype")]
-              (is (=? [{:id broken-model-id
-                        :type "card"
-                        :data {:name "A - Broken Model - cardtype"
-                               :type "model"}}]
+              (is (=? {:data [{:id broken-model-id
+                               :type "card"
+                               :data {:name "A - Broken Model - cardtype"
+                                      :type "model"}}]}
                       response))))
           (testing "filtering by metric only"
             (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/broken?types=card&card_types=metric&query=cardtype")]
-              (is (=? [{:id broken-metric-id
-                        :type "card"
-                        :data {:name "B - Broken Metric - cardtype"
-                               :type "metric"}}]
+              (is (=? {:data [{:id broken-metric-id
+                               :type "card"
+                               :data {:name "B - Broken Metric - cardtype"
+                                      :type "metric"}}]}
                       response))))
           (testing "filtering by model and metric as the default card types"
             (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/broken?types=card&query=cardtype")]
-              (is (=? [{:id broken-model-id
-                        :type "card"
-                        :data {:name "A - Broken Model - cardtype"
-                               :type "model"}}
-                       {:id broken-metric-id
-                        :type "card"
-                        :data {:name "B - Broken Metric - cardtype"
-                               :type "metric"}}]
+              (is (=? {:data [{:id broken-model-id
+                               :type "card"
+                               :data {:name "A - Broken Model - cardtype"
+                                      :type "model"}}
+                              {:id broken-metric-id
+                               :type "card"
+                               :data {:name "B - Broken Metric - cardtype"
+                                      :type "metric"}}]}
                       response)))))))))
 
 (deftest ^:sequential broken-archived-card-test
@@ -1428,12 +1428,12 @@
           (while (> (dependencies.findings/analyze-batch! :card 50) 0))
           (testing "archived=false (default) excludes archived broken card"
             (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/broken?types=card&card_types=question&query=archivedbrokentestcard")
-                  card-ids (set (map :id response))]
+                  card-ids (set (map :id (:data response)))]
               (is (contains? card-ids broken-card-id))
               (is (not (contains? card-ids archived-broken-card-id)))))
           (testing "archived=true includes archived broken card"
             (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/broken?types=card&card_types=question&query=archivedbrokentestcard&archived=true")
-                  card-ids (set (map :id response))]
+                  card-ids (set (map :id (:data response)))]
               (is (contains? card-ids broken-card-id))
               (is (contains? card-ids archived-broken-card-id)))))))))
 
@@ -1451,12 +1451,12 @@
         (while (> (dependencies.findings/analyze-batch! :segment 50) 0))
         (testing "archived=false (default) excludes archived broken segment"
           (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/broken?types=segment&query=archivedbrokentest")
-                segment-ids (set (map :id response))]
+                segment-ids (set (map :id (:data response)))]
             (is (contains? segment-ids broken-segment-id))
             (is (not (contains? segment-ids archived-broken-segment-id)))))
         (testing "archived=true includes archived broken segment"
           (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/broken?types=segment&query=archivedbrokentest&archived=true")
-                segment-ids (set (map :id response))]
+                segment-ids (set (map :id (:data response)))]
             (is (contains? segment-ids broken-segment-id))
             (is (contains? segment-ids archived-broken-segment-id))))))))
 
@@ -1481,12 +1481,12 @@
           (while (#'dependencies.backfill/backfill-dependencies!))
           (testing "archived=false (default) excludes archived measure"
             (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=measure&query=archivedtest")
-                  measure-ids (set (map :id response))]
+                  measure-ids (set (map :id (:data response)))]
               (is (contains? measure-ids unreffed-measure-id))
               (is (not (contains? measure-ids archived-measure-id)))))
           (testing "archived=true includes archived measure"
             (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=measure&query=archivedtest&archived=true")
-                  measure-ids (set (map :id response))]
+                  measure-ids (set (map :id (:data response)))]
               (is (contains? measure-ids unreffed-measure-id))
               (is (contains? measure-ids archived-measure-id)))))))))
 
@@ -1515,13 +1515,13 @@
             (while (#'dependencies.backfill/backfill-dependencies!))
             (testing "include_personal_collections=false (default) excludes cards in personal collections"
               (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=card&card_types=question&query=personalcolltest")
-                    card-ids (set (map :id response))]
+                    card-ids (set (map :id (:data response)))]
                 (is (not (contains? card-ids card-in-personal)))
                 (is (not (contains? card-ids card-in-sub-personal)))
                 (is (contains? card-ids card-regular))))
             (testing "include_personal_collections=true includes cards in personal collections"
               (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=card&card_types=question&query=personalcolltest&include_personal_collections=true")
-                    card-ids (set (map :id response))]
+                    card-ids (set (map :id (:data response)))]
                 (is (contains? card-ids card-in-personal))
                 (is (contains? card-ids card-in-sub-personal))
                 (is (contains? card-ids card-regular))))))))))
@@ -1539,12 +1539,12 @@
           (while (#'dependencies.backfill/backfill-dependencies!))
           (testing "include_personal_collections=false (default) excludes dashboards in personal collections"
             (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=dashboard&query=personalcolltest")
-                  dashboard-ids (set (map :id response))]
+                  dashboard-ids (set (map :id (:data response)))]
               (is (not (contains? dashboard-ids dash-in-personal)))
               (is (contains? dashboard-ids dash-regular))))
           (testing "include_personal_collections=true includes dashboards in personal collections"
             (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=dashboard&query=personalcolltest&include_personal_collections=true")
-                  dashboard-ids (set (map :id response))]
+                  dashboard-ids (set (map :id (:data response)))]
               (is (contains? dashboard-ids dash-in-personal))
               (is (contains? dashboard-ids dash-regular)))))))))
 
@@ -1566,11 +1566,11 @@
             (while (> (dependencies.findings/analyze-batch! :card 50) 0))
             (testing "include_personal_collections=false (default) excludes broken cards in personal collections"
               (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/broken?types=card&card_types=question&query=personalcollbrokentest")
-                    card-ids (set (map :id response))]
+                    card-ids (set (map :id (:data response)))]
                 (is (not (contains? card-ids broken-in-personal)))
                 (is (contains? card-ids broken-regular))))
             (testing "include_personal_collections=true includes broken cards in personal collections"
               (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/broken?types=card&card_types=question&query=personalcollbrokentest&include_personal_collections=true")
-                    card-ids (set (map :id response))]
+                    card-ids (set (map :id (:data response)))]
                 (is (contains? card-ids broken-in-personal))
                 (is (contains? card-ids broken-regular))))))))))

--- a/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
@@ -1359,8 +1359,8 @@
 (deftest ^:sequential unreferenced-sample-db-test
   (testing "GET /api/ee/dependencies/unreferenced - should not return tables from the sample database"
     (mt/with-premium-features #{:dependencies}
-      (mt/with-temp [:model/Database {db-id :id}    {:is_sample true}
-                     :model/Table    {table-id :id} {:db_id db-id :name "Sample DB table - unreftest"}]
+      (mt/with-temp [:model/Database {db-id :id} {:is_sample true}
+                     :model/Table    _           {:db_id db-id :name "Sample DB table - unreftest"}]
         (is (=? {:data   []
                  :total  0}
                 (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=table&query=unreftest")))))))

--- a/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
@@ -1604,12 +1604,12 @@
                        :model/Card {card2-id :id} {:name "Card 2 - brokentest"
                                                    :type :question
                                                    :dataset_query (lib/native-query mp "not a query")}]
-          (while (#'dependencies.backfill/backfill-dependencies!))
+          (while (> (dependencies.findings/analyze-batch! :card 50) 0))
           (is (=? {:data   [{:id card1-id}]
                    :total  2
                    :offset 0
                    :limit  1}
-                  (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/broken?types=card&card_types=questionquery=brokentest&offset=0&limit=1")))
+                  (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/broken?types=card&card_types=question&query=brokentest&offset=0&limit=1")))
           (is (=? {:data   [{:id card2-id}]
                    :total  2
                    :offset 1

--- a/enterprise/frontend/src/metabase-enterprise/api/dependencies.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/dependencies.ts
@@ -7,8 +7,10 @@ import type {
   DependencyNode,
   GetDependencyGraphRequest,
   ListBrokenGraphNodesRequest,
+  ListBrokenGraphNodesResponse,
   ListNodeDependentsRequest,
   ListUnreferencedGraphNodesRequest,
+  ListUnreferencedGraphNodesResponse,
 } from "metabase-types/api";
 
 import { EnterpriseApi } from "./api";
@@ -43,7 +45,7 @@ export const dependencyApi = EnterpriseApi.injectEndpoints({
         nodes ? provideDependencyNodeListTags(nodes) : [],
     }),
     listBrokenGraphNodes: builder.query<
-      DependencyNode[],
+      ListBrokenGraphNodesResponse,
       ListBrokenGraphNodesRequest
     >({
       query: (params) => ({
@@ -51,11 +53,11 @@ export const dependencyApi = EnterpriseApi.injectEndpoints({
         url: "/api/ee/dependencies/graph/broken",
         params,
       }),
-      providesTags: (nodes) =>
-        nodes ? provideDependencyNodeListTags(nodes) : [],
+      providesTags: (response) =>
+        response ? provideDependencyNodeListTags(response.data) : [],
     }),
     listUnreferencedGraphNodes: builder.query<
-      DependencyNode[],
+      ListUnreferencedGraphNodesResponse,
       ListUnreferencedGraphNodesRequest
     >({
       query: (params) => ({
@@ -63,8 +65,8 @@ export const dependencyApi = EnterpriseApi.injectEndpoints({
         url: "/api/ee/dependencies/graph/unreferenced",
         params,
       }),
-      providesTags: (nodes) =>
-        nodes ? provideDependencyNodeListTags(nodes) : [],
+      providesTags: (response) =>
+        response ? provideDependencyNodeListTags(response.data) : [],
     }),
     checkCardDependencies: builder.query<
       CheckDependenciesResponse,

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/DependencyList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/DependencyList.tsx
@@ -14,8 +14,10 @@ import { getCardTypes, getDependencyTypes, isSameNode } from "../../utils";
 import S from "./DependencyList.module.css";
 import { ListBody } from "./ListBody";
 import { ListHeader } from "./ListHeader";
+import { ListPaginationControls } from "./ListPaginationControls";
 import { ListSearchBar } from "./ListSearchBar";
 import { ListSidebar } from "./ListSidebar";
+import { PAGE_SIZE } from "./constants";
 import type { DependencyListMode } from "./types";
 import { getAvailableGroupTypes } from "./utils";
 
@@ -38,17 +40,17 @@ export function DependencyList({
       : useListUnreferencedGraphNodesQuery;
   const availableGroupTypes = getAvailableGroupTypes(mode);
 
-  const {
-    data: nodes = [],
-    isFetching,
-    isLoading,
-    error,
-  } = useListGraphNodesQuery({
+  const { data, isFetching, isLoading, error } = useListGraphNodesQuery({
     query: params.query,
     types: getDependencyTypes(params.groupTypes ?? availableGroupTypes),
     card_types: getCardTypes(params.groupTypes ?? availableGroupTypes),
     include_personal_collections: params.includePersonalCollections,
+    offset: (params.page ?? 0) * PAGE_SIZE,
+    limit: PAGE_SIZE,
   });
+
+  const nodes = data?.data ?? [];
+  const totalNodesCount = data?.total ?? 0;
 
   const selectedNode =
     selectedEntry != null
@@ -75,6 +77,14 @@ export function DependencyList({
             mode={mode}
             isLoading={isLoading}
             onSelect={setSelectedEntry}
+          />
+        )}
+        {!isLoading && error == null && (
+          <ListPaginationControls
+            params={params}
+            pageNodesCount={nodes.length}
+            totalNodesCount={totalNodesCount}
+            onParamsChange={onParamsChange}
           />
         )}
       </Stack>

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/DependencyList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/DependencyList.tsx
@@ -19,7 +19,7 @@ import { ListSearchBar } from "./ListSearchBar";
 import { ListSidebar } from "./ListSidebar";
 import { PAGE_SIZE } from "./constants";
 import type { DependencyListMode } from "./types";
-import { getAvailableGroupTypes } from "./utils";
+import { getDefaultGroupTypes } from "./utils";
 
 type DependencyListProps = {
   mode: DependencyListMode;
@@ -38,12 +38,12 @@ export function DependencyList({
     mode === "broken"
       ? useListBrokenGraphNodesQuery
       : useListUnreferencedGraphNodesQuery;
-  const availableGroupTypes = getAvailableGroupTypes(mode);
+  const defaultGroupTypes = getDefaultGroupTypes(mode);
 
   const { data, isFetching, isLoading, error } = useListGraphNodesQuery({
     query: params.query,
-    types: getDependencyTypes(params.groupTypes ?? availableGroupTypes),
-    card_types: getCardTypes(params.groupTypes ?? availableGroupTypes),
+    types: getDependencyTypes(params.groupTypes ?? defaultGroupTypes),
+    card_types: getCardTypes(params.groupTypes ?? defaultGroupTypes),
     include_personal_collections: params.includePersonalCollections,
     offset: (params.page ?? 0) * PAGE_SIZE,
     limit: PAGE_SIZE,

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/DependencyList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/DependencyList.tsx
@@ -19,7 +19,7 @@ import { ListSearchBar } from "./ListSearchBar";
 import { ListSidebar } from "./ListSidebar";
 import { PAGE_SIZE } from "./constants";
 import type { DependencyListMode } from "./types";
-import { getDefaultGroupTypes } from "./utils";
+import { getAvailableGroupTypes } from "./utils";
 
 type DependencyListProps = {
   mode: DependencyListMode;
@@ -38,13 +38,13 @@ export function DependencyList({
     mode === "broken"
       ? useListBrokenGraphNodesQuery
       : useListUnreferencedGraphNodesQuery;
-  const defaultGroupTypes = getDefaultGroupTypes(mode);
+  const availableGroupTypes = getAvailableGroupTypes(mode);
 
   const { data, isFetching, isLoading, error } = useListGraphNodesQuery({
     query: params.query,
-    types: getDependencyTypes(params.groupTypes ?? defaultGroupTypes),
-    card_types: getCardTypes(params.groupTypes ?? defaultGroupTypes),
-    include_personal_collections: params.includePersonalCollections,
+    types: getDependencyTypes(params.groupTypes ?? availableGroupTypes),
+    card_types: getCardTypes(params.groupTypes ?? availableGroupTypes),
+    include_personal_collections: params.includePersonalCollections ?? true,
     offset: (params.page ?? 0) * PAGE_SIZE,
     limit: PAGE_SIZE,
   });

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListBody/utils.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListBody/utils.tsx
@@ -19,6 +19,7 @@ function getNodeNameColumn(): TreeTableColumnDef<DependencyNode> {
     id: "name",
     header: t`Name`,
     minWidth: 100,
+    enableSorting: false,
     accessorFn: (node) => getNodeLabel(node),
     cell: ({ row }) => {
       const node = row.original;
@@ -32,6 +33,7 @@ function getNodeLocationColumn(): TreeTableColumnDef<DependencyNode> {
     id: "location",
     header: t`Location`,
     minWidth: 100,
+    enableSorting: false,
     accessorFn: (node) => {
       const location = getNodeLocationInfo(node);
       const links = location?.links ?? [];
@@ -49,6 +51,7 @@ function getNodeErrorsColumn(): TreeTableColumnDef<DependencyNode> {
     id: "error",
     header: t`Errors`,
     minWidth: 100,
+    enableSorting: false,
     accessorFn: (node) => node.errors?.length ?? 0,
     cell: ({ row }) => {
       const node = row.original;
@@ -66,6 +69,7 @@ function getNodeDependentsCountColumn(): TreeTableColumnDef<DependencyNode> {
     id: "dependents-count",
     header: t`Downstream dependents`,
     minWidth: 100,
+    enableSorting: false,
     accessorFn: (node) => getNodeDependentsCount(node),
     cell: ({ row }) => {
       const node = row.original;

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListPaginationControls/ListPaginationControls.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListPaginationControls/ListPaginationControls.tsx
@@ -1,0 +1,35 @@
+import { PaginationControls } from "metabase/common/components/PaginationControls";
+import type * as Urls from "metabase/lib/urls";
+import { Flex } from "metabase/ui";
+
+import { PAGE_SIZE } from "../constants";
+
+type ListPaginationControlsProps = {
+  params: Urls.DependencyListParams;
+  pageNodesCount: number;
+  totalNodesCount: number;
+  onParamsChange: (params: Urls.DependencyListParams) => void;
+};
+
+export function ListPaginationControls({
+  params,
+  pageNodesCount,
+  totalNodesCount,
+  onParamsChange,
+}: ListPaginationControlsProps) {
+  const { page = 0 } = params;
+
+  return (
+    <Flex justify="end">
+      <PaginationControls
+        page={page}
+        pageSize={PAGE_SIZE}
+        itemsLength={pageNodesCount}
+        total={totalNodesCount}
+        showTotal
+        onPreviousPage={() => onParamsChange({ ...params, page: page - 1 })}
+        onNextPage={() => onParamsChange({ ...params, page: page + 1 })}
+      />
+    </Flex>
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListPaginationControls/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListPaginationControls/index.ts
@@ -1,0 +1,1 @@
+export * from "./ListPaginationControls";

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListSearchBar/FilterOptionsPicker/LocationFilterPicker/LocationFilterPicker.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListSearchBar/FilterOptionsPicker/LocationFilterPicker/LocationFilterPicker.tsx
@@ -13,13 +13,15 @@ export function LocationFilterPicker({
   params,
   onParamsChange,
 }: LocationFilterPickerProps) {
+  const { includePersonalCollections = true } = params;
+
   const handleIncludeInPersonalCollectionsChange = (
     event: ChangeEvent<HTMLInputElement>,
   ) => {
     const newValue = event.target.checked;
     onParamsChange({
       ...params,
-      includePersonalCollections: newValue || undefined,
+      includePersonalCollections: newValue,
     });
   };
 
@@ -28,6 +30,7 @@ export function LocationFilterPicker({
       <Stack gap="sm" mt="sm">
         <Checkbox
           label={t`Include items in personal collections`}
+          checked={includePersonalCollections}
           onChange={handleIncludeInPersonalCollectionsChange}
         />
       </Stack>

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListSearchBar/FilterOptionsPicker/TypeFilterPicker/TypeFilterPicker.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListSearchBar/FilterOptionsPicker/TypeFilterPicker/TypeFilterPicker.tsx
@@ -6,7 +6,7 @@ import { Checkbox, Stack } from "metabase/ui";
 
 import { getDependencyGroupTypeInfo } from "../../../../../utils";
 import type { DependencyListMode } from "../../../types";
-import { getAvailableGroupTypes, getDefaultGroupTypes } from "../../../utils";
+import { getAvailableGroupTypes } from "../../../utils";
 
 type TypeFilterPickerProps = {
   mode: DependencyListMode;
@@ -20,12 +20,11 @@ export function TypeFilterPicker({
   onParamsChange,
 }: TypeFilterPickerProps) {
   const availableGroupTypes = getAvailableGroupTypes(mode);
-  const defaultGroupTypes = getDefaultGroupTypes(mode);
 
   // preserve selected options in state to allow to deselect all types
   // until the popover is closed
   const [groupTypes, setGroupTypes] = useState(
-    params.groupTypes ?? defaultGroupTypes,
+    params.groupTypes ?? availableGroupTypes,
   );
 
   const groupOptions = availableGroupTypes.map((groupType) => ({
@@ -40,7 +39,10 @@ export function TypeFilterPicker({
     setGroupTypes(newGroupTypes);
     onParamsChange({
       ...params,
-      groupTypes: newGroupTypes,
+      groupTypes:
+        newGroupTypes.length === availableGroupTypes.length
+          ? undefined
+          : newGroupTypes,
     });
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListSearchBar/FilterOptionsPicker/TypeFilterPicker/TypeFilterPicker.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListSearchBar/FilterOptionsPicker/TypeFilterPicker/TypeFilterPicker.tsx
@@ -6,7 +6,7 @@ import { Checkbox, Stack } from "metabase/ui";
 
 import { getDependencyGroupTypeInfo } from "../../../../../utils";
 import type { DependencyListMode } from "../../../types";
-import { getAvailableGroupTypes } from "../../../utils";
+import { getAvailableGroupTypes, getDefaultGroupTypes } from "../../../utils";
 
 type TypeFilterPickerProps = {
   mode: DependencyListMode;
@@ -20,11 +20,12 @@ export function TypeFilterPicker({
   onParamsChange,
 }: TypeFilterPickerProps) {
   const availableGroupTypes = getAvailableGroupTypes(mode);
+  const defaultGroupTypes = getDefaultGroupTypes(mode);
 
   // preserve selected options in state to allow to deselect all types
   // until the popover is closed
   const [groupTypes, setGroupTypes] = useState(
-    params.groupTypes ?? availableGroupTypes,
+    params.groupTypes ?? defaultGroupTypes,
   );
 
   const groupOptions = availableGroupTypes.map((groupType) => ({
@@ -39,10 +40,7 @@ export function TypeFilterPicker({
     setGroupTypes(newGroupTypes);
     onParamsChange({
       ...params,
-      groupTypes:
-        newGroupTypes.length === availableGroupTypes.length
-          ? undefined
-          : newGroupTypes,
+      groupTypes: newGroupTypes,
     });
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListSidebar/SidebarLocationInfo/SidebarLocationInfo.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListSidebar/SidebarLocationInfo/SidebarLocationInfo.tsx
@@ -2,7 +2,7 @@ import { Fragment } from "react";
 import { Link } from "react-router";
 import { t } from "ttag";
 
-import { Anchor, Box, Card, Group, Icon, Stack, Title } from "metabase/ui";
+import { Anchor, Card, Group, Icon, Stack, Title } from "metabase/ui";
 import type { DependencyNode } from "metabase-types/api";
 
 import { getNodeLocationInfo } from "../../../../utils";
@@ -25,7 +25,7 @@ export function SidebarLocationInfo({ node }: SidebarLocationInfoProps) {
       <Card p="md" shadow="none" withBorder>
         {locationInfo.links.map((link, linkIndex) => (
           <Fragment key={linkIndex}>
-            {linkIndex > 0 && <Box>/</Box>}
+            {linkIndex > 0 && <span>/</span>}
             <Anchor component={Link} to={link.url} target="_blank">
               <Group gap="sm" wrap="nowrap">
                 {linkIndex === 0 && <Icon name={locationInfo.icon} />}

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/constants.ts
@@ -1,0 +1,1 @@
+export const PAGE_SIZE = 5;

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/constants.ts
@@ -1,1 +1,1 @@
-export const PAGE_SIZE = 5;
+export const PAGE_SIZE = 25;

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/utils.ts
@@ -2,7 +2,7 @@ import type { DependencyGroupType } from "metabase-types/api";
 
 import type { DependencyListMode } from "./types";
 
-const BROKEN_GROUP_TYPES: DependencyGroupType[] = [
+const ALL_BROKEN_GROUP_TYPES: DependencyGroupType[] = [
   "question",
   "model",
   "metric",
@@ -11,13 +11,40 @@ const BROKEN_GROUP_TYPES: DependencyGroupType[] = [
   "transform",
 ];
 
-const UNREFERENCED_GROUP_TYPES: DependencyGroupType[] = [
+const DEFAULT_BROKEN_GROUP_TYPES: DependencyGroupType[] = [
   "model",
   "metric",
   "segment",
+  "measure",
+  "transform",
+];
+
+const ALL_UNREFERENCED_GROUP_TYPES: DependencyGroupType[] = [
+  "table",
+  "question",
+  "model",
+  "metric",
+  "segment",
+  "measure",
+  "snippet",
+];
+
+const DEFAULT_UNREFERENCED_GROUP_TYPES: DependencyGroupType[] = [
+  "model",
+  "metric",
+  "segment",
+  "measure",
   "snippet",
 ];
 
 export function getAvailableGroupTypes(mode: DependencyListMode) {
-  return mode === "broken" ? BROKEN_GROUP_TYPES : UNREFERENCED_GROUP_TYPES;
+  return mode === "broken"
+    ? ALL_BROKEN_GROUP_TYPES
+    : ALL_UNREFERENCED_GROUP_TYPES;
+}
+
+export function getDefaultGroupTypes(mode: DependencyListMode) {
+  return mode === "broken"
+    ? DEFAULT_BROKEN_GROUP_TYPES
+    : DEFAULT_UNREFERENCED_GROUP_TYPES;
 }

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/utils.ts
@@ -2,7 +2,7 @@ import type { DependencyGroupType } from "metabase-types/api";
 
 import type { DependencyListMode } from "./types";
 
-const ALL_BROKEN_GROUP_TYPES: DependencyGroupType[] = [
+const BROKEN_GROUP_TYPES: DependencyGroupType[] = [
   "question",
   "model",
   "metric",
@@ -11,15 +11,7 @@ const ALL_BROKEN_GROUP_TYPES: DependencyGroupType[] = [
   "transform",
 ];
 
-const DEFAULT_BROKEN_GROUP_TYPES: DependencyGroupType[] = [
-  "model",
-  "metric",
-  "segment",
-  "measure",
-  "transform",
-];
-
-const ALL_UNREFERENCED_GROUP_TYPES: DependencyGroupType[] = [
+const UNREFERENCED_GROUP_TYPES: DependencyGroupType[] = [
   "table",
   "question",
   "model",
@@ -29,22 +21,6 @@ const ALL_UNREFERENCED_GROUP_TYPES: DependencyGroupType[] = [
   "snippet",
 ];
 
-const DEFAULT_UNREFERENCED_GROUP_TYPES: DependencyGroupType[] = [
-  "model",
-  "metric",
-  "segment",
-  "measure",
-  "snippet",
-];
-
 export function getAvailableGroupTypes(mode: DependencyListMode) {
-  return mode === "broken"
-    ? ALL_BROKEN_GROUP_TYPES
-    : ALL_UNREFERENCED_GROUP_TYPES;
-}
-
-export function getDefaultGroupTypes(mode: DependencyListMode) {
-  return mode === "broken"
-    ? DEFAULT_BROKEN_GROUP_TYPES
-    : DEFAULT_UNREFERENCED_GROUP_TYPES;
+  return mode === "broken" ? BROKEN_GROUP_TYPES : UNREFERENCED_GROUP_TYPES;
 }

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyListPage/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyListPage/types.ts
@@ -1,7 +1,6 @@
 export type DependencyListQueryParams = {
-  query?: unknown;
-  groupTypes?: unknown;
-  selectedId?: unknown;
-  selectedType?: unknown;
-  includePersonalCollections?: unknown;
+  page?: string;
+  query?: string;
+  groupTypes?: string | string[];
+  includePersonalCollections?: string;
 };

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyListPage/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyListPage/utils.ts
@@ -1,7 +1,13 @@
 import type * as Urls from "metabase/lib/urls";
 import { DEPENDENCY_GROUP_TYPES } from "metabase-types/api";
 
-import { parseBoolean, parseEnum, parseList, parseString } from "../../utils";
+import {
+  parseBoolean,
+  parseEnum,
+  parseList,
+  parseNumber,
+  parseString,
+} from "../../utils";
 
 import type { DependencyListQueryParams } from "./types";
 
@@ -9,6 +15,7 @@ export function parseParams(
   params: DependencyListQueryParams,
 ): Urls.DependencyListParams {
   return {
+    page: parseNumber(params.page),
     query: parseString(params.query),
     groupTypes: parseList(params.groupTypes, (item) =>
       parseEnum(item, DEPENDENCY_GROUP_TYPES),

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/utils.ts
@@ -732,6 +732,13 @@ export function parseString(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
 }
 
+export function parseNumber(value: unknown): number | undefined {
+  if (typeof value === "string") {
+    const number = Number(value);
+    return Number.isFinite(number) ? number : undefined;
+  }
+}
+
 export function parseBoolean(value: unknown): boolean | undefined {
   switch (value) {
     case "true":

--- a/frontend/src/metabase-types/api/dependencies.ts
+++ b/frontend/src/metabase-types/api/dependencies.ts
@@ -7,6 +7,7 @@ import type { Card, CardType } from "./card";
 import type { Dashboard } from "./dashboard";
 import type { Document } from "./document";
 import type { Measure } from "./measure";
+import type { PaginationRequest, PaginationResponse } from "./pagination";
 import type { Segment } from "./segment";
 import type { NativeQuerySnippet } from "./snippets";
 import type { Table, TableId } from "./table";
@@ -279,16 +280,24 @@ export type CheckSnippetDependenciesRequest = Pick<NativeQuerySnippet, "id"> &
 export type CheckTransformDependenciesRequest = Pick<Transform, "id"> &
   Partial<Pick<Transform, "source">>;
 
-export type ListBrokenGraphNodesRequest = {
+export type ListBrokenGraphNodesRequest = PaginationRequest & {
   types?: DependencyType[];
   card_types?: CardType[];
   query?: string;
   include_personal_collections?: boolean;
 };
 
-export type ListUnreferencedGraphNodesRequest = {
+export type ListBrokenGraphNodesResponse = PaginationResponse & {
+  data: DependencyNode[];
+};
+
+export type ListUnreferencedGraphNodesRequest = PaginationRequest & {
   types?: DependencyType[];
   card_types?: CardType[];
   query?: string;
   include_personal_collections?: boolean;
+};
+
+export type ListUnreferencedGraphNodesResponse = PaginationResponse & {
+  data: DependencyNode[];
 };

--- a/frontend/src/metabase/lib/urls/dependencies.ts
+++ b/frontend/src/metabase/lib/urls/dependencies.ts
@@ -27,17 +27,22 @@ export function dependencyTasks() {
 }
 
 export type DependencyListParams = {
+  page?: number;
   query?: string;
   groupTypes?: DependencyGroupType[];
   includePersonalCollections?: boolean;
 };
 
 function dependencyListQueryString({
+  page,
   query,
   groupTypes,
   includePersonalCollections,
 }: DependencyListParams = {}) {
   const searchParams = new URLSearchParams();
+  if (page != null) {
+    searchParams.set("page", String(page));
+  }
   if (query != null) {
     searchParams.set("query", query);
   }

--- a/frontend/src/metabase/metadata/components/UserInput.tsx
+++ b/frontend/src/metabase/metadata/components/UserInput.tsx
@@ -81,8 +81,8 @@ export const UserInput = ({
             <Icon name="mail" />
           </Avatar>
         ) : userId === "unknown" ? (
-          <Avatar color="bg-light" name="unknown">
-            <Icon name="person" c="text-medium" />
+          <Avatar color="background-secondary" name="unknown">
+            <Icon name="person" c="text-secondary" />
           </Avatar>
         ) : null
       }

--- a/frontend/src/metabase/metadata/components/UserInput.tsx
+++ b/frontend/src/metabase/metadata/components/UserInput.tsx
@@ -97,7 +97,7 @@ export const UserInput = ({
             {option.type === "user" && <Avatar name={item.option.label} />}
             {option.type === "unknown" && (
               <Avatar>
-                <Icon name="person" c="text-medium" />
+                <Icon name="person" c="text-secondary" />
               </Avatar>
             )}
             {option.type === "email" && (


### PR DESCRIPTION
Adds pagination to both views. Exposes tables in the UI. Removes duplication between `broken-query` and `unreferenced-query`.

With `PAGE_SIZE = 5` (default is 25):

<img width="1728" height="844" alt="Screenshot 2026-01-13 at 00 59 13" src="https://github.com/user-attachments/assets/02dac986-2616-4cdc-924b-1206fa9234f8" />
