### PR TITLE
Fix untranslated webhook channel in alert modal

### DIFF
--- a/frontend/src/metabase/notifications/modals/ChannelSetupModal.tsx
+++ b/frontend/src/metabase/notifications/modals/ChannelSetupModal.tsx
@@ -24,7 +24,9 @@ const CHANNELS_CONFIG: {
     link: "/admin/settings/notifications",
   },
   {
-    title: "Add a webhook",
+    get title() {
+      return t`Add a webhook`;
+    },
     icon: "webhook",
     link: "/admin/settings/notifications",
     testId: "alerts-channel-create-webhook",


### PR DESCRIPTION
## Summary

This PR fixes an internationalization bug where the "Add a webhook" channel option in the alert modal was not translatable.

## Changes

- Wrapped the hardcoded `"Add a webhook"` string in the translation function `t` to enable internationalization
- Made it consistent with the Email and Slack channel options which were already properly translated

## Issue

Fixes #68174

## Testing

The fix ensures that the  webhook channel option will be properly translated instead of remaining in English.

### Before
The "Add a webhook" text remained in English regardless of locale setting.

### After  
The webhook channel label will be translated according to the user's locale preference, matching the behavior of Email and Slack options.

## Technical Details

**File changed:** `frontend/src/metabase/notifications/modals/ChannelSetupModal.tsx`

**Change:** Converted the `title` property from a plain string to a getter function that returns the translated string:
```typescript
// Before
{
  title: "Add a webhook",
  ...
}

// After
{
  get title() {
    return t\`Add a webhook\`;
  },
  ...
}
```

This pattern matches the existing implementation for Email and Slack channel options in the same config array.

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=105917501