### PR TITLE
GDGT-1516 add datetime formatting to Task Run Monitoring features

### DIFF
--- a/e2e/test/scenarios/admin/tools/tools.cy.spec.ts
+++ b/e2e/test/scenarios/admin/tools/tools.cy.spec.ts
@@ -244,7 +244,7 @@ describe("scenarios > admin > tools > tasks", () => {
     cy.window().then((window) => {
       cy.stub(window.navigator.clipboard, "writeText").resolves();
     });
-    cy.icon("copy").click();
+    cy.findByTestId("code-container").icon("copy").click();
     cy.window()
       .its("navigator.clipboard.writeText")
       .should("be.calledWith", formattedTaskJson);

--- a/frontend/src/metabase-types/api/mocks/task.ts
+++ b/frontend/src/metabase-types/api/mocks/task.ts
@@ -1,4 +1,4 @@
-import type { Task } from "metabase-types/api";
+import type { Task, TaskRun, TaskRunExtended } from "metabase-types/api";
 
 export const createMockTask = (task?: Partial<Task>): Task => ({
   id: 1,
@@ -12,4 +12,26 @@ export const createMockTask = (task?: Partial<Task>): Task => ({
   logs: task?.logs ?? null,
   run_id: task?.run_id ?? null,
   ...task,
+});
+
+export const createMockTaskRun = (taskRun?: Partial<TaskRun>): TaskRun => ({
+  id: 1,
+  run_type: "sync",
+  entity_type: "database",
+  entity_id: 1,
+  started_at: "2023-03-04T01:45:26.005475-08:00",
+  ended_at: "2023-03-04T01:45:26.518597-08:00",
+  status: "success",
+  entity_name: "Sample Database",
+  task_count: 3,
+  success_count: 3,
+  failed_count: 0,
+  ...taskRun,
+});
+
+export const createMockTaskRunExtended = (
+  taskRunExtended?: Partial<TaskRunExtended>,
+): TaskRunExtended => ({
+  ...createMockTaskRun(taskRunExtended),
+  tasks: taskRunExtended?.tasks ?? [],
 });

--- a/frontend/src/metabase/admin/tools/components/TaskDetailsPage/TaskDetailsPage.tsx
+++ b/frontend/src/metabase/admin/tools/components/TaskDetailsPage/TaskDetailsPage.tsx
@@ -109,15 +109,27 @@ export const TaskDetailsPage = ({ params }: TaskDetailsPageProps) => {
         <Flex gap="md" align="baseline">
           <Text fw="bold" w={120}>{t`Started at`}</Text>
           <Tooltip label={task.started_at}>
-            <DateTime value={task.started_at} unit="minute" />
+            <DateTime
+              value={task.started_at}
+              unit="minute"
+              data-testid="started-at"
+            />
           </Tooltip>
           <CopyButton value={task.started_at} />
         </Flex>
         <Flex gap="md">
           <Text fw="bold" w={120}>{t`Ended at`}</Text>
-          <Tooltip label={task.ended_at} disabled={!task.ended_at}>
-            <DateTime value={task.ended_at ?? "—"} unit="minute" />
-          </Tooltip>
+          {task.ended_at ? (
+            <Tooltip label={task.ended_at}>
+              <DateTime
+                value={task.ended_at}
+                unit="minute"
+                data-testid="ended-at"
+              />
+            </Tooltip>
+          ) : (
+            "—"
+          )}
           {task.ended_at && <CopyButton value={task.ended_at} />}
         </Flex>
         <Flex gap="md">

--- a/frontend/src/metabase/admin/tools/components/TaskDetailsPage/TaskDetailsPage.tsx
+++ b/frontend/src/metabase/admin/tools/components/TaskDetailsPage/TaskDetailsPage.tsx
@@ -6,6 +6,7 @@ import _ from "underscore";
 import { useGetTaskQuery, useListDatabasesQuery } from "metabase/api";
 import { CodeEditor } from "metabase/common/components/CodeEditor";
 import { CopyButton } from "metabase/common/components/CopyButton";
+import DateTime from "metabase/common/components/DateTime";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { openSaveDialog } from "metabase/lib/dom";
 import * as Urls from "metabase/lib/urls";
@@ -19,6 +20,7 @@ import {
   Stack,
   Text,
   Title,
+  Tooltip,
 } from "metabase/ui";
 import type { Database } from "metabase-types/api";
 
@@ -67,7 +69,7 @@ export const TaskDetailsPage = ({ params }: TaskDetailsPageProps) => {
         </Link>
       </Flex>
 
-      <Stack>
+      <Stack gap="sm">
         <Title order={3}>{t`Task details`}</Title>
         <Flex gap="md">
           <Text fw="bold" w={120}>{t`ID`}</Text>
@@ -104,13 +106,19 @@ export const TaskDetailsPage = ({ params }: TaskDetailsPageProps) => {
             {isLoadingDatabases ? <Loader size="xs" /> : db ? dbEngine : "—"}
           </Text>
         </Flex>
-        <Flex gap="md">
+        <Flex gap="md" align="baseline">
           <Text fw="bold" w={120}>{t`Started at`}</Text>
-          <Text>{task.started_at}</Text>
+          <Tooltip label={task.started_at}>
+            <DateTime value={task.started_at} unit="minute" />
+          </Tooltip>
+          <CopyButton value={task.started_at} />
         </Flex>
         <Flex gap="md">
           <Text fw="bold" w={120}>{t`Ended at`}</Text>
-          <Text>{task.ended_at ?? "—"}</Text>
+          <Tooltip label={task.ended_at} disabled={!task.ended_at}>
+            <DateTime value={task.ended_at ?? "—"} unit="minute" />
+          </Tooltip>
+          {task.ended_at && <CopyButton value={task.ended_at} />}
         </Flex>
         <Flex gap="md">
           <Text fw="bold" w={120}>{t`Duration (ms)`}</Text>

--- a/frontend/src/metabase/admin/tools/components/TaskDetailsPage/TaskDetailsPage.tsx
+++ b/frontend/src/metabase/admin/tools/components/TaskDetailsPage/TaskDetailsPage.tsx
@@ -137,6 +137,7 @@ export const TaskDetailsPage = ({ params }: TaskDetailsPageProps) => {
           p={linesCount > 1 ? 0 : "xs"}
           pos="relative"
           mt="md"
+          data-testid="code-container"
         >
           <CodeEditor
             language="json"

--- a/frontend/src/metabase/admin/tools/components/TaskDetailsPage/TaskDetailsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/tools/components/TaskDetailsPage/TaskDetailsPage.unit.spec.tsx
@@ -81,9 +81,10 @@ describe("TaskDetailsPage", () => {
 
     await waitForLoaderToBeRemoved();
 
-    expect(screen.getAllByText(/March 4, 2023/).length).toBeGreaterThanOrEqual(
-      1,
-    );
+    const startedAtElement = screen.getByTestId("started-at");
+    const endedAtElement = screen.getByTestId("ended-at");
+    expect(startedAtElement).toHaveTextContent("March 4, 2023, 1:45 AM");
+    expect(endedAtElement).toHaveTextContent("March 4, 2023, 1:46 AM");
   });
 
   it("should show raw ISO timestamp in tooltip on hover", async () => {
@@ -97,8 +98,8 @@ describe("TaskDetailsPage", () => {
 
     await waitForLoaderToBeRemoved();
 
-    const dateTimeElements = screen.getAllByText(/March 4, 2023/);
-    await userEvent.hover(dateTimeElements[0]);
+    const startedAtElement = screen.getByTestId("started-at");
+    await userEvent.hover(startedAtElement);
 
     expect(await screen.findByRole("tooltip")).toHaveTextContent(rawTimestamp);
   });

--- a/frontend/src/metabase/admin/tools/components/TaskDetailsPage/TaskDetailsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/tools/components/TaskDetailsPage/TaskDetailsPage.unit.spec.tsx
@@ -1,0 +1,87 @@
+import userEvent from "@testing-library/user-event";
+import { Route } from "react-router";
+
+import {
+  setupDatabasesEndpoints,
+  setupTaskEndpoint,
+} from "__support__/server-mocks";
+import {
+  renderWithProviders,
+  screen,
+  waitForLoaderToBeRemoved,
+} from "__support__/ui";
+import * as Urls from "metabase/lib/urls";
+import type { Task } from "metabase-types/api";
+import { createMockTask } from "metabase-types/api/mocks";
+import { createSampleDatabase } from "metabase-types/api/mocks/presets";
+
+import { TaskDetailsPage } from "./TaskDetailsPage";
+
+const PATHNAME = `${Urls.adminToolsTasksList()}/:taskId`;
+
+interface SetupOpts {
+  task?: Task;
+}
+
+const setup = ({ task = createMockTask() }: SetupOpts = {}) => {
+  setupDatabasesEndpoints([createSampleDatabase()]);
+  setupTaskEndpoint(task);
+
+  return renderWithProviders(
+    <Route path={PATHNAME} component={TaskDetailsPage} />,
+    {
+      initialRoute: Urls.adminToolsTaskDetails(task.id),
+      withRouter: true,
+    },
+  );
+};
+
+describe("TaskDetailsPage", () => {
+  it("should display task details", async () => {
+    const task = createMockTask({
+      id: 42,
+      task: "sync-database",
+      status: "success",
+    });
+
+    setup({ task });
+
+    await waitForLoaderToBeRemoved();
+
+    expect(screen.getByText("Task details")).toBeInTheDocument();
+    expect(screen.getByText("42")).toBeInTheDocument();
+    expect(screen.getByText("sync-database")).toBeInTheDocument();
+  });
+
+  it("should display formatted datetime for started_at and ended_at", async () => {
+    const task = createMockTask({
+      started_at: "2023-03-04T01:45:26.005475-08:00",
+      ended_at: "2023-03-04T01:46:26.518597-08:00",
+    });
+
+    setup({ task });
+
+    await waitForLoaderToBeRemoved();
+
+    expect(screen.getAllByText(/March 4, 2023/).length).toBeGreaterThanOrEqual(
+      1,
+    );
+  });
+
+  it("should show raw ISO timestamp in tooltip on hover", async () => {
+    const rawTimestamp = "2023-03-04T01:45:26.005475-08:00";
+    const task = createMockTask({
+      started_at: rawTimestamp,
+      ended_at: "2023-03-04T01:46:26.518597-08:00",
+    });
+
+    setup({ task });
+
+    await waitForLoaderToBeRemoved();
+
+    const dateTimeElements = screen.getAllByText(/March 4, 2023/);
+    await userEvent.hover(dateTimeElements[0]);
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(rawTimestamp);
+  });
+});

--- a/frontend/src/metabase/admin/tools/components/TaskListPage/TaskListPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/tools/components/TaskListPage/TaskListPage.unit.spec.tsx
@@ -620,8 +620,10 @@ describe("TaskListPage", () => {
     await waitForLoaderToBeRemoved();
 
     const row = screen.getByTestId("task");
-    const dateElements = within(row).getAllByText(/March 4, 2023/);
-    expect(dateElements.length).toBeGreaterThanOrEqual(1);
+    const startedAtElement = within(row).getByTestId("started-at");
+    const endedAtElement = within(row).getByTestId("ended-at");
+    expect(startedAtElement).toHaveTextContent("March 4, 2023, 1:45 AM");
+    expect(endedAtElement).toHaveTextContent("March 4, 2023, 1:46 AM");
   });
 
   it("should show raw ISO timestamp in tooltip on hover", async () => {
@@ -640,8 +642,8 @@ describe("TaskListPage", () => {
     await waitForLoaderToBeRemoved();
 
     const row = screen.getByTestId("task");
-    const dateTimeElements = within(row).getAllByText(/March 4, 2023/);
-    await userEvent.hover(dateTimeElements[0]);
+    const startedAtElement = within(row).getByTestId("started-at");
+    await userEvent.hover(startedAtElement);
 
     expect(await screen.findByRole("tooltip")).toHaveTextContent(rawTimestamp);
   });

--- a/frontend/src/metabase/admin/tools/components/TaskListPage/TaskListPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/tools/components/TaskListPage/TaskListPage.unit.spec.tsx
@@ -604,6 +604,47 @@ describe("TaskListPage", () => {
       "http://localhost/api/task?limit=50&offset=0&sort_column=duration&sort_direction=asc",
     ]);
   });
+
+  it("should display formatted datetime for started_at and ended_at", async () => {
+    setup({
+      tasksResponse: createMockTasksResponse({
+        data: [
+          createMockTask({
+            started_at: "2023-03-04T01:45:26.005475-08:00",
+            ended_at: "2023-03-04T01:46:26.518597-08:00",
+          }),
+        ],
+      }),
+    });
+
+    await waitForLoaderToBeRemoved();
+
+    const row = screen.getByTestId("task");
+    const dateElements = within(row).getAllByText(/March 4, 2023/);
+    expect(dateElements.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("should show raw ISO timestamp in tooltip on hover", async () => {
+    const rawTimestamp = "2023-03-04T01:45:26.005475-08:00";
+    setup({
+      tasksResponse: createMockTasksResponse({
+        data: [
+          createMockTask({
+            started_at: rawTimestamp,
+            ended_at: "2023-03-04T01:46:26.518597-08:00",
+          }),
+        ],
+      }),
+    });
+
+    await waitForLoaderToBeRemoved();
+
+    const row = screen.getByTestId("task");
+    const dateTimeElements = within(row).getAllByText(/March 4, 2023/);
+    await userEvent.hover(dateTimeElements[0]);
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(rawTimestamp);
+  });
 });
 
 function createMockTasksResponse(

--- a/frontend/src/metabase/admin/tools/components/TaskListPage/TasksTable.tsx
+++ b/frontend/src/metabase/admin/tools/components/TaskListPage/TasksTable.tsx
@@ -126,7 +126,7 @@ export const TasksTable = ({
                     </Ellipsified>
                   </td>
                   <td>
-                    {task.ended_at && (
+                    {task.ended_at ? (
                       <Ellipsified
                         style={{ maxWidth: 180 }}
                         alwaysShowTooltip={Boolean(task.ended_at)}
@@ -138,6 +138,8 @@ export const TasksTable = ({
                           data-testid="ended-at"
                         />
                       </Ellipsified>
+                    ) : (
+                      "—"
                     )}
                   </td>
                   <td>{task.duration}</td>

--- a/frontend/src/metabase/admin/tools/components/TaskListPage/TasksTable.tsx
+++ b/frontend/src/metabase/admin/tools/components/TaskListPage/TasksTable.tsx
@@ -118,17 +118,27 @@ export const TasksTable = ({
                       alwaysShowTooltip
                       tooltip={task.started_at}
                     >
-                      <DateTime value={task.started_at} unit="minute" />
+                      <DateTime
+                        value={task.started_at}
+                        unit="minute"
+                        data-testid="started-at"
+                      />
                     </Ellipsified>
                   </td>
                   <td>
-                    <Ellipsified
-                      style={{ maxWidth: 180 }}
-                      alwaysShowTooltip={Boolean(task.ended_at)}
-                      tooltip={task.ended_at}
-                    >
-                      <DateTime value={task.ended_at ?? "—"} unit="minute" />
-                    </Ellipsified>
+                    {task.ended_at && (
+                      <Ellipsified
+                        style={{ maxWidth: 180 }}
+                        alwaysShowTooltip={Boolean(task.ended_at)}
+                        tooltip={task.ended_at}
+                      >
+                        <DateTime
+                          value={task.ended_at}
+                          unit="minute"
+                          data-testid="ended-at"
+                        />
+                      </Ellipsified>
+                    )}
                   </td>
                   <td>{task.duration}</td>
                   <td>

--- a/frontend/src/metabase/admin/tools/components/TaskListPage/TasksTable.tsx
+++ b/frontend/src/metabase/admin/tools/components/TaskListPage/TasksTable.tsx
@@ -4,6 +4,7 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import { TaskStatusBadge } from "metabase/admin/tools/components/TaskStatusBadge";
+import DateTime from "metabase/common/components/DateTime";
 import { Ellipsified } from "metabase/common/components/Ellipsified";
 import { SortableColumnHeader } from "metabase/common/components/ItemsTable/BaseItemsTable";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
@@ -110,14 +111,23 @@ export const TasksTable = ({
                   <td className={CS.textBold}>{task.task}</td>
                   <td>{task.db_id ? name || t`Unknown name` : null}</td>
                   <td>{task.db_id ? engine || t`Unknown engine` : null}</td>
+
                   <td>
-                    <Ellipsified style={{ maxWidth: 100 }}>
-                      {task.started_at}
+                    <Ellipsified
+                      style={{ maxWidth: 180 }}
+                      alwaysShowTooltip
+                      tooltip={task.started_at}
+                    >
+                      <DateTime value={task.started_at} unit="minute" />
                     </Ellipsified>
                   </td>
                   <td>
-                    <Ellipsified style={{ maxWidth: 100 }}>
-                      {task.ended_at}
+                    <Ellipsified
+                      style={{ maxWidth: 180 }}
+                      alwaysShowTooltip={Boolean(task.ended_at)}
+                      tooltip={task.ended_at}
+                    >
+                      <DateTime value={task.ended_at ?? "—"} unit="minute" />
                     </Ellipsified>
                   </td>
                   <td>{task.duration}</td>

--- a/frontend/src/metabase/admin/tools/components/TaskRunDetailsPage/TaskRunDetailsPage.tsx
+++ b/frontend/src/metabase/admin/tools/components/TaskRunDetailsPage/TaskRunDetailsPage.tsx
@@ -5,12 +5,24 @@ import { t } from "ttag";
 
 import { SettingsSection } from "metabase/admin/components/SettingsSection";
 import { useGetTaskRunQuery } from "metabase/api";
+import { CopyButton } from "metabase/common/components/CopyButton";
+import DateTime from "metabase/common/components/DateTime";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import AdminS from "metabase/css/admin.module.css";
 import CS from "metabase/css/core/index.css";
 import { useDispatch } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
-import { Anchor, Box, Flex, Grid, Icon, Stack, Text, Title } from "metabase/ui";
+import {
+  Anchor,
+  Box,
+  Flex,
+  Grid,
+  Icon,
+  Stack,
+  Text,
+  Title,
+  Tooltip,
+} from "metabase/ui";
 import type { Task } from "metabase-types/api";
 
 import {
@@ -49,10 +61,10 @@ export const TaskRunDetailsPage = ({ params }: TaskRunDetailsPageProps) => {
         </Link>
       </Flex>
 
-      <Grid mt="md">
+      <Grid>
         <Grid.Col span={{ base: 12, lg: "content" }} maw="50%">
-          <Title order={3}>{t`Run details`}</Title>
-          <Stack gap="xs" mt="sm">
+          <Title order={3} mb="md">{t`Run details`}</Title>
+          <Stack gap="sm">
             <Flex gap="md">
               <Text fw="bold" w={120}>{t`ID`}</Text>
               <Text>{taskRun.id}</Text>
@@ -84,11 +96,17 @@ export const TaskRunDetailsPage = ({ params }: TaskRunDetailsPageProps) => {
             </Flex>
             <Flex gap="md">
               <Text fw="bold" w={120}>{t`Started at`}</Text>
-              <Text>{taskRun.started_at}</Text>
+              <Tooltip label={taskRun.started_at}>
+                <DateTime value={taskRun.started_at} unit="minute" />
+              </Tooltip>
+              <CopyButton value={taskRun.started_at} />
             </Flex>
             <Flex gap="md">
               <Text fw="bold" w={120}>{t`Ended at`}</Text>
-              <Text>{taskRun.ended_at ?? "—"}</Text>
+              <Tooltip label={taskRun.ended_at} disabled={!taskRun.ended_at}>
+                <DateTime value={taskRun.ended_at ?? "—"} unit="minute" />
+              </Tooltip>
+              {taskRun.ended_at && <CopyButton value={taskRun.ended_at} />}
             </Flex>
             <Flex gap="md">
               <Text fw="bold" w={120}>{t`Task count`}</Text>
@@ -98,7 +116,7 @@ export const TaskRunDetailsPage = ({ params }: TaskRunDetailsPageProps) => {
         </Grid.Col>
 
         <Grid.Col span={{ base: 12, lg: "auto" }}>
-          <Title order={3}>{t`Associated tasks`}</Title>
+          <Title order={3} mb="md">{t`Associated tasks`}</Title>
           <table
             className={cx(AdminS.ContentTable)}
             data-testid="task-run-tasks-table"

--- a/frontend/src/metabase/admin/tools/components/TaskRunDetailsPage/TaskRunDetailsPage.tsx
+++ b/frontend/src/metabase/admin/tools/components/TaskRunDetailsPage/TaskRunDetailsPage.tsx
@@ -97,16 +97,30 @@ export const TaskRunDetailsPage = ({ params }: TaskRunDetailsPageProps) => {
             <Flex gap="md">
               <Text fw="bold" w={120}>{t`Started at`}</Text>
               <Tooltip label={taskRun.started_at}>
-                <DateTime value={taskRun.started_at} unit="minute" />
+                <DateTime
+                  value={taskRun.started_at}
+                  unit="minute"
+                  data-testid="started-at"
+                />
               </Tooltip>
               <CopyButton value={taskRun.started_at} />
             </Flex>
             <Flex gap="md">
               <Text fw="bold" w={120}>{t`Ended at`}</Text>
-              <Tooltip label={taskRun.ended_at} disabled={!taskRun.ended_at}>
-                <DateTime value={taskRun.ended_at ?? "—"} unit="minute" />
-              </Tooltip>
-              {taskRun.ended_at && <CopyButton value={taskRun.ended_at} />}
+              {taskRun.ended_at ? (
+                <>
+                  <Tooltip label={taskRun.ended_at}>
+                    <DateTime
+                      value={taskRun.ended_at}
+                      unit="minute"
+                      data-testid="ended-at"
+                    />
+                  </Tooltip>
+                  <CopyButton value={taskRun.ended_at} />
+                </>
+              ) : (
+                "—"
+              )}
             </Flex>
             <Flex gap="md">
               <Text fw="bold" w={120}>{t`Task count`}</Text>

--- a/frontend/src/metabase/admin/tools/components/TaskRunDetailsPage/TaskRunDetailsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/tools/components/TaskRunDetailsPage/TaskRunDetailsPage.unit.spec.tsx
@@ -1,0 +1,67 @@
+import userEvent from "@testing-library/user-event";
+import { Route } from "react-router";
+
+import { setupTaskRunEndpoint } from "__support__/server-mocks";
+import {
+  renderWithProviders,
+  screen,
+  waitForLoaderToBeRemoved,
+} from "__support__/ui";
+import * as Urls from "metabase/lib/urls";
+import type { TaskRunExtended } from "metabase-types/api";
+import { createMockTaskRunExtended } from "metabase-types/api/mocks";
+
+import { TaskRunDetailsPage } from "./TaskRunDetailsPage";
+
+const PATHNAME = `${Urls.adminToolsTasksRuns()}/:runId`;
+
+interface SetupOpts {
+  taskRun?: TaskRunExtended;
+}
+
+const setup = ({ taskRun = createMockTaskRunExtended() }: SetupOpts = {}) => {
+  setupTaskRunEndpoint(taskRun);
+
+  return renderWithProviders(
+    <Route path={PATHNAME} component={TaskRunDetailsPage} />,
+    {
+      initialRoute: Urls.adminToolsTaskRunDetails(taskRun.id),
+      withRouter: true,
+    },
+  );
+};
+
+describe("TaskRunDetailsPage", () => {
+  it("should display formatted datetime for started_at and ended_at", async () => {
+    const taskRun = createMockTaskRunExtended({
+      started_at: "2023-03-04T01:45:26.005475-08:00",
+      ended_at: "2023-03-04T01:46:26.518597-08:00",
+    });
+
+    setup({ taskRun });
+
+    await waitForLoaderToBeRemoved();
+
+    // DateTime component should render humanized timestamps (e.g. "March 4, 2023, 1:45 AM")
+    expect(screen.getAllByText(/March 4, 2023/).length).toBeGreaterThanOrEqual(
+      1,
+    );
+  });
+
+  it("should show raw ISO timestamp in tooltip on hover", async () => {
+    const rawTimestamp = "2023-03-04T01:45:26.005475-08:00";
+    const taskRun = createMockTaskRunExtended({
+      started_at: rawTimestamp,
+      ended_at: "2023-03-04T01:46:26.518597-08:00",
+    });
+
+    setup({ taskRun });
+
+    await waitForLoaderToBeRemoved();
+
+    const dateTimeElements = screen.getAllByText(/March 4, 2023/);
+    await userEvent.hover(dateTimeElements[0]);
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(rawTimestamp);
+  });
+});

--- a/frontend/src/metabase/admin/tools/components/TaskRunDetailsPage/TaskRunDetailsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/tools/components/TaskRunDetailsPage/TaskRunDetailsPage.unit.spec.tsx
@@ -60,10 +60,10 @@ describe("TaskRunDetailsPage", () => {
 
     await waitForLoaderToBeRemoved();
 
-    // DateTime component should render humanized timestamps (e.g. "March 4, 2023, 1:45 AM")
-    expect(screen.getAllByText(/March 4, 2023/).length).toBeGreaterThanOrEqual(
-      1,
-    );
+    const startedAtElement = screen.getByTestId("started-at");
+    const endedAtElement = screen.getByTestId("ended-at");
+    expect(startedAtElement).toHaveTextContent("March 4, 2023, 1:45 AM");
+    expect(endedAtElement).toHaveTextContent("March 4, 2023, 1:46 AM");
   });
 
   it("should show raw ISO timestamp in tooltip on hover", async () => {
@@ -77,8 +77,8 @@ describe("TaskRunDetailsPage", () => {
 
     await waitForLoaderToBeRemoved();
 
-    const dateTimeElements = screen.getAllByText(/March 4, 2023/);
-    await userEvent.hover(dateTimeElements[0]);
+    const startedAtElement = screen.getByTestId("started-at");
+    await userEvent.hover(startedAtElement);
 
     expect(await screen.findByRole("tooltip")).toHaveTextContent(rawTimestamp);
   });

--- a/frontend/src/metabase/admin/tools/components/TaskRunsPage/TaskRunsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/tools/components/TaskRunsPage/TaskRunsPage.unit.spec.tsx
@@ -1,0 +1,96 @@
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+import { Route } from "react-router";
+
+import { setupTaskRunsEndpoints } from "__support__/server-mocks";
+import {
+  renderWithProviders,
+  screen,
+  waitForLoaderToBeRemoved,
+} from "__support__/ui";
+import * as Urls from "metabase/lib/urls";
+import type { ListTaskRunsResponse } from "metabase-types/api";
+import { createMockTaskRun } from "metabase-types/api/mocks";
+
+import { TaskRunsPage } from "./TaskRunsPage";
+
+const PATHNAME = Urls.adminToolsTasksRuns();
+
+interface SetupOpts {
+  taskRunsResponse?: ListTaskRunsResponse;
+  error?: boolean;
+}
+
+const setup = ({
+  taskRunsResponse = createMockTaskRunsResponse(),
+  error,
+}: SetupOpts = {}) => {
+  fetchMock.get("path:/api/task/runs/entities", []);
+
+  if (error) {
+    fetchMock.get("path:/api/task/runs", { status: 500 });
+  } else {
+    setupTaskRunsEndpoints(taskRunsResponse);
+  }
+
+  return renderWithProviders(
+    <Route path={PATHNAME} component={TaskRunsPage} />,
+    {
+      initialRoute: PATHNAME,
+      withRouter: true,
+    },
+  );
+};
+
+describe("TaskRunsPage", () => {
+  it("should display formatted datetime for started_at and ended_at", async () => {
+    setup({
+      taskRunsResponse: createMockTaskRunsResponse({
+        data: [
+          createMockTaskRun({
+            started_at: "2023-03-04T01:45:26.005475-08:00",
+            ended_at: "2023-03-04T01:46:26.518597-08:00",
+          }),
+        ],
+      }),
+    });
+
+    await waitForLoaderToBeRemoved();
+
+    const row = screen.getByTestId("task-run");
+    expect(row).toHaveTextContent(/March 4, 2023/);
+  });
+
+  it("should show raw ISO timestamp in tooltip on hover", async () => {
+    const rawTimestamp = "2023-03-04T01:45:26.005475-08:00";
+    setup({
+      taskRunsResponse: createMockTaskRunsResponse({
+        data: [
+          createMockTaskRun({
+            started_at: rawTimestamp,
+            ended_at: "2023-03-04T01:46:26.518597-08:00",
+          }),
+        ],
+      }),
+    });
+
+    await waitForLoaderToBeRemoved();
+
+    const dateTimeElements = screen.getAllByText(/March 4, 2023/);
+    await userEvent.hover(dateTimeElements[0]);
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(rawTimestamp);
+  });
+});
+
+function createMockTaskRunsResponse(
+  response?: Partial<ListTaskRunsResponse>,
+): ListTaskRunsResponse {
+  return {
+    data: [],
+    limit: 0,
+    offset: 0,
+    total: 0,
+    ...response,
+  };
+}

--- a/frontend/src/metabase/admin/tools/components/TaskRunsPage/TaskRunsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/tools/components/TaskRunsPage/TaskRunsPage.unit.spec.tsx
@@ -25,8 +25,6 @@ const setup = ({
   taskRunsResponse = createMockTaskRunsResponse(),
   error,
 }: SetupOpts = {}) => {
-  fetchMock.get("path:/api/task/runs/entities", []);
-
   if (error) {
     fetchMock.get("path:/api/task/runs", { status: 500 });
   } else {
@@ -57,8 +55,10 @@ describe("TaskRunsPage", () => {
 
     await waitForLoaderToBeRemoved();
 
-    const row = screen.getByTestId("task-run");
-    expect(row).toHaveTextContent(/March 4, 2023/);
+    const startedAtElement = screen.getByTestId("started-at");
+    const endedAtElement = screen.getByTestId("ended-at");
+    expect(startedAtElement).toHaveTextContent("March 4, 2023, 1:45 AM");
+    expect(endedAtElement).toHaveTextContent("March 4, 2023, 1:46 AM");
   });
 
   it("should show raw ISO timestamp in tooltip on hover", async () => {
@@ -76,8 +76,8 @@ describe("TaskRunsPage", () => {
 
     await waitForLoaderToBeRemoved();
 
-    const dateTimeElements = screen.getAllByText(/March 4, 2023/);
-    await userEvent.hover(dateTimeElements[0]);
+    const startedAtElement = screen.getByTestId("started-at");
+    await userEvent.hover(startedAtElement);
 
     expect(await screen.findByRole("tooltip")).toHaveTextContent(rawTimestamp);
   });

--- a/frontend/src/metabase/admin/tools/components/TaskRunsPage/TaskRunsTable.tsx
+++ b/frontend/src/metabase/admin/tools/components/TaskRunsPage/TaskRunsTable.tsx
@@ -92,17 +92,26 @@ export const TaskRunsTable = ({
                     alwaysShowTooltip
                     tooltip={taskRun.started_at}
                   >
-                    <DateTime value={taskRun.started_at} unit="minute" />
+                    <DateTime
+                      value={taskRun.started_at}
+                      unit="minute"
+                      data-testid="started-at"
+                    />
                   </Ellipsified>
                 </td>
                 <td>
-                  <Ellipsified
-                    style={{ maxWidth: 180 }}
-                    alwaysShowTooltip={Boolean(taskRun.ended_at)}
-                    tooltip={taskRun.ended_at}
-                  >
-                    <DateTime value={taskRun.ended_at ?? "—"} unit="minute" />
-                  </Ellipsified>
+                  {taskRun.ended_at && (
+                    <Ellipsified
+                      style={{ maxWidth: 180 }}
+                      tooltip={taskRun.ended_at}
+                    >
+                      <DateTime
+                        value={taskRun.ended_at}
+                        unit="minute"
+                        data-testid="ended-at"
+                      />
+                    </Ellipsified>
+                  )}
                 </td>
                 <td>
                   <TaskRunStatusBadge taskRun={taskRun} />

--- a/frontend/src/metabase/admin/tools/components/TaskRunsPage/TaskRunsTable.tsx
+++ b/frontend/src/metabase/admin/tools/components/TaskRunsPage/TaskRunsTable.tsx
@@ -2,6 +2,7 @@ import cx from "classnames";
 import { push } from "react-router-redux";
 import { t } from "ttag";
 
+import DateTime from "metabase/common/components/DateTime";
 import { Ellipsified } from "metabase/common/components/Ellipsified";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import AdminS from "metabase/css/admin.module.css";
@@ -86,13 +87,21 @@ export const TaskRunsTable = ({
                   </Ellipsified>
                 </td>
                 <td>
-                  <Ellipsified style={{ maxWidth: 150 }}>
-                    {taskRun.started_at}
+                  <Ellipsified
+                    style={{ maxWidth: 180 }}
+                    alwaysShowTooltip
+                    tooltip={taskRun.started_at}
+                  >
+                    <DateTime value={taskRun.started_at} unit="minute" />
                   </Ellipsified>
                 </td>
                 <td>
-                  <Ellipsified style={{ maxWidth: 150 }}>
-                    {taskRun.ended_at}
+                  <Ellipsified
+                    style={{ maxWidth: 180 }}
+                    alwaysShowTooltip={Boolean(taskRun.ended_at)}
+                    tooltip={taskRun.ended_at}
+                  >
+                    <DateTime value={taskRun.ended_at ?? "—"} unit="minute" />
                   </Ellipsified>
                 </td>
                 <td>

--- a/frontend/src/metabase/admin/tools/components/TaskRunsPage/TaskRunsTable.tsx
+++ b/frontend/src/metabase/admin/tools/components/TaskRunsPage/TaskRunsTable.tsx
@@ -100,7 +100,7 @@ export const TaskRunsTable = ({
                   </Ellipsified>
                 </td>
                 <td>
-                  {taskRun.ended_at && (
+                  {taskRun.ended_at ? (
                     <Ellipsified
                       style={{ maxWidth: 180 }}
                       tooltip={taskRun.ended_at}
@@ -111,6 +111,8 @@ export const TaskRunsTable = ({
                         data-testid="ended-at"
                       />
                     </Ellipsified>
+                  ) : (
+                    "—"
                   )}
                 </td>
                 <td>

--- a/frontend/test/__support__/server-mocks/task.ts
+++ b/frontend/test/__support__/server-mocks/task.ts
@@ -1,6 +1,11 @@
 import fetchMock, { type UserRouteConfig } from "fetch-mock";
 
-import type { ListTasksResponse, Task } from "metabase-types/api";
+import type {
+  ListTaskRunsResponse,
+  ListTasksResponse,
+  Task,
+  TaskRunExtended,
+} from "metabase-types/api";
 
 export function setupTasksEndpoints(
   response: ListTasksResponse,
@@ -19,4 +24,18 @@ export function setupUniqueTasksEndpoint(
   options?: UserRouteConfig,
 ) {
   fetchMock.get(`path:/api/task/unique-tasks`, tasks, options);
+}
+
+export function setupTaskRunsEndpoints(
+  response: ListTaskRunsResponse,
+  options?: UserRouteConfig,
+) {
+  fetchMock.get("path:/api/task/runs", response, options);
+}
+
+export function setupTaskRunEndpoint(
+  taskRun: TaskRunExtended,
+  options?: UserRouteConfig,
+) {
+  fetchMock.get(`path:/api/task/runs/${taskRun.id}`, taskRun, options);
 }

--- a/frontend/test/__support__/server-mocks/task.ts
+++ b/frontend/test/__support__/server-mocks/task.ts
@@ -31,6 +31,7 @@ export function setupTaskRunsEndpoints(
   options?: UserRouteConfig,
 ) {
   fetchMock.get("path:/api/task/runs", response, options);
+  fetchMock.get("path:/api/task/runs/entities", []);
 }
 
 export function setupTaskRunEndpoint(


### PR DESCRIPTION
Closes [GDGT-1516](https://linear.app/metabase/issue/GDGT-1516/humanize-subscription-log-timestamps-with-timezone-support)

### Description
I added datetime formatting (respects admin/settings/localization "Report timezone" setting). Additionally, I made it so when you hover over it, the tooltip shows the original value. Moreover, on the details page (both for a task run and a task) you can copy the original value now, which can be very handy since you can't select text in the tooltip to copy it

### How to verify
1. Go to `/admin/tools/tasks/list` or `/admin/tools/tasks/runs`
2. See that values in Started At or Ended At columns respects the timezone.
3. Hover over them and see that original raw value is displayed
4. Click on a task or task run and see the same on their details pages
5. On the details page for a task / task run see a copy button next to Started At or Ended At rows. It copies original raw values

### Demo


https://github.com/user-attachments/assets/770fd3ff-b5cf-40a5-99cf-6d7b960d2601



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
