### PR TITLE
Log error instead of warning if a subscription is not sent through the channel rather than a warning

### DIFF
--- a/src/metabase/notification/send.clj
+++ b/src/metabase/notification/send.clj
@@ -167,7 +167,7 @@
                           (doseq [message messages]
                             (channel-send-retrying! id payload_type handler message)))
                         (catch Exception e
-                          (log/error e "Error sending to channel %s" (handler->channel-name handler))))))
+                          (log/errorf e "Error sending to channel %s" (handler->channel-name handler))))))
                   (log/info "Done processing notification")))
               (do-after-notification-sent hydrated-notification notification-payload (some? skip-reason))
               (prometheus/inc! :metabase-notification/send-ok {:payload-type payload_type}))))
@@ -367,7 +367,7 @@
                                                    (log/warn "Notification worker interrupted, shutting down")
                                                    (throw (InterruptedException.)))
                                                  (catch Throwable e
-                                                   (log/errorf e "Error in notification worker")))))))
+                                                   (log/error e "Error in notification worker")))))))
         ensure-enough-workers! (fn []
                                  (dotimes [i (- pool-size (.getActiveCount ^ThreadPoolExecutor executor))]
                                    (log/debugf "Not enough workers, starting a new one %d/%d"

--- a/src/metabase/notification/send.clj
+++ b/src/metabase/notification/send.clj
@@ -367,7 +367,7 @@
                                                    (log/warn "Notification worker interrupted, shutting down")
                                                    (throw (InterruptedException.)))
                                                  (catch Throwable e
-                                                   (log/error e "Error in notification worker")))))))
+                                                   (log/errorf e "Error in notification worker")))))))
         ensure-enough-workers! (fn []
                                  (dotimes [i (- pool-size (.getActiveCount ^ThreadPoolExecutor executor))]
                                    (log/debugf "Not enough workers, starting a new one %d/%d"

--- a/src/metabase/notification/send.clj
+++ b/src/metabase/notification/send.clj
@@ -167,7 +167,7 @@
                           (doseq [message messages]
                             (channel-send-retrying! id payload_type handler message)))
                         (catch Exception e
-                          (log/warnf e "Error sending to channel %s" (handler->channel-name handler))))))
+                          (log/error e "Error sending to channel %s" (handler->channel-name handler))))))
                   (log/info "Done processing notification")))
               (do-after-notification-sent hydrated-notification notification-payload (some? skip-reason))
               (prometheus/inc! :metabase-notification/send-ok {:payload-type payload_type}))))


### PR DESCRIPTION
We were throwing a warning instead of an error in the logs. Can be confusing in case we have many errors and this should be a red color rather than a yellow