### PR TITLE
Remove ^:parallel meta for tests that search + hold locks

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/search/scoring_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/search/scoring_test.clj
@@ -184,7 +184,7 @@
                 ["card" 2 "card verified"]]
                (appdb.scoring-test/search-results* "card")))))))
 
-(deftest ^:parallel transforms-user-recency-test
+(deftest transforms-user-recency-test
   (mt/with-premium-features #{:transforms}
     (let [user-id (mt/user->id :crowberto)
           now     (Instant/now)

--- a/test/metabase/search/appdb/scoring_test.clj
+++ b/test/metabase/search/appdb/scoring_test.clj
@@ -235,7 +235,7 @@
 ;; ---- personalized rankers ---
 ;; These require some related appdb content
 
-(deftest ^:parallel bookmark-test
+(deftest bookmark-test
   (let [crowberto (mt/user->id :crowberto)
         rasta     (mt/user->id :rasta)]
     (mt/with-temp [:model/Card {c1 :id} {}
@@ -274,7 +274,7 @@
                     ["collection" c1 "collection normal"]]
                    (search-results :bookmarked "collection" {:current-user-id crowberto})))))))))
 
-(deftest ^:parallel user-recency-test
+(deftest user-recency-test
   (let [user-id     (mt/user->id :crowberto)
         right-now   (Instant/now)
         long-ago    (.minus right-now 10 ChronoUnit/DAYS)


### PR DESCRIPTION
A recent change to search permissions queries in [#67055](https://github.com/metabase/metabase/pull/67055) will cause H2 to use SYS locks during search operations. This is because H2 uses temporary tables to implement CTE's, and their creation/dropping requires global locks.

This commit removes some ^:parallel meta in an attempt to avoid test flakes due to lock timeout.

This change is a bit speculative:

- It is not 100% confirmed that parallel tests are the only problem (e.g. some background task might also hold a lock)
- The tests changed are based on a cursory scan for search tests that hold transactions (mt/with-temp). There may be other tests.

The impact of the CTE lock behaviour in production searches is likely minimal because:

a. Search queries will typically run in auto commit sessions and so lock lifetime will be short
b. concurrent multi-user deployments are most likely not on H2.

Should keep an eye on both tests and any reports in production of lock timeout errors / slow searches when using H2.
