### PR TITLE
Run `codespell` on schedule and auto-fix typos

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,23 +1,104 @@
 name: Codespell
 
 on:
-  push:
-    branches:
-      - "master"
-      - "release-**"
-  pull_request:
+  schedule:
+    # Run weekly on Saturday at 6:00 AM UTC
+    - cron: "0 6 * * 6"
+  workflow_dispatch:
 
 jobs:
   codespell:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
-      - uses: codespell-project/actions-codespell@v2
+
+      - name: Prepare back-end environment
+        uses: ./.github/actions/prepare-backend
+
+      - name: Set up git configuration
+        run: |
+          git config --global user.name "Claude Code[bot]"
+          git config --global user.email "noreply@anthropic.com"
+
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Run codespell check
+        id: codespell_check
+        continue-on-error: true
+        run: ./bin/mage codespell 2>&1 | tee codespell_output.txt
+
+      - name: Generate GitHub App Token for Claude
+        if: steps.codespell_check.outcome == 'failure'
+        uses: actions/create-github-app-token@v1
+        id: claude-app-token
         with:
-          # keep this list in sync with the list in `mage/src/mage/codespell.clj`
-          path: >-
-            docs
-            enterprise
-            frontend
-            modules/drivers
-            src
+          app-id: ${{ secrets.METABASE_BOT_APP_ID }}
+          private-key: ${{ secrets.METABASE_BOT_APP_PRIVATE_KEY }}
+
+      - name: Fix spelling errors with Claude Code
+        if: steps.codespell_check.outcome == 'failure'
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ steps.claude-app-token.outputs.token }}
+          prompt: |
+            You are tasked with fixing spelling errors detected by codespell in this repository.
+
+            ## Codespell Output
+            The following spelling errors were detected:
+            ```
+            $(cat codespell_output.txt)
+            ```
+
+            ## Instructions
+            1. **Review the codespell output** - Each line shows a file path, line number, the misspelled word, and suggested corrections
+            2. **Fix every spelling error** - Use the Edit tool to fix each misspelling with the suggested correction
+               - If codespell suggests multiple corrections, choose the most appropriate one based on context
+
+            Human reviewers will verify the changes before merging, so fix all errors reported by codespell.
+          claude_args: |
+            --allowedTools "Write,Read,Glob,Grep,Edit,MultiEdit,Bash(cat*),Bash(ls*)"
+            --disallowedTools "Bash(git commit*),Bash(git push*),Bash(gh*)"
+
+      - name: Create Pull Request
+        if: steps.codespell_check.outcome == 'failure'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: claude-fix/codespell-${{ steps.date.outputs.date }}
+          base: master
+          delete-branch: true
+          commit-message: |
+            Fix spelling errors detected by codespell (${{ steps.date.outputs.date }})
+
+            🤖 Generated with [Claude Code](https://claude.ai/code)
+
+            Co-Authored-By: Claude <noreply@anthropic.com>
+          committer: "Claude Code[bot] <noreply@anthropic.com>"
+          author: "Claude Code[bot] <noreply@anthropic.com>"
+          title: "Fix spelling errors detected by codespell (${{ steps.date.outputs.date }})"
+          body: |
+            This PR automatically fixes spelling errors detected by the scheduled codespell check.
+
+            ## Automated Fix
+            🤖 This fix was generated automatically by Claude Code based on codespell output.
+
+            **Please review carefully:**
+            - [ ] The spelling fixes are correct
+            - [ ] No code functionality was changed
+            - [ ] Technical terms were preserved correctly
+
+            ---
+
+            🤖 Generated with [Claude Code](https://claude.ai/code)
+
+            Co-Authored-By: Claude <noreply@anthropic.com>
+          labels: |
+            automated-fix
+            backport

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -35,7 +35,9 @@ jobs:
       - name: Run codespell check
         id: codespell_check
         continue-on-error: true
-        run: ./bin/mage codespell 2>&1 | tee codespell_output.txt
+        run: |
+          set -o pipefail
+          ./bin/mage codespell 2>&1 | tee codespell_output.txt
 
       - name: Generate GitHub App Token for Claude
         if: steps.codespell_check.outcome == 'failure'

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -2,8 +2,8 @@ name: Codespell
 
 on:
   schedule:
-    # Run weekly on Saturday at 6:00 AM UTC
-    - cron: "0 6 * * 6"
+    # Run nightly at 4:00 AM UTC
+    - cron: "0 4 * * *"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,7 +1,6 @@
 name: Codespell
 
 on:
-  push:
   schedule:
     # Run weekly on Saturday at 6:00 AM UTC
     - cron: "0 6 * * 6"

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -16,9 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Prepare back-end environment
-        uses: ./.github/actions/prepare-backend
-
       - name: Install codespell
         run: pip install codespell
 
@@ -62,7 +59,7 @@ jobs:
             ```
 
             ## Instructions
-            1. **Review the codespell output** - Each line shows a file path, line number, the misspelled word, and suggested corrections
+            1. **Review the codespell output and identify reported spelling errors** - The usual format codespell uses is `typo ==> correction`
             2. **Fix every spelling error** - Use the Edit tool to fix each misspelling with the suggested correction
                - If codespell suggests multiple corrections, choose the most appropriate one based on context
 
@@ -70,6 +67,10 @@ jobs:
           claude_args: |
             --allowedTools "Write,Read,Glob,Grep,Edit,MultiEdit,Bash(cat*),Bash(ls*)"
             --disallowedTools "Bash(git commit*),Bash(git push*),Bash(gh*)"
+
+      - name: Clean up temporary files
+        if: steps.codespell_check.outcome == 'failure'
+        run: rm -f codespell_output.txt
 
       - name: Create Pull Request
         if: steps.codespell_check.outcome == 'failure'

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
 
+      - name: Install codespell
+        run: pip install codespell
+
       - name: Set up git configuration
         run: |
           git config --global user.name "Claude Code[bot]"

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,6 +1,7 @@
 name: Codespell
 
 on:
+  push:
   schedule:
     # Run weekly on Saturday at 6:00 AM UTC
     - cron: "0 6 * * 6"

--- a/frontend/src/metabase/search/components/filters/TypeFilter/TypeFilterContent.tsx
+++ b/frontend/src/metabase/search/components/filters/TypeFilter/TypeFilterContent.tsx
@@ -13,7 +13,7 @@ const EMPTY_SEARCH_QUERY = {
   limit: 1,
   calculate_available_models: true as const,
 };
-// This is intentional typo whic should trigger a warning
+
 export const TypeFilterContent: SearchFilterDropdown<"type">["ContentComponent"] =
   ({ value, onChange, width }) => {
     const { metadata, isLoading } = useSearchListQuery({

--- a/frontend/src/metabase/search/components/filters/TypeFilter/TypeFilterContent.tsx
+++ b/frontend/src/metabase/search/components/filters/TypeFilter/TypeFilterContent.tsx
@@ -13,7 +13,7 @@ const EMPTY_SEARCH_QUERY = {
   limit: 1,
   calculate_available_models: true as const,
 };
-
+// This is intentional typo whic should trigger a warning
 export const TypeFilterContent: SearchFilterDropdown<"type">["ContentComponent"] =
   ({ value, onChange, width }) => {
     const { metadata, isLoading } = useSearchListQuery({


### PR DESCRIPTION
Resolves DEV-1282

This PR overhauls how we run the codespell action in CI.
Instead of it running on every PR, we're now using claude to fix potential typos on a ~~weekly~~ nightly schedule.

Context: https://metaboat.slack.com/archives/C084XNEPH6K/p1768941347788759?thread_ts=1768935763.465999&cid=C084XNEPH6K

## Test

This is the example of a PR opened by running this action on `workflow_dispatch` with an intentional typo.
https://github.com/metabase/metabase/pull/68443