### PR TITLE
Allow internal users to have perms on tenant colls

### DIFF
--- a/e2e/support/helpers/e2e-permissions-helpers.js
+++ b/e2e/support/helpers/e2e-permissions-helpers.js
@@ -17,18 +17,20 @@ export function modifyPermission(
   item,
   permissionIndex,
   value,
-  shouldPropagate = null,
+  shouldPropagateToChildren = null,
 ) {
   selectPermissionRow(item, permissionIndex);
 
   popover()
     .should("have.length", 1)
     .within(() => {
-      if (shouldPropagate !== null) {
+      if (shouldPropagateToChildren !== null) {
         cy.findByRole("switch")
           .as("toggle")
           .then(($el) => {
-            if ($el.attr("aria-checked") !== shouldPropagate.toString()) {
+            if (
+              $el.attr("aria-checked") !== shouldPropagateToChildren.toString()
+            ) {
               cy.get("@toggle").click();
             }
           });

--- a/enterprise/backend/test/metabase_enterprise/tenants/model_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/tenants/model_test.clj
@@ -132,7 +132,7 @@
             (testing "attempting to set personal_owner_id should fail"
               (is (thrown-with-msg?
                    Exception
-                   #"Personal Collections must be in the default namespace"
+                   #"You are not allowed to change the owner of a Tenant Collection."
                    (t2/update! :model/Collection tenant-collection-id
                                {:personal_owner_id user-id}))))))))))
 

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/CanAccessTenantSpecificRoute/CanAccessTenantSpecificRoute.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/CanAccessTenantSpecificRoute/CanAccessTenantSpecificRoute.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from "react";
+
+import { useGetCollectionQuery } from "metabase/api";
+import { Unauthorized } from "metabase/common/components/ErrorPages";
+import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
+import { useSelector } from "metabase/lib/redux";
+import { getUserIsAdmin } from "metabase/selectors/user";
+
+type Props = {
+  children: ReactNode;
+};
+
+export const CanAccessTenantSpecificRoute = ({ children }: Props) => {
+  const isAdmin = useSelector(getUserIsAdmin);
+
+  // Admins always have access, skip the API call
+  const { data, isLoading } = useGetCollectionQuery(
+    { id: "root", namespace: "tenant-specific" },
+    { skip: isAdmin },
+  );
+
+  if (isAdmin) {
+    return <>{children}</>;
+  }
+
+  if (isLoading) {
+    return <LoadingAndErrorWrapper loading />;
+  }
+
+  // If we got data back, user has access
+  if (data) {
+    return <>{children}</>;
+  }
+
+  // Error or no data means no access
+  return <Unauthorized />;
+};

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/CanAccessTenantSpecificRoute/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/CanAccessTenantSpecificRoute/index.ts
@@ -1,0 +1,1 @@
+export { CanAccessTenantSpecificRoute } from "./CanAccessTenantSpecificRoute";

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/MainNavSharedCollections/MainNavSharedCollections.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/MainNavSharedCollections/MainNavSharedCollections.tsx
@@ -28,11 +28,11 @@ import { CollectionSyncStatusBadge } from "metabase-enterprise/remote_sync/compo
 import type { Collection } from "metabase-types/api";
 
 export const MainNavSharedCollections = ({
-  canAccessTenantSpecific,
+  canAccessTenantSpecificCollections,
   canCreateSharedCollection,
   sharedTenantCollections,
 }: {
-  canAccessTenantSpecific: boolean;
+  canAccessTenantSpecificCollections: boolean;
   canCreateSharedCollection: boolean;
   sharedTenantCollections: Collection[] | undefined;
 }) => {
@@ -113,7 +113,7 @@ export const MainNavSharedCollections = ({
   const shouldShowSharedCollectionsSection =
     hasVisibleSharedTenantCollections ||
     canCreateSharedCollection ||
-    canAccessTenantSpecific;
+    canAccessTenantSpecificCollections;
 
   return (
     <>
@@ -146,7 +146,7 @@ export const MainNavSharedCollections = ({
               showChangesBadge(item?.id) && <CollectionSyncStatusBadge />
             }
           />
-          {canAccessTenantSpecific && (
+          {canAccessTenantSpecificCollections && (
             <PaddedSidebarLink icon="group" url={tenantSpecificCollections()}>
               {t`Tenant collections`}
             </PaddedSidebarLink>

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/MainNavSharedCollections/MainNavSharedCollections.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/MainNavSharedCollections/MainNavSharedCollections.tsx
@@ -28,9 +28,11 @@ import { CollectionSyncStatusBadge } from "metabase-enterprise/remote_sync/compo
 import type { Collection } from "metabase-types/api";
 
 export const MainNavSharedCollections = ({
+  canAccessTenantSpecific,
   canCreateSharedCollection,
   sharedTenantCollections,
 }: {
+  canAccessTenantSpecific: boolean;
   canCreateSharedCollection: boolean;
   sharedTenantCollections: Collection[] | undefined;
 }) => {
@@ -109,7 +111,9 @@ export const MainNavSharedCollections = ({
     sharedTenantCollectionTree.length > 0;
 
   const shouldShowSharedCollectionsSection =
-    hasVisibleSharedTenantCollections || canCreateSharedCollection;
+    hasVisibleSharedTenantCollections ||
+    canCreateSharedCollection ||
+    canAccessTenantSpecific;
 
   return (
     <>
@@ -142,7 +146,7 @@ export const MainNavSharedCollections = ({
               showChangesBadge(item?.id) && <CollectionSyncStatusBadge />
             }
           />
-          {isAdmin && (
+          {canAccessTenantSpecific && (
             <PaddedSidebarLink icon="group" url={tenantSpecificCollections()}>
               {t`Tenant collections`}
             </PaddedSidebarLink>

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/MainNavSharedCollections/MainNavSharedCollections.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/MainNavSharedCollections/MainNavSharedCollections.unit.spec.tsx
@@ -22,13 +22,13 @@ const setup = ({
   tenantCollections = MOCK_TENANT_COLLECTIONS,
   currentUser = createMockUser({ is_superuser: isAdmin }),
   canWriteToSharedCollectionRoot = false,
-  canAccessTenantSpecific = isAdmin,
+  canAccessTenantSpecificCollections = isAdmin,
 }: {
   isAdmin?: boolean;
   tenantCollections?: Collection[];
   currentUser?: ReturnType<typeof createMockUser>;
   canWriteToSharedCollectionRoot?: boolean;
-  canAccessTenantSpecific?: boolean;
+  canAccessTenantSpecificCollections?: boolean;
 } = {}) => {
   const settings = mockSettings({ "use-tenants": true });
 
@@ -44,7 +44,7 @@ const setup = ({
 
   renderWithProviders(
     <MainNavSharedCollections
-      canAccessTenantSpecific={canAccessTenantSpecific}
+      canAccessTenantSpecificCollections={canAccessTenantSpecificCollections}
       canCreateSharedCollection={canWriteToSharedCollectionRoot}
       sharedTenantCollections={tenantCollections}
     />,
@@ -145,7 +145,7 @@ describe("MainNavSharedCollections > section visibility", () => {
 
     renderWithProviders(
       <MainNavSharedCollections
-        canAccessTenantSpecific={false}
+        canAccessTenantSpecificCollections={false}
         canCreateSharedCollection={false}
         sharedTenantCollections={[]}
       />,

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/MainNavSharedCollections/MainNavSharedCollections.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/MainNavSharedCollections/MainNavSharedCollections.unit.spec.tsx
@@ -22,11 +22,13 @@ const setup = ({
   tenantCollections = MOCK_TENANT_COLLECTIONS,
   currentUser = createMockUser({ is_superuser: isAdmin }),
   canWriteToSharedCollectionRoot = false,
+  canAccessTenantSpecific = isAdmin,
 }: {
   isAdmin?: boolean;
   tenantCollections?: Collection[];
   currentUser?: ReturnType<typeof createMockUser>;
   canWriteToSharedCollectionRoot?: boolean;
+  canAccessTenantSpecific?: boolean;
 } = {}) => {
   const settings = mockSettings({ "use-tenants": true });
 
@@ -42,6 +44,7 @@ const setup = ({
 
   renderWithProviders(
     <MainNavSharedCollections
+      canAccessTenantSpecific={canAccessTenantSpecific}
       canCreateSharedCollection={canWriteToSharedCollectionRoot}
       sharedTenantCollections={tenantCollections}
     />,
@@ -142,6 +145,7 @@ describe("MainNavSharedCollections > section visibility", () => {
 
     renderWithProviders(
       <MainNavSharedCollections
+        canAccessTenantSpecific={false}
         canCreateSharedCollection={false}
         sharedTenantCollections={[]}
       />,

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantCollectionPermissionsPage/TenantCollectionPermissionsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantCollectionPermissionsPage/TenantCollectionPermissionsPage.tsx
@@ -58,7 +58,7 @@ type UpdateCollectionPermissionParams = {
   groupId: GroupId;
   collection: Collection;
   value: unknown;
-  shouldPropagate: boolean;
+  shouldPropagateToChildren: boolean;
 };
 
 type TenantCollectionPermissionsPageProps = {
@@ -71,7 +71,7 @@ type TenantCollectionPermissionsPageProps = {
     groupId,
     collection,
     value,
-    shouldPropagate,
+    shouldPropagateToChildren,
   }: UpdateCollectionPermissionParams) => void;
   isDirty: boolean;
   savePermissions: () => void;
@@ -107,7 +107,7 @@ function TenantCollectionPermissionsPageView({
         groupId: item.id,
         collection,
         value,
-        shouldPropagate: toggleState,
+        shouldPropagateToChildren: toggleState,
       });
     },
     [collection, updateCollectionPermission],

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantCollectionPermissionsPage/selectors.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantCollectionPermissionsPage/selectors.unit.spec.ts
@@ -5,6 +5,7 @@ import { createMockTokenFeatures } from "metabase-types/api/mocks";
 import type { State } from "metabase-types/store";
 import {
   createMockAdminState,
+  createMockPermissionsState,
   createMockState,
 } from "metabase-types/store/mocks";
 
@@ -34,16 +35,10 @@ const createMockStateWithPermissions = ({
       "token-features": createMockTokenFeatures({ tenants: true }),
     }),
     admin: createMockAdminState({
-      permissions: {
-        dataPermissions: {},
-        originalDataPermissions: {},
-        collectionPermissions: {},
-        originalCollectionPermissions: {},
+      permissions: createMockPermissionsState({
         tenantCollectionPermissions,
         originalTenantCollectionPermissions,
-        isHelpReferenceOpen: false,
-        hasRevisionChanged: { revision: null, hasChanged: false },
-      },
+      }),
     }),
   });
 

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantSpecificCollectionPermissionsPage/TenantSpecificCollectionPermissionsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantSpecificCollectionPermissionsPage/TenantSpecificCollectionPermissionsPage.tsx
@@ -35,7 +35,7 @@ type UpdateCollectionPermissionParams = {
   groupId: GroupId;
   collection: Collection;
   value: unknown;
-  shouldPropagate: boolean;
+  shouldPropagateToChildren: boolean;
 };
 
 type TenantSpecificCollectionPermissionsPageProps = {
@@ -85,14 +85,14 @@ function TenantSpecificCollectionPermissionsPageView({
       groupId,
       collection,
       value,
-      shouldPropagate,
+      shouldPropagateToChildren,
     }: UpdateCollectionPermissionParams) => {
       dispatch(
         updateTenantSpecificCollectionPermission({
           groupId,
           collection,
           value,
-          shouldPropagate,
+          shouldPropagateToChildren,
         }),
       );
     },
@@ -118,7 +118,7 @@ function TenantSpecificCollectionPermissionsPageView({
         groupId: item.id,
         collection: collection as Collection,
         value,
-        shouldPropagate: true,
+        shouldPropagateToChildren: true,
       });
     },
     [collection, updateCollectionPermission],

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantSpecificCollectionPermissionsPage/TenantSpecificCollectionPermissionsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantSpecificCollectionPermissionsPage/TenantSpecificCollectionPermissionsPage.tsx
@@ -1,0 +1,156 @@
+import { useCallback, useEffect } from "react";
+import type { Route } from "react-router";
+import { push } from "react-router-redux";
+import { t } from "ttag";
+import _ from "underscore";
+
+import { CollectionPermissionsHelp } from "metabase/admin/permissions/components/CollectionPermissionsHelp";
+import {
+  PermissionsEditor,
+  PermissionsEditorEmptyState,
+} from "metabase/admin/permissions/components/PermissionsEditor";
+import { PermissionsPageLayout } from "metabase/admin/permissions/components/PermissionsPageLayout";
+import { PermissionsSidebar } from "metabase/admin/permissions/components/PermissionsSidebar";
+import {
+  initializeTenantSpecificCollectionPermissions,
+  loadTenantSpecificCollectionPermissions,
+  saveTenantSpecificCollectionPermissions,
+  updateTenantSpecificCollectionPermission,
+} from "metabase/admin/permissions/permissions";
+import type {
+  CollectionIdProps,
+  CollectionPermissionEditorType,
+  CollectionSidebarType,
+} from "metabase/admin/permissions/selectors/collection-permissions";
+import { Collections } from "metabase/entities/collections";
+import { Groups } from "metabase/entities/groups";
+import { connect } from "metabase/lib/redux";
+import type { Collection, CollectionId, GroupId } from "metabase-types/api";
+import type { State } from "metabase-types/store";
+
+import {
+  getIsTenantSpecificDirty,
+  getTenantSpecificCollectionEntity,
+  getTenantSpecificCollectionsPermissionEditor,
+  getTenantSpecificCollectionsSidebar,
+  tenantSpecificCollectionsQuery,
+} from "./selectors";
+
+const mapDispatchToProps = {
+  initialize: initializeTenantSpecificCollectionPermissions,
+  loadPermissions: loadTenantSpecificCollectionPermissions,
+  navigateToItem: ({ id }: { id: CollectionId }) =>
+    push(`/admin/permissions/tenant-specific-collections/${id}`),
+  updateCollectionPermission: updateTenantSpecificCollectionPermission,
+  savePermissions: saveTenantSpecificCollectionPermissions,
+};
+
+const mapStateToProps = (state: State, props: CollectionIdProps) => {
+  return {
+    sidebar: getTenantSpecificCollectionsSidebar(state, props),
+    permissionEditor: getTenantSpecificCollectionsPermissionEditor(
+      state,
+      props,
+    ),
+    isDirty: getIsTenantSpecificDirty(state),
+    collection: getTenantSpecificCollectionEntity(state, props),
+  };
+};
+
+type UpdateCollectionPermissionParams = {
+  groupId: GroupId;
+  collection: Collection;
+  value: unknown;
+  shouldPropagate: boolean;
+};
+
+type TenantSpecificCollectionPermissionsPageProps = {
+  params: CollectionIdProps["params"];
+  sidebar: CollectionSidebarType;
+  permissionEditor: CollectionPermissionEditorType;
+  collection: Collection;
+  navigateToItem: (item: { id: CollectionId }) => void;
+  updateCollectionPermission: ({
+    groupId,
+    collection,
+    value,
+    shouldPropagate,
+  }: UpdateCollectionPermissionParams) => void;
+  isDirty: boolean;
+  savePermissions: () => void;
+  loadPermissions: () => void;
+  initialize: () => void;
+  route: Route;
+};
+
+function TenantSpecificCollectionPermissionsPageView({
+  sidebar,
+  permissionEditor,
+  collection,
+  isDirty,
+  savePermissions,
+  loadPermissions,
+  updateCollectionPermission,
+  navigateToItem,
+  initialize,
+  route,
+}: TenantSpecificCollectionPermissionsPageProps) {
+  useEffect(() => {
+    initialize();
+  }, [initialize]);
+
+  const handlePermissionChange = useCallback(
+    (
+      item: { id: GroupId },
+      _permission: unknown,
+      value: unknown,
+      _toggleState: boolean,
+    ) => {
+      // Always propagate to sub-collections for tenant-specific collections
+      updateCollectionPermission({
+        groupId: item.id,
+        collection,
+        value,
+        shouldPropagate: true,
+      });
+    },
+    [collection, updateCollectionPermission],
+  );
+
+  return (
+    <PermissionsPageLayout
+      tab="tenant-specific-collections"
+      isDirty={isDirty}
+      route={route}
+      onSave={savePermissions}
+      onLoad={() => loadPermissions()}
+      helpContent={<CollectionPermissionsHelp />}
+    >
+      <PermissionsSidebar {...sidebar} onSelect={navigateToItem} />
+
+      {!permissionEditor && (
+        <PermissionsEditorEmptyState
+          icon="folder"
+          message={t`Select a collection to see its permissions`}
+        />
+      )}
+
+      {permissionEditor && (
+        <PermissionsEditor
+          isLoading={undefined}
+          error={undefined}
+          {...permissionEditor}
+          onChange={handlePermissionChange}
+        />
+      )}
+    </PermissionsPageLayout>
+  );
+}
+
+export const TenantSpecificCollectionPermissionsPage = _.compose(
+  Collections.loadList({
+    entityQuery: tenantSpecificCollectionsQuery,
+  }),
+  Groups.loadList(),
+  connect(mapStateToProps, mapDispatchToProps),
+)(TenantSpecificCollectionPermissionsPageView);

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantSpecificCollectionPermissionsPage/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantSpecificCollectionPermissionsPage/index.ts
@@ -1,0 +1,1 @@
+export { TenantSpecificCollectionPermissionsPage } from "./TenantSpecificCollectionPermissionsPage";

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantSpecificCollectionPermissionsPage/selectors.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantSpecificCollectionPermissionsPage/selectors.tsx
@@ -1,0 +1,283 @@
+import { createSelector } from "@reduxjs/toolkit";
+import { getIn } from "icepick";
+import { t } from "ttag";
+import _ from "underscore";
+
+import { COLLECTION_OPTIONS } from "metabase/admin/permissions/constants/collections-permissions";
+import { Messages } from "metabase/admin/permissions/constants/messages";
+import type {
+  CollectionIdProps,
+  CollectionPermissionEditorType,
+  CollectionSidebarType,
+} from "metabase/admin/permissions/selectors/collection-permissions";
+import { getPermissionWarningModal } from "metabase/admin/permissions/selectors/confirmations";
+import type { DataPermissionValue } from "metabase/admin/permissions/types";
+import {
+  Collections,
+  ROOT_COLLECTION,
+  getCollectionIcon,
+} from "metabase/entities/collections";
+import { Groups } from "metabase/entities/groups";
+import {
+  getGroupNameLocalized,
+  isAdminGroup,
+  isDefaultGroup,
+} from "metabase/lib/groups";
+import { PLUGIN_TENANTS } from "metabase/plugins";
+import type {
+  Collection,
+  CollectionId,
+  CollectionPermissions,
+  Group as GroupType,
+} from "metabase-types/api";
+import type { ExpandedCollection, State } from "metabase-types/store";
+
+export const tenantSpecificCollectionsQuery = {
+  tree: true,
+  "exclude-other-user-collections": true,
+  "exclude-archived": true,
+  namespace: "tenant-specific",
+};
+
+export const getIsTenantSpecificDirty = createSelector(
+  (state: State) => state.admin.permissions.tenantSpecificCollectionPermissions,
+  (state: State) =>
+    state.admin.permissions.originalTenantSpecificCollectionPermissions,
+  (
+    permissions: CollectionPermissions,
+    originalPermissions: CollectionPermissions,
+  ) => JSON.stringify(permissions) !== JSON.stringify(originalPermissions),
+);
+
+export const getCurrentTenantSpecificCollectionId = (
+  _state: State,
+  props: CollectionIdProps,
+) => {
+  if (props.params.collectionId == null) {
+    return undefined;
+  }
+
+  return props.params.collectionId === ROOT_COLLECTION.id
+    ? ROOT_COLLECTION.id
+    : parseInt(String(props.params.collectionId));
+};
+
+const getTenantSpecificRootCollectionTreeItem = () => {
+  const rootCollectionIcon = getCollectionIcon(ROOT_COLLECTION);
+  return {
+    ...ROOT_COLLECTION,
+    name: t`Root tenant collection`,
+    icon: rootCollectionIcon.name,
+    iconColor: rootCollectionIcon.color,
+  };
+};
+
+const getTenantSpecificCollections = (state: State) =>
+  Collections.selectors.getList(state, {
+    entityQuery: tenantSpecificCollectionsQuery,
+  }) ?? [];
+
+const getTenantSpecificCollectionsTree = createSelector(
+  [getTenantSpecificCollections],
+  () => {
+    // Only show the single "Root tenant collection" in the sidebar
+    return [getTenantSpecificRootCollectionTreeItem()];
+  },
+);
+
+export const getTenantSpecificCollectionsSidebar = createSelector(
+  getTenantSpecificCollectionsTree,
+  getCurrentTenantSpecificCollectionId,
+  (collectionsTree, collectionId): CollectionSidebarType => {
+    return {
+      selectedId: collectionId,
+      title: t`Tenant collections`,
+      entityGroups: [collectionsTree || []],
+      filterPlaceholder: t`Search for a collection`,
+    };
+  },
+);
+
+const getTenantSpecificCollectionsPermissions = (state: State) =>
+  state.admin.permissions.tenantSpecificCollectionPermissions;
+
+const findCollection = (
+  collections: Collection[],
+  collectionId: CollectionId,
+): Collection | null => {
+  if (collections.length === 0) {
+    return null;
+  }
+
+  const collection = collections.find(
+    (collection) => collection.id === collectionId,
+  );
+
+  if (collection) {
+    return collection;
+  }
+
+  return findCollection(
+    collections.map((collection) => collection.children ?? []).flat(),
+    collectionId,
+  );
+};
+
+const getTenantSpecificCollection = createSelector(
+  [getCurrentTenantSpecificCollectionId, getTenantSpecificCollections],
+  (collectionId, collections) => {
+    if (collectionId == null) {
+      return null;
+    }
+
+    if (collectionId === ROOT_COLLECTION.id) {
+      return {
+        ...ROOT_COLLECTION,
+        name: t`Root tenant collection`,
+        children: collections,
+      };
+    }
+
+    return findCollection(collections, collectionId);
+  },
+);
+
+export const getTenantSpecificCollectionEntity = (
+  state: State,
+  props: CollectionIdProps,
+) => {
+  return getTenantSpecificCollection(state, props);
+};
+
+const getTenantSpecificCollectionPermission = (
+  permissions: CollectionPermissions,
+  groupId: number,
+  collectionId: CollectionId,
+) => getIn(permissions, [groupId, collectionId]) || "none";
+
+export const getTenantSpecificCollectionsPermissionEditor = createSelector(
+  getTenantSpecificCollectionsPermissions,
+  getTenantSpecificCollectionEntity,
+  Groups.selectors.getList,
+  (permissions, collection, groups): CollectionPermissionEditorType => {
+    if (!permissions || collection == null) {
+      return null;
+    }
+
+    // Filter out tenant groups - they get implicit permissions based on tenant membership
+    const nonTenantGroups = groups.filter(
+      (group: GroupType) => !PLUGIN_TENANTS.isTenantGroup(group),
+    );
+
+    const entities = nonTenantGroups
+      .map((group: GroupType) => {
+        const isAdmin = isAdminGroup(group);
+
+        const defaultGroup = _.find(nonTenantGroups, isDefaultGroup);
+
+        const defaultGroupPermission = defaultGroup
+          ? getTenantSpecificCollectionPermission(
+              permissions,
+              defaultGroup.id,
+              collection.id,
+            )
+          : "none";
+
+        const confirmations = (newValue: DataPermissionValue) => [
+          getPermissionWarningModal(
+            newValue,
+            defaultGroupPermission,
+            null,
+            defaultGroup,
+            group.id,
+          ),
+        ];
+
+        const options = [
+          COLLECTION_OPTIONS.write,
+          COLLECTION_OPTIONS.read,
+          COLLECTION_OPTIONS.none,
+        ];
+
+        const disabled = isAdmin;
+
+        return {
+          id: group.id,
+          name: getGroupNameLocalized(group),
+          permissions: [
+            {
+              // Always show toggle as checked and disabled for tenant-specific collections
+              toggleLabel: t`Also change sub-collections`,
+              hasChildren: true,
+              toggleDisabled: true,
+              toggleDefaultValue: true,
+              isDisabled: disabled,
+              disabledTooltip: disabled
+                ? Messages.UNABLE_TO_CHANGE_ADMIN_PERMISSIONS
+                : null,
+              value: getTenantSpecificCollectionPermission(
+                permissions,
+                group.id,
+                collection.id,
+              ),
+              warning: getTenantSpecificCollectionWarning(
+                group.id,
+                collection as ExpandedCollection,
+                permissions,
+              ),
+              confirmations,
+              options,
+            },
+          ],
+        };
+      })
+      .filter(Boolean);
+
+    return {
+      title: t`Permissions for ${collection.name}`,
+      filterPlaceholder: t`Search for a group`,
+      columns: [{ name: t`Group name` }, { name: t`Collection access` }],
+      entities,
+    };
+  },
+);
+
+const permissionsCollectionFilter = (collection: ExpandedCollection) =>
+  !collection.is_personal;
+
+function getDescendentCollections(
+  collection: ExpandedCollection,
+): ExpandedCollection[] {
+  const subCollections =
+    collection.children?.filter(permissionsCollectionFilter) || [];
+  return subCollections.concat(...subCollections.map(getDescendentCollections));
+}
+
+function getTenantSpecificCollectionWarning(
+  groupId: number,
+  collection: ExpandedCollection,
+  permissions: CollectionPermissions,
+) {
+  if (!collection) {
+    return;
+  }
+  const collectionPerm = getTenantSpecificCollectionPermission(
+    permissions,
+    groupId,
+    collection.id,
+  );
+  const descendentCollections = getDescendentCollections(collection);
+  const descendentPerms = new Set(
+    descendentCollections.map((c) =>
+      getTenantSpecificCollectionPermission(permissions, groupId, c.id),
+    ),
+  );
+  if (
+    collectionPerm === "none" &&
+    (descendentPerms.has("read") || descendentPerms.has("write"))
+  ) {
+    return t`This group has permission to view at least one subcollection of this collection.`;
+  } else if (collectionPerm === "read" && descendentPerms.has("write")) {
+    return t`This group has permission to edit at least one subcollection of this collection.`;
+  }
+}

--- a/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
@@ -287,7 +287,8 @@ export function initializePlugin() {
         { id: "root", namespace: "tenant-specific" },
         { skip: !useTenants || isTenantUser || isAdmin },
       );
-      const canAccessTenantSpecific = isAdmin || !!tenantSpecificRoot;
+      const canAccessTenantSpecificCollections =
+        isAdmin || !!tenantSpecificRoot;
 
       // Non-admins can create shared collections if they have curate permissions on the root shared collection
       const canCreateSharedCollection =
@@ -299,10 +300,10 @@ export function initializePlugin() {
         !isTenantUser &&
         (hasVisibleSharedCollections ||
           canCreateSharedCollection ||
-          canAccessTenantSpecific);
+          canAccessTenantSpecificCollections);
 
       return {
-        canAccessTenantSpecific,
+        canAccessTenantSpecificCollections,
         canCreateSharedCollection,
         showExternalCollectionsSection,
         sharedTenantCollections,

--- a/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
@@ -25,13 +25,14 @@ import {
   PLUGIN_ADMIN_USER_MENU_ROUTES,
   PLUGIN_TENANTS,
 } from "metabase/plugins";
-import { getIsTenantUser } from "metabase/selectors/user";
+import { getIsTenantUser, getUserIsAdmin } from "metabase/selectors/user";
 import { getApplicationName } from "metabase/selectors/whitelabel";
 import { Box, Text } from "metabase/ui";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import { EditUserStrategyModal } from "./EditUserStrategyModal";
 import { EditUserStrategySettingsButton } from "./EditUserStrategySettingsButton";
+import { CanAccessTenantSpecificRoute } from "./components/CanAccessTenantSpecificRoute";
 import { ExternalGroupDetailApp } from "./components/ExternalGroupDetailApp/ExternalGroupDetailApp";
 import { ExternalGroupsListingApp } from "./components/ExternalGroupsListingApp/ExternalGroupsListingApp";
 import { ExternalPeopleListingApp } from "./components/ExternalPeopleListingApp/ExternalPeopleListingApp";
@@ -43,6 +44,7 @@ import { TenantCollectionPermissionsPage } from "./components/TenantCollectionPe
 import { TenantDisplayName } from "./components/TenantDisplayName";
 import { FormTenantWidget } from "./components/TenantFormWidget";
 import { TenantGroupHintIcon } from "./components/TenantGroupHintIcon";
+import { TenantSpecificCollectionPermissionsPage } from "./components/TenantSpecificCollectionPermissionsPage";
 import { TenantSpecificCollectionsItemList } from "./components/TenantSpecificCollectionsItemList";
 import { TenantUsersList } from "./components/TenantUsersList";
 import { TenantUsersPersonalCollectionList } from "./components/TenantUsersPersonalCollectionList";
@@ -68,19 +70,32 @@ export function initializePlugin() {
   if (hasPremiumFeature("tenants")) {
     PLUGIN_TENANTS.isEnabled = true;
 
-    // Register tenant collection permissions tab and routes
+    // Register tenant collection permissions tabs and routes
     PLUGIN_ADMIN_PERMISSIONS_TABS.tabs.push({
       name: t`Shared collections`,
       value: "tenant-collections",
     });
 
+    PLUGIN_ADMIN_PERMISSIONS_TABS.tabs.push({
+      name: t`Tenant collections`,
+      value: "tenant-specific-collections",
+    });
+
     PLUGIN_ADMIN_PERMISSIONS_TABS.getRoutes = () => (
-      <Route
-        path="tenant-collections"
-        component={TenantCollectionPermissionsPage}
-      >
-        <Route path=":collectionId" />
-      </Route>
+      <>
+        <Route
+          path="tenant-collections"
+          component={TenantCollectionPermissionsPage}
+        >
+          <Route path=":collectionId" />
+        </Route>
+        <Route
+          path="tenant-specific-collections"
+          component={TenantSpecificCollectionPermissionsPage}
+        >
+          <Route path=":collectionId" />
+        </Route>
+      </>
     );
 
     PLUGIN_TENANTS.EditUserStrategyModal = EditUserStrategyModal;
@@ -178,6 +193,7 @@ export function initializePlugin() {
     PLUGIN_TENANTS.TenantSpecificCollectionsItemList =
       TenantSpecificCollectionsItemList;
     PLUGIN_TENANTS.TenantCollectionList = TenantCollectionList;
+    PLUGIN_TENANTS.CanAccessTenantSpecificRoute = CanAccessTenantSpecificRoute;
     PLUGIN_TENANTS.TenantUsersList = TenantUsersList;
     PLUGIN_TENANTS.TenantUsersPersonalCollectionList =
       TenantUsersPersonalCollectionList;
@@ -252,6 +268,7 @@ export function initializePlugin() {
     };
     PLUGIN_TENANTS.useTenantMainNavbarData = () => {
       const isTenantUser = useSelector(getIsTenantUser);
+      const isAdmin = useSelector(getUserIsAdmin);
       const useTenants = useSetting("use-tenants");
 
       const { data: sharedTenantCollections } = useListCollectionsTreeQuery(
@@ -265,6 +282,13 @@ export function initializePlugin() {
         { skip: !useTenants || isTenantUser },
       );
 
+      // Check if non-admin user has access to tenant-specific namespace
+      const { data: tenantSpecificRoot } = useGetCollectionQuery(
+        { id: "root", namespace: "tenant-specific" },
+        { skip: !useTenants || isTenantUser || isAdmin },
+      );
+      const canAccessTenantSpecific = isAdmin || !!tenantSpecificRoot;
+
       // Non-admins can create shared collections if they have curate permissions on the root shared collection
       const canCreateSharedCollection =
         sharedCollectionRoot?.can_write ?? false;
@@ -273,9 +297,12 @@ export function initializePlugin() {
       const showExternalCollectionsSection =
         useTenants &&
         !isTenantUser &&
-        (hasVisibleSharedCollections || canCreateSharedCollection);
+        (hasVisibleSharedCollections ||
+          canCreateSharedCollection ||
+          canAccessTenantSpecific);
 
       return {
+        canAccessTenantSpecific,
         canCreateSharedCollection,
         showExternalCollectionsSection,
         sharedTenantCollections,

--- a/frontend/src/metabase-types/store/admin.ts
+++ b/frontend/src/metabase-types/store/admin.ts
@@ -30,10 +30,16 @@ export interface AdminState {
   permissions: {
     dataPermissions: GroupsPermissions;
     originalDataPermissions: GroupsPermissions;
+    dataPermissionsRevision: number | null;
     collectionPermissions: CollectionPermissions;
     originalCollectionPermissions: CollectionPermissions;
+    collectionPermissionsRevision: number | null;
     tenantCollectionPermissions: CollectionPermissions;
     originalTenantCollectionPermissions: CollectionPermissions;
+    tenantCollectionPermissionsRevision: number | null;
+    tenantSpecificCollectionPermissions: CollectionPermissions;
+    originalTenantSpecificCollectionPermissions: CollectionPermissions;
+    tenantSpecificCollectionPermissionsRevision: number | null;
     saveError?: string;
     isHelpReferenceOpen: boolean;
     hasRevisionChanged: {

--- a/frontend/src/metabase-types/store/mocks/admin.ts
+++ b/frontend/src/metabase-types/store/mocks/admin.ts
@@ -25,10 +25,16 @@ export const createMockPermissionsState = (
   return {
     dataPermissions: {},
     originalDataPermissions: {},
+    dataPermissionsRevision: null,
     collectionPermissions: {},
     originalCollectionPermissions: {},
+    collectionPermissionsRevision: null,
     tenantCollectionPermissions: {},
     originalTenantCollectionPermissions: {},
+    tenantCollectionPermissionsRevision: null,
+    tenantSpecificCollectionPermissions: {},
+    originalTenantSpecificCollectionPermissions: {},
+    tenantSpecificCollectionPermissionsRevision: null,
     isHelpReferenceOpen: false,
     hasRevisionChanged: {
       revision: null,

--- a/frontend/src/metabase/admin/permissions/components/CollectionPermissionsModal/CollectionPermissionsModal.jsx
+++ b/frontend/src/metabase/admin/permissions/components/CollectionPermissionsModal/CollectionPermissionsModal.jsx
@@ -116,7 +116,7 @@ const CollectionPermissionsModal = ({
         groupId: item.id,
         collection,
         value,
-        shouldPropagate: toggleState,
+        shouldPropagateToChildren: toggleState,
         originalPermissionsState,
       });
     },

--- a/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsPageLayout.tsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsPageLayout.tsx
@@ -44,7 +44,8 @@ type PermissionsPageTab =
   | "data"
   | "collections"
   | "application"
-  | "tenant-collections";
+  | "tenant-collections"
+  | "tenant-specific-collections";
 type PermissionsPageLayoutProps = {
   children: ReactNode;
   tab: PermissionsPageTab;

--- a/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.jsx
@@ -11,7 +11,7 @@ import {
 } from "metabase/plugins";
 
 const propTypes = {
-  tab: PropTypes.oneOf(["data", "collections"]).isRequired,
+  tab: PropTypes.string.isRequired,
   onChangeTab: PropTypes.func.isRequired,
 };
 
@@ -21,7 +21,9 @@ export const PermissionsTabs = ({ tab, onChangeTab }) => {
   const adminPermissionsTabs = isUsingTenants
     ? PLUGIN_ADMIN_PERMISSIONS_TABS.tabs
     : PLUGIN_ADMIN_PERMISSIONS_TABS.tabs.filter(
-        (tab) => tab.value !== "tenant-collections",
+        (tab) =>
+          tab.value !== "tenant-collections" &&
+          tab.value !== "tenant-specific-collections",
       );
 
   return (

--- a/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelect.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelect.jsx
@@ -27,6 +27,8 @@ const propTypes = {
   value: PropTypes.string.isRequired,
   toggleLabel: PropTypes.string,
   hasChildren: PropTypes.bool,
+  toggleDisabled: PropTypes.bool,
+  toggleDefaultValue: PropTypes.bool,
   onChange: PropTypes.func.isRequired,
   onAction: PropTypes.func,
   isDisabled: PropTypes.bool,
@@ -41,6 +43,8 @@ export const PermissionsSelect = memo(function PermissionsSelect({
   value,
   toggleLabel,
   hasChildren,
+  toggleDisabled,
+  toggleDefaultValue,
   onChange,
   onAction,
   isDisabled,
@@ -48,7 +52,7 @@ export const PermissionsSelect = memo(function PermissionsSelect({
   warning,
   isHighlighted,
 }) {
-  const [toggleState, setToggleState] = useState(null);
+  const [toggleState, setToggleState] = useState(toggleDefaultValue ?? null);
   const [opened, setOpened] = useState(false);
   const selectedOption = options.find((option) => option.value === value);
   const selectableOptions = hasChildren
@@ -137,6 +141,7 @@ export const PermissionsSelect = memo(function PermissionsSelect({
                 small
                 value={toggleState || false}
                 onChange={onToggleChange}
+                disabled={toggleDisabled}
               />
             </ToggleContainer>
           )}

--- a/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/CollectionPermissionsPage.tsx
+++ b/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/CollectionPermissionsPage.tsx
@@ -63,7 +63,7 @@ type UpdateCollectionPermissionParams = {
   groupId: GroupId;
   collection: Collection;
   value: unknown;
-  shouldPropagate: boolean | null;
+  shouldPropagateToChildren: boolean | null;
   originalPermissionsState: CollectionPermissions;
 };
 
@@ -77,7 +77,7 @@ type CollectionPermissionsPageProps = {
     groupId,
     collection,
     value,
-    shouldPropagate,
+    shouldPropagateToChildren,
   }: UpdateCollectionPermissionParams) => void;
   isDirty: boolean;
   savePermissions: () => void;
@@ -117,7 +117,7 @@ function CollectionsPermissionsPageView({
         groupId: item.id,
         collection,
         value,
-        shouldPropagate: toggleState,
+        shouldPropagateToChildren: toggleState,
         originalPermissionsState,
       });
     },

--- a/frontend/src/metabase/admin/permissions/permissions.js
+++ b/frontend/src/metabase/admin/permissions/permissions.js
@@ -589,7 +589,7 @@ const collectionPermissions = handleActions(
           collection,
           groupId,
           originalPermissionsState,
-          shouldPropagate,
+          shouldPropagateToChildren,
           value,
         } = payload;
         let newPermissionsState = assocIn(
@@ -599,15 +599,15 @@ const collectionPermissions = handleActions(
         );
 
         /**
-         * Check if shouldPropagate is explicitly set (true or false) vs unset (null or undefined).
+         * Check if shouldPropagateToChildren is explicitly set (true or false) vs unset (null or undefined).
          * If it's a boolean, we either propagate the new value or restore the original. When not a boolean, we do nothing.
          */
-        if (isBoolean(shouldPropagate)) {
+        if (isBoolean(shouldPropagateToChildren)) {
           for (const descendent of getDecendentCollections(collection)) {
             newPermissionsState = assocIn(
               newPermissionsState,
               [groupId, descendent.id],
-              shouldPropagate
+              shouldPropagateToChildren
                 ? value
                 : getIn(originalPermissionsState, [groupId, descendent.id]),
             );
@@ -656,10 +656,11 @@ const tenantCollectionPermissions = handleActions(
     },
     [UPDATE_TENANT_COLLECTION_PERMISSION]: {
       next: (state, { payload }) => {
-        const { groupId, collection, value, shouldPropagate } = payload;
+        const { groupId, collection, value, shouldPropagateToChildren } =
+          payload;
         let newPermissions = assocIn(state, [groupId, collection.id], value);
 
-        if (shouldPropagate) {
+        if (shouldPropagateToChildren) {
           for (const descendent of getDecendentCollections(collection)) {
             newPermissions = assocIn(
               newPermissions,
@@ -710,10 +711,11 @@ const tenantSpecificCollectionPermissions = handleActions(
     },
     [UPDATE_TENANT_SPECIFIC_COLLECTION_PERMISSION]: {
       next: (state, { payload }) => {
-        const { groupId, collection, value, shouldPropagate } = payload;
+        const { groupId, collection, value, shouldPropagateToChildren } =
+          payload;
         let newPermissions = assocIn(state, [groupId, collection.id], value);
 
-        if (shouldPropagate) {
+        if (shouldPropagateToChildren) {
           for (const descendent of getDecendentCollections(collection)) {
             newPermissions = assocIn(
               newPermissions,

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarContainer.tsx
@@ -111,6 +111,7 @@ function MainNavbarContainer({
   });
 
   const {
+    canAccessTenantSpecific,
     canCreateSharedCollection,
     showExternalCollectionsSection,
     sharedTenantCollections,
@@ -210,6 +211,7 @@ function MainNavbarContainer({
         handleCloseNavbar={closeNavbar}
         handleLogout={logout}
         sharedTenantCollections={sharedTenantCollections}
+        canAccessTenantSpecific={canAccessTenantSpecific}
         canCreateSharedCollection={canCreateSharedCollection}
         showExternalCollectionsSection={showExternalCollectionsSection}
       />

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarContainer.tsx
@@ -111,7 +111,7 @@ function MainNavbarContainer({
   });
 
   const {
-    canAccessTenantSpecific,
+    canAccessTenantSpecificCollections,
     canCreateSharedCollection,
     showExternalCollectionsSection,
     sharedTenantCollections,
@@ -211,7 +211,7 @@ function MainNavbarContainer({
         handleCloseNavbar={closeNavbar}
         handleLogout={logout}
         sharedTenantCollections={sharedTenantCollections}
-        canAccessTenantSpecific={canAccessTenantSpecific}
+        canAccessTenantSpecificCollections={canAccessTenantSpecificCollections}
         canCreateSharedCollection={canCreateSharedCollection}
         showExternalCollectionsSection={showExternalCollectionsSection}
       />

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
@@ -60,6 +60,7 @@ type Props = {
   collections: CollectionTreeItem[];
   selectedItems: SelectedItem[];
   sharedTenantCollections?: Collection[];
+  canAccessTenantSpecific: boolean;
   canCreateSharedCollection: boolean;
   showExternalCollectionsSection: boolean;
   handleCloseNavbar: () => void;
@@ -84,6 +85,7 @@ export function MainNavbarView({
   handleCreateNewCollection,
   handleCloseNavbar,
   sharedTenantCollections,
+  canAccessTenantSpecific,
   canCreateSharedCollection,
   showExternalCollectionsSection,
 }: Props) {
@@ -233,6 +235,7 @@ export function MainNavbarView({
           {/* Tenant users don't see the section about "External collections" */}
           {showExternalCollectionsSection && (
             <PLUGIN_TENANTS.MainNavSharedCollections
+              canAccessTenantSpecific={canAccessTenantSpecific}
               canCreateSharedCollection={canCreateSharedCollection}
               sharedTenantCollections={sharedTenantCollections}
             />

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
@@ -60,7 +60,7 @@ type Props = {
   collections: CollectionTreeItem[];
   selectedItems: SelectedItem[];
   sharedTenantCollections?: Collection[];
-  canAccessTenantSpecific: boolean;
+  canAccessTenantSpecificCollections: boolean;
   canCreateSharedCollection: boolean;
   showExternalCollectionsSection: boolean;
   handleCloseNavbar: () => void;
@@ -85,7 +85,7 @@ export function MainNavbarView({
   handleCreateNewCollection,
   handleCloseNavbar,
   sharedTenantCollections,
-  canAccessTenantSpecific,
+  canAccessTenantSpecificCollections,
   canCreateSharedCollection,
   showExternalCollectionsSection,
 }: Props) {
@@ -235,7 +235,9 @@ export function MainNavbarView({
           {/* Tenant users don't see the section about "External collections" */}
           {showExternalCollectionsSection && (
             <PLUGIN_TENANTS.MainNavSharedCollections
-              canAccessTenantSpecific={canAccessTenantSpecific}
+              canAccessTenantSpecificCollections={
+                canAccessTenantSpecificCollections
+              }
               canCreateSharedCollection={canCreateSharedCollection}
               sharedTenantCollections={sharedTenantCollections}
             />

--- a/frontend/src/metabase/plugins/oss/tenants.ts
+++ b/frontend/src/metabase/plugins/oss/tenants.ts
@@ -43,7 +43,7 @@ const getDefaultPluginTenants = () => ({
     null as React.ReactElement | null,
   TenantGroupHintIcon: PluginPlaceholder,
   MainNavSharedCollections: PluginPlaceholder as React.ComponentType<{
-    canAccessTenantSpecific: boolean;
+    canAccessTenantSpecificCollections: boolean;
     canCreateSharedCollection: boolean;
     sharedTenantCollections: Collection[] | undefined;
   }>,
@@ -75,7 +75,7 @@ const getDefaultPluginTenants = () => ({
     null as string | null,
   getFlattenedCollectionsForNavbar: () => [],
   useTenantMainNavbarData: () => ({
-    canAccessTenantSpecific: false,
+    canAccessTenantSpecificCollections: false,
     canCreateSharedCollection: false,
     showExternalCollectionsSection: false,
     sharedTenantCollections: [],
@@ -86,7 +86,7 @@ export const PLUGIN_TENANTS: {
   isEnabled: boolean;
   userStrategyRoute: React.ReactElement | null;
   useTenantMainNavbarData: () => {
-    canAccessTenantSpecific: boolean;
+    canAccessTenantSpecificCollections: boolean;
     canCreateSharedCollection: boolean;
     showExternalCollectionsSection: boolean;
     sharedTenantCollections: Collection[] | undefined;
@@ -109,7 +109,7 @@ export const PLUGIN_TENANTS: {
   }) => React.ReactElement | null;
   TenantGroupHintIcon: React.ComponentType;
   MainNavSharedCollections: React.ComponentType<{
-    canAccessTenantSpecific: boolean;
+    canAccessTenantSpecificCollections: boolean;
     canCreateSharedCollection: boolean;
     sharedTenantCollections: Collection[] | undefined;
   }>;

--- a/frontend/src/metabase/plugins/oss/tenants.ts
+++ b/frontend/src/metabase/plugins/oss/tenants.ts
@@ -43,6 +43,7 @@ const getDefaultPluginTenants = () => ({
     null as React.ReactElement | null,
   TenantGroupHintIcon: PluginPlaceholder,
   MainNavSharedCollections: PluginPlaceholder as React.ComponentType<{
+    canAccessTenantSpecific: boolean;
     canCreateSharedCollection: boolean;
     sharedTenantCollections: Collection[] | undefined;
   }>,
@@ -51,6 +52,9 @@ const getDefaultPluginTenants = () => ({
   TenantSpecificCollectionsItemList: (_props: { pathIndex: number }) =>
     null as React.ReactElement | null,
   TenantCollectionList: PluginPlaceholder,
+  CanAccessTenantSpecificRoute: PluginPlaceholder as React.ComponentType<{
+    children: React.ReactNode;
+  }>,
   TenantUsersList: PluginPlaceholder,
   TenantUsersPersonalCollectionList: PluginPlaceholder as React.ComponentType<{
     params: { tenantId: string };
@@ -71,6 +75,7 @@ const getDefaultPluginTenants = () => ({
     null as string | null,
   getFlattenedCollectionsForNavbar: () => [],
   useTenantMainNavbarData: () => ({
+    canAccessTenantSpecific: false,
     canCreateSharedCollection: false,
     showExternalCollectionsSection: false,
     sharedTenantCollections: [],
@@ -81,6 +86,7 @@ export const PLUGIN_TENANTS: {
   isEnabled: boolean;
   userStrategyRoute: React.ReactElement | null;
   useTenantMainNavbarData: () => {
+    canAccessTenantSpecific: boolean;
     canCreateSharedCollection: boolean;
     showExternalCollectionsSection: boolean;
     sharedTenantCollections: Collection[] | undefined;
@@ -103,6 +109,7 @@ export const PLUGIN_TENANTS: {
   }) => React.ReactElement | null;
   TenantGroupHintIcon: React.ComponentType;
   MainNavSharedCollections: React.ComponentType<{
+    canAccessTenantSpecific: boolean;
     canCreateSharedCollection: boolean;
     sharedTenantCollections: Collection[] | undefined;
   }>;
@@ -113,6 +120,9 @@ export const PLUGIN_TENANTS: {
     pathIndex: number;
   }) => React.ReactElement | null;
   TenantCollectionList: React.ComponentType;
+  CanAccessTenantSpecificRoute: React.ComponentType<{
+    children: React.ReactNode;
+  }>;
   TenantUsersList: React.ComponentType;
   TenantUsersPersonalCollectionList: React.ComponentType<{
     params: { tenantId: string };

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -185,7 +185,10 @@ export const getRoutes = (store) => {
             <IndexRoute component={UserCollectionList} />
           </Route>
 
-          <Route path="collection/tenant-specific" component={IsAdmin}>
+          <Route
+            path="collection/tenant-specific"
+            component={PLUGIN_TENANTS.CanAccessTenantSpecificRoute}
+          >
             <IndexRoute component={PLUGIN_TENANTS.TenantCollectionList} />
           </Route>
 

--- a/src/metabase/permissions/models/permissions.clj
+++ b/src/metabase/permissions/models/permissions.clj
@@ -456,7 +456,7 @@
 (defn- is-trash-or-descendant? [collection]
   ((requiring-resolve 'metabase.collections.models.collection/is-trash-or-descendant?) collection))
 
-(defn- tenant-collection?
+(defn- shared-tenant-collection?
   [collection]
   ((requiring-resolve 'metabase.collections.models.collection/shared-tenant-collection?) collection))
 
@@ -504,9 +504,9 @@
   [group-or-id :- permissions.path/MapOrID collection-or-id :- permissions.path/MapOrID]
   (check-is-modifiable-collection collection-or-id)
   (let [collection (collection-or-id->collection collection-or-id)]
-    (when (and (not (tenant-collection? collection))
-               (perms-group/is-tenant-group? group-or-id))
-      (throw (ex-info (tru "Tenant groups cannot receive access to non-tenant collections.") {}))))
+    (when (perms-group/is-tenant-group? group-or-id)
+      (when-not (shared-tenant-collection? collection)
+        (throw (ex-info (tru "Tenant groups cannot receive access to non-tenant collections.") {})))))
   (grant-permissions! (u/the-id group-or-id) (permissions.path/collection-read-path collection-or-id)))
 
 (defenterprise current-user-has-application-permissions?


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/EMB-1176/allow-configuring-permissions-on-tenant-collections-for-internal-users
Notably, this required allowing internal users to list tenants. I think this is acceptable?
