### PR TITLE
Contain layout for notebook preview

### DIFF
--- a/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
@@ -1477,3 +1477,20 @@ describe("issue 66210", () => {
     H.entityPickerModalLevel(1).findByText(METRIC_NAME).should("not.exist");
   });
 });
+
+describe("issue #67903", () => {
+  beforeEach(() => {
+    cy.viewport(1000, 800);
+    H.restore();
+    cy.signInAsAdmin();
+  });
+
+  it("shoult not show preview table headers on top of other elements (metabase#67903)", () => {
+    H.startNewQuestion();
+    H.miniPickerBrowseAll().click();
+    H.entityPickerModalItem(1, "Orders").click();
+    H.getNotebookStep("data").findByTestId("step-preview-button").click();
+    H.queryBuilderHeader().findByLabelText("View SQL").click();
+    cy.findByTestId("table-header").should("not.be.visible");
+  });
+});

--- a/frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx
@@ -12,6 +12,8 @@ import Visualization from "metabase/visualizations/components/Visualization";
 import * as Lib from "metabase-lib";
 import Question from "metabase-lib/v1/Question";
 
+import S from "./NotebookStepPreview.module.css";
+
 const PREVIEW_ROWS_LIMIT = 10;
 
 const getPreviewQuestion = (step) => {
@@ -97,9 +99,16 @@ export const VisualizationPreview = ({ rawSeries, result, error }) => {
       rawSeries={rawSeries}
       error={err}
       queryBuilderMode="notebook"
-      className={cx(CS.bordered, CS.shadowed, CS.rounded, CS.bgWhite, {
-        [CS.p2]: err,
-      })}
+      className={cx(
+        S.PreviewVisualization,
+        CS.bordered,
+        CS.shadowed,
+        CS.rounded,
+        CS.bgWhite,
+        {
+          [CS.p2]: err,
+        },
+      )}
       style={{
         height: err ? "auto" : getPreviewHeightForResult(result),
       }}

--- a/frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.module.css
+++ b/frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.module.css
@@ -1,0 +1,3 @@
+.PreviewVisualization {
+  contain: strict;
+}


### PR DESCRIPTION
Fixes #67903 

Avoids the content of the preview section to leak out. 

This has the added benefit that the border radius also no longer overflows (check the preview corners in the screenshots below).

#### Before
<img width="1028" height="789" alt="ok" src="https://github.com/user-attachments/assets/90849191-0b9e-4177-b5e3-aeede98f913c" />
<img width="1028" height="789" alt="Screenshot 2026-01-21 at 13 02 59" src="https://github.com/user-attachments/assets/f6d674c1-1802-48b1-b36f-3812a25c96b4" />

#### After 
<img width="1028" height="789" alt="Screenshot 2026-01-21 at 13 02 23" src="https://github.com/user-attachments/assets/0e29c8a4-ad83-4632-90b8-eec10675def1" />
<img width="1123" height="725" alt="Screenshot 2026-01-21 at 13 04 11" src="https://github.com/user-attachments/assets/660939b6-bbfd-4cb2-a0bd-03457aed3fd7" />

