### PR TITLE
Paginate caching dashboard

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -276,6 +276,7 @@
            events
            models
            premium-features
+           request
            settings
            util}}
 

--- a/e2e/test/scenarios/data-studio/data-studio-metrics.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-studio-metrics.cy.spec.ts
@@ -363,6 +363,10 @@ describe("scenarios > data studio > library > metrics", () => {
       cy.findByRole("button", { name: "Save" }).click();
       cy.findByRole("button", { name: /Saved/ }).should("exist");
 
+      // wait for the save button to disappear - that means the form is no longer dirty
+      // and navigating away won't show the confirmation modal that was causing flakes
+      cy.findByRole("button", { name: /Saved/ }).should("not.exist");
+
       cy.log("Navigate away and come back to verify the change is persisted");
       H.DataStudio.Metrics.overviewTab().click();
       H.DataStudio.Metrics.cachingTab().click();

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/SidebarCacheForm.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/SidebarCacheForm.tsx
@@ -26,19 +26,18 @@ export const SidebarCacheForm = ({
 }: SidebarCacheFormProps) => {
   const configurableModels = useMemo(() => [model], [model]);
   const id: number = getItemId(model, item);
-  const { configs, setConfigs, loading, error } = useCacheConfigs({
-    configurableModels,
+  const { configs, isLoading, error } = useCacheConfigs({
+    model: configurableModels,
     id,
   });
 
-  const { savedStrategy, filteredConfigs } = useMemo(() => {
-    const targetConfig = _.findWhere(configs, { model_id: id });
+  const { savedStrategy } = useMemo(() => {
+    const targetConfig = _.findWhere(configs ?? [], { model_id: id });
     const savedStrategy = targetConfig?.strategy;
-    const filteredConfigs = _.compact([targetConfig]);
-    return { savedStrategy, filteredConfigs };
+    return { savedStrategy };
   }, [configs, id]);
 
-  const saveStrategy = useSaveStrategy(id, filteredConfigs, setConfigs, model);
+  const saveStrategy = useSaveStrategy(id, model);
   const saveAndBack = useCallback(
     async (values: CacheStrategy) => {
       await saveStrategy(values);
@@ -76,7 +75,7 @@ export const SidebarCacheForm = ({
         aria-labelledby={headingId}
         {...stackProps}
       >
-        <DelayedLoadingAndErrorWrapper loading={loading} error={error}>
+        <DelayedLoadingAndErrorWrapper loading={isLoading} error={error}>
           <StrategyForm
             targetId={id}
             targetModel={model}

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/SidebarCacheSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/SidebarCacheSection.tsx
@@ -20,14 +20,14 @@ export const SidebarCacheSection = ({
   const id = useMemo(() => getItemId(model, item), [model, item]);
   const configurableModels = useMemo(() => [model], [model]);
 
-  const { configs, loading, error } = useCacheConfigs({
-    configurableModels,
+  const { configs, isLoading, error } = useCacheConfigs({
+    model: configurableModels,
     id,
   });
 
   const targetConfig = useMemo(() => {
     const id = getItemId(model, item);
-    return _.findWhere(configs, { model, model_id: id });
+    return _.findWhere(configs ?? [], { model, model_id: id });
   }, [configs, model, item]);
   const savedStrategy = targetConfig?.strategy;
 
@@ -36,7 +36,7 @@ export const SidebarCacheSection = ({
   const labelId = "question-caching-policy-label";
 
   return (
-    <DelayedLoadingAndErrorWrapper delay={0} loading={loading} error={error}>
+    <DelayedLoadingAndErrorWrapper delay={0} loading={isLoading} error={error}>
       <Flex align="center" justify="space-between">
         <span id={labelId}>{t`When to get new results`}</span>
         <FormLauncher

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.tsx
@@ -4,22 +4,16 @@ import _ from "underscore";
 
 import { SettingsPageWrapper } from "metabase/admin/components/SettingsSection";
 import { StrategyForm } from "metabase/admin/performance/components/StrategyForm";
+import { useCacheConfigs } from "metabase/admin/performance/hooks/useCacheConfigs";
 import { useConfirmIfFormIsDirty } from "metabase/admin/performance/hooks/useConfirmIfFormIsDirty";
 import { useSaveStrategy } from "metabase/admin/performance/hooks/useSaveStrategy";
-import { translateConfigFromAPI } from "metabase/admin/performance/utils";
-import { useListCacheConfigsQuery } from "metabase/api";
 import { DelayedLoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper";
-import { PaginationControls } from "metabase/common/components/PaginationControls";
 import { Sidesheet } from "metabase/common/components/Sidesheet";
 import { Table } from "metabase/common/components/Table";
 import type { ColumnItem } from "metabase/common/components/Table/types";
 import { usePagination } from "metabase/common/hooks/use-pagination";
 import { Center, Flex, Repeat, Skeleton, Stack } from "metabase/ui";
-import type {
-  CacheConfig,
-  CacheSortColumn,
-  CacheableModel,
-} from "metabase-types/api";
+import type { CacheSortColumn, CacheableModel } from "metabase-types/api";
 import { CacheDurationUnit } from "metabase-types/api";
 import { SortDirection } from "metabase-types/api/sorting";
 
@@ -42,38 +36,20 @@ export const StrategyEditorForQuestionsAndDashboards = () => {
 
   const [targetModel, setTargetModel] = useState<CacheableModel | null>(null);
 
-  const { page, handleNextPage, handlePreviousPage, resetPage } =
-    usePagination();
+  const { page, setPage, resetPage } = usePagination();
 
   const [sortColumn, setSortColumn] = useState<CacheSortColumn>("name");
   const [sortDirection, setSortDirection] = useState<SortDirection>(
     SortDirection.Asc,
   );
 
-  const [configs, setConfigs] = useState<CacheConfig[]>([]);
-
-  const {
-    data: cacheConfigsResponse,
-    error: configsError,
-    isLoading: configsAreLoading,
-  } = useListCacheConfigsQuery({
+  const { configs, total, error, isLoading } = useCacheConfigs({
     model: ["dashboard", "question"],
     limit: PAGE_SIZE,
     offset: page * PAGE_SIZE,
     sort_column: sortColumn,
     sort_direction: sortDirection === SortDirection.Asc ? "asc" : "desc",
   });
-
-  const total = cacheConfigsResponse?.total ?? 0;
-  const configsFromAPI = useMemo(
-    () => (cacheConfigsResponse?.data ?? []).map(translateConfigFromAPI),
-    [cacheConfigsResponse?.data],
-  );
-
-  // Update local configs state when API data changes
-  useEffect(() => {
-    setConfigs(configsFromAPI);
-  }, [configsFromAPI]);
 
   // Handle sort column click
   const handleSort = useCallback(
@@ -85,13 +61,12 @@ export const StrategyEditorForQuestionsAndDashboards = () => {
     [resetPage],
   );
 
-  // Transform configs to cacheable items - data comes directly from API
   const cacheableItems: CacheableItem[] = useMemo(() => {
-    return configsFromAPI
-      .filter(
-        (config): config is typeof config & { name: string } =>
-          config.name !== undefined,
-      )
+    if (configs === undefined) {
+      return [];
+    }
+    return configs
+      .filter((config) => config.name !== undefined)
       .map((config) => ({
         id: config.model_id,
         model: config.model,
@@ -100,7 +75,7 @@ export const StrategyEditorForQuestionsAndDashboards = () => {
         collection: config.collection ?? undefined,
         iconModel: config.model === "question" ? "card" : "dashboard",
       }));
-  }, [configsFromAPI]);
+  }, [configs]);
 
   useEffect(
     /** When the user configures an item to 'Use default' and that item
@@ -118,20 +93,19 @@ export const StrategyEditorForQuestionsAndDashboards = () => {
   );
 
   /** The config for the object currently being edited */
-  const targetConfig = targetModel
-    ? _.findWhere(configs, {
-        model_id: targetId ?? undefined,
-        model: targetModel,
-      })
-    : undefined;
+  const targetConfig =
+    configs && targetModel
+      ? _.findWhere(configs, {
+          model_id: targetId ?? undefined,
+          model: targetModel,
+        })
+      : undefined;
 
-  // Create a mutable copy of the strategy since RTK Query data is frozen
   const savedStrategy = useMemo(() => {
     const strategy = targetConfig?.strategy;
     if (!strategy) {
       return undefined;
     }
-    // Return a mutable copy, normalizing duration unit to hours
     if (strategy.type === "duration") {
       return { ...strategy, unit: CacheDurationUnit.Hours };
     }
@@ -178,17 +152,9 @@ export const StrategyEditorForQuestionsAndDashboards = () => {
     ],
   );
 
-  const saveStrategy = useSaveStrategy(
-    targetId,
-    configs,
-    setConfigs,
-    targetModel,
-  );
+  const saveStrategy = useSaveStrategy(targetId, targetModel);
 
-  const error = configsError;
-  const loading = configsAreLoading;
-
-  const hasPagination = total > PAGE_SIZE;
+  const hasPagination = (total ?? 0) > PAGE_SIZE;
 
   const rowRenderer = useCallback(
     (item: CacheableItem) => (
@@ -226,43 +192,39 @@ export const StrategyEditorForQuestionsAndDashboards = () => {
         <Flex>
           <DelayedLoadingAndErrorWrapper
             error={error}
-            loading={loading}
+            loading={isLoading}
             loader={<TableSkeleton columns={tableColumns} />}
           >
-            <Stack gap="md" w="100%">
-              <Flex align="flex-start">
-                <Table<CacheableItem>
-                  className={Styles.CacheableItemTable}
-                  columns={tableColumns}
-                  data-testid="cache-config-table"
-                  rows={cacheableItems}
-                  rowRenderer={rowRenderer}
-                  emptyBody={<NoResultsTableRow />}
-                  aria-labelledby={explanatoryAsideId}
-                  sortColumnName={sortColumn}
-                  sortDirection={sortDirection}
-                  onSort={handleSort}
-                  cols={
-                    <>
-                      <col />
-                      <col />
-                      <col />
-                    </>
-                  }
-                />
-              </Flex>
-              {hasPagination && (
-                <PaginationControls
-                  page={page}
-                  pageSize={PAGE_SIZE}
-                  itemsLength={cacheableItems.length}
-                  total={total}
-                  showTotal
-                  onNextPage={handleNextPage}
-                  onPreviousPage={handlePreviousPage}
-                />
-              )}
-            </Stack>
+            <Table<CacheableItem>
+              className={Styles.CacheableItemTable}
+              columns={tableColumns}
+              data-testid="cache-config-table"
+              rows={cacheableItems}
+              rowRenderer={rowRenderer}
+              emptyBody={<NoResultsTableRow />}
+              aria-labelledby={explanatoryAsideId}
+              sortColumnName={sortColumn}
+              sortDirection={sortDirection}
+              onSort={handleSort}
+              cols={
+                <>
+                  <col />
+                  <col />
+                  <col />
+                </>
+              }
+              paginationProps={
+                hasPagination
+                  ? {
+                      page,
+                      pageSize: PAGE_SIZE,
+                      total,
+                      showTotal: true,
+                      onPageChange: setPage,
+                    }
+                  : undefined
+              }
+            />
           </DelayedLoadingAndErrorWrapper>
         </Flex>
       </Stack>

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyFormLauncherPanel.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyFormLauncherPanel.tsx
@@ -1,4 +1,4 @@
-import { type Dispatch, type SetStateAction, useMemo } from "react";
+import { useMemo } from "react";
 import { t } from "ttag";
 
 import { Panel } from "metabase/admin/performance/components/StrategyEditorForDatabases.styled";
@@ -19,7 +19,6 @@ import {
 
 export const StrategyFormLauncherPanel = ({
   configs,
-  setConfigs,
   targetId,
   updateTargetId,
   databases,
@@ -27,7 +26,6 @@ export const StrategyFormLauncherPanel = ({
   shouldShowResetButton,
 }: {
   configs: CacheConfig[];
-  setConfigs: Dispatch<SetStateAction<CacheConfig[]>>;
   targetId: number | null;
   updateTargetId: UpdateTargetId;
   databases: Database[];
@@ -40,8 +38,6 @@ export const StrategyFormLauncherPanel = ({
     handleSubmit: resetAllToDefault,
     versionNumber: resetFormVersionNumber,
   } = useResetToDefaultForm({
-    configs,
-    setConfigs,
     databaseIds,
     isFormVisible: targetId !== null,
   });

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/types.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/types.tsx
@@ -4,7 +4,6 @@ import type {
   CacheableModel,
   CollectionEssentials,
   SearchModel,
-  SearchResult,
 } from "metabase-types/api";
 
 /** Something with a configurable cache strategy */
@@ -16,9 +15,6 @@ export type CacheableItem = Omit<CacheConfig, "model_id"> & {
   /** In the sense of 'type of object' */
   iconModel?: SearchModel;
 };
-
-export type DashboardResult = SearchResult<number, "dashboard">;
-export type QuestionResult = SearchResult<number, "card">;
 
 export type UpdateTarget = (
   newValues: { id: number | null; model: CacheableModel | null },

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/metrics/pages/MetricCachingPage/MetricCachingPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/metrics/pages/MetricCachingPage/MetricCachingPage.tsx
@@ -19,7 +19,7 @@ import type { CacheableModel } from "metabase-types/api";
 
 import { MetricHeader } from "../../components/MetricHeader";
 
-const configurableModels: CacheableModel[] = ["question"];
+const model: CacheableModel[] = ["question"];
 
 export function MetricCachingPage({ params }: MetricSettingsPageProps) {
   const cardId = Urls.extractEntityId(params.cardId);
@@ -32,27 +32,20 @@ export function MetricCachingPage({ params }: MetricSettingsPageProps) {
 
   const {
     configs,
-    setConfigs,
-    loading: isLoadingConfigs,
+    isLoading: isLoadingConfigs,
     error: configsError,
   } = useCacheConfigs({
-    configurableModels,
+    model,
     id: cardId,
   });
 
-  const { savedStrategy, filteredConfigs } = useMemo(() => {
-    const targetConfig = _.findWhere(configs, { model_id: cardId });
+  const { savedStrategy } = useMemo(() => {
+    const targetConfig = _.findWhere(configs ?? [], { model_id: cardId });
     const savedStrategy = targetConfig?.strategy;
-    const filteredConfigs = _.compact([targetConfig]);
-    return { savedStrategy, filteredConfigs };
+    return { savedStrategy };
   }, [configs, cardId]);
 
-  const saveStrategy = useSaveStrategy(
-    cardId ?? null,
-    filteredConfigs,
-    setConfigs,
-    "question",
-  );
+  const saveStrategy = useSaveStrategy(cardId ?? null, "question");
 
   const { confirmationModal, setIsStrategyFormDirty } =
     useConfirmIfFormIsDirty();

--- a/frontend/src/metabase-types/api/performance.ts
+++ b/frontend/src/metabase-types/api/performance.ts
@@ -1,3 +1,5 @@
+import type { CollectionType } from "./collection";
+
 /** 'Model' as in 'type of object' */
 export type CacheableModel = "root" | "database" | "dashboard" | "question";
 
@@ -67,3 +69,34 @@ export interface CacheConfig {
 export type CacheConfigAPIResponse = {
   data: CacheConfig[];
 };
+
+export type CacheSortColumn = "name" | "collection" | "policy";
+export type SortDirection = "asc" | "desc";
+
+export interface ListCacheConfigsRequest {
+  model?: CacheableModel[];
+  collection?: number;
+  id?: number;
+  limit?: number;
+  offset?: number;
+  sort_column?: CacheSortColumn;
+  sort_direction?: SortDirection;
+}
+
+/** Cache config with hydrated name and collection data */
+export interface CacheConfigWithDetails extends CacheConfig {
+  name?: string;
+  collection?: {
+    id: number;
+    name: string;
+    authority_level?: "official" | null;
+    type?: CollectionType;
+  } | null;
+}
+
+export interface ListCacheConfigsResponse {
+  data: CacheConfigWithDetails[];
+  total: number;
+  limit: number | null;
+  offset: number | null;
+}

--- a/frontend/src/metabase-types/api/performance.ts
+++ b/frontend/src/metabase-types/api/performance.ts
@@ -66,10 +66,6 @@ export interface CacheConfig {
   strategy: CacheStrategy;
 }
 
-export type CacheConfigAPIResponse = {
-  data: CacheConfig[];
-};
-
 export type CacheSortColumn = "name" | "collection" | "policy";
 export type SortDirection = "asc" | "desc";
 

--- a/frontend/src/metabase/admin/performance/components/StrategyEditorForDatabases.tsx
+++ b/frontend/src/metabase/admin/performance/components/StrategyEditorForDatabases.tsx
@@ -106,7 +106,7 @@ export const StrategyEditorForDatabases: React.FC = () => {
     targetId,
     configs,
     setConfigs,
-    "database",
+    targetId === rootId ? "root" : "database",
   );
 
   const error = configsError || databasesResult.error;

--- a/frontend/src/metabase/admin/performance/components/StrategyEditorForDatabases.tsx
+++ b/frontend/src/metabase/admin/performance/components/StrategyEditorForDatabases.tsx
@@ -29,7 +29,7 @@ export const StrategyEditorForDatabases: React.FC = () => {
     setTargetId,
   ] = useState<number | null>(null);
 
-  const configurableModels: CacheableModel[] = useMemo(() => {
+  const model: CacheableModel[] = useMemo(() => {
     const ret: CacheableModel[] = ["root"];
     if (canOverrideRootStrategy) {
       ret.push("database");
@@ -39,12 +39,11 @@ export const StrategyEditorForDatabases: React.FC = () => {
 
   const {
     configs,
-    setConfigs,
     rootStrategyOverriddenOnce,
     rootStrategyRecentlyOverridden,
     error: configsError,
-    loading: areConfigsLoading,
-  } = useCacheConfigs({ configurableModels });
+    isLoading: areConfigsLoading,
+  } = useCacheConfigs({ model });
 
   const databasesResult = useListDatabasesQuery();
   const databases = databasesResult.data?.data ?? [];
@@ -53,14 +52,20 @@ export const StrategyEditorForDatabases: React.FC = () => {
     rootStrategyOverriddenOnce || rootStrategyRecentlyOverridden;
 
   /** The config for the model currently being edited */
-  const targetConfig = findWhere(configs, {
+  const targetConfig = findWhere(configs ?? [], {
     model_id: targetId ?? undefined,
   });
-  const savedStrategy = targetConfig?.strategy;
 
-  if (savedStrategy?.type === "duration") {
-    savedStrategy.unit = CacheDurationUnit.Hours;
-  }
+  const savedStrategy = useMemo(() => {
+    const strategy = targetConfig?.strategy;
+    if (!strategy) {
+      return undefined;
+    }
+    if (strategy.type === "duration") {
+      return { ...strategy, unit: CacheDurationUnit.Hours };
+    }
+    return { ...strategy };
+  }, [targetConfig?.strategy]);
 
   const {
     askBeforeDiscardingChanges,
@@ -96,18 +101,13 @@ export const StrategyEditorForDatabases: React.FC = () => {
     const inheritingRootStrategy = ["inherit", undefined].includes(
       savedStrategy?.type,
     );
-    const rootConfig = findWhere(configs, { model_id: rootId });
+    const rootConfig = findWhere(configs ?? [], { model_id: rootId });
     const inheritingDoNotCache =
       inheritingRootStrategy && !rootConfig?.strategy;
     return !inheritingDoNotCache;
   }, [configs, savedStrategy?.type, targetId]);
 
-  const saveStrategy = useSaveStrategy(
-    targetId,
-    configs,
-    setConfigs,
-    targetId === rootId ? "root" : "database",
-  );
+  const saveStrategy = useSaveStrategy(targetId, "database");
 
   const error = configsError || databasesResult.error;
   const loading = areConfigsLoading || databasesResult.isLoading;
@@ -132,8 +132,7 @@ export const StrategyEditorForDatabases: React.FC = () => {
         <RoundedBox twoColumns={canOverrideRootStrategy}>
           {canOverrideRootStrategy && (
             <PLUGIN_CACHING.StrategyFormLauncherPanel
-              configs={configs}
-              setConfigs={setConfigs}
+              configs={configs ?? []}
               targetId={targetId}
               updateTargetId={updateTargetId}
               databases={databases}

--- a/frontend/src/metabase/admin/performance/utils.tsx
+++ b/frontend/src/metabase/admin/performance/utils.tsx
@@ -304,7 +304,7 @@ export const translateConfig = <T extends CacheConfig>(
   config: T,
   direction: "fromAPI" | "toAPI",
 ): T => {
-  const translated = { ...config } as T;
+  const translated = { ...config, strategy: { ...config.strategy } } as T;
 
   // If strategy type is unsupported, use a fallback
   if (!isValidStrategyName(translated.strategy.type)) {

--- a/frontend/src/metabase/admin/performance/utils.tsx
+++ b/frontend/src/metabase/admin/performance/utils.tsx
@@ -300,11 +300,11 @@ export const getFieldsForStrategyType = (strategyType: CacheStrategyType) => {
   return fields;
 };
 
-export const translateConfig = (
-  config: CacheConfig,
+export const translateConfig = <T extends CacheConfig>(
+  config: T,
   direction: "fromAPI" | "toAPI",
-): CacheConfig => {
-  const translated: CacheConfig = { ...config };
+): T => {
+  const translated = { ...config } as T;
 
   // If strategy type is unsupported, use a fallback
   if (!isValidStrategyName(translated.strategy.type)) {
@@ -332,11 +332,11 @@ export const populateMinDurationSeconds = (strategy: AdaptiveStrategy) => ({
 });
 
 /** Translate a config from the API into a format the frontend can use */
-export const translateConfigFromAPI = (config: CacheConfig): CacheConfig =>
+export const translateConfigFromAPI = <T extends CacheConfig>(config: T): T =>
   translateConfig(config, "fromAPI");
 
 /** Translate a config from the frontend's format into the API's preferred format */
-export const translateConfigToAPI = (config: CacheConfig): CacheConfig =>
+export const translateConfigToAPI = <T extends CacheConfig>(config: T): T =>
   translateConfig(config, "toAPI");
 
 export const getPerformanceTabName = (tabId: PerformanceTabId) =>

--- a/frontend/src/metabase/api/cache-config.ts
+++ b/frontend/src/metabase/api/cache-config.ts
@@ -28,16 +28,37 @@ export const cacheConfigApi = Api.injectEndpoints({
       }),
       invalidatesTags: ["cache-config"],
     }),
-    deleteCacheConfig: builder.mutation<
+    deleteCacheConfigs: builder.mutation<
       void,
-      { model: CacheableModel; model_id: number }
+      { model: CacheableModel; model_id: number | number[] }
     >({
-      query: ({ model, model_id }) => ({
+      query: (body) => ({
         method: "DELETE",
         url: "/api/cache",
-        body: { model, model_id },
+        body,
       }),
+      extraOptions: {
+        hasBody: true,
+      },
       invalidatesTags: ["cache-config"],
+    }),
+    invalidateCacheConfigs: builder.mutation<
+      void,
+      {
+        include?: "overrides";
+        database?: number | number[];
+        dashboard?: number | number[];
+        question?: number | number[];
+      }
+    >({
+      query: (params) => ({
+        method: "POST",
+        url: "/api/cache/invalidate",
+        params,
+      }),
+      extraOptions: {
+        hasBody: false,
+      },
     }),
   }),
 });
@@ -45,5 +66,6 @@ export const cacheConfigApi = Api.injectEndpoints({
 export const {
   useListCacheConfigsQuery,
   useUpdateCacheConfigMutation,
-  useDeleteCacheConfigMutation,
+  useDeleteCacheConfigsMutation,
+  useInvalidateCacheConfigsMutation,
 } = cacheConfigApi;

--- a/frontend/src/metabase/api/cache-config.ts
+++ b/frontend/src/metabase/api/cache-config.ts
@@ -1,0 +1,49 @@
+import type {
+  CacheConfig,
+  CacheableModel,
+  ListCacheConfigsRequest,
+  ListCacheConfigsResponse,
+} from "metabase-types/api";
+
+import { Api } from "./api";
+
+export const cacheConfigApi = Api.injectEndpoints({
+  endpoints: (builder) => ({
+    listCacheConfigs: builder.query<
+      ListCacheConfigsResponse,
+      ListCacheConfigsRequest | void
+    >({
+      query: (params) => ({
+        method: "GET",
+        url: "/api/cache",
+        params,
+      }),
+      providesTags: ["cache-config"],
+    }),
+    updateCacheConfig: builder.mutation<CacheConfig, CacheConfig>({
+      query: (config) => ({
+        method: "PUT",
+        url: "/api/cache",
+        body: config,
+      }),
+      invalidatesTags: ["cache-config"],
+    }),
+    deleteCacheConfig: builder.mutation<
+      void,
+      { model: CacheableModel; model_id: number }
+    >({
+      query: ({ model, model_id }) => ({
+        method: "DELETE",
+        url: "/api/cache",
+        body: { model, model_id },
+      }),
+      invalidatesTags: ["cache-config"],
+    }),
+  }),
+});
+
+export const {
+  useListCacheConfigsQuery,
+  useUpdateCacheConfigMutation,
+  useDeleteCacheConfigMutation,
+} = cacheConfigApi;

--- a/frontend/src/metabase/api/index.ts
+++ b/frontend/src/metabase/api/index.ts
@@ -5,6 +5,7 @@ export * from "./api-key";
 export * from "./automagic-dashboards";
 export * from "./bookmark";
 export * from "./bug-report";
+export * from "./cache-config";
 export * from "./card";
 export * from "./channel";
 export * from "./cloud-migration";

--- a/frontend/src/metabase/api/query.ts
+++ b/frontend/src/metabase/api/query.ts
@@ -14,7 +14,7 @@ const isAllowedHTTPMethod = (method: any): method is AllowedHTTPMethods => {
 };
 
 // custom fetcher that wraps our Api client
-export const apiQuery: BaseQueryFn = async (args, ctx) => {
+export const apiQuery: BaseQueryFn = async (args, ctx, extraOptions) => {
   const method = typeof args === "string" ? "GET" : (args?.method ?? "GET");
   const url = typeof args === "string" ? args : args.url;
   const { bodyParamName, noEvent, formData, fetch } = args;
@@ -24,9 +24,6 @@ export const apiQuery: BaseQueryFn = async (args, ctx) => {
   }
 
   try {
-    // DELETE requests with body need hasBody: true to send JSON body instead of query params
-    const deleteWithBody = method === "DELETE" && args?.body != null;
-
     const response = await api[method](url)(
       // this will transform arrays to objects with numeric keys
       // we shouldn't be using top level-arrays in the API
@@ -37,7 +34,7 @@ export const apiQuery: BaseQueryFn = async (args, ctx) => {
         noEvent,
         formData,
         fetch,
-        ...(deleteWithBody && { hasBody: true }),
+        ...extraOptions,
       },
     );
     return { data: response };

--- a/frontend/src/metabase/api/query.ts
+++ b/frontend/src/metabase/api/query.ts
@@ -24,6 +24,9 @@ export const apiQuery: BaseQueryFn = async (args, ctx) => {
   }
 
   try {
+    // DELETE requests with body need hasBody: true to send JSON body instead of query params
+    const deleteWithBody = method === "DELETE" && args?.body != null;
+
     const response = await api[method](url)(
       // this will transform arrays to objects with numeric keys
       // we shouldn't be using top level-arrays in the API
@@ -34,8 +37,7 @@ export const apiQuery: BaseQueryFn = async (args, ctx) => {
         noEvent,
         formData,
         fetch,
-        // DELETE requests with body need hasBody: true to send JSON body instead of query params
-        hasBody: method === "DELETE" && args?.body != null,
+        ...(deleteWithBody && { hasBody: true }),
       },
     );
     return { data: response };

--- a/frontend/src/metabase/api/query.ts
+++ b/frontend/src/metabase/api/query.ts
@@ -34,6 +34,8 @@ export const apiQuery: BaseQueryFn = async (args, ctx) => {
         noEvent,
         formData,
         fetch,
+        // DELETE requests with body need hasBody: true to send JSON body instead of query params
+        hasBody: method === "DELETE" && args?.body != null,
       },
     );
     return { data: response };

--- a/frontend/src/metabase/api/tags/constants.ts
+++ b/frontend/src/metabase/api/tags/constants.ts
@@ -5,6 +5,7 @@ export const TAG_TYPES = [
   "alert",
   "api-key",
   "bookmark",
+  "cache-config",
   "card",
   "channel",
   "cloud-migration",

--- a/frontend/src/metabase/common/components/Table/Table.tsx
+++ b/frontend/src/metabase/common/components/Table/Table.tsx
@@ -5,7 +5,7 @@ import {
   PaginationControls,
   type PaginationControlsProps,
 } from "metabase/common/components/PaginationControls";
-import { Box, Flex, type FlexProps, Icon } from "metabase/ui";
+import { Box, Flex, type FlexProps, Icon, Stack } from "metabase/ui";
 import { SortDirection } from "metabase-types/api/sorting";
 
 import CS from "./Table.module.css";
@@ -22,7 +22,7 @@ export type TableProps<Row extends BaseRow> = {
   onSort?: (columnName: string, direction: SortDirection) => void;
   paginationProps?: Pick<
     PaginationControlsProps,
-    "page" | "pageSize" | "total"
+    "page" | "pageSize" | "total" | "showTotal"
   > & { onPageChange: (page: number) => void };
   emptyBody?: React.ReactNode;
   cols?: React.ReactNode;
@@ -57,7 +57,7 @@ export function Table<Row extends BaseRow>({
   ...rest
 }: TableProps<Row>) {
   return (
-    <>
+    <Stack gap="sm">
       <table className={cx(CS.Table, className)} {...rest}>
         {cols && <colgroup>{cols}</colgroup>}
         <thead>
@@ -104,6 +104,7 @@ export function Table<Row extends BaseRow>({
             page={paginationProps.page}
             pageSize={paginationProps.pageSize}
             total={paginationProps.total}
+            showTotal={paginationProps.showTotal}
             itemsLength={rows.length}
             onNextPage={() =>
               paginationProps.onPageChange(paginationProps.page + 1)
@@ -114,7 +115,7 @@ export function Table<Row extends BaseRow>({
           />
         </Flex>
       )}
-    </>
+    </Stack>
   );
 }
 

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -345,10 +345,3 @@ export const ActionsApi = {
     "/api/dashboard/:dashboardId/dashcard/:dashcardId/execute",
   ),
 };
-
-export const CacheConfigApi = {
-  list: GET("/api/cache"),
-  update: PUT("/api/cache"),
-  delete: DELETE("/api/cache"),
-  invalidate: POST("/api/cache/invalidate"),
-};

--- a/frontend/test/__support__/server-mocks/performance.ts
+++ b/frontend/test/__support__/server-mocks/performance.ts
@@ -2,7 +2,24 @@ import fetchMock from "fetch-mock";
 
 import type { CacheConfig } from "metabase-types/api";
 export function setupPerformanceEndpoints(cacheConfigs: CacheConfig[]) {
-  fetchMock.get("path:/api/cache", { data: cacheConfigs });
-  fetchMock.put("path:/api/cache", {});
-  fetchMock.delete("path:/api/cache", {});
+  let configs = [...cacheConfigs];
+
+  fetchMock.get("path:/api/cache", () => {
+    return { data: configs };
+  });
+
+  fetchMock.put("path:/api/cache", ({ options }) => {
+    const body = JSON.parse(options.body as string);
+    configs = [
+      ...configs.filter((config) => config.model_id !== body.model_id),
+      body,
+    ];
+    return {};
+  });
+
+  fetchMock.delete("path:/api/cache", ({ options }) => {
+    const body = JSON.parse(options.body as string);
+    configs = configs.filter((config) => config.model_id !== body.model_id);
+    return {};
+  });
 }

--- a/src/metabase/cache/api.clj
+++ b/src/metabase/cache/api.clj
@@ -132,11 +132,16 @@
              (not= model ["root"]))
     (throw (premium-features/ee-feature-error (tru "Granular Caching"))))
   (check-cache-access (first model) id)
-  (let [sort-params (select-keys params [:sort_column :sort_direction])]
-    {:data   (cache-config/get-list model collection id (request/limit) (request/offset) sort-params)
-     :total  (cache-config/get-list-total model collection id)
-     :limit  (request/limit)
-     :offset (request/offset)}))
+  (let [sort-params (select-keys params [:sort_column :sort_direction])
+        limit       (request/limit)
+        offset      (request/offset)
+        data        (cache-config/get-list model collection id limit offset sort-params)]
+    (if limit
+      {:data   data
+       :total  (cache-config/get-list-total model collection id)
+       :limit  limit
+       :offset offset}
+      {:data data})))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen

--- a/src/metabase/cache/api.clj
+++ b/src/metabase/cache/api.clj
@@ -5,6 +5,7 @@
    [metabase.cache.models.cache-config :as cache-config]
    [metabase.config.core :as config]
    [metabase.premium-features.core :as premium-features]
+   [metabase.request.core :as request]
    [metabase.util.cron :as u.cron]
    [metabase.util.i18n :refer [tru trun]]
    [metabase.util.malli :as mu]
@@ -114,21 +115,28 @@
 ;;
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/"
-  "Return cache configuration."
+  "Return cache configuration. Supports pagination via `limit` and `offset` query parameters,
+   and sorting via `sort_column` and `sort_direction`."
   [_route-params
-   {:keys [model collection id]}
-   :- [:map
-       [:model      {:default ["root"]} (mu/with (ms/QueryVectorOf cache-config/CachingModel)
-                                                 {:description "Type of model"})]
-       [:collection {:optional true} (mu/with [:maybe ms/PositiveInt]
-                                              {:description "Collection id to filter results. Returns everything if not supplied."})]
-       [:id         {:optional true} (mu/with [:maybe ms/PositiveInt]
-                                              {:description "Model id to get configuration for."})]]]
+   {:keys [model collection id] :as params}
+   :- [:merge
+       [:map
+        [:model      {:default ["root"]} (mu/with (ms/QueryVectorOf cache-config/CachingModel)
+                                                  {:description "Type of model"})]
+        [:collection {:optional true} (mu/with [:maybe ms/PositiveInt]
+                                               {:description "Collection id to filter results. Returns everything if not supplied."})]
+        [:id         {:optional true} (mu/with [:maybe ms/PositiveInt]
+                                               {:description "Model id to get configuration for."})]]
+       cache-config/SortParams]]
   (when (and (not (premium-features/enable-cache-granular-controls?))
              (not= model ["root"]))
     (throw (premium-features/ee-feature-error (tru "Granular Caching"))))
   (check-cache-access (first model) id)
-  {:data (cache-config/get-list model collection id)})
+  (let [sort-params (select-keys params [:sort_column :sort_direction])]
+    {:data   (cache-config/get-list model collection id (request/limit) (request/offset) sort-params)
+     :total  (cache-config/get-list-total model collection id)
+     :limit  (request/limit)
+     :offset (request/offset)}))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen

--- a/src/metabase/cache/models/cache_config.clj
+++ b/src/metabase/cache/models/cache_config.clj
@@ -7,11 +7,23 @@
    [metabase.events.core :as events]
    [metabase.models.interface :as mi]
    [metabase.util :as u]
+   [metabase.util.malli :as mu]
+   [metabase.util.malli.schema :as ms]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
 ;; TODO (Cam 10/3/25) -- change these to keywords and let API coercion convert them for us automatically
 (def CachingModel "Caching is configurable for those models" [:enum "root" "database" "dashboard" "question"])
+
+(def ^:private available-sort-columns
+  "Valid columns for sorting cache configs."
+  #{:name :collection :policy})
+
+(def SortParams
+  "Schema for sort parameters."
+  [:map
+   [:sort_column    {:default :name} (into [:enum] available-sort-columns)]
+   [:sort_direction {:default :asc}  [:enum :asc :desc]]])
 
 (doto :model/CacheConfig
   (derive :metabase/model)
@@ -46,13 +58,22 @@
   "Transform from how cache config is stored to how it's used/exposed in the API."
   [row]
   (when row
-    {:model    (:model row)
-     :model_id (:model_id row)
-     :strategy (-> (:config row)
-                   (assoc :type (:strategy row))
-                   (cond->
-                    (#{:duration :schedule} (:strategy row))
-                     (assoc :refresh_automatically (:refresh_automatically row))))}))
+    (cond-> {:model    (:model row)
+             :model_id (:model_id row)
+             :strategy (-> (:config row)
+                           (assoc :type (:strategy row))
+                           (cond->
+                            (#{:duration :schedule} (:strategy row))
+                             (assoc :refresh_automatically (:refresh_automatically row))))}
+      ;; Include name if present (from JOINed query)
+      (:item_name row)
+      (assoc :name (:item_name row))
+      ;; Include collection if present (from JOINed query)
+      (:collection_id row)
+      (assoc :collection {:id              (:collection_id row)
+                          :name            (:collection_name row)
+                          :authority_level (:collection_authority_level row)
+                          :type            (:collection_type row)}))))
 
 (defn card-strategy
   "Shapes `row` into strategy for a given `card`."
@@ -70,30 +91,69 @@
    :config                (dissoc strategy :type :refresh_automatically)
    :refresh_automatically (:refresh_automatically strategy)})
 
-(defn get-list
-  "Get a list of cache configurations for given `models` and a `collection`."
+(defn- sort-column->order-by
+  "Convert a sort column to the appropriate SQL order-by expression."
+  [sort-column]
+  (case sort-column
+    :name       [:coalesce :report_card.name :report_dashboard.name]
+    :collection [:coalesce :report_card.collection_id :report_dashboard.collection_id]
+    :policy     :cache_config.strategy))
+
+(defn- base-query
+  "Build the base query for cache configs with JOINs for name/collection access."
   [models collection id]
-  (->>
-   (if id
-     (t2/select :model/CacheConfig {:where [:and [:in :model models] [:= :model_id id]]})
-     (t2/select
-      :model/CacheConfig
-      :model [:in models]
-      {:left-join [:report_card      [:and
-                                      [:= :model [:inline "question"]]
-                                      [:= :model_id :report_card.id]
-                                      (when collection
-                                        [:= :report_card.collection_id collection])]
-                   :report_dashboard [:and
-                                      [:= :model [:inline "dashboard"]]
-                                      [:= :model_id :report_dashboard.id]
-                                      (when collection
-                                        [:= :report_dashboard.collection_id collection])]]
-       :where     [:case
-                   [:= :model [:inline "question"]]  [:!= :report_card.id nil]
-                   [:= :model [:inline "dashboard"]] [:!= :report_dashboard.id nil]
-                   :else                             true]}))
-   (mapv row->config)))
+  (if id
+    {:select [:cache_config.*]
+     :from   [:cache_config]
+     :where  [:and [:in :model models] [:= :model_id id]]}
+    {:select    [:cache_config.*
+                 [[:coalesce :report_card.name :report_dashboard.name] :item_name]
+                 [[:coalesce :report_card.collection_id :report_dashboard.collection_id] :collection_id]
+                 [:collection.name :collection_name]
+                 [:collection.authority_level :collection_authority_level]
+                 [:collection.type :collection_type]]
+     :from      [:cache_config]
+     :left-join [:report_card      [:and
+                                    [:= :model [:inline "question"]]
+                                    [:= :model_id :report_card.id]
+                                    (when collection
+                                      [:= :report_card.collection_id collection])]
+                 :report_dashboard [:and
+                                    [:= :model [:inline "dashboard"]]
+                                    [:= :model_id :report_dashboard.id]
+                                    (when collection
+                                      [:= :report_dashboard.collection_id collection])]
+                 :collection       [:= :collection.id
+                                    [:coalesce :report_card.collection_id
+                                     :report_dashboard.collection_id]]]
+     :where     [:case
+                 [:= :model [:inline "question"]]  [:!= :report_card.id nil]
+                 [:= :model [:inline "dashboard"]] [:!= :report_dashboard.id nil]
+                 :else                             true]}))
+
+(mu/defn get-list
+  "Get a list of cache configurations for given `models` and a `collection`.
+   Supports pagination via `limit` and `offset`, and sorting via `sort-params`."
+  [models collection id
+   limit       :- [:maybe ms/PositiveInt]
+   offset      :- [:maybe ms/IntGreaterThanOrEqualToZero]
+   sort-params :- [:maybe SortParams]]
+  (let [{:keys [sort_column sort_direction]
+         :or   {sort_column :name sort_direction :asc}} sort-params
+        query (cond-> (base-query models collection id)
+                true         (assoc :order-by [[(sort-column->order-by sort_column) sort_direction]])
+                limit        (assoc :limit limit)
+                offset       (assoc :offset offset))]
+    (->> (t2/select :model/CacheConfig query)
+         (mapv row->config))))
+
+(mu/defn get-list-total
+  "Get the total count of cache configurations for given `models` and a `collection`."
+  [models collection id]
+  (let [query (-> (base-query models collection id)
+                  (dissoc :select)
+                  (assoc :select [[[:count :*] :count]]))]
+    (:count (t2/query-one query))))
 
 (defn store!
   "Store cache configuration in DB."


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #68096
### Description

When there are a lot of questions or dashboards that are cached, the search request was erroring out due to such a long `&ids=x&ids=y...` call.

This PR switches the page to be paginated to avoid needing to fetch all the cache details at once and be such a huge page to go through as a user

Then, since we were changing the cache API anyway, made it join in the info needed by the page which was coming from the search API in the first place so we can also avoid the search call.

### Notes

Frontend code was mostly clauded, so LMK if that is close to right

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
