### PR TITLE
Fix `throw-if-last-admin!`

### DIFF
--- a/src/metabase/permissions/models/permissions_group_membership.clj
+++ b/src/metabase/permissions/models/permissions_group_membership.clj
@@ -2,7 +2,6 @@
   (:require
    [medley.core :as m]
    [metabase.api.common :as api]
-   [metabase.app-db.core :as app-db]
    [metabase.events.core :as events]
    [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.util :as u]
@@ -59,23 +58,17 @@
       (throw (ex-info (tru "You cannot add or remove users to/from the ''All tenant users'' group.")
                       {:status-code 400})))))
 
-(defn- admin-count
-  "The current number of non-archived admins (superusers)."
-  []
-  (:count
-   (first
-    (app-db/query {:select [[:%count.* :count]]
-                   :from   [[:permissions_group_membership :pgm]]
-                   :join   [[:core_user :user] [:= :user.id :pgm.user_id]]
-                   :where  [:and
-                            [:= :pgm.group_id (u/the-id (perms-group/admin))]
-                            [:= :user.is_active true]]}))))
-
 (defn throw-if-last-admin!
-  "Throw an Exception if there is only one admin (superuser) left. The assumption is that the one admin is about to be
+  "Throw an Exception if there are no admins left besides this one. The assumption is that the one admin is about to be
   archived or have their admin status removed."
-  []
-  (when (<= (admin-count) 1)
+  [user-id]
+  (when (zero?
+         (t2/count :model/PermissionsGroupMembership
+                   {:join   [[:core_user :user] [:= :user.id :user_id]]
+                    :where  [:and
+                             [:= :group_id (u/the-id (perms-group/admin))]
+                             [:= :user.is_active true]
+                             [:not= :user.id user-id]]}))
     (throw (ex-info (str fail-to-remove-last-admin-msg)
                     {:status-code 400}))))
 
@@ -88,7 +81,7 @@
   ;; If this is the Admin group...
   (when (= group_id (:id (perms-group/admin)))
     ;; ...and this is the last membership, throw an exception
-    (throw-if-last-admin!)
+    (throw-if-last-admin! user_id)
     ;; ...otherwise we're ok. Unset the `:is_superuser` flag for the user whose membership was revoked
     (when *update-user-when-added-to-admin-group?*
       (t2/update! 'User user_id {:is_superuser false})))

--- a/src/metabase/users/models/user.clj
+++ b/src/metabase/users/models/user.clj
@@ -187,9 +187,9 @@
 
 (defn- validate-last-admin-not-archived!
   "Prevent archiving the last admin user by throwing an exception."
-  [in-admin-group? active?]
+  [id in-admin-group? active?]
   (when (and in-admin-group? (false? active?))
-    (perms/throw-if-last-admin!)))
+    (perms/throw-if-last-admin! id)))
 
 ;;; -------------------------------------------------- User Archival --------------------------------------------------
 
@@ -276,7 +276,7 @@
                                               :group_id (:id (perms/admin-group))
                                               :user_id id)
         hashed-pw (prepare-password-for-update changes)]
-    (validate-last-admin-not-archived! in-admin-group? active?)
+    (validate-last-admin-not-archived! id in-admin-group? active?)
     (when email (validate-user-email! email))
     (when locale (validate-user-locale! locale))
     (handle-superuser-toggle! id superuser? in-admin-group?)

--- a/test/metabase/users_rest/api_test.clj
+++ b/test/metabase/users_rest/api_test.clj
@@ -1562,6 +1562,14 @@
             (is (= {:is_active true, :sso_source nil}
                    (mt/derecordize (t2/select-one [:model/User :is_active :sso_source] :id (u/the-id user)))))))))))
 
+(deftest reactivate-second-to-last-admin-test
+  (mt/with-single-admin-user! [{id :id}]
+    (testing "With two admins, one deactivated"
+      (mt/with-temp [:model/User {other-user :id} {:is_superuser true}]
+        (mt/user-http-request id :delete 200 (format "user/%d" other-user))
+        (testing "We can reactivate the other admin"
+          (mt/user-http-request id :put 200 (format "user/%d/reactivate" other-user)))))))
+
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                               Updating a Password -- PUT /api/user/:id/password                                |
 ;;; +----------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #59776
[UXW-341: Reactive old admin account is not possible](https://linear.app/metabase/issue/UXW-341/reactive-old-admin-account-is-not-possible)
