### PR TITLE
transforms: pass full object instead of re-querying db internally

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/transforms/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/util.clj
@@ -238,9 +238,8 @@
 
   Returns a map with `:query` (MBQL query selecting the max) and `:filter-column` (column metadata),
   or `nil` if the transform doesn't use checkpoint-based incremental strategy or the target table doesn't exist."
-  [transform-id]
-  (let [{:keys [source target] :as transform} (t2/select-one :model/Transform transform-id)
-        db-id (transforms.i/target-db-id transform)]
+  [{:keys [source target] :as transform}]
+  (let [db-id (transforms.i/target-db-id transform)]
     (when (checkpoint-incremental? source)
       (when-let [table (target-table db-id target)]
         (let [metadata-provider (lib-be/application-database-metadata-provider db-id)
@@ -313,11 +312,11 @@
 
 (defn compile-source
   "Compile the source query of a transform to SQL, applying incremental filtering if required."
-  [{:keys [id source]}]
+  [{:keys [source] :as transform}]
   (let [{:keys [source-incremental-strategy] query-type :type} source]
     (case (keyword query-type)
       :query
-      (let [checkpoint (next-checkpoint id)
+      (let [checkpoint (next-checkpoint transform)
             query (:query source)
             driver (some->> query :database (t2/select-one :model/Database) :engine keyword)]
         (binding [driver/*compile-with-inline-parameters*
@@ -627,7 +626,7 @@
   (when (driver.u/supports? (:engine database) :describe-indexes database)
     (let [driver     (:engine database)
           indexes    (driver/describe-table-indexes driver database target)
-          checkpoint (next-checkpoint (:id transform))
+          checkpoint (next-checkpoint transform)
           {:keys [drop create]}
           (decide-secondary-index-ddl
            {:filter-column (:filter-column checkpoint)

--- a/enterprise/backend/src/metabase_enterprise/transforms_python/python_runner.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms_python/python_runner.clj
@@ -271,9 +271,10 @@
   [table-id source-incremental-strategy transform-id limit]
   (let [db-id             (t2/select-one-fn :db_id (t2/table-name :model/Table) :id table-id)
         metadata-provider (lib-be/application-database-metadata-provider db-id)
-        table-metadata    (lib.metadata/table metadata-provider table-id)]
+        table-metadata    (lib.metadata/table metadata-provider table-id)
+        transform         (t2/select-one :model/Transform transform-id)]
     (cond-> (lib/query metadata-provider table-metadata)
-      source-incremental-strategy (transforms.u/preprocess-incremental-query source-incremental-strategy (transforms.u/next-checkpoint transform-id))
+      source-incremental-strategy (transforms.u/preprocess-incremental-query source-incremental-strategy (transforms.u/next-checkpoint transform))
       limit                       (lib/limit limit))))
 
 ;; TODO break this up such that s3 can be swapped out for other transfer mechanisms.


### PR DESCRIPTION
also makes logging poller stop when there is a failure (right now it'll log until process exits)