### PR TITLE
[Athena] Correctly recognize `:base_type` when db type is uppercase

### DIFF
--- a/modules/drivers/athena/src/metabase/driver/athena.clj
+++ b/modules/drivers/athena/src/metabase/driver/athena.clj
@@ -96,36 +96,42 @@
 
 ;;; ------------------------------------------------- sql-jdbc.sync --------------------------------------------------
 
+(def ^:private db-type->base-type
+  {:array                               :type/Array
+   :bigint                              :type/BigInteger
+   :binary                              :type/*
+   :varbinary                           :type/*
+   :boolean                             :type/Boolean
+   :char                                :type/Text
+   :date                                :type/Date
+   :decimal                             :type/Decimal
+   :double                              :type/Float
+   :float                               :type/Float
+   :integer                             :type/Integer
+   :int                                 :type/Integer
+   :uuid                                :type/UUID
+   :map                                 :type/*
+   :smallint                            :type/Integer
+   :string                              :type/Text
+   :struct                              :type/Dictionary
+   ;; Athena sort of has a time type, sort of does not. You can specify it in literals but I don't think you can store
+   ;; it.
+   :time                                :type/Time
+   :timestamp                           :type/DateTime
+   ;; Same for timestamp with time zone... the type sort of exists. You can't store it AFAIK but you can create one
+   ;; from a literal or by converting a `timestamp` column, e.g. with the `with_timezone` function.
+   (keyword "timestamp with time zone") :type/DateTimeWithZoneID
+   :tinyint                             :type/Integer
+   :varchar                             :type/Text})
+
 ;; Map of column types -> Field base types
 ;; https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC_2.0.5/docs/Simba+Athena+JDBC+Driver+Install+and+Configuration+Guide.pdf
 (defmethod sql-jdbc.sync/database-type->base-type :athena
   [_driver database-type]
-  ({:array                               :type/Array
-    :bigint                              :type/BigInteger
-    :binary                              :type/*
-    :varbinary                           :type/*
-    :boolean                             :type/Boolean
-    :char                                :type/Text
-    :date                                :type/Date
-    :decimal                             :type/Decimal
-    :double                              :type/Float
-    :float                               :type/Float
-    :integer                             :type/Integer
-    :int                                 :type/Integer
-    :uuid                                :type/UUID
-    :map                                 :type/*
-    :smallint                            :type/Integer
-    :string                              :type/Text
-    :struct                              :type/Dictionary
-    ;; Athena sort of has a time type, sort of does not. You can specify it in literals but I don't think you can store
-    ;; it.
-    :time                                :type/Time
-    :timestamp                           :type/DateTime
-    ;; Same for timestamp with time zone... the type sort of exists. You can't store it AFAIK but you can create one
-    ;; from a literal or by converting a `timestamp` column, e.g. with the `with_timezone` function.
-    (keyword "timestamp with time zone") :type/DateTimeWithZoneID
-    :tinyint                             :type/Integer
-    :varchar                             :type/Text} database-type))
+  ;; Most databases have a canonical spelling for the types returned by JDBC, and ignore the upper/lower case you type
+  ;; in eg. `CREATE TABLE` statements. However, Athena has an admin interface where the case typed by the user is what
+  ;; gets returned by JDBC calls. Therefore, lower-case the incoming `database-type` and then look up its `base-type`.
+  (-> database-type name u/lower-case-en keyword db-type->base-type))
 
 ;;; ------------------------------------------------ sql-jdbc execute ------------------------------------------------
 

--- a/modules/drivers/athena/test/metabase/driver/athena_test.clj
+++ b/modules/drivers/athena/test/metabase/driver/athena_test.clj
@@ -31,6 +31,10 @@
   [{:column_name "id", :type_name  "string"}
    {:column_name "ts", :type_name "string"}])
 
+(def ^:private upper-case-schema-columns
+  [{:column_name "id", :type_name "string"}
+   {:column_name "ts", :type_name "STRING"}])
+
 (deftest sync-test
   (testing "sync with nested fields"
     (with-redefs [athena/run-query (constantly nested-schema)]
@@ -47,7 +51,11 @@
   (testing "sync without nested fields"
     (is (= #{{:name "id", :base-type :type/Text, :database-type "string", :database-position 0}
              {:name "ts", :base-type :type/Text, :database-type "string", :database-position 1}}
-           (#'athena/describe-table-fields-without-nested-fields :athena "test" "test" flat-schema-columns)))))
+           (#'athena/describe-table-fields-without-nested-fields :athena "test" "test" flat-schema-columns))))
+  (testing "sync with upper-case letters in types (#68325)"
+    (is (= #{{:name "id", :base-type :type/Text, :database-type "string", :database-position 0}
+             {:name "ts", :base-type :type/Text, :database-type "STRING", :database-position 1}}
+           (#'athena/describe-table-fields-without-nested-fields :athena "test" "test" upper-case-schema-columns)))))
 
 (deftest ^:parallel describe-table-fields-with-nested-fields-test
   (driver/with-driver :athena


### PR DESCRIPTION
Fixes #68325.

### Description

Athena's JDBC driver returns type names with the same capitalization as
the user types into the admin interface, but the
`sql-jdbc.sync/database-type->base-type` implementation for Athena only
recognized lower-case names (which are the defaults, I gather).

I think most databases don't have this problem, since they ignore the
case you typed in e.g. `CREATE TABLE` statements and have the JDBC
driver always return the canonical spelling of the type names.

### How to verify

See the unit test. To really reproduce this, follow the repro in #68325:

1. Set up a new table in Athena
2. Let Glue crawl it
3. Edit the schema JSON in Glue's interface
4. Change the type's capitalization
5. Sync the table
6. The type is now correctly recognized regardless of upper, lower and mixed case.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
