### PR TITLE
Add random query parameter for EmbedJS iframe src

### DIFF
--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
@@ -29,7 +29,7 @@ const EMBEDDING_ROUTE = "embed/sdk/v1";
 /** list of active embeds, used to know which embeds to update when the global config changes */
 const _activeEmbeds: Set<MetabaseEmbedElement> = new Set();
 
-/** counter that used as a parameter in the iframe src to force parallel loading */
+/** counter used as a parameter in the iframe src to force parallel loading */
 let _iframeCounter = 0;
 
 // Setup a proxy to watch for changes to window.metabaseConfig and update all

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
@@ -342,7 +342,7 @@ export abstract class MetabaseEmbedElement
     // Random query param is needed to allow parallel EmbedJS iframes loading.
     // Without it multiple EmbedJS iframes on a page loaded sequentially.
     // We don't cache the iframe content, so random query parameter does not break caching.
-    this._iframe.src = `${this.globalSettings.instanceUrl}/${EMBEDDING_ROUTE}?v=${Date.now()}`;
+    this._iframe.src = `${this.globalSettings.instanceUrl}/${EMBEDDING_ROUTE}?v=${_activeEmbeds.size}`;
     this._iframe.style.width = "100%";
     this._iframe.style.height = "100%";
     this._iframe.style.border = "none";

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
@@ -29,6 +29,9 @@ const EMBEDDING_ROUTE = "embed/sdk/v1";
 /** list of active embeds, used to know which embeds to update when the global config changes */
 const _activeEmbeds: Set<MetabaseEmbedElement> = new Set();
 
+/** counter that used as a parameter in the iframe src to force parallel loading */
+let _iframeCounter = 0;
+
 // Setup a proxy to watch for changes to window.metabaseConfig and update all
 // active embeds when the config changes. It also setups a setter for
 // window.metabaseConfig to re-create the proxy if the whole object is replaced,
@@ -342,7 +345,7 @@ export abstract class MetabaseEmbedElement
     // Random query param is needed to allow parallel EmbedJS iframes loading.
     // Without it multiple EmbedJS iframes on a page loaded sequentially.
     // We don't cache the iframe content, so random query parameter does not break caching.
-    this._iframe.src = `${this.globalSettings.instanceUrl}/${EMBEDDING_ROUTE}?v=${_activeEmbeds.size}`;
+    this._iframe.src = `${this.globalSettings.instanceUrl}/${EMBEDDING_ROUTE}?v=${_iframeCounter++}`;
     this._iframe.style.width = "100%";
     this._iframe.style.height = "100%";
     this._iframe.style.border = "none";

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
@@ -339,7 +339,10 @@ export abstract class MetabaseEmbedElement
       : null;
 
     this._iframe = document.createElement("iframe");
-    this._iframe.src = `${this.globalSettings.instanceUrl}/${EMBEDDING_ROUTE}`;
+    // Random query param is needed to allow parallel EmbedJS iframes loading.
+    // Without it multiple EmbedJS iframes on a page loaded sequentially.
+    // We don't cache the iframe content, so random query parameter does not break caching.
+    this._iframe.src = `${this.globalSettings.instanceUrl}/${EMBEDDING_ROUTE}?v=${Date.now()}`;
     this._iframe.style.width = "100%";
     this._iframe.style.height = "100%";
     this._iframe.style.border = "none";

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.unit.spec.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.unit.spec.ts
@@ -188,4 +188,20 @@ describe("embed.js script tag for sdk iframe embedding", () => {
       defineMetabaseConfig({});
     }).not.toThrow();
   });
+
+  it("should include a random query parameter in the iframe src for cache busting", () => {
+    defineMetabaseConfig({
+      instanceUrl: "https://example.com",
+    });
+
+    const embed = document.createElement("metabase-dashboard");
+    embed.setAttribute("dashboard-id", "1");
+    document.body.appendChild(embed);
+
+    const iframe = embed.querySelector("iframe");
+    expect(iframe).not.toBeNull();
+    expect(iframe?.src).toMatch(
+      /^https:\/\/example\.com\/embed\/sdk\/v1\?v=\d+$/,
+    );
+  });
 });

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.unit.spec.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.unit.spec.ts
@@ -189,7 +189,7 @@ describe("embed.js script tag for sdk iframe embedding", () => {
     }).not.toThrow();
   });
 
-  it("should include a random query parameter in the iframe src for cache busting", () => {
+  it("should include a counter as a query parameter in the iframe src for parallel loading", () => {
     defineMetabaseConfig({
       instanceUrl: "https://example.com",
     });


### PR DESCRIPTION
Add a random query parameter for EmbedJS iframe src.

Why do we need it?
- browsers don't load in parallel mulple iframes containing the same src, instead such iframes loaded sequentially

To avoid it we can add a query param and it forces browsers to load it in parallel.
Query param breaks caching, but for Iframe html we don't have caching.

Before:
<img width="556" height="468" alt="image" src="https://github.com/user-attachments/assets/8a64d7bb-1d8e-43a4-997e-dc393eb41ac3" />
<img width="664" height="396" alt="image" src="https://github.com/user-attachments/assets/3aa99035-f2e0-4f1d-83d9-a31251b265b9" />


After:
<img width="530" height="412" alt="image" src="https://github.com/user-attachments/assets/e3207f5b-8826-41e4-8db8-f79f8fb308b9" />
<img width="644" height="392" alt="image" src="https://github.com/user-attachments/assets/bb590c20-0f81-425a-99db-d53de5cc8660" />
