### PR TITLE
Skipping first sso request if possible in EAJS/Modular Embedding

### DIFF
--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/constants.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/constants.ts
@@ -26,6 +26,7 @@ export const ALLOWED_EMBED_SETTING_KEYS_MAP = {
     "fetchRequestToken",
     "useExistingUserSession",
     "isGuest",
+    "jwtProviderUri",
   ] satisfies (keyof SdkIframeEmbedBaseSettings)[],
   dashboard: [
     "dashboardId",

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/types/auth-manager.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/types/auth-manager.ts
@@ -8,6 +8,7 @@ export interface EmbedAuthManagerContext {
     instanceUrl: string;
     preferredAuthMethod?: MetabaseAuthMethod;
     fetchRequestToken?: MetabaseFetchRequestTokenFn;
+    jwtProviderUri?: string;
   };
   sendMessage<Message extends SdkIframeEmbedMessage>(
     type: Message["type"],

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
@@ -181,6 +181,7 @@ export type SdkIframeEmbedBaseSettings = {
   theme?: MetabaseTheme;
   locale?: string;
   preferredAuthMethod?: MetabaseAuthMethod;
+  jwtProviderUri?: string;
   fetchRequestToken?: MetabaseFetchRequestTokenFn;
 
   /** Whether we should use the existing user session (i.e. admin user's cookie) */


### PR DESCRIPTION
Closes [EMB-1044: make EAJS benefit from the speed ups of skipping the first `/auth/sso` request for JWT sso](https://linear.app/metabase/issue/EMB-1044/make-eajs-benefit-from-the-speed-ups-of-skipping-the-first-authsso)

### Description

Followup of #66120 where we allow users to provide a Uri for their JWT provider, in order to skip one extraneous request and speed things up during authentication of an SDK app. This PR does the same for EAJS projects.

### How to verify

Set up a new modular embed authenticated with SSO, and pass in the `jwtProviderUri` to its MB config. It should only do two requests for authentication (one to get the token, the other to get the session from MB in exchange of the token).

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
