### PR TITLE
fix materialized views test

### DIFF
--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -264,7 +264,7 @@
                        SELECT 'Toucans are the coolest type of bird.' AS true_facts;
                        ANALYZE test_mview;"])
         (mt/with-temp [:model/Database database {:engine :postgres, :details (assoc details :dbname "materialized_views_test")}]
-          (is (=? [(default-table-result "test_mview" {:estimated_row_count (mt/malli=? int?)})]
+          (is (=? [(default-table-result "test_mview")]
                   (describe-database->tables :postgres database))))))))
 
 (deftest foreign-tables-test


### PR DESCRIPTION
https://github.com/metabase/metabase/pull/68190 did:

> Treats a 0 value of n_live_tup as NULL, due to confusion reported when
> auto analyze thresholds have not been met on a table.

I think what's happening is this is trying to suss out "i don't know" and not give misleading information. When there are no stats pg would report there are 0 rows rather than saying i don't know. So we toss away these unreliable 0 count estimations.

This test flakes 7% of the time. Our hypothesis is that stats are empty 7% of the time so this row count estimation now gets removed.

By default the schema is `:estimated_row_count (mt/malli=? [:maybe :int])` which was being clobbered with
`{:estimated_row_count (mt/malli=? int?)}` So the fix is to just not clobber