### PR TITLE
Fix the Glossary deduplication UX

### DIFF
--- a/frontend/src/metabase/reference/glossary/Glossary.module.css
+++ b/frontend/src/metabase/reference/glossary/Glossary.module.css
@@ -52,3 +52,9 @@
   border: none;
   padding-inline: 0 !important;
 }
+
+.inputError {
+  border: none;
+  padding-inline: 0 !important;
+  color: var(--mb-color-error) !important;
+}

--- a/frontend/src/metabase/reference/glossary/GlossaryTable.tsx
+++ b/frontend/src/metabase/reference/glossary/GlossaryTable.tsx
@@ -131,10 +131,12 @@ export function GlossaryTable({
         rowRenderer={(row) => {
           // Create row
           if ("kind" in row && row.kind === "create") {
+            const existingTerms = glossary.map((g) => g.term);
             return (
               <tr className={cx(S.row, S.rowEditor)}>
                 <GlossaryRowEditor
                   item={{ term: "", definition: "" }}
+                  existingTerms={existingTerms}
                   onCancel={() => setIsCreating(false)}
                   onSave={async (term, definition) => {
                     await onCreate(term, definition);
@@ -154,6 +156,9 @@ export function GlossaryTable({
                 <GlossaryRowEditor
                   item={item}
                   autoFocusField={editingField ?? "term"}
+                  existingTerms={glossary
+                    .filter((g) => g.id !== item.id)
+                    .map((g) => g.term)}
                   onCancel={() => setEditingId(null)}
                   onSave={async (newTerm, newDefinition) => {
                     await onEdit(item.id, newTerm, newDefinition);


### PR DESCRIPTION
Closes [UXW-2708](https://linear.app/metabase/issue/UXW-2708/fix-the-glossary-deduplication-ux)

### Description

This PR adds a safeguard to prevent duplicate terms from being added to the Data Studio Glossary.

### Demo

<img width="1714" height="542" alt="CleanShot 2026-01-15 at 12 16 17@2x" src="https://github.com/user-attachments/assets/32b9ec41-ef1a-4e8d-bae7-68267797c50a" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
