### PR TITLE
Gdgt 1273 add snowplow events to bulk metadata features

### DIFF
--- a/e2e/test/scenarios/data-studio/data-model/data-studio-bulk-table.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-model/data-studio-bulk-table.cy.spec.ts
@@ -22,6 +22,7 @@ interface Table {
 describe("bulk table operations", () => {
   beforeEach(() => {
     H.restore();
+    H.resetSnowplow();
     cy.signInAsAdmin();
     H.activateToken("bleeding-edge");
     cy.intercept("POST", "/api/ee/data-studio/table/sync-schema").as(
@@ -63,6 +64,9 @@ describe("bulk table operations", () => {
     cy.findByRole("heading", { name: /2 tables selected/ });
 
     cy.findByRole("button", { name: /Sync settings/ }).click();
+    H.expectUnstructuredSnowplowEvent({
+      event: "data_studio_bulk_sync_settings_clicked",
+    });
     cy.findByRole("button", { name: /Sync table schemas/ }).click();
     cy.findByRole("button", { name: /Sync triggered!/ }).should("be.visible");
     cy.get<number[]>("@tableIds").then((tableIds) => {
@@ -72,6 +76,10 @@ describe("bulk table operations", () => {
           expect(response?.statusCode).to.eq(204);
         },
       );
+    });
+    H.expectUnstructuredSnowplowEvent({
+      event: "data_studio_table_schema_synced",
+      result: "success",
     });
 
     cy.findByRole("button", { name: /Re-scan tables/ }).click();
@@ -85,6 +93,10 @@ describe("bulk table operations", () => {
         },
       );
     });
+    H.expectUnstructuredSnowplowEvent({
+      event: "data_studio_table_fields_rescanned",
+      result: "success",
+    });
 
     cy.findByRole("button", { name: /Discard cached field values/ }).click();
     cy.findByRole("button", { name: /Discard triggered!/ }).should(
@@ -97,6 +109,10 @@ describe("bulk table operations", () => {
         expect(request.body.table_ids).to.deep.eq(tableIds);
         expect(response?.statusCode).to.eq(204);
       });
+    });
+    H.expectUnstructuredSnowplowEvent({
+      event: "data_studio_table_field_values_discarded",
+      result: "success",
     });
   });
 
@@ -134,6 +150,9 @@ describe("bulk table operations", () => {
       cy.findByRole("button", { name: /Unpublish/ }).click();
       H.modal().findByText("Unpublish these tables").click();
       cy.wait("@unpublishTables");
+      H.expectUnstructuredSnowplowEvent({
+        event: "data_studio_table_unpublished",
+      });
       H.DataStudio.nav().findByLabelText("Library").click();
 
       H.DataStudio.Library.libraryPage().within(() => {
@@ -155,15 +174,35 @@ describe("bulk table operations", () => {
 
     H.selectHasValue("Owner", "").click();
     H.selectDropdown().contains("Bobby Tables").click();
+    H.expectUnstructuredSnowplowEvent({
+      event: "data_studio_bulk_attribute_updated",
+      event_detail: "owner",
+      result: "success",
+    });
 
     H.selectHasValue("Visibility type", "").click();
     H.selectDropdown().contains("Gold").click();
+    H.expectUnstructuredSnowplowEvent({
+      event: "data_studio_bulk_attribute_updated",
+      event_detail: "layer",
+      result: "success",
+    });
 
     H.selectHasValue("Entity type", "").click();
     H.selectDropdown().contains("Person").click();
+    H.expectUnstructuredSnowplowEvent({
+      event: "data_studio_bulk_attribute_updated",
+      event_detail: "entity_type",
+      result: "success",
+    });
 
     H.selectHasValue("Source", "").click();
     H.selectDropdown().contains("Ingested").click();
+    H.expectUnstructuredSnowplowEvent({
+      event: "data_studio_bulk_attribute_updated",
+      event_detail: "data_source",
+      result: "success",
+    });
     H.undoToastList().should("have.length", 4);
     TablePicker.getTable("Orders")
       .findByTestId("table-owner")

--- a/e2e/test/scenarios/data-studio/data-model/data-studio-bulk-table.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-model/data-studio-bulk-table.cy.spec.ts
@@ -78,7 +78,7 @@ describe("bulk table operations", () => {
       );
     });
     H.expectUnstructuredSnowplowEvent({
-      event: "data_studio_table_schema_synced",
+      event: "data_studio_table_schema_sync_started",
       result: "success",
     });
 
@@ -94,7 +94,7 @@ describe("bulk table operations", () => {
       );
     });
     H.expectUnstructuredSnowplowEvent({
-      event: "data_studio_table_fields_rescanned",
+      event: "data_studio_table_fields_rescan_started",
       result: "success",
     });
 
@@ -111,7 +111,7 @@ describe("bulk table operations", () => {
       });
     });
     H.expectUnstructuredSnowplowEvent({
-      event: "data_studio_table_field_values_discarded",
+      event: "data_studio_table_field_values_discard_started",
       result: "success",
     });
   });

--- a/e2e/test/scenarios/data-studio/data-model/datamodel-data-studio-search.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-model/datamodel-data-studio-search.cy.spec.ts
@@ -118,6 +118,7 @@ describe("Search", () => {
   it("should select/deselect databases and schemas", () => {
     H.DataModel.visitDataStudio();
     TablePicker.getSearchInput().type("a");
+    // wait for the tables to be loaded
     TablePicker.getTables().should("have.length", 4);
     const postgres = "Writable Postgres12";
     const sampleDatabaseName = "Sample Database";

--- a/e2e/test/scenarios/data-studio/data-model/datamodel-data-studio-search.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-model/datamodel-data-studio-search.cy.spec.ts
@@ -7,6 +7,7 @@ describe("Search", () => {
   beforeEach(() => {
     cy.signInAsAdmin();
     H.restore("postgres-writable");
+    H.resetSnowplow();
     H.activateToken("bleeding-edge");
     H.resetTestTable({ type: "postgres", table: "multi_schema" });
     H.resyncDatabase({ dbId: WRITABLE_DB_ID });
@@ -19,6 +20,9 @@ describe("Search", () => {
     TablePicker.getTables().should("have.length", 3);
     TablePicker.getTable("Analytic Events").should("be.visible");
     TablePicker.getTable("Animals").should("be.visible");
+    H.expectUnstructuredSnowplowEvent({
+      event: "data_studio_table_picker_search_performed",
+    });
   });
 
   it("should support wildcard search with *", () => {
@@ -26,10 +30,19 @@ describe("Search", () => {
 
     TablePicker.getSearchInput().type("irds");
     TablePicker.get().findByText("No tables found").should("be.visible");
+    H.expectUnstructuredSnowplowEvent({
+      event: "data_studio_table_picker_search_performed",
+    });
 
     TablePicker.getSearchInput().clear().type("*irds");
     TablePicker.getTables().should("have.length", 1);
     TablePicker.getTable("Birds").should("be.visible");
+    H.expectUnstructuredSnowplowEvent(
+      {
+        event: "data_studio_table_picker_search_performed",
+      },
+      2,
+    );
   });
 
   it("should allow using shift key to select multiple tables", () => {

--- a/e2e/test/scenarios/data-studio/data-model/datamodel-data-studio-search.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-model/datamodel-data-studio-search.cy.spec.ts
@@ -118,6 +118,7 @@ describe("Search", () => {
   it("should select/deselect databases and schemas", () => {
     H.DataModel.visitDataStudio();
     TablePicker.getSearchInput().type("a");
+    TablePicker.getTables().should("have.length", 4);
     const postgres = "Writable Postgres12";
     const sampleDatabaseName = "Sample Database";
     const domesticSchema = "Domestic";

--- a/e2e/test/scenarios/data-studio/data-model/datamodel-data-studio.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-model/datamodel-data-studio.cy.spec.ts
@@ -578,6 +578,9 @@ describe("scenarios > data studio > datamodel", () => {
         H.expectUnstructuredSnowplowEvent({
           event: "data_studio_table_picker_filters_applied",
         });
+        H.expectUnstructuredSnowplowEvent({
+          event: "data_studio_table_picker_search_performed",
+        });
 
         cy.get<TableId>("@goldTableId").then(expectTableVisible);
         cy.get<TableId>("@silverTableId").then(expectTableNotVisible);

--- a/e2e/test/scenarios/data-studio/data-model/datamodel-data-studio.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-model/datamodel-data-studio.cy.spec.ts
@@ -33,6 +33,7 @@ const CUSTOM_MAPPING_ERROR =
 describe("scenarios > data studio > datamodel", () => {
   beforeEach(() => {
     H.restore();
+    H.resetSnowplow();
     cy.signInAsAdmin();
     H.activateToken("bleeding-edge");
 
@@ -574,6 +575,9 @@ describe("scenarios > data studio > datamodel", () => {
         openFilterPopover();
         selectFilterOption("Visibility type", "Gold");
         applyFilters();
+        H.expectUnstructuredSnowplowEvent({
+          event: "data_studio_table_picker_filters_applied",
+        });
 
         cy.get<TableId>("@goldTableId").then(expectTableVisible);
         cy.get<TableId>("@silverTableId").then(expectTableNotVisible);

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/analytics.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/analytics.ts
@@ -80,29 +80,29 @@ export const trackDataStudioBulkAttributeUpdated = (
   });
 };
 
-export const trackDataStudioTableSchemaSynced = (
+export const trackDataStudioTableSchemaSyncStarted = (
   result: "success" | "failure",
 ) => {
   trackSimpleEvent({
-    event: "data_studio_table_schema_synced",
+    event: "data_studio_table_schema_sync_started",
     result,
   });
 };
 
-export const trackDataStudioTableFieldsRescanned = (
+export const trackDataStudioTableFieldsRescanStarted = (
   result: "success" | "failure",
 ) => {
   trackSimpleEvent({
-    event: "data_studio_table_fields_rescanned",
+    event: "data_studio_table_fields_rescan_started",
     result,
   });
 };
 
-export const trackDataStudioTableFieldValuesDiscarded = (
+export const trackDataStudioTableFieldValuesDiscardStarted = (
   result: "success" | "failure",
 ) => {
   trackSimpleEvent({
-    event: "data_studio_table_field_values_discarded",
+    event: "data_studio_table_field_values_discard_started",
     result,
   });
 };

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/analytics.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/analytics.ts
@@ -73,3 +73,30 @@ export const trackDataStudioBulkAttributeUpdated = (
     result,
   });
 };
+
+export const trackDataStudioTableSchemaSynced = (
+  result: "success" | "failure",
+) => {
+  trackSimpleEvent({
+    event: "data_studio_table_schema_synced",
+    result,
+  });
+};
+
+export const trackDataStudioTableFieldsRescanned = (
+  result: "success" | "failure",
+) => {
+  trackSimpleEvent({
+    event: "data_studio_table_fields_rescanned",
+    result,
+  });
+};
+
+export const trackDataStudioTableFieldValuesDiscarded = (
+  result: "success" | "failure",
+) => {
+  trackSimpleEvent({
+    event: "data_studio_table_field_values_discarded",
+    result,
+  });
+};

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/analytics.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/analytics.ts
@@ -8,7 +8,7 @@ export const trackDataStudioLibraryCreated = (id: CollectionId) => {
   });
 };
 
-export const trackDataStudioTablePublished = (id: ConcreteTableId) => {
+export const trackDataStudioTablePublished = (id?: ConcreteTableId) => {
   trackSimpleEvent({
     event: "data_studio_table_published",
     target_id: id,
@@ -54,7 +54,7 @@ export const trackDataStudioTablePickerSearchPerformed = () => {
   });
 };
 
-export const trackDataStudioTableUnpublished = (id: ConcreteTableId) => {
+export const trackDataStudioTableUnpublished = (id?: ConcreteTableId) => {
   trackSimpleEvent({
     event: "data_studio_table_unpublished",
     target_id: id,

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/analytics.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/analytics.ts
@@ -54,12 +54,10 @@ export const trackDataStudioTablePickerSearchPerformed = () => {
   });
 };
 
-export const trackDataStudioTableUnpublished = (
-  id: TableId | null | undefined,
-) => {
+export const trackDataStudioTableUnpublished = (id: TableId | null) => {
   trackSimpleEvent({
     event: "data_studio_table_unpublished",
-    target_id: id !== null && id !== undefined ? Number(id) : null,
+    target_id: id !== null ? Number(id) : null,
   });
 };
 

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/analytics.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/analytics.ts
@@ -47,3 +47,29 @@ export const trackDataStudioTablePickerFiltersCleared = () => {
     event: "data_studio_table_picker_filters_cleared",
   });
 };
+
+export const trackDataStudioTableUnpublished = (
+  id: TableId | null | undefined,
+) => {
+  trackSimpleEvent({
+    event: "data_studio_table_unpublished",
+    target_id: id !== null && id !== undefined ? Number(id) : null,
+  });
+};
+
+export const trackDataStudioBulkSyncSettingsClicked = () => {
+  trackSimpleEvent({
+    event: "data_studio_bulk_sync_settings_clicked",
+  });
+};
+
+export const trackDataStudioBulkAttributeUpdated = (
+  attributeType: "owner" | "layer" | "entity_type" | "data_source",
+  result: "success" | "failure",
+) => {
+  trackSimpleEvent({
+    event: "data_studio_bulk_attribute_updated",
+    event_detail: attributeType,
+    result,
+  });
+};

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/analytics.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/analytics.ts
@@ -35,3 +35,15 @@ export const trackDataStudioGlossaryTermDeleted = (id: number | null) => {
     target_id: id,
   });
 };
+
+export const trackDataStudioTablePickerFiltersApplied = () => {
+  trackSimpleEvent({
+    event: "data_studio_table_picker_filters_applied",
+  });
+};
+
+export const trackDataStudioTablePickerFiltersCleared = () => {
+  trackSimpleEvent({
+    event: "data_studio_table_picker_filters_cleared",
+  });
+};

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/analytics.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/analytics.ts
@@ -1,5 +1,5 @@
 import { trackSimpleEvent } from "metabase/lib/analytics";
-import type { CollectionId, TableId } from "metabase-types/api";
+import type { CollectionId, ConcreteTableId } from "metabase-types/api";
 
 export const trackDataStudioLibraryCreated = (id: CollectionId) => {
   trackSimpleEvent({
@@ -8,10 +8,10 @@ export const trackDataStudioLibraryCreated = (id: CollectionId) => {
   });
 };
 
-export const trackDataStudioTablePublished = (id: TableId | null) => {
+export const trackDataStudioTablePublished = (id: ConcreteTableId) => {
   trackSimpleEvent({
     event: "data_studio_table_published",
-    target_id: id != null ? Number(id) : null,
+    target_id: id,
   });
 };
 
@@ -54,10 +54,10 @@ export const trackDataStudioTablePickerSearchPerformed = () => {
   });
 };
 
-export const trackDataStudioTableUnpublished = (id: TableId | null) => {
+export const trackDataStudioTableUnpublished = (id: ConcreteTableId) => {
   trackSimpleEvent({
     event: "data_studio_table_unpublished",
-    target_id: id !== null ? Number(id) : null,
+    target_id: id,
   });
 };
 

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/analytics.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/analytics.ts
@@ -48,6 +48,12 @@ export const trackDataStudioTablePickerFiltersCleared = () => {
   });
 };
 
+export const trackDataStudioTablePickerSearchPerformed = () => {
+  trackSimpleEvent({
+    event: "data_studio_table_picker_search_performed",
+  });
+};
+
 export const trackDataStudioTableUnpublished = (
   id: TableId | null | undefined,
 ) => {

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/PublishTableModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/PublishTableModal.tsx
@@ -11,6 +11,7 @@ import { useMetadataToasts } from "metabase/metadata/hooks/useMetadataToasts";
 import { Box } from "metabase/ui";
 import { usePublishTablesMutation } from "metabase-enterprise/api/table";
 import { trackDataStudioTablePublished } from "metabase-enterprise/data-studio/analytics";
+import { isConcreteTableId } from "metabase-types/api";
 
 interface PublishTableModalProps {
   opened: boolean;
@@ -35,7 +36,9 @@ export function PublishTableModal({
     await publishTables({ table_ids: [item.id] }).unwrap(); // unwrap() allows EntityPicker's error handling to take over
     onClose();
     sendSuccessToast(t`Published`);
-    trackDataStudioTablePublished(item.id);
+    if (isConcreteTableId(item.id)) {
+      trackDataStudioTablePublished(item.id);
+    }
     onPublished(item);
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/PublishTablesModal/PublishTablesModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/PublishTablesModal/PublishTablesModal.tsx
@@ -32,7 +32,6 @@ import type {
   SchemaId,
   TableId,
 } from "metabase-types/api";
-import { isConcreteTableId } from "metabase-types/api";
 
 type PublishTablesModalProps = {
   databaseIds?: DatabaseId[];
@@ -142,9 +141,7 @@ function ModalBody({
       sendSuccessToast(t`Published`);
     }
 
-    if (isConcreteTableId(selected_table?.id)) {
-      trackDataStudioTablePublished(selected_table.id);
-    }
+    trackDataStudioTablePublished();
 
     onPublish();
   };

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/PublishTablesModal/PublishTablesModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/PublishTablesModal/PublishTablesModal.tsx
@@ -32,6 +32,7 @@ import type {
   SchemaId,
   TableId,
 } from "metabase-types/api";
+import { isConcreteTableId } from "metabase-types/api";
 
 type PublishTablesModalProps = {
   databaseIds?: DatabaseId[];
@@ -141,9 +142,9 @@ function ModalBody({
       sendSuccessToast(t`Published`);
     }
 
-    trackDataStudioTablePublished(
-      selected_table != null ? selected_table.id : null,
-    );
+    if (isConcreteTableId(selected_table?.id)) {
+      trackDataStudioTablePublished(selected_table.id);
+    }
 
     onPublish();
   };

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/UnpublishTablesModal/UnpublishTablesModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/UnpublishTablesModal/UnpublishTablesModal.tsx
@@ -127,7 +127,7 @@ function ModalBody({
       table_ids: tableIds,
     }).unwrap();
     sendSuccessToast(t`Unpublished`);
-    trackDataStudioTableUnpublished(selected_table?.id);
+    trackDataStudioTableUnpublished(selected_table?.id ?? null);
     onUnpublish();
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/UnpublishTablesModal/UnpublishTablesModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/UnpublishTablesModal/UnpublishTablesModal.tsx
@@ -29,7 +29,6 @@ import type {
   SchemaId,
   TableId,
 } from "metabase-types/api";
-import { isConcreteTableId } from "metabase-types/api";
 
 type UnpublishTablesModalProps = {
   databaseIds?: DatabaseId[];
@@ -128,9 +127,7 @@ function ModalBody({
       table_ids: tableIds,
     }).unwrap();
     sendSuccessToast(t`Unpublished`);
-    if (isConcreteTableId(selected_table?.id)) {
-      trackDataStudioTableUnpublished(selected_table.id);
-    }
+    trackDataStudioTableUnpublished();
     onUnpublish();
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/UnpublishTablesModal/UnpublishTablesModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/UnpublishTablesModal/UnpublishTablesModal.tsx
@@ -22,6 +22,7 @@ import {
   useGetTableSelectionInfoQuery,
   useUnpublishTablesMutation,
 } from "metabase-enterprise/api";
+import { trackDataStudioTableUnpublished } from "metabase-enterprise/data-studio/analytics";
 import type {
   BulkTableInfo,
   DatabaseId,
@@ -126,6 +127,7 @@ function ModalBody({
       table_ids: tableIds,
     }).unwrap();
     sendSuccessToast(t`Unpublished`);
+    trackDataStudioTableUnpublished(selected_table?.id);
     onUnpublish();
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/UnpublishTablesModal/UnpublishTablesModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/UnpublishTablesModal/UnpublishTablesModal.tsx
@@ -29,6 +29,7 @@ import type {
   SchemaId,
   TableId,
 } from "metabase-types/api";
+import { isConcreteTableId } from "metabase-types/api";
 
 type UnpublishTablesModalProps = {
   databaseIds?: DatabaseId[];
@@ -127,7 +128,9 @@ function ModalBody({
       table_ids: tableIds,
     }).unwrap();
     sendSuccessToast(t`Unpublished`);
-    trackDataStudioTableUnpublished(selected_table?.id ?? null);
+    if (isConcreteTableId(selected_table?.id)) {
+      trackDataStudioTableUnpublished(selected_table.id);
+    }
     onUnpublish();
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/DiscardTableFieldValuesButton/DiscardTableFieldValuesButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/DiscardTableFieldValuesButton/DiscardTableFieldValuesButton.tsx
@@ -4,6 +4,7 @@ import { useTemporaryState } from "metabase/common/hooks";
 import { useMetadataToasts } from "metabase/metadata/hooks";
 import { Button } from "metabase/ui";
 import { useDiscardTablesFieldValuesMutation } from "metabase-enterprise/api";
+import { trackDataStudioTableFieldValuesDiscarded } from "metabase-enterprise/data-studio/analytics";
 import type { DatabaseId, SchemaId, TableId } from "metabase-types/api";
 
 interface Props {
@@ -30,8 +31,10 @@ export const DiscardTableFieldValuesButton = ({
 
     if (error) {
       sendErrorToast(t`Failed to discard values`);
+      trackDataStudioTableFieldValuesDiscarded("failure");
     } else {
       setStarted(true);
+      trackDataStudioTableFieldValuesDiscarded("success");
     }
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/DiscardTableFieldValuesButton/DiscardTableFieldValuesButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/DiscardTableFieldValuesButton/DiscardTableFieldValuesButton.tsx
@@ -4,7 +4,7 @@ import { useTemporaryState } from "metabase/common/hooks";
 import { useMetadataToasts } from "metabase/metadata/hooks";
 import { Button } from "metabase/ui";
 import { useDiscardTablesFieldValuesMutation } from "metabase-enterprise/api";
-import { trackDataStudioTableFieldValuesDiscarded } from "metabase-enterprise/data-studio/analytics";
+import { trackDataStudioTableFieldValuesDiscardStarted } from "metabase-enterprise/data-studio/analytics";
 import type { DatabaseId, SchemaId, TableId } from "metabase-types/api";
 
 interface Props {
@@ -31,10 +31,10 @@ export const DiscardTableFieldValuesButton = ({
 
     if (error) {
       sendErrorToast(t`Failed to discard values`);
-      trackDataStudioTableFieldValuesDiscarded("failure");
+      trackDataStudioTableFieldValuesDiscardStarted("failure");
     } else {
       setStarted(true);
-      trackDataStudioTableFieldValuesDiscarded("success");
+      trackDataStudioTableFieldValuesDiscardStarted("success");
     }
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/RescanTableFieldsButton/RescanTableFieldsButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/RescanTableFieldsButton/RescanTableFieldsButton.tsx
@@ -4,6 +4,7 @@ import { useTemporaryState } from "metabase/common/hooks";
 import { useMetadataToasts } from "metabase/metadata/hooks";
 import { Button } from "metabase/ui";
 import { useRescanTablesFieldValuesMutation } from "metabase-enterprise/api";
+import { trackDataStudioTableFieldsRescanned } from "metabase-enterprise/data-studio/analytics";
 import type { DatabaseId, SchemaId, TableId } from "metabase-types/api";
 
 interface Props {
@@ -36,8 +37,10 @@ export const RescanTableFieldsButton = ({
 
     if (error) {
       sendErrorToast(t`Failed to start scan`);
+      trackDataStudioTableFieldsRescanned("failure");
     } else {
       setStarted(true);
+      trackDataStudioTableFieldsRescanned("success");
     }
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/RescanTableFieldsButton/RescanTableFieldsButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/RescanTableFieldsButton/RescanTableFieldsButton.tsx
@@ -4,7 +4,7 @@ import { useTemporaryState } from "metabase/common/hooks";
 import { useMetadataToasts } from "metabase/metadata/hooks";
 import { Button } from "metabase/ui";
 import { useRescanTablesFieldValuesMutation } from "metabase-enterprise/api";
-import { trackDataStudioTableFieldsRescanned } from "metabase-enterprise/data-studio/analytics";
+import { trackDataStudioTableFieldsRescanStarted } from "metabase-enterprise/data-studio/analytics";
 import type { DatabaseId, SchemaId, TableId } from "metabase-types/api";
 
 interface Props {
@@ -37,10 +37,10 @@ export const RescanTableFieldsButton = ({
 
     if (error) {
       sendErrorToast(t`Failed to start scan`);
-      trackDataStudioTableFieldsRescanned("failure");
+      trackDataStudioTableFieldsRescanStarted("failure");
     } else {
       setStarted(true);
-      trackDataStudioTableFieldsRescanned("success");
+      trackDataStudioTableFieldsRescanStarted("success");
     }
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/SyncTableSchemaButton/SyncTableSchemaButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/SyncTableSchemaButton/SyncTableSchemaButton.tsx
@@ -4,7 +4,7 @@ import { useTemporaryState } from "metabase/common/hooks";
 import { useMetadataToasts } from "metabase/metadata/hooks";
 import { Button } from "metabase/ui";
 import { useSyncTablesSchemasMutation } from "metabase-enterprise/api";
-import { trackDataStudioTableSchemaSynced } from "metabase-enterprise/data-studio/analytics";
+import { trackDataStudioTableSchemaSyncStarted } from "metabase-enterprise/data-studio/analytics";
 import type { DatabaseId, SchemaId, TableId } from "metabase-types/api";
 
 interface Props {
@@ -37,10 +37,10 @@ export function SyncTableSchemaButton({
 
     if (error) {
       sendErrorToast(t`Failed to start sync`);
-      trackDataStudioTableSchemaSynced("failure");
+      trackDataStudioTableSchemaSyncStarted("failure");
     } else {
       setStarted(true);
-      trackDataStudioTableSchemaSynced("success");
+      trackDataStudioTableSchemaSyncStarted("success");
     }
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/SyncTableSchemaButton/SyncTableSchemaButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/SyncTableSchemaButton/SyncTableSchemaButton.tsx
@@ -4,6 +4,7 @@ import { useTemporaryState } from "metabase/common/hooks";
 import { useMetadataToasts } from "metabase/metadata/hooks";
 import { Button } from "metabase/ui";
 import { useSyncTablesSchemasMutation } from "metabase-enterprise/api";
+import { trackDataStudioTableSchemaSynced } from "metabase-enterprise/data-studio/analytics";
 import type { DatabaseId, SchemaId, TableId } from "metabase-types/api";
 
 interface Props {
@@ -36,8 +37,10 @@ export function SyncTableSchemaButton({
 
     if (error) {
       sendErrorToast(t`Failed to start sync`);
+      trackDataStudioTableSchemaSynced("failure");
     } else {
       setStarted(true);
+      trackDataStudioTableSchemaSynced("success");
     }
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/FilterPopover.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/FilterPopover.tsx
@@ -7,6 +7,10 @@ import {
   UserInput,
 } from "metabase/metadata/components";
 import { Button, Checkbox, Group, Stack } from "metabase/ui";
+import {
+  trackDataStudioTablePickerFiltersApplied,
+  trackDataStudioTablePickerFiltersCleared,
+} from "metabase-enterprise/data-studio/analytics";
 
 import type { FilterState } from "../types";
 
@@ -19,6 +23,7 @@ export function FilterPopover({ filters, onSubmit }: Props) {
   const [form, setForm] = useState(filters);
 
   const handleReset = () => {
+    trackDataStudioTablePickerFiltersCleared();
     onSubmit({
       dataLayer: null,
       dataSource: null,
@@ -32,6 +37,7 @@ export function FilterPopover({ filters, onSubmit }: Props) {
     <form
       onSubmit={(event) => {
         event.preventDefault();
+        trackDataStudioTablePickerFiltersApplied();
         onSubmit(form);
       }}
       data-testid="table-picker-filter"

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/SearchNew.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/SearchNew.tsx
@@ -154,7 +154,9 @@ export function SearchNew({
 
   useEffect(() => {
     const startedFetching =
-      previousIsFetchingTables === false && isFetchingTables === true;
+      (previousIsFetchingTables === false ||
+        previousIsFetchingTables === undefined) &&
+      isFetchingTables === true;
     if (startedFetching) {
       trackDataStudioTablePickerSearchPerformed();
     }

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/SearchNew.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/SearchNew.tsx
@@ -5,6 +5,7 @@ import { useListDatabasesQuery } from "metabase/api";
 import { useListTablesQuery } from "metabase/api/table";
 import { parseRouteParams } from "metabase/metadata/pages/shared/utils";
 import { Box, Flex, Loader, Text } from "metabase/ui";
+import { trackDataStudioTablePickerSearchPerformed } from "metabase-enterprise/data-studio/analytics";
 import type { Table } from "metabase-types/api";
 
 import { useSelection } from "../../../pages/DataModel/contexts/SelectionContext";
@@ -143,6 +144,12 @@ export function SearchNew({
   useEffect(() => {
     resetSelection();
   }, [query, filters, resetSelection]);
+
+  useEffect(() => {
+    if (!isLoading && query.trim().length > 0) {
+      trackDataStudioTablePickerSearchPerformed();
+    }
+  }, [isLoading, query]);
 
   if (isLoading) {
     return (

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/SearchNew.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/SearchNew.tsx
@@ -153,7 +153,9 @@ export function SearchNew({
   }, [query, filters, resetSelection]);
 
   useEffect(() => {
-    if (previousIsFetchingTables === true && isFetchingTables === false) {
+    const startedFetching =
+      previousIsFetchingTables === false && isFetchingTables === true;
+    if (startedFetching) {
       trackDataStudioTablePickerSearchPerformed();
     }
   }, [previousIsFetchingTables, isFetchingTables]);

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/SearchNew.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/SearchNew.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo } from "react";
+import { usePrevious } from "react-use";
 import { t } from "ttag";
 
 import { useListDatabasesQuery } from "metabase/api";
@@ -99,7 +100,11 @@ export function SearchNew({
 }: SearchNewProps) {
   const { resetSelection } = useSelection();
   const routeParams = parseRouteParams(params);
-  const { data: tables, isLoading: isLoadingTables } = useListTablesQuery({
+  const {
+    data: tables,
+    isLoading: isLoadingTables,
+    isFetching: isFetchingTables,
+  } = useListTablesQuery({
     term: query,
     "data-layer": filters.dataLayer ?? undefined,
     "data-source":
@@ -120,6 +125,8 @@ export function SearchNew({
     {},
     { defaultExpanded: true },
   );
+
+  const previousIsFetchingTables = usePrevious(isFetchingTables);
 
   const allowedDatabaseIds = useMemo(
     () => new Set(databases?.data.map((database) => database.id) ?? []),
@@ -146,10 +153,10 @@ export function SearchNew({
   }, [query, filters, resetSelection]);
 
   useEffect(() => {
-    if (!isLoading && query.trim().length > 0) {
+    if (previousIsFetchingTables === true && isFetchingTables === false) {
       trackDataStudioTablePickerSearchPerformed();
     }
-  }, [isLoading, query]);
+  }, [previousIsFetchingTables, isFetchingTables]);
 
   if (isLoading) {
     return (

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/TablePicker.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/TablePicker.tsx
@@ -1,8 +1,10 @@
 import { useDisclosure } from "@mantine/hooks";
-import { useDeferredValue, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { usePrevious } from "react-use";
 import { t } from "ttag";
 
+import { useDebouncedValue } from "metabase/common/hooks/use-debounced-value";
+import { SEARCH_DEBOUNCE_DURATION } from "metabase/lib/constants";
 import {
   Badge,
   Box,
@@ -44,8 +46,8 @@ export function TablePicker({
 }: TablePickerProps) {
   const { resetSelection } = useSelection();
   const [query, setQuery] = useState("");
-  const deferredQuery = useDeferredValue(query);
-  const previousDeferredQuery = usePrevious(deferredQuery);
+  const debouncedQuery = useDebouncedValue(query, SEARCH_DEBOUNCE_DURATION);
+  const previousDebouncedQuery = usePrevious(debouncedQuery);
   const [filters, setFilters] = useState<FilterState>({
     dataLayer: null,
     dataSource: null,
@@ -58,12 +60,12 @@ export function TablePicker({
 
   useEffect(() => {
     const togglingBetweenSearchAndTree =
-      (previousDeferredQuery === "" && deferredQuery !== "") ||
-      (previousDeferredQuery !== "" && deferredQuery === "");
+      (previousDebouncedQuery === "" && debouncedQuery !== "") ||
+      (previousDebouncedQuery !== "" && debouncedQuery === "");
     if (togglingBetweenSearchAndTree) {
       resetSelection();
     }
-  }, [deferredQuery, previousDeferredQuery, resetSelection]);
+  }, [debouncedQuery, previousDebouncedQuery, resetSelection]);
 
   return (
     <Stack
@@ -139,7 +141,7 @@ export function TablePicker({
 
       <Box mih={0} flex="0 1 auto" display="flex" className={S.treeContainer}>
         <Card withBorder p={0} flex={1} mih={0} display="flex">
-          {deferredQuery === "" && filtersCount === 0 ? (
+          {debouncedQuery === "" && filtersCount === 0 ? (
             <Tree
               path={path}
               onChange={onChange}
@@ -147,7 +149,7 @@ export function TablePicker({
             />
           ) : (
             <SearchNew
-              query={deferredQuery}
+              query={debouncedQuery}
               params={params}
               filters={filters}
               onChange={onChange}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/TablePicker.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/TablePicker.unit.spec.tsx
@@ -391,13 +391,17 @@ describe("TablePicker", () => {
       await waitLoading();
 
       // Initially no tables should be visible in search mode
-      expect(item(FOO_TABLE)).not.toBeInTheDocument();
+      await waitFor(() => {
+        expect(item(FOO_TABLE)).not.toBeInTheDocument();
+      });
       expect(item(BAR_TABLE)).not.toBeInTheDocument();
 
       await userEvent.type(searchInput(), "foo");
       await waitLoading();
 
-      expect(item(FOO_TABLE)).toBeInTheDocument();
+      await waitFor(() => {
+        expect(item(FOO_TABLE)).toBeInTheDocument();
+      });
       expect(item(BAR_TABLE)).not.toBeInTheDocument();
     });
 
@@ -408,7 +412,9 @@ describe("TablePicker", () => {
       await userEvent.type(searchInput(), "nonexistent");
       await waitLoading();
 
-      expect(screen.getByText("No tables found")).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByText("No tables found")).toBeInTheDocument();
+      });
     });
 
     it("should clear search and return to tree view", async () => {
@@ -419,13 +425,17 @@ describe("TablePicker", () => {
       await userEvent.type(searchInput(), "foo");
       await waitLoading();
 
-      expect(item(FOO_TABLE)).toBeInTheDocument();
+      await waitFor(() => {
+        expect(item(FOO_TABLE)).toBeInTheDocument();
+      });
 
       await userEvent.clear(searchInput());
       await waitLoading();
 
       // Should return to tree view with databases
-      expect(item(DATABASE_WITH_MULTIPLE_SCHEMAS)).toBeInTheDocument();
+      await waitFor(() => {
+        expect(item(DATABASE_WITH_MULTIPLE_SCHEMAS)).toBeInTheDocument();
+      });
       expect(item(DATABASE_WITH_SINGLE_SCHEMA)).toBeInTheDocument();
     });
 
@@ -439,7 +449,9 @@ describe("TablePicker", () => {
       await waitLoading();
 
       // Should find "Bar" table
-      expect(item(BAR_TABLE)).toBeInTheDocument();
+      await waitFor(() => {
+        expect(item(BAR_TABLE)).toBeInTheDocument();
+      });
       expect(item(FOO_TABLE)).not.toBeInTheDocument();
     });
 
@@ -452,7 +464,9 @@ describe("TablePicker", () => {
       await userEvent.type(searchInput(), "oo");
       await waitLoading();
 
-      expect(item(FOO_TABLE)).toBeInTheDocument();
+      await waitFor(() => {
+        expect(item(FOO_TABLE)).toBeInTheDocument();
+      });
       expect(item(BAR_TABLE)).not.toBeInTheDocument();
 
       // Clear and search for "ar" should match "Bar"
@@ -462,7 +476,9 @@ describe("TablePicker", () => {
       await userEvent.type(searchInput(), "ar");
       await waitLoading();
 
-      expect(item(BAR_TABLE)).toBeInTheDocument();
+      await waitFor(() => {
+        expect(item(BAR_TABLE)).toBeInTheDocument();
+      });
       expect(item(FOO_TABLE)).not.toBeInTheDocument();
     });
 
@@ -476,7 +492,9 @@ describe("TablePicker", () => {
       await waitLoading();
 
       // Should match both QUU and QUX
-      expect(item(QUU)).toBeInTheDocument();
+      await waitFor(() => {
+        expect(item(QUU)).toBeInTheDocument();
+      });
       expect(item(QUX)).toBeInTheDocument();
       expect(item(FOO_TABLE)).not.toBeInTheDocument();
       expect(item(BAR_TABLE)).not.toBeInTheDocument();
@@ -493,7 +511,9 @@ describe("TablePicker", () => {
 
       // Should find FOO (from DATABASE_WITH_MULTIPLE_SCHEMAS)
       // and CORGE, GLORP (from DATABASE_WITH_UNNAMED_SCHEMA)
-      expect(item(FOO_TABLE)).toBeInTheDocument();
+      await waitFor(() => {
+        expect(item(FOO_TABLE)).toBeInTheDocument();
+      });
       expect(item(CORGE)).toBeInTheDocument();
       expect(item(GLORP)).toBeInTheDocument();
 

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/TableAttributesEditBulk.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/TableAttributesEditBulk.tsx
@@ -94,7 +94,6 @@ export function TableAttributesEditBulk({
 
     const result = error ? "failure" : "success";
 
-    // Track which attribute was updated
     if (email !== undefined || userId !== undefined) {
       trackDataStudioBulkAttributeUpdated("owner", result);
     }

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/TableAttributesEditBulk.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/TableAttributesEditBulk.tsx
@@ -12,6 +12,10 @@ import { useMetadataToasts } from "metabase/metadata/hooks";
 import { getUserIsAdmin } from "metabase/selectors/user";
 import { Box, Button, Group, Icon, Stack, Title } from "metabase/ui";
 import { useEditTablesMutation } from "metabase-enterprise/api";
+import {
+  trackDataStudioBulkAttributeUpdated,
+  trackDataStudioBulkSyncSettingsClicked,
+} from "metabase-enterprise/data-studio/analytics";
 import { CreateLibraryModal } from "metabase-enterprise/data-studio/common/components/CreateLibraryModal";
 import { PublishTablesModal } from "metabase-enterprise/data-studio/common/components/PublishTablesModal";
 import { UnpublishTablesModal } from "metabase-enterprise/data-studio/common/components/UnpublishTablesModal";
@@ -87,6 +91,22 @@ export function TableAttributesEditBulk({
           : (email ?? undefined),
       owner_user_id: userId === "unknown" ? null : (userId ?? undefined),
     });
+
+    const result = error ? "failure" : "success";
+
+    // Track which attribute was updated
+    if (email !== undefined || userId !== undefined) {
+      trackDataStudioBulkAttributeUpdated("owner", result);
+    }
+    if (dataLayer !== undefined) {
+      trackDataStudioBulkAttributeUpdated("layer", result);
+    }
+    if (entityType !== undefined) {
+      trackDataStudioBulkAttributeUpdated("entity_type", result);
+    }
+    if (dataSource !== undefined) {
+      trackDataStudioBulkAttributeUpdated("data_source", result);
+    }
 
     if (error) {
       sendErrorToast(t`Failed to update items`);
@@ -181,7 +201,10 @@ export function TableAttributesEditBulk({
             <Button
               flex={1}
               leftSection={<Icon name="settings" />}
-              onClick={() => setModalType("sync")}
+              onClick={() => {
+                trackDataStudioBulkSyncSettingsClicked();
+                setModalType("sync");
+              }}
             >
               {t`Sync settings`}
             </Button>

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/pages/DataModel/DataModel.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/pages/DataModel/DataModel.unit.spec.tsx
@@ -350,6 +350,13 @@ describe("DataModel", () => {
       const searchValue = ORDERS_TABLE.name.substring(0, 3);
       await userEvent.type(getTableSearchInput(), searchValue);
 
+      await waitFor(() => {
+        const path = "path:/api/table?term*";
+        expect(
+          fetchMock.callHistory.called(path, { method: "GET" }),
+        ).toBeTruthy();
+      });
+
       expect(
         await findTablePickerTable(ORDERS_TABLE.display_name),
       ).toBeInTheDocument();

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonDataPicker/PythonDataPicker.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonDataPicker/PythonDataPicker.tsx
@@ -9,6 +9,7 @@ import type {
   PythonTransformTableAliases,
   Table,
 } from "metabase-types/api";
+import { isConcreteTableId } from "metabase-types/api";
 
 import { AliasInput } from "./AliasInput";
 import S from "./PythonDataPicker.module.css";
@@ -16,7 +17,6 @@ import { TableSelector } from "./TableSelector";
 import type { TableSelection } from "./types";
 import {
   getInitialTableSelections,
-  isConcreteTableId,
   selectionsToTableAliases,
   slugify,
 } from "./utils";

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonDataPicker/TableSelector/TableSelector.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonDataPicker/TableSelector/TableSelector.tsx
@@ -23,8 +23,7 @@ import type {
   Table,
   TableId,
 } from "metabase-types/api";
-
-import { isConcreteTableId } from "../utils";
+import { isConcreteTableId } from "metabase-types/api";
 
 import S from "./TableSelector.module.css";
 

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonDataPicker/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonDataPicker/utils.ts
@@ -1,9 +1,5 @@
 import { slugify as toSlug } from "metabase/lib/formatting";
-import type {
-  ConcreteTableId,
-  PythonTransformTableAliases,
-  TableId,
-} from "metabase-types/api";
+import type { PythonTransformTableAliases } from "metabase-types/api";
 
 import type { TableSelection } from "./types";
 
@@ -62,10 +58,4 @@ export function slugify(
     }
   }
   return name;
-}
-
-export function isConcreteTableId(
-  id: TableId | undefined,
-): id is ConcreteTableId {
-  return typeof id === "number";
 }

--- a/frontend/src/metabase-types/analytics/event.ts
+++ b/frontend/src/metabase-types/analytics/event.ts
@@ -553,6 +553,10 @@ export type DataStudioTablePickerFiltersClearedEvent = ValidateEvent<{
   event: "data_studio_table_picker_filters_cleared";
 }>;
 
+export type DataStudioTablePickerSearchPerformedEvent = ValidateEvent<{
+  event: "data_studio_table_picker_search_performed";
+}>;
+
 export type DataStudioTableUnpublishedEvent = ValidateEvent<{
   event: "data_studio_table_unpublished";
   target_id: number | null;
@@ -591,6 +595,7 @@ export type DataStudioEvent =
   | DataStudioGlossaryDeletedEvent
   | DataStudioTablePickerFiltersAppliedEvent
   | DataStudioTablePickerFiltersClearedEvent
+  | DataStudioTablePickerSearchPerformedEvent
   | DataStudioTableUnpublishedEvent
   | DataStudioBulkSyncSettingsClickedEvent
   | DataStudioBulkAttributeUpdatedEvent

--- a/frontend/src/metabase-types/analytics/event.ts
+++ b/frontend/src/metabase-types/analytics/event.ts
@@ -573,17 +573,17 @@ export type DataStudioBulkAttributeUpdatedEvent = ValidateEvent<{
 }>;
 
 export type DataStudioTableSchemaSyncedEvent = ValidateEvent<{
-  event: "data_studio_table_schema_synced";
+  event: "data_studio_table_schema_sync_started";
   result: "success" | "failure";
 }>;
 
 export type DataStudioTableFieldsRescannedEvent = ValidateEvent<{
-  event: "data_studio_table_fields_rescanned";
+  event: "data_studio_table_fields_rescan_started";
   result: "success" | "failure";
 }>;
 
 export type DataStudioTableFieldValuesDiscardedEvent = ValidateEvent<{
-  event: "data_studio_table_field_values_discarded";
+  event: "data_studio_table_field_values_discard_started";
   result: "success" | "failure";
 }>;
 

--- a/frontend/src/metabase-types/analytics/event.ts
+++ b/frontend/src/metabase-types/analytics/event.ts
@@ -568,6 +568,21 @@ export type DataStudioBulkAttributeUpdatedEvent = ValidateEvent<{
   result: "success" | "failure";
 }>;
 
+export type DataStudioTableSchemaSyncedEvent = ValidateEvent<{
+  event: "data_studio_table_schema_synced";
+  result: "success" | "failure";
+}>;
+
+export type DataStudioTableFieldsRescannedEvent = ValidateEvent<{
+  event: "data_studio_table_fields_rescanned";
+  result: "success" | "failure";
+}>;
+
+export type DataStudioTableFieldValuesDiscardedEvent = ValidateEvent<{
+  event: "data_studio_table_field_values_discarded";
+  result: "success" | "failure";
+}>;
+
 export type DataStudioEvent =
   | DataStudioLibraryCreatedEvent
   | DataStudioTablePublishedEvent
@@ -578,7 +593,10 @@ export type DataStudioEvent =
   | DataStudioTablePickerFiltersClearedEvent
   | DataStudioTableUnpublishedEvent
   | DataStudioBulkSyncSettingsClickedEvent
-  | DataStudioBulkAttributeUpdatedEvent;
+  | DataStudioBulkAttributeUpdatedEvent
+  | DataStudioTableSchemaSyncedEvent
+  | DataStudioTableFieldsRescannedEvent
+  | DataStudioTableFieldValuesDiscardedEvent;
 
 export type UnsavedChangesWarningDisplayedEvent = ValidateEvent<{
   event: "unsaved_changes_warning_displayed";

--- a/frontend/src/metabase-types/analytics/event.ts
+++ b/frontend/src/metabase-types/analytics/event.ts
@@ -553,6 +553,21 @@ export type DataStudioTablePickerFiltersClearedEvent = ValidateEvent<{
   event: "data_studio_table_picker_filters_cleared";
 }>;
 
+export type DataStudioTableUnpublishedEvent = ValidateEvent<{
+  event: "data_studio_table_unpublished";
+  target_id: number | null;
+}>;
+
+export type DataStudioBulkSyncSettingsClickedEvent = ValidateEvent<{
+  event: "data_studio_bulk_sync_settings_clicked";
+}>;
+
+export type DataStudioBulkAttributeUpdatedEvent = ValidateEvent<{
+  event: "data_studio_bulk_attribute_updated";
+  event_detail: "owner" | "layer" | "entity_type" | "data_source";
+  result: "success" | "failure";
+}>;
+
 export type DataStudioEvent =
   | DataStudioLibraryCreatedEvent
   | DataStudioTablePublishedEvent
@@ -560,7 +575,10 @@ export type DataStudioEvent =
   | DataStudioGlossaryEditedEvent
   | DataStudioGlossaryDeletedEvent
   | DataStudioTablePickerFiltersAppliedEvent
-  | DataStudioTablePickerFiltersClearedEvent;
+  | DataStudioTablePickerFiltersClearedEvent
+  | DataStudioTableUnpublishedEvent
+  | DataStudioBulkSyncSettingsClickedEvent
+  | DataStudioBulkAttributeUpdatedEvent;
 
 export type UnsavedChangesWarningDisplayedEvent = ValidateEvent<{
   event: "unsaved_changes_warning_displayed";

--- a/frontend/src/metabase-types/analytics/event.ts
+++ b/frontend/src/metabase-types/analytics/event.ts
@@ -545,12 +545,22 @@ export type DataStudioGlossaryDeletedEvent = ValidateEvent<{
   target_id: number | null;
 }>;
 
+export type DataStudioTablePickerFiltersAppliedEvent = ValidateEvent<{
+  event: "data_studio_table_picker_filters_applied";
+}>;
+
+export type DataStudioTablePickerFiltersClearedEvent = ValidateEvent<{
+  event: "data_studio_table_picker_filters_cleared";
+}>;
+
 export type DataStudioEvent =
   | DataStudioLibraryCreatedEvent
   | DataStudioTablePublishedEvent
   | DataStudioGlossaryCreatedEvent
   | DataStudioGlossaryEditedEvent
-  | DataStudioGlossaryDeletedEvent;
+  | DataStudioGlossaryDeletedEvent
+  | DataStudioTablePickerFiltersAppliedEvent
+  | DataStudioTablePickerFiltersClearedEvent;
 
 export type UnsavedChangesWarningDisplayedEvent = ValidateEvent<{
   event: "unsaved_changes_warning_displayed";

--- a/frontend/src/metabase-types/analytics/event.ts
+++ b/frontend/src/metabase-types/analytics/event.ts
@@ -6,6 +6,7 @@ import type {
 import type { KeyboardShortcutId } from "metabase/palette/shortcuts";
 import type { ClickActionSection } from "metabase/visualizations/types";
 import type {
+  ConcreteTableId,
   Engine,
   RelatedDashboardXRays,
   TransformId,
@@ -527,7 +528,7 @@ export type DataStudioLibraryCreatedEvent = ValidateEvent<{
 
 export type DataStudioTablePublishedEvent = ValidateEvent<{
   event: "data_studio_table_published";
-  target_id: number | null;
+  target_id: ConcreteTableId | undefined;
 }>;
 
 export type DataStudioGlossaryCreatedEvent = ValidateEvent<{
@@ -559,7 +560,7 @@ export type DataStudioTablePickerSearchPerformedEvent = ValidateEvent<{
 
 export type DataStudioTableUnpublishedEvent = ValidateEvent<{
   event: "data_studio_table_unpublished";
-  target_id: number | null;
+  target_id: ConcreteTableId | undefined;
 }>;
 
 export type DataStudioBulkSyncSettingsClickedEvent = ValidateEvent<{

--- a/frontend/src/metabase-types/api/table.ts
+++ b/frontend/src/metabase-types/api/table.ts
@@ -13,6 +13,12 @@ export type VirtualTableId = string; // e.g. "card__17" where 17 is a card id
 export type TableId = ConcreteTableId | VirtualTableId;
 export type SchemaId = string; // ideally this should be typed as `${DatabaseId}:${SchemaName}`
 
+export function isConcreteTableId(
+  id: TableId | undefined,
+): id is ConcreteTableId {
+  return typeof id === "number";
+}
+
 export type TableVisibilityType =
   | null
   | "details-only"


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-1273/add-snowplow-events-to-bulk-metadata-features

### Description

New events added related to Bulk Metadata features

```
DataStudioTablePickerFiltersAppliedEvent
DataStudioTablePickerFiltersClearedEvent
DataStudioTablePickerSearchPerformedEvent
DataStudioTableUnpublishedEvent
DataStudioBulkSyncSettingsClickedEvent
DataStudioBulkAttributeUpdatedEvent
DataStudioTableSchemaSyncedEvent
DataStudioTableFieldsRescannedEvent
DataStudioTableFieldValuesDiscardedEvent
```

Additionally I've added debounce to Data Studio → Data Library → Search.

### How to verify

Explore around actions Data Studio features and observe events being set.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
