### PR TITLE
If a dashboard is back to just one tab, auto-assign all cards to that tab

### DIFF
--- a/src/metabase/dashboards_rest/api.clj
+++ b/src/metabase/dashboards_rest/api.clj
@@ -1012,11 +1012,18 @@
              (let [{current-dashcards :dashcards
                     current-tabs      :tabs
                     :as               hydrated-current-dash} (t2/hydrate current-dash [:dashcards :series :card] :tabs)
-                   _                                         (when (and (seq current-tabs)
+                   new-tabs                                  (map-indexed (fn [idx tab] (assoc tab :position idx)) tabs)
+                   dashcards                                 (if (= 1 (count new-tabs))
+                                                               (let [single-tab-id (-> new-tabs first :id)]
+                                                                 (mapv #(if (nil? (:dashboard_tab_id %))
+                                                                          (assoc % :dashboard_tab_id single-tab-id)
+                                                                          %)
+                                                                       dashcards))
+                                                               dashcards)
+                   _                                         (when (and (seq new-tabs)
                                                                         (not (every? #(some? (:dashboard_tab_id %)) dashcards)))
                                                                (throw (ex-info (tru "This dashboard has tab, makes sure every card has a tab")
                                                                                {:status-code 400})))
-                   new-tabs                                  (map-indexed (fn [idx tab] (assoc tab :position idx)) tabs)
                    {:keys [old->new-tab-id
                            deleted-tab-ids]
                     :as   tabs-changes-stats}                (dashboard-tab/do-update-tabs! (:id current-dash) current-tabs new-tabs)


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #67971
### Description

When a dashboard has tabs and all but one is deleted, it still has a dashboard_tab record which would trigger the "all cards need to be in a tab" error.

I thought about removing the dashboard_tab record when there is only one tab left, but then it would loose any tab renaming that may have been done and the user may want if/when they add another tab.

So, I added logic to auto-set the card tab if there is only one tab it can go in while still keeping the error check for when there are multiple tabs. 

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
