### PR TITLE
add started-at filter to task runs page

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1456,6 +1456,7 @@
            models
            permissions
            premium-features
+           query-processor
            request
            task
            util}}

--- a/e2e/test/scenarios/admin/tools/tools.cy.spec.ts
+++ b/e2e/test/scenarios/admin/tools/tools.cy.spec.ts
@@ -139,17 +139,14 @@ describe("issue 14636", () => {
       "have.value",
       "field values scanning",
     );
-    cy.findByPlaceholderText("Filter by status").should(
-      "have.value",
-      "Success",
-    );
+    getFilterByStatus().should("have.value", "Success");
     cy.findAllByTestId("task").should("have.length", 1);
     cy.findByTestId("task")
       .should("contain.text", "field values scanning")
       .and("contain.text", "Sample Database")
       .and("contain.text", "Success");
 
-    cy.findByPlaceholderText("Filter by status").click();
+    getFilterByStatus().click();
     H.popover().findByText("Failed").click();
     cy.location("search").should(
       "eq",
@@ -161,12 +158,9 @@ describe("issue 14636", () => {
       "No results",
     );
 
-    cy.findByPlaceholderText("Filter by status")
-      .parent()
-      .findByLabelText("Clear")
-      .click();
+    getFilterByStatus().parent().findByLabelText("Clear").click();
     cy.location("search").should("eq", "?task=field+values+scanning");
-    cy.findByPlaceholderText("Filter by status").should("have.value", "");
+    getFilterByStatus().should("have.value", "");
     cy.findAllByTestId("task").should("have.length", 1);
     cy.findByTestId("task")
       .should("contain.text", "field values scanning")
@@ -184,14 +178,14 @@ describe("issue 14636", () => {
 
     cy.log("should reset pagination when changing filters");
     cy.visit("/admin/tools/tasks/list?page=1");
-    cy.findByPlaceholderText("Filter by status").click();
+    getFilterByStatus().click();
     H.popover().findByText("Success").click();
     cy.location("search").should("eq", "?status=success");
 
     cy.log("should remove invalid query params");
     cy.visit("/admin/tools/tasks/list?status=foobar");
     cy.location("search").should("eq", "");
-    cy.findByPlaceholderText("Filter by status").should("have.value", "");
+    getFilterByStatus().should("have.value", "");
   });
 });
 
@@ -832,54 +826,40 @@ describe("scenarios > admin > tools > task runs filtering", () => {
     cy.wait("@getTaskRuns");
 
     cy.log("Filter by run type");
-    cy.findByPlaceholderText("Filter by run type").click();
+    getFilterByRun().click();
     H.popover().findByText("Sync").click();
     cy.location("search").should("contain", "run-type=sync");
+    cy.wait("@getTaskRuns");
+    cy.log("Filter by started at");
+    getFilterByStartedAt().click();
+    H.popover().findByText("Previous 30 days").click();
+    cy.location("search").should("contain", "started-at=past30days");
     cy.wait("@getTaskRuns");
 
     cy.wait("@getEntities");
     cy.log("Filter by entity");
-    cy.findByPlaceholderText("Filter by entity").click();
+    getFilterByEntity().click();
     H.popover().findByText("Sample Database").click();
     cy.location("search").should("contain", "entity-type=database");
     cy.location("search").should("contain", "entity-id=1");
     cy.wait("@getTaskRuns");
 
     cy.log("Filter by status");
-    cy.findByPlaceholderText("Filter by status").click();
+    getFilterByStatus().click();
     H.popover().findByText("Success").click();
     cy.location("search").should("contain", "status=success");
     cy.wait("@getTaskRuns");
 
     cy.log("Clear all filters");
-    cy.findByPlaceholderText("Filter by run type")
-      .parent()
-      .findByLabelText("Clear")
-      .click();
-    cy.findByPlaceholderText("Filter by status")
-      .parent()
-      .findByLabelText("Clear")
-      .click();
+    getFilterByRun().parent().findByLabelText("Clear").click();
+    getFilterByStartedAt().parent().findByLabelText("Clear").click();
+    getFilterByStatus().parent().findByLabelText("Clear").click();
     cy.location("search").should("eq", "");
   });
 
-  it("entity picker should be disabled/enabled based on run type and entities availability", () => {
+  it("entity picker should be disabled/enabled based on run type, started at and entities availability", () => {
     cy.visit("/admin/tools/tasks/runs");
     cy.wait("@getTaskRuns");
-
-    cy.log("Should be disabled when no run type is selected");
-    cy.findByPlaceholderText("Filter by entity").should("be.disabled");
-
-    cy.log("Should show tooltip 'Select a run type first' when hovering");
-    cy.findByPlaceholderText("Filter by entity").trigger("mouseenter", {
-      force: true,
-    });
-    cy.findByRole("tooltip").should("have.text", "Select a run type first");
-    cy.findByPlaceholderText("Filter by entity").trigger("mouseleave", {
-      force: true,
-    });
-
-    cy.log("Should show loader while loading entities");
     cy.intercept("GET", "/api/task/runs/entities?*", {
       body: [
         {
@@ -891,10 +871,24 @@ describe("scenarios > admin > tools > task runs filtering", () => {
       delay: 500,
     }).as("getEntitiesDelayed");
 
-    cy.findByPlaceholderText("Filter by run type").click();
+    cy.log("Should be disabled when no run type is selected");
+    getFilterByEntity().should("be.disabled");
+    assertFilterByEntityTooltipText("Select a run type first");
+
+    getFilterByRun().click();
     H.popover().findByText("Sync").click();
 
-    cy.findByPlaceholderText("Filter by entity")
+    cy.log("Should be still disabled until started at is selected");
+    getFilterByEntity().should("be.disabled");
+
+    cy.log("Should show tooltip 'Select a start time' when hovering");
+    assertFilterByEntityTooltipText("Select a start time");
+
+    getFilterByStartedAt().click();
+    H.popover().findByText("Previous 30 days").click();
+
+    cy.log("Should show loader while loading entities");
+    getFilterByEntity()
       .should("be.disabled")
       .closest(".mb-mantine-Select-root")
       .find(".mb-mantine-Loader-root")
@@ -903,30 +897,56 @@ describe("scenarios > admin > tools > task runs filtering", () => {
     cy.wait("@getEntitiesDelayed");
 
     cy.log("Should be enabled after entities are loaded");
-    cy.findByPlaceholderText("Filter by entity").should("not.be.disabled");
+    getFilterByEntity().should("not.be.disabled");
 
     cy.log("Should clear and disable entity filter when run type is cleared");
-    cy.findByPlaceholderText("Filter by run type")
-      .parent()
-      .findByLabelText("Clear")
-      .click();
+    getFilterByRun().parent().findByLabelText("Clear").click();
 
-    cy.findByPlaceholderText("Filter by entity").should("be.disabled");
-    cy.findByPlaceholderText("Filter by entity").should("have.value", "");
+    getFilterByEntity().should("be.disabled");
+    getFilterByEntity().should("have.value", "");
+
+    cy.log("Should clear and disable entity filter when started at is cleared");
+    getFilterByRun().click();
+    H.popover().findByText("Sync").click();
+    getFilterByStartedAt().parent().findByLabelText("Clear").click();
+
+    getFilterByEntity().should("be.disabled");
+    getFilterByEntity().should("have.value", "");
 
     cy.log("Should show tooltip 'No entities available' when no entities");
     cy.intercept("GET", "/api/task/runs/entities?*", {
       body: [],
     }).as("getEmptyEntities");
 
-    cy.findByPlaceholderText("Filter by run type").click();
+    getFilterByRun().click();
     H.popover().findByText("Alert").click();
+    getFilterByStartedAt().click();
+    H.popover().findByText("Previous 30 days").click();
     cy.wait("@getEmptyEntities");
 
-    cy.findByPlaceholderText("Filter by entity").should("be.disabled");
-    cy.findByPlaceholderText("Filter by entity").trigger("mouseenter", {
-      force: true,
-    });
-    cy.findByRole("tooltip").should("have.text", "No entities available");
+    getFilterByEntity().should("be.disabled");
+    assertFilterByEntityTooltipText("No entities available");
   });
 });
+
+function getFilterByRun() {
+  return cy.findByPlaceholderText("Filter by run type");
+}
+function getFilterByStartedAt() {
+  return cy.findByPlaceholderText("Filter by started at");
+}
+
+function getFilterByEntity() {
+  return cy.findByPlaceholderText("Filter by entity");
+}
+
+function getFilterByStatus() {
+  return cy.findByPlaceholderText("Filter by status");
+}
+
+function assertFilterByEntityTooltipText(text: string) {
+  getFilterByEntity().trigger("mouseenter", {
+    force: true,
+  });
+  cy.findByRole("tooltip").should("have.text", text);
+}

--- a/e2e/test/scenarios/admin/tools/tools.cy.spec.ts
+++ b/e2e/test/scenarios/admin/tools/tools.cy.spec.ts
@@ -882,7 +882,7 @@ describe("scenarios > admin > tools > task runs filtering", () => {
     getFilterByEntity().should("be.disabled");
 
     cy.log("Should show tooltip 'Select a start time' when hovering");
-    assertFilterByEntityTooltipText("Select a start time");
+    assertFilterByEntityTooltipText("Select a start time first");
 
     getFilterByStartedAt().click();
     H.popover().findByText("Previous 30 days").click();

--- a/frontend/src/metabase-types/api/task.ts
+++ b/frontend/src/metabase-types/api/task.ts
@@ -67,6 +67,15 @@ export type TaskInfo = {
 export type TaskRunType = "subscription" | "alert" | "sync" | "fingerprint";
 export type TaskRunEntityType = "database" | "card" | "dashboard";
 export type TaskRunStatus = "started" | "success" | "failed" | "abandoned";
+export type TaskRunDateFilterOption =
+  | "thisday"
+  | "past1days"
+  | "past1weeks"
+  | "past7days"
+  | "past30days"
+  | "past1months"
+  | "past3months"
+  | "past12months";
 
 export interface TaskRun {
   id: number;
@@ -97,6 +106,7 @@ export type ListTaskRunsRequest = {
   "entity-type"?: TaskRunEntityType;
   "entity-id"?: number;
   status?: TaskRunStatus;
+  "started-at"?: TaskRunDateFilterOption;
 } & PaginationRequest;
 
 export type ListTaskRunsResponse = {
@@ -105,4 +115,5 @@ export type ListTaskRunsResponse = {
 
 export type ListTaskRunEntitiesRequest = {
   "run-type": TaskRunType;
+  "started-at": TaskRunDateFilterOption;
 };

--- a/frontend/src/metabase-types/api/task.ts
+++ b/frontend/src/metabase-types/api/task.ts
@@ -69,13 +69,13 @@ export type TaskRunEntityType = "database" | "card" | "dashboard";
 export type TaskRunStatus = "started" | "success" | "failed" | "abandoned";
 export type TaskRunDateFilterOption =
   | "thisday"
-  | "past1days"
-  | "past1weeks"
-  | "past7days"
-  | "past30days"
-  | "past1months"
-  | "past3months"
-  | "past12months";
+  | "past1days~"
+  | "past1weeks~"
+  | "past7days~"
+  | "past30days~"
+  | "past1months~"
+  | "past3months~"
+  | "past12months~";
 
 export interface TaskRun {
   id: number;

--- a/frontend/src/metabase/admin/tools/components/TaskRunEntityPicker/TaskRunEntityPicker.tsx
+++ b/frontend/src/metabase/admin/tools/components/TaskRunEntityPicker/TaskRunEntityPicker.tsx
@@ -87,7 +87,7 @@ export const TaskRunEntityPicker = ({
   }
 
   if (!startedAt) {
-    return <Tooltip label={t`Select a start time`}>{select}</Tooltip>;
+    return <Tooltip label={t`Select a start time first`}>{select}</Tooltip>;
   }
 
   if (!isLoading && data.length === 0) {

--- a/frontend/src/metabase/admin/tools/components/TaskRunEntityPicker/TaskRunEntityPicker.tsx
+++ b/frontend/src/metabase/admin/tools/components/TaskRunEntityPicker/TaskRunEntityPicker.tsx
@@ -3,7 +3,7 @@ import { t } from "ttag";
 
 import { skipToken, useListTaskRunEntitiesQuery } from "metabase/api";
 import { Loader, Select, type SelectProps, Tooltip } from "metabase/ui";
-import type { TaskRunType } from "metabase-types/api";
+import type { TaskRunDateFilterOption, TaskRunType } from "metabase-types/api";
 
 import type { EntityValue } from "./types";
 import {
@@ -17,18 +17,26 @@ type TaskRunEntityPickerProps = Omit<
   "data" | "value" | "onChange"
 > & {
   runType: TaskRunType | null;
+  startedAt: TaskRunDateFilterOption | null;
   value: EntityValue | null;
   onChange: (value: EntityValue | null) => void;
 };
 
 export const TaskRunEntityPicker = ({
   runType,
+  startedAt,
   value,
   onChange,
   ...props
 }: TaskRunEntityPickerProps) => {
+  const hasAllRequiredParams = runType && startedAt;
   const { data: entities, isLoading } = useListTaskRunEntitiesQuery(
-    runType ? { "run-type": runType } : skipToken,
+    hasAllRequiredParams
+      ? {
+          "run-type": runType,
+          "started-at": startedAt,
+        }
+      : skipToken,
   );
 
   const data = useMemo(
@@ -47,7 +55,8 @@ export const TaskRunEntityPicker = ({
     onChange(parsed);
   };
 
-  const isDisabled = isLoading || !runType || (!isLoading && data.length === 0);
+  const isDisabled =
+    isLoading || !hasAllRequiredParams || (!isLoading && data.length === 0);
 
   const select = (
     <Select
@@ -75,6 +84,10 @@ export const TaskRunEntityPicker = ({
 
   if (!runType) {
     return <Tooltip label={t`Select a run type first`}>{select}</Tooltip>;
+  }
+
+  if (!startedAt) {
+    return <Tooltip label={t`Select a start time`}>{select}</Tooltip>;
   }
 
   if (!isLoading && data.length === 0) {

--- a/frontend/src/metabase/admin/tools/components/TaskRunStartedAtPicker/TaskRunDatePicker.tsx
+++ b/frontend/src/metabase/admin/tools/components/TaskRunStartedAtPicker/TaskRunDatePicker.tsx
@@ -23,13 +23,13 @@ export const TaskRunDatePicker = ({
    */
   const data: SelectData<TaskRunDateFilterOption> = [
     { label: t`Today`, value: "thisday" },
-    { label: t`Yesterday`, value: "past1days" },
-    { label: t`Previous week`, value: "past1weeks" },
-    { label: t`Previous 7 days`, value: "past7days" },
-    { label: t`Previous 30 days`, value: "past30days" },
-    { label: t`Previous month`, value: "past1months" },
-    { label: t`Previous 3 months`, value: "past3months" },
-    { label: t`Previous 12 months`, value: "past12months" },
+    { label: t`Yesterday`, value: "past1days~" },
+    { label: t`Previous week`, value: "past1weeks~" },
+    { label: t`Previous 7 days`, value: "past7days~" },
+    { label: t`Previous 30 days`, value: "past30days~" },
+    { label: t`Previous month`, value: "past1months~" },
+    { label: t`Previous 3 months`, value: "past3months~" },
+    { label: t`Previous 12 months`, value: "past12months~" },
   ];
 
   return (

--- a/frontend/src/metabase/admin/tools/components/TaskRunStartedAtPicker/TaskRunDatePicker.tsx
+++ b/frontend/src/metabase/admin/tools/components/TaskRunStartedAtPicker/TaskRunDatePicker.tsx
@@ -17,6 +17,10 @@ export const TaskRunDatePicker = ({
   onChange,
   ...props
 }: TaskRunDatePickerProps) => {
+  /**
+   * Using a simple version of TimeFilterWidget here in order to align with a design of admin page.
+   * That means no custom date ranges.
+   */
   const data: SelectData<TaskRunDateFilterOption> = [
     { label: t`Today`, value: "thisday" },
     { label: t`Yesterday`, value: "past1days" },

--- a/frontend/src/metabase/admin/tools/components/TaskRunStartedAtPicker/TaskRunDatePicker.tsx
+++ b/frontend/src/metabase/admin/tools/components/TaskRunStartedAtPicker/TaskRunDatePicker.tsx
@@ -1,0 +1,50 @@
+import { t } from "ttag";
+
+import { Select, type SelectProps } from "metabase/ui";
+import type { SelectData } from "metabase/ui/components/inputs/Select/Select";
+import type { TaskRunDateFilterOption } from "metabase-types/api";
+
+type TaskRunDatePickerProps = Omit<
+  SelectProps,
+  "data" | "value" | "onChange"
+> & {
+  value: TaskRunDateFilterOption | null;
+  onChange: (value: TaskRunDateFilterOption | null) => void;
+};
+
+export const TaskRunDatePicker = ({
+  value,
+  onChange,
+  ...props
+}: TaskRunDatePickerProps) => {
+  const data: SelectData<TaskRunDateFilterOption> = [
+    { label: t`Today`, value: "thisday" },
+    { label: t`Yesterday`, value: "past1days" },
+    { label: t`Previous week`, value: "past1weeks" },
+    { label: t`Previous 7 days`, value: "past7days" },
+    { label: t`Previous 30 days`, value: "past30days" },
+    { label: t`Previous month`, value: "past1months" },
+    { label: t`Previous 3 months`, value: "past3months" },
+    { label: t`Previous 12 months`, value: "past12months" },
+  ];
+
+  return (
+    <Select
+      comboboxProps={{
+        middlewares: {
+          flip: true,
+          size: {
+            padding: 6,
+          },
+        },
+        position: "bottom-start",
+        width: 300,
+      }}
+      clearable
+      data={data}
+      value={value}
+      onChange={onChange}
+      {...props}
+    />
+  );
+};

--- a/frontend/src/metabase/admin/tools/components/TaskRunStartedAtPicker/index.ts
+++ b/frontend/src/metabase/admin/tools/components/TaskRunStartedAtPicker/index.ts
@@ -1,4 +1,1 @@
-export {
-  TaskRunDatePicker,
-  type TaskRunDatePickerRange,
-} from "./TaskRunDatePicker";
+export { TaskRunDatePicker } from "./TaskRunDatePicker";

--- a/frontend/src/metabase/admin/tools/components/TaskRunStartedAtPicker/index.ts
+++ b/frontend/src/metabase/admin/tools/components/TaskRunStartedAtPicker/index.ts
@@ -1,0 +1,4 @@
+export {
+  TaskRunDatePicker,
+  type TaskRunDatePickerRange,
+} from "./TaskRunDatePicker";

--- a/frontend/src/metabase/admin/tools/components/TaskRunsPage/TaskRunsPage.tsx
+++ b/frontend/src/metabase/admin/tools/components/TaskRunsPage/TaskRunsPage.tsx
@@ -1,4 +1,5 @@
 import { type WithRouterProps, withRouter } from "react-router";
+import { t } from "ttag";
 
 import { useListTaskRunsQuery } from "metabase/api";
 import { PaginationControls } from "metabase/common/components/PaginationControls";
@@ -7,6 +8,7 @@ import { Flex } from "metabase/ui";
 
 import { TaskRunTypePicker } from "../RunTypePicker";
 import { TaskRunEntityPicker } from "../TaskRunEntityPicker";
+import { TaskRunDatePicker } from "../TaskRunStartedAtPicker";
 import { TaskRunStatusPicker } from "../TaskRunStatusPicker";
 import { TasksTabs } from "../TasksTabs";
 
@@ -21,6 +23,7 @@ const TaskRunsPageBase = ({ location }: WithRouterProps) => {
       "run-type": runType,
       "entity-type": entityType,
       "entity-id": entityId,
+      "started-at": startedAt,
       status,
     },
     { patchUrlState },
@@ -37,6 +40,7 @@ const TaskRunsPageBase = ({ location }: WithRouterProps) => {
       "run-type": runType ?? undefined,
       "entity-type": entityType ?? undefined,
       "entity-id": entityId ?? undefined,
+      "started-at": startedAt ?? undefined,
       status: status ?? undefined,
     },
     {
@@ -65,8 +69,22 @@ const TaskRunsPageBase = ({ location }: WithRouterProps) => {
             }
           />
 
+          <TaskRunDatePicker
+            value={startedAt}
+            placeholder={t`Filter by started at`}
+            onChange={(startedAt) =>
+              patchUrlState({
+                "started-at": startedAt,
+                "entity-type": null,
+                "entity-id": null,
+                page: 0,
+              })
+            }
+          />
+
           <TaskRunEntityPicker
             runType={runType}
+            startedAt={startedAt}
             value={entityValue}
             onChange={(entity) =>
               patchUrlState({

--- a/frontend/src/metabase/admin/tools/components/TaskRunsPage/utils.ts
+++ b/frontend/src/metabase/admin/tools/components/TaskRunsPage/utils.ts
@@ -4,6 +4,7 @@ import {
   getFirstParamValue,
 } from "metabase/common/hooks/use-url-state";
 import type {
+  TaskRunDateFilterOption,
   TaskRunEntityType,
   TaskRunStatus,
   TaskRunType,
@@ -12,6 +13,7 @@ import type {
 import {
   guardTaskRunEntityType,
   guardTaskRunRunType,
+  guardTaskRunStartedAtRange,
   guardTaskRunStatus,
 } from "../../utils";
 
@@ -21,6 +23,7 @@ type UrlState = {
   "entity-type": TaskRunEntityType | null;
   "entity-id": number | null;
   status: TaskRunStatus | null;
+  "started-at": TaskRunDateFilterOption | null;
 };
 
 export const urlStateConfig: UrlStateConfig<UrlState> = {
@@ -30,6 +33,7 @@ export const urlStateConfig: UrlStateConfig<UrlState> = {
     "entity-type": parseTaskRunEntityType(query["entity-type"]),
     "entity-id": parseTaskRunEntityId(query["entity-id"]),
     status: parseTaskRunStatus(query.status),
+    "started-at": parseTaskRunStartedAt(query["started-at"]),
   }),
   serialize: ({
     page,
@@ -37,12 +41,14 @@ export const urlStateConfig: UrlStateConfig<UrlState> = {
     "entity-type": entityType,
     "entity-id": entityId,
     status,
+    "started-at": startedAt,
   }) => ({
     page: page === 0 ? undefined : String(page),
     "run-type": runType === null ? undefined : runType,
     "entity-type": entityType === null ? undefined : entityType,
     "entity-id": entityId === null ? undefined : String(entityId),
     status: status === null ? undefined : status,
+    "started-at": startedAt === null ? undefined : startedAt,
   }),
 };
 
@@ -74,4 +80,9 @@ const parseTaskRunEntityId = (param: QueryParam): UrlState["entity-id"] => {
 const parseTaskRunStatus = (param: QueryParam): UrlState["status"] => {
   const value = getFirstParamValue(param);
   return value && guardTaskRunStatus(value) ? value : null;
+};
+
+const parseTaskRunStartedAt = (param: QueryParam): UrlState["started-at"] => {
+  const value = getFirstParamValue(param);
+  return value && guardTaskRunStartedAtRange(value) ? value : null;
 };

--- a/frontend/src/metabase/admin/tools/utils.ts
+++ b/frontend/src/metabase/admin/tools/utils.ts
@@ -111,12 +111,12 @@ export const guardTaskRunStartedAtRange = (
   (
     [
       "thisday",
-      "past1days",
-      "past1weeks",
-      "past7days",
-      "past30days",
-      "past1months",
-      "past3months",
-      "past12months",
+      "past1days~",
+      "past1weeks~",
+      "past7days~",
+      "past30days~",
+      "past1months~",
+      "past3months~",
+      "past12months~",
     ] satisfies TaskRunDateFilterOption[]
   ).includes(value as TaskRunDateFilterOption);

--- a/frontend/src/metabase/admin/tools/utils.ts
+++ b/frontend/src/metabase/admin/tools/utils.ts
@@ -110,12 +110,12 @@ export const guardTaskRunStartedAtRange = (
 ): value is TaskRunDateFilterOption =>
   (
     [
-      "today",
-      "yesterday",
-      "previousweek",
+      "thisday",
+      "past1days",
+      "past1weeks",
       "past7days",
       "past30days",
-      "previousmonth",
+      "past1months",
       "past3months",
       "past12months",
     ] satisfies TaskRunDateFilterOption[]

--- a/frontend/src/metabase/admin/tools/utils.ts
+++ b/frontend/src/metabase/admin/tools/utils.ts
@@ -5,6 +5,7 @@ import * as Urls from "metabase/lib/urls";
 import type {
   Task,
   TaskRun,
+  TaskRunDateFilterOption,
   TaskRunEntityType,
   TaskRunStatus,
   TaskRunType,
@@ -103,3 +104,19 @@ export const guardTaskRunStatus = (value: string): value is TaskRunStatus =>
   (
     ["started", "success", "failed", "abandoned"] satisfies TaskRunStatus[]
   ).includes(value as TaskRunStatus);
+
+export const guardTaskRunStartedAtRange = (
+  value: string,
+): value is TaskRunDateFilterOption =>
+  (
+    [
+      "today",
+      "yesterday",
+      "previousweek",
+      "past7days",
+      "past30days",
+      "previousmonth",
+      "past3months",
+      "past12months",
+    ] satisfies TaskRunDateFilterOption[]
+  ).includes(value as TaskRunDateFilterOption);


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-1520/add-started-at-date-filter-to-task-runs

Adds a started-at filter to the task runs page

<img width="1649" height="967" alt="image" src="https://github.com/user-attachments/assets/45598177-64e2-431e-8bc9-d4700837aba7" />

Note: we've made the datetime filter mandatory before being allowed to filter for entity, to reduce the amount of entities we may need to fetch