### PR TITLE
Fix flaky GeoJS-dependent tests by mocking external service

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1200,7 +1200,8 @@
    :api  #{metabase.request.core
            metabase.request.init
            metabase.request.schema}
-   :uses #{api
+   :uses #{analytics
+           api
            config
            embedding
            permissions ; FIXME

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -241,6 +241,10 @@
                        {:description "Number of emails sent."})
    (prometheus/counter :metabase-email/message-errors
                        {:description "Number of errors when sending emails."})
+   (prometheus/counter :metabase-geocoding/requests
+                       {:description "Number of successful IP geocoding requests via GeoJS."})
+   (prometheus/counter :metabase-geocoding/errors
+                       {:description "Number of errors when geocoding IP addresses via GeoJS."})
    (prometheus/counter :metabase-scim/response-ok
                        {:description "Number of successful responses from SCIM endpoints"})
    (prometheus/counter :metabase-scim/response-error

--- a/test/metabase/request/util_test.clj
+++ b/test/metabase/request/util_test.clj
@@ -1,6 +1,5 @@
 (ns metabase.request.util-test
   (:require
-   [cheshire.core :as json]
    [clj-http.client :as http]
    [clojure.string :as str]
    [clojure.test :refer :all]
@@ -8,6 +7,7 @@
    [java-time.api :as t]
    [metabase.request.util :as req.util]
    [metabase.test :as mt]
+   [metabase.util.json :as json]
    [ring.mock.request :as ring.mock]))
 
 (deftest ^:parallel cacheable?-test

--- a/test/metabase/request/util_test.clj
+++ b/test/metabase/request/util_test.clj
@@ -5,7 +5,6 @@
    [clojure.test :refer :all]
    [clojure.tools.reader.edn :as edn]
    [java-time.api :as t]
-   [metabase.analytics.prometheus :as prometheus]
    [metabase.request.util :as req.util]
    [metabase.test :as mt]
    [metabase.util.json :as json]


### PR DESCRIPTION
## Summary

Two tests were flaky because they depended on the external GeoJS service (`get.geojs.io`):

- `metabase.request.util-test/geocode-ip-addresses-test`
- `metabase.login-history.api-test/login-history-test`

**Root cause:** GeoJS is currently returning `"nil"` for latitude/longitude (upstream bug at https://github.com/jloh/geojs/issues/48), plus the service is subject to rate limits, timeouts, and availability issues. We hit it thousands of times daily across CI runs.

**Solution:** Mock the external calls while still testing the actual parsing/transformation logic:

- `util_test.clj`: Mock `clj-http.client/get` at the HTTP level to test JSON parsing, location description formatting, and timezone conversion
- `api_test.clj`: Mock `geocode-ip-addresses` function to test the full API endpoint flow with deterministic data

This follows the existing pattern in `session_test.clj` which already mocks geocoding.

## Why mocking is safe

GeoJS failures degrade gracefully—the code returns `nil` and users see "Unknown location" instead of real location. This doesn't block logins or break functionality. Production observability is sufficient for detecting service issues.

## Test plan

- [x] `clojure -X:dev:test :only metabase.request.util-test/geocode-ip-addresses-test` passes
- [x] `clojure -X:dev:test :only metabase.login-history.api-test/login-history-test` passes
- [x] Both full test namespaces pass: `clojure -X:dev:test :only '[metabase.request.util-test metabase.login-history.api-test]'`
- [x] CI passes
- [ ] After merge, unquarantine these tests

Closes DEV-1300