### PR TITLE
feat: support remote sync transforms in FE

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -524,6 +524,7 @@
    metabase-enterprise.cache.config-test/with-temp-persist-models                                                            hooks.common/with-seven-bindings
    metabase-enterprise.metabot-v3.tools.dependencies-test/with-dependent-transforms!                                         hooks.common/with-two-bindings
    metabase-enterprise.semantic-search.db.connection/with-migrate-tx                                                         hooks.common/let-one-with-optional-value
+   metabase-enterprise.serialization.api-test/with-serialization-test-data!                                                  hooks.common/with-three-bindings
    metabase-enterprise.serialization.test-util/with-temp-dpc                                                                 hooks.toucan2.tools.with-temp/with-temp
    metabase-enterprise.transforms-python.drivers-test/with-test-table                                                        hooks.common/with-two-bindings
    metabase.api.common.internal-test/with-jetty-server                                                                       hooks.common/with-one-binding

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/api.clj
@@ -138,6 +138,8 @@
        [:remote-sync-token {:optional true} [:maybe :string]]
        [:remote-sync-type {:optional true} [:maybe [:enum :read-only :read-write]]]
        [:remote-sync-branch {:optional true} [:maybe :string]]
+       [:remote-sync-auto-import {:optional true} [:maybe :boolean]]
+       [:remote-sync-transforms {:optional true} [:maybe :boolean]]
        [:collections {:optional true} [:maybe [:map-of pos-int? :boolean]]]]]
   (api/check-superuser)
   (api/check-400 (not (and (remote-sync.object/dirty?) (= :read-only remote-sync-type)))

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/settings.clj
@@ -149,7 +149,7 @@
           token-to-check (if obfuscated? current-token remote-sync-token)
           _ (check-git-settings! (assoc settings :remote-sync-token token-to-check))]
       (t2/with-transaction [_conn]
-        (doseq [k [:remote-sync-url :remote-sync-token :remote-sync-type :remote-sync-branch :remote-sync-auto-import]]
+        (doseq [k [:remote-sync-url :remote-sync-token :remote-sync-type :remote-sync-branch :remote-sync-auto-import :remote-sync-transforms]]
           (when (and (contains? settings k)
                      (not (and (= k :remote-sync-token) obfuscated?)))
             (setting/set! k (k settings))))))))

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/api_test.clj
@@ -972,3 +972,45 @@
             (is (=? {:success true} resp))
             (is (nil? (settings/remote-sync-token))
                 "Token should be cleared when explicitly set to nil")))))))
