### PR TITLE
Remove links from alerts test email

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -879,6 +879,7 @@
            config
            dashboards
            driver
+           embedding
            events
            models
            parameters

--- a/src/metabase/channel/email/dashboard_subscription.hbs
+++ b/src/metabase/channel/email/dashboard_subscription.hbs
@@ -5,7 +5,7 @@
         <td>
           <div class="container" style="background-color: white; max-width: 555px; border-radius: 24px; margin: 0 auto; padding: 30px;">
             {{#if context.include_branding}}
-              <a {{#unless payload.disable_links}}href="https://www.metabase.com?utm_source=product&utm_medium=export&utm_campaign=exports_branding&utm_content=dashboard_subscription"{{/unless}}>
+              <a {{#unless payload.dashboard_subscription.disable_links}}href="https://www.metabase.com?utm_source=product&utm_medium=export&utm_campaign=exports_branding&utm_content=dashboard_subscription"{{/unless}}>
                 <div style="text-align: right; height: 28px; margin-bottom: 16px; color: {{payload.style.color_text_dark}};">
                   <span style="font-size: 12px; vertical-align: middle;">Made with</span>
                   <img width="22.4" height="28" src="{{context.application_logo_url}}" style="vertical-align: middle; margin-inline: 4px;"/>
@@ -19,7 +19,7 @@
                   <img class="icon" style="padding-top: 4px; padding-right: 16px; width: 100%; height: auto; max-width: 20px" src="cid:{{computed.icon_cid}}"/>
                 </td>
                 <td>
-                  <a class="title" {{#unless payload.disable_links}}href="{{{dashboard-url payload.dashboard.id payload.parameters}}}"{{/unless}} style="font-size: 20px; font-weight: 700; padding-bottom: 4px;">
+                  <a class="title" {{#unless payload.dashboard_subscription.disable_links}}href="{{{dashboard-url payload.dashboard.id payload.parameters}}}"{{/unless}} style="font-size: 20px; font-weight: 700; padding-bottom: 4px;">
                     {{payload.dashboard.name}}
                   </a>
                 </td>
@@ -55,7 +55,7 @@
               <hr>
             {{/unless}}
             {{{computed.dashboard_content}}}
-            {{#unless payload.disable_links}}
+            {{#unless payload.dashboard_subscription.disable_links}}
               <hr>
               <div class="footer" style="font-size: 11px; width: max-content; margin: 0 auto">
                 Sent from <a href="{{context.site_url}}" style="color: {{context.application_color}}">{{context.site_url}}</a>.

--- a/src/metabase/channel/email/notification_card.hbs
+++ b/src/metabase/channel/email/notification_card.hbs
@@ -5,7 +5,7 @@
         <td>
           <div class="container" style="background-color: white; max-width: 555px; border-radius: 24px; margin: 0 auto; padding: 30px;">
             {{#if context.include_branding}}
-              <a {{#unless payload.disable_links}}href="https://www.metabase.com?utm_source=product&utm_medium=export&utm_campaign=exports_branding&utm_content=alert"{{/unless}}>
+              <a {{#unless payload.notification_card.disable_links}}href="https://www.metabase.com?utm_source=product&utm_medium=export&utm_campaign=exports_branding&utm_content=alert"{{/unless}}>
                 <div style="text-align: right; height: 28px; margin-bottom: 16px; color: {{payload.style.color_text_dark}};">
                   <span style="font-size: 12px; vertical-align: middle;">Made with</span>
                   <img width="22.4" height="28" src="{{context.application_logo_url}}" style="vertical-align: middle; margin-inline: 4px;"/>
@@ -19,7 +19,7 @@
                   <img class="icon" style="padding-top: 4px; padding-right: 16px; width: 100%; height: auto; max-width: 20px" src="cid:{{computed.icon_cid}}"/>
                 </td>
                 <td>
-                  <a class="title" {{#unless payload.disable_links}}href="{{{card-url payload.card.id}}}"{{/unless}} style="font-size: 20px; font-weight: 700; padding-bottom: 4px;">
+                  <a class="title" {{#unless payload.notification_card.disable_links}}href="{{{card-url payload.card.id}}}"{{/unless}} style="font-size: 20px; font-weight: 700; padding-bottom: 4px;">
                     {{payload.card.name}}
                   </a>
                 </td>
@@ -56,7 +56,7 @@
               We’ll stop sending you alerts about this question now.
               </p>
             {{/if}}
-            {{#unless payload.disable_links}}
+            {{#unless payload.notification_card.disable_links}}
               <hr>
               <div class="footer" style="font-size: 11px; width: max-content; margin: 0 auto">
                 Sent from <a href="{{context.site_url}}" style="color: {{context.application_color}}">{{context.site_url}}</a>.

--- a/src/metabase/channel/email/notification_card.hbs
+++ b/src/metabase/channel/email/notification_card.hbs
@@ -5,7 +5,7 @@
         <td>
           <div class="container" style="background-color: white; max-width: 555px; border-radius: 24px; margin: 0 auto; padding: 30px;">
             {{#if context.include_branding}}
-              <a href="https://www.metabase.com?utm_source=product&utm_medium=export&utm_campaign=exports_branding&utm_content=alert">
+              <a {{#unless payload.disable_links}}href="https://www.metabase.com?utm_source=product&utm_medium=export&utm_campaign=exports_branding&utm_content=alert"{{/unless}}>
                 <div style="text-align: right; height: 28px; margin-bottom: 16px; color: {{payload.style.color_text_dark}};">
                   <span style="font-size: 12px; vertical-align: middle;">Made with</span>
                   <img width="22.4" height="28" src="{{context.application_logo_url}}" style="vertical-align: middle; margin-inline: 4px;"/>
@@ -19,7 +19,7 @@
                   <img class="icon" style="padding-top: 4px; padding-right: 16px; width: 100%; height: auto; max-width: 20px" src="cid:{{computed.icon_cid}}"/>
                 </td>
                 <td>
-                  <a class="title" href="{{{card-url payload.card.id}}}" style="font-size: 20px; font-weight: 700; padding-bottom: 4px;">
+                  <a class="title" {{#unless payload.disable_links}}href="{{{card-url payload.card.id}}}"{{/unless}} style="font-size: 20px; font-weight: 700; padding-bottom: 4px;">
                     {{payload.card.name}}
                   </a>
                 </td>
@@ -56,11 +56,13 @@
               We’ll stop sending you alerts about this question now.
               </p>
             {{/if}}
-            <hr>
-            <div class="footer" style="font-size: 11px; width: max-content; margin: 0 auto">
-              Sent from <a href="{{context.site_url}}" style="color: {{context.application_color}}">{{context.site_url}}</a>.
-              <a href="{{{computed.management_url}}}" style="color: {{context.application_color}}">{{computed.management_text}}</a>
-            </div>
+            {{#unless payload.disable_links}}
+              <hr>
+              <div class="footer" style="font-size: 11px; width: max-content; margin: 0 auto">
+                Sent from <a href="{{context.site_url}}" style="color: {{context.application_color}}">{{context.site_url}}</a>.
+                <a href="{{{computed.management_url}}}" style="color: {{context.application_color}}">{{computed.management_text}}</a>
+              </div>
+            {{/unless}}
           </div>
         </td>
       </tr>

--- a/src/metabase/channel/impl/email.clj
+++ b/src/metabase/channel/impl/email.clj
@@ -1,6 +1,5 @@
 (ns metabase.channel.impl.email
   (:require
-   [clojure.pprint :as pprint]
    [clojure.string :as str]
    [hiccup.core :refer [html]]
    [medley.core :as m]
@@ -234,7 +233,6 @@
                                                                   (let [email-handler-id (:notification_handler_id
                                                                                           (m/find-first #(= non-user-email (-> % :details :value)) recipients))]
                                                                     (notification-unsubscribe-url-for-non-user email-handler-id non-user-email)))}))]
-    (pprint/pprint notification_card)
     (construct-emails template message-context-fn attachments recipients)))
 
 ;; ------------------------------------------------------------------------------------------------;;

--- a/src/metabase/channel/impl/email.clj
+++ b/src/metabase/channel/impl/email.clj
@@ -1,5 +1,6 @@
 (ns metabase.channel.impl.email
   (:require
+   [clojure.pprint :as pprint]
    [clojure.string :as str]
    [hiccup.core :refer [html]]
    [medley.core :as m]
@@ -204,7 +205,7 @@
         template           (or template (payload-type->default-template payload_type))
         timezone           (channel.render/defaulted-timezone card)
         rendered-card      (render-part timezone card_part {:channel.render/include-title? true
-                                                            :channel.render/disable-links? (boolean (:disable_links payload))})
+                                                            :channel.render/disable-links? (boolean (:disable_links notification_card))})
         icon-attachment    (apply make-message-attachment (icon-bundle :bell))
         card-attachments   (map make-message-attachment (:attachments rendered-card))
         result-attachments (email.result-attachment/result-attachment
@@ -233,6 +234,7 @@
                                                                   (let [email-handler-id (:notification_handler_id
                                                                                           (m/find-first #(= non-user-email (-> % :details :value)) recipients))]
                                                                     (notification-unsubscribe-url-for-non-user email-handler-id non-user-email)))}))]
+    (pprint/pprint notification_card)
     (construct-emails template message-context-fn attachments recipients)))
 
 ;; ------------------------------------------------------------------------------------------------;;
@@ -257,7 +259,7 @@
          html-contents]     (reduce
                              (fn [[merged-attachments result-attachments html-contents] part]
                                (let [{:keys [attachments content]} (render-part timezone part {:channel.render/include-title? true
-                                                                                               :channel.render/disable-links? (boolean (:disable_links payload))})
+                                                                                               :channel.render/disable-links? (boolean (:disable_links dashboard_subscription))})
                                      result-attachment             (email.result-attachment/result-attachment part)]
                                  [(merge merged-attachments attachments)
                                   (into result-attachments result-attachment)

--- a/src/metabase/channel/impl/email.clj
+++ b/src/metabase/channel/impl/email.clj
@@ -203,7 +203,8 @@
                 card]}     payload
         template           (or template (payload-type->default-template payload_type))
         timezone           (channel.render/defaulted-timezone card)
-        rendered-card      (render-part timezone card_part {:channel.render/include-title? true})
+        rendered-card      (render-part timezone card_part {:channel.render/include-title? true
+                                                            :channel.render/disable-links? (boolean (:disable_links payload))})
         icon-attachment    (apply make-message-attachment (icon-bundle :bell))
         card-attachments   (map make-message-attachment (:attachments rendered-card))
         result-attachments (email.result-attachment/result-attachment
@@ -256,7 +257,7 @@
          html-contents]     (reduce
                              (fn [[merged-attachments result-attachments html-contents] part]
                                (let [{:keys [attachments content]} (render-part timezone part {:channel.render/include-title? true
-                                                                                               :channel.render/disable-links? (boolean (:disable_links dashboard_subscription))})
+                                                                                               :channel.render/disable-links? (boolean (:disable_links payload))})
                                      result-attachment             (email.result-attachment/result-attachment part)]
                                  [(merge merged-attachments attachments)
                                   (into result-attachments result-attachment)

--- a/src/metabase/embedding/util.clj
+++ b/src/metabase/embedding/util.clj
@@ -20,8 +20,8 @@
   (or (has-react-sdk-header? request)
       (has-embedded-analytics-js-header? request)))
 
-(defn modular-embedding-or-modular-embedding-sdk-context?
+(defn is-modular-embedding-or-modular-embedding-sdk-request?
   "Check if the client is in modular embedding context."
-  [client]
-  (or (= client embedding-sdk-client)
-      (= client embedded-analytics-js-client)))
+  [request]
+  (contains? #{embedding-sdk-client embedded-analytics-js-client}
+             (get-in request [:headers "x-metabase-client"])))

--- a/src/metabase/notification/api/notification.clj
+++ b/src/metabase/notification/api/notification.clj
@@ -252,8 +252,7 @@
   (let [notification (-> body
                          (assoc :creator_id api/*current-user-id*)
                          (assoc-in [:payload :disable_links]
-                                   (embed.util/modular-embedding-or-modular-embedding-sdk-context?
-                                    (get-in request [:headers "x-metabase-client"])))
+                                   (embed.util/is-modular-embedding-or-modular-embedding-sdk-request? request))
                          promote-to-t2-instance)]
     (notification/send-notification! notification :notification/sync? true)))
 

--- a/src/metabase/notification/api/notification.clj
+++ b/src/metabase/notification/api/notification.clj
@@ -8,6 +8,7 @@
    [metabase.api.macros :as api.macros]
    [metabase.channel.email.messages :as messages]
    [metabase.channel.settings :as channel.settings]
+   [metabase.embedding.util :as embed.util]
    [metabase.events.core :as events]
    [metabase.models.interface :as mi]
    [metabase.notification.core :as notification]
@@ -245,11 +246,14 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/send"
   "Send an unsaved notification."
-  [_route _query body :- ::models.notification/FullyHydratedNotification]
+  [_route _query body :- ::models.notification/FullyHydratedNotification request]
   (api/create-check :model/Notification body)
   (models.notification/validate-email-handlers! (:handlers body))
   (let [notification (-> body
                          (assoc :creator_id api/*current-user-id*)
+                         (assoc-in [:payload :disable_links]
+                                   (embed.util/modular-embedding-or-modular-embedding-sdk-context?
+                                    (get-in request [:headers "x-metabase-client"])))
                          promote-to-t2-instance)]
     (notification/send-notification! notification :notification/sync? true)))
 

--- a/src/metabase/notification/payload/impl/card.clj
+++ b/src/metabase/notification/payload/impl/card.clj
@@ -29,7 +29,8 @@
                           :color_text_light  channel.render/color-text-light
                           :color_text_medium channel.render/color-text-medium}
        :notification_card payload
-       :subscriptions     subscriptions})))
+       :subscriptions     subscriptions
+       :disable_links     (:disable_links payload)})))
 
 (defn- goal-met? [{:keys [send_condition], :as notification_card} card_part]
   (let [goal-comparison      (if (= :goal_above (keyword send_condition)) >= <)

--- a/src/metabase/notification/payload/impl/card.clj
+++ b/src/metabase/notification/payload/impl/card.clj
@@ -29,8 +29,7 @@
                           :color_text_light  channel.render/color-text-light
                           :color_text_medium channel.render/color-text-medium}
        :notification_card payload
-       :subscriptions     subscriptions
-       :disable_links     (:disable_links payload)})))
+       :subscriptions     subscriptions})))
 
 (defn- goal-met? [{:keys [send_condition], :as notification_card} card_part]
   (let [goal-comparison      (if (= :goal_above (keyword send_condition)) >= <)

--- a/src/metabase/notification/payload/impl/dashboard.clj
+++ b/src/metabase/notification/payload/impl/dashboard.clj
@@ -42,8 +42,7 @@
                                 :color_text_light  channel.render/color-text-light
                                 :color_text_medium channel.render/color-text-medium}
        :parameters             parameters
-       :dashboard_subscription dashboard_subscription
-       :disable_links          (:disable_links dashboard_subscription)})))
+       :dashboard_subscription dashboard_subscription})))
 
 (mu/defmethod notification.payload/skip-reason :notification/dashboard
   [{:keys [payload] :as _noti-payload}]

--- a/src/metabase/pulse/api/pulse.clj
+++ b/src/metabase/pulse/api/pulse.clj
@@ -170,8 +170,7 @@
                     :collection_position collection-position
                     :dashboard_id        dashboard-id
                     :parameters          parameters
-                    :disable_links       (embed.util/modular-embedding-or-modular-embedding-sdk-context?
-                                          (get-in request [:headers "x-metabase-client"]))}]
+                    :disable_links       (embed.util/is-modular-embedding-or-modular-embedding-sdk-request? request)}]
     (api/create-check :model/Pulse (assoc pulse-data :cards cards))
     (t2/with-transaction [_conn]
       ;; Adding a new pulse at `collection_position` could cause other pulses in this collection to change position,
@@ -460,8 +459,7 @@
   (let [pulse (-> body
                   (assoc :creator_id api/*current-user-id*)
                   (assoc :disable_links
-                         (embed.util/modular-embedding-or-modular-embedding-sdk-context?
-                          (get-in request [:headers "x-metabase-client"]))))]
+                         (embed.util/is-modular-embedding-or-modular-embedding-sdk-request? request)))]
     (notification/with-default-options {:notification/sync? true}
       (pulse.send/send-pulse! pulse)))
   {:ok true})


### PR DESCRIPTION
closes EMB-1237

### Description

This PR removes all links from the alerts test emails

### How to verify

Test this on both modular embedding and modular embedding SDK

#### Prerequisite
1. Run any SMTP server e.g.
    ```sh
    docker run -d -p 1080:1080 -p 1025:1025 maildev/maildev
    ```
1. Set up SMTP

#### Modular embedding
1. Go to any saved question (doesn't work on models)
1. Click sharing icon > Embed
1. Check "Allows alerts"
1. Click the alert icon and the modal should opens up.
1. If there's no alert already, you'll be in the create alert modal, then you can click send test email here
    1. If there's already created notificaction click on one, and you'll be able to test test email there

#### Modular embedding SDK
Embed either `StaticQuestion>` or `InteractiveQuestion>` e.g.
1. <StaticQuestion .... withAlerts />
1. Click the alert icon and the modal should opens up.
1. If there's no alert already, you'll be in the create alert modal, then you can click send test email here
    1. If there's already created notificaction click on one, and you'll be able to test test email there

### Demo

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
