### PR TITLE
Row chart tooltip doesn't reflect column rename

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/RowChart/utils/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/utils/events.ts
@@ -91,9 +91,13 @@ const getColumnsData = (
   datasetColumns: DatasetColumn[],
   visualizationSettings: VisualizationSettings,
 ) => {
+  const dimensionKey =
+    visualizationSettings["graph.x_axis.title_text"] ??
+    chartColumns.dimension.column.display_name;
+
   const data = [
     {
-      key: chartColumns.dimension.column.display_name,
+      key: dimensionKey,
       value: formatNullable(datum.dimensionValue),
       col: chartColumns.dimension.column,
     },

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/utils/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/utils/events.ts
@@ -91,13 +91,13 @@ const getColumnsData = (
   datasetColumns: DatasetColumn[],
   visualizationSettings: VisualizationSettings,
 ) => {
-  const dimensionKey =
+  const columnTitle =
     visualizationSettings["graph.x_axis.title_text"] ??
     chartColumns.dimension.column.display_name;
 
   const data = [
     {
-      key: dimensionKey,
+      key: columnTitle,
       value: formatNullable(datum.dimensionValue),
       col: chartColumns.dimension.column,
     },

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/utils/events.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/utils/events.unit.spec.ts
@@ -89,6 +89,24 @@ const barData: BarData<GroupedDatum> = {
 
 describe("events utils", () => {
   describe("getHoverData", () => {
+    it("returns dimension key based on axis title setting when set", () => {
+      const keyValueData = getHoverData(
+        barData,
+        {
+          "graph.x_axis.title_text": "My Custom Dimension Label",
+        },
+        {
+          dimension: chartColumns.dimension,
+          metrics: [chartColumns.metrics[0]],
+        },
+        datasetColumns,
+        [series1],
+        seriesColors,
+      ).data;
+
+      expect(keyValueData?.[0].key).toBe("My Custom Dimension Label");
+    });
+
     it("returns key-value pairs based on series_settings for charts without a breakout", () => {
       const keyValueData = getHoverData(
         barData,


### PR DESCRIPTION
Closes [UXW-2666](https://linear.app/metabase/issue/UXW-2666/row-chart-tooltip-doesnt-reflect-column-rename) → #67778

### Description

This PR fixes chart tooltips to prefer using the dimension's label instead of the original name. Users would often change the label of a dimension but tooltips would keep displaying the dimension's actual name instead of the defined by the user.

### How to verify

1. Go to New Question -> Products -> Count by Created at: Month
2. Change the Axis Name from Created at: Month to Month
3. Swap to a row chart and hover over each row, the tooltip should display "Month" instead of "Created at: Month"

### Demo

![CleanShot 2026-01-13 at 12 49 51](https://github.com/user-attachments/assets/ab2e4802-848a-4945-b2f5-91002ee0b510)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
