### PR TITLE
Ask for loki stress testing

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,3 +25,4 @@ _Upload a demo video or before/after screenshots if sensible or remove the secti
 ### Checklist
 
 - [ ] Tests have been added/updated to cover changes in this PR
+- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)

--- a/.github/workflows/loki-stress-test-flake-fix.yml
+++ b/.github/workflows/loki-stress-test-flake-fix.yml
@@ -8,10 +8,10 @@ on:
         type: string
         required: true
       burn_in:
-        description: "Number of times to run the test (e.g. 20)"
+        description: "Number of times to run the test (e.g. 50)"
         type: string
         required: true
-        default: "20"
+        default: "50"
 
 jobs:
   workflow-summary:

--- a/docs/developers-guide/visual-tests.md
+++ b/docs/developers-guide/visual-tests.md
@@ -29,3 +29,5 @@ If the differences are intentional or caused by a flake, update the reference sn
 ## Adding new tests
 
 Adding new test is as simple as adding new stories. As of today, we use visual tests only for charts, however, you can use it for any other stories. Make sure the `storiesFilter` value in `loki.config.js` includes the stories you want to have as visual tests.
+
+Before merging, run the [Loki Visual Stress Test](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml) workflow to verify your new test isn't flaky. Enter your story filter pattern and run it 50 times.


### PR DESCRIPTION
### Description

Loki tests can be flaky which disrupts everyone's workflow when this happens.
With recently added [loki stress test workflow](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml) this PR asks developers to run the workflow if they add new loki tests.