### PR TITLE
simpler tests? you decide

### DIFF
--- a/.clj-kondo/macros/metabase/server/statistics_handler_test.clj
+++ b/.clj-kondo/macros/metabase/server/statistics_handler_test.clj
@@ -1,7 +1,6 @@
 (ns macros.metabase.server.statistics-handler-test)
 
 (defmacro with-server
-  [[hold-chan hit-chan] & body]
-  `(let [~hold-chan nil
-         ~hit-chan  nil]
+  [[_hold-chan _hit-chan] & body]
+  `(let []
      ~@body))

--- a/.clj-kondo/macros/metabase/server/statistics_handler_test.clj
+++ b/.clj-kondo/macros/metabase/server/statistics_handler_test.clj
@@ -1,9 +1,7 @@
 (ns macros.metabase.server.statistics-handler-test)
 
 (defmacro with-server
-  [_ _ [connector chan-start-handle chan-finish-handle chan-done-request] & body]
-  `(let [~connector          nil
-         ~chan-start-handle  nil
-         ~chan-finish-handle nil
-         ~chan-done-request  nil]
+  [[hold-chan hit-chan] & body]
+  `(let [~hold-chan nil
+         ~hit-chan  nil]
      ~@body))

--- a/test/metabase/server/statistics_handler_test.clj
+++ b/test/metabase/server/statistics_handler_test.clj
@@ -44,39 +44,41 @@
 (deftest server-stats-test
   (mt/with-prometheus-system! [_ system]
     (let [hold-chan (a/chan)
-          hit-chan (a/chan)]
+          hit-chan (a/chan)
+          value! (fn value! [& metric-args]
+                   (apply mt/metric-value system metric-args))]
       (with-server [hold-chan hit-chan]
         (fn [_server port]
           (testing "async"
             (let [route (format "http://localhost:%d/sync" port)]
               (is (= 200 (:status (http/get route))))
-              (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/requests-total)))
-              (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/dispatched-total)))
-              (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/dispatched-active-max)))
-              (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/dispatched-total)))
-              (is (prometheus-test/approx= 0 (mt/metric-value system :jetty/dispatched-active)))
-              (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/dispatched-active-max)))
-              (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/responses-total {:code "2xx"})))))
+              (is (prometheus-test/approx= 1 (value! :jetty/requests-total)))
+              (is (prometheus-test/approx= 1 (value! :jetty/dispatched-total)))
+              (is (prometheus-test/approx= 1 (value! :jetty/dispatched-active-max)))
+              (is (prometheus-test/approx= 1 (value! :jetty/dispatched-total)))
+              (is (prometheus-test/approx= 0 (value! :jetty/dispatched-active)))
+              (is (prometheus-test/approx= 1 (value! :jetty/dispatched-active-max)))
+              (is (prometheus-test/approx= 1 (value! :jetty/responses-total {:code "2xx"})))))
           (testing "requests active"
             (let [route (format "http://localhost:%d/hold" port)]
               (future
                 ;; this will wait on the hold chan
                 (is (= 200 (:status (http/get route))))
-                (is (prometheus-test/approx= 0 (mt/metric-value system :jetty/requests-active)))
-                (is (prometheus-test/approx= 0 (mt/metric-value system :jetty/dispatched-active))))
+                (is (prometheus-test/approx= 0 (value! :jetty/requests-active)))
+                (is (prometheus-test/approx= 0 (value! :jetty/dispatched-active))))
               (let [timeout (a/timeout 500)
                     [ch _v] (a/alts!! [hit-chan timeout])]
                 (is (not= ch timeout) "We timed out!")
-                (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/requests-active)))
-                (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/dispatched-active)))
+                (is (prometheus-test/approx= 1 (value! :jetty/requests-active)))
+                (is (prometheus-test/approx= 1 (value! :jetty/dispatched-active)))
                 (a/>!! hold-chan :continue))))
           (testing "300"
             (testing "when server responds 300"
               (let [route (format "http://localhost:%d/reroute" port)]
                 (http/get route {:redirect-strategy :none})
-                (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/responses-total {:code "3xx"}))))))
+                (is (prometheus-test/approx= 1 (value! :jetty/responses-total {:code "3xx"}))))))
           (testing "500"
             (testing "when server responds 500"
               (let [route (format "http://localhost:%d/blowup" port)]
                 (http/get route {:throw-exceptions false})
-                (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/responses-total {:code "5xx"})))))))))))
+                (is (prometheus-test/approx= 1 (value! :jetty/responses-total {:code "5xx"})))))))))))

