### PR TITLE
fix: derive events remote-sync needs in oss code

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -383,7 +383,6 @@
    :uses #{api
            app-db
            collections
-           config
            eid-translation
            events
            lib-be
@@ -1500,7 +1499,6 @@
    :uses #{analytics
            api
            collections
-           config
            events
            models
            util}}
@@ -1650,7 +1648,6 @@
    :uses #{analytics
            api
            app-db
-           config
            database-routing
            driver
            events

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/events_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/events_test.clj
@@ -5,7 +5,7 @@
   (:require
    [clojure.test :refer :all]
    [java-time.api :as t]
-   [metabase-enterprise.remote-sync.events :as lib.events]
+   [metabase-enterprise.remote-sync.events :as remote-sync.events]
    [metabase-enterprise.remote-sync.impl :as impl]
    [metabase.events.core :as events]
    [metabase.test :as mt]
@@ -496,7 +496,7 @@
       (mt/with-current-user (mt/user->id :rasta)
         (t2/delete! :model/RemoteSyncObject)
         (let [hydrate-fn (fn [id] (t2/select-one [:model/Card :name :collection_id :display] :id id))]
-          (#'lib.events/create-or-update-remote-sync-object-entry! "Card" (:id card) "create" hydrate-fn)
+          (#'remote-sync.events/create-or-update-remote-sync-object-entry! "Card" (:id card) "create" hydrate-fn)
           (let [entries (t2/select :model/RemoteSyncObject)]
             (is (= 1 (count entries)))
             (is (=? {:model_type "Card"
@@ -512,12 +512,12 @@
         (let [clock-t1 (t/mock-clock (t/instant "2024-01-01T10:00:00Z") (t/zone-id "UTC"))
               hydrate-fn (fn [id] (t2/select-one [:model/Dashboard :name :collection_id] :id id))]
           (t/with-clock clock-t1
-            (#'lib.events/create-or-update-remote-sync-object-entry! "Dashboard" (:id dashboard) "update" hydrate-fn))
+            (#'remote-sync.events/create-or-update-remote-sync-object-entry! "Dashboard" (:id dashboard) "update" hydrate-fn))
           (let [initial-entry (t2/select-one :model/RemoteSyncObject :model_type "Dashboard" :model_id (:id dashboard))
                 initial-time (:status_changed_at initial-entry)
                 clock-t2 (t/mock-clock (t/instant "2024-01-01T11:00:00Z") (t/zone-id "UTC"))]
             (t/with-clock clock-t2
-              (#'lib.events/create-or-update-remote-sync-object-entry! "Dashboard" (:id dashboard) "synced" hydrate-fn))
+              (#'remote-sync.events/create-or-update-remote-sync-object-entry! "Dashboard" (:id dashboard) "synced" hydrate-fn))
             (let [entries (t2/select :model/RemoteSyncObject :model_type "Dashboard" :model_id (:id dashboard))]
               (is (= 1 (count entries)))
               (let [update-entry (first entries)]
@@ -533,11 +533,11 @@
         (let [clock-t1 (t/mock-clock (t/instant "2024-01-01T10:00:00Z") (t/zone-id "UTC"))
               hydrate-fn (fn [id] (t2/select-one [:model/Dashboard :name :collection_id] :id id))]
           (t/with-clock clock-t1
-            (#'lib.events/create-or-update-remote-sync-object-entry! "Dashboard" (:id dashboard) "create" hydrate-fn))
+            (#'remote-sync.events/create-or-update-remote-sync-object-entry! "Dashboard" (:id dashboard) "create" hydrate-fn))
           (let [initial-entry (t2/select-one :model/RemoteSyncObject :model_type "Dashboard" :model_id (:id dashboard))
                 clock-t2 (t/mock-clock (t/instant "2024-01-01T11:00:00Z") (t/zone-id "UTC"))]
             (t/with-clock clock-t2
-              (#'lib.events/create-or-update-remote-sync-object-entry! "Dashboard" (:id dashboard) "synced" hydrate-fn))
+              (#'remote-sync.events/create-or-update-remote-sync-object-entry! "Dashboard" (:id dashboard) "synced" hydrate-fn))
             (let [entries (t2/select :model/RemoteSyncObject :model_type "Dashboard" :model_id (:id dashboard))]
               (is (= 1 (count entries)))
               (let [update-entry (first entries)]
@@ -551,7 +551,7 @@
       (t2/delete! :model/RemoteSyncObject)
       (let [existing-collection-id (t2/select-one-fn :id [:model/Collection :id])
             hydrate-fn (fn [id] (t2/select-one [:model/Collection :name [:id :collection_id]] :id id))]
-        (#'lib.events/create-or-update-remote-sync-object-entry! "Collection" existing-collection-id "create" hydrate-fn)
+        (#'remote-sync.events/create-or-update-remote-sync-object-entry! "Collection" existing-collection-id "create" hydrate-fn)
         (let [entries (t2/select :model/RemoteSyncObject)]
           (is (= 1 (count entries)))
           (is (=? {:model_type "Collection"
@@ -706,39 +706,39 @@
       (let [entries (t2/select :model/RemoteSyncObject :model_type "Card" :model_id (:id card))]
         (is (= 0 (count entries)))))))
 
-(deftest card-event-derivation-test
+(deftest ^:parallel card-event-derivation-test
   (testing "card events properly derive from :metabase/event"
-    (is (isa? ::lib.events/card-change-event :metabase/event))
-    (is (isa? :event/card-create ::lib.events/card-change-event))
-    (is (isa? :event/card-update ::lib.events/card-change-event))
-    (is (isa? :event/card-delete ::lib.events/card-change-event))))
+    (is (isa? ::remote-sync.events/card-change-event :metabase/event))
+    (is (isa? :event/card-create ::remote-sync.events/card-change-event))
+    (is (isa? :event/card-update ::remote-sync.events/card-change-event))
+    (is (isa? :event/card-delete ::remote-sync.events/card-change-event))))
 
-(deftest dashboard-event-derivation-test
+(deftest ^:parallel dashboard-event-derivation-test
   (testing "dashboard events properly derive from :metabase/event"
-    (is (isa? ::lib.events/dashboard-change-event :metabase/event))
-    (is (isa? :event/dashboard-create ::lib.events/dashboard-change-event))
-    (is (isa? :event/dashboard-update ::lib.events/dashboard-change-event))
-    (is (isa? :event/dashboard-delete ::lib.events/dashboard-change-event))))
+    (is (isa? ::remote-sync.events/dashboard-change-event :metabase/event))
+    (is (isa? :event/dashboard-create ::remote-sync.events/dashboard-change-event))
+    (is (isa? :event/dashboard-update ::remote-sync.events/dashboard-change-event))
+    (is (isa? :event/dashboard-delete ::remote-sync.events/dashboard-change-event))))
 
-(deftest document-event-derivation-test
+(deftest ^:parallel document-event-derivation-test
   (testing "document events properly derive from :metabase/event"
-    (is (isa? ::lib.events/document-change-event :metabase/event))
-    (is (isa? :event/document-create ::lib.events/document-change-event))
-    (is (isa? :event/document-update ::lib.events/document-change-event))
-    (is (isa? :event/document-delete ::lib.events/document-change-event))))
+    (is (isa? ::remote-sync.events/document-change-event :metabase/event))
+    (is (isa? :event/document-create ::remote-sync.events/document-change-event))
+    (is (isa? :event/document-update ::remote-sync.events/document-change-event))
+    (is (isa? :event/document-delete ::remote-sync.events/document-change-event))))
 
-(deftest snippet-event-derivation-test
+(deftest ^:parallel snippet-event-derivation-test
   (testing "snippet events properly derive from :metabase/event"
-    (is (isa? ::lib.events/snippet-change-event :metabase/event))
-    (is (isa? :event/snippet-create ::lib.events/snippet-change-event))
-    (is (isa? :event/snippet-update ::lib.events/snippet-change-event))
-    (is (isa? :event/snippet-delete ::lib.events/snippet-change-event))))
+    (is (isa? ::remote-sync.events/snippet-change-event :metabase/event))
+    (is (isa? :event/snippet-create ::remote-sync.events/snippet-change-event))
+    (is (isa? :event/snippet-update ::remote-sync.events/snippet-change-event))
+    (is (isa? :event/snippet-delete ::remote-sync.events/snippet-change-event))))
 
-(deftest collection-event-derivation-test
+(deftest ^:parallel collection-event-derivation-test
   (testing "collection events properly derive from :metabase/event"
-    (is (isa? ::lib.events/collection-change-event :metabase/event))
-    (is (isa? :event/collection-create ::lib.events/collection-change-event))
-    (is (isa? :event/collection-update ::lib.events/collection-change-event))))
+    (is (isa? ::remote-sync.events/collection-change-event :metabase/event))
+    (is (isa? :event/collection-create ::remote-sync.events/collection-change-event))
+    (is (isa? :event/collection-update ::remote-sync.events/collection-change-event))))
 
 (deftest timeline-create-event-creates-entry-test
   (testing "timeline-create event creates remote sync object entry with create status"
@@ -981,12 +981,12 @@
         (let [update-entry (t2/select-one :model/RemoteSyncObject :model_type "Table" :model_id (:id table))]
           (is (= "removed" (:status update-entry))))))))
 
-(deftest table-event-derivation-test
+(deftest ^:parallel table-event-derivation-test
   (testing "table events properly derive from :metabase/event"
-    (is (isa? ::lib.events/table-change-event :metabase/event))
-    (is (isa? :event/table-create ::lib.events/table-change-event))
-    (is (isa? :event/table-update ::lib.events/table-change-event))
-    (is (isa? :event/table-delete ::lib.events/table-change-event))))
+    (is (isa? ::remote-sync.events/table-change-event :metabase/event))
+    (is (isa? :event/table-create ::remote-sync.events/table-change-event))
+    (is (isa? :event/table-update ::remote-sync.events/table-change-event))
+    (is (isa? :event/table-delete ::remote-sync.events/table-change-event))))
 
 (deftest collection-becomes-remote-synced-tracks-existing-tables-test
   (testing "when collection becomes remote-synced, existing published tables are tracked with 'create' status"
@@ -1169,12 +1169,12 @@
         (let [update-entry (t2/select-one :model/RemoteSyncObject :model_type "Segment" :model_id (:id segment))]
           (is (= "update" (:status update-entry))))))))
 
-(deftest segment-event-derivation-test
+(deftest ^:parallel segment-event-derivation-test
   (testing "segment events properly derive from :metabase/event"
-    (is (isa? ::lib.events/segment-change-event :metabase/event))
-    (is (isa? :event/segment-create ::lib.events/segment-change-event))
-    (is (isa? :event/segment-update ::lib.events/segment-change-event))
-    (is (isa? :event/segment-delete ::lib.events/segment-change-event))))
+    (is (isa? ::remote-sync.events/segment-change-event :metabase/event))
+    (is (isa? :event/segment-create ::remote-sync.events/segment-change-event))
+    (is (isa? :event/segment-update ::remote-sync.events/segment-change-event))
+    (is (isa? :event/segment-delete ::remote-sync.events/segment-change-event))))
 
 ;;; Field Event Tests
 
@@ -1256,9 +1256,9 @@
         (let [update-entry (t2/select-one :model/RemoteSyncObject :model_type "Field" :model_id (:id field))]
           (is (= "removed" (:status update-entry))))))))
 
-(deftest field-event-derivation-test
+(deftest ^:parallel field-event-derivation-test
   (testing "field events properly derive from :metabase/event"
-    (is (isa? ::lib.events/field-change-event :metabase/event))
-    (is (isa? :event/field-create ::lib.events/field-change-event))
-    (is (isa? :event/field-update ::lib.events/field-change-event))
-    (is (isa? :event/field-delete ::lib.events/field-change-event))))
+    (is (isa? ::remote-sync.events/field-change-event :metabase/event))
+    (is (isa? :event/field-create ::remote-sync.events/field-change-event))
+    (is (isa? :event/field-update ::remote-sync.events/field-change-event))
+    (is (isa? :event/field-delete ::remote-sync.events/field-change-event))))

--- a/src/metabase/collections_rest/api.clj
+++ b/src/metabase/collections_rest/api.clj
@@ -16,7 +16,6 @@
    [metabase.collections-rest.settings :as collections-rest.settings]
    [metabase.collections.models.collection :as collection]
    [metabase.collections.models.collection.root :as collection.root]
-   [metabase.config.core :as config]
    [metabase.eid-translation.core :as eid-translation]
    [metabase.events.core :as events]
    [metabase.lib-be.core :as lib-be]
@@ -1418,8 +1417,7 @@
             (-> (apply-defaults-to-collection coll-data)
                 write-check-authority-level
                 validate-new-tenant-collection!))
-    (when config/ee-available?
-      (events/publish-event! :event/collection-create {:object <> :user-id api/*current-user-id*}))
+    (events/publish-event! :event/collection-create {:object <> :user-id api/*current-user-id*})
     (events/publish-event! :event/collection-touch {:collection-id (:id <>) :user-id api/*current-user-id*})))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
@@ -1631,8 +1629,7 @@
     ;; if we're trying to move or archive the Collection, go ahead and do that
     (move-or-archive-collection-if-needed! collection-before-update collection-updates)
     (let [updated-collection (t2/select-one :model/Collection :id id)]
-      (when config/ee-available?
-        (events/publish-event! :event/collection-update {:object updated-collection :user-id api/*current-user-id*}))
+      (events/publish-event! :event/collection-update {:object updated-collection :user-id api/*current-user-id*})
       (events/publish-event! :event/collection-touch {:collection-id id :user-id api/*current-user-id*})))
   ;; finally, return the updated object
   (collection-detail (t2/select-one :model/Collection :id id)))

--- a/src/metabase/remote_sync/events.clj
+++ b/src/metabase/remote_sync/events.clj
@@ -1,0 +1,25 @@
+(ns metabase.remote-sync.events
+  "Derives remote sync event keywords from :metabase/event so they can be published
+   without requiring ee code to be loaded.")
+
+;; Collection events
+(derive ::collection-event :metabase/event)
+(derive :event/collection-create ::collection-event)
+(derive :event/collection-update ::collection-event)
+
+;; Field events
+(derive ::field-event :metabase/event)
+(derive :event/field-update ::field-event)
+
+;; Table events
+(derive ::table-event :metabase/event)
+(derive :event/table-update ::table-event)
+
+;; Timeline events
+(derive ::timeline-event :metabase/event)
+(derive :event/timeline-create ::timeline-event)
+(derive :event/timeline-delete ::timeline-event)
+(derive :event/timeline-update ::timeline-event)
+
+;; Snippet events are derived in the the ...models.native-query-snippet interface
+;; with some indirection

--- a/src/metabase/remote_sync/init.clj
+++ b/src/metabase/remote_sync/init.clj
@@ -2,6 +2,7 @@
   (:require
    [metabase.api.common :as api]
    [metabase.models.interface :as mi]
+   [metabase.remote-sync.events]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 

--- a/src/metabase/timeline/api/timeline.clj
+++ b/src/metabase/timeline/api/timeline.clj
@@ -5,7 +5,6 @@
    [metabase.api.macros :as api.macros]
    [metabase.collections.models.collection :as collection]
    [metabase.collections.models.collection.root :as collection.root]
-   [metabase.config.core :as config]
    [metabase.events.core :as events]
    [metabase.timeline.models.timeline :as timeline]
    [metabase.timeline.models.timeline-event :as timeline-event]
@@ -46,8 +45,7 @@
             (when-not icon
               {:icon timeline-event/default-icon}))]
     (u/prog1 (first (t2/insert-returning-instances! :model/Timeline tl))
-      (when config/ee-available?
-        (events/publish-event! :event/timeline-create {:object <> :user-id api/*current-user-id*})))))
+      (events/publish-event! :event/timeline-create {:object <> :user-id api/*current-user-id*}))))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
@@ -123,8 +121,7 @@
     (when (and (some? archived) (not= current-archived archived))
       (t2/update! :model/TimelineEvent {:timeline_id id} {:archived archived}))
     (u/prog1 (t2/hydrate (t2/select-one :model/Timeline :id id) :creator [:collection :can_write] :is_remote_synced)
-      (when config/ee-available?
-        (events/publish-event! :event/timeline-update {:object <> :user-id api/*current-user-id*})))))
+      (events/publish-event! :event/timeline-update {:object <> :user-id api/*current-user-id*}))))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
@@ -136,8 +133,7 @@
                     [:id ms/PositiveInt]]]
   (let [timeline (api/write-check :model/Timeline id)]
     (t2/delete! :model/Timeline :id id)
-    (when config/ee-available?
-      (events/publish-event! :event/timeline-delete {:object timeline :user-id api/*current-user-id*})))
+    (events/publish-event! :event/timeline-delete {:object timeline :user-id api/*current-user-id*}))
   api/generic-204-no-content)
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to

--- a/src/metabase/warehouse_schema_rest/api/table.clj
+++ b/src/metabase/warehouse_schema_rest/api/table.clj
@@ -6,7 +6,6 @@
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.app-db.core :as app-db]
-   [metabase.config.core :as config]
    [metabase.database-routing.core :as database-routing]
    [metabase.driver.settings :as driver.settings]
    [metabase.driver.util :as driver.u]
@@ -233,12 +232,9 @@
           newly-unhidden (when (and (contains? body :visibility_type) (nil? visibility_type))
                            (into [] (filter (comp some? :visibility_type)) existing-tables))]
       (sync-unhidden-tables newly-unhidden)
-      ;; Publish update events for remote sync tracking, only when ee extensions are available to provide
-      ;; a handler for these events
-      (when config/ee-available?
-        (doseq [table updated-tables]
-          (events/publish-event! :event/table-update {:object  table
-                                                      :user-id api/*current-user-id*})))
+      (doseq [table updated-tables]
+        (events/publish-event! :event/table-update {:object  table
+                                                    :user-id api/*current-user-id*}))
       updated-tables)))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to


### PR DESCRIPTION
### Description

Removes config/ee-available? wrappers on some tests that are only consumed by ee code for remote-sync. 
