### PR TITLE
[MBQL lib] Creating "column keys" to give a robust identity to columns

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1055,7 +1055,8 @@
            metabase.lib.types.isa
            metabase.lib.util
            metabase.lib.util.match}
-   :uses #{config
+   :uses #{analytics
+           config
            graph
            legacy-mbql
            types

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1055,8 +1055,7 @@
            metabase.lib.types.isa
            metabase.lib.util
            metabase.lib.util.match}
-   :uses #{analytics
-           config
+   :uses #{config
            graph
            legacy-mbql
            types

--- a/enterprise/backend/test/metabase_enterprise/dependencies/metadata_provider_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/metadata_provider_test.clj
@@ -3,6 +3,7 @@
    [clojure.test :refer [deftest is testing]]
    [medley.core :as m]
    [metabase-enterprise.dependencies.metadata-provider :as deps.mp]
+   [metabase.lib.column-key :as lib.column-key]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.test-metadata :as meta]
@@ -20,8 +21,10 @@
                                           (lib.tu.macros/$ids orders
                                             [$subtotal $created-at]))
                                 (dissoc :result-metadata)))
-      (is (=? [(meta/field-metadata :orders :subtotal)
-               (meta/field-metadata :orders :created-at)]
+      (is (=? [(-> (meta/field-metadata :orders :subtotal)
+                   (update :lib/column-key lib.column-key/from-card (:id card)))
+               (-> (meta/field-metadata :orders :created-at)
+                   (update :lib/column-key lib.column-key/from-card (:id card)))]
               (->> (lib.metadata/card mp (:id card))
                    (lib/query mp)
                    lib/returned-columns))))))

--- a/enterprise/backend/test/metabase_enterprise/dependencies/metadata_provider_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/metadata_provider_test.clj
@@ -22,9 +22,9 @@
                                             [$subtotal $created-at]))
                                 (dissoc :result-metadata)))
       (is (=? [(-> (meta/field-metadata :orders :subtotal)
-                   (update :lib/column-key lib.column-key/from-card (:id card)))
+                   (lib.column-key/from-card mp (:id card)))
                (-> (meta/field-metadata :orders :created-at)
-                   (update :lib/column-key lib.column-key/from-card (:id card)))]
+                   (lib.column-key/from-card mp (:id card)))]
               (->> (lib.metadata/card mp (:id card))
                    (lib/query mp)
                    lib/returned-columns))))))

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -259,6 +259,8 @@
                        {:description "Number of errors when processing metrics in the metrics adjust middleware."})
    (prometheus/gauge   :metabase-query-processor/computed-weak-map-queries
                        {:description "Number of queries cached in lib.computed/weak-map."})
+   (prometheus/counter :metabase-query-processor/unresolvable-join-clause
+                       {:description "Number of times lib could not resolve a join alias to the join clause"})
    (prometheus/gauge   :metabase-card/unique-cards-failed-conversion
                        {:description "Number of distinct cards which have :dataset_query {}, meaning MBQL 4 to 5 conversion failed."})
    (prometheus/counter :metabase-card/conversions-requiring-cleaning

--- a/src/metabase/lib/aggregation.cljc
+++ b/src/metabase/lib/aggregation.cljc
@@ -3,6 +3,7 @@
   (:require
    [clojure.string :as str]
    [medley.core :as m]
+   [metabase.lib.column-key :as lib.column-key]
    [metabase.lib.common :as lib.common]
    [metabase.lib.computed :as lib.computed]
    [metabase.lib.dispatch :as lib.dispatch]
@@ -94,7 +95,8 @@
         (merge
          (lib.metadata.calculation/metadata query stage-number aggregation)
          {:lib/source :source/aggregations
-          :lib/source-uuid (:lib/uuid (second aggregation))}
+          :lib/source-uuid (:lib/uuid (second aggregation))
+          :lib/column-key  (lib.column-key/aggregation-key aggregation)}
 
          (when base-type
            {:base-type base-type})
@@ -305,7 +307,8 @@
      ;; This might be an inner aggregation expression without an ident of its own, but that's fine since we're only
      ;; here for its type!
      (select-keys (lib.metadata.calculation/metadata query stage-number first-arg) [:settings :semantic-type]))
-   ((get-method lib.metadata.calculation/metadata-method :default) query stage-number clause)))
+   ((get-method lib.metadata.calculation/metadata-method :default) query stage-number clause)
+   {:lib/column-key (lib.column-key/aggregation-key clause)}))
 
 (lib.common/defop count       [] [x])
 (lib.common/defop cum-count   [] [x])
