### PR TITLE
Fix filters not closing properly on native SQL questions

### DIFF
--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.tsx
@@ -253,6 +253,7 @@ export const ParameterValueWidget = ({
       position="bottom-start"
       trapFocus
       middlewares={{ flip: true, shift: true }}
+      clickOutsideEvents={["mousedown", "touchstart", "pointerdown"]}
       {...popoverProps}
     >
       <Popover.Target>

--- a/frontend/src/metabase/parameters/components/ParametersList/ParametersList.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParametersList/ParametersList.unit.spec.tsx
@@ -1,0 +1,46 @@
+import userEvent from "@testing-library/user-event";
+
+import { renderWithProviders, screen } from "__support__/ui";
+import { createMockParameter } from "metabase-types/api/mocks";
+
+import { ParametersList } from "./ParametersList";
+import type { ParametersListProps } from "./types";
+
+function setup(props: Partial<ParametersListProps> = {}) {
+  const parameters = [
+    createMockParameter({
+      id: "1",
+      name: "Parameter 1",
+      slug: "parameter-1",
+      type: "string/contains",
+    }),
+    createMockParameter({
+      id: "2",
+      name: "Parameter 2",
+      slug: "parameter-2",
+      type: "string/does-not-contain",
+    }),
+  ];
+  renderWithProviders(<ParametersList parameters={parameters} {...props} />);
+}
+
+describe("ParametersList", () => {
+  it("should render parameters", () => {
+    setup();
+    expect(screen.getByText("Parameter 1")).toBeInTheDocument();
+    expect(screen.getByText("Parameter 2")).toBeInTheDocument();
+  });
+
+  it("should close the first parameter widget when the second parameter widget is clicked metabase #67672", async () => {
+    setup({ isEditing: true });
+    await userEvent.click(screen.getByText("Parameter 1"));
+    expect(screen.getByText("Contains", { exact: false })).toBeInTheDocument();
+    await userEvent.click(screen.getByText("Parameter 2"));
+    expect(
+      screen.getByText("Does not contain", { exact: false }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Contains", { exact: false }),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #67672

### Description

Clicking on a filter in a native SQL question doesn't close other filters that are currently open.

This bug was introduced by #60725, which added calls to `stopPropagation` on `mousedown` events. By default, `Popover` uses `mousedown` events to decide when clicks outside the filter popover should close the filter, but these events were no longer being propagated. The simple fix is to also have `Popover` listen for `pointerdown` events.

### How to verify

1. Create a native SQL question with multiple filters ([Stats repro](https://stats.metabase.com/question/34130-67672?created_at=&category=))
2. Click on the first filter. Then click on the second. The first filter should close.

### Demo

[Loom](https://www.loom.com/share/7c1e152c3c1044babbd76b84074021d0)

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
