### PR TITLE
Remove embedding dev-related folders from Snyk

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -3,15 +3,15 @@ name: "Snyk"
 on:
   push:
     branches:
-      - 'master'
-      - 'release-**'
+      - "master"
+      - "release-**"
     paths:
-      - '**/deps.edn'
-      - '**/package.json'
-      - '.github/workflows/snyk.yml'
-      - '.github/scripts/write-poms.sh'
+      - "**/deps.edn"
+      - "**/package.json"
+      - ".github/workflows/snyk.yml"
+      - ".github/scripts/write-poms.sh"
   schedule:
-    - cron: '0 5 * * *'
+    - cron: "0 5 * * *"
 
 jobs:
   # Generate pom.xml files for all Maven projects
@@ -45,26 +45,6 @@ jobs:
             file: yarn.lock
             package-manager: yarn
             category: main-frontend-yarn
-          - name: Embedding SDK Template
-            file: bin/embedding-sdk/templates/yarn.lock
-            package-manager: yarn
-            category: embedding-sdk-template
-          - name: E2E Angular 20 Host App
-            file: e2e/embedding-sdk-host-apps/angular-20-host-app/package-lock.json
-            package-manager: npm
-            category: e2e-angular-host
-          - name: E2E Next 15 App Router
-            file: e2e/embedding-sdk-host-apps/next-15-app-router-host-app/package-lock.json
-            package-manager: npm
-            category: e2e-next-app-router
-          - name: E2E Next 15 Pages Router
-            file: e2e/embedding-sdk-host-apps/next-15-pages-router-host-app/package-lock.json
-            package-manager: npm
-            category: e2e-next-pages-router
-          - name: E2E Vite 6 Host App
-            file: e2e/embedding-sdk-host-apps/vite-6-host-app/package-lock.json
-            package-manager: npm
-            category: e2e-vite-host
           - name: Release Helper
             file: release/yarn.lock
             package-manager: yarn


### PR DESCRIPTION
All these embedding configurations are only related to the development. Those libraries are never touching the production code so they create a ton of false dependabot alerts that we have to dismiss.

This PR removes them from Snyk config.