### PR TITLE
note on slack notifications

### DIFF
--- a/docs/permissions/impersonation.md
+++ b/docs/permissions/impersonation.md
@@ -182,3 +182,7 @@ Admins won't ever see the effects of impersonation effects, because their privil
 Metabase's default Administrators group has "Can view" access to all databases, and Metabase uses the most permissive access for any person in multiple groups, so any admin will have "Can view" - not "Impersonated" - access to the database.
 
 To test impersonation, create a test user, assign them a user attribute with the database role, and add them to the impersonated group. Then, log in as the test user and verify the data access.
+
+## Impersonation and Slack notifications
+
+People in groups with impersonation access cannot create Slack [alerts](../questions/alerts.md) or [dashboard subscriptions](../dashboards/subscriptions.md). Email alerts and subscriptions are still available. See [Notification permissions](./notifications.md).

--- a/docs/permissions/notifications.md
+++ b/docs/permissions/notifications.md
@@ -9,10 +9,10 @@ Notifications in Metabase include [alerts](../questions/alerts.md) and [dashboar
 
 ## Who can edit dashboard subscriptions and alerts
 
-What you can do with alerts and dashboard subscriptions depends on whether you're in the Administrators group or in a group with [row and column security](../permissions/row-and-column-security.md).
+What you can do with alerts and dashboard subscriptions depends on whether you're in the Administrators group or in a group with [impersonation](./impersonation.md) or [row and column security](./row-and-column-security.md).
 
 - [All Users group](#all-users-group-notification-permissions)
-- [Restricted group](#notification-permissions-for-people-in-groups-with-row-and-column-security)
+- [Groups with impersonation or row and column security](#groups-with-impersonation-or-row-and-column-security)
 - [Administrators group](#administrators-group-notification-permissions)
 
 ### All Users group notification permissions

--- a/docs/permissions/notifications.md
+++ b/docs/permissions/notifications.md
@@ -25,9 +25,11 @@ Everyone's in the All Users group. Which means that everyone can:
 
 When a notification creator adds new recipients to an alert or subscription, Metabase will display data to the recipients using the **creator's** [data permissions](../permissions/data.md) and [collection permissions](../permissions/collections.md).
 
-### Notification permissions for people in groups with row and column security
+### Groups with impersonation or row and column security
 
-Same as everyone in the All Users group, but with a special case: **people in groups with row and column security will only see themselves in the list of recipients** when creating an alert or subscription.
+People in groups with [impersonation](./impersonation.md) or [row and column security](./row-and-column-security.md) permissions cannot create Slack [alerts](../questions/alerts.md) or [dashboard subscriptions](../dashboards/subscriptions.md). They can still set up email alerts and subscriptions.
+
+For email alerts and subscriptions, people in these groups will only see themselves in the list of recipients.
 
 ### Administrators group notification permissions
 

--- a/docs/permissions/row-and-column-security.md
+++ b/docs/permissions/row-and-column-security.md
@@ -203,7 +203,7 @@ For example, say have a table like this:
 | 3       | 5     |
 | 3       | 5     |
 
-If you want to give someone access to multiple user IDs (e.g., the person should see rows for both `User_ID` 1 and 2.), you can set up a user attribute, like `user_id` that can handle comma-separated values like "1,2". 
+If you want to give someone access to multiple user IDs (e.g., the person should see rows for both `User_ID` 1 and 2.), you can set up a user attribute, like `user_id` that can handle comma-separated values like "1,2".
 
 1. Create a SQL question that parses the comma-separated string and filters the table:
 
@@ -313,9 +313,13 @@ Create a SQL question that casts the advanced data type column to a basic data t
 
 If you can't use SQL casting in Metabase, create a view in your database that converts the advanced data type to a basic type, then set up row and column security on that view instead of the original table. You'll also need to block the original table.
 
-#### Option 3: Use transforms 
+#### Option 3: Use transforms
 
  Use a [transform](../data-modeling/transforms.md) to create a table that casts the advanced data type to a basic type. Then set up row and column security on the transformed table instead. You'll also need to block the original table.
+
+### People with row and column security can't create Slack subscriptions or alerts
+
+People in groups with row and column security can't create Slack [alerts](../questions/alerts.md) or [dashboard subscriptions](../dashboards/subscriptions.md). Email alerts and subscriptions are still available. See [Notification permissions](./notifications.md).
 
 ## Further reading
 


### PR DESCRIPTION
Mentions that Slack subscriptions and Alerts aren't available to groups with either impersonation or row and column permissions.