### PR TITLE
Hide other channels than email on the alert modal

### DIFF
--- a/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
@@ -419,7 +419,7 @@ describe("InteractiveQuestion", () => {
   });
 
   describe("alert modal", () => {
-    it("should not show email selector on the SDK", async () => {
+    it("should not show email selector on the SDK and use current logged in user as the recipient", async () => {
       await setup({
         withAlerts: true,
         isEmailSetup: true,

--- a/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
@@ -1,5 +1,8 @@
+import userEvent from "@testing-library/user-event";
+
 import { setupEnterpriseOnlyPlugin } from "__support__/enterprise";
 import {
+  findRequests,
   setupAlertsEndpoints,
   setupCardEndpoints,
   setupCardQueryEndpoints,
@@ -9,6 +12,11 @@ import {
   setupNotificationChannelsEndpoints,
   setupTableEndpoints,
 } from "__support__/server-mocks";
+import { setupWebhookChannelsEndpoint } from "__support__/server-mocks/channel";
+import {
+  setupCreateNotificationEndpoint,
+  setupListNotificationEndpoints,
+} from "__support__/server-mocks/notification";
 import {
   mockGetBoundingClientRect,
   screen,
@@ -55,6 +63,8 @@ const TEST_DATASET = createMockDataset({
 
 const TEST_CARD_ID: CardId = 1 as const;
 
+const USER_ID = 999;
+
 interface SetupOpts {
   title?: string | boolean;
   withChartTypeSelector?: boolean;
@@ -64,6 +74,7 @@ interface SetupOpts {
   canManageSubscriptions?: boolean;
   isSuperuser?: boolean;
   isModel?: boolean;
+  willOpenModal?: boolean;
   collectionType?: CollectionType;
   tokenFeatures?: Partial<TokenFeatures>;
   enterprisePlugins?: Parameters<typeof setupEnterpriseOnlyPlugin>[0][];
@@ -79,6 +90,7 @@ const setup = async ({
   canManageSubscriptions = true,
   isSuperuser = true,
   isModel = false,
+  willOpenModal,
   collectionType,
   tokenFeatures,
   enterprisePlugins,
@@ -89,6 +101,7 @@ const setup = async ({
   } as any);
 
   const user = createMockUser({
+    id: USER_ID,
     is_superuser: isSuperuser,
   });
 
@@ -144,6 +157,12 @@ const setup = async ({
   setupCollectionByIdEndpoint({
     collections: [TEST_COLLECTION],
   });
+
+  if (willOpenModal) {
+    setupWebhookChannelsEndpoint();
+    setupListNotificationEndpoints({ card_id: card.id }, []);
+    setupCreateNotificationEndpoint();
+  }
 
   renderWithSDKProviders(
     <InteractiveQuestion
@@ -398,4 +417,65 @@ describe("InteractiveQuestion", () => {
       });
     });
   });
+
+  describe("alert modal", () => {
+    it("should not show email selector on the SDK", async () => {
+      await setup({
+        withAlerts: true,
+        isEmailSetup: true,
+        canManageSubscriptions: true,
+        isModel: false,
+        enterprisePlugins: ["sdk_notifications"],
+        willOpenModal: true,
+      });
+
+      expect(
+        within(screen.getByRole("gridcell")).getByText("Test Row"),
+      ).toBeVisible();
+      await userEvent.click(screen.getByRole("button", { name: "Alerts" }));
+
+      const withinModal = within(getModal());
+      expect(
+        withinModal.getByRole("heading", { name: "New alert" }),
+      ).toBeVisible();
+      expect(
+        withinModal.getByText("What do you want to be alerted about?"),
+      ).toBeVisible();
+      expect(
+        withinModal.getByText("When do you want to check this?"),
+      ).toBeVisible();
+      // Email selector is within this section, checking only the header is fine
+      expect(
+        withinModal.queryByText("Where do you want to send the results?"),
+      ).not.toBeInTheDocument();
+      expect(withinModal.getByText("More options")).toBeVisible();
+      await userEvent.click(withinModal.getByRole("button", { name: "Done" }));
+
+      const createNotificationRequest = (await findRequests("POST")).find(
+        (postRequest) =>
+          postRequest.url === "http://localhost/api/notification",
+      );
+      // Checks that we're using the current logged in user as the sole recipient
+      expect(createNotificationRequest?.body).toMatchObject({
+        handlers: [
+          {
+            channel_type: "channel/email",
+            recipients: [
+              {
+                details: null,
+                type: "notification-recipient/user",
+                user_id: USER_ID,
+              },
+            ],
+          },
+        ],
+      });
+      // So that when we assert this value, we know we won't accidentally match the default mock ID
+      expect(USER_ID).not.toBe(1);
+    });
+  });
 });
+
+function getModal() {
+  return screen.getByRole("dialog");
+}

--- a/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.unit.spec.tsx
@@ -457,7 +457,7 @@ describe("StaticQuestion", () => {
   });
 
   describe("alert modal", () => {
-    it("should not show email selector on the SDK", async () => {
+    it("should not show email selector on the SDK and use current logged in user as the recipient", async () => {
       await setup({
         withAlerts: true,
         isEmailSetup: true,

--- a/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.unit.spec.tsx
@@ -1,5 +1,8 @@
+import userEvent from "@testing-library/user-event";
+
 import { setupEnterpriseOnlyPlugin } from "__support__/enterprise";
 import {
+  findRequests,
   setupAlertsEndpoints,
   setupCardEndpoints,
   setupCardQueryEndpoints,
@@ -9,6 +12,11 @@ import {
   setupNotificationChannelsEndpoints,
   setupTableEndpoints,
 } from "__support__/server-mocks";
+import { setupWebhookChannelsEndpoint } from "__support__/server-mocks/channel";
+import {
+  setupCreateNotificationEndpoint,
+  setupListNotificationEndpoints,
+} from "__support__/server-mocks/notification";
 import {
   mockGetBoundingClientRect,
   screen,
@@ -55,6 +63,8 @@ const TEST_DATASET = createMockDataset({
 
 const TEST_CARD_ID: CardId = 1 as const;
 
+const USER_ID = 999;
+
 interface SetupOpts {
   title?: string | boolean;
   withChartTypeSelector?: boolean;
@@ -64,6 +74,7 @@ interface SetupOpts {
   canManageSubscriptions?: boolean;
   isSuperuser?: boolean;
   isModel?: boolean;
+  willOpenModal?: boolean;
   collectionType?: CollectionType;
   tokenFeatures?: Partial<TokenFeatures>;
   enterprisePlugins?: Parameters<typeof setupEnterpriseOnlyPlugin>[0][];
@@ -79,6 +90,7 @@ const setup = async ({
   canManageSubscriptions = true,
   isSuperuser = true,
   isModel = false,
+  willOpenModal,
   collectionType,
   tokenFeatures,
   enterprisePlugins,
@@ -89,6 +101,7 @@ const setup = async ({
   } as any);
 
   const user = createMockUser({
+    id: USER_ID,
     is_superuser: isSuperuser,
   });
 
@@ -116,7 +129,6 @@ const setup = async ({
     id: COLLECTION_ID,
     location: "/",
     name: "Test collection",
-    personal_owner_id: 100,
     type: collectionType,
   });
 
@@ -144,6 +156,12 @@ const setup = async ({
   setupCollectionByIdEndpoint({
     collections: [TEST_COLLECTION],
   });
+
+  if (willOpenModal) {
+    setupWebhookChannelsEndpoint();
+    setupListNotificationEndpoints({ card_id: card.id }, []);
+    setupCreateNotificationEndpoint();
+  }
 
   renderWithSDKProviders(
     <StaticQuestion
@@ -437,4 +455,65 @@ describe("StaticQuestion", () => {
       expect(screen.getByTestId("chart-type-selector-button")).toBeVisible();
     });
   });
+
+  describe("alert modal", () => {
+    it("should not show email selector on the SDK", async () => {
+      await setup({
+        withAlerts: true,
+        isEmailSetup: true,
+        canManageSubscriptions: true,
+        isModel: false,
+        enterprisePlugins: ["sdk_notifications"],
+        willOpenModal: true,
+      });
+
+      expect(
+        within(screen.getByRole("gridcell")).getByText("Test Row"),
+      ).toBeVisible();
+      await userEvent.click(screen.getByRole("button", { name: "Alerts" }));
+
+      const withinModal = within(getModal());
+      expect(
+        withinModal.getByRole("heading", { name: "New alert" }),
+      ).toBeVisible();
+      expect(
+        withinModal.getByText("What do you want to be alerted about?"),
+      ).toBeVisible();
+      expect(
+        withinModal.getByText("When do you want to check this?"),
+      ).toBeVisible();
+      // Email selector is within this section, checking only the header is fine
+      expect(
+        withinModal.queryByText("Where do you want to send the results?"),
+      ).not.toBeInTheDocument();
+      expect(withinModal.getByText("More options")).toBeVisible();
+      await userEvent.click(withinModal.getByRole("button", { name: "Done" }));
+
+      const createNotificationRequest = (await findRequests("POST")).find(
+        (postRequest) =>
+          postRequest.url === "http://localhost/api/notification",
+      );
+      // Checks that we're using the current logged in user as the sole recipient
+      expect(createNotificationRequest?.body).toMatchObject({
+        handlers: [
+          {
+            channel_type: "channel/email",
+            recipients: [
+              {
+                details: null,
+                type: "notification-recipient/user",
+                user_id: USER_ID,
+              },
+            ],
+          },
+        ],
+      });
+      // So that when we assert this value, we know we won't accidentally match the default mock ID
+      expect(USER_ID).not.toBe(1);
+    });
+  });
 });
+
+function getModal() {
+  return screen.getByRole("dialog");
+}

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
@@ -11,6 +11,7 @@ import {
 } from "metabase/api";
 import ActionButton from "metabase/common/components/ActionButton";
 import CS from "metabase/css/core/index.css";
+import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { getResponseErrorMessage } from "metabase/lib/errors";
 import {
   alertIsValid,
@@ -361,26 +362,29 @@ export const CreateOrEditQuestionAlertModal = ({
             onScheduleChange={handleScheduleChange}
           />
         </AlertModalSettingsBlock>
-        <AlertModalSettingsBlock
-          title={t`Where do you want to send the results?`}
-        >
-          <NotificationChannelsPicker
-            notificationHandlers={notification.handlers}
-            channels={channelSpec ? channelSpec.channels : undefined}
-            onChange={(newHandlers: NotificationHandler[]) => {
-              setNotification({
-                ...notification,
-                handlers: newHandlers,
-              });
-            }}
-            emailRecipientText={t`Email alerts to:`}
-            getInvalidRecipientText={(domains) =>
-              userCanAccessSettings
-                ? t`You're only allowed to email alerts to addresses ending in ${domains}`
-                : t`You're only allowed to email alerts to allowed domains`
-            }
-          />
-        </AlertModalSettingsBlock>
+        {!isEmbeddingSdk() && (
+          <AlertModalSettingsBlock
+            title={t`Where do you want to send the results?`}
+          >
+            <NotificationChannelsPicker
+              notificationHandlers={notification.handlers}
+              channels={channelSpec ? channelSpec.channels : undefined}
+              onChange={(newHandlers: NotificationHandler[]) => {
+                setNotification({
+                  ...notification,
+                  handlers: newHandlers,
+                });
+              }}
+              emailRecipientText={t`Email alerts to:`}
+              getInvalidRecipientText={(domains) =>
+                userCanAccessSettings
+                  ? t`You're only allowed to email alerts to addresses ending in ${domains}`
+                  : t`You're only allowed to email alerts to allowed domains`
+              }
+            />
+          </AlertModalSettingsBlock>
+        )}
+
         <AlertModalSettingsBlock title={t`More options`}>
           <Switch
             label={t`Delete this Alert after it's triggered`}

--- a/frontend/test/__support__/server-mocks/notification.ts
+++ b/frontend/test/__support__/server-mocks/notification.ts
@@ -4,6 +4,7 @@ import type {
   ListNotificationsRequest,
   Notification,
 } from "metabase-types/api";
+import { createMockNotification } from "metabase-types/api/mocks";
 
 export const setupListNotificationEndpoints = (
   { card_id }: Partial<ListNotificationsRequest>,
@@ -14,5 +15,11 @@ export const setupListNotificationEndpoints = (
       card_id: card_id ? card_id.toString() : "",
       include_inactive: false.toString(),
     },
+  });
+};
+
+export const setupCreateNotificationEndpoint = () => {
+  fetchMock.post("path:/api/notification", ({ options }) => {
+    return createMockNotification(JSON.parse(options.body as string));
   });
 };


### PR DESCRIPTION
closes EMB-980
closes EMB-981

### Description

This PR ensures we never see any other channels than email, and also remove the email selector section from the alert modal.

Note that on the part that hides the channels itself, it's a noop for this PR, as we won't see the channel selector unless none of the 3 channels (Email, Slack, and Webhook) have been configured. Since the aletr button already requires email to be configured we can ignore this condition.

Also, there's no need to do anything special to set the logged in user as the recipient, as the logged in user email and the email channel is the default value for a new notification

### How to verify
1. Run the SDK using either component and ensure you have set up the email e.g.
    ```ts
    <StaticQuestion questionId={id} withAlerts />
    ```

### Demo

#### SDK
<img width="710" height="790" alt="image" src="https://github.com/user-attachments/assets/ab47ee4e-b6b2-4c8f-914c-43dd19e82b95" />

#### Core app
<img width="700" height="1041" alt="image" src="https://github.com/user-attachments/assets/68c50c7a-dc8f-4494-9a26-f77a8cb573a5" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
