### PR TITLE
[deps] When Table Metadata is edited, re-analyze all dependents

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/dependencies/events.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/events.clj
@@ -374,3 +374,21 @@
       (when (and (seq changes)
                  (deps.findings/mark-all-dependents-stale! {:table changes}))
         (task.entity-check/trigger-entity-check-job!)))))
+
+;; ### Admin UI Table/Field Metadata Updates
+;; When a table or field's metadata is updated via the admin UI, re-analyze all dependents of that table.
+(derive ::check-table-metadata-update :metabase/event)
+(derive :event/table-update ::check-table-metadata-update)
+
+(methodical/defmethod events/publish-event! ::check-table-metadata-update
+  [_ {:keys [object]}]
+  (when (premium-features/has-feature? :dependencies)
+    (deps.findings/mark-dependents-stale! :table (:id object))))
+
+(derive ::check-field-metadata-update :metabase/event)
+(derive :event/field-update ::check-field-metadata-update)
+
+(methodical/defmethod events/publish-event! ::check-field-metadata-update
+  [_ {:keys [object]}]
+  (when (premium-features/has-feature? :dependencies)
+    (deps.findings/mark-dependents-stale! :table (:table_id object))))

--- a/enterprise/backend/src/metabase_enterprise/dependencies/findings.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/findings.clj
@@ -61,7 +61,7 @@
 
 (def supported-entities
   "Entities supported by the analysis findings code"
-  #{:card :transform :segment})
+  #{:card :transform :segment :table})
 
 (def ^:private SupportedEntityType
   "Schema for entity types supported by analysis findings."


### PR DESCRIPTION
Fixes QUE-3000.

### Description

When either the table metadata or field metadata is edited, this runs
the analysis. Since only some metadata changes can impact the analysis,
this is over-sensitive and runs sometimes when it doesn't need to.

### How to verify

Edit the metadata for a table or field, and see that the analysis of any cards, transforms etc.
which depend on it get re-analyzed, transitively.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
