### PR TITLE
Add pre-commit hook to auto-fix unused requires flagged by clj-kondo

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,8 +1,5 @@
 yarn precommit
 
-# Fix unused requires flagged by clj-kondo (automatically removes them)
-./bin/mage fix-unused-requires-staged
-
 # Run the formatter
 # Note that this is stubbed in for now until we can gobally resolve some formatting issues such as what is described
 # here: https://github.com/metabase/metabase/pull/35511#pullrequestreview-1721758128

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,8 @@
 yarn precommit
 
+# Fix unused requires flagged by clj-kondo (automatically removes them)
+./bin/mage fix-unused-requires-staged
+
 # Run the formatter
 # Note that this is stubbed in for now until we can gobally resolve some formatting issues such as what is described
 # here: https://github.com/metabase/metabase/pull/35511#pullrequestreview-1721758128

--- a/bb.edn
+++ b/bb.edn
@@ -83,6 +83,21 @@
    :requires [[mage.kondo :as kondo]]
    :task (task! (kondo/kondo-updated (:arguments parsed)))}
 
+  fix-unused-requires
+  {:doc "Removes unused requires flagged by clj-kondo"
+   :examples [["./bin/mage fix-unused-requires src/metabase/lib/validate.cljc" "Fix unused requires in a specific file"]
+              ["./bin/mage fix-unused-requires src" "Fix unused requires in all files in src"]]
+   :requires [[mage.fix-unused-requires :as fix]]
+   :arg-schema [:sequential [:string {:name "file-or-directory"
+                                      :description "Files or directories to fix unused requires in"}]]
+   :task (task! (fix/fix-files parsed))}
+
+  fix-unused-requires-staged
+  {:doc "Removes unused requires in staged files"
+   :examples [["./bin/mage fix-unused-requires-staged" "Fix unused requires in staged files"]]
+   :requires [[mage.fix-unused-requires :as fix]]
+   :task (task! (fix/fix-staged parsed))}
+
   check
   {:doc "Checks whether we can compile all source files (and finds circular dependencies)"
    :examples [["./bin/mage check"]]

--- a/bb.edn
+++ b/bb.edn
@@ -92,12 +92,6 @@
                                       :description "Files or directories to fix unused requires in"}]]
    :task (task! (fix/fix-files parsed))}
 
-  fix-unused-requires-staged
-  {:doc "Removes unused requires in staged files"
-   :examples [["./bin/mage fix-unused-requires-staged" "Fix unused requires in staged files"]]
-   :requires [[mage.fix-unused-requires :as fix]]
-   :task (task! (fix/fix-staged parsed))}
-
   check
   {:doc "Checks whether we can compile all source files (and finds circular dependencies)"
    :examples [["./bin/mage check"]]

--- a/lint-staged.config.cjs
+++ b/lint-staged.config.cjs
@@ -15,7 +15,10 @@ module.exports = {
     "eslint --rulesdir frontend/lint/eslint-rules --max-warnings 0 --fix",
     "prettier --write",
   ],
-  "**/*.{clj,cljc,cljs,bb}": ["./bin/mage cljfmt-files"],
+  "**/*.{clj,cljc,cljs,bb}": [
+    "./bin/mage cljfmt-files",
+    "./bin/mage fix-unused-requires",
+  ],
   "e2e/test/scenarios/*/{*.(js|ts),!(helpers|shared)/*.(js|ts)}": [
     "node e2e/validate-e2e-test-files.js",
   ],

--- a/mage/src/mage/fix_unused_requires.clj
+++ b/mage/src/mage/fix_unused_requires.clj
@@ -8,8 +8,6 @@
    [mage.util :as u]
    [rewrite-clj.zip :as z]))
 
-;; NOTE: This is invoked via lint-staged which handles re-staging modified files automatically.
-
 (set! *warn-on-reflection* true)
 
 (defn- run-kondo

--- a/mage/src/mage/fix_unused_requires.clj
+++ b/mage/src/mage/fix_unused_requires.clj
@@ -156,17 +156,6 @@
         (println (c/green "Done!")))
       (println (c/green "No unused requires found.")))))
 
