### PR TITLE
Fix can't view created notifications the first time

### DIFF
--- a/frontend/src/metabase/notifications/modals/QuestionAlertListModal/QuestionAlertListModal.tsx
+++ b/frontend/src/metabase/notifications/modals/QuestionAlertListModal/QuestionAlertListModal.tsx
@@ -48,10 +48,18 @@ export const QuestionAlertListModal = ({
   );
 
   useEffect(() => {
-    if (questionNotifications) {
+    /**
+     * Attempt to set the active modal only once when it's null.
+     *
+     * In the core app, this is a noop because the data is already
+     * loaded and activeModal will not be null. However, in the SDK,
+     * we'll need to wait for the data to load, so the activeModal
+     * will be null at first.
+     */
+    if (questionNotifications && activeModal === null) {
       setActiveModal(getDefaultActiveModal(questionNotifications));
     }
-  }, [questionNotifications]);
+  }, [activeModal, questionNotifications]);
 
   const previousActiveModal = usePreviousDistinct(activeModal);
 

--- a/frontend/src/metabase/notifications/modals/QuestionAlertListModal/QuestionAlertListModal.tsx
+++ b/frontend/src/metabase/notifications/modals/QuestionAlertListModal/QuestionAlertListModal.tsx
@@ -170,6 +170,6 @@ export const QuestionAlertListModal = ({
 
 function getDefaultActiveModal(
   questionNotifications: Notification[],
-): AlertModalMode | (() => AlertModalMode) {
+): AlertModalMode {
   return questionNotifications.length === 0 ? "create-modal" : "list-modal";
 }

--- a/frontend/src/metabase/notifications/modals/QuestionAlertListModal/QuestionAlertListModal.tsx
+++ b/frontend/src/metabase/notifications/modals/QuestionAlertListModal/QuestionAlertListModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { usePreviousDistinct } from "react-use";
 import { t } from "ttag";
 
@@ -43,11 +43,15 @@ export const QuestionAlertListModal = ({
   const [updateNotification] = useUpdateNotificationMutation();
   const [unsubscribe] = useUnsubscribeFromNotificationMutation();
 
-  const [activeModal, setActiveModal] = useState<AlertModalMode>(
-    !questionNotifications || questionNotifications.length === 0
-      ? "create-modal"
-      : "list-modal",
+  const [activeModal, setActiveModal] = useState<AlertModalMode | null>(
+    questionNotifications ? getDefaultActiveModal(questionNotifications) : null,
   );
+
+  useEffect(() => {
+    if (questionNotifications) {
+      setActiveModal(getDefaultActiveModal(questionNotifications));
+    }
+  }, [questionNotifications]);
 
   const previousActiveModal = usePreviousDistinct(activeModal);
 
@@ -163,3 +167,9 @@ export const QuestionAlertListModal = ({
     </>
   );
 };
+
+function getDefaultActiveModal(
+  questionNotifications: Notification[],
+): AlertModalMode | (() => AlertModalMode) {
+  return questionNotifications.length === 0 ? "create-modal" : "list-modal";
+}


### PR DESCRIPTION
Closes EMB-1193

### Description

When there are already created alerts (notifications), when viewing on the SDK, after clicking the alert button, it will open the create alert modal instead of the list modal. This fixes the issue by waiting for the API call.

### How to verify

1. Run the SDK using either component and ensure you have set up the email e.g.
    ```ts
    <StaticQuestion questionId={id} withAlerts/>
1. Create an alert
2. Refresh the page to have the question component reload like new.
3. Click the alert button. You should see the alert list modal. If you check out the integration branch [emb-978-add-an-entry-to-the-question-alert-modal](https://github.com/metabase/metabase/tree/emb-978-add-an-entry-to-the-question-alert-modal), you should see the create alert modal instead.


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
