### PR TITLE
ensure common.py library is always available

### DIFF
--- a/e2e/test/scenarios/data-studio/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms.cy.spec.ts
@@ -2368,7 +2368,7 @@ LIMIT
         H.DataStudio.Transforms.settingsTab().click();
         getTableLink().click();
         H.queryBuilderHeader()
-          .findByText("Default Common Transform")
+          .findByText("Default Common")
           .should("be.visible");
         H.assertQueryBuilderRowCount(1);
         cy.findByTestId("scalar-value").should("have.text", "42");

--- a/resources/migrations/059_update_migrations.yaml
+++ b/resources/migrations/059_update_migrations.yaml
@@ -742,6 +742,7 @@ databaseChangeLog:
       changes:
         - sql:
             sql: INSERT INTO python_library (path) VALUES ('common.py')
+      rollback:
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/059_update_migrations.yaml
+++ b/resources/migrations/059_update_migrations.yaml
@@ -741,7 +741,7 @@ databaseChangeLog:
             sql: SELECT count(*) FROM python_library WHERE path = 'common.py'
       changes:
         - sql:
-            sql: INSERT INTO python_library (path) VALUES ('common.py')
+            sql: INSERT INTO python_library (path, source) VALUES ('common.py', '')
       rollback:
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<

--- a/resources/migrations/059_update_migrations.yaml
+++ b/resources/migrations/059_update_migrations.yaml
@@ -730,6 +730,19 @@ databaseChangeLog:
             path: instance_analytics_views/tasks/v2/h2-tasks.sql
             relativeToChangelogFile: true
 
+  - changeSet:
+      id: v59.2026-01-23T12:00:00
+      author: bronsa
+      comment: Insert default common.py entry in python_library if not exists
+      preConditions:
+        - onFail: MARK_RAN
+        - sqlCheck:
+            expectedResult: 0
+            sql: SELECT count(*) FROM python_library WHERE path = 'common.py'
+      changes:
+        - sql:
+            sql: INSERT INTO python_library (path) VALUES ('common.py')
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################


### PR DESCRIPTION
Since https://github.com/metabase/metabase/pull/68212, the python transform editor always imports the common library. 
However unless the user has defined it once, this library won't exist by default. 

This PR adds a migration to always ensure `common.py` exists, defaulting to an empty file