### PR TITLE
Don't show CORS settings in OSS/Starter editions

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-admin-settings-oss.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-admin-settings-oss.cy.spec.ts
@@ -54,5 +54,15 @@ describe(
           );
       });
     });
+
+    it("should not show CORS setting", () => {
+      cy.visit("/admin/embedding");
+
+      cy.findByTestId("admin-layout-content").within(() => {
+        cy.findByTestId("embedding-app-origins-sdk-setting").should(
+          "not.exist",
+        );
+      });
+    });
   },
 );

--- a/e2e/test/scenarios/embedding/embedding-admin-settings-starter.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-admin-settings-starter.cy.spec.ts
@@ -46,4 +46,12 @@ describe("scenarios > embedding > admin settings > starter", () => {
       cy.icon("gem").should("be.visible");
     });
   });
+
+  it("should not show CORS setting", () => {
+    cy.visit("/admin/embedding");
+
+    cy.findByTestId("admin-layout-content").within(() => {
+      cy.findByTestId("embedding-app-origins-sdk-setting").should("not.exist");
+    });
+  });
 });

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSettings/EmbeddingSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSettings/EmbeddingSettings.tsx
@@ -116,12 +116,7 @@ function EmbeddingSettingsEE() {
 }
 
 function EmbeddingSettingsOSS() {
-  return (
-    <SharedCombinedEmbeddingSettings
-      showCorsSettings
-      showContentTranslationSettings
-    />
-  );
+  return <SharedCombinedEmbeddingSettings showContentTranslationSettings />;
 }
 
 export const EmbeddingSettings = () => {

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/SharedCombinedEmbeddingSettings/SharedCombinedEmbeddingSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/SharedCombinedEmbeddingSettings/SharedCombinedEmbeddingSettings.tsx
@@ -40,7 +40,7 @@ export function SharedCombinedEmbeddingSettings({
     <>
       <EmbeddingSettingsCard
         title={t`Enable guest embeds`}
-        description={t`A secure way to embed charts and dashboards, without single sign-on, when you don’t want to offer ad-hoc querying or chart drill-through. Enables modular embedding and static embedding.`}
+        description={t`A secure way to embed charts and dashboards, without single sign-on, when you don’t want to offer ad-hoc querying or chart drill-through.`}
         settingKey="enable-embedding-static"
         actionButton={<NewEmbedButton />}
         sdk-setting-card


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #68559
Don't show CORS settings in OSS/Starter editions

Context: https://metaboat.slack.com/archives/C063Q3F1HPF/p1768830114406389

This PR removes CORS settings input from OSS/Starter editions. It was already disabled, but this PR completely hides it.

How to verify?
- in OSS and Starter edition open embedding settings in Admin UI and ensure that there's no CORS input