### PR TITLE
Add server-side sorting to broken & unreferenced items pages

### DIFF
--- a/e2e/test/scenarios/dependencies/dependency-unreferenced-list.cy.spec.ts
+++ b/e2e/test/scenarios/dependencies/dependency-unreferenced-list.cy.spec.ts
@@ -88,6 +88,10 @@ const MODELS_SORTED_BY_LOCATION = [
   MODEL_FOR_METRIC_DATA_SOURCE,
   MODEL_FOR_MODEL_DATA_SOURCE,
   MODEL_FOR_QUESTION_DATA_SOURCE,
+  MODEL_FOR_NATIVE_QUESTION_CARD_TAG,
+  MODEL_FOR_NATIVE_QUESTION_PARAMETER_SOURCE,
+  MODEL_FOR_DASHBOARD_CARD,
+  MODEL_FOR_DASHBOARD_PARAMETER_SOURCE,
 ];
 
 describe("scenarios > dependencies > unreferenced list", () => {
@@ -242,7 +246,7 @@ describe("scenarios > dependencies > unreferenced list", () => {
     it("should sort by location", () => {
       createEntities();
       H.DataStudio.Tasks.visitUnreferencedEntities();
-      H.DataStudio.Tasks.searchInput().type("data source");
+      H.DataStudio.Tasks.searchInput().type("Model for");
 
       cy.log("sorted by location ascending");
       H.DataStudio.Tasks.list().findByText("Location").click();

--- a/e2e/test/scenarios/dependencies/dependency-unreferenced-list.cy.spec.ts
+++ b/e2e/test/scenarios/dependencies/dependency-unreferenced-list.cy.spec.ts
@@ -74,6 +74,26 @@ const ENTITY_NAMES = [
   ...SNIPPET_NAMES,
 ];
 
+const MODELS_SORTED_BY_NAME = [
+  MODEL_FOR_DASHBOARD_CARD,
+  MODEL_FOR_DASHBOARD_PARAMETER_SOURCE,
+  MODEL_FOR_METRIC_DATA_SOURCE,
+  MODEL_FOR_MODEL_DATA_SOURCE,
+  MODEL_FOR_NATIVE_QUESTION_CARD_TAG,
+  MODEL_FOR_NATIVE_QUESTION_PARAMETER_SOURCE,
+  MODEL_FOR_QUESTION_DATA_SOURCE,
+];
+
+const MODELS_SORTED_BY_LOCATION = [
+  MODEL_FOR_METRIC_DATA_SOURCE,
+  MODEL_FOR_MODEL_DATA_SOURCE,
+  MODEL_FOR_DASHBOARD_CARD,
+  MODEL_FOR_DASHBOARD_PARAMETER_SOURCE,
+  MODEL_FOR_NATIVE_QUESTION_CARD_TAG,
+  MODEL_FOR_NATIVE_QUESTION_PARAMETER_SOURCE,
+  MODEL_FOR_QUESTION_DATA_SOURCE,
+];
+
 describe("scenarios > dependencies > unreferenced list", () => {
   beforeEach(() => {
     H.restore();
@@ -195,6 +215,49 @@ describe("scenarios > dependencies > unreferenced list", () => {
           MODEL_FOR_METRIC_DATA_SOURCE,
           SNIPPET_FOR_NATIVE_QUESTION_CARD_TAG,
         ],
+      });
+    });
+  });
+
+  describe("sorting", () => {
+    it("should sort by name", () => {
+      createEntities();
+      H.DataStudio.Tasks.visitUnreferencedEntities();
+      H.DataStudio.Tasks.searchInput().type("Model for");
+
+      cy.log("sorted by name by default");
+      checkListSorting({
+        visibleEntities: MODELS_SORTED_BY_NAME,
+      });
+
+      cy.log("sorted by name ascending");
+      H.DataStudio.Tasks.list().findByText("Name").click();
+      checkListSorting({
+        visibleEntities: MODELS_SORTED_BY_NAME,
+      });
+
+      cy.log("sorted by name descending");
+      H.DataStudio.Tasks.list().findByText("Name").click();
+      checkListSorting({
+        visibleEntities: [...MODELS_SORTED_BY_NAME].reverse(),
+      });
+    });
+
+    it("should sort by location", () => {
+      createEntities();
+      H.DataStudio.Tasks.visitUnreferencedEntities();
+      H.DataStudio.Tasks.searchInput().type("Model for");
+
+      cy.log("sorted by location ascending");
+      H.DataStudio.Tasks.list().findByText("Location").click();
+      checkListSorting({
+        visibleEntities: MODELS_SORTED_BY_LOCATION,
+      });
+
+      cy.log("sorted by location descending");
+      H.DataStudio.Tasks.list().findByText("Location").click();
+      checkListSorting({
+        visibleEntities: [...MODELS_SORTED_BY_LOCATION].reverse(),
       });
     });
   });
@@ -930,6 +993,16 @@ function checkList({
     });
     hiddenEntities.forEach((name) => {
       cy.findByText(name).should("not.exist");
+    });
+  });
+}
+
+function checkListSorting({ visibleEntities }: { visibleEntities: string[] }) {
+  H.DataStudio.Tasks.list().within(() => {
+    visibleEntities.forEach((name, index) => {
+      cy.findByText(name)
+        .parents("[data-index]")
+        .should("have.attr", "data-index", index.toString());
     });
   });
 }

--- a/e2e/test/scenarios/dependencies/dependency-unreferenced-list.cy.spec.ts
+++ b/e2e/test/scenarios/dependencies/dependency-unreferenced-list.cy.spec.ts
@@ -87,10 +87,6 @@ const MODELS_SORTED_BY_NAME = [
 const MODELS_SORTED_BY_LOCATION = [
   MODEL_FOR_METRIC_DATA_SOURCE,
   MODEL_FOR_MODEL_DATA_SOURCE,
-  MODEL_FOR_DASHBOARD_CARD,
-  MODEL_FOR_DASHBOARD_PARAMETER_SOURCE,
-  MODEL_FOR_NATIVE_QUESTION_CARD_TAG,
-  MODEL_FOR_NATIVE_QUESTION_PARAMETER_SOURCE,
   MODEL_FOR_QUESTION_DATA_SOURCE,
 ];
 
@@ -246,7 +242,7 @@ describe("scenarios > dependencies > unreferenced list", () => {
     it("should sort by location", () => {
       createEntities();
       H.DataStudio.Tasks.visitUnreferencedEntities();
-      H.DataStudio.Tasks.searchInput().type("Model for");
+      H.DataStudio.Tasks.searchInput().type("data source");
 
       cy.log("sorted by location ascending");
       H.DataStudio.Tasks.list().findByText("Location").click();

--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -658,7 +658,7 @@
                                         (#{:card :transform :snippet :dashboard :document} entity-type)))
         needs-dashboard-join? (and sort-by-location? (= entity-type :card))
         needs-document-join? (and sort-by-location? (= entity-type :card))
-        needs-location-table-join? (and sort-by-location? (#{:segment :measure} entity-type))]
+        needs-table-join? (and sort-by-location? (#{:segment :measure} entity-type))]
     {:select [[[:inline (name entity-type)] :entity_type]
               [:entity.id :entity_id]
               [sort-key-column :sort_key]]
@@ -668,7 +668,7 @@
                   needs-collection-join? (conj :collection [:= :entity.collection_id :collection.id])
                   needs-dashboard-join? (conj [:report_dashboard :dashboard] [:= :entity.dashboard_id :dashboard.id])
                   needs-document-join? (conj :document [:= :entity.document_id :document.id])
-                  needs-location-table-join? (conj [:metabase_table :table] [:= :entity.table_id :table.id]))
+                  needs-table-join? (conj [:metabase_table :table] [:= :entity.table_id :table.id]))
      :where (cond->> dependency-filter
               card-type-filter
               (conj [:and card-type-filter])

--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -587,13 +587,17 @@
                       :table :entity.display_name
                       :sandbox [:cast :entity.id (if (= :mysql (mdb/db-type)) :char :text)]
                       :entity.name)
+        root-collection (collection.root/root-collection-with-ui-details (case entity-type
+                                                                           :transform :transforms
+                                                                           :snippet :snippets
+                                                                           nil))
         location-column (case entity-type
                           :card [:case
                                  [:not= :entity.dashboard_id nil] :dashboard.name
                                  [:not= :entity.document_id nil] :document.name
-                                 :else :collection.name]
+                                 :else [:coalesce :collection.name [:inline (:name root-collection)]]]
                           :table :database.name
-                          (:transform :snippet :dashboard :document) :collection.name
+                          (:transform :snippet :dashboard :document) [:coalesce :collection.name [:inline (:name root-collection)]]
                           :sandbox [:cast :entity.id (if (= :mysql (mdb/db-type)) :char :text)]
                           (:segment :measure) :table.display_name)
         dependents-count-column {:select [[:%count.*]]

--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -765,7 +765,7 @@
                            selected-types)
         union-query {:union-all union-queries}
         all-ids (->> (t2/query (assoc union-query
-                                      :order-by [[:sort_key sort_direction]]
+                                      :order-by [[:sort_key sort_direction] [:entity_id sort_direction] [:entity_type sort_direction]]
                                       :offset offset
                                       :limit limit))
                      (map (fn [{:keys [entity_id entity_type]}]
@@ -824,7 +824,7 @@
                            selected-types)
         union-query {:union-all union-queries}
         all-ids (->> (t2/query (assoc union-query
-                                      :order-by [[:sort_key sort_direction]]
+                                      :order-by [[:sort_key sort_direction] [:entity_id sort_direction] [:entity_type sort_direction]]
                                       :offset offset
                                       :limit limit))
                      (map (fn [{:keys [entity_id entity_type]}]

--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -730,7 +730,7 @@
    - `query`: Search string to filter by name or location
    - `archived`: Controls whether archived entities are included
    - `include_personal_collections`: Controls whether items in personal collections are included (default: false)
-   - `sort_column`: Sort column - `:name`, `:location`, or `:dependents_count` (default: `:name`)
+   - `sort_column`: Sort column - `:name`, `:location`, or `:dependents-count` (default: `:name`)
    - `sort_direction`: Sort direction - `:asc` or `:desc` (default: `:asc`)
    - `offset`: Default 0
    - `limit`: Default 50

--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -600,7 +600,11 @@
                                  :from [:dependency]
                                  :where [:and
                                          [:= :dependency.to_entity_id :entity.id]
-                                         [:= :dependency.to_entity_type [:inline (name entity-type)]]]}
+                                         [:= :dependency.to_entity_type [:inline (name entity-type)]]
+                                         (visible-entities-filter-clause
+                                          :dependency.from_entity_type
+                                          :dependency.from_entity_id
+                                          {:include-archived-items include-archived-items})]}
         dependency-join (case query-type
                           :unreferenced [:dependency [:and
                                                       [:= :dependency.to_entity_id :entity.id]

--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -789,7 +789,7 @@
    - `query`: Search string to filter by name or location
    - `archived`: Controls whether archived entities are included
    - `include_personal_collections`: Controls whether items in personal collections are included (default: false)
-   - `sort_column`: Sort column - `:name`, `:location`, or `:dependents_count` (default: `:name`)
+   - `sort_column`: Sort column - `:name`, `:location`, or `:dependents-count` (default: `:name`)
    - `sort_direction`: Sort direction - `:asc` or `:desc` (default: `:asc`)
    - `offset`: Default 0
    - `limit`: Default 50

--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -589,13 +589,13 @@
                       :entity.name)
         location-column (case entity-type
                           :card [:case
-                                 [:not= :entity.dashboard_id nil] :location_dashboard.name
-                                 [:not= :entity.document_id nil] :location_document.name
+                                 [:not= :entity.dashboard_id nil] :dashboard.name
+                                 [:not= :entity.document_id nil] :document.name
                                  :else :collection.name]
                           :table :database.name
                           (:transform :snippet :dashboard :document) :collection.name
                           :sandbox [:cast :entity.id (if (= :mysql (mdb/db-type)) :char :text)]
-                          (:segment :measure) :location_table.name)
+                          (:segment :measure) :table.display_name)
         dependents-count-column {:select [[:%count.*]]
                                  :from [:dependency]
                                  :where [:and
@@ -666,9 +666,9 @@
      :left-join (cond-> dependency-join
                   needs-database-join? (conj [:metabase_database :database] [:= :entity.db_id :database.id])
                   needs-collection-join? (conj :collection [:= :entity.collection_id :collection.id])
-                  needs-dashboard-join? (conj [:report_dashboard :location_dashboard] [:= :entity.dashboard_id :location_dashboard.id])
-                  needs-document-join? (conj [:document :location_document] [:= :entity.document_id :location_document.id])
-                  needs-location-table-join? (conj [:metabase_table :location_table] [:= :entity.table_id :location_table.id]))
+                  needs-dashboard-join? (conj [:report_dashboard :dashboard] [:= :entity.dashboard_id :dashboard.id])
+                  needs-document-join? (conj :document [:= :entity.document_id :document.id])
+                  needs-location-table-join? (conj [:metabase_table :table] [:= :entity.table_id :table.id]))
      :where (cond->> dependency-filter
               card-type-filter
               (conj [:and card-type-filter])

--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -473,7 +473,9 @@
               (->> (map collection.root/hydrate-root-collection))
               (revisions/with-last-edit-info :card))
     :table (t2/hydrate entities :fields :db)
-    :transform (t2/hydrate entities :creator :table-with-db-and-fields :last_run)
+    :transform (-> entities
+                   (t2/hydrate :creator :table-with-db-and-fields :last_run :collection)
+                   (->> (map #(collection.root/hydrate-root-collection % (collection.root/hydrated-root-collection :transforms)))))
     :dashboard (-> entities
                    (t2/hydrate :creator [:collection :is_personal])
                    (->> (map collection.root/hydrate-root-collection))
@@ -483,7 +485,7 @@
                   (->> (map collection.root/hydrate-root-collection)))
     :sandbox (t2/hydrate entities [:table :db :fields])
     :snippet (-> entities
-                 (t2/hydrate :creator)
+                 (t2/hydrate :creator :collection)
                  (->> (map #(collection.root/hydrate-root-collection % (collection.root/hydrated-root-collection :snippets)))))
     (:segment :measure) (t2/hydrate entities :creator [:table :db])))
 

--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -724,8 +724,8 @@
    - `query`: Search string to filter by name or location
    - `archived`: Controls whether archived entities are included
    - `include_personal_collections`: Controls whether items in personal collections are included (default: false)
-   - `sort_column`: Column to sort by (\"name\", \"location\", or \"dependents_count\", default: \"name\")
-   - `sort_direction`: Sort direction, either \"asc\" or \"desc\" (default: \"asc\")
+   - `sort_column`: Sort column - `:name`, `:location`, or `:dependents_count` (default: `:name`)
+   - `sort_direction`: Sort direction - `:asc` or `:desc` (default: `:asc`)
    - `offset`: Default 0
    - `limit`: Default 50
 
@@ -783,8 +783,8 @@
    - `query`: Search string to filter by name or location
    - `archived`: Controls whether archived entities are included
    - `include_personal_collections`: Controls whether items in personal collections are included (default: false)
-   - `sort_column`: Column to sort by (\"name\", \"location\", or \"dependents_count\", default: \"name\")
-   - `sort_direction`: Sort direction, either \"asc\" or \"desc\" (default: \"asc\")
+   - `sort_column`: Sort column - `:name`, `:location`, or `:dependents_count` (default: `:name`)
+   - `sort_direction`: Sort direction - `:asc` or `:desc` (default: `:asc`)
    - `offset`: Default 0
    - `limit`: Default 50
 

--- a/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
@@ -1640,7 +1640,7 @@
   (testing "GET /api/ee/dependencies/graph/unreferenced - sorting by name"
     (mt/with-premium-features #{:dependencies}
       (mt/with-temp [:model/Card _ {:name "A Card sorttest"}
-                     :model/Table _ {:name "B Table" :display_name "B Table sorttest"}
+                     :model/Table _ {:name "B Table sorttest" :display_name "B Table sorttest"}
                      :model/Transform _ {:name "C Transform sorttest"}
                      :model/NativeQuerySnippet _ {:name "D Snippet sorttest"}
                      :model/Dashboard _ {:name "E Dashboard sorttest"}
@@ -1648,7 +1648,6 @@
                      :model/Segment _ {:name "G Segment sorttest"}
                      :model/Measure _ {:name "H Measure sorttest"}]
         (while (#'dependencies.backfill/backfill-dependencies!))
-
         (doseq [sort-direction [:asc :desc]]
           (let [response (mt/user-http-request :crowberto :get 200
                                                "ee/dependencies/graph/unreferenced"
@@ -1664,4 +1663,4 @@
                                   "F Document sorttest"
                                   "G Segment sorttest"
                                   "H Measure sorttest"]
-                           (sort-direction :desc) reverse)))))))))
+                           (= sort-direction :desc) reverse)))))))))

--- a/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
@@ -1667,7 +1667,6 @@
 (deftest ^:sequential unreferenced-sort-by-location-test
   (testing "GET /api/ee/dependencies/graph/unreferenced - sorting by location"
     (mt/with-premium-features #{:dependencies}
-
       (mt/with-temp [;; locations
                      :model/Database {db-id :id} {:name "0 Database"}
                      :model/Table {table1-id :id} {:name "1 Table", :display_name "2 Table", :db_id db-id}
@@ -1683,13 +1682,13 @@
                      :model/Card _ {:name "Card with Collection 1 sorttest", :collection_id collection1-id}
                      :model/Card _ {:name "Card with Dahsboard sorttest", :collection_id collection1-id, :dashboard_id dashboard-id}
                      :model/Card _ {:name "Card with Document sorttest", :collection_id collection1-id, :document_id document-id}
-                     :model/Table _ {:name "Table with Database sorttest", :display_name "Table sorttest", :db_id db-id}]
-        :model/Transform _ {:name "Transform with Collection 2 sorttest", :collection_id collection2-id}
-        :model/Snippet _ {:name "Snippet with Collection 3 sorttest", :collection_id collection3-id}
-        :model/Dashboard _ {:name "Dashboard with Collection 4 sorttest", :collection_id collection4-id}
-        :model/Document _ {:name "Document with Collection 5 sorttest", :collection_id collection5-id}
-        :model/Segment _ {:name "Segment with Table 1 sorttest", :table_id table1-id}
-        :model/Measure _ {:name "Measure with Table 2 sorttest", :table_id table2-id}
+                     :model/Table _ {:name "Table with Database sorttest", :display_name "Table sorttest", :db_id db-id}
+                     :model/Transform _ {:name "Transform with Collection 2 sorttest", :collection_id collection2-id}
+                     :model/Snippet _ {:name "Snippet with Collection 3 sorttest", :collection_id collection3-id}
+                     :model/Dashboard _ {:name "Dashboard with Collection 4 sorttest", :collection_id collection4-id}
+                     :model/Document _ {:name "Document with Collection 5 sorttest", :collection_id collection5-id}
+                     :model/Segment _ {:name "Segment with Table 1 sorttest", :table_id table1-id}
+                     :model/Measure _ {:name "Measure with Table 2 sorttest", :table_id table2-id}]
         (while (#'dependencies.backfill/backfill-dependencies!))
         (doseq [sort-direction [:asc :desc]]
           (let [response (mt/user-http-request :crowberto :get 200

--- a/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
@@ -1668,27 +1668,42 @@
   (testing "GET /api/ee/dependencies/graph/unreferenced - sorting by location"
     (mt/with-premium-features #{:dependencies}
       (mt/with-temp [;; locations
-                     :model/Database {db-id :id} {:name "0 Database"}
-                     :model/Table {table1-id :id} {:name "1 Table", :display_name "2 Table", :db_id db-id}
-                     :model/Table {table2-id :id} {:name "2 Table", :display_name "2 Table", :db_id db-id}
+                     :model/Database   {db-id :id}          {:name "0 Database"}
+                     :model/Table      {table1-id :id}      {:name "1 Table", :display_name "1 Table", :db_id db-id}
+                     :model/Table      {table2-id :id}      {:name "2 Table", :display_name "2 Table", :db_id db-id}
                      :model/Collection {collection1-id :id} {:name "3 Collection"}
-                     :model/Collection {collection2-id :id} {:name "4 Collection"}
-                     :model/Collection {collection3-id :id} {:name "5 Collection"}
-                     :model/Collection {collection3-id :id} {:name "6 Collection"}
-                     :model/Collection {collection3-id :id} {:name "7 Collection"}
-                     :model/Dashboard {dashboard-id :id} {:name "8 Dashboard", :collection_id collection1-id}
-                     :model/Document {document-id :id} {:name "9 Document", :collection_id collection1-id}
+                     :model/Collection {collection2-id :id} {:name "4 Collection"
+                                                             :namespace :transforms}
+                     :model/Collection {collection3-id :id} {:name "5 Collection"
+                                                             :namespace :snippets}
+                     :model/Collection {collection4-id :id} {:name "6 Collection"}
+                     :model/Collection {collection5-id :id} {:name "7 Collection"}
+                     :model/Dashboard  {dashboard-id :id}   {:name "8 Dashboard", :collection_id collection1-id}
+                     :model/Document   {document-id :id}    {:name "9 Document", :collection_id collection1-id}
                      ;; entities
-                     :model/Card _ {:name "Card with Collection 1 sorttest", :collection_id collection1-id}
-                     :model/Card _ {:name "Card with Dahsboard sorttest", :collection_id collection1-id, :dashboard_id dashboard-id}
-                     :model/Card _ {:name "Card with Document sorttest", :collection_id collection1-id, :document_id document-id}
-                     :model/Table _ {:name "Table with Database sorttest", :display_name "Table sorttest", :db_id db-id}
-                     :model/Transform _ {:name "Transform with Collection 2 sorttest", :collection_id collection2-id}
-                     :model/Snippet _ {:name "Snippet with Collection 3 sorttest", :collection_id collection3-id}
-                     :model/Dashboard _ {:name "Dashboard with Collection 4 sorttest", :collection_id collection4-id}
-                     :model/Document _ {:name "Document with Collection 5 sorttest", :collection_id collection5-id}
-                     :model/Segment _ {:name "Segment with Table 1 sorttest", :table_id table1-id}
-                     :model/Measure _ {:name "Measure with Table 2 sorttest", :table_id table2-id}]
+                     :model/Card               _ {:name "Card with Collection 1 sorttest"
+                                                  :collection_id collection1-id}
+                     :model/Card               _ {:name "Card with Dahsboard sorttest"
+                                                  :collection_id collection1-id
+                                                  :dashboard_id dashboard-id}
+                     :model/Card               _ {:name "Card with Document sorttest"
+                                                  :collection_id collection1-id
+                                                  :document_id document-id}
+                     :model/Table              _ {:name "Table with Database sorttest"
+                                                  :display_name "Table sorttest"
+                                                  :db_id db-id}
+                     :model/Transform          _ {:name "Transform with Collection 2 sorttest"
+                                                  :collection_id collection2-id}
+                     :model/NativeQuerySnippet _ {:name "Snippet with Collection 3 sorttest"
+                                                  :collection_id collection3-id}
+                     :model/Dashboard          _ {:name "Dashboard with Collection 4 sorttest"
+                                                  :collection_id collection4-id}
+                     :model/Document           _ {:name "Document with Collection 5 sorttest"
+                                                  :collection_id collection5-id}
+                     :model/Segment            _ {:name "Segment with Table 1 sorttest"
+                                                  :table_id table1-id}
+                     :model/Measure            _ {:name "Measure with Table 2 sorttest"
+                                                  :table_id table2-id}]
         (while (#'dependencies.backfill/backfill-dependencies!))
         (doseq [sort-direction [:asc :desc]]
           (let [response (mt/user-http-request :crowberto :get 200

--- a/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
@@ -1634,8 +1634,6 @@
                    :limit  1}
                   (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/broken?types=card&card_types=question&query=brokentest&offset=1&limit=1"))))))))
 
-;;; ------------------------------------------------- Sorting tests -------------------------------------------------
-
 (deftest ^:sequential unreferenced-sort-by-name-test
   (testing "GET /api/ee/dependencies/graph/unreferenced - sorting by name"
     (mt/with-premium-features #{:dependencies}

--- a/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
@@ -1683,7 +1683,7 @@
                      ;; entities
                      :model/Card               _ {:name "Card with Collection 1 sorttest"
                                                   :collection_id collection1-id}
-                     :model/Card               _ {:name "Card with Dahsboard sorttest"
+                     :model/Card               _ {:name "Card with Dashboard sorttest"
                                                   :collection_id collection1-id
                                                   :dashboard_id dashboard-id}
                      :model/Card               _ {:name "Card with Document sorttest"
@@ -1720,7 +1720,7 @@
                             "Snippet with Collection 3 sorttest"
                             "Dashboard with Collection 4 sorttest"
                             "Document with Collection 5 sorttest"
-                            "Card with Dahsboard sorttest"
+                            "Card with Dashboard sorttest"
                             "Card with Document sorttest"]
                      (= sort-direction :desc) reverse)
                    names))))))))

--- a/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
@@ -1640,7 +1640,7 @@
   (testing "GET /api/ee/dependencies/graph/unreferenced - sorting by name"
     (mt/with-premium-features #{:dependencies}
       (mt/with-temp [:model/Card _ {:name "A Card sorttest"}
-                     :model/Table _ {:name "B" :display_name "B Table sorttest"}
+                     :model/Table _ {:name "B Table" :display_name "B Table sorttest"}
                      :model/Transform _ {:name "C Transform sorttest"}
                      :model/NativeQuerySnippet _ {:name "D Snippet sorttest"}
                      :model/Dashboard _ {:name "E Dashboard sorttest"}
@@ -1656,12 +1656,12 @@
                                                :sort_column :name
                                                :sort_direction sort-direction)
                 names (mapv #(get-in % [:data :name]) (:data response))]
-            (is (= names (cond-> expected-names-asc ["A Card sorttest"
-                                                     "B Table sorttest"
-                                                     "C Transform sorttest"
-                                                     "D Snippet sorttest"
-                                                     "E Dashboard sorttest"
-                                                     "F Document sorttest"
-                                                     "G Segment sorttest"
-                                                     "H Measure sorttest"]
-                                 (sort-direction :desc) reverse)))))))))
+            (is (= names (cond-> ["A Card sorttest"
+                                  "B Table sorttest"
+                                  "C Transform sorttest"
+                                  "D Snippet sorttest"
+                                  "E Dashboard sorttest"
+                                  "F Document sorttest"
+                                  "G Segment sorttest"
+                                  "H Measure sorttest"]
+                           (sort-direction :desc) reverse)))))))))

--- a/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
@@ -1657,10 +1657,10 @@
                             "1 Table sorttest"
                             "2 Transform sorttest"
                             "3 Snippet sorttest"
-                            "4 Dashboard - sorttest"
-                            "4 Document sorttest"
-                            "5 Segment sorttest"
-                            "6 Measure sorttest"]
+                            "4 Dashboard sorttest"
+                            "5 Document sorttest"
+                            "6 Segment sorttest"
+                            "7 Measure sorttest"]
                      (= sort-direction :desc) reverse)
                    names))))))))
 

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/DataStudioLayout/DataStudioLayout.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/DataStudioLayout/DataStudioLayout.tsx
@@ -5,6 +5,7 @@ import { t } from "ttag";
 import DataStudioLogo from "assets/img/data-studio-logo.svg";
 import { ForwardRefLink } from "metabase/common/components/Link";
 import { useUserKeyValue } from "metabase/common/hooks/use-user-key-value";
+import { isCypressActive } from "metabase/env";
 import { isMac } from "metabase/lib/browser";
 import { useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
@@ -146,7 +147,8 @@ function DataStudioNav({ isNavbarOpened, onNavbarToggle }: DataStudioNavProps) {
             showLabel={isNavbarOpened}
           />
         )}
-        {PLUGIN_DEPENDENCIES.isEnabled && (
+        {/* TODO (Alex P 01/15/2026): remove isCypressActive once we are ready to release this feature */}
+        {PLUGIN_DEPENDENCIES.isEnabled && isCypressActive && (
           <DataStudioTab
             label={t`Dependency diagnostics`}
             icon="list"

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/DependencyList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/DependencyList.tsx
@@ -43,11 +43,11 @@ export function DependencyList({
       : useListUnreferencedGraphNodesQuery;
 
   const {
-    page = 0,
     query,
     groupTypes = getAvailableGroupTypes(mode),
-    sorting,
     includePersonalCollections = true,
+    sorting,
+    page = 0,
   } = params;
 
   const { data, isFetching, isLoading, error } = useListGraphNodesQuery({

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/DependencyList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/DependencyList.tsx
@@ -7,7 +7,10 @@ import {
   useListBrokenGraphNodesQuery,
   useListUnreferencedGraphNodesQuery,
 } from "metabase-enterprise/api";
-import type { DependencyEntry } from "metabase-types/api";
+import type {
+  DependencyEntry,
+  DependencySortingOptions,
+} from "metabase-types/api";
 
 import { getCardTypes, getDependencyTypes, isSameNode } from "../../utils";
 
@@ -38,14 +41,23 @@ export function DependencyList({
     mode === "broken"
       ? useListBrokenGraphNodesQuery
       : useListUnreferencedGraphNodesQuery;
-  const availableGroupTypes = getAvailableGroupTypes(mode);
+
+  const {
+    page = 0,
+    query,
+    groupTypes = getAvailableGroupTypes(mode),
+    sorting,
+    includePersonalCollections = true,
+  } = params;
 
   const { data, isFetching, isLoading, error } = useListGraphNodesQuery({
-    query: params.query,
-    types: getDependencyTypes(params.groupTypes ?? availableGroupTypes),
-    card_types: getCardTypes(params.groupTypes ?? availableGroupTypes),
-    include_personal_collections: params.includePersonalCollections ?? true,
-    offset: (params.page ?? 0) * PAGE_SIZE,
+    query,
+    types: getDependencyTypes(groupTypes),
+    card_types: getCardTypes(groupTypes),
+    sort_column: sorting?.column,
+    sort_direction: sorting?.direction,
+    include_personal_collections: includePersonalCollections,
+    offset: page * PAGE_SIZE,
     limit: PAGE_SIZE,
   });
 
@@ -56,6 +68,12 @@ export function DependencyList({
     selectedEntry != null
       ? nodes.find((node) => isSameNode(node, selectedEntry))
       : undefined;
+
+  const handleSortingChange = (
+    sorting: DependencySortingOptions | undefined,
+  ) => {
+    onParamsChange({ ...params, sorting });
+  };
 
   return (
     <Flex h="100%">
@@ -75,8 +93,10 @@ export function DependencyList({
           <ListBody
             nodes={nodes}
             mode={mode}
+            sorting={sorting}
             isLoading={isLoading}
             onSelect={setSelectedEntry}
+            onSortingChange={handleSortingChange}
           />
         )}
         {!isLoading && error == null && (

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/DependencyList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/DependencyList.tsx
@@ -54,9 +54,9 @@ export function DependencyList({
     query,
     types: getDependencyTypes(groupTypes),
     card_types: getCardTypes(groupTypes),
+    include_personal_collections: includePersonalCollections,
     sort_column: sorting?.column,
     sort_direction: sorting?.direction,
-    include_personal_collections: includePersonalCollections,
     offset: page * PAGE_SIZE,
     limit: PAGE_SIZE,
   });

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListBody/ListBody.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListBody/ListBody.tsx
@@ -1,5 +1,5 @@
-import type { Row } from "@tanstack/react-table";
-import { memo, useCallback, useMemo } from "react";
+import type { Row, SortingState, Updater } from "@tanstack/react-table";
+import { useCallback, useMemo } from "react";
 
 import {
   Card,
@@ -7,39 +7,65 @@ import {
   TreeTableSkeleton,
   useTreeTableInstance,
 } from "metabase/ui";
-import type { DependencyNode } from "metabase-types/api";
+import type {
+  DependencyNode,
+  DependencySortingOptions,
+} from "metabase-types/api";
 
 import { getNodeId } from "../../../utils";
 import { ListEmptyState } from "../ListEmptyState";
 import type { DependencyListMode } from "../types";
 
-import { getColumnWidths, getColumns, getNotFoundMessage } from "./utils";
+import {
+  getColumnWidths,
+  getColumns,
+  getNotFoundMessage,
+  getSortingOptions,
+  getSortingState,
+} from "./utils";
 
 type ListBodyProps = {
   nodes: DependencyNode[];
   mode: DependencyListMode;
+  sorting: DependencySortingOptions | undefined;
   isLoading?: boolean;
   onSelect: (node: DependencyNode) => void;
+  onSortingChange: (sorting: DependencySortingOptions | undefined) => void;
 };
 
-export const ListBody = memo(function ListBody({
+export const ListBody = function ListBody({
   nodes,
   mode,
+  sorting,
   isLoading = false,
   onSelect,
+  onSortingChange,
 }: ListBodyProps) {
   const columns = useMemo(() => getColumns(mode), [mode]);
+  const sortingState = useMemo(() => getSortingState(sorting), [sorting]);
 
   const handleRowActivate = useCallback(
     (row: Row<DependencyNode>) => onSelect(row.original),
     [onSelect],
   );
 
+  const handleSortingChange = useCallback(
+    (updater: Updater<SortingState>) => {
+      const newSortingState =
+        typeof updater === "function" ? updater(sortingState) : updater;
+      onSortingChange(getSortingOptions(newSortingState));
+    },
+    [sortingState, onSortingChange],
+  );
+
   const treeTableInstance = useTreeTableInstance<DependencyNode>({
     data: nodes,
     columns,
+    sorting: sortingState,
+    manualSorting: true,
     getNodeId: (node) => getNodeId(node.id, node.type),
     onRowActivate: handleRowActivate,
+    onSortingChange: handleSortingChange,
   });
 
   return (
@@ -55,4 +81,4 @@ export const ListBody = memo(function ListBody({
       )}
     </Card>
   );
-});
+};

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListBody/utils.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListBody/utils.tsx
@@ -1,7 +1,12 @@
+import type { SortingState } from "@tanstack/react-table";
 import { t } from "ttag";
 
 import type { TreeTableColumnDef } from "metabase/ui";
-import type { DependencyNode } from "metabase-types/api";
+import type {
+  DependencyNode,
+  DependencySortColumn,
+  DependencySortingOptions,
+} from "metabase-types/api";
 
 import {
   getNodeDependentsCount,
@@ -19,7 +24,6 @@ function getNodeNameColumn(): TreeTableColumnDef<DependencyNode> {
     id: "name",
     header: t`Name`,
     minWidth: 100,
-    enableSorting: false,
     accessorFn: (node) => getNodeLabel(node),
     cell: ({ row }) => {
       const node = row.original;
@@ -33,7 +37,6 @@ function getNodeLocationColumn(): TreeTableColumnDef<DependencyNode> {
     id: "location",
     header: t`Location`,
     minWidth: 100,
-    enableSorting: false,
     accessorFn: (node) => {
       const location = getNodeLocationInfo(node);
       const links = location?.links ?? [];
@@ -69,7 +72,6 @@ function getNodeDependentsCountColumn(): TreeTableColumnDef<DependencyNode> {
     id: "dependents-count",
     header: t`Downstream dependents`,
     minWidth: 100,
-    enableSorting: false,
     accessorFn: (node) => getNodeDependentsCount(node),
     cell: ({ row }) => {
       const node = row.original;
@@ -95,6 +97,27 @@ export function getColumnWidths(mode: DependencyListMode): number[] {
   } else {
     return [0.5, 0.5];
   }
+}
+
+export function getSortingState(
+  sorting: DependencySortingOptions | undefined,
+): SortingState {
+  return sorting != null
+    ? [{ id: sorting.column, desc: sorting.direction === "desc" }]
+    : [];
+}
+
+export function getSortingOptions(
+  sortingState: SortingState,
+): DependencySortingOptions | undefined {
+  if (sortingState.length === 0) {
+    return undefined;
+  }
+  const { id, desc } = sortingState[0];
+  return {
+    column: id as DependencySortColumn,
+    direction: desc ? "desc" : "asc",
+  };
 }
 
 export function getNotFoundMessage(mode: DependencyListMode) {

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListBody/utils.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListBody/utils.tsx
@@ -24,6 +24,7 @@ function getNodeNameColumn(): TreeTableColumnDef<DependencyNode> {
     id: "name",
     header: t`Name`,
     minWidth: 100,
+    enableSorting: true,
     accessorFn: (node) => getNodeLabel(node),
     cell: ({ row }) => {
       const node = row.original;
@@ -37,6 +38,7 @@ function getNodeLocationColumn(): TreeTableColumnDef<DependencyNode> {
     id: "location",
     header: t`Location`,
     minWidth: 100,
+    enableSorting: true,
     accessorFn: (node) => {
       const location = getNodeLocationInfo(node);
       const links = location?.links ?? [];

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListBody/utils.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListBody/utils.tsx
@@ -72,6 +72,7 @@ function getNodeDependentsCountColumn(): TreeTableColumnDef<DependencyNode> {
     id: "dependents-count",
     header: t`Downstream dependents`,
     minWidth: 100,
+    enableSorting: false,
     accessorFn: (node) => getNodeDependentsCount(node),
     cell: ({ row }) => {
       const node = row.original;

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListBody/utils.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListBody/utils.tsx
@@ -74,7 +74,7 @@ function getNodeDependentsCountColumn(): TreeTableColumnDef<DependencyNode> {
     id: "dependents-count",
     header: t`Downstream dependents`,
     minWidth: 100,
-    enableSorting: false,
+    enableSorting: true,
     accessorFn: (node) => getNodeDependentsCount(node),
     cell: ({ row }) => {
       const node = row.original;

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListSearchBar/FilterOptionsPicker/LocationFilterPicker/LocationFilterPicker.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListSearchBar/FilterOptionsPicker/LocationFilterPicker/LocationFilterPicker.tsx
@@ -21,7 +21,7 @@ export function LocationFilterPicker({
     const newValue = event.target.checked;
     onParamsChange({
       ...params,
-      includePersonalCollections: newValue,
+      includePersonalCollections: newValue ? undefined : false,
     });
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyListPage/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyListPage/types.ts
@@ -6,8 +6,8 @@ import type {
 export type DependencyListQueryParams = {
   page?: string;
   query?: string;
-  groupTypes?: string | string[];
-  includePersonalCollections?: string;
-  sortColumn?: DependencySortColumn;
-  sortDirection?: DependencySortDirection;
+  "group-types"?: string | string[];
+  "include-personal-collections"?: string;
+  "sort-column"?: DependencySortColumn;
+  "sort-direction"?: DependencySortDirection;
 };

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyListPage/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyListPage/types.ts
@@ -1,6 +1,13 @@
+import type {
+  DependencySortColumn,
+  DependencySortDirection,
+} from "metabase-types/api";
+
 export type DependencyListQueryParams = {
   page?: string;
   query?: string;
   groupTypes?: string | string[];
   includePersonalCollections?: string;
+  sortColumn?: DependencySortColumn;
+  sortDirection?: DependencySortDirection;
 };

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyListPage/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyListPage/utils.ts
@@ -18,22 +18,24 @@ import type { DependencyListQueryParams } from "./types";
 export function parseParams(
   params: DependencyListQueryParams,
 ): Urls.DependencyListParams {
-  const sortColumn = parseEnum(params.sortColumn, DEPENDENCY_SORT_COLUMNS);
+  const sortColumn = parseEnum(params["sort-column"], DEPENDENCY_SORT_COLUMNS);
   const sortDirection = parseEnum(
-    params.sortDirection,
+    params["sort-direction"],
     DEPENDENCY_SORT_DIRECTIONS,
   );
 
   return {
     page: parseNumber(params.page),
     query: parseString(params.query),
-    groupTypes: parseList(params.groupTypes, (item) =>
+    groupTypes: parseList(params["group-types"], (item) =>
       parseEnum(item, DEPENDENCY_GROUP_TYPES),
     ),
     sorting:
       sortColumn != null && sortDirection != null
         ? { column: sortColumn, direction: sortDirection }
         : undefined,
-    includePersonalCollections: parseBoolean(params.includePersonalCollections),
+    includePersonalCollections: parseBoolean(
+      params["include-personal-collections"],
+    ),
   };
 }

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyListPage/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyListPage/utils.ts
@@ -1,5 +1,9 @@
 import type * as Urls from "metabase/lib/urls";
-import { DEPENDENCY_GROUP_TYPES } from "metabase-types/api";
+import {
+  DEPENDENCY_GROUP_TYPES,
+  DEPENDENCY_SORT_COLUMNS,
+  DEPENDENCY_SORT_DIRECTIONS,
+} from "metabase-types/api";
 
 import {
   parseBoolean,
@@ -14,12 +18,22 @@ import type { DependencyListQueryParams } from "./types";
 export function parseParams(
   params: DependencyListQueryParams,
 ): Urls.DependencyListParams {
+  const sortColumn = parseEnum(params.sortColumn, DEPENDENCY_SORT_COLUMNS);
+  const sortDirection = parseEnum(
+    params.sortDirection,
+    DEPENDENCY_SORT_DIRECTIONS,
+  );
+
   return {
     page: parseNumber(params.page),
     query: parseString(params.query),
     groupTypes: parseList(params.groupTypes, (item) =>
       parseEnum(item, DEPENDENCY_GROUP_TYPES),
     ),
+    sorting:
+      sortColumn != null && sortDirection != null
+        ? { column: sortColumn, direction: sortDirection }
+        : undefined,
     includePersonalCollections: parseBoolean(params.includePersonalCollections),
   };
 }

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyListPage/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyListPage/utils.ts
@@ -25,17 +25,17 @@ export function parseParams(
   );
 
   return {
-    page: parseNumber(params.page),
     query: parseString(params.query),
     groupTypes: parseList(params["group-types"], (item) =>
       parseEnum(item, DEPENDENCY_GROUP_TYPES),
+    ),
+    includePersonalCollections: parseBoolean(
+      params["include-personal-collections"],
     ),
     sorting:
       sortColumn != null && sortDirection != null
         ? { column: sortColumn, direction: sortDirection }
         : undefined,
-    includePersonalCollections: parseBoolean(
-      params["include-personal-collections"],
-    ),
+    page: parseNumber(params.page),
   };
 }

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/routes.tsx
@@ -1,5 +1,7 @@
 import { IndexRedirect, IndexRoute, Route } from "react-router";
 
+import { isCypressActive } from "metabase/env";
+
 import { DependencyGraphPage } from "./pages/DependencyGraphPage";
 import {
   BrokenDependencyListPage,
@@ -11,6 +13,11 @@ export function getDataStudioDependencyRoutes() {
 }
 
 export function getDataStudioTasksRoutes() {
+  /* TODO (Alex P 01/15/2026): remove isCypressActive once we are ready to release this feature */
+  if (!isCypressActive) {
+    return null;
+  }
+
   return (
     <>
       <IndexRedirect to="broken" />

--- a/frontend/src/metabase-types/api/dependencies.ts
+++ b/frontend/src/metabase-types/api/dependencies.ts
@@ -280,11 +280,29 @@ export type CheckSnippetDependenciesRequest = Pick<NativeQuerySnippet, "id"> &
 export type CheckTransformDependenciesRequest = Pick<Transform, "id"> &
   Partial<Pick<Transform, "source">>;
 
+export const DEPENDENCY_SORT_COLUMNS = [
+  "name",
+  "location",
+  "dependents-count",
+] as const;
+export type DependencySortColumn = (typeof DEPENDENCY_SORT_COLUMNS)[number];
+
+export const DEPENDENCY_SORT_DIRECTIONS = ["asc", "desc"] as const;
+export type DependencySortDirection =
+  (typeof DEPENDENCY_SORT_DIRECTIONS)[number];
+
+export type DependencySortingOptions = {
+  column: DependencySortColumn;
+  direction: DependencySortDirection;
+};
+
 export type ListBrokenGraphNodesRequest = PaginationRequest & {
   types?: DependencyType[];
   card_types?: CardType[];
   query?: string;
   include_personal_collections?: boolean;
+  sort_column?: DependencySortColumn;
+  sort_direction?: DependencySortDirection;
 };
 
 export type ListBrokenGraphNodesResponse = PaginationResponse & {
@@ -296,6 +314,8 @@ export type ListUnreferencedGraphNodesRequest = PaginationRequest & {
   card_types?: CardType[];
   query?: string;
   include_personal_collections?: boolean;
+  sort_column?: DependencySortColumn;
+  sort_direction?: DependencySortDirection;
 };
 
 export type ListUnreferencedGraphNodesResponse = PaginationResponse & {

--- a/frontend/src/metabase-types/api/dependencies.ts
+++ b/frontend/src/metabase-types/api/dependencies.ts
@@ -280,11 +280,7 @@ export type CheckSnippetDependenciesRequest = Pick<NativeQuerySnippet, "id"> &
 export type CheckTransformDependenciesRequest = Pick<Transform, "id"> &
   Partial<Pick<Transform, "source">>;
 
-export const DEPENDENCY_SORT_COLUMNS = [
-  "name",
-  "location",
-  "dependents-count",
-] as const;
+export const DEPENDENCY_SORT_COLUMNS = ["name", "location"] as const;
 export type DependencySortColumn = (typeof DEPENDENCY_SORT_COLUMNS)[number];
 
 export const DEPENDENCY_SORT_DIRECTIONS = ["asc", "desc"] as const;

--- a/frontend/src/metabase-types/api/dependencies.ts
+++ b/frontend/src/metabase-types/api/dependencies.ts
@@ -280,7 +280,11 @@ export type CheckSnippetDependenciesRequest = Pick<NativeQuerySnippet, "id"> &
 export type CheckTransformDependenciesRequest = Pick<Transform, "id"> &
   Partial<Pick<Transform, "source">>;
 
-export const DEPENDENCY_SORT_COLUMNS = ["name", "location"] as const;
+export const DEPENDENCY_SORT_COLUMNS = [
+  "name",
+  "location",
+  "dependents-count",
+] as const;
 export type DependencySortColumn = (typeof DEPENDENCY_SORT_COLUMNS)[number];
 
 export const DEPENDENCY_SORT_DIRECTIONS = ["asc", "desc"] as const;

--- a/frontend/src/metabase/lib/urls/dependencies.ts
+++ b/frontend/src/metabase/lib/urls/dependencies.ts
@@ -54,16 +54,16 @@ function dependencyListQueryString({
   }
   if (groupTypes != null) {
     groupTypes.forEach((groupType) => {
-      searchParams.append("groupTypes", groupType);
+      searchParams.append("group-types", groupType);
     });
   }
   if (sorting != null) {
-    searchParams.set("sortColumn", sorting.column);
-    searchParams.set("sortDirection", sorting.direction);
+    searchParams.set("sort-column", sorting.column);
+    searchParams.set("sort-direction", sorting.direction);
   }
   if (includePersonalCollections != null) {
     searchParams.set(
-      "includePersonalCollections",
+      "include-personal-collections",
       String(includePersonalCollections),
     );
   }

--- a/frontend/src/metabase/lib/urls/dependencies.ts
+++ b/frontend/src/metabase/lib/urls/dependencies.ts
@@ -31,24 +31,22 @@ export function dependencyTasks() {
 }
 
 export type DependencyListParams = {
-  page?: number;
   query?: string;
   groupTypes?: DependencyGroupType[];
-  sorting?: DependencySortingOptions;
   includePersonalCollections?: boolean;
+  sorting?: DependencySortingOptions;
+  page?: number;
 };
 
 function dependencyListQueryString({
-  page,
   query,
   groupTypes,
-  sorting,
   includePersonalCollections,
+  sorting,
+  page,
 }: DependencyListParams = {}) {
   const searchParams = new URLSearchParams();
-  if (page != null) {
-    searchParams.set("page", String(page));
-  }
+
   if (query != null) {
     searchParams.set("query", query);
   }
@@ -57,15 +55,18 @@ function dependencyListQueryString({
       searchParams.append("group-types", groupType);
     });
   }
-  if (sorting != null) {
-    searchParams.set("sort-column", sorting.column);
-    searchParams.set("sort-direction", sorting.direction);
-  }
   if (includePersonalCollections != null) {
     searchParams.set(
       "include-personal-collections",
       String(includePersonalCollections),
     );
+  }
+  if (sorting != null) {
+    searchParams.set("sort-column", sorting.column);
+    searchParams.set("sort-direction", sorting.direction);
+  }
+  if (page != null) {
+    searchParams.set("page", String(page));
   }
 
   const queryString = searchParams.toString();

--- a/frontend/src/metabase/lib/urls/dependencies.ts
+++ b/frontend/src/metabase/lib/urls/dependencies.ts
@@ -1,4 +1,8 @@
-import type { DependencyEntry, DependencyGroupType } from "metabase-types/api";
+import type {
+  DependencyEntry,
+  DependencyGroupType,
+  DependencySortingOptions,
+} from "metabase-types/api";
 
 const BASE_URL = `/data-studio`;
 const GRAPH_URL = `${BASE_URL}/dependencies`;
@@ -30,6 +34,7 @@ export type DependencyListParams = {
   page?: number;
   query?: string;
   groupTypes?: DependencyGroupType[];
+  sorting?: DependencySortingOptions;
   includePersonalCollections?: boolean;
 };
 
@@ -37,6 +42,7 @@ function dependencyListQueryString({
   page,
   query,
   groupTypes,
+  sorting,
   includePersonalCollections,
 }: DependencyListParams = {}) {
   const searchParams = new URLSearchParams();
@@ -50,6 +56,10 @@ function dependencyListQueryString({
     groupTypes.forEach((groupType) => {
       searchParams.append("groupTypes", groupType);
     });
+  }
+  if (sorting != null) {
+    searchParams.set("sortColumn", sorting.column);
+    searchParams.set("sortDirection", sorting.direction);
   }
   if (includePersonalCollections != null) {
     searchParams.set(

--- a/frontend/src/metabase/ui/components/data-display/TreeTable/TreeTableHeader/TreeTableHeader.tsx
+++ b/frontend/src/metabase/ui/components/data-display/TreeTable/TreeTableHeader/TreeTableHeader.tsx
@@ -1,6 +1,5 @@
 import { flexRender } from "@tanstack/react-table";
 import cx from "classnames";
-import { memo } from "react";
 
 import { Flex } from "metabase/ui";
 
@@ -11,7 +10,7 @@ import { getColumnStyle } from "../utils";
 import { HeaderCell } from "./HeaderCell";
 import S from "./TreeTableHeader.module.css";
 
-function TreeTableHeaderInner<TData extends TreeNodeData>({
+export function TreeTableHeader<TData extends TreeNodeData>({
   table,
   columnWidths,
   showCheckboxes,
@@ -112,9 +111,3 @@ function TreeTableHeaderInner<TData extends TreeNodeData>({
     </Flex>
   );
 }
-
-export const TreeTableHeader = memo(TreeTableHeaderInner) as <
-  TData extends TreeNodeData,
->(
-  props: TreeTableHeaderProps<TData>,
-) => JSX.Element;


### PR DESCRIPTION
It's now possible to sort by `name`, `location`, `dependents-count` in the broken & unreferenced tables. 

<img width="1614" height="838" alt="Screenshot 2026-01-15 at 00 25 35" src="https://github.com/user-attachments/assets/3a444ab6-27d5-4cc5-bb96-f2459448e462" />
