### PR TITLE
Hide 0 estimate row counts to avoid confusion

### DIFF
--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -258,7 +258,12 @@
                            :else nil]
                           :type]
                          [:d.description :description]
-                         [:stat.n_live_tup :estimated_row_count]]
+                         ;; In many cases tables will yield 0 as they have not been analyzed (recently).
+                         ;; if they actually have 0 rows, showing they have 0 is mostly uninteresting.
+                         ;; so we 'hide' 0, as on balance it seems to cause _less_ confusion.
+                         ;; Also considered: analyze during sync, doing a bounded count or limited scan.
+                         ;; we might change our mind on this when we explore estimates with more drivers.
+                         [[:nullif :stat.n_live_tup 0] :estimated_row_count]]
              :from      [[:pg_catalog.pg_class :c]]
              :join      [[:pg_catalog.pg_namespace :n]   [:= :c.relnamespace :n.oid]]
              :left-join [[:pg_catalog.pg_description :d] [:and [:= :c.oid :d.objoid] [:= :d.objsubid 0] [:= :d.classoid [:raw "'pg_class'::regclass"]]]

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -261,7 +261,8 @@
         (jdbc/execute! (sql-jdbc.conn/connection-details->spec :postgres details)
                        ["DROP MATERIALIZED VIEW IF EXISTS test_mview;
                        CREATE MATERIALIZED VIEW test_mview AS
-                       SELECT 'Toucans are the coolest type of bird.' AS true_facts;"])
+                       SELECT 'Toucans are the coolest type of bird.' AS true_facts;
+                       ANALYZE test_mview;"])
         (mt/with-temp [:model/Database database {:engine :postgres, :details (assoc details :dbname "materialized_views_test")}]
           (is (=? [(default-table-result "test_mview" {:estimated_row_count (mt/malli=? int?)})]
                   (describe-database->tables :postgres database))))))))
@@ -297,7 +298,19 @@
                               GRANT ALL ON public.local_table to PUBLIC;")])
         (mt/with-temp [:model/Database database {:engine :postgres, :details (assoc details :dbname "fdw_test")}]
           (is (=? [(default-table-result "foreign_table")
-                   (default-table-result "local_table" {:estimated_row_count (mt/malli=? int?)})]
+                   (default-table-result "local_table" {:estimated_row_count nil})]
+                  (describe-database->tables :postgres database))))))))
+
+(deftest estimated-row-count-hides-zero-test
+  (mt/test-driver :postgres
+    (testing "Check that tables with n_live_tup = 0 return nil for estimated_row_count to avoid confusion with stale stats"
+      (tx/drop-if-exists-and-create-db! driver/*driver* "estimated_count_test")
+      (let [details (mt/dbdef->connection-details :postgres :db {:database-name "estimated_count_test"})]
+        (jdbc/execute! (sql-jdbc.conn/connection-details->spec :postgres details)
+                       ["CREATE TABLE empty_table (id INTEGER);
+                         ANALYZE empty_table;"])
+        (mt/with-temp [:model/Database database {:engine :postgres, :details (assoc details :dbname "estimated_count_test")}]
+          (is (=? [(default-table-result "empty_table" {:estimated_row_count nil})]
                   (describe-database->tables :postgres database))))))))
 
 (deftest recreated-views-test


### PR DESCRIPTION
Treats a `0` value of `n_live_tup` as `NULL`, due to confusion reported when auto analyze thresholds have not been met on a table.

To justify:
- You have a non-zero estimate (No change)
- A zero estimate but actually have rows (We now hide the estimate)
- A zero estimate and actually have zero rows (We now hide the estimate, unfortunately)

This behaviour is considered on balance preferable to the behaviour now where users will likely be confused, even though we explicitly label the field 'estimated'.

Other options considered that we might explore in the future:
- Forcing `ANALYZE`, e.g. on sync
- Bounded/`LIMIT` count
- Some policy based on last analyze timestamps
- Better tooltips or explaination on frontend

We should revisit in the future once we have a better idea for how estimates should work across drivers (as its only postgres for now).
