### PR TITLE
Remove Security and Appearance from embedding settings related links on OSS

### DIFF
--- a/frontend/src/metabase/admin/components/RelatedSettingsSection/constants.ts
+++ b/frontend/src/metabase/admin/components/RelatedSettingsSection/constants.ts
@@ -1,6 +1,5 @@
 import { t } from "ttag";
 
-import { isEEBuild } from "metabase/lib/utils";
 import { PLUGIN_TENANTS } from "metabase/plugins";
 import type { IconName } from "metabase/ui";
 
@@ -12,14 +11,15 @@ export interface RelatedSettingItem {
 
 export const getModularEmbeddingRelatedSettingItems = ({
   isUsingTenants,
+  hasSimpleEmbedding,
 }: {
   isUsingTenants?: boolean;
+  hasSimpleEmbedding?: boolean;
 }): RelatedSettingItem[] => {
   const isTenantsFeatureAvailable = PLUGIN_TENANTS.isEnabled;
-  const isEE = isEEBuild();
 
   const items: RelatedSettingItem[] = [
-    ...(isEE
+    ...(hasSimpleEmbedding
       ? [
           {
             icon: "shield_outline" as const,
@@ -48,7 +48,7 @@ export const getModularEmbeddingRelatedSettingItems = ({
       name: t`Permissions`,
       to: "/admin/permissions",
     },
-    ...(isEE
+    ...(hasSimpleEmbedding
       ? [
           {
             icon: "palette" as const,

--- a/frontend/src/metabase/admin/components/RelatedSettingsSection/constants.ts
+++ b/frontend/src/metabase/admin/components/RelatedSettingsSection/constants.ts
@@ -1,5 +1,6 @@
 import { t } from "ttag";
 
+import { isEEBuild } from "metabase/lib/utils";
 import { PLUGIN_TENANTS } from "metabase/plugins";
 import type { IconName } from "metabase/ui";
 
@@ -15,13 +16,18 @@ export const getModularEmbeddingRelatedSettingItems = ({
   isUsingTenants?: boolean;
 }): RelatedSettingItem[] => {
   const isTenantsFeatureAvailable = PLUGIN_TENANTS.isEnabled;
+  const isEE = isEEBuild();
 
   const items: RelatedSettingItem[] = [
-    {
-      icon: "shield_outline",
-      name: t`Security`,
-      to: "/admin/embedding/security",
-    },
+    ...(isEE
+      ? [
+          {
+            icon: "shield_outline" as const,
+            name: t`Security`,
+            to: "/admin/embedding/security",
+          },
+        ]
+      : []),
     {
       icon: "lock",
       name: t`Authentication`,
@@ -42,11 +48,15 @@ export const getModularEmbeddingRelatedSettingItems = ({
       name: t`Permissions`,
       to: "/admin/permissions",
     },
-    {
-      icon: "palette",
-      name: t`Appearance`,
-      to: "/admin/settings/appearance",
-    },
+    ...(isEE
+      ? [
+          {
+            icon: "palette" as const,
+            name: t`Appearance`,
+            to: "/admin/settings/appearance",
+          },
+        ]
+      : []),
     ...(isTenantsFeatureAvailable
       ? [
           {

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSettings/EmbeddingSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSettings/EmbeddingSettings.tsx
@@ -30,13 +30,17 @@ import { SharedCombinedEmbeddingSettings } from "../SharedCombinedEmbeddingSetti
 function EmbeddingSettingsPageWrapper({ children }: PropsWithChildren) {
   const isEE = isEEBuild();
   const isUsingTenants = useSetting("use-tenants");
+  const hasSimpleEmbedding = useHasTokenFeature("embedding_simple");
 
   return (
     <SettingsPageWrapper title={t`Embedding settings`}>
       {children}
 
       <RelatedSettingsSection
-        items={getModularEmbeddingRelatedSettingItems({ isUsingTenants })}
+        items={getModularEmbeddingRelatedSettingItems({
+          isUsingTenants,
+          hasSimpleEmbedding,
+        })}
       />
 
       {isEE && <UpsellDevInstances location="embedding-page" />}

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSettings/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSettings/tests/common.unit.spec.tsx
@@ -33,7 +33,7 @@ describe("EmbeddingSdkSettings (OSS)", () => {
 
   it("should show cards with related settings", async () => {
     await setup({
-      isEmbeddingSdkEnabled: true,
+      isEmbeddingSdkEnabled: false,
       showSdkEmbedTerms: false,
     });
 

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSettings/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSettings/tests/common.unit.spec.tsx
@@ -40,14 +40,12 @@ describe("EmbeddingSdkSettings (OSS)", () => {
     const relatedSettingCards = await screen.findAllByTestId(
       "related-setting-card",
     );
-    expect(relatedSettingCards).toHaveLength(6);
+    expect(relatedSettingCards).toHaveLength(4);
 
-    expect(await screen.findByText("Security")).toBeInTheDocument();
     expect(await screen.findByText("Authentication")).toBeInTheDocument();
     expect(await screen.findByText("Databases")).toBeInTheDocument();
     expect(await screen.findByText("People")).toBeInTheDocument();
     expect(await screen.findByText("Permissions")).toBeInTheDocument();
-    expect(await screen.findByText("Appearance")).toBeInTheDocument();
   });
 
   it("does not show the modular embedding toggle when token features are missing", () => {

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSettings/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSettings/tests/enterprise.unit.spec.tsx
@@ -53,4 +53,17 @@ describe("EmbeddingSdkSettings (EE)", () => {
 
     expect(screen.getByText("Tenants")).toBeInTheDocument();
   });
+
+  it("should show Security and Appearance in related settings", async () => {
+    await setup({
+      enterprisePlugins: [
+        "embedding-sdk",
+        "embedding_iframe_sdk",
+        "embedding_iframe_sdk_setup",
+      ],
+    });
+
+    expect(screen.getByText("Security")).toBeInTheDocument();
+    expect(screen.getByText("Appearance")).toBeInTheDocument();
+  });
 });

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSettings/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSettings/tests/enterprise.unit.spec.tsx
@@ -54,16 +54,14 @@ describe("EmbeddingSdkSettings (EE)", () => {
     expect(screen.getByText("Tenants")).toBeInTheDocument();
   });
 
-  it("should show Security and Appearance in related settings", async () => {
+  it("should not show Security and Appearance in related settings without token", async () => {
     await setup({
-      enterprisePlugins: [
-        "embedding-sdk",
-        "embedding_iframe_sdk",
-        "embedding_iframe_sdk_setup",
-      ],
+      isEmbeddingSdkEnabled: false,
+      isEmbeddingSimpleEnabled: false,
+      showSdkEmbedTerms: false,
     });
 
-    expect(screen.getByText("Security")).toBeInTheDocument();
-    expect(screen.getByText("Appearance")).toBeInTheDocument();
+    expect(screen.queryByText("Security")).not.toBeInTheDocument();
+    expect(screen.queryByText("Appearance")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSettings/tests/premium.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSettings/tests/premium.unit.spec.tsx
@@ -76,4 +76,15 @@ describe("EmbeddingSdkSettings (EE with Embedding SDK token)", () => {
       ).not.toBeInTheDocument();
     });
   });
+
+  it("should show Security and Appearance in related settings", async () => {
+    await setup({
+      isEmbeddingSdkEnabled: true,
+      isEmbeddingSimpleEnabled: true,
+      showSdkEmbedTerms: false,
+    });
+
+    expect(screen.getByText("Security")).toBeInTheDocument();
+    expect(screen.getByText("Appearance")).toBeInTheDocument();
+  });
 });

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubAdminSettingsPage.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubAdminSettingsPage.tsx
@@ -4,13 +4,14 @@ import {
   RelatedSettingsSection,
   getModularEmbeddingRelatedSettingItems,
 } from "metabase/admin/components/RelatedSettingsSection";
-import { useSetting } from "metabase/common/hooks";
+import { useHasTokenFeature, useSetting } from "metabase/common/hooks";
 import { Stack, Text, Title } from "metabase/ui";
 
 import { EmbeddingHub } from "./EmbeddingHub";
 
 export const EmbeddingHubAdminSettingsPage = () => {
   const isUsingTenants = useSetting("use-tenants");
+  const hasSimpleEmbedding = useHasTokenFeature("embedding_simple");
 
   return (
     <Stack mx="auto" py="xl" gap="xl" maw={800}>
@@ -24,7 +25,10 @@ export const EmbeddingHubAdminSettingsPage = () => {
 
       <Stack ml="2.7rem">
         <RelatedSettingsSection
-          items={getModularEmbeddingRelatedSettingItems({ isUsingTenants })}
+          items={getModularEmbeddingRelatedSettingItems({
+            isUsingTenants,
+            hasSimpleEmbedding,
+          })}
         />
       </Stack>
     </Stack>


### PR DESCRIPTION
Closes [UXW-2697](https://linear.app/metabase/issue/UXW-2697/fix-embedding-settings-links-to-security-and-appearance-on-oss)

### Description

Adds a check to `getModularEmbeddingRelatedSettingItems` to determine whether the current build is EE, and if not, removes the Security and Appearance related links.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Run an OSS version of Metabase, navigate to admin/embedding, and verify the Security and Appearance links are removed
2. Run an EE version of Metabase, navigate to admin/embedding, and verity the Security and Appearance links remain visible

### Demo

Before (OSS):
<img width="3586" height="2074" alt="image" src="https://github.com/user-attachments/assets/341d7e2d-a73f-49cd-baf8-687715aecfa4" />

After (OSS):
<img width="1306" height="800" alt="image" src="https://github.com/user-attachments/assets/5466de08-560f-4526-94be-eaa616aeff2e" />

After (EE, unchanged):
<img width="1250" height="677" alt="image" src="https://github.com/user-attachments/assets/1b620286-374f-4738-a0c0-b644a3a3493a" />


### Checklist

- [X] Tests have been added/updated to cover changes in this PR
