### PR TITLE
Make Python and SQL editing in Data Studio consistent

### DIFF
--- a/e2e/test/scenarios/data-studio/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms.cy.spec.ts
@@ -234,7 +234,7 @@ describe("scenarios > admin > transforms", () => {
           event_detail: "python",
         });
 
-        cy.findByTestId("python-data-picker")
+        cy.findByTestId("python-transform-top-bar")
           .findByText("Writable Postgres12")
           .click();
 
@@ -246,7 +246,7 @@ describe("scenarios > admin > transforms", () => {
         cy.log("Select database");
         H.popover().findByText(DB_NAME).click();
 
-        getPythonDataPicker().button("Select a table…").click();
+        getPythonDataPicker().findByText("Select a table…").click();
         H.entityPickerModal().findByText("Animals").click();
 
         getPythonDataPicker().within(() => {
@@ -1611,10 +1611,6 @@ LIMIT
         cy.log("results panel should be visible in edit mode");
         cy.findByTestId("python-results").should("be.visible");
 
-        cy.log("library buttons should be visible in edit mode");
-        cy.findByLabelText("Import common library").should("be.visible");
-        cy.findByLabelText("Edit common library").should("be.visible");
-
         cy.log("Edit definition button should be hidden in edit mode");
         H.DataStudio.Transforms.editDefinition().should("not.exist");
       },
@@ -1980,8 +1976,12 @@ LIMIT
         cy.button("Create a transform").click();
         H.popover().findByText("Python script").click();
 
+        cy.log("import common should be included by default");
+        H.PythonEditor.value().should("contain", "import common");
+
         H.PythonEditor.clear().type(
           dedent`
+            import common
             import pandas as pd
 
             def transform():
@@ -1989,9 +1989,6 @@ LIMIT
           `,
           { allowFastSet: true },
         );
-
-        getQueryEditor().findByLabelText("Import common library").click();
-        H.PythonEditor.value().should("contain", "import common");
 
         cy.findByTestId("python-data-picker")
           .findByText("Select a table…")
@@ -3285,7 +3282,9 @@ describe("scenarios > admin > transforms", () => {
     cy.button("Create a transform").click();
     H.popover().findByText("Python script").click();
 
-    getPythonDataPicker().findByText("Select a database").should("be.visible");
+    cy.findByTestId("python-transform-top-bar")
+      .findByText("Select a database")
+      .should("be.visible");
   });
 });
 

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonDataPicker/PythonDataPicker.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonDataPicker/PythonDataPicker.tsx
@@ -32,6 +32,7 @@ import {
 type PythonDataPickerProps = {
   database?: DatabaseId;
   tables: PythonTransformTableAliases;
+  readOnly?: boolean;
   onChange: (
     database: number,
     tables: PythonTransformTableAliases,
@@ -42,6 +43,7 @@ type PythonDataPickerProps = {
 export function PythonDataPicker({
   database,
   tables,
+  readOnly,
   onChange,
 }: PythonDataPickerProps) {
   const [tableSelections, setTableSelections] = useState<TableSelection[]>(
@@ -162,6 +164,7 @@ export function PythonDataPicker({
           selectedDatabaseId={database}
           setDatabaseFn={handleDatabaseChange}
           databases={databases?.data ?? []}
+          readOnly={readOnly}
           databaseIsDisabled={(database: Database) =>
             !doesDatabaseSupportTransforms(database) ||
             !hasFeature(database, "transforms/python")
@@ -187,12 +190,12 @@ export function PythonDataPicker({
                   handleSelectionChange(index, selection)
                 }
                 onRemove={() => handleRemoveTable(index)}
-                disabled={isLoadingTables}
+                disabled={isLoadingTables || readOnly}
               />
             ))}
             <AddTableButton
               onClick={handleAddTable}
-              disabled={availableTables.length === 0}
+              disabled={availableTables.length === 0 || readOnly}
             />
           </Stack>
         </Box>

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonDataPicker/PythonDataPicker.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonDataPicker/PythonDataPicker.tsx
@@ -1,18 +1,10 @@
 import { useEffect, useState } from "react";
 import { t } from "ttag";
 
-import { hasFeature } from "metabase/admin/databases/utils";
-import {
-  skipToken,
-  useListDatabasesQuery,
-  useListTablesQuery,
-} from "metabase/api";
+import { skipToken, useListTablesQuery } from "metabase/api";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
-import { DatabaseDataSelector } from "metabase/query_builder/components/DataSelector";
 import { Box, Button, Icon, Stack, Text } from "metabase/ui";
-import { doesDatabaseSupportTransforms } from "metabase-enterprise/transforms/utils";
 import type {
-  Database,
   DatabaseId,
   PythonTransformTableAliases,
   Table,
@@ -55,12 +47,6 @@ export function PythonDataPicker({
   }, [tables]);
 
   const {
-    data: databases,
-    isLoading: isLoadingDatabases,
-    error: databaseError,
-  } = useListDatabasesQuery();
-
-  const {
     data: tablesData,
     isLoading: isLoadingTables,
     error: tablesError,
@@ -74,22 +60,15 @@ export function PythonDataPicker({
       : skipToken,
   );
 
-  const handleChange = (
-    database: DatabaseId | undefined,
-    selections: TableSelection[],
-  ) => {
+  const handleChange = (selections: TableSelection[]) => {
     if (database) {
       const tableAliases = selectionsToTableAliases(selections);
       onChange(database, tableAliases, tablesData ?? []);
     }
   };
 
-  if (databaseError || tablesError) {
-    return <LoadingAndErrorWrapper error={databaseError || tablesError} />;
-  }
-
-  if (isLoadingDatabases) {
-    return <LoadingAndErrorWrapper loading />;
+  if (tablesError) {
+    return <LoadingAndErrorWrapper error={tablesError} />;
   }
 
   const availableTables = (tablesData || []).filter(
@@ -98,24 +77,6 @@ export function PythonDataPicker({
 
   const usedAliases = new Set(tableSelections.map((s) => s.alias));
 
-  const handleDatabaseChange = (value: string | null) => {
-    const newDatabase = value ? parseInt(value) : undefined;
-
-    if (newDatabase === database) {
-      return;
-    }
-
-    // Clear selections since they won't make sense
-    const newSelections = [
-      {
-        tableId: undefined,
-        alias: "",
-      },
-    ];
-    setTableSelections(newSelections);
-    handleChange(newDatabase, newSelections);
-  };
-
   const handleSelectionChange = (
     selectionIndex: number,
     selection: TableSelection,
@@ -123,7 +84,7 @@ export function PythonDataPicker({
     const newSelections = Array.from(tableSelections);
     newSelections[selectionIndex] = selection;
     setTableSelections(newSelections);
-    handleChange(database, newSelections);
+    handleChange(newSelections);
   };
 
   const handleAddTable = () => {
@@ -140,8 +101,12 @@ export function PythonDataPicker({
     const newSelections = Array.from(tableSelections);
     newSelections.splice(selectionIndex, 1);
     setTableSelections(newSelections);
-    handleChange(database, newSelections);
+    handleChange(newSelections);
   };
+
+  if (!database) {
+    return null;
+  }
 
   return (
     <Stack
@@ -154,52 +119,30 @@ export function PythonDataPicker({
       data-testid="python-data-picker"
     >
       <Box>
-        <Text fw="bold">{t`Source database`}</Text>
+        <Text fw="bold">{t`Pick tables and alias them`}</Text>
         <Text size="sm" c="text-tertiary" mb="sm">
-          {t`Select the database that contains your source data.`}
+          {t`Select tables to use as data sources and provide aliases that can be referenced in your Python script.`}
         </Text>
-
-        <DatabaseDataSelector
-          className={S.databaseSelector}
-          selectedDatabaseId={database}
-          setDatabaseFn={handleDatabaseChange}
-          databases={databases?.data ?? []}
-          readOnly={readOnly}
-          databaseIsDisabled={(database: Database) =>
-            !doesDatabaseSupportTransforms(database) ||
-            !hasFeature(database, "transforms/python")
-          }
-        />
-      </Box>
-      {database && (
-        <Box>
-          <Text fw="bold">{t`Pick tables and alias them`}</Text>
-          <Text size="sm" c="text-tertiary" mb="sm">
-            {t`Select tables to use as data sources and provide aliases that can be referenced in your Python script.`}
-          </Text>
-          <Stack gap="md">
-            {tableSelections.map((selection, index) => (
-              <SelectionInput
-                key={index}
-                selection={selection}
-                database={database}
-                tables={tables}
-                usedAliases={usedAliases}
-                availableTables={availableTables}
-                onChange={(selection) =>
-                  handleSelectionChange(index, selection)
-                }
-                onRemove={() => handleRemoveTable(index)}
-                disabled={isLoadingTables || readOnly}
-              />
-            ))}
-            <AddTableButton
-              onClick={handleAddTable}
-              disabled={availableTables.length === 0 || readOnly}
+        <Stack gap="md">
+          {tableSelections.map((selection, index) => (
+            <SelectionInput
+              key={index}
+              selection={selection}
+              database={database}
+              tables={tables}
+              usedAliases={usedAliases}
+              availableTables={availableTables}
+              onChange={(selection) => handleSelectionChange(index, selection)}
+              onRemove={() => handleRemoveTable(index)}
+              disabled={isLoadingTables || readOnly}
             />
-          </Stack>
-        </Box>
-      )}
+          ))}
+          <AddTableButton
+            onClick={handleAddTable}
+            disabled={availableTables.length === 0 || readOnly}
+          />
+        </Stack>
+      </Box>
     </Stack>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonEditorBody/PythonEditorBody.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonEditorBody/PythonEditorBody.tsx
@@ -3,25 +3,12 @@ import { ResizableBox } from "react-resizable";
 import { useWindowSize } from "react-use";
 import { t } from "ttag";
 
-import { ForwardRefLink } from "metabase/common/components/Link";
-import * as Urls from "metabase/lib/urls";
 import RunButtonWithTooltip from "metabase/query_builder/components/RunButtonWithTooltip";
-import {
-  ActionIcon,
-  Button,
-  Flex,
-  Group,
-  Icon,
-  Stack,
-  Tooltip,
-} from "metabase/ui";
-import { SHARED_LIB_IMPORT_PATH } from "metabase-enterprise/transforms-python/constants";
+import { Button, Flex, Icon, Stack, Tooltip } from "metabase/ui";
 
 import { PythonEditor } from "../../PythonEditor";
 
-import S from "./PythonEditorBody.module.css";
 import { ResizableBoxHandle } from "./ResizableBoxHandle";
-import { hasImport, insertImport, removeImport } from "./utils";
 
 type PythonEditorBodyProps = {
   source: string;
@@ -119,13 +106,6 @@ export function PythonEditorBody({
             />
           </Stack>
         )}
-        {!readOnly && (
-          <SharedLibraryActions
-            source={source}
-            onChange={onChange}
-            readOnly={readOnly}
-          />
-        )}
       </Flex>
     </ResizableBox>
   );
@@ -147,75 +127,4 @@ function useInitialEditorHeight(readOnly?: boolean) {
   );
 
   return Math.min(availableHeight - previewInitialHeight, EDITOR_HEIGHT);
-}
-
-function SharedLibraryActions({
-  source,
-  onChange,
-  readOnly,
-}: {
-  source: string;
-  onChange: (source: string) => void;
-  readOnly?: boolean;
-}) {
-  return (
-    <Group className={S.libraryActions} p="md" gap="sm">
-      <SharedLibraryImportButton
-        source={source}
-        onChange={onChange}
-        disabled={readOnly}
-      />
-      <SharedLibraryEditLink disabled={readOnly} />
-    </Group>
-  );
-}
-
-function SharedLibraryImportButton({
-  source,
-  onChange,
-  disabled,
-}: {
-  source: string;
-  onChange: (source: string) => void;
-  disabled?: boolean;
-}) {
-  const label = t`Import common library`;
-
-  const handleToggleSharedLib = () => {
-    if (hasImport(source, SHARED_LIB_IMPORT_PATH)) {
-      onChange(removeImport(source, SHARED_LIB_IMPORT_PATH));
-    } else {
-      onChange(insertImport(source, SHARED_LIB_IMPORT_PATH));
-    }
-  };
-
-  return (
-    <Tooltip label={label}>
-      <ActionIcon
-        aria-label={label}
-        onClick={handleToggleSharedLib}
-        disabled={disabled}
-      >
-        <Icon name="reference" c="text-primary" />
-      </ActionIcon>
-    </Tooltip>
-  );
-}
-
-function SharedLibraryEditLink({ disabled }: { disabled?: boolean }) {
-  const label = t`Edit common library`;
-
-  return (
-    <Tooltip label={label}>
-      <ActionIcon
-        component={ForwardRefLink}
-        target="_blank"
-        aria-label={label}
-        to={Urls.transformPythonLibrary({ path: SHARED_LIB_IMPORT_PATH })}
-        disabled={disabled}
-      >
-        <Icon name="pencil" c="text-primary" />
-      </ActionIcon>
-    </Tooltip>
-  );
 }

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonEditorBody/PythonEditorBody.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonEditorBody/PythonEditorBody.tsx
@@ -14,7 +14,7 @@ type PythonEditorBodyProps = {
   source: string;
   proposedSource?: string;
   isRunnable: boolean;
-  readOnly?: boolean;
+  isEditMode?: boolean;
   onChange: (source: string) => void;
   onRun?: () => void;
   onCancel?: () => void;
@@ -35,7 +35,7 @@ export function PythonEditorBody({
   proposedSource,
   onChange,
   isRunnable,
-  readOnly,
+  isEditMode,
   onRun,
   onCancel,
   isRunning,
@@ -45,14 +45,14 @@ export function PythonEditorBody({
   onRejectProposed,
 }: PythonEditorBodyProps) {
   const [isResizing, setIsResizing] = useState(false);
-  const editorHeight = useInitialEditorHeight(readOnly);
+  const editorHeight = useInitialEditorHeight(isEditMode);
 
   return (
     <ResizableBox
       axis="y"
       height={editorHeight}
       handle={<ResizableBoxHandle />}
-      resizeHandles={readOnly || !withDebugger ? [] : ["s"]}
+      resizeHandles={!isEditMode || !withDebugger ? [] : ["s"]}
       style={isResizing ? undefined : { transition: "height 0.25s" }}
       onResizeStart={() => setIsResizing(true)}
       onResizeStop={() => setIsResizing(false)}
@@ -63,11 +63,11 @@ export function PythonEditorBody({
           proposedValue={proposedSource}
           onChange={onChange}
           withPandasCompletions
-          readOnly={readOnly}
+          readOnly={!isEditMode}
           data-testid="python-editor"
         />
 
-        {!readOnly && (
+        {isEditMode && (
           <Stack m="1rem" gap="md" mt="auto">
             {proposedSource && onRejectProposed && onAcceptProposed && (
               <>
@@ -112,12 +112,12 @@ export function PythonEditorBody({
   );
 }
 
-function useInitialEditorHeight(readOnly?: boolean) {
+function useInitialEditorHeight(isEditMode?: boolean) {
   const { height: windowHeight } = useWindowSize();
   const availableHeight = windowHeight - HEADER_HEIGHT;
 
-  if (readOnly) {
-    // When read-only, we don't need to split the container to show the results panel on the bottom
+  if (!isEditMode) {
+    // When not in edit mode, we don't need to split the container to show the results panel on the bottom
     return availableHeight;
   }
 

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonEditorBody/PythonEditorBody.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonEditorBody/PythonEditorBody.tsx
@@ -63,6 +63,7 @@ export function PythonEditorBody({
           proposedValue={proposedSource}
           onChange={onChange}
           withPandasCompletions
+          readOnly={readOnly}
           data-testid="python-editor"
         />
 

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonEditorBody/PythonEditorBody.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonEditorBody/PythonEditorBody.tsx
@@ -66,49 +66,53 @@ export function PythonEditorBody({
           data-testid="python-editor"
         />
 
-        <Stack m="1rem" gap="md" mt="auto">
-          {proposedSource && onRejectProposed && onAcceptProposed && (
-            <>
-              <Tooltip label={t`Accept proposed changes`} position="left">
-                <Button
-                  data-testid="accept-proposed-changes-button"
-                  variant="filled"
-                  bg="success"
-                  px="0"
-                  w="2.5rem"
-                  onClick={onAcceptProposed}
-                >
-                  <Icon name="check" />
-                </Button>
-              </Tooltip>
-              <Tooltip label={t`Reject proposed changes`} position="left">
-                <Button
-                  data-testid="reject-proposed-changes-button"
-                  w="2.5rem"
-                  px="0"
-                  variant="filled"
-                  bg="danger"
-                  onClick={onRejectProposed}
-                >
-                  <Icon name="close" />
-                </Button>
-              </Tooltip>
-            </>
-          )}
-          <RunButtonWithTooltip
-            disabled={!isRunnable || readOnly}
-            isRunning={isRunning}
-            isDirty={isDirty}
-            onRun={onRun}
-            onCancel={onCancel}
-            getTooltip={() => t`Run Python script`}
+        {!readOnly && (
+          <Stack m="1rem" gap="md" mt="auto">
+            {proposedSource && onRejectProposed && onAcceptProposed && (
+              <>
+                <Tooltip label={t`Accept proposed changes`} position="left">
+                  <Button
+                    data-testid="accept-proposed-changes-button"
+                    variant="filled"
+                    bg="success"
+                    px="0"
+                    w="2.5rem"
+                    onClick={onAcceptProposed}
+                  >
+                    <Icon name="check" />
+                  </Button>
+                </Tooltip>
+                <Tooltip label={t`Reject proposed changes`} position="left">
+                  <Button
+                    data-testid="reject-proposed-changes-button"
+                    w="2.5rem"
+                    px="0"
+                    variant="filled"
+                    bg="danger"
+                    onClick={onRejectProposed}
+                  >
+                    <Icon name="close" />
+                  </Button>
+                </Tooltip>
+              </>
+            )}
+            <RunButtonWithTooltip
+              disabled={!isRunnable}
+              isRunning={isRunning}
+              isDirty={isDirty}
+              onRun={onRun}
+              onCancel={onCancel}
+              getTooltip={() => t`Run Python script`}
+            />
+          </Stack>
+        )}
+        {!readOnly && (
+          <SharedLibraryActions
+            source={source}
+            onChange={onChange}
+            readOnly={readOnly}
           />
-        </Stack>
-        <SharedLibraryActions
-          source={source}
-          onChange={onChange}
-          readOnly={readOnly}
-        />
+        )}
       </Flex>
     </MaybeResizableBox>
   );

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonEditorBody/PythonEditorBody.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonEditorBody/PythonEditorBody.tsx
@@ -27,6 +27,7 @@ type PythonEditorBodyProps = {
   source: string;
   proposedSource?: string;
   isRunnable: boolean;
+  readOnly?: boolean;
   onChange: (source: string) => void;
   onRun?: () => void;
   onCancel?: () => void;
@@ -45,6 +46,7 @@ export function PythonEditorBody({
   proposedSource,
   onChange,
   isRunnable,
+  readOnly,
   onRun,
   onCancel,
   isRunning,
@@ -94,7 +96,7 @@ export function PythonEditorBody({
             </>
           )}
           <RunButtonWithTooltip
-            disabled={!isRunnable}
+            disabled={!isRunnable || readOnly}
             isRunning={isRunning}
             isDirty={isDirty}
             onRun={onRun}
@@ -102,7 +104,11 @@ export function PythonEditorBody({
             getTooltip={() => t`Run Python script`}
           />
         </Stack>
-        <SharedLibraryActions source={source} onChange={onChange} />
+        <SharedLibraryActions
+          source={source}
+          onChange={onChange}
+          readOnly={readOnly}
+        />
       </Flex>
     </MaybeResizableBox>
   );
@@ -138,14 +144,20 @@ function MaybeResizableBox({
 function SharedLibraryActions({
   source,
   onChange,
+  readOnly,
 }: {
   source: string;
   onChange: (source: string) => void;
+  readOnly?: boolean;
 }) {
   return (
     <Group className={S.libraryActions} p="md" gap="sm">
-      <SharedLibraryImportButton source={source} onChange={onChange} />
-      <SharedLibraryEditLink />
+      <SharedLibraryImportButton
+        source={source}
+        onChange={onChange}
+        disabled={readOnly}
+      />
+      <SharedLibraryEditLink disabled={readOnly} />
     </Group>
   );
 }
@@ -153,9 +165,11 @@ function SharedLibraryActions({
 function SharedLibraryImportButton({
   source,
   onChange,
+  disabled,
 }: {
   source: string;
   onChange: (source: string) => void;
+  disabled?: boolean;
 }) {
   const label = t`Import common library`;
 
@@ -169,14 +183,18 @@ function SharedLibraryImportButton({
 
   return (
     <Tooltip label={label}>
-      <ActionIcon aria-label={label} onClick={handleToggleSharedLib}>
+      <ActionIcon
+        aria-label={label}
+        onClick={handleToggleSharedLib}
+        disabled={disabled}
+      >
         <Icon name="reference" c="text-primary" />
       </ActionIcon>
     </Tooltip>
   );
 }
 
-function SharedLibraryEditLink() {
+function SharedLibraryEditLink({ disabled }: { disabled?: boolean }) {
   const label = t`Edit common library`;
 
   return (
@@ -186,6 +204,7 @@ function SharedLibraryEditLink() {
         target="_blank"
         aria-label={label}
         to={Urls.transformPythonLibrary({ path: SHARED_LIB_IMPORT_PATH })}
+        disabled={disabled}
       >
         <Icon name="pencil" c="text-primary" />
       </ActionIcon>

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonEditorBody/PythonEditorBody.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonEditorBody/PythonEditorBody.unit.spec.tsx
@@ -7,7 +7,7 @@ import { PythonEditorBody } from "./PythonEditorBody";
 type SetupOpts = {
   source?: string;
   proposedSource?: string;
-  readOnly?: boolean;
+  isEditMode?: boolean;
   isRunnable?: boolean;
   isRunning?: boolean;
   isDirty?: boolean;
@@ -19,7 +19,7 @@ type SetupOpts = {
 function setup({
   source = "# test script",
   proposedSource,
-  readOnly = false,
+  isEditMode = true,
   isRunnable = true,
   isRunning = false,
   isDirty = false,
@@ -31,7 +31,7 @@ function setup({
     <PythonEditorBody
       source={source}
       proposedSource={proposedSource}
-      readOnly={readOnly}
+      isEditMode={isEditMode}
       isRunnable={isRunnable}
       isRunning={isRunning}
       isDirty={isDirty}
@@ -46,15 +46,15 @@ function setup({
 }
 
 describe("PythonEditorBody", () => {
-  describe("read-only mode", () => {
-    it("should not render run button when readOnly is true", () => {
-      setup({ readOnly: true });
+  describe("view mode (not editing)", () => {
+    it("should not render run button when not in edit mode", () => {
+      setup({ isEditMode: false });
       expect(screen.queryByTestId("run-button")).not.toBeInTheDocument();
     });
 
-    it("should not render proposed changes buttons when readOnly is true", () => {
+    it("should not render proposed changes buttons when not in edit mode", () => {
       setup({
-        readOnly: true,
+        isEditMode: false,
         proposedSource: "# proposed",
         onAcceptProposed: jest.fn(),
         onRejectProposed: jest.fn(),
@@ -69,20 +69,20 @@ describe("PythonEditorBody", () => {
     });
 
     it("should render the python editor", () => {
-      setup({ readOnly: true });
+      setup({ isEditMode: false });
       expect(screen.getByTestId("python-editor")).toBeInTheDocument();
     });
   });
 
   describe("edit mode", () => {
-    it("should render run button when readOnly is false", () => {
-      setup({ readOnly: false });
+    it("should render run button in edit mode", () => {
+      setup({ isEditMode: true });
       expect(screen.getByTestId("run-button")).toBeInTheDocument();
     });
 
     it("should render proposed changes buttons when proposedSource and callbacks are provided", () => {
       setup({
-        readOnly: false,
+        isEditMode: true,
         proposedSource: "# proposed changes",
         onAcceptProposed: jest.fn(),
         onRejectProposed: jest.fn(),
@@ -97,7 +97,7 @@ describe("PythonEditorBody", () => {
     });
 
     it("should not render proposed changes buttons when proposedSource is not provided", () => {
-      setup({ readOnly: false });
+      setup({ isEditMode: true });
 
       expect(
         screen.queryByTestId("accept-proposed-changes-button"),
@@ -108,7 +108,7 @@ describe("PythonEditorBody", () => {
     });
 
     it("should render the python editor", () => {
-      setup({ readOnly: false });
+      setup({ isEditMode: true });
       expect(screen.getByTestId("python-editor")).toBeInTheDocument();
     });
   });

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonEditorBody/PythonEditorBody.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonEditorBody/PythonEditorBody.unit.spec.tsx
@@ -27,10 +27,6 @@ function setup({
   onAcceptProposed,
   onRejectProposed,
 }: SetupOpts = {}) {
-  const onChange = jest.fn();
-  const onRun = jest.fn();
-  const onCancel = jest.fn();
-
   renderWithProviders(
     <PythonEditorBody
       source={source}
@@ -40,15 +36,13 @@ function setup({
       isRunning={isRunning}
       isDirty={isDirty}
       withDebugger={withDebugger}
-      onChange={onChange}
-      onRun={onRun}
-      onCancel={onCancel}
+      onChange={jest.fn()}
+      onRun={jest.fn()}
+      onCancel={jest.fn()}
       onAcceptProposed={onAcceptProposed}
       onRejectProposed={onRejectProposed}
     />,
   );
-
-  return { onChange, onRun, onCancel };
 }
 
 describe("PythonEditorBody", () => {
@@ -59,13 +53,11 @@ describe("PythonEditorBody", () => {
     });
 
     it("should not render proposed changes buttons when readOnly is true", () => {
-      const onAccept = jest.fn();
-      const onReject = jest.fn();
       setup({
         readOnly: true,
         proposedSource: "# proposed",
-        onAcceptProposed: onAccept,
-        onRejectProposed: onReject,
+        onAcceptProposed: jest.fn(),
+        onRejectProposed: jest.fn(),
       });
 
       expect(
@@ -89,13 +81,11 @@ describe("PythonEditorBody", () => {
     });
 
     it("should render proposed changes buttons when proposedSource and callbacks are provided", () => {
-      const onAccept = jest.fn();
-      const onReject = jest.fn();
       setup({
         readOnly: false,
         proposedSource: "# proposed changes",
-        onAcceptProposed: onAccept,
-        onRejectProposed: onReject,
+        onAcceptProposed: jest.fn(),
+        onRejectProposed: jest.fn(),
       });
 
       expect(

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonEditorBody/PythonEditorBody.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonEditorBody/PythonEditorBody.unit.spec.tsx
@@ -1,0 +1,166 @@
+import { screen } from "@testing-library/react";
+
+import { renderWithProviders } from "__support__/ui";
+
+import { PythonEditorBody } from "./PythonEditorBody";
+
+// Mock matchMedia to include matches property
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: jest.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});
+
+// Mock the PythonEditor component since it requires complex setup
+jest.mock("../../PythonEditor", () => ({
+  PythonEditor: () => <div data-testid="python-editor-mock">Python Editor</div>,
+}));
+
+// Mock ResizableBox since it has complex behavior
+jest.mock("react-resizable", () => ({
+  ResizableBox: ({
+    children,
+  }: {
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) => <div data-testid="resizable-box">{children}</div>,
+}));
+
+// Mock the ResizableBoxHandle
+jest.mock("./ResizableBoxHandle", () => ({
+  ResizableBoxHandle: () => <div data-testid="resize-handle" />,
+}));
+
+// Mock react-use hooks
+jest.mock("react-use", () => ({
+  ...jest.requireActual("react-use"),
+  useWindowSize: () => ({ height: 800, width: 1200 }),
+}));
+
+type SetupOpts = {
+  source?: string;
+  proposedSource?: string;
+  readOnly?: boolean;
+  isRunnable?: boolean;
+  isRunning?: boolean;
+  isDirty?: boolean;
+  withDebugger?: boolean;
+  onAcceptProposed?: () => void;
+  onRejectProposed?: () => void;
+};
+
+function setup({
+  source = "# test script",
+  proposedSource,
+  readOnly = false,
+  isRunnable = true,
+  isRunning = false,
+  isDirty = false,
+  withDebugger = true,
+  onAcceptProposed,
+  onRejectProposed,
+}: SetupOpts = {}) {
+  const onChange = jest.fn();
+  const onRun = jest.fn();
+  const onCancel = jest.fn();
+
+  renderWithProviders(
+    <PythonEditorBody
+      source={source}
+      proposedSource={proposedSource}
+      readOnly={readOnly}
+      isRunnable={isRunnable}
+      isRunning={isRunning}
+      isDirty={isDirty}
+      withDebugger={withDebugger}
+      onChange={onChange}
+      onRun={onRun}
+      onCancel={onCancel}
+      onAcceptProposed={onAcceptProposed}
+      onRejectProposed={onRejectProposed}
+    />,
+  );
+
+  return { onChange, onRun, onCancel };
+}
+
+describe("PythonEditorBody", () => {
+  describe("read-only mode", () => {
+    it("should not render run button when readOnly is true", () => {
+      setup({ readOnly: true });
+      expect(screen.queryByTestId("run-button")).not.toBeInTheDocument();
+    });
+
+    it("should not render proposed changes buttons when readOnly is true", () => {
+      const onAccept = jest.fn();
+      const onReject = jest.fn();
+      setup({
+        readOnly: true,
+        proposedSource: "# proposed",
+        onAcceptProposed: onAccept,
+        onRejectProposed: onReject,
+      });
+
+      expect(
+        screen.queryByTestId("accept-proposed-changes-button"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("reject-proposed-changes-button"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should render the python editor", () => {
+      setup({ readOnly: true });
+      expect(screen.getByTestId("python-editor-mock")).toBeInTheDocument();
+    });
+  });
+
+  describe("edit mode", () => {
+    it("should render run button when readOnly is false", () => {
+      setup({ readOnly: false });
+      expect(screen.getByTestId("run-button")).toBeInTheDocument();
+    });
+
+    it("should render proposed changes buttons when proposedSource and callbacks are provided", () => {
+      const onAccept = jest.fn();
+      const onReject = jest.fn();
+      setup({
+        readOnly: false,
+        proposedSource: "# proposed changes",
+        onAcceptProposed: onAccept,
+        onRejectProposed: onReject,
+      });
+
+      expect(
+        screen.getByTestId("accept-proposed-changes-button"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("reject-proposed-changes-button"),
+      ).toBeInTheDocument();
+    });
+
+    it("should not render proposed changes buttons when proposedSource is not provided", () => {
+      setup({ readOnly: false });
+
+      expect(
+        screen.queryByTestId("accept-proposed-changes-button"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("reject-proposed-changes-button"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should render the python editor", () => {
+      setup({ readOnly: false });
+      expect(screen.getByTestId("python-editor-mock")).toBeInTheDocument();
+    });
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonEditorBody/PythonEditorBody.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonEditorBody/PythonEditorBody.unit.spec.tsx
@@ -4,47 +4,6 @@ import { renderWithProviders } from "__support__/ui";
 
 import { PythonEditorBody } from "./PythonEditorBody";
 
-// Mock matchMedia to include matches property
-Object.defineProperty(window, "matchMedia", {
-  writable: true,
-  value: jest.fn().mockImplementation((query: string) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addEventListener: jest.fn(),
-    removeEventListener: jest.fn(),
-    addListener: jest.fn(),
-    removeListener: jest.fn(),
-    dispatchEvent: jest.fn(),
-  })),
-});
-
-// Mock the PythonEditor component since it requires complex setup
-jest.mock("../../PythonEditor", () => ({
-  PythonEditor: () => <div data-testid="python-editor-mock">Python Editor</div>,
-}));
-
-// Mock ResizableBox since it has complex behavior
-jest.mock("react-resizable", () => ({
-  ResizableBox: ({
-    children,
-  }: {
-    children: React.ReactNode;
-    [key: string]: unknown;
-  }) => <div data-testid="resizable-box">{children}</div>,
-}));
-
-// Mock the ResizableBoxHandle
-jest.mock("./ResizableBoxHandle", () => ({
-  ResizableBoxHandle: () => <div data-testid="resize-handle" />,
-}));
-
-// Mock react-use hooks
-jest.mock("react-use", () => ({
-  ...jest.requireActual("react-use"),
-  useWindowSize: () => ({ height: 800, width: 1200 }),
-}));
-
 type SetupOpts = {
   source?: string;
   proposedSource?: string;
@@ -119,7 +78,7 @@ describe("PythonEditorBody", () => {
 
     it("should render the python editor", () => {
       setup({ readOnly: true });
-      expect(screen.getByTestId("python-editor-mock")).toBeInTheDocument();
+      expect(screen.getByTestId("python-editor")).toBeInTheDocument();
     });
   });
 
@@ -160,7 +119,7 @@ describe("PythonEditorBody", () => {
 
     it("should render the python editor", () => {
       setup({ readOnly: false });
-      expect(screen.getByTestId("python-editor-mock")).toBeInTheDocument();
+      expect(screen.getByTestId("python-editor")).toBeInTheDocument();
     });
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.tsx
@@ -20,7 +20,7 @@ import { updateTransformSignature } from "./utils";
 export function PythonTransformEditor({
   source,
   proposedSource,
-  readOnly,
+  isEditMode,
   transformId,
   onChangeSource,
   onAcceptProposed,
@@ -68,7 +68,7 @@ export function PythonTransformEditor({
   };
 
   const handleCmdEnter = () => {
-    if (readOnly) {
+    if (!isEditMode) {
       return;
     }
     if (isRunning) {
@@ -84,17 +84,16 @@ export function PythonTransformEditor({
     <Flex h="100%" w="100%" direction="column">
       <PythonTransformTopBar
         databaseId={source["source-database"]}
-        readOnly={readOnly}
+        isEditMode={isEditMode}
         transformId={transformId}
         onDatabaseChange={handleDatabaseChange}
       />
       <Flex h="100%" w="100%" style={{ minHeight: 0 }}>
-        {!readOnly && (
+        {isEditMode && (
           <PythonDataPicker
             database={source["source-database"]}
             tables={source["source-tables"]}
             onChange={handleDataChange}
-            readOnly={readOnly}
           />
         )}
         <Stack w="100%" h="100%" gap={0}>
@@ -102,17 +101,17 @@ export function PythonTransformEditor({
             isRunnable={isPythonTransformSource(source)}
             isRunning={isRunning}
             isDirty={isDirty}
-            readOnly={readOnly}
+            isEditMode={isEditMode}
             onRun={run}
             onCancel={cancel}
             source={source.body}
             proposedSource={proposedSource?.body}
             onChange={handleScriptChange}
-            withDebugger={!readOnly}
+            withDebugger={isEditMode}
             onAcceptProposed={onAcceptProposed}
             onRejectProposed={onRejectProposed}
           />
-          {!readOnly && (
+          {isEditMode && (
             <PythonEditorResults
               isRunning={isRunning}
               executionResult={executionResult}

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.tsx
@@ -26,13 +26,8 @@ export function PythonTransformEditor({
   onAcceptProposed,
   onRejectProposed,
 }: PythonTransformEditorProps) {
-  const {
-    isRunning,
-    cancel,
-    run,
-    executionResult,
-    isDirty: isTestDirty,
-  } = useTestPythonTransform(source);
+  const { isRunning, cancel, run, executionResult, isDirty } =
+    useTestPythonTransform(source);
 
   const handleScriptChange = (body: string) => {
     const newSource = {
@@ -108,7 +103,7 @@ export function PythonTransformEditor({
           <PythonEditorBody
             isRunnable={isPythonTransformSource(source)}
             isRunning={isRunning}
-            isDirty={isTestDirty}
+            isDirty={isDirty}
             readOnly={readOnly}
             onRun={run}
             onCancel={cancel}

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.tsx
@@ -9,6 +9,7 @@ import { isPythonTransformSource } from "../../utils";
 import { PythonDataPicker } from "./PythonDataPicker";
 import { PythonEditorBody } from "./PythonEditorBody";
 import { PythonEditorResults } from "./PythonEditorResults";
+import { PythonTransformTopBar } from "./PythonTransformTopBar";
 import { useTestPythonTransform } from "./hooks";
 import { updateTransformSignature } from "./utils";
 
@@ -16,6 +17,8 @@ export function PythonTransformEditor({
   source,
   proposedSource,
   isDirty,
+  readOnly,
+  transformId,
   onChangeSource,
   onAcceptProposed,
   onRejectProposed,
@@ -52,6 +55,9 @@ export function PythonTransformEditor({
   };
 
   const handleCmdEnter = () => {
+    if (readOnly) {
+      return;
+    }
     if (isRunning) {
       cancel();
     } else if (isPythonTransformSource(source)) {
@@ -62,31 +68,40 @@ export function PythonTransformEditor({
   useHotkeys([["mod+Enter", handleCmdEnter]], []);
 
   return (
-    <Flex h="100%" w="100%">
-      <PythonDataPicker
-        database={source["source-database"]}
-        tables={source["source-tables"]}
-        onChange={handleDataChange}
+    <Flex h="100%" w="100%" direction="column">
+      <PythonTransformTopBar
+        databaseId={source["source-database"]}
+        readOnly={readOnly}
+        transformId={transformId}
       />
-      <Stack w="100%" h="100%" gap={0}>
-        <PythonEditorBody
-          isRunnable={isPythonTransformSource(source)}
-          isRunning={isRunning}
-          isDirty={isDirty}
-          onRun={run}
-          onCancel={cancel}
-          source={source.body}
-          proposedSource={proposedSource?.body}
-          onChange={handleScriptChange}
-          withDebugger
-          onAcceptProposed={onAcceptProposed}
-          onRejectProposed={onRejectProposed}
+      <Flex h="100%" w="100%" style={{ minHeight: 0 }}>
+        <PythonDataPicker
+          database={source["source-database"]}
+          tables={source["source-tables"]}
+          onChange={handleDataChange}
+          readOnly={readOnly}
         />
-        <PythonEditorResults
-          isRunning={isRunning}
-          executionResult={executionResult}
-        />
-      </Stack>
+        <Stack w="100%" h="100%" gap={0}>
+          <PythonEditorBody
+            isRunnable={isPythonTransformSource(source)}
+            isRunning={isRunning}
+            isDirty={isDirty}
+            readOnly={readOnly}
+            onRun={run}
+            onCancel={cancel}
+            source={source.body}
+            proposedSource={proposedSource?.body}
+            onChange={handleScriptChange}
+            withDebugger
+            onAcceptProposed={onAcceptProposed}
+            onRejectProposed={onRejectProposed}
+          />
+          <PythonEditorResults
+            isRunning={isRunning}
+            executionResult={executionResult}
+          />
+        </Stack>
+      </Flex>
     </Flex>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.tsx
@@ -86,9 +86,7 @@ export function PythonTransformEditor({
         databaseId={source["source-database"]}
         readOnly={readOnly}
         transformId={transformId}
-        source={source.body}
         onDatabaseChange={handleDatabaseChange}
-        onSourceChange={handleScriptChange}
       />
       <Flex h="100%" w="100%" style={{ minHeight: 0 }}>
         {!readOnly && (

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.tsx
@@ -87,7 +87,9 @@ export function PythonTransformEditor({
         databaseId={source["source-database"]}
         readOnly={readOnly}
         transformId={transformId}
+        source={source.body}
         onDatabaseChange={handleDatabaseChange}
+        onSourceChange={handleScriptChange}
       />
       <Flex h="100%" w="100%" style={{ minHeight: 0 }}>
         {!readOnly && (

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.tsx
@@ -2,7 +2,11 @@ import { useHotkeys } from "@mantine/hooks";
 
 import type { PythonTransformEditorProps } from "metabase/plugins";
 import { Flex, Stack } from "metabase/ui";
-import type { PythonTransformTableAliases, Table } from "metabase-types/api";
+import type {
+  DatabaseId,
+  PythonTransformTableAliases,
+  Table,
+} from "metabase-types/api";
 
 import { isPythonTransformSource } from "../../utils";
 
@@ -30,6 +34,16 @@ export function PythonTransformEditor({
     const newSource = {
       ...source,
       body,
+    };
+    onChangeSource(newSource);
+  };
+
+  const handleDatabaseChange = (databaseId: DatabaseId) => {
+    // Clear table selections when database changes
+    const newSource = {
+      ...source,
+      "source-database": databaseId,
+      "source-tables": {},
     };
     onChangeSource(newSource);
   };
@@ -73,6 +87,7 @@ export function PythonTransformEditor({
         databaseId={source["source-database"]}
         readOnly={readOnly}
         transformId={transformId}
+        onDatabaseChange={handleDatabaseChange}
       />
       <Flex h="100%" w="100%" style={{ minHeight: 0 }}>
         {!readOnly && (

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.tsx
@@ -75,12 +75,14 @@ export function PythonTransformEditor({
         transformId={transformId}
       />
       <Flex h="100%" w="100%" style={{ minHeight: 0 }}>
-        <PythonDataPicker
-          database={source["source-database"]}
-          tables={source["source-tables"]}
-          onChange={handleDataChange}
-          readOnly={readOnly}
-        />
+        {!readOnly && (
+          <PythonDataPicker
+            database={source["source-database"]}
+            tables={source["source-tables"]}
+            onChange={handleDataChange}
+            readOnly={readOnly}
+          />
+        )}
         <Stack w="100%" h="100%" gap={0}>
           <PythonEditorBody
             isRunnable={isPythonTransformSource(source)}
@@ -92,14 +94,16 @@ export function PythonTransformEditor({
             source={source.body}
             proposedSource={proposedSource?.body}
             onChange={handleScriptChange}
-            withDebugger
+            withDebugger={!readOnly}
             onAcceptProposed={onAcceptProposed}
             onRejectProposed={onRejectProposed}
           />
-          <PythonEditorResults
-            isRunning={isRunning}
-            executionResult={executionResult}
-          />
+          {!readOnly && (
+            <PythonEditorResults
+              isRunning={isRunning}
+              executionResult={executionResult}
+            />
+          )}
         </Stack>
       </Flex>
     </Flex>

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.tsx
@@ -20,15 +20,19 @@ import { updateTransformSignature } from "./utils";
 export function PythonTransformEditor({
   source,
   proposedSource,
-  isDirty,
   readOnly,
   transformId,
   onChangeSource,
   onAcceptProposed,
   onRejectProposed,
 }: PythonTransformEditorProps) {
-  const { isRunning, cancel, run, executionResult } =
-    useTestPythonTransform(source);
+  const {
+    isRunning,
+    cancel,
+    run,
+    executionResult,
+    isDirty: isTestDirty,
+  } = useTestPythonTransform(source);
 
   const handleScriptChange = (body: string) => {
     const newSource = {
@@ -104,7 +108,7 @@ export function PythonTransformEditor({
           <PythonEditorBody
             isRunnable={isPythonTransformSource(source)}
             isRunning={isRunning}
-            isDirty={isDirty}
+            isDirty={isTestDirty}
             readOnly={readOnly}
             onRun={run}
             onCancel={cancel}

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.unit.spec.tsx
@@ -22,13 +22,13 @@ const mockPythonSource: PythonTransformSourceDraft = {
 
 type SetupOpts = {
   source?: PythonTransformSourceDraft;
-  readOnly?: boolean;
+  isEditMode?: boolean;
   transformId?: number;
 };
 
 function setup({
   source = mockPythonSource,
-  readOnly = false,
+  isEditMode = true,
   transformId = 1,
 }: SetupOpts = {}) {
   setupDatabasesEndpoints([mockDatabase]);
@@ -38,7 +38,7 @@ function setup({
   renderWithProviders(
     <PythonTransformEditor
       source={source}
-      readOnly={readOnly}
+      isEditMode={isEditMode}
       transformId={transformId}
       onChangeSource={jest.fn()}
       onAcceptProposed={jest.fn()}
@@ -51,62 +51,54 @@ function setup({
 }
 
 describe("PythonTransformEditor", () => {
-  beforeEach(() => {
-    jest.spyOn(console, "error").mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
-  describe("read-only mode", () => {
-    it("should not render the data picker sidebar when readOnly is true", () => {
-      setup({ readOnly: true });
+  describe("view mode (not editing)", () => {
+    it("should not render the data picker sidebar when not in edit mode", () => {
+      setup({ isEditMode: false });
       expect(
         screen.queryByTestId("python-data-picker"),
       ).not.toBeInTheDocument();
     });
 
-    it("should not render the results panel when readOnly is true", () => {
-      setup({ readOnly: true });
+    it("should not render the results panel when not in edit mode", () => {
+      setup({ isEditMode: false });
       expect(screen.queryByTestId("python-results")).not.toBeInTheDocument();
     });
 
     it("should render the top bar", () => {
-      setup({ readOnly: true });
+      setup({ isEditMode: false });
       expect(
         screen.getByTestId("python-transform-top-bar"),
       ).toBeInTheDocument();
     });
 
-    it("should render EditDefinitionButton in read-only mode", () => {
-      setup({ readOnly: true, transformId: 1 });
+    it("should render EditDefinitionButton when not in edit mode", () => {
+      setup({ isEditMode: false, transformId: 1 });
       expect(screen.getByText(/edit definition/i)).toBeInTheDocument();
     });
   });
 
   describe("edit mode", () => {
-    it("should render the data picker sidebar when readOnly is false", async () => {
-      setup({ readOnly: false });
+    it("should render the data picker sidebar in edit mode", async () => {
+      setup({ isEditMode: true });
       expect(
         await screen.findByTestId("python-data-picker"),
       ).toBeInTheDocument();
     });
 
-    it("should render the results panel when readOnly is false", () => {
-      setup({ readOnly: false });
+    it("should render the results panel in edit mode", () => {
+      setup({ isEditMode: true });
       expect(screen.getByTestId("python-results")).toBeInTheDocument();
     });
 
     it("should render the top bar", () => {
-      setup({ readOnly: false });
+      setup({ isEditMode: true });
       expect(
         screen.getByTestId("python-transform-top-bar"),
       ).toBeInTheDocument();
     });
 
     it("should not render EditDefinitionButton in edit mode", () => {
-      setup({ readOnly: false });
+      setup({ isEditMode: true });
       expect(screen.queryByText(/edit definition/i)).not.toBeInTheDocument();
     });
   });

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.unit.spec.tsx
@@ -35,6 +35,7 @@ jest.mock("react-use", () => ({
 jest.mock("./hooks", () => ({
   useTestPythonTransform: () => ({
     isRunning: false,
+    isDirty: true,
     cancel: jest.fn(),
     run: jest.fn(),
     executionResult: null,
@@ -104,14 +105,12 @@ const mockPythonSource: PythonTransformSourceDraft = {
 type SetupOpts = {
   source?: PythonTransformSourceDraft;
   readOnly?: boolean;
-  isDirty?: boolean;
   transformId?: number;
 };
 
 function setup({
   source = mockPythonSource,
   readOnly = false,
-  isDirty = false,
   transformId = 1,
 }: SetupOpts = {}) {
   const onChangeSource = jest.fn();
@@ -128,7 +127,6 @@ function setup({
     <PythonTransformEditor
       source={source}
       readOnly={readOnly}
-      isDirty={isDirty}
       transformId={transformId}
       onChangeSource={onChangeSource}
       onAcceptProposed={onAcceptProposed}

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.unit.spec.tsx
@@ -1,0 +1,217 @@
+import {
+  setupDatabasesEndpoints,
+  setupSearchEndpoints,
+  setupTableEndpoints,
+} from "__support__/server-mocks";
+import { renderWithProviders, screen } from "__support__/ui";
+import type { PythonTransformSourceDraft } from "metabase-types/api";
+import { createMockDatabase, createMockTable } from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks";
+
+import { PythonTransformEditor } from "./PythonTransformEditor";
+
+// Mock matchMedia to include matches property (required for ColorSchemeProvider)
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: jest.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});
+
+// Mock react-use hooks
+jest.mock("react-use", () => ({
+  ...jest.requireActual("react-use"),
+  useWindowSize: () => ({ height: 800, width: 1200 }),
+}));
+
+// Mock the hooks
+jest.mock("./hooks", () => ({
+  useTestPythonTransform: () => ({
+    isRunning: false,
+    cancel: jest.fn(),
+    run: jest.fn(),
+    executionResult: null,
+  }),
+}));
+
+// Mock child components to avoid deep dependency issues
+jest.mock("./PythonEditorBody", () => ({
+  PythonEditorBody: ({
+    readOnly,
+  }: {
+    readOnly?: boolean;
+    [key: string]: unknown;
+  }) => (
+    <div data-testid="python-editor-body">
+      {!readOnly && <button data-testid="run-button">Run</button>}
+    </div>
+  ),
+}));
+
+jest.mock("./PythonEditorResults", () => ({
+  PythonEditorResults: () => (
+    <div data-testid="python-results">Results Panel</div>
+  ),
+}));
+
+jest.mock("./PythonDataPicker", () => ({
+  PythonDataPicker: () => (
+    <div data-testid="python-data-picker">Data Picker</div>
+  ),
+}));
+
+jest.mock("./PythonTransformTopBar", () => ({
+  PythonTransformTopBar: ({
+    readOnly,
+    transformId,
+  }: {
+    readOnly?: boolean;
+    transformId?: number;
+    [key: string]: unknown;
+  }) => (
+    <div data-testid="python-transform-top-bar">
+      {readOnly && transformId && (
+        <a href="#" aria-label="Edit definition">
+          Edit definition
+        </a>
+      )}
+      {!readOnly && (
+        <>
+          <button aria-label="Import common library">Import</button>
+          <button aria-label="Edit common library">Edit</button>
+        </>
+      )}
+    </div>
+  ),
+}));
+
+const mockDatabase = createMockDatabase({ id: 1, name: "Test Database" });
+
+const mockPythonSource: PythonTransformSourceDraft = {
+  type: "python",
+  body: "# Python script\nprint('Hello, world!')",
+  "source-database": 1,
+  "source-tables": {},
+};
+
+type SetupOpts = {
+  source?: PythonTransformSourceDraft;
+  readOnly?: boolean;
+  isDirty?: boolean;
+  transformId?: number;
+};
+
+function setup({
+  source = mockPythonSource,
+  readOnly = false,
+  isDirty = false,
+  transformId = 1,
+}: SetupOpts = {}) {
+  const onChangeSource = jest.fn();
+  const onAcceptProposed = jest.fn();
+  const onRejectProposed = jest.fn();
+
+  const mockTable = createMockTable({ id: 1, db_id: 1, name: "Test Table" });
+
+  setupDatabasesEndpoints([mockDatabase]);
+  setupSearchEndpoints([]);
+  setupTableEndpoints(mockTable);
+
+  renderWithProviders(
+    <PythonTransformEditor
+      source={source}
+      readOnly={readOnly}
+      isDirty={isDirty}
+      transformId={transformId}
+      onChangeSource={onChangeSource}
+      onAcceptProposed={onAcceptProposed}
+      onRejectProposed={onRejectProposed}
+    />,
+    {
+      storeInitialState: createMockState(),
+    },
+  );
+
+  return { onChangeSource, onAcceptProposed, onRejectProposed };
+}
+
+describe("PythonTransformEditor", () => {
+  beforeEach(() => {
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("read-only mode", () => {
+    it("should not render the data picker sidebar when readOnly is true", () => {
+      setup({ readOnly: true });
+      expect(
+        screen.queryByTestId("python-data-picker"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should not render the results panel when readOnly is true", () => {
+      setup({ readOnly: true });
+      expect(screen.queryByTestId("python-results")).not.toBeInTheDocument();
+    });
+
+    it("should render the top bar", () => {
+      setup({ readOnly: true });
+      expect(
+        screen.getByTestId("python-transform-top-bar"),
+      ).toBeInTheDocument();
+    });
+
+    it("should render EditDefinitionButton in read-only mode", () => {
+      setup({ readOnly: true, transformId: 1 });
+      expect(
+        screen.getByRole("link", { name: /edit definition/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("edit mode", () => {
+    it("should render the data picker sidebar when readOnly is false", async () => {
+      setup({ readOnly: false });
+      expect(
+        await screen.findByTestId("python-data-picker"),
+      ).toBeInTheDocument();
+    });
+
+    it("should render the results panel when readOnly is false", () => {
+      setup({ readOnly: false });
+      expect(screen.getByTestId("python-results")).toBeInTheDocument();
+    });
+
+    it("should render the top bar", () => {
+      setup({ readOnly: false });
+      expect(
+        screen.getByTestId("python-transform-top-bar"),
+      ).toBeInTheDocument();
+    });
+
+    it("should not render EditDefinitionButton in edit mode", () => {
+      setup({ readOnly: false });
+      expect(
+        screen.queryByRole("link", { name: /edit definition/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should render library buttons in edit mode", () => {
+      setup({ readOnly: false });
+      expect(
+        screen.getByLabelText(/import common library/i),
+      ).toBeInTheDocument();
+      expect(screen.getByLabelText(/edit common library/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.unit.spec.tsx
@@ -31,10 +31,6 @@ function setup({
   readOnly = false,
   transformId = 1,
 }: SetupOpts = {}) {
-  const onChangeSource = jest.fn();
-  const onAcceptProposed = jest.fn();
-  const onRejectProposed = jest.fn();
-
   setupDatabasesEndpoints([mockDatabase]);
   setupTablesEndpoints([mockTable]);
   setupSearchEndpoints([]);
@@ -44,16 +40,14 @@ function setup({
       source={source}
       readOnly={readOnly}
       transformId={transformId}
-      onChangeSource={onChangeSource}
-      onAcceptProposed={onAcceptProposed}
-      onRejectProposed={onRejectProposed}
+      onChangeSource={jest.fn()}
+      onAcceptProposed={jest.fn()}
+      onRejectProposed={jest.fn()}
     />,
     {
       storeInitialState: createMockState(),
     },
   );
-
-  return { onChangeSource, onAcceptProposed, onRejectProposed };
 }
 
 describe("PythonTransformEditor", () => {

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.unit.spec.tsx
@@ -115,13 +115,5 @@ describe("PythonTransformEditor", () => {
       setup({ readOnly: false });
       expect(screen.queryByText(/edit definition/i)).not.toBeInTheDocument();
     });
-
-    it("should render library buttons in edit mode", () => {
-      setup({ readOnly: false });
-      expect(
-        screen.getByLabelText(/import common library/i),
-      ).toBeInTheDocument();
-      expect(screen.getByLabelText(/edit common library/i)).toBeInTheDocument();
-    });
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformTopBar/PythonTransformTopBar.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformTopBar/PythonTransformTopBar.module.css
@@ -1,0 +1,3 @@
+.TopBar {
+  border-bottom: 1px solid var(--mb-color-border);
+}

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformTopBar/PythonTransformTopBar.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformTopBar/PythonTransformTopBar.module.css
@@ -1,3 +1,8 @@
 .TopBar {
   border-bottom: 1px solid var(--mb-color-border);
 }
+
+.databaseSelector {
+  padding: var(--mantine-spacing-sm) var(--mantine-spacing-md);
+  cursor: pointer;
+}

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformTopBar/PythonTransformTopBar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformTopBar/PythonTransformTopBar.tsx
@@ -14,18 +14,18 @@ import S from "./PythonTransformTopBar.module.css";
 
 type PythonTransformTopBarProps = {
   databaseId?: DatabaseId;
-  readOnly?: boolean;
+  isEditMode?: boolean;
   transformId?: TransformId;
   onDatabaseChange?: (databaseId: DatabaseId) => void;
 };
 
 export function PythonTransformTopBar({
   databaseId,
-  readOnly,
+  isEditMode,
   transformId,
   onDatabaseChange,
 }: PythonTransformTopBarProps) {
-  const showReadonlyControls = readOnly && transformId;
+  const showEditDefinitionButton = !isEditMode && transformId;
 
   const { data: database } = useGetDatabaseQuery(
     databaseId != null ? { id: databaseId } : skipToken,
@@ -46,7 +46,21 @@ export function PythonTransformTopBar({
       data-testid="python-transform-top-bar"
       className={S.TopBar}
     >
-      {readOnly ? (
+      {isEditMode ? (
+        <Flex h="3rem" ml="sm" align="center" data-testid="selected-database">
+          <DatabaseDataSelector
+            className={S.databaseSelector}
+            selectedDatabaseId={databaseId}
+            setDatabaseFn={handleDatabaseChange}
+            databases={databases?.data ?? []}
+            readOnly={!isEditMode}
+            databaseIsDisabled={(database: Database) =>
+              !doesDatabaseSupportTransforms(database) ||
+              !hasFeature(database, "transforms/python")
+            }
+          />
+        </Flex>
+      ) : (
         <Flex
           h="3rem"
           p="md"
@@ -56,22 +70,8 @@ export function PythonTransformTopBar({
         >
           {database?.name}
         </Flex>
-      ) : (
-        <Flex h="3rem" ml="sm" align="center" data-testid="selected-database">
-          <DatabaseDataSelector
-            className={S.databaseSelector}
-            selectedDatabaseId={databaseId}
-            setDatabaseFn={handleDatabaseChange}
-            databases={databases?.data ?? []}
-            readOnly={readOnly}
-            databaseIsDisabled={(database: Database) =>
-              !doesDatabaseSupportTransforms(database) ||
-              !hasFeature(database, "transforms/python")
-            }
-          />
-        </Flex>
       )}
-      {showReadonlyControls && (
+      {showEditDefinitionButton && (
         <Flex ml="auto" mr="lg" align="center" h="3rem">
           <EditDefinitionButton
             bg="transparent"

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformTopBar/PythonTransformTopBar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformTopBar/PythonTransformTopBar.tsx
@@ -1,14 +1,25 @@
+import { t } from "ttag";
+
 import { hasFeature } from "metabase/admin/databases/utils";
 import {
   skipToken,
   useGetDatabaseQuery,
   useListDatabasesQuery,
 } from "metabase/api";
+import { ForwardRefLink } from "metabase/common/components/Link";
+import * as Urls from "metabase/lib/urls";
 import { DatabaseDataSelector } from "metabase/query_builder/components/DataSelector";
-import { Flex } from "metabase/ui";
+import { ActionIcon, Flex, Group, Icon, Tooltip } from "metabase/ui";
 import { EditDefinitionButton } from "metabase-enterprise/transforms/components/TransformEditor/EditDefinitionButton";
 import { doesDatabaseSupportTransforms } from "metabase-enterprise/transforms/utils";
+import { SHARED_LIB_IMPORT_PATH } from "metabase-enterprise/transforms-python/constants";
 import type { Database, DatabaseId, TransformId } from "metabase-types/api";
+
+import {
+  hasImport,
+  insertImport,
+  removeImport,
+} from "../PythonEditorBody/utils";
 
 import S from "./PythonTransformTopBar.module.css";
 
@@ -16,15 +27,21 @@ type PythonTransformTopBarProps = {
   databaseId?: DatabaseId;
   readOnly?: boolean;
   transformId?: TransformId;
+  source?: string;
   onDatabaseChange?: (databaseId: DatabaseId) => void;
+  onSourceChange?: (source: string) => void;
 };
 
 export function PythonTransformTopBar({
   databaseId,
   readOnly,
   transformId,
+  source,
   onDatabaseChange,
+  onSourceChange,
 }: PythonTransformTopBarProps) {
+  const showReadonlyControls = readOnly && transformId;
+
   const { data: database } = useGetDatabaseQuery(
     databaseId != null ? { id: databaseId } : skipToken,
   );
@@ -34,6 +51,16 @@ export function PythonTransformTopBar({
     const newDatabaseId = value ? parseInt(value) : undefined;
     if (newDatabaseId != null && newDatabaseId !== databaseId) {
       onDatabaseChange?.(newDatabaseId);
+    }
+  };
+
+  const handleToggleSharedLib = () => {
+    if (source != null && onSourceChange) {
+      if (hasImport(source, SHARED_LIB_IMPORT_PATH)) {
+        onSourceChange(removeImport(source, SHARED_LIB_IMPORT_PATH));
+      } else {
+        onSourceChange(insertImport(source, SHARED_LIB_IMPORT_PATH));
+      }
     }
   };
 
@@ -69,8 +96,8 @@ export function PythonTransformTopBar({
           />
         </Flex>
       )}
-      {readOnly && transformId && (
-        <Flex ml="auto" mr="lg" align="center" h="3rem">
+      <Flex ml="auto" mr="lg" align="center" h="3rem">
+        {showReadonlyControls ? (
           <EditDefinitionButton
             bg="transparent"
             fz="sm"
@@ -79,8 +106,31 @@ export function PythonTransformTopBar({
             size="xs"
             transformId={transformId}
           />
-        </Flex>
-      )}
+        ) : (
+          <Group gap="sm">
+            <Tooltip label={t`Import common library`}>
+              <ActionIcon
+                aria-label={t`Import common library`}
+                onClick={handleToggleSharedLib}
+              >
+                <Icon name="reference" c="text-primary" />
+              </ActionIcon>
+            </Tooltip>
+            <Tooltip label={t`Edit common library`}>
+              <ActionIcon
+                component={ForwardRefLink}
+                target="_blank"
+                aria-label={t`Edit common library`}
+                to={Urls.transformPythonLibrary({
+                  path: SHARED_LIB_IMPORT_PATH,
+                })}
+              >
+                <Icon name="pencil" c="text-primary" />
+              </ActionIcon>
+            </Tooltip>
+          </Group>
+        )}
+      </Flex>
     </Flex>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformTopBar/PythonTransformTopBar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformTopBar/PythonTransformTopBar.tsx
@@ -1,0 +1,48 @@
+import { skipToken, useGetDatabaseQuery } from "metabase/api";
+import { Flex } from "metabase/ui";
+import { EditDefinitionButton } from "metabase-enterprise/transforms/components/TransformEditor/EditDefinitionButton";
+import type { DatabaseId, TransformId } from "metabase-types/api";
+
+import S from "./PythonTransformTopBar.module.css";
+
+type PythonTransformTopBarProps = {
+  databaseId?: DatabaseId;
+  readOnly?: boolean;
+  transformId?: TransformId;
+};
+
+export function PythonTransformTopBar({
+  databaseId,
+  readOnly,
+  transformId,
+}: PythonTransformTopBarProps) {
+  const { data: database } = useGetDatabaseQuery(
+    databaseId != null ? { id: databaseId } : skipToken,
+  );
+
+  return (
+    <Flex
+      align="center"
+      justify="space-between"
+      h="3rem"
+      px="md"
+      bg="background-secondary"
+      data-testid="python-transform-top-bar"
+      className={S.TopBar}
+    >
+      <Flex align="center" fw="bold" data-testid="selected-database">
+        {database?.name}
+      </Flex>
+      {readOnly && transformId && (
+        <EditDefinitionButton
+          bg="transparent"
+          fz="sm"
+          h="1.5rem"
+          px="sm"
+          size="xs"
+          transformId={transformId}
+        />
+      )}
+    </Flex>
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformTopBar/PythonTransformTopBar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformTopBar/PythonTransformTopBar.tsx
@@ -1,25 +1,14 @@
-import { t } from "ttag";
-
 import { hasFeature } from "metabase/admin/databases/utils";
 import {
   skipToken,
   useGetDatabaseQuery,
   useListDatabasesQuery,
 } from "metabase/api";
-import { ForwardRefLink } from "metabase/common/components/Link";
-import * as Urls from "metabase/lib/urls";
 import { DatabaseDataSelector } from "metabase/query_builder/components/DataSelector";
-import { ActionIcon, Flex, Group, Icon, Tooltip } from "metabase/ui";
+import { Flex } from "metabase/ui";
 import { EditDefinitionButton } from "metabase-enterprise/transforms/components/TransformEditor/EditDefinitionButton";
 import { doesDatabaseSupportTransforms } from "metabase-enterprise/transforms/utils";
-import { SHARED_LIB_IMPORT_PATH } from "metabase-enterprise/transforms-python/constants";
 import type { Database, DatabaseId, TransformId } from "metabase-types/api";
-
-import {
-  hasImport,
-  insertImport,
-  removeImport,
-} from "../PythonEditorBody/utils";
 
 import S from "./PythonTransformTopBar.module.css";
 
@@ -27,18 +16,14 @@ type PythonTransformTopBarProps = {
   databaseId?: DatabaseId;
   readOnly?: boolean;
   transformId?: TransformId;
-  source?: string;
   onDatabaseChange?: (databaseId: DatabaseId) => void;
-  onSourceChange?: (source: string) => void;
 };
 
 export function PythonTransformTopBar({
   databaseId,
   readOnly,
   transformId,
-  source,
   onDatabaseChange,
-  onSourceChange,
 }: PythonTransformTopBarProps) {
   const showReadonlyControls = readOnly && transformId;
 
@@ -51,16 +36,6 @@ export function PythonTransformTopBar({
     const newDatabaseId = value ? parseInt(value) : undefined;
     if (newDatabaseId != null && newDatabaseId !== databaseId) {
       onDatabaseChange?.(newDatabaseId);
-    }
-  };
-
-  const handleToggleSharedLib = () => {
-    if (source != null && onSourceChange) {
-      if (hasImport(source, SHARED_LIB_IMPORT_PATH)) {
-        onSourceChange(removeImport(source, SHARED_LIB_IMPORT_PATH));
-      } else {
-        onSourceChange(insertImport(source, SHARED_LIB_IMPORT_PATH));
-      }
     }
   };
 
@@ -96,8 +71,8 @@ export function PythonTransformTopBar({
           />
         </Flex>
       )}
-      <Flex ml="auto" mr="lg" align="center" h="3rem">
-        {showReadonlyControls ? (
+      {showReadonlyControls && (
+        <Flex ml="auto" mr="lg" align="center" h="3rem">
           <EditDefinitionButton
             bg="transparent"
             fz="sm"
@@ -106,31 +81,8 @@ export function PythonTransformTopBar({
             size="xs"
             transformId={transformId}
           />
-        ) : (
-          <Group gap="sm">
-            <Tooltip label={t`Import common library`}>
-              <ActionIcon
-                aria-label={t`Import common library`}
-                onClick={handleToggleSharedLib}
-              >
-                <Icon name="reference" c="text-primary" />
-              </ActionIcon>
-            </Tooltip>
-            <Tooltip label={t`Edit common library`}>
-              <ActionIcon
-                component={ForwardRefLink}
-                target="_blank"
-                aria-label={t`Edit common library`}
-                to={Urls.transformPythonLibrary({
-                  path: SHARED_LIB_IMPORT_PATH,
-                })}
-              >
-                <Icon name="pencil" c="text-primary" />
-              </ActionIcon>
-            </Tooltip>
-          </Group>
-        )}
-      </Flex>
+        </Flex>
+      )}
     </Flex>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformTopBar/PythonTransformTopBar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformTopBar/PythonTransformTopBar.tsx
@@ -22,26 +22,31 @@ export function PythonTransformTopBar({
 
   return (
     <Flex
-      align="center"
-      justify="space-between"
-      h="3rem"
-      px="md"
+      align="flex-start"
       bg="background-secondary"
       data-testid="python-transform-top-bar"
       className={S.TopBar}
     >
-      <Flex align="center" fw="bold" data-testid="selected-database">
+      <Flex
+        h="3rem"
+        p="md"
+        ml="sm"
+        align="center"
+        data-testid="selected-database"
+      >
         {database?.name}
       </Flex>
       {readOnly && transformId && (
-        <EditDefinitionButton
-          bg="transparent"
-          fz="sm"
-          h="1.5rem"
-          px="sm"
-          size="xs"
-          transformId={transformId}
-        />
+        <Flex ml="auto" mr="lg" align="center" h="3rem">
+          <EditDefinitionButton
+            bg="transparent"
+            fz="sm"
+            h="1.5rem"
+            px="sm"
+            size="xs"
+            transformId={transformId}
+          />
+        </Flex>
       )}
     </Flex>
   );

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformTopBar/PythonTransformTopBar.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformTopBar/PythonTransformTopBar.unit.spec.tsx
@@ -1,0 +1,113 @@
+import { Route } from "react-router";
+
+import {
+  setupDatabasesEndpoints,
+  setupSearchEndpoints,
+} from "__support__/server-mocks";
+import { renderWithProviders, screen } from "__support__/ui";
+import { createMockDatabase } from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks";
+
+import { PythonTransformTopBar } from "./PythonTransformTopBar";
+
+const mockDatabase = createMockDatabase({ id: 1, name: "Test Database" });
+
+type SetupOpts = {
+  databaseId?: number;
+  readOnly?: boolean;
+  transformId?: number;
+  source?: string;
+};
+
+function setup({
+  databaseId = 1,
+  readOnly = false,
+  transformId = 1,
+  source = "# test script",
+}: SetupOpts = {}) {
+  const onDatabaseChange = jest.fn();
+  const onSourceChange = jest.fn();
+
+  setupDatabasesEndpoints([mockDatabase]);
+  setupSearchEndpoints([]);
+
+  renderWithProviders(
+    <Route
+      component={() => (
+        <PythonTransformTopBar
+          databaseId={databaseId}
+          readOnly={readOnly}
+          transformId={transformId}
+          source={source}
+          onDatabaseChange={onDatabaseChange}
+          onSourceChange={onSourceChange}
+        />
+      )}
+      path="/"
+    />,
+    {
+      withRouter: true,
+      initialRoute: "/",
+      storeInitialState: createMockState(),
+    },
+  );
+
+  return { onDatabaseChange, onSourceChange };
+}
+
+describe("PythonTransformTopBar", () => {
+  beforeEach(() => {
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("read-only mode", () => {
+    it("should render EditDefinitionButton when readOnly is true", () => {
+      setup({ readOnly: true, transformId: 1 });
+      expect(
+        screen.getByRole("link", { name: /edit definition/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("should not render library buttons when readOnly is true", () => {
+      setup({ readOnly: true });
+      expect(
+        screen.queryByLabelText(/import common library/i),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByLabelText(/edit common library/i),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should display database name as static text when readOnly is true", async () => {
+      setup({ readOnly: true, databaseId: 1 });
+      // In read-only mode, database name is displayed as text, not a dropdown
+      expect(await screen.findByText("Test Database")).toBeInTheDocument();
+    });
+  });
+
+  describe("edit mode", () => {
+    it("should render library buttons when readOnly is false", () => {
+      setup({ readOnly: false });
+      expect(
+        screen.getByLabelText(/import common library/i),
+      ).toBeInTheDocument();
+      expect(screen.getByLabelText(/edit common library/i)).toBeInTheDocument();
+    });
+
+    it("should not render EditDefinitionButton when readOnly is false", () => {
+      setup({ readOnly: false });
+      expect(
+        screen.queryByRole("link", { name: /edit definition/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should render database selector when readOnly is false", () => {
+      setup({ readOnly: false });
+      expect(screen.getByTestId("selected-database")).toBeInTheDocument();
+    });
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformTopBar/PythonTransformTopBar.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformTopBar/PythonTransformTopBar.unit.spec.tsx
@@ -16,17 +16,14 @@ type SetupOpts = {
   databaseId?: number;
   readOnly?: boolean;
   transformId?: number;
-  source?: string;
 };
 
 function setup({
   databaseId = 1,
   readOnly = false,
   transformId = 1,
-  source = "# test script",
 }: SetupOpts = {}) {
   const onDatabaseChange = jest.fn();
-  const onSourceChange = jest.fn();
 
   setupDatabasesEndpoints([mockDatabase]);
   setupSearchEndpoints([]);
@@ -38,9 +35,7 @@ function setup({
           databaseId={databaseId}
           readOnly={readOnly}
           transformId={transformId}
-          source={source}
           onDatabaseChange={onDatabaseChange}
-          onSourceChange={onSourceChange}
         />
       )}
       path="/"
@@ -52,7 +47,7 @@ function setup({
     },
   );
 
-  return { onDatabaseChange, onSourceChange };
+  return { onDatabaseChange };
 }
 
 describe("PythonTransformTopBar", () => {
@@ -72,16 +67,6 @@ describe("PythonTransformTopBar", () => {
       ).toBeInTheDocument();
     });
 
-    it("should not render library buttons when readOnly is true", () => {
-      setup({ readOnly: true });
-      expect(
-        screen.queryByLabelText(/import common library/i),
-      ).not.toBeInTheDocument();
-      expect(
-        screen.queryByLabelText(/edit common library/i),
-      ).not.toBeInTheDocument();
-    });
-
     it("should display database name as static text when readOnly is true", async () => {
       setup({ readOnly: true, databaseId: 1 });
       // In read-only mode, database name is displayed as text, not a dropdown
@@ -90,14 +75,6 @@ describe("PythonTransformTopBar", () => {
   });
 
   describe("edit mode", () => {
-    it("should render library buttons when readOnly is false", () => {
-      setup({ readOnly: false });
-      expect(
-        screen.getByLabelText(/import common library/i),
-      ).toBeInTheDocument();
-      expect(screen.getByLabelText(/edit common library/i)).toBeInTheDocument();
-    });
-
     it("should not render EditDefinitionButton when readOnly is false", () => {
       setup({ readOnly: false });
       expect(

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformTopBar/PythonTransformTopBar.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformTopBar/PythonTransformTopBar.unit.spec.tsx
@@ -14,13 +14,13 @@ const mockDatabase = createMockDatabase({ id: 1, name: "Test Database" });
 
 type SetupOpts = {
   databaseId?: number;
-  readOnly?: boolean;
+  isEditMode?: boolean;
   transformId?: number;
 };
 
 function setup({
   databaseId = 1,
-  readOnly = false,
+  isEditMode = true,
   transformId = 1,
 }: SetupOpts = {}) {
   const onDatabaseChange = jest.fn();
@@ -33,7 +33,7 @@ function setup({
       component={() => (
         <PythonTransformTopBar
           databaseId={databaseId}
-          readOnly={readOnly}
+          isEditMode={isEditMode}
           transformId={transformId}
           onDatabaseChange={onDatabaseChange}
         />
@@ -51,39 +51,31 @@ function setup({
 }
 
 describe("PythonTransformTopBar", () => {
-  beforeEach(() => {
-    jest.spyOn(console, "error").mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
-  describe("read-only mode", () => {
-    it("should render EditDefinitionButton when readOnly is true", () => {
-      setup({ readOnly: true, transformId: 1 });
+  describe("view mode (not editing)", () => {
+    it("should render EditDefinitionButton when not in edit mode", () => {
+      setup({ isEditMode: false, transformId: 1 });
       expect(
         screen.getByRole("link", { name: /edit definition/i }),
       ).toBeInTheDocument();
     });
 
-    it("should display database name as static text when readOnly is true", async () => {
-      setup({ readOnly: true, databaseId: 1 });
-      // In read-only mode, database name is displayed as text, not a dropdown
+    it("should display database name as static text when not in edit mode", async () => {
+      setup({ isEditMode: false, databaseId: 1 });
+      // When not in edit mode, database name is displayed as text, not a dropdown
       expect(await screen.findByText("Test Database")).toBeInTheDocument();
     });
   });
 
   describe("edit mode", () => {
-    it("should not render EditDefinitionButton when readOnly is false", () => {
-      setup({ readOnly: false });
+    it("should not render EditDefinitionButton in edit mode", () => {
+      setup({ isEditMode: true });
       expect(
         screen.queryByRole("link", { name: /edit definition/i }),
       ).not.toBeInTheDocument();
     });
 
-    it("should render database selector when readOnly is false", () => {
-      setup({ readOnly: false });
+    it("should render database selector in edit mode", () => {
+      setup({ isEditMode: true });
       expect(screen.getByTestId("selected-database")).toBeInTheDocument();
     });
   });

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformTopBar/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformTopBar/index.ts
@@ -1,0 +1,1 @@
+export { PythonTransformTopBar } from "./PythonTransformTopBar";

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/utils.ts
@@ -1,25 +1,8 @@
-import { useSelector } from "metabase/lib/redux";
-import * as Urls from "metabase/lib/urls";
-import { getLocation } from "metabase/selectors/routing";
 import type {
   PythonTransformTableAliases,
   Table,
   TableId,
-  TransformId,
 } from "metabase-types/api";
-
-export function useTransformId(): TransformId | undefined {
-  const location = useSelector(getLocation);
-  const pathSegments = location?.pathname?.split("/") ?? [];
-  const transformIndex = pathSegments.indexOf("transforms");
-
-  if (transformIndex === -1 || transformIndex === pathSegments.length - 1) {
-    return undefined;
-  }
-
-  const transformIdSegment = pathSegments[transformIndex + 1];
-  return Urls.extractEntityId(transformIdSegment);
-}
 
 export function updateTransformSignature(
   script: string,

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/utils.ts
@@ -1,8 +1,25 @@
+import { useSelector } from "metabase/lib/redux";
+import * as Urls from "metabase/lib/urls";
+import { getLocation } from "metabase/selectors/routing";
 import type {
   PythonTransformTableAliases,
   Table,
   TableId,
+  TransformId,
 } from "metabase-types/api";
+
+export function useTransformId(): TransformId | undefined {
+  const location = useSelector(getLocation);
+  const pathSegments = location?.pathname?.split("/") ?? [];
+  const transformIndex = pathSegments.indexOf("transforms");
+
+  if (transformIndex === -1 || transformIndex === pathSegments.length - 1) {
+    return undefined;
+  }
+
+  const transformIdSegment = pathSegments[transformIndex + 1];
+  return Urls.extractEntityId(transformIdSegment);
+}
 
 export function updateTransformSignature(
   script: string,

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/NewTransformPage/NewTransformPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/NewTransformPage/NewTransformPage.tsx
@@ -165,7 +165,6 @@ function NewTransformPageBody({
               proposedSource={
                 proposedSource?.type === "python" ? proposedSource : undefined
               }
-              isDirty={isDirty}
               onChangeSource={setSourceAndRejectProposed}
               onAcceptProposed={acceptProposed}
               onRejectProposed={rejectProposed}

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/NewTransformPage/NewTransformPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/NewTransformPage/NewTransformPage.tsx
@@ -165,6 +165,7 @@ function NewTransformPageBody({
               proposedSource={
                 proposedSource?.type === "python" ? proposedSource : undefined
               }
+              isEditMode
               onChangeSource={setSourceAndRejectProposed}
               onAcceptProposed={acceptProposed}
               onRejectProposed={rejectProposed}

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/NewTransformPage/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/NewTransformPage/utils.ts
@@ -30,6 +30,7 @@ export function getInitialPythonSource(): PythonTransformSourceDraft {
     "source-database": undefined,
     "source-tables": {},
     body: `# Write your Python transformation script here
+import common
 import pandas as pd
 
 def transform():

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformQueryPage/TransformPaneHeaderActions.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformQueryPage/TransformPaneHeaderActions.tsx
@@ -59,7 +59,7 @@ export const TransformPaneHeaderActions = (props: Props) => {
 
   return (
     <PaneHeaderActions
-      alwaysVisible={!isPythonTransform && isEditMode}
+      alwaysVisible={isEditMode}
       errorMessage={validationResult.errorMessage}
       isDirty={isDirty}
       isSaving={isSaving}

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformQueryPage/TransformQueryPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformQueryPage/TransformQueryPage.tsx
@@ -192,7 +192,6 @@ function TransformQueryPageBody({
               proposedSource={
                 proposedSource?.type === "python" ? proposedSource : undefined
               }
-              isDirty={isDirty}
               readOnly={!isEditMode}
               transformId={transform.id}
               onChangeSource={setSourceAndRejectProposed}

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformQueryPage/TransformQueryPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformQueryPage/TransformQueryPage.tsx
@@ -193,6 +193,8 @@ function TransformQueryPageBody({
                 proposedSource?.type === "python" ? proposedSource : undefined
               }
               isDirty={isDirty}
+              readOnly={!isEditMode}
+              transformId={transform.id}
               onChangeSource={setSourceAndRejectProposed}
               onAcceptProposed={acceptProposed}
               onRejectProposed={rejectProposed}

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformQueryPage/TransformQueryPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformQueryPage/TransformQueryPage.tsx
@@ -192,7 +192,7 @@ function TransformQueryPageBody({
               proposedSource={
                 proposedSource?.type === "python" ? proposedSource : undefined
               }
-              readOnly={!isEditMode}
+              isEditMode={isEditMode}
               transformId={transform.id}
               onChangeSource={setSourceAndRejectProposed}
               onAcceptProposed={acceptProposed}

--- a/frontend/src/metabase/common/components/CodeEditor/CodeEditor.tsx
+++ b/frontend/src/metabase/common/components/CodeEditor/CodeEditor.tsx
@@ -50,6 +50,7 @@ export function CodeEditor({
       className={className}
       extensions={extensions}
       id={id}
+      editable={!readOnly}
       readOnly={readOnly}
       value={proposedValue ?? value}
       onChange={onChange}

--- a/frontend/src/metabase/plugins/oss/transforms.ts
+++ b/frontend/src/metabase/plugins/oss/transforms.ts
@@ -45,7 +45,7 @@ export type TransformsPlugin = {
 export type PythonTransformEditorProps = {
   source: PythonTransformSourceDraft;
   proposedSource?: PythonTransformSourceDraft;
-  readOnly?: boolean;
+  isEditMode?: boolean;
   transformId?: TransformId;
   onChangeSource: (source: PythonTransformSourceDraft) => void;
   onAcceptProposed: () => void;

--- a/frontend/src/metabase/plugins/oss/transforms.ts
+++ b/frontend/src/metabase/plugins/oss/transforms.ts
@@ -45,7 +45,6 @@ export type TransformsPlugin = {
 export type PythonTransformEditorProps = {
   source: PythonTransformSourceDraft;
   proposedSource?: PythonTransformSourceDraft;
-  isDirty: boolean;
   readOnly?: boolean;
   transformId?: TransformId;
   onChangeSource: (source: PythonTransformSourceDraft) => void;

--- a/frontend/src/metabase/plugins/oss/transforms.ts
+++ b/frontend/src/metabase/plugins/oss/transforms.ts
@@ -46,6 +46,8 @@ export type PythonTransformEditorProps = {
   source: PythonTransformSourceDraft;
   proposedSource?: PythonTransformSourceDraft;
   isDirty: boolean;
+  readOnly?: boolean;
+  transformId?: TransformId;
   onChangeSource: (source: PythonTransformSourceDraft) => void;
   onAcceptProposed: () => void;
   onRejectProposed: () => void;


### PR DESCRIPTION
Closes [UXW-2699](https://linear.app/metabase/issue/UXW-2699/make-python-and-sql-editing-in-data-studio-consistent)

### Description

Python transforms will now follow the same read-only/editing mode & UI patterns as SQL transforms. Transforms open in read-only mode by default, and clicking "Edit definition" enters edit mode where users can make changes.

Some of the consistency added includes the following changes: 

- Add a topbar holding the data source selector, and the "Edit definition" button
- Hide transform controls & inputs by default
- Fix the "Run" button styling to be solid blue with the "Play" icon, instead of always being the outline circular arrow (which denotes that a run for the current state has already happened)
-  Add UI transition for the results pane 
- Remove common library controls, and default to always `import common` for new transforms

### Demo

| Mode | SQL | Python |
| - | - |- |
| New Transform | <img width="2350" height="1632" alt="CleanShot 2026-01-14 at 17 08 18@2x" src="https://github.com/user-attachments/assets/fb04b974-89e6-4902-8f88-c06aa9373868" /> | <img width="2350" height="1632" alt="CleanShot 2026-01-14 at 17 08 24@2x" src="https://github.com/user-attachments/assets/4daff1e1-9d27-4ac3-b477-06413024424e" /> |
| Read-only | <img width="2350" height="1632" alt="CleanShot 2026-01-14 at 17 08 08@2x" src="https://github.com/user-attachments/assets/e23d4e73-92a4-4e72-ac09-f4ef60b38ca1" /> | <img width="2350" height="1632" alt="CleanShot 2026-01-14 at 17 09 53@2x" src="https://github.com/user-attachments/assets/e06aca77-7774-4694-833b-0c2493d67f67" /> |
| Edit | <img width="2350" height="1632" alt="CleanShot 2026-01-14 at 17 09 53@2x" src="https://github.com/user-attachments/assets/069c6a6e-550a-44a6-bf69-ceceb05274ff" /> | <img width="2350" height="1632" alt="CleanShot 2026-01-14 at 17 10 59@2x" src="https://github.com/user-attachments/assets/b28ca901-fed5-4dd7-a573-746fb845be53" /> |

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
