### PR TITLE
Hide Alert (and download) button on edit mode

### DIFF
--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.tsx
@@ -272,8 +272,12 @@ export const SdkQuestionDefaultView = ({
               )}
             </Group>
             <Group gap="sm" ml="auto" data-hide-empty>
-              <DownloadWidgetDropdown />
-              <QuestionAlertsButton />
+              {!isEditorOpen && (
+                <>
+                  <DownloadWidgetDropdown />
+                  <QuestionAlertsButton />
+                </>
+              )}
               <EditorButton isOpen={isEditorOpen} onClick={toggleEditor} />
             </Group>
           </ResultToolbar>

--- a/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.unit.spec.tsx
@@ -165,7 +165,7 @@ const setup = async ({
    * We only want to avoid getting fetch-mock's unmocked endpoints error.
    */
   setupUserRecipientsEndpoint({ users: [] });
-  setupWebhookChannelsEndpoint([]);
+  setupWebhookChannelsEndpoint();
   setupCreateNotificationEndpoint();
 
   renderWithSDKProviders(


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #68188
closes EMB-1195
closes EMB-994

### Description

The alert and download buttons don't make sense in edit mode. Because we we could potentially modify the question query and it would be unclear what these buttons would correspond to. e.g. would we download the results from the original question or the new edited and unsaved question?

To remove this ambiguity, it's best to hide these buttons on edit mode.

See, also the [Slack discussion](https://metaboat.slack.com/archives/C063Q3F1HPF/p1768402975063079)

### How to verify

1. Run the SDK using either component and ensure you have set up the email e.g.
    ```ts
    <StaticQuestion questionId={id} withAlerts withDownloads/>
    ```
1. Observe that both buttons are visible
1. Click "Edit question", both buttons should disappear.

### Demo
#### This PR
<img width="819" height="567" alt="image" src="https://github.com/user-attachments/assets/d7c9acee-eaa1-4469-a9e2-5bb0a1f34092" />

<img width="804" height="625" alt="image" src="https://github.com/user-attachments/assets/3fe59699-b2e3-4e75-99ca-7505e6e67c4c" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
