### PR TITLE
Flake fix: allow clicking gridcells while animating

### DIFF
--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -1999,7 +1999,9 @@ describe("issue 38747", () => {
 
     H.modal().button("Save").click();
 
-    cy.findByRole("gridcell", { name: "Nolan-Wolff" }).click();
+    cy.findByRole("gridcell", { name: "Nolan-Wolff" }).click({
+      waitForAnimations: false,
+    });
 
     // Assert that we're at an adhoc question with aproprate filters
     cy.location("pathname").should("equal", "/question");


### PR DESCRIPTION
Closes QUE-2964

The test flakes because Cypress does not allow clicking animating elements by default.
This PR allows that in this case.

[stress test](https://github.com/metabase/metabase/actions/runs/21014996013)