### PR TITLE
Fixed no-literal-metabase-strings eslint rule for `export * from './MetabaseThing';`

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-package/components/public/MetabaseProvider/index.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/components/public/MetabaseProvider/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line no-literal-metabase-strings -- Export
 export * from "./MetabaseProvider";

--- a/frontend/lint/eslint-rules/no-literal-metabase-strings.js
+++ b/frontend/lint/eslint-rules/no-literal-metabase-strings.js
@@ -27,9 +27,11 @@ module.exports = {
       Literal(node) {
         if (
           typeof node.value !== "string" ||
-          ["ExportNamedDeclaration", "ImportDeclaration"].includes(
-            node.parent.type,
-          )
+          [
+            "ExportNamedDeclaration",
+            "ImportDeclaration",
+            "ExportAllDeclaration",
+          ].includes(node.parent.type)
         ) {
           return;
         }

--- a/frontend/lint/tests/no-literal-metabase-strings.unit.spec.js
+++ b/frontend/lint/tests/no-literal-metabase-strings.unit.spec.js
@@ -22,6 +22,11 @@ import OpenInMetabase from "../components/OpenInMetabase";`,
 export { MetabaseLinksToggleWidget } from "./MetabaseLinksToggleWidget";`,
   },
   {
+    // "Metabase in * reexports"
+    code: `
+export * from "./MetabaseLinksToggleWidget";`,
+  },
+  {
     // "No Metabase string",
     code: `
   const label = "some string"`,

--- a/frontend/src/metabase/embedding-sdk/theme/index.ts
+++ b/frontend/src/metabase/embedding-sdk/theme/index.ts
@@ -1,5 +1,4 @@
 export * from "./default-component-theme";
-// eslint-disable-next-line no-literal-metabase-strings -- file name
 export * from "./MetabaseTheme";
 
 export * from "./define-metabase-theme";


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #68230
Closes [EMB-1197: ESLint custom rule `no-literal-metabase-strings` doesn't ignore `export *`](https://linear.app/metabase/issue/EMB-1197/eslint-custom-rule-no-literal-metabase-strings-doesnt-ignore-export)

### Description

Fixes the eslint rule that prevents from using litteral "Metabase" strings. It would error out on wildcard exports, and no longer does so.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
