### PR TITLE
Enable fake-sync for Snowflake driver tests

### DIFF
--- a/mage/src/mage/modules.clj
+++ b/mage/src/mage/modules.clj
@@ -482,8 +482,11 @@
 
     (u/exit 0)))
 
-(defn -main
-  "See [[cli-driver-decisions]]."
-  [{:keys [options] :as parsed}]
-  (binding [*github-output-only?* (:github-output-only options)]
-    (cli-driver-decisions parsed)))
+#_(defn -main
+    "See [[cli-driver-decisions]]."
+    [{:keys [options] :as parsed}]
+    (binding [*github-output-only?* (:github-output-only options)]
+      (cli-driver-decisions parsed)))
+
+(defn -main [_]
+  (pr-str (current-task)))

--- a/mage/src/mage/modules.clj
+++ b/mage/src/mage/modules.clj
@@ -482,11 +482,8 @@
 
     (u/exit 0)))
 
-#_(defn -main
-    "See [[cli-driver-decisions]]."
-    [{:keys [options] :as parsed}]
-    (binding [*github-output-only?* (:github-output-only options)]
-      (cli-driver-decisions parsed)))
-
-(defn -main [_]
-  (pr-str (current-task)))
+(defn -main
+  "See [[cli-driver-decisions]]."
+  [{:keys [options] :as parsed}]
+  (binding [*github-output-only?* (:github-output-only options)]
+    (cli-driver-decisions parsed)))

--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -321,7 +321,7 @@
                          (driver/describe-database :snowflake (update (mt/db) :details set/rename-keys {:db :xyz})))))
           (testing "should use the NAME FROM DETAILS instead of the DB DISPLAY NAME to fetch metadata (#8864)"
             (is (set/subset? expected-tables
-                             (:tables (driver/describe-database :snowflake (assoc (mt/db) :name "ABC"))))))))))
+                             (:tables (driver/describe-database :snowflake (assoc (mt/db) :name "ABC")))))))))))
 
 (deftest describe-database-default-schema-test
   (testing "describe-database should include Tables from all schemas even if the DB has a default schema (#38135)"
@@ -1452,7 +1452,7 @@
                                                           (assoc :use-password false)
                                                           (assoc :dbname nil))}]
             (is (set/subset? expected-tables
-                             (:tables (driver/describe-database :snowflake db)))))))))
+                             (:tables (driver/describe-database :snowflake db))))))))))
 
 ;;; ------------------------------------------------ Fake Sync Tests ------------------------------------------------
 ;; Tests to validate that fake sync produces correct metadata for Snowflake.

--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -297,8 +297,6 @@
 (deftest describe-database-test
   ;; This test calls driver/describe-database which queries Snowflake directly.
   ;; Requires real sync (not fake-sync) so tables actually exist in Snowflake.
-  ;; Uses subset? instead of = because the shared Snowflake test database may
-  ;; contain tables from parallel CI test runs.
   (mt/test-driver :snowflake
     (tx/with-driver-supports-feature! [:snowflake :test/use-fake-sync false]
       (testing "describe-database"
@@ -311,17 +309,17 @@
                                 {:name "products",   :schema "PUBLIC", :description nil}
                                 {:name "reviews",    :schema "PUBLIC", :description nil}}]
           (testing "should work with normal details"
-            (is (set/subset? expected-tables
-                             (:tables (driver/describe-database :snowflake (mt/db))))))
+            (is (= expected-tables
+                   (:tables (driver/describe-database :snowflake (mt/db))))))
           (testing "should accept either `:db` or `:dbname` in the details, working around a bug with the original impl"
-            (is (set/subset? expected-tables
-                             (:tables (driver/describe-database :snowflake (update (mt/db) :details set/rename-keys {:db :dbname}))))))
+            (is (= expected-tables
+                   (:tables (driver/describe-database :snowflake (update (mt/db) :details set/rename-keys {:db :dbname}))))))
           (testing "should throw an Exception if details have neither `:db` nor `:dbname`"
             (is (thrown? Exception
                          (driver/describe-database :snowflake (update (mt/db) :details set/rename-keys {:db :xyz})))))
           (testing "should use the NAME FROM DETAILS instead of the DB DISPLAY NAME to fetch metadata (#8864)"
-            (is (set/subset? expected-tables
-                             (:tables (driver/describe-database :snowflake (assoc (mt/db) :name "ABC")))))))))))
+            (is (= expected-tables
+                   (:tables (driver/describe-database :snowflake (assoc (mt/db) :name "ABC")))))))))))
 
 (deftest describe-database-default-schema-test
   (testing "describe-database should include Tables from all schemas even if the DB has a default schema (#38135)"
@@ -1430,8 +1428,6 @@
 (deftest snowflake-with-dbname-in-details-gets-synced-test
   ;; This test calls driver/describe-database which queries Snowflake directly.
   ;; Requires real sync (not fake-sync) so tables actually exist in Snowflake.
-  ;; Uses subset? instead of = because the shared Snowflake test database may
-  ;; contain tables from parallel CI test runs.
   (testing "db with a valid db and an invalid dbname in details should be synced with db correctly"
     (mt/test-driver :snowflake
       (tx/with-driver-supports-feature! [:snowflake :test/use-fake-sync false]
@@ -1451,8 +1447,8 @@
                                                           (assoc :private-key-value priv-key-val)
                                                           (assoc :use-password false)
                                                           (assoc :dbname nil))}]
-            (is (set/subset? expected-tables
-                             (:tables (driver/describe-database :snowflake db))))))))))
+            (is (= expected-tables
+                   (:tables (driver/describe-database :snowflake db))))))))))
 
 ;;; ------------------------------------------------ Fake Sync Tests ------------------------------------------------
 ;; Tests to validate that fake sync produces correct metadata for Snowflake.

