### PR TITLE
Add alerts to modular embedding

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
@@ -576,7 +576,7 @@ describe(suiteTitle, () => {
     cy.log("snippet should show alerts as false");
     getEmbedSidebar().findByText("Get code").click();
 
-    // TODO: (Kelvin 2025-01-16) Uncomment this assertion after (metabase#68285) is fixed
+    // TODO: (Kelvin 2026-01-16) Uncomment this assertion after (metabase#68285) is fixed
     // H.expectUnstructuredSnowplowEvent({
     //   event: "embed_wizard_options_completed",
     //   event_detail: "settings=default",
@@ -669,7 +669,7 @@ describe(suiteTitle, () => {
     cy.log("snippet should be updated");
     getEmbedSidebar().findByText("Get code").click();
 
-    // TODO: (Kelvin 2025-01-16) Uncomment this assertion when working on (EMB-1166)
+    // TODO: (Kelvin 2026-01-16) Uncomment this assertion when working on (EMB-1166)
     // H.expectUnstructuredSnowplowEvent({
     //   event: "embed_wizard_options_completed",
     //   event_detail:

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
@@ -44,7 +44,7 @@ describe("OSS", { tags: "@OSS" }, () => {
       getEmbedSidebar().findByTestId("upsell-card").should("be.visible");
     });
 
-    it("should show upsell for Allow alert option", () => {
+    it("should show upsell for Allow alerts option", () => {
       navigateToEmbedOptionsStep({
         experience: "chart",
         resourceName: QUESTION_NAME,

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
@@ -625,6 +625,23 @@ describe(suiteTitle, () => {
       .click()
       .should("be.checked");
 
+    cy.log("assert that alert button appears in preview");
+    H.getSimpleEmbedIframeContent()
+      .findByRole("button", { name: "Alerts" })
+      .should("be.visible");
+
+    cy.log(
+      "test that with drills off, alerts still work because it will now render <StaticQuestion /> (from <SdkQuestion />)",
+    );
+    getEmbedSidebar()
+      .findByLabelText("Allow people to drill through on data points")
+      .should("be.checked")
+      .click()
+      .should("not.be.checked");
+    H.getSimpleEmbedIframeContent()
+      .findByRole("button", { name: "Alerts" })
+      .should("be.visible");
+
     cy.log("assert that unchecking alerts will close the alert modal");
     const newAlertModalTitle = "New alert";
     H.getSimpleEmbedIframeContent().within(() => {

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
@@ -576,11 +576,10 @@ describe(suiteTitle, () => {
     cy.log("snippet should show alerts as false");
     getEmbedSidebar().findByText("Get code").click();
 
-    // TODO: (Kelvin 2026-01-16) Uncomment this assertion after (metabase#68285) is fixed
-    // H.expectUnstructuredSnowplowEvent({
-    //   event: "embed_wizard_options_completed",
-    //   event_detail: "settings=default",
-    // });
+    H.expectUnstructuredSnowplowEvent({
+      event: "embed_wizard_options_completed",
+      event_detail: "settings=default",
+    });
 
     cy.log("test non-guest embeds");
     getEmbedSidebar().within(() => {
@@ -589,7 +588,11 @@ describe(suiteTitle, () => {
       cy.button("Back").click();
 
       cy.findByLabelText("Metabase account (SSO)").click();
+    });
 
+    embedModalEnableEmbedding();
+
+    getEmbedSidebar().within(() => {
       cy.button("Next").click();
       cy.button("Next").click();
 

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
@@ -43,6 +43,15 @@ describe("OSS", { tags: "@OSS" }, () => {
 
       getEmbedSidebar().findByTestId("upsell-card").should("be.visible");
     });
+
+    it("should show upsell for Allow alert option", () => {
+      navigateToEmbedOptionsStep({
+        experience: "chart",
+        resourceName: QUESTION_NAME,
+      });
+
+      getEmbedSidebar().findByTestId("upsell-card").should("be.visible");
+    });
   });
 });
 
@@ -536,6 +545,121 @@ describe(suiteTitle, () => {
     H.getSimpleEmbedIframeContent()
       .findByText("Orders, Count")
       .should("be.visible");
+  });
+
+  it("cannot select alerts for question when email is not set up", () => {
+    navigateToEmbedOptionsStep({
+      experience: "chart",
+      resourceName: QUESTION_NAME,
+    });
+
+    getEmbedSidebar()
+      .findByLabelText("Allow alerts")
+      .should("not.be.checked")
+      .and("be.disabled");
+
+    cy.log("Email warning should only be shown on non-guest embedding");
+    getEmbedSidebar()
+      .findByLabelText("Allow alerts")
+      .closest("[data-testid=tooltip-warning]")
+      .icon("info")
+      .realHover();
+    H.tooltip().should(
+      "contain.text",
+      "Not available if Guest Mode is selected",
+    );
+
+    H.getSimpleEmbedIframeContent()
+      .findByRole("button", { name: "Alerts" })
+      .should("not.exist");
+
+    cy.log("snippet should show alerts as false");
+    getEmbedSidebar().findByText("Get code").click();
+
+    // TODO: (Kelvin 2025-01-16) Uncomment this assertion after (metabase#68285) is fixed
+    // H.expectUnstructuredSnowplowEvent({
+    //   event: "embed_wizard_options_completed",
+    //   event_detail: "settings=default",
+    // });
+
+    cy.log("test non-guest embeds");
+    getEmbedSidebar().within(() => {
+      cy.button("Back").click();
+      cy.button("Back").click();
+      cy.button("Back").click();
+
+      cy.findByLabelText("Metabase account (SSO)").click();
+
+      cy.button("Next").click();
+      cy.button("Next").click();
+
+      cy.findByLabelText("Allow alerts")
+        .closest("[data-testid=tooltip-warning]")
+        .icon("info")
+        .realHover();
+    });
+    H.hovercard().should(
+      "contain.text",
+      "To allow alerts, set up email in admin settings",
+    );
+  });
+
+  it("toggles alerts for question when email is set up", () => {
+    H.setupSMTP();
+
+    navigateToEmbedOptionsStep({
+      experience: "chart",
+      resourceName: QUESTION_NAME,
+      preselectSso: true,
+    });
+
+    getEmbedSidebar().findByLabelText("Allow alerts").should("not.be.checked");
+
+    H.getSimpleEmbedIframeContent()
+      .findByRole("button", { name: "Alerts" })
+      .should("not.exist");
+
+    cy.log("turn on alerts");
+    getEmbedSidebar()
+      .findByLabelText("Allow alerts")
+      .click()
+      .should("be.checked");
+
+    cy.log("assert that unchecking alerts will close the alert modal");
+    const newAlertModalTitle = "New alert";
+    H.getSimpleEmbedIframeContent().within(() => {
+      cy.findByRole("button", { name: "Alerts" }).should("be.visible").click();
+
+      cy.findByRole("heading", { name: newAlertModalTitle }).should(
+        "be.visible",
+      );
+    });
+
+    getEmbedSidebar()
+      .findByLabelText("Allow alerts")
+      .click()
+      .should("not.be.checked");
+    H.getSimpleEmbedIframeContent()
+      .findByRole("heading", { name: newAlertModalTitle })
+      .should("not.exist");
+
+    cy.log("toggle alerts back on");
+    getEmbedSidebar()
+      .findByLabelText("Allow alerts")
+      .click()
+      .should("be.checked");
+
+    cy.log("snippet should be updated");
+    getEmbedSidebar().findByText("Get code").click();
+
+    // TODO: (Kelvin 2025-01-16) Uncomment this assertion when working on (EMB-1166)
+    // H.expectUnstructuredSnowplowEvent({
+    //   event: "embed_wizard_options_completed",
+    //   event_detail:
+    //     "settings=custom,experience=chart,authType=sso,drills=true,withDownloads=false,withAlerts=true,withTitle=true,isSaveEnabled=false,theme=default",
+    // });
+
+    codeBlock().should("contain", 'with-alerts="true"');
   });
 
   ["exploration", "chart"].forEach((experience) => {

--- a/enterprise/frontend/src/embedding-sdk-ee/notifications/QuestionAlertsButton.tsx
+++ b/enterprise/frontend/src/embedding-sdk-ee/notifications/QuestionAlertsButton.tsx
@@ -53,4 +53,6 @@ export const QuestionAlertsButton = (props: QuestionAlertsButtonProps) => {
       />
     );
   }
+
+  return null;
 };

--- a/enterprise/frontend/src/embedding-sdk-ee/notifications/QuestionAlertsButton.tsx
+++ b/enterprise/frontend/src/embedding-sdk-ee/notifications/QuestionAlertsButton.tsx
@@ -19,35 +19,38 @@ export const QuestionAlertsButton = (props: QuestionAlertsButtonProps) => {
   const { toggle: toggleModal, close: closeModal } =
     useQuestionAlertModalContext();
 
-  useEffect(() => {
-    return closeModal;
-  }, [closeModal]);
-
   const isSaved = question?.isSaved();
   const isModel = question?.type() === "model";
   const isAnalytics = isInstanceAnalyticsCollection(question?.collection());
   const hasEmailSetup = useHasEmailSetup();
+
+  const shouldRenderAlertsButton =
+    hasEmailSetup &&
+    withAlerts &&
+    isSaved &&
+    canManageSubscriptions &&
+    !isModel &&
+    !isAnalytics;
+
+  useEffect(() => {
+    if (!shouldRenderAlertsButton) {
+      closeModal();
+    }
+
+    return closeModal;
+  }, [closeModal, shouldRenderAlertsButton]);
   /**
    * Use the same logic as in the core app. But we don't need `isAdmin` because it's already included in `canManageSubscriptions`.
    * @see {@link https://github.com/metabase/metabase/blob/363baef1d937078ecc1efe9710cbe883f830c819/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionMoreActionsMenu/QuestionMoreActionsMenu.tsx#L131}
    */
-  if (
-    !hasEmailSetup ||
-    !withAlerts ||
-    !isSaved ||
-    !canManageSubscriptions ||
-    isModel ||
-    isAnalytics
-  ) {
-    return null;
+  if (shouldRenderAlertsButton) {
+    return (
+      <SdkActionIcon
+        tooltip={t`Alerts`}
+        icon="alert"
+        onClick={toggleModal}
+        {...props}
+      />
+    );
   }
-
-  return (
-    <SdkActionIcon
-      tooltip={t`Alerts`}
-      icon="alert"
-      onClick={toggleModal}
-      {...props}
-    />
-  );
 };

--- a/enterprise/frontend/src/embedding-sdk-ee/notifications/index.ts
+++ b/enterprise/frontend/src/embedding-sdk-ee/notifications/index.ts
@@ -1,11 +1,12 @@
 import { PLUGIN_NOTIFICATIONS_SDK } from "embedding-sdk-bundle/components/public/notifications";
+import { EMBEDDING_SDK_CONFIG } from "metabase/embedding-sdk/config";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import { DashboardSubscriptionsButton } from "./DashboardSubscriptionsButton";
 import { QuestionAlertsButton } from "./QuestionAlertsButton";
 
 export function initializePlugin() {
-  if (hasPremiumFeature("embedding_sdk")) {
+  if (hasPremiumFeature(EMBEDDING_SDK_CONFIG.tokenFeatureKey)) {
     PLUGIN_NOTIFICATIONS_SDK.DashboardSubscriptionsButton =
       DashboardSubscriptionsButton;
     PLUGIN_NOTIFICATIONS_SDK.QuestionAlertsButton = QuestionAlertsButton;

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/index.ts
@@ -1,14 +1,8 @@
 import { PLUGIN_EMBEDDING_IFRAME_SDK } from "metabase/plugins";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
-import { DashboardSubscriptionsButton } from "../../embedding-sdk-ee/notifications/DashboardSubscriptionsButton";
-import { QuestionAlertsButton } from "../../embedding-sdk-ee/notifications/QuestionAlertsButton";
-
 export function initializePlugin() {
   if (hasPremiumFeature("embedding_simple")) {
     PLUGIN_EMBEDDING_IFRAME_SDK.isEnabled = () => true;
-    PLUGIN_EMBEDDING_IFRAME_SDK.DashboardSubscriptionsButton =
-      DashboardSubscriptionsButton;
-    PLUGIN_EMBEDDING_IFRAME_SDK.QuestionAlertsButton = QuestionAlertsButton;
   }
 }

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/index.ts
@@ -2,11 +2,13 @@ import { PLUGIN_EMBEDDING_IFRAME_SDK } from "metabase/plugins";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import { DashboardSubscriptionsButton } from "../../embedding-sdk-ee/notifications/DashboardSubscriptionsButton";
+import { QuestionAlertsButton } from "../../embedding-sdk-ee/notifications/QuestionAlertsButton";
 
 export function initializePlugin() {
   if (hasPremiumFeature("embedding_simple")) {
     PLUGIN_EMBEDDING_IFRAME_SDK.isEnabled = () => true;
     PLUGIN_EMBEDDING_IFRAME_SDK.DashboardSubscriptionsButton =
       DashboardSubscriptionsButton;
+    PLUGIN_EMBEDDING_IFRAME_SDK.QuestionAlertsButton = QuestionAlertsButton;
   }
 }

--- a/frontend/src/embedding-sdk-bundle/components/public/notifications/QuestionAlertsButton.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/notifications/QuestionAlertsButton.tsx
@@ -1,11 +1,11 @@
 import { PLUGIN_NOTIFICATIONS_SDK } from "embedding-sdk-bundle/components/public/notifications";
-import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
+import { isEmbeddingEajs, isEmbeddingSdk } from "metabase/embedding-sdk/config";
+import { PLUGIN_EMBEDDING_IFRAME_SDK } from "metabase/plugins";
 
 export function QuestionAlertsButton() {
-  // XXX: Uncomment this when working on EMB-996
-  // if (isEmbeddingEajs()) {
-  //   return <PLUGIN_EMBEDDING_IFRAME_SDK.QuestionAlertsButton />;
-  // }
+  if (isEmbeddingEajs()) {
+    return <PLUGIN_EMBEDDING_IFRAME_SDK.QuestionAlertsButton />;
+  }
 
   // This flag isn't exclusive it could mean we're on either modular embedding or modular embedding SDK
   if (isEmbeddingSdk()) {

--- a/frontend/src/embedding-sdk-bundle/components/public/notifications/QuestionAlertsButton.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/notifications/QuestionAlertsButton.tsx
@@ -1,16 +1,5 @@
 import { PLUGIN_NOTIFICATIONS_SDK } from "embedding-sdk-bundle/components/public/notifications";
-import { isEmbeddingEajs, isEmbeddingSdk } from "metabase/embedding-sdk/config";
-import { PLUGIN_EMBEDDING_IFRAME_SDK } from "metabase/plugins";
 
 export function QuestionAlertsButton() {
-  if (isEmbeddingEajs()) {
-    return <PLUGIN_EMBEDDING_IFRAME_SDK.QuestionAlertsButton />;
-  }
-
-  // This flag isn't exclusive it could mean we're on either modular embedding or modular embedding SDK
-  if (isEmbeddingSdk()) {
-    return <PLUGIN_NOTIFICATIONS_SDK.QuestionAlertsButton />;
-  }
-
-  return null;
+  return <PLUGIN_NOTIFICATIONS_SDK.QuestionAlertsButton />;
 }

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/DashboardSubscriptionsButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/DashboardSubscriptionsButton.tsx
@@ -1,16 +1,5 @@
 import { PLUGIN_NOTIFICATIONS_SDK } from "embedding-sdk-bundle/components/public/notifications";
-import { isEmbeddingEajs, isEmbeddingSdk } from "metabase/embedding-sdk/config";
-import { PLUGIN_EMBEDDING_IFRAME_SDK } from "metabase/plugins";
 
 export function DashboardSubscriptionsButton() {
-  if (isEmbeddingEajs()) {
-    return <PLUGIN_EMBEDDING_IFRAME_SDK.DashboardSubscriptionsButton />;
-  }
-
-  // This flag isn't exclusive it could mean we're on either modular embedding or modular embedding SDK
-  if (isEmbeddingSdk()) {
-    return <PLUGIN_NOTIFICATIONS_SDK.DashboardSubscriptionsButton />;
-  }
-
-  return null;
+  return <PLUGIN_NOTIFICATIONS_SDK.DashboardSubscriptionsButton />;
 }

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SelectEmbedOptionsStep.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SelectEmbedOptionsStep.tsx
@@ -55,7 +55,9 @@ const BehaviorSection = () => {
             disabled={settings.isGuest}
             checked={settings.isSaveEnabled}
             onChange={(e) =>
-              updateSettings({ isSaveEnabled: e.target.checked })
+              updateSettings({
+                isSaveEnabled: e.target.checked,
+              } satisfies Partial<typeof settings>)
             }
           />
         ),
@@ -70,7 +72,11 @@ const BehaviorSection = () => {
                   label={t`Allow people to drill through on data points`}
                   disabled={disabled}
                   checked={settings.drills}
-                  onChange={(e) => updateSettings({ drills: e.target.checked })}
+                  onChange={(e) =>
+                    updateSettings({
+                      drills: e.target.checked,
+                    } satisfies Partial<typeof settings>)
+                  }
                 />
               )}
             </WithNotAvailableForOssOrGuestEmbedsGuard>
@@ -80,7 +86,9 @@ const BehaviorSection = () => {
               disabled={!isSimpleEmbedFeatureAvailable}
               checked={settings.withDownloads}
               onChange={(e) =>
-                updateSettings({ withDownloads: e.target.checked })
+                updateSettings({
+                  withDownloads: e.target.checked,
+                } satisfies Partial<typeof settings>)
               }
             />
 
@@ -91,10 +99,56 @@ const BehaviorSection = () => {
                   disabled={disabled}
                   checked={settings.isSaveEnabled}
                   onChange={(e) =>
-                    updateSettings({ isSaveEnabled: e.target.checked })
+                    updateSettings({
+                      isSaveEnabled: e.target.checked,
+                    } satisfies Partial<typeof settings>)
                   }
                 />
               )}
+            </WithNotAvailableForOssOrGuestEmbedsGuard>
+
+            <WithNotAvailableForOssOrGuestEmbedsGuard>
+              {({ disabled: disabledInGuestEmbedding }) => {
+                return (
+                  <Flex align="center" gap="xs">
+                    <Checkbox
+                      disabled={!hasEmailSetup || disabledInGuestEmbedding}
+                      label={t`Allow alerts`}
+                      checked={settings.withAlerts}
+                      onChange={(e) =>
+                        updateSettings({
+                          withAlerts: e.target.checked,
+                        } satisfies Partial<typeof settings>)
+                      }
+                    />
+                    {!hasEmailSetup && !disabledInGuestEmbedding && (
+                      <HoverCard>
+                        <HoverCard.Target>
+                          <Icon name="info" size={14} c="text-secondary" />
+                        </HoverCard.Target>
+                        <HoverCard.Dropdown p="sm">
+                          <Text>{c(
+                            "{0} is a link to email settings page with text 'admin settings'",
+                          ).jt`To allow alerts, set up email in ${(
+                            <Link
+                              key="admin-settings-link"
+                              to="/admin/settings/email"
+                            >
+                              <Text
+                                display="inline"
+                                c="text-brand"
+                                fw="bold"
+                              >{c(
+                                "is a link in a sentence 'To allow alerts, set up email in admin settings'",
+                              ).t`admin settings`}</Text>
+                            </Link>
+                          )}`}</Text>
+                        </HoverCard.Dropdown>
+                      </HoverCard>
+                    )}
+                  </Flex>
+                );
+              }}
             </WithNotAvailableForOssOrGuestEmbedsGuard>
           </Stack>
         ),
@@ -109,7 +163,11 @@ const BehaviorSection = () => {
                   label={t`Allow people to drill through on data points`}
                   disabled={disabled}
                   checked={settings.drills}
-                  onChange={(e) => updateSettings({ drills: e.target.checked })}
+                  onChange={(e) =>
+                    updateSettings({
+                      drills: e.target.checked,
+                    } satisfies Partial<typeof settings>)
+                  }
                 />
               )}
             </WithNotAvailableForOssOrGuestEmbedsGuard>
@@ -119,7 +177,9 @@ const BehaviorSection = () => {
               disabled={!isSimpleEmbedFeatureAvailable}
               checked={settings.withDownloads}
               onChange={(e) =>
-                updateSettings({ withDownloads: e.target.checked })
+                updateSettings({
+                  withDownloads: e.target.checked,
+                } satisfies Partial<typeof settings>)
               }
             />
 
@@ -132,7 +192,9 @@ const BehaviorSection = () => {
                       label={t`Allow subscriptions`}
                       checked={settings.withSubscriptions}
                       onChange={(e) =>
-                        updateSettings({ withSubscriptions: e.target.checked })
+                        updateSettings({
+                          withSubscriptions: e.target.checked,
+                        } satisfies Partial<typeof settings>)
                       }
                     />
                     {!hasEmailSetup && !disabledInGuestEmbedding && (
@@ -174,7 +236,11 @@ const BehaviorSection = () => {
             label={t`Allow editing dashboards and questions`}
             disabled={settings.isGuest}
             checked={!settings.readOnly}
-            onChange={(e) => updateSettings({ readOnly: !e.target.checked })}
+            onChange={(e) =>
+              updateSettings({
+                readOnly: !e.target.checked,
+              } satisfies Partial<typeof settings>)
+            }
           />
         ),
       )
@@ -228,7 +294,7 @@ const AppearanceSection = () => {
 
   const updateThemePreset = useCallback(
     (preset: MetabaseThemePreset) => {
-      updateSettings({ theme: { preset } });
+      updateSettings({ theme: { preset } } satisfies Partial<typeof settings>);
     },
     [updateSettings],
   );
@@ -237,7 +303,7 @@ const AppearanceSection = () => {
     (nextColors: Partial<MetabaseColors>) => {
       updateSettings({
         theme: { ...theme, colors: { ...theme?.colors, ...nextColors } },
-      });
+      } satisfies Partial<typeof settings>);
     },
     [theme, updateSettings],
   );
@@ -257,7 +323,11 @@ const AppearanceSection = () => {
           <Checkbox
             label={label}
             checked={settings.withTitle}
-            onChange={(e) => updateSettings({ withTitle: e.target.checked })}
+            onChange={(e) =>
+              updateSettings({
+                withTitle: e.target.checked,
+              } satisfies Partial<typeof settings>)
+            }
           />
         );
       },
@@ -270,7 +340,11 @@ const AppearanceSection = () => {
         <ColorCustomizationSection
           theme={theme}
           onColorChange={updateColors}
-          onColorReset={() => updateSettings({ theme: undefined })}
+          onColorReset={() =>
+            updateSettings({ theme: undefined } satisfies Partial<
+              typeof settings
+            >)
+          }
         />
       ) : (
         <SimpleThemeSwitcherSection

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-default-sdk-iframe-embed-setting.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-default-sdk-iframe-embed-setting.ts
@@ -61,6 +61,7 @@ export const getDefaultSdkIframeEmbedSettings = ({
         questionId: resourceId,
         drills: true,
         withDownloads: false,
+        withAlerts: false,
         withTitle: true,
         isSaveEnabled: false,
         initialSqlParameters: {},

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
@@ -232,6 +232,7 @@ const SdkIframeEmbedView = ({
               key={rerenderKey}
               {...entityProps}
               withDownloads={settings.withDownloads}
+              withAlerts={settings.withAlerts}
               height="100%"
               initialSqlParameters={settings.initialSqlParameters}
               hiddenParameters={settings.hiddenParameters}

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
@@ -253,6 +253,7 @@ const SdkIframeEmbedView = ({
             questionId={settings.questionId ?? null}
             token={settings.token}
             withDownloads={settings.withDownloads}
+            withAlerts={settings.withAlerts}
             height="100%"
             initialSqlParameters={settings.initialSqlParameters}
             hiddenParameters={settings.hiddenParameters}

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/constants.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/constants.ts
@@ -41,6 +41,7 @@ export const ALLOWED_EMBED_SETTING_KEYS_MAP = {
     "isSaveEnabled",
     "withTitle",
     "withDownloads",
+    "withAlerts",
     "initialSqlParameters",
     "hiddenParameters",
     "drills",

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
@@ -506,6 +506,7 @@ const MetabaseQuestionElement = createCustomElement("metabase-question", [
   "token",
   "with-title",
   "with-downloads",
+  "with-alerts",
   "drills",
   "initial-sql-parameters",
   "hidden-parameters",

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
@@ -95,6 +95,7 @@ export type QuestionEmbedOptions = StrictUnion<
   drills?: boolean;
   withTitle?: boolean;
   withDownloads?: boolean;
+  withAlerts?: boolean;
   targetCollection?: CollectionId;
   entityTypes?: EntityTypeFilterKeys[];
   isSaveEnabled?: boolean;

--- a/frontend/src/metabase/plugins/oss/embedding-iframe-sdk.ts
+++ b/frontend/src/metabase/plugins/oss/embedding-iframe-sdk.ts
@@ -1,9 +1,15 @@
-import type { DashboardSubscriptionsButtonProps } from "embedding-sdk-bundle/components/public/notifications";
+import type {
+  DashboardSubscriptionsButtonProps,
+  QuestionAlertsButtonProps,
+} from "embedding-sdk-bundle/components/public/notifications";
 
 const getDefaultPluginEmbeddingIframeSdk = () => ({
   isEnabled: () => false,
   DashboardSubscriptionsButton: (
     _props: DashboardSubscriptionsButtonProps,
+  ): JSX.Element | null => null,
+  QuestionAlertsButton: (
+    _props: QuestionAlertsButtonProps,
   ): JSX.Element | null => null,
 });
 

--- a/frontend/src/metabase/plugins/oss/embedding-iframe-sdk.ts
+++ b/frontend/src/metabase/plugins/oss/embedding-iframe-sdk.ts
@@ -1,16 +1,5 @@
-import type {
-  DashboardSubscriptionsButtonProps,
-  QuestionAlertsButtonProps,
-} from "embedding-sdk-bundle/components/public/notifications";
-
 const getDefaultPluginEmbeddingIframeSdk = () => ({
   isEnabled: () => false,
-  DashboardSubscriptionsButton: (
-    _props: DashboardSubscriptionsButtonProps,
-  ): JSX.Element | null => null,
-  QuestionAlertsButton: (
-    _props: QuestionAlertsButtonProps,
-  ): JSX.Element | null => null,
 });
 
 export const PLUGIN_EMBEDDING_IFRAME_SDK = getDefaultPluginEmbeddingIframeSdk();


### PR DESCRIPTION
closes EMB-996

### Description

This PR adds support for alerts in modular embedding

### How to verify
1. Go to any saved question.
2. Click the sharing icon > Embed
3. Select SSO (Alerts don't work on guest embeds)
4. Check/uncheck the "Allow alerts" checkbox and play with the preview

### Demo

https://www.loom.com/share/1cb0a97789ef41be89b7f7528d62bd10

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
