### PR TITLE
[QP] Move logging-only work inside the `log/*` call

### DIFF
--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -270,9 +270,8 @@
      *  The result *rows* of the query must be less than `query-caching-max-kb` when serialized (before compression)."
   [qp :- ::qp.schema/qp]
   (fn maybe-return-cached-results* [query rff]
-    (let [cacheable? (is-cacheable? query)
-          description (get-cache-eligibility-description query)]
-      (log/tracef "Query is %scacheable: %s" (if-not cacheable? "not " "") description)
+    (let [cacheable? (is-cacheable? query)]
+      (log/tracef "Query is %scacheable: %s" (if-not cacheable? "not " "") (get-cache-eligibility-description query))
       (if cacheable?
         (run-query-with-cache qp query rff)
         (qp query rff)))))


### PR DESCRIPTION
### Description

Move some logging-only computations into the `(log/* ...)` call so it won't be executed
unless the log level is sufficiently verbose for the log to actually be output.

### How to verify

Nothing visible, just better performance with log levels below `trace` in `qp.middleware.cache`.

### Checklist

- ~~Tests have been added/updated to cover changes in this PR~~
- ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
