### PR TITLE
gdgt-1377 deselect and hide from bulk view tables not matching selection

### DIFF
--- a/e2e/support/helpers/e2e-data-studio-helpers.ts
+++ b/e2e/support/helpers/e2e-data-studio-helpers.ts
@@ -2,6 +2,7 @@ import type { MeasureId, SegmentId, TableId } from "metabase-types/api";
 
 import { codeMirrorHelpers } from "./e2e-codemirror-helpers";
 import { popover } from "./e2e-ui-elements-helpers";
+const { H } = cy;
 
 const libraryPage = () => cy.findByTestId("library-page");
 const newSnippetPage = () => cy.findByTestId("new-snippet-page");
@@ -111,6 +112,10 @@ export const DataStudio = {
         cy
           .findByTestId("table-description-section")
           .findByPlaceholderText("No description"),
+    },
+    openFilterPopover: () => {
+      cy.findByRole("button", { name: "Filter" }).click();
+      H.popover();
     },
   },
   Library: {

--- a/e2e/support/helpers/e2e-datamodel-helpers.ts
+++ b/e2e/support/helpers/e2e-datamodel-helpers.ts
@@ -5,6 +5,8 @@ import type {
   TableId,
 } from "metabase-types/api";
 
+import { popover } from "./e2e-ui-elements-helpers";
+
 export const DataModel = {
   visit,
   visitDataStudio,
@@ -15,14 +17,19 @@ export const DataModel = {
     get: getTablePicker,
     getDatabase: getTablePickerDatabase,
     getDatabaseToggle: getTablePickerDatabaseToggle,
+    getDatabaseCheckbox,
     getDatabases: getTablePickerDatabases,
     getSchemas: getTablePickerSchemas,
     getSchema: getTablePickerSchema,
     getSchemaToggle: getTablePickerSchemaToggle,
+    getSchemaCheckbox,
     getTables: getTablePickerTables,
     getTable: getTablePickerTable,
     getSearchInput: getTablePickerSearchInput,
     getFilterForm: getTablePickerFilter,
+    openFilterPopover,
+    selectFilterOption,
+    applyFilters,
   },
   TableSection: {
     get: getTableSection,
@@ -663,4 +670,27 @@ function getMeasureEditorDependenciesTab() {
 
 function getMeasureRevisionHistory() {
   return cy.findByTestId("measure-revision-history-page");
+}
+
+export function openFilterPopover() {
+  cy.findByRole("button", { name: "Filter" }).click();
+  popover();
+}
+
+export function selectFilterOption(fieldLabel: string, optionLabel: string) {
+  cy.findByRole("textbox", { name: fieldLabel }).click();
+  popover().contains(optionLabel).click();
+}
+
+export function applyFilters() {
+  cy.findByRole("button", { name: "Apply" }).click();
+  cy.wait("@listTables");
+}
+
+export function getDatabaseCheckbox(databaseName: string) {
+  return getTablePickerDatabase(databaseName).find('input[type="checkbox"]');
+}
+
+export function getSchemaCheckbox(schemaName: string) {
+  return getTablePickerSchema(schemaName).find('input[type="checkbox"]');
 }

--- a/e2e/test/scenarios/data-studio/data-model/datamodel-data-studio.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-model/datamodel-data-studio.cy.spec.ts
@@ -562,15 +562,15 @@ describe("scenarios > data studio > datamodel", () => {
 
         H.DataModel.visitDataStudio();
 
-        openFilterPopover();
+        TablePicker.openFilterPopover();
 
         cy.log("Filter popover should close on click outside");
         H.DataModel.TablePicker.getSearchInput().click();
         H.DataModel.TablePicker.getFilterForm().should("not.exist");
 
-        openFilterPopover();
-        selectFilterOption("Visibility type", "Gold");
-        applyFilters();
+        TablePicker.openFilterPopover();
+        TablePicker.selectFilterOption("Visibility type", "Gold");
+        TablePicker.applyFilters();
         H.expectUnstructuredSnowplowEvent({
           event: "data_studio_table_picker_filters_applied",
         });
@@ -600,9 +600,9 @@ describe("scenarios > data studio > datamodel", () => {
 
         H.DataModel.visitDataStudio();
 
-        openFilterPopover();
-        selectFilterOption("Owner", "Unspecified");
-        applyFilters();
+        TablePicker.openFilterPopover();
+        TablePicker.selectFilterOption("Owner", "Unspecified");
+        TablePicker.applyFilters();
 
         cy.get<TableId>("@unownedTableId").then(expectTableVisible);
         cy.get<TableId>("@ownedTableId").then(expectTableNotVisible);
@@ -627,11 +627,11 @@ describe("scenarios > data studio > datamodel", () => {
 
         H.DataModel.visitDataStudio();
 
-        openFilterPopover();
+        TablePicker.openFilterPopover();
         cy.get<string>("@ownerName").then((ownerName) => {
           selectOwnerByName(ownerName);
         });
-        applyFilters();
+        TablePicker.applyFilters();
 
         cy.get<TableId>("@ownedTableId").then(expectTableVisible);
         cy.get<TableId>("@unownedTableId").then(expectTableNotVisible);
@@ -653,9 +653,9 @@ describe("scenarios > data studio > datamodel", () => {
 
         H.DataModel.visitDataStudio();
 
-        openFilterPopover();
+        TablePicker.openFilterPopover();
         selectOwnerByEmail(OWNER_EMAIL);
-        applyFilters();
+        TablePicker.applyFilters();
 
         cy.get<TableId>("@emailOwnedTableId").then(expectTableVisible);
         cy.get<TableId>("@otherTableId").then(expectTableNotVisible);
@@ -676,9 +676,9 @@ describe("scenarios > data studio > datamodel", () => {
 
         H.DataModel.visitDataStudio();
 
-        openFilterPopover();
-        selectFilterOption("Source", "Uploaded data");
-        applyFilters();
+        TablePicker.openFilterPopover();
+        TablePicker.selectFilterOption("Source", "Uploaded data");
+        TablePicker.applyFilters();
 
         cy.get<TableId>("@uploadedTableId").then(expectTableVisible);
         cy.get<TableId>("@ingestedTableId").then(expectTableNotVisible);
@@ -711,9 +711,9 @@ describe("scenarios > data studio > datamodel", () => {
 
         H.DataModel.visitDataStudio();
 
-        openFilterPopover();
+        TablePicker.openFilterPopover();
         toggleUnusedFilter(true);
-        applyFilters();
+        TablePicker.applyFilters();
 
         cy.get<TableId>("@unusedTableId").then(expectTableVisible);
         cy.get<TableId>("@usedTableId").then(expectTableNotVisible);
@@ -3924,21 +3924,6 @@ type TableLookup = {
   displayName?: string;
   name?: string;
 };
-
-function openFilterPopover() {
-  cy.findByRole("button", { name: "Filter" }).click();
-  H.popover();
-}
-
-function applyFilters() {
-  cy.findByRole("button", { name: "Apply" }).click();
-  cy.wait("@listTables");
-}
-
-function selectFilterOption(fieldLabel: string, optionLabel: string) {
-  cy.findByRole("textbox", { name: fieldLabel }).click();
-  H.popover().contains(optionLabel).click();
-}
 
 function selectOwnerByName(ownerLabel: string) {
   cy.findByRole("textbox", { name: "Owner" }).click();

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/SearchNew.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/SearchNew.tsx
@@ -139,10 +139,8 @@ export function SearchNew({
       return [];
     }
 
-    filterSelectedTables(tables.map((table) => table.id));
-
     return tables.filter((table) => allowedDatabaseIds.has(table.db_id));
-  }, [allowedDatabaseIds, tables, filterSelectedTables]);
+  }, [allowedDatabaseIds, tables]);
 
   const isLoading = isLoadingTables || isLoadingDatabases;
 
@@ -150,6 +148,10 @@ export function SearchNew({
     () => buildResultTree(filteredTables),
     [filteredTables],
   );
+
+  useEffect(() => {
+    filterSelectedTables(filteredTables.map((table) => table.id));
+  }, [filteredTables, filterSelectedTables]);
 
   useEffect(() => {
     resetSelection();

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/SearchNew.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/components/SearchNew.tsx
@@ -98,7 +98,8 @@ export function SearchNew({
   filters,
   onChange,
 }: SearchNewProps) {
-  const { resetSelection } = useSelection();
+  const { resetSelection, filterSelectedTables } = useSelection();
+
   const routeParams = parseRouteParams(params);
   const {
     data: tables,
@@ -138,8 +139,10 @@ export function SearchNew({
       return [];
     }
 
+    filterSelectedTables(tables.map((table) => table.id));
+
     return tables.filter((table) => allowedDatabaseIds.has(table.db_id));
-  }, [allowedDatabaseIds, tables]);
+  }, [allowedDatabaseIds, tables, filterSelectedTables]);
 
   const isLoading = isLoadingTables || isLoadingDatabases;
 

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/TableAttributesEditBulk.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/TableAttributesEditBulk.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { usePrevious } from "react-use";
 import { t } from "ttag";
 
 import { useSelector } from "metabase/lib/redux";
@@ -59,6 +60,9 @@ export function TableAttributesEditBulk({
   const [entityType, setEntityType] = useState<string | null>(null);
   const [userId, setUserId] = useState<UserId | "unknown" | null>(null);
   const [modalType, setModalType] = useState<TableModalType>();
+  const previousTables = usePrevious(selectedTables);
+  const previousSchemas = usePrevious(selectedSchemas);
+  const previousDatabases = usePrevious(selectedDatabases);
 
   const hasOnlyTablesSelected =
     selectedTables.size > 0 &&
@@ -141,12 +145,30 @@ export function TableAttributesEditBulk({
   };
 
   useEffect(() => {
-    setDataLayer(null);
-    setDataSource(null);
-    setEmail(null);
-    setEntityType(null);
-    setUserId(null);
-  }, [selectedTables, selectedSchemas, selectedDatabases]);
+    if (!previousTables || !previousSchemas || !previousDatabases) {
+      return;
+    }
+
+    const shouldReset =
+      !selectedTables.isSubsetOf(previousTables) ||
+      !selectedSchemas.isSubsetOf(previousSchemas) ||
+      !selectedDatabases.isSubsetOf(previousDatabases);
+
+    if (shouldReset) {
+      setDataLayer(null);
+      setDataSource(null);
+      setEmail(null);
+      setEntityType(null);
+      setUserId(null);
+    }
+  }, [
+    previousDatabases,
+    previousSchemas,
+    previousTables,
+    selectedDatabases,
+    selectedSchemas,
+    selectedTables,
+  ]);
 
   return (
     <>

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/TableAttributesEditBulk.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/TableAttributesEditBulk.tsx
@@ -150,9 +150,9 @@ export function TableAttributesEditBulk({
     }
 
     const shouldReset =
-      !selectedTables.isSubsetOf(previousTables) ||
-      !selectedSchemas.isSubsetOf(previousSchemas) ||
-      !selectedDatabases.isSubsetOf(previousDatabases);
+      !isSubsetOf(selectedTables, previousTables) ||
+      !isSubsetOf(selectedSchemas, previousSchemas) ||
+      !isSubsetOf(selectedDatabases, previousDatabases);
 
     if (shouldReset) {
       setDataLayer(null);
@@ -342,4 +342,8 @@ export function TableAttributesEditBulk({
       />
     </>
   );
+}
+
+function isSubsetOf<T>(subset: Set<T>, superset: Set<T>): boolean {
+  return Array.from(subset).every((element) => superset.has(element));
 }

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/TableAttributesEditBulk.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/TableAttributesEditBulk.unit.spec.tsx
@@ -21,9 +21,11 @@ import { TableAttributesEditBulk } from "./TableAttributesEditBulk";
 // Component that allows controlling selection for testing
 function SelectionController({
   initialTables,
+  nextTables,
   onSelectionChange,
 }: {
   initialTables: Set<TableId>;
+  nextTables?: Set<TableId>;
   onSelectionChange: () => void;
 }) {
   const { setSelectedTables } = useSelection();
@@ -38,7 +40,7 @@ function SelectionController({
       data-testid="change-selection"
       onClick={() => {
         // Change selection to a different table
-        setSelectedTables(new Set([999]));
+        setSelectedTables(nextTables ?? new Set([999]));
         onSelectionChange();
       }}
     >
@@ -49,8 +51,10 @@ function SelectionController({
 
 function TestWrapper({
   initialTables = new Set([1]),
+  nextTables,
 }: {
   initialTables?: Set<TableId>;
+  nextTables?: Set<TableId>;
 }) {
   const [_selectionChanged, setSelectionChanged] = useState(false);
 
@@ -59,6 +63,7 @@ function TestWrapper({
       <TableAttributesEditBulk hasLibrary onUpdate={_.noop} />
       <SelectionController
         initialTables={initialTables}
+        nextTables={nextTables}
         onSelectionChange={() => setSelectionChanged(true)}
       />
     </SelectionProvider>
@@ -67,12 +72,14 @@ function TestWrapper({
 
 type SetupOpts = {
   initialTables?: Set<TableId>;
+  nextTables?: Set<TableId>;
   isAdmin?: boolean;
   isDataAnalyst?: boolean;
 };
 
 function setup({
   initialTables = new Set([1]),
+  nextTables,
   isAdmin = false,
   isDataAnalyst = false,
 }: SetupOpts = {}) {
@@ -93,15 +100,18 @@ function setup({
     },
   });
 
-  renderWithProviders(<TestWrapper initialTables={initialTables} />, {
-    withRouter: false,
-    storeInitialState: {
-      currentUser: createMockUser({
-        is_superuser: isAdmin,
-        is_data_analyst: isDataAnalyst,
-      }),
+  renderWithProviders(
+    <TestWrapper initialTables={initialTables} nextTables={nextTables} />,
+    {
+      withRouter: false,
+      storeInitialState: {
+        currentUser: createMockUser({
+          is_superuser: isAdmin,
+          is_data_analyst: isDataAnalyst,
+        }),
+      },
     },
-  });
+  );
 }
 
 describe("TableAttributesEditBulk", () => {
@@ -148,6 +158,35 @@ describe("TableAttributesEditBulk", () => {
 
     await waitFor(() => {
       expect(screen.getByRole("textbox", { name: "Owner" })).toHaveValue("");
+    });
+  });
+
+  it("should keep form state when selection is a subset", async () => {
+    setup({
+      initialTables: new Set([1, 2]),
+      nextTables: new Set([1]),
+    });
+    const userName = "Testy Tableton";
+
+    await waitFor(() => {
+      expect(screen.getByText(/tables selected/i)).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole("textbox", { name: "Owner" }));
+    await userEvent.click(screen.getByText(userName));
+    await waitFor(() => {
+      expect(screen.getByRole("textbox", { name: "Owner" })).toHaveValue(
+        userName,
+      );
+    });
+
+    const changeSelectionButton = screen.getByTestId("change-selection");
+    await userEvent.click(changeSelectionButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole("textbox", { name: "Owner" })).toHaveValue(
+        userName,
+      );
     });
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/pages/DataModel/contexts/SelectionContext.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/pages/DataModel/contexts/SelectionContext.tsx
@@ -22,6 +22,7 @@ interface SelectionContextValue {
   selectedItemsCount: number;
   hasOnlyOneTableSelected: boolean;
   hasSelectedMoreThanOneTable: boolean;
+  filterSelectedTables: (tables: TableId[]) => void;
 }
 
 const SelectionContext = createContext<SelectionContextValue | null>(null);
@@ -39,6 +40,13 @@ export function SelectionProvider({ children }: { children: ReactNode }) {
     setSelectedTables(new Set());
     setSelectedSchemas(new Set());
     setSelectedDatabases(new Set());
+  }, []);
+
+  const filterSelectedTables = useCallback((tables: TableId[]) => {
+    setSelectedTables(
+      (oldTables) =>
+        new Set([...oldTables].filter((tableId) => tables.includes(tableId))),
+    );
   }, []);
 
   const hasSelectedItems =
@@ -71,6 +79,7 @@ export function SelectionProvider({ children }: { children: ReactNode }) {
         selectedItemsCount,
         hasOnlyOneTableSelected,
         hasSelectedMoreThanOneTable,
+        filterSelectedTables,
       }}
     >
       {children}


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-1377/issues-with-filters-and-edit-properties-that-are-filtered-by

### Description

This PR modifies the behavior of search&filter view, when items were matched by filter, after mutation, are not matching current search&filter criteria. We've decided to mimic behavior of apps like Gmail or Linear, where items disappear from the view when they no longer match filters.



### How to verify

1. Perform filtering one one of criteria what can be changed by bulk edit (e.g. visibility type = Copper) and have at least one matching item 
2. Select one or more items and change their visibility type.
3. Those items should disappear from the view.
4. If no elements are matching current search, then bulk edit pane should disappear and we should see default "No tables found" text.

### Demo

https://github.com/user-attachments/assets/accaa62a-0a23-4e86-ac48-b336ae5310bd

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
