### PR TITLE
bit more cleanup

### DIFF
--- a/.clj-kondo/macros/metabase/server/statistics_handler_test.clj
+++ b/.clj-kondo/macros/metabase/server/statistics_handler_test.clj
@@ -1,6 +1,0 @@
-(ns macros.metabase.server.statistics-handler-test)
-
-(defmacro with-server
-  [[_hold-chan _hit-chan] & body]
-  `(let []
-     ~@body))

--- a/test/metabase/server/statistics_handler_test.clj
+++ b/test/metabase/server/statistics_handler_test.clj
@@ -1,7 +1,6 @@
 (ns metabase.server.statistics-handler-test
   (:require
    [clj-http.client :as http]
-   [clojure.core.async :as a]
    [clojure.test :refer [deftest is testing]]
    [compojure.core :as compojure :refer #_{:clj-kondo/ignore [:discouraged-var]} [GET]]
    [compojure.route :as route]

--- a/test/metabase/server/statistics_handler_test.clj
+++ b/test/metabase/server/statistics_handler_test.clj
@@ -4,6 +4,7 @@
    [clojure.core.async :as a]
    [clojure.test :refer [deftest is testing]]
    [compojure.core :as compojure :refer #_{:clj-kondo/ignore [:discouraged-var]} [GET]]
+   [compojure.route :as route]
    [metabase.analytics.prometheus-test :as prometheus-test]
    [metabase.server.instance :as server.instance]
    [metabase.test :as mt])
@@ -12,73 +13,41 @@
 
 (set! *warn-on-reflection* true)
 
-(defn routes
-  [hold-chan hit-chan]
+(defn- routes []
   #_{:clj-kondo/ignore [:discouraged-var]}
   (compojure/routes
-   (GET "/sync" [] {:status 200 :headers {} :body "you got it sync"})
-   (GET "/hold" []
-     (a/>!! hit-chan :hit)
-     (let [timeout (a/timeout 500)
-           [ch _val] (a/alts!! [hold-chan timeout])]
-       (if (= ch timeout)
-         (throw (ex-info "We timed out!" {}))
-         {:status 200 :headers {} :body "you got held"})))
-   (GET "/async" []
+   (GET "/route" []
      (fn [_req respond _raise]
-       (respond {:status 200 :headers {} :body "you got it async"})))
+       (respond {:status 200 :headers {} :body "just a route"})))
    (GET "/blowup" []
      (throw (ex-info "Kaboom. you get a 500" {})))
    (GET "/reroute" []
-     {:status 301 :headers {"Location" "http://localhost:3000/app"} :body "go somewher else"})))
-
-(defmacro with-server
-  [[hold-chan hit-chan] f]
-  `(let [^Server server# (doto (server.instance/create-server (routes ~hold-chan ~hit-chan) {:port 0 :join? false})
-                           (.start))
-         port# (.. server# getURI getPort)
-         wait# (promise)]
-     (~f server# port#)
-     (.stop server#)))
+     {:status 301 :headers {"Location" "http://localhost:3000/app"} :body "go somewher else"})
+   (route/not-found {:status 404 :body "not found"})))
 
 (deftest server-stats-test
   (mt/with-prometheus-system! [_ system]
-    (let [hold-chan (a/chan)
-          hit-chan (a/chan)
-          value! (fn value! [& metric-args]
-                   (apply mt/metric-value system metric-args))]
-      (with-server [hold-chan hit-chan]
-        (fn [_server port]
-          (testing "async"
-            (let [route (format "http://localhost:%d/sync" port)]
-              (is (= 200 (:status (http/get route))))
-              (is (prometheus-test/approx= 1 (value! :jetty/requests-total)))
-              (is (prometheus-test/approx= 1 (value! :jetty/dispatched-total)))
-              (is (prometheus-test/approx= 1 (value! :jetty/dispatched-active-max)))
-              (is (prometheus-test/approx= 1 (value! :jetty/dispatched-total)))
-              (is (prometheus-test/approx= 0 (value! :jetty/dispatched-active)))
-              (is (prometheus-test/approx= 1 (value! :jetty/dispatched-active-max)))
-              (is (prometheus-test/approx= 1 (value! :jetty/responses-total {:code "2xx"})))))
-          (testing "requests active"
-            (let [route (format "http://localhost:%d/hold" port)]
-              (future
-                ;; this will wait on the hold chan
-                (is (= 200 (:status (http/get route))))
-                (is (prometheus-test/approx= 0 (value! :jetty/requests-active)))
-                (is (prometheus-test/approx= 0 (value! :jetty/dispatched-active))))
-              (let [timeout (a/timeout 500)
-                    [ch _v] (a/alts!! [hit-chan timeout])]
-                (is (not= ch timeout) "We timed out!")
-                (is (prometheus-test/approx= 1 (value! :jetty/requests-active)))
-                (is (prometheus-test/approx= 1 (value! :jetty/dispatched-active)))
-                (a/>!! hold-chan :continue))))
-          (testing "300"
-            (testing "when server responds 300"
-              (let [route (format "http://localhost:%d/reroute" port)]
-                (http/get route {:redirect-strategy :none})
-                (is (prometheus-test/approx= 1 (value! :jetty/responses-total {:code "3xx"}))))))
-          (testing "500"
-            (testing "when server responds 500"
-              (let [route (format "http://localhost:%d/blowup" port)]
-                (http/get route {:throw-exceptions false})
-                (is (prometheus-test/approx= 1 (value! :jetty/responses-total {:code "5xx"})))))))))))
+    (let [value! (fn value! [& metric-args]
+                   (apply mt/metric-value system metric-args))
+          ^Server server (doto (server.instance/create-server (routes)
+                                                              {:port 0 :join? false})
+                           (.start))
+          port (.. server getURI getPort)]
+      (try
+        (is (= 200 (:status (http/get (format "http://localhost:%d/route" port)))))
+        (is (= 301 (:status (http/get (format "http://localhost:%d/reroute" port)
+                                      {:redirect-strategy :none}))))
+        (is (= 404 (:status (http/get (format "http://localhost:%d/unknown" port)
+                                      {:throw-exceptions false}))))
+        (is (= 500 (:status (http/get (format "http://localhost:%d/blowup" port)
+                                      {:throw-exceptions false}))))
+        (is (prometheus-test/approx= 4 (value! :jetty/requests-total)))
+        (is (prometheus-test/approx= 4 (value! :jetty/dispatched-total)))
+        (is (prometheus-test/approx= 1 (value! :jetty/dispatched-active-max)))
+        (is (prometheus-test/approx= 0 (value! :jetty/dispatched-active)))
+        (is (prometheus-test/approx= 1 (value! :jetty/dispatched-active-max)))
+        (is (prometheus-test/approx= 1 (value! :jetty/responses-total {:code "2xx"})))
+        (is (prometheus-test/approx= 1 (value! :jetty/responses-total {:code "3xx"})))
+        (is (prometheus-test/approx= 1 (value! :jetty/responses-total {:code "4xx"})))
+        (is (prometheus-test/approx= 1 (value! :jetty/responses-total {:code "5xx"})))
+        (finally (.stop server))))))

