### PR TITLE
Fixed missing bg color for dashboards

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -104,7 +104,7 @@ const DashboardDefaultView = ({ className }: { className?: string }) => {
         mih={0}
         className={cx(S.DashboardBody, {
           [S.isEditingOrSharing]: isEditing || isSharing,
-          [S.isEmbeddingSdk]: isEmbeddingSdk,
+          [S.isEmbeddingSdk]: isEmbeddingSdk(),
         })}
       >
         <Box


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #68647
Closes [EMB-1245: Dashboards are missing their background color](https://linear.app/metabase/issue/EMB-1245/dashboards-are-missing-their-background-color)

### Description

Fixed a background color issue introduced in #68539