### PR TITLE
Fixes computing columns for Question -> Question -> Model on the FE

### DIFF
--- a/src/metabase/lib/card.cljc
+++ b/src/metabase/lib/card.cljc
@@ -254,9 +254,10 @@
                             (source-model-card metadata-providerable card))
             model-cols    (when model-card
                             (card-cols* metadata-providerable model-card))
-            native-model? (when model-card
-                            (-> (card->underlying-query metadata-providerable model-card)
-                                (lib.util/native-stage? -1)))]
+            native-model? (and (some? model-card)
+                               (some? (:dataset-query model-card))
+                               (-> (card->underlying-query metadata-providerable model-card)
+                                   (lib.util/native-stage? -1)))]
         (not-empty
          (into []
                ;; do not truncate the desired column aliases coming back in card metadata, if the query returns a

--- a/src/metabase/lib/card.cljc
+++ b/src/metabase/lib/card.cljc
@@ -254,6 +254,9 @@
                             (source-model-card metadata-providerable card))
             model-cols    (when model-card
                             (card-cols* metadata-providerable model-card))
+            ;; the BE passes metadata to the FE as virtual tables that contain `:type` and `:fields` but not `:dataset-query`
+            ;; in this case we should not override the `:id` and assume that the `card` metadata is up-to-date
+            ;; see (metabase#68012) for more details
             native-model? (and (some? model-card)
                                (some? (:dataset-query model-card))
                                (-> (card->underlying-query metadata-providerable model-card)

--- a/test/metabase/lib/card_test.cljc
+++ b/test/metabase/lib/card_test.cljc
@@ -624,3 +624,26 @@
             ["Product__RATING" true]]
            (map (juxt :lib/desired-column-alias :active)
                 (lib/returned-columns query))))))
+
+(deftest ^:parallel card-returned-columns-source-model-without-query-test
+  (testing "should not throw when the source model does not have a query (metabase#68012)"
+    (let [model-id    1
+          model-query (lib/query meta/metadata-provider (meta/table-metadata :orders))
+          mp         (lib.tu/mock-metadata-provider
+                      meta/metadata-provider
+                       ;; intentionally omitting `:dataset-query`
+                      {:cards [{:id              model-id
+                                :type            :model
+                                :database-id     (meta/id)
+                                :result-metadata (lib/returned-columns model-query)}]})
+          question-id   2
+          question-query (lib/query mp (lib.metadata/card mp model-id))
+          mp         (lib.tu/mock-metadata-provider
+                      mp
+                      {:cards [{:id              question-id
+                                :type            :question
+                                :database-id     (meta/id)
+                                :dataset-query   question-query
+                                :result-metadata (lib/returned-columns question-query)}]})
+          adhoc-query      (lib/query mp (lib.metadata/card mp question-id))]
+      (is (some? (lib/returned-columns adhoc-query))))))

--- a/test/metabase/lib/card_test.cljc
+++ b/test/metabase/lib/card_test.cljc
@@ -627,23 +627,23 @@
 
 (deftest ^:parallel card-returned-columns-source-model-without-query-test
   (testing "should not throw when the source model does not have a query (metabase#68012)"
-    (let [model-id    1
+    (let [model-id 1
           model-query (lib/query meta/metadata-provider (meta/table-metadata :orders))
-          mp         (lib.tu/mock-metadata-provider
-                      meta/metadata-provider
-                       ;; intentionally omitting `:dataset-query`
-                      {:cards [{:id              model-id
-                                :type            :model
-                                :database-id     (meta/id)
-                                :result-metadata (lib/returned-columns model-query)}]})
-          question-id   2
+          mp (lib.tu/mock-metadata-provider
+              meta/metadata-provider
+               ;; intentionally omitting `:dataset-query`
+              {:cards [{:id              model-id
+                        :type            :model
+                        :database-id     (meta/id)
+                        :result-metadata (lib/returned-columns model-query)}]})
+          question-id 2
           question-query (lib/query mp (lib.metadata/card mp model-id))
-          mp         (lib.tu/mock-metadata-provider
-                      mp
-                      {:cards [{:id              question-id
-                                :type            :question
-                                :database-id     (meta/id)
-                                :dataset-query   question-query
-                                :result-metadata (lib/returned-columns question-query)}]})
-          adhoc-query      (lib/query mp (lib.metadata/card mp question-id))]
+          mp (lib.tu/mock-metadata-provider
+              mp
+              {:cards [{:id              question-id
+                        :type            :question
+                        :database-id     (meta/id)
+                        :dataset-query   question-query
+                        :result-metadata (lib/returned-columns question-query)}]})
+          adhoc-query (lib/query mp (lib.metadata/card mp question-id))]
       (is (some? (lib/returned-columns adhoc-query))))))


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/68012
Regression since https://github.com/metabase/metabase/pull/67773 (v58 only)

The original PR broke a case on the FE where we might have a virtual table for a model but not a card object. In this PR, I add a check for the dataset query and assume that we should not override the column `:id` in this case; relying on the intermediate question metadata to be up-to-date. 