### PR TITLE
Compute fingerprints from in-memory test data for fake sync

### DIFF
--- a/test/metabase/test/data/impl/get_or_create.clj
+++ b/test/metabase/test/data/impl/get_or_create.clj
@@ -295,7 +295,12 @@
             (t2/update! :model/Field (:id db-field)
                         {:fingerprint         fp
                          :fingerprint_version version
-                         :last_analyzed       (t/offset-date-time)})))))))
+                         :last_analyzed       (t/offset-date-time)})
+            ;; Verify the fingerprint was saved correctly (debug assertion)
+            (let [saved-field (t2/select-one :model/Field :id (:id db-field))]
+              (when-not (= fp (:fingerprint saved-field))
+                (log/errorf "FINGERPRINT MISMATCH! Expected: %s, Got: %s"
+                            (pr-str fp) (pr-str (:fingerprint saved-field))))))))))))
 
 (defn- fake-fingerprint-database!
   "Compute and save fingerprints for all tables in a database definition using in-memory test data."

--- a/test/metabase/test/data/impl/get_or_create.clj
+++ b/test/metabase/test/data/impl/get_or_create.clj
@@ -300,7 +300,7 @@
             (let [saved-field (t2/select-one :model/Field :id (:id db-field))]
               (when-not (= fp (:fingerprint saved-field))
                 (log/errorf "FINGERPRINT MISMATCH! Expected: %s, Got: %s"
-                            (pr-str fp) (pr-str (:fingerprint saved-field))))))))))))
+                            (pr-str fp) (pr-str (:fingerprint saved-field)))))))))))
 
 (defn- fake-fingerprint-database!
   "Compute and save fingerprints for all tables in a database definition using in-memory test data."

--- a/test/metabase/test/data/impl/get_or_create.clj
+++ b/test/metabase/test/data/impl/get_or_create.clj
@@ -271,7 +271,8 @@
   [db-id database-name {:keys [table-name field-definitions rows]}]
   (when (seq rows)
     (let [qualified-name  (tx/db-qualified-table-name database-name table-name)
-          qualified-table (t2/select-one :model/Table :db_id db-id :name qualified-name)
+          ;; Use case-insensitive lookup to handle databases that normalize names differently
+          qualified-table (t2/select-one :model/Table :db_id db-id :%lower.name (u/lower-case-en qualified-name))
           fingerprints    (compute-fingerprints-from-rows field-definitions rows)
           version         @(requiring-resolve 'metabase.sync.interface/*latest-fingerprint-version*)]
       (when qualified-table


### PR DESCRIPTION
## Summary

For drivers using fake sync (e.g., Redshift), compute fingerprints from the in-memory test data rows instead of querying the database. This avoids network round-trips while still exercising the real fingerprinting code (HyperLogLog, histograms, etc.).

**Changes:**
- Converts FieldDefinitions to Field-like maps for fingerprinter dispatch
- Runs the actual fingerprinting transducers on dbdef rows
- Saves fingerprints to the Field table with proper version/timestamp

This is a follow-up to the fake sync work in PR #67603.

## Test plan

- [x] REPL testing confirmed fingerprints are computed correctly for Text, Number, DateTime, FK, and PK fields
- [x] CI passes
- [ ] Redshift tests still work correctly