### PR TITLE
Deduplicate field refs by ignoring `:source-field-name` unless it matters

### DIFF
--- a/src/metabase/lib/schema.cljc
+++ b/src/metabase/lib/schema.cljc
@@ -155,6 +155,8 @@
    {:decode/normalize deduplicate-refs-ignoring-source-field-name-when-possible}
    :any])
 
+;; TODO (Cam 2026-01-13) -- we should ensure sequences like these are [[vector?]] and normalize them to vectors if
+;; they're not
 (mr/def ::fields
   [:and
    [:sequential {:min 1} [:ref ::ref/ref]]

--- a/src/metabase/lib/schema.cljc
+++ b/src/metabase/lib/schema.cljc
@@ -9,6 +9,7 @@
   (:refer-clojure :exclude [ref every? some select-keys empty? get-in])
   (:require
    [medley.core :as m]
+   [metabase.lib.options :as lib.options]
    [metabase.lib.schema.actions :as actions]
    [metabase.lib.schema.aggregation :as aggregation]
    [metabase.lib.schema.common :as common]
@@ -123,10 +124,41 @@
    [:sequential {:min 1} ::breakout]
    [:ref ::lib.schema.util/distinct-mbql-clauses]])
 
+(defn- deduplicate-refs-ignoring-source-field-name-when-possible
+  "`:source-field-name` is only relevant when we have multiple field refs with the same `:source-field` AND different
+  `:source-field-name`s (see documentation in `:metabase.lib.schema.ref/field.options`). Deduplicate refs ignoring
+  this value when it is not relevant."
+  [fields]
+  (let [source-field->refs        (group-by (fn [[_tag opts _field-id :as _ref]]
+                                              (:source-field opts))
+                                            fields)
+        source-field->names       (update-vals source-field->refs
+                                               (fn [field-refs]
+                                                 (into #{}
+                                                       (keep #(:source-field-name (lib.options/options %)))
+                                                       field-refs)))
+        remove-source-field-name? (fn [[_tag {:keys [source-field source-field-name], :as _opts} _id-or-name :as _ref]]
+                                    (when source-field-name
+                                      (let [source-field-names-for-source-field (source-field->names source-field)]
+                                        (< (count source-field-names-for-source-field) 2))))]
+    (m/distinct-by
+     (fn [field-ref]
+       (lib.schema.util/mbql-clause-distinct-key
+        (cond-> field-ref
+          (remove-source-field-name? field-ref)
+          (lib.options/update-options dissoc :source-field-name))))
+     fields)))
+
+(mr/def ::deduplicate-refs-ignoring-source-field-name-when-possible
+  [:schema
+   {:decode/normalize deduplicate-refs-ignoring-source-field-name-when-possible}
+   :any])
+
 (mr/def ::fields
   [:and
    [:sequential {:min 1} [:ref ::ref/ref]]
-   [:ref ::lib.schema.util/distinct-mbql-clauses]])
+   [:ref ::lib.schema.util/distinct-mbql-clauses]
+   [:ref ::deduplicate-refs-ignoring-source-field-name-when-possible]])
 
 (mr/def ::filters
   [:sequential {:min 1} [:ref ::expression/boolean]])

--- a/src/metabase/lib/schema.cljc
+++ b/src/metabase/lib/schema.cljc
@@ -137,16 +137,17 @@
                                                  (into #{}
                                                        (keep #(:source-field-name (lib.options/options %)))
                                                        field-refs)))
-        remove-source-field-name? (fn [[_tag {:keys [source-field source-field-name], :as _opts} _id-or-name :as _ref]]
+        ignore-source-field-name? (fn [[_tag {:keys [source-field source-field-name], :as _opts} _id-or-name :as _ref]]
                                     (when source-field-name
                                       (let [source-field-names-for-source-field (source-field->names source-field)]
                                         (< (count source-field-names-for-source-field) 2))))]
