### PR TITLE
Delete from cache in batches of 1000

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/cache/task/refresh_cache_configs.clj
+++ b/enterprise/backend/src/metabase_enterprise/cache/task/refresh_cache_configs.clj
@@ -146,7 +146,8 @@
   "Deletes any existing cache entries for queries that we are about to re-run, so that subsequent tasks don't also try
   to re-run them before the cache has been refreshed. "
   [queries]
-  (t2/delete! :model/QueryCache :query_hash [:in (map :cache-hash queries)]))
+  (doseq [batch (partition 1000 1000 nil queries)]
+    (t2/delete! :model/QueryCache :query_hash [:in (map :cache-hash batch)])))
 
 (defn- maybe-refresh-duration-caches!
   "Detects caches with strategy=duration that are eligible for refreshing, and returns a count of the refresh jobs that


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/68353

### Description

There's apparently an instance on cloud that is trying to remove 70k queries from the cache at once, and postgres doesn't allow 70k params to a query.  Batching the deletes in groups of 1000 should fix that.

### How to verify

Caches still delete.  An actual repro would presumably require 70k queries, but we can certainly verify that the new code doesn't error.

### Checklist

- [] Tests have been added/updated to cover changes in this PR
- [] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
