### PR TITLE
Custom ref schema that reuses the cache

### DIFF
--- a/test/metabase/util/malli/registry_test.cljc
+++ b/test/metabase/util/malli/registry_test.cljc
@@ -12,7 +12,8 @@
   (testing (str "For things that aren't ever equal when you re-evaluate them (like Regex literals) maybe sure we do"
                 " something smart to avoid creating infinite cache entries")
     (let [unique-schema [:re {:id (rand)} #"\d{4}"]]
-      (is (= 1 (with-returning-cache-miss-count
+      ;; 2 misses as we cache both the Schema and validator.
+      (is (= 2 (with-returning-cache-miss-count
                  (mr/validate unique-schema "1234"))))
       (is (= 0 (with-returning-cache-miss-count
                  (mr/validate unique-schema "1234")
@@ -23,7 +24,8 @@
   (testing (str "For things that aren't ever equal when you re-evaluate them (like Regex literals) maybe sure we do"
                 " something smart to avoid creating infinite cache entries")
     (let [unique-id (rand)]
-      (is (= 1 (with-returning-cache-miss-count
+      ;; 2 misses as we cache both the Schema and validator.
+      (is (= 2 (with-returning-cache-miss-count
                  (mr/validate [:and {:id unique-id} :string [:re #"\d{4}"]] "1234"))))
       (let [validator-key-set (set (keys (:validator @@#'mr/cache)))]
         (is (contains? validator-key-set
@@ -35,7 +37,7 @@
                (mr/validate [:and {:id unique-id} :string [:re #"\d{4}"]] "1234")
                (mr/validate [:and {:id unique-id} :string [:re #"\d{4}"]] "1234")))
           "Calling validate with a previously cached schema does not miss cache")
-      (is (= 3
+      (is (= 6
              (with-returning-cache-miss-count
                ;; one
                (mr/validate [:and {:id unique-id} [:re #"\d{1}"] :string] "1234")


### PR DESCRIPTION
Malli (as of 0.2.0) will re-allocate a specialised Schema object for a reference site as well as allocating the referent's Schema. Such allocations are realised lazily as values are explored e.g. by validators or coercers.

The unique Schema object for the referent will then go on and re-allocate again for nested references,
In Malli 0.2.0 this can go on forever at runtime, resembling a memory leak.

Even without significant runtime value complexity this very quickly leads to large heap memory usage
as we retain validator roots in our cache.

---

This PR provides a custom `:ref` implementation that seeks to reduce memory usage and OOM likely-hood.

We allow references to reuse a cached Schema object if the following conditions hold:

 a. The registry is identical to the default, so a name refers to the same Schema object each time (mutable registries caveat applies to malli also, no change there)
 b. The reference itself has no attributes that specialise it (such as documentation).

This means that most refs in our schemas will incur a pointer-like incremental cost, rather than an inlining-the-whole-subgraph type exponential cost.

Work is ongoing in malli to introduce knot-ties that do limit runtime growth somewhat in cyclic cases,
However it appears we still see exponential memory scaling without this `cached-ref-schema` fix.
We should revisit the need for this override with newer versions of malli.

---

Early tests are quite positive. Take a heap dump after loading a single dashboard before + after this fix. For me, on the example dashboard, I see a before after like so:

### Before:

<img width="640" height="79" alt="image" src="https://github.com/user-attachments/assets/8dd44f16-c2bd-4229-bff5-8169e61ef8f1" />

### After

<img width="733" height="88" alt="image" src="https://github.com/user-attachments/assets/0dd197a4-212f-4df1-8b40-87d478c81513" />
