### PR TITLE
Fix NativeQueryEditor's action buttons

### DIFF
--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.module.css
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.module.css
@@ -14,6 +14,10 @@
   flex-direction: column;
 }
 
+.resizableBoxContent {
+  overflow: hidden;
+}
+
 .actionButtons {
   /* min-height of the top bar, it's needed for vertical alignment when there
   are several template tags */

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -325,74 +325,78 @@ export const NativeQueryEditor = forwardRef<
             initialHeight={getInitialEditorHeight({ query, availableHeight })}
             className={S.resizableArea}
           >
-            <CodeMirrorEditor
-              ref={editorRef}
-              query={question.query()}
-              proposedQuery={proposedQuestion?.query()}
-              readOnly={readOnly}
-              placeholder={placeholder}
-              highlightedLineNumbers={highlightedLineNumbers}
-              extensions={extensions}
-              onBlur={onBlur}
-              onChange={handleChange}
-              onRunQuery={runQuery}
-              onSelectionChange={setNativeEditorSelectedRange}
-              onCursorMoveOverCardTag={openDataReferenceAtQuestion}
-              onRightClickSelection={handleRightClickSelection}
-              onFormatQuery={handleFormatQuery}
-            />
+            <Flex w="100%" flex="1" className={S.resizableBoxContent}>
+              <CodeMirrorEditor
+                ref={editorRef}
+                query={question.query()}
+                proposedQuery={proposedQuestion?.query()}
+                readOnly={readOnly}
+                placeholder={placeholder}
+                highlightedLineNumbers={highlightedLineNumbers}
+                extensions={extensions}
+                onBlur={onBlur}
+                onChange={handleChange}
+                onRunQuery={runQuery}
+                onSelectionChange={setNativeEditorSelectedRange}
+                onCursorMoveOverCardTag={openDataReferenceAtQuestion}
+                onRightClickSelection={handleRightClickSelection}
+                onFormatQuery={handleFormatQuery}
+              />
 
-            <Stack m="1rem" gap="md" mt="auto">
-              {proposedQuestion && onRejectProposed && onAcceptProposed && (
-                <>
-                  <Tooltip label={t`Accept proposed changes`} position="top">
-                    <Button
-                      data-testid="accept-proposed-changes-button"
-                      variant="filled"
-                      bg="success"
-                      px="0"
-                      w="2.5rem"
-                      onClick={() => {
-                        const proposedQuery =
-                          proposedQuestion.legacyNativeQuery();
-                        if (proposedQuery) {
-                          handleChange(proposedQuery.queryText());
-                          onAcceptProposed(proposedQuery.datasetQuery());
-                        }
-                      }}
-                    >
-                      <Icon name="check" />
-                    </Button>
-                  </Tooltip>
-                  <Tooltip label={t`Reject proposed changes`} position="top">
-                    <Button
-                      data-testid="reject-proposed-changes-button"
-                      w="2.5rem"
-                      px="0"
-                      variant="filled"
-                      bg="danger"
-                      onClick={onRejectProposed}
-                    >
-                      <Icon name="close" />
-                    </Button>
-                  </Tooltip>
-                </>
-              )}
-              <Flex gap="sm">
-                {extraButton}
-                {hasRunButton && !readOnly && (
-                  <NativeQueryEditorRunButton
-                    cancelQuery={cancelQuery}
-                    isResultDirty={isResultDirty}
-                    isRunnable={isRunnable}
-                    isRunning={isRunning}
-                    nativeEditorSelectedText={nativeEditorSelectedText}
-                    runQuery={runQuery}
-                    questionErrors={Lib.validateTemplateTags(question.query())}
-                  />
+              <Stack m="1rem" gap="md" mt="auto">
+                {proposedQuestion && onRejectProposed && onAcceptProposed && (
+                  <>
+                    <Tooltip label={t`Accept proposed changes`} position="top">
+                      <Button
+                        data-testid="accept-proposed-changes-button"
+                        variant="filled"
+                        bg="success"
+                        px="0"
+                        w="2.5rem"
+                        onClick={() => {
+                          const proposedQuery =
+                            proposedQuestion.legacyNativeQuery();
+                          if (proposedQuery) {
+                            handleChange(proposedQuery.queryText());
+                            onAcceptProposed(proposedQuery.datasetQuery());
+                          }
+                        }}
+                      >
+                        <Icon name="check" />
+                      </Button>
+                    </Tooltip>
+                    <Tooltip label={t`Reject proposed changes`} position="top">
+                      <Button
+                        data-testid="reject-proposed-changes-button"
+                        w="2.5rem"
+                        px="0"
+                        variant="filled"
+                        bg="danger"
+                        onClick={onRejectProposed}
+                      >
+                        <Icon name="close" />
+                      </Button>
+                    </Tooltip>
+                  </>
                 )}
-              </Flex>
-            </Stack>
+                <Flex gap="sm">
+                  {extraButton}
+                  {hasRunButton && !readOnly && (
+                    <NativeQueryEditorRunButton
+                      cancelQuery={cancelQuery}
+                      isResultDirty={isResultDirty}
+                      isRunnable={isRunnable}
+                      isRunning={isRunning}
+                      nativeEditorSelectedText={nativeEditorSelectedText}
+                      runQuery={runQuery}
+                      questionErrors={Lib.validateTemplateTags(
+                        question.query(),
+                      )}
+                    />
+                  )}
+                </Flex>
+              </Stack>
+            </Flex>
           </ResizableArea>
         )}
       </div>


### PR DESCRIPTION
### Description

#67896 introduced an issue where the run button got moved to the left. For codegen features, the run + accept / reject buttons were getting completely moved off screen for long outputs (most of our e2e outputs were short enough to not encounter this).

(EDIT: this also reverts some of the style changes done by #68107)

This PR adds back the <Flex> component that was here previously, along with it's previous css class.

### Demo

Before
<img width="2320" height="1060" alt="CleanShot 2026-01-23 at 11 48 59@2x (1)" src="https://github.com/user-attachments/assets/3bfb2bdc-4b4b-4e9e-8e75-3b781cfd8cef" />

<img width="2982" height="2128" alt="CleanShot 2026-01-23 at 14 52 32@2x" src="https://github.com/user-attachments/assets/b3e4192a-fa50-4e97-83d8-75152f608ec4" />

After
<img width="3008" height="1322" alt="CleanShot 2026-01-23 at 14 53 56@2x" src="https://github.com/user-attachments/assets/c39e964e-d056-4162-befd-931aaeaf122f" />

<img width="2990" height="2118" alt="CleanShot 2026-01-23 at 14 53 33@2x" src="https://github.com/user-attachments/assets/34819a55-22e4-4baf-9588-8fb8295442c8" />

