### PR TITLE
fix: custom Logo isn't loaded properly on User Invite Email

### DIFF
--- a/src/metabase/channel/impl/email.clj
+++ b/src/metabase/channel/impl/email.clj
@@ -20,6 +20,7 @@
    [metabase.notification.models :as models.notification]
    [metabase.util :as u]
    [metabase.util.i18n :refer [trs]]
+   [metabase.util.jvm :as u.jvm]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
@@ -293,6 +294,35 @@
 ;;                                         System Events                                           ;;
 ;; ------------------------------------------------------------------------------------------------;;
 
+(def ^:private data-uri-pattern
+  #"^data:([^;]+);base64,(.+)$")
+
+(defn- parse-data-uri
+  "Parse a data URI and return {:content-type <string> :bytes <byte-array>}, or nil if not a data URI."
+  [data-uri]
+  (when-let [[_ content-type base64-data] (re-matches data-uri-pattern data-uri)]
+    {:content-type content-type
+     :bytes        (u.jvm/decode-base64-to-bytes base64-data)}))
+
+(defn- logo-bundle
+  "Create a logo bundle from the application logo URL.
+   Returns {:image-src <url-or-cid> :attachment <attachment-map-or-nil>}.
+   For data URIs, converts to an embedded attachment for email compatibility."
+  [logo-url]
+  (cond
+    (nil? logo-url)
+    nil
+
+    (str/starts-with? logo-url "data:")
+    (when-let [{:keys [bytes]} (parse-data-uri logo-url)]
+      (let [bundle (channel.render/make-image-bundle :attachment bytes)]
+        {:image-src  (:image-src bundle)
+         :attachment (channel.render/image-bundle->attachment bundle)}))
+
+    :else
+    {:image-src logo-url
+     :attachment nil}))
+
 (defn- notification-recipients->emails
   [recipients notification-payload]
   (into [] cat (for [recipient recipients
@@ -319,8 +349,16 @@
                                      [:template ::models.channel/ChannelTemplate]
                                      [:recipients [:sequential ::models.notification/NotificationRecipient]]]]
   (assert (some? template) "Template is required for system event notifications")
-  [(construct-email (channel.params/substitute-params (-> template :details :subject) notification-payload)
-                    (notification-recipients->emails recipients notification-payload)
-                    [{:type    "text/html; charset=utf-8"
-                      :content (render-body template notification-payload)}]
-                    (-> template :details :recipient-type keyword))])
+  (let [logo-url              (get-in notification-payload [:context :application_logo_url])
+        logo                  (logo-bundle logo-url)
+        ;; Update context with the processed logo URL (cid: reference if data URI was converted)
+        updated-payload       (if (:image-src logo)
+                                (assoc-in notification-payload [:context :application_logo_url] (:image-src logo))
+                                notification-payload)
+        logo-attachment       (when (:attachment logo)
+                                [(make-message-attachment (first (:attachment logo)))])
+        attachments           logo-attachment]
+    [(construct-email (channel.params/substitute-params (-> template :details :subject) updated-payload)
+                      (notification-recipients->emails recipients updated-payload)
+                      (render-message-body template updated-payload attachments)
+                      (-> template :details :recipient-type keyword))]))

--- a/src/metabase/notification/payload/core.clj
+++ b/src/metabase/notification/payload/core.clj
@@ -101,15 +101,13 @@
     [:notification/testing   :map]]])
 
 (defn- logo-url
-  "Return the URL for the application logo. If the logo is the default, return a URL to the Metabase logo."
+  "Return the URL for the application logo. If the logo is the default, return a URL to the Metabase logo.
+   For data URIs, returns the raw data URI - the email channel will convert it to an attachment."
   []
   (let [url (appearance/application-logo-url)]
-    (cond
-      (= url "app/assets/img/logo.svg") "http://static.metabase.com/email_logo.png"
-      ;; NOTE: disabling whitelabeled URLs for now since some email clients don't render them correctly
-      ;; We need to extract them and embed as attachments like we do in metabase.channel.render.image-bundle
-      ;; (data-uri-svg? url)               (themed-image-url url color)
-      :else url)))
+    (if (= url "app/assets/img/logo.svg")
+      "http://static.metabase.com/email_logo.png"
+      url)))
 
 (defn- button-style
   "Return a CSS style string for a button with the given color."

--- a/src/metabase/notification/payload/core.clj
+++ b/src/metabase/notification/payload/core.clj
@@ -109,7 +109,7 @@
       ;; NOTE: disabling whitelabeled URLs for now since some email clients don't render them correctly
       ;; We need to extract them and embed as attachments like we do in metabase.channel.render.image-bundle
       ;; (data-uri-svg? url)               (themed-image-url url color)
-      :else nil)))
+      :else url)))
 
 (defn- button-style
   "Return a CSS style string for a button with the given color."

--- a/test/metabase/notification/payload/impl/system_event_test.clj
+++ b/test/metabase/notification/payload/impl/system_event_test.clj
@@ -112,7 +112,8 @@
   (let [check (fn [sent-from-setup? expected-subject regexes invitor-name]
                 (let [email (mt/with-temporary-setting-values
                               [site-url  "https://metabase.com"
-                               site-name "SuperStar"]
+                               site-name "SuperStar"
+                               application-logo-url "https://metabase.com/superstar.png"]
                               (-> (notification.tu/with-captured-channel-send!
                                     (publish-user-invited-event! (t2/select-one :model/User :email "crowberto@metabase.com")
                                                                  {:first_name invitor-name :email "ngoc@metabase.com"}
@@ -166,7 +167,14 @@
                [#"You are invited to help setting up Metabase"
                 #"Your Metabase is up and running, but your help is needed to connect data. You'll probably need:"
                 #"<a[^>]*href=\"https?://metabase\.com/auth/reset_password/.*\?redirect(&#x3D;|=)/admin/databases/create.*#new\"[^>]*>"]
-               nil)))))
+               nil)))
+
+    (testing "with custom application logo"
+      (mt/with-premium-features #{:whitelabel}
+        (check false
+               "You're invited to join SuperStar's Metabase"
+               [#"<img[^>]*src=\"https://metabase\.com/superstar\.png\"[^>]*>"]
+               "Ngoc")))))
 
 (deftest notification-create-email-test
   (mt/with-temporary-setting-values [site-url "https://metabase.com"]


### PR DESCRIPTION
Closes #68452 

### Description

The custom logo is not showing up in the emails because they were explicitly removed with this comment:
```clj
;; NOTE: disabling whitelabeled URLs for now since some email clients don't render them correctly
;; We need to extract them and embed as attachments like we do in metabase.channel.render.image-bundle
;; (data-uri-svg? url)               (themed-image-url url color)
```

Fixed this by
1. Not returning nil
2. Attaching logos instead of including the data uri


### How to verify

1. Go to admin > People
2. Invite someone
3. Check the email

### Demo

Before:
<img width="1840" height="1105" alt="image" src="https://github.com/user-attachments/assets/123f0c21-f657-4f04-be81-ab246ce182ac" />

After: 
<img width="1840" height="1105" alt="image" src="https://github.com/user-attachments/assets/f633b8fa-76c8-4c59-89df-97a2fa10d2e2" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