-    (m/distinct-by
-     (fn [field-ref]
-       (lib.schema.util/mbql-clause-distinct-key
-        (cond-> field-ref
-          (remove-source-field-name? field-ref)
-          (lib.options/update-options dissoc :source-field-name))))
+    (into
+     []
+     (m/distinct-by (fn [field-ref]
+                      (lib.schema.util/mbql-clause-distinct-key
+                       (cond-> field-ref
+                         (ignore-source-field-name? field-ref)
+                         (lib.options/update-options dissoc :source-field-name)))))
      fields)))
 
 (mr/def ::deduplicate-refs-ignoring-source-field-name-when-possible

--- a/src/metabase/lib/schema/ref.cljc
+++ b/src/metabase/lib/schema/ref.cljc
@@ -97,10 +97,34 @@
      ;; `:source-field` should be for information purposes only.
      [:source-field {:optional true} [:ref ::id/field]]
      ;;
-     ;; The name or desired alias of the field used for an implicit join.
+     ;; The name or source column alias of the field used for an implicit join.
+     ;;
+     ;; TODO (Cam 2026-01-13): Not really clear which on we're using in practice -- we need to investigate this
+     ;; further and write down clear notes about when and where this is set.
+     ;;
+     ;; This is needed in some cases to disambiguate fields when there are multiple joins that all bring in multiple
+     ;; copies of `:source-field` -- `:source-field-name` will be used to disambiguate which particular copy we want
+     ;; to use.
+     ;;
+     ;; TODO (Cam 2026-01-13): It doesn't seem like [[metabase.lib.field.resolution]] is using `:source-field-name`
+     ;; for disambiguation purposes which seems like a clear bug... we should add some tests around this and make sure
+     ;; it can pick the correct field when `:source-field-name` is present. (The same applies for
+     ;; `:source-field-join-alias`.)
+     ;;
+     ;; TODO (Cam 2026-01-13): I think `:source-field-join-alias` is much better suited for purposes of disambiguating
+     ;; two copies of a column from two different joins, and it's much easier to resolve than `:source-field-name` and
+     ;; clearer
+     ;;
      [:source-field-name {:optional true} ::common/non-blank-string]
      ;;
      ;; The join alias of the source field used for an implicit join.
+     ;;
+     ;; TODO (Cam 2026-01-13): This apparently serves a similar purpose to `:source-field-name`, but it's not clear
+     ;; that anyone actually sets this... it's also ignored by [[metabase.lib.field.resolution]], and seems like it
+     ;; could trigger duplicate ref issues similar to #67808. Let's either remove this as a key entirely or commit to
+     ;; actually documenting and supporting it, and making sure `:field` deduplication works correctly with two copies
+     ;; of the same ref where one has this and one does not.
+     ;;
      [:source-field-join-alias {:optional true} ::common/non-blank-string]
      ;;
      ;; Inherited temporal unit captures the temporal unit, that has been set on a ref, for next stages. It is attached

--- a/test/metabase/query_processor/middleware/add_implicit_joins_test.clj
+++ b/test/metabase/query_processor/middleware/add_implicit_joins_test.clj
@@ -1179,11 +1179,11 @@
     (let [mp (-> (mt/metadata-provider)
                  (lib.tu/remap-metadata-provider (mt/id :orders :product_id) (mt/id :products :title))
                  (as-> $mp
-                     (let [model-query (lib/query $mp (lib.metadata/table $mp (mt/id :orders)))]
-                       (lib.tu/mock-metadata-provider
-                        $mp
-                        {:cards [{:id            1
-                                  :dataset-query model-query}]}))))
+                       (let [model-query (lib/query $mp (lib.metadata/table $mp (mt/id :orders)))]
+                         (lib.tu/mock-metadata-provider
+                          $mp
+                          {:cards [{:id            1
+                                    :dataset-query model-query}]}))))
           q  (-> (lib/query mp (lib.metadata/card mp 1))
                  (lib/filter (lib/= (-> (lib.metadata/field mp (mt/id :products :title))
                                         (lib/ref)

--- a/test/metabase/query_processor/middleware/add_implicit_joins_test.clj
+++ b/test/metabase/query_processor/middleware/add_implicit_joins_test.clj
@@ -1173,3 +1173,39 @@
                                                 [:field {} "C__D_ID"]
                                                 [:field {:join-alias "D__via__D_ID_2"} 40]]]}]}]}
               (qp.preprocess/preprocess query))))))
