### PR TITLE
Library empty state: expand Data, Metrics and SQL snippets

### DIFF
--- a/e2e/test/scenarios/data-studio/data-studio-library.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-studio-library.cy.spec.ts
@@ -137,7 +137,7 @@ describe("scenarios > data studio > library", () => {
   });
 
   describe("empty state", () => {
-    it("should show empty states with action links when sections are empty", () => {
+    it("should show empty states with interactions when sections are empty", () => {
       H.createLibrary();
       H.DataStudio.Library.visit();
 
@@ -169,23 +169,25 @@ describe("scenarios > data studio > library", () => {
       H.DataStudio.Library.libraryPage()
         .findByRole("link", { name: "New snippet" })
         .should("be.visible");
-    });
 
-    it("should open publish table modal when clicking 'Publish a table' in empty state", () => {
-      H.createLibrary();
-      H.DataStudio.Library.visit();
-
-      cy.log("Click on the 'Publish a table' button in the empty state");
+      cy.log("Click on 'Publish a table' button and verify modal opens");
       H.DataStudio.Library.libraryPage()
         .findByRole("button", { name: "Publish a table" })
         .click();
-
-      cy.log("Verify the publish table modal opens");
       H.entityPickerModal().should("be.visible");
       H.entityPickerModalItem(3, "Orders").should("exist");
+      H.entityPickerModal().button("Close").click();
+
+      cy.log("Search for text and verify empty states are excluded");
+      H.DataStudio.Library.libraryPage()
+        .findByPlaceholderText("Search...")
+        .type("Publish");
+      H.DataStudio.Library.libraryPage()
+        .findByText("Cleaned, pre-transformed data sources ready for exploring")
+        .should("not.exist");
     });
 
-    it("should hide empty state when section has items", () => {
+    it("should hide empty states when items are added and keep empty sections expanded on navigation", () => {
       H.createLibrary();
       H.DataStudio.Library.visit();
 
@@ -194,52 +196,23 @@ describe("scenarios > data studio > library", () => {
         .findByText("Cleaned, pre-transformed data sources ready for exploring")
         .should("be.visible");
 
-      cy.log("Publish a table");
+      cy.log("Publish a table via the +New menu");
       H.DataStudio.Library.newButton().click();
       H.popover().findByText("Publish a table").click();
       H.entityPickerModalItem(3, "Orders").click();
       H.entityPickerModal().button("Publish").click();
 
-      cy.log("Navigate back to the library");
+      cy.log("Navigate back to Library via breadcrumbs");
       H.DataStudio.breadcrumbs().findByRole("link", { name: "Data" }).click();
 
-      cy.log("Verify Data empty state is hidden and table is visible");
+      cy.log("Verify Data section shows the table (empty state hidden)");
       H.DataStudio.Library.tableItem("Orders").should("be.visible");
       H.DataStudio.Library.libraryPage()
         .findByText("Cleaned, pre-transformed data sources ready for exploring")
         .should("not.exist");
-    });
-
-    it("should not show empty states in search results", () => {
-      H.createLibrary();
-      H.DataStudio.Library.visit();
-
-      cy.log("Search for 'Publish'");
-      H.DataStudio.Library.libraryPage()
-        .findByPlaceholderText("Search...")
-        .type("Publish");
-
-      cy.log("Verify empty state descriptions are not in search results");
-      H.DataStudio.Library.libraryPage()
-        .findByText("Cleaned, pre-transformed data sources ready for exploring")
-        .should("not.exist");
-    });
-
-    it("should keep empty sections expanded when navigating back via breadcrumbs", () => {
-      H.createLibrary();
-      H.DataStudio.Library.visit();
-
-      cy.log("Publish a table so Data section has content");
-      H.DataStudio.Library.newButton().click();
-      H.popover().findByText("Publish a table").click();
-      H.entityPickerModalItem(3, "Orders").click();
-      H.entityPickerModal().button("Publish").click();
-
-      cy.log("Navigate back to Data section via breadcrumbs");
-      H.DataStudio.breadcrumbs().findByRole("link", { name: "Data" }).click();
 
       cy.log(
-        "Verify empty sections (Metrics, SQL snippets) are still expanded and showing empty states",
+        "Verify Metrics and SQL snippets still show empty states (always expanded behavior)",
       );
       H.DataStudio.Library.libraryPage()
         .findByText("Standardized calculations with known dimensions")
@@ -247,9 +220,6 @@ describe("scenarios > data studio > library", () => {
       H.DataStudio.Library.libraryPage()
         .findByText("Reusable bits of code that save your time")
         .should("be.visible");
-
-      cy.log("Verify the Data section table is also visible");
-      H.DataStudio.Library.tableItem("Orders").should("be.visible");
     });
   });
 });

--- a/e2e/test/scenarios/data-studio/data-studio-library.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-studio-library.cy.spec.ts
@@ -135,4 +135,121 @@ describe("scenarios > data studio > library", () => {
       );
     });
   });
+
+  describe("empty state", () => {
+    it("should show empty states with action links when sections are empty", () => {
+      H.createLibrary();
+      H.DataStudio.Library.visit();
+
+      cy.log("Verify all sections are expanded");
+      H.DataStudio.Library.collectionItem("Data").should("be.visible");
+      H.DataStudio.Library.collectionItem("Metrics").should("be.visible");
+      H.DataStudio.Library.collectionItem("SQL snippets").should("be.visible");
+
+      cy.log("Verify Data section empty state");
+      H.DataStudio.Library.libraryPage()
+        .findByText("Cleaned, pre-transformed data sources ready for exploring")
+        .should("be.visible");
+      H.DataStudio.Library.libraryPage()
+        .findByRole("button", { name: "Publish a table" })
+        .should("be.visible");
+
+      cy.log("Verify Metrics section empty state");
+      H.DataStudio.Library.libraryPage()
+        .findByText("Standardized calculations with known dimensions")
+        .should("be.visible");
+      H.DataStudio.Library.libraryPage()
+        .findByRole("link", { name: "New metric" })
+        .should("be.visible");
+
+      cy.log("Verify SQL snippets section empty state");
+      H.DataStudio.Library.libraryPage()
+        .findByText("Reusable bits of code that save your time")
+        .should("be.visible");
+      H.DataStudio.Library.libraryPage()
+        .findByRole("link", { name: "New snippet" })
+        .should("be.visible");
+    });
+
+    it("should open publish table modal when clicking 'Publish a table' in empty state", () => {
+      H.createLibrary();
+      H.DataStudio.Library.visit();
+
+      cy.log("Click on the 'Publish a table' button in the empty state");
+      H.DataStudio.Library.libraryPage()
+        .findByRole("button", { name: "Publish a table" })
+        .click();
+
+      cy.log("Verify the publish table modal opens");
+      H.entityPickerModal().should("be.visible");
+      H.entityPickerModalItem(3, "Orders").should("exist");
+    });
+
+    it("should hide empty state when section has items", () => {
+      H.createLibrary();
+      H.DataStudio.Library.visit();
+
+      cy.log("Verify Data empty state is visible initially");
+      H.DataStudio.Library.libraryPage()
+        .findByText("Cleaned, pre-transformed data sources ready for exploring")
+        .should("be.visible");
+
+      cy.log("Publish a table");
+      H.DataStudio.Library.newButton().click();
+      H.popover().findByText("Publish a table").click();
+      H.entityPickerModalItem(3, "Orders").click();
+      H.entityPickerModal().button("Publish").click();
+
+      cy.log("Navigate back to the library");
+      H.DataStudio.breadcrumbs().findByRole("link", { name: "Data" }).click();
+
+      cy.log("Verify Data empty state is hidden and table is visible");
+      H.DataStudio.Library.tableItem("Orders").should("be.visible");
+      H.DataStudio.Library.libraryPage()
+        .findByText("Cleaned, pre-transformed data sources ready for exploring")
+        .should("not.exist");
+    });
+
+    it("should not show empty states in search results", () => {
+      H.createLibrary();
+      H.DataStudio.Library.visit();
+
+      cy.log("Search for 'Publish'");
+      H.DataStudio.Library.libraryPage()
+        .findByPlaceholderText("Search...")
+        .type("Publish");
+
+      cy.log("Verify empty state descriptions are not in search results");
+      H.DataStudio.Library.libraryPage()
+        .findByText("Cleaned, pre-transformed data sources ready for exploring")
+        .should("not.exist");
+    });
+
+    it("should keep empty sections expanded when navigating back via breadcrumbs", () => {
+      H.createLibrary();
+      H.DataStudio.Library.visit();
+
+      cy.log("Publish a table so Data section has content");
+      H.DataStudio.Library.newButton().click();
+      H.popover().findByText("Publish a table").click();
+      H.entityPickerModalItem(3, "Orders").click();
+      H.entityPickerModal().button("Publish").click();
+
+      cy.log("Navigate back to Data section via breadcrumbs");
+      H.DataStudio.breadcrumbs().findByRole("link", { name: "Data" }).click();
+
+      cy.log(
+        "Verify empty sections (Metrics, SQL snippets) are still expanded and showing empty states",
+      );
+      H.DataStudio.Library.libraryPage()
+        .findByText("Standardized calculations with known dimensions")
+        .should("be.visible");
+      H.DataStudio.Library.libraryPage()
+        .findByText("Reusable bits of code that save your time")
+        .should("be.visible");
+
+      cy.log("Verify the Data section table is also visible");
+      H.DataStudio.Library.tableItem("Orders").should("be.visible");
+    });
+  });
 });

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/types.ts
@@ -6,16 +6,30 @@ import type {
   CollectionNamespace,
 } from "metabase-types/api";
 
+export type LibrarySectionType = "data" | "metrics" | "snippets";
+
+export type EmptyStateData = {
+  model: "empty-state";
+  sectionType: LibrarySectionType;
+  description: string;
+  actionLabel: string;
+  actionUrl?: string;
+};
+
+export type TreeItemModel = CollectionItemModel | "empty-state";
+
 export type TreeItem = {
   id: string;
   name: string;
   icon: IconName;
   updatedAt?: string;
-  model: CollectionItemModel;
-  data: (Collection | Omit<CollectionItem, "getUrl">) & {
-    model: CollectionItem["model"];
-    namespace?: CollectionNamespace | null;
-  };
+  model: TreeItemModel;
+  data:
+    | ((Collection | Omit<CollectionItem, "getUrl">) & {
+        model: CollectionItem["model"];
+        namespace?: CollectionNamespace | null;
+      })
+    | EmptyStateData;
   children?: TreeItem[];
 };
 
@@ -23,4 +37,10 @@ export const isCollection = (
   c: Collection | Omit<CollectionItem, "getUrl">,
 ): c is Collection => {
   return Object.keys(c).includes("namespace");
+};
+
+export const isEmptyStateData = (
+  data: TreeItem["data"],
+): data is EmptyStateData => {
+  return data.model === "empty-state";
 };

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/utils.ts
@@ -1,13 +1,15 @@
 import { t } from "ttag";
 
 import { isRootCollection } from "metabase/collections/utils";
+import * as Urls from "metabase/lib/urls";
 import type {
   Collection,
+  CollectionId,
   CollectionType,
   NativeQuerySnippet,
 } from "metabase-types/api";
 
-import type { TreeItem } from "./types";
+import type { LibrarySectionType, TreeItem } from "./types";
 
 function createSnippetNode(snippet: NativeQuerySnippet): TreeItem {
   return {
@@ -71,7 +73,13 @@ export function buildSnippetTree(
     activeSnippets,
   );
 
-  return [{ ...rootNode, name: t`SQL snippets` }];
+  // If the root has no children (no snippets or subfolders), add an empty state
+  const hasContent = activeSnippets.length > 0 || nonRootCollections.length > 0;
+  const children = hasContent
+    ? rootNode.children
+    : [createEmptyStateItem("snippets")];
+
+  return [{ ...rootNode, name: t`SQL snippets`, children }];
 }
 
 export function getWritableCollection(
@@ -104,4 +112,64 @@ export function getAccessibleCollection(
     return collection;
   }
   return collection.can_write ? collection : undefined;
+}
+
+type EmptyStateConfig = {
+  sectionType: LibrarySectionType;
+  description: string;
+  actionLabel: string;
+  actionUrl?: string;
+};
+
+function getEmptyStateConfig(
+  sectionType: LibrarySectionType,
+): Omit<EmptyStateConfig, "sectionType" | "actionUrl"> {
+  const config: Record<
+    LibrarySectionType,
+    Omit<EmptyStateConfig, "sectionType" | "actionUrl">
+  > = {
+    data: {
+      description: t`Cleaned, pre-transformed data sources ready for exploring`,
+      actionLabel: t`Publish a table`,
+    },
+    metrics: {
+      description: t`Standardized calculations with known dimensions`,
+      actionLabel: t`New metric`,
+    },
+    snippets: {
+      description: t`Reusable bits of code that save your time`,
+      actionLabel: t`New snippet`,
+    },
+  };
+
+  return config[sectionType];
+}
+
+export function createEmptyStateItem(
+  sectionType: LibrarySectionType,
+  metricCollectionId?: CollectionId,
+): TreeItem {
+  const config = getEmptyStateConfig(sectionType);
+
+  let actionUrl: string | undefined;
+  if (sectionType === "metrics" && metricCollectionId) {
+    actionUrl = Urls.newDataStudioMetric({ collectionId: metricCollectionId });
+  } else if (sectionType === "snippets") {
+    actionUrl = Urls.newDataStudioSnippet();
+  }
+  // "data" section opens a modal, so no actionUrl
+
+  return {
+    id: `empty-state:${sectionType}`,
+    name: "",
+    icon: "empty",
+    model: "empty-state",
+    data: {
+      model: "empty-state",
+      sectionType,
+      description: config.description,
+      actionLabel: config.actionLabel,
+      actionUrl,
+    },
+  };
 }


### PR DESCRIPTION
Closes [UXW-2703](https://linear.app/metabase/issue/UXW-2703/library-empty-state-expand-data-metrics-and-sql-snippets)

### Description

This pull request adds empty states for the library in Data Studio. For each empty category, a small message with a CTA will be displayed. 

### Demo

https://www.loom.com/share/27707305f7d9401798e406f3fe6ed742

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
