### PR TITLE
Split out more granular error codes for metabot tools

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/entity_details.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/entity_details.clj
@@ -374,7 +374,9 @@
                                       {:agent-error? true :status-code 400})))]
         {:structured-output details}))
     (catch Exception e
-      (metabot-v3.tools.u/handle-agent-error e))))
+      (if (= (:status-code (ex-data e)) 404)
+        {:output (ex-message e) :status-code 404}
+        (metabot-v3.tools.u/handle-agent-error e)))))
 
 (defn get-metric-details
   "Get information about the metric with ID `metric-id`."
@@ -389,7 +391,9 @@
                                       {:agent-error? true :status-code 400})))]
         {:structured-output details}))
     (catch Exception e
-      (metabot-v3.tools.u/handle-agent-error e))))
+      (if (= (:status-code (ex-data e)) 404)
+        {:output (ex-message e) :status-code 404}
+        (metabot-v3.tools.u/handle-agent-error e)))))
 
 (defn get-report-details
   "Get information about the report (card) with ID `report-id`."
@@ -407,7 +411,9 @@
                                       {:agent-error? true :status-code 400})))]
         {:structured-output details}))
     (catch Exception e
-      (metabot-v3.tools.u/handle-agent-error e))))
+      (if (= (:status-code (ex-data e)) 404)
+        {:output (ex-message e) :status-code 404}
+        (metabot-v3.tools.u/handle-agent-error e)))))
 
 (defn get-document-details
   "Get information about the document with ID `document-id`."

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/entity_details.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/entity_details.clj
@@ -372,11 +372,11 @@
                           (or (table-details (parse-long table-id) options)
                               (throw (ex-info (str "Table " table-id " not found")
                                               {:agent-error? true :status-code 404})))
-                          (throw (ex-info "invalid table_id format"
+                          (throw (ex-info "Invalid table_id format"
                                           {:agent-error? true :status-code 400}))))
 
                       :else
-                      (throw (ex-info "invalid arguments: must provide table-id or model-id"
+                      (throw (ex-info "Invalid arguments: must provide table_id or model_id"
                                       {:agent-error? true :status-code 400})))]
         {:structured-output details}))
     (catch Exception e
@@ -393,7 +393,7 @@
                       (or (metric-details metric-id options)
                           (throw (ex-info (str "Metric " metric-id " not found")
                                           {:agent-error? true :status-code 404})))
-                      (throw (ex-info "invalid metric_id format"
+                      (throw (ex-info "Invalid metric_id format"
                                       {:agent-error? true :status-code 400})))]
         {:structured-output details}))
     (catch Exception e

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/entity_details.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/entity_details.clj
@@ -346,37 +346,58 @@
   `model-id` is an integer ID of a model (card). Exactly one of `table-id` or `model-id`
   should be supplied."
   [{:keys [model-id table-id] :as arguments}]
-  (lib-be/with-metadata-provider-cache
-    (let [options (cond-> arguments
-                    (= (:with-field-values? arguments) false) (assoc :field-values-fn identity))
-          details (cond
-                    (int? model-id)    (let [card (card-details model-id (assoc options :only-model true))]
-                                         (if (= :model (:type card))
-                                           card
-                                           (format "ID %s is not a valid model id, it's a question" model-id)))
-                    (int? table-id)    (table-details table-id options)
-                    (string? table-id) (if-let [[_ card-id] (re-matches #"card__(\d+)" table-id)]
-                                         (card-details (parse-long card-id) options)
-                                         (if (re-matches #"\d+" table-id)
-                                           (table-details (parse-long table-id) options)
-                                           "invalid table_id"))
-                    :else "invalid arguments")]
-      (if (map? details)
-        {:structured-output details}
-        {:output (or details "table not found")}))))
+  (try
+    (lib-be/with-metadata-provider-cache
+      (let [options (cond-> arguments
+                      (= (:with-field-values? arguments) false) (assoc :field-values-fn identity))
+            details (cond
+                      (int? model-id)
+                      (let [card (card-details model-id (assoc options :only-model true))]
+                        (if (= :model (:type card))
+                          card
+                          (throw (ex-info (format "ID %s is not a valid model id, it's a question" model-id)
+                                          {:agent-error? true :status-code 400}))))
+
+                      (int? table-id)
+                      (or (table-details table-id options)
+                          (throw (ex-info (str "Table " table-id " not found")
+                                          {:agent-error? true :status-code 404})))
+
+                      (string? table-id)
+                      (if-let [[_ card-id] (re-matches #"card__(\d+)" table-id)]
+                        (or (card-details (parse-long card-id) options)
+                            (throw (ex-info (str "Model " card-id " not found")
+                                            {:agent-error? true :status-code 404})))
+                        (if (re-matches #"\d+" table-id)
+                          (or (table-details (parse-long table-id) options)
+                              (throw (ex-info (str "Table " table-id " not found")
+                                              {:agent-error? true :status-code 404})))
+                          (throw (ex-info "invalid table_id format"
+                                          {:agent-error? true :status-code 400}))))
+
+                      :else
+                      (throw (ex-info "invalid arguments: must provide table-id or model-id"
+                                      {:agent-error? true :status-code 400})))]
+        {:structured-output details}))
+    (catch Exception e
+      (metabot-v3.tools.u/handle-agent-error e))))
 
 (defn get-metric-details
   "Get information about the metric with ID `metric-id`."
   [{:keys [metric-id] :as arguments}]
-  (lib-be/with-metadata-provider-cache
-    (let [options (cond-> arguments
-                    (= (:with-field-values? arguments) false) (assoc :field-values-fn identity))
-          details (if (int? metric-id)
-                    (metric-details metric-id options)
-                    "invalid metric_id")]
-      (if (map? details)
-        {:structured-output details}
-        {:output (or details "metric not found")}))))
+  (try
+    (lib-be/with-metadata-provider-cache
+      (let [options (cond-> arguments
+                      (= (:with-field-values? arguments) false) (assoc :field-values-fn identity))
+            details (if (int? metric-id)
+                      (or (metric-details metric-id options)
+                          (throw (ex-info (str "Metric " metric-id " not found")
+                                          {:agent-error? true :status-code 404})))
+                      (throw (ex-info "invalid metric_id format"
+                                      {:agent-error? true :status-code 400})))]
+        {:structured-output details}))
+    (catch Exception e
+      (metabot-v3.tools.u/handle-agent-error e))))
 
 (defn get-report-details
   "Get information about the report (card) with ID `report-id`."

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/field_stats.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/field_stats.clj
@@ -33,39 +33,39 @@
 (defn- table-field-stats
   [table-id agent-field-id limit]
   (try
-    (let [query (metabot-v3.tools.u/table-query table-id)]
-      (if query
-        (let [field-id-prefix (metabot-v3.tools.u/table-field-id-prefix table-id)
-              visible-cols (lib/visible-columns query)
-              col (:column (metabot-v3.tools.u/resolve-column {:field-id agent-field-id} field-id-prefix visible-cols))]
-          {:structured-output (field-statistics col limit)})
-        {:output (str "No table found with ID " table-id)}))
+    (let [query (or (metabot-v3.tools.u/table-query table-id)
+                    (throw (ex-info (str "No table found with ID " table-id)
+                                    {:agent-error? true :status-code 404})))
+          field-id-prefix (metabot-v3.tools.u/table-field-id-prefix table-id)
+          visible-cols (lib/visible-columns query)
+          col (:column (metabot-v3.tools.u/resolve-column {:field-id agent-field-id} field-id-prefix visible-cols))]
+      {:structured-output (field-statistics col limit)})
     (catch Exception ex
       (metabot-v3.tools.u/handle-agent-error ex))))
 
 (defn- card-field-stats
   [card-id agent-field-id limit card-type]
   (try
-    (let [query (metabot-v3.tools.u/card-query card-id)]
-      (if query
-        (let [field-id-prefix (metabot-v3.tools.u/card-field-id-prefix card-id)
-              visible-cols (lib/visible-columns query)
-              col (:column (metabot-v3.tools.u/resolve-column {:field-id agent-field-id} field-id-prefix visible-cols))]
-          {:structured-output (field-statistics col limit)})
-        {:output (str "No " card-type " found with ID " card-id)}))
+    (let [query (or (metabot-v3.tools.u/card-query card-id)
+                    (throw (ex-info (str "No " card-type " found with ID " card-id)
+                                    {:agent-error? true :status-code 404})))
+          field-id-prefix (metabot-v3.tools.u/card-field-id-prefix card-id)
+          visible-cols (lib/visible-columns query)
+          col (:column (metabot-v3.tools.u/resolve-column {:field-id agent-field-id} field-id-prefix visible-cols))]
+      {:structured-output (field-statistics col limit)})
     (catch Exception ex
       (metabot-v3.tools.u/handle-agent-error ex))))
 
 (defn- metric-field-stats
   [metric-id agent-field-id limit]
   (try
-    (let [query (metabot-v3.tools.u/metric-query metric-id)]
-      (if query
-        (let [field-id-prefix (metabot-v3.tools.u/card-field-id-prefix metric-id)
-              filterable-cols (lib/filterable-columns query)
-              col (:column (metabot-v3.tools.u/resolve-column {:field-id agent-field-id} field-id-prefix filterable-cols))]
-          {:structured-output (field-statistics col limit)})
-        {:output (str "No metric found with ID " metric-id)}))
+    (let [query (or (metabot-v3.tools.u/metric-query metric-id)
+                    (throw (ex-info (str "No metric found with ID " metric-id)
+                                    {:agent-error? true :status-code 404})))
+          field-id-prefix (metabot-v3.tools.u/card-field-id-prefix metric-id)
+          filterable-cols (lib/filterable-columns query)
+          col (:column (metabot-v3.tools.u/resolve-column {:field-id agent-field-id} field-id-prefix filterable-cols))]
+      {:structured-output (field-statistics col limit)})
     (catch Exception ex
       (metabot-v3.tools.u/handle-agent-error ex))))
 

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
@@ -379,8 +379,7 @@
                       {:agent-error? true :status-code 400})))
     (catch Exception e
       (if (= (:status-code (ex-data e)) 404)
-        {:output       (ex-message e)
-         :status-code 404}
+        {:output (ex-message e) :status-code 404}
         (metabot-v3.tools.u/handle-agent-error e)))))
 
 (defn- base-query

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
@@ -307,10 +307,22 @@
   [{:keys [table-id model-id]}]
   (cond
     model-id
-    [(metabot-v3.tools.u/card-field-id-prefix model-id) (metabot-v3.tools.u/card-query model-id)]
+    (try
+      [(metabot-v3.tools.u/card-field-id-prefix model-id) (metabot-v3.tools.u/card-query model-id)]
+      (catch clojure.lang.ExceptionInfo e
+        (throw (if (= (:status-code (ex-data e)) 404)
+                 (ex-info (str "No model found with model_id " model-id)
+                          {:agent-error? true :status-code 404} e)
+                 e))))
 
     table-id
-    [(metabot-v3.tools.u/table-field-id-prefix table-id) (metabot-v3.tools.u/table-query table-id)]
+    (try
+      [(metabot-v3.tools.u/table-field-id-prefix table-id) (metabot-v3.tools.u/table-query table-id)]
+      (catch clojure.lang.ExceptionInfo e
+        (throw (if (= (:status-code (ex-data e)) 404)
+                 (ex-info (str "No table found with table_id " table-id)
+                          {:agent-error? true :status-code 404} e)
+                 e))))
 
     :else
     (throw (ex-info "Either table-id or model-id must be provided" {:agent-error? true}))))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
