### PR TITLE
ci: add H2 OSS driver tests to catch OSS-only failures

### DIFF
--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -12,6 +12,10 @@ inputs:
   logs-artifact-suffix:
     required: false
     description: Suffix to append to the test logs artifact name to avoid conflicts in matrix jobs
+  edition:
+    required: false
+    default: 'ee'
+    description: Edition to test (oss or ee)
 
 runs:
   using: "composite"
@@ -28,7 +32,7 @@ runs:
       env:
         MB_EDITION: ee
     - name: Test database driver
-      run: clojure -X:dev:ci:ee:ee-dev:drivers:drivers-dev:test ${{ inputs.test-args }}
+      run: clojure -X:dev:ci:${{ inputs.edition }}:${{ inputs.edition }}-dev:drivers:drivers-dev:test ${{ inputs.test-args }}
       shell: bash
       id: run-test
       # Trunk Quarantine controls the final state of the run in the CI!

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -510,6 +510,37 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
 
+  be-tests-h2-oss:
+    needs: determine-driver-skips
+    if: ${{ needs.determine-driver-skips.outputs.h2-should-run == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      CI: 'true'
+    name: H2 (OSS)
+    steps:
+    - uses: actions/checkout@v4
+    - name: Test H2 driver (OSS)
+      id: test-driver
+      uses: ./.github/actions/test-driver
+      with:
+        junit-name: 'be-tests-h2-oss'
+        edition: 'oss'
+        test-args: >-
+          :only-tags [:mb/driver-tests]
+          :exclude-tags [:mb/transforms-python-test]
+    - name: Upload Test Results
+      uses: ./.github/actions/upload-test-results
+      if: always()
+      with:
+        input-path: ./target/junit/
+        output-name: ${{ github.job }}
+        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ vars.AWS_REGION }}
+        trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
+
   be-tests-mysql-mariadb:
     needs: determine-driver-skips
     if: ${{ needs.determine-driver-skips.outputs.mysql-mariadb-should-run == 'true' }}

--- a/test/metabase/warehouse_schema_rest/api/table_test.clj
+++ b/test/metabase/warehouse_schema_rest/api/table_test.clj
@@ -1315,39 +1315,8 @@
                                      {:visibility_type  "hidden"
                                       :data_layer "copper"})))))))
 
-(deftest unused-only-filter-test
-  (mt/with-premium-features #{:dependencies}
-    (testing "GET /api/table?unused-only=true"
-      (testing "filters tables that have no non-transform dependents"
-        (mt/with-temp [:model/Database {db-id :id} {}
-                       :model/Table {table-1-id :id} {:db_id db-id, :name "table_1", :active true}
-                       :model/Table {table-2-id :id} {:db_id db-id, :name "table_2", :active true}]
-          (testing "both tables returned without filter"
-            (is (= #{table-1-id table-2-id}
-                   (->> (mt/user-http-request :crowberto :get 200 "table")
-                        (filter #(= (:db_id %) db-id))
-                        (map :id)
-                        set))))
-
-          (testing "both tables returned with unused_only=false"
-            (is (= #{table-1-id table-2-id}
-                   (->> (mt/user-http-request :crowberto :get 200 "table" :unused-only false)
-                        (filter #(= (:db_id %) db-id))
-                        (map :id)
-                        set))))
-
-          (mt/with-temp [:model/Card card {:database_id   db-id
-                                           :table_id      table-1-id
-                                           :dataset_query {:database db-id
-                                                           :type     :query
-                                                           :query    {:source-table table-1-id}}}]
-            (events/publish-event! :event/card-create {:object card :user-id (:creator_id card)})
-            (testing "after creating card that depends on table-1, only table-2 is unuseded"
-              (is (= #{table-2-id}
-                     (->> (mt/user-http-request :crowberto :get 200 "table" :unused-only true)
-                          (filter #(= (:db_id %) db-id))
-                          (map :id)
-                          set))))))))))
+;; NOTE: unused-only-filter-test moved to enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
+;; because it depends on EE event handlers to populate the dependency table
 
 (deftest orphan-only-filter-test
   (testing "GET /api/table?orphan-only=true"


### PR DESCRIPTION
## Summary

We discovered a gap in our CI: OSS code can call `publish-event!` for events only derived in EE, and we won't catch it until a customer runs OSS. This PR adds H2 driver tests that run **without EE code loaded**, and unlike the current H2 OSS tests, will run the **driver** tests.

The current tests exclude the `:mb/driver-tests` tag, and we were skipping testing parts of the OSS code because of that.

### The problem

In #67327, `publish-event!` calls were added to OSS code for events like `:event/field-update` that were only derived in `metabase-enterprise.remote-sync.events`. This broke OSS, but CI didn't catch it because:

1. Our OSS backend tests (`backend.yml`) exclude `:mb/driver-tests`
2. Our driver tests (`drivers.yml`) always run with EE loaded

Ed fixed the immediate issue in #68590 by moving derivations to OSS, but the underlying gap remains.

### The fix

Add a new `be-tests-h2-oss` job that runs H2 driver tests with the `:oss:oss-dev` aliases (which don't include `enterprise/backend/src`). If OSS code depends on EE-only functionality, this job will fail.

### Changes

- **`.github/actions/test-driver/action.yml`**: Add `edition` input (defaults to 'ee' for backwards compatibility)
- **`.github/workflows/drivers.yml`**: Add `be-tests-h2-oss` job mirroring the existing H2 job but with `edition: 'oss'`

## Test plan

- [ ] CI passes (the new H2 OSS job should pass since #68590 fixed the event derivations)
- [x] Verify the new job appears in the workflow and runs with the correct aliases

---

## Fix for `unused-only-filter-test` failure

The new H2 OSS job caught another issue: `unused-only-filter-test` in `test/metabase/warehouse_schema_rest/api/table_test.clj` was failing.

**Root cause:** The test used `mt/with-premium-features #{:dependencies}` to enable the feature flag, but it actually depends on EE event handlers (`metabase-enterprise.dependencies.*`) to populate the `dependency` table when `:event/card-create` is published. Mocking the feature flag doesn't load EE code.

**Fix:** Moved the test to `enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj` where it belongs, since it tests EE behavior.