### PR TITLE
fix: "Connect to Slack" CTA remains visible after Slack is configured

### DIFF
--- a/frontend/src/metabase/admin/settings/components/SettingsPages/NotificationSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/NotificationSettingsPage.tsx
@@ -21,8 +21,9 @@ import {
 } from "metabase/ui";
 import type { NotificationChannel } from "metabase-types/api";
 
-import { SlackBadge } from "../../slack/SlackBadge";
 import { SlackSettingsModal } from "../../slack/SlackSettingsModal";
+import { SlackSetup } from "../../slack/SlackSetup";
+import { SlackStatus } from "../../slack/SlackStatus";
 import { CreateWebhookModal } from "../widgets/Notifications/CreateWebhookModal";
 import { EditWebhookModal } from "../widgets/Notifications/EditWebhookModal";
 
@@ -33,8 +34,8 @@ export const NotificationSettingsPage = () => {
     useDisclosure(false);
   const [webhookModal, setWebhookModal] = useState<NotificationModals>(null);
   const [currentChannel, setCurrentChannel] = useState<NotificationChannel>();
+  const slackAppToken = useSetting("slack-app-token");
   const slackBotToken = useSetting("slack-token");
-  const isSlackTokenValid = useSetting("slack-token-valid?");
 
   const { data: channels } = useListChannelsQuery();
 
@@ -44,27 +45,32 @@ export const NotificationSettingsPage = () => {
     <>
       <SettingsPageWrapper title={t`Notifications`}>
         <SettingsSection title={t`Slack`}>
-          <UnstyledButton onClick={openSlackModal} variant="unstyled" w="100%">
+          {slackAppToken || slackBotToken ? (
             <Paper shadow="0" withBorder p="lg">
-              <Flex gap="0.5rem" align="center" mb="0.5rem">
+              <Flex gap="0.5rem" align="center" mb="1rem">
                 <Icon name="slack_colorized" />
-                <Title order={3}>
-                  {isSlackTokenValid
-                    ? t`Connected to Slack`
-                    : t`Connect to Slack`}
-                </Title>
-                <SlackBadge
-                  ml="auto"
-                  isBot={!!slackBotToken}
-                  isValid={isSlackTokenValid}
-                />
+                <Title order={3}>{t`Slack`}</Title>
               </Flex>
-              <Text>
-                {t`If your team uses Slack, you can send dashboard subscriptions and
-              alerts there`}
-              </Text>
+              {slackAppToken ? <SlackStatus /> : <SlackSetup />}
             </Paper>
-          </UnstyledButton>
+          ) : (
+            <UnstyledButton
+              onClick={openSlackModal}
+              variant="unstyled"
+              w="100%"
+            >
+              <Paper shadow="0" withBorder p="lg">
+                <Flex gap="0.5rem" align="center" mb="0.5rem">
+                  <Icon name="slack_colorized" />
+                  <Title order={3}>{t`Connect to Slack`}</Title>
+                </Flex>
+                <Text>
+                  {t`If your team uses Slack, you can send dashboard subscriptions and
+              alerts there`}
+                </Text>
+              </Paper>
+            </UnstyledButton>
+          )}
         </SettingsSection>
 
         <SettingsSection>

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/NotificationSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/NotificationSettingsPage.tsx
@@ -7,6 +7,7 @@ import {
   SettingsSection,
 } from "metabase/admin/components/SettingsSection";
 import { useListChannelsQuery } from "metabase/api/channel";
+import { useSetting } from "metabase/common/hooks";
 import {
   Button,
   Flex,
@@ -20,6 +21,7 @@ import {
 } from "metabase/ui";
 import type { NotificationChannel } from "metabase-types/api";
 
+import { SlackBadge } from "../../slack/SlackBadge";
 import { SlackSettingsModal } from "../../slack/SlackSettingsModal";
 import { CreateWebhookModal } from "../widgets/Notifications/CreateWebhookModal";
 import { EditWebhookModal } from "../widgets/Notifications/EditWebhookModal";
@@ -31,6 +33,8 @@ export const NotificationSettingsPage = () => {
     useDisclosure(false);
   const [webhookModal, setWebhookModal] = useState<NotificationModals>(null);
   const [currentChannel, setCurrentChannel] = useState<NotificationChannel>();
+  const slackBotToken = useSetting("slack-token");
+  const isSlackTokenValid = useSetting("slack-token-valid?");
 
   const { data: channels } = useListChannelsQuery();
 
@@ -41,10 +45,19 @@ export const NotificationSettingsPage = () => {
       <SettingsPageWrapper title={t`Notifications`}>
         <SettingsSection title={t`Slack`}>
           <UnstyledButton onClick={openSlackModal} variant="unstyled" w="100%">
-            <Paper shadow="0" withBorder p="lg" mb="2.5rem">
+            <Paper shadow="0" withBorder p="lg">
               <Flex gap="0.5rem" align="center" mb="0.5rem">
                 <Icon name="slack_colorized" />
-                <Title order={3}>{t`Connect to Slack`}</Title>
+                <Title order={3}>
+                  {isSlackTokenValid
+                    ? t`Connected to Slack`
+                    : t`Connect to Slack`}
+                </Title>
+                <SlackBadge
+                  ml="auto"
+                  isBot={!!slackBotToken}
+                  isValid={isSlackTokenValid}
+                />
               </Flex>
               <Text>
                 {t`If your team uses Slack, you can send dashboard subscriptions and

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/NotificationSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/NotificationSettingsPage.tsx
@@ -41,7 +41,7 @@ export const NotificationSettingsPage = () => {
       <SettingsPageWrapper title={t`Notifications`}>
         <SettingsSection title={t`Slack`}>
           <UnstyledButton onClick={openSlackModal} variant="unstyled" w="100%">
-            <Paper shadow="0" withBorder p="lg" w="47rem" mb="2.5rem">
+            <Paper shadow="0" withBorder p="lg" mb="2.5rem">
               <Flex gap="0.5rem" align="center" mb="0.5rem">
                 <Icon name="slack_colorized" />
                 <Title order={3}>{t`Connect to Slack`}</Title>

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/NotificationSettingsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/NotificationSettingsPage.unit.spec.tsx
@@ -16,13 +16,14 @@ import { NotificationSettingsPage } from "./NotificationSettingsPage";
 
 const setup = async ({
   isSlackTokenValid = true,
+  slackAppToken = "xoxb-test-token",
 }: {
   isSlackTokenValid?: boolean;
+  slackAppToken?: string | null;
 } = {}) => {
   const settings = createMockSettings({
-    "slack-token": "xoxb-test-token",
     "slack-token-valid?": isSlackTokenValid,
-    "slack-app-token": "",
+    "slack-app-token": slackAppToken,
   });
 
   setupPropertiesEndpoints(settings);
@@ -44,17 +45,21 @@ const setup = async ({
 };
 
 describe("NotificationSettingsPage", () => {
-  it("shows connected Slack status with a badge when connected", async () => {
+  it("shows Slack status inside the card when connected", async () => {
     await setup();
 
-    expect(screen.getByText("Connected to Slack")).toBeInTheDocument();
-    expect(screen.getByText("Slack bot is working.")).toBeInTheDocument();
+    expect(screen.getByText("Slack app is working")).toBeInTheDocument();
   });
 
-  it("shows not connected Slack status with a badge when token is invalid", async () => {
+  it("shows Slack error status when the token is invalid", async () => {
     await setup({ isSlackTokenValid: false });
 
+    expect(screen.getByText("Slack app is not working.")).toBeInTheDocument();
+  });
+
+  it("shows connect CTA when the Slack app is not configured", async () => {
+    await setup({ slackAppToken: null });
+
     expect(screen.getByText("Connect to Slack")).toBeInTheDocument();
-    expect(screen.getByText("Slack bot is not working.")).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/NotificationSettingsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/NotificationSettingsPage.unit.spec.tsx
@@ -1,0 +1,60 @@
+import {
+  setupPropertiesEndpoints,
+  setupSettingsEndpoints,
+  setupSlackManifestEndpoint,
+} from "__support__/server-mocks";
+import { setupWebhookChannelsEndpoint } from "__support__/server-mocks/channel";
+import { renderWithProviders, screen } from "__support__/ui";
+import type { SettingKey } from "metabase-types/api";
+import {
+  createMockSettingDefinition,
+  createMockSettings,
+} from "metabase-types/api/mocks";
+import { createMockSettingsState } from "metabase-types/store/mocks";
+
+import { NotificationSettingsPage } from "./NotificationSettingsPage";
+
+const setup = async ({
+  isSlackTokenValid = true,
+}: {
+  isSlackTokenValid?: boolean;
+} = {}) => {
+  const settings = createMockSettings({
+    "slack-token": "xoxb-test-token",
+    "slack-token-valid?": isSlackTokenValid,
+    "slack-app-token": "",
+  });
+
+  setupPropertiesEndpoints(settings);
+  setupSettingsEndpoints(
+    Object.entries(settings).map(([key, value]) =>
+      createMockSettingDefinition({ key: key as SettingKey, value }),
+    ),
+  );
+  setupSlackManifestEndpoint();
+  setupWebhookChannelsEndpoint();
+
+  renderWithProviders(<NotificationSettingsPage />, {
+    storeInitialState: {
+      settings: createMockSettingsState(settings),
+    },
+  });
+
+  await screen.findByText("Notifications");
+};
+
+describe("NotificationSettingsPage", () => {
+  it("shows connected Slack status with a badge when connected", async () => {
+    await setup();
+
+    expect(screen.getByText("Connected to Slack")).toBeInTheDocument();
+    expect(screen.getByText("Slack bot is working.")).toBeInTheDocument();
+  });
+
+  it("shows not connected Slack status with a badge when token is invalid", async () => {
+    await setup({ isSlackTokenValid: false });
+
+    expect(screen.getByText("Connect to Slack")).toBeInTheDocument();
+    expect(screen.getByText("Slack bot is not working.")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/admin/settings/slack/SlackBadge.tsx
+++ b/frontend/src/metabase/admin/settings/slack/SlackBadge.tsx
@@ -1,10 +1,10 @@
 import { t } from "ttag";
 
-import { Box, Center, Text } from "metabase/ui";
+import { Box, Center, type CenterProps, Text } from "metabase/ui";
 
 import S from "./slack.module.css";
 
-export interface SlackBadgeProps {
+export interface SlackBadgeProps extends CenterProps {
   isBot?: boolean;
   isValid?: boolean;
 }
@@ -12,11 +12,12 @@ export interface SlackBadgeProps {
 export const SlackBadge = ({
   isBot,
   isValid,
+  ...props
 }: SlackBadgeProps): JSX.Element => {
   const color = isValid ? "success" : "error";
 
   return (
-    <Center>
+    <Center {...props}>
       <Box className={S.StatusBadge} bg={color} />
       <Text fw="bold" c={color}>
         {getMessage(isBot, isValid)}

--- a/frontend/src/metabase/admin/settings/slack/SlackSettingsModal.tsx
+++ b/frontend/src/metabase/admin/settings/slack/SlackSettingsModal.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { t } from "ttag";
 
 import { useAdminSetting } from "metabase/api/utils";
@@ -5,7 +6,6 @@ import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErr
 import { Modal } from "metabase/ui";
 
 import { SlackSetup } from "./SlackSetup";
-import { SlackStatus } from "./SlackStatus";
 
 export const SlackSettingsModal = ({
   isOpen,
@@ -16,6 +16,12 @@ export const SlackSettingsModal = ({
 }) => {
   const { value: isApp, isLoading } = useAdminSetting("slack-app-token");
 
+  useEffect(() => {
+    if (isApp) {
+      onClose();
+    }
+  }, [isApp, onClose]);
+
   return (
     <Modal
       opened={isOpen}
@@ -24,7 +30,7 @@ export const SlackSettingsModal = ({
       padding="xl"
     >
       <LoadingAndErrorWrapper loading={isLoading}>
-        {isApp ? <SlackStatus /> : <SlackSetup />}
+        <SlackSetup />
       </LoadingAndErrorWrapper>
     </Modal>
   );

--- a/frontend/src/metabase/admin/settings/slack/SlackSettingsModal.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/slack/SlackSettingsModal.unit.spec.tsx
@@ -29,24 +29,27 @@ const setup = async ({
 
   setupSlackManifestEndpoint();
 
-  renderWithProviders(<SlackSettingsModal isOpen onClose={() => {}} />);
+  const onClose = jest.fn();
+
+  renderWithProviders(<SlackSettingsModal isOpen onClose={onClose} />);
 
   await screen.findByText("Metabase on Slack");
+
+  return { onClose };
 };
 
 describe("SlackSettingsModal", () => {
-  it("should render the status display when the app is configured", async () => {
-    await setup({ isApp: true, isBot: false, isValid: true });
+  it("should request closing when the app is configured", async () => {
+    const { onClose } = await setup({
+      isApp: true,
+      isBot: false,
+      isValid: true,
+    });
 
     expect(screen.getByText("Metabase on Slack")).toBeInTheDocument();
-    expect(await screen.findByText("Slack app is working")).toBeInTheDocument();
-
-    const gets = await findRequests("GET");
-    expect(gets).toHaveLength(2);
-    const manifestRequest = gets.find((request) =>
-      request.url.includes("manifest"),
-    );
-    expect(manifestRequest).not.toBeDefined();
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled();
+    });
   });
 
   it("should render the setup display and load the manifest when the app is not configured", async () => {


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #67989
Closes [UXW-2724: "Connect to Slack" CTA remains visible after Slack is configured](https://linear.app/metabase/issue/UXW-2724/connect-to-slack-cta-remains-visible-after-slack-is-configured)

### Description

Connect to slack button wasn't showing the correct state of if it's connected, now it does.

### How to verify

1. Go to admin -> Notification channels
2. Connect to slack

### Demo

<img width="778" height="465" alt="image" src="https://github.com/user-attachments/assets/b8f1dcef-74ec-4b6c-b3db-7ca787b055ba" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