@@ -379,10 +379,7 @@
                       {:agent-error? true :status-code 400})))
     (catch Exception e
       (if (= (:status-code (ex-data e)) 404)
-        {:output (cond
-                   table-id (str "No table found with table_id " table-id)
-                   model-id (str "No model found with model_id " model-id)
-                   :else "Resource not found")
+        {:output       (ex-message e)
          :status-code 404}
         (metabot-v3.tools.u/handle-agent-error e)))))
 

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
@@ -83,6 +83,7 @@
       (lib/filter query segment)
       (throw (ex-info (tru "Segment with id {0} not found" segment-id)
                       {:agent-error? true
+                       :status-code 404
                        :segment-id segment-id})))
     ;; Standard field-based filter logic
     (let [{:keys [operation value values]} llm-filter
@@ -143,7 +144,8 @@
             :number-greater-than-or-equal (lib/>= expr value)
             :number-less-than             (lib/< expr value)
             :number-less-than-or-equal    (lib/<= expr value)
-            (throw (ex-info (str "unknown filter operation " operation) {:agent-error? true})))]
+            (throw (ex-info (str "unknown filter operation " operation)
+                            {:agent-error? true :status-code 400})))]
       (lib/filter query filter))))
 
 (defn- add-breakout
@@ -186,10 +188,11 @@
   (try
     (if (int? metric-id)
       {:structured-output (query-metric* arguments)}
-      {:output (str "Invalid metric_id " metric-id)})
+      (throw (ex-info (str "Invalid metric_id " metric-id)
+                      {:agent-error? true :status-code 400})))
     (catch Exception e
       (if (= (:status-code (ex-data e)) 404)
-        {:output (str "No metric found with metric_id " metric-id)}
+        {:output (str "No metric found with metric_id " metric-id) :status-code 404}
         (metabot-v3.tools.u/handle-agent-error e)))))
 
 (defn- apply-aggregation-sort-order
@@ -211,6 +214,7 @@
             (lib/aggregate query measure)
             (throw (ex-info (tru "Measure with id {0} not found" measure-id)
                             {:agent-error? true
+                             :status-code 404
                              :measure-id measure-id})))
           ;; Field-based aggregation
           (let [expr (bucketed-column aggregation)
@@ -352,18 +356,34 @@
   [{:keys [table-id model-id] :as arguments}]
   (try
     (cond
-      (and table-id model-id) (throw (ex-info "Cannot provide both table_id and model_id" {:agent-error? true}))
-      (int? model-id) {:structured-output (query-datasource* arguments)}
-      (int? table-id) {:structured-output (query-datasource* arguments)}
-      model-id        {:output (str "Invalid model_id " model-id)}
-      table-id        {:output (str "Invalid table_id " table-id)}
-      :else           {:output "Either table_id or model_id must be provided"})
+      (and table-id model-id)
+      (throw (ex-info "Cannot provide both table_id and model_id"
+                      {:agent-error? true :status-code 400}))
+
+      (int? model-id)
+      {:structured-output (query-datasource* arguments)}
+
+      (int? table-id)
+      {:structured-output (query-datasource* arguments)}
+
+      model-id
+      (throw (ex-info (str "Invalid model_id " model-id)
+                      {:agent-error? true :status-code 400}))
+
+      table-id
+      (throw (ex-info (str "Invalid table_id " table-id)
+                      {:agent-error? true :status-code 400}))
+
+      :else
+      (throw (ex-info "Either table_id or model_id must be provided"
+                      {:agent-error? true :status-code 400})))
     (catch Exception e
       (if (= (:status-code (ex-data e)) 404)
         {:output (cond
                    table-id (str "No table found with table_id " table-id)
                    model-id (str "No model found with model_id " model-id)
-                   :else "Resource not found")}
+                   :else "Resource not found")
+         :status-code 404}
         (metabot-v3.tools.u/handle-agent-error e)))))
 
 (defn- base-query
@@ -383,29 +403,29 @@
       model-id
       (if-let [model-query (metabot-v3.tools.u/card-query model-id)]
         [(metabot-v3.tools.u/card-field-id-prefix model-id) model-query]
-        (throw (ex-info (str "No table found with table_id " table-id) {:agent-error? true
-                                                                        :data-source data-source})))
+        (throw (ex-info (str "No model found with model_id " model-id)
+                        {:agent-error? true :status-code 404 :data-source data-source})))
 
       table-id
       (let [table-id (cond-> table-id
                        (string? table-id) parse-long)]
         (if-let [table-query (metabot-v3.tools.u/table-query table-id)]
           [(metabot-v3.tools.u/table-field-id-prefix table-id) table-query]
-          (throw (ex-info (str "No table found with table_id " table-id) {:agent-error? true
-                                                                          :data-source data-source}))))
+          (throw (ex-info (str "No table found with table_id " table-id)
+                          {:agent-error? true :status-code 404 :data-source data-source}))))
 
       report-id
       (if-let [query (metabot-v3.tools.u/card-query report-id)]
         [(metabot-v3.tools.u/card-field-id-prefix report-id) query]
-        (throw (ex-info (str "No report found with report_id " report-id) {:agent-error? true
-                                                                           :data-source data-source})))
+        (throw (ex-info (str "No report found with report_id " report-id)
+                        {:agent-error? true :status-code 404 :data-source data-source})))
 
       query
       (handle-query query query-id)
 
       :else
