### PR TITLE
Transforms job runs keep trying other transforms if one fails.

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2326,6 +2326,7 @@
            premium-features
            queries
            query-processor
+           revisions
            request
            search
            settings

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2316,6 +2316,7 @@
    :uses #{analytics
            api
            app-db
+           channel
            collections
            driver
            events

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2326,8 +2326,8 @@
            premium-features
            queries
            query-processor
-           revisions
            request
+           revisions
            search
            settings
            sync

--- a/enterprise/backend/src/metabase_enterprise/transforms/jobs.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/jobs.clj
@@ -139,7 +139,7 @@
       (email/send-message! {:subject (i18n/trun "[Metabase] Failed transform run" "Failed transform runs" (count failures))
                             :recipients [(:email user)]
                             :message-type :text
-                            :message (i18n/trs "Hello,\n\nThe following {0} occured when running the transform job called {1}:\n\n{2}\n\nVisit {3} for more information.\n\nThanks\n\nYour Metabase job scheduler"
+                            :message (i18n/trs "Hello,\n\nThe following {0} occurred when running the transform job called {1}:\n\n{2}\n\nVisit {3} for more information.\n\nThanks\n\nYour Metabase job scheduler"
                                                (i18n/trun "failure" "failures" (count failures))
                                                (:name job)
                                                (compile-transform-failure-messages failures)
@@ -151,7 +151,7 @@
     (email/send-message! {:subject (i18n/trs "[Metabase] Failed transform job")
                           :recipients admin-emails
                           :message-type :text
-                          :message (i18n/trs "Hello,\n\nThe following errors occured when running the transform job called {0}:\n\n{1}\n\nVisit {2} for more information.\n\nThanks\n\nYour Metabase job scheduler"
+                          :message (i18n/trs "Hello,\n\nThe following errors occurred when running the transform job called {0}:\n\n{1}\n\nVisit {2} for more information.\n\nThanks\n\nYour Metabase job scheduler"
                                              (:name job)
                                              message
                                              (urls/transform-job-url job-id))})))

--- a/enterprise/backend/src/metabase_enterprise/transforms/jobs.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/jobs.clj
@@ -87,7 +87,7 @@
   "Run a series of transforms and their dependencies.
 
   Updates the transform-job-run specified by run-id after every completion.
-  Returns a map with :status and a :message if failed."
+  Returns a map with :status and a collection of :failures if failed."
   [run-id transform-ids-to-run {:keys [run-method start-promise]}]
   (let [{plan :order deps :deps} (get-plan transform-ids-to-run)
         successful (volatile! #{})

--- a/enterprise/backend/src/metabase_enterprise/transforms/jobs.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/jobs.clj
@@ -212,9 +212,7 @@
                               :job_name (:name job)
                               :job_href (urls/transform-job-url job-id)
                               :failure_count 1
-                              :failures [{:transform_name (:name job)
-                                          :transform_href (urls/transform-job-url job-id)
-                                          :message (structure-message message)}]}))))
+                              :failures [{:message (structure-message message)}]}))))
 
 (defn run-job!
   "Runs all transforms for a given job and their dependencies."

--- a/enterprise/backend/src/metabase_enterprise/transforms/jobs.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/jobs.clj
@@ -98,7 +98,7 @@
           (run-transform! run-id run-method transform)
           (vswap! successful conj (:id transform))
           (catch Exception e
-            (vswap! messages conj (str "Tranform " (:name transform) " failed: " (.getMessage e)))))))
+            (vswap! messages conj (str (:name transform) ":\n" (.getMessage e)))))))
 
     (if @messages
       {:status :failed
@@ -138,7 +138,8 @@
                 :failed (transforms.job-run/fail-started-run! run-id {:message (:message result)})))
             (catch Throwable t
               (transforms.job-run/fail-started-run! run-id {:message (.getMessage t)})
-              (throw t))))))))
+              (throw t))))
+        run-id))))
 
 (def ^:private job-key "metabase-enterprise.transforms.jobs.timeout-job")
 

