### PR TITLE
Improve AI chart analysis: add SVG legend rendering and reusable SmartScalar utilities

### DIFF
--- a/frontend/src/metabase-types/api/metabot.ts
+++ b/frontend/src/metabase-types/api/metabot.ts
@@ -106,6 +106,10 @@ export type MetabotSeriesConfig = {
   stacked?: boolean;
 };
 
+// Extended display type for AI service - includes "histogram" which isn't a separate CardDisplayType
+// but is a specific configuration of bar charts that needs to be distinguished
+export type MetabotDisplayType = CardDisplayType | "histogram";
+
 export type MetabotChartConfig = {
   image_base_64?: string;
   title?: string | null;
@@ -121,7 +125,7 @@ export type MetabotChartConfig = {
     timestamp: string;
   }>;
   query?: DatasetQuery;
-  display_type?: CardDisplayType;
+  display_type?: MetabotDisplayType;
 };
 
 export type MetabotCardInfo = {

--- a/frontend/src/metabase/query_builder/containers/use-register-query-builder-metabot-context.tsx
+++ b/frontend/src/metabase/query_builder/containers/use-register-query-builder-metabot-context.tsx
@@ -15,6 +15,7 @@ import type Question from "metabase-lib/v1/Question";
 import type {
   MetabotChartConfig,
   MetabotColumnType,
+  MetabotDisplayType,
   MetabotSeriesConfig,
   RawSeries,
   TimelineEvent,
@@ -172,6 +173,16 @@ function getVisualizationDataUri(question: Question) {
     .exhaustive();
 }
 
+const getDisplayType = (
+  question: Question,
+  visualizationSettings: ComputedVisualizationSettings | undefined,
+): MetabotDisplayType => {
+  if (visualizationSettings?.["graph.x_axis.scale"] === "histogram") {
+    return "histogram";
+  }
+  return question.display();
+};
+
 const getChartConfigs = async ({
   question,
   series,
@@ -192,7 +203,7 @@ const getChartConfigs = async ({
         series: processSeriesData(series, visualizationSettings),
         timeline_events: processTimelineEvents(timelineEvents),
         query: question.datasetQuery(),
-        display_type: question.display(),
+        display_type: getDisplayType(question, visualizationSettings),
       },
     ];
   } catch (err) {

--- a/frontend/src/metabase/query_builder/containers/use-register-query-builder-metabot-context.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/use-register-query-builder-metabot-context.unit.spec.tsx
@@ -251,6 +251,49 @@ describe("registerQueryBuilderMetabotContextFn", () => {
       },
     });
   });
+
+  it("should set display_type to histogram when graph.x_axis.scale is histogram", async () => {
+    const card = createMockCard({
+      name: "Value distribution",
+      display: "bar",
+      visualization_settings: createMockVisualizationSettings({
+        "graph.dimensions": ["value"],
+        "graph.metrics": ["count"],
+        "graph.x_axis.scale": "histogram",
+      }),
+    });
+    const data = createMockData({
+      question: new Question(card),
+      series: [
+        createMockSingleSeries(card, {
+          data: {
+            cols: [
+              createMockColumn({
+                name: "value",
+                display_name: "Value",
+                base_type: "type/Integer",
+              }),
+              createMockColumn({
+                name: "count",
+                display_name: "Count",
+                base_type: "type/Integer",
+                source: "aggregation",
+              }),
+            ],
+            rows: [
+              [10, 5],
+              [20, 8],
+              [30, 3],
+            ],
+          },
+        }),
+      ],
+    });
+    const result = await registerQueryBuilderMetabotContextFn(data);
+
+    const chartConfig = getChartConfig(result)!;
+    expect(chartConfig.display_type).toEqual("histogram");
+  });
 });
 
 it("should return empty result when metabot is disabled", async () => {

--- a/frontend/src/metabase/visualizations/lib/image-exports.ts
+++ b/frontend/src/metabase/visualizations/lib/image-exports.ts
@@ -9,8 +9,10 @@ import {
 } from "metabase/dashboard/constants";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { isStorybookActive } from "metabase/env";
+import { color } from "metabase/lib/colors";
 import { utf8_to_b64 } from "metabase/lib/encoding";
 import { openImageBlobOnStorybook } from "metabase/lib/loki-utils";
+import { measureTextWidth } from "metabase/lib/measure-text";
 import EmbedFrameS from "metabase/public/components/EmbedFrame/EmbedFrame.module.css";
 
 import { getCardKey } from "./utils";
@@ -183,27 +185,254 @@ export const getDashboardImage = async (
   return canvas.toDataURL("image/png").split(",")[1];
 };
 
-export const getVisualizationSvgDataUri = (
-  selector: string,
-): string | undefined => {
+interface LegendItem {
+  color: string;
+  label: string;
+}
+
+const LEGEND_CONFIG = {
+  dotRadius: 5,
+  fontSize: 12, // Smaller font to match actual legend
+  fontFamily: "Lato, sans-serif",
+  fontWeight: "700",
+  itemGap: 16, // Gap between items
+  rowHeight: 20,
+  paddingX: 16,
+  paddingY: 8,
+  dotToTextGap: 8,
+  maxWidth: 600, // Max width for legend row before wrapping
+} as const;
+
+function rgbToHex(rgb: string): string {
+  const match = rgb.match(/^rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+  if (!match) {
+    return rgb;
+  }
+  const [, r, g, b] = match;
+  const toHex = (n: string) => {
+    const hex = parseInt(n, 10).toString(16);
+    return hex.length === 1 ? "0" + hex : hex;
+  };
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+function isTransparentColor(bgColor: string): boolean {
+  return bgColor === "transparent" || bgColor.startsWith("rgba(0, 0, 0, 0");
+}
+
+function extractLegendItems(container: HTMLElement): LegendItem[] {
+  const items = container.querySelectorAll('[data-testid="legend-item"]');
+
+  return Array.from(items).flatMap((item) => {
+    const dotContainer =
+      item.querySelector('[data-testid="legend-item-dot"]') ??
+      item.querySelector("button");
+
+    if (!dotContainer) {
+      return [];
+    }
+
+    // The legend dot has two divs: OuterCircle (border color) and InnerCircle (series color)
+    // We want the InnerCircle which is the second div
+    const circles = Array.from(dotContainer.querySelectorAll("div"));
+    const innerCircle = circles.length >= 2 ? circles[1] : circles[0];
+
+    if (!innerCircle) {
+      return [];
+    }
+
+    const bgColor = getComputedStyle(innerCircle).backgroundColor;
+    if (isTransparentColor(bgColor)) {
+      return [];
+    }
+
+    const color = rgbToHex(bgColor);
+    const label = item.textContent?.trim() ?? "";
+
+    return color && label ? [{ color, label }] : [];
+  });
+}
+
+function createSvgElement<K extends keyof SVGElementTagNameMap>(
+  tag: K,
+  attrs: Record<string, string | number>,
+): SVGElementTagNameMap[K] {
+  const element = document.createElementNS("http://www.w3.org/2000/svg", tag);
+  for (const [key, value] of Object.entries(attrs)) {
+    element.setAttribute(key, String(value));
+  }
+  return element;
+}
+
+function getTextColor(): string {
+  return (
+    getComputedStyle(document.documentElement)
+      .getPropertyValue("--mb-color-text-primary")
+      .trim() || color("white")
+  );
+}
+
+function measureLegendTextWidth(text: string): number {
+  const { fontSize, fontFamily, fontWeight } = LEGEND_CONFIG;
+  return measureTextWidth(text, {
+    size: fontSize,
+    family: fontFamily,
+    weight: fontWeight,
+  });
+}
+
+function calculateItemWidth(label: string): number {
+  const { dotRadius, dotToTextGap, itemGap } = LEGEND_CONFIG;
+  const textWidth = measureLegendTextWidth(label);
+  return dotRadius * 2 + dotToTextGap + textWidth + itemGap;
+}
+
+interface LegendLayout {
+  x: number;
+  y: number;
+}
+
+function calculateLegendLayout(legendItems: LegendItem[]): LegendLayout[] {
+  const { paddingX, rowHeight, maxWidth } = LEGEND_CONFIG;
+
+  const layout: LegendLayout[] = [];
+  let currentX = paddingX;
+  let currentY = 0;
+
+  for (const item of legendItems) {
+    const itemWidth = calculateItemWidth(item.label);
+
+    // Wrap to next row if item doesn't fit
+    if (currentX + itemWidth > maxWidth && currentX > paddingX) {
+      currentX = paddingX;
+      currentY += rowHeight;
+    }
+
+    layout.push({ x: currentX, y: currentY });
+    currentX += itemWidth;
+  }
+
+  return layout;
+}
+
+function renderLegendAsSvg(
+  legendItems: LegendItem[],
+  startY: number,
+): SVGGElement {
+  const { dotRadius, fontSize, paddingY, dotToTextGap } = LEGEND_CONFIG;
+
+  const legendGroup = createSvgElement("g", { class: "chart-legend" });
+  const textColor = getTextColor();
+  const layout = calculateLegendLayout(legendItems);
+
+  for (let i = 0; i < legendItems.length; i++) {
+    const item = legendItems[i];
+    const { x, y } = layout[i];
+    const actualY = startY + paddingY + y + dotRadius;
+
+    const itemGroup = createSvgElement("g", {});
+
+    const circle = createSvgElement("circle", {
+      cx: x,
+      cy: actualY,
+      r: dotRadius,
+      fill: item.color,
+    });
+    itemGroup.appendChild(circle);
+
+    const text = createSvgElement("text", {
+      x: x + dotRadius + dotToTextGap,
+      y: actualY + 4,
+      "font-size": fontSize,
+      "font-family": "Lato, sans-serif",
+      "font-weight": "700",
+      fill: textColor,
+    });
+    text.textContent = item.label;
+    itemGroup.appendChild(text);
+
+    legendGroup.appendChild(itemGroup);
+  }
+
+  return legendGroup;
+}
+
+function getBasicSvgDataUri(selector: string): string | undefined {
   const element = document.querySelector(selector)?.cloneNode(true);
   if (element && !(element instanceof SVGElement)) {
     throw new Error("Selector did not provide an SVG element");
   }
 
-  const backgroundColor = getComputedStyle(document.documentElement)
-    .getPropertyValue("--mb-color-bg-dashboard")
-    .trim();
-  if (backgroundColor && element instanceof SVGElement) {
-    element.style.backgroundColor = backgroundColor;
-  }
   if (!element) {
     return undefined;
   }
 
   const svgString = new XMLSerializer().serializeToString(element);
   return `data:image/svg+xml;base64,${utf8_to_b64(svgString)}`;
-};
+}
+
+function calculateLegendHeight(legendItems: LegendItem[]): number {
+  if (legendItems.length === 0) {
+    return 0;
+  }
+
+  const layout = calculateLegendLayout(legendItems);
+  const lastItem = layout[layout.length - 1];
+  const { rowHeight, paddingY } = LEGEND_CONFIG;
+
+  // Height = last item's Y position + one row height + padding
+  return lastItem.y + rowHeight + paddingY * 2;
+}
+
+function copyChildrenToGroup(source: SVGElement, target: SVGGElement): void {
+  for (const child of source.children) {
+    target.appendChild(child.cloneNode(true));
+  }
+}
+
+export function getVisualizationSvgDataUri(
+  selector: string,
+): string | undefined {
+  const container = document.querySelector(selector);
+  if (!(container instanceof HTMLElement)) {
+    return undefined;
+  }
+
+  const chartSvg = container.querySelector('svg:not([role="img"])');
+  const fallbackSelector = `${selector} svg:not([role="img"])`;
+
+  if (!(chartSvg instanceof SVGElement)) {
+    return getBasicSvgDataUri(fallbackSelector);
+  }
+
+  const legendItems = extractLegendItems(container);
+  if (legendItems.length === 0) {
+    return getBasicSvgDataUri(fallbackSelector);
+  }
+
+  const chartRect = chartSvg.getBoundingClientRect();
+  const legendHeight = calculateLegendHeight(legendItems);
+  const totalHeight = chartRect.height + legendHeight;
+
+  const wrapperSvg = createSvgElement("svg", {
+    width: chartRect.width,
+    height: totalHeight,
+    viewBox: `0 0 ${chartRect.width} ${totalHeight}`,
+    xmlns: "http://www.w3.org/2000/svg",
+  });
+
+  const legendSvg = renderLegendAsSvg(legendItems, 0);
+  wrapperSvg.appendChild(legendSvg);
+
+  const chartGroup = createSvgElement("g", {
+    transform: `translate(0, ${legendHeight})`,
+  });
+  copyChildrenToGroup(chartSvg.cloneNode(true) as SVGElement, chartGroup);
+  wrapperSvg.appendChild(chartGroup);
+
+  const svgString = new XMLSerializer().serializeToString(wrapperSvg);
+  return `data:image/svg+xml;base64,${utf8_to_b64(svgString)}`;
+}
 
 export const getChartSelector = (
   input: { dashcardId: number | undefined } | { cardId: number | undefined },


### PR DESCRIPTION
## Summary
This is related to ai-service changes in here: https://github.com/metabase/ai-service/pull/600

This PR improves AI chart analysis by:
1. Adding programmatic SVG legend rendering for chart exports
2. Extracting reusable comparison utilities from SmartScalar compute logic
3. Adding scalar and smartscalar chart support to the metabot context

## Changes

### SVG Legend Rendering (image-exports.ts)
- Extracts legend items from DOM and renders them as SVG elements
- Uses Canvas API for accurate text width measurement to prevent label overlap
- Implements dynamic wrapping layout (max 600px width per row)
- Fixes legend colors by targeting InnerCircle instead of OuterCircle
- Converts RGB colors to hex format for SVG compatibility

### SmartScalar Comparison Utilities (compute.ts)
- Extracts 3 reusable utility functions:
  - `findStaticNumberValue()` - for static number comparisons
  - `findAnotherColumnValue()` - for column-based comparisons
  - `findPreviousValue()` - for time-based previous value comparisons
- Refactors existing comparison functions to use these shared utilities
- Eliminates code duplication between compute and metabot context

### Metabot Context Enhancements (use-register-query-builder-metabot-context.tsx)
- Adds scalar and smartscalar chart support for AI analysis
- Uses shared SmartScalar comparison utilities (eliminates ~47 lines of duplication)
- Implements `processScalarSeries()` for simple scalar charts
- Implements `processSmartScalarSeries()` with time dimension support
- Handles both string and array dimensions for pie charts
- Extracts only relevant data points (current + comparison) for smartscalar
