### PR TITLE
fix: page hangs without a loader when saving a PDF

### DIFF
--- a/e2e/support/helpers/e2e-downloads-helpers.ts
+++ b/e2e/support/helpers/e2e-downloads-helpers.ts
@@ -47,6 +47,8 @@ export const exportFromDashcard = (format: string) => {
     cy.findByText(format).click();
     cy.findByTestId("download-results-button").click();
   });
+
+  cy.findByTestId("status-root-container").should("contain", "Downloading");
 };
 
 /**

--- a/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
+++ b/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
@@ -487,6 +487,10 @@ describe("scenarios > dashboard > download pdf", () => {
     });
 
     H.openSharingMenu("Export as PDF");
+    cy.findByTestId("status-root-container")
+      .should("contain", "Downloading")
+      .and("contain", `Dashboard for saving pdf dashboard - ${date}`);
+
     cy.log("We're adding a 'Metabase-' prefix for non-whitelabelled instances");
     cy.verifyDownload(`Metabase - saving pdf dashboard - ${date}.pdf`);
   });
@@ -511,6 +515,10 @@ describe("[snowplow] scenarios > dashboard", () => {
     }).then(({ dashboard }) => {
       H.visitDashboard(dashboard.id);
       H.openSharingMenu("Export as PDF");
+
+      cy.findByTestId("status-root-container")
+        .should("contain", "Downloading")
+        .and("contain", "Dashboard for test dashboard");
 
       H.expectUnstructuredSnowplowEvent({
         event: "dashboard_pdf_exported",

--- a/frontend/src/metabase/common/utils/wait-until-next-frame-paints.ts
+++ b/frontend/src/metabase/common/utils/wait-until-next-frame-paints.ts
@@ -1,0 +1,12 @@
+// Double rAF is needed here to ensure we actually paint the next frame.
+// First rAF will be called on the next frame BEFORE painting,
+// and the second rAF is scheduled to run AFTER the first frame is painted, but BEFORE the next frame is painted.
+export function waitUntilNextFramePainted() {
+  return new Promise<void>((resolve) => {
+    requestAnimationFrame(async () => {
+      requestAnimationFrame(async () => {
+        resolve();
+      });
+    });
+  });
+}

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/ExportAsPdfButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/ExportAsPdfButton.tsx
@@ -1,44 +1,26 @@
 import type { ButtonHTMLAttributes } from "react";
-import { match } from "ts-pattern";
 import { t } from "ttag";
 
 import { ToolbarButton } from "metabase/common/components/ToolbarButton";
-import { useHasTokenFeature } from "metabase/common/hooks";
-import {
-  type DashboardAccessedVia,
-  trackExportDashboardToPDF,
-} from "metabase/dashboard/analytics";
-import { DASHBOARD_PDF_EXPORT_ROOT_ID } from "metabase/dashboard/constants";
-import { useDashboardContext } from "metabase/dashboard/context/context";
-import { isJWT } from "metabase/lib/utils";
-import { isUuid } from "metabase/lib/uuid";
+import { useDashboardContext } from "metabase/dashboard/context";
+import { useDispatch } from "metabase/lib/redux";
+import { checkNotNull } from "metabase/lib/types";
+import { downloadDashboardToPdf } from "metabase/redux/downloads";
 import type { ActionIconProps } from "metabase/ui";
-import { saveDashboardPdf } from "metabase/visualizations/lib/save-dashboard-pdf";
 
 export const ExportAsPdfButton = (
   props: ActionIconProps & ButtonHTMLAttributes<HTMLButtonElement>,
 ) => {
   const { dashboard } = useDashboardContext();
-  const isWhitelabeled = useHasTokenFeature("whitelabel");
-  const includeBranding = !isWhitelabeled;
+  const dispatch = useDispatch();
 
   const saveAsPDF = () => {
-    const dashboardAccessedVia = match(dashboard?.id)
-      .returnType<DashboardAccessedVia>()
-      .when(isJWT, () => "static-embed")
-      .when(isUuid, () => "public-link")
-      .otherwise(() => "sdk-embed");
-
-    trackExportDashboardToPDF({
-      dashboardAccessedVia,
-    });
-
-    const cardNodeSelector = `#${DASHBOARD_PDF_EXPORT_ROOT_ID}`;
-    return saveDashboardPdf({
-      selector: cardNodeSelector,
-      dashboardName: dashboard?.name ?? t`Exported dashboard`,
-      includeBranding,
-    });
+    dispatch(
+      downloadDashboardToPdf({
+        dashboard: checkNotNull(dashboard),
+        id: Date.now(),
+      }),
+    );
   };
 
   return (

--- a/frontend/src/metabase/embedding/components/SharingMenu/MenuItems/ExportPdfMenuItem.tsx
+++ b/frontend/src/metabase/embedding/components/SharingMenu/MenuItems/ExportPdfMenuItem.tsx
@@ -1,29 +1,8 @@
-import { useHasTokenFeature } from "metabase/common/hooks";
-import { trackExportDashboardToPDF } from "metabase/dashboard/analytics";
-import { DASHBOARD_PDF_EXPORT_ROOT_ID } from "metabase/dashboard/constants";
-import { isWithinIframe } from "metabase/lib/dom";
+import { useDispatch } from "metabase/lib/redux";
+import { downloadDashboardToPdf } from "metabase/redux/downloads";
 import { Icon, Menu } from "metabase/ui";
-import {
-  getExportTabAsPdfButtonText,
-  saveDashboardPdf,
-} from "metabase/visualizations/lib/save-dashboard-pdf";
+import { getExportTabAsPdfButtonText } from "metabase/visualizations/lib/save-dashboard-pdf";
 import type { Dashboard } from "metabase-types/api";
-
-const handleClick = async (dashboard: Dashboard, includeBranding: boolean) => {
-  const cardNodeSelector = `#${DASHBOARD_PDF_EXPORT_ROOT_ID}`;
-  await saveDashboardPdf({
-    selector: cardNodeSelector,
-    dashboardName: dashboard.name,
-    includeBranding,
-  }).then(() => {
-    trackExportDashboardToPDF({
-      dashboardId: dashboard.id,
-      dashboardAccessedVia: isWithinIframe()
-        ? "interactive-iframe-embed"
-        : "internal",
-    });
-  });
-};
 
 export const ExportPdfMenuItem = ({
   dashboard,
@@ -32,14 +11,22 @@ export const ExportPdfMenuItem = ({
   dashboard: Dashboard;
   loading?: boolean;
 }) => {
-  const isWhitelabeled = useHasTokenFeature("whitelabel");
-  const includeBranding = !isWhitelabeled;
+  const dispatch = useDispatch();
+
+  const handleClick = async () => {
+    dispatch(
+      downloadDashboardToPdf({
+        dashboard,
+        id: Date.now(),
+      }),
+    );
+  };
 
   return (
     <Menu.Item
       data-testid="dashboard-export-pdf-button"
       leftSection={<Icon name="document" />}
-      onClick={() => handleClick(dashboard, includeBranding)}
+      onClick={handleClick}
       disabled={loading}
       style={loading ? { cursor: "wait" } : undefined}
     >

--- a/frontend/src/metabase/redux/downloads.ts
+++ b/frontend/src/metabase/redux/downloads.ts
@@ -1,19 +1,32 @@
-import { createAction, createSlice } from "@reduxjs/toolkit";
+import {
+  createSlice,
+  isAnyOf,
+  isFulfilled,
+  isPending,
+  isRejected,
+} from "@reduxjs/toolkit";
 import { t } from "ttag";
 import _ from "underscore";
 
+import { waitUntilNextFramePainted } from "metabase/common/utils/wait-until-next-frame-paints";
+import { trackExportDashboardToPDF } from "metabase/dashboard/analytics";
+import { DASHBOARD_PDF_EXPORT_ROOT_ID } from "metabase/dashboard/constants";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import api, { GET, POST } from "metabase/lib/api";
 import { isWithinIframe, openSaveDialog } from "metabase/lib/dom";
 import { createAsyncThunk } from "metabase/lib/redux";
 import { checkNotNull } from "metabase/lib/types";
 import * as Urls from "metabase/lib/urls";
+import { isJWT } from "metabase/lib/utils";
+import { isUuid } from "metabase/lib/uuid";
 import { getTokenFeature } from "metabase/setup/selectors";
 import { saveChartImage } from "metabase/visualizations/lib/save-chart-image";
+import { saveDashboardPdf } from "metabase/visualizations/lib/save-dashboard-pdf";
 import { getCardKey } from "metabase/visualizations/lib/utils";
 import type Question from "metabase-lib/v1/Question";
 import type {
   DashCardId,
+  Dashboard,
   DashboardId,
   Dataset,
   VisualizationSettings,
@@ -138,13 +151,75 @@ const getDownloadedResourceType = ({
   };
 };
 
-export const DOWNLOAD_TO_IMAGE = "metabase/downloads/DOWNLOAD_TO_IMAGE";
-export const downloadToImage = createAction<boolean>(DOWNLOAD_TO_IMAGE);
+export const downloadToImage = createAsyncThunk(
+  "metabase/downloads/downloadToImage",
+  async (
+    {
+      opts: { question, dashcardId },
+      id,
+    }: { opts: DownloadQueryResultsOpts; id: number },
+    { getState },
+  ) => {
+    const isWhitelabeled = getTokenFeature(getState(), "whitelabel");
+    const includeBranding = !isWhitelabeled;
+    const fileName = getChartFileName(question, includeBranding);
+
+    const chartSelector =
+      dashcardId != null
+        ? `[data-dashcard-key='${dashcardId}']`
+        : `[data-card-key='${getCardKey(question.id())}']`;
+
+    // Long-running main thread blocking operation incoming; wait until the loader is painted.
+    await waitUntilNextFramePainted();
+
+    await saveChartImage({
+      selector: chartSelector,
+      fileName,
+      includeBranding,
+    });
+
+    return { id, fileName };
+  },
+);
+
+export const downloadDashboardToPdf = createAsyncThunk(
+  "metabase/downloads/downloadDashboardToPdf",
+  async (
+    { dashboard, id }: { dashboard: Dashboard; id: number },
+    { getState },
+  ) => {
+    const isWhitelabeled = getTokenFeature(getState(), "whitelabel");
+    const includeBranding = !isWhitelabeled;
+    const cardNodeSelector = `#${DASHBOARD_PDF_EXPORT_ROOT_ID}`;
+    const fileName = getDashboardPdfFileName(dashboard, includeBranding);
+
+    // Long-running main thread blocking operation incoming; wait until the loader is painted.
+    await waitUntilNextFramePainted();
+
+    await saveDashboardPdf({
+      fileName,
+      selector: cardNodeSelector,
+      dashboardName: dashboard.name,
+      includeBranding,
+    });
+
+    trackExportDashboardToPDF({
+      dashboardId: dashboard.id,
+      dashboardAccessedVia: getAccessedVia(
+        isUuid(dashboard.id),
+        isJWT(dashboard.id),
+      ),
+    });
+
+    return { id, fileName };
+  },
+);
 
 export const downloadQueryResults = createAsyncThunk(
   "metabase/downloads/downloadQueryResults",
-  async (opts: DownloadQueryResultsOpts, { dispatch, getState }) => {
+  async (opts: DownloadQueryResultsOpts, { dispatch }) => {
     const { resourceType, accessedVia } = getDownloadedResourceType(opts);
+
     trackDownloadResults({
       resourceType,
       accessedVia,
@@ -152,51 +227,23 @@ export const downloadQueryResults = createAsyncThunk(
     });
 
     if (opts.type === Urls.exportFormatPng) {
-      dispatch(downloadToImage(true));
-
-      const isWhitelabeled = getTokenFeature(getState(), "whitelabel");
-      const includeBranding = !isWhitelabeled;
-      try {
-        await downloadChart({ opts, includeBranding });
-      } finally {
-        dispatch(downloadToImage(false));
-      }
+      await dispatch(downloadToImage({ opts, id: Date.now() }));
     } else {
       await dispatch(downloadDataset({ opts, id: Date.now() }));
     }
   },
 );
 
-const downloadChart = async ({
-  opts,
-  includeBranding,
-}: {
-  opts: DownloadQueryResultsOpts;
-  includeBranding: boolean;
-}) => {
-  const { question, dashcardId } = opts;
-  const fileName = getChartFileName(question, includeBranding);
-  const chartSelector =
-    dashcardId != null
-      ? `[data-dashcard-key='${dashcardId}']`
-      : `[data-card-key='${getCardKey(question.id())}']`;
-  await saveChartImage({
-    selector: chartSelector,
-    fileName,
-    includeBranding,
-  });
-};
-
 export const downloadDataset = createAsyncThunk(
   "metabase/downloads/downloadDataset",
   async ({ opts, id }: { opts: DownloadQueryResultsOpts; id: number }) => {
     const params = getDatasetParams(opts);
     const response = await getDatasetResponse(params);
-    const name = getDatasetFileName(response.headers, opts.type);
+    const fileName = getDatasetFileName(response.headers, opts.type);
     const fileContent = await response.blob();
-    openSaveDialog(name, fileContent);
+    openSaveDialog(fileName, fileContent);
 
-    return { id, name };
+    return { id, fileName };
   },
 );
 
@@ -547,6 +594,18 @@ export const getChartFileName = (question: Question, branded: boolean) => {
   return branded ? `Metabase-${fileName}` : fileName;
 };
 
+export const getDashboardPdfFileName = (
+  dashboard: Dashboard,
+  branded: boolean,
+) => {
+  const originalFileName = `${dashboard.name}.pdf`;
+  const fileName = branded
+    ? // eslint-disable-next-line no-literal-metabase-strings -- Used explicitly in non-whitelabeled instances
+      `Metabase - ${originalFileName}`
+    : originalFileName;
+  return fileName;
+};
+
 export const getDownloads = (state: State) => state.downloads.datasetRequests;
 export const hasActiveDownloads = (state: State) =>
   state.downloads.datasetRequests.some(
@@ -570,38 +629,68 @@ const downloads = createSlice({
   extraReducers: (builder) => {
     builder
       .addCase(downloadDataset.pending, (state, action) => {
-        const title = t`Results for ${
-          action.meta.arg.opts.question.card().name
-        }`;
         state.datasetRequests.push({
           id: action.meta.arg.id,
-          title,
+          title: t`Results for ${action.meta.arg.opts.question.card().name}`,
           status: "in-progress",
         });
       })
-      .addCase(downloadDataset.fulfilled, (state, action) => {
-        const download = state.datasetRequests.find(
-          (item) => item.id === action.meta.arg.id,
-        );
-        if (download) {
-          download.status = "complete";
-          download.title = action.payload.name;
-        }
+      .addCase(downloadDashboardToPdf.pending, (state, action) => {
+        state.datasetRequests.push({
+          id: action.meta.arg.id,
+          title: t`Dashboard for ${action.meta.arg.dashboard.name}`,
+          status: "in-progress",
+        });
       })
-      .addCase(downloadDataset.rejected, (state, action) => {
-        const download = state.datasetRequests.find(
-          (item) => item.id === action.meta.arg.id,
-        );
-        if (download) {
-          download.status = "error";
-          download.error =
-            action.error.message ?? t`Could not download the file`;
-        }
-      });
+      .addCase(downloadToImage.pending, (state, action) => {
+        state.datasetRequests.push({
+          id: action.meta.arg.id,
+          title: t`Image for ${action.meta.arg.opts.question.card().name}`,
+          status: "in-progress",
+        });
+      })
+      .addMatcher(
+        isFulfilled(downloadDataset, downloadDashboardToPdf, downloadToImage),
+        (state, action) => {
+          const download = state.datasetRequests.find(
+            (item) => item.id === action.meta.arg.id,
+          );
+          if (download) {
+            download.status = "complete";
+            download.title = action.payload.fileName;
+          }
+        },
+      )
+      .addMatcher(
+        isRejected(downloadDataset, downloadDashboardToPdf, downloadToImage),
+        (state, action) => {
+          const download = state.datasetRequests.find(
+            (item) => item.id === action.meta.arg.id,
+          );
+          if (download) {
+            download.status = "error";
+            download.error =
+              action.error.message ?? t`Could not download the file`;
+          }
+        },
+      );
 
-    builder.addCase(downloadToImage, (state, action) => {
-      state.isDownloadingToImage = action.payload;
-    });
+    builder
+      .addMatcher(
+        isPending(downloadDashboardToPdf, downloadToImage),
+        (state) => {
+          state.isDownloadingToImage = true;
+        },
+      )
+      .addMatcher(
+        isAnyOf(
+          isRejected(downloadDashboardToPdf, downloadToImage),
+          isFulfilled(downloadDashboardToPdf, downloadToImage),
+        ),
+        (state) => {
+          state.isDownloadingToImage = false;
+        },
+      );
   },
 });
 

--- a/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
+++ b/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
@@ -152,6 +152,7 @@ const PARAMETERS_MARGIN_BOTTOM = 12;
 const PAGE_PADDING = 16;
 
 interface SavePdfProps {
+  fileName: string;
   selector: string;
   dashboardName: string;
   includeBranding: boolean;
@@ -170,16 +171,11 @@ async function isValidColor(str: string) {
 }
 
 export const saveDashboardPdf = async ({
+  fileName,
   selector,
   dashboardName,
   includeBranding,
 }: SavePdfProps) => {
-  const originalFileName = `${dashboardName}.pdf`;
-  const fileName = includeBranding
-    ? // eslint-disable-next-line no-literal-metabase-strings -- Used explicitly in non-whitelabeled instances
-      `Metabase - ${originalFileName}`
-    : originalFileName;
-
   const dashboardRoot = document.querySelector(selector);
   const gridNode = dashboardRoot?.querySelector(".react-grid-layout");
 


### PR DESCRIPTION
Closes [UXW-2637: Show a Loading indicator for dashboard PNG + PDF Exports](https://linear.app/metabase/issue/UXW-2637/show-a-loading-indicator-for-dashboard-png-pdf-exports)

### Description

Since PDF exports can take a long time, we should show a Loading indicator for dashboard exports.
Some trickery with double-rAF was required to make sure the loader is actually painted before the long-running main thread PDF export starts.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Go to a dashboard
2. Click "Sharing" in the header
3. Click "Export as PDF"

### Demo

https://github.com/user-attachments/assets/e034cb3e-9324-4925-a5a5-0db58b710b61

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
