### PR TITLE
fix: search in mini data picker only shows loading on the first load

### DIFF
--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
@@ -317,11 +317,11 @@ function SearchItemList({ query }: { query: string }) {
 
   return (
     <ItemList>
-      <Box>
-        {!isFetchingDebounced && searchResults.length === 0 && (
+      {!isFetchingDebounced && searchResults.length === 0 && (
+        <Box>
           <Text px="md" py="sm" c="text-secondary">{t`No search results`}</Text>
-        )}
-      </Box>
+        </Box>
+      )}
       {isFetchingDebounced && <MiniPickerListLoader />}
       {!isFetchingDebounced &&
         searchResults.map((item) => {
@@ -342,13 +342,11 @@ function SearchItemList({ query }: { query: string }) {
 }
 
 export const MiniPickerListLoader = () => (
-  <>
-    <Repeat times={3}>
-      <Box px="sm" py="2px">
-        <Skeleton height={35} />
-      </Box>
-    </Repeat>
-  </>
+  <Repeat times={3}>
+    <Box px="sm" py="2px">
+      <Skeleton height="2rem" />
+    </Box>
+  </Repeat>
 );
 
 const isTableInDb = (


### PR DESCRIPTION
Closes [UXW-2628: Add loading state to mini data picker search results](https://linear.app/metabase/issue/UXW-2628/add-loading-state-to-mini-data-picker-search-results)

### Description

The loader for mini data picker was using `isLoading` for displaying the loader, which only appears on the first load, not on any subsequent ones. Replaced with `isFetching` + some debounce for fast loads. Replaced the loader with skeleton.

### How to verify

1. New -> New question
2. Start typing in the data picker field

### Demo


https://github.com/user-attachments/assets/17a8011a-fd67-413c-8bf9-4f8356c72430



### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