-      (throw (ex-info "Invalid data_source" {:agent-error? true
-                                             :data-source data-source})))))
+      (throw (ex-info "Invalid data_source"
+                      {:agent-error? true :status-code 400 :data-source data-source})))))
 
 (defn filter-records
   "Add `filters` to the query referenced by `data-source`"

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
@@ -191,7 +191,9 @@
       (throw (ex-info (str "Invalid metric_id " metric-id)
                       {:agent-error? true :status-code 400})))
     (catch Exception e
-      (metabot-v3.tools.u/handle-agent-error e))))
+      (if (= (:status-code (ex-data e)) 404)
+        {:output (ex-message e) :status-code 404}
+        (metabot-v3.tools.u/handle-agent-error e)))))
 
 (defn- apply-aggregation-sort-order
   "If sort-order is specified, add an order-by clause for the last aggregation in the query."
@@ -296,7 +298,9 @@
       (throw (ex-info (str "Invalid model_id " model-id)
                       {:agent-error? true :status-code 400})))
     (catch Exception e
-      (metabot-v3.tools.u/handle-agent-error e))))
+      (if (= (:status-code (ex-data e)) 404)
+        {:output (ex-message e) :status-code 404}
+        (metabot-v3.tools.u/handle-agent-error e)))))
 
 (defn- resolve-datasource
   "Resolve datasource parameters to [field-id-prefix base-query] tuple.
@@ -387,7 +391,9 @@
       (throw (ex-info "Either table_id or model_id must be provided"
                       {:agent-error? true :status-code 400})))
     (catch Exception e
-      (metabot-v3.tools.u/handle-agent-error e))))
+      (if (= (:status-code (ex-data e)) 404)
+        {:output (ex-message e) :status-code 404}
+        (metabot-v3.tools.u/handle-agent-error e)))))
 
 (defn- base-query
   [data-source]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
@@ -191,9 +191,7 @@
       (throw (ex-info (str "Invalid metric_id " metric-id)
                       {:agent-error? true :status-code 400})))
     (catch Exception e
-      (if (= (:status-code (ex-data e)) 404)
-        {:output (str "No metric found with metric_id " metric-id) :status-code 404}
-        (metabot-v3.tools.u/handle-agent-error e)))))
+      (metabot-v3.tools.u/handle-agent-error e))))
 
 (defn- apply-aggregation-sort-order
   "If sort-order is specified, add an order-by clause for the last aggregation in the query."
@@ -295,11 +293,10 @@
   (try
     (if (int? model-id)
       {:structured-output (query-model* arguments)}
-      {:output (str "Invalid model_id " model-id)})
+      (throw (ex-info (str "Invalid model_id " model-id)
+                      {:agent-error? true :status-code 400})))
     (catch Exception e
-      (if (= (:status-code (ex-data e)) 404)
-        {:output (str "No model found with model_id " model-id)}
-        (metabot-v3.tools.u/handle-agent-error e)))))
+      (metabot-v3.tools.u/handle-agent-error e))))
 
 (defn- resolve-datasource
   "Resolve datasource parameters to [field-id-prefix base-query] tuple.
@@ -325,7 +322,7 @@
                  e))))
 
     :else
