### PR TITLE
Streaming API response schema for documentation

### DIFF
--- a/src/metabase/api/macros/defendpoint/open_api.clj
+++ b/src/metabase/api/macros/defendpoint/open_api.clj
@@ -131,9 +131,17 @@
 (mu/defn- schema->response-obj :- [:maybe :metabase.api.open-api/path-item.responses]
   "Convert a Malli schema to an OpenAPI response schema.
 
-  This is used to convert the `:response-schema` in [[metabase.api.macros/defendpoint]] to an OpenAPI response schema."
+  This is used to convert the `:response-schema` in [[metabase.api.macros/defendpoint]] to an OpenAPI response schema.
+
+  If the schema has `:openapi/response-schema` in its properties (e.g., for streaming responses), that schema
+  is used for documentation instead of the actual schema. This allows streaming endpoints to document the
+  JSON content they return while validating that the return value is a StreamingResponse instance."
   [schema]
-  (let [jss-schema (mjs-collect-definitions schema)]
+  (let [resolved-schema (mr/resolve-schema schema)
+        ;; Check for :openapi/response-schema in the schema properties - used by ms/StreamingResponse
+        content-schema  (or (-> resolved-schema mc/properties :openapi/response-schema)
+                            schema)
+        jss-schema      (mjs-collect-definitions content-schema)]
     {"2XX" (-> {:description (or (:description jss-schema) "Successful response")}
                (assoc :content {"application/json" {:schema (fix-json-schema jss-schema)}}))}))
 

--- a/src/metabase/api/macros/defendpoint/open_api.clj
+++ b/src/metabase/api/macros/defendpoint/open_api.clj
@@ -138,7 +138,7 @@
   JSON content they return while validating that the return value is a StreamingResponse instance."
   [schema]
   (let [resolved-schema (mr/resolve-schema schema)
-        ;; Check for :openapi/response-schema in the schema properties - used by ms/StreamingResponse
+        ;; Check for :openapi/response-schema in the schema properties - used by server/streaming-response-schema
         content-schema  (or (-> resolved-schema mc/properties :openapi/response-schema)
                             schema)
         jss-schema      (mjs-collect-definitions content-schema)]

--- a/src/metabase/query_processor/api.clj
+++ b/src/metabase/query_processor/api.clj
@@ -90,12 +90,12 @@
           (qp/process-query (update query :info merge info) rff))))))
 
 (api.macros/defendpoint :post "/"
+  :- (server/streaming-response-schema ::qp.schema/query-result)
   "Execute a query and retrieve the results in the usual format. The query will not use the cache."
   [_route-params
    _query-params
    query :- [:map
              [:database {:optional true} [:maybe :int]]]]
-  :- (server/streaming-response-schema ::qp.schema/query-result)
   (run-streaming-query
    (-> query
        (update-in [:middleware :js-int-to-string?] (fnil identity true))
@@ -122,6 +122,7 @@
     (keyword json-key)))
 
 (api.macros/defendpoint :post ["/:export-format", :export-format qp.schema/export-formats-regex]
+  :- (server/streaming-response-schema ::qp.schema/query-result)
   "Execute a query and download the result data as a file in the specified format."
   [{:keys [export-format]} :- [:map
                                [:export-format ::qp.schema/export-format]]
@@ -143,7 +144,6 @@
                                                                 (string? x) (json/decode viz-setting-key-fn)))}]]
        [:format_rows            {:default false} ms/BooleanValue]
        [:pivot_results          {:default false} ms/BooleanValue]]]
