### PR TITLE
Respect abbreviate date style and be defensive around missing settings

### DIFF
--- a/frontend/src/metabase/parameters/utils/formatting.unit.spec.ts
+++ b/frontend/src/metabase/parameters/utils/formatting.unit.spec.ts
@@ -286,4 +286,102 @@ describe("metabase/parameters/utils/formatting", () => {
       },
     );
   });
+
+  describe("formatParameterValue with settings and abbreviated dates", () => {
+    const cases = [
+      {
+        type: "date/single",
+        value: "2018-01-01",
+        expected: "1 Jan, 2018",
+      },
+      {
+        type: "date/single",
+        value: "2018-01-01T12:30:00",
+        expected: "1 Jan, 2018 12:30 pm",
+      },
+      {
+        type: "date/range",
+        value: "1995-01-01~1995-01-10",
+        expected: "1 Jan, 1995 - 10 Jan, 1995",
+      },
+      {
+        type: "date/range",
+        value: "2018-01-01T12:30:00~2018-01-10",
+        expected: "1 Jan, 2018 12:30 pm - 10 Jan, 2018 12:00 am",
+      },
+      {
+        type: "date/range",
+        value: "2018-01-01~2018-01-10T08:15:00",
+        expected: "1 Jan, 2018 12:00 am - 10 Jan, 2018 08:15 am",
+      },
+      {
+        type: "date/range",
+        value: "2018-01-01T12:30:00~2018-01-10T08:15:00",
+        expected: "1 Jan, 2018 12:30 pm - 10 Jan, 2018 08:15 am",
+      },
+      {
+        type: "date/all-options",
+        value: "2018-01-01",
+        expected: "On 1 Jan, 2018",
+      },
+      {
+        type: "date/month-year",
+        value: "2018-01",
+        expected: "Jan 2018",
+      },
+      {
+        type: "date/quarter-year",
+        value: "Q1-2018",
+        expected: "Q1 2018",
+      },
+      {
+        type: "date/relative",
+        value: "past30days",
+        expected: "Previous 30 days",
+      },
+      {
+        type: "date/month-year",
+        value: "thisday",
+        expected: "Today",
+      },
+      {
+        type: "date/month-year",
+        value: "thisweek",
+        expected: "This week",
+      },
+      {
+        type: "date/month-year",
+        value: "past1days",
+        expected: "Yesterday",
+      },
+      {
+        type: "date/month-year",
+        value: "past1weeks",
+        expected: "Previous week",
+      },
+      {
+        type: "date/month-year",
+        value: "2023-10-02~2023-10-24",
+        expected: "2 Oct, 2023 - 24 Oct, 2023",
+      },
+    ];
+
+    const formattingSettings = {
+      "type/Temporal": {
+        date_style: "D MMMM, YYYY",
+        time_style: "hh:mm a",
+        date_abbreviate: true,
+      },
+    };
+
+    test.each(cases)(
+      "should format $type parameter",
+      ({ value, expected, ...parameterProps }) => {
+        const parameter = createMockUiParameter(parameterProps);
+        expect(
+          formatParameterValue(value, parameter, formattingSettings),
+        ).toEqual(expected);
+      },
+    );
+  });
 });

--- a/frontend/src/metabase/parameters/utils/formatting.unit.spec.ts
+++ b/frontend/src/metabase/parameters/utils/formatting.unit.spec.ts
@@ -384,4 +384,18 @@ describe("metabase/parameters/utils/formatting", () => {
       },
     );
   });
+
+  describe("formatParameterValue with unset settings", () => {
+    it("should render a sensical value even if the date style is unset", () => {
+      const parameter = createMockUiParameter({ type: "date/month-year" });
+      const value = "2023-10-02~2023-10-24";
+      const expected = "October 2, 2023 - October 24, 2023";
+
+      expect(formatParameterValue(value, parameter)).toEqual(expected);
+      expect(formatParameterValue(value, parameter, undefined)).toEqual(
+        expected,
+      );
+      expect(formatParameterValue(value, parameter, {})).toEqual(expected);
+    });
+  });
 });