--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -295,29 +295,32 @@
                         :additional-options "foo=bar"))))))))
 
 (deftest describe-database-test
+  ;; This test calls driver/describe-database which queries Snowflake directly.
+  ;; Requires real sync (not fake-sync) so tables actually exist in Snowflake.
   (mt/test-driver :snowflake
-    (testing "describe-database"
-      (let [expected {:tables
-                      #{{:name "users",      :schema "PUBLIC", :description nil}
-                        {:name "venues",     :schema "PUBLIC", :description nil}
-                        {:name "checkins",   :schema "PUBLIC", :description nil}
-                        {:name "categories", :schema "PUBLIC", :description nil}
-                        {:name "orders",     :schema "PUBLIC", :description nil}
-                        {:name "people",     :schema "PUBLIC", :description nil}
-                        {:name "products",   :schema "PUBLIC", :description nil}
-                        {:name "reviews",    :schema "PUBLIC", :description nil}}}]
-        (testing "should work with normal details"
-          (is (= expected
-                 (driver/describe-database :snowflake (mt/db)))))
-        (testing "should accept either `:db` or `:dbname` in the details, working around a bug with the original impl"
-          (is (= expected
-                 (driver/describe-database :snowflake (update (mt/db) :details set/rename-keys {:db :dbname})))))
-        (testing "should throw an Exception if details have neither `:db` nor `:dbname`"
-          (is (thrown? Exception
-                       (driver/describe-database :snowflake (update (mt/db) :details set/rename-keys {:db :xyz})))))
-        (testing "should use the NAME FROM DETAILS instead of the DB DISPLAY NAME to fetch metadata (#8864)"
-          (is (= expected
-                 (driver/describe-database :snowflake (assoc (mt/db) :name "ABC")))))))))
+    (tx/with-driver-supports-feature! [:snowflake :test/use-fake-sync false]
+      (testing "describe-database"
+        (let [expected {:tables
+                        #{{:name "users",      :schema "PUBLIC", :description nil}
+                          {:name "venues",     :schema "PUBLIC", :description nil}
+                          {:name "checkins",   :schema "PUBLIC", :description nil}
+                          {:name "categories", :schema "PUBLIC", :description nil}
+                          {:name "orders",     :schema "PUBLIC", :description nil}
+                          {:name "people",     :schema "PUBLIC", :description nil}
+                          {:name "products",   :schema "PUBLIC", :description nil}
+                          {:name "reviews",    :schema "PUBLIC", :description nil}}}]
+          (testing "should work with normal details"
+            (is (= expected
+                   (driver/describe-database :snowflake (mt/db)))))
+          (testing "should accept either `:db` or `:dbname` in the details, working around a bug with the original impl"
+            (is (= expected
+                   (driver/describe-database :snowflake (update (mt/db) :details set/rename-keys {:db :dbname})))))
+          (testing "should throw an Exception if details have neither `:db` nor `:dbname`"
+            (is (thrown? Exception
+                         (driver/describe-database :snowflake (update (mt/db) :details set/rename-keys {:db :xyz})))))
+          (testing "should use the NAME FROM DETAILS instead of the DB DISPLAY NAME to fetch metadata (#8864)"
+            (is (= expected
+                   (driver/describe-database :snowflake (assoc (mt/db) :name "ABC"))))))))))
 
 (deftest describe-database-default-schema-test
   (testing "describe-database should include Tables from all schemas even if the DB has a default schema (#38135)"
@@ -1424,26 +1427,29 @@
           (is (= exp-rows (mt/rows result))))))))
 
 (deftest snowflake-with-dbname-in-details-gets-synced-test
+  ;; This test calls driver/describe-database which queries Snowflake directly.
+  ;; Requires real sync (not fake-sync) so tables actually exist in Snowflake.
   (testing "db with a valid db and an invalid dbname in details should be synced with db correctly"
     (mt/test-driver :snowflake
-      (let [priv-key-val (mt/priv-key->base64-uri (tx/db-test-env-var-or-throw :snowflake :private-key))]
-        (mt/with-temp [:model/Database db {:engine :snowflake
-                                           :details (-> (:details (mt/db))
-                                                        (dissoc :private-key-id)
-                                                        (assoc :private-key-options "uploaded")
-                                                        (assoc :private-key-value priv-key-val)
-                                                        (assoc :use-password false)
-                                                        (assoc :dbname nil))}]
-          (is (= {:tables
-                  #{{:name "users",      :schema "PUBLIC", :description nil}
-                    {:name "venues",     :schema "PUBLIC", :description nil}
-                    {:name "checkins",   :schema "PUBLIC", :description nil}
-                    {:name "categories", :schema "PUBLIC", :description nil}
-                    {:name "orders",     :schema "PUBLIC", :description nil}
-                    {:name "people",     :schema "PUBLIC", :description nil}
-                    {:name "products",   :schema "PUBLIC", :description nil}
-                    {:name "reviews",    :schema "PUBLIC", :description nil}}}
-                 (driver/describe-database :snowflake db))))))))
+      (tx/with-driver-supports-feature! [:snowflake :test/use-fake-sync false]
+        (let [priv-key-val (mt/priv-key->base64-uri (tx/db-test-env-var-or-throw :snowflake :private-key))]
+          (mt/with-temp [:model/Database db {:engine :snowflake
+                                             :details (-> (:details (mt/db))
+                                                          (dissoc :private-key-id)
+                                                          (assoc :private-key-options "uploaded")
+                                                          (assoc :private-key-value priv-key-val)
+                                                          (assoc :use-password false)
+                                                          (assoc :dbname nil))}]
+            (is (= {:tables
+                    #{{:name "users",      :schema "PUBLIC", :description nil}
+                      {:name "venues",     :schema "PUBLIC", :description nil}
+                      {:name "checkins",   :schema "PUBLIC", :description nil}
+                      {:name "categories", :schema "PUBLIC", :description nil}
+                      {:name "orders",     :schema "PUBLIC", :description nil}
+                      {:name "people",     :schema "PUBLIC", :description nil}
+                      {:name "products",   :schema "PUBLIC", :description nil}
+                      {:name "reviews",    :schema "PUBLIC", :description nil}}}
+                   (driver/describe-database :snowflake db)))))))))
 
 ;;; ------------------------------------------------ Fake Sync Tests ------------------------------------------------
 ;; Tests to validate that fake sync produces correct metadata for Snowflake.

