### PR TITLE
feat: add remote-sync support for PythonLibrary

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2352,8 +2352,10 @@
            app-db
            config
            driver
+           events
            lib
            lib-be
+           models
            query-processor
            settings
            util

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
@@ -144,7 +144,7 @@
               (log/infof (:message <>)))
             (let [path-filters (cond-> [#"collections/.*" #"databases/.*" #"actions/.*"]
                                  (settings/remote-sync-transforms)
-                                 (conj #"transforms/.*")
+                                 (conj #"transforms/.*" #"python-libraries/.*")
                                  (settings/library-is-remote-synced?)
                                  (conj #"snippets/.*"))
                   ingestable-snapshot (->> (source.p/->ingestable snapshot {:path-filters path-filters})

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
@@ -35,7 +35,7 @@
     (conj "Setting")
 
     (not (:no-transforms opts))
-    (conj "Transform" "TransformTag" "TransformJob")))
+    (conj "Transform" "TransformTag" "TransformJob" "PythonLibrary")))
 
 (defn make-targets-of-type
   "Returns a targets seq with model type and given ids"

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/ingest.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/ingest.clj
@@ -74,7 +74,7 @@
       read-timestamps))
 
 (def legal-top-level-paths "Known top-level paths for directory with serialization output"
-  #{"actions" "collections" "databases" "snippets" "glossary" "transforms"}) ; But return the hierarchy without labels.
+  #{"actions" "collections" "databases" "glossary" "python-libraries" "snippets" "transforms"})
 
 (defn- ingest-all [^File root-dir]
   ;; This returns a map {unlabeled-hierarchy [original-hierarchy File]}.

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
@@ -27,8 +27,7 @@
    "Document"
    "Glossary"
    "NativeQuerySnippet"
-   "Timeline"
-   "Transform"])
+   "Timeline"])
 
 (def exported-models
   "The list of all models exported by serialization by default. Used for production code and by tests."
@@ -36,7 +35,9 @@
           content
           ["FieldValues"
            "Metabot"
+           "PythonLibrary"
            "Setting"
+           "Transform"
            "TransformJob"
            "TransformTag"]))
 
@@ -96,7 +97,6 @@
    "PermissionsGroupMembership"
    "PermissionsRevision"
    "PersistedInfo"
-   "PythonLibrary"
    "Pulse"
    "PulseCard"
    "PulseChannel"

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/spec_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/spec_test.clj
@@ -12,7 +12,7 @@
 (deftest all-specs-have-required-keys-test
   (testing "Every spec has all required keys"
     (let [required-keys #{:model-type :model-key :identity :events :eligibility
-                          :archived-key :tracking :removal :export-path :enabled?}]
+                          :archived-key :tracking :removal :enabled?}]
       (doseq [[model-key spec] spec/remote-sync-specs]
         (testing (str "Spec for " model-key)
           (let [missing-keys (set/difference required-keys (set (keys spec)))]
@@ -78,15 +78,6 @@
           (is (keyword? scope-key)
               "removal :scope-key should be a keyword when present"))))))
 
