### PR TITLE
Fix - It's not possible to continue editing a bad transform

### DIFF
--- a/e2e/test/scenarios/dependencies/dependency-checks.cy.spec.ts
+++ b/e2e/test/scenarios/dependencies/dependency-checks.cy.spec.ts
@@ -193,10 +193,6 @@ describe("scenarios > dependencies > dependency checks", () => {
       });
       cy.get("@updateTransform.all").should("have.length", 0);
 
-      H.DataStudio.Transforms.editDefinition().click();
-      H.getNotebookStep("data").findByLabelText("Pick columns").click();
-      H.popover().findByLabelText("Score").click();
-
       cy.log("confirm breaking changes");
       H.DataStudio.Transforms.saveChangesButton().click();
       H.modal().within(() => {

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformQueryPage/TransformQueryPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformQueryPage/TransformQueryPage.tsx
@@ -120,6 +120,10 @@ function TransformQueryPageBody({
         sendErrorToast(t`Failed to update transform query`);
       } else {
         sendSuccessToast(t`Transform query updated`);
+
+        if (isEditMode) {
+          dispatch(push(Urls.transform(transform.id)));
+        }
       }
     },
   });
@@ -149,11 +153,8 @@ function TransformQueryPageBody({
         return;
       }
     }
-    await handleInitialSave({ id: transform.id, source });
 
-    if (isEditMode) {
-      dispatch(push(Urls.transform(transform.id)));
-    }
+    await handleInitialSave({ id: transform.id, source });
   };
 
   const handleCancel = () => {


### PR DESCRIPTION
Fixes #68272
Fixes [GDGT-1514](https://linear.app/metabase/issue/GDGT-1541/its-not-possible-to-continue-editing-a-bad-transform)

### Description

When saving a transform, navigation from `/transform/:id/edit` page to `/transform/:id` page was happening regardless of whether `CheckDependenciesModal` was getting shown to prevent the save.

I also verified that other places using `useCheckDependencies` hook don't have similar problems.

### How to verify

1. Create an MBQL transform that gives you 2 fields. Save it and run it.
2. Create an MBQL question that uses the transform's output table as source, and uses one of the fields in a filter.
3. Edit the transform so that it no longer returns the field used in a filter.
4. Click Save.
5. A modal appears. Click Cancel.

You should still be in transform editing mode, with "Cancel" and "Save" buttons visible (previously "Edit definition" button was shown instead). Your previous edits from step 3 should still be there.