### PR TITLE
Restore future in mock client calls so that interrupts are isolated from caller

### DIFF
--- a/test/metabase/test/http_client.clj
+++ b/test/metabase/test/http_client.clj
@@ -455,7 +455,12 @@
   [& args]
   (let [parsed (parse-http-client-args args)]
     (log/trace parsed)
-    (-mock-client parsed)))
+    ;; despite no timeout, it is still important to run the server logic in a future, to ensure any server-set .interrupted flag
+    ;; does not influence subsequent client calls.
+    (try
+      @(future (-mock-client parsed))
+      (catch java.util.concurrent.ExecutionException ex
+        (throw (ex-cause ex))))))
 
 (defn client-real-response
   "Identical to `real-client` except returns the full HTTP response map, not just the body of the response."


### PR DESCRIPTION
An intentional server side .interrupt might leak and cause subsequent code to fail.

Prior to https://github.com/metabase/metabase/pull/65872 the client-full-response used a with-timeout, which incidentally put the http handler in a future (isolating the interrupt).

This PR restores the previous future behaviour, in a more intentional way.