### PR TITLE
feat: add conditional formatting color for number

### DIFF
--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -314,6 +314,7 @@ export type VisualizationSettings = {
   "scalar.switch_positive_negative"?: boolean;
   "scalar.compact_primary_number"?: boolean;
   "scalar.segments"?: ScalarSegment[];
+  "scalar.formatting"?: ScalarFormattingSetting[];
 
   // Pie Settings
   "pie.dimension"?: string | string[];
@@ -500,3 +501,25 @@ export type ScalarSegment = {
   color: string;
   label?: string;
 };
+
+export type ScalarFormattingOperator = "=" | "!=" | "<" | ">" | "<=" | ">=";
+
+export type ScalarSingleFormattingSetting = {
+  type: "single";
+  operator: ScalarFormattingOperator;
+  color: string;
+  value: string | number;
+};
+
+export type ScalarRangeFormattingSetting = {
+  type: "range";
+  colors: string[];
+  min_type: "custom";
+  max_type: "custom";
+  min_value?: number;
+  max_value?: number;
+};
+
+export type ScalarFormattingSetting =
+  | ScalarSingleFormattingSetting
+  | ScalarRangeFormattingSetting;

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsNumberFormatting/ChartSettingsNumberFormatting.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsNumberFormatting/ChartSettingsNumberFormatting.tsx
@@ -1,0 +1,72 @@
+import { useState } from "react";
+
+import { DEFAULTS_BY_TYPE } from "./constants";
+import { RuleEditor } from "./RuleEditor";
+import { RuleListing } from "./RuleListing";
+import type { NumberFormattingSetting } from "./types";
+
+export interface ChartSettingsNumberFormattingProps {
+  value: NumberFormattingSetting[];
+  onChange: (rules: NumberFormattingSetting[]) => void;
+}
+
+export const ChartSettingsNumberFormatting = ({
+  value,
+  onChange,
+}: ChartSettingsNumberFormattingProps) => {
+  const [editingRule, setEditingRule] = useState<number | null>(null);
+  const [editingRuleIsNew, setEditingRuleIsNew] = useState<boolean | null>(
+    null,
+  );
+
+  if (editingRule !== null && value[editingRule]) {
+    return (
+      <RuleEditor
+        rule={value[editingRule]}
+        isNew={!!editingRuleIsNew}
+        onChange={(rule) => {
+          onChange([
+            ...value.slice(0, editingRule),
+            rule,
+            ...value.slice(editingRule + 1),
+          ]);
+        }}
+        onRemove={() => {
+          onChange([
+            ...value.slice(0, editingRule),
+            ...value.slice(editingRule + 1),
+          ]);
+          setEditingRule(null);
+          setEditingRuleIsNew(null);
+        }}
+        onDone={() => {
+          setEditingRule(null);
+          setEditingRuleIsNew(null);
+        }}
+      />
+    );
+  } else {
+    return (
+      <RuleListing
+        rules={value}
+        onEdit={(index) => {
+          setEditingRule(index);
+          setEditingRuleIsNew(false);
+        }}
+        onAdd={async () => {
+          await onChange([
+            {
+              ...DEFAULTS_BY_TYPE["single"],
+            },
+            ...value,
+          ]);
+          setEditingRuleIsNew(true);
+          setEditingRule(0);
+        }}
+        onRemove={(index) => {
+          onChange([...value.slice(0, index), ...value.slice(index + 1)]);
+        }}
+      />
+    );
+  }
+};

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsNumberFormatting/RuleBackground.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsNumberFormatting/RuleBackground.tsx
@@ -1,0 +1,22 @@
+import type { CSSProperties } from "react";
+
+import { ColorRange } from "metabase/common/components/ColorRange";
+import { Box } from "metabase/ui";
+
+import type { NumberFormattingSetting } from "./types";
+
+export const RuleBackground = ({
+  rule,
+  className,
+  style,
+}: {
+  rule: NumberFormattingSetting;
+  className?: string;
+  style: CSSProperties;
+}) =>
+  rule.type === "range" ? (
+    <ColorRange colors={rule.colors} className={className} style={style} />
+  ) : rule.type === "single" ? (
+    // @ts-expect-error viz settings need to accept hex color values
+    <Box className={className} style={style} bg={rule.color} />
+  ) : null;

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsNumberFormatting/RuleDescription.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsNumberFormatting/RuleDescription.tsx
@@ -1,0 +1,33 @@
+import { match } from "ts-pattern";
+import { jt, t } from "ttag";
+
+import { Text } from "metabase/ui";
+
+import { NUMBER_OPERATOR_NAMES } from "./get-operators";
+import type { NumberFormattingSetting } from "./types";
+
+export const RuleDescription = ({
+  rule,
+}: {
+  rule: NumberFormattingSetting;
+}) => {
+  return (
+    <Text component="span" lh="normal">
+      {match(rule)
+        .with(
+          { type: "range" },
+          () => t`The number will be tinted based on its value.`,
+        )
+        .with(
+          { type: "single" },
+          (singleRule) =>
+            jt`When the number ${(
+              <Text component="span" key="bold" fw="bold" lh="normal">
+                {NUMBER_OPERATOR_NAMES[singleRule.operator]} {singleRule.value}
+              </Text>
+            )} it will be this color.`,
+        )
+        .otherwise(() => null)}
+    </Text>
+  );
+};

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsNumberFormatting/RuleEditor.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsNumberFormatting/RuleEditor.tsx
@@ -1,0 +1,136 @@
+import cx from "classnames";
+import { t } from "ttag";
+import _ from "underscore";
+
+import { ColorRangeSelector } from "metabase/common/components/ColorRangeSelector";
+import { ColorSelector } from "metabase/common/components/ColorSelector";
+import CS from "metabase/css/core/index.css";
+import {
+  Box,
+  Button,
+  Select,
+  Stack,
+  Text,
+} from "metabase/ui";
+
+import { ChartSettingInputNumeric } from "../ChartSettingInputNumeric";
+import { ChartSettingRadio } from "../ChartSettingRadio";
+
+import { COLORS, COLOR_RANGES, DEFAULTS_BY_TYPE } from "./constants";
+import { NUMBER_OPERATOR_NAMES } from "./get-operators";
+import type {
+  NumberFormattingOperator,
+  NumberFormattingSetting,
+} from "./types";
+
+interface RuleEditorProps {
+  rule: NumberFormattingSetting;
+  isNew: boolean;
+  onChange: (rule: NumberFormattingSetting) => void;
+  onDone: () => void;
+  onRemove: () => void;
+}
+
+const INPUT_CLASSNAME = cx(CS.mt1, CS.full);
+
+export const RuleEditor = ({
+  rule,
+  isNew,
+  onChange,
+  onDone,
+  onRemove,
+}: RuleEditorProps) => {
+  return (
+    <Stack gap="1.5rem" px="2rem" py="1rem">
+      <Box>
+        <Text fw="bold" mb="sm">{t`Formatting style`}</Text>
+        <ChartSettingRadio
+          options={[
+            { name: t`Single color`, value: "single" },
+            { name: t`Color range`, value: "range" },
+          ]}
+          value={rule.type}
+          onChange={(type) =>
+            onChange(DEFAULTS_BY_TYPE[type as "single" | "range"])
+          }
+        />
+      </Box>
+      {rule.type === "single" ? (
+        <>
+          <Box>
+            <Text fw="bold" mb="sm">{t`When the number…`}</Text>
+            <Select<NumberFormattingOperator>
+              comboboxProps={{ withinPortal: false }}
+              value={rule.operator}
+              onChange={(operator) => onChange({ ...rule, operator })}
+              data={_.pairs(NUMBER_OPERATOR_NAMES).map(([value, label]) => ({
+                value,
+                label,
+              }))}
+              data-testid="conditional-formatting-value-operator-button"
+            />
+            <ChartSettingInputNumeric
+              data-testid="conditional-formatting-value-input"
+              className={INPUT_CLASSNAME}
+              value={typeof rule.value === "number" ? rule.value : parseFloat(rule.value) || undefined}
+              onChange={(value) =>
+                onChange({ ...rule, value: value ?? "" })
+              }
+              placeholder="0"
+            />
+          </Box>
+          <Box>
+            <Text fw="bold" mb="sm">{t`…use this color:`}</Text>
+            <ColorSelector
+              data-testid="conditional-formatting-color-selector"
+              value={rule.color}
+              colors={COLORS}
+              onChange={(color) => onChange({ ...rule, color })}
+              withinPortal={false}
+            />
+          </Box>
+        </>
+      ) : rule.type === "range" ? (
+        <>
+          <Box>
+            <Text fw="bold" mb="sm">{t`Colors`}</Text>
+            <ColorRangeSelector
+              value={rule.colors}
+              onChange={(colors) => {
+                onChange({ ...rule, colors });
+              }}
+              colors={COLORS}
+              colorRanges={COLOR_RANGES}
+              withinPortal={false}
+            />
+          </Box>
+          <Box>
+            <Text fw="bold" mb="sm">{t`Start the range at`}</Text>
+            <ChartSettingInputNumeric
+              className={INPUT_CLASSNAME}
+              value={rule.min_value}
+              onChange={(min_value) =>
+                onChange({ ...rule, min_value: min_value ?? undefined })
+              }
+            />
+          </Box>
+          <Box>
+            <Text fw="bold" mb="sm">{t`End the range at`}</Text>
+            <ChartSettingInputNumeric
+              className={INPUT_CLASSNAME}
+              value={rule.max_value}
+              onChange={(max_value) =>
+                onChange({ ...rule, max_value: max_value ?? undefined })
+              }
+            />
+          </Box>
+        </>
+      ) : null}
+      <Box>
+        <Button variant="filled" onClick={onDone}>
+          {isNew ? t`Add rule` : t`Update rule`}
+        </Button>
+      </Box>
+    </Stack>
+  );
+};

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsNumberFormatting/RuleListing.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsNumberFormatting/RuleListing.tsx
@@ -1,0 +1,58 @@
+import type { MouseEventHandler } from "react";
+import { t } from "ttag";
+
+import { Box, Button, Icon, Stack, Text } from "metabase/ui";
+
+import { RulePreview } from "./RulePreview";
+import type { NumberFormattingSetting } from "./types";
+
+export interface RuleListingProps {
+  rules: NumberFormattingSetting[];
+  onEdit: (index: number) => void;
+  onAdd: MouseEventHandler<HTMLButtonElement>;
+  onRemove: (index: number) => void;
+}
+
+export const RuleListing = ({
+  rules,
+  onEdit,
+  onAdd,
+  onRemove,
+}: RuleListingProps) => (
+  <Stack gap="1.5rem" px="2rem" py="1rem">
+    <Box>
+      <Text fw="bold" mb="sm">{t`Conditional formatting`}</Text>
+      <Text c="text-medium" fz="sm">
+        {t`You can add rules to make the number change color if it meets certain conditions.`}
+      </Text>
+    </Box>
+    <Box ml="-0.5rem">
+      <Button
+        variant="subtle"
+        color="brand"
+        onClick={onAdd}
+        leftSection={<Icon name="add" />}
+      >
+        {t`Add a rule`}
+      </Button>
+    </Box>
+    {rules.length > 0 && (
+      <>
+        <Box>
+          <Text fw="bold" mb="sm">{t`Rules will be applied in this order`}</Text>
+          <Text c="text-medium" fz="sm">{t`The first matching rule will be used.`}</Text>
+        </Box>
+        <Stack gap="sm">
+          {rules.map((rule, index) => (
+            <RulePreview
+              key={index}
+              rule={rule}
+              onClick={() => onEdit(index)}
+              onRemove={() => onRemove(index)}
+            />
+          ))}
+        </Stack>
+      </>
+    )}
+  </Stack>
+);

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsNumberFormatting/RulePreview.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsNumberFormatting/RulePreview.tsx
@@ -1,0 +1,62 @@
+import cx from "classnames";
+import type { MouseEventHandler } from "react";
+import { t } from "ttag";
+
+import CS from "metabase/css/core/index.css";
+import {
+  ActionIcon,
+  Divider,
+  Group,
+  Icon,
+  Paper,
+  type PaperProps,
+  Text,
+} from "metabase/ui";
+
+import { RuleBackground } from "./RuleBackground";
+import { RuleDescription } from "./RuleDescription";
+import type { NumberFormattingSetting } from "./types";
+
+export const RulePreview = ({
+  rule,
+  onClick,
+  onRemove,
+  ...paperProps
+}: {
+  rule: NumberFormattingSetting;
+  onClick: MouseEventHandler<HTMLDivElement>;
+  onRemove: () => void;
+} & PaperProps) => (
+  <Paper
+    withBorder
+    className={CS.overflowHidden}
+    onClick={onClick}
+    data-testid="formatting-rule-preview"
+    {...paperProps}
+  >
+    <Group wrap="nowrap" px="md" bg="background-secondary">
+      <Text flex="1" fw="bold" fz="md">
+        {rule.type === "single" ? t`Conditional color` : t`Color range`}
+      </Text>
+      <ActionIcon
+        onClick={(e) => {
+          e.stopPropagation();
+          onRemove();
+        }}
+      >
+        <Icon name="close" />
+      </ActionIcon>
+    </Group>
+    <Divider></Divider>
+    <Group wrap="nowrap" p="md" gap="xs">
+      <RuleBackground
+        rule={rule}
+        className={cx(CS.mr2, CS.flexNoShrink, CS.rounded, {
+          [CS.bordered]: rule.type === "range",
+        })}
+        style={{ width: 40, height: 40 }}
+      />
+      <RuleDescription rule={rule} />
+    </Group>
+  </Paper>
+);

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsNumberFormatting/constants.ts
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsNumberFormatting/constants.ts
@@ -1,0 +1,31 @@
+import {
+  getAccentColors,
+  getStatusColorRanges,
+} from "metabase/lib/colors/groups";
+import type {
+  NumberRangeFormattingSetting,
+  NumberSingleFormattingSetting,
+} from "./types";
+
+export const COLORS = getAccentColors({ dark: false });
+export const COLOR_RANGES = getStatusColorRanges();
+
+export const DEFAULTS_BY_TYPE: {
+  single: NumberSingleFormattingSetting;
+  range: NumberRangeFormattingSetting;
+} = {
+  single: {
+    type: "single",
+    operator: "=",
+    value: "",
+    color: COLORS[0],
+  },
+  range: {
+    type: "range",
+    colors: COLOR_RANGES[0],
+    min_type: "custom",
+    max_type: "custom",
+    min_value: 0,
+    max_value: 100,
+  },
+};

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsNumberFormatting/get-operators.ts
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsNumberFormatting/get-operators.ts
@@ -1,0 +1,18 @@
+import { t } from "ttag";
+
+import type { NumberFormattingOperator } from "./types";
+
+export const NUMBER_OPERATOR_NAMES: Record<NumberFormattingOperator, string> = {
+  // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
+  "=": t`is equal to`,
+  // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
+  "!=": t`is not equal to`,
+  // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
+  "<": t`is less than`,
+  // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
+  ">": t`is greater than`,
+  // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
+  "<=": t`is less than or equal to`,
+  // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
+  ">=": t`is greater than or equal to`,
+};

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsNumberFormatting/index.ts
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsNumberFormatting/index.ts
@@ -1,0 +1,7 @@
+export { ChartSettingsNumberFormatting } from "./ChartSettingsNumberFormatting";
+export type {
+  NumberFormattingSetting,
+  NumberSingleFormattingSetting,
+  NumberRangeFormattingSetting,
+  NumberFormattingOperator,
+} from "./types";

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsNumberFormatting/types.ts
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsNumberFormatting/types.ts
@@ -1,0 +1,23 @@
+import type { ConditionalFormattingComparisonOperator } from "metabase-types/api";
+
+export type NumberFormattingOperator = ConditionalFormattingComparisonOperator;
+
+export type NumberSingleFormattingSetting = {
+  type: "single";
+  operator: NumberFormattingOperator;
+  color: string;
+  value: string | number;
+};
+
+export type NumberRangeFormattingSetting = {
+  type: "range";
+  colors: string[];
+  min_type: "custom";
+  max_type: "custom";
+  min_value?: number;
+  max_value?: number;
+};
+
+export type NumberFormattingSetting =
+  | NumberSingleFormattingSetting
+  | NumberRangeFormattingSetting;

--- a/frontend/src/metabase/visualizations/lib/scalar_format.ts
+++ b/frontend/src/metabase/visualizations/lib/scalar_format.ts
@@ -1,0 +1,121 @@
+import Color from "color";
+
+import { getColorScale, getSafeColor } from "metabase/lib/colors/scales";
+import type {
+  NumberFormattingSetting,
+  NumberRangeFormattingSetting,
+  NumberSingleFormattingSetting,
+} from "metabase/visualizations/components/settings/ChartSettingsNumberFormatting";
+
+const GRADIENT_ALPHA = 0.75;
+const MIN_ALPHA = 0.000001;
+
+type FormatterFn = (value: number) => string | null;
+
+const OPERATOR_FORMATTER_FACTORIES: Record<
+  NumberSingleFormattingSetting["operator"],
+  (value: number, color: string) => FormatterFn
+> = {
+  "<": (value, color) => (v) => v < value ? color : null,
+  "<=": (value, color) => (v) => v <= value ? color : null,
+  ">=": (value, color) => (v) => v >= value ? color : null,
+  ">": (value, color) => (v) => v > value ? color : null,
+  "=": (value, color) => (v) => v === value ? color : null,
+  "!=": (value, color) => (v) => v !== value ? color : null,
+};
+
+function clampAlpha(alpha: number): number {
+  if (alpha === 0) {
+    return 0;
+  }
+  return Math.min(GRADIENT_ALPHA, Math.max(MIN_ALPHA, alpha));
+}
+
+function compileSingleFormatter(
+  format: NumberSingleFormattingSetting,
+): FormatterFn {
+  const { operator, value, color } = format;
+  const numericValue = typeof value === "string" ? parseFloat(value) : value;
+
+  if (Number.isNaN(numericValue)) {
+    return () => null;
+  }
+
+  const formatterFactory = OPERATOR_FORMATTER_FACTORIES[operator];
+  if (formatterFactory) {
+    return formatterFactory(numericValue, color);
+  }
+
+  console.error("Unsupported formatting operator:", operator);
+  return () => null;
+}
+
+function compileRangeFormatter(
+  format: NumberRangeFormattingSetting,
+): FormatterFn {
+  const min = format.min_value ?? 0;
+  const max = format.max_value ?? 100;
+
+  if (typeof max !== "number" || typeof min !== "number") {
+    console.warn("Invalid range min/max", min, max);
+    return () => null;
+  }
+
+  const scale = getColorScale(
+    [min, max],
+    format.colors.map((c) => {
+      const color = Color(c);
+      const alpha = color.alpha();
+      return color.alpha(clampAlpha(alpha)).toString();
+    }),
+  );
+
+  // scaleLinear has clamp method, scaleQuantile does not
+  if ("clamp" in scale) {
+    (scale as { clamp: (clamp: boolean) => void }).clamp(true);
+  }
+
+  return (value: number) => {
+    const colorValue = scale(value);
+    if (!colorValue) {
+      return null;
+    }
+    return getSafeColor(colorValue);
+  };
+}
+
+export function compileNumberFormatter(
+  format: NumberFormattingSetting,
+): FormatterFn {
+  if (format.type === "single") {
+    return compileSingleFormatter(format);
+  } else if (format.type === "range") {
+    return compileRangeFormatter(format);
+  }
+  return () => null;
+}
+
+export function getNumberColor(
+  value: unknown,
+  formattingRules: NumberFormattingSetting[] | undefined,
+): string | null {
+  if (!formattingRules || formattingRules.length === 0) {
+    return null;
+  }
+
+  const numericValue = typeof value === "number" ? value : parseFloat(String(value));
+
+  if (Number.isNaN(numericValue)) {
+    return null;
+  }
+
+  for (const rule of formattingRules) {
+    const formatter = compileNumberFormatter(rule);
+    const color = formatter(numericValue);
+    if (color != null) {
+      return color;
+    }
+  }
+
+  return null;
+}

--- a/frontend/src/metabase/visualizations/visualizations/Scalar/Scalar.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Scalar/Scalar.tsx
@@ -3,21 +3,17 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import DashboardS from "metabase/css/dashboard.module.css";
-import { Box, Tooltip } from "metabase/ui";
+import { Box } from "metabase/ui";
 import {
   ScalarValue,
   ScalarWrapper,
 } from "metabase/visualizations/components/ScalarValue/ScalarValue";
 import { TransformedVisualization } from "metabase/visualizations/components/TransformedVisualization";
-import { ChartSettingSegmentsEditor } from "metabase/visualizations/components/settings/ChartSettingSegmentsEditor";
-import {
-  compactifyValue,
-  getColor,
-  getTooltipContent,
-} from "metabase/visualizations/lib/scalar_utils";
+import { ChartSettingsNumberFormatting } from "metabase/visualizations/components/settings/ChartSettingsNumberFormatting";
+import { getNumberColor } from "metabase/visualizations/lib/scalar_format";
+import { compactifyValue } from "metabase/visualizations/lib/scalar_utils";
 import { columnSettings } from "metabase/visualizations/lib/settings/column";
 import { fieldSetting } from "metabase/visualizations/lib/settings/utils";
-import { segmentIsValid } from "metabase/visualizations/lib/utils";
 import {
   getDefaultSize,
   getMinSize,
@@ -84,19 +80,16 @@ export class Scalar extends Component<
         },
       ]) => cols.length < 2,
     }),
