### PR TITLE
Revert "🤖 backported "Delete invalid `source-card-id`s on native SQL questions" (#68262)"

### DIFF
--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -1220,57 +1220,6 @@ databaseChangeLog:
             tableName: pulse
             columnName: disable_links
 
-  - changeSet:
-      id: v58.2026-01-12T22:43:43
-      author: galdre
-      comment: "Clear source_card_id for native queries to prevent cascade deletion (#68080)"
-      changes:
-        - update:
-            tableName: report_card
-            columns:
-              - column:
-                  name: source_card_id
-                  value: null
-            where: query_type = 'native' AND source_card_id IS NOT NULL
-      rollback:
-        # No rollback - we can't know what the original source_card_id values were
-
-  - changeSet:
-      id: v58.2026-01-13T12:00:00
-      author: galdre
-      comment: "Drop source_card_id FK in preparation for changing to SET NULL (#68080)"
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: report_card
-            constraintName: fk_report_card_source_card_id_ref_report_card_id
-      rollback:
-        - addForeignKeyConstraint:
-            baseTableName: report_card
-            baseColumnNames: source_card_id
-            referencedTableName: report_card
-            referencedColumnNames: id
-            constraintName: fk_report_card_source_card_id_ref_report_card_id
-            nullable: true
-            deleteCascade: true
-
-  - changeSet:
-      id: v58.2026-01-13T12:00:01
-      author: galdre
-      comment: "Add source_card_id FK with ON DELETE SET NULL (#68080)"
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: report_card
-            baseColumnNames: source_card_id
-            referencedTableName: report_card
-            referencedColumnNames: id
-            constraintName: fk_report_card_source_card_id_ref_report_card_id
-            nullable: true
-            onDelete: SET NULL
-      rollback:
-        - dropForeignKeyConstraint:
-            baseTableName: report_card
-            constraintName: fk_report_card_source_card_id_ref_report_card_id
-
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -338,27 +338,27 @@
   [{query :dataset_query, :as card} :- ::queries.schema/card]
   (merge
    card
-   ;; mega HACK FIXME -- don't update this stuff when doing deserialization because it might differ from what's in the
-   ;; YAML file and break tests like [[metabase-enterprise.serialization.v2.e2e.yaml-test/e2e-storage-ingestion-test]].
-   ;; The root cause of this issue is that we're generating Cards that have a different Database ID or Table ID from
-   ;; what's actually in their query -- we need to fix [[metabase.test.generate]], but I'm not sure how to do that
-   (when (and (seq query)
-              (map? query)
-              (not mi/*deserializing?*))
+   (when (seq query)
      (merge
-      ;; This used to be conditional on not nilling source-card-id, changed due to #68080.
-      {:source_card_id (source-card-id query)}
-      (when-let [{:keys [database-id table-id]} (query/query->database-and-table-ids query)]
-        ;; TODO -- not sure `query_type` is actually used for anything important anyway
-        (let [query-type (if (query/query-is-native? query)
-                           :native
-                           :query)]
-          (merge
-           {:query_type (keyword query-type)}
-           (when database-id
-             {:database_id database-id})
-           (when table-id
-             {:table_id table-id}))))))))
+      (when-let [source-id (source-card-id query)]
+        {:source_card_id source-id})
+      ;; mega HACK FIXME -- don't update this stuff when doing deserialization because it might differ from what's in the
+      ;; YAML file and break tests like [[metabase-enterprise.serialization.v2.e2e.yaml-test/e2e-storage-ingestion-test]].
+      ;; The root cause of this issue is that we're generating Cards that have a different Database ID or Table ID from
+      ;; what's actually in their query -- we need to fix [[metabase.test.generate]], but I'm not sure how to do that
+      (when (and (map? query)
+                 (not mi/*deserializing?*))
+        (when-let [{:keys [database-id table-id]} (query/query->database-and-table-ids query)]
+          ;; TODO -- not sure `query_type` is actually used for anything important anyway
+          (let [query-type (if (query/query-is-native? query)
+                             :native
+                             :query)]
+            (merge
+             {:query_type (keyword query-type)}
+             (when database-id
+               {:database_id database-id})
+             (when table-id
+               {:table_id table-id})))))))))
 
 ;;; TODO -- move this to [[metabase.query-processor.card]] or MLv2 so the logic can be shared between the backend and
 ;;; frontend (?)
@@ -423,10 +423,7 @@
 
 (mu/defn- assert-valid-type
   "Check that the card is a valid model if being saved as one. Throw an exception if not."
-  [{query :dataset_query, card-type :type, source-card :source_card_id, :as _card} :- [:maybe ::queries.schema/card]]
-  (assert (not (and (query/query-is-native? query)
-                    (some? source-card)))
-          "A native SQL question cannot have a source card.")
+  [{query :dataset_query, card-type :type, :as _card} :- [:maybe ::queries.schema/card]]
   (when (= (keyword card-type) :model)
     (let [template-tag-types (into #{}
                                    (map :type)
@@ -633,7 +630,7 @@
         (parameter-card/upsert-or-delete-from-parameters! "card" id (:parameters changes)))
       ;; additional checks (Enterprise Edition only)
       (pre-update-check-sandbox-constraints card changes)
-      (assert-valid-type card))))
+      (assert-valid-type (merge old-card-info changes)))))
 
 (defn- add-query-description-to-metric-card
   "Add `:query_description` key to returned card.
@@ -824,9 +821,8 @@
         (apply-dashboard-question-updates changes)
         (m/update-existing :dataset_query lib-be/normalize-query)
         (populate-result-metadata changes verified-result-metadata?)
-        ;; populate-query-fields must run before pre-update in case source_card_id should be nilled
-        populate-query-fields
         (pre-update changes)
+        populate-query-fields
         maybe-populate-initially-published-at)))
 
 ;; Cards don't normally get deleted (they get archived instead) so this mostly affects tests

--- a/test/metabase/dashboards_rest/api_test.clj
+++ b/test/metabase/dashboards_rest/api_test.clj
@@ -4793,14 +4793,12 @@
                   :tables     [{:id (str "card__" card-id-1)}]
                   :databases  [{:id (mt/id) :engine string?}]}
                  (query-metadata))))
-         ;; After delete, card-id-2 still exists on the dashboard but its source is gone.
-         ;; The source table can't be resolved, but the database should still be present.
          #(testing "After delete"
             (is (=? {:cards      empty?
                      :fields     empty?
                      :dashboards empty?
                      :tables     empty?
-                     :databases [{:id (mt/id) :engine string?}]}
+                     :databases  empty?}
                     (query-metadata)))))))))
 
 (deftest dashboard-query-metadata-no-tables-test

--- a/test/metabase/queries/models/card_test.clj
+++ b/test/metabase/queries/models/card_test.clj
@@ -1057,49 +1057,6 @@
           (is (= (mt/id :venues) (:table_id updated-card)))
           (is (= :query (:query_type updated-card))))))))
 
-(deftest source-card-id-cleared-on-conversion-to-native-test
-  (testing "source_card_id should be set to nil when a model-based question is converted to native SQL (#68080)"
-    (mt/with-temp [:model/Card {model-id :id} {:name          "Test Model"
-                                               :type          :model
-                                               :dataset_query (mt/mbql-query venues)}
-                   :model/Card {question-id :id} {:name          "Test Question"
-                                                  :dataset_query {:database (mt/id)
-                                                                  :type     :query
-                                                                  :query    {:source-table (str "card__" model-id)}}}]
-      (testing "source_card_id is cleared when converting to native SQL"
-        (t2/update! :model/Card question-id
-                    {:dataset_query {:database (mt/id)
-                                     :type     :native
-                                     :native   {:query "SELECT * FROM venues"}}})
-        (is (nil? (:source_card_id (t2/select-one :model/Card question-id)))))))
-  (testing "deleting a model should not cascade delete questions that were converted to native SQL"
-    (mt/with-temp [:model/Card {model-id :id} {:name          "Test Model"
-                                               :type          :model
-                                               :dataset_query (mt/mbql-query venues)}
-                   :model/Card {question-id :id} {:name          "Test Question"
-                                                  :dataset_query {:database (mt/id)
-                                                                  :type     :query
-                                                                  :query    {:source-table (str "card__" model-id)}}}]
-      (t2/update! :model/Card question-id
-                  {:dataset_query {:database (mt/id)
-                                   :type     :native
-                                   :native   {:query "SELECT * FROM venues"}}})
-      (t2/delete! :model/Card model-id)
-      (testing "model should be deleted"
-        (is (not (t2/exists? :model/Card model-id))))
-      (testing "converted question should survive"
-        (is (t2/exists? :model/Card question-id))))))
-
-(deftest assert-no-source-card-id-for-native-query-test
-  (testing "assertion fires if native query has source_card_id set"
-    (with-redefs [card/populate-query-fields identity]
-      (is (thrown-with-msg? Exception #"Assert failed"
-                            (t2/insert! :model/Card
-                                        {:name "Bad Card"
-                                         :dataset_query (mt/native-query {:query "SELECT 1"})
-                                         :source_card_id 999
-                                         :database_id (mt/id)}))))))
-
 (deftest before-update-embedding-timestamp-test
   (testing "maybe-populate-initially-published-at is called"
     (mt/with-temp [:model/Card {card-id :id} {:enable_embedding false}]

--- a/test/metabase/queries_rest/api/card_test.clj
+++ b/test/metabase/queries_rest/api/card_test.clj
@@ -3883,14 +3883,9 @@
                     :databases [{:id (mt/id) :engine string?}]}
                    (query-metadata 200 card-id)))))
          #(testing "After delete"
-            ;; card-id-1 is deleted, so it should return 404
-            (is (= "Not found."
-                   (query-metadata 404 card-id-1)))
-            ;; card-id-2 still exists but its source is gone, so it should return empty metadata
-            (is (=? {:fields empty?
-                     :tables empty?
-                     :databases [{:id (mt/id) :engine string?}]}
-                    (query-metadata 200 card-id-2)))))))))
+            (doseq [card-id [card-id-1 card-id-2]]
+              (is (= "Not found."
+                     (query-metadata 404 card-id))))))))))
 
 (deftest card-query-metadata-no-tables-test
   (testing "Don't throw an error if users doesn't have access to any tables #44043"

--- a/test/metabase/query_processor/api_test.clj
+++ b/test/metabase/query_processor/api_test.clj
@@ -1042,18 +1042,12 @@
                     :databases [{:id (mt/id) :engine string?}]}
                    (query-metadata 200 card-id)))))
          #(testing "After delete"
-            ;; card-id-1 is deleted, so querying it as a source returns empty tables
-            (is (=?
-                 {:fields    empty?
-                  :tables    empty?
-                  :databases [{:id (mt/id) :engine string?}]}
-                 (query-metadata 200 card-id-1)))
-            ;; card-id-2 still exists, so querying it as a source still works
-            (is (=?
-                 {:fields    empty?
-                  :tables    [{:id (str "card__" card-id-2)}]
-                  :databases [{:id (mt/id) :engine string?}]}
-                 (query-metadata 200 card-id-2)))))))))
+            (doseq [card-id [card-id-1 card-id-2]]
+              (is (=?
+                   {:fields    empty?
+                    :tables    empty?
+                    :databases [{:id (mt/id) :engine string?}]}
+                   (query-metadata 200 card-id))))))))))
 
 (deftest published-table-does-not-grant-database-access-oss-test
   (testing "POST /api/dataset in OSS: published table access does NOT grant database access"

--- a/test/metabase/search/appdb/index_test.clj
+++ b/test/metabase/search/appdb/index_test.clj
@@ -548,7 +548,7 @@
    "metabase_database" #{"action" "metabase_table" "model_index_value" "report_card" "segment"}
    "metabase_table"    #{"action" "model_index_value" "report_card" "segment"}
    "document"          #{"action" "model_index_value" "report_card"}
-   "report_card"       #{"action" "model_index_value"}
+   "report_card"       #{"action" "model_index_value" "report_card"}
    "report_dashboard"  #{"action" "model_index_value" "report_card"}})
 
 (deftest search-model-cascade-test

--- a/test/metabase/warehouse_schema_rest/api/table_test.clj
+++ b/test/metabase/warehouse_schema_rest/api/table_test.clj
@@ -839,13 +839,8 @@
                        :type              "question"}
                       (query-metadata 200 card-id)))))
          #(testing "After delete"
-            ;; card-id-1 is deleted, so it returns 204 empty
-            (is (empty? (query-metadata 204 card-id-1)))
-            ;; card-id-2 still exists, so it returns 200 with metadata
-            (is (=? {:db_id (mt/id)
-                     :id (str "card__" card-id-2)
-                     :type "question"}
-                    (query-metadata 200 card-id-2)))))))))
+            (doseq [card-id [card-id-1 card-id-2]]
+              (is (empty? (query-metadata 204 card-id))))))))))
 
 (deftest ^:parallel include-date-dimensions-in-nested-query-test
   (testing "GET /api/table/:id/query_metadata"


### PR DESCRIPTION
This reverts commit e741e086325199f5c8448518d709e9dfe127512b, merged too soon. [Context](https://metaboat.slack.com/archives/C0645JP1W81/p1769022442802429).
