### PR TITLE
fix: documents ignore base path when linking to dashboards

### DIFF
--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/SmartLink/SmartLinkNode.tsx
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/SmartLink/SmartLinkNode.tsx
@@ -19,7 +19,7 @@ import {
   useGetTableQuery,
   useListMentionsQuery,
 } from "metabase/api";
-import Link from "metabase/common/components/Link";
+import { Link } from "metabase/common/components/Link";
 import { updateMentionsCache } from "metabase/documents/documents.slice";
 import {
   type IconModel,

--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/SmartLink/SmartLinkNode.tsx
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/SmartLink/SmartLinkNode.tsx
@@ -19,6 +19,7 @@ import {
   useGetTableQuery,
   useListMentionsQuery,
 } from "metabase/api";
+import Link from "metabase/common/components/Link";
 import { updateMentionsCache } from "metabase/documents/documents.slice";
 import {
   type IconModel,
@@ -516,8 +517,8 @@ export const SmartLinkComponent = memo(
 
     return (
       <NodeViewWrapper as="span" data-type="smart-link">
-        <a
-          href={entityUrl || "#"}
+        <Link
+          to={entityUrl || "#"}
           target="_blank"
           rel="noreferrer"
           tabIndex={-1}
@@ -531,7 +532,7 @@ export const SmartLinkComponent = memo(
             <Icon name={iconData.name} className={styles.icon} />
             {getName(entity)}
           </span>
-        </a>
+        </Link>
       </NodeViewWrapper>
     );
   },


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #68238
Closes [UXW-2755: Docs ignore base path when linking to dashboards](https://linear.app/metabase/issue/UXW-2755/docs-ignore-base-path-when-linking-to-dashboards)

### Description

Documents were not using `react-router`'s `<Link>` component, thus not using the correct site url. Fixed by using the actual component.

### How to verify

1. Host metabase with pro self hosted token
2. Spin up some reverse proxy like `caddy` with `http://localhost:8080/prefix/` -> `http://localhost:3000`
3. Set site url in the admin settings
4. Create a new document
5. Add a link to a dashboard in a document with /link

### Demo

https://github.com/user-attachments/assets/6e64eae6-5a36-4c5f-95cf-ae6cd23735d3


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