-(defn fix-staged
-  "Fix unused requires in staged Clojure files.
-   Re-stages files after fixing them so the commit includes the fix."
-  [_parsed]
-  (let [staged-files (u/staged-files)]
-    (if (seq staged-files)
-      (do
-        (println (c/cyan (str "Checking " (count staged-files) " staged file(s)...")))
-        (fix-unused-requires! staged-files {:restage? true}))
-      (println "No staged Clojure files."))))
-
 (defn fix-files
   "Fix unused requires in specified files."
   [{:keys [arguments]}]

--- a/mage/src/mage/fix_unused_requires.clj
+++ b/mage/src/mage/fix_unused_requires.clj
@@ -1,0 +1,175 @@
+(ns mage.fix-unused-requires
+  "Fix unused requires reported by clj-kondo by removing them from source files."
+  (:require
+   [babashka.process :as p]
+   [clojure.edn :as edn]
+   [clojure.string :as str]
+   [mage.color :as c]
+   [mage.util :as u]
+   [rewrite-clj.zip :as z]))
+
+(set! *warn-on-reflection* true)
+
+(defn- run-kondo
+  "Run clj-kondo on the given files and return the EDN output."
+  [files]
+  (let [{:keys [out exit]}
+        (p/sh {:out :string
+               :err :inherit
+               :dir u/project-root-directory}
+              "clojure" "-M:kondo"
+              "--config" "{:output {:format :edn}}"
+              "--lint" (str/join ":" files))]
+    (when (and (not= exit 0) (seq out))
+      (edn/read-string out))))
+
+(defn- unused-namespace-findings
+  "Filter findings to only unused-namespace warnings."
+  [findings]
+  (->> findings
+       (filter #(= :unused-namespace (:type %)))))
+
+(defn- group-by-file
+  "Group findings by filename."
+  [findings]
+  (group-by :filename findings))
+
+(defn- find-require-form
+  "Navigate to the :require form inside an ns declaration."
+  [zloc]
+  (loop [loc (z/down zloc)]
+    (when loc
+      (let [node (z/sexpr loc)]
+        (if (and (sequential? node)
+                 (= :require (first node)))
+          loc
+          (recur (z/right loc)))))))
+
+(defn- namespace-matches?
+  "Check if a require spec matches the given namespace symbol."
+  [ns-sym spec]
+  (cond
+    ;; Simple symbol: [foo.bar]
+    (symbol? spec)
+    (= ns-sym spec)
+
+    ;; Vector form: [foo.bar :as f] or [foo.bar :refer [...]]
+    (vector? spec)
+    (= ns-sym (first spec))
+
+    ;; List/seq form for prefix notation: (foo bar baz) meaning foo.bar foo.baz
+    ;; This is complex and uncommon, skip for now
+    :else false))
+
+(defn- remove-require-entry
+  "Remove a require entry matching the namespace from a :require form.
+   Returns the updated zipper location positioned at the root of the require form."
+  [require-loc ns-sym]
+  (loop [loc (z/down require-loc)]
+    (if (nil? loc)
+      ;; No more children, return the require form unchanged
+      require-loc
+      (let [sexpr (try (z/sexpr loc) (catch Exception _ nil))]
+        (cond
+          ;; Skip the :require keyword and whitespace/comments (nil sexpr)
+          (or (nil? sexpr)
+              (= :require sexpr)
+              (not (namespace-matches? ns-sym sexpr)))
+          (recur (z/right loc))
+
+          ;; Found the matching entry, remove it and return to root
+          :else
+          (-> loc z/remove z/up))))))
+
+(defn- require-form-empty?
+  "Check if a require form only contains the :require keyword (no actual requires)."
+  [require-loc]
+  (let [children (loop [loc (z/down require-loc)
+                        result []]
+                   (if (nil? loc)
+                     result
+                     (let [sexpr (try (z/sexpr loc) (catch Exception _ nil))]
+                       (recur (z/right loc)
+                              (if (and sexpr (not= :require sexpr))
+                                (conj result sexpr)
+                                result)))))]
+    (empty? children)))
+
+(defn- fix-file!
+  "Fix unused requires in a single file.
+   Returns true if changes were made."
+  [filename unused-namespaces]
+  (let [content (slurp filename)
+        zloc (z/of-string content {:track-position? true})
+        ;; Find the ns form
+        ns-loc (loop [loc zloc]
+                 (when loc
+                   (let [node (z/sexpr loc)]
+                     (if (and (sequential? node)
+                              (= 'ns (first node)))
+                       loc
+                       (recur (z/right loc))))))]
+    (when ns-loc
+      (when-let [require-loc (find-require-form ns-loc)]
+        (let [updated-require
+              (reduce
+               (fn [loc ns-sym]
+                 (or (remove-require-entry loc ns-sym) loc))
+               require-loc
+               unused-namespaces)
+              ;; If require form is now empty, remove the entire :require form
+              final-loc (if (require-form-empty? updated-require)
+                          (z/remove updated-require)
+                          updated-require)
+              new-content (z/root-string final-loc)]
+          (when (not= content new-content)
+            (spit filename new-content)
+            true))))))
+
+(defn- fix-unused-requires!
+  "Main function to fix unused requires.
+   Takes a list of files to check.
+   Options:
+   - :restage? - if true, re-stage the files after fixing (for pre-commit hooks)"
+  [files {:keys [restage?]}]
+  (println (c/cyan "Running clj-kondo to find unused requires..."))
+  (let [kondo-result (run-kondo files)]
+    (if-let [findings (seq (unused-namespace-findings (:findings kondo-result)))]
+      (let [by-file (group-by-file findings)
+            fixed-files (atom [])]
+        (println (c/yellow (str "Found " (count findings) " unused require(s) in "
+                                (count by-file) " file(s)")))
+        (doseq [[filename file-findings] by-file]
+          (let [unused-ns (mapv :ns file-findings)]
+            (println (str "  " (c/white filename) ": removing "
+                          (str/join ", " (map #(c/red (str %)) unused-ns))))
+            (try
+              (when (fix-file! filename unused-ns)
+                (swap! fixed-files conj filename))
+              (catch Exception e
+                (println (c/red (str "  Error fixing " filename ": " (ex-message e))))))))
+        ;; Re-stage files if requested (for pre-commit hook)
+        (when (and restage? (seq @fixed-files))
+          (println (c/cyan "Re-staging fixed files..."))
+          (doseq [f @fixed-files]
+            (p/sh {:dir u/project-root-directory} "git" "add" f)))
+        (println (c/green "Done!")))
+      (println (c/green "No unused requires found.")))))
+
+(defn fix-staged
+  "Fix unused requires in staged Clojure files.
+   Re-stages files after fixing them so the commit includes the fix."
+  [_parsed]
+  (let [staged-files (u/staged-files)]
+    (if (seq staged-files)
+      (do
+        (println (c/cyan (str "Checking " (count staged-files) " staged file(s)...")))
+        (fix-unused-requires! staged-files {:restage? true}))
+      (println "No staged Clojure files."))))
+
+(defn fix-files
+  "Fix unused requires in specified files."
+  [{:keys [arguments]}]
+  (if (seq arguments)
+    (fix-unused-requires! arguments {})
+    (println (c/red "No files specified."))))

--- a/mage/test/mage/core_test.clj
+++ b/mage/test/mage/core_test.clj
@@ -7,6 +7,7 @@
    [clojure.test :refer [deftest is testing]]
    [mage.alias-test]
    [mage.doctor-test]
+   [mage.fix-unused-requires-test]
    [mage.merge-yaml-migrations-test :as merge-yaml-migrations-test]
    [mage.modules-test]
    [mage.token-scan-test]
@@ -16,6 +17,7 @@
 (comment
   ;; Load test namespaces to ensure code coverage
   mage.doctor-test/keep-me
+  mage.fix-unused-requires-test/keep-me
   mage.util-test/keep-me
   mage.modules-test/keep-me
   merge-yaml-migrations-test/keep-me

--- a/mage/test/mage/fix_unused_requires_test.clj
+++ b/mage/test/mage/fix_unused_requires_test.clj
@@ -1,0 +1,144 @@
+(ns mage.fix-unused-requires-test
+  (:require
+   [babashka.fs :as fs]
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]
+   [mage.fix-unused-requires :as fix]
+   [mage.util :as u]))
+
+(def ^:private test-dir (str u/project-root-directory "/mage/test/mage/fix_unused_requires_test_files"))
+
+(defn- test-file [name]
+  (str test-dir "/" name))
+
+(defn- with-test-file
+  "Creates a temp test file with the given content, runs f, then cleans up."
+  [filename content f]
+  (fs/create-dirs test-dir)
+  (let [path (test-file filename)]
+    (try
+      (spit path content)
+      (f path)
+      (finally
+        (fs/delete-if-exists path)
+        (fs/delete-if-exists test-dir)))))
+
+(deftest fix-single-unused-require-test
+  (testing "Removes a single unused require"
+    (with-test-file
+      "single_unused.cljc"
+      "(ns test.single-unused
+  (:require
+   [medley.core :as m]
+   [clojure.string :as str]))
+
+(defn foo []
+  (str/upper-case \"hello\"))"
+      (fn [path]
+        (fix/fix-files {:arguments [path]})
+        (let [result (slurp path)]
+          (is (not (str/includes? result "medley.core"))
+              "medley.core should be removed")
+          (is (str/includes? result "clojure.string")
+              "clojure.string should remain"))))))
+
+(deftest fix-multiple-unused-requires-test
+  (testing "Removes multiple unused requires"
+    (with-test-file
+      "multiple_unused.cljc"
+      "(ns test.multiple-unused
+  (:require
+   [medley.core :as m]
+   [clojure.set :as set]
+   [clojure.string :as str]
+   [clojure.walk :as walk]))
+
+(defn foo []
+  (str/upper-case \"hello\"))"
+      (fn [path]
+        (fix/fix-files {:arguments [path]})
+        (let [result (slurp path)]
+          (is (not (str/includes? result "medley.core"))
+              "medley.core should be removed")
+          (is (not (str/includes? result "clojure.set"))
+              "clojure.set should be removed")
+          (is (not (str/includes? result "clojure.walk"))
+              "clojure.walk should be removed")
+          (is (str/includes? result "clojure.string")
+              "clojure.string should remain"))))))
+
+(deftest fix-all-requires-removed-test
+  (testing "Removes entire :require form when all requires are unused"
+    (with-test-file
+      "all_unused.cljc"
+      "(ns test.all-unused
+  (:require
+   [medley.core :as m]
+   [clojure.set :as set]))
+
+(defn foo []
+  42)"
+      (fn [path]
+        (fix/fix-files {:arguments [path]})
+        (let [result (slurp path)]
+          (is (not (str/includes? result ":require"))
+              ":require form should be removed entirely")
+          (is (str/includes? result "(ns test.all-unused)")
+              "ns form should remain"))))))
+
+(deftest no-unused-requires-test
+  (testing "Does nothing when there are no unused requires"
+    (with-test-file
+      "no_unused.cljc"
+      "(ns test.no-unused
+  (:require
+   [clojure.string :as str]))
+
+(defn foo []
+  (str/upper-case \"hello\"))"
+      (fn [path]
+        (let [original (slurp path)]
+          (fix/fix-files {:arguments [path]})
+          (is (= original (slurp path))
+              "File should not be modified"))))))
+
+(deftest no-require-form-test
+  (testing "Handles files without :require form"
+    (with-test-file
+      "no_require.cljc"
+      "(ns test.no-require)
+
+(defn foo []
+  42)"
+      (fn [path]
+        (let [original (slurp path)]
+          (fix/fix-files {:arguments [path]})
+          (is (= original (slurp path))
+              "File should not be modified"))))))
+
+(deftest preserves-other-ns-forms-test
+  (testing "Preserves :import and other ns forms"
+    (with-test-file
+      "with_import.cljc"
+      "(ns test.with-import
+  (:require
+   [medley.core :as m]
+   [clojure.string :as str])
+  (:import
+   [java.util UUID]))
+
+(defn foo []
+  (str/upper-case (str (UUID/randomUUID))))"
+      (fn [path]
+        (fix/fix-files {:arguments [path]})
+        (let [result (slurp path)]
+          (is (not (str/includes? result "medley.core"))
+              "medley.core should be removed")
+          (is (str/includes? result "clojure.string")
+              "clojure.string should remain")
+          (is (str/includes? result ":import")
+              ":import form should remain")
+          (is (str/includes? result "java.util UUID")
+              "UUID import should remain"))))))
+
+(def keep-me "Ensures this namespace is loaded by mage.core-test")


### PR DESCRIPTION
Resolves DEV-1274

## Summary

- Adds a new `fix-unused-requires` mage task that automatically removes unused require statements detected by clj-kondo
- Integrates with lint-staged to run on staged .clj, .cljc, .cljs, and .bb files during pre-commit
- Prevents CI failures like https://github.com/metabase/metabase/actions/runs/21047115883/job/60524244990?pr=68092 where kondo reports unused requires

### How it works

  1. Runs **clj-kondo** with EDN output to detect `:unused-namespace` warnings
  2. Uses *rewrite-clj** to parse the source and remove the unused require entries
  3. Removes the entire `:require` form if all requires become unused
  4. **lint-staged** automatically re-stages the fixed files

### Test plan

  - Verify ./bin/mage fix-unused-requires <file> removes unused requires from a file
  - Verify lint-staged runs the fix on staged Clojure files during commit
  - Verify ./bin/mage -test fix-unused passes (6 tests covering single/multiple removal, edge cases)


🤖 Generated with [Claude Code](https://claude.com/claude-code)

- [x] Tests have been added/updated to cover changes in this PR