-    (throw (ex-info "Either table-id or model-id must be provided" {:agent-error? true}))))
+    (throw (ex-info "Either table-id or model-id must be provided" {:agent-error? true :status-code 400}))))
 
 (defn- query-datasource*
   [{:keys [fields filters aggregations group-by order-by limit] :as arguments}]
@@ -390,9 +387,7 @@
       (throw (ex-info "Either table_id or model_id must be provided"
                       {:agent-error? true :status-code 400})))
     (catch Exception e
-      (if (= (:status-code (ex-data e)) 404)
-        {:output (ex-message e) :status-code 404}
-        (metabot-v3.tools.u/handle-agent-error e)))))
+      (metabot-v3.tools.u/handle-agent-error e))))
 
 (defn- base-query
   [data-source]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
@@ -143,7 +143,7 @@
                          :model-id model-id
                          :field-index field-index
                          :available-columns-count (count columns)}))))
-    (throw (ex-info (str "invalid field_id format: " field-id)
+    (throw (ex-info (str "Invalid field_id format: " field-id)
                     {:agent-error? true
                      :status-code 400
                      :field-id field-id}))))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
@@ -15,13 +15,14 @@
    [toucan2.core :as t2]))
 
 (defn handle-agent-error
-  "Return an agent output for agent errors, re-throw `e` otherwise.
-   Preserves :status-code from ex-data for proper HTTP status codes in agent API."
+  "Return an agent output for errors with known HTTP status codes, re-throw `e` otherwise.
+   Handles both explicit agent errors (:agent-error? true) and framework errors
+   from api/read-check and friends (which carry :status-code but not :agent-error?)."
   [e]
-  (let [data (ex-data e)]
-    (if (:agent-error? data)
+  (let [{:keys [agent-error? status-code]} (ex-data e)]
+    (if (or agent-error? status-code)
       (cond-> {:output (ex-message e)}
-        (:status-code data) (assoc :status-code (:status-code data)))
+        status-code (assoc :status-code status-code))
       (throw e))))
 
 (defn convert-field-type

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
@@ -15,12 +15,11 @@
    [toucan2.core :as t2]))
 
 (defn handle-agent-error
-  "Return an agent output for errors with known HTTP status codes, re-throw `e` otherwise.
-   Handles both explicit agent errors (:agent-error? true) and framework errors
-   from api/read-check and friends (which carry :status-code but not :agent-error?)."
+  "Return an agent output for agent errors, re-throw `e` otherwise.
+   Preserves :status-code from ex-data for proper HTTP status codes in agent API."
   [e]
   (let [{:keys [agent-error? status-code]} (ex-data e)]
-    (if (or agent-error? status-code)
+    (if agent-error?
       (cond-> {:output (ex-message e)}
         status-code (assoc :status-code status-code))
       (throw e))))

--- a/enterprise/backend/test/metabase_enterprise/agent_api/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/agent_api/api_test.clj
@@ -279,7 +279,12 @@
 
     (testing "Returns 404 for non-existent table"
       (is (= "Not found."
-             (agent-client :crowberto :get 404 "agent/v1/table/999999/field/t999999-0/values"))))))
+             (agent-client :crowberto :get 404 "agent/v1/table/999999/field/t999999-0/values"))))
+
+    (testing "Returns 400 for invalid field-id format"
+      (let [table-id (mt/id :people)]
+        (is (= "invalid field_id format: not-a-valid-id"
+               (agent-client :crowberto :get 400 (format "agent/v1/table/%d/field/not-a-valid-id/values" table-id))))))))
 
 (deftest search-test
   (with-agent-api-setup!
@@ -364,7 +369,12 @@
 
       (testing "Returns 404 for non-existent metric"
         (is (= "Not found."
-               (agent-client :rasta :get 404 "agent/v1/metric/999999/field/c999999-0/values")))))))
+               (agent-client :rasta :get 404 "agent/v1/metric/999999/field/c999999-0/values"))))
+
+      (testing "Returns 400 for field-id from wrong entity type"
+        ;; Using a table field-id (t-prefix) when querying a metric should fail
+        (is (re-find #"does not match expected prefix"
+                     (agent-client :rasta :get 400 (format "agent/v1/metric/%d/field/t123-0/values" (:id metric)))))))))
 
 (deftest construct-metric-query-test
   (with-agent-api-setup!

--- a/enterprise/backend/test/metabase_enterprise/agent_api/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/agent_api/api_test.clj
@@ -391,7 +391,7 @@
             (is (= (mt/id) (lib/database-id decoded))))))
 
       (testing "Returns 404 for non-existent metric"
-        (is (= "No metric found with metric_id 999999"
+        (is (= "Not found."
                (agent-client :rasta :post 404 "agent/v1/construct-query"
                              {:metric_id 999999})))))))
 

