### PR TITLE
Bump toucan2 version to fix dashboards sometimes failing to load

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -80,7 +80,7 @@
   hiccup/hiccup                             {:mvn/version "2.0.0"}              ; HTML templating
   inflections/inflections                   {:mvn/version "0.15.0"}             ; Clojure/Script library used for prularizing words
   instaparse/instaparse                     {:mvn/version "1.5.0"}              ; Make your own parser
-  io.github.camsaul/toucan2                 {:mvn/version "1.0.569"}
+  io.github.camsaul/toucan2                 {:mvn/version "1.0.570"}
   io.github.eerohele/pp                     {#_#_:git/tag "2024-11-13.77"       ; super fast pretty-printing library
                                              :git/sha "ffc4edc482c057cd9412c62f018a41e9140c618b"
                                              :git/url "https://github.com/eerohele/pp"}

--- a/test/metabase/dashboards_rest/api_test.clj
+++ b/test/metabase/dashboards_rest/api_test.clj
@@ -4803,6 +4803,30 @@
                      :databases [{:id (mt/id) :engine string?}]}
                     (query-metadata)))))))))
 
+(deftest dashboard-query-metadata-with-archived-table-test
+  (testing "Don't throw an error if the dashboard uses an archived table (#68493)"
+    (let [mp (mt/metadata-provider)]
+      (mt/with-temp
+        [:model/Table         {inactive-table-id :id} {:active false}
+         :model/Table         {active-table-id :id}   {}
+         :model/Field         {}                      {:table_id active-table-id}
+         :model/Card          {card-id-1 :id}         {:dataset_query (lib/query mp (lib.metadata/table mp inactive-table-id))}
+         :model/Card          {card-id-2 :id}         {:dataset_query (lib/query mp (lib.metadata/table mp active-table-id))}
+         :model/Dashboard     {dashboard-id :id}      {}
+         :model/DashboardCard _                       {:card_id      card-id-1
+                                                       :dashboard_id dashboard-id}
+         :model/DashboardCard _                       {:card_id      card-id-2
+                                                       :dashboard_id dashboard-id}]
+        (is (=?
+             {:cards      empty?
+              :fields     empty?
+              :dashboards empty?
+              :tables     [{:id inactive-table-id :name string?}
+                           {:id active-table-id :name string?}]
+              :databases  [{:id (mt/id) :engine string?}]}
+             (-> (mt/user-http-request :crowberto :get 200 (str "dashboard/" dashboard-id "/query_metadata"))
+                 (api.test-util/select-query-metadata-keys-for-debugging))))))))
+
 (deftest dashboard-query-metadata-no-tables-test
   (testing "Don't throw an error if users doesn't have access to any tables #44043"
     (let [original-can-read? mi/can-read?]

--- a/test/metabase/dashboards_rest/api_test.clj
+++ b/test/metabase/dashboards_rest/api_test.clj
@@ -4809,7 +4809,7 @@
       (mt/with-temp
         [:model/Table         {inactive-table-id :id} {:active false}
          :model/Table         {active-table-id :id}   {}
-         :model/Field         {}                      {:table_id active-table-id}
+         :model/Field         _                       {:table_id active-table-id}
          :model/Card          {card-id-1 :id}         {:dataset_query (lib/query mp (lib.metadata/table mp inactive-table-id))}
          :model/Card          {card-id-2 :id}         {:dataset_query (lib/query mp (lib.metadata/table mp active-table-id))}
          :model/Dashboard     {dashboard-id :id}      {}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/68493

### Description

If the first table mentioned by a dashboard has no fields (presumably because the table and its field are all inactive), /api/dashboard/id/query_metadata would fail due to a toucan2 bug.  This bumps toucan2 to fix the bug and adds a test to verify that this case now works.

### How to verify

See case

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
