### PR TITLE
Add alerts analytics

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/guest-embed-ee.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/guest-embed-ee.cy.spec.ts
@@ -208,7 +208,7 @@ describe("scenarios > embedding > sdk iframe embed setup > guest-embed", () => {
       H.expectUnstructuredSnowplowEvent({
         event: "embed_wizard_options_completed",
         event_detail:
-          'settings=custom,experience=chart,guestEmbedEnabled=true,guestEmbedType=guest-embed,authType=guest-embed,drills=false,withDownloads=false,withTitle=true,isSaveEnabled=false,params={"disabled":0,"locked":1,"enabled":0},theme=default',
+          'settings=custom,experience=chart,guestEmbedEnabled=true,guestEmbedType=guest-embed,authType=guest-embed,drills=false,withDownloads=false,withAlerts=false,withTitle=true,isSaveEnabled=false,params={"disabled":0,"locked":1,"enabled":0},theme=default',
       });
 
       // Get code step

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/guest-embed-oss.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/guest-embed-oss.cy.spec.ts
@@ -226,7 +226,7 @@ describe(
         H.expectUnstructuredSnowplowEvent({
           event: "embed_wizard_options_completed",
           event_detail:
-            'settings=custom,experience=chart,guestEmbedEnabled=true,guestEmbedType=guest-embed,authType=guest-embed,drills=false,withDownloads=true,withTitle=true,isSaveEnabled=false,params={"disabled":0,"locked":1,"enabled":0},theme=default',
+            'settings=custom,experience=chart,guestEmbedEnabled=true,guestEmbedType=guest-embed,authType=guest-embed,drills=false,withDownloads=true,withAlerts=false,withTitle=true,isSaveEnabled=false,params={"disabled":0,"locked":1,"enabled":0},theme=default',
         });
 
         // Get code step

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
@@ -480,7 +480,7 @@ describe(suiteTitle, () => {
     H.expectUnstructuredSnowplowEvent({
       event: "embed_wizard_options_completed",
       event_detail:
-        'settings=custom,experience=chart,guestEmbedEnabled=true,guestEmbedType=guest-embed,authType=guest-embed,drills=false,withDownloads=true,withTitle=true,isSaveEnabled=false,params={"disabled":0,"locked":0,"enabled":0},theme=default',
+        'settings=custom,experience=chart,guestEmbedEnabled=true,guestEmbedType=guest-embed,authType=guest-embed,drills=false,withDownloads=true,withAlerts=false,withTitle=true,isSaveEnabled=false,params={"disabled":0,"locked":0,"enabled":0},theme=default',
     });
 
     codeBlock().should("contain", 'with-downloads="true"');
@@ -672,12 +672,11 @@ describe(suiteTitle, () => {
     cy.log("snippet should be updated");
     getEmbedSidebar().findByText("Get code").click();
 
-    // TODO: (Kelvin 2026-01-16) Uncomment this assertion when working on (EMB-1166)
-    // H.expectUnstructuredSnowplowEvent({
-    //   event: "embed_wizard_options_completed",
-    //   event_detail:
-    //     "settings=custom,experience=chart,authType=sso,drills=true,withDownloads=false,withAlerts=true,withTitle=true,isSaveEnabled=false,theme=default",
-    // });
+    H.expectUnstructuredSnowplowEvent({
+      event: "embed_wizard_options_completed",
+      event_detail:
+        "settings=custom,experience=chart,authType=sso,drills=false,withDownloads=false,withAlerts=true,withTitle=true,isSaveEnabled=false,theme=default",
+    });
 
     codeBlock().should("contain", 'with-alerts="true"');
   });
@@ -734,7 +733,7 @@ describe(suiteTitle, () => {
         event: "embed_wizard_options_completed",
         event_detail:
           experience === "chart"
-            ? "settings=custom,experience=chart,authType=sso,drills=true,withDownloads=false,withTitle=true,isSaveEnabled=true,theme=default"
+            ? "settings=custom,experience=chart,authType=sso,drills=true,withDownloads=false,withAlerts=false,withTitle=true,isSaveEnabled=true,theme=default"
             : "settings=custom,experience=exploration,authType=sso,isSaveEnabled=true,theme=default",
       });
 

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-iframe-embedding.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-iframe-embedding.cy.spec.ts
@@ -396,6 +396,10 @@ describe("scenarios > embedding > Modular embedding", () => {
           false: 1,
           true: 0,
         },
+        with_alerts: {
+          false: 1,
+          true: 0,
+        },
       },
       exploration: {
         is_save_enabled: {

--- a/frontend/src/metabase-types/analytics/embedded-analytics-js.ts
+++ b/frontend/src/metabase-types/analytics/embedded-analytics-js.ts
@@ -14,6 +14,7 @@ export type EmbeddedAnalyticsJsEventSchema = {
     with_downloads: BOOLEAN_COUNT;
     with_title: BOOLEAN_COUNT;
     is_save_enabled: BOOLEAN_COUNT;
+    with_alerts: BOOLEAN_COUNT;
   };
   exploration?: {
     is_save_enabled: BOOLEAN_COUNT;
@@ -78,6 +79,7 @@ type EmbeddedAnalyticsJsSetupEvent = ValidateEvent<{
     with_downloads: BOOLEAN_COUNT;
     with_title: BOOLEAN_COUNT;
     is_save_enabled: BOOLEAN_COUNT;
+    with_alerts: BOOLEAN_COUNT;
   };
   exploration?: {
     is_save_enabled: BOOLEAN_COUNT;

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/analytics.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/analytics.ts
@@ -37,6 +37,7 @@ const EMBED_SETTINGS_TO_TRACK: SdkIframeEmbedSettingKey[] = [
   "withTitle",
   "withDownloads",
   "withSubscriptions",
+  "withAlerts",
   "isSaveEnabled",
   "readOnly",
   "layout",

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/analytics.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/analytics.ts
@@ -35,6 +35,8 @@ const DEFAULT_VALUES: DefaultValues = {
     with_title: true,
     /** @see {@link https://github.com/metabase/metabase/blob/9e62f8c2b7d3739670d9f4259e1d4e28f5b654cc/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx#L256} */
     is_save_enabled: false,
+    /** @see {@link https://github.com/metabase/metabase/blob/c1b57eeb3f6f99126cc52e3a960b98f5c8bbc109/frontend/src/embedding-sdk-bundle/components/public/SdkQuestion/SdkQuestion.tsx#L137} */
+    with_alerts: false,
   },
   exploration: {
     /** @see {@link https://github.com/metabase/metabase/blob/9e62f8c2b7d3739670d9f4259e1d4e28f5b654cc/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx#L256} */
@@ -157,6 +159,7 @@ export function createEmbeddedAnalyticsJsUsage(
               with_downloads: { true: 0, false: 0 },
               with_title: { true: 0, false: 0 },
               is_save_enabled: { true: 0, false: 0 },
+              with_alerts: { true: 0, false: 0 },
             } satisfies EmbeddedAnalyticsJsEvent["question"]);
           }
           usage = incrementComponentPropertyCount(
@@ -180,6 +183,11 @@ export function createEmbeddedAnalyticsJsUsage(
           usage = incrementComponentPropertyCount(
             "question.is_save_enabled",
             properties.isSaveEnabled,
+            usage,
+          );
+          usage = incrementComponentPropertyCount(
+            "question.with_alerts",
+            properties.withAlerts,
             usage,
           );
         },

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/analytics.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/analytics.unit.spec.tsx
@@ -203,6 +203,7 @@ describe("createEmbeddedAnalyticsJsUsage", () => {
               with_downloads: { true: 0, false: 1 },
               with_title: { true: 1, false: 0 },
               is_save_enabled: { true: 0, false: 1 },
+              with_alerts: { true: 0, false: 1 },
             },
           }),
         );
@@ -219,6 +220,7 @@ describe("createEmbeddedAnalyticsJsUsage", () => {
                 "with-downloads": false,
                 "with-title": true,
                 "is-save-enabled": false,
+                "with-alerts": false,
               }),
             ]),
           ),
@@ -229,6 +231,7 @@ describe("createEmbeddedAnalyticsJsUsage", () => {
               with_downloads: { true: 0, false: 1 },
               with_title: { true: 1, false: 0 },
               is_save_enabled: { true: 0, false: 1 },
+              with_alerts: { true: 0, false: 1 },
             },
           }),
         );
@@ -243,6 +246,7 @@ describe("createEmbeddedAnalyticsJsUsage", () => {
                 "with-downloads": true,
                 "with-title": false,
                 "is-save-enabled": true,
+                "with-alerts": true,
               }),
             ]),
           ),