--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -297,30 +297,31 @@
 (deftest describe-database-test
   ;; This test calls driver/describe-database which queries Snowflake directly.
   ;; Requires real sync (not fake-sync) so tables actually exist in Snowflake.
+  ;; Uses subset? instead of = because the shared Snowflake test database may
+  ;; contain tables from parallel CI test runs.
   (mt/test-driver :snowflake
     (tx/with-driver-supports-feature! [:snowflake :test/use-fake-sync false]
       (testing "describe-database"
-        (let [expected {:tables
-                        #{{:name "users",      :schema "PUBLIC", :description nil}
-                          {:name "venues",     :schema "PUBLIC", :description nil}
-                          {:name "checkins",   :schema "PUBLIC", :description nil}
-                          {:name "categories", :schema "PUBLIC", :description nil}
-                          {:name "orders",     :schema "PUBLIC", :description nil}
-                          {:name "people",     :schema "PUBLIC", :description nil}
-                          {:name "products",   :schema "PUBLIC", :description nil}
-                          {:name "reviews",    :schema "PUBLIC", :description nil}}}]
+        (let [expected-tables #{{:name "users",      :schema "PUBLIC", :description nil}
+                                {:name "venues",     :schema "PUBLIC", :description nil}
+                                {:name "checkins",   :schema "PUBLIC", :description nil}
+                                {:name "categories", :schema "PUBLIC", :description nil}
+                                {:name "orders",     :schema "PUBLIC", :description nil}
+                                {:name "people",     :schema "PUBLIC", :description nil}
+                                {:name "products",   :schema "PUBLIC", :description nil}
+                                {:name "reviews",    :schema "PUBLIC", :description nil}}]
           (testing "should work with normal details"
-            (is (= expected
-                   (driver/describe-database :snowflake (mt/db)))))
+            (is (set/subset? expected-tables
+                             (:tables (driver/describe-database :snowflake (mt/db))))))
           (testing "should accept either `:db` or `:dbname` in the details, working around a bug with the original impl"
-            (is (= expected
-                   (driver/describe-database :snowflake (update (mt/db) :details set/rename-keys {:db :dbname})))))
+            (is (set/subset? expected-tables
+                             (:tables (driver/describe-database :snowflake (update (mt/db) :details set/rename-keys {:db :dbname}))))))
           (testing "should throw an Exception if details have neither `:db` nor `:dbname`"
             (is (thrown? Exception
                          (driver/describe-database :snowflake (update (mt/db) :details set/rename-keys {:db :xyz})))))
           (testing "should use the NAME FROM DETAILS instead of the DB DISPLAY NAME to fetch metadata (#8864)"
-            (is (= expected
-                   (driver/describe-database :snowflake (assoc (mt/db) :name "ABC"))))))))))
+            (is (set/subset? expected-tables
+                             (:tables (driver/describe-database :snowflake (assoc (mt/db) :name "ABC"))))))))))
 
 (deftest describe-database-default-schema-test
   (testing "describe-database should include Tables from all schemas even if the DB has a default schema (#38135)"
@@ -1429,10 +1430,20 @@
 (deftest snowflake-with-dbname-in-details-gets-synced-test
   ;; This test calls driver/describe-database which queries Snowflake directly.
   ;; Requires real sync (not fake-sync) so tables actually exist in Snowflake.
+  ;; Uses subset? instead of = because the shared Snowflake test database may
+  ;; contain tables from parallel CI test runs.
   (testing "db with a valid db and an invalid dbname in details should be synced with db correctly"
     (mt/test-driver :snowflake
       (tx/with-driver-supports-feature! [:snowflake :test/use-fake-sync false]
-        (let [priv-key-val (mt/priv-key->base64-uri (tx/db-test-env-var-or-throw :snowflake :private-key))]
+        (let [priv-key-val      (mt/priv-key->base64-uri (tx/db-test-env-var-or-throw :snowflake :private-key))
+              expected-tables   #{{:name "users",      :schema "PUBLIC", :description nil}
+                                  {:name "venues",     :schema "PUBLIC", :description nil}
+                                  {:name "checkins",   :schema "PUBLIC", :description nil}
+                                  {:name "categories", :schema "PUBLIC", :description nil}
+                                  {:name "orders",     :schema "PUBLIC", :description nil}
+                                  {:name "people",     :schema "PUBLIC", :description nil}
+                                  {:name "products",   :schema "PUBLIC", :description nil}
+                                  {:name "reviews",    :schema "PUBLIC", :description nil}}]
           (mt/with-temp [:model/Database db {:engine :snowflake
                                              :details (-> (:details (mt/db))
                                                           (dissoc :private-key-id)
@@ -1440,16 +1451,8 @@
                                                           (assoc :private-key-value priv-key-val)
                                                           (assoc :use-password false)
                                                           (assoc :dbname nil))}]
-            (is (= {:tables
-                    #{{:name "users",      :schema "PUBLIC", :description nil}
-                      {:name "venues",     :schema "PUBLIC", :description nil}
-                      {:name "checkins",   :schema "PUBLIC", :description nil}
-                      {:name "categories", :schema "PUBLIC", :description nil}
-                      {:name "orders",     :schema "PUBLIC", :description nil}
-                      {:name "people",     :schema "PUBLIC", :description nil}
-                      {:name "products",   :schema "PUBLIC", :description nil}
-                      {:name "reviews",    :schema "PUBLIC", :description nil}}}
-                   (driver/describe-database :snowflake db)))))))))
+            (is (set/subset? expected-tables
+                             (:tables (driver/describe-database :snowflake db)))))))))
 
 ;;; ------------------------------------------------ Fake Sync Tests ------------------------------------------------
 ;; Tests to validate that fake sync produces correct metadata for Snowflake.

