### PR TITLE
Fix flaky test that uses readonly db that lacks permissions

### DIFF
--- a/e2e/test/scenarios/admin/admin-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/admin/admin-reproductions.cy.spec.js
@@ -3,7 +3,7 @@ import { SAMPLE_DB_ID, WRITABLE_DB_ID } from "e2e/support/cypress_data";
 
 describe("issue 26470", { tags: "@external" }, () => {
   beforeEach(() => {
-    H.restore("postgres_12");
+    H.restore("postgres-writable");
     cy.signInAsAdmin();
     cy.request("POST", "/api/persist/enable");
   });


### PR DESCRIPTION
Closes UXW-2745

### Description

Fix flaky e2e test that used incorrect db snapshot that lacks permissions to apply schema change.

### How to verify

Check https://github.com/metabase/metabase/actions/runs/21176206289/job/60905629925#step:12:61
