### PR TITLE
GDGT 1533 improve discoverability of python library in transforms UI

### DIFF
--- a/e2e/test/scenarios/data-studio/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms.cy.spec.ts
@@ -2298,6 +2298,27 @@ LIMIT
       },
     );
 
+    it(
+      "should open the common library in a new tab when cmd-clicking 'common' in an import statement",
+      { tags: ["@python"] },
+      () => {
+        visitTransformListPage();
+        cy.window().then((win) => {
+          cy.stub(win, "open").as("windowOpen");
+        });
+        cy.button("Create a transform").click();
+        H.popover().findByText("Python script").click();
+        cy.get(".cm-clickable-token")
+          .should("be.visible")
+          .click({ metaKey: true });
+
+        cy.get("@windowOpen").should(
+          "have.been.calledWithMatch",
+          "/data-studio/transforms/library/common.py",
+        );
+      },
+    );
+
     function visitCommonLibrary(path = "common.py") {
       cy.visit(`/data-studio/transforms/library/${path}`);
     }

--- a/e2e/test/scenarios/data-studio/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms.cy.spec.ts
@@ -2284,6 +2284,20 @@ LIMIT
       },
     );
 
+    it(
+      "should navigate to the common library when clicking 'common' in an import statement",
+      { tags: ["@python"] },
+      () => {
+        visitTransformListPage();
+        cy.button("Create a transform").click();
+        H.popover().findByText("Python script").click();
+        cy.get(".cm-clickable-token").should("be.visible").click();
+        H.modal().button("Discard changes").click();
+        cy.url().should("include", "/data-studio/transforms/library/common.py");
+        cy.findByTestId("python-library-header").should("be.visible");
+      },
+    );
+
     function visitCommonLibrary(path = "common.py") {
       cy.visit(`/data-studio/transforms/library/${path}`);
     }

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonEditor/PythonEditor.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonEditor/PythonEditor.tsx
@@ -1,4 +1,6 @@
+import type { Extension } from "@uiw/react-codemirror";
 import cx from "classnames";
+import _ from "underscore";
 
 import { CodeEditor } from "metabase/common/components/CodeEditor";
 
