### PR TITLE
Use Metabase Bot GitHub App to create timings PR

### DIFF
--- a/.github/workflows/update-e2e-timings.yml
+++ b/.github/workflows/update-e2e-timings.yml
@@ -96,4 +96,7 @@ jobs:
             Co-Authored-By: GitHub Actions <actions@github.com>
           labels: |
             .CI & Tests
+            no-backport
           add-paths: e2e/support/timings.json
+          team-reviewers: |
+            devexp

--- a/.github/workflows/update-e2e-timings.yml
+++ b/.github/workflows/update-e2e-timings.yml
@@ -23,9 +23,16 @@ jobs:
     env:
       DAYS_BACK: ${{ inputs.days_back || 7 }}
     steps:
+      - name: Generate GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.METABASE_BOT_APP_ID }}
+          private-key: ${{ secrets.METABASE_BOT_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -41,7 +48,7 @@ jobs:
             const result = await collectAndAverageTimings({
               github,
               context,
-              token: '${{ secrets.GITHUB_TOKEN }}',
+              token: '${{ steps.app-token.outputs.token }}',
               daysBack: ${{ env.DAYS_BACK }},
               existingTimingsPath: 'e2e/support/timings.json'
             });
@@ -59,7 +66,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           branch: ${{ env.BRANCH_NAME }}
           base: master
           commit-message: |


### PR DESCRIPTION
The automated timings PRs were getting stuck in CI because of the token I was using.

Also add `no-backport` label and adds `DevExp` as reviewers