--- a/test/metabase/server/statistics_handler_test.clj
+++ b/test/metabase/server/statistics_handler_test.clj
@@ -1,7 +1,7 @@
 (ns metabase.server.statistics-handler-test
   (:require
    [clj-http.client :as http]
-   [clojure.test :refer [deftest is testing]]
+   [clojure.test :refer [deftest is]]
    [compojure.core :as compojure :refer #_{:clj-kondo/ignore [:discouraged-var]} [GET]]
    [compojure.route :as route]
    [metabase.analytics.prometheus-test :as prometheus-test]


### PR DESCRIPTION
kept having a few flakes, couldn't consistently get it to pass 45 times in a row locally. So just simplify it. Don't worry about "in process" stats. Trying to get the webserver paused in the middle of a request was occasionally deadlocking, often flaking.

So just calculate the simple ones and it's fine

```clojure
statistics-handler-test=> (clojure.test/run-test server-stats-test)

Testing metabase.server.statistics-handler-test

Ran 1 tests containing 13 assertions.
0 failures, 0 errors.
{:test 1, :pass 13, :fail 0, :error 0, :type :summary}
statistics-handler-test=> (dotimes [_ 100](server-stats-test))
nil
```

Also got rid of the macro that really only existed to collect the forms into an anonymous function. Everything in-lined and now don't need a kondo hook, etc