### PR TITLE
Fix mage doctor on Linux: use `which` instead of `command -v`

### DIFF
--- a/mage/src/mage/util.clj
+++ b/mage/src/mage/util.clj
@@ -198,7 +198,9 @@
 (def ^:dynamic *skip-warning* "Skips warnings for can-run?" false)
 
 (defn can-run? [cmd]
-  (try (boolean (sh (str "command -v " cmd)))
+  ;; Use "which" instead of "command -v" because "command" is a shell builtin
+  ;; that doesn't exist as a binary on Linux (only macOS has /usr/bin/command)
+  (try (boolean (sh "which" cmd))
        (catch Exception _
          (when-not *skip-warning*
            (println (c/red "MAGE checked if you can run " cmd ", but it is not installed. Consider installing it for a better experience.")))


### PR DESCRIPTION
resolves DEV-1280

## Summary
- Fixes `mage doctor` reporting all tools as "Not installed" on Linux
- `command` is a shell builtin that doesn't exist as a standalone binary on Linux (only macOS has `/usr/bin/command` as a wrapper)
- When babashka tries to execute `command -v git` directly, it fails on Linux because there's no `command` binary to run
- Using `which` instead works on both platforms since it's an actual binary

## Test plan
- [x] Verified `./bin/mage doctor` works on macOS
- [x] Test on Linux/Ubuntu to confirm fix

