### PR TITLE
JWTs can set tenant attributes

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/settings.clj
@@ -252,6 +252,14 @@ using, this usually looks like `https://your-org-name.example.com` or `https://e
   :feature    :sso-jwt
   :audit      :getter)
 
+(defsetting jwt-attribute-tenant-attributes
+  (deferred-tru "Key to retrieve the JWT user''s tenant attributes")
+  :export?    false
+  :encryption :when-encryption-key-set
+  :default    "@tenant.attributes"
+  :feature    :sso-jwt
+  :audit      :getter)
+
 (defsetting jwt-attribute-groups
   (deferred-tru "Key to retrieve the JWT user''s groups")
   :default    "groups"

--- a/enterprise/backend/src/metabase_enterprise/tenants/auth_provider.clj
+++ b/enterprise/backend/src/metabase_enterprise/tenants/auth_provider.clj
@@ -61,17 +61,13 @@
                        :tenant-slug/is-active (:is_active existing-tenant)
                        :status-code 403})))))
 
-(defn- merge-tenant-attributes
-  "Merge new attributes into existing, preserving existing values (existing wins)."
-  [existing-attrs new-attrs]
-  (merge new-attrs existing-attrs))
-
 (defn- maybe-update-tenant-attributes!
   "If tenant exists and there are new attributes to add, update the tenant.
    Only adds attributes that don't already exist (preserves existing)."
   [existing-tenant tenant-attributes]
   (when (and existing-tenant tenant-attributes)
-    (let [merged (merge-tenant-attributes (:attributes existing-tenant) tenant-attributes)]
+    ;; merge new attrs into existing, with existing taking precedence (existing wins)
+    (let [merged (merge tenant-attributes (:attributes existing-tenant))]
       (when (not= merged (:attributes existing-tenant))
         (request/as-admin
          (api.tenants/update-tenant! (:id existing-tenant) {:attributes merged}))))))

--- a/enterprise/backend/src/metabase_enterprise/tenants/auth_provider.clj
+++ b/enterprise/backend/src/metabase_enterprise/tenants/auth_provider.clj
@@ -61,23 +61,40 @@
                        :tenant-slug/is-active (:is_active existing-tenant)
                        :status-code 403})))))
 
+(defn- merge-tenant-attributes
+  "Merge new attributes into existing, preserving existing values (existing wins)."
+  [existing-attrs new-attrs]
+  (merge new-attrs existing-attrs))
+
+(defn- maybe-update-tenant-attributes!
+  "If tenant exists and there are new attributes to add, update the tenant.
+   Only adds attributes that don't already exist (preserves existing)."
+  [existing-tenant tenant-attributes]
+  (when (and existing-tenant tenant-attributes)
+    (let [merged (merge-tenant-attributes (:attributes existing-tenant) tenant-attributes)]
+      (when (not= merged (:attributes existing-tenant))
+        (request/as-admin
+         (api.tenants/update-tenant! (:id existing-tenant) {:attributes merged}))))))
+
 (defn- create-tenant-if-not-exists!
-  [{:as request :keys [user tenant-slug user-provisioning-enabled?]} existing-tenant]
+  [{:as request :keys [user tenant-slug tenant-attributes user-provisioning-enabled?]} existing-tenant]
   (if-not (setting/get :use-tenants)
     (do (validate-with-tenants-disabled! request)
         request)
     (do (validate-user-and-tenant-slug! user existing-tenant (boolean tenant-slug))
         (maybe-reactivate-tenant! existing-tenant user-provisioning-enabled?)
+        (maybe-update-tenant-attributes! existing-tenant tenant-attributes)
         (cond-> request
           (boolean tenant-slug)
           (assoc-in [:user-data :tenant_id]
                     (u/the-id (or existing-tenant
                                   (request/as-admin
-                                   (api.tenants/create-tenant! {:slug tenant-slug :name tenant-slug})))))))))
+                                   (api.tenants/create-tenant!
+                                    (cond-> {:slug tenant-slug :name tenant-slug}
+                                      tenant-attributes (assoc :attributes tenant-attributes)))))))))))
 
 (methodical/defmethod auth-identity/login! ::create-tenant-if-not-exists
-  [provider {:keys [tenant-slug]
-             :as request}]
+  [provider {:keys [tenant-slug] :as request}]
   (let [existing-tenant (when tenant-slug (t2/select-one :model/Tenant :slug tenant-slug))]
     (next-method provider (create-tenant-if-not-exists! request existing-tenant))))
 

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
@@ -1231,7 +1231,7 @@
                                                               :first_name "New"
                                                               :last_name "User"}
                                                              default-jwt-secret))]
-                  (is (saml-test/successful-login? response))
+                  (is (sso.test-setup/successful-login? response))
                   (let [tenant (t2/select-one :model/Tenant :slug "new-tenant-with-attrs")]
                     (is (some? tenant))
                     (is (= {"plan" "enterprise" "region" "us-west"}
@@ -1257,7 +1257,7 @@
                                                               :first_name "New"
                                                               :last_name "User"}
                                                              default-jwt-secret))]
-                  (is (saml-test/successful-login? response))
+                  (is (sso.test-setup/successful-login? response))
                   (let [tenant (t2/select-one :model/Tenant tenant-id)]
                     (testing "existing 'plan' attribute is preserved, not overwritten"
                       (is (= "enterprise" (get (:attributes tenant) "plan"))))
@@ -1281,7 +1281,7 @@
                                                               :first_name "New"
                                                               :last_name "User"}
                                                              default-jwt-secret))]
-                  (is (saml-test/successful-login? response))
+                  (is (sso.test-setup/successful-login? response))
                   (let [tenant (t2/select-one :model/Tenant :slug "tenant-invalid-attrs")]
                     (is (some? tenant))
                     (testing "tenant created but with no attributes since the value wasn't a map"


### PR DESCRIPTION
[EMB-1211: Support tenant attributes in JWT SSO](https://linear.app/metabase/issue/EMB-1211/support-tenant-attributes-in-jwt-sso)

This PR adds support for passing tenant attributes when creating new tenants.
Syntax:

```
{
  "@tenant": "my-tenant",
  "@tenant.attributes": {
    "some-attribute": "here it is"
  },
  "email": "another@another.com",
  "first_name": "Testy",
  "last_name": "Testy"
}
```

The tenant attributes will be persisted in new tenants created from JWT, as well as existing tenants, as long as the tenant attribute key is new. The values of existing tenant attributes won't be overwritten: 

When the tenant already exists, 
* if the tenant attribute doesn't exist yet, it is created
* if the tenant attribute exists, its value is NOT updated

