### PR TITLE
Remove ^:parallel meta for tests that search + hold locks (#68240)

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/search/scoring_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/search/scoring_test.clj
@@ -184,7 +184,7 @@
                 ["card" 2 "card verified"]]
                (appdb.scoring-test/search-results* "card")))))))
 
-(deftest ^:parallel transforms-user-recency-test
+(deftest transforms-user-recency-test
   (mt/with-premium-features #{:transforms}
     (let [user-id (mt/user->id :crowberto)
           now     (Instant/now)

--- a/test/metabase/search/appdb/scoring_test.clj
+++ b/test/metabase/search/appdb/scoring_test.clj
@@ -235,7 +235,7 @@
 ;; ---- personalized rankers ---
 ;; These require some related appdb content
 
-(deftest ^:parallel bookmark-test
+(deftest bookmark-test
   (let [crowberto (mt/user->id :crowberto)
         rasta     (mt/user->id :rasta)]
     (mt/with-temp [:model/Card {c1 :id} {}
@@ -274,7 +274,7 @@
                     ["collection" c1 "collection normal"]]
                    (search-results :bookmarked "collection" {:current-user-id crowberto})))))))))
 
-(deftest ^:parallel user-recency-test
+(deftest user-recency-test
   (let [user-id     (mt/user->id :crowberto)
         right-now   (Instant/now)
         long-ago    (.minus right-now 10 ChronoUnit/DAYS)


### PR DESCRIPTION
Manual backport of [#68240](https://github.com/metabase/metabase/pull/68240)