### PR TITLE
Implement read-only on Library & Data Structure pages

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/CreateMenu.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/CreateMenu.tsx
@@ -12,6 +12,7 @@ import {
   getUserIsAdmin,
 } from "metabase/selectors/user";
 import { Button, FixedSizeIcon, Icon, Menu } from "metabase/ui";
+import { getIsRemoteSyncReadOnly } from "metabase-enterprise/remote_sync/selectors";
 import type { CollectionId } from "metabase-types/api";
 
 import { PublishTableModal } from "./PublishTableModal";
@@ -30,6 +31,11 @@ export const CreateMenu = ({
   const isAdmin = useSelector(getUserIsAdmin);
   const hasNativeWrite = useSelector(canUserCreateNativeQueries);
   const hasDataAccess = useSelector(canUserCreateQueries);
+  const remoteSyncReadOnly = useSelector(getIsRemoteSyncReadOnly);
+
+  if (remoteSyncReadOnly) {
+    return null;
+  }
 
   const canCreateMetric =
     hasDataAccess && metricCollectionId && canWriteToMetricCollection;

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/RootSnippetsCollectionMenu.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/RootSnippetsCollectionMenu.tsx
@@ -3,6 +3,7 @@ import { t } from "ttag";
 import { useSelector } from "metabase/lib/redux";
 import { getUserIsAdmin } from "metabase/selectors/user";
 import { ActionIcon, FixedSizeIcon, Menu, Tooltip } from "metabase/ui";
+import { getIsRemoteSyncReadOnly } from "metabase-enterprise/remote_sync/selectors";
 import type { CollectionId } from "metabase-types/api";
 
 export const RootSnippetsCollectionMenu = ({
@@ -11,8 +12,9 @@ export const RootSnippetsCollectionMenu = ({
   setPermissionsCollectionId: (id: CollectionId) => void;
 }) => {
   const isAdmin = useSelector(getUserIsAdmin);
+  const remoteSyncReadOnly = useSelector(getIsRemoteSyncReadOnly);
 
-  if (!isAdmin) {
+  if (!isAdmin || remoteSyncReadOnly) {
     return null;
   }
 

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/RootSnippetsCollectionMenu.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/RootSnippetsCollectionMenu.unit.spec.tsx
@@ -1,0 +1,84 @@
+import userEvent from "@testing-library/user-event";
+
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen } from "__support__/ui";
+import type { EnterpriseSettings } from "metabase-types/api";
+import { createMockUser } from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks/state";
+
+import { RootSnippetsCollectionMenu } from "./RootSnippetsCollectionMenu";
+
+interface SetupOptions {
+  isSuperuser?: boolean;
+  remoteSyncType?: EnterpriseSettings["remote-sync-type"];
+}
+
+const setPermissionsCollectionId = jest.fn();
+
+const setup = ({ isSuperuser = true, remoteSyncType }: SetupOptions = {}) => {
+  const state = createMockState({
+    settings: mockSettings({
+      "remote-sync-type": remoteSyncType,
+      "remote-sync-enabled": !!remoteSyncType,
+    }),
+    currentUser: createMockUser({ is_superuser: isSuperuser }),
+  });
+  return renderWithProviders(
+    <RootSnippetsCollectionMenu
+      setPermissionsCollectionId={setPermissionsCollectionId}
+    />,
+    {
+      storeInitialState: state,
+    },
+  );
+};
+
+describe("RootSnippetsCollectionMenu", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders snippets options menu", () => {
+    setup();
+    expect(
+      screen.getByRole("button", { name: "Snippet collection options" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders nothing if user is not a superuser", () => {
+    setup({ isSuperuser: false });
+    expect(
+      screen.queryByRole("button", { name: "Snippet collection options" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders nothing if remote sync is set to read-only", () => {
+    setup({ remoteSyncType: "read-only" });
+    expect(
+      screen.queryByRole("button", { name: "Snippet collection options" }),
+    ).not.toBeInTheDocument();
+  });
+
+  describe("show permissions options", () => {
+    it("is rendered on menu click", async () => {
+      setup();
+      await userEvent.click(
+        screen.getByRole("button", { name: "Snippet collection options" }),
+      );
+      expect(
+        screen.getByRole("menuitem", { name: /Change permissions/ }),
+      ).toBeInTheDocument();
+    });
+
+    it("calls setPermissionsCollectionId on click", async () => {
+      setup();
+      await userEvent.click(
+        screen.getByRole("button", { name: "Snippet collection options" }),
+      );
+      await userEvent.click(
+        screen.getByRole("menuitem", { name: /Change permissions/ }),
+      );
+      expect(setPermissionsCollectionId).toHaveBeenCalledWith("root");
+    });
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/MeasureList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/MeasureList.tsx
@@ -2,8 +2,10 @@ import { t } from "ttag";
 
 import EmptyState from "metabase/common/components/EmptyState";
 import { ForwardRefLink } from "metabase/common/components/Link";
+import { useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { Button, Group, Icon, Stack } from "metabase/ui";
+import { getIsRemoteSyncReadOnly } from "metabase-enterprise/remote_sync/selectors";
 import type { Table } from "metabase-types/api";
 
 import { MeasureItem } from "./MeasureItem";
@@ -21,24 +23,27 @@ export function MeasureList({ table }: MeasureListProps) {
       tableId: table.id,
       measureId,
     });
+  const remoteSyncReadOnly = useSelector(getIsRemoteSyncReadOnly);
 
   return (
     <Stack gap="md" data-testid="table-measures-page">
-      <Group gap="md" justify="flex-start" wrap="nowrap">
-        <Button
-          component={ForwardRefLink}
-          to={Urls.newDataStudioDataModelMeasure({
-            databaseId: table.db_id,
-            schemaName: table.schema,
-            tableId: table.id,
-          })}
-          h={32}
-          px="sm"
-          py="xs"
-          size="xs"
-          leftSection={<Icon name="add" />}
-        >{t`New measure`}</Button>
-      </Group>
+      {!remoteSyncReadOnly && (
+        <Group gap="md" justify="flex-start" wrap="nowrap">
+          <Button
+            component={ForwardRefLink}
+            to={Urls.newDataStudioDataModelMeasure({
+              databaseId: table.db_id,
+              schemaName: table.schema,
+              tableId: table.id,
+            })}
+            h={32}
+            px="sm"
+            py="xs"
+            size="xs"
+            leftSection={<Icon name="add" />}
+          >{t`New measure`}</Button>
+        </Group>
+      )}
 
       {measures.length === 0 ? (
         <EmptyState

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/SegmentList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/SegmentList.tsx
@@ -6,6 +6,7 @@ import { useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { getUserCanWriteSegments } from "metabase/selectors/user";
 import { Button, Group, Icon, Stack } from "metabase/ui";
+import { getIsRemoteSyncReadOnly } from "metabase-enterprise/remote_sync/selectors";
 import type { Table } from "metabase-types/api";
 
 import { SegmentItem } from "./SegmentItem";
@@ -24,10 +25,11 @@ export function SegmentList({ table }: SegmentListProps) {
       tableId: table.id,
       segmentId,
     });
+  const remoteSyncReadOnly = useSelector(getIsRemoteSyncReadOnly);
 
   return (
     <Stack gap="md" data-testid="table-segments-page">
-      {canCreateSegment && (
+      {canCreateSegment && !remoteSyncReadOnly && (
         <Group gap="md" justify="flex-start" wrap="nowrap">
           <Button
             component={ForwardRefLink}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/TableSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/TableSection.tsx
@@ -35,6 +35,7 @@ import {
 import { CreateLibraryModal } from "metabase-enterprise/data-studio/common/components/CreateLibraryModal";
 import { PublishTablesModal } from "metabase-enterprise/data-studio/common/components/PublishTablesModal";
 import { UnpublishTablesModal } from "metabase-enterprise/data-studio/common/components/UnpublishTablesModal";
+import { getIsRemoteSyncReadOnly } from "metabase-enterprise/remote_sync/selectors";
 import type { FieldId, Table, TableFieldOrder } from "metabase-types/api";
 
 import { MeasureList } from "./MeasureList";
@@ -72,6 +73,7 @@ const TableSectionBase = ({
     useMetadataToasts();
   const [isSorting, setIsSorting] = useState(false);
   const hasFields = Boolean(table.fields && table.fields.length > 0);
+  const remoteSyncReadOnly = useSelector(getIsRemoteSyncReadOnly);
 
   const getFieldHref = (fieldId: FieldId) => {
     return Urls.dataStudioData({
@@ -215,7 +217,7 @@ const TableSectionBase = ({
       </Box>
 
       <Group justify="stretch" gap="sm">
-        {isAdmin && (
+        {isAdmin && !remoteSyncReadOnly && (
           <Button
             flex="1"
             p="sm"

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/measures/components/MeasureEditor/MeasureEditor.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/measures/components/MeasureEditor/MeasureEditor.tsx
@@ -11,6 +11,7 @@ type MeasureEditorProps = {
   description: string;
   onQueryChange: (query: Lib.Query) => void;
   onDescriptionChange: (description: string) => void;
+  readOnly?: boolean;
 };
 
 export function MeasureEditor({
@@ -18,12 +19,17 @@ export function MeasureEditor({
   description,
   onQueryChange,
   onDescriptionChange,
+  readOnly,
 }: MeasureEditorProps) {
   return (
     <Card withBorder p="xl">
       <Stack flex={1} gap="xl" p={0} className={S.scrollable}>
         {query && (
-          <MeasureAggregationPicker query={query} onChange={onQueryChange} />
+          <MeasureAggregationPicker
+            onChange={onQueryChange}
+            query={query}
+            readOnly={readOnly}
+          />
         )}
         <TextInput
           label={t`Give it a description`}
@@ -34,6 +40,7 @@ export function MeasureEditor({
           classNames={{
             label: S.descriptionLabel,
           }}
+          readOnly={readOnly}
         />
       </Stack>
     </Card>

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/measures/components/MeasureEditor/MeasureEditor.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/measures/components/MeasureEditor/MeasureEditor.unit.spec.tsx
@@ -1,0 +1,48 @@
+import { renderWithProviders, screen } from "__support__/ui";
+import { createQuery } from "metabase-lib/test-helpers";
+
+import { MeasureEditor } from "./MeasureEditor";
+
+describe("MeasureEditor", () => {
+  const query = createQuery();
+  const description = "A sample description";
+  const onQueryChange = jest.fn();
+  const onDescriptionChange = jest.fn();
+
+  it("renders editable inputs when not read-only", () => {
+    renderWithProviders(
+      <MeasureEditor
+        query={query}
+        description={description}
+        onQueryChange={onQueryChange}
+        onDescriptionChange={onDescriptionChange}
+      />,
+    );
+
+    expect(screen.getByLabelText("Give it a description")).not.toHaveAttribute(
+      "readonly",
+    );
+    expect(
+      screen.getByText("Pick an aggregation function"),
+    ).toBeInTheDocument();
+  });
+
+  it("disables inputs when read-only", () => {
+    renderWithProviders(
+      <MeasureEditor
+        query={query}
+        description={description}
+        onQueryChange={onQueryChange}
+        onDescriptionChange={onDescriptionChange}
+        readOnly
+      />,
+    );
+
+    expect(screen.getByLabelText("Give it a description")).toHaveAttribute(
+      "readonly",
+    );
+    expect(
+      screen.queryByText("Pick an aggregation function"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/measures/components/MeasureHeader/MeasureHeader.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/measures/components/MeasureHeader/MeasureHeader.tsx
@@ -24,6 +24,7 @@ type MeasureHeaderProps = {
   onNameChange?: (name: string) => void;
   breadcrumbs?: ReactNode;
   actions?: ReactNode;
+  readOnly?: boolean;
 };
 
 export function MeasureHeader({
@@ -34,16 +35,26 @@ export function MeasureHeader({
   onNameChange,
   breadcrumbs,
   actions,
+  readOnly,
 }: MeasureHeaderProps) {
   return (
     <Stack gap={0}>
       <PaneHeader
         data-testid="measure-pane-header"
         title={
-          <MeasureNameInput measure={measure} onNameChange={onNameChange} />
+          <MeasureNameInput
+            measure={measure}
+            onNameChange={onNameChange}
+            readOnly={readOnly}
+          />
         }
         icon="sum"
-        menu={<MeasureMoreMenu previewUrl={previewUrl} onRemove={onRemove} />}
+        menu={
+          <MeasureMoreMenu
+            previewUrl={previewUrl}
+            onRemove={readOnly ? undefined : onRemove}
+          />
+        }
         tabs={<EntityDetailTabs urls={tabUrls} />}
         actions={actions}
         breadcrumbs={breadcrumbs}
@@ -55,9 +66,14 @@ export function MeasureHeader({
 type MeasureNameInputProps = {
   measure: Measure;
   onNameChange?: (name: string) => void;
+  readOnly?: boolean;
 };
 
-function MeasureNameInput({ measure, onNameChange }: MeasureNameInputProps) {
+function MeasureNameInput({
+  measure,
+  onNameChange,
+  readOnly,
+}: MeasureNameInputProps) {
   const [updateMeasure] = useUpdateMeasureMutation();
   const { sendSuccessToast, sendErrorToast } = useMetadataToasts();
 
@@ -88,6 +104,7 @@ function MeasureNameInput({ measure, onNameChange }: MeasureNameInputProps) {
       maxLength={MEASURE_NAME_MAX_LENGTH}
       onChange={handleChange}
       onContentChange={onNameChange}
+      readOnly={readOnly}
     />
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/measures/components/MeasureHeader/MeasureHeader.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/measures/components/MeasureHeader/MeasureHeader.unit.spec.tsx
@@ -1,0 +1,72 @@
+import userEvent from "@testing-library/user-event";
+
+import { renderWithProviders, screen } from "__support__/ui";
+import { createMockMeasure } from "metabase-types/api/mocks";
+
+import { MeasureHeader } from "./MeasureHeader";
+
+type SetupOpts = {
+  readOnly?: boolean;
+};
+
+const setup = ({ readOnly }: SetupOpts = {}) => {
+  const tabUrls = {
+    definition: "/measures/1/definition",
+    revisions: "/measures/1/revisions",
+    dependencies: "/measures/1/dependencies",
+  };
+  const measure = createMockMeasure({ name: "Order count" });
+
+  renderWithProviders(
+    <MeasureHeader
+      measure={measure}
+      onRemove={jest.fn()}
+      readOnly={readOnly}
+      tabUrls={tabUrls}
+      previewUrl="/measures/1/preview"
+    />,
+  );
+};
+
+describe("MeasureHeader", () => {
+  it("renders an input with the measure name", () => {
+    setup();
+    expect(screen.getByPlaceholderText("New measure")).toBeEnabled();
+    expect(screen.getByPlaceholderText("New measure")).toHaveValue(
+      "Order count",
+    );
+  });
+
+  it("shows preview and remove options in the actions menu", async () => {
+    setup();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Measure actions" }),
+    );
+    expect(
+      screen.getByRole("menuitem", { name: /Preview/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /Remove measure/ }),
+    ).toBeInTheDocument();
+  });
+
+  describe("when read-only", () => {
+    it("disables the name input", () => {
+      setup({ readOnly: true });
+      expect(screen.getByPlaceholderText("New measure")).toBeDisabled();
+    });
+
+    it("does not render the remove measure menu option", async () => {
+      setup({ readOnly: true });
+      await userEvent.click(
+        screen.getByRole("button", { name: "Measure actions" }),
+      );
+      expect(
+        screen.getByRole("menuitem", { name: /Preview/ }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("menuitem", { name: /Remove measure/ }),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/measures/pages/MeasureDetailPage/MeasureDetailPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/measures/pages/MeasureDetailPage/MeasureDetailPage.tsx
@@ -11,6 +11,7 @@ import { getMetadata } from "metabase/selectors/metadata";
 import { Button, Group } from "metabase/ui";
 import { PageContainer } from "metabase-enterprise/data-studio/common/components/PageContainer";
 import { getDatasetQueryPreviewUrl } from "metabase-enterprise/data-studio/common/utils/get-dataset-query-preview-url";
+import { getIsRemoteSyncReadOnly } from "metabase-enterprise/remote_sync/selectors";
 import * as Lib from "metabase-lib";
 import type { Measure } from "metabase-types/api";
 
@@ -35,6 +36,7 @@ export function MeasureDetailPage({
   onRemove,
 }: MeasureDetailPageProps) {
   const metadata = useSelector(getMetadata);
+  const remoteSyncReadOnly = useSelector(getIsRemoteSyncReadOnly);
   const { sendSuccessToast, sendErrorToast } = useMetadataToasts();
 
   const [description, setDescription] = useState(measure.description ?? "");
@@ -117,12 +119,14 @@ export function MeasureDetailPage({
             </Group>
           )
         }
+        readOnly={remoteSyncReadOnly}
       />
       <MeasureEditor
         query={query}
         description={description}
         onQueryChange={setQuery}
         onDescriptionChange={setDescription}
+        readOnly={remoteSyncReadOnly}
       />
       <LeaveRouteConfirmModal
         key={measure.id}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/segments/pages/SegmentDetailPage/SegmentDetailPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/segments/pages/SegmentDetailPage/SegmentDetailPage.tsx
@@ -12,6 +12,7 @@ import { getUserCanWriteSegments } from "metabase/selectors/user";
 import { Button, Group } from "metabase/ui";
 import { PageContainer } from "metabase-enterprise/data-studio/common/components/PageContainer";
 import { getDatasetQueryPreviewUrl } from "metabase-enterprise/data-studio/common/utils/get-dataset-query-preview-url";
+import { getIsRemoteSyncReadOnly } from "metabase-enterprise/remote_sync/selectors";
 import * as Lib from "metabase-lib";
 import type { Segment } from "metabase-types/api";
 
@@ -35,8 +36,9 @@ export function SegmentDetailPage({
   breadcrumbs,
   onRemove,
 }: SegmentDetailPageProps) {
-  const canEditSegments = useSelector(getUserCanWriteSegments);
+  const canWriteSegments = useSelector(getUserCanWriteSegments);
   const metadata = useSelector(getMetadata);
+  const remoteSyncReadOnly = useSelector(getIsRemoteSyncReadOnly);
   const { sendSuccessToast, sendErrorToast } = useMetadataToasts();
 
   const [description, setDescription] = useState(segment.description ?? "");
@@ -44,6 +46,7 @@ export function SegmentDetailPage({
   const [savedSegment, setSavedSegment] = useState(segment);
 
   const { query, filters } = useSegmentQuery(definition, metadata);
+  const canEditSegments = canWriteSegments && !remoteSyncReadOnly;
 
   const isDirty = useMemo(
     () =>

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/tables/components/TableHeader/TableMoreMenu/TableMoreMenu.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/tables/components/TableHeader/TableMoreMenu/TableMoreMenu.tsx
@@ -3,10 +3,11 @@ import { push } from "react-router-redux";
 import { c, t } from "ttag";
 
 import { ForwardRefLink } from "metabase/common/components/Link";
-import { useDispatch } from "metabase/lib/redux";
+import { useDispatch, useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { ActionIcon, Icon, Menu } from "metabase/ui";
 import { UnpublishTablesModal } from "metabase-enterprise/data-studio/common/components/UnpublishTablesModal";
+import { getIsRemoteSyncReadOnly } from "metabase-enterprise/remote_sync/selectors";
 import type { Table } from "metabase-types/api";
 
 type TableModalType = "unpublish";
@@ -18,6 +19,7 @@ type TableMoreMenuProps = {
 export function TableMoreMenu({ table }: TableMoreMenuProps) {
   const dispatch = useDispatch();
   const [modalType, setModalType] = useState<TableModalType>();
+  const remoteSyncReadOnly = useSelector(getIsRemoteSyncReadOnly);
 
   const handleUnpublish = () => {
     setModalType(undefined);
@@ -28,7 +30,7 @@ export function TableMoreMenu({ table }: TableMoreMenuProps) {
     <>
       <Menu>
         <Menu.Target>
-          <ActionIcon size="sm">
+          <ActionIcon size="sm" aria-label={t`Show table options`}>
             <Icon name="ellipsis" />
           </ActionIcon>
         </Menu.Target>
@@ -41,12 +43,14 @@ export function TableMoreMenu({ table }: TableMoreMenuProps) {
           >
             {c("A verb, not a noun").t`View`}
           </Menu.Item>
-          <Menu.Item
-            leftSection={<Icon name="unpublish" />}
-            onClick={() => setModalType("unpublish")}
-          >
-            {t`Unpublish`}
-          </Menu.Item>
+          {!remoteSyncReadOnly && (
+            <Menu.Item
+              leftSection={<Icon name="unpublish" />}
+              onClick={() => setModalType("unpublish")}
+            >
+              {t`Unpublish`}
+            </Menu.Item>
+          )}
         </Menu.Dropdown>
       </Menu>
       <UnpublishTablesModal

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/tables/components/TableHeader/TableMoreMenu/TableMoreMenu.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/tables/components/TableHeader/TableMoreMenu/TableMoreMenu.unit.spec.tsx
@@ -1,0 +1,58 @@
+import userEvent from "@testing-library/user-event";
+import { Route } from "react-router";
+
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen } from "__support__/ui";
+import type { EnterpriseSettings } from "metabase-types/api";
+import { createMockTable } from "metabase-types/api/mocks";
+
+import { TableMoreMenu } from "./TableMoreMenu";
+
+type SetupOpts = {
+  remoteSyncType?: EnterpriseSettings["remote-sync-type"];
+};
+
+const setup = ({ remoteSyncType }: SetupOpts = {}) => {
+  const mockTable = createMockTable({
+    id: 1,
+    db_id: 1,
+    schema: "PUBLIC",
+  });
+
+  renderWithProviders(
+    <Route path="/" component={() => <TableMoreMenu table={mockTable} />} />,
+    {
+      withRouter: true,
+      storeInitialState: {
+        settings: mockSettings({
+          "remote-sync-type": remoteSyncType,
+          "remote-sync-enabled": !!remoteSyncType,
+        }),
+      },
+    },
+  );
+};
+
+describe("TableMoreMenu", () => {
+  it("renders the View and the Unpublish menu options", async () => {
+    setup();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Show table options" }),
+    );
+    expect(screen.getByRole("menuitem", { name: /View/ })).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /Unpublish/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render the Unpublish option when remote sync is set to read-only", async () => {
+    setup({ remoteSyncType: "read-only" });
+    await userEvent.click(
+      screen.getByRole("button", { name: "Show table options" }),
+    );
+    expect(screen.getByRole("menuitem", { name: /View/ })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("menuitem", { name: /Unpublish/ }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/tables/pages/TableMeasuresPage/TableMeasures.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/tables/pages/TableMeasuresPage/TableMeasures.tsx
@@ -1,7 +1,9 @@
 import { t } from "ttag";
 
+import { useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { Flex } from "metabase/ui";
+import { getIsRemoteSyncReadOnly } from "metabase-enterprise/remote_sync/selectors";
 import type { Table } from "metabase-types/api";
 
 import {
@@ -14,7 +16,15 @@ type TableMeasuresProps = {
 };
 
 export function TableMeasures({ table }: TableMeasuresProps) {
+  const remoteSyncReadOnly = useSelector(getIsRemoteSyncReadOnly);
   const measures = table.measures ?? [];
+  let newButtonLabel: string | undefined;
+  let newButtonUrl: string | undefined;
+
+  if (!remoteSyncReadOnly) {
+    newButtonLabel = t`New measure`;
+    newButtonUrl = Urls.dataStudioPublishedTableMeasureNew(table.id);
+  }
 
   return (
     <Flex direction="column" flex={1}>
@@ -26,8 +36,8 @@ export function TableMeasures({ table }: TableMeasuresProps) {
           title: t`No measures yet`,
           message: t`Create a measure to define aggregations for this table.`,
         }}
-        newButtonLabel={t`New measure`}
-        newButtonUrl={Urls.dataStudioPublishedTableMeasureNew(table.id)}
+        newButtonLabel={newButtonLabel}
+        newButtonUrl={newButtonUrl}
         renderItem={(measure) => (
           <EntityListItem
             key={measure.id}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/tables/pages/TableMeasuresPage/TableMeasures.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/tables/pages/TableMeasuresPage/TableMeasures.unit.spec.tsx
@@ -1,0 +1,53 @@
+import { Route } from "react-router";
+
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen } from "__support__/ui";
+import type { EnterpriseSettings } from "metabase-types/api";
+import { createMockTable } from "metabase-types/api/mocks";
+
+import { TableMeasures } from "./TableMeasures";
+
+type SetupOpts = {
+  remoteSyncType?: EnterpriseSettings["remote-sync-type"];
+};
+
+const setup = ({ remoteSyncType }: SetupOpts = {}) => {
+  const mockTable = createMockTable({
+    id: 1,
+    db_id: 1,
+    schema: "PUBLIC",
+  });
+
+  renderWithProviders(
+    <Route path="/" component={() => <TableMeasures table={mockTable} />} />,
+    {
+      withRouter: true,
+      storeInitialState: {
+        settings: mockSettings({
+          "remote-sync-type": remoteSyncType,
+          "remote-sync-enabled": !!remoteSyncType,
+        }),
+      },
+    },
+  );
+};
+
+describe("TablesMeasures", () => {
+  it("renders the new measure button", () => {
+    setup();
+    expect(
+      screen.getByRole("link", { name: /New measure/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /New measure/ })).toHaveAttribute(
+      "href",
+      "/data-studio/library/tables/1/measures/new",
+    );
+  });
+
+  it("does not render the new measure button if remote sync is set to read-only", () => {
+    setup({ remoteSyncType: "read-only" });
+    expect(
+      screen.queryByRole("link", { name: /New measure/ }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/tables/pages/TableSegmentsPage/TableSegments.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/tables/pages/TableSegmentsPage/TableSegments.tsx
@@ -4,6 +4,7 @@ import { useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { getUserCanWriteSegments } from "metabase/selectors/user";
 import { Flex } from "metabase/ui";
+import { getIsRemoteSyncReadOnly } from "metabase-enterprise/remote_sync/selectors";
 import type { Table } from "metabase-types/api";
 
 import {
@@ -17,7 +18,15 @@ type TableSegmentsProps = {
 
 export function TableSegments({ table }: TableSegmentsProps) {
   const canWriteSegments = useSelector(getUserCanWriteSegments);
+  const remoteSyncReadOnly = useSelector(getIsRemoteSyncReadOnly);
   const segments = table.segments ?? [];
+  let newButtonLabel: string | undefined;
+  let newButtonUrl: string | undefined;
+
+  if (!remoteSyncReadOnly && canWriteSegments) {
+    newButtonLabel = t`New segment`;
+    newButtonUrl = Urls.dataStudioPublishedTableSegmentNew(table.id);
+  }
 
   return (
     <Flex direction="column" flex={1}>
@@ -29,12 +38,8 @@ export function TableSegments({ table }: TableSegmentsProps) {
           title: t`No segments yet`,
           message: t`Create a segment to filter rows in this table.`,
         }}
-        newButtonLabel={canWriteSegments ? t`New segment` : undefined}
-        newButtonUrl={
-          canWriteSegments
-            ? Urls.dataStudioPublishedTableSegmentNew(table.id)
-            : undefined
-        }
+        newButtonLabel={newButtonLabel}
+        newButtonUrl={newButtonUrl}
         renderItem={(segment) => (
           <EntityListItem
             key={segment.id}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/tables/pages/TableSegmentsPage/TableSegments.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/tables/pages/TableSegmentsPage/TableSegments.unit.spec.tsx
@@ -1,0 +1,62 @@
+import { Route } from "react-router";
+
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen } from "__support__/ui";
+import type { EnterpriseSettings } from "metabase-types/api";
+import { createMockTable, createMockUser } from "metabase-types/api/mocks";
+
+import { TableSegments } from "./TableSegments";
+
+type SetupOpts = {
+  isAdmin?: boolean;
+  remoteSyncType?: EnterpriseSettings["remote-sync-type"];
+};
+
+const setup = ({ isAdmin = true, remoteSyncType }: SetupOpts = {}) => {
+  const mockTable = createMockTable({
+    id: 1,
+    db_id: 1,
+    schema: "PUBLIC",
+  });
+
+  renderWithProviders(
+    <Route path="/" component={() => <TableSegments table={mockTable} />} />,
+    {
+      withRouter: true,
+      storeInitialState: {
+        settings: mockSettings({
+          "remote-sync-type": remoteSyncType,
+          "remote-sync-enabled": !!remoteSyncType,
+        }),
+        currentUser: createMockUser({ is_superuser: isAdmin }),
+      },
+    },
+  );
+};
+
+describe("TableSegments", () => {
+  it("renders the new segment button", () => {
+    setup();
+    expect(
+      screen.getByRole("link", { name: /New segment/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /New segment/ })).toHaveAttribute(
+      "href",
+      "/data-studio/library/tables/1/segments/new",
+    );
+  });
+
+  it("does not render the new segment button if remote sync is set to read-only", () => {
+    setup({ remoteSyncType: "read-only" });
+    expect(
+      screen.queryByRole("link", { name: /New segment/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render the new segment button if the user is not an admin", () => {
+    setup({ isAdmin: false });
+    expect(
+      screen.queryByRole("link", { name: /New segment/ }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/selectors.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/selectors.ts
@@ -1,5 +1,6 @@
 import { createSelector } from "@reduxjs/toolkit";
 
+import { getSetting } from "metabase/selectors/settings";
 import { remoteSyncApi } from "metabase-enterprise/api";
 import type { State } from "metabase-types/store";
 
@@ -56,3 +57,13 @@ export const getHasPendingMutation = createSelector(
     );
   },
 );
+
+/**
+ * Checks if the remote sync is enabled and in read-only mode.
+ */
+export function getIsRemoteSyncReadOnly(state: State): boolean {
+  return !!(
+    getSetting(state, "remote-sync-enabled") &&
+    getSetting(state, "remote-sync-type") === "read-only"
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionMenu/SnippetCollectionMenu.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionMenu/SnippetCollectionMenu.tsx
@@ -14,6 +14,7 @@ import {
   Menu,
   Tooltip,
 } from "metabase/ui";
+import { getIsRemoteSyncReadOnly } from "metabase-enterprise/remote_sync/selectors";
 
 export function SnippetCollectionMenu({
   collection,
@@ -24,11 +25,12 @@ export function SnippetCollectionMenu({
 
   const isAdmin = useSelector(getUserIsAdmin);
   const [updateCollection] = useUpdateCollectionMutation();
+  const remoteSyncReadOnly = useSelector(getIsRemoteSyncReadOnly);
 
   const isRoot = isRootCollection(collection);
   const isArchived = collection.archived;
 
-  if (!collection.can_write) {
+  if (!collection.can_write || remoteSyncReadOnly) {
     return null;
   }
 

--- a/enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionMenu/SnippetCollectionMenu.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionMenu/SnippetCollectionMenu.unit.spec.tsx
@@ -1,0 +1,59 @@
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen } from "__support__/ui";
+import type { Collection, EnterpriseSettings } from "metabase-types/api";
+import { createMockCollection, createMockUser } from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks/state";
+
+import { SnippetCollectionMenu } from "./SnippetCollectionMenu";
+
+interface SetupOptions {
+  remoteSyncType?: EnterpriseSettings["remote-sync-type"];
+  collection?: Partial<Collection>;
+}
+
+const onEditDetails = jest.fn();
+const onChangePermissions = jest.fn();
+
+const setup = ({ remoteSyncType, collection }: SetupOptions = {}) => {
+  const state = createMockState({
+    settings: mockSettings({
+      "remote-sync-type": remoteSyncType,
+      "remote-sync-enabled": !!remoteSyncType,
+    }),
+    currentUser: createMockUser(),
+  });
+
+  return renderWithProviders(
+    <SnippetCollectionMenu
+      collection={createMockCollection(collection)}
+      onChangePermissions={onChangePermissions}
+      onEditDetails={onEditDetails}
+    />,
+    {
+      storeInitialState: state,
+    },
+  );
+};
+
+describe("RootSnippetsCollectionMenu", () => {
+  it("renders snippet collection options menu", () => {
+    setup();
+    expect(
+      screen.getByRole("button", { name: "Snippet folder options" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders nothing if collection is not writable", () => {
+    setup({ collection: { can_write: false } });
+    expect(
+      screen.queryByRole("button", { name: "Snippet folder options" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders nothing if remote sync is set to read-only", () => {
+    setup({ remoteSyncType: "read-only" });
+    expect(
+      screen.queryByRole("button", { name: "Snippet folder options" }),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-2646/remove-editing-from-ux-when-in-read-only-in-library
Closes https://linear.app/metabase/issue/UXW-2717/create-read-only-state-for-measures

### Description

Our goal here is to remove any editing capabilities from Data Studio's Library & Data Structure pages when remote sync is in read-only mode.
In follow-up PRs we will also apply read-only for other remote-synced entities in DS, like measures & snippets on a table detail page and transforms pages.

### How to verify

1. Have Remote Sync enabled in read-only mode and navigate to Data Studio
2. On the Library page:
  2.1 Make sure you don't see the "New" button (so that you can't create items)
  2.2 Make sure you can't see the ellipsis menu for the snippets row or for snippets folders
3. Navigate to Data Structure:
  3.1 Click a table and notice you don't have the publish or unpublish button.
  3.2 You also don't have buttons to create segments or measures
  3.3 On measure and segment detail pages, you can't edit their definitions

### Demo
https://www.loom.com/share/88272313fad74694a08038f8314e5598

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