--- a/frontend/src/metabase/querying/filters/utils/dates.ts
+++ b/frontend/src/metabase/querying/filters/utils/dates.ts
@@ -327,14 +327,31 @@ export function getDateFilterDisplayName(
 export function formatDate(
   date: Date,
   hasTime: boolean,
-  formattingSettings: DateFormattingSettings = {
-    date_style: "LL", // fall back to local date format
-    time_style: DEFAULT_TIME_STYLE,
-  },
+  formattingSettings: DateFormattingSettings = {},
 ) {
-  const { date_style, time_style } = formattingSettings;
-  const format = hasTime ? `${date_style} ${time_style}` : date_style;
+  const format = formattingSettingsToFormatString(formattingSettings, hasTime);
   return dayjs(date).format(format);
+}
+
+function formattingSettingsToFormatString(
+  {
+    date_style = "LL",
+    time_style = DEFAULT_TIME_STYLE,
+    date_abbreviate = false,
+  }: DateFormattingSettings = {},
+  hasTime: boolean = false,
+) {
+  let format = hasTime ? `${date_style} ${time_style}` : date_style;
+
+  if (date_abbreviate) {
+    format = abbreviateFormat(format);
+  }
+
+  return format;
+}
+
+function abbreviateFormat(format: string) {
+  return format.replace(/MMMM/, "MMM").replace(/dddd/, "ddd");
 }
 
 function formatMonth(month: number, year: number) {

--- a/frontend/src/metabase/querying/filters/utils/dates.ts
+++ b/frontend/src/metabase/querying/filters/utils/dates.ts
@@ -316,7 +316,7 @@ export function getDateFilterDisplayName(
       return t`Not empty`;
     })
     .with({ type: "month" }, ({ month, year }) => {
-      return formatMonth(month, year);
+      return formatMonth(month, year, formattingSettings);
     })
     .with({ type: "quarter" }, ({ quarter, year }) => {
       return formatQuarter(quarter, year);
@@ -334,31 +334,35 @@ export function formatDate(
 }
 
 function formattingSettingsToFormatString(
-  {
-    date_style = "LL",
-    time_style = DEFAULT_TIME_STYLE,
-    date_abbreviate = false,
-  }: DateFormattingSettings = {},
+  formattingSettings: DateFormattingSettings = {},
   hasTime: boolean = false,
 ) {
-  let format = hasTime ? `${date_style} ${time_style}` : date_style;
+  const { date_style = "LL", time_style = DEFAULT_TIME_STYLE } =
+    formattingSettings;
 
-  if (date_abbreviate) {
-    format = abbreviateFormat(format);
-  }
-
-  return format;
+  const format = hasTime ? `${date_style} ${time_style}` : date_style;
+  return abbreviateFormat(format, formattingSettings);
 }
 
-function abbreviateFormat(format: string) {
+function abbreviateFormat(
+  format: string,
+  formattingSettings: DateFormattingSettings = {},
+) {
+  if (!formattingSettings.date_abbreviate) {
+    return format;
+  }
   return format.replace(/MMMM/, "MMM").replace(/dddd/, "ddd");
 }
 
-function formatMonth(month: number, year: number) {
+function formatMonth(
+  month: number,
+  year: number,
+  formattingSettings: DateFormattingSettings = {},
+) {
   return dayjs()
     .year(year)
     .month(month - 1)
-    .format("MMMM YYYY");
+    .format(abbreviateFormat("MMMM YYYY", formattingSettings));
 }
 
 function formatQuarter(quarter: number, year: number) {

--- a/frontend/src/metabase/querying/filters/utils/dates.unit.spec.ts
+++ b/frontend/src/metabase/querying/filters/utils/dates.unit.spec.ts
@@ -2,6 +2,7 @@ import { setLocalization } from "metabase/lib/i18n";
 import type { DateFilterValue } from "metabase/querying/filters/types";
 import * as Lib from "metabase-lib";
 import { columnFinder, createQuery } from "metabase-lib/test-helpers";
+import type { DateFormattingSettings } from "metabase-types/api";
 
 import {
   formatDate,
@@ -148,6 +149,7 @@ type DateFilterDisplayNameCase = {
   value: DateFilterValue;
   displayName: string;
   withPrefix?: boolean;
+  formattingSettings?: DateFormattingSettings;
 };
 
 describe("getDateFilterDisplayName", () => {
@@ -317,12 +319,50 @@ describe("getDateFilterDisplayName", () => {
       },
       displayName: "Not empty",
     },
+    {
+      value: {
+        type: "specific",
+        operator: "=",
+        values: [new Date(2024, 2, 5)],
+        hasTime: false,
+      },
+      formattingSettings: {
+        date_style: "dddd MMMM D, YYYY",
+      },
+      displayName: "Tuesday March 5, 2024",
+    },
+    {
+      value: {
+        type: "specific",
+        operator: "=",
+        values: [new Date(2024, 2, 5)],
+        hasTime: false,
+      },
+      formattingSettings: {
+        date_style: "dddd MMMM D, YYYY",
+        date_abbreviate: true,
+      },
+      displayName: "Tue Mar 5, 2024",
+    },
+    {
+      value: {
+        type: "specific",
+        operator: "=",
+        values: [new Date(2024, 2, 5)],
+        hasTime: true,
+      },
+      formattingSettings: {
+        date_style: "dddd MMMM D, YYYY",
+        date_abbreviate: true,
+      },
+      displayName: "Tue Mar 5, 2024 12:00 AM",
+    },
   ])(
     "should format a relative date filter",
-    ({ value, displayName, withPrefix }) => {
-      expect(getDateFilterDisplayName(value, { withPrefix })).toEqual(
-        displayName,
-      );
+    ({ value, displayName, withPrefix, formattingSettings }) => {
+      expect(
+        getDateFilterDisplayName(value, { withPrefix, formattingSettings }),
+      ).toEqual(displayName);
     },
   );
 });


### PR DESCRIPTION
Closes #68574 

This PR makes the date format utility respect the `Abbreviate days and months` setting and allows for `Date and time formatting setting` to be unset.

> [!NOTE] 
> This PR does not deal solve the missing settings value that was reported in #68574, but it handles it more gracefully.