### PR TITLE
Remove links from alert email via tasks

### DIFF
--- a/resources/migrations/059_update_migrations.yaml
+++ b/resources/migrations/059_update_migrations.yaml
@@ -804,6 +804,26 @@ databaseChangeLog:
             tableName: python_library
             constraintName: unique_python_library_entity_id
 
+  - changeSet:
+      id: v59.2026-01-28T12:00:00
+      author: winlost
+      comment: Add disable_links column to notification_card table
+      changes:
+        - addColumn:
+            tableName: notification_card
+            columns:
+              - column:
+                  name: disable_links
+                  type: ${boolean.type}
+                  remarks: "Whether to disable alert email links"
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: true
+      rollback:
+        - dropColumn:
+            tableName: notification_card
+            columnName: disable_links
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################


### PR DESCRIPTION
closes EMB-1238

### Description



### How to verify

1. Run Metabase with Postgres DB (required for the next flag) with `MB_ANALYTICS_DEV_MODE=true`
1. Run any SMTP server and configure it on Metabase (otherwise, the subscription button won't be visible)
    ```sh
    docker run -d -p 1080:1080 -p 1025:1025 maildev/maildev
    ```
1. Create alerts in modular embedding, modular embedding SDK, and Metabase.
1. Check the notification card, from the sidebar: Database > Internal Metabase Database > Notification Card
1. Disable links should be true only when the subscriptions are created from either a modular embedding or a modular embedding SDK.
1. Now test the actual alert task
1. Build the static viz bundle
    ```sh
    yarn build-static-viz
    ```
1. REPL into the running BE.
    ```sh
    clj -Sdeps '{:deps {reply/reply {:mvn/version "0.5.1"}}}' -M -m reply.main --attach 50605
    ```
1. Open the Notification Subscription table, and take note of the latest 3 subscriptions you created (modular embedding, modular embedding SDK, and Metabase)
1. 1. Send the alert by going back to the repl.
    ```sh
    (ns metabase.notification.task.send)
    ;; take the IDs from the previous step <alert-id> from "ID"
    (send-notification* <alert-id>)
    ```
1. Checks the email you receive, in case you use maildev from the above command. Go to http://localhost:1080. And see that for subscriptions from modular embedding and modular embedding SDK, there must be no links, but for normal alerts (created in Metabase directly) there should still be links.


### Demo

#### Metabase (has links, and footer)
<img width="655" height="707" alt="image" src="https://github.com/user-attachments/assets/0e05c16e-98db-40c0-92dc-539e6b94a66a" />

#### Modular embedding, and modular embedding SDK (has no links, and no footer)
<img width="658" height="664" alt="image" src="https://github.com/user-attachments/assets/9829dae2-9659-4ab5-831c-afed072a5a74" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
