### PR TITLE
fix: python tests failing when client on same thread

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/transforms_python/transforms_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_python/transforms_api_test.clj
@@ -159,7 +159,7 @@
     :else (recur (rest xs) ys)))
 
 (defn- get-last-run [transform-id]
-  (:last_run (mt/user-http-request :crowberto :get 200 (format "ee/transform/%d" transform-id))))
+  (:last_run (mt/user-real-request :crowberto :get 200 (format "ee/transform/%d" transform-id))))
 
 (defn- open-message-value-observer
   "Polls the `:message` state of the last run and stores the value every time it is different to the last observation.
@@ -199,7 +199,7 @@
 
           (create-transform [{:keys [program]} target]
             {:post [(integer? %)]}
-            (:id (mt/user-http-request :crowberto :post 200 "ee/transform"
+            (:id (mt/user-real-request :crowberto :post 200 "ee/transform"
                                        {:name   "Python logging test"
                                         :source {:type            "python"
                                                  :body            (program->source program)


### PR DESCRIPTION
### Description

Describe the overall approach and the problem being solved.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> ...
2. ...

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
