### PR TITLE
FE fixes for upstream dependencies

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListBody/ErrorsCell/ErrorsCell.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListBody/ErrorsCell/ErrorsCell.tsx
@@ -8,7 +8,7 @@ type ErrorsCellProps = {
 };
 
 export function ErrorsCell({ node }: ErrorsCellProps) {
-  const errors = node.errors ?? [];
+  const errors = node.dependents_errors ?? [];
   const errorsInfo = getDependencyErrorInfo(errors);
 
   if (!errorsInfo) {

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListBody/utils.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListBody/utils.tsx
@@ -19,10 +19,12 @@ import { ErrorsCell } from "./ErrorsCell";
 import { LocationCell } from "./LocationCell";
 import { NameCell } from "./NameCell";
 
-function getNodeNameColumn(): TreeTableColumnDef<DependencyNode> {
+function getNodeNameColumn(
+  mode: DependencyListMode,
+): TreeTableColumnDef<DependencyNode> {
   return {
     id: "name",
-    header: t`Name`,
+    header: mode === "broken" ? t`Dependency` : t`Name`,
     minWidth: 100,
     enableSorting: true,
     accessorFn: (node) => getNodeLabel(node),
@@ -53,14 +55,14 @@ function getNodeLocationColumn(): TreeTableColumnDef<DependencyNode> {
 
 function getNodeErrorsColumn(): TreeTableColumnDef<DependencyNode> {
   return {
-    id: "error",
-    header: t`Errors`,
+    id: "dependents-errors",
+    header: t`Problems`,
     minWidth: 100,
     enableSorting: false,
-    accessorFn: (node) => node.errors?.length ?? 0,
+    accessorFn: (node) => node.dependents_errors?.length ?? 0,
     cell: ({ row }) => {
       const node = row.original;
-      const errors = node.errors ?? [];
+      const errors = node.dependents_errors ?? [];
       if (errors.length === 0) {
         return null;
       }
@@ -72,7 +74,7 @@ function getNodeErrorsColumn(): TreeTableColumnDef<DependencyNode> {
 function getNodeDependentsCountColumn(): TreeTableColumnDef<DependencyNode> {
   return {
     id: "dependents-count",
-    header: t`Downstream dependents`,
+    header: t`Dependents`,
     minWidth: 100,
     enableSorting: true,
     accessorFn: (node) => getNodeDependentsCount(node),
@@ -87,7 +89,7 @@ export function getColumns(
   mode: DependencyListMode,
 ): TreeTableColumnDef<DependencyNode>[] {
   return [
-    getNodeNameColumn(),
+    getNodeNameColumn(mode),
     getNodeLocationColumn(),
     ...(mode === "broken" ? [getNodeErrorsColumn()] : []),
     ...(mode === "broken" ? [getNodeDependentsCountColumn()] : []),

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListHeader/ListHeader.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListHeader/ListHeader.tsx
@@ -12,7 +12,7 @@ import {
 export const ListHeader = memo(function ListHeader() {
   const tabs: PaneHeaderTab[] = [
     {
-      label: t`Broken entities`,
+      label: t`Broken dependencies`,
       to: Urls.brokenDependencies(),
       icon: "list",
     },

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListSidebar/ListSidebar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListSidebar/ListSidebar.tsx
@@ -20,7 +20,7 @@ export const ListSidebar = memo(function ListSidebar({
   node,
   onClose,
 }: ListSidebarProps) {
-  const errorGroups = getDependencyErrorGroups(node.errors ?? []);
+  const errorGroups = getDependencyErrorGroups(node.dependents_errors ?? []);
 
   return (
     <Stack

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListSidebar/SidebarErrorInfo/SidebarErrorInfo.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListSidebar/SidebarErrorInfo/SidebarErrorInfo.tsx
@@ -3,10 +3,7 @@ import { Ellipsified } from "metabase/common/components/Ellipsified";
 import { Card, Group, Stack, Title } from "metabase/ui";
 import type { DependencyError, DependencyErrorType } from "metabase-types/api";
 
-import {
-  getDependencyErrorDetail,
-  getDependencyErrorTypeCountMessage,
-} from "../../../../utils";
+import { getDependencyErrorTypeCountMessage } from "../../../../utils";
 
 import S from "./SidebarErrorInfo.module.css";
 
@@ -18,7 +15,7 @@ type SidebarErrorInfoProps = {
 export function SidebarErrorInfo({ type, errors }: SidebarErrorInfoProps) {
   const title = getDependencyErrorTypeCountMessage(type, errors.length);
   const details = errors
-    .map((error) => getDependencyErrorDetail(error))
+    .map((error) => error.detail)
     .filter((detail) => detail != null);
 
   return (

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/types.ts
@@ -26,5 +26,5 @@ export type DependentGroup = {
 
 export type DependencyErrorInfo = {
   label: string;
-  detail: string | null;
+  detail?: string | null;
 };

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/utils.ts
@@ -630,16 +630,16 @@ export function getDependentGroupLabel({
 
 export function getDependencyErrorTypeLabel(type: DependencyErrorType): string {
   switch (type) {
-    case "validate/missing-column":
+    case "missing-column":
       return t`Missing column`;
-    case "validate/missing-table-alias":
+    case "missing-table-alias":
       return t`Missing table alias`;
-    case "validate/duplicate-column":
+    case "duplicate-column":
       return t`Duplicate column`;
-    case "validate/syntax-error":
+    case "syntax-error":
       return t`Syntax error`;
-    case "validate/validation-error":
-      return t`Unknown error`;
+    case "validation-error":
+      return t`Unknown problem`;
   }
 }
 
@@ -648,50 +648,36 @@ export function getDependencyErrorTypeCountMessage(
   count: number,
 ): string {
   switch (type) {
-    case "validate/missing-column":
+    case "missing-column":
       return ngettext(
         msgid`${count} missing column`,
         `${count} missing columns`,
         count,
       );
-    case "validate/missing-table-alias":
+    case "missing-table-alias":
       return ngettext(
         msgid`${count} missing table alias`,
         `${count} missing table aliases`,
         count,
       );
-    case "validate/duplicate-column":
+    case "duplicate-column":
       return ngettext(
         msgid`${count} duplicate column`,
         `${count} duplicate columns`,
         count,
       );
-    case "validate/syntax-error":
+    case "syntax-error":
       return ngettext(
         msgid`${count} syntax error`,
         `${count} syntax errors`,
         count,
       );
-    case "validate/validation-error":
+    case "validation-error":
       return ngettext(
-        msgid`${count} unknown error`,
-        `${count} unknown errors`,
+        msgid`${count} unknown problem`,
+        `${count} unknown problems`,
         count,
       );
-  }
-}
-
-export function getDependencyErrorDetail(
-  error: DependencyError,
-): string | null {
-  switch (error.type) {
-    case "validate/missing-column":
-    case "validate/missing-table-alias":
-    case "validate/duplicate-column":
-      return error.name;
-    case "validate/syntax-error":
-    case "validate/validation-error":
-      return null;
   }
 }
 
@@ -705,7 +691,7 @@ export function getDependencyErrorInfo(
   if (errors.length === 1) {
     const [error] = errors;
     const label = getDependencyErrorTypeLabel(error.type);
-    const detail = getDependencyErrorDetail(error);
+    const detail = error.detail;
     return { label, detail };
   }
 
@@ -720,8 +706,8 @@ export function getDependencyErrorInfo(
 
   return {
     label: ngettext(
-      msgid`${errors.length} error`,
-      `${errors.length} errors`,
+      msgid`${errors.length} problem`,
+      `${errors.length} problems`,
       errors.length,
     ),
     detail: null,

--- a/frontend/src/metabase-types/api/dependencies.ts
+++ b/frontend/src/metabase-types/api/dependencies.ts
@@ -54,8 +54,8 @@ type BaseDependencyNode<TType extends DependencyType, TData> = {
   id: DependencyId;
   type: TType;
   data: TData;
-  errors?: DependencyError[] | null;
   dependents_count?: DependentsCount | null;
+  dependents_errors?: DependencyError[] | null;
 };
 
 export type TableDependencyNodeData = Pick<
@@ -200,45 +200,18 @@ export type DependencyNode =
   | MeasureDependencyNode;
 
 export const DEPENDENCY_ERROR_TYPES = [
-  "validate/missing-column",
-  "validate/missing-table-alias",
-  "validate/duplicate-column",
-  "validate/syntax-error",
-  "validate/validation-error",
+  "missing-column",
+  "missing-table-alias",
+  "duplicate-column",
+  "syntax-error",
+  "validation-error",
 ] as const;
 export type DependencyErrorType = (typeof DEPENDENCY_ERROR_TYPES)[number];
 
-type BaseDependencyError<TType extends DependencyErrorType> = {
-  type: TType;
+export type DependencyError = {
+  type: DependencyErrorType;
+  detail?: string | null;
 };
-
-export type MissingColumnDependencyError =
-  BaseDependencyError<"validate/missing-column"> & {
-    name: string;
-  };
-
-export type MissingTableAliasDependencyError =
-  BaseDependencyError<"validate/missing-table-alias"> & {
-    name: string;
-  };
-
-export type DuplicateColumnDependencyError =
-  BaseDependencyError<"validate/duplicate-column"> & {
-    name: string;
-  };
-
-export type SyntaxErrorDependencyError =
-  BaseDependencyError<"validate/syntax-error">;
-
-export type ValidationErrorDependencyError =
-  BaseDependencyError<"validate/validation-error">;
-
-export type DependencyError =
-  | MissingColumnDependencyError
-  | MissingTableAliasDependencyError
-  | DuplicateColumnDependencyError
-  | SyntaxErrorDependencyError
-  | ValidationErrorDependencyError;
 
 export type DependencyEdge = {
   from_entity_id: DependencyId;


### PR DESCRIPTION
`errors` -> `dependents_errors`
fields in errors are now `type` and `detail`, matching closer the underlying model.
no `validate/` prefix