### PR TITLE
feat: Add duplicate alert functionality

### DIFF
--- a/frontend/src/metabase/api/notification.ts
+++ b/frontend/src/metabase/api/notification.ts
@@ -87,6 +87,14 @@ export const notificationApi = Api.injectEndpoints({
         body,
       }),
     }),
+    duplicateAlert: builder.mutation<unknown, number>({
+      query: (alertId) => ({
+        method: "POST",
+        url: `/api/alert/${alertId}/duplicate`,
+      }),
+      invalidatesTags: (result, error) =>
+        invalidateTags(error, [listTag("notification")]),
+    }),
   }),
 });
 
@@ -101,4 +109,5 @@ export const {
   useUpdateNotificationMutation,
   useUnsubscribeFromNotificationMutation,
   useSendUnsavedNotificationMutation,
+  useDuplicateAlertMutation,
 } = notificationApi;

--- a/frontend/src/metabase/notifications/modals/QuestionAlertListModal/AlertListItem.tsx
+++ b/frontend/src/metabase/notifications/modals/QuestionAlertListModal/AlertListItem.tsx
@@ -33,6 +33,7 @@ type AlertListItemProps = {
   onEdit: (alert: Notification) => void;
   onUnsubscribe: (alert: Notification) => void;
   onDelete: (alert: Notification) => void;
+  onDuplicate: (alert: Notification) => void;
 };
 
 export const AlertListItem = ({
@@ -43,6 +44,7 @@ export const AlertListItem = ({
   onEdit,
   onUnsubscribe,
   onDelete,
+  onDuplicate,
 }: AlertListItemProps) => {
   const user = useSelector(getUser);
 
@@ -68,6 +70,12 @@ export const AlertListItem = ({
     e.stopPropagation();
 
     onDelete(alert);
+  };
+
+  const handleDuplicate = (e: MouseEvent) => {
+    e.stopPropagation();
+
+    onDuplicate(alert);
   };
 
   const handleMouseEnter = () => {
@@ -139,11 +147,18 @@ export const AlertListItem = ({
       {showHoverActions && (
         <div className={S.actionButtonContainer}>
           {canEdit ? (
-            <AlertListItemActionButton
-              label={t`Delete this alert`}
-              iconName="trash"
-              onClick={handleDelete}
-            />
+            <>
+              <AlertListItemActionButton
+                label={t`Duplicate this alert`}
+                iconName="copy"
+                onClick={handleDuplicate}
+              />
+              <AlertListItemActionButton
+                label={t`Delete this alert`}
+                iconName="trash"
+                onClick={handleDelete}
+              />
+            </>
           ) : (
             <AlertListItemActionButton
               label={t`Unsubscribe from this`}

--- a/frontend/src/metabase/notifications/modals/QuestionAlertListModal/AlertListModal.tsx
+++ b/frontend/src/metabase/notifications/modals/QuestionAlertListModal/AlertListModal.tsx
@@ -19,6 +19,7 @@ type AlertListModalProps = {
   onEdit: (notification: Notification) => void;
   onDelete: (notification: Notification) => void;
   onUnsubscribe: (notification: Notification) => void;
+  onDuplicate: (notification: Notification) => void;
   onClose: () => void;
 };
 
@@ -29,6 +30,7 @@ export const AlertListModal = ({
   onEdit,
   onDelete,
   onUnsubscribe,
+  onDuplicate,
   onClose,
 }: AlertListModalProps) => {
   const user = useSelector(getUser);
@@ -78,6 +80,7 @@ export const AlertListModal = ({
               onEdit={onEdit}
               onDelete={onDelete}
               onUnsubscribe={onUnsubscribe}
+              onDuplicate={onDuplicate}
             />
           );
         })}

--- a/frontend/src/metabase/notifications/modals/QuestionAlertListModal/QuestionAlertListModal.tsx
+++ b/frontend/src/metabase/notifications/modals/QuestionAlertListModal/QuestionAlertListModal.tsx
@@ -3,6 +3,7 @@ import { usePreviousDistinct } from "react-use";
 import { t } from "ttag";
 
 import {
+  useDuplicateAlertMutation,
   useListNotificationsQuery,
   useUnsubscribeFromNotificationMutation,
   useUpdateNotificationMutation,
@@ -42,6 +43,7 @@ export const QuestionAlertListModal = ({
 
   const [updateNotification] = useUpdateNotificationMutation();
   const [unsubscribe] = useUnsubscribeFromNotificationMutation();
+  const [duplicateAlert] = useDuplicateAlertMutation();
 
   const [activeModal, setActiveModal] = useState<AlertModalMode>(
     !questionNotifications || questionNotifications.length === 0
@@ -106,6 +108,21 @@ export const QuestionAlertListModal = ({
     }
   };
 
+  const handleDuplicate = async (alert: Notification) => {
+    const result = await duplicateAlert(alert.id);
+
+    if (result.error) {
+      sendToast({
+        icon: "warning",
+        toastColor: "error",
+        message: t`Failed to duplicate alert`,
+      });
+      return;
+    }
+
+    sendToast({ message: t`Alert duplicated successfully` });
+  };
+
   if (!question.isSaved()) {
     return null;
   }
@@ -130,6 +147,7 @@ export const QuestionAlertListModal = ({
             setEditingItem(notification);
             setActiveModal("unsubscribe-confirm-modal");
           }}
+          onDuplicate={handleDuplicate}
         />
       )}
 

--- a/src/metabase/pulse/api/alert.clj
+++ b/src/metabase/pulse/api/alert.clj
@@ -116,6 +116,20 @@
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
 ;;
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
+(api.macros/defendpoint :post "/:id/duplicate"
+  "Duplicate an alert, creating a new alert with the same configuration.
+  Returns the duplicated alert."
+  [{:keys [id]} :- [:map
+                    [:id ms/PositiveInt]]]
+  (let [original-notification (-> (notification.api/get-notification id)
+                                   api/read-check)]
+    (-> (notification.api/duplicate-notification! original-notification api/*current-user-id*)
+        notification->pulse)))
+
+;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
+;; use our API + we will need it when we make auto-TypeScript-signature generation happen
+;;
+#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :delete "/:id/subscription"
   "For users to unsubscribe themselves from the given alert."
   [{:keys [id]} :- [:map


### PR DESCRIPTION
- Add POST /api/alert/:id/duplicate endpoint to duplicate alerts
- Implement duplicate-notification! function that copies all alert properties (channels, subscriptions, recipients, payload)
- Add useDuplicateAlertMutation hook for frontend API calls
- Add duplicate button in AlertListItem with copy icon
- Show success/error toast notifications
- Automatically refresh alert list after duplication
- Add backend unit tests for duplicate alert functionality
- Respect permissions (only editable alerts show duplicate button)

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
