### PR TITLE
Revert ClickHouse from 0.9.5 to 0.8.4

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
@@ -804,30 +804,31 @@
                                (mt/run-mbql-query venues
                                  {:aggregation [[:count]]}))))))))))))))))
 
-(deftest clickhouse-double-hyphen-test
-  (testing "can use impersonation on clickhouse with role containing a double hyphen (#57016)"
-    (mt/test-driver :clickhouse
-      (mt/with-premium-features #{:advanced-permissions}
-        (let [venues-table (sql.tx/qualify-and-quote driver/*driver* "test-data" "venues")
-              role-a "role--with--double--hyphens"]
-          (tx/with-temp-roles! driver/*driver*
-            (impersonation-granting-details driver/*driver* (mt/db))
-            {role-a {venues-table {}}}
-            (impersonation-default-user driver/*driver*)
-            (impersonation-default-role driver/*driver*)
-            (mt/with-temp [:model/Database database {:engine driver/*driver*,
-                                                     :details (impersonation-details driver/*driver* (mt/db))}]
-              (mt/with-db database
-                (when (driver/database-supports? driver/*driver* :connection-impersonation-requires-role nil)
-                  (t2/update! :model/Database :id (mt/id) (assoc-in (mt/db) [:details :role] (impersonation-default-role driver/*driver*))))
-                (sync/sync-database! database {:scan :schema})
-                (impersonation.util-test/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-                                                               :attributes     {"impersonation_attr" role-a}}
-                  (is (= [[100]]
-                         (mt/formatted-rows [int]
-                                            (mt/run-mbql-query venues
-                                              {:aggregation [[:count]]}))))
-                  (is (thrown?
-                       java.lang.Exception
-                       (mt/run-mbql-query checkins
-                         {:aggregation [[:count]]}))))))))))))
+;; TODO(rileythomp, 2026-01-23): Enable this test when we upgrade ClickHouse JDBC driver past 0.8.4
+#_(deftest clickhouse-double-hyphen-test
+    (testing "can use impersonation on clickhouse with role containing a double hyphen (#57016)"
+      (mt/test-driver :clickhouse
+        (mt/with-premium-features #{:advanced-permissions}
+          (let [venues-table (sql.tx/qualify-and-quote driver/*driver* "test-data" "venues")
+                role-a "role--with--double--hyphens"]
+            (tx/with-temp-roles! driver/*driver*
+              (impersonation-granting-details driver/*driver* (mt/db))
+              {role-a {venues-table {}}}
+              (impersonation-default-user driver/*driver*)
+              (impersonation-default-role driver/*driver*)
+              (mt/with-temp [:model/Database database {:engine driver/*driver*,
+                                                       :details (impersonation-details driver/*driver* (mt/db))}]
+                (mt/with-db database
+                  (when (driver/database-supports? driver/*driver* :connection-impersonation-requires-role nil)
+                    (t2/update! :model/Database :id (mt/id) (assoc-in (mt/db) [:details :role] (impersonation-default-role driver/*driver*))))
+                  (sync/sync-database! database {:scan :schema})
+                  (impersonation.util-test/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                                 :attributes     {"impersonation_attr" role-a}}
+                    (is (= [[100]]
+                           (mt/formatted-rows [int]
+                                              (mt/run-mbql-query venues
+                                                {:aggregation [[:count]]}))))
+                    (is (thrown?
+                         java.lang.Exception
+                         (mt/run-mbql-query checkins
+                           {:aggregation [[:count]]}))))))))))))

--- a/modules/drivers/clickhouse/deps.edn
+++ b/modules/drivers/clickhouse/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "resources"]
  :deps
- {com.clickhouse/clickhouse-jdbc {:mvn/version "0.9.5"
+ {com.clickhouse/clickhouse-jdbc {:mvn/version "0.8.4"
                                   :exclusions [org.apache.commons/commons-lang3]}
   org.lz4/lz4-java {:mvn/version "1.8.0"}}}

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_data_types_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_data_types_test.clj
@@ -441,19 +441,19 @@
          [{:field-name "mystring" :base-type :type/Text}]
          [["foo"] ["bar"] ["   "] [""] [nil]]]])
       (testing "null strings count"
-        (is (= 2
+        (is (= 2M
                (-> (mt/run-mbql-query test-data-nullable-strings
                      {:filter [:is-null $mystring]
                       :aggregation [:count]})
                    mt/first-row last))))
       (testing "nullable strings not null filter"
-        (is (= 3
+        (is (= 3M
                (-> (mt/run-mbql-query test-data-nullable-strings
                      {:filter [:not-null $mystring]
                       :aggregation [:count]})
                    mt/first-row last))))
       (testing "filter nullable string by value"
-        (is (= 1
+        (is (= 1M
                (-> (mt/run-mbql-query test-data-nullable-strings
                      {:filter [:= $mystring "foo"]
                       :aggregation [:count]})

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
@@ -250,32 +250,34 @@
                                 :target [:dimension [:template-tag "category_name"]]
                                 :value  ["African"]}]}))))))))
 
-(deftest ^:parallel ternary-with-variable-test
-  (mt/test-driver :clickhouse
-    (testing "a query with a ternary and a variable should work correctly (#56690)"
-      (is (= [[1 "African" 1]]
-             (mt/rows
-              (qp/process-query
-               {:database (mt/id)
-                :type :native
-                :native {:query "SELECT *, true ? 1 : 0 AS foo
+;; TODO(rileythomp, 2026-01-21): Re-enable this test when the ClickHouse JDBC driver is upgraded
+#_(deftest ^:parallel ternary-with-variable-test
+    (mt/test-driver :clickhouse
+      (testing "a query with a ternary and a variable should work correctly (#56690)"
+        (is (= [[1 "African" 1]]
+               (mt/rows
+                (qp/process-query
+                 {:database (mt/id)
+                  :type :native
+                  :native {:query "SELECT *, true ? 1 : 0 AS foo
                                  FROM test_data.categories
                                  WHERE name = {{category_name}};"
-                         :template-tags {"category_name" {:type         :text
-                                                          :name         "category_name"
-                                                          :display-name "Category Name"}}}
-                :parameters [{:type   :category
-                              :target [:variable [:template-tag "category_name"]]
-                              :value  "African"}]})))))))
+                           :template-tags {"category_name" {:type         :text
+                                                            :name         "category_name"
+                                                            :display-name "Category Name"}}}
+                  :parameters [{:type   :category
+                                :target [:variable [:template-tag "category_name"]]
+                                :value  "African"}]})))))))
 
-(deftest ^:parallel line-comment-block-comment-test
-  (mt/test-driver :clickhouse
-    (testing "a query with a line comment followed by a block comment should work correctly (#57149, #62741)"
-      (is (= [[1]]
-             (mt/rows
-              (qp/process-query
-               (mt/native-query
-                {:query "-- foo
+;; TODO(rileythomp, 2026-01-21): Re-enable this test when the ClickHouse JDBC driver is upgraded
+#_(deftest ^:parallel line-comment-block-comment-test
+    (mt/test-driver :clickhouse
+      (testing "a query with a line comment followed by a block comment should work correctly (#57149, #62741)"
+        (is (= [[1]]
+               (mt/rows
+                (qp/process-query
+                 (mt/native-query
+                  {:query "-- foo
                          /* comment */
                          select 1;"}))))))))
 
@@ -336,6 +338,30 @@
   (is (= :username-or-password-incorrect (driver/humanize-connection-error-message :clickhouse ["Failed to create connection"
                                                                                                 "Failed to get server info"
                                                                                                 "Code: 516. DB::Exception: asdf: Authentication failed: password is incorrect, or there is no user with such name. (AUTHENTICATION_FAILED) (version 25.7.4.11 (official build))"]))))
+
+;; Dataset for testing reserved SQL keyword as table name (#68423)
+;; The table name "transaction" is a SQL keyword that causes parsing issues with JDBC driver 0.9.5
+(mt/defdataset reserved-keyword-table-name
+  [["transaction"
+    [{:field-name "event_id", :base-type :type/Integer}
+     {:field-name "event_name", :base-type :type/Text}
+     {:field-name "amount", :base-type :type/Float}]
+    [[1 "purchase" 99.99]
+     [2 "refund" -25.00]
+     [3 "purchase" 149.50]]]])
+
+(deftest ^:parallel reserved-keyword-table-name-native-query-test
+  (mt/test-driver :clickhouse
+    (testing "native query against a table named 'transaction' (SQL keyword) should work (#68423)"
+      (mt/dataset reserved-keyword-table-name
+        (let [db-name (-> (mt/db) :details :db)
+              results (qp/process-query
+                       (mt/native-query
+                        {:query (format "SELECT * FROM %s.transaction" db-name)}))]
+          (is (= [[1 1 "purchase" 99.99]
+                  [2 2 "refund" -25.0]
+                  [3 3 "purchase" 149.5]]
+                 (mt/rows results))))))))
 
 (deftest ^:parallel uploads-supported-test
   (mt/test-driver :clickhouse


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/68423

### Description

Reverts to 0.8.4 to fix a jdbc parser issue

This needs to be backported to 58 to revert https://github.com/metabase/metabase/pull/68147

### How to verify

1. Create a clickhouse table called transaction
2. Try to run "select * from transaction"
3. It should work with 0.8.4

### Demo

todo

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
