### PR TITLE
Fix untranslated string in an alert modal

### DIFF
--- a/frontend/src/metabase/notifications/modals/ChannelSetupModal.tsx
+++ b/frontend/src/metabase/notifications/modals/ChannelSetupModal.tsx
@@ -24,7 +24,9 @@ const CHANNELS_CONFIG: {
     link: "/admin/settings/notifications",
   },
   {
-    title: "Add a webhook",
+    get title() {
+      return t`Add a webhook`;
+    },
     icon: "webhook",
     link: "/admin/settings/notifications",
     testId: "alerts-channel-create-webhook",


### PR DESCRIPTION
Fixes #68174

This PR runs #68208 within the org so that it can run CI. Thanks @josephadamsdev for the contribution.