@@ -253,6 +257,7 @@ describe("createEmbeddedAnalyticsJsUsage", () => {
               with_downloads: { true: 1, false: 0 },
               with_title: { true: 0, false: 1 },
               is_save_enabled: { true: 1, false: 0 },
+              with_alerts: { true: 1, false: 0 },
             },
           }),
         );
@@ -268,6 +273,7 @@ describe("createEmbeddedAnalyticsJsUsage", () => {
                 "with-downloads": true,
                 "with-title": false,
                 "is-save-enabled": true,
+                "with-alerts": true,
               }),
             ]),
           ),
@@ -278,6 +284,7 @@ describe("createEmbeddedAnalyticsJsUsage", () => {
               with_downloads: { true: 1, false: 2 },
               with_title: { true: 2, false: 1 },
               is_save_enabled: { true: 1, false: 2 },
+              with_alerts: { true: 1, false: 2 },
             },
           }),
         );

--- a/frontend/src/metabase/lib/analytics.ts
+++ b/frontend/src/metabase/lib/analytics.ts
@@ -23,7 +23,7 @@ const VERSIONS: Record<SchemaType, SchemaVersion> = {
   downloads: "1-0-0",
   embed_flow: "1-0-3",
   embed_share: "1-0-1",
-  embedded_analytics_js: "2-0-0",
+  embedded_analytics_js: "2-0-1",
   embedding_homepage: "1-0-0",
   simple_event: "1-0-0",
   invite: "1-0-1",

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/embedded_analytics_js/jsonschema/2-0-1
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/embedded_analytics_js/jsonschema/2-0-1
@@ -5,7 +5,7 @@
     "vendor": "com.metabase",
     "name": "embedded_analytics_js",
     "format": "jsonschema",
-    "version": "2-0-0"
+    "version": "2-0-1"
   },
   "type": "object",
   "properties": {

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/embedded_analytics_js/jsonschema/2-0-1
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/embedded_analytics_js/jsonschema/2-0-1
@@ -1,0 +1,357 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Modular embedding configuration",
+  "self": {
+    "vendor": "com.metabase",
+    "name": "embedded_analytics_js",
+    "format": "jsonschema",
+    "version": "2-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "event": {
+      "description": "The type of event being recorded. For example, when the modular embedding is initialized, or when the Metabase configuration is updated.",
+      "type": "string",
+      "enum": [
+        "setup"
+      ],
+      "maxLength": 1024
+    },
+    "global": {
+      "description": "Global configuration for modular embedding.",
+      "type": "object",
+      "properties": {
+        "auth_method": {
+          "description": "Authentication method used for the modular embedding.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "session",
+            "api_key",
+            "sso",
+            "guest"
+          ],
+          "maxLength": 1024
+        }
+      }
+    },
+    "dashboard": {
+      "description": "Aggregated configuration counts for <metabase-dashboard>",
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "drills": {
+          "description": "Counts of dashboards with drills enabled or disabled.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "true": {
+              "description": "Number of dashboards with drills enabled.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            },
+            "false": {
+              "description": "Number of dashboards with drills disabled.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            }
+          },
+          "required": [
+            "true",
+            "false"
+          ]
+        },
+        "with_downloads": {
+          "description": "Counts of dashboards with downloads enabled or disabled.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "true": {
+              "description": "Number of dashboards with downloads enabled.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            },
+            "false": {
+              "description": "Number of dashboards with downloads disabled.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            }
+          },
+          "required": [
+            "true",
+            "false"
+          ]
+        },
+        "with_title": {
+          "description": "Counts of dashboards with title visible or hidden.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "true": {
+              "description": "Number of dashboards with title visible.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            },
+            "false": {
+              "description": "Number of dashboards with title hidden.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            }
+          },
+          "required": [
+            "true",
+            "false"
+          ]
+        },
+        "with_subscriptions": {
+          "description": "Counts of dashboards with subscriptions enabled or disabled.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "true": {
+              "description": "Number of dashboards with subscriptions enabled.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            },
+            "false": {
+              "description": "Number of dashboards with subscriptions disabled.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            }
+          },
+          "required": [
+            "true",
+            "false"
+          ]
+        }
+      }
+    },
+    "question": {
+      "description": "Aggregated configuration counts for <metabase-question>",
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "drills": {
+          "description": "Counts of questions with drills enabled or disabled.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "true": {
+              "description": "Number of questions with drills enabled.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            },
+            "false": {
+              "description": "Number of questions with drills disabled.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            }
+          },
+          "required": [
+            "true",
+            "false"
+          ]
+        },
+        "with_downloads": {
+          "description": "Counts of questions with downloads enabled or disabled.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "true": {
+              "description": "Number of questions with downloads enabled.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            },
+            "false": {
+              "description": "Number of questions with downloads disabled.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            }
+          },
+          "required": [
+            "true",
+            "false"
+          ]
+        },
+        "with_title": {
+          "description": "Counts of questions with title visible or hidden.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "true": {
+              "description": "Number of questions with title visible.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            },
+            "false": {
+              "description": "Number of questions with title hidden.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            }
+          },
+          "required": [
+            "true",
+            "false"
+          ]
+        },
+        "is_save_enabled": {
+          "description": "Counts of questions with save enabled or disabled.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "true": {
+              "description": "Number of questions with save enabled.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            },
+            "false": {
+              "description": "Number of questions with save disabled.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            }
+          },
+          "required": [
+            "true",
+            "false"
+          ]
+        },
+        "with_alerts": {
+          "description": "Counts of questions with alerts enabled or disabled.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "true": {
+              "description": "Number of questions with alerts enabled.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            },
+            "false": {
+              "description": "Number of questions with alerts disabled.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            }
+          },
+          "required": [
+            "true",
+            "false"
+          ]
+        }
+      }
+    },
+    "exploration": {
+      "description": "Aggregated configuration counts for <metabase-question> with question-id=\"new\"",
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "is_save_enabled": {
+          "description": "Counts of explorations with save enabled or disabled.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "true": {
+              "description": "Number of explorations with save enabled.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            },
+            "false": {
+              "description": "Number of explorations with save disabled.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            }
+          },
+          "required": [
+            "true",
+            "false"
+          ]
+        }
+      }
+    },
+    "browser": {
+      "description": "Aggregated configuration counts for <metabase-browser>",
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "read_only": {
+          "description": "Counts of browsers with read-only mode enabled or disabled.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "true": {
+              "description": "Number of browsers with read-only mode enabled.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            },
+            "false": {
+              "description": "Number of browsers with read-only mode disabled.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            }
+          },
+          "required": [
+            "true",
+            "false"
+          ]
+        }
+      }
+    }
+  },
+  "required": [
+    "event",
+    "global"
+  ],
+  "additionalProperties": true
+}


### PR DESCRIPTION
closes EMB-1166

### Description

This PR modify/add alerts analytics in
- Modular embedding setup (wizard)
- Modular embedding (the actual embed)

### How to verify
There are 2 scenarios to verify
1. In the modular embedding wizard (setup)
    2. Try to embed a question and see that the event `embed_wizard_options_completed` should now include `withAlerts=false|true` depending on whether the allows alerts checkbox is checked or not.
3. In the actual modular embedding itself: The event `setup` should have the `question.with_alerts` property with proper counts. The default value is `false`, so for every question instance with `with-alerts="true"`, the `true` count should be increased by one.


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
