### PR TITLE
Fix UXW-2759 - Snippet edits in data studio are not saved

### DIFF
--- a/e2e/test/scenarios/data-studio/snippets.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/snippets.cy.spec.ts
@@ -121,6 +121,42 @@ describe("scenarios > data studio > snippets", () => {
 
       H.DataStudio.Snippets.editPage().should("be.visible");
     });
+
+    it("should preserve unsaved content changes when description or name is edited", () => {
+      cy.log("Navigate to a snippet and edit its content");
+      H.createSnippet({
+        name: "Test snippet",
+        content: "SELECT * FROM orders",
+      });
+      H.DataStudio.Library.visit();
+      H.DataStudio.Library.libraryPage().findByText("Test snippet").click();
+      H.DataStudio.Snippets.editor.type("1");
+
+      cy.log("Edit its name");
+      cy.findByPlaceholderText("Name").type("1").blur();
+      H.undoToast().findByText("Snippet name updated").should("be.visible");
+      H.undoToast().icon("close").click();
+
+      cy.log("Edit its description");
+      H.DataStudio.Snippets.descriptionInput().type("desc").blur();
+      H.undoToast()
+        .findByText("Snippet description updated")
+        .should("be.visible");
+      H.undoToast().icon("close").click();
+
+      cy.log("Verify unsaved changes are preserved");
+      H.DataStudio.Snippets.editor
+        .value()
+        .should("eq", "SELECT * FROM orders1");
+
+      cy.log(
+        "Verify Save button saves the content without reverting the name and description changes",
+      );
+      H.DataStudio.Snippets.saveButton().click();
+      H.undoToast().findByText("Snippet content updated").should("be.visible");
+      cy.findByPlaceholderText("Name").should("have.value", "Test snippet1");
+      H.DataStudio.Snippets.editPage().findByText("desc").should("be.visible");
+    });
   });
 
   describe("description", () => {

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/snippets/components/SnippetDescriptionSection/SnippetDescriptionSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/snippets/components/SnippetDescriptionSection/SnippetDescriptionSection.tsx
@@ -43,6 +43,7 @@ export function SnippetDescriptionSection({
       isMarkdown
       onChange={handleChange}
       isDisabled={isDisabled}
+      isOptional
     />
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/snippets/pages/EditSnippetPage/EditSnippetPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/snippets/pages/EditSnippetPage/EditSnippetPage.tsx
@@ -1,6 +1,7 @@
 import { sql } from "@codemirror/lang-sql";
 import { useLayoutEffect, useMemo, useState } from "react";
 import type { Route } from "react-router";
+import { usePreviousDistinct } from "react-use";
 import { t } from "ttag";
 
 import {
@@ -54,11 +55,12 @@ export function EditSnippetPage({ params, route }: EditSnippetPageProps) {
     [content, snippet],
   );
 
+  const previousSnippet = usePreviousDistinct(snippet);
   useLayoutEffect(() => {
-    if (snippet) {
+    if (snippet && previousSnippet?.id !== snippet.id) {
       setContent(snippet.content);
     }
-  }, [snippet]);
+  }, [snippet, previousSnippet]);
 
   const handleSave = async () => {
     if (!snippet) {


### PR DESCRIPTION
Closes UXW-2759

### Description

Updating a snippet's name or description in the data studio triggers a GET call (when the PUT finishes), which makes the editor update its content. This PR adds an extra check so that it only resets the content when the `id` changes (or if we previously didn't have a snippet loaded in).

This PR also lets you _remove_ a description for a snippet.

### How to verify

1. Navigate to a snippet in the data studio
2. Updating name, description, and content should be intuitive

### Demo

https://github.com/user-attachments/assets/11623665-af3a-44d2-bc45-eb403d0743c3

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [n/a] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
