### PR TITLE
Fix EE Starter Edition Embedding Admin page visuals

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-admin-settings-oss.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-admin-settings-oss.cy.spec.ts
@@ -1,13 +1,21 @@
 const { H } = cy;
 
+const { IS_ENTERPRISE } = Cypress.env();
+const IS_OSS = !IS_ENTERPRISE;
+
 // These tests will run on both OSS and EE instances, both without a token.
 describe(
   "scenarios > embedding > admin settings > oss",
-  { tags: "@OSS" },
+  { ...(IS_OSS && { tags: "@OSS" }) },
   () => {
     beforeEach(() => {
       H.restore();
       cy.signInAsAdmin();
+
+      if (IS_ENTERPRISE) {
+        H.deleteToken();
+      }
+
       H.updateSetting("show-sdk-embed-terms", false);
     });
 

--- a/e2e/test/scenarios/embedding/embedding-admin-settings-oss.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-admin-settings-oss.cy.spec.ts
@@ -13,7 +13,7 @@ describe(
       cy.signInAsAdmin();
 
       if (IS_ENTERPRISE) {
-        H.deleteToken();
+        H.activateToken("starter");
       }
 
       H.updateSetting("show-sdk-embed-terms", false);

--- a/e2e/test/scenarios/embedding/embedding-admin-settings-oss.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-admin-settings-oss.cy.spec.ts
@@ -1,12 +1,11 @@
 const { H } = cy;
 
 const { IS_ENTERPRISE } = Cypress.env();
-const IS_OSS = !IS_ENTERPRISE;
 
 // These tests will run on both OSS and EE instances, both without a token.
 describe(
   "scenarios > embedding > admin settings > oss",
-  { ...(IS_OSS && { tags: "@OSS" }) },
+  { tags: ["@OSS", "@EE"] },
   () => {
     beforeEach(() => {
       H.restore();

--- a/e2e/test/scenarios/embedding/embedding-admin-settings-oss.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-admin-settings-oss.cy.spec.ts
@@ -1,19 +1,12 @@
 const { H } = cy;
 
-const { IS_ENTERPRISE } = Cypress.env();
-
-// These tests will run on both OSS and EE instances, both without a token.
 describe(
   "scenarios > embedding > admin settings > oss",
-  { tags: ["@OSS", "@EE"] },
+  { tags: "@OSS" },
   () => {
     beforeEach(() => {
       H.restore();
       cy.signInAsAdmin();
-
-      if (IS_ENTERPRISE) {
-        H.activateToken("starter");
-      }
 
       H.updateSetting("show-sdk-embed-terms", false);
     });
@@ -53,13 +46,11 @@ describe(
         cy.log("upsell gem icon should be visible");
         cy.icon("gem").should("be.visible");
 
-        const plan = !IS_ENTERPRISE ? "oss" : "starter";
-
         cy.findByRole("link", { name: "Upgrade" })
           .should("have.attr", "href")
           .and(
             "eq",
-            `https://www.metabase.com/upgrade?utm_source=product&utm_medium=upsell&utm_content=embedding-page&source_plan=${plan}&utm_users=10&utm_campaign=embedded-analytics-js`,
+            "https://www.metabase.com/upgrade?utm_source=product&utm_medium=upsell&utm_content=embedding-page&source_plan=oss&utm_users=10&utm_campaign=embedded-analytics-js",
           );
       });
     });

--- a/e2e/test/scenarios/embedding/embedding-admin-settings-oss.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-admin-settings-oss.cy.spec.ts
@@ -53,11 +53,13 @@ describe(
         cy.log("upsell gem icon should be visible");
         cy.icon("gem").should("be.visible");
 
+        const plan = !IS_ENTERPRISE ? "oss" : "starter";
+
         cy.findByRole("link", { name: "Upgrade" })
           .should("have.attr", "href")
           .and(
             "eq",
-            "https://www.metabase.com/upgrade?utm_source=product&utm_medium=upsell&utm_content=embedding-page&source_plan=oss&utm_users=10&utm_campaign=embedded-analytics-js",
+            `https://www.metabase.com/upgrade?utm_source=product&utm_medium=upsell&utm_content=embedding-page&source_plan=${plan}&utm_users=10&utm_campaign=embedded-analytics-js`,
           );
       });
     });

--- a/e2e/test/scenarios/embedding/embedding-admin-settings-starter.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-admin-settings-starter.cy.spec.ts
@@ -1,0 +1,56 @@
+const { H } = cy;
+
+describe("scenarios > embedding > admin settings > starter", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+
+    H.activateToken("starter");
+
+    H.updateSetting("show-sdk-embed-terms", false);
+  });
+
+  it("shows all embedding types without the setup guide", () => {
+    cy.log("Navigate to Embedding admin section");
+    cy.visit("/admin/embedding");
+
+    cy.log("Check that we're on the embedding settings page");
+    cy.url().should("include", "/admin/embedding");
+    cy.get("main").findByText("Embedding settings").should("be.visible");
+
+    cy.log("Verify sidebar does not contain setup guide");
+    cy.findByTestId("admin-layout-sidebar")
+      .findByRole("link", { name: /Setup guide/ })
+      .should("not.exist");
+
+    cy.log("Verify sidebar does not contain guest embeds link");
+    cy.findByTestId("admin-layout-sidebar")
+      .findByRole("link", { name: /Guest embeds/ })
+      .should("not.exist");
+
+    cy.log("Verify sidebar does not contain security settings link");
+    cy.findByTestId("admin-layout-sidebar")
+      .findByRole("link", { name: /Security/ })
+      .should("not.exist");
+  });
+
+  it("should show embedding upsell on oss", () => {
+    cy.visit("/admin/embedding/interactive");
+
+    cy.findByTestId("admin-layout-content").within(() => {
+      cy.findByRole("heading", { name: "Embedding settings" }).should(
+        "be.visible",
+      );
+
+      cy.log("upsell gem icon should be visible");
+      cy.icon("gem").should("be.visible");
+
+      cy.findByRole("link", { name: "Upgrade" })
+        .should("have.attr", "href")
+        .and(
+          "eq",
+          "https://www.metabase.com/upgrade?utm_source=product&utm_medium=upsell&utm_content=embedding-page&source_plan=starter&utm_users=10&utm_campaign=embedded-analytics-js",
+        );
+    });
+  });
+});

