### PR TITLE
Add back typo fix removed by merge

### DIFF
--- a/src/metabase/lib/metadata/protocols.cljc
+++ b/src/metabase/lib/metadata/protocols.cljc
@@ -19,7 +19,7 @@
   `:id` and `:name` are mutually exclusive.
 
   When fetching metadata that can be inactive/archived/hidden, only active/unarchived/unhidden objects are fetched
-  unless `:id` or `:name` is specifed.
+  unless `:id` or `:name` is specified.
 
   `:include-sensitive?` can be set to `true` to include Fields with `:visibility-type` `:sensitive` in the results."
   [:and


### PR DESCRIPTION
### Description

I used VS code for resolving merge conflicts and misread the helpfully highlighted `i`. The fix got reverted as a result. This PR brings it back again.