-(deftest all-specs-have-valid-export-path-test
-  (testing "Every spec has valid export-path configuration"
-    (let [valid-path-types #{:collection-entity :table-path :field-path
-                             :segment-path :measure-path :transform-path :transform-tag-path :snippet-path}]
-      (doseq [[model-key spec] spec/remote-sync-specs]
-        (testing (str "Spec for " model-key)
-          (is (contains? valid-path-types (get-in spec [:export-path :type]))
-              (str "Invalid export-path type: " (get-in spec [:export-path :type]))))))))
-
 ;;; ------------------------------------------------ Helper Function Tests ---------------------------------------------
 
 (deftest spec-for-model-type-test
@@ -116,7 +107,7 @@
       (is (contains? types "Measure"))
       (is (contains? types "Transform"))
       (is (contains? types "TransformTag"))
-      (is (= 12 (count types))))))
+      (is (= 13 (count types))))))
 
 (deftest specs-by-identity-type-test
   (testing "specs-by-identity-type filters correctly"

--- a/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
@@ -38,7 +38,8 @@
    #"/snippets/(.*)\.yaml"                     :snippet
    #"/databases/.*/schemas/(.*)"               :schema
    #"/databases/(.*)\.yaml"                    :database
-   #"/transforms/(.*)\.yaml"                   :transform])
+   #"/transforms/(.*)\.yaml"                   :transform
+   #"/python-libraries/(.*)\.yaml"             :python-library])
 
 (defn- file-type
   "Find out entity type by file path"
@@ -121,13 +122,13 @@
               (testing "API respects parameters"
                 (let [f (mt/user-http-request :crowberto :post 200 "ee/serialization/export" {}
                                               :all_collections false :data_model false :settings true)]
-                  (is (= #{:log :dir :settings :transform}
+                  (is (= #{:log :dir :settings :transform :python-library}
                          (tar-file-types f)))))
 
               (testing "We can export just a single collection"
                 (let [f (mt/user-http-request :crowberto :post 200 "ee/serialization/export" {}
                                               :collection (:id coll) :data_model false :settings false)]
-                  (is (= #{:log :dir :dashboard :card :collection :transform}
+                  (is (= #{:log :dir :dashboard :card :collection :transform :python-library}
                          (tar-file-types f)))))
 
               (testing "We can export two collections"
@@ -143,18 +144,18 @@
                 (let [f (mt/user-http-request :crowberto :post 200 "ee/serialization/export" {}
                                               ;; eid:... syntax is kept for backward compat
                                               :collection (str "eid:" (:entity_id coll)) :data_model false :settings false)]
-                  (is (= #{:log :dir :dashboard :card :collection :transform}
+                  (is (= #{:log :dir :dashboard :card :collection :transform :python-library}
                          (tar-file-types f)))))
 
               (testing "We can export that collection using entity id"
                 (let [f (mt/user-http-request :crowberto :post 200 "ee/serialization/export" {}
                                               :collection (:entity_id coll) :data_model false :settings false)]
-                  (is (= #{:log :dir :dashboard :card :collection :transform}
+                  (is (= #{:log :dir :dashboard :card :collection :transform :python-library}
                          (tar-file-types f)))))
 
               (testing "Default export: all-collections, data-model, settings"
                 (let [f (mt/user-http-request :crowberto :post 200 "ee/serialization/export" {})]
-                  (is (= #{:transform :log :dir :dashboard :card :collection :settings :schema :database}
+                  (is (= #{:transform :log :dir :dashboard :card :collection :settings :schema :database :python-library}
                          (tar-file-types f)))))
 
               (testing "On exception API returns log"

--- a/enterprise/backend/test/metabase_enterprise/serialization/cmd_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/cmd_test.clj
@@ -45,7 +45,7 @@
                          "settings"        true
                          "field_values"    false
                          "duration_ms"     pos?
-                         "count"           11
+                         "count"           12
                          "source"          "cli"
                          "secrets"         false
                          "success"         true
@@ -60,8 +60,8 @@
                          "direction"     "import"
                          "duration_ms"   pos?
                          "source"        "cli"
-                         "models"        "Card,Collection,Setting,TransformJob,TransformTag"
-                         "count"         11
+                         "models"        "Card,Collection,PythonLibrary,Setting,TransformJob,TransformTag"
+                         "count"         12
                          "success"       true
                          "error_message" nil}
                         (-> (snowplow-test/pop-event-data-and-user-id!) first :data))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/models/entity_id_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/models/entity_id_test.clj
@@ -100,7 +100,6 @@
     :model/TransformJobRun
     :model/TransformJobTransformTag
     :model/TransformTransformTag
-    :model/PythonLibrary
     :model/Undo
     :model/User
     :model/UserParameterValue

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/hooks/use-has-transform-dirty-changes.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/hooks/use-has-transform-dirty-changes.ts
@@ -35,10 +35,14 @@ export function useHasTransformDirtyChanges(): boolean {
     );
 
     // Check if any dirty entity is:
-    // 1. A transform or transform tag
+    // 1. A transform, transform tag, or Python library
     // 2. A collection in the transforms namespace
     return dirty.some((entity) => {
-      if (entity.model === "transform" || entity.model === "transformtag") {
+      if (
+        entity.model === "transform" ||
+        entity.model === "transformtag" ||
+        entity.model === "pythonlibrary"
+      ) {
         return true;
       }
       if (

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/hooks/use-has-transform-dirty-changes.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/hooks/use-has-transform-dirty-changes.unit.spec.ts
@@ -141,6 +141,22 @@ describe("useHasTransformDirtyChanges", () => {
     });
   });
 
+  it("returns true when a pythonlibrary entity is dirty", async () => {
+    const { result } = setup({
+      collections: [createMockTransformsCollection()],
+      dirty: [
+        createMockRemoteSyncEntity({
+          model: "pythonlibrary",
+          name: "common.py",
+        }),
+      ],
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBe(true);
+    });
+  });
+
   it("returns true when a transforms-namespace collection is dirty", async () => {
     const transformsCollection = createMockTransformsCollection({ id: 100 });
     const { result } = setup({

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/middleware/model-configs.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/middleware/model-configs.ts
@@ -12,6 +12,7 @@ import { tableApi as coreTableApi } from "metabase/api/table";
 import { timelineApi } from "metabase/api/timeline";
 import { timelineEventApi } from "metabase/api/timeline-event";
 import { getCollectionFromCollectionsTree } from "metabase/selectors/collection";
+import { pythonLibraryApi } from "metabase-enterprise/api/python-transform-library";
 import { tableApi as enterpriseTableApi } from "metabase-enterprise/api/table";
 import { transformApi } from "metabase-enterprise/api/transform";
 import { transformTagApi } from "metabase-enterprise/api/transform-tag";
@@ -205,6 +206,14 @@ export const MODEL_MUTATION_CONFIGS: ModelMutationConfig[] = [
     ],
     deleteEndpoints: [
       transformTagApi.endpoints.deleteTransformTag.matchFulfilled,
+    ],
+    invalidation: { type: InvalidationType.Always },
+  },
+  {
+    modelType: "pythonLibrary",
+    // PythonLibrary only has an upsert endpoint (updatePythonLibrary creates or updates)
+    updateEndpoints: [
+      pythonLibraryApi.endpoints.updatePythonLibrary.matchFulfilled,
     ],
     invalidation: { type: InvalidationType.Always },
   },

--- a/frontend/src/metabase-types/api/remote-sync.ts
+++ b/frontend/src/metabase-types/api/remote-sync.ts
@@ -16,7 +16,8 @@ export type RemoteSyncEntityModel =
   | "measure"
   | "transform"
   | "transformtag"
-  | "transformjob";
+  | "transformjob"
+  | "pythonlibrary";
 
 export type RemoteSyncEntityStatus =
   | "create"

--- a/frontend/src/metabase/lib/icon.ts
+++ b/frontend/src/metabase/lib/icon.ts
@@ -22,7 +22,8 @@ export type IconModel =
   | "question"
   | "transform"
   | "user"
-  | "nativequerysnippet";
+  | "nativequerysnippet"
+  | "pythonlibrary";
 
 export type ObjectWithModel = {
   id?: unknown;
@@ -59,6 +60,7 @@ export const modelIconMap: Record<IconModel, IconName> = {
   timeline: "calendar",
   transform: "transform",
   user: "person",
+  pythonlibrary: "code_block",
 };
 
 export type IconData = {

--- a/frontend/src/metabase/lib/icon.unit.spec.ts
+++ b/frontend/src/metabase/lib/icon.unit.spec.ts
@@ -36,6 +36,10 @@ describe("getIcon", () => {
     expect(getIcon({ model: "indexed-entity" })).toEqual({ name: "index" });
   });
 
+  it("should return the correct icon for a python library", () => {
+    expect(getIcon({ model: "pythonlibrary" })).toEqual({ name: "code_block" });
+  });
+
   it("should return the correct icon for a dashboard", () => {
     expect(getIcon({ model: "dashboard" })).toEqual({ name: "dashboard" });
   });

--- a/resources/migrations/059_update_migrations.yaml
+++ b/resources/migrations/059_update_migrations.yaml
@@ -744,6 +744,66 @@ databaseChangeLog:
             sql: INSERT INTO python_library (path, source) VALUES ('common.py', '')
       rollback:
 
+  - changeSet:
+      id: v59.2026-01-27T12:00:00
+      author: epaget
+      comment: Add entity_id column to python_library table
+      changes:
+        - addColumn:
+            tableName: python_library
+            columns:
+              - column:
+                  name: entity_id
+                  type: char(21)
+                  remarks: Random NanoID tag for unique identity
+                  constraints:
+                    nullable: true
+      rollback:
+        - dropColumn:
+            tableName: python_library
+            columnName: entity_id
+
+  - changeSet:
+      id: v59.2026-01-27T12:00:01
+      author: epaget
+      comment: Backfill entity_id for existing common.py python_library row
+      changes:
+        - sql:
+            sql: UPDATE python_library SET entity_id = 'cWWH9qJPvHNB3rP2vLZrK' WHERE path = 'common.py' AND entity_id IS NULL
+      rollback:
+        - sql:
+            sql: UPDATE python_library SET entity_id = NULL WHERE path = 'common.py'
+
+  - changeSet:
+      id: v59.2026-01-27T12:00:02
+      author: epaget
+      comment: Add index on entity_id column in python_library table
+      changes:
+        - createIndex:
+            tableName: python_library
+            indexName: idx_python_library_entity_id
+            columns:
+              - column:
+                  name: entity_id
+      rollback:
+        - dropIndex:
+            tableName: python_library
+            indexName: idx_python_library_entity_id
+
+  - changeSet:
+      id: v59.2026-01-27T12:00:03
+      author: epaget
+      comment: Add unique constraint on entity_id column in python_library table
+      changes:
+        - addUniqueConstraint:
+            tableName: python_library
+            columnNames: entity_id
+            constraintName: unique_python_library_entity_id
+      rollback:
+        - dropUniqueConstraint:
+            tableName: python_library
+            constraintName: unique_python_library_entity_id
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/serialization-order.edn
+++ b/resources/serialization-order.edn
@@ -165,6 +165,11 @@
  :TransformJob                   []
  [:TransformJob :job_tags]       []
  :TransformTag                   []
+ :PythonLibrary                  [:path
+                                  :source
+                                  :entity_id
+                                  :created_at
+                                  :serdes/meta]
  :Metabot                        [:name
                                   :description
                                   :created_at

--- a/test_resources/serialization_baseline/python-libraries/cWWH9qJPvHNB3rP2vLZrK.yaml
+++ b/test_resources/serialization_baseline/python-libraries/cWWH9qJPvHNB3rP2vLZrK.yaml
@@ -1,0 +1,9 @@
+created_at: '2026-01-21T21:50:59.518133Z'
+entity_id: cWWH9qJPvHNB3rP2vLZrK
+path: common.py
+source: |-
+  def helper():
+      return 42
+serdes/meta:
+- id: cWWH9qJPvHNB3rP2vLZrK
+  model: PythonLibrary

--- a/test_resources/serialization_baseline/settings.yaml
+++ b/test_resources/serialization_baseline/settings.yaml
@@ -12,9 +12,9 @@ available-timezones: null
 breakout-bins-num: null
 custom-formatting: null
 custom-geojson: null
+custom-geojson-enabled: null
 custom-homepage: null
 custom-homepage-dashboard: null
-custom-geojson-enabled: null
 default-maps-enabled: null
 disable-cors-on-localhost: null
 email-max-recipients-per-second: null


### PR DESCRIPTION
### Description

Add support for syncing PythonLibrary entities (Python transform libraries) with a Git repository when remote-sync-transforms setting is enabled.

Implements serdes serialization for pythonlibraries using `path` as the entity id.

Adds FE changes to refresh on dirty state and show changes in the AllChangesView

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