--- a/test/metabase/server/statistics_handler_test.clj
+++ b/test/metabase/server/statistics_handler_test.clj
@@ -1,252 +1,81 @@
 (ns metabase.server.statistics-handler-test
   (:require
+   [clj-http.client :as http]
    [clojure.core.async :as a]
-   [clojure.test :refer [deftest testing is]]
+   [clojure.test :refer [deftest is testing]]
+   [compojure.core :as compojure :refer #_{:clj-kondo/ignore [:discouraged-var]} [GET]]
    [metabase.analytics.prometheus-test :as prometheus-test]
-   [metabase.server.statistics-handler :as sut]
+   [metabase.server.instance :as server.instance]
    [metabase.test :as mt])
   (:import
-   (jakarta.servlet AsyncListener)
-   (jakarta.servlet.http HttpServletRequest HttpServletResponse)
-   (org.eclipse.jetty.ee9.nested HandlerWrapper Request)
-   (org.eclipse.jetty.ee9.servlet ServletHandler ServletContextHandler)
-   (org.eclipse.jetty.server LocalConnector Server)))
+   (org.eclipse.jetty.server Server)))
 
 (set! *warn-on-reflection* true)
 
-(defn on-complete-listener
-  [done-channel]
-  (proxy [AsyncListener] []
-    (onComplete [_]
-      (a/go
-        (a/>! done-channel :done)))))
+(defn routes
+  [hold-chan hit-chan]
+  (compojure/routes
+   (GET "/sync" [] {:status 200 :headers {} :body "you got it sync"})
+   (GET "/hold" []
+        (a/>!! hit-chan :hit)
+        (let [timeout (a/timeout 500)
+              [ch _val] (a/alts!! [hold-chan timeout])]
+          (if (= ch timeout)
+            (throw (ex-info "We timed out!" {}))
+            {:status 200 :headers {} :body "you got held"})))
+   (GET "/async" []
+        (fn [_req respond _raise]
+          (respond {:status 200 :headers {} :body "you got it async"})))
+   (GET "/blowup" []
+        (throw (ex-info "Kaboom. you get a 500" {})))
+   (GET "/reroute" []
+        {:status 301 :headers {"Location" "http://localhost:3000/app"} :body "go somewher else"})))
 