--- a/e2e/test/scenarios/embedding/embedding-admin-settings-starter.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-admin-settings-starter.cy.spec.ts
@@ -44,13 +44,6 @@ describe("scenarios > embedding > admin settings > starter", () => {
 
       cy.log("upsell gem icon should be visible");
       cy.icon("gem").should("be.visible");
-
-      cy.findByRole("link", { name: "Upgrade" })
-        .should("have.attr", "href")
-        .and(
-          "eq",
-          "https://www.metabase.com/upgrade?utm_source=product&utm_medium=upsell&utm_content=embedding-page&source_plan=starter&utm_users=10&utm_campaign=embedded-analytics-js",
-        );
     });
   });
 });

--- a/frontend/src/metabase/admin/embedding/components/EmbeddingNav.tsx
+++ b/frontend/src/metabase/admin/embedding/components/EmbeddingNav.tsx
@@ -38,6 +38,7 @@ export function EmbeddingNav() {
           icon="gear"
         />
 
+        {/* EE with non-starter plan has embedding settings on different pages */}
         {hasSimpleEmbedding && (
           <>
             <EmbeddingNavItem

--- a/frontend/src/metabase/admin/embedding/components/EmbeddingNav.tsx
+++ b/frontend/src/metabase/admin/embedding/components/EmbeddingNav.tsx
@@ -7,7 +7,6 @@ import {
 } from "metabase/admin/components/AdminNav";
 import { useHasTokenFeature } from "metabase/common/hooks";
 import { useSelector } from "metabase/lib/redux";
-import { isEEBuild } from "metabase/lib/utils";
 import { getLocation } from "metabase/selectors/routing";
 import { Divider, Flex, Stack } from "metabase/ui";
 
@@ -39,7 +38,7 @@ export function EmbeddingNav() {
           icon="gear"
         />
 
-        {isEEBuild() && (
+        {hasSimpleEmbedding && (
           <>
             <EmbeddingNavItem
               path="/admin/embedding/guest"

--- a/frontend/src/metabase/admin/routes.jsx
+++ b/frontend/src/metabase/admin/routes.jsx
@@ -182,6 +182,7 @@ const getRoutes = (store, CanAccessSettings, IsAdmin) => {
               component={EmbeddingHubAdminSettingsPage}
             />
 
+            {/* EE with non-starter plan has embedding settings on different pages */}
             {hasSimpleEmbedding && (
               <>
                 <Route

--- a/frontend/src/metabase/admin/routes.jsx
+++ b/frontend/src/metabase/admin/routes.jsx
@@ -40,7 +40,6 @@ import { TasksApp } from "metabase/admin/tools/components/TasksApp";
 import { ToolsApp } from "metabase/admin/tools/components/ToolsApp";
 import { EmbeddingHubAdminSettingsPage } from "metabase/embedding/embedding-hub";
 import { ModalRoute } from "metabase/hoc/ModalRoute";
-import { isEEBuild } from "metabase/lib/utils";
 import { DataModelV1 } from "metabase/metadata/pages/DataModelV1";
 import {
   PLUGIN_ADMIN_TOOLS,
@@ -52,6 +51,7 @@ import {
   PLUGIN_SUPPORT,
   PLUGIN_TENANTS,
 } from "metabase/plugins";
+import { getTokenFeature } from "metabase/setup";
 
 import { ModelPersistenceConfiguration } from "./performance/components/ModelPersistenceConfiguration";
 import { StrategyEditorForDatabases } from "./performance/components/StrategyEditorForDatabases";
@@ -64,254 +64,269 @@ import {
   createTenantsRouteGuard,
 } from "./utils";
 
-const getRoutes = (store, CanAccessSettings, IsAdmin) => (
-  <Route path="/admin" component={CanAccessSettings}>
-    <Route component={AdminApp}>
-      <IndexRoute component={RedirectToAllowedSettings} />
-      <Route
-        path="databases"
-        title={t`Databases`}
-        component={createAdminRouteGuard("databases")}
-      >
-        <IndexRoute component={DatabaseListApp} />
-        <Route component={IsAdmin}>
-          <Route path="create" component={DatabasePage} />
+const getRoutes = (store, CanAccessSettings, IsAdmin) => {
+  const hasSimpleEmbedding = getTokenFeature(
+    store.getState(),
+    "embedding_simple",
+  );
+
+  return (
+    <Route path="/admin" component={CanAccessSettings}>
+      <Route component={AdminApp}>
+        <IndexRoute component={RedirectToAllowedSettings} />
+        <Route
+          path="databases"
+          title={t`Databases`}
+          component={createAdminRouteGuard("databases")}
+        >
+          <IndexRoute component={DatabaseListApp} />
+          <Route component={IsAdmin}>
+            <Route path="create" component={DatabasePage} />
+          </Route>
+          <Route path=":databaseId/edit" component={DatabasePage} />
+          <Route path=":databaseId" component={DatabaseEditApp}>
+            {PLUGIN_DB_ROUTING.getDestinationDatabaseRoutes(IsAdmin)}
+          </Route>
         </Route>
-        <Route path=":databaseId/edit" component={DatabasePage} />
-        <Route path=":databaseId" component={DatabaseEditApp}>
-          {PLUGIN_DB_ROUTING.getDestinationDatabaseRoutes(IsAdmin)}
-        </Route>
-      </Route>
-      <Route path="datamodel" component={createAdminRouteGuard("data-model")}>
-        <Route title={t`Table Metadata`}>
-          <IndexRedirect to="database" />
-          <Route path="database" component={DataModelV1} />
-          <Route path="database/:databaseId" component={DataModelV1} />
-          <Route
-            path="database/:databaseId/schema/:schemaId"
-            component={DataModelV1}
-          />
-          <Route
-            path="database/:databaseId/schema/:schemaId/table/:tableId"
-            component={DataModelV1}
-          />
-          <Route
-            path="database/:databaseId/schema/:schemaId/table/:tableId/field/:fieldId"
-            component={DataModelV1}
-          />
-          <Route component={DataModelV1}>
-            <Route path="segments" component={SegmentListApp} />
-            <Route path="segment/create" component={IsAdmin}>
-              <IndexRoute component={SegmentApp} />
-            </Route>
-            <Route path="segment/:id" component={IsAdmin}>
-              <IndexRoute component={SegmentApp} />
-            </Route>
+        <Route path="datamodel" component={createAdminRouteGuard("data-model")}>
+          <Route title={t`Table Metadata`}>
+            <IndexRedirect to="database" />
+            <Route path="database" component={DataModelV1} />
+            <Route path="database/:databaseId" component={DataModelV1} />
             <Route
-              path="segment/:id/revisions"
-              component={RevisionHistoryApp}
+              path="database/:databaseId/schema/:schemaId"
+              component={DataModelV1}
+            />
+            <Route
+              path="database/:databaseId/schema/:schemaId/table/:tableId"
+              component={DataModelV1}
+            />
+            <Route
+              path="database/:databaseId/schema/:schemaId/table/:tableId/field/:fieldId"
+              component={DataModelV1}
+            />
+            <Route component={DataModelV1}>
+              <Route path="segments" component={SegmentListApp} />
+              <Route path="segment/create" component={IsAdmin}>
+                <IndexRoute component={SegmentApp} />
+              </Route>
+              <Route path="segment/:id" component={IsAdmin}>
+                <IndexRoute component={SegmentApp} />
+              </Route>
+              <Route
+                path="segment/:id/revisions"
+                component={RevisionHistoryApp}
+              />
+            </Route>
+            <Redirect
+              from="database/:databaseId/schema/:schemaId/table/:tableId/settings"
+              to="database/:databaseId/schema/:schemaId/table/:tableId"
+            />
+            <Redirect
+              from="database/:databaseId/schema/:schemaId/table/:tableId/field/:fieldId/:section"
+              to="database/:databaseId/schema/:schemaId/table/:tableId/field/:fieldId"
             />
           </Route>
-          <Redirect
-            from="database/:databaseId/schema/:schemaId/table/:tableId/settings"
-            to="database/:databaseId/schema/:schemaId/table/:tableId"
-          />
-          <Redirect
-            from="database/:databaseId/schema/:schemaId/table/:tableId/field/:fieldId/:section"
-            to="database/:databaseId/schema/:schemaId/table/:tableId/field/:fieldId"
-          />
         </Route>
-      </Route>
-      {/* PEOPLE */}
-      <Route path="people" component={createAdminRouteGuard("people")}>
-        <Route title={t`People`} component={AdminPeopleApp}>
-          <IndexRoute component={PeopleListingApp} />
+        {/* PEOPLE */}
+        <Route path="people" component={createAdminRouteGuard("people")}>
+          <Route title={t`People`} component={AdminPeopleApp}>
+            <IndexRoute component={PeopleListingApp} />
 
-          {/*NOTE: this must come before the other routes otherwise it will be masked by them*/}
-          <Route path="groups" title={t`Groups`}>
-            <IndexRoute component={GroupsListingApp} />
-            <Route path=":groupId" component={GroupDetailApp} />
-          </Route>
+            {/*NOTE: this must come before the other routes otherwise it will be masked by them*/}
+            <Route path="groups" title={t`Groups`}>
+              <IndexRoute component={GroupsListingApp} />
+              <Route path=":groupId" component={GroupDetailApp} />
+            </Route>
 
-          {/* Tenants */}
-          <Route path="tenants" component={createTenantsRouteGuard()}>
-            {PLUGIN_TENANTS.tenantsRoutes}
-          </Route>
+            {/* Tenants */}
+            <Route path="tenants" component={createTenantsRouteGuard()}>
+              {PLUGIN_TENANTS.tenantsRoutes}
+            </Route>
 
-          <Route path="" component={PeopleListingApp}>
-            <ModalRoute path="new" modal={NewUserModal} noWrap />
-            {PLUGIN_TENANTS.userStrategyRoute}
-          </Route>
+            <Route path="" component={PeopleListingApp}>
+              <ModalRoute path="new" modal={NewUserModal} noWrap />
+              {PLUGIN_TENANTS.userStrategyRoute}
+            </Route>
 
-          <Route path=":userId" component={PeopleListingApp}>
-            <IndexRedirect to="/admin/people" />
-            <ModalRoute path="edit" modal={EditUserModal} noWrap />
-            <ModalRoute path="success" modal={UserSuccessModal} noWrap />
-            <ModalRoute path="reset" modal={UserPasswordResetModal} noWrap />
-            <ModalRoute path="deactivate" modal={UserActivationModal} noWrap />
-            <ModalRoute path="reactivate" modal={UserActivationModal} noWrap />
-            {PLUGIN_ADMIN_USER_MENU_ROUTES.map((getRoutes, index) => (
-              <Fragment key={index}>{getRoutes(store)}</Fragment>
-            ))}
-          </Route>
-        </Route>
-      </Route>
-
-      {/* EMBEDDING */}
-      <Route path="embedding" component={createAdminRouteGuard("embedding")}>
-        <Route title={t`Embedding`} component={AdminEmbeddingApp}>
-          <IndexRoute component={EmbeddingSettings} />
-
-          <Route
-            path="setup-guide"
-            title={t`Setup guide`}
-            component={EmbeddingHubAdminSettingsPage}
-          />
-
-          {isEEBuild() && (
-            <>
-              <Route
-                path="guest"
-                title={t`Unauthenticated embeds`}
-                component={GuestEmbedsSettings}
-              />
-
-              <Route
-                path="security"
-                title={t`Security`}
-                component={EmbeddingSecuritySettings}
-              />
-            </>
-          )}
-        </Route>
-      </Route>
-
-      {/* EE has all embedding settings on the same page */}
-      {!isEEBuild() && (
-        <>
-          <Redirect from="/admin/embedding/guest" to="/admin/embedding" />
-
-          <Redirect from="/admin/embedding/security" to="/admin/embedding" />
-        </>
-      )}
-
-      {/* Backwards compatibility for embedding settings */}
-      <Redirect from="/admin/embedding/modular" to="/admin/embedding" />
-      <Redirect from="/admin/embedding/interactive" to="/admin/embedding" />
-      <Redirect
-        from="/admin/settings/embedding-in-other-applications"
-        to="/admin/embedding"
-      />
-      <Redirect
-        from="/admin/settings/embedding-in-other-applications/full-app"
-        to="/admin/embedding"
-      />
-      <Redirect
-        from="/admin/settings/embedding-in-other-applications/standalone"
-        to="/admin/embedding/guest"
-      />
-      <Redirect
-        from="/admin/settings/embedding-in-other-applications/sdk"
-        to="/admin/embedding"
-      />
-
-      {/* SETTINGS */}
-      <Route path="settings" component={createAdminRouteGuard("settings")}>
-        {getSettingsRoutes()}
-      </Route>
-      {/* PERMISSIONS */}
-      <Route path="permissions" component={IsAdmin}>
-        {getAdminPermissionsRoutes(store)}
-      </Route>
-
-      {/* PERFORMANCE */}
-      <Route
-        path="performance"
-        component={createAdminRouteGuard("performance")}
-      >
-        <Route title={t`Performance`} component={PerformanceApp}>
-          <IndexRedirect to={PerformanceTabId.Databases} />
-          <Route
-            path="databases"
-            title={t`Databases`}
-            component={StrategyEditorForDatabases}
-          />
-          <Route
-            path="models"
-            title={t`Models`}
-            component={ModelPersistenceConfiguration}
-          />
-          <Route
-            path="dashboards-and-questions"
-            title={t`Dashboards and questions`}
-            component={PLUGIN_CACHING.StrategyEditorForQuestionsAndDashboards}
-          />
-        </Route>
-      </Route>
-      {PLUGIN_METABOT.getAdminRoutes()}
-      <Route path="tools" component={createAdminRouteGuard("tools")}>
-        <Route title={t`Tools`} component={ToolsApp}>
-          <IndexRedirect to="help" />
-          <Route
-            key="error-overview"
-            path="errors"
-            title={t`Erroring Questions`}
-            // If the audit_app feature flag is present, our enterprise plugin system kicks in and we render the
-            // appropriate enterprise component. The upsell component is shown in all other cases.
-            component={PLUGIN_ADMIN_TOOLS.COMPONENT || ToolsUpsell}
-          />
-          <Route
-            path="model-caching"
-            title={t`Model Caching Log`}
-            component={ModelCachePage}
-          >
-            <ModalRoute path=":jobId" modal={ModelCacheRefreshJobModal} />
-          </Route>
-          <Route path="help" component={Help}>
-            {PLUGIN_SUPPORT.isEnabled && (
+            <Route path=":userId" component={PeopleListingApp}>
+              <IndexRedirect to="/admin/people" />
+              <ModalRoute path="edit" modal={EditUserModal} noWrap />
+              <ModalRoute path="success" modal={UserSuccessModal} noWrap />
+              <ModalRoute path="reset" modal={UserPasswordResetModal} noWrap />
               <ModalRoute
-                modal={PLUGIN_SUPPORT.GrantAccessModal}
-                path="grant-access"
+                path="deactivate"
+                modal={UserActivationModal}
+                noWrap
+              />
+              <ModalRoute
+                path="reactivate"
+                modal={UserActivationModal}
+                noWrap
+              />
+              {PLUGIN_ADMIN_USER_MENU_ROUTES.map((getRoutes, index) => (
+                <Fragment key={index}>{getRoutes(store)}</Fragment>
+              ))}
+            </Route>
+          </Route>
+        </Route>
+
+        {/* EMBEDDING */}
+        <Route path="embedding" component={createAdminRouteGuard("embedding")}>
+          <Route title={t`Embedding`} component={AdminEmbeddingApp}>
+            <IndexRoute component={EmbeddingSettings} />
+
+            <Route
+              path="setup-guide"
+              title={t`Setup guide`}
+              component={EmbeddingHubAdminSettingsPage}
+            />
+
+            {hasSimpleEmbedding && (
+              <>
+                <Route
+                  path="guest"
+                  title={t`Unauthenticated embeds`}
+                  component={GuestEmbedsSettings}
+                />
+
+                <Route
+                  path="security"
+                  title={t`Security`}
+                  component={EmbeddingSecuritySettings}
+                />
+              </>
+            )}
+          </Route>
+        </Route>
+
+        {/* OSS/Starter has all embedding settings on the same page */}
+        {!hasSimpleEmbedding && (
+          <>
+            <Redirect from="/admin/embedding/guest" to="/admin/embedding" />
+
+            <Redirect from="/admin/embedding/security" to="/admin/embedding" />
+          </>
+        )}
+
+        {/* Backwards compatibility for embedding settings */}
+        <Redirect from="/admin/embedding/modular" to="/admin/embedding" />
+        <Redirect from="/admin/embedding/interactive" to="/admin/embedding" />
+        <Redirect
+          from="/admin/settings/embedding-in-other-applications"
+          to="/admin/embedding"
+        />
+        <Redirect
+          from="/admin/settings/embedding-in-other-applications/full-app"
+          to="/admin/embedding"
+        />
+        <Redirect
+          from="/admin/settings/embedding-in-other-applications/standalone"
+          to="/admin/embedding/guest"
+        />
+        <Redirect
+          from="/admin/settings/embedding-in-other-applications/sdk"
+          to="/admin/embedding"
+        />
+
+        {/* SETTINGS */}
+        <Route path="settings" component={createAdminRouteGuard("settings")}>
+          {getSettingsRoutes()}
+        </Route>
+        {/* PERMISSIONS */}
+        <Route path="permissions" component={IsAdmin}>
+          {getAdminPermissionsRoutes(store)}
+        </Route>
+
+        {/* PERFORMANCE */}
+        <Route
+          path="performance"
+          component={createAdminRouteGuard("performance")}
+        >
+          <Route title={t`Performance`} component={PerformanceApp}>
+            <IndexRedirect to={PerformanceTabId.Databases} />
+            <Route
+              path="databases"
+              title={t`Databases`}
+              component={StrategyEditorForDatabases}
+            />
+            <Route
+              path="models"
+              title={t`Models`}
+              component={ModelPersistenceConfiguration}
+            />
+            <Route
+              path="dashboards-and-questions"
+              title={t`Dashboards and questions`}
+              component={PLUGIN_CACHING.StrategyEditorForQuestionsAndDashboards}
+            />
+          </Route>
+        </Route>
+        {PLUGIN_METABOT.getAdminRoutes()}
+        <Route path="tools" component={createAdminRouteGuard("tools")}>
+          <Route title={t`Tools`} component={ToolsApp}>
+            <IndexRedirect to="help" />
+            <Route
+              key="error-overview"
+              path="errors"
+              title={t`Erroring Questions`}
+              // If the audit_app feature flag is present, our enterprise plugin system kicks in and we render the
+              // appropriate enterprise component. The upsell component is shown in all other cases.
+              component={PLUGIN_ADMIN_TOOLS.COMPONENT || ToolsUpsell}
+            />
+            <Route
+              path="model-caching"
+              title={t`Model Caching Log`}
+              component={ModelCachePage}
+            >
+              <ModalRoute path=":jobId" modal={ModelCacheRefreshJobModal} />
+            </Route>
+            <Route path="help" component={Help}>
+              {PLUGIN_SUPPORT.isEnabled && (
+                <ModalRoute
+                  modal={PLUGIN_SUPPORT.GrantAccessModal}
+                  path="grant-access"
+                />
+              )}
+            </Route>
+            <Route path="tasks" component={TasksApp}>
+              <ModalRoute
+                path=":taskId"
+                modal={TaskModal}
+                modalProps={{
+                  // EventSandbox interferes with mouse text selection in CodeMirror editor
+                  disableEventSandbox: true,
+                }}
+              />
+            </Route>
+            <Route path="jobs" component={JobInfoApp}>
+              <ModalRoute
+                path=":jobKey"
+                modal={JobTriggersModal}
+                modalProps={{ wide: true }}
+              />
+            </Route>
+            <Route path="logs" component={Logs}>
+              <ModalRoute
+                path="levels"
+                modal={LogLevelsModal}
+                modalProps={{
+                  // EventSandbox interferes with mouse text selection in CodeMirror editor
+                  disableEventSandbox: true,
+                }}
+              />
+            </Route>
+            {PLUGIN_DEPENDENCIES.isEnabled && (
+              <Route
+                path="dependencies"
+                component={PLUGIN_DEPENDENCIES.DependencyGraphPage}
               />
             )}
           </Route>
-          <Route path="tasks" component={TasksApp}>
-            <ModalRoute
-              path=":taskId"
-              modal={TaskModal}
-              modalProps={{
-                // EventSandbox interferes with mouse text selection in CodeMirror editor
-                disableEventSandbox: true,
-              }}
-            />
-          </Route>
-          <Route path="jobs" component={JobInfoApp}>
-            <ModalRoute
-              path=":jobKey"
-              modal={JobTriggersModal}
-              modalProps={{ wide: true }}
-            />
-          </Route>
-          <Route path="logs" component={Logs}>
-            <ModalRoute
-              path="levels"
-              modal={LogLevelsModal}
-              modalProps={{
-                // EventSandbox interferes with mouse text selection in CodeMirror editor
-                disableEventSandbox: true,
-              }}
-            />
-          </Route>
-          {PLUGIN_DEPENDENCIES.isEnabled && (
-            <Route
-              path="dependencies"
-              component={PLUGIN_DEPENDENCIES.DependencyGraphPage}
-            />
-          )}
         </Route>
       </Route>
     </Route>
-  </Route>
-);
+  );
+};
 
 export default getRoutes;

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSettings/EmbeddingSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSettings/EmbeddingSettings.tsx
@@ -9,7 +9,11 @@ import { SettingsPageWrapper } from "metabase/admin/components/SettingsSection";
 import { NewEmbedButton } from "metabase/admin/settings/components/EmbeddingSettings/NewEmbedButton/NewEmbedButton";
 import { UpsellDevInstances } from "metabase/admin/upsells";
 import ExternalLink from "metabase/common/components/ExternalLink";
-import { useDocsUrl, useSetting } from "metabase/common/hooks";
+import {
+  useDocsUrl,
+  useHasTokenFeature,
+  useSetting,
+} from "metabase/common/hooks";
 import { isEEBuild } from "metabase/lib/utils";
 import {
   PLUGIN_ADMIN_SETTINGS,
@@ -121,11 +125,11 @@ function EmbeddingSettingsOSS() {
 }
 
 export const EmbeddingSettings = () => {
-  const isEE = isEEBuild();
+  const hasSimpleEmbedding = useHasTokenFeature("embedding_simple");
 
   return (
     <EmbeddingSettingsPageWrapper>
-      {isEE ? <EmbeddingSettingsEE /> : <EmbeddingSettingsOSS />}
+      {hasSimpleEmbedding ? <EmbeddingSettingsEE /> : <EmbeddingSettingsOSS />}
     </EmbeddingSettingsPageWrapper>
   );
 };

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSettings/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSettings/tests/enterprise.unit.spec.tsx
@@ -4,7 +4,10 @@ import { type SetupOpts, setup as baseSetup } from "./setup";
 
 const setup = (opts: SetupOpts = {}) =>
   baseSetup({
-    tokenFeatures: { embedding_sdk: opts.isEmbeddingSdkEnabled },
+    tokenFeatures: {
+      embedding_sdk: opts.isEmbeddingSdkEnabled,
+      embedding_simple: opts.isEmbeddingSimpleEnabled,
+    },
     ...opts,
   });
 
@@ -12,6 +15,7 @@ describe("EmbeddingSdkSettings (EE)", () => {
   it("should not tell users to switch binaries when they have a EE build", async () => {
     await setup({
       isEmbeddingSdkEnabled: false,
+      isEmbeddingSimpleEnabled: true,
       showSdkEmbedTerms: false,
       isHosted: true,
       enterprisePlugins: [

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSettings/tests/premium.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSettings/tests/premium.unit.spec.tsx
@@ -4,7 +4,10 @@ import { type SetupOpts, setup as baseSetup } from "./setup";
 
 const setup = (opts: SetupOpts = {}) =>
   baseSetup({
-    tokenFeatures: { embedding_sdk: opts.isEmbeddingSdkEnabled },
+    tokenFeatures: {
+      embedding_simple: opts.isEmbeddingSimpleEnabled,
+      embedding_sdk: opts.isEmbeddingSdkEnabled,
+    },
     ...opts,
   });
 
@@ -12,6 +15,7 @@ describe("EmbeddingSdkSettings (EE with Embedding SDK token)", () => {
   it("should not tell users to upgrade or switch binaries", async () => {
     await setup({
       isEmbeddingSdkEnabled: true,
+      isEmbeddingSimpleEnabled: true,
       showSdkEmbedTerms: false,
       enterprisePlugins: [
         "embedding-sdk",
@@ -42,6 +46,7 @@ describe("EmbeddingSdkSettings (EE with Embedding SDK token)", () => {
     it("should offer users version pinning when they have a cloud instance", async () => {
       await setup({
         isEmbeddingSdkEnabled: true,
+        isEmbeddingSimpleEnabled: true,
         showSdkEmbedTerms: false,
         isHosted: true,
         enterprisePlugins: [


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #68224
Fix EE Starter Edition Embedding Admin page visuals

Context: https://metaboat.slack.com/archives/C063Q3F1HPF/p1768426773839819

Bug:
- we display the wrong state of Admin UI for Embedding Page for EE Starter Edition. It should be the same as in OSS version. But currently we display it as for EE edition with `simple embedding` enabled.

We can rely just on `simple embedding` token feature.
We should adjust visuals and routes.

PS: wizard behaves correctly.