@@ -12,6 +14,7 @@ export function PythonEditor({
   withPandasCompletions,
   className,
   readOnly,
+  extensions: externalExtensions,
   ...rest
 }: {
   value: string;
@@ -21,7 +24,13 @@ export function PythonEditor({
   withPandasCompletions?: boolean;
   className?: string;
   readOnly?: boolean;
+  extensions?: Extension[];
 }) {
+  const extensions = _.compact([
+    ...(externalExtensions ?? []),
+    withPandasCompletions ? completion : undefined,
+  ]);
+
   return (
     <CodeEditor
       className={cx(S.editor, className)}
@@ -29,7 +38,7 @@ export function PythonEditor({
       proposedValue={proposedValue}
       onChange={onChange}
       language="python"
-      extensions={withPandasCompletions ? completion : undefined}
+      extensions={extensions}
       readOnly={readOnly}
       {...rest}
     />

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonEditorBody/PythonEditorBody.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonEditorBody/PythonEditorBody.tsx
@@ -55,10 +55,17 @@ export function PythonEditorBody({
   const dispatch = useDispatch();
 
   const navigateToCommonLibrary = useCallback(
-    () =>
-      dispatch(
-        push(Urls.transformPythonLibrary({ path: SHARED_LIB_IMPORT_PATH })),
-      ),
+    (e: MouseEvent) => {
+      const openInNewTab = e.metaKey || e.ctrlKey || e.button === 1;
+      const href = Urls.transformPythonLibrary({
+        path: SHARED_LIB_IMPORT_PATH,
+      });
+      if (openInNewTab) {
+        window.open(href, "_blank", "noopener,noreferrer");
+      } else {
+        dispatch(push(href));
+      }
+    },
     [dispatch],
   );
 
@@ -67,7 +74,7 @@ export function PythonEditorBody({
       clickableTokens([
         {
           tokenLocator: createPythonImportTokenLocator("common"),
-          onClick: () => navigateToCommonLibrary(),
+          onClick: (e) => navigateToCommonLibrary(e),
         },
       ]),
     [navigateToCommonLibrary],

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonEditorBody/PythonEditorBody.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonEditorBody/PythonEditorBody.tsx
@@ -1,14 +1,20 @@
-import { useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { ResizableBox } from "react-resizable";
+import { push } from "react-router-redux";
 import { useWindowSize } from "react-use";
 import { t } from "ttag";
 
+import { clickableTokens } from "metabase/common/components/CodeMirror";
+import { useDispatch } from "metabase/lib/redux";
+import * as Urls from "metabase/lib/urls";
 import RunButtonWithTooltip from "metabase/query_builder/components/RunButtonWithTooltip";
 import { Button, Flex, Icon, Stack, Tooltip } from "metabase/ui";
+import { SHARED_LIB_IMPORT_PATH } from "metabase-enterprise/transforms-python/constants";
 
 import { PythonEditor } from "../../PythonEditor";
 
 import { ResizableBoxHandle } from "./ResizableBoxHandle";
+import { createPythonImportTokenLocator } from "./utils";
 
 type PythonEditorBodyProps = {
   source: string;
@@ -46,6 +52,26 @@ export function PythonEditorBody({
 }: PythonEditorBodyProps) {
   const [isResizing, setIsResizing] = useState(false);
   const editorHeight = useInitialEditorHeight(isEditMode);
+  const dispatch = useDispatch();
+
+  const navigateToCommonLibrary = useCallback(
+    () =>
+      dispatch(
+        push(Urls.transformPythonLibrary({ path: SHARED_LIB_IMPORT_PATH })),
+      ),
+    [dispatch],
+  );
+
+  const clickableTokensExtension = useMemo(
+    () =>
+      clickableTokens([
+        {
+          tokenLocator: createPythonImportTokenLocator("common"),
+          onClick: () => navigateToCommonLibrary(),
+        },
+      ]),
+    [navigateToCommonLibrary],
+  );
 
   return (
     <ResizableBox
@@ -64,6 +90,7 @@ export function PythonEditorBody({
           onChange={onChange}
           withPandasCompletions
           readOnly={!isEditMode}
+          extensions={[clickableTokensExtension]}
           data-testid="python-editor"
         />
 

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonEditorBody/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonEditorBody/utils.ts
@@ -1,3 +1,6 @@
+import type { EditorView } from "@codemirror/view";
+import type { SyntaxNodeRef } from "@lezer/common";
+
 export function insertImport(source: string, path: string) {
   const lines = source.split("\n");
 
@@ -31,3 +34,23 @@ export function hasImport(source: string, path: string) {
   const regex = libImportRegex(path);
   return regex.test(source);
 }
+
+export const createPythonImportTokenLocator =
+  (moduleName: string) =>
+  (view: EditorView, node: SyntaxNodeRef): boolean => {
+    if (node.type.name !== "VariableName") {
+      return false;
+    }
+    const variableName = view.state.doc.sliceString(node.from, node.to);
+    if (variableName !== moduleName) {
+      return false;
+    }
+    let cur: SyntaxNodeRef | null = node;
+    while (cur) {
+      if (cur.type.name === "ImportStatement") {
+        return true;
+      }
+      cur = cur.node.parent;
+    }
+    return false;
+  };

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformListPage/TransformListPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformListPage/TransformListPage.tsx
@@ -16,7 +16,6 @@ import type { ColorName } from "metabase/lib/colors/types";
 import * as Urls from "metabase/lib/urls";
 import { type NamedUser, getUserName } from "metabase/lib/user";
 import { PLUGIN_TRANSFORMS_PYTHON } from "metabase/plugins";
-import type { TreeTableColumnDef } from "metabase/ui";
 import {
   Avatar,
   Card,
@@ -26,6 +25,7 @@ import {
   Stack,
   TextInput,
   TreeTable,
+  type TreeTableColumnDef,
   TreeTableSkeleton,
   useTreeTableInstance,
 } from "metabase/ui";
@@ -62,6 +62,8 @@ const NODE_ICON_COLORS: Record<TreeNode["nodeType"], ColorName> = {
   transform: "brand",
   library: "text-primary",
 };
+
+const COMMON_PYTHON_LIBRARY_ID = "library";
 
 const getNodeIconColor = (node: TreeNode) => NODE_ICON_COLORS[node.nodeType];
 const globalFilterFn = (
@@ -113,7 +115,7 @@ export const TransformListPage = ({ location }: WithRouterProps) => {
     const data = buildTreeData(collections, transforms);
     if (PLUGIN_TRANSFORMS_PYTHON.isEnabled) {
       data.push({
-        id: "library",
+        id: COMMON_PYTHON_LIBRARY_ID,
         name: t`Python library`,
         nodeType: "library",
         icon: "snippet",
@@ -265,6 +267,16 @@ export const TransformListPage = ({ location }: WithRouterProps) => {
     onGlobalFilterChange: setSearchQuery,
     globalFilterFn,
     isFilterable,
+    ...(PLUGIN_TRANSFORMS_PYTHON.isEnabled
+      ? {
+          enableRowPinning: true,
+          initialState: {
+            rowPinning: {
+              bottom: [COMMON_PYTHON_LIBRARY_ID],
+            },
+          },
+        }
+      : undefined),
   });
 
   const handleRowClick = useCallback((row: Row<TreeNode>) => {

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformListPage/TransformListPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformListPage/TransformListPage.tsx
@@ -63,8 +63,6 @@ const NODE_ICON_COLORS: Record<TreeNode["nodeType"], ColorName> = {
   library: "text-primary",
 };
 
-const COMMON_PYTHON_LIBRARY_ID = "library";
-
 const getNodeIconColor = (node: TreeNode) => NODE_ICON_COLORS[node.nodeType];
 const globalFilterFn = (
   row: { original: TreeNode },
@@ -115,7 +113,7 @@ export const TransformListPage = ({ location }: WithRouterProps) => {
     const data = buildTreeData(collections, transforms);
     if (PLUGIN_TRANSFORMS_PYTHON.isEnabled) {
       data.push({
-        id: COMMON_PYTHON_LIBRARY_ID,
+        id: "library",
         name: t`Python library`,
         nodeType: "library",
         icon: "snippet",
@@ -267,16 +265,6 @@ export const TransformListPage = ({ location }: WithRouterProps) => {
     onGlobalFilterChange: setSearchQuery,
     globalFilterFn,
     isFilterable,
-    ...(PLUGIN_TRANSFORMS_PYTHON.isEnabled
-      ? {
-          enableRowPinning: true,
-          initialState: {
-            rowPinning: {
-              bottom: [COMMON_PYTHON_LIBRARY_ID],
-            },
-          },
-        }
-      : undefined),
   });
 
   const handleRowClick = useCallback((row: Row<TreeNode>) => {

--- a/frontend/src/metabase/common/components/CodeMirror/clickableTokens.ts
+++ b/frontend/src/metabase/common/components/CodeMirror/clickableTokens.ts
@@ -68,16 +68,21 @@ export const clickableTokens = (tokenDefs: TokenDef[]) => {
     {
       decorations: (v) => v.decorations,
       eventHandlers: {
-        click({ target }) {
-          if (!(target instanceof Element)) {
+        click(e) {
+          if (!(e.target instanceof Element)) {
             return false;
           }
-          const key = target
-            .closest(TOKEN_CLASS)
-            ?.getAttribute(DATA_TOKEN_ATTRIBUTE);
+          const el = e.target.closest(TOKEN_CLASS);
+          if (!el) {
+            return false;
+          }
+          const key = el.getAttribute(DATA_TOKEN_ATTRIBUTE);
           if (key) {
-            tokenDefsMap.get(key)?.onClick();
-            return true;
+            const tokenDef = tokenDefsMap.get(key);
+            if (tokenDef?.onClick) {
+              tokenDef.onClick(e);
+              return true;
+            }
           }
           return false;
         },
@@ -92,7 +97,7 @@ export const clickableTokens = (tokenDefs: TokenDef[]) => {
   return [plugin, theme];
 };
 
-export type TokenDef = {
+type TokenDef = {
   tokenLocator: (view: EditorView, node: SyntaxNodeRef) => boolean;
-  onClick: () => void;
+  onClick: (e: MouseEvent) => void;
 };

--- a/frontend/src/metabase/common/components/CodeMirror/clickableTokens.ts
+++ b/frontend/src/metabase/common/components/CodeMirror/clickableTokens.ts
@@ -1,0 +1,98 @@
+import { syntaxTree } from "@codemirror/language";
+import { RangeSetBuilder } from "@codemirror/state";
+import {
+  Decoration,
+  type DecorationSet,
+  EditorView,
+  ViewPlugin,
+  type ViewUpdate,
+} from "@codemirror/view";
+import type { SyntaxNodeRef } from "@lezer/common";
+
+const TOKEN_CLASS_NAME = "cm-clickable-token";
+const TOKEN_CLASS = `.${TOKEN_CLASS_NAME}`;
+const DATA_TOKEN_ATTRIBUTE = "data-token-key";
+
+const computeTokenDecorations = (
+  view: EditorView,
+  tokenDefsMap: Map<string, TokenDef>,
+): DecorationSet => {
+  const builder = new RangeSetBuilder<Decoration>();
+  const tree = syntaxTree(view.state);
+
+  for (const { from, to } of view.visibleRanges) {
+    tree.iterate({
+      from,
+      to,
+      enter(node) {
+        for (const [key, tokenDef] of tokenDefsMap.entries()) {
+          if (!tokenDef.tokenLocator(view, node)) {
+            continue;
+          }
+          builder.add(
+            node.from,
+            node.to,
+            Decoration.mark({
+              attributes: {
+                class: TOKEN_CLASS_NAME,
+                [DATA_TOKEN_ATTRIBUTE]: key,
+              },
+            }),
+          );
+        }
+      },
+    });
+  }
+
+  return builder.finish();
+};
+
+export const clickableTokens = (tokenDefs: TokenDef[]) => {
+  const tokenDefsMap = new Map<string, TokenDef>();
+  tokenDefs.forEach((tokenDef, index) =>
+    tokenDefsMap.set(`${index}`, tokenDef),
+  );
+
+  const plugin = ViewPlugin.fromClass(
+    class {
+      decorations: DecorationSet;
+      constructor(view: EditorView) {
+        this.decorations = computeTokenDecorations(view, tokenDefsMap);
+      }
+      update(update: ViewUpdate) {
+        if (update.docChanged || update.viewportChanged) {
+          this.decorations = computeTokenDecorations(update.view, tokenDefsMap);
+        }
+      }
+    },
+    {
+      decorations: (v) => v.decorations,
+      eventHandlers: {
+        click({ target }) {
+          if (!(target instanceof Element)) {
+            return false;
+          }
+          const key = target
+            .closest(TOKEN_CLASS)
+            ?.getAttribute(DATA_TOKEN_ATTRIBUTE);
+          if (key) {
+            tokenDefsMap.get(key)?.onClick();
+            return true;
+          }
+          return false;
+        },
+      },
+    },
+  );
+
+  const theme = EditorView.baseTheme({
+    [TOKEN_CLASS]: { cursor: "pointer", textDecoration: "underline" },
+  });
+
+  return [plugin, theme];
+};
+
+export type TokenDef = {
+  tokenLocator: (view: EditorView, node: SyntaxNodeRef) => boolean;
+  onClick: () => void;
+};

--- a/frontend/src/metabase/common/components/CodeMirror/index.ts
+++ b/frontend/src/metabase/common/components/CodeMirror/index.ts
@@ -1,2 +1,3 @@
 export { CodeMirror, type CodeMirrorProps } from "./CodeMirror";
 export { type CodeMirrorRef } from "./types";
+export { clickableTokens } from "./clickableTokens";

--- a/frontend/src/metabase/ui/components/data-display/TreeTable/TreeTable.tsx
+++ b/frontend/src/metabase/ui/components/data-display/TreeTable/TreeTable.tsx
@@ -1,4 +1,5 @@
 import type { Row } from "@tanstack/react-table";
+import type { VirtualItem } from "@tanstack/react-virtual";
 import cx from "classnames";
 import {
   type KeyboardEvent,
@@ -9,7 +10,12 @@ import {
   useRef,
 } from "react";
 
-import { Box, Center, Flex } from "metabase/ui";
+import {
+  Box,
+  Center,
+  Flex,
+  type TreeTableRowPinnedPosition,
+} from "metabase/ui";
 
 import S from "./TreeTable.module.css";
 import { TreeTableHeader } from "./TreeTableHeader";
@@ -39,6 +45,9 @@ export function TreeTable<TData extends TreeNodeData>({
   const {
     table,
     rows,
+    topPinnedRows,
+    centerRows,
+    bottomPinnedRows,
     virtualRows,
     totalSize,
     virtualizer,
@@ -120,6 +129,39 @@ export function TreeTable<TData extends TreeNodeData>({
 
   const showEmptyState = rows.length === 0 && emptyState;
 
+  const renderRow = (
+    row: Row<TData>,
+    index: number,
+    virtualItemOrPinnedPosition: VirtualItem | TreeTableRowPinnedPosition,
+  ) => (
+    <TreeTableRow<TData>
+      key={row.id}
+      row={row}
+      rowIndex={index}
+      virtualItemOrPinnedPosition={virtualItemOrPinnedPosition}
+      table={table}
+      columnWidths={columnWidths}
+      showCheckboxes={showCheckboxes}
+      showExpandButtons={hasExpandableNodes}
+      indentWidth={indentWidth}
+      activeRowId={activeRowId}
+      selectedRowId={selectedRowId}
+      isExpanded={row.getIsExpanded()}
+      canExpand={row.getCanExpand()}
+      measureElement={measureElement}
+      onRowClick={handleRowClick}
+      onRowDoubleClick={onRowDoubleClick}
+      isDisabled={isRowDisabled?.(row)}
+      isChildrenLoading={isChildrenLoading?.(row)}
+      getSelectionState={getSelectionState}
+      onCheckboxClick={onCheckboxClick}
+      classNames={classNames}
+      styles={styles}
+      getRowProps={getRowProps}
+      href={getRowHref?.(row)}
+    />
+  );
+
   return (
     <Flex
       ref={rootRef}
@@ -147,56 +189,60 @@ export function TreeTable<TData extends TreeNodeData>({
           </Center>
         ) : (
           <>
-            <TreeTableHeader<TData>
-              table={table}
-              columnWidths={columnWidths}
-              showCheckboxes={showCheckboxes}
-              headerVariant={headerVariant}
-              classNames={classNames}
-              styles={styles}
-              isMeasured={isMeasured}
-              totalContentWidth={totalContentWidth}
-            />
+            <Box
+              pos="sticky"
+              top={0}
+              style={{ minWidth: totalContentWidth, zIndex: 1 }}
+            >
+              <TreeTableHeader<TData>
+                table={table}
+                columnWidths={columnWidths}
+                showCheckboxes={showCheckboxes}
+                headerVariant={headerVariant}
+                classNames={classNames}
+                styles={styles}
+                isMeasured={isMeasured}
+                totalContentWidth={totalContentWidth}
+              />
+              {topPinnedRows.length > 0 && (
+                <Box
+                  className={classNames?.pinnedTop}
+                  style={{ minWidth: totalContentWidth, ...styles?.pinnedTop }}
+                >
+                  {topPinnedRows.map((row, index) =>
+                    renderRow(row, index, "top"),
+                  )}
+                </Box>
+              )}
+            </Box>
             <Box
               pos="relative"
               style={{ height: totalSize, minWidth: totalContentWidth }}
             >
               {virtualRows.map((virtualItem) => {
-                const row = rows[virtualItem.index];
+                const row = centerRows[virtualItem.index];
                 if (!row) {
                   return null;
                 }
-
-                return (
-                  <TreeTableRow<TData>
-                    key={row.id}
-                    row={row}
-                    rowIndex={virtualItem.index}
-                    virtualItem={virtualItem}
-                    table={table}
-                    columnWidths={columnWidths}
-                    showCheckboxes={showCheckboxes}
-                    showExpandButtons={hasExpandableNodes}
-                    indentWidth={indentWidth}
-                    activeRowId={activeRowId}
-                    selectedRowId={selectedRowId}
-                    isExpanded={row.getIsExpanded()}
-                    canExpand={row.getCanExpand()}
-                    measureElement={measureElement}
-                    onRowClick={handleRowClick}
-                    onRowDoubleClick={onRowDoubleClick}
-                    isDisabled={isRowDisabled?.(row)}
-                    isChildrenLoading={isChildrenLoading?.(row)}
-                    getSelectionState={getSelectionState}
-                    onCheckboxClick={onCheckboxClick}
-                    classNames={classNames}
-                    styles={styles}
-                    getRowProps={getRowProps}
-                    href={getRowHref?.(row)}
-                  />
-                );
+                const rowIndex = topPinnedRows.length + virtualItem.index;
+                return renderRow(row, rowIndex, virtualItem);
               })}
             </Box>
+
+            {bottomPinnedRows.length > 0 && (
+              <Box
+                pos="sticky"
+                bottom={0}
+                className={classNames?.pinnedBottom}
+                style={{ minWidth: totalContentWidth, ...styles?.pinnedBottom }}
+              >
+                {bottomPinnedRows.map((row, index) => {
+                  const rowIndex =
+                    topPinnedRows.length + centerRows.length + index;
+                  return renderRow(row, rowIndex, "bottom");
+                })}
+              </Box>
+            )}
           </>
         )}
       </Box>

--- a/frontend/src/metabase/ui/components/data-display/TreeTable/TreeTable.tsx
+++ b/frontend/src/metabase/ui/components/data-display/TreeTable/TreeTable.tsx
@@ -194,7 +194,7 @@ export function TreeTable<TData extends TreeNodeData>({
               top={0}
               style={{ minWidth: totalContentWidth, zIndex: 1 }}
             >
-              <TreeTableHeader<TData>
+              <TreeTableHeader
                 table={table}
                 columnWidths={columnWidths}
                 showCheckboxes={showCheckboxes}

--- a/frontend/src/metabase/ui/components/data-display/TreeTable/TreeTableHeader/TreeTableHeader.tsx
+++ b/frontend/src/metabase/ui/components/data-display/TreeTable/TreeTableHeader/TreeTableHeader.tsx
@@ -17,7 +17,6 @@ export function TreeTableHeader<TData extends TreeNodeData>({
   classNames,
   styles,
   isMeasured = true,
-  totalContentWidth,
   headerVariant = "pill",
 }: TreeTableHeaderProps<TData>) {
   const headerGroups = table.getHeaderGroups();
@@ -27,8 +26,6 @@ export function TreeTableHeader<TData extends TreeNodeData>({
       className={cx(S.header, classNames?.header, {
         [S.measuring]: !isMeasured,
       })}
-      pos="sticky"
-      top={0}
       style={styles?.header}
     >
       {headerGroups.map((headerGroup) => (
@@ -36,7 +33,7 @@ export function TreeTableHeader<TData extends TreeNodeData>({
           key={headerGroup.id}
           className={cx(S.headerRow, classNames?.headerRow)}
           w="100%"
-          style={{ minWidth: totalContentWidth, ...styles?.headerRow }}
+          style={styles?.headerRow}
         >
           {showCheckboxes && (
             <Flex

--- a/frontend/src/metabase/ui/components/data-display/TreeTable/TreeTableRow/TreeTableRow.module.css
+++ b/frontend/src/metabase/ui/components/data-display/TreeTable/TreeTableRow/TreeTableRow.module.css
@@ -9,6 +9,21 @@
   }
 }
 
+.pinned {
+  position: relative;
+  background-color: var(--mb-color-background-primary);
+
+  --border-style: 1px solid var(--mb-color-border);
+
+  &[data-position="top"] {
+    border-bottom: var(--border-style);
+  }
+
+  &[data-position="bottom"] {
+    border-top: var(--border-style);
+  }
+}
+
 .content {
   display: flex;
   cursor: pointer;

--- a/frontend/src/metabase/ui/components/data-display/TreeTable/TreeTableRow/TreeTableRow.module.css
+++ b/frontend/src/metabase/ui/components/data-display/TreeTable/TreeTableRow/TreeTableRow.module.css
@@ -15,11 +15,14 @@
 
   --border-style: 1px solid var(--mb-color-border);
 
-  &[data-position="top"] {
+  &[data-position="top"]:not(:last-child),
+  &[data-position="top"].hasCenterRows {
     border-bottom: var(--border-style);
   }
 
-  &[data-position="bottom"] {
+  &[data-position="bottom"]:not(:first-child),
+  &[data-position="bottom"].hasCenterRows,
+  &[data-position="bottom"].hasTopPinned {
     border-top: var(--border-style);
   }
 }

--- a/frontend/src/metabase/ui/components/data-display/TreeTable/TreeTableRow/TreeTableRow.tsx
+++ b/frontend/src/metabase/ui/components/data-display/TreeTable/TreeTableRow/TreeTableRow.tsx
@@ -260,7 +260,10 @@ export function TreeTableRow<TData extends TreeNodeData>({
     return (
       <div
         data-position={virtualItemOrPinnedPosition}
-        className={cx(S.root, S.pinned)}
+        className={cx(S.root, S.pinned, {
+          [S.hasCenterRows]: table.getCenterRows().length > 0,
+          [S.hasTopPinned]: table.getTopRows().length > 0,
+        })}
       >
         {renderContent()}
       </div>

--- a/frontend/src/metabase/ui/components/data-display/TreeTable/TreeTableRow/TreeTableRow.tsx
+++ b/frontend/src/metabase/ui/components/data-display/TreeTable/TreeTableRow/TreeTableRow.tsx
@@ -199,7 +199,7 @@ const TreeTableRowContent = memo(function TreeTableRowContent<
 export function TreeTableRow<TData extends TreeNodeData>({
   row,
   rowIndex,
-  virtualItem,
+  virtualItemOrPinnedPosition,
   table,
   columnWidths,
   showCheckboxes,
@@ -247,21 +247,35 @@ export function TreeTableRow<TData extends TreeNodeData>({
       rowProps={rowProps}
     />
   );
+  const renderContent = () =>
+    href ? (
+      <Link to={href} className={S.link}>
+        {content}
+      </Link>
+    ) : (
+      content
+    );
 
+  if (typeof virtualItemOrPinnedPosition === "string") {
+    return (
+      <div
+        data-position={virtualItemOrPinnedPosition}
+        className={cx(S.root, S.pinned)}
+      >
+        {renderContent()}
+      </div>
+    );
+  }
   return (
     <div
       ref={measureElement}
-      data-index={virtualItem.index}
+      data-index={virtualItemOrPinnedPosition.index}
       className={S.root}
-      style={{ transform: `translateY(${virtualItem.start}px)` }}
+      style={{
+        transform: `translateY(${virtualItemOrPinnedPosition.start}px)`,
+      }}
     >
-      {href ? (
-        <Link to={href} className={S.link}>
-          {content}
-        </Link>
-      ) : (
-        content
-      )}
+      {renderContent()}
     </div>
   );
 }

--- a/frontend/src/metabase/ui/components/data-display/TreeTable/types.ts
+++ b/frontend/src/metabase/ui/components/data-display/TreeTable/types.ts
@@ -4,11 +4,13 @@ import type {
   FilterFn,
   OnChangeFn,
   Row,
+  RowPinningPosition,
   RowSelectionState,
   SortingState,
   Table,
 } from "@tanstack/react-table";
 import type { VirtualItem, Virtualizer } from "@tanstack/react-virtual";
+import type { InitialTableState } from "@tanstack/table-core/src/types";
 import type {
   CSSProperties,
   KeyboardEvent,
@@ -91,6 +93,7 @@ export interface UseTreeTableInstanceOptions<TData extends TreeNodeData> {
   enableSubRowSelection?: boolean;
   rowSelection?: RowSelectionState;
   onRowSelectionChange?: OnChangeFn<RowSelectionState>;
+  enableRowPinning?: boolean | ((row: Row<TData>) => boolean);
 
   enableSorting?: boolean;
   sorting?: SortingState;
@@ -121,6 +124,8 @@ export interface UseTreeTableInstanceOptions<TData extends TreeNodeData> {
    * Independent from keyboard navigation focus.
    */
   selectedRowId?: string | null;
+
+  initialState?: InitialTableState;
 }
 
 /**
@@ -139,6 +144,9 @@ export interface TreeTableInstance<TData extends TreeNodeData> {
   table: Table<TData>;
 
   rows: Row<TData>[];
+  topPinnedRows: Row<TData>[];
+  centerRows: Row<TData>[];
+  bottomPinnedRows: Row<TData>[];
 
   virtualizer: Virtualizer<HTMLDivElement, Element>;
   containerRef: RefObject<HTMLDivElement>;
@@ -171,11 +179,14 @@ export type TreeTableStylesNames =
   | "row"
   | "rowActive"
   | "rowDisabled"
+  | "rowPinned"
   | "cell"
   | "treeCell"
   | "treeCellContent"
   | "expandButton"
-  | "checkbox";
+  | "checkbox"
+  | "pinnedTop"
+  | "pinnedBottom";
 
 export type TreeTableHeaderVariant = "pill" | "plain";
 
@@ -247,6 +258,8 @@ export interface TreeTableProps<TData extends TreeNodeData>
   ariaLabelledBy?: string;
 }
 
+export type TreeTableRowPinnedPosition = Exclude<RowPinningPosition, false>;
+
 /**
  * Props for TreeTableRow component.
  */
@@ -254,7 +267,7 @@ export interface TreeTableRowProps<TData extends TreeNodeData>
   extends TreeTableStylesProps {
   row: Row<TData>;
   rowIndex: number;
-  virtualItem: VirtualItem;
+  virtualItemOrPinnedPosition: VirtualItem | TreeTableRowPinnedPosition;
   table: Table<TData>;
   columnWidths: Record<string, number>;
   showCheckboxes: boolean;


### PR DESCRIPTION
Closes [GDGT-1533](https://linear.app/metabase/issue/GDGT-1533/improve-discoverability-of-python-library-in-transforms-ui)

### Description
To ensure users can always see the Python Library row in the table, I added support for pinned rows to `TreeTable`.
To highlight the `common` token in Python scripts, I created a new `CodeMirror` extension that highlights arbitrary tokens and makes them clickable.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Go to any Python transform
2. See that `common` library is highlighted and clickable (should lead to `/data-studio/transforms/library/common.py`

### Demo
(ignore Python library pinning as it was decided to remove this feature)
https://www.loom.com/share/3475efe468fd486d838f83eec93304d6

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
