### PR TITLE
Fix tracking event never set to default in embed

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
@@ -12,10 +12,7 @@ const { H } = cy;
 const DASHBOARD_NAME = "Orders in a dashboard";
 const QUESTION_NAME = "Orders, Count";
 
-const suiteTitle =
-  "scenarios > embedding > sdk iframe embed setup > get code step";
-
-describe(suiteTitle, () => {
+describe("scenarios > embedding > sdk iframe embed setup > get code step", () => {
   beforeEach(() => {
     H.restore();
     H.resetSnowplow();
@@ -157,6 +154,18 @@ describe(suiteTitle, () => {
         event_detail:
           "experience=dashboard,snippetType=frontend,authSubType=user-session",
       });
+    });
+  });
+
+  it("should track embed_wizard_options_completed with settings=default properly (metabase#68285)", () => {
+    navigateToGetCodeStep({
+      experience: "chart",
+      resourceName: QUESTION_NAME,
+    });
+
+    H.expectUnstructuredSnowplowEvent({
+      event: "embed_wizard_options_completed",
+      event_detail: "settings=default",
     });
   });
 

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-default-sdk-iframe-embed-setting.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-default-sdk-iframe-embed-setting.ts
@@ -63,6 +63,7 @@ export const getDefaultSdkIframeEmbedSettings = ({
         withDownloads: false,
         withTitle: true,
         isSaveEnabled: false,
+        initialSqlParameters: {},
       }),
     )
     .with(

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-default-sdk-iframe-embed-setting.unit.spec.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-default-sdk-iframe-embed-setting.unit.spec.ts
@@ -43,6 +43,7 @@ describe("getDefaultSdkIframeEmbedSettings", () => {
         withDownloads: false,
         withTitle: true,
         isSaveEnabled: false,
+        initialSqlParameters: {},
       },
     },
     {


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #68285
Closes [EMB-1207: Modular embedding analytics never track charts as using default settings when nothing is changed](https://linear.app/metabase/issue/EMB-1207/modular-embedding-analytics-never-track-charts-as-using-default)

### Description

When selecting a question in a new embed, the settings would contain `initialSqlParameters: {}`, but this wasn't present in the initial settings. That made tracking always consider that somethig had been changed.

### How to verify

1. Run MB with `MB_LOG_ANALYTICS=true`
2. New embed -> chart
3. Select a question (not the default one)
4. Go all the way until you can click on "Get code"
5. Check `http://localhost:9090/micro/good`, you should see an event like `{"event":"embed_wizard_options_completed","event_detail":"settings=default"}`

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
