### PR TITLE
fix: word wrap overflows row when reordering in dashboard table card

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
@@ -696,6 +696,99 @@ describe("scenarios > visualizations > table > dashboards context", () => {
     });
   });
 
+  it("should update row heights correctly when sorting with text wrapping enabled (metabase#61164)", () => {
+    // This test verifies that when sorting changes, row heights are recalculated
+    // based on the new row content at each position (not the old cached heights)
+    H.createQuestionAndDashboard({
+      questionDetails: {
+        name: "reviews for sorting test",
+        type: "model",
+        query: {
+          "source-table": SAMPLE_DATABASE.REVIEWS_ID,
+          limit: 10,
+        },
+        visualization_settings: {
+          "table.column_widths": [200, 100, 100, 100, 100],
+          column_settings: {
+            '["name","BODY"]': {
+              text_wrapping: true,
+            },
+          },
+          "table.columns": [
+            {
+              name: "BODY",
+              enabled: true,
+            },
+            {
+              name: "RATING",
+              enabled: true,
+            },
+            {
+              name: "ID",
+              enabled: true,
+            },
+            {
+              name: "PRODUCT_ID",
+              enabled: true,
+            },
+            {
+              name: "REVIEWER",
+              enabled: true,
+            },
+          ],
+        },
+      },
+      dashboardDetails: {
+        name: "Dashboard",
+      },
+      cardDetails: {
+        size_x: 24,
+        size_y: 12,
+      },
+    }).then(({ body: { dashboard_id } }) => {
+      H.visitDashboard(dashboard_id);
+
+      // Wait for table to render, then sort and verify rows don't overlap
+      H.tableInteractive()
+        .find("[data-index=0]")
+        .should("exist")
+        .then(() => {
+          H.tableHeaderClick("Rating");
+
+          // Verify rows don't overlap by checking their bounding rects
+          H.tableInteractive()
+            .find("[role=row]")
+            .then(($rows) => {
+              const rects = $rows
+                .toArray()
+                .map((row) => row.getBoundingClientRect())
+                .sort((a, b) => a.top - b.top);
+
+              // Each row's top should equal the previous row's bottom (no overlap)
+              for (let i = 1; i < rects.length; i++) {
+                expect(rects[i].top).to.equal(rects[i - 1].bottom);
+              }
+            });
+
+          // Sort again (descending) to verify heights update on subsequent sorts
+          H.tableHeaderClick("Rating");
+
+          H.tableInteractive()
+            .find("[role=row]")
+            .then(($rows) => {
+              const rects = $rows
+                .toArray()
+                .map((row) => row.getBoundingClientRect())
+                .sort((a, b) => a.top - b.top);
+
+              for (let i = 1; i < rects.length; i++) {
+                expect(rects[i].top).to.equal(rects[i - 1].bottom);
+              }
+            });
+        });
+    });
+  });
+
   it("should support the row index setting", () => {
     H.visitDashboard(ORDERS_DASHBOARD_ID);
     H.editDashboard();

--- a/frontend/src/metabase/data-grid/components/DataGrid/DataGrid.tsx
+++ b/frontend/src/metabase/data-grid/components/DataGrid/DataGrid.tsx
@@ -82,6 +82,7 @@ export const DataGrid = function DataGrid<TData>({
   onWheel,
   tableFooterExtraButtons,
   rowsTruncated,
+  sorting,
 }: DataGridProps<TData>) {
   const {
     virtualColumns,
@@ -103,7 +104,8 @@ export const DataGrid = function DataGrid<TData>({
     (element: HTMLElement | null) => {
       rowVirtualizer.measureElement(element);
     },
-    [rowVirtualizer],
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- `sorting` triggers re-measurement when sorting changes
+    [rowVirtualizer, sorting],
   );
 
   const forceUpdate = useForceUpdate();

--- a/frontend/src/metabase/data-grid/hooks/use-data-grid-instance.tsx
+++ b/frontend/src/metabase/data-grid/hooks/use-data-grid-instance.tsx
@@ -538,5 +538,6 @@ export const useDataGridInstance = <TData, TValue>({
     getTotalHeight,
     getVisibleRows,
     enablePagination,
+    sorting,
   };
 };

--- a/frontend/src/metabase/data-grid/types.ts
+++ b/frontend/src/metabase/data-grid/types.ts
@@ -297,6 +297,7 @@ export interface DataGridInstance<TData> {
   enableRowVirtualization: boolean;
   enablePagination: boolean;
   theme?: DataGridTheme;
+  sorting: SortingState | undefined;
   getTotalHeight: () => number;
   getVisibleRows: () => MaybeVirtualRow<TData>[];
   onHeaderCellClick?: (


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #61164
Closes [UXW-71: Word wrap overflows row when reordering in dashboard table card](https://linear.app/metabase/issue/UXW-71/word-wrap-overflows-row-when-reordering-in-dashboard-table-card)

### Description

The virtualizer wasn't being updated whenever the sorting order changed. It is not guaranteed that when we do sorting all the elements inside will be re-mounted, some might have been reused from previously rendered list. This fix guarantees that the resizing callback is called whenever sorting order changes.

### How to verify

1. Import a [dataset with long text in some column](https://github.com/user-attachments/files/24805643/long_text_wrapping.csv)
2. Add it to a dashboard
3. Set the column to wrap words
4. Sort it

### Demo

https://github.com/user-attachments/assets/71103e80-ef46-4949-9043-bb3df4c66ef9


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
