### PR TITLE
Analysts can do crud on segments and measures

### DIFF
--- a/src/metabase/segments/models/segment.clj
+++ b/src/metabase/segments/models/segment.clj
@@ -85,24 +85,42 @@
   ([model pk]
    (mi/can-read? (t2/select-one model pk))))
 
-;; Segments can be written by superusers, but only if the parent table is editable
-;; (not in a remote-synced collection in read-only mode).
+;; Segments can be created by
+;; a) superusers
+;; b) OR data analysts with unrestricted view-data permissions
+;; But ONLY if the parent table is editable (not in a remote-synced collection in read-only mode).
 (defmethod mi/can-write? :model/Segment
   ([instance]
    (let [table (or (:table instance)
                    (t2/select-one :model/Table :id (:table_id instance)))]
-     (and (mi/superuser?)
+     (and (or (mi/superuser?)
+              (and api/*is-data-analyst?*
+                   (perms/user-has-permission-for-table?
+                    api/*current-user-id*
+                    :perms/view-data
+                    :unrestricted
+                    (:db_id table)
+                    (u/the-id table))))
           (remote-sync/table-editable? table))))
   ([model pk]
    (mi/can-write? (t2/select-one model pk))))
 
-;; Segments can be created by superusers, but only if the parent table is editable
-;; (not in a remote-synced collection in read-only mode).
+;; Segments can be created by
+;; a) superusers
+;; b) OR data analysts with unrestricted view-data permissions
+;; But ONLY if the parent table is editable (not in a remote-synced collection in read-only mode).
 (defmethod mi/can-create? :model/Segment
   [_model instance]
   (let [table (or (:table instance)
                   (t2/select-one :model/Table :id (:table_id instance)))]
-    (and (mi/superuser?)
+    (and (or (mi/superuser?)
+             (and api/*is-data-analyst?*
+                  (perms/user-has-permission-for-table?
+                   api/*current-user-id*
+                   :perms/view-data
+                   :unrestricted
+                   (:db_id table)
+                   (u/the-id table))))
          (remote-sync/table-editable? table))))
 
 (methodical/defmethod t2/batched-hydrate [:model/Segment :can_write]

--- a/test/metabase/segments/models/segment_test.clj
+++ b/test/metabase/segments/models/segment_test.clj
@@ -190,14 +190,16 @@
 
 ;;; ------------------------------------------------ Permission Tests ------------------------------------------------
 
-(deftest can-write?-test
+(deftest can-write?-superuser-test
   (testing "Superusers can write segments"
     (mt/with-temp [:model/Segment segment {:name "Test Segment"
                                            :table_id (mt/id :venues)
                                            :creator_id (mt/user->id :rasta)
                                            :definition {:filter [:> [:field (mt/id :venues :price) nil] 2]}}]
       (mt/with-test-user :crowberto
-        (is (true? (mi/can-write? segment))))))
+        (is (true? (mi/can-write? segment)))))))
+
+(deftest can-write?-analyst-unrestricted-test
   (testing "Data analysts with unrestricted view-data can write segments"
     (mt/with-no-data-perms-for-all-users!
       (mt/with-temp [:model/PermissionsGroup {group-id :id} {}
@@ -209,7 +211,9 @@
         (perms/add-user-to-group! analyst-id group-id)
         (data-perms/set-table-permission! group-id (mt/id :venues) :perms/view-data :unrestricted)
         (session/with-current-user analyst-id
-          (is (mi/can-write? segment))))))
+          (is (mi/can-write? segment)))))))
+
+(deftest can-write?-analyst-restricted-test
   (testing "Data analysts without unrestricted view-data cannot write segments"
     (mt/with-no-data-perms-for-all-users!
       (mt/with-temp [:model/User {analyst-id :id} {:is_data_analyst true}
@@ -218,7 +222,9 @@
                                              :creator_id (mt/user->id :rasta)
                                              :definition {:filter [:> [:field (mt/id :venues :price) nil] 2]}}]
         (session/with-current-user analyst-id
-          (is (false? (mi/can-write? segment)))))))
+          (is (false? (mi/can-write? segment))))))))
+
+(deftest can-write?-non-analyst-test
   (testing "Non-data-analysts cannot write segments"
     (mt/with-temp [:model/Segment segment {:name "Test Segment"
                                            :table_id (mt/id :venues)
@@ -227,12 +233,14 @@
       (mt/with-test-user :rasta
         (is (false? (mi/can-write? segment)))))))
 
-(deftest can-create?-test
+(deftest can-create?-superuser-test
   (testing "Superusers can create segments"
     (mt/with-test-user :crowberto
       (is (true? (mi/can-create? :model/Segment {:name "Test Segment"
                                                  :table_id (mt/id :venues)
-                                                 :definition {:filter [:> [:field (mt/id :venues :price) nil] 2]}})))))
+                                                 :definition {:filter [:> [:field (mt/id :venues :price) nil] 2]}}))))))
+
+(deftest can-create?-analyst-unrestricted-test
   (testing "Data analysts with unrestricted view-data can create segments"
     (mt/with-no-data-perms-for-all-users!
       (mt/with-temp [:model/PermissionsGroup {group-id :id} {}
@@ -242,14 +250,18 @@
         (session/with-current-user analyst-id
           (is (true? (mi/can-create? :model/Segment {:name "Test Segment"
                                                      :table_id (mt/id :venues)
-                                                     :definition {:filter [:> [:field (mt/id :venues :price) nil] 2]}})))))))
+                                                     :definition {:filter [:> [:field (mt/id :venues :price) nil] 2]}}))))))))
+
+(deftest can-create?-analyst-restricted-test
   (testing "Data analysts without unrestricted view-data cannot create segments"
     (mt/with-no-data-perms-for-all-users!
       (mt/with-temp [:model/User {analyst-id :id} {:is_data_analyst true}]
         (session/with-current-user analyst-id
           (is (false? (mi/can-create? :model/Segment {:name "Test Segment"
                                                       :table_id (mt/id :venues)
-                                                      :definition {:filter [:> [:field (mt/id :venues :price) nil] 2]}})))))))
+                                                      :definition {:filter [:> [:field (mt/id :venues :price) nil] 2]}}))))))))
+
+(deftest can-create?-non-analyst-test
   (testing "Non-data-analysts cannot create segments"
     (mt/with-test-user :rasta
       (is (false? (mi/can-create? :model/Segment {:name "Test Segment"

--- a/test/metabase/segments/models/segment_test.clj
+++ b/test/metabase/segments/models/segment_test.clj
@@ -1,7 +1,11 @@
 (ns metabase.segments.models.segment-test
   (:require
    [clojure.test :refer :all]
+   [metabase.models.interface :as mi]
    [metabase.models.serialization :as serdes]
+   [metabase.permissions.core :as perms]
+   [metabase.permissions.models.data-permissions :as data-perms]
+   [metabase.request.session :as session]
    [metabase.test :as mt]
    [metabase.util.json :as json]
    [toucan2.core :as t2]))
@@ -183,3 +187,71 @@
            Exception
            #"[Cc]ycle"
            (t2/update! :model/Segment segment-1-id {:definition {:filter [:segment segment-2-id]}}))))))
+
+;;; ------------------------------------------------ Permission Tests ------------------------------------------------
+
+(deftest can-write?-test
+  (testing "Superusers can write segments"
+    (mt/with-temp [:model/Segment segment {:name "Test Segment"
+                                           :table_id (mt/id :venues)
+                                           :creator_id (mt/user->id :rasta)
+                                           :definition {:filter [:> [:field (mt/id :venues :price) nil] 2]}}]
+      (mt/with-test-user :crowberto
+        (is (true? (mi/can-write? segment))))))
+  (testing "Data analysts with unrestricted view-data can write segments"
+    (mt/with-no-data-perms-for-all-users!
+      (mt/with-temp [:model/PermissionsGroup {group-id :id} {}
+                     :model/User {analyst-id :id} {:is_data_analyst true}
+                     :model/Segment segment {:name "Test Segment"
+                                             :table_id (mt/id :venues)
+                                             :creator_id (mt/user->id :rasta)
+                                             :definition {:filter [:> [:field (mt/id :venues :price) nil] 2]}}]
+        (perms/add-user-to-group! analyst-id group-id)
+        (data-perms/set-table-permission! group-id (mt/id :venues) :perms/view-data :unrestricted)
+        (session/with-current-user analyst-id
+          (is (mi/can-write? segment))))))
+  (testing "Data analysts without unrestricted view-data cannot write segments"
+    (mt/with-no-data-perms-for-all-users!
+      (mt/with-temp [:model/User {analyst-id :id} {:is_data_analyst true}
+                     :model/Segment segment {:name "Test Segment"
+                                             :table_id (mt/id :venues)
+                                             :creator_id (mt/user->id :rasta)
+                                             :definition {:filter [:> [:field (mt/id :venues :price) nil] 2]}}]
+        (session/with-current-user analyst-id
+          (is (false? (mi/can-write? segment)))))))
+  (testing "Non-data-analysts cannot write segments"
+    (mt/with-temp [:model/Segment segment {:name "Test Segment"
+                                           :table_id (mt/id :venues)
+                                           :creator_id (mt/user->id :rasta)
+                                           :definition {:filter [:> [:field (mt/id :venues :price) nil] 2]}}]
+      (mt/with-test-user :rasta
+        (is (false? (mi/can-write? segment)))))))
+
+(deftest can-create?-test
+  (testing "Superusers can create segments"
+    (mt/with-test-user :crowberto
+      (is (true? (mi/can-create? :model/Segment {:name "Test Segment"
+                                                 :table_id (mt/id :venues)
+                                                 :definition {:filter [:> [:field (mt/id :venues :price) nil] 2]}})))))
+  (testing "Data analysts with unrestricted view-data can create segments"
+    (mt/with-no-data-perms-for-all-users!
+      (mt/with-temp [:model/PermissionsGroup {group-id :id} {}
+                     :model/User {analyst-id :id} {:is_data_analyst true}]
+        (perms/add-user-to-group! analyst-id group-id)
+        (data-perms/set-table-permission! group-id (mt/id :venues) :perms/view-data :unrestricted)
+        (session/with-current-user analyst-id
+          (is (true? (mi/can-create? :model/Segment {:name "Test Segment"
+                                                     :table_id (mt/id :venues)
+                                                     :definition {:filter [:> [:field (mt/id :venues :price) nil] 2]}})))))))
+  (testing "Data analysts without unrestricted view-data cannot create segments"
+    (mt/with-no-data-perms-for-all-users!
+      (mt/with-temp [:model/User {analyst-id :id} {:is_data_analyst true}]
+        (session/with-current-user analyst-id
+          (is (false? (mi/can-create? :model/Segment {:name "Test Segment"
+                                                      :table_id (mt/id :venues)
+                                                      :definition {:filter [:> [:field (mt/id :venues :price) nil] 2]}})))))))
+  (testing "Non-data-analysts cannot create segments"
+    (mt/with-test-user :rasta
+      (is (false? (mi/can-create? :model/Segment {:name "Test Segment"
+                                                  :table_id (mt/id :venues)
+                                                  :definition {:filter [:> [:field (mt/id :venues :price) nil] 2]}}))))))


### PR DESCRIPTION
[UXW-2782: Analysts should be able to perform CRUD on segments and measures if they have full data access to a database](https://linear.app/metabase/issue/UXW-2782/analysts-should-be-able-to-perform-crud-on-segments-and-measures-if)