### PR TITLE
Gdgt 1554 reset active table when search is activated

### DIFF
--- a/frontend/src/metabase/data-studio/data-model/components/TablePicker/components/SearchNew.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TablePicker/components/SearchNew.tsx
@@ -141,10 +141,8 @@ export function SearchNew({
       return [];
     }
 
-    filterSelectedTables(tables.map((table) => table.id));
-
     return tables.filter((table) => allowedDatabaseIds.has(table.db_id));
-  }, [allowedDatabaseIds, tables, filterSelectedTables]);
+  }, [allowedDatabaseIds, tables]);
 
   const isLoading = isLoadingTables || isLoadingDatabases;
 
@@ -153,15 +151,22 @@ export function SearchNew({
     [filteredTables],
   );
 
-  // when search is loaded, let's reset the active table, as it often might not even be visible in search results
-  //  that leads to confusion and has no added benefit
+  // when active table is not present in search results, let's reset the active table
   useEffect(() => {
-    onChange?.({
-      databaseId: undefined,
-      schemaName: undefined,
-      tableId: undefined,
-    });
-  }, [onChange]);
+    if (isFetchingTables || routeParams.tableId === undefined) {
+      return;
+    }
+    const isActiveTableVisible = filteredTables.some(
+      (table) => table.id === routeParams.tableId,
+    );
+    if (!isActiveTableVisible) {
+      onChange?.({
+        databaseId: undefined,
+        schemaName: undefined,
+        tableId: undefined,
+      });
+    }
+  }, [filteredTables, routeParams.tableId, onChange, isFetchingTables]);
 
   useEffect(() => {
     filterSelectedTables(filteredTables.map((table) => table.id));

--- a/frontend/src/metabase/data-studio/data-model/components/TablePicker/components/SearchNew.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TablePicker/components/SearchNew.tsx
@@ -141,8 +141,10 @@ export function SearchNew({
       return [];
     }
 
+    filterSelectedTables(tables.map((table) => table.id));
+
     return tables.filter((table) => allowedDatabaseIds.has(table.db_id));
-  }, [allowedDatabaseIds, tables]);
+  }, [allowedDatabaseIds, tables, filterSelectedTables]);
 
   const isLoading = isLoadingTables || isLoadingDatabases;
 

--- a/frontend/src/metabase/data-studio/data-model/components/TablePicker/components/SearchNew.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TablePicker/components/SearchNew.tsx
@@ -153,6 +153,16 @@ export function SearchNew({
     [filteredTables],
   );
 
+  // when search is loaded, let's reset the active table, as it often might not even be visible in search results
+  //  that leads to confusion and has no added benefit
+  useEffect(() => {
+    onChange?.({
+      databaseId: undefined,
+      schemaName: undefined,
+      tableId: undefined,
+    });
+  }, [onChange]);
+
   useEffect(() => {
     filterSelectedTables(filteredTables.map((table) => table.id));
   }, [filteredTables, filterSelectedTables]);


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-1554/reset-active-table-when-search-is-activated

### Description



### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> ...
2. ...

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