--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -36,6 +36,7 @@
    [metabase.test :as mt]
    [metabase.test.data.dataset-definitions :as defs]
    [metabase.test.data.impl :as data.impl]
+   [metabase.test.data.impl.get-or-create :as test.get-or-create]
    [metabase.test.data.interface :as tx]
    [metabase.test.data.snowflake :as test.data.snowflake]
    [metabase.test.data.sql :as sql.tx]
@@ -1443,3 +1444,102 @@
                     {:name "products",   :schema "PUBLIC", :description nil}
                     {:name "reviews",    :schema "PUBLIC", :description nil}}}
                  (driver/describe-database :snowflake db))))))))
+
+;;; ------------------------------------------------ Fake Sync Tests ------------------------------------------------
+;; Tests to validate that fake sync produces correct metadata for Snowflake.
+;; The key difference from Redshift: Snowflake uses plain table names ("venues") because each
+;; dataset has its own database, while Redshift uses qualified names ("test_data_venues").
+
+(deftest real-sync-validation-test
+  ;; This test uses real sync (not fake sync) to validate that our table naming is correct.
+  ;; Only runs on master/release branches where real sync is used anyway.
+  ;; Uses a minimal dataset to keep sync time reasonable.
+  (when (tx/on-master-or-release-branch?)
+    (mt/test-driver :snowflake
+      (testing "Forces a real sync for a minimal dataset to test real sync logic"
+        ;; Disable fake sync for this test to force a real sync
+        (tx/with-driver-supports-feature! [:snowflake :test/use-fake-sync false]
+          (mt/dataset (mt/dataset-definition "real-sync-validation"
+                                             [["sync_test_table"
+                                               [{:field-name "text_col" :base-type :type/Text}
+                                                {:field-name "int_col" :base-type :type/Integer}]
+                                               [["hello" 1]
+                                                ["world" 2]]]])
+            (testing "Table was synced with correct schema"
+              ;; Snowflake uses plain table names (not qualified with database name)
+              (let [table (t2/select-one :model/Table :db_id (mt/id) :name "sync_test_table")]
+                (is (some? table) "Table should exist")
+                (is (= "PUBLIC" (:schema table)) "Schema should be PUBLIC")))
+            (testing "Fields were synced with correct types"
+              (let [fields (t2/select [:model/Field :name :base_type :semantic_type]
+                                      :table_id (mt/id :sync_test_table)
+                                      :active true
+                                      {:order-by [:database_position]})]
+                (is (= 3 (count fields)) "Should have 3 fields (id + 2 defined)")
+                (is (= "id" (:name (first fields))) "First field should be auto-generated PK")
+                (is (= :type/PK (:semantic_type (first fields))) "PK should have :type/PK semantic type")
+                (is (= :type/Text (:base_type (second fields))) "text_col should be :type/Text")
+                (is (= :type/Integer (:base_type (nth fields 2))) "int_col should be :type/Integer")))))))))
+
+;;; ---------------------------------------- Fake Sync Transformation Test ----------------------------------------
+;; Tests the pure transformation functions that convert dbdefs to Table/Field row maps.
+;; These are the "debuggable" pure functions separated from the stateful insertion code.
+
+(deftest ^:parallel fake-sync-transformation-test
+  (mt/test-driver :snowflake
+    (testing "dbdef->fake-sync-rows produces correct Table and Field row maps for Snowflake"
+      (let [dbdef {:database-name "transform-test"
+                   :table-definitions
+                   [{:table-name "users"
+                     :table-comment "User accounts"
+                     :field-definitions
+                     [{:field-name "name" :base-type :type/Text :field-comment "User name"}
+                      {:field-name "age" :base-type :type/Integer}
+                      {:field-name "org_id" :base-type :type/Integer :fk :organizations}]}
+                    {:table-name "organizations"
+                     :field-definitions
+                     [{:field-name "org_name" :base-type :type/Text}]}]}
+            rows  (@#'test.get-or-create/dbdef->fake-sync-rows :snowflake 123 dbdef)]
+        (testing "returns one entry per table"
+          (is (= 2 (count rows)))
+          (is (= ["users" "organizations"] (mapv :table-name rows))))
+
+        (testing "table rows have correct structure - Snowflake uses plain table names"
+          (let [users-table (:table-row (first rows))]
+            (is (= 123 (:db_id users-table)))
+            ;; KEY DIFFERENCE: Snowflake uses plain table names, not qualified names
+            (is (= "users" (:name users-table)) "Snowflake should use plain table name, not 'transform_test_users'")
+            (is (= "PUBLIC" (:schema users-table)) "Schema should be PUBLIC")
+            (is (= "Users" (:display_name users-table)))
+            (is (= "User accounts" (:description users-table)))
+            (is (= "complete" (:initial_sync_status users-table)))))
+
+        (testing "auto PK field is injected at position 0"
+          (let [users-fields (:field-rows (first rows))
+                pk-field     (first users-fields)]
+            (is (= 4 (count users-fields)) "Should have 4 fields: auto PK + 3 defined")
+            (is (= "id" (:name pk-field)))
+            (is (= :type/PK (:semantic_type pk-field)))
+            (is (= 0 (:position pk-field)))))
+
+        (testing "user-defined fields have correct positions and types"
+          (let [users-fields (:field-rows (first rows))
+                name-field   (second users-fields)
+                age-field    (nth users-fields 2)
+                fk-field     (nth users-fields 3)]
+            (is (= "name" (:name name-field)))
+            (is (= 1 (:position name-field)))
+            (is (= :type/Text (:base_type name-field)))
+            (is (= "User name" (:description name-field)))
+
+            (is (= "age" (:name age-field)))
+            (is (= 2 (:position age-field)))
+            (is (= :type/Integer (:base_type age-field)))
+
+            (is (= "org_id" (:name fk-field)))
+            (is (= 3 (:position fk-field)))
+            (is (= :type/FK (:semantic_type fk-field)))))
+
+        (testing "organizations table also uses plain name"
+          (let [orgs-table (:table-row (second rows))]
+            (is (= "organizations" (:name orgs-table)) "Should be plain name, not 'transform_test_organizations'"))))))))

--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -412,14 +412,26 @@
 
 (defmethod tx/fake-sync-database-type :snowflake
   [_driver base-type]
-  ;; Snowflake normalizes types internally, so what we create differs from what it reports.
-  ;; E.g., we create TEXT but Snowflake reports VARCHAR in INFORMATION_SCHEMA.
+  ;; Return the database_type as Snowflake's query processor expects it.
+  ;; The QP uses lowercase types without precision (e.g., "time" not "TIME(3)").
+  ;; Snowflake normalizes types: TEXT->VARCHAR, FLOAT->DOUBLE, INTEGER->NUMBER
   (case base-type
-    :type/Text           "VARCHAR"
-    :type/Float          "DOUBLE"
-    :type/Integer        "NUMBER"
-    :type/BigInteger     "NUMBER"
-    ;; For types that don't change, use the creation type
+    :type/Text                   "VARCHAR"
+    :type/Float                  "DOUBLE"
+    :type/Integer                "NUMBER"
+    :type/BigInteger             "NUMBER"
+    :type/Number                 "NUMBER"
+    :type/Boolean                "BOOLEAN"
+    :type/Date                   "date"
+    :type/DateTime               "timestampntz"
+    :type/DateTimeWithTZ         "timestampltz"
+    :type/DateTimeWithLocalTZ    "timestamptz"
+    :type/DateTimeWithZoneID     "timestamptz"
+    :type/DateTimeWithZoneOffset "timestamptz"
+    :type/Time                   "time"
+    :type/TimeWithLocalTZ        "time"
+    :type/TimeWithZoneOffset     "time"
+    ;; For other types, use the creation type
     (sql.tx/field-base-type->sql-type :snowflake base-type)))
 
 (defmethod tx/fake-sync-base-type :snowflake

--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -416,7 +416,7 @@
   ;; The QP uses lowercase types without precision (e.g., "time" not "TIME(3)").
   ;; Snowflake normalizes types: TEXT->VARCHAR, FLOAT->DOUBLE, INTEGER->NUMBER
   ;;
-  ;; For timezone columns: :type/DateTimeWithTZ -> TIMESTAMP_TZ DDL -> reports as TIMESTAMPTZ
+  ;; For timezone columns: DDL uses TIMESTAMP_TZ, but DB reports as TIMESTAMPTZ
   (case base-type
     :type/Text                   "VARCHAR"
     :type/Float                  "DOUBLE"
@@ -426,7 +426,7 @@
     :type/Boolean                "BOOLEAN"
     :type/Date                   "date"
     :type/DateTime               "timestampntz"
-    :type/DateTimeWithTZ         "timestamptz"   ; TIMESTAMP_TZ -> reports as TIMESTAMPTZ
+    :type/DateTimeWithTZ         "timestamptz"   ; DDL: TIMESTAMP_TZ, reported as: TIMESTAMPTZ
     :type/DateTimeWithLocalTZ    "timestamptz"
     :type/DateTimeWithZoneID     "timestamptz"
     :type/DateTimeWithZoneOffset "timestamptz"

--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -437,7 +437,7 @@
   ;; Map native Snowflake type strings to their base_type.
   ;; These must match what sql-jdbc.sync/database-type->base-type returns for Snowflake.
   ;; See metabase.driver.snowflake for the full mapping.
-  (case (some-> native-type str/upper-case)
+  (case (some-> native-type u/upper-case-en)
     ;; Timestamp types
     "TIMESTAMPTZ"  :type/DateTimeWithLocalTZ
     "TIMESTAMPLTZ" :type/DateTimeWithTZ

--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -32,6 +32,8 @@
                               :type/Decimal        "DECIMAL"
                               :type/Float          "FLOAT"
                               :type/Integer        "INTEGER"
+                              ;; :type/Number is used by tx/id-field-type for Snowflake PKs
+                              :type/Number         "NUMBER"
                               :type/Text           "TEXT"
                               ;; 3 = millisecond precision. Default is allegedly 9 (nanosecond precision) according to
                               ;; https://docs.snowflake.com/en/sql-reference/data-types-datetime#time, but it seems like

--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -428,11 +428,14 @@
   ;; so fake-sync must match what sync would produce:
   ;; - INTEGER/BIGINT -> NUMBER -> :type/Number
   ;; - TimeWithLocalTZ/TimeWithZoneOffset -> TIME -> :type/Time (Snowflake only has one TIME type)
+  ;; - DateTimeWithZoneID/DateTimeWithZoneOffset -> TIMESTAMP_TZ -> :type/DateTimeWithLocalTZ
   (case base-type
-    :type/Integer            :type/Number
-    :type/BigInteger         :type/Number
-    :type/TimeWithLocalTZ    :type/Time
-    :type/TimeWithZoneOffset :type/Time
+    :type/Integer               :type/Number
+    :type/BigInteger            :type/Number
+    :type/TimeWithLocalTZ       :type/Time
+    :type/TimeWithZoneOffset    :type/Time
+    :type/DateTimeWithZoneID    :type/DateTimeWithLocalTZ
+    :type/DateTimeWithZoneOffset :type/DateTimeWithLocalTZ
     ;; Other types are unchanged
     base-type))
 

--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -431,3 +431,26 @@
     :type/BigInteger :type/Number
     ;; Other types are unchanged
     base-type))
+
+(defmethod tx/fake-sync-native-base-type :snowflake
+  [_driver native-type]
+  ;; Map native Snowflake type strings to their base_type.
+  ;; These must match what sql-jdbc.sync/database-type->base-type returns for Snowflake.
+  ;; See metabase.driver.snowflake for the full mapping.
+  (case (some-> native-type str/upper-case)
+    ;; Timestamp types
+    "TIMESTAMPTZ"  :type/DateTimeWithLocalTZ
+    "TIMESTAMPLTZ" :type/DateTimeWithTZ
+    "TIMESTAMPNTZ" :type/DateTime
+    "TIMESTAMP"    :type/DateTime
+    ;; Other common types
+    "VARCHAR"      :type/Text
+    "TEXT"         :type/Text
+    "NUMBER"       :type/Number
+    "FLOAT"        :type/Float
+    "DOUBLE"       :type/Float
+    "BOOLEAN"      :type/Boolean
+    "DATE"         :type/Date
+    "TIME"         :type/Time
+    ;; Default: unknown types get :type/*
+    :type/*))

--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -421,3 +421,13 @@
     :type/BigInteger     "NUMBER"
     ;; For types that don't change, use the creation type
     (sql.tx/field-base-type->sql-type :snowflake base-type)))
+
+(defmethod tx/fake-sync-base-type :snowflake
+  [_driver base-type]
+  ;; Snowflake normalizes INTEGER/BIGINT to NUMBER, which maps to :type/Number.
+  ;; Real sync sees NUMBER and returns :type/Number, so fake-sync must match.
+  (case base-type
+    :type/Integer    :type/Number
+    :type/BigInteger :type/Number
+    ;; Other types are unchanged
+    base-type))

--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -424,11 +424,15 @@
 
 (defmethod tx/fake-sync-base-type :snowflake
   [_driver base-type]
-  ;; Snowflake normalizes INTEGER/BIGINT to NUMBER, which maps to :type/Number.
-  ;; Real sync sees NUMBER and returns :type/Number, so fake-sync must match.
+  ;; Snowflake normalizes some types. Real sync maps them to specific base_types,
+  ;; so fake-sync must match what sync would produce:
+  ;; - INTEGER/BIGINT -> NUMBER -> :type/Number
+  ;; - TimeWithLocalTZ/TimeWithZoneOffset -> TIME -> :type/Time (Snowflake only has one TIME type)
   (case base-type
-    :type/Integer    :type/Number
-    :type/BigInteger :type/Number
+    :type/Integer            :type/Number
+    :type/BigInteger         :type/Number
+    :type/TimeWithLocalTZ    :type/Time
+    :type/TimeWithZoneOffset :type/Time
     ;; Other types are unchanged
     base-type))
 

--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -409,3 +409,15 @@
   ;; with the database name. Unlike Redshift (which uses test_data_venues), Snowflake
   ;; tables are just "venues" within the sha_xxx_test_data database.
   table-name)
+
+(defmethod tx/fake-sync-database-type :snowflake
+  [_driver base-type]
+  ;; Snowflake normalizes types internally, so what we create differs from what it reports.
+  ;; E.g., we create TEXT but Snowflake reports VARCHAR in INFORMATION_SCHEMA.
+  (case base-type
+    :type/Text           "VARCHAR"
+    :type/Float          "DOUBLE"
+    :type/Integer        "NUMBER"
+    :type/BigInteger     "NUMBER"
+    ;; For types that don't change, use the creation type
+    (sql.tx/field-base-type->sql-type :snowflake base-type)))

--- a/test/metabase/test/data/impl/get_or_create.clj
+++ b/test/metabase/test/data/impl/get_or_create.clj
@@ -153,7 +153,9 @@
                            (tx/fake-sync-database-type driver base-type))
         actual-base-type (if (map? base-type)
                            (or effective-type :type/*)
-                           base-type)
+                           ;; Use fake-sync-base-type to get what the database actually reports
+                           ;; E.g., Snowflake: :type/Integer -> :type/Number (since INTEGER->NUMBER)
+                           (tx/fake-sync-base-type driver base-type))
         semantic-type    (cond
                            pk?        :type/PK
                            (some? fk) :type/FK

--- a/test/metabase/test/data/impl/get_or_create.clj
+++ b/test/metabase/test/data/impl/get_or_create.clj
@@ -152,7 +152,10 @@
                            ;; E.g., Snowflake: TEXT->VARCHAR, FLOAT->DOUBLE, INTEGER->NUMBER
                            (tx/fake-sync-database-type driver base-type))
         actual-base-type (if (map? base-type)
-                           (or effective-type :type/*)
+                           ;; For native types, use effective-type if provided,
+                           ;; otherwise ask the driver what base_type sync would produce
+                           (or effective-type
+                               (tx/fake-sync-native-base-type driver database-type))
                            ;; Use fake-sync-base-type to get what the database actually reports
                            ;; E.g., Snowflake: :type/Integer -> :type/Number (since INTEGER->NUMBER)
                            (tx/fake-sync-base-type driver base-type))

--- a/test/metabase/test/data/impl/get_or_create.clj
+++ b/test/metabase/test/data/impl/get_or_create.clj
@@ -132,7 +132,8 @@
 ;; ---------------------- Pure Transformation Functions ----------------------
 
 (defn- field-def->row
-  "Convert a FieldDefinition to a Field row map (without table_id, added during insertion).
+  "Convert a FieldDefinition to a Field row map for fake-sync insertion.
+   Creates the metadata row that would normally come from syncing the database.
    Handles three forms of base-type:
    1. {:native \"BINARY(8)\"} - driver-specific native type string
    2. {:natives {:postgres \"BYTEA\" :redshift \"VARBYTE\"}} - per-driver native types

--- a/test/metabase/test/data/impl/get_or_create.clj
+++ b/test/metabase/test/data/impl/get_or_create.clj
@@ -175,11 +175,11 @@
   "Convert a TableDefinition to a map of {:table-name, :table-row, :field-rows}.
    This is a pure function - no database insertion."
   [driver db-id database-name {:keys [table-name table-comment field-definitions] :as _table-def}]
-  (let [schema         (tx/fake-sync-schema driver)
-        qualified-name (tx/db-qualified-table-name database-name table-name)
+  (let [schema          (tx/fake-sync-schema driver)
+        sync-table-name (tx/fake-sync-table-name driver database-name table-name)
         has-custom-pk? (some :pk? field-definitions)
         table-row      {:db_id               db-id
-                        :name                qualified-name
+                        :name                sync-table-name
                         :schema              schema
                         :display_name        (humanization/name->human-readable-name :simple table-name)
                         :description         table-comment

--- a/test/metabase/test/data/impl/get_or_create.clj
+++ b/test/metabase/test/data/impl/get_or_create.clj
@@ -147,10 +147,10 @@
                            (get-in base-type [:natives driver])
 
                            :else
-                           ;; Use the SQL type from sql.tx/field-base-type->sql-type to get
-                           ;; the actual database type (e.g., "TIMESTAMPTZ" instead of "DateTimeWithTZ").
-                           ;; Use requiring-resolve to avoid cyclic dependency.
-                           ((requiring-resolve 'metabase.test.data.sql/field-base-type->sql-type) driver base-type))
+                           ;; Use fake-sync-database-type to get the type the database reports
+                           ;; (which may differ from the DDL type used to create columns).
+                           ;; E.g., Snowflake: TEXT->VARCHAR, FLOAT->DOUBLE, INTEGER->NUMBER
+                           (tx/fake-sync-database-type driver base-type))
         actual-base-type (if (map? base-type)
                            (or effective-type :type/*)
                            base-type)

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -528,6 +528,20 @@
   [_driver]
   nil)
 
+(defmulti fake-sync-table-name
+  "Return the table name to use for fake sync Table rows.
+   Default uses `db-qualified-table-name` (e.g., 'test_data_venues') for drivers
+   that share a single database across datasets (like Redshift, Oracle).
+   Drivers with separate databases per dataset (like Snowflake) should override
+   to return just the table name."
+  {:arglists '([driver database-name table-name]), :added "0.57.0"}
+  dispatch-on-driver-with-test-extensions
+  :hierarchy #'driver/hierarchy)
+
+(defmethod fake-sync-table-name ::test-extensions
+  [_driver database-name table-name]
+  (db-qualified-table-name database-name table-name))
+
 (defn on-master-or-release-branch?
   "Returns true if running on master or a release-* branch.
    Detection methods (in priority order):

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -557,6 +557,20 @@
   ;; Default: use the DDL type (what we create columns with)
   ((requiring-resolve 'metabase.test.data.sql/field-base-type->sql-type) driver base-type))
 
+(defmulti fake-sync-base-type
+  "Return the base_type for fake sync Field rows.
+   By default returns the base-type from the test definition unchanged.
+   Drivers where the reported type differs (like Snowflake where INTEGER columns
+   are reported as NUMBER with base_type :type/Number) should override."
+  {:arglists '([driver base-type]), :added "0.57.0"}
+  dispatch-on-driver-with-test-extensions
+  :hierarchy #'driver/hierarchy)
+
+(defmethod fake-sync-base-type ::test-extensions
+  [_driver base-type]
+  ;; Default: use the base-type from the test definition unchanged
+  base-type)
+
 (defn on-master-or-release-branch?
   "Returns true if running on master or a release-* branch.
    Detection methods (in priority order):

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -571,6 +571,21 @@
   ;; Default: use the base-type from the test definition unchanged
   base-type)
 
+(defmulti fake-sync-native-base-type
+  "Return the base_type for fake sync Field rows when using native database types.
+   Called when base-type is a map like {:native \"timestamptz\"} and no effective-type
+   is specified. By default returns :type/*, but drivers should override this to
+   return the base_type that sync would actually produce for that native type.
+   For example, Snowflake should map \"timestamptz\" -> :type/DateTimeWithLocalTZ."
+  {:arglists '([driver native-type-string]), :added "0.57.0"}
+  dispatch-on-driver-with-test-extensions
+  :hierarchy #'driver/hierarchy)
+
+(defmethod fake-sync-native-base-type ::test-extensions
+  [_driver _native-type]
+  ;; Default: return :type/* for unknown native types
+  :type/*)
+
 (defn on-master-or-release-branch?
   "Returns true if running on master or a release-* branch.
    Detection methods (in priority order):


### PR DESCRIPTION
## Enable fake-sync for Snowflake driver tests

### What is fake-sync?

When tests create a dataset like `(mt/dataset test-data ...)`, we already know the schema - it's defined in the dataset definition:

```clojure
(tx/defdataset test-data
  [["venues"
    [{:field-name "name", :base-type :type/Text}
     {:field-name "category_id", :base-type :type/Integer, :fk :categories}]
    [["Red Medicine" 4] ...]]])
```

Normally after creating tables, we call `sync-database!` which queries Snowflake's `INFORMATION_SCHEMA` to discover what we just created. This is slow (~10+ min on CI!) and redundant because we already have the metadata.

**Fake-sync** skips the network calls and directly inserts Table/Field rows from the dataset definition we started with.

### Why Snowflake has custom mappings

Snowflake normalizes types differently than what we use in DDL:
- `TEXT` → reports as `VARCHAR`
- `INTEGER` → reports as `NUMBER`
- `TIMESTAMP_TZ` → reports as `TIMESTAMPTZ`

I ran real Snowflake sync against test datasets and captured all the `field → database_type → base_type` mappings. The fake-sync multimethods (`fake-sync-database-type`, `fake-sync-base-type`) reproduce exactly what real sync produces.

### How Snowflake differs from Redshift

- **Redshift**: Single shared database -> table names are prefixed: `test_data_venues`
- **Snowflake**: Separate database per dataset -> table names are plain: `venues`

This required implementing `fake-sync-table-name` to return just the table name for Snowflake.

### If a test needs real sync

~97% of tests just need Table/Field rows to exist. For tests that need fingerprints, field values, or other sync-derived metadata:

```clojure
(deftest my-test
  (mt/test-driver :snowflake
    (tx/with-driver-supports-feature! [:snowflake :test/use-fake-sync false]
      ;; This test will real sync
      ...)))
```

There isn't a risk of releasing a bug if `tx/with-driver-supports-feature!` isn't included: the test should fail if it needs to exercise the real sync implementation.

### Fingerprinting?

Fingerprinting happens as normal, tho there is ongoing work to setup fake fingerprinting as well.

### Alternatives considered

| Approach | Impact | Complexity | Chosen? |
|----------|--------|------------|---------|
| **Fake sync** | High (~10 min savings) | Medium | ✅ Yes |
| Pre-warm DBs in CI setup | Medium | High | No - doesn't help local dev |
| Skip full sync for non-test-data | Low | Low | Already implemented |
| Docker image with pre-synced DBs | High | Very High | Overkill for now |

### Changes

- Add Snowflake implementations for `fake-sync-schema`, `fake-sync-table-name`, `fake-sync-database-type`, `fake-sync-base-type`, `fake-sync-native-base-type`
- Add `:type/Number` SQL type mapping (Snowflake's `id-field-type` returns `:type/Number`)
- Tests that call `driver/describe-database` directly disable fake-sync since they query Snowflake