+
+;;; ------------------------------------------- Transforms Setting Tests -------------------------------------------
+
+(deftest settings-updates-transforms-setting-test
+  (testing "PUT /api/ee/remote-sync/settings can update remote-sync-transforms setting"
+    (let [mock-source (test-helpers/create-mock-source)]
+      (with-redefs [settings/check-git-settings! (constantly nil)
+                    source/source-from-settings (constantly mock-source)]
+        (mt/with-temporary-setting-values [remote-sync-url "https://github.com/test/repo.git"
+                                           remote-sync-token "test-token"
+                                           remote-sync-branch "main"
+                                           remote-sync-type :read-write
+                                           remote-sync-transforms false]
+          (testing "can enable transforms sync"
+            (let [{:as resp :keys [task_id]} (mt/user-http-request :crowberto :put 200 "ee/remote-sync/settings"
+                                                                   {:remote-sync-transforms true})]
+              (wait-for-task-completion task_id)
+              (is (=? {:success true} resp))
+              (is (true? (settings/remote-sync-transforms)))))
+          (testing "can disable transforms sync"
+            (let [{:as resp :keys [task_id]} (mt/user-http-request :crowberto :put 200 "ee/remote-sync/settings"
+                                                                   {:remote-sync-transforms false})]
+              (wait-for-task-completion task_id)
+              (is (=? {:success true} resp))
+              (is (false? (settings/remote-sync-transforms))))))))))
+
+(deftest settings-preserves-transforms-when-not-specified-test
+  (testing "PUT /api/ee/remote-sync/settings preserves transforms setting when not specified"
+    (let [mock-source (test-helpers/create-mock-source)]
+      (with-redefs [settings/check-git-settings! (constantly nil)
+                    source/source-from-settings (constantly mock-source)]
+        (mt/with-temporary-setting-values [remote-sync-url "https://github.com/test/repo.git"
+                                           remote-sync-token "test-token"
+                                           remote-sync-branch "main"
+                                           remote-sync-type :read-write
+                                           remote-sync-transforms true]
+          (let [{:as resp :keys [task_id]} (mt/user-http-request :crowberto :put 200 "ee/remote-sync/settings"
+                                                                 {:remote-sync-branch "develop"})]
+            (wait-for-task-completion task_id)
+            (is (=? {:success true} resp))
+            (is (true? (settings/remote-sync-transforms))
+                "Transforms setting should be preserved when not included in request")))))))

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/transforms_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/transforms_test.clj
@@ -371,7 +371,11 @@ is_sample: false
                          :model/Transform {transform-id :id transform-eid :entity_id}
                          {:name "Child Transform"
                           :collection_id coll-id
-                          :entity_id "child-transform-xxxxx"}]
+                          :entity_id "child-transform-xxxxx"}
+                         :model/Transform {root-transform-id :id root-transform-eid :entity_id}
+                         {:name "Root Transform"
+                          :collection_id nil
+                          :entity_id "root-transform-xxxxxx"}]
             (t2/insert! :model/RemoteSyncObject
                         [{:model_type "Collection"
                           :model_id coll-id
@@ -383,6 +387,12 @@ is_sample: false
                           :model_name "Child Transform"
                           :model_collection_id coll-id
                           :status "synced"
+                          :status_changed_at (t/offset-date-time)}
+                         {:model_type "Transform"
+                          :model_id root-transform-id
+                          :model_name "Root Transform"
+                          :model_collection_id nil
+                          :status "create"
                           :status_changed_at (t/offset-date-time)}])
             (let [initial-files {"main" {(str "collections/" coll-eid "_transforms_collection/" coll-eid "_transforms_collection.yaml")
                                          (generate-transforms-namespace-collection-yaml coll-eid "Transforms Collection")
@@ -401,4 +411,7 @@ is_sample: false
                 (is (= :success (:status result)))
                 (let [files-after-export (get @(:files-atom mock-source) "main")]
                   (is (not (some #(str/includes? % coll-eid) (keys files-after-export))))
-                  (is (not (some #(str/includes? % transform-eid) (keys files-after-export)))))))))))))
+                  (is (not (some #(str/includes? % transform-eid) (keys files-after-export))))
+                  ;; Root transform should still be exported
+                  (is (some #(str/includes? % root-transform-eid) (keys files-after-export))
+                      "Root transform should be exported"))))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
@@ -80,6 +80,29 @@
        read-string
        (walk/postwalk #(-> % (sanitize-key :id) (sanitize-key :entity_id)))))
 
+(defmacro with-serialization-test-data!
+  "Sets up standard test context: search index, snowplow, premium features, and test entities."
+  [[coll dash card] & body]
+  `(search.tu/with-temp-index-table
+     (snowplow-test/with-fake-snowplow-collector
+       (mt/with-premium-features #{:serialization}
+         (mt/with-temp [:model/Collection ~coll  {}
+                        :model/Dashboard  ~dash  {:collection_id (:id ~coll), :name "thraddash"}
+                        :model/Card       ~card  {:collection_id (:id ~coll), :name "frobinate", :type :model
+                                                  :query_type    :native
+                                                  :dataset_query {:type     :native
+                                                                  :database (t2/select-one-pk :model/Database)
+                                                                  :native   {:query "SELECT 1"}}}]
+           ~@body)))))
+
+(defn- do-export
+  "Helper to perform an export and return the byte array."
+  [coll-id]
+  (-> (mt/user-http-request :crowberto :post 200 "ee/serialization/export"
+                            :collection coll-id :data_model false :settings false)
+      io/input-stream
+      (#'api.serialization/ba-copy)))
+
 (deftest export-test
   (testing "Serialization API export"
     (let [known-files (set (.list (io/file api.serialization/parent-dir)))]
@@ -183,236 +206,283 @@
       :current-user-perms    #{"/"}
       :search-string         search-string}))))
 
-#_{:clj-kondo/ignore [:metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests]}
-(deftest export-import-test
-  (testing "Serialization API e2e"
-    (search.tu/with-temp-index-table
-      (let [known-files (set (.list (io/file api.serialization/parent-dir)))]
-        (snowplow-test/with-fake-snowplow-collector
-          (mt/with-premium-features #{:serialization}
-            (testing "POST /api/ee/serialization/export"
-              (mt/with-temp [:model/Collection coll  {}
-                             :model/Dashboard  dash  {:collection_id (:id coll), :name "thraddash"}
-                             :model/Card       card  {:collection_id (:id coll), :name "frobinate", :type :model
-                                                      :query_type    :native
-                                                      :dataset_query {:type     :native
-                                                                      :database (t2/select-one-pk :model/Database)
-                                                                      :native   {:query "SELECT 1"}}}]
+(deftest export-happy-path-test
+  (testing "Successful export creates valid archive with correct files and Snowplow event"
+    (with-serialization-test-data! [coll dash card]
+      ;; Clear entities from search index to verify export works independently
+      (search/delete! :model/Dashboard [(str (:id dash))])
+      (search/delete! :model/Card [(str (:id card))])
+      (is (= 0 (search-result-count "dashboard" "thraddash")))
+      (is (= 0 (search-result-count "dataset" "frobinate")))
 
-                (testing "We clear the card from the search index"
-                  (is (= 1 (search-result-count "dashboard" "thraddash")))
-                  (is (= 1 (search-result-count "dataset" "frobinate")))
-                  (search/delete! :model/Dashboard [(str (:id dash))])
-                  (search/delete! :model/Card [(str (:id card))])
-                  (is (= 0 (search-result-count "dashboard" "thraddash")))
-                  (is (= 0 (search-result-count "dataset" "frobinate"))))
+      (let [res (-> (mt/user-http-request :crowberto :post 200 "ee/serialization/export"
+                                          :collection (:id coll) :data_model false :settings false)
+                    io/input-stream)
+            ba  (#'api.serialization/ba-copy res)]
+        (testing "Archive contains correct number of files with proper log entries"
+          (is (= 8
+                 (with-open [tar (open-tar ba)]
+                   (count
+                    (for [^TarArchiveEntry e (u.compress/entries tar)
+                          :when              (.isFile e)]
+                      (do
+                        (condp re-find (.getName e)
+                          #"/export.log$" (testing "Log contains extract and store entries"
+                                            (is (= (+ #_extract 7 #_store 7)
+                                                   (count (line-seq (io/reader tar))))))
+                          nil)
+                        (.getName e))))))))
 
-                (let [res (-> (mt/user-http-request :crowberto :post 200 "ee/serialization/export"
-                                                    :collection (:id coll) :data_model false :settings false)
-                              io/input-stream)
-                    ;; we're going to reuse it for import, so a copy is necessary
-                      ba  (#'api.serialization/ba-copy res)]
-                  (testing "We get only our data and a log file in an archive"
-                    (is (= 12
-                           (with-open [tar (open-tar ba)]
-                             (count
-                              (for [^TarArchiveEntry e (u.compress/entries tar)
-                                    :when              (.isFile e)]
-                                (do
-                                  (condp re-find (.getName e)
-                                    #"/export.log$" (testing "Three lines in a log for data files"
-                                                      (is (= (+ #_extract 11 #_store 11)
-                                                             (count (line-seq (io/reader tar))))))
-                                    nil)
-                                  (.getName e))))))))
+        (testing "Snowplow export event was sent"
+          (is (=? {"event"           "serialization"
+                   "direction"       "export"
+                   "collection"      (str (:id coll))
+                   "all_collections" false
+                   "data_model"      false
+                   "settings"        false
+                   "field_values"    false
+                   "duration_ms"     (every-pred number? pos?)
+                   "count"           7
+                   "error_count"     0
+                   "source"          "api"
+                   "secrets"         false
+                   "success"         true
+                   "error_message"   nil}
+                  (-> (snowplow-test/pop-event-data-and-user-id!) last :data))))))))
 
-                  (testing "Snowplow export event was sent"
-                    (is (=? {"event"           "serialization"
-                             "direction"       "export"
-                             "collection"      (str (:id coll))
-                             "all_collections" false
-                             "data_model"      false
-                             "settings"        false
-                             "field_values"    false
-                             "duration_ms"     (every-pred number? pos?)
-                             "count"           11
-                             "error_count"     0
-                             "source"          "api"
-                             "secrets"         false
-                             "success"         true
-                             "error_message"   nil}
-                            (-> (snowplow-test/pop-event-data-and-user-id!) last :data))))
+(deftest import-restores-entities-test
+  (testing "Import restores deleted/renamed entities and updates search index"
+    (with-serialization-test-data! [coll dash card]
+      ;; Clear entities from search index
+      (search/delete! :model/Dashboard [(str (:id dash))])
+      (search/delete! :model/Card [(str (:id card))])
 
-                  (testing "POST /api/ee/serialization/import"
-                    (t2/update! :model/Dashboard {:id (:id dash)} {:name "urquan"})
-                    (t2/delete! :model/Card (:id card))
+      ;; Export the data
+      (let [ba (do-export (:id coll))]
+        ;; Pop the export snowplow event
+        (snowplow-test/pop-event-data-and-user-id!)
 
-                    (let [re-indexed? (atom false)
-                          res         (mt/with-dynamic-fn-redefs [search/reindex! (fn [& _] (reset! re-indexed? true) (future nil))]
-                                        (mt/user-http-request :crowberto :post 200 "ee/serialization/import?reindex=false"
-                                                              {:request-options {:headers {"content-type" "multipart/form-data"}}}
-                                                              {:file ba}))]
-                      (testing "We get our data items back"
-                        (is (= #{"Collection" "Dashboard" "Card" "TransformTag" "TransformJob"}
-                               (log-types (line-seq (io/reader (io/input-stream res)))))))
-                      (testing "And they hit the db"
-                        (is (= (:name dash) (t2/select-one-fn :name :model/Dashboard :entity_id (:entity_id dash))))
-                        (is (= (:name card) (t2/select-one-fn :name :model/Card :entity_id (:entity_id card)))))
-                      (testing "Snowplow import event was sent"
-                        (is (=? {"event"         "serialization"
-                                 "direction"     "import"
-                                 "duration_ms"   pos?
-                                 "source"        "api"
-                                 "models"        "Card,Collection,Dashboard,TransformJob,TransformTag"
-                                 "count"         11
-                                 "error_count"   0
-                                 "success"       true
-                                 "error_message" nil}
-                                (-> (snowplow-test/pop-event-data-and-user-id!) last :data))))
+        ;; Modify entities in the database
+        (t2/update! :model/Dashboard {:id (:id dash)} {:name "urquan"})
+        (t2/delete! :model/Card (:id card))
 
-                      (testing "we did not re-index"
-                        (is (false? @re-indexed?)))
-
-                      (testing "The loaded entities are added to the search index"
-                        (is (= 1 (search-result-count "dashboard" "thraddash")))
-                        (is (= 0 (search-result-count "dashboard" "urquan")))
-                        (is (= 1 (search-result-count "dataset" "frobinate"))))))
-
-                  (mt/with-dynamic-fn-redefs [v2.ingest/ingest-file (let [ingest-file (mt/dynamic-value #'v2.ingest/ingest-file)]
-                                                                      (fn [^File file]
-                                                                        (cond-> (ingest-file file)
-                                                                          (str/includes? (.getName file) (:entity_id card))
-                                                                          (assoc :collection_id "DoesNotExist"))))]
-                    (testing "ERROR /api/ee/serialization/import"
-                      (let [res (binding [api.serialization/*additive-logging* false]
-                                  (mt/user-http-request :crowberto :post 500 "ee/serialization/import"
-                                                        {:request-options {:headers {"content-type" "multipart/form-data"}}}
-                                                        {:file ba}))
-                            log (slurp (io/input-stream res))]
-                        (is (re-find #"Failed to read file \{:path \"Collection DoesNotExist\"}" log))
-                        (testing "Snowplow event about error was sent"
-                          (is (=? {"success"       false
-                                   "event"         "serialization"
-                                   "direction"     "import"
-                                   "source"        "api"
-                                   "duration_ms"   int?
-                                   "count"         0
-                                   "error_count"   0
-                                   "error_message" "Failed to read file {:path \"Collection DoesNotExist\"}"}
-                                  (-> (snowplow-test/pop-event-data-and-user-id!) last :data))))))
-
-                    (testing "Skipping errors /api/ee/serialization/import"
-                      (let [res (mt/user-http-request :crowberto :post 200 "ee/serialization/import"
-                                                      {:request-options {:headers {"content-type" "multipart/form-data"}}}
-                                                      {:file ba}
-                                                      :continue_on_error true)
-                            log (slurp (io/input-stream res))]
-                        (testing "3 header lines, then card+database+coll, error, then dashboard+coll"
-                          (is (= #{"Dashboard" "Card" "Collection" "TransformTag" "TransformJob"}
-                                 (log-types (str/split-lines log))))
-                          (is (re-find #"Failed to read file \{:path \"Collection DoesNotExist\"}" log)))
-                        (testing "Snowplow event about error was sent"
-                          (is (=? {"success"     true
-                                   "event"       "serialization"
-                                   "direction"   "import"
-                                   "source"      "api"
-                                   "duration_ms" int?
-                                   "count"       10
-                                   "error_count" 1
-                                   "models"      "Collection,Dashboard,TransformJob,TransformTag"}
-                                  (-> (snowplow-test/pop-event-data-and-user-id!) last :data))))))))
-
-                (testing "Client error /api/ee/serialization/import"
-                  (let [res (mt/user-http-request :crowberto :post 422 "ee/serialization/import"
+        (let [re-indexed? (atom false)
+              res         (mt/with-dynamic-fn-redefs [search/reindex! (fn [& _] (reset! re-indexed? true) (future nil))]
+                            (mt/user-http-request :crowberto :post 200 "ee/serialization/import?reindex=false"
                                                   {:request-options {:headers {"content-type" "multipart/form-data"}}}
-                                                  {:file (.getBytes "not an archive" "UTF-8")})
-                        log (slurp (io/input-stream res))]
-                    (is (re-find #"Cannot unpack archive" log))))
+                                                  {:file ba}))]
+          (testing "Log contains imported entity types"
+            (is (= #{"Collection" "Dashboard" "Card" "TransformJob"}
+                   (log-types (line-seq (io/reader (io/input-stream res)))))))
 
-                (mt/with-dynamic-fn-redefs [serdes/extract-one (extract-one-error (:entity_id card)
-                                                                                  (mt/dynamic-value serdes/extract-one))]
-                  (testing "ERROR /api/ee/serialization/export"
-                    (binding [api.serialization/*additive-logging* false]
-                      (let [res (mt/user-http-request :crowberto :post 500 "ee/serialization/export"
-                                                      :collection (:id coll) :data_model false :settings false)
-                            log (slurp (io/input-stream res))]
-                        (is (= {:id        "**ID**",
-                                :entity_id "**ID**",
-                                :model     "Card",
-                                :table     :report_card
-                                :cause     "[test] deliberate error message"}
-                               (extract-and-sanitize-exception-map log)))))
+          (testing "Entities are restored in the database"
+            (is (= (:name dash) (t2/select-one-fn :name :model/Dashboard :entity_id (:entity_id dash))))
+            (is (= (:name card) (t2/select-one-fn :name :model/Card :entity_id (:entity_id card)))))
 
-                    (testing "Snowplow event about error was sent"
-                      (is (=? {"event"           "serialization"
-                               "direction"       "export"
-                               "duration_ms"     pos?
-                               "source"          "api"
-                               "count"           0
-                               "collection"      (str (:id coll))
-                               "all_collections" false
-                               "data_model"      false
-                               "settings"        false
-                               "field_values"    false
-                               "secrets"         false
-                               "success"         false
-                               "error_message"   #"(?s)Error extracting Card \d+ .*"}
-                              (-> (snowplow-test/pop-event-data-and-user-id!) last :data))))
+          (testing "Snowplow import event was sent"
+            (is (=? {"event"         "serialization"
+                     "direction"     "import"
+                     "duration_ms"   pos?
+                     "source"        "api"
+                     "models"        "Card,Collection,Dashboard,TransformJob"
+                     "count"         7
+                     "error_count"   0
+                     "success"       true
+                     "error_message" nil}
+                    (-> (snowplow-test/pop-event-data-and-user-id!) last :data))))
 
-                    (testing "Full stacktrace"
-                      (binding [api.serialization/*additive-logging* false]
-                        (let [res (mt/user-http-request :crowberto :post 500 "ee/serialization/export"
-                                                        :collection (:id coll) :data_model false :settings false
-                                                        :full_stacktrace true)
-                              log (slurp (io/input-stream res))]
-                          (is (< 200
-                                 (count (str/split-lines log))))
-                        ;; pop out the error
-                          (snowplow-test/pop-event-data-and-user-id!)))))
+          (testing "Full reindex was not triggered (reindex=false)"
+            (is (false? @re-indexed?)))
 
-                  (testing "Skipping errors /api/ee/serialization/export"
-                    (let [res (-> (mt/user-http-request :crowberto :post 200 "ee/serialization/export"
-                                                        :collection (:id coll) :data_model false :settings false
-                                                        :continue_on_error true)
-                                ;; consume response to remove on-disk data
-                                  io/input-stream)]
-                      (with-open [tar (open-tar res)]
-                        (doseq [^TarArchiveEntry e (u.compress/entries tar)]
-                          (condp re-find (.getName e)
-                            #"/export.log$" (testing "Three lines in a log for data files"
-                                              (is (= (+ #_extract 11 #_error 1 #_store 10)
-                                                     (count (line-seq (io/reader tar))))))
-                            nil))))
-                    (testing "Snowplow export event was sent"
-                      (is (=? {"event"           "serialization"
-                               "direction"       "export"
-                               "collection"      (str (:id coll))
-                               "all_collections" false
-                               "data_model"      false
-                               "settings"        false
-                               "field_values"    false
-                               "duration_ms"     pos?
-                               "count"           10
-                               "error_count"     1
-                               "source"          "api"
-                               "secrets"         false
-                               "success"         true
-                               "error_message"   nil}
-                              (-> (snowplow-test/pop-event-data-and-user-id!) last :data))))))
+          (testing "Entities are added to the search index"
+            (is (= 1 (search-result-count "dashboard" "thraddash")))
+            (is (= 0 (search-result-count "dashboard" "urquan")))
+            (is (= 1 (search-result-count "dataset" "frobinate")))))))))
 
-                (testing "Only admins can export/import"
-                  (is (= "You don't have permissions to do that."
-                         (mt/user-http-request :rasta :post 403 "ee/serialization/export")))
-                  (is (= "You don't have permissions to do that."
-                         (mt/user-http-request :rasta :post 403 "ee/serialization/import"
-                                               {:request-options {:headers {"content-type" "multipart/form-data"}}}
-                                               {:file (byte-array 0)}))))))))
+(deftest import-collection-reference-error-test
+  (testing "Import fails with 500 when collection reference is invalid"
+    (with-serialization-test-data! [coll _dash card]
+      (let [ba (do-export (:id coll))]
+        ;; Pop the export snowplow event
+        (snowplow-test/pop-event-data-and-user-id!)
 
-        (testing "We've left no new files, every request is cleaned up"
-         ;; if this breaks, check if you consumed every response with io/input-stream. Or `future` is taking too long
-         ;; in `api/on-response!`, so maybe add some Thread/sleep here.
-          (is (= known-files
-                 (set (.list (io/file api.serialization/parent-dir))))))))))
+        (mt/with-dynamic-fn-redefs [v2.ingest/ingest-file (let [ingest-file (mt/dynamic-value #'v2.ingest/ingest-file)]
+                                                            (fn [^File file]
+                                                              (cond-> (ingest-file file)
+                                                                (str/includes? (.getName file) (:entity_id card))
+                                                                (assoc :collection_id "DoesNotExist"))))]
+          (let [res (binding [api.serialization/*additive-logging* false]
+                      (mt/user-http-request :crowberto :post 500 "ee/serialization/import"
+                                            {:request-options {:headers {"content-type" "multipart/form-data"}}}
+                                            {:file ba}))
+                log (slurp (io/input-stream res))]
+            (testing "Error message indicates missing collection"
+              (is (re-find #"Failed to read file \{:path \"Collection DoesNotExist\"}" log)))
+
+            (testing "Snowplow failure event was sent"
+              (is (=? {"success"       false
+                       "event"         "serialization"
+                       "direction"     "import"
+                       "source"        "api"
+                       "duration_ms"   int?
+                       "count"         0
+                       "error_count"   0
+                       "error_message" "Failed to read file {:path \"Collection DoesNotExist\"}"}
+                      (-> (snowplow-test/pop-event-data-and-user-id!) last :data))))))))))
+
+(deftest import-continue-on-error-test
+  (testing "Import with continue_on_error=true succeeds partially despite errors"
+    (with-serialization-test-data! [coll _dash card]
+      (let [ba (do-export (:id coll))]
+        ;; Pop the export snowplow event
+        (snowplow-test/pop-event-data-and-user-id!)
+
+        (mt/with-dynamic-fn-redefs [v2.ingest/ingest-file (let [ingest-file (mt/dynamic-value #'v2.ingest/ingest-file)]
+                                                            (fn [^File file]
+                                                              (cond-> (ingest-file file)
+                                                                (str/includes? (.getName file) (:entity_id card))
+                                                                (assoc :collection_id "DoesNotExist"))))]
+          (let [res (mt/user-http-request :crowberto :post 200 "ee/serialization/import"
+                                          {:request-options {:headers {"content-type" "multipart/form-data"}}}
+                                          {:file ba}
+                                          :continue_on_error true)
+                log (slurp (io/input-stream res))]
+            (testing "Log shows loaded entities and error"
+              (is (= #{"Dashboard" "Card" "Collection" "TransformJob"}
+                     (log-types (str/split-lines log))))
+              (is (re-find #"Failed to read file \{:path \"Collection DoesNotExist\"}" log)))
+
+            (testing "Snowplow event shows partial success with error count"
+              (is (=? {"success"     true
+                       "event"       "serialization"
+                       "direction"   "import"
+                       "source"      "api"
+                       "duration_ms" int?
+                       "count"       6
+                       "error_count" 1
+                       "models"      "Collection,Dashboard,TransformJob"}
+                      (-> (snowplow-test/pop-event-data-and-user-id!) last :data))))))))))
+
+(deftest import-invalid-archive-test
+  (testing "Import with invalid archive returns 422 client error"
+    (mt/with-premium-features #{:serialization}
+      (let [res (mt/user-http-request :crowberto :post 422 "ee/serialization/import"
+                                      {:request-options {:headers {"content-type" "multipart/form-data"}}}
+                                      {:file (.getBytes "not an archive" "UTF-8")})
+            log (slurp (io/input-stream res))]
+        (is (re-find #"Cannot unpack archive" log))))))
+
+(deftest export-extraction-error-test
+  (testing "Export fails with 500 when entity extraction fails"
+    (with-serialization-test-data! [coll _dash card]
+      (mt/with-dynamic-fn-redefs [serdes/extract-one (extract-one-error (:entity_id card)
+                                                                        (mt/dynamic-value serdes/extract-one))]
+        (testing "Error response contains exception details"
+          (binding [api.serialization/*additive-logging* false]
+            (let [res (mt/user-http-request :crowberto :post 500 "ee/serialization/export"
+                                            :collection (:id coll) :data_model false :settings false)
+                  log (slurp (io/input-stream res))]
+              (is (= {:id        "**ID**"
+                      :entity_id "**ID**"
+                      :model     "Card"
+                      :table     :report_card
+                      :cause     "[test] deliberate error message"}
+                     (extract-and-sanitize-exception-map log))))))
+
+        (testing "Snowplow failure event was sent"
+          (is (=? {"event"           "serialization"
+                   "direction"       "export"
+                   "duration_ms"     pos?
+                   "source"          "api"
+                   "count"           0
+                   "collection"      (str (:id coll))
+                   "all_collections" false
+                   "data_model"      false
+                   "settings"        false
+                   "field_values"    false
+                   "secrets"         false
+                   "success"         false
+                   "error_message"   #"(?s)Error extracting Card \d+ .*"}
+                  (-> (snowplow-test/pop-event-data-and-user-id!) last :data))))
+
+        (testing "full_stacktrace parameter includes full stack trace"
+          (binding [api.serialization/*additive-logging* false]
+            (let [res (mt/user-http-request :crowberto :post 500 "ee/serialization/export"
+                                            :collection (:id coll) :data_model false :settings false
+                                            :full_stacktrace true)
+                  log (slurp (io/input-stream res))]
+              (is (< 200 (count (str/split-lines log))))
+              ;; Pop out the error event
+              (snowplow-test/pop-event-data-and-user-id!))))))))
+
+(deftest export-continue-on-error-test
+  (testing "Export with continue_on_error=true succeeds partially despite errors"
+    (with-serialization-test-data! [coll _dash card]
+      (mt/with-dynamic-fn-redefs [serdes/extract-one (extract-one-error (:entity_id card)
+                                                                        (mt/dynamic-value serdes/extract-one))]
+        (let [res (-> (mt/user-http-request :crowberto :post 200 "ee/serialization/export"
+                                            :collection (:id coll) :data_model false :settings false
+                                            :continue_on_error true)
+                      io/input-stream)]
+          (with-open [tar (open-tar res)]
+            (doseq [^TarArchiveEntry e (u.compress/entries tar)]
+              (condp re-find (.getName e)
+                #"/export.log$" (testing "Log shows extract entries, error, and store entries"
+                                  (is (= (+ #_extract 7 #_error 1 #_store 6)
+                                         (count (line-seq (io/reader tar))))))
+                nil))))
+
+        (testing "Snowplow event shows partial success with error count"
+          (is (=? {"event"           "serialization"
+                   "direction"       "export"
+                   "collection"      (str (:id coll))
+                   "all_collections" false
+                   "data_model"      false
+                   "settings"        false
+                   "field_values"    false
+                   "duration_ms"     pos?
+                   "count"           6
+                   "error_count"     1
+                   "source"          "api"
+                   "secrets"         false
+                   "success"         true
+                   "error_message"   nil}
+                  (-> (snowplow-test/pop-event-data-and-user-id!) last :data))))))))
+
+(deftest serialization-permissions-test
+  (testing "Only admins can export/import"
+    (mt/with-premium-features #{:serialization}
+      (testing "Non-admin cannot export"
+        (is (= "You don't have permissions to do that."
+               (mt/user-http-request :rasta :post 403 "ee/serialization/export"))))
+
+      (testing "Non-admin cannot import"
+        (is (= "You don't have permissions to do that."
+               (mt/user-http-request :rasta :post 403 "ee/serialization/import"
+                                     {:request-options {:headers {"content-type" "multipart/form-data"}}}
+                                     {:file (byte-array 0)})))))))
+
+(deftest serialization-cleanup-test
+  (testing "No temp files are left behind after export/import operations"
+    (let [known-files (set (.list (io/file api.serialization/parent-dir)))]
+      (with-serialization-test-data! [coll _dash _card]
+        (let [ba (do-export (:id coll))]
+          ;; Consume the export response
+          (snowplow-test/pop-event-data-and-user-id!)
+
+          ;; Do an import to exercise that code path too
+          (let [res (mt/user-http-request :crowberto :post 200 "ee/serialization/import"
+                                          {:request-options {:headers {"content-type" "multipart/form-data"}}}
+                                          {:file ba})]
+            ;; Consume the import response
+            (slurp (io/input-stream res))
+            (snowplow-test/pop-event-data-and-user-id!))))
+
+      ;; Verify no new files were left behind
+      ;; if this breaks, check if you consumed every response with io/input-stream. Or `future` is taking too long
+      ;; in `api/on-response!`, so maybe add some Thread/sleep here.
+      (is (= known-files
+             (set (.list (io/file api.serialization/parent-dir))))))))
 
 (deftest find-serialization-dir-test
   (testing "We are able to find serialization dir even in presence of various hidden dirs"

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/DataStudioLayout/DataStudioLayout.setup.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/DataStudioLayout/DataStudioLayout.setup.spec.tsx
@@ -1,6 +1,5 @@
-import fetchMock from "fetch-mock";
-
 import {
+  setupCollectionsEndpoints,
   setupPropertiesEndpoints,
   setupRemoteSyncEndpoints,
   setupSettingsEndpoints,
@@ -12,116 +11,233 @@ import { initializePlugin as initializeDependenciesPlugin } from "metabase-enter
 import { initializePlugin as initializeFeatureLevelPermissionsPlugin } from "metabase-enterprise/feature_level_permissions";
 import { initializePlugin as initializeRemoteSyncPlugin } from "metabase-enterprise/remote_sync";
 import { initializePlugin as initializeTransformsPlugin } from "metabase-enterprise/transforms";
-import type { RemoteSyncEntity } from "metabase-types/api";
+import type { Collection, RemoteSyncEntity } from "metabase-types/api";
 import {
-  createMockCollection,
+  createMockDirtyCardEntity,
+  createMockDirtyTransformEntity,
+  createMockLibraryCollection,
   createMockSettings,
   createMockTokenFeatures,
+  createMockTransformsCollection,
   createMockUser,
 } from "metabase-types/api/mocks";
-import { createMockRemoteSyncEntity } from "metabase-types/api/mocks/remote-sync";
 import { createMockState } from "metabase-types/store/mocks";
 
 import { DataStudioLayout } from "./DataStudioLayout";
 
-interface SetupEndpointsOpts {
-  isNavbarOpened?: boolean;
-  remoteSyncEnabled?: boolean;
-  remoteSyncBranch?: string | null;
-  remoteSyncType?: "read-only" | "read-write";
-  hasDirtyChanges?: boolean;
+// ============================================================================
+// Settings Helpers
+// ============================================================================
+
+const DEFAULT_TOKEN_FEATURES = createMockTokenFeatures({
+  remote_sync: true,
+  advanced_permissions: true,
+  transforms: true,
+});
+
+interface RemoteSyncSettings {
+  enabled: boolean;
+  branch: string | null;
+  type: "read-only" | "read-write";
+  transforms: boolean;
 }
 
-const setupEndpoints = ({
-  isNavbarOpened = true,
-  remoteSyncEnabled = false,
-  remoteSyncBranch = null,
-  remoteSyncType = "read-write",
-  hasDirtyChanges = false,
-}: SetupEndpointsOpts = {}) => {
-  // Mock session properties for settings (used by useAdminSetting and useSetting)
-  setupPropertiesEndpoints(
-    createMockSettings({
-      "remote-sync-enabled": remoteSyncEnabled,
-      "remote-sync-branch": remoteSyncBranch,
-      "remote-sync-type": remoteSyncType,
-    }),
-  );
+const createRemoteSyncSettings = ({
+  enabled = false,
+  branch = null,
+  type = "read-write",
+  transforms = false,
+}: Partial<RemoteSyncSettings> = {}) => ({
+  "remote-sync-enabled": enabled,
+  "remote-sync-branch": branch,
+  "remote-sync-type": type,
+  "remote-sync-transforms": transforms,
+});
 
-  // Mock settings details endpoint
+// ============================================================================
+// Endpoint Setup Functions
+// ============================================================================
+
+export const setupBaseEndpoints = () => {
   setupSettingsEndpoints([]);
+};
 
-  // Mock collection tree endpoint (used by useHasLibraryDirtyChanges)
-  fetchMock.get("path:/api/collection/tree", () => {
-    if (hasDirtyChanges) {
-      return [
-        createMockCollection({
-          id: 1,
-          name: "Library",
-          type: "library",
-        }),
-      ];
+export const setupRemoteSyncSettingsEndpoints = (
+  settings: Partial<RemoteSyncSettings> = {},
+) => {
+  const remoteSyncSettings = createRemoteSyncSettings(settings);
+  setupPropertiesEndpoints(createMockSettings(remoteSyncSettings));
+};
+
+export const setupGitSyncVisibleEndpoints = (
+  settings: Partial<Omit<RemoteSyncSettings, "enabled" | "branch">> = {},
+) => {
+  setupRemoteSyncSettingsEndpoints({
+    enabled: true,
+    branch: "main",
+    type: "read-write",
+    ...settings,
+  });
+};
+
+export const setupGitSettingsVisibleEndpoints = () => {
+  setupRemoteSyncSettingsEndpoints({
+    enabled: false,
+    branch: null,
+  });
+};
+
+export const setupDirtyEndpoints = ({
+  dirty = [],
+  collections = [],
+}: {
+  dirty?: RemoteSyncEntity[];
+  collections?: Collection[];
+} = {}) => {
+  const changedCollections: Record<number, boolean> = {};
+  for (const entity of dirty) {
+    if (entity.collection_id != null) {
+      changedCollections[entity.collection_id] = true;
     }
-    return [];
+  }
+
+  setupRemoteSyncEndpoints({
+    dirty,
+    changedCollections,
+    branches: ["main"],
   });
 
-  const dirty: RemoteSyncEntity[] = hasDirtyChanges
-    ? [createMockRemoteSyncEntity({ id: 1, model: "card", collection_id: 1 })]
-    : [];
-  const branches = remoteSyncBranch ? [remoteSyncBranch] : [];
-  setupRemoteSyncEndpoints({ dirty, branches });
+  setupCollectionsEndpoints({ collections });
+};
 
+export const setupNavbarEndpoints = (isOpened = true) => {
   setupUserKeyValueEndpoints({
     namespace: "data_studio",
     key: "isNavbarOpened",
-    value: isNavbarOpened,
+    value: isOpened,
   });
-
-  // Mock user key value PUT endpoint
-  fetchMock.put(
-    "express:/api/user-key-value/namespace/data_studio/key/isNavbarOpened",
-    { status: 200 },
-  );
 };
 
-const createStoreState = ({
-  isAdmin = true,
-  remoteSyncEnabled = false,
-  remoteSyncBranch = null as string | null,
-  remoteSyncType = "read-write" as "read-only" | "read-write",
-  canAccessDataModel = true,
-}: {
+// ============================================================================
+// Store State Helpers
+// ============================================================================
+
+interface StoreStateOptions {
   isAdmin?: boolean;
-  remoteSyncEnabled?: boolean;
-  remoteSyncBranch?: string | null;
-  remoteSyncType?: "read-only" | "read-write";
-  canAccessDataModel?: boolean;
-} = {}) => {
+  remoteSyncSettings?: Partial<RemoteSyncSettings>;
+}
+
+export const createStoreState = ({
+  isAdmin = true,
+  remoteSyncSettings = {},
+}: StoreStateOptions = {}) => {
+  const settings = createRemoteSyncSettings(remoteSyncSettings);
+
   return createMockState({
     currentUser: createMockUser({
       is_superuser: isAdmin,
       permissions: {
-        can_access_data_model: canAccessDataModel,
+        can_access_data_model: isAdmin,
         can_access_db_details: false,
       },
     }),
     settings: mockSettings({
-      "remote-sync-enabled": remoteSyncEnabled,
-      "remote-sync-branch": remoteSyncBranch,
-      "remote-sync-type": remoteSyncType,
-      "token-features": createMockTokenFeatures({
-        remote_sync: true,
-        advanced_permissions: true,
-      }),
+      ...settings,
+      "token-features": DEFAULT_TOKEN_FEATURES,
     }),
   });
 };
+
+// ============================================================================
+// Plugin Initialization
+// ============================================================================
+
+export const initializePlugins = () => {
+  initializeRemoteSyncPlugin();
+  initializeFeatureLevelPermissionsPlugin();
+  initializeTransformsPlugin();
+  initializeDependenciesPlugin();
+};
+
+// ============================================================================
+// Render Helper
+// ============================================================================
+
+export const renderDataStudioLayout = (
+  storeOptions: StoreStateOptions = {},
+) => {
+  renderWithProviders(
+    <DataStudioLayout>
+      <div data-testid="content">{"Content"}</div>
+    </DataStudioLayout>,
+    {
+      storeInitialState: createStoreState(storeOptions),
+      withRouter: false,
+    },
+  );
+
+  initializePlugins();
+};
+
+// ============================================================================
+// Convenience Setup Functions (for common test scenarios)
+// ============================================================================
+
+export const setupForGitSyncVisible = ({
+  isNavbarOpened = true,
+  dirty = [] as RemoteSyncEntity[],
+  collections = [] as Collection[],
+  transforms = false,
+}: {
+  isNavbarOpened?: boolean;
+  dirty?: RemoteSyncEntity[];
+  collections?: Collection[];
+  transforms?: boolean;
+} = {}) => {
+  setupBaseEndpoints();
+  setupGitSyncVisibleEndpoints({ transforms });
+  setupDirtyEndpoints({ dirty, collections });
+  setupNavbarEndpoints(isNavbarOpened);
+
+  renderDataStudioLayout({
+    remoteSyncSettings: {
+      enabled: true,
+      branch: "main",
+      type: "read-write",
+      transforms,
+    },
+  });
+};
+
+export const setupForGitSettingsVisible = ({
+  isNavbarOpened = true,
+}: {
+  isNavbarOpened?: boolean;
+} = {}) => {
+  setupBaseEndpoints();
+  setupGitSettingsVisibleEndpoints();
+  setupDirtyEndpoints();
+  setupNavbarEndpoints(isNavbarOpened);
+
+  renderDataStudioLayout({
+    remoteSyncSettings: {
+      enabled: false,
+      branch: null,
+    },
+  });
+};
+
+// ============================================================================
+// Legacy setup function (for backwards compatibility during migration)
+// ============================================================================
 
 interface SetupOpts {
   isGitSyncVisible?: boolean;
   isGitSettingsVisible?: boolean;
   isAdmin?: boolean;
   hasDirtyChanges?: boolean;
+  hasTransformDirtyChanges?: boolean;
+  remoteSyncTransforms?: boolean;
   isNavbarOpened?: boolean;
 }
 
@@ -130,55 +246,57 @@ export const setup = ({
   isGitSettingsVisible = false,
   isAdmin = true,
   hasDirtyChanges = false,
+  hasTransformDirtyChanges = false,
+  remoteSyncTransforms = false,
   isNavbarOpened = true,
 }: SetupOpts = {}) => {
-  // Derive API state from the visibility flags
-  // useGitSyncVisible returns isVisible when: isAdmin && remoteSyncEnabled && currentBranch && syncType === "read-write"
-  // useGitSettingsVisible returns true when: isAdmin && !remoteSyncEnabled
+  // Build collections list
+  const collections: Collection[] = [];
+  if (hasDirtyChanges) {
+    collections.push(createMockLibraryCollection());
+  }
+  if (hasTransformDirtyChanges) {
+    collections.push(createMockTransformsCollection());
+  }
+
+  // Build dirty entities list
+  const dirty: RemoteSyncEntity[] = [];
+  if (hasDirtyChanges) {
+    dirty.push(createMockDirtyCardEntity());
+  }
+  if (hasTransformDirtyChanges) {
+    dirty.push(createMockDirtyTransformEntity());
+  }
+
+  // Determine remote sync settings from visibility flags
   let remoteSyncEnabled: boolean;
   let remoteSyncBranch: string | null;
-  const remoteSyncType = "read-write" as const;
 
   if (isGitSyncVisible) {
-    // Git sync visible requires: enabled + branch + admin + read-write
     remoteSyncEnabled = true;
     remoteSyncBranch = "main";
   } else if (isGitSettingsVisible) {
-    // Git settings visible requires: admin + NOT enabled
     remoteSyncEnabled = false;
     remoteSyncBranch = null;
   } else {
-    // Neither visible - could be enabled with no branch, or not admin
     remoteSyncEnabled = true;
     remoteSyncBranch = null;
   }
 
-  setupEndpoints({
-    isNavbarOpened,
-    remoteSyncEnabled,
-    remoteSyncBranch,
-    remoteSyncType,
-    hasDirtyChanges,
+  const remoteSyncSettings: Partial<RemoteSyncSettings> = {
+    enabled: remoteSyncEnabled,
+    branch: remoteSyncBranch,
+    type: "read-write",
+    transforms: remoteSyncTransforms,
+  };
+
+  setupBaseEndpoints();
+  setupRemoteSyncSettingsEndpoints(remoteSyncSettings);
+  setupDirtyEndpoints({ dirty, collections });
+  setupNavbarEndpoints(isNavbarOpened);
+
+  renderDataStudioLayout({
+    isAdmin,
+    remoteSyncSettings,
   });
-
-  renderWithProviders(
-    <DataStudioLayout>
-      <div data-testid="content">{"Content"}</div>
-    </DataStudioLayout>,
-    {
-      storeInitialState: createStoreState({
-        isAdmin,
-        remoteSyncEnabled,
-        remoteSyncBranch,
-        remoteSyncType,
-        canAccessDataModel: isAdmin,
-      }),
-      withRouter: false,
-    },
-  );
-
-  initializeRemoteSyncPlugin();
-  initializeFeatureLevelPermissionsPlugin();
-  initializeTransformsPlugin();
-  initializeDependenciesPlugin();
 };

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/DataStudioLayout/DataStudioLayout.setup.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/DataStudioLayout/DataStudioLayout.setup.spec.tsx
@@ -58,36 +58,14 @@ const createRemoteSyncSettings = ({
 // Endpoint Setup Functions
 // ============================================================================
 
-export const setupBaseEndpoints = () => {
-  setupSettingsEndpoints([]);
-};
-
-export const setupRemoteSyncSettingsEndpoints = (
+const setupRemoteSyncSettingsEndpoints = (
   settings: Partial<RemoteSyncSettings> = {},
 ) => {
   const remoteSyncSettings = createRemoteSyncSettings(settings);
   setupPropertiesEndpoints(createMockSettings(remoteSyncSettings));
 };
 
-export const setupGitSyncVisibleEndpoints = (
-  settings: Partial<Omit<RemoteSyncSettings, "enabled" | "branch">> = {},
-) => {
-  setupRemoteSyncSettingsEndpoints({
-    enabled: true,
-    branch: "main",
-    type: "read-write",
-    ...settings,
-  });
-};
-
-export const setupGitSettingsVisibleEndpoints = () => {
-  setupRemoteSyncSettingsEndpoints({
-    enabled: false,
-    branch: null,
-  });
-};
-
-export const setupDirtyEndpoints = ({
+const setupDirtyEndpoints = ({
   dirty = [],
   collections = [],
 }: {
@@ -110,7 +88,7 @@ export const setupDirtyEndpoints = ({
   setupCollectionsEndpoints({ collections });
 };
 
-export const setupNavbarEndpoints = (isOpened = true) => {
+const setupNavbarEndpoints = (isOpened = true) => {
   setupUserKeyValueEndpoints({
     namespace: "data_studio",
     key: "isNavbarOpened",
@@ -127,7 +105,7 @@ interface StoreStateOptions {
   remoteSyncSettings?: Partial<RemoteSyncSettings>;
 }
 
-export const createStoreState = ({
+const createStoreState = ({
   isAdmin = true,
   remoteSyncSettings = {},
 }: StoreStateOptions = {}) => {
@@ -152,7 +130,7 @@ export const createStoreState = ({
 // Plugin Initialization
 // ============================================================================
 
-export const initializePlugins = () => {
+const initializePlugins = () => {
   initializeRemoteSyncPlugin();
   initializeFeatureLevelPermissionsPlugin();
   initializeTransformsPlugin();
@@ -163,9 +141,7 @@ export const initializePlugins = () => {
 // Render Helper
 // ============================================================================
 
-export const renderDataStudioLayout = (
-  storeOptions: StoreStateOptions = {},
-) => {
+const renderDataStudioLayout = (storeOptions: StoreStateOptions = {}) => {
   renderWithProviders(
     <DataStudioLayout>
       <div data-testid="content">{"Content"}</div>
@@ -180,60 +156,12 @@ export const renderDataStudioLayout = (
 };
 
 // ============================================================================
-// Convenience Setup Functions (for common test scenarios)
-// ============================================================================
-
-export const setupForGitSyncVisible = ({
-  isNavbarOpened = true,
-  dirty = [] as RemoteSyncEntity[],
-  collections = [] as Collection[],
-  transforms = false,
-}: {
-  isNavbarOpened?: boolean;
-  dirty?: RemoteSyncEntity[];
-  collections?: Collection[];
-  transforms?: boolean;
-} = {}) => {
-  setupBaseEndpoints();
-  setupGitSyncVisibleEndpoints({ transforms });
-  setupDirtyEndpoints({ dirty, collections });
-  setupNavbarEndpoints(isNavbarOpened);
-
-  renderDataStudioLayout({
-    remoteSyncSettings: {
-      enabled: true,
-      branch: "main",
-      type: "read-write",
-      transforms,
-    },
-  });
-};
-
-export const setupForGitSettingsVisible = ({
-  isNavbarOpened = true,
-}: {
-  isNavbarOpened?: boolean;
-} = {}) => {
-  setupBaseEndpoints();
-  setupGitSettingsVisibleEndpoints();
-  setupDirtyEndpoints();
-  setupNavbarEndpoints(isNavbarOpened);
-
-  renderDataStudioLayout({
-    remoteSyncSettings: {
-      enabled: false,
-      branch: null,
-    },
-  });
-};
-
-// ============================================================================
-// Legacy setup function (for backwards compatibility during migration)
+// Setup function
 // ============================================================================
 
 interface SetupOpts {
-  isGitSyncVisible?: boolean;
-  isGitSettingsVisible?: boolean;
+  remoteSyncEnabled?: boolean;
+  remoteSyncBranch?: string | null;
   isAdmin?: boolean;
   hasDirtyChanges?: boolean;
   hasTransformDirtyChanges?: boolean;
@@ -242,8 +170,8 @@ interface SetupOpts {
 }
 
 export const setup = ({
-  isGitSyncVisible = false,
-  isGitSettingsVisible = false,
+  remoteSyncEnabled = true,
+  remoteSyncBranch = null,
   isAdmin = true,
   hasDirtyChanges = false,
   hasTransformDirtyChanges = false,
@@ -268,21 +196,6 @@ export const setup = ({
     dirty.push(createMockDirtyTransformEntity());
   }
 
-  // Determine remote sync settings from visibility flags
-  let remoteSyncEnabled: boolean;
-  let remoteSyncBranch: string | null;
-
-  if (isGitSyncVisible) {
-    remoteSyncEnabled = true;
-    remoteSyncBranch = "main";
-  } else if (isGitSettingsVisible) {
-    remoteSyncEnabled = false;
-    remoteSyncBranch = null;
-  } else {
-    remoteSyncEnabled = true;
-    remoteSyncBranch = null;
-  }
-
   const remoteSyncSettings: Partial<RemoteSyncSettings> = {
     enabled: remoteSyncEnabled,
     branch: remoteSyncBranch,
@@ -290,7 +203,7 @@ export const setup = ({
     transforms: remoteSyncTransforms,
   };
 
-  setupBaseEndpoints();
+  setupSettingsEndpoints([]);
   setupRemoteSyncSettingsEndpoints(remoteSyncSettings);
   setupDirtyEndpoints({ dirty, collections });
   setupNavbarEndpoints(isNavbarOpened);

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/DataStudioLayout/DataStudioLayout.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/DataStudioLayout/DataStudioLayout.tsx
@@ -89,6 +89,8 @@ function DataStudioNav({ isNavbarOpened, onNavbarToggle }: DataStudioNavProps) {
     PLUGIN_TRANSFORMS.canAccessTransforms,
   );
   const hasDirtyChanges = PLUGIN_REMOTE_SYNC.useHasLibraryDirtyChanges();
+  const hasTransformDirtyChanges =
+    PLUGIN_REMOTE_SYNC.useHasTransformDirtyChanges();
   const [isGitSettingsOpen, setIsGitSettingsOpen] = useState(false);
 
   const currentTab = getCurrentTab(pathname);
@@ -160,6 +162,12 @@ function DataStudioNav({ isNavbarOpened, onNavbarToggle }: DataStudioNavProps) {
             to={Urls.transformList()}
             isSelected={currentTab === "transforms"}
             showLabel={isNavbarOpened}
+            rightSection={
+              hasTransformDirtyChanges &&
+              PLUGIN_REMOTE_SYNC.CollectionSyncStatusBadge ? (
+                <PLUGIN_REMOTE_SYNC.CollectionSyncStatusBadge />
+              ) : null
+            }
           />
         )}
       </Stack>

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/DataStudioLayout/DataStudioLayout.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/DataStudioLayout/DataStudioLayout.unit.spec.tsx
@@ -1,7 +1,7 @@
 import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 
-import { screen, waitFor } from "__support__/ui";
+import { screen, waitFor, within } from "__support__/ui";
 
 import { setup } from "./DataStudioLayout.setup.spec";
 
@@ -134,6 +134,65 @@ describe("DataStudioLayout", () => {
       });
 
       expect(screen.getByTestId("content")).toBeInTheDocument();
+    });
+  });
+
+  describe("transform dirty indicator", () => {
+    it("should show dirty indicator on Transforms tab when transforms have dirty changes", async () => {
+      setup({
+        isGitSyncVisible: true,
+        isNavbarOpened: true,
+        hasTransformDirtyChanges: true,
+        remoteSyncTransforms: true,
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("data-studio-nav")).toBeInTheDocument();
+      });
+
+      // Should show the dirty indicator badge
+      const transformsTab = screen.getByLabelText("Transforms");
+      await waitFor(() => {
+        expect(
+          within(transformsTab).getByTestId("remote-sync-status"),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("should not show dirty indicator on Transforms tab when no dirty changes", async () => {
+      setup({
+        isGitSyncVisible: true,
+        isNavbarOpened: true,
+        hasTransformDirtyChanges: false,
+        remoteSyncTransforms: true,
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("data-studio-nav")).toBeInTheDocument();
+      });
+
+      const transformsTab = screen.getByLabelText("Transforms");
+      expect(
+        within(transformsTab).queryByTestId("remote-sync-status"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should not show dirty indicator when remote-sync-transforms setting is disabled", async () => {
+      setup({
+        isGitSyncVisible: true,
+        isNavbarOpened: true,
+        hasTransformDirtyChanges: true,
+        remoteSyncTransforms: false,
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("data-studio-nav")).toBeInTheDocument();
+      });
+
+      const transformsTab = screen.getByLabelText("Transforms");
+      expect(
+        within(transformsTab).queryByTestId("remote-sync-status"),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/DataStudioLayout/DataStudioLayout.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/DataStudioLayout/DataStudioLayout.unit.spec.tsx
@@ -18,7 +18,7 @@ describe("DataStudioLayout", () => {
 
   describe("Set up git sync button", () => {
     it("should show Set up git sync button when git settings is visible", async () => {
-      setup({ isGitSettingsVisible: true });
+      setup({ remoteSyncEnabled: false });
 
       await waitFor(() => {
         expect(screen.getByTestId("data-studio-nav")).toBeInTheDocument();
@@ -28,7 +28,7 @@ describe("DataStudioLayout", () => {
     });
 
     it("should hide Set up git sync button when git settings is not visible", async () => {
-      setup({ isGitSettingsVisible: false });
+      setup({ remoteSyncEnabled: true });
 
       await waitFor(() => {
         expect(screen.getByTestId("data-studio-nav")).toBeInTheDocument();
@@ -40,7 +40,7 @@ describe("DataStudioLayout", () => {
     });
 
     it("should open modal when Set up git sync button is clicked", async () => {
-      setup({ isGitSettingsVisible: true });
+      setup({ remoteSyncEnabled: false });
 
       await waitFor(() => {
         expect(screen.getByTestId("data-studio-nav")).toBeInTheDocument();
@@ -57,7 +57,7 @@ describe("DataStudioLayout", () => {
     });
 
     it("should close modal when onClose is called", async () => {
-      setup({ isGitSettingsVisible: true });
+      setup({ remoteSyncEnabled: false });
 
       await waitFor(() => {
         expect(screen.getByTestId("data-studio-nav")).toBeInTheDocument();
@@ -84,7 +84,7 @@ describe("DataStudioLayout", () => {
     });
 
     it("should show Set up git sync text when sidebar is expanded", async () => {
-      setup({ isGitSettingsVisible: true, isNavbarOpened: true });
+      setup({ remoteSyncEnabled: false, isNavbarOpened: true });
 
       await waitFor(() => {
         expect(screen.getByTestId("data-studio-nav")).toBeInTheDocument();
@@ -96,7 +96,7 @@ describe("DataStudioLayout", () => {
 
   describe("sidebar rendering", () => {
     it("should render the sidebar with navigation tabs", async () => {
-      setup({ isGitSyncVisible: true });
+      setup({ remoteSyncBranch: "main" });
 
       await waitFor(() => {
         expect(screen.getByTestId("data-studio-nav")).toBeInTheDocument();
@@ -107,7 +107,7 @@ describe("DataStudioLayout", () => {
     });
 
     it("should render GitSyncAppBarControls when sidebar is expanded", async () => {
-      setup({ isGitSyncVisible: true, isNavbarOpened: true });
+      setup({ remoteSyncBranch: "main", isNavbarOpened: true });
 
       await waitFor(() => {
         expect(screen.getByTestId("data-studio-nav")).toBeInTheDocument();
@@ -117,7 +117,7 @@ describe("DataStudioLayout", () => {
     });
 
     it("should not render GitSyncAppBarControls when sidebar is collapsed", async () => {
-      setup({ isGitSyncVisible: true, isNavbarOpened: false });
+      setup({ remoteSyncBranch: "main", isNavbarOpened: false });
 
       await waitFor(() => {
         expect(screen.getByTestId("data-studio-nav")).toBeInTheDocument();
@@ -127,7 +127,7 @@ describe("DataStudioLayout", () => {
     });
 
     it("should render content area", async () => {
-      setup({ isGitSyncVisible: false });
+      setup({ remoteSyncBranch: null });
 
       await waitFor(() => {
         expect(screen.getByTestId("data-studio-nav")).toBeInTheDocument();
@@ -140,7 +140,7 @@ describe("DataStudioLayout", () => {
   describe("transform dirty indicator", () => {
     it("should show dirty indicator on Transforms tab when transforms have dirty changes", async () => {
       setup({
-        isGitSyncVisible: true,
+        remoteSyncBranch: "main",
         isNavbarOpened: true,
         hasTransformDirtyChanges: true,
         remoteSyncTransforms: true,
@@ -161,7 +161,7 @@ describe("DataStudioLayout", () => {
 
     it("should not show dirty indicator on Transforms tab when no dirty changes", async () => {
       setup({
-        isGitSyncVisible: true,
+        remoteSyncBranch: "main",
         isNavbarOpened: true,
         hasTransformDirtyChanges: false,
         remoteSyncTransforms: true,
@@ -179,7 +179,7 @@ describe("DataStudioLayout", () => {
 
     it("should not show dirty indicator when remote-sync-transforms setting is disabled", async () => {
       setup({
-        isGitSyncVisible: true,
+        remoteSyncBranch: "main",
         isNavbarOpened: true,
         hasTransformDirtyChanges: true,
         remoteSyncTransforms: false,

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/ChangesLists/AllChangesView.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/ChangesLists/AllChangesView.tsx
@@ -48,11 +48,13 @@ interface AllChangesViewProps {
 
 export const AllChangesView = ({ entities, title }: AllChangesViewProps) => {
   const isUsingTenants = useSetting("use-tenants");
+  const isTransformsSyncEnabled = useSetting("remote-sync-transforms");
   const { data: collectionTree = [] } = useListCollectionsTreeQuery({
     namespaces: [
       "",
       "analytics",
       ...(isUsingTenants ? ["shared-tenant-collection"] : []),
+      ...(isTransformsSyncEnabled ? ["transforms"] : []),
     ],
     "include-library": true,
   });

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/ChangesLists/AllChangesView.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/ChangesLists/AllChangesView.unit.spec.tsx
@@ -1,8 +1,13 @@
-import fetchMock from "fetch-mock";
-
+import {
+  setupCollectionTreeEndpoint,
+  setupPropertiesEndpoints,
+} from "__support__/server-mocks";
 import { renderWithProviders, screen } from "__support__/ui";
 import type { Collection, RemoteSyncEntity } from "metabase-types/api";
-import { createMockCollection } from "metabase-types/api/mocks";
+import {
+  createMockCollection,
+  createMockSettings,
+} from "metabase-types/api/mocks";
 import { createMockRemoteSyncEntity } from "metabase-types/api/mocks/remote-sync";
 
 import { AllChangesView } from "./AllChangesView";
@@ -31,13 +36,20 @@ const deletedEntity = createMockRemoteSyncEntity({
 const setup = ({
   entities = [updatedEntity],
   collections = [defaultCollection],
+  isTransformsSyncEnabled = false,
 }: {
   entities: RemoteSyncEntity[];
   collections?: Collection[];
+  isTransformsSyncEnabled?: boolean;
 }) => {
-  // Mock the new useListCollectionsTreeQuery endpoint format
-  fetchMock.get("path:/api/collection/tree", collections);
-  fetchMock.get("path:/api/session/properties", { "use-tenants": false });
+  // Use setupCollectionTreeEndpoint for simple tree mocking without complex filtering
+  setupCollectionTreeEndpoint(collections);
+  setupPropertiesEndpoints(
+    createMockSettings({
+      "use-tenants": false,
+      "remote-sync-transforms": isTransformsSyncEnabled,
+    }),
+  );
 
   renderWithProviders(<AllChangesView entities={entities} />);
 };
@@ -140,6 +152,96 @@ describe("AllChangesView", () => {
 
       expect(await screen.findByText("Entity Collection")).toBeInTheDocument();
       expect(screen.getByText("Regular Item")).toBeInTheDocument();
+    });
+  });
+
+  describe("transforms namespace collections", () => {
+    it("should display transforms collections when remote-sync-transforms is enabled", async () => {
+      const transformsCollection = createMockCollection({
+        id: 100,
+        name: "My Transforms Collection",
+        namespace: "transforms",
+        effective_ancestors: [],
+      });
+      const transformEntity = createMockRemoteSyncEntity({
+        id: 200,
+        name: "Transform in Collection",
+        model: "transform",
+        collection_id: 100,
+        sync_status: "create",
+      });
+
+      setup({
+        entities: [transformEntity],
+        collections: [transformsCollection],
+        isTransformsSyncEnabled: true,
+      });
+
+      expect(
+        await screen.findByText("My Transforms Collection"),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Transform in Collection")).toBeInTheDocument();
+    });
+
+    it("should display transforms collection hierarchy when remote-sync-transforms is enabled", async () => {
+      const childTransformsCollection = createMockCollection({
+        id: 101,
+        name: "Child Transforms Collection",
+        namespace: "transforms",
+      });
+      const parentTransformsCollection = createMockCollection({
+        id: 100,
+        name: "Parent Transforms Collection",
+        namespace: "transforms",
+        children: [childTransformsCollection],
+      });
+      const transformEntity = createMockRemoteSyncEntity({
+        id: 200,
+        name: "Transform in Child",
+        model: "transform",
+        collection_id: 101,
+        sync_status: "update",
+      });
+
+      setup({
+        entities: [transformEntity],
+        collections: [parentTransformsCollection],
+        isTransformsSyncEnabled: true,
+      });
+
+      expect(
+        await screen.findByText("Parent Transforms Collection"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Child Transforms Collection"),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Transform in Child")).toBeInTheDocument();
+    });
+
+    it("should display dirty transforms collections themselves", async () => {
+      const transformsCollection = createMockCollection({
+        id: 100,
+        name: "New Transforms Collection",
+        namespace: "transforms",
+        effective_ancestors: [],
+      });
+      const collectionEntity = createMockRemoteSyncEntity({
+        id: 100,
+        name: "New Transforms Collection",
+        model: "collection",
+        collection_id: 100,
+        sync_status: "create",
+      });
+
+      setup({
+        entities: [collectionEntity],
+        collections: [transformsCollection],
+        isTransformsSyncEnabled: true,
+      });
+
+      expect(
+        await screen.findByText("New Transforms Collection"),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.setup.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.setup.spec.tsx
@@ -38,6 +38,7 @@ const setupEndpoints = ({
   remoteSyncType = "read-only" as const,
   remoteSyncBranch = "main",
   remoteSyncAutoImport = false,
+  remoteSyncTransforms = false,
   libraryCollection = null as Collection | null,
   dirty = [] as any[],
 }: {
@@ -47,6 +48,7 @@ const setupEndpoints = ({
   remoteSyncType?: "read-only" | "read-write";
   remoteSyncBranch?: string;
   remoteSyncAutoImport?: boolean;
+  remoteSyncTransforms?: boolean;
   libraryCollection?: Collection | null;
   dirty?: any[];
 } = {}) => {
@@ -57,6 +59,7 @@ const setupEndpoints = ({
     "remote-sync-type": remoteSyncType,
     "remote-sync-branch": remoteSyncBranch,
     "remote-sync-auto-import": remoteSyncAutoImport,
+    "remote-sync-transforms": remoteSyncTransforms,
   });
 
   setupPropertiesEndpoints(settings);
@@ -93,6 +96,7 @@ interface SetupOpts {
   remoteSyncToken?: string;
   remoteSyncType?: "read-only" | "read-write";
   remoteSyncBranch?: string;
+  remoteSyncTransforms?: boolean;
   libraryCollection?: Collection | null;
   dirty?: any[];
   variant?: RemoteSyncSettingsFormProps["variant"];
@@ -105,6 +109,7 @@ export const setup = ({
   remoteSyncToken = "",
   remoteSyncType = "read-only",
   remoteSyncBranch = "main",
+  remoteSyncTransforms = false,
   libraryCollection = null,
   dirty = [],
   variant,
@@ -115,6 +120,7 @@ export const setup = ({
     remoteSyncToken,
     remoteSyncType,
     remoteSyncBranch,
+    remoteSyncTransforms,
     libraryCollection,
     dirty,
   });

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.tsx
@@ -53,6 +53,7 @@ import {
   REMOTE_SYNC_KEY,
   REMOTE_SYNC_SCHEMA,
   TOKEN_KEY,
+  TRANSFORMS_KEY,
   TYPE_KEY,
   URL_KEY,
 } from "../../constants";
@@ -411,23 +412,39 @@ export const RemoteSyncSettingsForm = (props: RemoteSyncSettingsFormProps) => {
               )}
 
               {/* Section 4: Collections to sync */}
-              {isRemoteSyncEnabled && (
+              {(isRemoteSyncEnabled || values?.[TYPE_KEY] === "read-write") &&
+                !isModalVariant && (
+                  <RemoteSyncSettingsSection
+                    description={t`Choose which collections to sync with git.`}
+                    title={t`Collections to sync`}
+                    variant={variant}
+                  >
+                    <Stack gap="lg">
+                      <TopLevelCollectionsList />
+                      {useTenants && (
+                        <>
+                          <Text fw={700} size="md" lh="1rem">
+                            {t`Shared collections`}
+                          </Text>
+                          <SharedTenantCollectionsList />
+                        </>
+                      )}
+                    </Stack>
+                  </RemoteSyncSettingsSection>
+                )}
+
+              {/* Section 5: Transforms sync */}
+              {(isRemoteSyncEnabled || values?.[TYPE_KEY] === "read-write") && (
                 <RemoteSyncSettingsSection
-                  description={t`Choose which collections to sync with git.`}
-                  title={t`Collections to sync`}
+                  title={t`Transforms`}
                   variant={variant}
                 >
-                  <Stack gap="lg">
-                    <TopLevelCollectionsList />
-                    {useTenants && (
-                      <>
-                        <Text fw={700} size="md" lh="1rem">
-                          {t`Shared collections`}
-                        </Text>
-                        <SharedTenantCollectionsList />
-                      </>
-                    )}
-                  </Stack>
+                  <FormSwitch
+                    label={t`Sync transforms with git`}
+                    description={t`When enabled, all transforms and transform tags will be synced.`}
+                    name={TRANSFORMS_KEY}
+                    size="sm"
+                  />
                 </RemoteSyncSettingsSection>
               )}
 

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.unit.spec.tsx
@@ -159,4 +159,98 @@ describe("RemoteSyncSettingsForm", () => {
       ).not.toBeInTheDocument();
     });
   });
+
+  describe("transforms sync toggle", () => {
+    it("should not display transforms toggle when remote sync is disabled and read-only mode", () => {
+      setup({
+        remoteSyncEnabled: false,
+        remoteSyncType: "read-only",
+      });
+
+      expect(screen.queryByText("Transforms")).not.toBeInTheDocument();
+      expect(
+        screen.queryByLabelText("Sync transforms with git"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should display transforms section in admin variant when read-write mode is selected during initial setup", async () => {
+      setup({
+        remoteSyncEnabled: false,
+        remoteSyncType: "read-write",
+      });
+
+      // Wait for the form to be fully rendered with read-write mode
+      await waitFor(() => {
+        expect(screen.getByLabelText("Read-write")).toBeChecked();
+      });
+
+      expect(screen.getByText("Transforms")).toBeInTheDocument();
+    });
+
+    it("should display transforms section in modal variant when read-write mode is selected during initial setup", async () => {
+      setup({
+        remoteSyncEnabled: false,
+        remoteSyncType: "read-write",
+        variant: "settings-modal",
+      });
+
+      // Wait for the form to be fully rendered with read-write mode
+      await waitFor(() => {
+        expect(screen.getByLabelText("Read-write")).toBeChecked();
+      });
+
+      expect(screen.getByText("Transforms")).toBeInTheDocument();
+    });
+  });
+
+  describe("collections to sync section", () => {
+    it("should display collections section in admin variant when read-write mode is selected during initial setup", async () => {
+      setup({
+        remoteSyncEnabled: false,
+        remoteSyncType: "read-write",
+      });
+
+      // Wait for the form to be fully rendered with read-write mode
+      await waitFor(() => {
+        expect(screen.getByLabelText("Read-write")).toBeChecked();
+      });
+
+      expect(screen.getByText("Collections to sync")).toBeInTheDocument();
+    });
+
+    it("should not display collections section in modal variant when read-write mode is selected", async () => {
+      setup({
+        remoteSyncEnabled: false,
+        remoteSyncType: "read-write",
+        variant: "settings-modal",
+      });
+
+      // Wait for the form to be fully rendered with read-write mode
+      await waitFor(() => {
+        expect(screen.getByLabelText("Read-write")).toBeChecked();
+      });
+
+      // Transforms should be visible but collections should not
+      expect(screen.getByText("Transforms")).toBeInTheDocument();
+      expect(screen.queryByText("Collections to sync")).not.toBeInTheDocument();
+    });
+
+    it("should not display collections section in modal variant even when remote sync is enabled", async () => {
+      setup({
+        remoteSyncEnabled: true,
+        remoteSyncType: "read-write",
+        remoteSyncUrl: "https://github.com/test/repo.git",
+        variant: "settings-modal",
+      });
+
+      // Wait for the form to be fully rendered with read-write mode
+      await waitFor(() => {
+        expect(screen.getByLabelText("Read-write")).toBeChecked();
+      });
+
+      // Transforms should be visible but collections should not
+      expect(screen.getByText("Transforms")).toBeInTheDocument();
+      expect(screen.queryByText("Collections to sync")).not.toBeInTheDocument();
+    });
+  });
 });

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/constants.ts
@@ -8,6 +8,7 @@ export const TYPE_KEY = "remote-sync-type";
 export const BRANCH_KEY = "remote-sync-branch";
 export const REMOTE_SYNC_KEY = "remote-sync-enabled";
 export const AUTO_IMPORT_KEY = "remote-sync-auto-import";
+export const TRANSFORMS_KEY = "remote-sync-transforms";
 export const COLLECTIONS_KEY = "collections";
 
 export const REMOTE_SYNC_SCHEMA = Yup.object({
@@ -15,6 +16,7 @@ export const REMOTE_SYNC_SCHEMA = Yup.object({
   [URL_KEY]: Yup.string().nullable().default(null),
   [TOKEN_KEY]: Yup.string().nullable().default(null),
   [AUTO_IMPORT_KEY]: Yup.boolean().nullable().default(false),
+  [TRANSFORMS_KEY]: Yup.boolean().nullable().default(false),
   [TYPE_KEY]: Yup.string()
     .oneOf(["read-only", "read-write"] as const)
     .nullable()

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/hooks/use-has-transform-dirty-changes.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/hooks/use-has-transform-dirty-changes.ts
@@ -1,0 +1,59 @@
+import { useMemo } from "react";
+
+import { useListCollectionsTreeQuery } from "metabase/api";
+import { getAllDescendantIds } from "metabase/common/components/tree/utils";
+import { useSetting } from "metabase/common/hooks";
+import { buildCollectionTree } from "metabase/entities/collections";
+
+import { useGitSyncVisible } from "./use-git-sync-visible";
+import { useRemoteSyncDirtyState } from "./use-remote-sync-dirty-state";
+
+export function useHasTransformDirtyChanges(): boolean {
+  const { isVisible: isGitSyncVisible } = useGitSyncVisible();
+  const transformsSetting = useSetting("remote-sync-transforms");
+  const { dirty, isDirty } = useRemoteSyncDirtyState();
+
+  // Fetch transforms-namespace collections to check for dirty collections
+  const { data: transformsCollections = [] } = useListCollectionsTreeQuery(
+    { namespace: "transforms" },
+    { skip: !isGitSyncVisible || !transformsSetting },
+  );
+
+  return useMemo(() => {
+    // Only show if git sync is visible and transforms setting is enabled
+    if (!isGitSyncVisible || !transformsSetting || !isDirty) {
+      return false;
+    }
+
+    // Build set of transforms-namespace collection IDs
+    const transformsTree = buildCollectionTree(transformsCollections);
+    const transformsCollectionIds = getAllDescendantIds(transformsTree);
+    const numericCollectionIds = new Set(
+      [...transformsCollectionIds].filter(
+        (id): id is number => typeof id === "number",
+      ),
+    );
+
+    // Check if any dirty entity is:
+    // 1. A transform or transform tag
+    // 2. A collection in the transforms namespace
+    return dirty.some((entity) => {
+      if (entity.model === "transform" || entity.model === "transformtag") {
+        return true;
+      }
+      if (
+        entity.model === "collection" &&
+        numericCollectionIds.has(entity.id)
+      ) {
+        return true;
+      }
+      return false;
+    });
+  }, [
+    isGitSyncVisible,
+    transformsSetting,
+    dirty,
+    isDirty,
+    transformsCollections,
+  ]);
+}

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/hooks/use-has-transform-dirty-changes.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/hooks/use-has-transform-dirty-changes.unit.spec.ts
@@ -1,0 +1,178 @@
+import { setupEnterprisePlugins } from "__support__/enterprise";
+import {
+  setupCollectionsEndpoints,
+  setupPropertiesEndpoints,
+  setupRemoteSyncDirtyEndpoint,
+  setupSettingsEndpoints,
+} from "__support__/server-mocks";
+import { mockSettings } from "__support__/settings";
+import { renderHookWithProviders, waitFor } from "__support__/ui";
+import type { Collection, RemoteSyncEntity } from "metabase-types/api";
+import {
+  createMockCollection,
+  createMockRemoteSyncEntity,
+  createMockSettings,
+  createMockTokenFeatures,
+  createMockTransformsCollection,
+  createMockUser,
+} from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks";
+
+import { useHasTransformDirtyChanges } from "./use-has-transform-dirty-changes";
+
+interface SetupOptions {
+  isGitSyncVisible?: boolean;
+  isTransformsSyncEnabled?: boolean;
+  collections?: Collection[];
+  dirty?: RemoteSyncEntity[];
+}
+
+/**
+ * Compute changedCollections map from dirty entities.
+ * This mirrors what the backend does - marking collections that contain dirty entities.
+ */
+const computeChangedCollections = (
+  dirty: RemoteSyncEntity[],
+): Record<number, boolean> => {
+  const changedCollections: Record<number, boolean> = {};
+  for (const entity of dirty) {
+    if (entity.collection_id != null) {
+      changedCollections[entity.collection_id] = true;
+    }
+  }
+  return changedCollections;
+};
+
+const setup = ({
+  isGitSyncVisible = true,
+  isTransformsSyncEnabled = true,
+  collections = [],
+  dirty = [],
+}: SetupOptions = {}) => {
+  setupEnterprisePlugins();
+
+  const tokenFeatures = createMockTokenFeatures({ data_studio: true });
+  const settings = createMockSettings({
+    "remote-sync-enabled": isGitSyncVisible,
+    "remote-sync-branch": isGitSyncVisible ? "main" : null,
+    "remote-sync-type": "read-write",
+    "remote-sync-transforms": isTransformsSyncEnabled,
+    "token-features": tokenFeatures,
+  });
+
+  const changedCollections = computeChangedCollections(dirty);
+
+  setupPropertiesEndpoints(settings);
+  setupSettingsEndpoints([]);
+  setupRemoteSyncDirtyEndpoint({ dirty, changedCollections });
+  setupCollectionsEndpoints({ collections });
+
+  const storeInitialState = createMockState({
+    currentUser: createMockUser({ is_superuser: true }),
+    settings: mockSettings({
+      "remote-sync-enabled": isGitSyncVisible,
+      "remote-sync-branch": isGitSyncVisible ? "main" : null,
+      "remote-sync-type": "read-write",
+      "remote-sync-transforms": isTransformsSyncEnabled,
+      "token-features": tokenFeatures,
+    }),
+  });
+
+  return renderHookWithProviders(() => useHasTransformDirtyChanges(), {
+    storeInitialState,
+  });
+};
+
+describe("useHasTransformDirtyChanges", () => {
+  it("returns false when no dirty changes exist", async () => {
+    const { result } = setup({
+      collections: [createMockTransformsCollection()],
+      dirty: [],
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBe(false);
+    });
+  });
+
+  it("returns false when git sync is not visible", async () => {
+    const { result } = setup({
+      isGitSyncVisible: false,
+      collections: [createMockTransformsCollection()],
+      dirty: [createMockRemoteSyncEntity({ model: "transform" })],
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBe(false);
+    });
+  });
+
+  it("returns false when remote-sync-transforms setting is disabled", async () => {
+    const { result } = setup({
+      isTransformsSyncEnabled: false,
+      collections: [createMockTransformsCollection()],
+      dirty: [createMockRemoteSyncEntity({ model: "transform" })],
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBe(false);
+    });
+  });
+
+  it("returns true when a transform entity is dirty", async () => {
+    const { result } = setup({
+      collections: [createMockTransformsCollection()],
+      dirty: [createMockRemoteSyncEntity({ model: "transform" })],
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBe(true);
+    });
+  });
+
+  it("returns true when a transform tag entity is dirty", async () => {
+    const { result } = setup({
+      collections: [createMockTransformsCollection()],
+      dirty: [createMockRemoteSyncEntity({ model: "transformtag" })],
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBe(true);
+    });
+  });
+
+  it("returns true when a transforms-namespace collection is dirty", async () => {
+    const transformsCollection = createMockTransformsCollection({ id: 100 });
+    const { result } = setup({
+      collections: [transformsCollection],
+      dirty: [createMockRemoteSyncEntity({ id: 100, model: "collection" })],
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBe(true);
+    });
+  });
+
+  it("returns false when dirty changes exist but not transform-related", async () => {
+    const { result } = setup({
+      collections: [createMockTransformsCollection()],
+      dirty: [createMockRemoteSyncEntity({ model: "card" })],
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBe(false);
+    });
+  });
+
+  it("returns false when collection is dirty but not in transforms namespace", async () => {
+    const regularCollection = createMockCollection({ id: 50 });
+    const { result } = setup({
+      collections: [createMockTransformsCollection(), regularCollection],
+      dirty: [createMockRemoteSyncEntity({ id: 50, model: "collection" })],
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBe(false);
+    });
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/index.ts
@@ -18,6 +18,7 @@ import {
 import { REMOTE_SYNC_INVALIDATION_TAGS } from "./constants";
 import { useGitSyncVisible } from "./hooks/use-git-sync-visible";
 import { useHasLibraryDirtyChanges } from "./hooks/use-has-library-dirty-changes";
+import { useHasTransformDirtyChanges } from "./hooks/use-has-transform-dirty-changes";
 import { useSyncStatus } from "./hooks/use-sync-status";
 import { remoteSyncListenerMiddleware } from "./middleware/remote-sync-listener-middleware";
 import { remoteSyncReducer } from "./sync-task-slice";
@@ -41,6 +42,8 @@ export function initializePlugin() {
     PLUGIN_REMOTE_SYNC.useGitSyncVisible = useGitSyncVisible;
     PLUGIN_REMOTE_SYNC.GitSyncSetupMenuItem = GitSyncSetupMenuItem;
     PLUGIN_REMOTE_SYNC.useHasLibraryDirtyChanges = useHasLibraryDirtyChanges;
+    PLUGIN_REMOTE_SYNC.useHasTransformDirtyChanges =
+      useHasTransformDirtyChanges;
 
     PLUGIN_REDUX_MIDDLEWARES.push(remoteSyncListenerMiddleware.middleware);
     PLUGIN_REDUCERS.remoteSyncPlugin = remoteSyncReducer;

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/middleware/remote-sync-listener-middleware.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/middleware/remote-sync-listener-middleware.ts
@@ -9,13 +9,14 @@ import { documentApi } from "metabase/api/document";
 import { fieldApi } from "metabase/api/field";
 import { segmentApi } from "metabase/api/segment";
 import { tableApi as coreTableApi } from "metabase/api/table";
-import { tag } from "metabase/api/tags";
 import { timelineApi } from "metabase/api/timeline";
 import { timelineEventApi } from "metabase/api/timeline-event";
 import { getCollectionFromCollectionsTree } from "metabase/selectors/collection";
 import { getSetting } from "metabase/selectors/settings";
+import { EnterpriseApi } from "metabase-enterprise/api/api";
 import { remoteSyncApi } from "metabase-enterprise/api/remote-sync";
 import { tableApi as enterpriseTableApi } from "metabase-enterprise/api/table";
+import { tag } from "metabase-enterprise/api/tags";
 import { transformApi } from "metabase-enterprise/api/transform";
 import { transformTagApi } from "metabase-enterprise/api/transform-tag";
 import type {
@@ -72,6 +73,8 @@ const ALL_INVALIDATION_TAGS = [
   tag("subscription-channel"),
   tag("timeline"),
   tag("timeline-event"),
+  tag("transform"),
+  tag("python-transform-library"),
 ];
 
 function shouldInvalidateForEntity(
@@ -490,7 +493,7 @@ remoteSyncListenerMiddleware.startListening({
           }, 500);
 
           if (isImportTask) {
-            dispatch(Api.util.invalidateTags(ALL_INVALIDATION_TAGS));
+            dispatch(EnterpriseApi.util.invalidateTags(ALL_INVALIDATION_TAGS));
           }
         }
 

--- a/frontend/src/metabase-types/api/mocks/collection.ts
+++ b/frontend/src/metabase-types/api/mocks/collection.ts
@@ -61,3 +61,23 @@ export const createMockCollectionEssential = (
   name: `Collection ${opts?.id || 1}`,
   ...opts,
 });
+
+export const createMockLibraryCollection = (
+  opts?: Partial<Collection>,
+): Collection =>
+  createMockCollection({
+    id: 1,
+    name: "Library",
+    type: "library",
+    ...opts,
+  });
+
+export const createMockTransformsCollection = (
+  opts?: Partial<Collection>,
+): Collection =>
+  createMockCollection({
+    id: 100,
+    name: "Transforms",
+    namespace: "transforms",
+    ...opts,
+  });

--- a/frontend/src/metabase-types/api/mocks/index.ts
+++ b/frontend/src/metabase-types/api/mocks/index.ts
@@ -25,6 +25,7 @@ export * from "./performance";
 export * from "./permissions";
 export * from "./pulse";
 export * from "./query";
+export * from "./remote-sync";
 export * from "./revision";
 export * from "./schema";
 export * from "./search";

--- a/frontend/src/metabase-types/api/mocks/remote-sync.ts
+++ b/frontend/src/metabase-types/api/mocks/remote-sync.ts
@@ -9,3 +9,23 @@ export const createMockRemoteSyncEntity = (
   sync_status: "update",
   ...opts,
 });
+
+export const createMockDirtyCardEntity = (
+  opts?: Partial<RemoteSyncEntity>,
+): RemoteSyncEntity =>
+  createMockRemoteSyncEntity({
+    id: 1,
+    model: "card",
+    collection_id: 1,
+    ...opts,
+  });
+
+export const createMockDirtyTransformEntity = (
+  opts?: Partial<RemoteSyncEntity>,
+): RemoteSyncEntity =>
+  createMockRemoteSyncEntity({
+    id: 10,
+    model: "transform",
+    name: "Test Transform",
+    ...opts,
+  });

--- a/frontend/src/metabase-types/api/remote-sync.ts
+++ b/frontend/src/metabase-types/api/remote-sync.ts
@@ -82,6 +82,7 @@ export type RemoteSyncConfigurationSettings = Pick<
   | "remote-sync-token"
   | "remote-sync-type"
   | "remote-sync-branch"
+  | "remote-sync-transforms"
 > & {
   collections?: CollectionSyncPreferences;
 };

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -676,6 +676,7 @@ export interface EnterpriseSettings extends Settings {
   "remote-sync-branch"?: string | null;
   "remote-sync-type"?: "read-only" | "read-write" | null;
   "remote-sync-auto-import"?: boolean | null;
+  "remote-sync-transforms"?: boolean | null;
   "login-page-illustration"?: IllustrationSettingValue;
   "login-page-illustration-custom"?: string;
   "landing-page-illustration"?: IllustrationSettingValue;

--- a/frontend/src/metabase/plugins/oss/remote-sync.ts
+++ b/frontend/src/metabase/plugins/oss/remote-sync.ts
@@ -42,6 +42,7 @@ const getDefaultPluginRemoteSync = () => ({
   }),
   useGitSyncVisible: () => ({ isVisible: false, currentBranch: null }),
   useHasLibraryDirtyChanges: () => false,
+  useHasTransformDirtyChanges: () => false,
 });
 
 export const PLUGIN_REMOTE_SYNC: {
@@ -66,6 +67,7 @@ export const PLUGIN_REMOTE_SYNC: {
     currentBranch: string | null | undefined;
   };
   useHasLibraryDirtyChanges: () => boolean;
+  useHasTransformDirtyChanges: () => boolean;
 } = getDefaultPluginRemoteSync();
 
 /**

--- a/frontend/test/__support__/server-mocks/remote-sync.ts
+++ b/frontend/test/__support__/server-mocks/remote-sync.ts
@@ -50,6 +50,41 @@ const setupRemoteSyncCurrentTaskEndpoint = (
   );
 };
 
+export interface RemoteSyncSettingsResponse {
+  success: boolean;
+  task_id?: number;
+}
+
+/**
+ * Setup the remote-sync settings PUT endpoint
+ */
+export const setupRemoteSyncSettingsEndpoint = ({
+  success = true,
+  task_id,
+}: Partial<RemoteSyncSettingsResponse> = {}) => {
+  fetchMock.removeRoute("remote-sync-settings");
+  fetchMock.put(
+    "path:/api/ee/remote-sync/settings",
+    { success, ...(task_id !== undefined && { task_id }) },
+    { name: "remote-sync-settings" },
+  );
+};
+
+/**
+ * Setup the remote-sync import POST endpoint
+ */
+export const setupRemoteSyncImportEndpoint = ({
+  status = "running",
+  task_id = 456,
+}: { status?: string; task_id?: number } = {}) => {
+  fetchMock.removeRoute("remote-sync-import");
+  fetchMock.post(
+    "path:/api/ee/remote-sync/import",
+    { status, task_id },
+    { name: "remote-sync-import" },
+  );
+};
+
 /**
  * Setup all remote-sync endpoints at once
  */
@@ -58,18 +93,20 @@ export const setupRemoteSyncEndpoints = ({
   dirty = [],
   changedCollections = {},
   hasRemoteChanges = false,
+  settingsResponse = { success: true },
 }: {
   branches?: string[];
   dirty?: RemoteSyncEntity[];
   changedCollections?: Record<number, boolean>;
   hasRemoteChanges?: boolean;
+  settingsResponse?: Partial<RemoteSyncSettingsResponse>;
 } = {}) => {
   setupRemoteSyncBranchesEndpoint(branches);
   setupRemoteSyncDirtyEndpoint({ dirty, changedCollections });
   setupRemoteSyncCurrentTaskEndpoint("idle");
-  fetchMock.post("path:/api/ee/remote-sync/import", {});
+  setupRemoteSyncImportEndpoint();
+  setupRemoteSyncSettingsEndpoint(settingsResponse);
   fetchMock.post("path:/api/ee/remote-sync/create-branch", {});
-  fetchMock.put("path:/api/ee/remote-sync/settings", { success: true });
   fetchMock.get("path:/api/ee/remote-sync/has-remote-changes", {
     has_changes: hasRemoteChanges,
   });


### PR DESCRIPTION
### Description

1. Updates the DataStudioLayout to show transform dirty state

   We get the orange dot next to Transforms if transforms or transform collections are dirty.

2. Update the all changes view to include transforms

   Also includes their collection heirarchy if the transforms sync setting is enabled

3. Add the transforms sync setting

   To both the remote sync admin page and the Set up git sync modal in the data studio

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
