### PR TITLE
Fix migration for data studio

### DIFF
--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -1331,6 +1331,21 @@ databaseChangeLog:
               DELETE FROM permissions
               WHERE group_id IN (SELECT id FROM permissions_group WHERE magic_group_type = 'data-analyst');
 
+  - changeSet:
+      id: v58.2026-01-23T05:55:14
+      author: johnswanson
+      comment: Fix missing perm_value/perm_type/collection_id from v58.2026-01-09T12:00:01
+      changes:
+        - sql:
+            sql: >-
+              UPDATE permissions
+              SET perm_value = 'read-and-write',
+                  perm_type = 'perms/collection-access',
+                  collection_id = CAST(SUBSTRING(object FROM 13 FOR LENGTH(object) - 13) AS INTEGER)
+              WHERE group_id IN (SELECT id FROM permissions_group WHERE magic_group_type = 'data-analyst')
+                AND object LIKE '/collection/%/'
+                AND perm_value IS NULL
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -1335,16 +1335,54 @@ databaseChangeLog:
       id: v58.2026-01-23T05:55:14
       author: johnswanson
       comment: Fix missing perm_value/perm_type/collection_id from v58.2026-01-09T12:00:01
+      rollback: # not needed
       changes:
         - sql:
+            dbms: postgres
             sql: >-
-              UPDATE permissions
+              UPDATE permissions p
               SET perm_value = 'read-and-write',
                   perm_type = 'perms/collection-access',
-                  collection_id = CAST(SUBSTRING(object FROM 13 FOR LENGTH(object) - 13) AS INTEGER)
-              WHERE group_id IN (SELECT id FROM permissions_group WHERE magic_group_type = 'data-analyst')
-                AND object LIKE '/collection/%/'
-                AND perm_value IS NULL
+                  collection_id = c.id
+              FROM permissions_group pg, collection c
+              WHERE p.group_id = pg.id
+                AND pg.magic_group_type = 'data-analyst'
+                AND p.object = '/collection/' || c.id || '/'
+                AND c.type IN ('library', 'library-data', 'library-metrics')
+                AND p.perm_value IS NULL
+        - sql:
+            dbms: mysql,mariadb
+            sql: >-
+              UPDATE permissions p
+              JOIN permissions_group pg ON p.group_id = pg.id
+              JOIN collection c ON p.object = CONCAT('/collection/', c.id, '/')
+              SET p.perm_value = 'read-and-write',
+                  p.perm_type = 'perms/collection-access',
+                  p.collection_id = c.id
+              WHERE pg.magic_group_type = 'data-analyst'
+                AND c.type IN ('library', 'library-data', 'library-metrics')
+                AND p.perm_value IS NULL
+        - sql:
+            dbms: h2
+            sql: >-
+              UPDATE permissions p
+              SET (perm_value, perm_type, collection_id) = (
+                SELECT 'read-and-write', 'perms/collection-access', c.id
+                FROM permissions_group pg, collection c
+                WHERE p.group_id = pg.id
+                  AND pg.magic_group_type = 'data-analyst'
+                  AND p.object = '/collection/' || c.id || '/'
+                  AND c.type IN ('library', 'library-data', 'library-metrics')
+              )
+              WHERE p.perm_value IS NULL
+                AND EXISTS (
+                  SELECT 1
+                  FROM permissions_group pg, collection c
+                  WHERE p.group_id = pg.id
+                    AND pg.magic_group_type = 'data-analyst'
+                    AND p.object = '/collection/' || c.id || '/'
+                    AND c.type IN ('library', 'library-data', 'library-metrics')
+                )
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 


### PR DESCRIPTION
We usually auto-populate some other fields in permissions based on the value of object - perm_value, perm_type, and collection_id.

This obviously doesn't happen in a migration! So set them manually here.
