### PR TITLE
fix: `Button`'s `subtle` variant has no background color on hover

### DIFF
--- a/frontend/src/metabase/ui/components/buttons/Button/Button.module.css
+++ b/frontend/src/metabase/ui/components/buttons/Button/Button.module.css
@@ -67,7 +67,7 @@
   &[data-variant="subtle"] {
     &:hover {
       color: alpha(var(--button-color), 0.88);
-      background-color: transparent;
+      background-color: var(--mb-color-background-hover);
     }
 
     &:disabled,


### PR DESCRIPTION
### Description

`subtle` variant of `Button` in mantine has background color on hover, but we remove it in our styling for some reason. This PR adds back the hover effect and fixes all the buttons around the app that don't expect to have background color.

[Discussion on Slack](https://metaboat.slack.com/archives/C096M2BBGHH/p1768950486198809)

### How to verify

1. Open the app
2. Look for the buttons!

__TODO: actually provide some ways to test that__

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
