### PR TITLE
fix proper bg color for embedded dashboards with custom theme

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.module.css
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.module.css
@@ -2,6 +2,10 @@
   flex: 1 0 auto;
   background-color: var(--mb-color-background-secondary);
 
+  &.isEmbeddingSdk {
+    background-color: var(--mb-color-bg-dashboard);
+  }
+
   &.isEditingOrSharing {
     flex-basis: 0;
   }

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -104,6 +104,7 @@ const DashboardDefaultView = ({ className }: { className?: string }) => {
         mih={0}
         className={cx(S.DashboardBody, {
           [S.isEditingOrSharing]: isEditing || isSharing,
+          [S.isEmbeddingSdk]: isEmbeddingSdk,
         })}
       >
         <Box


### PR DESCRIPTION
Closes [EMB-1236: Embedded dashboards don't fully use custom theme color](https://linear.app/metabase/issue/EMB-1236/embedded-dashboards-dont-fully-use-custom-theme-color)

### Description

Fixes custom background color not being used on the entire embedded dashboard.

Given this theme:

```js
const theme = defineMetabaseTheme({
  colors: {
    background: "red",
  },
  components: {
    dashboard: {
      backgroundColor: "green",

      card: {
        backgroundColor: "blue",
      },
    },
  },
});
```

Before:
<img width="1648" height="679" alt="image" src="https://github.com/user-attachments/assets/fd79fc88-c622-4909-8b5e-23b73d9a26d1" />


After:
<img width="1648" height="679" alt="image" src="https://github.com/user-attachments/assets/ef415981-44e2-4a1a-a584-7016b46e2704" />
