### PR TITLE
[Metabot] Send `transforms_codegen` profile on transforms pages again

### DIFF
--- a/e2e/test/scenarios/metabot/transforms-codegen.cy.spec.ts
+++ b/e2e/test/scenarios/metabot/transforms-codegen.cy.spec.ts
@@ -60,6 +60,13 @@ const assertEditorDiffState = (opts: { exists: boolean }) => {
     .should(should);
 };
 
+const sendCodgeBotMessage = (message: string) => {
+  H.sendMetabotMessage(message);
+  cy.wait("@metabotAgent").its("request.body").should("deep.include", {
+    profile_id: "transforms_codegen",
+  });
+};
+
 const assertAcceptRejectUI = (opts: { visible: boolean }) => {
   const should = opts.visible ? "be.visible" : "not.exist";
   acceptSuggestionBtn().should(should);
@@ -96,7 +103,7 @@ describe(
               createMockNativeTransformJSON(null, WRITABLE_DB_ID, "SELECT 1"),
             ),
           });
-          H.sendMetabotMessage(
+          sendCodgeBotMessage(
             "Create a new native SQL transform that gives me the number 1",
           );
           assertSuggestionInSidebar({ newSourcePartial: "SELECT 1" });
@@ -115,7 +122,7 @@ describe(
               createMockNativeTransformJSON(null, WRITABLE_DB_ID, "SELECT 2"),
             ),
           });
-          H.sendMetabotMessage("Make this give me the number 2 instead");
+          sendCodgeBotMessage("Make this give me the number 2 instead");
           assertSuggestionInSidebar({
             oldSourcePartial: "SELECT 1",
             newSourcePartial: "SELECT 2",
@@ -137,7 +144,7 @@ describe(
               createMockNativeTransformJSON(null, WRITABLE_DB_ID, "SELECT 4"),
             ),
           });
-          H.sendMetabotMessage("Make this give me the number 4 instead");
+          sendCodgeBotMessage("Make this give me the number 4 instead");
           assertSuggestionInSidebar({
             oldSourcePartial: "SELECT 3",
             newSourcePartial: "SELECT 4",
@@ -166,7 +173,7 @@ describe(
               ),
             ),
           });
-          H.sendMetabotMessage(
+          sendCodgeBotMessage(
             "Create a new native python transform that gives me the number 1",
           );
           assertSuggestionInSidebar({
@@ -192,7 +199,7 @@ describe(
               ),
             ),
           });
-          H.sendMetabotMessage("Make this give me the number 2 instead");
+          sendCodgeBotMessage("Make this give me the number 2 instead");
           assertSuggestionInSidebar({
             oldSourcePartial: "pd.DataFrame({'value': [1]})",
             newSourcePartial: "pd.DataFrame({'value': [2]})",
@@ -226,7 +233,7 @@ describe(
               ),
             ),
           });
-          H.sendMetabotMessage("Make this give me the number 4 instead");
+          sendCodgeBotMessage("Make this give me the number 4 instead");
           assertSuggestionInSidebar({
             oldSourcePartial: "pd.DataFrame({'value': [3]})",
             newSourcePartial: "pd.DataFrame({'value': [4]})",
@@ -274,7 +281,7 @@ describe(
                 ),
               ),
             });
-            H.sendMetabotMessage(
+            sendCodgeBotMessage(
               "Create a transform that queries the Test Model",
             );
             assertSuggestionInSidebar({ newSourcePartial: "SELECT * FROM" });
@@ -319,7 +326,7 @@ describe(
               ),
             });
           });
-          H.sendMetabotMessage(
+          sendCodgeBotMessage(
             "Update my SQL transform to select 2 instead of 1.",
           );
           assertSuggestionInSidebar({
@@ -352,7 +359,7 @@ describe(
               ),
             });
           });
-          H.sendMetabotMessage("Make this give me the number 4 instead");
+          sendCodgeBotMessage("Make this give me the number 4 instead");
           assertSuggestionInSidebar({
             oldSourcePartial: "SELECT 3",
             newSourcePartial: "SELECT 4",
@@ -396,7 +403,7 @@ describe(
                     ),
                   });
                 });
-                H.sendMetabotMessage(
+                sendCodgeBotMessage(
                   "Update my SQL transform to select 2 instead of 1.",
                 );
                 assertSuggestionInSidebar({
@@ -438,7 +445,7 @@ describe(
                     ),
                   ),
                 });
-                H.sendMetabotMessage("Make this give me the number 4 instead");
+                sendCodgeBotMessage("Make this give me the number 4 instead");
                 assertSuggestionInSidebar({
                   oldSourcePartial: "pd.DataFrame({'value': [3]})",
                   newSourcePartial: "pd.DataFrame({'value': [4]})",

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-agent.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-agent.ts
@@ -19,7 +19,6 @@ import {
   getMetabotReactionsState,
   getMetabotRequestId,
   getMetabotVisible,
-  getProfileOverride,
   resetConversation as resetConversationAction,
   retryPrompt,
   setProfileOverride as setProfileOverrideAction,
@@ -172,9 +171,6 @@ export const useMetabotAgent = (agentId: MetabotAgentId = "omnibot") => {
       getActiveToolCalls(state, agentId),
     ),
     debugMode: useMetabotSelector(getDebugMode),
-    profileOverride: useMetabotSelector((state) =>
-      getProfileOverride(state, agentId),
-    ),
     reactions: useMetabotSelector(getMetabotReactionsState),
   };
 };


### PR DESCRIPTION
### Description

I didn't sleuth that hard, but I _think_ we made a mistake of removing this logic when reverting our use cases PRs. Works out because the new NLQ page would have subtly broke this experience if you had asked a question from the new `/question/ask` route then gone to the transforms codegen page.

I've also updated our tests to assert that we're sending the right profile, as we could have caught this issue earlier if they had. 

### How to verify

- Go to transforms page + open metabot
- Ask a question, the experience should work again and you should see a `profile_id` in the body of the outbound request

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
