### PR TITLE
Bump dependency analysis version

### DIFF
--- a/e2e/test/scenarios/dependencies/dependency-broken-list.cy.spec.ts
+++ b/e2e/test/scenarios/dependencies/dependency-broken-list.cy.spec.ts
@@ -318,6 +318,7 @@ function createTransform() {
   );
   cy.get<TransformId>("@transformId").then((transformId) => {
     H.runTransform(transformId);
+    H.resyncDatabase({ dbId: WRITABLE_DB_ID, tableName: TABLE_NAME });
     H.waitForTransformRuns(
       (runs) =>
         runs.length === 1 && runs.every((run) => run.status === "succeeded"),

--- a/enterprise/backend/src/metabase_enterprise/dependencies/models/analysis_finding.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/models/analysis_finding.clj
@@ -23,8 +23,9 @@
   Version history:
   - 3: Initial version
   - 4: Disable naive sql validation
-  - 5: Added source entity tracking in analysis_finding_error table"
-  5)
+  - 5: Added source entity tracking in analysis_finding_error table
+  - 6: Removed validate prefix from error_type in analysis_finding_error"
+  6)
 
 (defn- error->finding-error-row
   "Convert an error from lib/find-bad-refs-with-source to a row for analysis_finding_error table.


### PR DESCRIPTION
### Description

Bump dependency analysis version after https://github.com/metabase/metabase/pull/68282

### How to verify

todo

### Demo


https://github.com/user-attachments/assets/cdb85253-1c55-4a27-85fe-7fc55e8d3c96



### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