--- a/enterprise/backend/src/metabase_enterprise/transforms/jobs.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/jobs.clj
@@ -131,7 +131,11 @@
   (:order (get-plan (job-transform-ids job-id))))
 
 (defn- compile-transform-failure-messages [failures]
-  (str/join "\n\n" (map #(str (:name (:transform %)) ":\n" (:message %)) failures)))
+  (str/join "\n\n" (map #(format "%s %s:\n%s"
+                                 (:name (:transform %))
+                                 (urls/transform-run-url
+                                  (:id (:transform %)))
+                                 (:message %)) failures)))
 
 (defn- notify-transform-failures [job-id failures]
   (let [job (t2/select-one :model/TransformJob job-id)
@@ -144,7 +148,7 @@
       (email/send-message! {:subject (i18n/trun "[Metabase] Failed transform run" "Failed transform runs" (count failures))
                             :recipients [(:email user)]
                             :message-type :text
-                            :message (i18n/trs "Hello,\n\nThe following {0} occurred when running the transform job called {1}:\n\n{2}\n\nVisit {3} for more information.\n\nThanks\n\nYour Metabase job scheduler"
+                            :message (i18n/trs "Hello,\n\nThe following {0} occurred when running the transform job called {1}:\n\n{2}\n\nVisit {3} for more information."
                                                (i18n/trun "failure" "failures" (count failures))
                                                (:name job)
                                                (compile-transform-failure-messages failures)
@@ -156,7 +160,7 @@
     (email/send-message! {:subject (i18n/trs "[Metabase] Failed transform job")
                           :recipients admin-emails
                           :message-type :text
-                          :message (i18n/trs "Hello,\n\nThe following errors occurred when running the transform job called {0}:\n\n{1}\n\nVisit {2} for more information.\n\nThanks\n\nYour Metabase job scheduler"
+                          :message (i18n/trs "Hello,\n\nThe following errors occurred when running the transform job called {0}:\n\n{1}\n\nVisit {2} for more information."
                                              (:name job)
                                              message
                                              (urls/transform-job-url job-id))})))

--- a/enterprise/backend/src/metabase_enterprise/transforms/jobs.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/jobs.clj
@@ -106,7 +106,7 @@
         (vswap! failures conj {:transform transform
                                :message (i18n/trs "Failed to run because one or more of the transforms it depends on failed.")})))
 
-    (if @failures
+    (if (seq @failures)
       {:status :failed
        :failures @failures}
       {:status :succeeded})))

--- a/enterprise/backend/src/metabase_enterprise/transforms/jobs.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/jobs.clj
@@ -136,8 +136,6 @@
         by-owner (group-by (comp :creator_id :transform) failures)]
     (doseq [[user-id failures] by-owner
             :let [user (t2/select-one :model/User user-id)]]
-      (println "Sending message:")
-      (prn user)
       (email/send-message! {:subject (i18n/trun "[Metabase] Failed transform run" "Failed transform runs" (count failures))
                             :recipients [(:email user)]
                             :message-type :text

--- a/enterprise/backend/test/metabase_enterprise/transforms/jobs_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/jobs_test.clj
@@ -11,6 +11,7 @@
    [metabase-enterprise.transforms.test-util :refer [with-transform-cleanup!]]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.notification.seed :as notification.seed]
    [metabase.query-processor.compile :as qp.compile]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
@@ -153,187 +154,187 @@
   (mt/with-premium-features #{:transforms}
     (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
       (mt/dataset transforms-dataset/transforms-test
-        (mt/with-fake-inbox
-          (let [mp (mt/metadata-provider)
-                table (t2/select-one :model/Table (mt/id :transforms_products))
-                ;; generate sql for different dbs
-                sql (-> (lib/query mp (lib.metadata/table mp (mt/id :transforms_products)))
-                        (lib/with-fields [(lib.metadata/field mp (mt/id :transforms_products :name))])
-                        (lib/limit 10)
-                        qp.compile/compile
-                        :query)]
-            (with-transform-cleanup! [target0 {:type   "table"
-                                               :schema (:schema table)
-                                               :name "t0"}]
-              (mt/with-temp [:model/TransformTag tag {:name "test-tag"}
-                             :model/TransformJob job {:name "test-job"
-                                                      :schedule "0 0 * * * ? *"}
-                             :model/TransformJobTransformTag _ {:job_id (:id job)
-                                                                :tag_id (:id tag)
-                                                                :position 0}
-                             ;; independent transform
-                             :model/Transform t0 {:name   "transform0"
-                                                  :source {:type  :query
-                                                           :query (lib/native-query mp sql)}
-                                                  :creator_id (mt/user->id :crowberto)
-                                                  :target target0}
-                             :model/TransformTransformTag _tag0 {:transform_id (:id t0)
-                                                                 :tag_id (:id tag)
-                                                                 :position 0}]
-                (let [run-id-atom (atom nil)]
-                  (with-redefs [jobs/run-transforms! (fn [run-id & _]
-                                                       (reset! run-id-atom run-id)
-                                                       (throw (ex-info "Uncaught error" {})))]
-                    (try
-                      (jobs/run-job! (:id job) {:run-method :cron})
-                      (catch clojure.lang.ExceptionInfo _))
-                    (try
+        (mt/with-model-cleanup [:model/Notification
+                                :model/TransformJobRun]
+          (mt/with-fake-inbox
+            (notification.seed/seed-notification!)
+            (let [mp (mt/metadata-provider)
+                  table (t2/select-one :model/Table (mt/id :transforms_products))
+                  ;; generate sql for different dbs
+                  sql (-> (lib/query mp (lib.metadata/table mp (mt/id :transforms_products)))
+                          (lib/with-fields [(lib.metadata/field mp (mt/id :transforms_products :name))])
+                          (lib/limit 10)
+                          qp.compile/compile
+                          :query)]
+              (with-transform-cleanup! [target0 {:type "table"
+                                                 :schema (:schema table)
+                                                 :name "t0"}]
+                (mt/with-temp [:model/TransformTag tag {:name "test-tag"}
+                               :model/TransformJob job {:name "test-job"
+                                                        :schedule "0 0 * * * ? *"}
+                               :model/TransformJobTransformTag _ {:job_id (:id job)
+                                                                  :tag_id (:id tag)
+                                                                  :position 0}
+                               ;; independent transform
+                               :model/Transform t0 {:name "transform0"
+                                                    :source {:type :query
+                                                             :query (lib/native-query mp sql)}
+                                                    :creator_id (mt/user->id :crowberto)
+                                                    :target target0}
+                               :model/TransformTransformTag _tag0 {:transform_id (:id t0)
+                                                                   :tag_id (:id tag)
+                                                                   :position 0}]
+                  (let [run-id-atom (atom nil)]
+                    (with-redefs [jobs/run-transforms! (fn [run-id & _]
+                                                         (reset! run-id-atom run-id)
+                                                         (throw (ex-info "Uncaught error" {})))]
+                      (try
+                        (jobs/run-job! (:id job) {:run-method :cron})
+                        (catch clojure.lang.ExceptionInfo _))
                       (is (some? @run-id-atom))
                       (is (=? {:status :failed
                                :message string?}
                               (t2/select-one :model/TransformJobRun :id @run-id-atom)))
-                      (is (mt/received-email-subject? :crowberto #"Failed transform job"))
-                      (is (mt/received-email-body? :crowberto #"Uncaught error"))
-                      (finally ;; I don't know why transform_job_run is not cascaded from transform_job
-                        (when @run-id-atom
-                          (t2/delete! :model/TransformJobRun :id @run-id-atom))))))))))))))
+                        ;; crowberto is a superuser/admin, so they receive the notification
+                      (is (mt/received-email-subject? :crowberto #"Transform job failed: test-job"))
+                      (is (mt/received-email-body? :crowberto #"Uncaught error")))))))))))))
 
 (deftest job-run-boom-manual-no-email-test
   (mt/with-premium-features #{:transforms}
     (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
       (mt/dataset transforms-dataset/transforms-test
-        (mt/with-fake-inbox
-          (let [mp (mt/metadata-provider)
-                table (t2/select-one :model/Table (mt/id :transforms_products))
-                ;; generate sql for different dbs
-                sql (-> (lib/query mp (lib.metadata/table mp (mt/id :transforms_products)))
-                        (lib/with-fields [(lib.metadata/field mp (mt/id :transforms_products :name))])
-                        (lib/limit 10)
-                        qp.compile/compile
-                        :query)]
-            (with-transform-cleanup! [target0 {:type   "table"
-                                               :schema (:schema table)
-                                               :name "t0"}]
-              (mt/with-temp [:model/TransformTag tag {:name "test-tag"}
-                             :model/TransformJob job {:name "test-job"
-                                                      :schedule "0 0 * * * ? *"}
-                             :model/TransformJobTransformTag _ {:job_id (:id job)
-                                                                :tag_id (:id tag)
-                                                                :position 0}
-                             ;; independent transform
-                             :model/Transform t0 {:name   "transform0"
-                                                  :source {:type  :query
-                                                           :query (lib/native-query mp sql)}
-                                                  :creator_id (mt/user->id :crowberto)
-                                                  :target target0}
-                             :model/TransformTransformTag _tag0 {:transform_id (:id t0)
-                                                                 :tag_id (:id tag)
-                                                                 :position 0}]
-                (let [run-id-atom (atom nil)]
-                  (with-redefs [jobs/run-transforms! (fn [run-id & _]
-                                                       (reset! run-id-atom run-id)
-                                                       (throw (ex-info "Uncaught error" {})))]
-                    (try
-                      (jobs/run-job! (:id job) {:run-method :manual})
-                      (catch clojure.lang.ExceptionInfo _))
-                    (try
+        (mt/with-model-cleanup [:model/Notification
+                                :model/TransformJobRun]
+          (mt/with-fake-inbox
+            (notification.seed/seed-notification!)
+            (let [mp (mt/metadata-provider)
+                  table (t2/select-one :model/Table (mt/id :transforms_products))
+                  ;; generate sql for different dbs
+                  sql (-> (lib/query mp (lib.metadata/table mp (mt/id :transforms_products)))
+                          (lib/with-fields [(lib.metadata/field mp (mt/id :transforms_products :name))])
+                          (lib/limit 10)
+                          qp.compile/compile
+                          :query)]
+              (with-transform-cleanup! [target0 {:type "table"
+                                                 :schema (:schema table)
+                                                 :name "t0"}]
+                (mt/with-temp [:model/TransformTag tag {:name "test-tag"}
+                               :model/TransformJob job {:name "test-job"
+                                                        :schedule "0 0 * * * ? *"}
+                               :model/TransformJobTransformTag _ {:job_id (:id job)
+                                                                  :tag_id (:id tag)
+                                                                  :position 0}
+                               ;; independent transform
+                               :model/Transform t0 {:name "transform0"
+                                                    :source {:type :query
+                                                             :query (lib/native-query mp sql)}
+                                                    :creator_id (mt/user->id :crowberto)
+                                                    :target target0}
+                               :model/TransformTransformTag _tag0 {:transform_id (:id t0)
+                                                                   :tag_id (:id tag)
+                                                                   :position 0}]
+                  (let [run-id-atom (atom nil)]
+                    (with-redefs [jobs/run-transforms! (fn [run-id & _]
+                                                         (reset! run-id-atom run-id)
+                                                         (throw (ex-info "Uncaught error" {})))]
+                      (try
+                        (jobs/run-job! (:id job) {:run-method :manual})
+                        (catch clojure.lang.ExceptionInfo _))
                       (is (some? @run-id-atom))
                       (is (=? {:status :failed
                                :message string?}
                               (t2/select-one :model/TransformJobRun :id @run-id-atom)))
-                      (is (zero? (count @mt/inbox)))
-                      (finally ;; I don't know why transform_job_run is not cascaded from transform_job
-                        (when @run-id-atom
-                          (t2/delete! :model/TransformJobRun :id @run-id-atom))))))))))))))
+                      (is (zero? (count @mt/inbox))))))))))))))
 
 (deftest job-run-with-tranform-run-failure-test
   (mt/with-premium-features #{:transforms}
     (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
       (mt/dataset transforms-dataset/transforms-test
-        (mt/with-fake-inbox
-          (let [mp (mt/metadata-provider)
-                table (t2/select-one :model/Table (mt/id :transforms_products))
-                ;; generate sql for different dbs
-                sql (-> (lib/query mp (lib.metadata/table mp (mt/id :transforms_products)))
-                        (lib/with-fields [(lib.metadata/field mp (mt/id :transforms_products :name))])
-                        (lib/limit 10)
-                        qp.compile/compile
-                        :query)]
-            (with-transform-cleanup! [target0 {:type   "table"
-                                               :schema (:schema table)
-                                               :name "t0"}
-                                      target1 {:type "table"
-                                               :schema (:schema table)
-                                               :name   "t1"}
-                                      target2 {:type   "table"
-                                               :schema (:schema table)
-                                               :name   "t2"}
-                                      target3 {:type   "table"
-                                               :schema (:schema table)
-                                               :name   "t3"}]
-              (mt/with-temp [:model/TransformTag tag {:name "test-tag"}
-                             :model/TransformJob job {:name "test-job"
-                                                      :schedule "0 0 * * * ? *"}
-                             :model/TransformJobTransformTag _ {:job_id (:id job)
-                                                                :tag_id (:id tag)
-                                                                :position 0}
-                             ;; independent transform
-                             :model/Transform t0 {:name   "transform0"
-                                                  :source {:type  :query
-                                                           :query (lib/native-query mp sql)}
-                                                  :creator_id (mt/user->id :crowberto)
-                                                  :target target0}
-                             :model/TransformTransformTag _tag0 {:transform_id (:id t0)
-                                                                 :tag_id (:id tag)
-                                                                 :position 0}
-                             ;; faulty transform
-                             :model/Transform t1 {:name   "transform1"
-                                                  :source {:type  :query
-                                                           :query (lib/native-query mp (str/replace sql "name" "bame"))}
-                                                  :creator_id (mt/user->id :crowberto)
-                                                  :target target1}
-                             :model/TransformTransformTag _tag1 {:transform_id (:id t1)
-                                                                 :tag_id (:id tag)
-                                                                 :position 0}
-                             ;; depends on faulty transform
-                             :model/Transform t2 {:name   "transform2"
-                                                  :source {:type  :query
-                                                           :query (lib/native-query mp (str/replace sql "transforms_products" (:name target1)))}
-                                                  :creator_id (mt/user->id :crowberto)
-                                                  :target target2}
-                             :model/TransformTransformTag _tag2 {:transform_id (:id t2)
-                                                                 :tag_id (:id tag)
-                                                                 :position 0}
-                             ;; independent transform
-                             :model/Transform t3 {:name   "transform3"
-                                                  :source {:type  :query
-                                                           :query (lib/native-query mp sql)}
-                                                  :creator_id (mt/user->id :crowberto)
-                                                  :target target3}
-                             :model/TransformTransformTag _tag3 {:transform_id (:id t3)
-                                                                 :tag_id (:id tag)
-                                                                 :position 0}]
-                (let [run-id (jobs/run-job! (:id job) {:run-method :cron})]
-                  (try
-                    (is (=? [{:status :succeeded}]
-                            (t2/select :model/TransformRun :transform_id (:id t0))))
-                    (is (=? {:status :failed
-                             :message string?}
-                            (t2/select-one :model/TransformJobRun :id run-id)))
-                    ;; will fail because wrong column name
-                    (is (=? [{:status :failed
-                              :message string?}]
-                            (t2/select :model/TransformRun :transform_id (:id t1))))
-                    ;; will not run
-                    (is (= []
-                           (t2/select :model/TransformRun :transform_id (:id t2))))
-                    ;; should still succeed
-                    (is (=? [{:status :succeeded}]
-                            (t2/select :model/TransformRun :transform_id (:id t3))))
-                    (is (= 1 ;; we want to make sure 2 failures send 1 email
-                           (count @mt/inbox)))
-                    (is (mt/received-email-subject? :crowberto #"Failed transform run"))
-                    (is (mt/received-email-body? :crowberto #"transform1"))
-                    (is (mt/received-email-body? :crowberto #"transform2"))
-                    (finally ;; I don't know why transform_job_run is not cascaded from transform_job
-                      (t2/delete! :model/TransformJobRun :id run-id))))))))))))
+        (mt/with-model-cleanup [:model/Notification]
+          (mt/with-fake-inbox
+            (mt/with-model-cleanup [:model/Notification
+                                    :model/TransformJobRun]
+              (notification.seed/seed-notification!)
+              (let [mp (mt/metadata-provider)
+                    table (t2/select-one :model/Table (mt/id :transforms_products))
+                    ;; generate sql for different dbs
+                    sql (-> (lib/query mp (lib.metadata/table mp (mt/id :transforms_products)))
+                            (lib/with-fields [(lib.metadata/field mp (mt/id :transforms_products :name))])
+                            (lib/limit 10)
+                            qp.compile/compile
+                            :query)]
+                (with-transform-cleanup! [target0 {:type "table"
+                                                   :schema (:schema table)
+                                                   :name "t0"}
+                                          target1 {:type "table"
+                                                   :schema (:schema table)
+                                                   :name "t1"}
+                                          target2 {:type "table"
+                                                   :schema (:schema table)
+                                                   :name "t2"}
+                                          target3 {:type "table"
+                                                   :schema (:schema table)
+                                                   :name "t3"}]
+                  (mt/with-temp [:model/TransformTag tag {:name "test-tag"}
+                                 :model/TransformJob job {:name "test-job"
+                                                          :schedule "0 0 * * * ? *"}
+                                 :model/TransformJobTransformTag _ {:job_id (:id job)
+                                                                    :tag_id (:id tag)
+                                                                    :position 0}
+                                 ;; independent transform
+                                 :model/Transform t0 {:name "transform0"
+                                                      :source {:type :query
+                                                               :query (lib/native-query mp sql)}
+                                                      :creator_id (mt/user->id :crowberto)
+                                                      :target target0}
+                                 :model/TransformTransformTag _tag0 {:transform_id (:id t0)
+                                                                     :tag_id (:id tag)
+                                                                     :position 0}
+                                 ;; faulty transform
+                                 :model/Transform t1 {:name "transform1"
+                                                      :source {:type :query
+                                                               :query (lib/native-query mp (str/replace sql "name" "bame"))}
+                                                      :creator_id (mt/user->id :crowberto)
+                                                      :target target1}
+                                 :model/TransformTransformTag _tag1 {:transform_id (:id t1)
+                                                                     :tag_id (:id tag)
+                                                                     :position 0}
+                                 ;; depends on faulty transform
+                                 :model/Transform t2 {:name "transform2"
+                                                      :source {:type :query
+                                                               :query (lib/native-query mp (str/replace sql "transforms_products" (:name target1)))}
+                                                      :creator_id (mt/user->id :crowberto)
+                                                      :target target2}
+                                 :model/TransformTransformTag _tag2 {:transform_id (:id t2)
+                                                                     :tag_id (:id tag)
+                                                                     :position 0}
+                                 ;; independent transform
+                                 :model/Transform t3 {:name "transform3"
+                                                      :source {:type :query
+                                                               :query (lib/native-query mp sql)}
+                                                      :creator_id (mt/user->id :crowberto)
+                                                      :target target3}
+                                 :model/TransformTransformTag _tag3 {:transform_id (:id t3)
+                                                                     :tag_id (:id tag)
+                                                                     :position 0}]
+                    (let [run-id (jobs/run-job! (:id job) {:run-method :cron})]
+                      (is (=? [{:status :succeeded}]
+                              (t2/select :model/TransformRun :transform_id (:id t0))))
+                      (is (=? {:status :failed
+                               :message string?}
+                              (t2/select-one :model/TransformJobRun :id run-id)))
+                      ;; will fail because wrong column name
+                      (is (=? [{:status :failed
+                                :message string?}]
+                              (t2/select :model/TransformRun :transform_id (:id t1))))
+                      ;; will not run
+                      (is (= []
+                             (t2/select :model/TransformRun :transform_id (:id t2))))
+                      ;; should still succeed
+                      (is (=? [{:status :succeeded}]
+                              (t2/select :model/TransformRun :transform_id (:id t3))))
+                      (is (= 1 ;; we want to make sure 2 failures send 1 email
+                             (count @mt/inbox)))
+                      (is (mt/received-email-subject? :crowberto #"Transform job failed: test-job"))
+                      (is (mt/received-email-body? :crowberto #"transform1"))
+                      (is (mt/received-email-body? :crowberto #"transform2")))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/transforms/jobs_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/jobs_test.clj
@@ -1,14 +1,17 @@
-(ns metabase-enterprise.transforms.jobs-test
+(ns ^:mb/driver-tests metabase-enterprise.transforms.jobs-test
   #_{:clj-kondo/ignore [:discouraged-namespace]}
   (:require
+   [clojure.string :as str]
    [clojure.test :refer :all]
    [clojure.tools.logging :as log]
    [metabase-enterprise.transforms.execute :as transforms.execute]
    [metabase-enterprise.transforms.jobs :as jobs]
    [metabase-enterprise.transforms.models.transform-run :as transform-run]
    [metabase-enterprise.transforms.test-dataset :as transforms-dataset]
-   [metabase-enterprise.transforms.test-util :as transforms.tu :refer [with-transform-cleanup! delete-schema!]]
+   [metabase-enterprise.transforms.test-util :refer [with-transform-cleanup!]]
    [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.query-processor.compile :as qp.compile]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 
@@ -146,65 +149,191 @@
           (is @run-called?
               "Should call run-mbql-transform! when feature is enabled"))))))
 
-(deftest execute-test
+(deftest job-run-boom-test
   (mt/with-premium-features #{:transforms}
     (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
       (mt/dataset transforms-dataset/transforms-test
-        (let [mp (mt/metadata-provider)
-              table (t2/select-one :model/Table (mt/id :transforms_products))]
-          (with-transform-cleanup! [target1 {:type   "table"
-                                             :schema (:schema table)
-                                             :name   "t1"}
-                                    target2 {:type   "table"
-                                             :schema (:schema table)
-                                             :name   "t2"}
-                                    target3 {:type   "table"
-                                             :schema (:schema table)
-                                             :name   "t3"}]
-            (mt/with-temp [:model/TransformTag tag {:name "test-tag"}
-                           :model/TransformJob job {:name "test-job"
-                                                    :schedule "0 0 * * * ? *"}
-                           :model/TransformJobTransformTag _ {:job_id (:id job)
-                                                              :tag_id (:id tag)
-                                                              :position 0}
-                           ;; faulty transform
-                           :model/Transform t1 {:name   "transform1"
-                                                :source {:type  :query
-                                                         :query (lib/native-query mp (str "SELECT bame from \"" (:name table) "\";"))}
-                                                :target target1}
-                           :model/TransformTransformTag _tag1 {:transform_id (:id t1)
-                                                               :tag_id (:id tag)
-                                                               :position 0}
-                           ;; depends on faulty transform
-                           :model/Transform t2 {:name   "transform2"
-                                                :source {:type  :query
-                                                         :query (lib/native-query mp (str "SELECT name from \"" (:name target1) "\";"))}
-                                                :target target2}
-                           :model/TransformTransformTag _tag2 {:transform_id (:id t2)
-                                                               :tag_id (:id tag)
-                                                               :position 0}
-                           ;; independent transform
-                           :model/Transform t3 {:name   "transform1"
-                                                :source {:type  :query
-                                                         :query (lib/native-query mp (str "SELECT name from " (:name table) ";"))}
-                                                :target target3}
-                           :model/TransformTransformTag _tag3 {:transform_id (:id t3)
-                                                               :tag_id (:id tag)
-                                                               :position 0}]
-              (let [run-id (jobs/run-job! (:id job) {:run-method :manual})]
-                (try
-                  (is (=? {:status :failed
-                           :message string?}
-                          (t2/select-one :model/TransformJobRun :id run-id)))
-                  ;; will fail because wrong column name
-                  (is (=? [{:status :failed
-                            :message string?}]
-                          (t2/select :model/TransformRun :transform_id (:id t1))))
-                  ;; will not run
-                  (is (= []
-                         (t2/select :model/TransformRun :transform_id (:id t2))))
-                  ;; should still succeed
-                  (is (=? [{:status :succeeded}]
-                          (t2/select :model/TransformRun :transform_id (:id t3))))
-                  (finally ;; I don't know why transform_job_run is not cascaded from transform_job
-                    (t2/delete! :model/TransformJobRun :id run-id)))))))))))
+        (mt/with-fake-inbox
+          (let [mp (mt/metadata-provider)
+                table (t2/select-one :model/Table (mt/id :transforms_products))
+                ;; generate sql for different dbs
+                sql (-> (lib/query mp (lib.metadata/table mp (mt/id :transforms_products)))
+                        (lib/with-fields [(lib.metadata/field mp (mt/id :transforms_products :name))])
+                        (lib/limit 10)
+                        qp.compile/compile
+                        :query)]
+            (with-transform-cleanup! [target0 {:type   "table"
+                                               :schema (:schema table)
+                                               :name "t0"}]
+              (mt/with-temp [:model/TransformTag tag {:name "test-tag"}
+                             :model/TransformJob job {:name "test-job"
+                                                      :schedule "0 0 * * * ? *"}
+                             :model/TransformJobTransformTag _ {:job_id (:id job)
+                                                                :tag_id (:id tag)
+                                                                :position 0}
+                             ;; independent transform
+                             :model/Transform t0 {:name   "transform0"
+                                                  :source {:type  :query
+                                                           :query (lib/native-query mp sql)}
+                                                  :creator_id (mt/user->id :crowberto)
+                                                  :target target0}
+                             :model/TransformTransformTag _tag0 {:transform_id (:id t0)
+                                                                 :tag_id (:id tag)
+                                                                 :position 0}]
+                (let [run-id-atom (atom nil)]
+                  (with-redefs [jobs/run-transforms! (fn [run-id & _]
+                                                       (reset! run-id-atom run-id)
+                                                       (throw (ex-info "Uncaught error" {})))]
+                    (try
+                      (jobs/run-job! (:id job) {:run-method :cron})
+                      (catch clojure.lang.ExceptionInfo _))
+                    (try
+                      (is (some? @run-id-atom))
+                      (is (=? {:status :failed
+                               :message string?}
+                              (t2/select-one :model/TransformJobRun :id @run-id-atom)))
+                      (is (mt/received-email-subject? :crowberto #"Failed transform job"))
+                      (is (mt/received-email-body? :crowberto #"Uncaught error"))
+                      (finally ;; I don't know why transform_job_run is not cascaded from transform_job
+                        (when @run-id-atom
+                          (t2/delete! :model/TransformJobRun :id @run-id-atom))))))))))))))
+
+(deftest job-run-boom-manual-no-email-test
+  (mt/with-premium-features #{:transforms}
+    (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
+      (mt/dataset transforms-dataset/transforms-test
+        (mt/with-fake-inbox
+          (let [mp (mt/metadata-provider)
+                table (t2/select-one :model/Table (mt/id :transforms_products))
+                ;; generate sql for different dbs
+                sql (-> (lib/query mp (lib.metadata/table mp (mt/id :transforms_products)))
+                        (lib/with-fields [(lib.metadata/field mp (mt/id :transforms_products :name))])
+                        (lib/limit 10)
+                        qp.compile/compile
+                        :query)]
+            (with-transform-cleanup! [target0 {:type   "table"
+                                               :schema (:schema table)
+                                               :name "t0"}]
+              (mt/with-temp [:model/TransformTag tag {:name "test-tag"}
+                             :model/TransformJob job {:name "test-job"
+                                                      :schedule "0 0 * * * ? *"}
+                             :model/TransformJobTransformTag _ {:job_id (:id job)
+                                                                :tag_id (:id tag)
+                                                                :position 0}
+                             ;; independent transform
+                             :model/Transform t0 {:name   "transform0"
+                                                  :source {:type  :query
+                                                           :query (lib/native-query mp sql)}
+                                                  :creator_id (mt/user->id :crowberto)
+                                                  :target target0}
+                             :model/TransformTransformTag _tag0 {:transform_id (:id t0)
+                                                                 :tag_id (:id tag)
+                                                                 :position 0}]
+                (let [run-id-atom (atom nil)]
+                  (with-redefs [jobs/run-transforms! (fn [run-id & _]
+                                                       (reset! run-id-atom run-id)
+                                                       (throw (ex-info "Uncaught error" {})))]
+                    (try
+                      (jobs/run-job! (:id job) {:run-method :manual})
+                      (catch clojure.lang.ExceptionInfo _))
+                    (try
+                      (is (some? @run-id-atom))
+                      (is (=? {:status :failed
+                               :message string?}
+                              (t2/select-one :model/TransformJobRun :id @run-id-atom)))
+                      (is (zero? (count @mt/inbox)))
+                      (finally ;; I don't know why transform_job_run is not cascaded from transform_job
+                        (when @run-id-atom
+                          (t2/delete! :model/TransformJobRun :id @run-id-atom))))))))))))))
+
+(deftest job-run-with-tranform-run-failure-test
+  (mt/with-premium-features #{:transforms}
+    (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
+      (mt/dataset transforms-dataset/transforms-test
+        (mt/with-fake-inbox
+          (let [mp (mt/metadata-provider)
+                table (t2/select-one :model/Table (mt/id :transforms_products))
+                ;; generate sql for different dbs
+                sql (-> (lib/query mp (lib.metadata/table mp (mt/id :transforms_products)))
+                        (lib/with-fields [(lib.metadata/field mp (mt/id :transforms_products :name))])
+                        (lib/limit 10)
+                        qp.compile/compile
+                        :query)]
+            (with-transform-cleanup! [target0 {:type   "table"
+                                               :schema (:schema table)
+                                               :name "t0"}
+                                      target1 {:type "table"
+                                               :schema (:schema table)
+                                               :name   "t1"}
+                                      target2 {:type   "table"
+                                               :schema (:schema table)
+                                               :name   "t2"}
+                                      target3 {:type   "table"
+                                               :schema (:schema table)
+                                               :name   "t3"}]
+              (mt/with-temp [:model/TransformTag tag {:name "test-tag"}
+                             :model/TransformJob job {:name "test-job"
+                                                      :schedule "0 0 * * * ? *"}
+                             :model/TransformJobTransformTag _ {:job_id (:id job)
+                                                                :tag_id (:id tag)
+                                                                :position 0}
+                             ;; independent transform
+                             :model/Transform t0 {:name   "transform0"
+                                                  :source {:type  :query
+                                                           :query (lib/native-query mp sql)}
+                                                  :creator_id (mt/user->id :crowberto)
+                                                  :target target0}
+                             :model/TransformTransformTag _tag0 {:transform_id (:id t0)
+                                                                 :tag_id (:id tag)
+                                                                 :position 0}
+                             ;; faulty transform
+                             :model/Transform t1 {:name   "transform1"
+                                                  :source {:type  :query
+                                                           :query (lib/native-query mp (str/replace sql "name" "bame"))}
+                                                  :creator_id (mt/user->id :crowberto)
+                                                  :target target1}
+                             :model/TransformTransformTag _tag1 {:transform_id (:id t1)
+                                                                 :tag_id (:id tag)
+                                                                 :position 0}
+                             ;; depends on faulty transform
+                             :model/Transform t2 {:name   "transform2"
+                                                  :source {:type  :query
+                                                           :query (lib/native-query mp (str/replace sql "transforms_products" (:name target1)))}
+                                                  :creator_id (mt/user->id :crowberto)
+                                                  :target target2}
+                             :model/TransformTransformTag _tag2 {:transform_id (:id t2)
+                                                                 :tag_id (:id tag)
+                                                                 :position 0}
+                             ;; independent transform
+                             :model/Transform t3 {:name   "transform3"
+                                                  :source {:type  :query
+                                                           :query (lib/native-query mp sql)}
+                                                  :creator_id (mt/user->id :crowberto)
+                                                  :target target3}
+                             :model/TransformTransformTag _tag3 {:transform_id (:id t3)
+                                                                 :tag_id (:id tag)
+                                                                 :position 0}]
+                (let [run-id (jobs/run-job! (:id job) {:run-method :cron})]
+                  (try
+                    (is (=? [{:status :succeeded}]
+                            (t2/select :model/TransformRun :transform_id (:id t0))))
+                    (is (=? {:status :failed
+                             :message string?}
+                            (t2/select-one :model/TransformJobRun :id run-id)))
+                    ;; will fail because wrong column name
+                    (is (=? [{:status :failed
+                              :message string?}]
+                            (t2/select :model/TransformRun :transform_id (:id t1))))
+                    ;; will not run
+                    (is (= []
+                           (t2/select :model/TransformRun :transform_id (:id t2))))
+                    ;; should still succeed
+                    (is (=? [{:status :succeeded}]
+                            (t2/select :model/TransformRun :transform_id (:id t3))))
+                    (is (= 1 ;; we want to make sure 2 failures send 1 email
+                           (count @mt/inbox)))
+                    (is (mt/received-email-subject? :crowberto #"Failed transform run"))
+                    (is (mt/received-email-body? :crowberto #"transform1"))
+                    (is (mt/received-email-body? :crowberto #"transform2"))
+                    (finally ;; I don't know why transform_job_run is not cascaded from transform_job
+                      (t2/delete! :model/TransformJobRun :id run-id))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/transforms/jobs_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/jobs_test.clj
@@ -196,7 +196,7 @@
                                :message string?}
                               (t2/select-one :model/TransformJobRun :id @run-id-atom)))
                         ;; crowberto is a superuser/admin, so they receive the notification
-                      (is (mt/received-email-subject? :crowberto #"Transform job failed: test-job"))
+                      (is (mt/received-email-subject? :crowberto #"The job .* had failures"))
                       (is (mt/received-email-body? :crowberto #"Uncaught error")))))))))))))
 
 (deftest job-run-boom-manual-no-email-test
@@ -335,6 +335,6 @@
                               (t2/select :model/TransformRun :transform_id (:id t3))))
                       (is (= 1 ;; we want to make sure 2 failures send 1 email
                              (count @mt/inbox)))
-                      (is (mt/received-email-subject? :crowberto #"Transform job failed: test-job"))
+                      (is (mt/received-email-subject? :crowberto #"The job .* had failures"))
                       (is (mt/received-email-body? :crowberto #"transform1"))
                       (is (mt/received-email-body? :crowberto #"transform2")))))))))))))

--- a/src/metabase/channel/email/transform_failed.hbs
+++ b/src/metabase/channel/email/transform_failed.hbs
@@ -1,0 +1,66 @@
+{{> metabase/channel/email/_dashsub_alert_header.hbs }}
+  <body style="padding: 0px; margin: 0px">
+    <table class="background" width="100%" border="0" cellspacing="0" cellpadding="0" style="background-color: #F9F9F9; padding: 48px; table-layout: fixed;">
+      <tr>
+        <td>
+          <div class="container" style="background-color: white; max-width: 555px; border-radius: 24px; margin: 0 auto; padding: 40px; border: 1px solid rgba(7, 23, 34, 0.14)">
+            <div style="text-align: center; height: 45px; margin-bottom: 32px;">
+              <img width="35.55" height="45" src="{{context.application_logo_url}}" alt="Metabase logo"/>
+            </div>
+
+            <h1 style="text-align: center; font-size: 27px; line-height: 36px; font-weight: 400; margin: 0 0 8px 0; color: #2F3C45;">
+              The job &ldquo;{{payload.event_info.job_name}}&rdquo; had failures
+            </h1>
+
+            <div style="text-align: center; margin-bottom: 32px;">
+              <a href="{{payload.event_info.job_href}}" style="font-size: 15px; line-height: 165%; font-weight: 700; color: {{context.application_color}}; text-decoration: none;">
+                <svg style="vertical-align:middle" viewBox="0 0 16 16" fill="currentcolor" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="Icon Icon-clock" role="img" aria-label="clock icon" width="16" height="16"><path d="M8.75 5.6a.75.75 0 1 0-1.5 0V8c0 .199.079.39.22.53l2.4 2.4a.75.75 0 1 0 1.06-1.06L8.75 7.69V5.6z"></path><path fill-rule="evenodd" clip-rule="evenodd" d="M8 1.25a6.75 6.75 0 1 0 0 13.5 6.75 6.75 0 0 0 0-13.5zM2.75 8a5.25 5.25 0 1 1 10.5 0 5.25 5.25 0 0 1-10.5 0z"></path></svg>
+                <span style="margin-left: 4px; vertical-align: middle;">{{payload.event_info.job_name}}</span>
+              </a>
+            </div>
+
+            {{!-- Failures block --}}
+            {{#each payload.event_info.failures}}
+            <div style="background-color: #FAFAFB; border-radius: 12px; padding: 24px; margin: 24px auto 24px auto;">
+              <a href="{{this.transform_href}}" style="font-weight: 700; font-size: 0.875rem; color: {{../context.application_color}}; text-decoration: none;">
+                {{this.transform_name}}
+              </a>
+              <div style="line-height: 20px; color: #2F3C45; font-weight: 400; margin-top: 8px;">
+                {{this.message.first_line}}
+                {{#if this.message.details}}
+                <div style="padding-left: 1em; margin-top: 4px;">
+                  {{#each this.message.details}}
+                  {{this}}<br>
+                  {{/each}}
+                </div>
+                {{/if}}
+              </div>
+            </div>
+            {{/each}}
+
+            <hr style="margin-top: 32px; margin-bottom: 32px;">
+            <div style="font-size: 12px; line-height: 16px; width: max-content; margin: 0 auto; color: #656F76; text-align: center;">
+              Sent from <a href="{{context.site_url}}" style="color: {{context.application_color}}">{{context.site_url}}</a>.
+            </div>
+          </div>
+
+          <div style="margin-top: 40px;">
+            <div style="text-align: center; color: #92999E; font-size: 13px;">
+              Metabase, Inc.
+            </div>
+
+            <div style="text-align: center; color: #92999E; font-size: 13px;">
+              9740 Campo Rd., Suite 1029, Spring Valley, CA 91977
+            </div>
+
+            <div style="text-align: center; margin-top: 8px;">
+              <a href="https://www.metabase.com" style="color: #656F76 !important; font-size: 13px;">
+                www.metabase.com
+              </a>
+            </div>
+          </div>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/src/metabase/channel/email/transform_failed.hbs
+++ b/src/metabase/channel/email/transform_failed.hbs
@@ -22,9 +22,11 @@
             {{!-- Failures block --}}
             {{#each payload.event_info.failures}}
             <div style="background-color: #FAFAFB; border-radius: 12px; padding: 24px; margin: 24px auto 24px auto;">
+              {{#if this.transform_name}}
               <a href="{{this.transform_href}}" style="font-weight: 700; font-size: 0.875rem; color: {{../context.application_color}}; text-decoration: none;">
                 {{this.transform_name}}
               </a>
+              {{/if}}
               <div style="line-height: 20px; color: #2F3C45; font-weight: 400; margin-top: 8px;">
                 {{this.message.first_line}}
                 {{#if this.message.details}}

--- a/src/metabase/channel/events/transforms.clj
+++ b/src/metabase/channel/events/transforms.clj
@@ -1,0 +1,4 @@
+(ns metabase.channel.events.transforms)
+
+(derive ::event :metabase/event)
+(derive :event/transform-failed ::event)

--- a/src/metabase/channel/init.clj
+++ b/src/metabase/channel/init.clj
@@ -5,6 +5,7 @@
    [metabase.channel.events.comments]
    [metabase.channel.events.persisted-model-refresh-error]
    [metabase.channel.events.slack]
+   [metabase.channel.events.transforms]
    [metabase.channel.impl.email]
    [metabase.channel.impl.http]
    [metabase.channel.impl.slack]

--- a/src/metabase/channel/urls.clj
+++ b/src/metabase/channel/urls.clj
@@ -113,3 +113,13 @@
   "Return an appropriate URL for linking to caching log details."
   [^Integer persisted-info-id]
   (format "%s/admin/tools/model-caching/%d" (site-url) persisted-info-id))
+
+(defn transform-job-url
+  "URL for a transform job."
+  [job-id]
+  (format "%s/data-studio/transforms/jobs/%s" (site-url) job-id))
+
+(defn transform-run-url
+  "URL for a transform's run tab."
+  [transform-id]
+  (format "%s/data-studio/transforms/%s/run" (site-url) transform-id))

--- a/src/metabase/notification/events/notification.clj
+++ b/src/metabase/notification/events/notification.clj
@@ -16,7 +16,8 @@
                                   :event/notification-create
                                   :event/slack-token-invalid
                                   :event/comment-created
-                                  :event/support-access-grant-created})
+                                  :event/support-access-grant-created
+                                  :event/transform-failed})
 
 (def ^:private hydrate-transformer
   (mtx/transformer

--- a/src/metabase/notification/seed.clj
+++ b/src/metabase/notification/seed.clj
@@ -151,7 +151,7 @@
                        :template {:name "Transform Failed email template"
                                   :channel_type :channel/email
                                   :details {:type "email/handlebars-resource"
-                                            :subject "Transform job failed: {{payload.event_info.job_name}}"
+                                            :subject "The job \"{{payload.event_info.job_name}}\" had failures"
                                             :path "metabase/channel/email/transform_failed.hbs"
                                             :recipient-type "cc"}}
                        :recipients [{:type :notification-recipient/template

--- a/src/metabase/notification/seed.clj
+++ b/src/metabase/notification/seed.clj
@@ -137,7 +137,25 @@
                                             :path "metabase/channel/email/support_access_grant.hbs"
                                             :recipient-type "cc"}}
                        :recipients [{:type :notification-recipient/template
-                                     :details {:pattern "{{payload.event_info.support_email}}"}}]}]}]))
+                                     :details {:pattern "{{payload.event_info.support_email}}"}}]}]}
+
+          ;; transform job failed
+          {:internal_id "system-event/transform-failed"
+           :active true
+           :payload_type :notification/system-event
+           :subscriptions [{:type :notification-subscription/system-event
+                            :event_name :event/transform-failed}]
+           :handlers [{:active true
+                       :channel_type :channel/email
+                       :channel_id nil
+                       :template {:name "Transform Failed email template"
+                                  :channel_type :channel/email
+                                  :details {:type "email/handlebars-resource"
+                                            :subject "Transform job failed: {{payload.event_info.job_name}}"
+                                            :path "metabase/channel/email/transform_failed.hbs"
+                                            :recipient-type "cc"}}
+                       :recipients [{:type :notification-recipient/template
+                                     :details {:pattern "{{payload.event_info.email}}"}}]}]}]))
 
 (defn- cleanup-notification!
   [internal-id existing-row]

--- a/src/metabase/revisions/core.clj
+++ b/src/metabase/revisions/core.clj
@@ -10,6 +10,7 @@
 
 (p/import-vars
  [metabase.revisions.models.revision
+  latest-revisions
   serialize-instance
   revert-to-revision!]
  [metabase.revisions.models.revision.last-edit

--- a/src/metabase/revisions/core.clj
+++ b/src/metabase/revisions/core.clj
@@ -10,9 +10,9 @@
 
 (p/import-vars
  [metabase.revisions.models.revision
-  latest-revisions
   serialize-instance
-  revert-to-revision!]
+  revert-to-revision!
+  revisions]
  [metabase.revisions.models.revision.last-edit
   MaybeAnnotated
   edit-information-for-user

--- a/src/metabase/revisions/models/revision.clj
+++ b/src/metabase/revisions/models/revision.clj
@@ -179,6 +179,23 @@
   (let [model-name (name model)]
     (t2/select :model/Revision :model model-name :model_id id {:order-by [[:id :desc]]})))
 
+(mu/defn latest-revisions
+  "Get the latest revision for `model` for the given `ids`."
+  [model :- [:fn toucan-model?]
+   ids   :- [:sequential {:min 1} pos-int?]]
+  (let [model-name (name model)]
+    (t2/select :model/Revision
+               {:select [:revision.*]
+                :from [:revision]
+                :join [[{:select [[:%max.id :jid]]
+                         :from [:revision]
+                         :where [:and
+                                 [:= :model model-name]
+                                 [:in :model_id ids]]
+                         :group-by [:model_id]}
+                        :j]
+                       [:= :id :jid]]})))
+
 (mu/defn revisions+details
   "Fetch `revisions` for `model` with `id` and add details."
   [model :- [:fn toucan-model?]

--- a/src/metabase/revisions/models/revision.clj
+++ b/src/metabase/revisions/models/revision.clj
@@ -179,23 +179,6 @@
   (let [model-name (name model)]
     (t2/select :model/Revision :model model-name :model_id id {:order-by [[:id :desc]]})))
 
-(mu/defn latest-revisions
-  "Get the latest revision for `model` for the given `ids`."
-  [model :- [:fn toucan-model?]
-   ids   :- [:sequential {:min 1} pos-int?]]
-  (let [model-name (name model)]
-    (t2/select :model/Revision
-               {:select [:revision.*]
-                :from [:revision]
-                :join [[{:select [[:%max.id :jid]]
-                         :from [:revision]
-                         :where [:and
-                                 [:= :model model-name]
-                                 [:in :model_id ids]]
-                         :group-by [:model_id]}
-                        :j]
-                       [:= :id :jid]]})))
-
 (mu/defn revisions+details
   "Fetch `revisions` for `model` with `id` and add details."
   [model :- [:fn toucan-model?]

--- a/test/metabase/channel/email_test.clj
+++ b/test/metabase/channel/email_test.clj
@@ -152,7 +152,9 @@
   [user-or-email regex]
   (let [address (if (string? user-or-email) user-or-email (:username (test.users/user->credentials user-or-email)))
         emails  (get @inbox address)]
-    (boolean (some #(re-find regex %) (map (comp :content first :body) emails)))))
+    (boolean (some #(re-find regex %) (map #(if (string? (:body %))
+                                              (:body %)
+                                              (-> % :body first :content)) emails)))))
 
 (deftest regex-email-bodies-test
   (letfn [(email [body] {:to #{"mail"}


### PR DESCRIPTION
Closes QUE-2890

### Description

Previously, when running a transform job (e.g., daily), it would fail if a single transform in the run failed. This PR makes it so that the job continues to run transforms that don't depend on any failed transform. As previously, if any transform in the run fails, the job is marked as failed.

### How to verify

1. Create a native question Q1 on Orders.
2. Create a transform using Q1 called T1.
3. Create a transform using Orders called T2.
4. Mark both T1 and T2 with `daily` label.
5. Run the daily job. Note that it passes.
6. Modify Q1 to introduce an error, for instance add a stray character to a column name.
7. Run daily job. Note that it fails.
8. Go to transform runs tab and see that T1 failed but T2 succeeded.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
