### PR TITLE
Library empty state: display content in the page body

### DIFF
--- a/e2e/test/scenarios/data-studio/data-studio-library.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-studio-library.cy.spec.ts
@@ -22,13 +22,8 @@ describe("scenarios > data studio > library", () => {
     H.DataModel.visitDataStudio();
     H.DataStudio.nav().findByLabelText("Library").click();
 
-    cy.log("Closing the modal should send you back");
-    H.modal().button("Cancel").click();
-    H.DataModel.get().should("exist");
-
-    cy.log("Create library via modal");
-    H.DataStudio.nav().findByLabelText("Library").click();
-    H.modal().within(() => {
+    cy.log("Create library via inline empty state");
+    H.DataStudio.Library.libraryPage().within(() => {
       cy.findByText("Create your Library").should("be.visible");
       cy.findByText("Create my Library").click();
     });

--- a/e2e/test/scenarios/data-studio/data-studio-library.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-studio-library.cy.spec.ts
@@ -24,7 +24,7 @@ describe("scenarios > data studio > library", () => {
 
     cy.log("Create library via inline empty state");
     H.DataStudio.Library.libraryPage().within(() => {
-      cy.findByText("Create your Library").should("be.visible");
+      cy.findByText("A source of truth for analytics").should("be.visible");
       cy.findByText("Create my Library").click();
     });
 

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/LibrarySectionLayout.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/LibrarySectionLayout/LibrarySectionLayout.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useMemo, useState } from "react";
-import { goBack } from "react-router-redux";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -8,7 +7,6 @@ import { isLibraryCollection } from "metabase/collections/utils";
 import DateTime from "metabase/common/components/DateTime";
 import { ForwardRefLink } from "metabase/common/components/Link";
 import { usePageTitle } from "metabase/hooks/use-page-title";
-import { useDispatch } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { PLUGIN_SNIPPET_FOLDERS } from "metabase/plugins";
 import { useRouter } from "metabase/router";
@@ -26,8 +24,8 @@ import {
   TreeTableSkeleton,
   useTreeTableInstance,
 } from "metabase/ui";
-import { CreateLibraryModal } from "metabase-enterprise/data-studio/common/components/CreateLibraryModal";
 import { DataStudioBreadcrumbs } from "metabase-enterprise/data-studio/common/components/DataStudioBreadcrumbs";
+import { LibraryEmptyState } from "metabase-enterprise/data-studio/common/components/LibraryEmptyState";
 import { PaneHeader } from "metabase-enterprise/data-studio/common/components/PaneHeader";
 import type { ExpandedState } from "metabase-enterprise/data-studio/data-model/components/TablePicker/types";
 import { ListEmptyState } from "metabase-enterprise/transforms/components/ListEmptyState";
@@ -91,7 +89,6 @@ function EmptyStateAction({ data, onPublishTable }: EmptyStateActionProps) {
 
 export function LibrarySectionLayout() {
   usePageTitle(t`Library`);
-  const dispatch = useDispatch();
   const { location } = useRouter();
   const [editingCollection, setEditingCollection] = useState<Collection | null>(
     null,
@@ -357,42 +354,50 @@ export function LibrarySectionLayout() {
           px="3.5rem"
           style={{ overflow: "hidden" }}
         >
-          <Flex gap="md">
-            <TextInput
-              placeholder={t`Search...`}
-              leftSection={<Icon name="search" />}
-              bdrs="md"
-              flex="1"
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-            />
-            <CreateMenu
-              metricCollectionId={writableMetricCollection?.id}
-              canWriteToMetricCollection={!!writableMetricCollection}
-            />
-          </Flex>
-          <Card withBorder p={0}>
-            {isLoading ? (
-              <TreeTableSkeleton columnWidths={[0.6, 0.2, 0.05]} />
-            ) : (
-              <TreeTable
-                instance={treeTableInstance}
-                emptyState={
-                  emptyMessage ? <ListEmptyState label={emptyMessage} /> : null
-                }
-                onRowClick={(row) => {
-                  if (row.original.model === "empty-state") {
-                    return;
-                  }
-                  if (row.getCanExpand()) {
-                    row.toggleExpanded();
-                  }
-                  // Navigation for leaf nodes is handled by the link
-                }}
-                getRowHref={getRowHref}
-              />
-            )}
-          </Card>
+          {!libraryCollection && !isLoadingCollections ? (
+            <LibraryEmptyState />
+          ) : (
+            <>
+              <Flex gap="md">
+                <TextInput
+                  placeholder={t`Search...`}
+                  leftSection={<Icon name="search" />}
+                  bdrs="md"
+                  flex="1"
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                />
+                <CreateMenu
+                  metricCollectionId={writableMetricCollection?.id}
+                  canWriteToMetricCollection={!!writableMetricCollection}
+                />
+              </Flex>
+              <Card withBorder p={0}>
+                {isLoading ? (
+                  <TreeTableSkeleton columnWidths={[0.6, 0.2, 0.05]} />
+                ) : (
+                  <TreeTable
+                    instance={treeTableInstance}
+                    emptyState={
+                      emptyMessage ? (
+                        <ListEmptyState label={emptyMessage} />
+                      ) : null
+                    }
+                    onRowClick={(row) => {
+                      if (row.original.model === "empty-state") {
+                        return;
+                      }
+                      if (row.getCanExpand()) {
+                        row.toggleExpanded();
+                      }
+                      // Navigation for leaf nodes is handled by the link
+                    }}
+                    getRowHref={getRowHref}
+                  />
+                )}
+              </Card>
+            </>
+          )}
         </Stack>
       </SectionLayout>
       {editingCollection && (
@@ -408,12 +413,6 @@ export function LibrarySectionLayout() {
           onClose={() => setPermissionsCollectionId(null)}
         />
       )}
-      <CreateLibraryModal
-        isOpened={!isLoadingCollections && !libraryCollection}
-        onClose={() => {
-          dispatch(goBack());
-        }}
-      />
       <PublishTableModal
         opened={isPublishTableModalOpen}
         onClose={() => setIsPublishTableModalOpen(false)}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/LibraryEmptyState/LibraryEmptyState.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/LibraryEmptyState/LibraryEmptyState.tsx
@@ -1,18 +1,14 @@
 import { t } from "ttag";
 
-import {
-  Form,
-  FormErrorMessage,
-  FormProvider,
-  FormSubmitButton,
-} from "metabase/forms";
 import { useMetadataToasts } from "metabase/metadata/hooks";
 import {
-  Box,
-  Center,
-  FixedSizeIcon,
+  Button,
+  Card,
   Group,
-  List,
+  Icon,
+  type IconName,
+  Paper,
+  SimpleGrid,
   Stack,
   Text,
   Title,
@@ -21,7 +17,7 @@ import { useCreateLibraryMutation } from "metabase-enterprise/api";
 import { trackDataStudioLibraryCreated } from "metabase-enterprise/data-studio/analytics";
 
 export function LibraryEmptyState() {
-  const [createLibrary] = useCreateLibraryMutation();
+  const [createLibrary, { isLoading }] = useCreateLibraryMutation();
   const { sendSuccessToast } = useMetadataToasts();
 
   const handleSubmit = async () => {
@@ -31,63 +27,70 @@ export function LibraryEmptyState() {
   };
 
   return (
-    <FormProvider initialValues={{}} onSubmit={handleSubmit}>
-      <Form>
-        <Center h="100%">
-          <Stack gap="lg" maw={480}>
-            <Group gap="sm">
-              <Center w="2rem" h="2rem" c="brand" bg="brand-light" bdrs="md">
-                <FixedSizeIcon name="repository" />
-              </Center>
-              <Title order={3}>{t`Create your Library`}</Title>
-            </Group>
-            <Stack gap="sm">
-              <Text>
-                {t`The Library helps you create a source of truth for analytics by providing a centrally managed set of curated content. It separates authoritative, reusable components from ad-hoc analyses.`}
-              </Text>
-              <List spacing="sm">
-                <ListItem
-                  title={t`Tables`}
-                  description={t`Cleaned, pre-transformed data sources ready for exploring`}
-                />
-                <ListItem
-                  title={t`Metrics`}
-                  description={t`Standardized calculations with known dimensions`}
-                />
-                <ListItem
-                  title={t`Version control`}
-                  description={t`Sync your Library to Git`}
-                />
-                <ListItem
-                  title={t`High trust`}
-                  description={t`Default to reliable sources your data team prescribes`}
-                />
-              </List>
-            </Stack>
-            <Group gap="sm">
-              <Box flex={1}>
-                <FormErrorMessage />
-              </Box>
-              <FormSubmitButton label={t`Create my Library`} variant="filled" />
-            </Group>
+    <Card bg="background-primary" p={48} maw={640} mx="auto" withBorder>
+      <Stack gap="3rem">
+        <Stack gap="md">
+          <Stack gap="sm">
+            <Title order={3}>{t`A source of truth for analytics`}</Title>
+            <Text c="text-secondary" lh="1.25rem">
+              {t`The Library helps you create a source of truth for analytics by providing a centrally managed set of curated content. It separates authoritative, reusable components from ad-hoc analyses.`}
+            </Text>
           </Stack>
-        </Center>
-      </Form>
-    </FormProvider>
+          <Group gap="sm">
+            <Button
+              variant="filled"
+              onClick={handleSubmit}
+              loading={isLoading}
+            >{t`Create my Library`}</Button>
+          </Group>
+        </Stack>
+        <SimpleGrid cols={2} spacing="sm">
+          <FeatureCard
+            icon="table"
+            title={t`Tables`}
+            description={t`Cleaned, pre-transformed data sources ready for exploring`}
+          />
+          <FeatureCard
+            icon="metric"
+            title={t`Metrics`}
+            description={t`Standardized calculations with known dimensions`}
+          />
+          <FeatureCard
+            icon="git_branch"
+            title={t`Version control`}
+            description={t`Sync your Library to Git`}
+          />
+          <FeatureCard
+            icon="verified_round"
+            title={t`High trust`}
+            description={t`Default to reliable sources your data team prescribes`}
+          />
+        </SimpleGrid>
+      </Stack>
+    </Card>
   );
 }
 
-type ListItemProps = {
+type FeatureCardProps = {
+  icon: IconName;
   title: string;
   description: string;
 };
 
-function ListItem({ title, description }: ListItemProps) {
+function FeatureCard({ icon, title, description }: FeatureCardProps) {
   return (
-    <List.Item>
-      <strong>{title}</strong>
-      {": "}
-      {description}
-    </List.Item>
+    <Paper bg="background-secondary" p="md" radius="8px">
+      <Group gap="sm" align="flex-start" wrap="nowrap">
+        <Icon name={icon} size={16} c="brand" style={{ flexShrink: 0 }} />
+        <Stack gap="xs">
+          <Text fw="bold" lh="1rem">
+            {title}
+          </Text>
+          <Text c="text-secondary" lh="1rem">
+            {description}
+          </Text>
+        </Stack>
+      </Group>
+    </Paper>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/LibraryEmptyState/LibraryEmptyState.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/LibraryEmptyState/LibraryEmptyState.tsx
@@ -94,7 +94,7 @@ type FeatureCardProps = {
 
 function FeatureCard({ icon, title, description }: FeatureCardProps) {
   return (
-    <Paper bg="background-secondary" p="md" radius="8px">
+    <Paper bg="background-secondary" p="md" radius="8px" shadow="none">
       <Group gap="sm" align="flex-start" wrap="nowrap">
         <Icon name={icon} size={16} c="brand" style={{ flexShrink: 0 }} />
         <Stack gap="xs">

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/LibraryEmptyState/LibraryEmptyState.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/LibraryEmptyState/LibraryEmptyState.tsx
@@ -1,0 +1,93 @@
+import { t } from "ttag";
+
+import {
+  Form,
+  FormErrorMessage,
+  FormProvider,
+  FormSubmitButton,
+} from "metabase/forms";
+import { useMetadataToasts } from "metabase/metadata/hooks";
+import {
+  Box,
+  Center,
+  FixedSizeIcon,
+  Group,
+  List,
+  Stack,
+  Text,
+  Title,
+} from "metabase/ui";
+import { useCreateLibraryMutation } from "metabase-enterprise/api";
+import { trackDataStudioLibraryCreated } from "metabase-enterprise/data-studio/analytics";
+
+export function LibraryEmptyState() {
+  const [createLibrary] = useCreateLibraryMutation();
+  const { sendSuccessToast } = useMetadataToasts();
+
+  const handleSubmit = async () => {
+    const collection = await createLibrary().unwrap();
+    sendSuccessToast(t`Library created`);
+    trackDataStudioLibraryCreated(collection.id);
+  };
+
+  return (
+    <FormProvider initialValues={{}} onSubmit={handleSubmit}>
+      <Form>
+        <Center h="100%">
+          <Stack gap="lg" maw={480}>
+            <Group gap="sm">
+              <Center w="2rem" h="2rem" c="brand" bg="brand-light" bdrs="md">
+                <FixedSizeIcon name="repository" />
+              </Center>
+              <Title order={3}>{t`Create your Library`}</Title>
+            </Group>
+            <Stack gap="sm">
+              <Text>
+                {t`The Library helps you create a source of truth for analytics by providing a centrally managed set of curated content. It separates authoritative, reusable components from ad-hoc analyses.`}
+              </Text>
+              <List spacing="sm">
+                <ListItem
+                  title={t`Tables`}
+                  description={t`Cleaned, pre-transformed data sources ready for exploring`}
+                />
+                <ListItem
+                  title={t`Metrics`}
+                  description={t`Standardized calculations with known dimensions`}
+                />
+                <ListItem
+                  title={t`Version control`}
+                  description={t`Sync your Library to Git`}
+                />
+                <ListItem
+                  title={t`High trust`}
+                  description={t`Default to reliable sources your data team prescribes`}
+                />
+              </List>
+            </Stack>
+            <Group gap="sm">
+              <Box flex={1}>
+                <FormErrorMessage />
+              </Box>
+              <FormSubmitButton label={t`Create my Library`} variant="filled" />
+            </Group>
+          </Stack>
+        </Center>
+      </Form>
+    </FormProvider>
+  );
+}
+
+type ListItemProps = {
+  title: string;
+  description: string;
+};
+
+function ListItem({ title, description }: ListItemProps) {
+  return (
+    <List.Item>
+      <strong>{title}</strong>
+      {": "}
+      {description}
+    </List.Item>
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/LibraryEmptyState/LibraryEmptyState.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/LibraryEmptyState/LibraryEmptyState.unit.spec.tsx
@@ -1,0 +1,39 @@
+import userEvent from "@testing-library/user-event";
+
+import {
+  setupCreateLibraryEndpoint,
+  setupCreateLibraryEndpointError,
+} from "__support__/server-mocks";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
+
+import { LibraryEmptyState } from "./LibraryEmptyState";
+
+type SetupOpts = {
+  hasCreateError?: boolean;
+};
+
+function setup({ hasCreateError }: SetupOpts = {}) {
+  if (hasCreateError) {
+    setupCreateLibraryEndpointError();
+  } else {
+    setupCreateLibraryEndpoint();
+  }
+
+  renderWithProviders(<LibraryEmptyState />);
+}
+
+describe("LibraryEmptyState", () => {
+  it("should be able to create the library", async () => {
+    setup();
+    await userEvent.click(screen.getByText("Create my Library"));
+    await waitFor(() =>
+      expect(screen.queryByText("Create my Library")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("should show a library creation error", async () => {
+    setup({ hasCreateError: true });
+    await userEvent.click(screen.getByText("Create my Library"));
+    expect(await screen.findByText("An error occurred")).toBeInTheDocument();
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/LibraryEmptyState/LibraryEmptyState.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/LibraryEmptyState/LibraryEmptyState.unit.spec.tsx
@@ -34,6 +34,6 @@ describe("LibraryEmptyState", () => {
   it("should show a library creation error", async () => {
     setup({ hasCreateError: true });
     await userEvent.click(screen.getByText("Create my Library"));
-    expect(await screen.findByText("An error occurred")).toBeInTheDocument();
+    expect(await screen.findByText("Something went wrong")).toBeInTheDocument();
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/LibraryEmptyState/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/common/components/LibraryEmptyState/index.ts
@@ -1,0 +1,1 @@
+export { LibraryEmptyState } from "./LibraryEmptyState";


### PR DESCRIPTION
Closes UXW-2702

### Description

This PR implements the new designs for Data Studio's library empty state.

### Demo

| Before | After |
| --- | --- |
| <img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/11742d73-02a0-4950-b696-7e8cd12a00e7" /> | <img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/20bcd473-e5c0-424c-9f12-bcd50db9a0d2" /> | 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
