### PR TITLE
Always bucket dates in on filter clauses

### DIFF
--- a/src/metabase/lib/fe_util.cljc
+++ b/src/metabase/lib/fe_util.cljc
@@ -503,8 +503,7 @@
    column     :- ::lib.schema.metadata/column
    values     :- [:maybe [:sequential [:fn u.time/valid?]]]
    with-time? :- [:maybe :boolean]]
-  (let [column (cond-> column
-                 with-time? (lib.temporal-bucket/with-temporal-bucket :minute))
+  (let [column (lib.temporal-bucket/with-temporal-bucket column (if with-time? :minute :day))
         values (mapv #(u.time/format-for-base-type % (if with-time? :type/DateTime :type/Date)) values)]
     (expression-clause operator (into [column] values) {})))
 

--- a/test/metabase/lib/fe_util_test.cljc
+++ b/test/metabase/lib/fe_util_test.cljc
@@ -578,6 +578,18 @@
         (lib.filter/is-null (meta/field-metadata :venues :name))
         (lib.filter/and (lib.filter/= column true) true)))))
 
+(deftest ^:parallel specific-date-filter-clause-bucketing-test
+  (testing "specific-date-filter-clause adds bucketing appropriately"
+    (let [query  (lib.tu/venues-query)
+          column (-> (m/filter-vals some? (meta/field-metadata :checkins :date))
+                     (assoc :base-type :type/DateTime :effective-type :type/DateTime))]
+      (doseq [[with-time? bucket date] [[true :minute (u.time/local-date-time 2024 11 28 0 0)]
+                                        [false :day (u.time/local-date-time 2024 11 28 0 0)]
+                                        [false :day (u.time/local-date 2024 11 28)]]]
+        (is (=? bucket
+                (-> (lib.fe-util/specific-date-filter-clause := column [date] with-time?)
+                    (get-in [2 1 :temporal-unit]))))))))
+
 (defn- format-date-filter-parts
   [{:keys [with-time?], :as parts}]
   (update parts :values


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/68538

### Description

If a date field has sufficiently weird types, auto-bucketing can get confused and stop bucketing queries like `[:= col '2020-01-01']`.  With fresh queries, we have no actual reason to rely on auto-bucketing here, so adding in explicit bucketing lets us ensure that we'll get the bucketing we want.

### How to verify

Create a query with a "fixed range" filter for a specific date and verify that :temporal-unit is set to :day.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