-    "scalar.segments": {
+    "scalar.formatting": {
       get section() {
-        return t`Conditional colors`;
+        return t`Conditional formatting`;
       },
       getDefault() {
         return [];
       },
-      widget: ChartSettingSegmentsEditor,
+      widget: ChartSettingsNumberFormatting,
       persistDefault: true,
       noPadding: true,
-      props: {
-        canRemoveAll: true,
-      },
     },
     ...columnSettings({
       getColumns: (
@@ -195,10 +188,8 @@ export class Scalar extends Component<
       jsx: true,
     };
 
-    const segments = settings["scalar.segments"]?.filter(segmentIsValid);
-
-    const color = getColor(value, segments);
-    const tooltipContent = getTooltipContent(segments);
+    const formattingRules = settings["scalar.formatting"];
+    const color = getNumberColor(value, formattingRules) ?? undefined;
 
     const { displayValue, fullScalarValue } = compactifyValue(
       value,
@@ -238,28 +229,20 @@ export class Scalar extends Component<
           alwaysShowTooltip={fullScalarValue !== displayValue}
           isClickable={isClickable}
         >
-          <Tooltip
-            label={tooltipContent}
-            position="bottom"
-            px="0.375rem"
-            py="xs"
-            disabled={!tooltipContent}
+          <Box
+            onClick={handleClick}
+            ref={(scalar: HTMLElement | null) => (this._scalar = scalar)}
           >
-            <Box
-              onClick={handleClick}
-              ref={(scalar) => (this._scalar = scalar)}
-            >
-              <ScalarValue
-                color={color}
-                fontFamily={fontFamily}
-                gridSize={gridSize}
-                height={Math.max(height - PADDING * 2, 0)}
-                totalNumGridCols={totalNumGridCols}
-                value={displayValue as string}
-                width={Math.max(width - PADDING, 0)}
-              />
-            </Box>
-          </Tooltip>
+            <ScalarValue
+              color={color}
+              fontFamily={fontFamily}
+              gridSize={gridSize}
+              height={Math.max(height - PADDING * 2, 0)}
+              totalNumGridCols={totalNumGridCols}
+              value={displayValue as string}
+              width={Math.max(width - PADDING, 0)}
+            />
+          </Box>
         </ScalarValueContainer>
       </ScalarWrapper>
     );


### PR DESCRIPTION
Added conditional formatting for Number visualization, similar to how it works in Tables. Users can now add color rules based on conditions (=, !=, <, >, etc.) or color ranges.

Create a question that returns a single number
Change visualization to "Number"
Open visualization settings
Click on "Conditional formatting" tab
Add rules to change number color based on conditions

<img width="1917" height="758" alt="image" src="https://github.com/user-attachments/assets/d5612070-326a-4aeb-b8dd-7169544bc864" />
<img width="1918" height="767" alt="image" src="https://github.com/user-attachments/assets/6e1564d5-3b18-44a1-b2a1-95c37acdece3" />

Related to #63709