### PR TITLE
Stop reporting errors on archived or inaccessible entities

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [medley.core :as m]
+   [metabase-enterprise.dependencies.api :as deps.api]
    [metabase-enterprise.dependencies.events]
    [metabase-enterprise.dependencies.findings :as dependencies.findings]
    [metabase-enterprise.dependencies.task.backfill :as dependencies.backfill]
@@ -2272,3 +2273,103 @@
       (create-dependent! base-card user "Should not appear")
       (is (=? [{:data {:name "A Match"}} {:data {:name "B Match"}} {:data {:name "C Match"}}]
               (get-dependents base-card-id :query "Match" :sort_column :name :sort_direction :asc))))))
+
+(deftest ^:parallel entity-archived-test
+  (testing "entity-archived? for collection-based types uses :archived field"
+    (doseq [entity-type [:card :dashboard :document :snippet :segment :measure]
+            archived?   [false true]]
+      (is (= archived? (#'deps.api/entity-archived? entity-type {:archived archived?})))))
+
+  (testing "entity-archived? for tables uses active and visibility_type"
+    (are [entity expected]
+         (= expected (#'deps.api/entity-archived? :table entity))
+      {:active true  :visibility_type nil}      false
+      {:active false :visibility_type nil}      true
+      {:active true  :visibility_type "hidden"} true
+      {:active false :visibility_type "hidden"} true))
+
+  (testing "entity-archived? for types without archived field always returns false"
+    (are [entity-type]
+         (false? (#'deps.api/entity-archived? entity-type {}))
+      :transform
+      :sandbox)))
+
+(deftest ^:sequential entity-visible-test
+  (testing "entity-visible? loads entity and checks visibility"
+    (testing "returns falsy for non-existent entity"
+      (with-redefs [t2/select-one (constantly nil)]
+        (is (not (#'deps.api/entity-visible? :card 999)))))
+    (testing "returns falsy for unknown entity type"
+      (is (not (#'deps.api/entity-visible? :unknown-type 1))))))
+
+(deftest ^:parallel source-error-visible-test
+  (testing "source-error-visible? predicate"
+    (are [visible? error expected]
+         (= expected (#'deps.api/source-error-visible? (constantly visible?) error))
+      true  {:source_entity_type nil   :source_entity_id nil} true
+      false {:source_entity_type nil   :source_entity_id nil} true
+      true  {:source_entity_type :card :source_entity_id 1}   true
+      false {:source_entity_type :card :source_entity_id 1}   false
+      false {:source_entity_type :card :source_entity_id nil} true
+      false {:source_entity_type nil   :source_entity_id 1}   true)))
+
+(deftest ^:sequential node-errors-filtering-test
+  (testing "node-errors filters by source visibility"
+    (let [visible-error    {:analyzed_entity_type :card
+                            :analyzed_entity_id   1
+                            :source_entity_type   :card
+                            :source_entity_id     10
+                            :error_type           :missing-column
+                            :error_detail         "col1"}
+          hidden-error     {:analyzed_entity_type :card
+                            :analyzed_entity_id   1
+                            :source_entity_type   :card
+                            :source_entity_id     20
+                            :error_type           :missing-column
+                            :error_detail         "col2"}
+          nil-source-error {:analyzed_entity_type :card
+                            :analyzed_entity_id   1
+                            :source_entity_type   nil
+                            :source_entity_id     nil
+                            :error_type           :invalid-query}]
+      (with-redefs [t2/select (constantly [visible-error hidden-error nil-source-error])
+                    deps.api/entity-visible? (fn [_ id] (= id 10))]
+        (let [result      (#'deps.api/node-errors {:card [1]})
+              card-errors (get result [:card 1])]
+          (testing "includes errors with visible source"
+            (is (contains? card-errors {:type :missing-column :detail "col1"})))
+          (testing "excludes errors with hidden source"
+            (is (not (contains? card-errors {:type :missing-column :detail "col2"}))))
+          (testing "includes errors with nil source"
+            (is (contains? card-errors {:type :invalid-query}))))))))
+
+(deftest ^:parallel analyzed-error-visible-test
+  (testing "analyzed-error-visible? predicate delegates to visibility function"
+    (are [visible?]
+         (= visible?
+            (#'deps.api/analyzed-error-visible?
+             (constantly visible?)
+             {:analyzed_entity_type :card :analyzed_entity_id 1}))
+      true
+      false)))
+
+(deftest ^:sequential node-downstream-errors-filtering-test
+  (testing "node-downstream-errors filters by analyzed entity visibility"
+    (let [visible-error {:analyzed_entity_type :card
+                         :analyzed_entity_id   100
+                         :source_entity_type   :card
+                         :source_entity_id     1
+                         :error_type           :missing-column}
+          hidden-error  {:analyzed_entity_type :card
+                         :analyzed_entity_id   200
+                         :source_entity_type   :card
+                         :source_entity_id     1
+                         :error_type           :missing-column}]
+      (with-redefs [t2/select (constantly [visible-error hidden-error])
+                    deps.api/entity-visible? (fn [_ id] (= id 100))]
+        (let [result      (#'deps.api/node-downstream-errors {:card [1]})
+              card-errors (get result [:card 1])]
+          (testing "includes errors with visible analyzed entity"
+            (is (= 1 (count card-errors))))
+          (testing "the included error is the visible one"
+            (is (= 100 (:analyzed_entity_id (first card-errors))))))))))


### PR DESCRIPTION
Closes QUE-2999

### Description

See QUE-2999.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