--- a/enterprise/backend/test/metabase_enterprise/agent_api/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/agent_api/api_test.clj
@@ -283,7 +283,7 @@
 
     (testing "Returns 400 for invalid field-id format"
       (let [table-id (mt/id :people)]
-        (is (= "invalid field_id format: not-a-valid-id"
+        (is (= "Invalid field_id format: not-a-valid-id"
                (agent-client :crowberto :get 400 (format "agent/v1/table/%d/field/not-a-valid-id/values" table-id))))))))
 
 (deftest search-test

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/filters_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/filters_test.clj
@@ -158,7 +158,7 @@
                                    :operation :not-equals
                                    :values [3 42]}]}))))))
         (testing "Missing metric results in an error."
-          (is (= {:output (str "No metric found with metric_id " Integer/MAX_VALUE)
+          (is (= {:output "Not found."
                   :status-code 404}
                  (metabot-v3.tools.filters/query-metric {:metric-id Integer/MAX_VALUE}))))
         (testing "Invalid metric-id results in an error."
@@ -299,10 +299,12 @@
               (assoc input :fields nil)
               (assoc input :fields [])))))
       (testing "Missing model results in an error."
-        (is (= {:output (str "No model found with model_id " Integer/MAX_VALUE)}
+        (is (= {:output "Not found."
+                :status-code 404}
                (metabot-v3.tools.filters/query-model {:model-id Integer/MAX_VALUE}))))
       (testing "Invalid model-id results in an error."
-        (is (= {:output (str "Invalid model_id " model-id)}
+        (is (= {:output (str "Invalid model_id " model-id)
+                :status-code 400}
                (metabot-v3.tools.filters/query-model {:model-id (str model-id)})))))))
 
 (deftest ^:parallel filter-records-table-test

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/filters_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/filters_test.clj
@@ -158,10 +158,12 @@
                                    :operation :not-equals
                                    :values [3 42]}]}))))))
         (testing "Missing metric results in an error."
-          (is (= {:output (str "No metric found with metric_id " Integer/MAX_VALUE)}
+          (is (= {:output (str "No metric found with metric_id " Integer/MAX_VALUE)
+                  :status-code 404}
                  (metabot-v3.tools.filters/query-metric {:metric-id Integer/MAX_VALUE}))))
         (testing "Invalid metric-id results in an error."
-          (is (= {:output (str "Invalid metric_id " metric-id)}
+          (is (= {:output (str "Invalid metric_id " metric-id)
+                  :status-code 400}
                  (metabot-v3.tools.filters/query-metric {:metric-id (str metric-id)}))))))))
 
 (deftest ^:parallel query-model-test
@@ -676,32 +678,38 @@
 (deftest ^:parallel query-datasource-validation-test
   (mt/with-current-user (mt/user->id :crowberto)
     (testing "Error when neither table-id nor model-id provided"
-      (is (= {:output "Either table_id or model_id must be provided"}
+      (is (= {:output "Either table_id or model_id must be provided"
+              :status-code 400}
              (metabot-v3.tools.filters/query-datasource {}))))
 
     (testing "Error when both table-id and model-id provided"
-      (is (= {:output "Cannot provide both table_id and model_id"}
+      (is (= {:output "Cannot provide both table_id and model_id"
+              :status-code 400}
              (metabot-v3.tools.filters/query-datasource
               {:table-id (mt/id :orders)
                :model-id 123}))))
 
     (testing "Error with invalid table-id"
-      (is (= {:output "Invalid table_id not-a-number"}
+      (is (= {:output "Invalid table_id not-a-number"
+              :status-code 400}
              (metabot-v3.tools.filters/query-datasource
               {:table-id "not-a-number"}))))
 
     (testing "Error with invalid model-id"
-      (is (= {:output "Invalid model_id not-a-number"}
+      (is (= {:output "Invalid model_id not-a-number"
+              :status-code 400}
              (metabot-v3.tools.filters/query-datasource
               {:model-id "not-a-number"}))))
 
     (testing "Error with non-existent table"
-      (is (= {:output (str "No table found with table_id " Integer/MAX_VALUE)}
+      (is (= {:output (str "No table found with table_id " Integer/MAX_VALUE)
+              :status-code 404}
              (metabot-v3.tools.filters/query-datasource
               {:table-id Integer/MAX_VALUE}))))
 
     (testing "Error with non-existent model"
-      (is (= {:output (str "No model found with model_id " Integer/MAX_VALUE)}
+      (is (= {:output (str "No model found with model_id " Integer/MAX_VALUE)
+              :status-code 404}
              (metabot-v3.tools.filters/query-datasource
               {:model-id Integer/MAX_VALUE}))))))
 

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/util_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/util_test.clj
@@ -237,11 +237,11 @@
       (testing "throws for invalid field ID format"
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
-             #"invalid field_id format"
+             #"Invalid field_id format"
              (metabot-v3.tools.util/resolve-column {:field-id "invalid"} "t1-" columns)))
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
-             #"invalid field_id format"
+             #"Invalid field_id format"
              (metabot-v3.tools.util/resolve-column {:field-id "t154/1"} "t154-" columns))))
 
       (testing "throws when field index is out of bounds"


### PR DESCRIPTION
- Adds `:status-code` keys to a number of Metabot tool error responses, so that the agent API can return more specific HTTP status codes instead of defaulting everything to 404s
- Misc refactor of some tool implementations, all related to error handling and exception propagation (e.g. removed some dead `or` branches in `get-table-details` and `get-metric-details`)
- Added/adjusted some error messages