@@ -371,7 +374,8 @@
                               (-> metadata
                                   (u/assoc-default :effective-type (or (:base-type metadata) :type/*))
                                   (assoc :lib/source      :source/aggregations
-                                         :lib/source-uuid (lib.options/uuid aggregation))))))))))
+                                         :lib/source-uuid (lib.options/uuid aggregation)
+                                         :lib/column-key  (lib.column-key/aggregation-key aggregation))))))))))
 
 (mr/def ::operator-with-columns
   [:merge

--- a/src/metabase/lib/breakout.cljc
+++ b/src/metabase/lib/breakout.cljc
@@ -3,6 +3,7 @@
   (:require
    [clojure.string :as str]
    [metabase.lib.binning :as lib.binning]
+   [metabase.lib.column-key :as lib.column-key]
    [metabase.lib.equality :as lib.equality]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.ref :as lib.ref]
@@ -43,7 +44,8 @@
    (some->> (breakouts query stage-number)
             (mapv (mu/fn [a-ref :- [:or :mbql.clause/field :mbql.clause/expression]]
                     (-> (lib.metadata.calculation/metadata query stage-number a-ref)
-                        (assoc :lib/breakout? true)))))))
+                        (assoc :lib/breakout?  true
+                               :lib/column-key (lib.column-key/breakout-key a-ref))))))))
 
 (mu/defn breakout :- ::lib.schema/query
   "Add a new breakout on an expression, presumably a Field reference. Ignores attempts to add a duplicate breakout."
@@ -155,7 +157,7 @@
                                                         {:generous? true})]
      (let [binning (lib.binning/binning breakout-ref)
            bucket  (lib.temporal-bucket/temporal-bucket breakout-ref)]
-       (cond-> column
+       (cond-> (assoc column :lib/column-key (lib.column-key/breakout-key breakout-ref))
          binning (lib.binning/with-binning binning)
          bucket  (lib.temporal-bucket/with-temporal-bucket bucket))))))
 

--- a/src/metabase/lib/breakout.cljc
+++ b/src/metabase/lib/breakout.cljc
@@ -43,9 +43,10 @@
     stage-number :- :int]
    (some->> (breakouts query stage-number)
             (mapv (mu/fn [a-ref :- [:or :mbql.clause/field :mbql.clause/expression]]
-                    (-> (lib.metadata.calculation/metadata query stage-number a-ref)
-                        (assoc :lib/breakout?  true
-                               :lib/column-key (lib.column-key/breakout-key a-ref))))))))
+                    (let [col (lib.metadata.calculation/metadata query stage-number a-ref)]
+                      (-> col
+                          (assoc :lib/breakout?  true)
+                          (assoc :lib/column-key (lib.column-key/breakout-key col a-ref)))))))))
 
 (mu/defn breakout :- ::lib.schema/query
   "Add a new breakout on an expression, presumably a Field reference. Ignores attempts to add a duplicate breakout."
@@ -157,7 +158,7 @@
                                                         {:generous? true})]
      (let [binning (lib.binning/binning breakout-ref)
            bucket  (lib.temporal-bucket/temporal-bucket breakout-ref)]
-       (cond-> (assoc column :lib/column-key (lib.column-key/breakout-key breakout-ref))
+       (cond-> (assoc column :lib/column-key (lib.column-key/breakout-key column breakout-ref))
          binning (lib.binning/with-binning binning)
          bucket  (lib.temporal-bucket/with-temporal-bucket bucket))))))
 

--- a/src/metabase/lib/card.cljc
+++ b/src/metabase/lib/card.cljc
@@ -71,7 +71,7 @@
   * `field-metadata`      = Field metadata (`:metadata/column`) from the metadata provider for the Field with ID"
   [metadata-providerable :- ::lib.schema.metadata/metadata-providerable
    source-metadata-col   :- :map
-   card-id               :- [:maybe ::lib.schema.id/card]
+   card-id               :- ::lib.schema.id/card
    field-metadata        :- [:maybe ::lib.schema.metadata/column]]
   (let [source-metadata-col (-> source-metadata-col
                                 (perf/update-keys u/->kebab-case-en))
@@ -107,11 +107,7 @@
               ;; original DB field but should not be treated as FKs unless the metadata is configured
               ;; accordingly.
               (not= (:semantic-type source-metadata-col) :type/FK)
-              (assoc :fk-target-field-id nil)
-
-              (not (:lib/column-key col))
-              (as-> $c (assoc $c :lib/column-key (mu/disable-enforcement
-                                                   (lib.column-key/opaque-on-card metadata-providerable $c)))))]
+              (assoc :fk-target-field-id nil))]
     (-> col
         lib.field.util/update-keys-for-col-from-previous-stage
         (merge (when card-id
@@ -127,27 +123,24 @@
   "Massage possibly-legacy Card results metadata into MLv2 ColumnMetadata.
 
   If the metadata does not have `:lib/column-key`, this will add one, treating the card's columns as opaque."
-  ([metadata-providerable cols]
-   (->card-metadata-columns metadata-providerable nil cols))
-
-  ([metadata-providerable :- ::lib.schema.metadata/metadata-providerable
-    card-or-id-or-nil     :- [:maybe [:or ::lib.schema.id/card ::lib.schema.metadata/card]]
-    cols                  :- [:maybe [:or
-                                      [:sequential ::lib.schema.metadata/lib-or-legacy-column]
-                                      [:map
-                                       [:columns [:sequential ::lib.schema.metadata/lib-or-legacy-column]]]]]]
-   ;; Card `result-metadata` SHOULD be a sequence of column infos, but just to be safe handle a map that
-   ;; contains` :columns` as well.
-   (when-let [cols (not-empty (cond
-                                (map? cols)        (:columns cols)
-                                (sequential? cols) cols))]
-     (let [metadata-provider (lib.metadata/->metadata-provider metadata-providerable)
-           card-id           (when card-or-id-or-nil (u/the-id card-or-id-or-nil))
-           field-ids         (not-empty (into #{} (keep :id) cols))
-           fields            (when field-ids
-                               (lib.metadata.protocols/metadatas metadata-provider {:lib/type :metadata/column, :id field-ids}))
-           field-id->field   (m/index-by :id fields)]
-       (mapv #(->card-metadata-column metadata-provider % card-id (get field-id->field (:id %))) cols)))))
+  [metadata-providerable :- ::lib.schema.metadata/metadata-providerable
+   card-or-id            :- [:or ::lib.schema.id/card ::lib.schema.metadata/card]
+   cols                  :- [:maybe [:or
+                                     [:sequential ::lib.schema.metadata/lib-or-legacy-column]
+                                     [:map
+                                      [:columns [:sequential ::lib.schema.metadata/lib-or-legacy-column]]]]]]
+  ;; Card `result-metadata` SHOULD be a sequence of column infos, but just to be safe handle a map that
+  ;; contains` :columns` as well.
+  (when-let [cols (not-empty (cond
+                               (map? cols)        (:columns cols)
+                               (sequential? cols) cols))]
+    (let [metadata-provider (lib.metadata/->metadata-provider metadata-providerable)
+          card-id           (u/the-id card-or-id)
+          field-ids         (not-empty (into #{} (keep :id) cols))
+          fields            (when field-ids
+                              (lib.metadata.protocols/metadatas metadata-provider {:lib/type :metadata/column, :id field-ids}))
+          field-id->field   (m/index-by :id fields)]
+      (mapv #(->card-metadata-column metadata-provider % card-id (get field-id->field (:id %))) cols))))
 
 (mr/def ::column
   [:merge

--- a/src/metabase/lib/card.cljc
+++ b/src/metabase/lib/card.cljc
@@ -4,6 +4,7 @@
    [clojure.string :as str]
    [medley.core :as m]
    [metabase.lib.binning :as lib.binning]
+   [metabase.lib.column-key :as lib.column-key]
    [metabase.lib.computed :as lib.computed]
    [metabase.lib.display-name :as lib.display-name]
    [metabase.lib.field.util :as lib.field.util]
@@ -91,7 +92,9 @@
                               (assoc :lib/original-display-name (:display-name source-metadata-col)))
         col (merge
              {:base-type :type/*, :lib/type :metadata/column}
-             field-metadata
+             ;; Disregard the column key from the field-metadata; it's always the underlying field's key and might
+             ;; be missing a join, nested card, or other wrapping.
+             (dissoc field-metadata :lib/column-key)
              (m/filter-vals some? source-metadata-col)
              {:lib/type                :metadata/column
               :lib/source-column-alias ((some-fn :lib/source-column-alias :name) source-metadata-col)})
@@ -104,7 +107,11 @@
               ;; original DB field but should not be treated as FKs unless the metadata is configured
               ;; accordingly.
               (not= (:semantic-type source-metadata-col) :type/FK)
-              (assoc :fk-target-field-id nil))]
+              (assoc :fk-target-field-id nil)
+
+              (not (:lib/column-key col))
+              (as-> $c (assoc $c :lib/column-key (mu/disable-enforcement
+                                                   (lib.column-key/opaque-on-card metadata-providerable $c)))))]
     (-> col
         lib.field.util/update-keys-for-col-from-previous-stage
         (merge (when card-id
@@ -113,10 +120,13 @@
         ;; [[metabase.warehouse-schema-rest.api.table/card-result-metadata->virtual-fields]]
         (u/assoc-default :effective-type (:base-type col))
         ;; add original display name IF not already present AND we have a value
-        (->> (lib.normalize/normalize ::lib.schema.metadata/column)))))
+        (->> (lib.normalize/normalize ::lib.schema.metadata/column))
+        (update :lib/column-key lib.column-key/from-card card-id))))
 
 (mu/defn ->card-metadata-columns :- [:maybe [:sequential ::lib.schema.metadata/column]]
-  "Massage possibly-legacy Card results metadata into MLv2 ColumnMetadata."
+  "Massage possibly-legacy Card results metadata into MLv2 ColumnMetadata.
+
+  If the metadata does not have `:lib/column-key`, this will add one, treating the card's columns as opaque."
   ([metadata-providerable cols]
    (->card-metadata-columns metadata-providerable nil cols))
 
@@ -154,7 +164,8 @@
   #{})
 
 (defn- updated-result-metadata
-  "Get `:result-metadata` from Card, but merge in updated values of `:active` and `:visibility-type`."
+  "Get `:result-metadata` from Card, but merge in updated values of `:active` and `:visibility-type`, plus add
+  `:lib/column-key` values."
   [metadata-providerable card]
   (when-let [saved-metadata-cols (not-empty (:result-metadata card))]
     (let [ids                       (into #{} (keep :id) saved-metadata-cols)

--- a/src/metabase/lib/card.cljc
+++ b/src/metabase/lib/card.cljc
@@ -121,7 +121,7 @@
         (u/assoc-default :effective-type (:base-type col))
         ;; add original display name IF not already present AND we have a value
         (->> (lib.normalize/normalize ::lib.schema.metadata/column))
-        (update :lib/column-key lib.column-key/from-card card-id))))
+        (lib.column-key/from-card metadata-providerable card-id))))
 
 (mu/defn ->card-metadata-columns :- [:maybe [:sequential ::lib.schema.metadata/column]]
   "Massage possibly-legacy Card results metadata into MLv2 ColumnMetadata.

--- a/src/metabase/lib/column_key.cljc
+++ b/src/metabase/lib/column_key.cljc
@@ -1,0 +1,106 @@
+(ns metabase.lib.column-key
+  "Helpers for constructing the [[lib.schema.column-key/column-key]] for various kinds of entities."
+  (:require
+   [metabase.lib.field.util :as lib.field.util]
+   [metabase.lib.join.util :as lib.join.util]
+   [metabase.lib.options :as lib.options]
+   [metabase.lib.schema :as lib.schema]
+   [metabase.lib.schema.aggregation :as lib.schema.aggregation]
+   [metabase.lib.schema.column-key :as lib.schema.column-key]
+   [metabase.lib.schema.common :as lib.schema.common]
+   [metabase.lib.schema.id :as lib.schema.id]
+   [metabase.lib.schema.join :as lib.schema.join]
+   [metabase.lib.schema.metadata :as lib.schema.metadata]
+   [metabase.util.malli :as mu]))
+
+(mu/defn field-key :- ::lib.schema.column-key/column-key
+  "Returns the column key for a plain database field, given its ID.
+
+  (If you don't have an ID, you need a different kind of column key.)"
+  [field-id :- ::lib.schema.id/field]
+  {:lib/type        :column/key
+   :column.field/id field-id})
+
+(defn- join-uuid [join-clause-or-uuid]
+  (if (string? join-clause-or-uuid)
+    join-clause-or-uuid
+    (lib.options/uuid join-clause-or-uuid)))
+
+(mu/defn explicitly-joined :- ::lib.schema.column-key/column-key
+  "Constructs the column key for an explicitly joined column, given either the explicit join clause or its UUID,
+  and the column's key inside the join's RHS."
+  [inner-column-key    :- ::lib.schema.column-key/column-key
+   join-clause-or-uuid :- [:or ::lib.schema.join/join ::lib.schema.common/uuid]]
+  {:lib/type                   :column/key
+   :column.joined/join-uuid    (join-uuid join-clause-or-uuid)
+   :column.joined/inner-column inner-column-key})
+
+(mu/defn from-join? :- :boolean
+  "Returns true if the given `column-key` is already marked as being explicitly joined by `join-clause-or-uuid`."
+  [column-key          :- ::lib.schema.column-key/column-key
+   join-clause-or-uuid :- [:or ::lib.schema.join/join ::lib.schema.common/uuid]]
+  (and (map? column-key)
+       (contains? column-key :column.joined/join-uuid)
+       (= (:column.joined/join-uuid column-key)
+          (join-uuid join-clause-or-uuid))))
+
+(defn- ->key [column-or-key]
+  (if (and (map? column-or-key)
+           (= (:lib/type column-or-key) :column/key))
+    column-or-key
+    (:lib/column-key column-or-key)))
+
+(mu/defn implicitly-joined-via
+  "Given a `target-column-or-key` for an implicitly joinable column, and the `fk-column-or-key` for the FK column which
+  enables the implicit join, returns the column key for the implicitly joined column."
+  [target-column-or-key :- [:or ::lib.schema.metadata/column ::lib.schema.column-key/column-key]
+   fk-column-or-key     :- [:or ::lib.schema.metadata/column ::lib.schema.column-key/column-key]]
+  {:lib/type                      :column/key
+   :column.implicit/fk-column     (->key fk-column-or-key)
+   :column.implicit/target-column (->key target-column-or-key)})
+
+(mu/defn from-card
+  "Given a `inner-column-or-key` for a column as seen inside a card and the `card-id`, wrap up the inner column key
+  as coming from the card."
+  [inner-column-or-key :- [:or ::lib.schema.metadata/column ::lib.schema.column-key/column-key]
+   card-id             :- [:maybe ::lib.schema.id/card]]
+  (cond-> {:lib/type                 :column/key
+           :column.card/inner-column (->key inner-column-or-key)}
+    card-id (assoc :column.card/card-id card-id)))
+
+(mu/defn opaque-on-card
+  "Given a column or its `:lib/desired-column-alias` stage-unique string alias, returns the placeholder column key for
+  a column from a card whose definition we don't know at present."
+  [metadata-providerable :- ::lib.schema.metadata/metadata-providerable
+   column-or-alias       :- [:or ::lib.schema.metadata/column ::lib.schema.metadata/desired-column-alias]]
+  {:lib/type                        :column/key
+   :column.card.opaque/column-alias (or (and (string? column-or-alias) column-or-alias)
+                                        (:lib/desired-column-alias column-or-alias)
+                                        (lib.field.util/inherited-column-name column-or-alias)
+                                        (lib.join.util/desired-alias metadata-providerable column-or-alias)
+                                        (throw (ex-info "Failed to identify the unique alias for an opaque column"
+                                                        {:column-or-alias column-or-alias})))})
+
+(mu/defn breakout-key :- ::lib.schema.column-key/column-key
+  "Given a breakout clause like `[:field ...]`, construct its column key."
+  [brk-clause :- ::lib.schema/breakout]
+  {:lib/type             :column/key
+   :column.breakout/uuid (lib.options/uuid brk-clause)})
+
+(mu/defn aggregation-key :- ::lib.schema.column-key/column-key
+  "Given an aggregation clause like `[:max ...]`, construct its column key."
+  [agg-clause :- ::lib.schema.aggregation/aggregation]
+  {:lib/type                :column/key
+   :column.aggregation/uuid (lib.options/uuid agg-clause)})
+
+(mu/defn expression-key :- ::lib.schema.column-key/column-key
+  "Given an aggregation clause like `[:max ...]`, construct its column key."
+  [expr-clause :- :any] ;; FIXME: Get the right schema.
+  {:lib/type               :column/key
+   :column.expression/uuid (lib.options/uuid expr-clause)})
+
+(mu/defn native-key :- ::lib.schema.column-key/column-key
+  "Given the `unique-column-name` of a native query column, return its column key."
+  [unique-column-name :- ::lib.schema.common/non-blank-string]
+  {:lib/type                  :column/key
+   :column.native/unique-name unique-column-name})

--- a/src/metabase/lib/column_key.cljc
+++ b/src/metabase/lib/column_key.cljc
@@ -59,15 +59,6 @@
    :column.implicit/fk-column     (->key fk-column-or-key)
    :column.implicit/target-column (->key target-column-or-key)})
 
-(mu/defn from-card
-  "Given a `inner-column-or-key` for a column as seen inside a card and the `card-id`, wrap up the inner column key
-  as coming from the card."
-  [inner-column-or-key :- [:or ::lib.schema.metadata/column ::lib.schema.column-key/column-key]
-   card-id             :- [:maybe ::lib.schema.id/card]]
-  (cond-> {:lib/type                 :column/key
-           :column.card/inner-column (->key inner-column-or-key)}
-    card-id (assoc :column.card/card-id card-id)))
-
 (mu/defn opaque-on-card
   "Given a column or its `:lib/desired-column-alias` stage-unique string alias, returns the placeholder column key for
   a column from a card whose definition we don't know at present."
@@ -80,6 +71,17 @@
                                         (lib.join.util/desired-alias metadata-providerable column-or-alias)
                                         (throw (ex-info "Failed to identify the unique alias for an opaque column"
                                                         {:column-or-alias column-or-alias})))})
+
+(mu/defn from-card :- ::lib.schema.metadata/column
+  "Given **the complete `column-metadata`** for a column returned by a card, and the ID of the card, add the
+  `:lib/column-key` for the opaque column coming from the card.
+  as coming from the card."
+  [column-metadata       :- ::lib.schema.metadata/column
+   metadata-providerable :- ::lib.schema.metadata/metadata-providerable
+   card-id               :- [:maybe ::lib.schema.id/card]]
+  (let [column-key (cond-> (opaque-on-card metadata-providerable column-metadata)
+                     card-id (assoc :column.card/card-id card-id))]
+    (assoc column-metadata :lib/column-key column-key)))
 
 (mu/defn breakout-key :- ::lib.schema.column-key/column-key
   "Given a breakout clause like `[:field ...]`, construct its column key."

--- a/src/metabase/lib/column_key.cljc
+++ b/src/metabase/lib/column_key.cljc
@@ -59,29 +59,20 @@
    :column.implicit/fk-column     (->key fk-column-or-key)
    :column.implicit/target-column (->key target-column-or-key)})
 
-(mu/defn opaque-on-card
-  "Given a column or its `:lib/desired-column-alias` stage-unique string alias, returns the placeholder column key for
-  a column from a card whose definition we don't know at present."
-  [metadata-providerable :- ::lib.schema.metadata/metadata-providerable
-   column-or-alias       :- [:or ::lib.schema.metadata/column ::lib.schema.metadata/desired-column-alias]]
-  {:lib/type                        :column/key
-   :column.card.opaque/column-alias (or (and (string? column-or-alias) column-or-alias)
-                                        (:lib/desired-column-alias column-or-alias)
-                                        (lib.field.util/inherited-column-name column-or-alias)
-                                        (lib.join.util/desired-alias metadata-providerable column-or-alias)
-                                        (throw (ex-info "Failed to identify the unique alias for an opaque column"
-                                                        {:column-or-alias column-or-alias})))})
-
 (mu/defn from-card :- ::lib.schema.metadata/column
   "Given **the complete `column-metadata`** for a column returned by a card, and the ID of the card, add the
-  `:lib/column-key` for the opaque column coming from the card.
-  as coming from the card."
-  [column-metadata       :- ::lib.schema.metadata/column
+  `:lib/column-key` for the opaque column coming from the card."
+  [column-metadata       ; :- ::lib.schema.metadata/column - Not actually a valid column - might not have a column key.
    metadata-providerable :- ::lib.schema.metadata/metadata-providerable
-   card-id               :- [:maybe ::lib.schema.id/card]]
-  (let [column-key (cond-> (opaque-on-card metadata-providerable column-metadata)
-                     card-id (assoc :column.card/card-id card-id))]
-    (assoc column-metadata :lib/column-key column-key)))
+   card-id               :- ::lib.schema.id/card]
+  (assoc column-metadata :lib/column-key
+         {:lib/type                        :column/key
+          :column.card/card-id             card-id
+          :column.card.opaque/column-alias (or (:lib/desired-column-alias column-metadata)
+                                               (lib.field.util/inherited-column-name column-metadata)
+                                               (lib.join.util/desired-alias metadata-providerable column-metadata)
+                                               (throw (ex-info "Failed to find unique alias for an opaque column"
+                                                               {:column column-metadata})))}))
 
 (mu/defn breakout-key :- ::lib.schema.column-key/column-key
   "Given the `input-column-or-key` for a breakout's input column, and the breakout clause, return the column key for

--- a/src/metabase/lib/column_key.cljc
+++ b/src/metabase/lib/column_key.cljc
@@ -8,6 +8,7 @@
    [metabase.lib.schema.aggregation :as lib.schema.aggregation]
    [metabase.lib.schema.column-key :as lib.schema.column-key]
    [metabase.lib.schema.common :as lib.schema.common]
+   [metabase.lib.schema.expression :as lib.schema.expression]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.join :as lib.schema.join]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
@@ -91,7 +92,7 @@
 
 (mu/defn expression-key :- ::lib.schema.column-key/column-key
   "Given an aggregation clause like `[:max ...]`, construct its column key."
-  [expr-clause :- :any] ;; FIXME: Get the right schema.
+  [expr-clause :- ::lib.schema.expression/expression]
   {:lib/type               :column/key
    :column.expression/uuid (lib.options/uuid expr-clause)})
 

--- a/src/metabase/lib/column_key.cljc
+++ b/src/metabase/lib/column_key.cljc
@@ -84,10 +84,13 @@
     (assoc column-metadata :lib/column-key column-key)))
 
 (mu/defn breakout-key :- ::lib.schema.column-key/column-key
-  "Given a breakout clause like `[:field ...]`, construct its column key."
-  [brk-clause :- ::lib.schema/breakout]
-  {:lib/type             :column/key
-   :column.breakout/uuid (lib.options/uuid brk-clause)})
+  "Given the `input-column-or-key` for a breakout's input column, and the breakout clause, return the column key for
+  that breakout."
+  [input-column-or-key :- [:or ::lib.schema.metadata/column ::lib.schema.column-key/column-key]
+   brk-clause          :- ::lib.schema/breakout]
+  {:lib/type                     :column/key
+   :column.breakout/input-column (->key input-column-or-key)
+   :column.breakout/uuid         (lib.options/uuid brk-clause)})
 
 (mu/defn aggregation-key :- ::lib.schema.column-key/column-key
   "Given an aggregation clause like `[:max ...]`, construct its column key."
@@ -106,3 +109,12 @@
   [unique-column-name :- ::lib.schema.common/non-blank-string]
   {:lib/type                  :column/key
    :column.native/unique-name unique-column-name})
+
+(mu/defn fallback-key :- ::lib.schema.column-key/column-key
+  "Creates a column key for *fallback metadata*, when a ref cannot be resolved."
+  [id-or-name :- [:or :string :int]]
+  (let [k (if (string? id-or-name)
+            :column.fallback/column-name
+            :column.fallback/field-id)]
+    {:lib/type :column/key
+     k         id-or-name}))

--- a/src/metabase/lib/expression.cljc
+++ b/src/metabase/lib/expression.cljc
@@ -5,6 +5,7 @@
    [clojure.string :as str]
    [malli.core :as mc]
    [medley.core :as m]
+   [metabase.lib.column-key :as lib.column-key]
    [metabase.lib.common :as lib.common]
    [metabase.lib.computed :as lib.computed]
    [metabase.lib.display-name :as lib.display-name]
@@ -92,11 +93,13 @@
   (lib.computed/with-cache-ephemeral* query [:expression-metadata/by-ref stage-number expression-ref-clause
                                              (lib.metadata.calculation/cacheable-options {})]
     (fn []
-      (let [base-type (lib.metadata.calculation/type-of query stage-number expression-ref-clause)]
+      (let [expr      (resolve-expression query stage-number expression-name)
+            base-type (lib.metadata.calculation/type-of query stage-number expression-ref-clause)]
         (merge {:lib/type                :metadata/column
                 ;; TODO (Cam 8/7/25) -- is the source UUID of an expression ref supposed to be the ID of the ref, or the ID
                 ;; of the expression definition??
                 :lib/source-uuid         (:lib/uuid opts)
+                :lib/column-key          (lib.column-key/expression-key expr)
                 :name                    expression-name
                 :lib/expression-name     expression-name
                 :lib/source-column-alias expression-name
@@ -445,6 +448,7 @@
         (assoc :lib/source          :source/expressions
                :lib/source-uuid     (lib.options/uuid expression-definition)
                :lib/expression-name expression-name
+               :lib/column-key      (lib.column-key/expression-key expression-definition)
                :name                expression-name
                :display-name        expression-name))))
 

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -719,25 +719,6 @@
         ;; Then drop any redundant :fields clauses.
         lib.remove-replace/normalize-fields-clauses)))
 
-(mu/defn find-column-for-name :- [:maybe ::lib.schema.metadata/column]
-  "Find the first column in `columns` whose `:name` matches `column-name`.
-  Matching is case-insensitive.
-
-  Optionally pass a `pred` function for additional filtering; only columns
-  satisfying `(pred column)` will be considered."
-  ([columns :- [:sequential ::lib.schema.metadata/column]
-    column-name :- :string]
-   (find-column-for-name columns column-name nil))
-
-  ([columns :- [:sequential ::lib.schema.metadata/column]
-    column-name :- :string
-    pred :- [:maybe ifn?]]
-   (let [lower-name (u/lower-case-en column-name)]
-     (m/find-first (fn [col]
-                     (and (= (u/lower-case-en (:name col)) lower-name)
-                          (or (nil? pred) (pred col))))
-                   columns))))
-
 (mu/defn json-field? :- :boolean
   "Return true if field is a JSON field, false if not."
   [field :- [:maybe ::lib.schema.metadata/column]]

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -738,7 +738,7 @@
                           (or (nil? pred) (pred col))))
                    columns))))
 
-(defn json-field?
+(mu/defn json-field? :- :boolean
   "Return true if field is a JSON field, false if not."
   [field :- [:maybe ::lib.schema.metadata/column]]
   (some? (:nfc-path field)))

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -7,7 +7,6 @@
    [metabase.lib.aggregation :as lib.aggregation]
    [metabase.lib.binning :as lib.binning]
    [metabase.lib.computed :as lib.computed]
-   [metabase.lib.dispatch :as lib.dispatch]
    [metabase.lib.equality :as lib.equality]
    [metabase.lib.expression :as lib.expression]
    [metabase.lib.field.resolution :as lib.field.resolution]
@@ -720,25 +719,26 @@
         ;; Then drop any redundant :fields clauses.
         lib.remove-replace/normalize-fields-clauses)))
 
-;; TODO: Refactor this away? The special handling for aggregations is strange.
-(mu/defn find-visible-column-for-ref :- [:maybe ::lib.schema.metadata/column]
-  "Return the visible column in `query` at `stage-number` referenced by `field-ref`. If `stage-number` is omitted, the
-  last stage is used. This is currently only meant for use with `:field` clauses."
-  ([query field-ref]
-   (find-visible-column-for-ref query -1 field-ref))
+(mu/defn find-column-for-name :- [:maybe ::lib.schema.metadata/column]
+  "Find the first column in `columns` whose `:name` matches `column-name`.
+  Matching is case-insensitive.
 
-  ([query        :- ::lib.schema/query
-    stage-number :- :int
-    field-ref    :- some?]
-   (let [;; not 100% sure why, but [[lib.metadata.calculation/visible-columns]] doesn't seem to return aggregations,
-         ;; so we have to use [[lib.metadata.calculation/returned-columns]] instead.
-         columns ((if (= (lib.dispatch/dispatch-value field-ref) :aggregation)
-                    lib.metadata.calculation/returned-columns
-                    lib.metadata.calculation/visible-columns)
-                  query stage-number)]
-     (lib.equality/find-matching-column query stage-number field-ref columns))))
+  Optionally pass a `pred` function for additional filtering; only columns
+  satisfying `(pred column)` will be considered."
+  ([columns :- [:sequential ::lib.schema.metadata/column]
+    column-name :- :string]
+   (find-column-for-name columns column-name nil))
 
-(mu/defn json-field? :- :boolean
+  ([columns :- [:sequential ::lib.schema.metadata/column]
+    column-name :- :string
+    pred :- [:maybe ifn?]]
+   (let [lower-name (u/lower-case-en column-name)]
+     (m/find-first (fn [col]
+                     (and (= (u/lower-case-en (:name col)) lower-name)
+                          (or (nil? pred) (pred col))))
+                   columns))))
+
+(defn json-field?
   "Return true if field is a JSON field, false if not."
   [field :- [:maybe ::lib.schema.metadata/column]]
   (some? (:nfc-path field)))

--- a/src/metabase/lib/field/resolution.cljc
+++ b/src/metabase/lib/field/resolution.cljc
@@ -543,6 +543,7 @@
     ;; guess that the column came from the previous stage
     :lib/source          :source/previous-stage
     :base-type           :type/*
+    :lib/column-key      (lib.column-key/fallback-key id-or-name)
     ::fallback-metadata? true}
    (if (pos-int? id-or-name)
      {:id                      id-or-name

--- a/src/metabase/lib/field/resolution.cljc
+++ b/src/metabase/lib/field/resolution.cljc
@@ -9,6 +9,7 @@
    [clojure.set :as set]
    [clojure.string :as str]
    [medley.core :as m]
+   [metabase.lib.column-key :as lib.column-key]
    [metabase.lib.expression :as lib.expression]
    [metabase.lib.field.util :as lib.field.util]
    [metabase.lib.join :as lib.join]
@@ -435,9 +436,10 @@
   (when-some [col (or (field-metadata query nil id-or-name)
                       (resolve-name-in-implicit-join-this-stage query source-field-id id-or-name))]
     ;; if we managed to resolve it then update metadata appropriately.
-    (assoc col
-           :lib/source :source/implicitly-joinable
-           :fk-field-id source-field-id)))
+    (-> col
+        (assoc :lib/source :source/implicitly-joinable
+               :fk-field-id source-field-id)
+        (update :lib/column-key lib.column-key/implicitly-joined-via (lib.column-key/field-key source-field-id)))))
 
 ;;; See for
 ;;; example [[metabase.query-processor.field-ref-repro-test/model-with-implicit-join-and-external-remapping-test]],

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -2,6 +2,8 @@
   "Functions related to manipulating EXPLICIT joins in MBQL."
   (:refer-clojure :exclude [mapv run! some empty? not-empty get-in #?(:clj for)])
   (:require
+   ;; TODO: (bshepherdson, 2026/03/30) Make analytics.core into a CLJC module, even if the CLJS versions do nothing.
+   #?@(:clj ([metabase.analytics.core :as analytics]))
    [clojure.set :as set]
    [clojure.string :as str]
    [inflections.core :as inflections]
@@ -254,7 +256,7 @@
                               [:lib/type [:= :metadata/column]]]
   "For a column that comes from a join, add or update metadata as needed, e.g. include join name in the display name."
   ([query stage-number col join-alias]
-   (column-from-join query stage-number col join-alias (maybe-resolve-join query stage-number join-alias)))
+   (column-from-join query stage-number col join-alias nil))
   ([query        :- ::lib.schema/query
     stage-number :- :int
     col          :- [:map
@@ -276,7 +278,9 @@
                                      (if (lib.column-key/from-join? (:lib/column-key col) join)
                                        (:lib/column-key col)
                                        (lib.column-key/explicitly-joined (:lib/column-key col) join))
-                                     ::failed-to-resolve-join-clause)
+                                     (do
+                                       #?(:clj (analytics/inc! :metabase-query-processor/unresolvable-join-clause))
+                                       ::failed-to-resolve-join-clause))
         :lib/original-name         ((some-fn :lib/original-name :name) col)
         :lib/original-display-name (or (:lib/original-display-name col)
                                        (lib.metadata.calculation/display-name query stage-number (dissoc col ::join-alias :lib/original-join-alias :source-alias))))

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -7,6 +7,7 @@
    [inflections.core :as inflections]
    [medley.core :as m]
    [metabase.lib.card :as lib.card]
+   [metabase.lib.column-key :as lib.column-key]
    [metabase.lib.common :as lib.common]
    [metabase.lib.dispatch :as lib.dispatch]
    [metabase.lib.equality :as lib.equality]
@@ -252,21 +253,38 @@
 (mu/defn column-from-join :- [:map
                               [:lib/type [:= :metadata/column]]]
   "For a column that comes from a join, add or update metadata as needed, e.g. include join name in the display name."
-  [query        :- ::lib.schema/query
-   stage-number :- :int
-   col          :- [:map
-                    [:lib/type [:= :metadata/column]]]
-   join-alias   :- ::lib.schema.join/alias]
-  (-> col
-      (assoc
-       :lib/original-join-alias   join-alias
-       :lib/source                :source/joins
-       :lib/join-alias               join-alias
-       :lib/original-name         ((some-fn :lib/original-name :name) col)
-       :lib/original-display-name (or (:lib/original-display-name col)
-                                      (lib.metadata.calculation/display-name query stage-number (dissoc col :lib/join-alias :lib/original-join-alias))))
-      (set/rename-keys {:lib/expression-name :lib/original-expression-name})
-      (as-> $col (assoc $col :display-name (lib.metadata.calculation/display-name query stage-number $col)))))
+  ([query stage-number col join-alias]
+   (column-from-join query stage-number col join-alias (maybe-resolve-join query stage-number join-alias)))
+  ([query        :- ::lib.schema/query
+    stage-number :- :int
+    col          :- [:map
+                     [:lib/type [:= :metadata/column]]]
+    join-alias   :- ::lib.schema.join/alias
+    clause       :- [:maybe ::lib.join.util/partial-join]]
+   (-> col
+       (assoc
+         ;; TODO (Cam 6/19/25) -- we need to get rid of `:source-alias` it's just causing confusion; don't need two
+         ;; keys for join aliases.
+        :source-alias              join-alias
+        :lib/original-join-alias   join-alias
+        :lib/source                :source/joins
+        ::join-alias               join-alias
+        :lib/column-key            (if-let [join (or clause
+                                                     (maybe-resolve-join query stage-number join-alias))]
+                                      ;; HACK: Convoluted code at the stage boundary can result in this getting called
+                                      ;; more than once on the same column. To avoid "double-bagging" the column keys,
+                                      ;; check if it's already marked as coming from this join.
+                                      ;; TODO: (Braden, 2026/01/12) Clean up the `returned-columns` logic so this hack is
+                                      ;; not needed anymore.
+                                     (if (lib.column-key/from-join? (:lib/column-key col) join)
+                                       (:lib/column-key col)
+                                       (lib.column-key/explicitly-joined (:lib/column-key col) join))
+                                     ::failed-to-resolve-join-clause)
+        :lib/original-name         ((some-fn :lib/original-name :name) col)
+        :lib/original-display-name (or (:lib/original-display-name col)
+                                       (lib.metadata.calculation/display-name query stage-number (dissoc col ::join-alias :lib/original-join-alias :source-alias))))
+       (set/rename-keys {:lib/expression-name :lib/original-expression-name})
+       (as-> $col (assoc $col :display-name (lib.metadata.calculation/display-name query stage-number $col))))))
 
 (defn- HACK-column-from-incomplete-join
   "Hack until I can figure out a better way to fix this. Once I made `:lib/join-alias` required for columns with
@@ -337,7 +355,7 @@
    (into []
          (comp
           (map lib.field.util/update-keys-for-col-from-previous-stage)
-          (map #(column-from-join query stage-number % join-alias))
+          (map #(column-from-join query stage-number % join-alias join))
           (if-let [fk-field-id (:fk-field-id join)]
             (map (fn [col]
                    (assoc col :fk-field-id fk-field-id)))
@@ -398,7 +416,7 @@
                   options))]
       ;; TODO (Cam 8/1/25) -- doesn't [[join-returned-columns-relative-to-parent-stage]] already
       ;; call [[column-from-join]] ???
-      (mapv #(column-from-join query stage-number % join-alias)
+      (mapv #(column-from-join query stage-number % join-alias join)
             cols'))))
 
 ;;; VISIBLE COLUMNS FOR A JOIN ARE RELATIVE TO THE LAST STAGE OF A JOIN!!!! IF YOU WANT THEM WITH APPROPRIATE METADATA
@@ -412,7 +430,7 @@
    options                       :- [:maybe ::lib.metadata.calculation/returned-columns.options]]
   (into []
         (comp (map lib.field.util/update-keys-for-col-from-previous-stage)
-              (map #(column-from-join query stage-number % join-alias)))
+              (map #(column-from-join query stage-number % join-alias join)))
         (lib.metadata.calculation/returned-columns query stage-number join options)))
 
 (mu/defn all-joins-visible-columns-relative-to-parent-stage :- ::lib.metadata.calculation/visible-columns

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -263,12 +263,9 @@
     clause       :- [:maybe ::lib.join.util/partial-join]]
    (-> col
        (assoc
-         ;; TODO (Cam 6/19/25) -- we need to get rid of `:source-alias` it's just causing confusion; don't need two
-         ;; keys for join aliases.
-        :source-alias              join-alias
         :lib/original-join-alias   join-alias
         :lib/source                :source/joins
-        ::join-alias               join-alias
+        :lib/join-alias            join-alias
         :lib/column-key            (if-let [join (or clause
                                                      (maybe-resolve-join query stage-number join-alias))]
                                       ;; HACK: Convoluted code at the stage boundary can result in this getting called

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -2,8 +2,6 @@
   "Functions related to manipulating EXPLICIT joins in MBQL."
   (:refer-clojure :exclude [mapv run! some empty? not-empty get-in #?(:clj for)])
   (:require
-   ;; TODO: (bshepherdson, 2026/03/30) Make analytics.core into a CLJC module, even if the CLJS versions do nothing.
-   #?@(:clj ([metabase.analytics.core :as analytics]))
    [clojure.set :as set]
    [clojure.string :as str]
    [inflections.core :as inflections]
@@ -278,9 +276,10 @@
                                      (if (lib.column-key/from-join? (:lib/column-key col) join)
                                        (:lib/column-key col)
                                        (lib.column-key/explicitly-joined (:lib/column-key col) join))
-                                     (do
-                                       #?(:clj (analytics/inc! :metabase-query-processor/unresolvable-join-clause))
-                                       ::failed-to-resolve-join-clause))
+                                     ;; TODO: (bshepherdson, 2026/03/30) Including analytics.core causes a circular dep.
+                                     ;; Need a CLJC solution for analytics that lib can use. Add a counter for this join
+                                     ;; resolution failure once we have the infrastructure in place.
+                                     ::failed-to-resolve-join-clause)
         :lib/original-name         ((some-fn :lib/original-name :name) col)
         :lib/original-display-name (or (:lib/original-display-name col)
                                        (lib.metadata.calculation/display-name query stage-number (dissoc col ::join-alias :lib/original-join-alias :source-alias))))

--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -5,6 +5,7 @@
       :cljs [metabase.lib.cache :as lib.cache])
    [clojure.string :as str]
    [medley.core :as m]
+   [metabase.lib.column-key :as lib.column-key]
    [metabase.lib.computed :as lib.computed]
    [metabase.lib.dispatch :as lib.dispatch]
    [metabase.lib.field.util :as lib.field.util]
@@ -698,29 +699,31 @@
         id->target-fields (m/index-by :id (lib.metadata/bulk-metadata
                                            query :metadata/column (into #{} (map :fk-target-field-id) fk-fields)))
         target-fields (into []
-                            (comp (keep (fn [{source-field-id :id
-                                              :keys [fk-target-field-id]
-                                              :as   source}]
-                                          ;; the target field might not exist
-                                          (when-let [target (id->target-fields fk-target-field-id)]
-                                            (assoc target
-                                                   ::fk-field-id   source-field-id
-                                                   ::fk-field-name (lib.field.util/inherited-column-name source)
-                                                   ::fk-join-alias (:lib/join-alias source)))))
+                            (comp (map (fn [{source-field-id :id
+                                             :keys [fk-target-field-id]
+                                             :as   source}]
+                                         ;; the target field might not exist
+                                         (when-let [target (id->target-fields fk-target-field-id)]
+                                           (assoc target
+                                                  ::fk-field-id   source-field-id
+                                                  ::fk-field-name (lib.field.util/inherited-column-name source)
+                                                  ::fk-column-key (:lib/column-key source)
+                                                  ::fk-join-alias (:lib/join-alias source)))))
                                   (remove #(contains? existing-table-ids (:table-id %))))
                             fk-fields)
         id->table (m/index-by :id (lib.metadata/bulk-metadata
                                    query :metadata/table (into #{} (map :table-id) target-fields)))]
     (into []
-          (mapcat (fn [{:keys [table-id], ::keys [fk-field-id fk-field-name fk-join-alias]}]
+          (mapcat (fn [{:keys [table-id], ::keys [fk-field-id fk-field-name fk-join-alias fk-column-key]}]
                     (let [table (id->table table-id)]
                       (for [field (returned-columns query stage-number table)]
-                        (m/assoc-some field
-                                      :fk-field-id              fk-field-id
-                                      :fk-field-name            fk-field-name
-                                      :fk-join-alias            fk-join-alias
-                                      :lib/source               :source/implicitly-joinable
-                                      :lib/source-column-alias  (:name field))))))
+                        (-> field
+                            (m/assoc-some :fk-field-id              fk-field-id
+                                          :fk-field-name            fk-field-name
+                                          :fk-join-alias            fk-join-alias
+                                          :lib/source               :source/implicitly-joinable
+                                          :lib/source-column-alias  (:name field))
+                            (update :lib/column-key lib.column-key/implicitly-joined-via fk-column-key))))))
           target-fields)))
 
 (mu/defn default-columns-for-stage :- ::returned-columns

--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -699,16 +699,16 @@
         id->target-fields (m/index-by :id (lib.metadata/bulk-metadata
                                            query :metadata/column (into #{} (map :fk-target-field-id) fk-fields)))
         target-fields (into []
-                            (comp (map (fn [{source-field-id :id
-                                             :keys [fk-target-field-id]
-                                             :as   source}]
-                                         ;; the target field might not exist
-                                         (when-let [target (id->target-fields fk-target-field-id)]
-                                           (assoc target
-                                                  ::fk-field-id   source-field-id
-                                                  ::fk-field-name (lib.field.util/inherited-column-name source)
-                                                  ::fk-column-key (:lib/column-key source)
-                                                  ::fk-join-alias (:lib/join-alias source)))))
+                            (comp (keep (fn [{source-field-id :id
+                                              :keys [fk-target-field-id]
+                                              :as   source}]
+                                          ;; the target field might not exist
+                                          (when-let [target (id->target-fields fk-target-field-id)]
+                                            (assoc target
+                                                   ::fk-field-id   source-field-id
+                                                   ::fk-field-name (lib.field.util/inherited-column-name source)
+                                                   ::fk-column-key (:lib/column-key source)
+                                                   ::fk-join-alias (:lib/join-alias source)))))
                                   (remove #(contains? existing-table-ids (:table-id %))))
                             fk-fields)
         id->table (m/index-by :id (lib.metadata/bulk-metadata

--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -712,7 +712,7 @@
                                   (remove #(contains? existing-table-ids (:table-id %))))
                             fk-fields)
         id->table (m/index-by :id (lib.metadata/bulk-metadata
-                                   query :metadata/table (into #{} (map :table-id) target-fields)))]
+                                   query :metadata/table (into #{} (keep :table-id) target-fields)))]
     (into []
           (mapcat (fn [{:keys [table-id], ::keys [fk-field-id fk-field-name fk-join-alias fk-column-key]}]
                     (let [table (id->table table-id)]

--- a/src/metabase/lib/metadata/result_metadata.cljc
+++ b/src/metabase/lib/metadata/result_metadata.cljc
@@ -453,8 +453,10 @@
 ;;; TODO (Cam 6/12/25) -- remove `:lib/uuid` because it causes way to many test failures. Probably would be better to
 ;;; keep it around but I don't have time to update a million tests. Why do columns have `:lib/uuid` anyway? They
 ;;; should maybe have `:lib/source-uuid` but I don't think they should have `:lib/uuid`.
+;;; TODO (Braden 2026/01/16) It would be good to put `:lib/column-key` into result-metadata but it perturbs too many
+;;; tests. I agree with Cam's TODO above that the UUIDs should be dropped.
 (defn- remove-lib-uuids [col]
-  (dissoc col :lib/uuid :lib/source-uuid :lib/original-ref-style-for-result-metadata-purposes))
+  (dissoc col :lib/uuid :lib/source-uuid :lib/original-ref-style-for-result-metadata-purposes :lib/column-key))
 
 (mu/defn- col->legacy-metadata :- ::kebab-cased-map
   "Convert Lib-style `:metadata/column` column metadata to the `snake_case` legacy format we've come to know and love

--- a/src/metabase/lib/metadata/result_metadata.cljc
+++ b/src/metabase/lib/metadata/result_metadata.cljc
@@ -368,8 +368,9 @@
   "Merge in snake-cased `:metadata/model-metadata`."
   [query :- ::lib.schema/query
    cols  :- [:sequential ::kebab-cased-map]]
-  (let [model-metadata (some->> (get-in query [:info :metadata/model-metadata])
-                                (lib.card/->card-metadata-columns query))]
+  (let [card-id        (get-in query [:info :card-id])
+        model-metadata (some->> (get-in query [:info :metadata/model-metadata])
+                                (lib.card/->card-metadata-columns query card-id))]
     (if-not (seq model-metadata)
       cols ; If not a model, nothing to change
       (let [last-stage (lib.util/query-stage query -1)

--- a/src/metabase/lib/remove_replace.cljc
+++ b/src/metabase/lib/remove_replace.cljc
@@ -606,8 +606,13 @@
 (defn- remove-matching-missing-columns
   [query-after query-before stage-number match-spec]
   (let [removed-cols (set/difference
-                      (set (lib.metadata.calculation/visible-columns query-before stage-number))
-                      (set (lib.metadata.calculation/visible-columns query-after stage-number)))]
+                      ;; TODO: (Braden, 2026-01-15) This is a hack to preserve the behaviour from before
+                      ;; `:lib/column-key` was added. Remove-replace logic for matching up refs with the original query
+                      ;; should be powered by `:lib/column-key` rather than working around it.
+                      (into #{} (map #(dissoc % :lib/column-key))
+                            (lib.metadata.calculation/visible-columns query-before stage-number))
+                      (into #{} (map #(dissoc % :lib/column-key))
+                            (lib.metadata.calculation/visible-columns query-after stage-number)))]
     (reduce
      #(apply remove-local-references %1 stage-number query-after (match-spec %2))
      query-after

--- a/src/metabase/lib/schema/column_key.cljc
+++ b/src/metabase/lib/schema/column_key.cljc
@@ -1,0 +1,133 @@
+(ns metabase.lib.schema.column-key
+  "Unique-by-construction keys for all columns in a query. Useful for \"renaming\" approaches like turning a model into
+  a transform, and updating all its (transitive) dependents to reference the transform's output table instead.
+
+  **NOTE:** These are unique *within any column list* at all stages of a query. They are not unique across the entire
+  query, so don't try to use them as keys globally. The weak link here is native columns; identifying them by a card
+  ID is not possible in general, so their names can be reused in different parts of the query."
+  (:require
+   [metabase.lib.schema.common :as lib.schema.common]
+   [metabase.lib.schema.id :as lib.schema.id]
+   [metabase.util.malli.registry :as mr]))
+
+;; Column keys are maps with `:lib/type :column/key` and one or more other namespaced keys that declare the salient
+;; details of this key. Column keys are recursive! Several flavours of column keys embed other column keys.
+
+;; It is vital that these keys be unique by construction. They mirror the path of how the column got into the query in
+;; the first place: from the source table or card, an explicit or implicit join, an expression, aggregation or breakout.
+;; Note that breakouts are considered distinct columns from their inputs!
+
+;; On the other hand, these are not globally unique, only unique within any list of columns. This simplifies the logic
+;; considerably! Native columns only need their own names, not the context of the card they came from or anything else.
+;; As long as the column names are unique in the SQL query - and Metabase contrives that even if the user's query has
+;; duplicated names in it! - any single source will have unique column names. When multiple sources come together all
+;; but one will be wrapped with a join.
+
+;; Note that stage boundaries mean nothing to a column key, though card boundaries do. Especially because model
+;; overrides can be applied at the card boundary, but also because a card boundary implies a level of nesting, which
+;; has an impact on aliasing and so on.
+
+(mr/def ::by-field-id
+  "Fields directly from the table are keyed by the field ID."
+  [:map {:decode/normalize lib.schema.common/normalize-map}
+   [:lib/type [:= :column/key]]
+   [:column.field/id ::lib.schema.id/field]])
+
+(mr/def ::explicitly-joined
+  "Explicitly joined columns refer to the join clause by UUID, and embed the column's key within the join's subtree."
+  [:map {:decode/normalize lib.schema.common/normalize-map}
+   [:lib/type [:= :column/key]]
+   [:column.joined/join-uuid [:ref ::lib.schema.common/uuid]]
+   [:column.joined/inner-column [:ref ::column-key]]])
+
+;; Implicit join: a pair of column keys, for the FK column and the target column.
+;; Generally the target column is `::by-field-id`, but it doesn't have to be.
+(mr/def ::implicitly-joined
+  "Implicit joins are specified by the target column's key in the foreign table, *plus* the key of the FK used for
+  the join.
+
+  The target column is usually `::by-field-id` but it doesn't have to be."
+  [:map {:decode/normalize lib.schema.common/normalize-map}
+   [:lib/type [:= :column/key]]
+   [:column.implicit/fk-column     [:ref ::column-key]]
+   [:column.implicit/target-column [:ref ::column-key]]])
+
+;; See above regarding native columns and unique names.
+(mr/def ::native
+  "Native columns coming straight from SQL or a Mongo query are identified only by their (unique) column name.
+
+  Note that Metabase contrives to give all the columns unique names in the metadata, even if the SQL query itself has
+  duplicated names. This is a possible source of dangling or sneakily-changed references if the user edits the native
+  query, but there's no way around that.
+
+  Note that these names might not be unique across the entirety of a complex query, but they don't need to be. They're
+  unique within any given stage, since whenever multiple sources come together all but one is wrapped in a join. So
+  these still serve the purpose of being unique keys within a stage.
+
+  **DO NOT** try to use column keys as e.g. a map key for all columns or refs across an entire query; there can be
+  collisions in different parts of the query. (It's too bad, because being unique across a query would be useful!)"
+  [:map {:decode/normalize lib.schema.common/normalize-map}
+   [:lib/type [:= :column/key]]
+   [:column.native/unique-name :string]])
+
+(mr/def ::from-card
+  "Columns from cards are always wrapped up with the card's ID and the inner column's key.
+
+  Usually this doesn't matter, but model overrides and other things make the column inside the card and outside it
+  distinct from each other. They also get different aliasing especially when joined."
+  [:map {:decode/normalize lib.schema.common/normalize-map}
+   [:lib/type [:= :column/key]]
+   ;; Optional for testing - some queries are analyzed as cards without having an ID.
+   [:column.card/card-id {:optional true} ::lib.schema.id/card]
+   [:column.card/inner-column [:ref ::column-key]]])
+
+(mr/def ::opaque-card
+  "Sometimes for a column from a card, we only have its column name and not its complete picture. It's impractical to
+  backfill these perfectly, but all we need in practice is a stage-unique placeholder that can be overwritten later,
+  i.e. when inlining the card's definition.
+
+  Note that this is intended to be used as the *inner* column key of a column on a card. When that card is used from
+  somewhere else, this will be wrapped in a [[::from-card]] like any other inner column."
+  [:map {:decode/normalize lib.schema.common/normalize-map}
+   [:lib/type [:= :column/key]]
+   [:column.card.opaque/column-alias [:ref :metabase.lib.schema.metadata/desired-column-alias]]])
+
+(mr/def ::expression
+  "Expressions are *fresh* columns introduced on a stage; they're keyed by UUID."
+  [:map {:decode/normalize lib.schema.common/normalize-map}
+   [:lib/type [:= :column/key]]
+   [:column.expression/uuid [:ref ::lib.schema.common/uuid]]])
+
+(mr/def ::aggregation
+  "Aggregations are *fresh* columns introduced on a stage; they're keyed by UUID."
+  [:map {:decode/normalize lib.schema.common/normalize-map}
+   [:lib/type [:= :column/key]]
+   [:column.aggregation/uuid [:ref ::lib.schema.common/uuid]]])
+
+(mr/def ::breakout
+  "Breakouts are *fresh* columns introduced on a stage; they're keyed by UUID.
+
+
+  The UUID for a breakout column is the `:lib/uuid` of the `:field` or `:expression` **ref** that appears in the
+  `:breakout` list.
+
+  It is a departure for the lib to treat breakouts as distinct from their input columns, but it matches the semantics
+  of breakouts. In particular, two breakouts of the same input column with different temporal units are distinct
+  columns, and the `:order-by` logic takes care to distinguish them by matching the binning and temporal units."
+  [:map {:decode/normalize lib.schema.common/normalize-map}
+   [:lib/type [:= :column/key]]
+   [:column.breakout/uuid [:ref ::lib.schema.common/uuid]]])
+
+(mr/def ::column-key
+  "A generic column key, any one of the supported flavours of column keys."
+  [:or
+   {:error/message "A valid :lib/column-key"}
+   ::by-field-id
+   ::explicitly-joined
+   ::implicitly-joined
+   ::native
+   ::from-card
+   ::opaque-card
+   ::expression
+   ::aggregation
+   ::breakout])

--- a/src/metabase/lib/schema/column_key.cljc
+++ b/src/metabase/lib/schema/column_key.cljc
@@ -70,26 +70,17 @@
    [:lib/type [:= :column/key]]
    [:column.native/unique-name :string]])
 
-(mr/def ::from-card
-  "Columns from cards are always wrapped up with the card's ID and the inner column's key.
+(mr/def ::opaque-card
+  "A leaf column key for a column coming from a `:source-card`. Cards are treated as opaque in the lib, and the columns
+  are given aliases that are unique on the card. The `card-id` + `alias` pair is unique within the stage, as required
+  for column keys.
 
-  Usually this doesn't matter, but model overrides and other things make the column inside the card and outside it
-  distinct from each other. They also get different aliasing especially when joined."
+  When a card's definition gets inlined, these opaque leaf keys can be replaced 1-1 with the *inner* column keys from
+  the card's query."
   [:map {:decode/normalize lib.schema.common/normalize-map}
    [:lib/type [:= :column/key]]
    ;; Optional for testing - some queries are analyzed as cards without having an ID.
    [:column.card/card-id {:optional true} ::lib.schema.id/card]
-   [:column.card/inner-column [:ref ::column-key]]])
-
-(mr/def ::opaque-card
-  "Sometimes for a column from a card, we only have its column name and not its complete picture. It's impractical to
-  backfill these perfectly, but all we need in practice is a stage-unique placeholder that can be overwritten later,
-  i.e. when inlining the card's definition.
-
-  Note that this is intended to be used as the *inner* column key of a column on a card. When that card is used from
-  somewhere else, this will be wrapped in a [[::from-card]] like any other inner column."
-  [:map {:decode/normalize lib.schema.common/normalize-map}
-   [:lib/type [:= :column/key]]
    [:column.card.opaque/column-alias [:ref :metabase.lib.schema.metadata/desired-column-alias]]])
 
 (mr/def ::expression
@@ -126,7 +117,6 @@
    ::explicitly-joined
    ::implicitly-joined
    ::native
-   ::from-card
    ::opaque-card
    ::expression
    ::aggregation

--- a/src/metabase/lib/schema/column_key.cljc
+++ b/src/metabase/lib/schema/column_key.cljc
@@ -96,8 +96,8 @@
    [:column.aggregation/uuid [:ref ::lib.schema.common/uuid]]])
 
 (mr/def ::breakout
-  "Breakouts are *fresh* columns introduced on a stage; they're keyed by UUID.
-
+  "Breakouts wrap their input column's key, and include the UUID of the breakout column to distinguish multiple
+  breakouts with the same input column but different bucketing.
 
   The UUID for a breakout column is the `:lib/uuid` of the `:field` or `:expression` **ref** that appears in the
   `:breakout` list.
@@ -107,7 +107,26 @@
   columns, and the `:order-by` logic takes care to distinguish them by matching the binning and temporal units."
   [:map {:decode/normalize lib.schema.common/normalize-map}
    [:lib/type [:= :column/key]]
-   [:column.breakout/uuid [:ref ::lib.schema.common/uuid]]])
+   [:column.breakout/input-column [:ref ::column-key]]
+   [:column.breakout/uuid         [:ref ::lib.schema.common/uuid]]])
+
+(mr/def ::fallback-id
+  "Sometimes we cannot resolve a field ref properly and resort to *fallback metadata*. In that case, there is only the
+  name or ID given in the ref to go by.
+
+  This schema is for the field ID variant; see `::fallback-name` for the name counterpart."
+  [:map {:decode/normalize lib.schema.common/normalize-map}
+   [:lib/type [:= :column/key]]
+   [:column.fallback/field-id ::lib.schema.id/field]])
+
+(mr/def ::fallback-name
+  "Sometimes we cannot resolve a field ref properly and resort to *fallback metadata*. In that case, there is only the
+  name or ID given in the ref to go by.
+
+  This schema is for the name variant; see `::fallback-id` for the field ID counterpart."
+  [:map {:decode/normalize lib.schema.common/normalize-map}
+   [:lib/type [:= :column/key]]
+   [:column.fallback/column-name [:ref :metabase.lib.schema.metadata/desired-column-alias]]])
 
 (mr/def ::column-key
   "A generic column key, any one of the supported flavours of column keys."
@@ -120,4 +139,6 @@
    ::opaque-card
    ::expression
    ::aggregation
-   ::breakout])
+   ::breakout
+   ::fallback-id
+   ::fallback-name])

--- a/src/metabase/lib/schema/column_key.cljc
+++ b/src/metabase/lib/schema/column_key.cljc
@@ -80,7 +80,7 @@
   [:map {:decode/normalize lib.schema.common/normalize-map}
    [:lib/type [:= :column/key]]
    ;; Optional for testing - some queries are analyzed as cards without having an ID.
-   [:column.card/card-id {:optional true} ::lib.schema.id/card]
+   [:column.card/card-id ::lib.schema.id/card]
    [:column.card.opaque/column-alias [:ref :metabase.lib.schema.metadata/desired-column-alias]]])
 
 (mr/def ::expression

--- a/src/metabase/lib/schema/join.cljc
+++ b/src/metabase/lib/schema/join.cljc
@@ -2,6 +2,7 @@
   "Schemas for things related to joins."
   (:refer-clojure :exclude [mapv every? empty? not-empty])
   (:require
+   [metabase.lib.options :as lib.options]
    [metabase.lib.schema.common :as common]
    [metabase.lib.schema.expression :as expression]
    [metabase.lib.schema.util :as lib.schema.util]
@@ -76,6 +77,11 @@
    :inner-join
    :full-join])
 
+(defn- normalize-join-options [join-opts]
+  (let [join-opts (common/normalize-map join-opts)]
+    (cond-> join-opts
+      (not (:lib/uuid join-opts)) (assoc :lib/uuid (str (random-uuid))))))
+
 (defn- normalize-join [join]
   (when join
     (let [{:keys [fields], :as join} (common/normalize-map join)]
@@ -87,6 +93,8 @@
         (-> (assoc-in [:stages (dec (count (:stages join))) :lib/stage-metadata] {:lib/type :metadata/results
                                                                                   :columns  (:source-metadata join)})
             (dissoc :source-metadata))
+
+        true (lib.options/update-options normalize-join-options)
 
         ;; automatically fix :condition => :conditions if we run into it. Kinda overlapping responsibility
         ;; with [[metabase.lib.convert]] but this lets us write busted stuff in tests more easily
@@ -125,7 +133,11 @@
     [:conditions  ::conditions]
     [:alias       ::alias]
     [:fields   {:optional true} ::fields]
-    [:strategy {:optional true} ::strategy]]
+    [:strategy {:optional true} ::strategy]
+    [:lib/options {:optional         true
+                   :decode/normalize normalize-join-options}
+     [:map
+      [:lib/uuid {:optional true} ::common/uuid]]]]
    (common/disallowed-keys
     {:lib/stage-metadata "joins should not have metadata attached directly to them; attach metadata to their last stage instead"
      :source-metadata    "joins should not have metadata attached directly to them; attach metadata to their last stage instead"

--- a/src/metabase/lib/schema/metadata.cljc
+++ b/src/metabase/lib/schema/metadata.cljc
@@ -346,8 +346,8 @@
     [:base-type {:default :type/*} ::lib.schema.common/base-type]
 
     ;; Include column keys everywhere because they need to be built up by construction, which mirrors how metadata is
-    ;; calculated. These are required, to make sure they are not missed on any path that constructs metadata.
-
+    ;; calculated. These should be required, they are always returned on every `foo-columns` list, but there are lots
+    ;; of internal functions that expect column metadata but the column key isn't defined yet.
     [:lib/column-key {:optional true} [:ref ::lib.schema.column-key/column-key]]
 
     ;; This is nillable because internal remap columns have `:id nil`.

--- a/src/metabase/lib/schema/metadata.cljc
+++ b/src/metabase/lib/schema/metadata.cljc
@@ -6,6 +6,7 @@
    [clojure.set :as set]
    [medley.core :as m]
    [metabase.lib.schema.binning :as lib.schema.binning]
+   [metabase.lib.schema.column-key :as lib.schema.column-key]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.join :as lib.schema.join]
@@ -324,7 +325,12 @@
   [:and
    [:map
     {:error/message    "Valid column metadata"
-     :decode/normalize normalize-column}
+     :decode/normalize normalize-column
+     :decode/mock      (fn [col]
+                         (cond-> col
+                           (and (:id col) (not (:lib/column-key col)))
+                           (assoc :lib/column-key {:lib/type :column/key
+                                                   :column.field/id (:id col)})))}
     [:lib/type  [:= {:decode/normalize lib.schema.common/normalize-keyword, :default :metadata/column} :metadata/column]]
     ;;
     ;; TODO (Cam 6/19/25) -- change all these comments to proper `:description`s like we have
@@ -338,6 +344,12 @@
     [:name      :string]
     ;; TODO -- ignore `base_type` and make `effective_type` required; see #29707
     [:base-type {:default :type/*} ::lib.schema.common/base-type]
+
+    ;; Include column keys everywhere because they need to be built up by construction, which mirrors how metadata is
+    ;; calculated. These are required, to make sure they are not missed on any path that constructs metadata.
+
+    [:lib/column-key {:optional true} [:ref ::lib.schema.column-key/column-key]]
+
     ;; This is nillable because internal remap columns have `:id nil`.
     [:id             {:optional true} [:maybe ::lib.schema.id/field]]
     [:display-name   {:optional true} [:maybe :string]]

--- a/src/metabase/lib_be/metadata/jvm.clj
+++ b/src/metabase/lib_be/metadata/jvm.clj
@@ -7,6 +7,7 @@
    [clojure.core.cache.wrapped :as cache.wrapped]
    [clojure.string :as str]
    [honey.sql.helpers :as sql.helpers]
+   [metabase.lib.column-key :as lib.column-key]
    [metabase.lib.metadata.cached-provider :as lib.metadata.cached-provider]
    [metabase.lib.metadata.invocation-tracker :as lib.metadata.invocation-tracker]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
@@ -195,6 +196,7 @@
              :table
              :dimension/human-readable-field-id :dimension/id :dimension/name :dimension/type
              :values/human-readable-values :values/values)
+     {:lib/column-key (lib.column-key/field-key (:id field))}
      (when (and (= dimension-type :external)
                 (:dimension/human-readable-field-id field))
        {:lib/external-remap {:lib/type :metadata.column.remapping/external

--- a/test/metabase/lib/aggregation_test.cljc
+++ b/test/metabase/lib/aggregation_test.cljc
@@ -811,7 +811,10 @@
                        lib/available-aggregation-operators
                        (m/find-first #(= (:short %) :sum))
                        lib/aggregation-operator-columns
-                       (map #(dissoc % :lib/source-uuid))))]
+                       (map #(-> %
+                                 (dissoc :lib/source-uuid)
+                                 (assoc-in [:lib/column-key :column.expression/uuid]
+                                           "11111111-2222-3333-4444-555555555555")))))]
       (is (= (clean built-query)
              (clean converted-query))))))
 

--- a/test/metabase/lib/breakout_test.cljc
+++ b/test/metabase/lib/breakout_test.cljc
@@ -5,6 +5,7 @@
    [medley.core :as m]
    [metabase.lib.breakout :as lib.breakout]
    [metabase.lib.core :as lib]
+   [metabase.lib.options :as lib.options]
    [metabase.lib.query :as lib.query]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
@@ -282,36 +283,63 @@
                     :base-type                    :type/Text}]
                   (lib/breakoutable-columns query))))))))
 
+(defn- from-card [column-key]
+  {:lib/type                 :column/key
+   :column.card/card-id      1
+   :column.card/inner-column column-key})
+
 (deftest ^:parallel breakoutable-columns-source-card-test
-  (doseq [varr [#'lib.tu/query-with-source-card
-                #'lib.tu/query-with-source-card-with-result-metadata]
+  (doseq [[varr user-id-col-key count-col-key] [[#'lib.tu/query-with-source-card
+                                                 (from-card {:lib/type                :column/key
+                                                             :column.breakout/uuid    string?})
+                                                 (from-card {:lib/type                :column/key
+                                                             :column.aggregation/uuid string?})]
+                                                [#'lib.tu/query-with-source-card-with-result-metadata
+                                                 (from-card {:lib/type                        :column/key
+                                                             :column.card.opaque/column-alias "USER_ID"})
+                                                 (from-card {:lib/type                        :column/key
+                                                             :column.card.opaque/column-alias "count"})]]
           :let [query (@varr)]]
     (testing (str (pr-str varr) \newline (lib.util/format "Query =\n%s" (u/pprint-to-str query)))
       (let [columns (lib/breakoutable-columns query)]
-        (is (=? [{:name         "USER_ID"
-                  :display-name "User ID"
-                  :base-type    :type/Integer
-                  :lib/source   :source/card}
-                 {:name         "count"
-                  :display-name "Count"
-                  :base-type    :type/Integer
-                  :lib/source   :source/card}
+        (is (=? [{:name           "USER_ID"
+                  :display-name   "User ID"
+                  :base-type      :type/Integer
+                  :lib/source     :source/card
+                  :lib/column-key user-id-col-key}
+                 {:name           "count"
+                  :display-name   "Count"
+                  :base-type      :type/Integer
+                  :lib/source     :source/card
+                  :lib/column-key count-col-key}
                  ;; Implicitly joinable columns
                  {:name         "ID"
                   :display-name "ID"
                   :base-type    :type/BigInteger
                   :lib/source   :source/implicitly-joinable
-                  :fk-field-id  (meta/id :checkins :user-id)}
+                  :fk-field-id  (meta/id :checkins :user-id)
+                  :lib/column-key {:lib/type :column/key
+                                   :column.implicit/fk-column     user-id-col-key
+                                   :column.implicit/target-column {:lib/type        :column/key
+                                                                   :column.field/id (meta/id :users :id)}}}
                  {:name         "NAME"
                   :display-name "Name"
                   :base-type    :type/Text
                   :lib/source   :source/implicitly-joinable
-                  :fk-field-id  (meta/id :checkins :user-id)}
+                  :fk-field-id  (meta/id :checkins :user-id)
+                  :lib/column-key {:lib/type :column/key
+                                   :column.implicit/fk-column     user-id-col-key
+                                   :column.implicit/target-column {:lib/type        :column/key
+                                                                   :column.field/id (meta/id :users :name)}}}
                  {:name         "LAST_LOGIN"
                   :display-name "Last Login"
                   :base-type    :type/DateTime
                   :lib/source   :source/implicitly-joinable
-                  :fk-field-id  (meta/id :checkins :user-id)}]
+                  :fk-field-id  (meta/id :checkins :user-id)
+                  :lib/column-key {:lib/type :column/key
+                                   :column.implicit/fk-column     user-id-col-key
+                                   :column.implicit/target-column {:lib/type        :column/key
+                                                                   :column.field/id (meta/id :users :last-login)}}}]
                 columns))
         (testing `lib/display-info
           (is (=? [{:name                   "USER_ID"
@@ -735,9 +763,11 @@
           breakouts  (lib/breakouts query)]
       (is (= 2
              (count breakouts)))
-      (is (=? category
+      (is (=? (assoc category :lib/column-key {:lib/type             :column/key
+                                               :column.breakout/uuid (lib.options/uuid (first breakouts))})
               (lib.breakout/breakout-column query (first breakouts))))
-      (is (=? price
+      (is (=? (assoc price :lib/column-key {:lib/type             :column/key
+                                            :column.breakout/uuid (lib.options/uuid (second breakouts))})
               (lib.breakout/breakout-column query (second breakouts)))))))
 
 (deftest ^:parallel breakout-column-test-2

--- a/test/metabase/lib/breakout_test.cljc
+++ b/test/metabase/lib/breakout_test.cljc
@@ -283,22 +283,21 @@
                     :base-type                    :type/Text}]
                   (lib/breakoutable-columns query))))))))
 
-(defn- from-card [column-key]
-  {:lib/type                 :column/key
-   :column.card/card-id      1
-   :column.card/inner-column column-key})
-
 (deftest ^:parallel breakoutable-columns-source-card-test
   (doseq [[varr user-id-col-key count-col-key] [[#'lib.tu/query-with-source-card
-                                                 (from-card {:lib/type                :column/key
-                                                             :column.breakout/uuid    string?})
-                                                 (from-card {:lib/type                :column/key
-                                                             :column.aggregation/uuid string?})]
+                                                 {:lib/type                        :column/key
+                                                  :column.card/card-id             1
+                                                  :column.card.opaque/column-alias "USER_ID"}
+                                                 {:lib/type                        :column/key
+                                                  :column.card/card-id             1
+                                                  :column.card.opaque/column-alias "count"}]
                                                 [#'lib.tu/query-with-source-card-with-result-metadata
-                                                 (from-card {:lib/type                        :column/key
-                                                             :column.card.opaque/column-alias "USER_ID"})
-                                                 (from-card {:lib/type                        :column/key
-                                                             :column.card.opaque/column-alias "count"})]]
+                                                 {:lib/type                        :column/key
+                                                  :column.card/card-id             1
+                                                  :column.card.opaque/column-alias "USER_ID"}
+                                                 {:lib/type                        :column/key
+                                                  :column.card/card-id             1
+                                                  :column.card.opaque/column-alias "count"}]]
           :let [query (@varr)]]
     (testing (str (pr-str varr) \newline (lib.util/format "Query =\n%s" (u/pprint-to-str query)))
       (let [columns (lib/breakoutable-columns query)]

--- a/test/metabase/lib/card_test.cljc
+++ b/test/metabase/lib/card_test.cljc
@@ -6,6 +6,7 @@
    [medley.core :as m]
    [metabase.lib.breakout-test]
    [metabase.lib.card :as lib.card]
+   [metabase.lib.column-key :as lib.column-key]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
@@ -77,6 +78,7 @@
         (is (=? (for [col (get-in (lib.tu/mock-cards) [:venues :result-metadata])]
                   (-> col
                       (assoc :lib/source :source/card)
+                      (update :lib/column-key lib.column-key/from-card (:id metadata))
                       (dissoc :fk-target-field-id)))
                 (lib/returned-columns query)))))))
 
@@ -96,32 +98,44 @@
   (for [col cols]
     (assoc col :lib/source src)))
 
-(defn- implicitly-joined [cols]
-  (from :source/implicitly-joinable cols))
+(defn- implicitly-joined [fk-key cols]
+  (->> (from :source/implicitly-joinable cols)
+       (map #(update % :lib/column-key lib.column-key/implicitly-joined-via fk-key))))
 
-(defn- explicitly-joined [cols]
-  (from :source/joins cols))
+(defn- explicitly-joined [join-or-uuid cols]
+  (->> (from :source/joins cols)
+       (map #(update % :lib/column-key lib.column-key/explicitly-joined join-or-uuid))))
 
 (defn- cols-of [table]
   (for [col (meta/fields table)]
     (meta/field-metadata table col)))
+
+(defn- from-card [card-id cols]
+  (->> (from :source/card cols)
+       (map #(update % :lib/column-key lib.column-key/from-card card-id))))
 
 (defn- sort-cols [cols]
   (sort-by (juxt :id :name :lib/join-alias :lib/desired-column-alias) cols))
 
 (deftest ^:parallel visible-columns-use-result-metadata-test
   (testing "visible-columns should use the Card's `:result-metadata` (regardless of what's actually in the Card)"
-    (let [venues-query (lib/query
-                        (lib.tu/mock-metadata-provider
-                         meta/metadata-provider
-                         {:cards [(assoc (:orders (lib.tu/mock-cards)) :dataset-query (lib.tu/venues-query))]})
-                        (:orders (lib.tu/mock-cards)))]
+    (let [venues-query   (lib/query
+                          (lib.tu/mock-metadata-provider
+                           meta/metadata-provider
+                           {:cards [(assoc (:orders (lib.tu/mock-cards)) :dataset-query (lib.tu/venues-query))]})
+                          (:orders (lib.tu/mock-cards)))
+          user-id-key    (-> (meta/id :orders :user-id)
+                             lib.column-key/field-key
+                             (lib.column-key/from-card (:id (:orders (lib.tu/mock-cards)))))
+          product-id-key (-> (meta/id :orders :product-id)
+                             lib.column-key/field-key
+                             (lib.column-key/from-card (:id (:orders (lib.tu/mock-cards)))))]
       (is (=? (->> (cols-of :orders)
                    sort-cols)
               (sort-cols (get-in (lib.tu/mock-cards) [:orders :result-metadata]))))
-      (is (=? (->> (concat (from :source/card (cols-of :orders))
-                           (implicitly-joined (cols-of :people))
-                           (implicitly-joined (cols-of :products)))
+      (is (=? (->> (concat (from-card (:id (:orders (lib.tu/mock-cards))) (cols-of :orders))
+                           (implicitly-joined user-id-key    (cols-of :people))
+                           (implicitly-joined product-id-key (cols-of :products)))
                    sort-cols)
               (sort-cols (lib/visible-columns venues-query)))))))
 
@@ -191,19 +205,20 @@
 
 (deftest ^:parallel card-source-query-visible-columns-test
   (testing "Explicitly joined fields do not also appear as implictly joinable"
-    (let [base       (lib/query meta/metadata-provider (meta/table-metadata :orders))
-          join       (lib/join-clause (meta/table-metadata :products)
-                                      [(lib/= (lib/ref (meta/field-metadata :orders :product-id))
-                                              (lib/ref (meta/field-metadata :products :id)))])
-          query      (lib/join base join)]
+    (let [query  (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                     (lib/join (lib/join-clause (meta/table-metadata :products)
+                                                [(lib/= (lib/ref (meta/field-metadata :orders :product-id))
+                                                        (lib/ref (meta/field-metadata :products :id)))])))
+          [join] (lib/joins query)]
       (is (=? (->> (concat (from :source/table-defaults (cols-of :orders))
-                           (explicitly-joined (cols-of :products)))
+                           (explicitly-joined join (cols-of :products)))
                    sort-cols
                    (map #(dissoc % :name)))
               (->> query lib.metadata.calculation/returned-columns sort-cols)))
       (is (=? (->> (concat (from :source/table-defaults (cols-of :orders))
-                           (explicitly-joined (cols-of :products))
-                           (implicitly-joined (cols-of :people)))
+                           (explicitly-joined join (cols-of :products))
+                           (implicitly-joined (lib.column-key/field-key (meta/id :orders :user-id))
+                                              (cols-of :people)))
                    sort-cols)
               (->> query lib.metadata.calculation/visible-columns sort-cols)))
       ;; TODO: Currently if the source-card has an explicit join for a table, those fields will also be duplicated as

--- a/test/metabase/lib/card_test.cljc
+++ b/test/metabase/lib/card_test.cljc
@@ -77,8 +77,8 @@
                                    :source-card (:id metadata)}]}]
         (is (=? (for [col (get-in (lib.tu/mock-cards) [:venues :result-metadata])]
                   (-> col
-                      (assoc :lib/source :source/card)
-                      (update :lib/column-key lib.column-key/from-card (:id metadata))
+                      (assoc :lib/source :source/card, :lib/card-id (:id metadata))
+                      (lib.column-key/from-card query (:id metadata))
                       (dissoc :fk-target-field-id)))
                 (lib/returned-columns query)))))))
 
@@ -110,9 +110,14 @@
   (for [col (meta/fields table)]
     (meta/field-metadata table col)))
 
-(defn- from-card [card-id cols]
+(defn- column-from-card [column metadata-providerable card-id]
+  (-> column
+      (assoc :lib/source :source/card, :lib/card-id card-id)
+      (lib.column-key/from-card metadata-providerable card-id)))
+
+(defn- from-card [metadata-providerable card-id cols]
   (->> (from :source/card cols)
-       (map #(update % :lib/column-key lib.column-key/from-card card-id))))
+       (map #(column-from-card % metadata-providerable card-id))))
 
 (defn- sort-cols [cols]
   (sort-by (juxt :id :name :lib/join-alias :lib/desired-column-alias) cols))
@@ -124,16 +129,13 @@
                            meta/metadata-provider
                            {:cards [(assoc (:orders (lib.tu/mock-cards)) :dataset-query (lib.tu/venues-query))]})
                           (:orders (lib.tu/mock-cards)))
-          user-id-key    (-> (meta/id :orders :user-id)
-                             lib.column-key/field-key
-                             (lib.column-key/from-card (:id (:orders (lib.tu/mock-cards)))))
-          product-id-key (-> (meta/id :orders :product-id)
-                             lib.column-key/field-key
-                             (lib.column-key/from-card (:id (:orders (lib.tu/mock-cards)))))]
+          card-id        (:id (:orders (lib.tu/mock-cards)))
+          user-id-key    (column-from-card (meta/field-metadata :orders :user-id)    venues-query card-id)
+          product-id-key (column-from-card (meta/field-metadata :orders :product-id) venues-query card-id)]
       (is (=? (->> (cols-of :orders)
                    sort-cols)
               (sort-cols (get-in (lib.tu/mock-cards) [:orders :result-metadata]))))
-      (is (=? (->> (concat (from-card (:id (:orders (lib.tu/mock-cards))) (cols-of :orders))
+      (is (=? (->> (concat (from-card venues-query (:id (:orders (lib.tu/mock-cards))) (cols-of :orders))
                            (implicitly-joined user-id-key    (cols-of :people))
                            (implicitly-joined product-id-key (cols-of :products)))
                    sort-cols)

--- a/test/metabase/lib/drill_thru/zoom_in_geographic_test.cljc
+++ b/test/metabase/lib/drill_thru/zoom_in_geographic_test.cljc
@@ -3,6 +3,7 @@
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
    [clojure.test :refer [deftest is testing use-fixtures]]
    [medley.core :as m]
+   [metabase.lib.column-key :as lib.column-key]
    [metabase.lib.core :as lib]
    [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]
    [metabase.lib.metadata :as lib.metadata]
@@ -569,9 +570,13 @@
              :type      :drill-thru/zoom-in.geographic
              :subtype   :drill-thru.zoom-in.geographic/country-state-city->binned-lat-lon
              :column    state-col
-             :latitude  {:column    (meta/field-metadata :people :latitude)
+             :latitude  {:column    (-> (meta/field-metadata :people :latitude)
+                                        (update :lib/column-key
+                                                lib.column-key/explicitly-joined (first (lib/joins query))))
                          :bin-width 1}
-             :longitude {:column    (meta/field-metadata :people :longitude)
+             :longitude {:column    (-> (meta/field-metadata :people :longitude)
+                                        (update :lib/column-key
+                                                lib.column-key/explicitly-joined (first (lib/joins query))))
                          :bin-width 1}}
             zoom-in))
     (is (=? {:stages [{:filters  [[:= {} [:field {} (meta/id :people :state)] "MN"]]

--- a/test/metabase/lib/equality_test.cljc
+++ b/test/metabase/lib/equality_test.cljc
@@ -6,6 +6,7 @@
    [clojure.test.check.generators :as gen]
    [malli.generator :as mg]
    [medley.core :as m]
+   [metabase.lib.column-key :as lib.column-key]
    [metabase.lib.core :as lib]
    [metabase.lib.equality :as lib.equality]
    [metabase.lib.metadata :as lib.metadata]
@@ -355,10 +356,12 @@
 (deftest ^:parallel find-matching-column-self-join-test
   (testing "find-matching-column with a self join"
     (let [query     (lib.tu/query-with-self-join)
+          [join]    (lib/joins query)
           cols      (for [col (meta/fields :orders)]
                       (meta/field-metadata :orders col))
           table-col #(assoc % :lib/source :source/table-defaults)
           join-col  #(-> %
+                         (update :lib/column-key lib.column-key/explicitly-joined join)
                          (merge {:lib/source                   :source/joins
                                  :lib/join-alias "Orders_2"}))
           sorted    #(sort-by (juxt :position :lib/original-join-alias) %)

--- a/test/metabase/lib/field/resolution_test.cljc
+++ b/test/metabase/lib/field/resolution_test.cljc
@@ -6,6 +6,7 @@
    [metabase.lib.breakout-test]
    [metabase.lib.card :as lib.card]
    [metabase.lib.card-test]
+   [metabase.lib.column-key :as lib.column-key]
    [metabase.lib.core :as lib]
    [metabase.lib.field-test]
    [metabase.lib.field.resolution :as lib.field.resolution]
@@ -369,11 +370,15 @@
     (binding [lib.metadata.calculation/*display-name-style* :long]
       (is (=? (merge
                (m/filter-vals some? (meta/field-metadata :categories :name))
-               {:display-name                                      "Categories → Name"
-                :lib/original-display-name                         "Name"
-                :lib/original-name                                 "NAME"
-                :lib/source-uuid                                   string?
-                :lib/join-alias                      "Categories"
+               {:display-name                       "Categories → Name"
+                :lib/original-display-name          "Name"
+                :lib/original-name                  "NAME"
+                :lib/source-uuid                    string?
+                :lib/column-key                     (-> (meta/id :categories :name)
+                                                        lib.column-key/field-key
+                                                        (lib.column-key/explicitly-joined
+                                                         (first (lib/joins query))))
+                :lib/join-alias                     "Categories"
                 :lib/transformation-added-base-type true})
               (lib.field.resolution/resolve-field-ref query -1 (first (lib/fields query -1))))))))
 

--- a/test/metabase/lib/field_test.cljc
+++ b/test/metabase/lib/field_test.cljc
@@ -1738,10 +1738,10 @@
                                       (lib.metadata.calculation/visible-columns query)
                                       (lib.metadata.calculation/returned-columns query)))
 
-(defn- column-key-from-card [inner-column-key card-id]
-  {:lib/type                 :column/key
-   :column.card/card-id      card-id
-   :column.card/inner-column inner-column-key})
+(defn- column-key-from-card [column-alias card-id]
+  {:lib/type                        :column/key
+   :column.card/card-id             card-id
+   :column.card.opaque/column-alias column-alias})
 
 (defn- column-key-as-joined [inner-column-key join-clause]
   {:lib/type                   :column/key
@@ -1765,20 +1765,22 @@
           provider       (lib.tu/metadata-provider-with-cards-for-queries meta/metadata-provider [card-query])
           card-id        1
           query          (lib/query provider (lib.metadata/card provider card-id))
-          order-cols     (for [col (meta/fields :orders)]
-                           (-> (meta/field-metadata :orders col)
+          order-cols     (for [col-key (meta/fields :orders)
+                               :let [col (meta/field-metadata :orders col-key)]]
+                           (-> col
                                (assoc :lib/source :source/card)
-                               (update :lib/column-key column-key-from-card card-id)
+                               (assoc :lib/column-key
+                                      (column-key-from-card
+                                       ((some-fn :lib/desired-column-alias :lib/source-column-alias :name) col)
+                                       card-id))
                                (dissoc :id :table-id)))
           join-cols      [(-> (meta/field-metadata :products :category)
                               (assoc :lib/source              :source/card
                                      :lib/original-join-alias "Products")
                               (update :lib/column-key column-key-as-joined (first (lib/joins card-query)))
-                              (update :lib/column-key column-key-from-card card-id)
+                              (assoc :lib/column-key (column-key-from-card "Products__CATEGORY" card-id))
                               (dissoc :id :table-id))]
-          user-id-key    (-> (meta/field-metadata :orders :user-id)
-                             :lib/column-key
-                             (column-key-from-card card-id))
+          user-id-key    (column-key-from-card "USER_ID" card-id)
           implicit-cols  (for [col (meta/fields :people)]
                            (-> (meta/field-metadata :people col)
                                (assoc :lib/source :source/implicitly-joinable)

--- a/test/metabase/lib/field_test.cljc
+++ b/test/metabase/lib/field_test.cljc
@@ -1839,13 +1839,17 @@
                                                  [:field {:lib/uuid (str (random-uuid))} 12345]))))))
 
 (deftest ^:parallel column-key-test-1-plain-field-by-id
-  (let [query (lib/query meta/metadata-provider (meta/table-metadata :orders))]
-    (doseq [table-key (meta/tables)
-            field-key (meta/fields table-key)
-            :let [id (meta/id table-key field-key)]]
-      (is (=? {:id             id
-               :lib/column-key {:lib/type :column/key, :column.field/id id}}
-              (lib/metadata query (lib/ref (meta/field-metadata table-key field-key))))))))
+  (doseq [table-key (meta/tables)
+          :let [query (lib/query meta/metadata-provider (meta/table-metadata table-key))]
+          field-key (meta/fields table-key)
+          :let [id (meta/id table-key field-key)]]
+    (is (=? {:id             id
+             :lib/column-key {:lib/type :column/key, :column.field/id id}}
+            (lib/metadata query (lib/ref (meta/field-metadata table-key field-key)))))))
+
+(comment
+  (lib/metadata (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                (lib/ref (meta/field-metadata :orders :subtotal))))
 
 (deftest ^:parallel column-key-test-2a-expression-same-stage
   (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))

--- a/test/metabase/lib/field_test.cljc
+++ b/test/metabase/lib/field_test.cljc
@@ -69,6 +69,8 @@
                     :semantic-type                              :type/CreationTimestamp
                     :lib/breakout?                              true
                     :lib/card-id                                1
+                    :lib/column-key                             {:lib/type :column/key
+                                                                 :column.native/unique-name "CREATED_AT_2"}
                     :lib/deduplicated-name                      "CREATED_AT_2"
                     :lib/desired-column-alias                   "CREATED_AT_2"
                     :lib/original-name                          "CREATED_AT"
@@ -1597,61 +1599,6 @@
         (is (thrown-with-msg? #?(:cljs :default :clj Exception) #"Only source columns"
                               (lib/remove-field query -1 (second columns))))))))
 
-(deftest ^:parallel find-visible-column-for-ref-test
-  (testing "precise references"
-    (doseq [query-var [#'lib.tu/query-with-expression
-                       #'lib.tu/query-with-join-with-explicit-fields
-                       #'lib.tu/query-with-source-card]
-            :let [query (@query-var)]
-            col (lib/visible-columns query)
-            :let [col-ref (lib/ref col)]]
-      (testing (str "ref " col-ref " of " (symbol query-var))
-        (is (= (-> col
-                   (dissoc :lib/source-uuid))
-               (-> (lib/find-visible-column-for-ref query col-ref)
-                   (dissoc :lib/source-uuid))))))))
-
-(deftest ^:parallel find-visible-column-for-ref-test-2
-  (testing "reference by ID instead of name"
-    (let [query (lib.tu/query-with-source-card)
-          col-ref [:field
-                   {:lib/uuid "ae24a9b0-cbb5-40b6-bace-c8a5ac6a7e42"
-                    :base-type :type/Integer
-                    :effective-type :type/Integer}
-                   (meta/id :checkins :user-id)]]
-      (is (=? {:lib/type :metadata/column
-               :base-type :type/Integer
-               :semantic-type :type/FK
-               :name "USER_ID"
-               :lib/card-id 1
-               :lib/source :source/card
-               :lib/source-column-alias "USER_ID"
-               :effective-type :type/Integer
-               :id (meta/id :checkins :user-id)
-               :display-name "User ID"}
-              (lib/find-visible-column-for-ref query col-ref))))))
-
-(deftest ^:parallel find-visible-column-for-ref-aggregation-test
-  (testing "find-visible-column-for-ref works with aggregation refs"
-    (let [query    (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
-                       (lib/aggregate (lib/count)))
-          agg-cols (filter #(= :source/aggregations (:lib/source %))
-                           (lib/returned-columns query))
-          agg-ref  (lib/ref (first agg-cols))]
-      (is (=? {:lib/type     :metadata/column
-               :display-name "Count"}
-              (lib/find-visible-column-for-ref query agg-ref))))))
-
-(deftest ^:parallel find-visible-column-for-ref-multi-stage-test
-  (testing "2-arity find-visible-column-for-ref uses last stage"
-    (let [query     (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
-                        (lib/aggregate (lib/count))
-                        lib/append-stage)
-          cols      (lib/visible-columns query)
-          col       (first cols)
-          field-ref (lib/ref col)]
-      (is (some? (lib/find-visible-column-for-ref query field-ref))))))
-
 (deftest ^:parallel self-join-ambiguity-test
   (testing "Even when doing a tree-like self join, fields are matched correctly"
     (let [base         (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
@@ -1791,6 +1738,21 @@
                                       (lib.metadata.calculation/visible-columns query)
                                       (lib.metadata.calculation/returned-columns query)))
 
+(defn- column-key-from-card [inner-column-key card-id]
+  {:lib/type                 :column/key
+   :column.card/card-id      card-id
+   :column.card/inner-column inner-column-key})
+
+(defn- column-key-as-joined [inner-column-key join-clause]
+  {:lib/type                   :column/key
+   :column.joined/join-uuid    (lib.options/uuid join-clause)
+   :column.joined/inner-column inner-column-key})
+
+(defn- column-key-as-implicitly-joined [target-column-key fk-column-key]
+  {:lib/type                   :column/key
+   :column.implicit/fk-column     fk-column-key
+   :column.implicit/target-column target-column-key})
+
 (deftest ^:parallel nested-query-join-with-fields-test
   (testing "a nested query which has an explicit join with :fields"
     (let [base           (lib/query meta/metadata-provider (meta/table-metadata :orders))
@@ -1799,21 +1761,28 @@
                              (lib/with-join-conditions [(lib/= (lib/ref (meta/field-metadata :orders :product-id))
                                                                (lib/ref (meta/field-metadata :products :id)))])
                              (lib/with-join-fields [(meta/field-metadata :products :category)]))
-          provider       (lib.tu/metadata-provider-with-cards-for-queries
-                          meta/metadata-provider
-                          [(lib/join base -1 join)])
-          query          (lib/query provider (lib.metadata/card provider 1))
+          card-query     (lib/join base -1 join)
+          provider       (lib.tu/metadata-provider-with-cards-for-queries meta/metadata-provider [card-query])
+          card-id        1
+          query          (lib/query provider (lib.metadata/card provider card-id))
           order-cols     (for [col (meta/fields :orders)]
                            (-> (meta/field-metadata :orders col)
                                (assoc :lib/source :source/card)
+                               (update :lib/column-key column-key-from-card card-id)
                                (dissoc :id :table-id)))
           join-cols      [(-> (meta/field-metadata :products :category)
                               (assoc :lib/source              :source/card
                                      :lib/original-join-alias "Products")
+                              (update :lib/column-key column-key-as-joined (first (lib/joins card-query)))
+                              (update :lib/column-key column-key-from-card card-id)
                               (dissoc :id :table-id))]
+          user-id-key    (-> (meta/field-metadata :orders :user-id)
+                             :lib/column-key
+                             (column-key-from-card card-id))
           implicit-cols  (for [col (meta/fields :people)]
                            (-> (meta/field-metadata :people col)
-                               (assoc :lib/source :source/implicitly-joinable)))
+                               (assoc :lib/source :source/implicitly-joinable)
+                               (update :lib/column-key column-key-as-implicitly-joined user-id-key)))
           sorted         #(sort-by (juxt :name :join-alias :id :table-id) %)]
       (is (=? (sorted (concat order-cols join-cols))
               (sorted (lib.metadata.calculation/returned-columns query))))
@@ -1868,6 +1837,147 @@
                :display-name    "Unknown Field"}
               (lib.metadata.calculation/metadata (lib.tu/venues-query) -1
                                                  [:field {:lib/uuid (str (random-uuid))} 12345]))))))
+
+(deftest ^:parallel column-key-test-1-plain-field-by-id
+  (let [query (lib/query meta/metadata-provider (meta/table-metadata :orders))]
+    (doseq [table-key (meta/tables)
+            field-key (meta/fields table-key)
+            :let [id (meta/id table-key field-key)]]
+      (is (=? {:id             id
+               :lib/column-key {:lib/type :column/key, :column.field/id id}}
+              (lib/metadata query (lib/ref (meta/field-metadata table-key field-key))))))))
+
+(deftest ^:parallel column-key-test-2a-expression-same-stage
+  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                  (lib/expression "tax rate" (lib// (meta/field-metadata :orders :tax)
+                                                    (meta/field-metadata :orders :subtotal))))
+        expr  (first (lib/expressions query))]
+    (is (=? {:name           "tax rate"
+             :lib/column-key {:lib/type :column/key, :column.expression/uuid (lib.options/uuid expr)}}
+            (lib/metadata query (lib/expression-ref query "tax rate"))))))
+
+(deftest ^:parallel column-key-test-2b-expression-previous-stage
+  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                  (lib/expression "tax rate" (lib// (meta/field-metadata :orders :tax)
+                                                    (meta/field-metadata :orders :subtotal)))
+                  lib/append-stage)
+        expr  (first (lib/expressions query 0))]
+    (is (=? {:name           "tax rate"
+             :lib/column-key {:lib/type :column/key, :column.expression/uuid (lib.options/uuid expr)}}
+            (lib/metadata query [:field {:lib/uuid (str (random-uuid)), :base-type :type/Float} "tax rate"])))))
+
+(deftest ^:parallel column-key-test-3a-aggregation-same-stage
+  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                  (lib/aggregate (lib/sum (meta/field-metadata :orders :subtotal))))
+        agg   (first (lib/aggregations query))]
+    (is (=? {:name           "sum"
+             :lib/column-key {:lib/type :column/key, :column.aggregation/uuid (lib.options/uuid agg)}}
+            (lib/metadata query (lib/aggregation-ref query -1 0))))))
+
+(deftest ^:parallel column-key-test-3b-aggregation-nested
+  (let [base  (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                  (lib/aggregate (lib/sum (meta/field-metadata :orders :subtotal)))
+                  (lib/aggregate (lib/sum (meta/field-metadata :orders :quantity))))
+        query (lib/aggregate base (lib// (lib/aggregation-ref base -1 0)
+                                         (lib/aggregation-ref base -1 1)))
+        [sum-subtotal sum-quantity ratio] (lib/aggregations query)]
+    (is (=? {:display-name   "Sum of Subtotal"
+             :lib/column-key {:lib/type :column/key, :column.aggregation/uuid (lib.options/uuid sum-subtotal)}}
+            (lib/metadata query (lib/aggregation-ref query -1 0))))
+    (is (=? {:display-name   "Sum of Quantity"
+             :lib/column-key {:lib/type :column/key, :column.aggregation/uuid (lib.options/uuid sum-quantity)}}
+            (lib/metadata query (lib/aggregation-ref query -1 1))))
+    (is (=? {:display-name   "Sum of Subtotal ÷ Sum of Quantity"
+             :lib/column-key {:lib/type :column/key, :column.aggregation/uuid (lib.options/uuid ratio)}}
+            (lib/metadata query (lib/aggregation-ref query -1 2))))))
+
+(deftest ^:parallel column-key-test-3c-aggregation-previous-stage
+  (let [base  (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                  (lib/aggregate (lib/sum (meta/field-metadata :orders :subtotal)))
+                  (lib/aggregate (lib/sum (meta/field-metadata :orders :quantity))))
+        query (-> base
+                  (lib/aggregate (lib// (lib/aggregation-ref base -1 0)
+                                        (lib/aggregation-ref base -1 1)))
+                  lib/append-stage)
+        [sum-subtotal sum-quantity ratio] (lib/aggregations query 0)]
+    (is (=? {:display-name   "Sum of Subtotal"
+             :lib/column-key {:lib/type :column/key, :column.aggregation/uuid (lib.options/uuid sum-subtotal)}}
+            (lib/metadata query [:field {:lib/uuid (str (random-uuid)), :base-type :type/Float} "sum"])))
+    (is (=? {:display-name   "Sum of Quantity"
+             :lib/column-key {:lib/type :column/key, :column.aggregation/uuid (lib.options/uuid sum-quantity)}}
+            (lib/metadata query [:field {:lib/uuid (str (random-uuid)), :base-type :type/Float} "sum_2"])))
+    (is (=? {:display-name   "Sum of Subtotal ÷ Sum of Quantity"
+             :lib/column-key {:lib/type :column/key, :column.aggregation/uuid (lib.options/uuid ratio)}}
+            (lib/metadata query [:field {:lib/uuid (str (random-uuid)), :base-type :type/Float} "expression"])))))
+
+(deftest ^:parallel column-key-test-4a-breakout-same-stage
+  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                  (lib/breakout (lib/with-temporal-bucket (meta/field-metadata :orders :created-at) :month))
+                  (lib/aggregate (lib/sum (meta/field-metadata :orders :subtotal))))
+        [agg] (lib/aggregations query)
+        [brk] (lib/breakouts query)]
+    (is (=? [{:display-name    "Created At: Month"
+              :lib/column-key  {:lib/type :column/key, :column.breakout/uuid (lib.options/uuid brk)}}
+             {:name           "sum"
+              :lib/column-key {:lib/type :column/key, :column.aggregation/uuid (lib.options/uuid agg)}}]
+            (lib/orderable-columns query)))))
+
+(deftest ^:parallel column-key-test-4b-breakout-next-stage
+  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                  (lib/breakout (lib/with-temporal-bucket (meta/field-metadata :orders :created-at) :month))
+                  (lib/aggregate (lib/sum (meta/field-metadata :orders :subtotal)))
+                  lib/append-stage)
+        [brk] (lib/breakouts query 0)]
+    (is (=? {:display-name   "Created At: Month"
+             :lib/column-key {:lib/type :column/key, :column.breakout/uuid (lib.options/uuid brk)}}
+            (lib/metadata query [:field {:lib/uuid (str (random-uuid)), :base-type :type/Date} "CREATED_AT"])))))
+
+(deftest ^:parallel column-key-test-5a-explicit-join-same-stage
+  (let [query  (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                   (lib/join (meta/table-metadata :products)))
+        [join] (lib/joins query)]
+    (is (=? {:id             (meta/id :products :category)
+             :lib/column-key {:lib/type                   :column/key
+                              :column.joined/join-uuid    (lib.options/uuid join)
+                              :column.joined/inner-column {:lib/type        :column/key
+                                                           :column.field/id (meta/id :products :category)}}}
+            (lib/metadata query [:field {:lib/uuid   (str (random-uuid))
+                                         :base-type  :type/Text
+                                         :join-alias "Products"}
+                                 (meta/id :products :category)])))))
+
+(deftest ^:parallel column-key-test-5b-explicit-join-previous-stage
+  (let [query  (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                   (lib/join (meta/table-metadata :products))
+                   lib/append-stage)
+        [join] (lib/joins query 0)]
+    (is (=? {:id             (meta/id :products :category)
+             :lib/column-key {:lib/type                   :column/key
+                              :column.joined/join-uuid    (lib.options/uuid join)
+                              :column.joined/inner-column {:lib/type        :column/key
+                                                           :column.field/id (meta/id :products :category)}}}
+            (lib/metadata query [:field {:lib/uuid   (str (random-uuid))
+                                         :base-type  :type/Text}
+                                 "Products__CATEGORY"])))))
+
+(deftest ^:parallel column-key-test-6a-implicit-join-same-stage
+  (let [query       (lib/query meta/metadata-provider (meta/table-metadata :orders))
+        cols        (lib/filterable-columns query)
+        source      (m/find-first #(= (:id %) (meta/id :people :source)) cols)
+        user-id-key {:lib/type        :column/key
+                     :column.field/id (meta/id :orders :user-id)}
+        source-key  {:lib/type        :column/key
+                     :column.field/id (meta/id :people :source)}]
+    (is (=? {:id             (meta/id :people :source)
+             :lib/column-key {:lib/type                      :column/key
+                              :column.implicit/fk-column     user-id-key
+                              :column.implicit/target-column source-key}}
+            (lib/metadata query (lib/ref source))))
+    (is (=? {:id             (meta/id :people :source)
+             :lib/column-key {:lib/type                      :column/key
+                              :column.implicit/fk-column     user-id-key
+                              :column.implicit/target-column source-key}}
+            (lib/metadata query source)))))
 
 (deftest ^:parallel field-values-search-info-test
   (testing "type/PK field remapped to a type/Name field within the same table"
@@ -1993,7 +2103,9 @@
                              :id 1
                              :name "search"
                              :display-name "Search"
-                             :base-type :type/Text})
+                             :base-type :type/Text
+                             :lib/column-key {:lib/type                  :column/key
+                                              :column.native/unique-name "search"}})
                  lib/visible-columns
                  last))))
     (is (= {:field-id 1
@@ -2007,7 +2119,9 @@
                             :id 1
                             :name "num"
                             :display-name "Random number"
-                            :base-type :type/Integer})
+                            :base-type :type/Integer
+                            :lib/column-key {:lib/type                  :column/key
+                                             :column.native/unique-name "search"}})
                 lib/visible-columns
                 last))))))
 

--- a/test/metabase/lib/join_test.cljc
+++ b/test/metabase/lib/join_test.cljc
@@ -3,6 +3,7 @@
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
    [clojure.test :refer [are deftest is testing]]
    [medley.core :as m]
+   [metabase.lib.column-key :as lib.column-key]
    [metabase.lib.core :as lib]
    [metabase.lib.join :as lib.join]
    [metabase.lib.join.util :as lib.join.util]
@@ -250,9 +251,13 @@
                  :lib/metadata meta/metadata-provider}
           metadata (lib/returned-columns query)]
       (is (=? [(merge (m/filter-vals some? (meta/field-metadata :categories :name))
-                      {:display-name         "Name"
-                       :lib/source           :source/joins
-                       :lib/join-alias "CATEGORIES__via__CATEGORY_ID"})]
+                      {:display-name   "Name"
+                       :lib/source     :source/joins
+                       :lib/join-alias "CATEGORIES__via__CATEGORY_ID"
+                       :lib/column-key (-> (meta/id :categories :name)
+                                           lib.column-key/field-key
+                                           (lib.column-key/explicitly-joined
+                                             "490a5abb-54c2-4e62-9196-7e9e99e8d291"))})]
               metadata))
       (is (=? "CATEGORIES__via__CATEGORY_ID"
               (lib.join.util/current-join-alias (first metadata))))

--- a/test/metabase/lib/metadata/calculation_test.cljc
+++ b/test/metabase/lib/metadata/calculation_test.cljc
@@ -3,6 +3,7 @@
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
    [clojure.test :refer [deftest is testing]]
    [medley.core :as m]
+   [metabase.lib.column-key :as lib.column-key]
    [metabase.lib.computed :as lib.computed]
    [metabase.lib.core :as lib]
    [metabase.lib.field.util :as lib.field.util]
@@ -188,23 +189,29 @@
 
 (deftest ^:parallel source-cards-test
   (testing "with :source-card"
-    (let [query {:lib/type     :mbql/query
+    (let [card-id (:id (:orders (lib.tu/mock-cards)))
+          query {:lib/type     :mbql/query
                  :lib/metadata (lib.tu/metadata-provider-with-mock-cards)
                  :database     (meta/id)
                  :stages       [{:lib/type :mbql.stage/mbql
-                                 :source-card (:id (:orders (lib.tu/mock-cards)))}]}
+                                 :source-card card-id}]}
           own-fields (for [field (lib.metadata/fields (lib.tu/metadata-provider-with-mock-cards) (meta/id :orders))]
                        (-> field
-                           (assoc :lib/source :source/card)))]
+                           (assoc :lib/source :source/card)
+                           (update :lib/column-key lib.column-key/from-card card-id)))
+          implicit-via (fn [table-id fk-field-id]
+                         (let [fk-column-key (-> fk-field-id
+                                                 lib.column-key/field-key
+                                                 (lib.column-key/from-card card-id))]
+                           (for [field (lib.metadata/fields (lib.tu/metadata-provider-with-mock-cards) table-id)]
+                             (-> field
+                                 (assoc :lib/source :source/implicitly-joinable)
+                                 (update :lib/column-key lib.column-key/implicitly-joined-via fk-column-key)))))]
       (testing "implicitly joinable columns"
         (testing "are included by visible-columns"
           (is (=? (->> (concat own-fields
-                               (for [field (lib.metadata/fields (lib.tu/metadata-provider-with-mock-cards) (meta/id :people))]
-                                 (assoc field
-                                        :lib/source :source/implicitly-joinable))
-                               (for [field (lib.metadata/fields (lib.tu/metadata-provider-with-mock-cards) (meta/id :products))]
-                                 (assoc field
-                                        :lib/source :source/implicitly-joinable)))
+                               (implicit-via (meta/id :people) (meta/id :orders :user-id))
+                               (implicit-via (meta/id :products) (meta/id :orders :product-id)))
                        (sort-by (juxt :name :id)))
                   (sort-by (juxt :name :id) (lib.metadata.calculation/visible-columns query)))))
         (testing "are not included by returned-columns"
@@ -218,22 +225,19 @@
               query      (lib/append-stage query)]
           (testing "are included by visible-columns"
             (is (=? (->> (concat own-fields
-                                 (for [field (lib.metadata/fields (lib.tu/metadata-provider-with-mock-cards) (meta/id :people))]
-                                   (assoc field
-                                          :lib/source :source/implicitly-joinable))
-                                 (for [field (lib.metadata/fields (lib.tu/metadata-provider-with-mock-cards) (meta/id :products))]
-                                   (assoc field
-                                          :lib/source :source/implicitly-joinable)))
+                                 (implicit-via (meta/id :people) (meta/id :orders :user-id))
+                                 (implicit-via (meta/id :products) (meta/id :orders :product-id)))
                          (sort-by (juxt :lib/source :name :id)))
                     (sort-by (juxt :lib/source :name :id) (lib.metadata.calculation/visible-columns query)))))
           (testing "are not included by returned-columns"
             (is (=? (sort-by (juxt :name :id) own-fields)
                     (sort-by (juxt :name :id) (lib.metadata.calculation/returned-columns query))))))))))
 
-(defn- implicitly-joined [table-key]
+(defn- implicitly-joined [fk-metadata table-key]
   (->> (for [field-key (meta/fields table-key)]
          (-> (meta/field-metadata table-key field-key)
-             (assoc :lib/source :source/implicitly-joinable)))
+             (assoc :lib/source :source/implicitly-joinable)
+             (update :lib/column-key lib.column-key/implicitly-joined-via (:lib/column-key fk-metadata))))
        (sort-by :position)))
 
 (deftest ^:parallel self-join-visible-columns-test
@@ -245,18 +249,28 @@
                                                                (meta/field-metadata :orders :id))])
                                       (lib/with-join-fields (for [field [:id :tax]]
                                                               (lib/ref (meta/field-metadata :orders field)))))))
-        orders-cols (for [field-name ["ID" "USER_ID" "PRODUCT_ID" "SUBTOTAL" "TAX"
-                                      "TOTAL" "DISCOUNT" "CREATED_AT" "QUANTITY"]]
-                      {:name                    field-name
-                       :lib/source-column-alias field-name
-                       :lib/source              :source/table-defaults})
+        join-clause (first (lib/joins query))
+        orders-cols (for [field-key [:id :user-id :product-id :subtotal :tax
+                                     :total :discount :created-at :quantity]
+                          :let      [field (meta/field-metadata :orders field-key)]]
+                      {:name                    (:name field)
+                       :lib/source-column-alias (:name field)
+                       :lib/source              :source/table-defaults
+                       :lib/column-key          (lib.column-key/field-key (meta/id :orders field-key))})
         joined-cols (for [field-key [:id :user-id :product-id :subtotal :tax
                                      :total :discount :created-at :quantity]
                           :let      [field (meta/field-metadata :orders field-key)]]
                       {:name                         (:name field)
                        :lib/join-alias "Orders_2"
                        :lib/source-column-alias      (:name field)
-                       :lib/source                   :source/joins})]
+                       :lib/source                   :source/joins
+                       :lib/column-key               (-> (meta/id :orders field-key)
+                                                         lib.column-key/field-key
+                                                         (lib.column-key/explicitly-joined join-clause))})
+        base-user-id    (m/find-first #(= (:name %) "USER_ID") orders-cols)
+        join-user-id    (m/find-first #(= (:name %) "USER_ID") joined-cols)
+        base-product-id (m/find-first #(= (:name %) "PRODUCT_ID") orders-cols)
+        join-product-id (m/find-first #(= (:name %) "PRODUCT_ID") joined-cols)]
     (testing "just own columns"
       (is (=? (concat orders-cols joined-cols)
               (lib/visible-columns query -1 {:include-implicitly-joinable? false}))))
@@ -264,11 +278,11 @@
       (is (=? (concat orders-cols
                       joined-cols
                       ;; First set of implicit joins
-                      (implicitly-joined :people)
-                      (implicitly-joined :products)
+                      (implicitly-joined base-user-id :people)
+                      (implicitly-joined base-product-id :products)
                       ;; Second set of implicit joins
-                      (implicitly-joined :people)
-                      (implicitly-joined :products))
+                      (implicitly-joined join-user-id :people)
+                      (implicitly-joined join-product-id :products))
               (lib/visible-columns query -1))))))
 
 (deftest ^:parallel implicitly-joinable-requires-numeric-id-test

--- a/test/metabase/lib/metadata/calculation_test.cljc
+++ b/test/metabase/lib/metadata/calculation_test.cljc
@@ -197,16 +197,15 @@
                                  :source-card card-id}]}
           own-fields (for [field (lib.metadata/fields (lib.tu/metadata-provider-with-mock-cards) (meta/id :orders))]
                        (-> field
-                           (assoc :lib/source :source/card)
-                           (update :lib/column-key lib.column-key/from-card card-id)))
+                           (assoc :lib/source :source/card :lib/card-id card-id)
+                           (lib.column-key/from-card query card-id)))
           implicit-via (fn [table-id fk-field-id]
-                         (let [fk-column-key (-> fk-field-id
-                                                 lib.column-key/field-key
-                                                 (lib.column-key/from-card card-id))]
+                         (let [fk-column (-> (lib.metadata/field query fk-field-id)
+                                             (lib.column-key/from-card query card-id))]
                            (for [field (lib.metadata/fields (lib.tu/metadata-provider-with-mock-cards) table-id)]
                              (-> field
                                  (assoc :lib/source :source/implicitly-joinable)
-                                 (update :lib/column-key lib.column-key/implicitly-joined-via fk-column-key)))))]
+                                 (update :lib/column-key lib.column-key/implicitly-joined-via fk-column)))))]
       (testing "implicitly joinable columns"
         (testing "are included by visible-columns"
           (is (=? (->> (concat own-fields

--- a/test/metabase/lib/metadata/result_metadata_test.cljc
+++ b/test/metabase/lib/metadata/result_metadata_test.cljc
@@ -957,7 +957,8 @@
                                             :semantic-type (base-type->semantic-type (:base-type col))))]
       (testing "respect :metadata/model-metadata"
         (let [query (-> query
-                        (assoc-in [:info :metadata/model-metadata] user-edited))]
+                        (assoc-in [:info :metadata/model-metadata] user-edited)
+                        (assoc-in [:info :card-id] 123))]
           (is (=? [{:name "ID",          :description "user description", :display-name "user display name", :semantic-type :type/Quantity}
                    {:name "NAME",        :description "user description", :display-name "user display name", :semantic-type :type/Name}
                    {:name "CATEGORY_ID", :description "user description", :display-name "user display name", :semantic-type :type/Quantity}
@@ -987,7 +988,9 @@
                                          :id            (meta/id :orders :id)
                                          :table_id      (meta/id :orders)})
             ;; Add stale metadata to query
-            query-with-stale-metadata (assoc-in query [:info :metadata/model-metadata] stale-model-metadata)
+            query-with-stale-metadata (-> query
+                                          (assoc-in [:info :metadata/model-metadata] stale-model-metadata)
+                                          (assoc-in [:info :card-id] 123))
             result-cols               (result-metadata/returned-columns query-with-stale-metadata)]
         (is (= real-id (:id (first result-cols)))
             "MBQL models should use :id from query analysis, not stale model metadata")))
@@ -1001,7 +1004,9 @@
                                    :base_type    :type/BigInteger
                                    :id           (meta/id :venues :id)
                                    :table_id     (meta/id :venues)}]
-            query-with-metadata  (assoc-in native-query [:info :metadata/model-metadata] user-mapped-metadata)
+            query-with-metadata  (-> native-query
+                                     (assoc-in [:info :metadata/model-metadata] user-mapped-metadata)
+                                     (assoc-in [:info :card-id] 456))
             result-cols          (result-metadata/returned-columns query-with-metadata)]
         (is (= (meta/id :venues :id) (:id (first result-cols)))
             "Native models should preserve :id from model metadata (user mappings)")))))

--- a/test/metabase/lib/test_metadata.cljc
+++ b/test/metabase/lib/test_metadata.cljc
@@ -3065,6 +3065,7 @@
    :fingerprint          nil
    :fk-target-field-id   nil
    :id                   (id :feedback :id)
+   :lib/column-key       {:lib/type :column/key :column.field/id (id :feedback :id)}
    :name                 "ID"
    :nfc-path             nil
    :parent-id            nil
@@ -3088,6 +3089,7 @@
    :fingerprint          {:global {:distinct-count 642, :nil% 0.0}}
    :fk-target-field-id   (id :accounts :id)
    :id                   (id :feedback :account-id)
+   :lib/column-key       {:lib/type :column/key :column.field/id (id :feedback :account-id)}
    :name                 "ACCOUNT_ID"
    :nfc-path             nil
    :parent-id            nil
@@ -3116,6 +3118,7 @@
                                                :average-length 28.327102803738317}}}
    :fk-target-field-id   nil
    :id                   (id :feedback :email)
+   :lib/column-key       {:lib/type :column/key :column.field/id (id :feedback :email)}
    :name                 "EMAIL"
    :nfc-path             nil
    :parent-id            nil
@@ -3140,6 +3143,7 @@
                           :type   {:type/DateTime {:earliest "2020-11-20T00:00:00Z", :latest "2031-12-01T00:00:00Z"}}}
    :fk-target-field-id   nil
    :id                   (id :feedback :date-received)
+   :lib/column-key       {:lib/type :column/key :column.field/id (id :feedback :date-received)}
    :name                 "DATE_RECEIVED"
    :nfc-path             nil
    :parent-id            nil
@@ -3169,6 +3173,7 @@
                                                  :avg 3.3629283489096573}}}
    :fk-target-field-id   nil
    :id                   (id :feedback :rating)
+   :lib/column-key       {:lib/type :column/key :column.field/id (id :feedback :rating)}
    :name                 "RATING"
    :nfc-path             nil
    :parent-id            nil
@@ -3197,6 +3202,7 @@
                                                :average-length 6.453271028037383}}}
    :fk-target-field-id   nil
    :id                   (id :feedback :rating-mapped)
+   :lib/column-key       {:lib/type :column/key :column.field/id (id :feedback :rating-mapped)}
    :name                 "RATING_MAPPED"
    :nfc-path             nil
    :parent-id            nil
@@ -3225,6 +3231,7 @@
                                                :average-length 438.15264797507785}}}
    :fk-target-field-id   nil
    :id                   (id :feedback :body)
+   :lib/column-key       {:lib/type :column/key :column.field/id (id :feedback :body)}
    :name                 "BODY"
    :nfc-path             nil
    :parent-id            nil
@@ -3267,6 +3274,7 @@
    :fingerprint          nil
    :fk-target-field-id   nil
    :id                   (id :accounts :id)
+   :lib/column-key       {:lib/type :column/key :column.field/id (id :accounts :id)}
    :name                 "ID"
    :nfc-path             nil
    :parent-id            nil
@@ -3295,6 +3303,7 @@
                                                :average-length 28.185971943887775}}}
    :fk-target-field-id   nil
    :id                   (id :accounts :email)
+   :lib/column-key       {:lib/type :column/key :column.field/id (id :accounts :email)}
    :name                 "EMAIL"
    :nfc-path             nil
    :parent-id            nil
@@ -3323,6 +3332,7 @@
                                                :average-length 5.997595190380761}}}
    :fk-target-field-id   nil
    :id                   (id :accounts :first-name)
+   :lib/column-key       {:lib/type :column/key :column.field/id (id :accounts :first-name)}
    :name                 "FIRST_NAME"
    :nfc-path             nil
    :parent-id            nil
@@ -3351,6 +3361,7 @@
                                                :average-length 6.536673346693386}}}
    :fk-target-field-id   nil
    :id                   (id :accounts :last-name)
+   :lib/column-key       {:lib/type :column/key :column.field/id (id :accounts :last-name)}
    :name                 "LAST_NAME"
    :nfc-path             nil
    :parent-id            nil
@@ -3379,6 +3390,7 @@
                                                :average-length 5.1062124248497}}}
    :fk-target-field-id   nil
    :id                   (id :accounts :plan)
+   :lib/column-key       {:lib/type :column/key :column.field/id (id :accounts :plan)}
    :name                 "PLAN"
    :nfc-path             nil
    :parent-id            nil
@@ -3407,6 +3419,7 @@
                                                :average-length 4.4705410821643286}}}
    :fk-target-field-id   nil
    :id                   (id :accounts :source)
+   :lib/column-key       {:lib/type :column/key :column.field/id (id :accounts :source)}
    :name                 "SOURCE"
    :nfc-path             nil
    :parent-id            nil
@@ -3436,6 +3449,7 @@
                                                  :avg 16.21763527054108}}}
    :fk-target-field-id   nil
    :id                   (id :accounts :seats)
+   :lib/column-key       {:lib/type :column/key :column.field/id (id :accounts :seats)}
    :name                 "SEATS"
    :nfc-path             nil
    :parent-id            nil
@@ -3460,6 +3474,7 @@
                           :type   {:type/DateTime {:earliest "2020-09-15T16:11:50Z", :latest "2031-10-10T19:14:48Z"}}}
    :fk-target-field-id   nil
    :id                   (id :accounts :created-at)
+   :lib/column-key       {:lib/type :column/key :column.field/id (id :accounts :created-at)}
    :name                 "CREATED_AT"
    :nfc-path             nil
    :parent-id            nil
@@ -3484,6 +3499,7 @@
                           :type   {:type/DateTime {:earliest "2020-09-30T12:00:00Z", :latest "2031-10-25T12:00:00Z"}}}
    :fk-target-field-id   nil
    :id                   (id :accounts :trial-ends-at)
+   :lib/column-key       {:lib/type :column/key :column.field/id (id :accounts :trial-ends-at)}
    :name                 "TRIAL_ENDS_AT"
    :nfc-path             nil
    :parent-id            nil
@@ -3508,6 +3524,7 @@
                           :type   {:type/DateTime {:earliest "2020-10-01T15:43:40Z", :latest "2032-06-03T14:01:15Z"}}}
    :fk-target-field-id   nil
    :id                   (id :accounts :canceled-at)
+   :lib/column-key       {:lib/type :column/key :column.field/id (id :accounts :canceled-at)}
    :name                 "CANCELED_AT"
    :nfc-path             nil
    :parent-id            nil
@@ -3531,6 +3548,7 @@
    :fingerprint          {:global {:distinct-count 2, :nil% 0.0}}
    :fk-target-field-id   nil
    :id                   (id :accounts :trial-converted)
+   :lib/column-key       {:lib/type :column/key :column.field/id (id :accounts :trial-converted)}
    :name                 "TRIAL_CONVERTED"
    :nfc-path             nil
    :parent-id            nil
@@ -3554,6 +3572,7 @@
    :fingerprint          {:global {:distinct-count 2, :nil% 0.0}}
    :fk-target-field-id   nil
    :id                   (id :accounts :active-subscription)
+   :lib/column-key       {:lib/type :column/key :column.field/id (id :accounts :active-subscription)}
    :name                 "ACTIVE_SUBSCRIPTION"
    :nfc-path             nil
    :parent-id            nil
@@ -3577,6 +3596,7 @@
    :fingerprint          {:global {:distinct-count 2, :nil% 0.0}}
    :fk-target-field-id   nil
    :id                   (id :accounts :legacy-plan)
+   :lib/column-key       {:lib/type :column/key :column.field/id (id :accounts :legacy-plan)}
    :name                 "LEGACY_PLAN"
    :nfc-path             nil
    :parent-id            nil
@@ -3606,6 +3626,7 @@
                                                  :avg 31.35760681046913}}}
    :fk-target-field-id   nil
    :id                   (id :accounts :latitude)
+   :lib/column-key       {:lib/type :column/key :column.field/id (id :accounts :latitude)}
    :name                 "LATITUDE"
    :nfc-path             nil
    :parent-id            nil
@@ -3635,6 +3656,7 @@
                                                  :avg 2.6042336031796345}}}
    :fk-target-field-id   nil
    :id                   (id :accounts :longitude)
+   :lib/column-key       {:lib/type :column/key :column.field/id (id :accounts :longitude)}
    :name                 "LONGITUDE"
    :nfc-path             nil
    :parent-id            nil
@@ -3663,6 +3685,7 @@
                                                :average-length 1.9983967935871743}}}
    :fk-target-field-id   nil
    :id                   (id :accounts :country)
+   :lib/column-key       {:lib/type :column/key :column.field/id (id :accounts :country)}
    :name                 "COUNTRY"
    :nfc-path             nil
    :parent-id            nil
@@ -3714,6 +3737,7 @@
    :fingerprint          nil
    :fk-target-field-id   nil
    :id                   (id :analytic-events :id)
+   :lib/column-key       {:lib/type :column/key :column.field/id (id :analytic-events :id)}
    :name                 "ID"
    :nfc-path             nil
    :parent-id            nil
@@ -3737,6 +3761,7 @@
    :fingerprint          {:global {:distinct-count 589, :nil% 0.0}}
    :fk-target-field-id   (id :accounts :id)
    :id                   (id :analytic-events :account-id)
+   :lib/column-key       {:lib/type :column/key :column.field/id (id :analytic-events :account-id)}
    :name                 "ACCOUNT_ID"
    :nfc-path             nil
    :parent-id            nil
@@ -3765,6 +3790,7 @@
                                                :average-length 11.3906}}}
    :fk-target-field-id   nil
    :id                   (id :analytic-events :event)
+   :lib/column-key       {:lib/type :column/key :column.field/id (id :analytic-events :event)}
    :name                 "EVENT"
    :nfc-path             nil
    :parent-id            nil
@@ -3789,6 +3815,7 @@
                           :type   {:type/DateTime {:earliest "2022-03-15T00:18:25Z", :latest "2022-04-11T20:24:02Z"}}}
    :fk-target-field-id   nil
    :id                   (id :analytic-events :timestamp)
+   :lib/column-key       {:lib/type :column/key :column.field/id (id :analytic-events :timestamp)}
    :name                 "TIMESTAMP"
    :nfc-path             nil
    :parent-id            nil
@@ -3817,6 +3844,7 @@
                                                :average-length 22.2674}}}
    :fk-target-field-id   nil
    :id                   (id :analytic-events :page-url)
+   :lib/column-key       {:lib/type :column/key :column.field/id (id :analytic-events :page-url)}
    :name                 "PAGE_URL"
    :nfc-path             nil
    :parent-id            nil
@@ -3841,6 +3869,7 @@
                           :type   {:type/Text {:percent-json 0.0, :percent-url 0.0, :percent-email 0.0, :percent-state 0.0, :average-length 1.0552}}}
    :fk-target-field-id   nil
    :id                   (id :analytic-events :button-label)
+   :lib/column-key       {:lib/type :column/key :column.field/id (id :analytic-events :button-label)}
    :name                 "BUTTON_LABEL"
    :nfc-path             nil
    :parent-id            nil
@@ -3882,6 +3911,7 @@
    :fingerprint          nil
    :fk-target-field-id   nil
    :id                   (id :invoices :id)
+   :lib/column-key       {:lib/type :column/key, :column.field/id (id :invoices :id)}
    :name                 "ID"
    :nfc-path             nil
    :parent-id            nil
@@ -3905,6 +3935,7 @@
    :fingerprint          {:global {:distinct-count 1449, :nil% 0.0}}
    :fk-target-field-id   (id :accounts :id)
    :id                   (id :invoices :account-id)
+   :lib/column-key       {:lib/type :column/key, :column.field/id (id :invoices :account-id)}
    :name                 "ACCOUNT_ID"
    :nfc-path             nil
    :parent-id            nil
@@ -3934,6 +3965,7 @@
                                                  :avg 519.4153400000004}}}
    :fk-target-field-id   nil
    :id                   (id :invoices :payment)
+   :lib/column-key       {:lib/type :column/key, :column.field/id (id :invoices :payment)}
    :name                 "PAYMENT"
    :nfc-path             nil
    :parent-id            nil
@@ -3957,6 +3989,7 @@
    :fingerprint          {:global {:distinct-count 2, :nil% 0.0}}
    :fk-target-field-id   nil
    :id                   (id :invoices :expected-invoice)
+   :lib/column-key       {:lib/type :column/key, :column.field/id (id :invoices :expected-invoice)}
    :name                 "EXPECTED_INVOICE"
    :nfc-path             nil
    :parent-id            nil
@@ -3981,6 +4014,7 @@
                           :type   {:type/Text {:percent-json 0.0, :percent-url 0.0, :percent-email 0.0, :percent-state 0.0, :average-length 5.2931}}}
    :fk-target-field-id   nil
    :id                   (id :invoices :plan)
+   :lib/column-key       {:lib/type :column/key, :column.field/id (id :invoices :plan)}
    :name                 "PLAN"
    :nfc-path             nil
    :parent-id            nil
@@ -4005,6 +4039,7 @@
                           :type   {:type/DateTime {:earliest "2020-09-30T00:00:00Z", :latest "2027-05-02T00:00:00Z"}}}
    :fk-target-field-id   nil
    :id                   (id :invoices :date-received)
+   :lib/column-key       {:lib/type :column/key, :column.field/id (id :invoices :date-received)}
    :name                 "DATE_RECEIVED"
    :nfc-path             nil
    :parent-id            nil

--- a/test/metabase/lib/test_metadata.cljc
+++ b/test/metabase/lib/test_metadata.cljc
@@ -223,6 +223,7 @@
    :nfc-path            nil
    :parent-id           nil
    :id                  (id :categories :id)
+   :lib/column-key      {:lib/type :column/key, :column.field/id (id :categories :id)}
    :position            0
    :visibility-type     :normal
    :target              nil
@@ -254,6 +255,7 @@
    :nfc-path            nil
    :parent-id           nil
    :id                  (id :categories :name)
+   :lib/column-key      {:lib/type :column/key, :column.field/id (id :categories :name)}
    :position            1
    :visibility-type     :normal
    :target              nil
@@ -312,6 +314,7 @@
    :nfc-path            nil
    :parent-id           nil
    :id                  (id :checkins :id)
+   :lib/column-key      {:lib/type :column/key, :column.field/id (id :checkins :id)}
    :position            0
    :visibility-type     :normal
    :target              nil
@@ -343,6 +346,7 @@
    :nfc-path            nil
    :parent-id           nil
    :id                  (id :checkins :date)
+   :lib/column-key      {:lib/type :column/key, :column.field/id (id :checkins :date)}
    :position            1
    :visibility-type     :normal
    :target              nil
@@ -375,6 +379,7 @@
    :nfc-path            nil
    :parent-id           nil
    :id                  (id :checkins :user-id)
+   :lib/column-key      {:lib/type :column/key, :column.field/id (id :checkins :user-id)}
    :position            2
    :visibility-type     :normal
    :target              nil
@@ -406,6 +411,7 @@
    :nfc-path            nil
    :parent-id           nil
    :id                  (id :checkins :venue-id)
+   :lib/column-key      {:lib/type :column/key, :column.field/id (id :checkins :venue-id)}
    :position            3
    :visibility-type     :normal
    :target              nil
@@ -461,6 +467,7 @@
    :nfc-path            nil
    :parent-id           nil
    :id                  (id :users :id)
+   :lib/column-key      {:lib/type :column/key, :column.field/id (id :users :id)}
    :position            0
    :visibility-type     :normal
    :target              nil
@@ -492,6 +499,7 @@
    :nfc-path            nil
    :parent-id           nil
    :id                  (id :users :name)
+   :lib/column-key      {:lib/type :column/key, :column.field/id (id :users :name)}
    :position            1
    :visibility-type     :normal
    :target              nil
@@ -529,6 +537,7 @@
    :nfc-path            nil
    :parent-id           nil
    :id                  (id :users :last-login)
+   :lib/column-key      {:lib/type :column/key, :column.field/id (id :users :last-login)}
    :position            2
    :visibility-type     :normal
    :target              nil
@@ -561,6 +570,7 @@
    :nfc-path            nil
    :parent-id           nil
    :id                  (id :users :password)
+   :lib/column-key      {:lib/type :column/key, :column.field/id (id :users :password)}
    :position            3
    :visibility-type     :sensitive
    :target              nil
@@ -622,6 +632,7 @@
    :nfc-path            nil
    :parent-id           nil
    :id                  (id :venues :id)
+   :lib/column-key      {:lib/type :column/key, :column.field/id (id :venues :id)}
    :position            0
    :visibility-type     :normal
    :target              nil
@@ -653,6 +664,7 @@
    :nfc-path            nil
    :parent-id           nil
    :id                  (id :venues :name)
+   :lib/column-key      {:lib/type :column/key, :column.field/id (id :venues :name)}
    :position            1
    :visibility-type     :normal
    :target              nil
@@ -690,6 +702,7 @@
    :nfc-path            nil
    :parent-id           nil
    :id                  (id :venues :category-id)
+   :lib/column-key      {:lib/type :column/key, :column.field/id (id :venues :category-id)}
    :position            2
    :visibility-type     :normal
    :target              nil
@@ -721,6 +734,7 @@
    :nfc-path            nil
    :parent-id           nil
    :id                  (id :venues :latitude)
+   :lib/column-key      {:lib/type :column/key, :column.field/id (id :venues :latitude)}
    :position            3
    :visibility-type     :normal
    :target              nil
@@ -759,6 +773,7 @@
    :nfc-path            nil
    :parent-id           nil
    :id                  (id :venues :longitude)
+   :lib/column-key      {:lib/type :column/key, :column.field/id (id :venues :longitude)}
    :position            4
    :visibility-type     :normal
    :target              nil
@@ -798,6 +813,7 @@
    :nfc-path            nil
    :parent-id           nil
    :id                  (id :venues :price)
+   :lib/column-key      {:lib/type :column/key, :column.field/id (id :venues :price)}
    :position            5
    :visibility-type     :normal
    :target              nil
@@ -862,6 +878,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :products :id)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :products :id)}
    :database-is-auto-increment true
    :position                   0
    :visibility-type            :normal
@@ -893,6 +910,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :products :rating)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :products :rating)}
    :database-is-auto-increment false
    :position                   6
    :visibility-type            :normal
@@ -930,6 +948,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :products :category)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :products :category)}
    :database-is-auto-increment false
    :position                   3
    :visibility-type            :normal
@@ -966,6 +985,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :products :price)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :products :price)}
    :database-is-auto-increment false
    :position                   5
    :visibility-type            :normal
@@ -1003,6 +1023,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :products :title)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :products :title)}
    :database-is-auto-increment false
    :position                   2
    :visibility-type            :normal
@@ -1039,6 +1060,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :products :created-at)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :products :created-at)}
    :database-is-auto-increment false
    :position                   7
    :visibility-type            :normal
@@ -1072,6 +1094,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :products :vendor)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :products :vendor)}
    :database-is-auto-increment false
    :position                   4
    :visibility-type            :normal
@@ -1108,6 +1131,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :products :ean)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :products :ean)}
    :database-is-auto-increment false
    :position                   1
    :visibility-type            :normal
@@ -1170,6 +1194,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :orders :id)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :orders :id)}
    :database-is-auto-increment true
    :position                   0
    :visibility-type            :normal
@@ -1201,6 +1226,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :orders :subtotal)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :orders :subtotal)}
    :database-is-auto-increment false
    :position                   3
    :visibility-type            :normal
@@ -1239,6 +1265,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :orders :total)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :orders :total)}
    :database-is-auto-increment false
    :position                   5
    :visibility-type            :normal
@@ -1277,6 +1304,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :orders :tax)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :orders :tax)}
    :database-is-auto-increment false
    :position                   4
    :visibility-type            :normal
@@ -1315,6 +1343,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :orders :discount)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :orders :discount)}
    :database-is-auto-increment false
    :position                   6
    :visibility-type            :normal
@@ -1352,6 +1381,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :orders :quantity)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :orders :quantity)}
    :database-is-auto-increment false
    :position                   8
    :visibility-type            :normal
@@ -1389,6 +1419,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :orders :created-at)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :orders :created-at)}
    :database-is-auto-increment false
    :position                   7
    :visibility-type            :normal
@@ -1422,6 +1453,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :orders :product-id)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :orders :product-id)}
    :database-is-auto-increment false
    :position                   2
    :visibility-type            :normal
@@ -1453,6 +1485,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :orders :user-id)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :orders :user-id)}
    :database-is-auto-increment false
    :position                   1
    :visibility-type            :normal
@@ -1511,6 +1544,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :people :id)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :people :id)}
    :database-is-auto-increment true
    :position                   0
    :visibility-type            :normal
@@ -1542,6 +1576,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :people :state)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :people :state)}
    :database-is-auto-increment false
    :position                   7
    :visibility-type            :normal
@@ -1578,6 +1613,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :people :city)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :people :city)}
    :database-is-auto-increment false
    :position                   5
    :visibility-type            :normal
@@ -1614,6 +1650,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :people :address)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :people :address)}
    :database-is-auto-increment false
    :position                   1
    :visibility-type            :normal
@@ -1650,6 +1687,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :people :name)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :people :name)}
    :database-is-auto-increment false
    :position                   4
    :visibility-type            :normal
@@ -1686,6 +1724,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :people :source)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :people :source)}
    :database-is-auto-increment false
    :position                   8
    :visibility-type            :normal
@@ -1722,6 +1761,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :people :zip)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :people :zip)}
    :database-is-auto-increment false
    :position                   10
    :visibility-type            :normal
@@ -1758,6 +1798,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :people :latitude)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :people :latitude)}
    :database-is-auto-increment false
    :position                   11
    :visibility-type            :normal
@@ -1795,6 +1836,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :people :password)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :people :password)}
    :database-is-auto-increment false
    :position                   3
    :visibility-type            :normal
@@ -1831,6 +1873,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :people :birth-date)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :people :birth-date)}
    :database-is-auto-increment false
    :position                   9
    :visibility-type            :normal
@@ -1863,6 +1906,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :people :longitude)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :people :longitude)}
    :database-is-auto-increment false
    :position                   6
    :visibility-type            :normal
@@ -1900,6 +1944,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :people :email)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :people :email)}
    :database-is-auto-increment false
    :position                   2
    :visibility-type            :normal
@@ -1936,6 +1981,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :people :created-at)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :people :created-at)}
    :database-is-auto-increment false
    :position                   12
    :visibility-type            :normal
@@ -2000,6 +2046,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :reviews :id)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :reviews :id)}
    :database-is-auto-increment true
    :position                   0
    :visibility-type            :normal
@@ -2031,6 +2078,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :reviews :created-at)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :reviews :created-at)}
    :database-is-auto-increment false
    :position                   5
    :visibility-type            :normal
@@ -2064,6 +2112,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :reviews :rating)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :reviews :rating)}
    :database-is-auto-increment false
    :position                   3
    :visibility-type            :normal
@@ -2101,6 +2150,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :reviews :reviewer)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :reviews :reviewer)}
    :database-is-auto-increment false
    :position                   2
    :visibility-type            :normal
@@ -2137,6 +2187,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :reviews :body)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :reviews :body)}
    :database-is-auto-increment false
    :position                   4
    :visibility-type            :normal
@@ -2173,6 +2224,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :reviews :product-id)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :reviews :product-id)}
    :database-is-auto-increment false
    :position                   1
    :visibility-type            :normal
@@ -2228,6 +2280,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :ic/accounts :id)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :ic/accounts :id)}
    :last-analyzed              nil
    :database-is-auto-increment false
    :json-unfolding             false
@@ -2261,6 +2314,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :ic/accounts :name)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :ic/accounts :name)}
    :database-is-auto-increment false
    :json-unfolding             false
    :position                   1
@@ -2319,6 +2373,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :ic/reports :id)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :ic/reports :id)}
    :database-is-auto-increment false
    :json-unfolding             false
    :position                   0
@@ -2353,6 +2408,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :ic/reports :created-by)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :ic/reports :created-by)}
    :database-is-auto-increment false
    :json-unfolding             false
    :position                   1
@@ -2385,6 +2441,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :ic/reports :updated-by)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :ic/reports :updated-by)}
    :database-is-auto-increment false
    :json-unfolding             false
    :position                   2
@@ -2429,6 +2486,7 @@
    :semantic-type              :type/PK
    :table-id                   (id :gh/issues)
    :id                         (id :gh/issues :id)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :gh/issues :id)}
    :name                       "ID"
    :coercion-strategy          nil
    :fingerprint-version        5
@@ -2462,6 +2520,7 @@
    :semantic-type              :type/FK
    :table-id                   (id :gh/issues)
    :id                         (id :gh/issues :reporter-id)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :gh/issues :reporter-id)}
    :name                       "REPORTER_ID"
    :display-name               "Reporter ID"
    :coercion-strategy          nil
@@ -2499,6 +2558,7 @@
    :semantic-type              :type/FK
    :table-id                   (id :gh/issues)
    :id                         (id :gh/issues :assignee-id)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :gh/issues :assignee-id)}
    :name                       "ASSIGNEE_ID"
    :display-name               "Assignee ID"
    :coercion-strategy          nil
@@ -2536,6 +2596,7 @@
    :semantic-type              :type/Category
    :table-id                   (id :gh/issues)
    :id                         (id :gh/issues :is-open)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :gh/issues :is-open)}
    :name                       "IS_OPEN"
    :display-name               "Is Open"
    :coercion-strategy          nil
@@ -2570,6 +2631,7 @@
    :semantic-type              nil
    :table-id                   (id :gh/issues)
    :id                         (id :gh/issues :reported-at)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :gh/issues :reported-at)}
    :name                       "REPORTED_AT"
    :display-name               "Reported At"
    :coercion-strategy          nil
@@ -2604,6 +2666,7 @@
    :semantic-type              nil
    :table-id                   (id :gh/issues)
    :id                         (id :gh/issues :closed-at)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :gh/issues :closed-at)}
    :name                       "CLOSED_AT"
    :display-name               "Closed At"
    :coercion-strategy          nil
@@ -2663,6 +2726,7 @@
    :semantic-type              :type/PK
    :table-id                   (id :gh/users)
    :id                         (id :gh/users :id)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :gh/users :id)}
    :name                       "ID"
    :display-name               "Username"
    :coercion-strategy          nil
@@ -2700,6 +2764,7 @@
    :semantic-type              nil
    :table-id                   (id :gh/users)
    :id                         (id :gh/users :birthday)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :gh/users :birthday)}
    :name                       "BIRTHDAY"
    :display-name               "Birthday"
    :coercion-strategy          nil
@@ -2733,6 +2798,7 @@
    :semantic-type              :type/Email
    :table-id                   (id :gh/users)
    :id                         (id :gh/users :email)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :gh/users :email)}
    :name                       "EMAIL"
    :display-name               "Email"
    :coercion-strategy          nil
@@ -2792,6 +2858,7 @@
    :semantic-type              :type/PK
    :table-id                   (id :gh/comments)
    :id                         (id :gh/comments :id)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :gh/comments :id)}
    :name                       "ID"
    :display-name               "ID"
    :coercion-strategy          nil
@@ -2825,6 +2892,7 @@
    :semantic-type              :type/FK
    :table-id                   (id :gh/comments)
    :id                         (id :gh/comments :author-id)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :gh/comments :author-id)}
    :name                       "AUTHOR_ID"
    :display-name               "Author ID"
    :coercion-strategy          nil
@@ -2862,6 +2930,7 @@
    :semantic-type              :type/CreationDate
    :table-id                   (id :gh/comments)
    :id                         (id :gh/comments :posted-at)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :gh/comments :posted-at)}
    :name                       "POSTED_AT"
    :display-name               "Posted At"
    :coercion-strategy          nil
@@ -2896,6 +2965,7 @@
    :semantic-type              :type/FK
    :table-id                   (id :gh/comments)
    :id                         (id :gh/comments :reply-to)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :gh/comments :reply-to)}
    :name                       "REPLY_TO"
    :display-name               "Reply To"
    :coercion-strategy          nil
@@ -2929,6 +2999,7 @@
    :semantic-type              nil
    :table-id                   (id :gh/comments)
    :id                         (id :gh/comments :body-markdown)
+   :lib/column-key             {:lib/type :column/key, :column.field/id (id :gh/comments :body-markdown)}
    :name                       "BODY_MARKDOWN"
    :display-name               "Body Markdown"
    :coercion-strategy          nil

--- a/test/metabase/lib/test_util.cljc
+++ b/test/metabase/lib/test_util.cljc
@@ -4,6 +4,7 @@
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
    [clojure.test :refer [deftest is]]
    [medley.core :as m]
+   [metabase.lib.column-key :as lib.column-key]
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
@@ -205,16 +206,18 @@
    :database     (meta/id)
    :stages       [{:lib/type           :mbql.stage/native
                    :lib/stage-metadata {:lib/type :metadata/results
-                                        :columns  [{:lib/type      :metadata/column
-                                                    :name          "abc"
-                                                    :display-name  "another Field"
-                                                    :base-type     :type/Integer
-                                                    :semantic-type :type/FK}
-                                                   {:lib/type      :metadata/column
-                                                    :name          "sum"
-                                                    :display-name  "sum of User ID"
-                                                    :base-type     :type/Integer
-                                                    :semantic-type :type/FK}]}
+                                        :columns  [{:lib/type       :metadata/column
+                                                    :name           "abc"
+                                                    :display-name   "another Field"
+                                                    :base-type      :type/Integer
+                                                    :semantic-type  :type/FK
+                                                    :lib/column-key (lib.column-key/native-key "abc")}
+                                                   {:lib/type       :metadata/column
+                                                    :name           "sum"
+                                                    :display-name   "sum of User ID"
+                                                    :base-type      :type/Integer
+                                                    :semantic-type  :type/FK
+                                                    :lib/column-key (lib.column-key/native-key "sum")}]}
                    :native             "SELECT whatever"}]})
 
 (defn base-metadata-provider

--- a/test/metabase/lib/test_util/matrix.cljc
+++ b/test/metabase/lib/test_util/matrix.cljc
@@ -37,7 +37,9 @@
                      :position 1
                      :has-field-values nil
                      :preview-display true
-                     :database-position 1}]
+                     :database-position 1
+                     :lib/column-key {:lib/type        :column/key
+                                      :column.field/id 2}}]
     (assoc (assoc (dissoc meta/metadata :tables) :id 1)
            :tables
            [{:description nil,
@@ -82,7 +84,9 @@
                        :target nil,
                        :preview-display true,
                        :database-position 0,
-                       :fingerprint nil}
+                       :fingerprint nil
+                       :lib/column-key {:lib/type        :column/key
+                                        :column.field/id 1}}
                       test-column]}
             {:description nil,
              :schema "PUBLIC",
@@ -126,7 +130,9 @@
                        :target nil,
                        :preview-display true,
                        :database-position 0,
-                       :fingerprint nil}
+                       :fingerprint nil
+                       :lib/column-key {:lib/type        :column/key
+                                        :column.field/id 10}}
                       {:description nil
                        :lib/type :metadata/column
                        :database-is-auto-increment false
@@ -154,6 +160,8 @@
                        :has-field-values nil
                        :preview-display true
                        :database-position 1
+                       :lib/column-key {:lib/type        :column/key
+                                        :column.field/id 20}
                        :fingerprint {:global {:distinct-count 200
                                               :nil% 0.0}}}]}])))
 

--- a/test/metabase/query_processor/middleware/resolve_joins_test.clj
+++ b/test/metabase/query_processor/middleware/resolve_joins_test.clj
@@ -261,11 +261,12 @@
 
 (deftest ^:parallel native-model-field-ref-test
   (testing "should use name-based field refs for joined native models with mapped database fields (metabase#58829)"
-    (let [source-metadata [{:name          "_USER_ID"
-                            :display_name  "User ID"
-                            :base_type     :type/Integer
-                            :semantic_type :type/FK
-                            :fingerprint   {:global {:distinct-count 15, :nil% 0.0}}}]]
+    (let [source-metadata [{:name           "_USER_ID"
+                            :display_name   "User ID"
+                            :base_type      :type/Integer
+                            :semantic_type  :type/FK
+                            :lib/column-key {:lib/type :column/key, :column.native/unique-name "_USER_ID"}
+                            :fingerprint    {:global {:distinct-count 15, :nil% 0.0}}}]]
       (is (= (lib.tu.macros/mbql-query users
                {:fields [$id
                          [:field "_USER_ID" {:base-type          :type/Integer

--- a/test/metabase/query_processor/middleware/results_metadata_test.clj
+++ b/test/metabase/query_processor/middleware/results_metadata_test.clj
@@ -240,7 +240,8 @@
                 native-query (str "SELECT " fields " FROM VENUES")
                 existing-metadata (add-preserved (default-card-results-native))
                 results (-> (mt/native-query   {:query native-query})
-                            (qp/userland-query {:metadata/model-metadata existing-metadata})
+                            (qp/userland-query {:metadata/model-metadata existing-metadata
+                                                :card-id                 123})
                             qp/process-query)]
             (is (= (map choose existing-metadata)
                    (map choose (-> results :data :results_metadata :columns))))))
@@ -257,7 +258,8 @@
                           (update query
                                   :info
                                   merge
-                                  {:metadata/model-metadata existing-metadata})))]
+                                  {:metadata/model-metadata existing-metadata
+                                   :card-id                 123})))]
             (is (= (map choose existing-metadata)
                    (map choose (-> results :data :results_metadata :columns))))))))))
 

--- a/test/metabase/query_processor/pivot_test.clj
+++ b/test/metabase/query_processor/pivot_test.clj
@@ -456,12 +456,16 @@
             (qp.pivot/run-pivot-query (qp.pivot.test-util/parameters-query))))))
 
 (defn- clean-pivot-results [results]
-  (let [no-uuid #(dissoc % :lib/source_uuid)]
+  (let [clean-col #(-> %
+                       (dissoc :lib/source_uuid)
+                       (m/update-existing-in [:lib/column-key :column.breakout/uuid] (constantly "breakout-uuid"))
+                       (m/update-existing-in [:lib/column-key :column.aggregation/uuid] (constantly "breakout-uuid")))]
     (-> results
         (dissoc :running_time :started_at :json_query)
         (m/dissoc-in [:data :results_metadata :checksum])
         (m/dissoc-in [:data :native_form])
-        (update-in [:data :cols] #(mapv no-uuid %)))))
+        (update-in [:data :cols] #(mapv clean-col %))
+        (update-in [:data :results_metadata :columns] #(mapv clean-col %)))))
 
 (deftest ^:parallel pivots-should-not-return-expressions-test
   (mt/dataset test-data

--- a/test/metabase/query_processor/preprocess_test.clj
+++ b/test/metabase/query_processor/preprocess_test.clj
@@ -283,7 +283,8 @@
       (testing "respect :metadata/model-metadata"
         (let [card  (lib.metadata/card edited-mp 1)
               query (-> (:dataset-query card)
-                        (assoc-in [:info :metadata/model-metadata] (:result-metadata card)))]
+                        (assoc-in [:info :metadata/model-metadata] (:result-metadata card))
+                        (assoc-in [:info :card-id]                 1))]
           (is (=? [{:name "ID",          :description "user description", :display_name "user display name", :semantic_type :type/Quantity}
                    {:name "NAME",        :description "user description", :display_name "user display name", :semantic_type :type/Name}
                    {:name "CATEGORY_ID", :description "user description", :display_name "user display name", :semantic_type :type/Quantity}


### PR DESCRIPTION
This is laying a foundation for a handful of current and upcoming projects
that want a robust way to match up the columns between two copies of
"the same" query. (Models into Transforms needs this, among others.)

### Description

Adds `:lib/column-key` to all `:metadata/column` maps.

These keys are nested descriptions of how each column "got into"
the query.

- Plain table fields are leaf columns identified by their ID.
- Native query columns are leaf columns identified by their (unique)
  column name.
- Breakouts, aggregations and expressions all introducea new column,
  identified by the UUID of the clause that defines them.

That's all the leaf columns.

Then there are three transformations that matter:

- Explicit joins: the key within the join is wrapped up along with the
  join clause's UUID.
- Implicit joins: the target column's key is wrapped up along with the
  FK's key.
- Cards: keys are wrapped up with the card ID.
  - If the card is opaque (e.g. in the FE) the `:lib/desired-column-alias`
    is used for a `:column.card.opaque/column-alias` key.
  - If the card is visible (e.g. in the QP) the inner column key is
    wrapped.

Those are all the ways to get a column into a query. Therefore, all
column keys on any stage are _unique within that stage_. They're not
quite unique across the whole query, since two native queries that are
later joined together could have duplicate column names.

Note two vital things that column keys **are not** impacted by:
- Stage boundaries
- Column names or aliases
  - Except native columns and opaque cards' columns - but see below.

Native columns and opaque cards' columns don't cause much harm - the
names are _unique_, and both appear only at the leaves of the query
tree. No change to the later MBQL can impact these incoming aliases.

Therefore, column keys are unaffected by most of the transformations
we do to queries! Adding extra stages (nesting), changing an
expression's name, reordering or deleting aggregations, turning an
implicit join into an explicit join, etc. all don't change the column
keys. They're predictable and non-contextual. This has the potential
to greatly reduce bookkeeping costs and complexity in the QP and lib.

But one thing at a time - this PR only adds the `:lib/column-key` to
`visible-columns`, `returned-columns`, etc. They're not consumed
anywhere outside of tests yet.

### How to verify

Tests only; these new keys are not consumed anywhere currently.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
