### PR TITLE
Increase verbosity in the caching middleware

### DIFF
--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -233,22 +233,28 @@
   (not= (:type cache-strategy) :nocache))
 
 (defn- is-cacheable?
-  "Returns a map with :eligible? and :description detailing cache eligibility."
+  "Returns true if query caching is enabled and the query has a valid cache strategy."
+  [{:keys [cache-strategy], :as _query}]
+  (let [enabled?    (caching-enabled?)
+        has-strat?  (has-cache-strategy? cache-strategy)
+        not-nocache? (strategy-not-nocache? cache-strategy)]
+    (and enabled? has-strat? not-nocache?)))
+
+(defn- get-cache-eligibility-description
+  "Returns a descriptive string explaining why a query is or isn't cacheable."
   [{:keys [cache-strategy], :as _query}]
   (let [enabled?    (caching-enabled?)
         has-strat?  (has-cache-strategy? cache-strategy)
         not-nocache? (strategy-not-nocache? cache-strategy)]
     (if (and enabled? has-strat? not-nocache?)
-      {:eligible? true
-       :description (str "query caching is enabled; "
-                         "cache strategy provided: " (pr-str cache-strategy) "; "
-                         "cache strategy type is not :nocache")}
-      {:eligible? false
-       :description (str/join ", "
-                              (cond-> []
-                                (not enabled?)     (conj "query caching is disabled")
-                                (not has-strat?)   (conj "no cache strategy provided")
-                                (not not-nocache?) (conj "cache strategy is :nocache")))})))
+      (str "query caching is enabled; "
+           "cache strategy provided: " (pr-str cache-strategy) "; "
+           "cache strategy type is not :nocache")
+      (str/join ", "
+                (cond-> []
+                  (not enabled?)     (conj "query caching is disabled")
+                  (not has-strat?)   (conj "no cache strategy provided")
+                  (not not-nocache?) (conj "cache strategy is :nocache"))))))
 
 (mu/defn maybe-return-cached-results :- ::qp.schema/qp
   "Middleware for caching results of a query if applicable.
@@ -264,8 +270,9 @@
      *  The result *rows* of the query must be less than `query-caching-max-kb` when serialized (before compression)."
   [qp :- ::qp.schema/qp]
   (fn maybe-return-cached-results* [query rff]
-    (let [{:keys [eligible? description]} (is-cacheable? query)]
-      (log/tracef "Query is %scacheable: %s" (if-not eligible? "not " "") description)
-      (if eligible?
+    (let [cacheable? (is-cacheable? query)
+          description (get-cache-eligibility-description query)]
+      (log/tracef "Query is %scacheable: %s" (if-not cacheable? "not " "") description)
+      (if cacheable?
         (run-query-with-cache qp query rff)
         (qp query rff)))))

--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -232,7 +232,7 @@
 (defn- strategy-not-nocache? [cache-strategy]
   (not= (:type cache-strategy) :nocache))
 
-(defn- get-cache-eligibility-details [{:keys [cache-strategy], :as _query}]
+(defn- is-cacheable? [{:keys [cache-strategy], :as _query}]
   "Returns a map with :eligible? and :description detailing cache eligibility."
   (let [enabled?    (caching-enabled?)
         has-strat?  (has-cache-strategy? cache-strategy)
@@ -263,7 +263,7 @@
      *  The result *rows* of the query must be less than `query-caching-max-kb` when serialized (before compression)."
   [qp :- ::qp.schema/qp]
   (fn maybe-return-cached-results* [query rff]
-    (let [{:keys [eligible? description]} (get-cache-eligibility-details query)]
+    (let [{:keys [eligible? description]} (is-cacheable? query)]
       (log/tracef "Query is %scacheable: %s" (if-not eligible? "not ") description)
       (if eligible?
         (run-query-with-cache qp query rff)

--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -232,8 +232,9 @@
 (defn- strategy-not-nocache? [cache-strategy]
   (not= (:type cache-strategy) :nocache))
 
-(defn- is-cacheable? [{:keys [cache-strategy], :as _query}]
+(defn- is-cacheable?
   "Returns a map with :eligible? and :description detailing cache eligibility."
+  [{:keys [cache-strategy], :as _query}]
   (let [enabled?    (caching-enabled?)
         has-strat?  (has-cache-strategy? cache-strategy)
         not-nocache? (strategy-not-nocache? cache-strategy)]
@@ -264,7 +265,7 @@
   [qp :- ::qp.schema/qp]
   (fn maybe-return-cached-results* [query rff]
     (let [{:keys [eligible? description]} (is-cacheable? query)]
-      (log/tracef "Query is %scacheable: %s" (if-not eligible? "not ") description)
+      (log/tracef "Query is %scacheable: %s" (if-not eligible? "not " "") description)
       (if eligible?
         (run-query-with-cache qp query rff)
         (qp query rff)))))

--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -9,6 +9,7 @@
   about how the cache backends themselves."
   (:refer-clojure :exclude [get-in])
   (:require
+   [clojure.string :as str]
    [java-time.api :as t]
    [medley.core :as m]
    [metabase.cache.core :as cache]
@@ -229,9 +230,9 @@
         all-conditions-met? (and caching-enabled? has-strategy? not-nocache?)]
     (if all-conditions-met?
       {:cacheable? true
-       :conditions [(str "query caching is enabled")
+       :conditions ["query caching is enabled"
                     (str "cache strategy provided: " (pr-str cache-strategy))
-                    (str "cache strategy type is not :nocache")]}
+                    "cache strategy type is not :nocache"]}
       {:cacheable? false
        :reasons    (cond-> []
                      (not caching-enabled?) (conj "query caching is disabled")
@@ -254,8 +255,8 @@
   (fn maybe-return-cached-results* [query rff]
     (let [{:keys [cacheable? reasons conditions]} (is-cacheable? query)]
       (if cacheable?
-        (log/tracef "Query is cacheable: %s" (clojure.string/join "; " conditions))
-        (log/tracef "Query is not cacheable: %s" (clojure.string/join ", " reasons)))
+        (log/tracef "Query is cacheable: %s" (str/join "; " conditions))
+        (log/tracef "Query is not cacheable: %s" (str/join ", " reasons)))
       (if cacheable?
         (run-query-with-cache qp query rff)
         (qp query rff)))))


### PR DESCRIPTION
Can't see why a query is not being cached (when it should) so I'm adding more verbosity to the middleware

New logs when there's a cacheable query: TRACE metabase.query-processor.middleware.cache Query is cacheable: query caching is enabled; cache strategy provided: {:unit "hours", :duration 24, :type :duration, :refresh_automatically false}; cache strategy type is not :nocache