-(defn- async-servlet-handler
-  ^ServletHandler [status-code chan-start-handle chan-finish-handle]
-  (proxy [ServletHandler] []
-    (doHandle [_ ^Request request _ ^HttpServletResponse response]
-      (let [async-context (.startAsync request)]
-        (.setHandled request true)
-        (a/<!! chan-start-handle)
-        (a/go
-          (.setStatus response status-code)
-          (.setContentLength response 0)
-          (.. response getOutputStream close)
-          (a/<! chan-finish-handle)
-          (.complete async-context))
-        (a/<!! chan-finish-handle)))))
+(defmacro avec-server
+  [[hold-chan hit-chan] f]
+  `(let [^Server server# (doto (server.instance/create-server (routes ~hold-chan ~hit-chan) {:port 0 :join? false})
+                           (.start))
+         port# (.. server# getURI getPort)
+         wait# (promise)]
+     (~f server# port#)
+     (.stop server#)))
 
-(defn- servlet-handler
-  ^ServletHandler [status-code chan-start-handle chan-finish-handle]
-  (proxy [ServletHandler] []
-    (doHandle [_ ^Request request _ ^HttpServletResponse response]
-      (.setHandled request true)
-      (a/<!! chan-start-handle)
-      (.setStatus response status-code)
-      (.setContentLength response 0)
-      (.. response getOutputStream close)
-      (a/<!! chan-finish-handle))))
-
-(defn- waiting-wrapper
-  "Sits above the statistics handler so we can wait for the handler to finish in tests"
-  ^HandlerWrapper [chan-done-request]
-  (proxy [HandlerWrapper] []
-    (handle [^String path ^Request base-request ^HttpServletRequest request ^HttpServletResponse response]
-      (try
-        (.handle (.getHandler ^HandlerWrapper this) path base-request request response)
-        (finally
-          (let [state (.getHttpChannelState base-request)]
-            (when (and (.isInitial state) (.isAsyncStarted state))
-              (.addListener state (on-complete-listener chan-done-request))))
-          (a/>!! chan-done-request :done))))))
-
-(defn- do-with-server
-  ^LocalConnector [status-code async? thunk]
-  (let [chan-start-handle       (a/chan)
-        chan-finish-handle      (a/chan)
-        chan-done-request       (a/chan)
-        handler                 (if async?
-                                  (async-servlet-handler status-code chan-start-handle chan-finish-handle)
-                                  (servlet-handler status-code chan-start-handle chan-finish-handle))
-        servlet-context-handler (doto (ServletContextHandler.)
-                                  (.setAllowNullPathInfo true)
-                                  (.insertHandler (doto (waiting-wrapper chan-done-request)
-                                                    (.setHandler (sut/new-handler))))
-                                  (.setServletHandler handler))
-        server                   (doto (Server.)
-                                   (.setHandler servlet-context-handler))
-        connector                (LocalConnector. server)]
-    (.start server)
-    (.start connector)
-    (thunk connector chan-start-handle chan-finish-handle chan-done-request)
-    (.stop connector)
-    (.stop server)))
-
-(defmacro with-server
-  [status-code async arguments & body]
-  `(do-with-server ~status-code ~async (fn ~arguments ~@body)))
-
-(deftest test-synchronous-metrics
-  (testing "records stats for synchronous requests"
-    (mt/with-prometheus-system! [_ system]
-      (testing "when server responds 200"
-        (with-server 200 false
-          [^LocalConnector connector chan-start-handle chan-finish-handle chan-done-request]
-          (.executeRequest connector "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
-          (a/>!! chan-start-handle :done)
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/requests-total)))
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/requests-active)))
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/dispatched-total)))
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/dispatched-active)))
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/dispatched-active-max)))
-          (a/>!! chan-finish-handle :done)
-          (a/<!! chan-done-request)
-          (is (prometheus-test/approx= 0 (mt/metric-value system :jetty/async-requests-waiting-max)))
-          (is (prometheus-test/approx= 0 (mt/metric-value system :jetty/async-requests-total)))
-          (is (prometheus-test/approx= 0 (mt/metric-value system :jetty/async-requests-waiting)))
-          (is (prometheus-test/approx= 0 (mt/metric-value system :jetty/requests-active)))
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/dispatched-total)))
-          (is (prometheus-test/approx= 0 (mt/metric-value system :jetty/dispatched-active)))
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/dispatched-active-max)))
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/responses-total {:code "2xx"})))))
-      (testing "when server responds 400"
-        (with-server 400 false
-          [^LocalConnector connector chan-start-handle chan-finish-handle chan-done-request]
-          (.executeRequest connector "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
-          (a/>!! chan-start-handle :done)
-          (is (prometheus-test/approx= 2 (mt/metric-value system :jetty/requests-total)))
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/requests-active)))
-          (is (prometheus-test/approx= 2 (mt/metric-value system :jetty/dispatched-total)))
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/dispatched-active)))
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/dispatched-active-max)))
-          (is (prometheus-test/approx= 0 (mt/metric-value system :jetty/async-requests-waiting-max)))
-          (is (prometheus-test/approx= 0 (mt/metric-value system :jetty/async-requests-total)))
-          (is (prometheus-test/approx= 0 (mt/metric-value system :jetty/async-requests-waiting)))
-          (a/>!! chan-finish-handle :done)
-          (a/<!! chan-done-request)
-          (is (prometheus-test/approx= 0 (mt/metric-value system :jetty/async-requests-waiting-max)))
-          (is (prometheus-test/approx= 0 (mt/metric-value system :jetty/async-requests-total)))
-          (is (prometheus-test/approx= 0 (mt/metric-value system :jetty/async-requests-waiting)))
-          (is (prometheus-test/approx= 0 (mt/metric-value system :jetty/requests-active)))
-          (is (prometheus-test/approx= 2 (mt/metric-value system :jetty/dispatched-total)))
-          (is (prometheus-test/approx= 0 (mt/metric-value system :jetty/dispatched-active)))
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/dispatched-active-max)))
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/responses-total {:code "4xx"})))))
-      (testing "when server responds 300"
-        (with-server 300 false
-          [^LocalConnector connector chan-start-handle chan-finish-handle chan-done-request]
-          (.executeRequest connector "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
-          (a/>!! chan-start-handle :done)
-          (a/>!! chan-finish-handle :done)
-          (a/<!! chan-done-request)
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/responses-total {:code "3xx"})))))
-      (testing "when server responds 500"
-        (with-server 500 false
-          [^LocalConnector connector chan-start-handle chan-finish-handle chan-done-request]
-          (.executeRequest connector "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
-          (a/>!! chan-start-handle :done)
-          (a/>!! chan-finish-handle :done)
-          (a/<!! chan-done-request)
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/responses-total {:code "5xx"}))))))))
-
-(deftest test-asynchronous-metrics
-  (testing "records stats for asynchronous requests"
-    (mt/with-prometheus-system! [_ system]
-      (testing "when server responds 200"
-        (with-server 200 true
-          [^LocalConnector connector chan-start-handle chan-finish-handle chan-done-request]
-          (.executeRequest connector "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
-          (a/>!! chan-start-handle :done)
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/requests-total)))
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/requests-active)))
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/dispatched-total)))
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/dispatched-active)))
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/dispatched-active-max)))
-          (a/>!! chan-finish-handle :done) ;; finish the synchronous handler
-          (a/<!! chan-done-request) ;; finished the synchronous wrapper
-          (is (prometheus-test/approx= 0 (mt/metric-value system :jetty/dispatched-active)))
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/requests-active)))
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/async-requests-waiting-max)))
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/async-requests-total)))
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/async-requests-waiting)))
-          (a/>!! chan-finish-handle :done) ;; finish the async thread
-          (a/<!! chan-done-request) ;; finished the async listener
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/async-requests-waiting-max)))
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/async-requests-total)))
-          (is (prometheus-test/approx= 0 (mt/metric-value system :jetty/async-requests-waiting)))
-          (is (prometheus-test/approx= 0 (mt/metric-value system :jetty/requests-active)))
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/dispatched-total)))
-          (is (prometheus-test/approx= 0 (mt/metric-value system :jetty/dispatched-active)))
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/dispatched-active-max)))
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/responses-total {:code "2xx"})))))
-      (testing "when server responds 400"
-        (with-server 400 true
-          [^LocalConnector connector chan-start-handle chan-finish-handle chan-done-request]
-          (.executeRequest connector "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
-          (a/>!! chan-start-handle :done)
-          (is (prometheus-test/approx= 2 (mt/metric-value system :jetty/requests-total)))
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/requests-active)))
-          (is (prometheus-test/approx= 2 (mt/metric-value system :jetty/dispatched-total)))
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/dispatched-active)))
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/dispatched-active-max)))
-          (a/>!! chan-finish-handle :done)
-          (a/<!! chan-done-request)
-          (is (prometheus-test/approx= 0 (mt/metric-value system :jetty/dispatched-active)))
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/requests-active)))
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/async-requests-waiting-max)))
-          (is (prometheus-test/approx= 2 (mt/metric-value system :jetty/async-requests-total)))
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/async-requests-waiting)))
-          (a/>!! chan-finish-handle :done) ;; finish the async thread
-          (a/<!! chan-done-request)
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/async-requests-waiting-max)))
-          (is (prometheus-test/approx= 2 (mt/metric-value system :jetty/async-requests-total)))
-          (is (prometheus-test/approx= 0 (mt/metric-value system :jetty/async-requests-waiting)))
-          (is (prometheus-test/approx= 0 (mt/metric-value system :jetty/requests-active)))
-          (is (prometheus-test/approx= 2 (mt/metric-value system :jetty/dispatched-total)))
-          (is (prometheus-test/approx= 0 (mt/metric-value system :jetty/dispatched-active)))
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/dispatched-active-max)))
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/responses-total {:code "4xx"})))))
-      (testing "when server responds 300"
-        (with-server 300 true
-          [^LocalConnector connector chan-start-handle chan-finish-handle chan-done-request]
-          (.executeRequest connector "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
-          (a/>!! chan-start-handle :done)
-          (a/>!! chan-finish-handle :done)
-          (a/<!! chan-done-request)
-          (a/>!! chan-finish-handle :done) ;; finish the async thread
-          (a/<!! chan-done-request)        ;; finished the outer async listener
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/responses-total {:code "3xx"})))))
-      (testing "when server responds 500"
-        (with-server 500 true
-          [^LocalConnector connector chan-start-handle chan-finish-handle chan-done-request]
-          (.executeRequest connector "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
-          (a/>!! chan-start-handle :done)
-          (a/>!! chan-finish-handle :done)
-          (a/<!! chan-done-request)
-          (a/>!! chan-finish-handle :done) ;; finish the async thread
-          (a/<!! chan-done-request)        ;; finished the outer async listener
-          (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/responses-total {:code "5xx"}))))))))
-
-(deftest test-request-duration-metrics
+(deftest server-stats-test
   (mt/with-prometheus-system! [_ system]
-    (testing "when sync server responds 200"
-      (with-server 200 false
-        [^LocalConnector connector chan-start-handle chan-finish-handle chan-done-request]
-        (.executeRequest connector "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
-        (a/>!! chan-start-handle :done)
-        (Thread/sleep 1000)
-        (a/>!! chan-finish-handle :done) ;; finish the synchronous handler
-        (a/<!! chan-done-request)        ;; finished the synchronous wrapper
-        (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/request-time-max-seconds) 0.5)))))
-  (mt/with-prometheus-system! [_ system]
-    (testing "when sync server responds 200"
-      (with-server 200 true
-        [^LocalConnector connector chan-start-handle chan-finish-handle chan-done-request]
-        (.executeRequest connector "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
-        (a/>!! chan-start-handle :done)
-        (Thread/sleep 1000)
-        (a/>!! chan-finish-handle :done) ;; finish the synchronous handler
-        (a/<!! chan-done-request)        ;; finished the synchronous wrapper
-        (a/>!! chan-finish-handle :done) ;; finish the asynchronous handler
-        (a/<!! chan-done-request)        ;; finished the asynchronous wrapper
-        (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/request-time-max-seconds) 0.5))))))
+    (let [hold-chan (a/chan)
+          hit-chan (a/chan)]
+      (avec-server [hold-chan hit-chan]
+                   (fn [_server port]
+                     (testing "async"
+                       (let [route (format "http://localhost:%d/sync" port)]
+                         (is (= 200 (:status (http/get route))))
+                         (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/requests-total)))
+                         (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/dispatched-total)))
+                         (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/dispatched-active-max)))
+                         (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/dispatched-total)))
+                         (is (prometheus-test/approx= 0 (mt/metric-value system :jetty/dispatched-active)))
+                         (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/dispatched-active-max)))
+                         (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/responses-total {:code "2xx"})))))
+                     (testing "requests active"
+                       (let [route (format "http://localhost:%d/hold" port)]
+                         (future
+                           ;; this will wait on the hold chan
+                           (is (= 200 (:status (http/get route))))
+                           (is (prometheus-test/approx= 0 (mt/metric-value system :jetty/requests-active)))
+                           (is (prometheus-test/approx= 0 (mt/metric-value system :jetty/dispatched-active))))
+                         (let [timeout (a/timeout 500)
+                               [ch _v] (a/alts!! [hit-chan timeout])]
+                           (is (not= ch timeout) "We timed out!")
+                           (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/requests-active)))
+                           (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/dispatched-active)))
+                           (a/>!! hold-chan :continue))))
+                     (testing "300"
+                       (testing "when server responds 300"
+                         (let [route (format "http://localhost:%d/reroute" port)]
+                           (http/get route {:redirect-strategy :none})
+                           (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/responses-total {:code "3xx"}))))))
+                     (testing "500"
+                       (testing "when server responds 500"
+                         (let [route (format "http://localhost:%d/blowup" port)]
+                           (http/get route {:throw-exceptions false})
+                           (is (prometheus-test/approx= 1 (mt/metric-value system :jetty/responses-total {:code "5xx"})))))))))))