-  :- (server/streaming-response-schema ::qp.schema/query-result)
   (let [viz-settings                  (-> visualization-settings
                                           mi/normalize-visualization-settings
                                           mb.viz/norm->db)
@@ -208,12 +208,12 @@
         pretty (update :query prettify)))))
 
 (api.macros/defendpoint :post "/pivot"
+  :- (server/streaming-response-schema ::qp.schema/query-result)
   "Generate a pivoted dataset for an ad-hoc query"
   [_route-params
    _query-params
    {:keys [database] :as query} :- [:map
                                     [:database ms/PositiveInt]]]
-  :- (server/streaming-response-schema ::qp.schema/query-result)
   (api/read-check :model/Database database)
   (let [info {:executed-by api/*current-user-id*
               :context     :ad-hoc}]

--- a/src/metabase/query_processor/schema.clj
+++ b/src/metabase/query_processor/schema.clj
@@ -104,11 +104,11 @@
    [:row_count              :int]
    [:data                   {:optional true} ::query-result.data]
    [:running_time           {:optional true} :int]
-   [:started_at             {:optional true} :any]
+   [:started_at             {:optional true} :string]
    [:database_id            {:optional true} ::lib.schema.id/database]
    [:json_query             {:optional true} :map]
    [:average_execution_time {:optional true} [:maybe :int]]
    [:context                {:optional true} :any]
-   [:cached                 {:optional true} [:maybe :any]]
+   [:cached                 {:optional true} [:maybe :string]]
    [:error                  {:optional true} :string]
    [:error_type             {:optional true} :keyword]])

--- a/src/metabase/query_processor/schema.clj
+++ b/src/metabase/query_processor/schema.clj
@@ -80,3 +80,35 @@
 (mr/def ::result-metadata.columns
   "A sequence of result metadata columns as returned by the Query Processor."
   [:sequential ::result-metadata.column])
+
+;;; ------------------------------------------------ Query Results -------------------------------------------------
+
+(mr/def ::query-result.data
+  "Schema for the :data key of query results."
+  [:map
+   [:cols              [:sequential ::result-metadata.column]]
+   [:rows              [:sequential [:sequential :any]]]
+   [:native_form       {:optional true} :map]
+   [:results_timezone  {:optional true} :string]
+   [:results_metadata  {:optional true} [:map
+                                         [:columns [:sequential ::result-metadata.column]]]]
+   [:insights          {:optional true} [:sequential :map]]
+   [:download_perms    {:optional true} :string]
+   [:is_sandboxed      {:optional true} :boolean]
+   [:format-rows?      {:optional true} :boolean]])
+
+(mr/def ::query-result
+  "Schema for query execution results returned by the Query Processor."
+  [:map
+   [:status                 [:enum :completed :failed]]
+   [:row_count              :int]
+   [:data                   {:optional true} ::query-result.data]
+   [:running_time           {:optional true} :int]
+   [:started_at             {:optional true} :any]
+   [:database_id            {:optional true} ::lib.schema.id/database]
+   [:json_query             {:optional true} :map]
+   [:average_execution_time {:optional true} [:maybe :int]]
+   [:context                {:optional true} :any]
+   [:cached                 {:optional true} [:maybe :any]]
+   [:error                  {:optional true} :string]
+   [:error_type             {:optional true} :keyword]])

--- a/src/metabase/server/core.clj
+++ b/src/metabase/server/core.clj
@@ -8,13 +8,15 @@
    [metabase.server.middleware.json]
    [metabase.server.protocols]
    [metabase.server.routes]
+   [metabase.server.streaming-response]
    [potemkin :as p]))
 
 (comment
   metabase.server.handler/keep-me
   metabase.server.instance/keep-me
   metabase.server.protocols/keep-me
-  metabase.server.routes/keep-me)
+  metabase.server.routes/keep-me
+  metabase.server.streaming-response/keep-me)
 
 (p/import-vars
  [metabase.server.handler
@@ -30,4 +32,6 @@
   make-routes]
  [metabase.server.middleware.json
   wrap-json-body
-  wrap-streamed-json-response])
+  wrap-streamed-json-response]
+ [metabase.server.streaming-response
+  streaming-response-schema])

--- a/src/metabase/server/streaming_response.clj
+++ b/src/metabase/server/streaming_response.clj
@@ -328,7 +328,8 @@
   "Malli schema for a streaming HTTP response that will contain JSON matching `content-schema`.
 
   At runtime, validates that the response is a StreamingResponse instance.
-  For OpenAPI documentation, uses `content-schema` to describe the JSON response body.
+  WARNING: DOES NOT VALIDATE the actual data being streamed at runtime. For OpenAPI documentation, uses `content-schema`
+  to describe the JSON response body.
 
   Example:
     (api.macros/defendpoint :post \"/query\"
@@ -340,5 +341,6 @@
   [content-schema]
   [:fn
    {:openapi/response-schema content-schema
-    :description             "Streaming JSON response"}
+    :description             "Streaming JSON response"
+    :error/message           "Non-streaming response returned from streaming endpoint"}
    #(instance? StreamingResponse %)])

--- a/src/metabase/server/streaming_response.clj
+++ b/src/metabase/server/streaming_response.clj
@@ -321,3 +321,24 @@
   {:pre [(= (count bindings) 2)]}
   `(-streaming-response (bound-fn [~(vary-meta os-binding assoc :tag 'java.io.OutputStream) ~canceled-chan-binding] ~@body)
                         ~options))
+
+;;;; Malli schema for StreamingResponse
+
+(defn streaming-response-schema
+  "Malli schema for a streaming HTTP response that will contain JSON matching `content-schema`.
+
+  At runtime, validates that the response is a StreamingResponse instance.
+  For OpenAPI documentation, uses `content-schema` to describe the JSON response body.
+
+  Example:
+    (api.macros/defendpoint :post \"/query\"
+      :- (server/streaming-response-schema
+           [:map
+            [:data [:map [:cols sequential?] [:rows sequential?]]]
+            [:row_count :int]])
+      ...)"
+  [content-schema]
+  [:fn
+   {:openapi/response-schema content-schema
+    :description             "Streaming JSON response"}
+   #(instance? StreamingResponse %)])

--- a/test/metabase/api/macros/defendpoint/open_api_test.clj
+++ b/test/metabase/api/macros/defendpoint/open_api_test.clj
@@ -5,6 +5,7 @@
    [malli.json-schema :as mjs]
    [metabase.api.macros.defendpoint.open-api :as defendpoint.open-api]
    [metabase.lib.schema.common :as lib.schema.common]
+   [metabase.server.core :as server]
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]))
 
@@ -80,3 +81,21 @@
                   :body []}
             result (#'defendpoint.open-api/path-item "/api/upload" form)]
         (is (true? (:deprecated result)))))))
+
+(deftest ^:parallel streaming-response-schema-test
+  (testing "server/streaming-response-schema uses content schema for OpenAPI docs"
+    (binding [defendpoint.open-api/*definitions* (atom (sorted-map))]
+      (let [content-schema [:map
+                            [:data [:map [:cols [:sequential :any]] [:rows [:sequential :any]]]]
+                            [:row_count :int]
+                            [:status [:enum "completed" "failed"]]]
+            response-schema (server/streaming-response-schema content-schema)
+            result (#'defendpoint.open-api/schema->response-obj response-schema)]
+        (testing "generates 2XX response"
+          (is (contains? result "2XX")))
+        (testing "uses content schema properties, not StreamingResponse fn"
+          (let [json-schema (get-in result ["2XX" :content "application/json" :schema])]
+            (is (= :object (:type json-schema)))
+            (is (contains? (:properties json-schema) "data"))
+            (is (contains? (:properties json-schema) "row_count"))
+            (is (contains? (:properties json-schema) "status"))))))))


### PR DESCRIPTION
Resolves [DEV-1279](https://linear.app/metabase/issue/DEV-1279/add-malli-response-schemas-for-streaming-query-endpoints)

POC of a way to attach Malli schemas to streaming endpoints, for the purpose of OpenAPI documentation generation. Adds a `streaming-response-schema` function which generates a Malli schema which:
- Validates that a streaming endpoint correctly returns a `StreamingResponse` instance
- Attaches a `:openapi/response-schema` key to the schema properties which contains the schema to use for generating documentation

I've also added basic schemas for some of our query execution endpoints as usage examples. Not 100% sure this is all accurate so I'm definitely open to corrections here (but there shouldn't be risk if there's wrong aside from incorrect documentation).

See [this thread](https://metaboat.slack.com/archives/CKZEMT1MJ/p1768841529710479) for some relevant discussion.