### PR TITLE
Tweak data loading behavior for a test after MySQL 9.6.0 release

### DIFF
--- a/test/metabase/test/data/mysql.clj
+++ b/test/metabase/test/data/mysql.clj
@@ -94,6 +94,16 @@
   ;; load data all at once
   nil)
 
+(defmethod load-data/do-insert! :mysql
+  [driver conn table-identifier rows]
+  ;; Disable FK checks during insert to allow self-referencing FK rows in the same batch
+  ;; (MySQL 9.6+ enforces FK constraints row-by-row during bulk INSERT, maybe??)
+  (jdbc/execute! {:connection conn} ["SET FOREIGN_KEY_CHECKS = 0"])
+  (try
+    ((get-method load-data/do-insert! :sql-jdbc/test-extensions) driver conn table-identifier rows)
+    (finally
+      (jdbc/execute! {:connection conn} ["SET FOREIGN_KEY_CHECKS = 1"]))))
+
 (defmethod sql.tx/pk-sql-type :mysql [_] "INTEGER NOT NULL AUTO_INCREMENT")
 
 ;;; use one single global lock for all datasets. MySQL needs a global lock to do DDL stuff and blows up if other queries

--- a/test/metabase/test/data/sql_jdbc/load_data.clj
+++ b/test/metabase/test/data/sql_jdbc/load_data.clj
@@ -24,6 +24,11 @@
 
 (set! *warn-on-reflection* true)
 
+(def ^:dynamic *disable-fk-checks*
+  "When bound to `true`, drivers that support it (e.g., MySQL) will disable foreign key checks during data insertion.
+   This is useful for tests that need to insert self-referencing data in a single batch."
+  false)
+
 (defmulti row-xform
   "Return a transducer that should be applied to each row when loading test data. Default is [[identity]], e.g. apply no
   transform, but a few common ones are available, such as [[add-ids-xform]] and [[maybe-add-ids-xform]].


### PR DESCRIPTION
Closes DEV-1289

### Description

Within the last day or two, `metabase.query-processor-test.remapping-test/self-referencing-test` began failing on MySQL Latest. I hypothesize this has to do with the [latest release](https://dev.mysql.com/doc/relnotes/mysql/9.6/en/news-9-6-0.html) fixing an unknown bug around batch inserts in InnoDB and the deprecation of a recusive [sic] fk-related flag.

The error is thrown not in the test conditions, but in the test setup -- MySQL apparently now checks foreign key constraints row-per-row even on a batch insert.

This adds a flag that the test can set which changes the test data-loading behavior to disable the FK check before insertion and re-enable it after.

### How to verify

CI should pass. Only test code was changed. Verify that the changes are unrelated to the purpose of the test.