+
+(deftest ^:parallel filter-creator-full-name-test
+  (testing "Implicit join through a filter on field with a remap only shows field once (#66418)"
+    (let [mp (-> (mt/metadata-provider)
+                 (lib.tu/remap-metadata-provider (mt/id :orders :product_id) (mt/id :products :title))
+                 (as-> $mp
+                     (let [model-query (lib/query $mp (lib.metadata/table $mp (mt/id :orders)))]
+                       (lib.tu/mock-metadata-provider
+                        $mp
+                        {:cards [{:id            1
+                                  :dataset-query model-query}]}))))
+          q  (-> (lib/query mp (lib.metadata/card mp 1))
+                 (lib/filter (lib/= (-> (lib.metadata/field mp (mt/id :products :title))
+                                        (lib/ref)
+                                        ;; these options can get passed in from the frontend
+                                        (lib/update-options assoc
+                                                            :source-field-name "PRODUCT_ID"
+                                                            :source-field   (mt/id :orders :product_id)))
+                                    "Blah")))]
+      (is (=? [[:field {} (mt/id :orders :id)]
+               [:field {} (mt/id :orders :user_id)]
+               [:field {} (mt/id :orders :product_id)]
+               [:field {} (mt/id :orders :subtotal)]
+               [:field {} (mt/id :orders :tax)]
+               [:field {} (mt/id :orders :total)]
+               [:field {} (mt/id :orders :discount)]
+               [:field {} (mt/id :orders :created_at)]
+               [:field {} (mt/id :orders :quantity)]
+               [:field
+                {:source-field (mt/id :orders :product_id)
+                 :join-alias   "PRODUCTS__via__PRODUCT_ID"}
+                (mt/id :products :title)]
+               ;; should only have one product title... this is broken if we have a second copy that includes
+               ;; `:source-field-name`
+               ]
+              (get-in (qp.preprocess/preprocess q) [:stages 0 :fields]))))))

--- a/test/metabase/query_processor/pivot_test.clj
+++ b/test/metabase/query_processor/pivot_test.clj
@@ -672,6 +672,8 @@
 
 (deftest ^:parallel fe-friendly-legacy-field-refs-test
   (testing "field_refs in the result metadata should match the 'traditional' legacy shape the FE expects, or it will break"
+    ;; (This is calculated by [[metabase.lib.metadata.result-metadata/super-broken-legacy-field-ref]])
+    ;;
     ;; `e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js` will break if the `field_ref`s don't come
     ;; back in this EXACT shape =(, see [[metabase.query-processor.middleware.annotate/fe-friendly-legacy-ref]]
     (let [query (merge


### PR DESCRIPTION
Fixes #66418

The root cause of #66418 is that multiple copies of a field ref where one has `:source-field-name` and one did not were considered distinct, not deduplicated, and compiled to broken SQL, e.g.

```clj
[[:field {:source-field 1}]
 [:field {:source-field 1, :source-field-name "ID"}]]
```

`:source-field-name` is only relevant when we have multiple field refs with distinct values for it with the same `:source-field`... so ignore it for deduplication purposes.

```clj
[[:field {:source-field 1}]
  ;; no other fields with the same `:source-field` but a different `:source-field-name`, 
  ;; thus ignore `:source-field-name`
 [:field {:source-field 1, :source-field-name "ID"}]]
``` 

This is not a perfect fix as I suspect we'd still run into issues if you have multiple joins and then have duplicate refs that do or don't have `:source-field-name`, e.g.

```clj
[[:field {:source-field 1}] ; <-- this is ambiguous, and won't be deduplicated -- query likely will not work correctly
 [:field {:source-field 1, :source-field-name "ID"}]
 [:field {:source-field 1, :source-field-name "CATEGORY_ID"}]]
 ```
 
 but that situation seems rare and this query is sort of broken and ambiguous anyway.
 
 I think a **better** way to fix this would be to ensure we have `:source-field-name` everywhere we have `:source-field` (or possibly `:source-field-join-alias` instead) but that's a much more involved fix (both QP and Lib will need to be updated to "fill this in" I think), and this might just be good enough for now. I did investigate this a little bit and implemented it in the QP so it's definitely feasible but I think we might want to punt on that for now and pick it up as a future project... sometimes fixing 99% of a bug in 2 hours is better than fixing 100% of it in a week right