--- a/test/metabase/server/statistics_handler_test.clj
+++ b/test/metabase/server/statistics_handler_test.clj
@@ -18,19 +18,19 @@
   (compojure/routes
    (GET "/sync" [] {:status 200 :headers {} :body "you got it sync"})
    (GET "/hold" []
-        (a/>!! hit-chan :hit)
-        (let [timeout (a/timeout 500)
-              [ch _val] (a/alts!! [hold-chan timeout])]
-          (if (= ch timeout)
-            (throw (ex-info "We timed out!" {}))
-            {:status 200 :headers {} :body "you got held"})))
+     (a/>!! hit-chan :hit)
+     (let [timeout (a/timeout 500)
+           [ch _val] (a/alts!! [hold-chan timeout])]
+       (if (= ch timeout)
+         (throw (ex-info "We timed out!" {}))
+         {:status 200 :headers {} :body "you got held"})))
    (GET "/async" []
-        (fn [_req respond _raise]
-          (respond {:status 200 :headers {} :body "you got it async"})))
+     (fn [_req respond _raise]
+       (respond {:status 200 :headers {} :body "you got it async"})))
    (GET "/blowup" []
-        (throw (ex-info "Kaboom. you get a 500" {})))
+     (throw (ex-info "Kaboom. you get a 500" {})))
    (GET "/reroute" []
-        {:status 301 :headers {"Location" "http://localhost:3000/app"} :body "go somewher else"})))
+     {:status 301 :headers {"Location" "http://localhost:3000/app"} :body "go somewher else"})))
 
 (defmacro with-server
   [[hold-chan hit-chan] f]

--- a/test/metabase/server/statistics_handler_test.clj
+++ b/test/metabase/server/statistics_handler_test.clj
@@ -14,6 +14,7 @@
 
 (defn routes
   [hold-chan hit-chan]
+  #_{:clj-kondo/ignore [:discouraged-var]}
   (compojure/routes
    (GET "/sync" [] {:status 200 :headers {} :body "you got it sync"})
    (GET "/hold" []


### PR DESCRIPTION
## Why do this?

The older tests were a bit brittle and sometimes would just block for an hour until the job runner was killed. The last log would be:

```javascript
{"instant":{"epochSecond":1768313768,"nanoOfSecond":37793056},
 "thread":"main","level":"INFO","loggerName":"org.eclipse.jetty.server.AbstractConnector",
"message":"Started oejs.LocalConnector@44e76fdd{HTTP/1.1, (http/1.1)}",
"contextMap":{"mb-test":"metabase.server.statistics-handler-test/test-asynchronous-metrics"},
"endOfBatch":false,"loggerFqcn":"org.apache.logging.slf4j.Log4jLogger",
"threadId":1,"threadPriority":5}
```

these tests are trying to be a bit simpler. I reuse the normal server stuff that wires this all together and then just check the prometheus system.

only one route cares about channels and they are just to hold open the request and assert stuff during and then after the request.

everything else is straightforward. hopefully no more issues where this test hogs the main thread and we hit the 60 minute timeout.

i dropped the sync test because our server actually makes everything async so we are testing something that doesn't ever happen in practice.

## will this be flaky?

```
statistics-handler-test=> (dotimes [_ 45 ] (server-stats-test))
nil
statistics-handler-test=> (dotimes [_ 45 ] (server-stats-test))
nil
statistics-handler-test=> (dotimes [_ 45 ] (server-stats-test))
nil
statistics-handler-test=> (dotimes [_ 45 ] (server-stats-test))
nil
statistics-handler-test=> (dotimes [_ 45 ] (server-stats-test))
nil
statistics-handler-test=> (dotimes [_ 45 ] (server-stats-test))
nil
statistics-handler-test=> (dotimes [_ 45 ] (server-stats-test))
nil
statistics-handler-test=> 
nil
statistics-handler-test=> (dotimes [_ 45 ] (server-stats-test))
nil
```

No flakes in 360 runs