### PR TITLE
feat: add thread-local isolation support to settings cache

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -189,6 +189,11 @@
      metabase-enterprise.workspaces.test-util/create-ready-ws!
      ;; Safe in tests, where we typically use a private, temporary index per thread.
      metabase.search.core/reindex!
+     metabase.test/discard-setting-changes!
+     metabase.test/test-helpers-set-global-values!
+     metabase.test.util/discard-setting-changes!
+     metabase.test.util.thread-local/do-test-helpers-set-global-values!
+     metabase.test.util.thread-local/test-helpers-set-global-values!
      metabase.util/run-count!
      next.jdbc/execute!}}
 
@@ -643,14 +648,17 @@
    metabase.test.util.generators.jvm/with-random-cards                                                                       hooks.metabase.test.util.generators.jvm/with-random-cards
    metabase.test.util.log/with-log-level                                                                                     hooks.common/with-ignored-first-arg
    metabase.test.util/discard-setting-changes                                                                                hooks.common/with-ignored-first-arg
+   metabase.test.util/discard-setting-changes!                                                                               hooks.common/with-ignored-first-arg
    metabase.test.util/with-column-remappings                                                                                 hooks.common/with-ignored-first-arg
    metabase.test.util/with-non-admin-groups-no-root-collection-perms                                                         hooks.common/do*
    metabase.test.util/with-prometheus-system!                                                                                hooks.common/with-two-bindings
    metabase.test.util/with-temp-file                                                                                         hooks.metabase.test.util/with-temp-file
    metabase.test.util/with-temporary-setting-values                                                                          hooks.metabase.test.util/with-temporary-setting-values
+   metabase.test.util/with-temporary-setting-values!                                                                         hooks.metabase.test.util/with-temporary-setting-values
    metabase.test/$ids                                                                                                        hooks.metabase.test.data/$ids
    metabase.test/dataset                                                                                                     hooks.metabase.test.data/dataset
    metabase.test/discard-setting-changes                                                                                     hooks.common/with-ignored-first-arg
+   metabase.test/discard-setting-changes!                                                                                    hooks.common/with-ignored-first-arg
    metabase.test/mbql-query                                                                                                  hooks.metabase.test.data/mbql-query
    metabase.test/query                                                                                                       hooks.metabase.test.data/mbql-query
    metabase.test/run-mbql-query                                                                                              hooks.metabase.test.data/mbql-query
@@ -667,6 +675,7 @@
    metabase.test/with-temp                                                                                                   hooks.toucan2.tools.with-temp/with-temp
    metabase.test/with-temp-file                                                                                              hooks.metabase.test.util/with-temp-file
    metabase.test/with-temporary-setting-values                                                                               hooks.metabase.test.util/with-temporary-setting-values
+   metabase.test/with-temporary-setting-values!                                                                              hooks.metabase.test.util/with-temporary-setting-values
    metabase.users-rest.api-test/with-temp-user-email!                                                                        hooks.common/with-one-binding
    metabase.util.i18n/deferred-trs                                                                                           hooks.metabase.util.i18n/deferred-trs
    metabase.util.i18n/deferred-tru                                                                                           hooks.metabase.util.i18n/deferred-tru
@@ -722,9 +731,11 @@
    metabase.test.data.users/with-group-for-user                                                 macros.metabase.test.data.users/with-group-for-user
    metabase.test.util/with-temp-env-var-value!                                                  macros.metabase.test.util/with-temp-env-var-value!
    metabase.test.util/with-temporary-raw-setting-values                                         macros.metabase.test.util/with-temporary-raw-setting-values
+   metabase.test.util/with-temporary-raw-setting-values!                                        macros.metabase.test.util/with-temporary-raw-setting-values
    metabase.test/with-group-for-user                                                            macros.metabase.test.data.users/with-group-for-user
    metabase.test/with-temp-env-var-value!                                                       macros.metabase.test.util/with-temp-env-var-value!
    metabase.test/with-temporary-raw-setting-values                                              macros.metabase.test.util/with-temporary-raw-setting-values
+   metabase.test/with-temporary-raw-setting-values!                                             macros.metabase.test.util/with-temporary-raw-setting-values
    metabase.users.models.user-test/with-groups!                                                 macros.metabase.users.models.user-test/with-groups!
    metabase.util.namespaces/import-fn                                                           macros.metabase.util.namespaces/import-fn
    metabase.xrays.related-test/with-world                                                       macros.metabase.xrays.related-test/with-world}}

--- a/.clj-kondo/src/hooks/clojure/test.clj
+++ b/.clj-kondo/src/hooks/clojure/test.clj
@@ -186,5 +186,5 @@
   {:node node})
 
 (defn use-fixtures [{:keys [node config]}]
-  (warn-about-disallowed-parallel-forms node config)
+  (warn-about-disallowed-parallel-forms node (get-in config [:linters :metabase/validate-deftest]))
   {:node node})

--- a/bin/ci-failures
+++ b/bin/ci-failures
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Usage: bin/ci-failures <run-id-or-url> [job-name-filter]
+#
+# Extract unique failing test names from a GitHub Actions CI run.
+#
+# Examples:
+#   bin/ci-failures 23808103321
+#   bin/ci-failures 23808103321 "Postgres"
+#   bin/ci-failures https://github.com/metabase/metabase/actions/runs/23808103321/job/69387249218
+
+set -uo pipefail
+
+REPO="metabase/metabase"
+
+input="${1:?Usage: bin/ci-failures <run-id-or-url> [job-name-filter]}"
+filter="${2:-}"
+
+# Extract run ID and optional job ID from URL
+if [[ "$input" =~ /job/([0-9]+) ]]; then
+  job_id="${BASH_REMATCH[1]}"
+  run_id=$(echo "$input" | grep -oE 'runs/[0-9]+' | cut -d/ -f2)
+elif [[ "$input" =~ runs/([0-9]+) ]]; then
+  run_id="${BASH_REMATCH[1]}"
+  job_id=""
+elif [[ "$input" =~ ^[0-9]+$ ]]; then
+  run_id="$input"
+  job_id=""
+else
+  echo "Error: could not parse run/job ID from: $input" >&2
+  exit 1
+fi
+
+get_failures() {
+  local jid="$1"
+  local jname="$2"
+  local failures
+  failures=$(LC_ALL=C gh api "repos/$REPO/actions/jobs/$jid/logs" 2>&1 \
+    | LC_ALL=C sed 's/\x1b\[[0-9;]*m//g' \
+    | grep -aoE '(FAIL|ERROR) in [a-zA-Z0-9._!?/-]+' \
+    | sed 's/^FAIL in //' \
+    | sed 's/^ERROR in //' \
+    | sort -u || true)
+  if [ -n "$failures" ]; then
+    echo "=== $jname ==="
+    echo "$failures"
+    echo
+  fi
+}
+
+if [ -n "$job_id" ]; then
+  get_failures "$job_id" "Job $job_id"
+else
+  gh run view "$run_id" --repo "$REPO" --json jobs 2>&1 \
+    | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for j in data['jobs']:
+    if j['conclusion'] == 'failure':
+        print(str(j['databaseId']) + '\t' + j['name'])
+" | while IFS=$'\t' read -r jid jname; do
+    if [ -z "$filter" ] || echo "$jname" | grep -qi "$filter"; then
+      get_failures "$jid" "$jname"
+    fi
+  done
+fi

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/api_test.clj
@@ -40,11 +40,17 @@
             (mt/id)
             (f))))
 
+;; Tests in this namespace need global (non-thread-local) setting changes because run-async!
+;; spawns virtual threads via bound-fn* which would inherit *current-connectable* from a
+;; thread-local rollback transaction, causing JDBC connection sharing issues between threads.
+;; This means tests in this namespace cannot be run with ^:parallel.
+#_{:clj-kondo/ignore [:metabase/validate-deftest]}
 (use-fixtures :each
   test-helpers/clean-remote-sync-state
   (fn [f]
-    (mt/with-premium-features #{:remote-sync}
-      (f))))
+    (mt/test-helpers-set-global-values!
+      (mt/with-premium-features #{:remote-sync}
+        (f)))))
 
 (defn- wait-for-task-completion [task-id]
   (when task-id

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
@@ -22,8 +22,11 @@
 ;; `reindex!` below is ok in a parallel test since it's not actually executing anything
 #_{:clj-kondo/ignore [:metabase/validate-deftest]}
 (use-fixtures :each (fn [f]
-                      (mt/with-dynamic-fn-redefs [search/reindex! (constantly nil)]
-                        (test-helpers/clean-remote-sync-state f))))
+                      ;; Use global values because import! reads/writes settings that need
+                      ;; to be visible across savepoint boundaries on MySQL/MariaDB
+                      (mt/test-helpers-set-global-values!
+                        (mt/with-dynamic-fn-redefs [search/reindex! (constantly nil)]
+                          (test-helpers/clean-remote-sync-state f)))))
 
 ;; import! tests
 

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/transforms_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/transforms_test.clj
@@ -23,8 +23,11 @@
 
 #_{:clj-kondo/ignore [:metabase/validate-deftest]}
 (use-fixtures :each (fn [f]
-                      (mt/with-dynamic-fn-redefs [search/reindex! (constantly nil)]
-                        (test-helpers/clean-remote-sync-state f))))
+                      ;; Use global values because import! reads/writes settings that need
+                      ;; to be visible across savepoint boundaries on MySQL/MariaDB
+                      (mt/test-helpers-set-global-values!
+                        (mt/with-dynamic-fn-redefs [search/reindex! (constantly nil)]
+                          (test-helpers/clean-remote-sync-state f)))))
 
 (deftest transform-event-creates-sync-object-when-setting-enabled-test
   (testing "Creating a transform creates a RemoteSyncObject entry when remote-sync-transforms is enabled"

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -822,21 +822,23 @@
           (is (= "https://app.example.com" origin)))))))
 
 (deftest saml-embedding-sdk-integration-includes-token-tests
-  (mt/with-temporary-setting-values [sdk-encryption-validation-key "1FlZMdousOLX9d3SSL+KuWq2+l1gfKoFM7O4ZHqKjTgabo7QdqP8US2bNPN+PqisP1QOKvesxkxOigIrvvd5OQ=="]
-    (testing "should include token in the redirect URL when embedding SDK header is present with origin"
-      (with-other-sso-types-disabled!
-        (with-saml-default-setup!
-          (let [result (client/client-real-response
-                        :get 200 "/auth/sso"
-                        {:request-options {:headers {"x-metabase-client" "embedding-sdk-react"
-                                                     "origin" "https://app.example.com"}}})
-                token (-> (get-in result [:body :url])
-                          uri->params-map
-                          :RelayState
-                          u/decode-base64
-                          uri->params-map
-                          :token)]
-            (is (not (nil? token)))))))))
+  ;; This test uses real HTTP client, so settings must be set globally
+  (mt/test-helpers-set-global-values!
+    (mt/with-temporary-setting-values [sdk-encryption-validation-key "1FlZMdousOLX9d3SSL+KuWq2+l1gfKoFM7O4ZHqKjTgabo7QdqP8US2bNPN+PqisP1QOKvesxkxOigIrvvd5OQ=="]
+      (testing "should include token in the redirect URL when embedding SDK header is present with origin"
+        (with-other-sso-types-disabled!
+          (with-saml-default-setup!
+            (let [result (client/client-real-response
+                          :get 200 "/auth/sso"
+                          {:request-options {:headers {"x-metabase-client" "embedding-sdk-react"
+                                                       "origin" "https://app.example.com"}}})
+                  token (-> (get-in result [:body :url])
+                            uri->params-map
+                            :RelayState
+                            u/decode-base64
+                            uri->params-map
+                            :token)]
+              (is (not (nil? token))))))))))
 
 (deftest saml-embedding-sdk-integration-no-embedding-tests
   (testing "should redirect to IdP when no embedding SDK header is present"

--- a/src/metabase/app_db/connection.clj
+++ b/src/metabase/app_db/connection.clj
@@ -139,14 +139,30 @@
   []
   (pos? *transaction-depth*))
 
-(defn- do-transaction [^java.sql.Connection connection f]
+(defn- do-transaction
+  "Execute `f` within a transaction on `connection`.
+
+  At the top level (depth 1), manages autocommit and commit/rollback directly, supporting
+  `:rollback-only` to rollback instead of commit on success.
+
+  At nested levels, uses savepoints for isolation so that errors in nested transactions can be
+  caught without aborting the outer transaction. When `:rollback-only` is true for a nested
+  transaction, the savepoint is rolled back on success to undo the nested changes."
+  [^java.sql.Connection connection {:keys [rollback-only]} f]
   (letfn [(thunk []
             (let [savepoint (.setSavepoint connection)]
               (try
                 (let [result (f connection)]
-                  (when (= *transaction-depth* 1)
-                    ;; top-level transaction, commit
-                    (.commit connection))
+                  (cond
+                    ;; top-level transaction: commit or rollback
+                    (= *transaction-depth* 1)
+                    (if rollback-only
+                      (.rollback connection)
+                      (.commit connection))
+
+                    ;; nested rollback-only: rollback to savepoint
+                    rollback-only
+                    (.rollback connection savepoint))
                   result)
                 (catch Throwable txn-e
                   (try
@@ -156,7 +172,6 @@
                               (str "Error rolling back after previous error: " (ex-message txn-e))
                               {:rollback-error rollback-e}
                               txn-e))))
-
                   (throw txn-e)))))]
     ;; optimization: don't set and unset autocommit if it's already false
     (if (.getAutoCommit connection)
@@ -203,7 +218,7 @@
 
     :else
     (binding [*transaction-depth* (inc *transaction-depth*)]
-      (do-transaction connection f))))
+      (do-transaction connection options f))))
 
 (methodical/defmethod t2.pipeline/transduce-query :before :default
   "Make sure application database calls are not done inside core.async dispatch pool threads. This is done relatively

--- a/src/metabase/settings/models/setting.clj
+++ b/src/metabase/settings/models/setting.clj
@@ -70,6 +70,15 @@
     "user-recent-views"
     "most-recently-viewed-dashboard"})
 
+(def ^:dynamic *env-var-overrides*
+  "Thread-local overrides for env var values. A map of env-var-keyword (as used in `environ.core/env`,
+  e.g. `:mb-api-key`) to string value. A value of `\"\"` (empty string) means 'explicitly unset' --
+  [[env-var-value]] will treat it the same as an empty env var (i.e., return nil via `not-empty`).
+
+  Used by test helpers like `do-with-temporary-setting-value` to override env-var-backed settings in a
+  thread-safe manner without modifying global `env/env`."
+  nil)
+
 (def ^:dynamic *allow-retired-setting-names*
   "A dynamic val that controls whether it's allowed to use retired settings.
   Primarily used in test to disable retired setting check."
@@ -477,12 +486,18 @@
   (let [setting (resolve-setting setting-definition-or-name)]
     (when (and (allows-site-wide-values? setting)
                (allows-setting-via-env? setting))
-      (if-let [v (env/env (setting-env-map-name setting))]
-        ;; primary env var is set — return it only if non-empty
-        (not-empty v)
-        ;; primary env var is absent — try deprecated name
-        (when-let [deprecated-name (:deprecated-name setting)]
-          (not-empty (env/env (setting-env-map-name deprecated-name))))))))
+      (let [env-kw (setting-env-map-name setting)]
+        (if-some [entry (when *env-var-overrides*
+                          (find *env-var-overrides* env-kw))]
+          ;; thread-local override found — use its val ("" means explicitly unset, not-empty returns nil)
+          (not-empty (val entry))
+          ;; no override — fall through to env/env
+          (if-let [v (env/env env-kw)]
+            ;; primary env var is set — return it only if non-empty
+            (not-empty v)
+            ;; primary env var is absent — try deprecated name
+            (when-let [deprecated-name (:deprecated-name setting)]
+              (not-empty (env/env (setting-env-map-name deprecated-name))))))))))
 
 (defn log-deprecated-env-var-usage!
   "Log warnings for any settings currently using a deprecated env var name.
@@ -614,7 +629,7 @@
 
   1. From [[*user-local-values*]] if this Setting is allowed to have User-local values
   2. From [[*database-local-values*]] if this Setting is allowed to have Database-local values
-  3. From the corresponding env var (excluding empty string values)
+  3. From the corresponding env var (excluding empty string values), checking [[*env-var-overrides*]] first
   4. From the application database (i.e., set via the admin panel) (excluding empty string values)
   5. The default value, if one was specified
 

--- a/src/metabase/settings/models/setting/cache.clj
+++ b/src/metabase/settings/models/setting/cache.clj
@@ -1,6 +1,10 @@
 (ns metabase.settings.models.setting.cache
   "Settings cache. Cache is a 1:1 mapping of what's in the DB. Cached lookup time is ~60µs, compared to ~1800µs for DB
-  lookup."
+   lookup.
+
+   The cache supports thread-local isolation via dynamic vars. When [[*cache-atom*]], [[*restore-cache-lock*]], and
+   [[*last-update-check*]] are bound, operations use those instead of the global state. Use [[with-isolated-cache]] to
+   bind all three together for complete thread isolation."
   (:require
    [clojure.core :as core]
    [clojure.java.jdbc :as jdbc]
@@ -15,36 +19,142 @@
 
 (set! *warn-on-reflection* true)
 
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                         call-on-change multimethod                                              |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
 (defmulti call-on-change
   "Whenever something changes in the Settings cache it will invoke
 
-    (call-on-change old-cache new-cache
+    (call-on-change old-cache new-cache)
 
   Actual implementation is provided in [[metabase.settings.models.setting]] rather than here (to prevent
   circular references)."
   {:arglists '([old new])}
   (constantly :default))
 
-;; Setting cache is unique to the application DB; if it's swapped out for tests or mocking or whatever then use a new
-;; cache.
-(def ^:private ^{:arglists '([])} cache*
-  (mdb/memoize-for-application-db
-   (fn []
-     (doto (atom nil)
-       (add-watch :call-on-change (fn [_key _ref old new]
-                                    (call-on-change old new)))))))
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                       Thread-local bindable state                                               |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(def ^:dynamic *cache-atom*
+  "When bound, use this atom for the settings cache instead of the global cache.
+   The atom should have a `call-on-change` watch installed; use [[new-cache-atom]] to create one."
+  nil)
+
+(def ^:dynamic *restore-cache-lock*
+  "When bound, use this ReentrantLock for cache restoration instead of the global lock."
+  nil)
+
+(def ^:dynamic *last-update-check*
+  "When bound, use this AtomicLong for tracking last update check time instead of the global one."
+  nil)
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                              Global defaults                                                    |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(defn new-cache-atom
+  "Create a new cache atom with the `call-on-change` watch installed.
+   Use this when creating atoms for [[*cache-atom*]] binding."
+  ([]
+   (new-cache-atom nil))
+  ([initial-value]
+   (doto (atom initial-value)
+     (add-watch :call-on-change (fn [_key _ref old new]
+                                  (call-on-change old new))))))
+
+;; Global cache - unique per application DB. When the application DB is swapped (e.g. in tests), a new cache is used.
+(def ^:private ^{:arglists '([])} global-cache*
+  (mdb/memoize-for-application-db new-cache-atom))
+
+(defonce ^:private ^ReentrantLock global-restore-cache-lock (ReentrantLock.))
+
+(defonce ^:private ^AtomicLong global-last-update-check (AtomicLong. 0))
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                                 Accessors                                                       |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(defn- cache-atom
+  "Returns the current cache atom - thread-local override if bound, otherwise the global cache."
+  []
+  (or *cache-atom* (global-cache*)))
+
+(defn- restore-lock
+  "Returns the current restore lock - thread-local override if bound, otherwise the global lock."
+  ^ReentrantLock []
+  (or *restore-cache-lock* global-restore-cache-lock))
+
+(defn- update-check-timestamp
+  "Returns the current update check timestamp - thread-local override if bound, otherwise the global one."
+  ^AtomicLong []
+  (or *last-update-check* global-last-update-check))
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                          Isolated cache context                                                 |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(defn do-with-isolated-cache
+  "Execute `thunk` with an isolated settings cache context. The cache atom, lock, and update timestamp are all
+   thread-local, providing complete isolation from global state.
+
+   If `initial-cache` is provided (a map of setting-name string -> value string), the cache starts with that value.
+   Otherwise it starts empty and will be populated from the DB on first access via [[restore-cache-if-needed!]]."
+  ([thunk]
+   (do-with-isolated-cache nil thunk))
+  ([initial-cache thunk]
+   (binding [*cache-atom*         (new-cache-atom initial-cache)
+             *restore-cache-lock* (ReentrantLock.)
+             *last-update-check*  (AtomicLong. 0)]
+     (thunk))))
+
+(defmacro with-isolated-cache
+  "Execute body with an isolated settings cache context. The cache, lock, and update timestamp are all thread-local.
+
+   Example:
+     (with-isolated-cache
+       (setting/set! :my-setting \"test-value\")
+       ;; changes only visible in this thread
+       (setting/get :my-setting))"
+  {:style/indent 0}
+  [& body]
+  `(do-with-isolated-cache (fn [] ~@body)))
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                            Public cache API                                                     |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(def ^String settings-last-updated-key
+  "Internal key used to store the last updated timestamp for Settings."
+  "settings-last-updated")
 
 (defn cache
   "Fetch the current contents of the Settings cache, a map of key (string) -> value (string)."
   []
-  @(cache*))
+  @(cache-atom))
 
 (defn update-cache!
   "Update the String value of a Setting in the Settings cache."
   [setting-name, ^String new-value]
   (if (seq new-value)
-    (swap! (cache*) assoc  setting-name new-value)
-    (swap! (cache*) dissoc setting-name)))
+    (swap! (cache-atom) assoc setting-name new-value)
+    (swap! (cache-atom) dissoc setting-name)))
+
+(defn cache-last-updated-at
+  "Fetch the value of `settings-last-updated`, indicating the timestamp of the settings cache. Possibly null."
+  []
+  (core/get (cache) settings-last-updated-key))
+
+(defn restore-cache!
+  "Populate cache with the latest hotness from the db"
+  []
+  (log/debug "Refreshing Settings cache...")
+  (reset! (cache-atom) (t2/select-fn->fn :key :value :model/Setting)))
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                          Cache synchronization                                                  |
+;;; +----------------------------------------------------------------------------------------------------------------+
 
 ;; CACHE SYNCHRONIZATION
 ;;
@@ -64,45 +174,21 @@
 ;; and comparing values of `settings-last-updated`. Because the Setting table itself only stores text values, we'll
 ;; need to cast it between TEXT and TIMESTAMP SQL types as needed.
 
-(def ^String settings-last-updated-key
-  "Internal key used to store the last updated timestamp for Settings."
-  "settings-last-updated")
+(def ^:const cache-update-check-interval-ms
+  "How often we should check whether the Settings cache is out of date (which requires a DB call)?"
+  (u/minutes->ms 1))
 
-(defn update-settings-last-updated!
-  "Update the value of `settings-last-updated` in the DB; if the row does not exist, insert one."
+(defn- time-for-another-update-check?
+  "Has it has been more than a minute since the last time we checked for updates?"
   []
-  (log/debug "Updating value of settings-last-updated in DB...")
-  ;; for MySQL, cast(current_timestamp AS char); for H2 & Postgres, cast(current_timestamp AS text)
-  (let [current-timestamp-as-string-honeysql (h2x/cast (if (= (mdb/db-type) :mysql) :char :text)
-                                                       [:raw "current_timestamp"])]
-    ;; attempt to UPDATE the existing row. If no row exists, `t2/update!` will return 0...
-    (or (pos? (t2/update! :setting  {:key settings-last-updated-key} {:value current-timestamp-as-string-honeysql}))
-        ;; ...at which point we will try to INSERT a new row. Note that it is entirely possible two instances can both
-        ;; try to INSERT it at the same time; one instance would fail because it would violate the PK constraint on
-        ;; `key`, and throw a SQLException. As long as one instance updates the value, we are fine, so we can go ahead
-        ;; and ignore that Exception if one is thrown.
-        (try
-          ;; Use `simple-insert!` because we do *not* want to trigger pre-insert behavior, such as encrypting `:value`
-          (t2/insert! (t2/table-name (t2/resolve-model :model/Setting)) :key settings-last-updated-key, :value current-timestamp-as-string-honeysql)
-          (catch java.sql.SQLException e
-            ;; go ahead and log the Exception anyway on the off chance that it *wasn't* just a race condition issue
-            (log/errorf "Error updating Settings last updated value: %s"
-                        (with-out-str (jdbc/print-sql-exception-chain e)))))))
-  ;; Now that we updated the value in the DB, go ahead and update our cached value as well, because we know about the
-  ;; changes
-  (swap! (cache*) assoc settings-last-updated-key (t2/select-one-fn :value :model/Setting :key settings-last-updated-key)))
-
-(defn cache-last-updated-at
-  "Fetch the value of `settings-last-updated`, indicating the timestamp of the settings cache. Possibly null."
-  []
-  (let [current-cache (cache)]
-    (core/get current-cache settings-last-updated-key)))
+  (> (quot (- (System/nanoTime) (.get (update-check-timestamp))) 1000000)
+     cache-update-check-interval-ms))
 
 (defn- cache-out-of-date?
   "Check whether our Settings cache is out of date. We know the cache is out of date if either of the following
   conditions is true:
 
-   *  The cache is empty (the `(cache*` atom is `nil`), which of course means it needs to be updated
+   *  The cache is empty (the cache atom is `nil`), which of course means it needs to be updated
    *  There is a value of `settings-last-updated` in the cache, and it is older than the value of in the DB. (There
       will be no value until the first time a normal Setting is updated; thus if it is not yet set, we do not yet need
       to invalidate our cache.)"
@@ -126,26 +212,6 @@
           (when <>
             (log/info (u/format-color :red "Settings have been changed on another instance, and will be reloaded here.")))))))))
 
-(def ^:const cache-update-check-interval-ms
-  "How often we should check whether the Settings cache is out of date (which requires a DB call)?"
-  (u/minutes->ms 1))
-
-(defonce ^:private ^AtomicLong last-update-check (AtomicLong. 0))
-
-(defn- time-for-another-update-check?
-  "Has it has been more than a minute since the last time we checked for updates?"
-  []
-  (> (quot (- (System/nanoTime) (.get last-update-check)) 1000000)
-     cache-update-check-interval-ms))
-
-(defn restore-cache!
-  "Populate cache with the latest hotness from the db"
-  []
-  (log/debug "Refreshing Settings cache...")
-  (reset! (cache*) (t2/select-fn->fn :key :value :model/Setting)))
-
-(defonce ^:private ^ReentrantLock restore-cache-lock (ReentrantLock.))
-
 (defn restore-cache-if-needed!
   "Check whether we need to repopulate the cache with fresh values from the DB (because the cache is either empty or
   known to be out-of-date), and do so if needed. This is intended to be called every time a Setting value is
@@ -159,14 +225,42 @@
   ;; This is not desirable, since either situation would result in duplicate work. Better to just add a quick lock
   ;; here so only one of them does it, since at any rate waiting for the other thread to finish the task in progress is
   ;; certainly quicker than starting the task ourselves from scratch
-  (when (time-for-another-update-check?)
-    ;; if the lock is not already held by any thread, including this one...
-    (when-not (.isLocked restore-cache-lock)
-      ;; attempt to acquire the lock. Returns immediately if lock is already held.
-      (when (.tryLock restore-cache-lock)
+  (let [lock (restore-lock)]
+    (when (time-for-another-update-check?)
+      ;; if the lock is not already held by any thread, including this one...
+      (when-not (.isLocked lock)
+        ;; attempt to acquire the lock. Returns immediately if lock is already held.
+        (when (.tryLock lock)
+          (try
+            (.set (update-check-timestamp) (System/nanoTime))
+            (when (cache-out-of-date?)
+              (restore-cache!))
+            (finally
+              (.unlock lock))))))))
+
+(defn update-settings-last-updated!
+  "Update the value of `settings-last-updated` in the DB; if the row does not exist, insert one."
+  []
+  (log/debug "Updating value of settings-last-updated in DB...")
+  ;; for MySQL, cast(current_timestamp AS char); for H2 & Postgres, cast(current_timestamp AS text)
+  (let [current-timestamp-as-string-honeysql (h2x/cast (if (= (mdb/db-type) :mysql) :char :text)
+                                                       [:raw "current_timestamp"])]
+    ;; attempt to UPDATE the existing row. If no row exists, `t2/update!` will return 0...
+    (or (pos? (t2/update! :setting {:key settings-last-updated-key} {:value current-timestamp-as-string-honeysql}))
+        ;; ...at which point we will try to INSERT a new row. Note that it is entirely possible two instances can both
+        ;; try to INSERT it at the same time; one instance would fail because it would violate the PK constraint on
+        ;; `key`, and throw a SQLException. As long as one instance updates the value, we are fine, so we can go ahead
+        ;; and ignore that Exception if one is thrown.
         (try
-          (.set last-update-check (System/nanoTime))
-          (when (cache-out-of-date?)
-            (restore-cache!))
-          (finally
-            (.unlock restore-cache-lock)))))))
+          ;; Use `simple-insert!` because we do *not* want to trigger pre-insert behavior, such as encrypting `:value`
+          (t2/insert! (t2/table-name (t2/resolve-model :model/Setting))
+                      :key settings-last-updated-key
+                      :value current-timestamp-as-string-honeysql)
+          (catch java.sql.SQLException e
+            ;; go ahead and log the Exception anyway on the off chance that it *wasn't* just a race condition issue
+            (log/errorf "Error updating Settings last updated value: %s"
+                        (with-out-str (jdbc/print-sql-exception-chain e)))))))
+  ;; Now that we updated the value in the DB, go ahead and update our cached value as well, because we know about the
+  ;; changes
+  (swap! (cache-atom) assoc settings-last-updated-key
+         (t2/select-one-fn :value :model/Setting :key settings-last-updated-key)))

--- a/test/metabase/analytics/snowplow_test.clj
+++ b/test/metabase/analytics/snowplow_test.clj
@@ -114,11 +114,16 @@
 
 (deftest ip-address-override-test
   (testing "IP address on Snowplow subject is overridden with a dummy value (127.0.0.1)"
-    (with-fake-snowplow-collector
-      (mt/with-test-user :rasta
-        (analytics/track-event! :snowplow/dashboard {:dashboard-id 1})
-        (is (partial= {:uid (str (mt/user->id :rasta)) :ip "127.0.0.1"}
-                      (:subject (first @*snowplow-collector*))))))))
+    ;; with-fake-snowplow-collector uses with-redefs, so must use global values
+    (mt/test-helpers-set-global-values!
+      (with-fake-snowplow-collector
+        (mt/with-test-user :rasta
+          (analytics/track-event! :snowplow/dashboard {:dashboard-id 1})
+          ;; Use `last` because the instance-creation setting's lazy getter can fire a
+          ;; new_instance_created event via track-event-impl! during the context() call
+          ;; inside our track-event! call above, if instance-creation hasn't been persisted yet.
+          (is (partial= {:uid (str (mt/user->id :rasta)) :ip "127.0.0.1"}
+                        (:subject (last @*snowplow-collector*)))))))))
 
 (deftest track-event-test
   (with-fake-snowplow-collector

--- a/test/metabase/app_db/connection_test.clj
+++ b/test/metabase/app_db/connection_test.clj
@@ -134,6 +134,42 @@
             (when-not (is-transaction-exception? e)
               (throw e))))))))
 
+(deftest rollback-only-top-level-test
+  (let [email (mt/random-email)]
+    (t2/with-transaction [_ nil {:rollback-only true}]
+      (t2/insert! :model/User (assoc (mt/with-temp-defaults :model/User) :email email))
+      (is (t2/exists? :model/User :email email)
+          "user should exist inside the transaction"))
+    (is (not (t2/exists? :model/User :email email))
+        "user should NOT exist after rollback-only transaction completes")))
+
+(deftest rollback-only-nested-test
+  (let [email-outer              (mt/random-email)
+        email-inner              (mt/random-email)
+        transaction-exception    (Exception. "(abort)")
+        is-transaction-exception (fn is-tx? [e]
+                                   (or (identical? e transaction-exception)
+                                       (some-> (ex-cause e) is-tx?)))]
+    (try
+      (t2/with-transaction []
+        (t2/insert! :model/User (assoc (mt/with-temp-defaults :model/User) :email email-outer))
+        (t2/with-transaction [_ nil {:rollback-only true}]
+          (t2/insert! :model/User (assoc (mt/with-temp-defaults :model/User) :email email-inner))
+          (is (t2/exists? :model/User :email email-inner)
+              "inner user should exist inside rollback-only transaction"))
+        (is (not (t2/exists? :model/User :email email-inner))
+            "inner user should NOT exist after rollback-only transaction")
+        (is (t2/exists? :model/User :email email-outer)
+            "outer user should still exist")
+        (throw transaction-exception))
+      (catch Exception e
+        (when-not (is-transaction-exception e)
+          (throw e))))
+    (is (not (t2/exists? :model/User :email email-outer))
+        "outer user should not exist after outer transaction aborted")
+    (is (not (t2/exists? :model/User :email email-inner))
+        "inner user should not exist after outer transaction aborted")))
+
 (deftest ^:parallel transaction-isolation-level-test
   (testing "We should always use READ_COMMITTED for the app DB (#44505)"
     (with-open [conn (.getConnection mdb.connection/*application-db*)]

--- a/test/metabase/channel/api/email_test.clj
+++ b/test/metabase/channel/api/email_test.clj
@@ -134,24 +134,26 @@
 
 (deftest clear-email-settings-test
   (testing "DELETE /api/email"
-    (mt/with-temp-env-var-value! [MB_EMAIL_SMTP_HOST     nil
-                                  MB_EMAIL_SMTP_PORT  nil
-                                  MB_EMAIL_SMTP_SECURITY nil
-                                  MB_EMAIL_SMTP_USERNAME nil
-                                  MB_EMAIL_SMTP_PASSWORD nil]
-      (tu/discard-setting-changes [email-smtp-host email-smtp-port email-smtp-security email-smtp-username email-smtp-password]
-        (with-redefs [email/test-smtp-settings (constantly {::email/error nil})]
-          (is (= (-> default-email-settings
-                     (assoc :with-corrections {})
-                     (update :email-smtp-security name))
-                 (mt/user-http-request :crowberto :put 200 "email" default-email-settings)))
-          (let [new-email-settings (email-settings)]
-            (is (nil? (mt/user-http-request :crowberto :delete 204 "email")))
-            (is (= default-email-settings
-                   new-email-settings))
-            (is (= {:email-smtp-host     nil
-                    :email-smtp-port     nil
-                    :email-smtp-security :none
-                    :email-smtp-username nil
-                    :email-smtp-password nil}
-                   (email-settings)))))))))
+    ;; This test modifies settings via HTTP API and reads them back, so settings must be set globally
+    (mt/test-helpers-set-global-values!
+      (mt/with-temp-env-var-value! [MB_EMAIL_SMTP_HOST     nil
+                                    MB_EMAIL_SMTP_PORT  nil
+                                    MB_EMAIL_SMTP_SECURITY nil
+                                    MB_EMAIL_SMTP_USERNAME nil
+                                    MB_EMAIL_SMTP_PASSWORD nil]
+        (tu/discard-setting-changes [email-smtp-host email-smtp-port email-smtp-security email-smtp-username email-smtp-password]
+          (with-redefs [email/test-smtp-settings (constantly {::email/error nil})]
+            (is (= (-> default-email-settings
+                       (assoc :with-corrections {})
+                       (update :email-smtp-security name))
+                   (mt/user-http-request :crowberto :put 200 "email" default-email-settings)))
+            (let [new-email-settings (email-settings)]
+              (is (nil? (mt/user-http-request :crowberto :delete 204 "email")))
+              (is (= default-email-settings
+                     new-email-settings))
+              (is (= {:email-smtp-host     nil
+                      :email-smtp-port     nil
+                      :email-smtp-security :none
+                      :email-smtp-username nil
+                      :email-smtp-password nil}
+                     (email-settings))))))))))

--- a/test/metabase/cloud_migration/api_test.clj
+++ b/test/metabase/cloud_migration/api_test.clj
@@ -8,9 +8,14 @@
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 
+;; Tests in this namespace directly mutate settings (e.g. read-only-mode!) and make HTTP calls
+;; that need to see the mutated values. This requires global (non-thread-local) setting changes,
+;; which means tests in this namespace cannot be run with ^:parallel.
+#_{:clj-kondo/ignore [:metabase/validate-deftest]}
 (use-fixtures :each (fn [thunk]
-                      (mt/discard-setting-changes [read-only-mode]
-                        (thunk))))
+                      (mt/test-helpers-set-global-values!
+                        (mt/discard-setting-changes [read-only-mode]
+                          (thunk)))))
 
 (set! *warn-on-reflection* true)
 

--- a/test/metabase/cloud_migration/models/cloud_migration_test.clj
+++ b/test/metabase/cloud_migration/models/cloud_migration_test.clj
@@ -10,8 +10,9 @@
    [toucan2.core :as t2]))
 
 (use-fixtures :each (fn [thunk]
-                      (mt/discard-setting-changes [read-only-mode]
-                        (thunk))))
+                      (mt/test-helpers-set-global-values!
+                        (mt/discard-setting-changes [read-only-mode]
+                          (thunk)))))
 
 (defmacro mock-external-calls!
   "Mock external calls around migration creation."

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -1238,24 +1238,25 @@
 ;;; ------------------------------------------------ Timezone-related ------------------------------------------------
 
 (deftest timezone-test
-  (mt/test-driver :postgres
-    (letfn [(get-timezone-with-report-timezone [report-timezone]
-              (mt/with-temporary-setting-values [report-timezone report-timezone]
-                (ffirst
-                 (mt/rows
-                  (qp/process-query {:database (mt/id)
-                                     :type     :native
-                                     :native   {:query "SELECT current_setting('TIMEZONE') AS timezone;"}})))))]
-      (testing "check that if we set report-timezone to US/Pacific that the session timezone is in fact US/Pacific"
-        (is  (= "America/Los_Angeles"
-                (get-timezone-with-report-timezone "America/Los_Angeles"))))
-      (testing "check that we can set it to something else: America/Chicago"
-        (is (= "America/Chicago"
-               (get-timezone-with-report-timezone "America/Chicago"))))
-      (testing (str "ok, check that if we try to put in a fake timezone that the query still reëxecutes without a "
-                    "custom timezone. This should give us the same result as if we didn't try to set a timezone at all")
-        (is (= (get-timezone-with-report-timezone nil)
-               (get-timezone-with-report-timezone "Crunk Burger")))))))
+  (mt/test-helpers-set-global-values!
+    (mt/test-driver :postgres
+      (letfn [(get-timezone-with-report-timezone [report-timezone]
+                (mt/with-temporary-setting-values [report-timezone report-timezone]
+                  (ffirst
+                   (mt/rows
+                    (qp/process-query {:database (mt/id)
+                                       :type     :native
+                                       :native   {:query "SELECT current_setting('TIMEZONE') AS timezone;"}})))))]
+        (testing "check that if we set report-timezone to US/Pacific that the session timezone is in fact US/Pacific"
+          (is  (= "America/Los_Angeles"
+                  (get-timezone-with-report-timezone "America/Los_Angeles"))))
+        (testing "check that we can set it to something else: America/Chicago"
+          (is (= "America/Chicago"
+                 (get-timezone-with-report-timezone "America/Chicago"))))
+        (testing (str "ok, check that if we try to put in a fake timezone that the query still reëxecutes without a "
+                      "custom timezone. This should give us the same result as if we didn't try to set a timezone at all")
+          (is (= (get-timezone-with-report-timezone nil)
+                 (get-timezone-with-report-timezone "Crunk Burger"))))))))
 
 (deftest fingerprint-time-fields-test
   (mt/test-driver :postgres

--- a/test/metabase/metabot/example_question_generator_test.clj
+++ b/test/metabase/metabot/example_question_generator_test.clj
@@ -163,25 +163,27 @@
 
 (deftest call-llm-snowplow-test
   (testing "fires token_usage snowplow event for call-llm"
-    (let [rasta-id (mt/user->id :rasta)]
-      (mt/with-temporary-setting-values [llm-metabot-provider "openrouter/test-model"]
-        (with-redefs [openrouter/openrouter
-                      (constantly (test-util/mock-llm-response
-                                   [{:type :start :id "msg-1"}
-                                    {:type :tool-input :id "call-1" :function "json"
-                                     :arguments {:questions ["q1"]}}
-                                    {:type :usage :usage {:promptTokens 100 :completionTokens 20}
-                                     :model "test-model" :id "msg-1"}]))]
-          (mt/with-current-user rasta-id
-            (snowplow-test/with-fake-snowplow-collector
-              (#'native-generator/call-llm "test prompt")
-              (is (=? [{:user-id (str rasta-id)
-                        :data    {"model_id"           "openrouter/test-model"
-                                  "total_tokens"        120
-                                  "prompt_tokens"       100
-                                  "completion_tokens"   20
-                                  "estimated_costs_usd" 0.0
-                                  "duration_ms"         nat-int?
-                                  "source"              "example_question_generation_batch"
-                                  "tag"                 "example-question-generation"}}]
-                      (snowplow-test/pop-event-data-and-user-id!))))))))))
+    ;; with-fake-snowplow-collector uses with-redefs, so must use global values
+    (mt/test-helpers-set-global-values!
+      (let [rasta-id (mt/user->id :rasta)]
+        (mt/with-temporary-setting-values [llm-metabot-provider "openrouter/test-model"]
+          (with-redefs [openrouter/openrouter
+                        (constantly (test-util/mock-llm-response
+                                     [{:type :start :id "msg-1"}
+                                      {:type :tool-input :id "call-1" :function "json"
+                                       :arguments {:questions ["q1"]}}
+                                      {:type :usage :usage {:promptTokens 100 :completionTokens 20}
+                                       :model "test-model" :id "msg-1"}]))]
+            (mt/with-current-user rasta-id
+              (snowplow-test/with-fake-snowplow-collector
+                (#'native-generator/call-llm "test prompt")
+                (is (=? [{:user-id (str rasta-id)
+                          :data    {"model_id"           "openrouter/test-model"
+                                    "total_tokens"        120
+                                    "prompt_tokens"       100
+                                    "completion_tokens"   20
+                                    "estimated_costs_usd" 0.0
+                                    "duration_ms"         nat-int?
+                                    "source"              "example_question_generation_batch"
+                                    "tag"                 "example-question-generation"}}]
+                        (snowplow-test/pop-event-data-and-user-id!)))))))))))

--- a/test/metabase/premium_features/api_test.clj
+++ b/test/metabase/premium_features/api_test.clj
@@ -49,9 +49,11 @@
 
 (deftest token-refresh-sets-premium-features-cookie-test
   (testing "POST /api/premium-features/token/refresh sets the premium-features-last-updated cookie"
-    (mt/with-random-premium-token! [_token]
-      (let [cs (cookies/cookie-store)]
-        (mt/user-real-request :crowberto :post 200 "premium-features/token/refresh"
-                              {:request-options {:cookie-store cs}})
-        (let [pf-cookie (get (cookies/get-cookies cs) "metabase.PREMIUM_FEATURES_LAST_UPDATED")]
-          (is (some? pf-cookie) "No premium-features-last-updated cookie set"))))))
+    ;; This test uses real HTTP client, so settings must be set globally
+    (mt/test-helpers-set-global-values!
+      (mt/with-random-premium-token! [_token]
+        (let [cs (cookies/cookie-store)]
+          (mt/user-real-request :crowberto :post 200 "premium-features/token/refresh"
+                                {:request-options {:cookie-store cs}})
+          (let [pf-cookie (get (cookies/get-cookies cs) "metabase.PREMIUM_FEATURES_LAST_UPDATED")]
+            (is (some? pf-cookie) "No premium-features-last-updated cookie set")))))))

--- a/test/metabase/query_processor/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor/date_time_zone_functions_test.clj
@@ -1173,21 +1173,22 @@
 
 ;;; there is an Athena version of this test in [[metabase.driver.athena-test/datetime-diff-time-zones-test]]
 (deftest datetime-diff-time-zones-test
-  (mt/test-drivers (mt/normal-drivers-with-feature :datetime-diff :test/timestamptz-type)
-    (mt/dataset diff-time-zones-cases
-      (let [diffs (fn [a-str b-str]
-                    (let [units [:second :minute :hour :day :week :month :quarter :year]]
-                      (->> (mt/run-mbql-query times
-                             {:filter [:and [:= a-str $a_dt_tz_text] [:= b-str $b_dt_tz_text]]
-                              :expressions (into {} (for [unit units]
-                                                      [(name unit) [:datetime-diff $a_dt_tz $b_dt_tz unit]]))
-                              :fields (into [] (for [unit units]
-                                                 [:expression (name unit)]))})
-                           (mt/formatted-rows
-                            (repeat (count units) int))
-                           first
-                           (zipmap units))))]
-        (run-datetime-diff-time-zone-tests! diffs)))))
+  (mt/test-helpers-set-global-values!
+    (mt/test-drivers (mt/normal-drivers-with-feature :datetime-diff :test/timestamptz-type)
+      (mt/dataset diff-time-zones-cases
+        (let [diffs (fn [a-str b-str]
+                      (let [units [:second :minute :hour :day :week :month :quarter :year]]
+                        (->> (mt/run-mbql-query times
+                               {:filter [:and [:= a-str $a_dt_tz_text] [:= b-str $b_dt_tz_text]]
+                                :expressions (into {} (for [unit units]
+                                                        [(name unit) [:datetime-diff $a_dt_tz $b_dt_tz unit]]))
+                                :fields (into [] (for [unit units]
+                                                   [:expression (name unit)]))})
+                             (mt/formatted-rows
+                              (repeat (count units) int))
+                             first
+                             (zipmap units))))]
+          (run-datetime-diff-time-zone-tests! diffs))))))
 
 (deftest ^:parallel datetime-diff-expressions-test
   (mt/test-drivers (mt/normal-drivers-with-feature :datetime-diff)

--- a/test/metabase/query_processor/streaming_test.clj
+++ b/test/metabase/query_processor/streaming_test.clj
@@ -270,8 +270,9 @@
                   :time           #inst "1899-12-31T00:23:18.000-00:00"
                   :time-ltz       #inst "1899-12-31T07:23:18.000-00:00"
                   :time-tz        #inst "1899-12-31T07:23:18.000-00:00"})))
-            (mt/with-temporary-setting-values [report-timezone "US/Pacific"]
-              (test-results
+            (mt/test-helpers-set-global-values!
+              (mt/with-temporary-setting-values [report-timezone "US/Pacific"]
+                (test-results
                (case export-format
                  (:csv :json)
                  ;; With the updates to make exports conform with FE behavior (See #36726) dates and times are now
@@ -303,7 +304,7 @@
                   :datetime-tz-id #inst "2019-11-01T00:23:18.331-00:00"
                   :time           #inst "1899-12-31T00:23:18.000-00:00"
                   :time-ltz       #inst "1899-12-31T23:23:18.000-00:00"
-                  :time-tz        #inst "1899-12-31T23:23:18.000-00:00"})))))))))
+                  :time-tz        #inst "1899-12-31T23:23:18.000-00:00"}))))))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                             Export E2E tests                                                   |

--- a/test/metabase/query_processor/timezones_test.clj
+++ b/test/metabase/query_processor/timezones_test.clj
@@ -42,30 +42,31 @@
 
 ;; TODO - we should also do similar tests for timezone-unaware columns
 (deftest result-rows-test
-  (mt/dataset tz-test-data
-    (mt/test-drivers (timezone-aware-column-drivers)
-      (is (= [[12 "2014-07-03T01:30:00Z"]
-              [10 "2014-07-03T19:30:00Z"]]
-             (mt/formatted-rows
-              [int identity]
-              (mt/run-mbql-query users
-                {:fields   [$id $last_login]
-                 :filter   [:= $id 10 12]
-                 :order-by [[:asc $last_login]]})))
-          "Basic sanity check: make sure the rows come back with the values we'd expect without setting report-timezone"))
-    (mt/test-drivers (set-timezone-drivers)
-      (doseq [[timezone expected-rows] {"UTC"        [[12 "2014-07-03T01:30:00Z"]
-                                                      [10 "2014-07-03T19:30:00Z"]]
-                                        "America/Los_Angeles" [[10 "2014-07-03T12:30:00-07:00"]]}]
-        (mt/with-temporary-setting-values [report-timezone timezone]
-          (is (= expected-rows
-                 (mt/formatted-rows
-                  [int identity]
-                  (mt/run-mbql-query users
-                    {:fields   [$id $last_login]
-                     :filter   [:= $last_login "2014-07-03"]
-                     :order-by [[:asc $last_login]]})))
-              (format "There should be %d checkins on July 3rd in the %s timezone" (count expected-rows) timezone)))))))
+  (mt/test-helpers-set-global-values!
+    (mt/dataset tz-test-data
+      (mt/test-drivers (timezone-aware-column-drivers)
+        (is (= [[12 "2014-07-03T01:30:00Z"]
+                [10 "2014-07-03T19:30:00Z"]]
+               (mt/formatted-rows
+                [int identity]
+                (mt/run-mbql-query users
+                  {:fields   [$id $last_login]
+                   :filter   [:= $id 10 12]
+                   :order-by [[:asc $last_login]]})))
+            "Basic sanity check: make sure the rows come back with the values we'd expect without setting report-timezone"))
+      (mt/test-drivers (set-timezone-drivers)
+        (doseq [[timezone expected-rows] {"UTC"        [[12 "2014-07-03T01:30:00Z"]
+                                                        [10 "2014-07-03T19:30:00Z"]]
+                                          "America/Los_Angeles" [[10 "2014-07-03T12:30:00-07:00"]]}]
+          (mt/with-temporary-setting-values [report-timezone timezone]
+            (is (= expected-rows
+                   (mt/formatted-rows
+                    [int identity]
+                    (mt/run-mbql-query users
+                      {:fields   [$id $last_login]
+                       :filter   [:= $last_login "2014-07-03"]
+                       :order-by [[:asc $last_login]]})))
+                (format "There should be %d checkins on July 3rd in the %s timezone" (count expected-rows) timezone))))))))
 
 (deftest filter-test
   (mt/dataset tz-test-data

--- a/test/metabase/server/middleware/settings_cache_test.clj
+++ b/test/metabase/server/middleware/settings_cache_test.clj
@@ -32,29 +32,31 @@
     (.addCookie cs cookie)))
 
 (deftest setting-settings-include-timestamp
-  (mt/discard-setting-changes [site-name]
-    (let [^CookieStore cs (cookies/cookie-store)]
-      (testing "it sets the cookie when updating settings"
-        (mt/user-real-request  :crowberto :put 204 "setting/site-name"
-                               {:request-options {:cookie-store cs}}
-                               {:value "foo"})
-        (let [setting-cookie (get (cookies/get-cookies cs) cookie-name)]
-          (is (some? setting-cookie) "No cookie set")
-          (is (= (setting/cache-last-updated-at)
-                 (-> setting-cookie :value codec/form-decode))
-              "Cookie value is not most recent cache updated at timestamp")))
+  ;; Uses real HTTP client + with-redefs, so must use global values
+  (mt/test-helpers-set-global-values!
+    (mt/discard-setting-changes [site-name]
+      (let [^CookieStore cs (cookies/cookie-store)]
+        (testing "it sets the cookie when updating settings"
+          (mt/user-real-request  :crowberto :put 204 "setting/site-name"
+                                 {:request-options {:cookie-store cs}}
+                                 {:value "foo"})
+          (let [setting-cookie (get (cookies/get-cookies cs) cookie-name)]
+            (is (some? setting-cookie) "No cookie set")
+            (is (= (setting/cache-last-updated-at)
+                   (-> setting-cookie :value codec/form-decode))
+                "Cookie value is not most recent cache updated at timestamp")))
 
-      (testing "And when that timestamp is outdated it restores the setting cache"
-        (let [calls (atom 0)]
+        (testing "And when that timestamp is outdated it restores the setting cache"
+          (let [calls (atom 0)]
           ;; value in 2042 to simulate client has more recent settings
-          (update-cookie cs cookie-name "2042-12-02+19%3A57%3A49.775909%2B00")
-          (with-redefs [setting/restore-cache! (fn [] (swap! calls inc))]
-            (mt/user-real-request :crowberto :get 200 "user/current"
-                                  {:request-options {:cookie-store cs}})
-            (is (= 1 @calls) "Cache was not restored based on cookie value")
-            (testing "And that header resets the settings last updated at so we don't keep updating the cache"
-              (let [setting-cookie (get (cookies/get-cookies cs) cookie-name)]
-                (is (some? setting-cookie) "No cookie set")
-                (is (= (setting/cache-last-updated-at)
-                       (-> setting-cookie :value codec/form-decode))
-                    "The most recent updated at was not set in the header")))))))))
+            (update-cookie cs cookie-name "2042-12-02+19%3A57%3A49.775909%2B00")
+            (with-redefs [setting/restore-cache! (fn [] (swap! calls inc))]
+              (mt/user-real-request :crowberto :get 200 "user/current"
+                                    {:request-options {:cookie-store cs}})
+              (is (= 1 @calls) "Cache was not restored based on cookie value")
+              (testing "And that header resets the settings last updated at so we don't keep updating the cache"
+                (let [setting-cookie (get (cookies/get-cookies cs) cookie-name)]
+                  (is (some? setting-cookie) "No cookie set")
+                  (is (= (setting/cache-last-updated-at)
+                         (-> setting-cookie :value codec/form-decode))
+                      "The most recent updated at was not set in the header"))))))))))

--- a/test/metabase/session/api_test.clj
+++ b/test/metabase/session/api_test.clj
@@ -581,22 +581,24 @@
 
 (deftest google-auth-remember-test
   (testing "POST /google_auth"
-    (mt/with-temporary-setting-values [google-auth-client-id "pretend-client-id.apps.googleusercontent.com"]
-      (mt/with-model-cleanup [:model/User]
-        (t2/insert! :model/User (merge  (mt/with-temp-defaults :model/User) {:email "test@metabase.com" :is_active true}))
-        (testing "Google auth works with remember me and rasta"
-          (with-redefs [http/post (constantly
-                                   {:status 200
-                                    :body   (str "{\"aud\":\"pretend-client-id.apps.googleusercontent.com\","
-                                                 "\"email_verified\":\"true\","
-                                                 "\"given_name\":\"test\","
-                                                 "\"family_name\":\"user\","
-                                                 "\"email\":\"test@metabase.com\"}")})]
-            (testing "Test that 'remember me' checkbox sets expiration on session"
-              (let [response (mt/client-real-response :post 200 "session/google_auth" {:token "foo" :remember true})]
-                (is (some? (get-in response [:cookies session-cookie :expires])) "Session should have expiration set when remember=true"))
-              (let [response (mt/client-real-response :post 200 "session/google_auth" {:token "foo" :remember false})]
-                (is (nil? (get-in response [:cookies session-cookie :expires])) "Session should not have expiration set when remember=false")))))))))
+    ;; This test uses real HTTP client, so settings must be set globally
+    (mt/test-helpers-set-global-values!
+      (mt/with-temporary-setting-values [google-auth-client-id "pretend-client-id.apps.googleusercontent.com"]
+        (mt/with-model-cleanup [:model/User]
+          (t2/insert! :model/User (merge  (mt/with-temp-defaults :model/User) {:email "test@metabase.com" :is_active true}))
+          (testing "Google auth works with remember me and rasta"
+            (with-redefs [http/post (constantly
+                                     {:status 200
+                                      :body   (str "{\"aud\":\"pretend-client-id.apps.googleusercontent.com\","
+                                                   "\"email_verified\":\"true\","
+                                                   "\"given_name\":\"test\","
+                                                   "\"family_name\":\"user\","
+                                                   "\"email\":\"test@metabase.com\"}")})]
+              (testing "Test that 'remember me' checkbox sets expiration on session"
+                (let [response (mt/client-real-response :post 200 "session/google_auth" {:token "foo" :remember true})]
+                  (is (some? (get-in response [:cookies session-cookie :expires])) "Session should have expiration set when remember=true"))
+                (let [response (mt/client-real-response :post 200 "session/google_auth" {:token "foo" :remember false})]
+                  (is (nil? (get-in response [:cookies session-cookie :expires])) "Session should not have expiration set when remember=false"))))))))))
 
 (deftest google-auth-test
   (testing "POST /google_auth"

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -263,6 +263,7 @@
   call-with-map-params
   call-with-paused-query
   discard-setting-changes
+  discard-setting-changes!
   doall-recursive
   file->bytes
   file-path->bytes
@@ -303,7 +304,9 @@
   with-temp-scheduler!
   with-temp-vals-in-db
   with-temporary-setting-values
+  with-temporary-setting-values!
   with-temporary-raw-setting-values
+  with-temporary-raw-setting-values!
   with-user-in-groups
   with-verified!
   works-after]

--- a/test/metabase/test/redefs.clj
+++ b/test/metabase/test/redefs.clj
@@ -25,7 +25,7 @@
   ;; run `f` in a transaction if it's the top-level with-temp
   (if (and tu.thread-local/*thread-local* (not *in-with-temp*))
     (binding [*in-with-temp* true]
-      (t2.connection/with-transaction [_ t2.connection/*current-connectable* {:rollback-only true}]
+      (t2.connection/with-transaction [_ t2.connection/*current-connectable*]
         (next-method model attributes f)))
     (next-method model attributes f)))
 

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -26,10 +26,11 @@
    [metabase.permissions.models.permissions-group-membership :as pgm]
    [metabase.permissions.test-util :as perms.test-util]
    [metabase.premium-features.test-util :as premium-features.test-util]
+   [metabase.premium-features.token-check :as token-check]
    [metabase.query-processor.util :as qp.util]
    [metabase.search.core :as search]
    [metabase.settings.core :as setting]
-   [metabase.settings.models.setting]
+   [metabase.settings.models.setting :as setting.impl]
    [metabase.settings.models.setting.cache :as setting.cache]
    [metabase.task.core :as task]
    [metabase.task.impl :as task.impl]
@@ -38,6 +39,7 @@
    [metabase.test.fixtures :as fixtures]
    [metabase.test.initialize :as initialize]
    [metabase.test.util.log]
+   [metabase.test.util.thread-local :as thread-local]
    [metabase.timeline.models.timeline-event :as timeline-event]
    [metabase.util :as u]
    [metabase.util.files :as u.files]
@@ -539,9 +541,70 @@
     (t2/delete! :model/Setting :key setting-k))
   (setting.cache/restore-cache!))
 
+;; Most of the time setting/set! is not threadsafe. It is only threadsafe here because we are wrapping
+;; it in [[setting.cache/do-with-isolated-cache]] which binds a thread-local settings cache for us
+#_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
+(defn do-with-temporary-setting-value
+  "Thread-safe version: temporarily set the value of the Setting named by keyword `setting-k` to `value` and execute
+  `thunk`. Uses an isolated cache and a rollback-only transaction to ensure thread isolation.
+
+  This is the preferred implementation for parallel tests. Changes are visible only to the current thread and are
+  rolled back when the thunk completes.
+
+  If the setting requires a premium feature (via its `:feature` key), this function will temporarily enable that
+  feature using thread-local binding, preserving any features already enabled by the test. This is thread-safe
+  unlike [[do-with-temporary-setting-value!]] which uses `with-redefs`.
+
+  When an env var value is set for the setting, a thread-local override is bound via
+  [[setting.impl/*env-var-overrides*]] so the env var value is overridden in a thread-safe manner.
+
+  Prefer the macro [[with-temporary-setting-values]] over using this function directly."
+  [setting-k value thunk & {:keys [raw-setting?]}]
+  (initialize/initialize-if-needed! :db :plugins)
+  (let [setting-k (name setting-k)
+        setting   (try
+                    (#'setting/resolve-setting setting-k)
+                    (catch Exception e
+                      (when-not raw-setting?
+                        (throw e))))
+        initial-cache (t2/select-fn->fn :key :value :model/Setting)
+        ;; Build env var override if this setting has an env var value
+        env-kw       (when-not raw-setting?
+                       (setting/setting-env-map-name setting-k))
+        env-override (when (and env-kw (env/env env-kw))
+                       {env-kw (if (some? value) (str value) "")})]
+    (t2/with-transaction [_conn nil {:rollback-only true}]
+      (setting.cache/do-with-isolated-cache
+       initial-cache
+       (fn []
+         ;; Bind env var overrides, merging with any existing overrides from outer calls
+         (binding [setting.impl/*env-var-overrides* (merge setting.impl/*env-var-overrides* env-override)]
+           (try
+             (if raw-setting?
+               (upsert-raw-setting! (get initial-cache setting-k) setting-k value)
+               (let [required-feature (:feature setting)
+                     current-features (token-check/*token-features*)
+                     features-with-required (if required-feature
+                                              (conj current-features (name required-feature))
+                                              current-features)]
+                 (binding [token-check/*token-features* (constantly features-with-required)]
+                   (setting/set! setting-k value :bypass-read-only? true))))
+             (catch Throwable e
+               (throw (ex-info (str "Error in with-temporary-setting-values: " (ex-message e))
+                               {:setting  setting-k
+                                :location (when setting
+                                            (symbol (name (:namespace setting)) (name setting-k)))
+                                :value    value}
+                               e))))
+           (testing (colorize/blue (format "\nSetting %s = %s\n" (keyword setting-k) (pr-str value)))
+             (thunk))))))))
+
 (defn do-with-temporary-setting-value!
-  "Temporarily set the value of the Setting named by keyword `setting-k` to `value` and execute `f`, then re-establish
-  the original value. This works much the same way as [[binding]].
+  "Non-thread-safe version: temporarily set the value of the Setting named by keyword `setting-k` to `value` and
+  execute `f`, then re-establish the original value. This works much the same way as [[binding]].
+
+  WARNING: This modifies global state and is not safe for parallel tests. Prefer the thread-safe version
+  [[do-with-temporary-setting-value]] for new code.
 
   If an env var value is set for the setting, this acts as a wrapper around [[do-with-temp-env-var-value!]].
 
@@ -554,7 +617,7 @@
   directly."
   [setting-k value thunk & {:keys [raw-setting? skip-init?]}]
   ;; plugins have to be initialized because changing `report-timezone` will call driver methods
-  (mb.hawk.parallel/assert-test-is-not-parallel "do-with-temporary-setting-value")
+  (mb.hawk.parallel/assert-test-is-not-parallel "do-with-temporary-setting-value!")
   (initialize/initialize-if-needed! :db :plugins)
   (let [setting-k (name setting-k)
         setting (try
@@ -598,17 +661,42 @@
                                  :original-value original-value}
                                 e))))))))))
 
-;;; TODO FIXME -- either rename this to `with-temporary-setting-values!` or fix it and make it thread-safe
-#_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defmacro with-temporary-setting-values
-  "Temporarily bind the site-wide values of one or more `Settings`, execute body, and re-establish the original values.
-  This works much the same way as `binding`.
+  "Temporarily bind the site-wide values of one or more `Settings`, execute body.
+  By default uses an isolated cache and rollback-only transaction for thread isolation.
+
+  When inside [[metabase.test/test-helpers-set-global-values!]], uses global state instead (non-thread-safe).
 
      (with-temporary-setting-values [google-auth-auto-create-accounts-domain \"metabase.com\"]
        (google-auth-auto-create-accounts-domain)) -> \"metabase.com\"
 
   If an env var value is set for the setting, this will change the env var rather than the setting stored in the DB.
-  To temporarily override the value of *read-only* env vars, use [[with-temp-env-var-value!]]."
+  To temporarily override the value of *read-only* env vars, use [[with-temp-env-var-value!]].
+
+  For explicitly non-thread-safe behavior, use [[with-temporary-setting-values!]]."
+  [[setting-k value & more :as bindings] & body]
+  (assert (even? (count bindings)) "mismatched setting/value pairs: is each setting name followed by a value?")
+  (if (empty? bindings)
+    `(do ~@body)
+    `((if thread-local/*thread-local*
+        do-with-temporary-setting-value
+        do-with-temporary-setting-value!)
+      ~(keyword setting-k) ~value
+      (fn []
+        (with-temporary-setting-values ~more
+          ~@body)))))
+
+(defmacro with-temporary-setting-values!
+  "Non-thread-safe version: temporarily bind the site-wide values of one or more `Settings`, execute body,
+  and re-establish the original values. This modifies global state.
+
+     (with-temporary-setting-values! [google-auth-auto-create-accounts-domain \"metabase.com\"]
+       (google-auth-auto-create-accounts-domain)) -> \"metabase.com\"
+
+  If an env var value is set for the setting, this will change the env var rather than the setting stored in the DB.
+  To temporarily override the value of *read-only* env vars, use [[with-temp-env-var-value!]].
+
+  For thread-safe behavior, use [[with-temporary-setting-values]]."
   [[setting-k value & more :as bindings] & body]
   (assert (even? (count bindings)) "mismatched setting/value pairs: is each setting name followed by a value?")
   (if (empty? bindings)
@@ -616,26 +704,60 @@
     `(do-with-temporary-setting-value!
       ~(keyword setting-k) ~value
       (fn []
-        (with-temporary-setting-values ~more
+        (with-temporary-setting-values! ~more
           ~@body)))))
 
-;;; TODO FIXME -- either rename this to `with-temporary-raw-setting-values!` or fix it and make it thread-safe
-#_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defmacro with-temporary-raw-setting-values
-  "Like [[with-temporary-setting-values]] but works with raw value and it allows settings that are not defined
-  using [[metabase.settings.models.setting/defsetting]]."
+  "Like [[with-temporary-setting-values]] but works with raw values and allows settings
+  that are not defined using [[metabase.settings.models.setting/defsetting]].
+
+  When inside [[metabase.test/test-helpers-set-global-values!]], uses global state instead (non-thread-safe).
+
+  For explicitly non-thread-safe behavior, use [[with-temporary-raw-setting-values!]]."
   [[setting-k value & more :as bindings] & body]
   (assert (even? (count bindings)) "mismatched setting/value pairs: is each setting name followed by a value?")
   (if (empty? bindings)
     `(do ~@body)
-    `(do-with-temporary-setting-value!
+    `((if thread-local/*thread-local*
+        do-with-temporary-setting-value
+        do-with-temporary-setting-value!)
       ~(keyword setting-k) ~value
       (fn []
         (with-temporary-raw-setting-values ~more
           ~@body))
       :raw-setting? true)))
 
-(defn do-with-discarded-setting-changes! [settings thunk]
+(defmacro with-temporary-raw-setting-values!
+  "Non-thread-safe version: like [[with-temporary-setting-values!]] but works with raw values and allows settings
+  that are not defined using [[metabase.settings.models.setting/defsetting]].
+
+  For thread-safe behavior, use [[with-temporary-raw-setting-values]]."
+  [[setting-k value & more :as bindings] & body]
+  (assert (even? (count bindings)) "mismatched setting/value pairs: is each setting name followed by a value?")
+  (if (empty? bindings)
+    `(do ~@body)
+    `(do-with-temporary-setting-value!
+      ~(keyword setting-k) ~value
+      (fn []
+        (with-temporary-raw-setting-values! ~more
+          ~@body))
+      :raw-setting? true)))
+
+(defn do-with-discarded-setting-changes
+  "Thread-safe version: execute `thunk` and discard any changes to `settings`."
+  [settings thunk]
+  (initialize/initialize-if-needed! :db :plugins)
+  ((reduce
+    (fn [thunk setting-k]
+      (fn []
+        (let [value (setting/read-setting setting-k)]
+          (do-with-temporary-setting-value setting-k value thunk :skip-init? true))))
+    thunk
+    settings)))
+
+(defn do-with-discarded-setting-changes!
+  "Non-thread-safe version: execute `thunk` and discard any changes to `settings`."
+  [settings thunk]
   (initialize/initialize-if-needed! :db :plugins)
   ((reduce
     (fn [thunk setting-k]
@@ -645,14 +767,31 @@
     thunk
     settings)))
 
-;;; TODO FIXME -- either rename this to `with-discarded-setting-changes!` or fix it and make it thread-safe
-#_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defmacro discard-setting-changes
-  "Execute `body` in a try-finally block, restoring any changes to listed `settings` to their original values at its
-  conclusion.
+  "Execute `body` in a try-finally block, restoring any changes to listed `settings`
+  to their original values at its conclusion.
+
+  When inside [[metabase.test/test-helpers-set-global-values!]], uses global state instead (non-thread-safe).
 
     (discard-setting-changes [site-name]
-      ...)"
+      ...)
+
+  For explicitly non-thread-safe behavior, use [[discard-setting-changes!]]."
+  {:style/indent 1}
+  [settings & body]
+  `((if thread-local/*thread-local*
+      do-with-discarded-setting-changes
+      do-with-discarded-setting-changes!)
+    ~(mapv keyword settings) (fn [] ~@body)))
+
+(defmacro discard-setting-changes!
+  "Non-thread-safe version: execute `body` in a try-finally block, restoring any changes to listed `settings`
+  to their original values at its conclusion.
+
+    (discard-setting-changes! [site-name]
+      ...)
+
+  For thread-safe behavior, use [[discard-setting-changes]]."
   {:style/indent 1}
   [settings & body]
   `(do-with-discarded-setting-changes! ~(mapv keyword settings) (fn [] ~@body)))
@@ -667,7 +806,7 @@
   The token-value binding will contain the random token that was set."
   [[token-value] & body]
   `(let [~token-value (premium-features.test-util/random-token)]
-     (with-redefs [metabase.premium-features.token-check/check-token
+     (with-redefs [token-check/check-token
                    (constantly {:valid    true
                                 :status   "fake"
                                 :features ["test" "fixture"]

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -637,7 +637,7 @@
             (if raw-setting?
               (upsert-raw-setting! original-value setting-k value)
               ;; bypass the feature check when setting up mock data
-              (with-redefs [metabase.settings.models.setting/has-feature? (constantly true)]
+              (with-redefs [setting.impl/has-feature? (constantly true)]
                 (setting/set! setting-k value :bypass-read-only? true)))
             (catch Throwable e
               (throw (ex-info (str "Error in with-temporary-setting-values: " (ex-message e))
@@ -652,7 +652,7 @@
               (if raw-setting?
                 (restore-raw-setting! original-value setting-k)
                 ;; bypass the feature check when reset settings to the original value
-                (with-redefs [metabase.settings.models.setting/has-feature? (constantly true)]
+                (with-redefs [setting.impl/has-feature? (constantly true)]
                   (setting/set! setting-k original-value :bypass-read-only? true)))
               (catch Throwable e
                 (throw (ex-info (str "Error restoring original Setting value: " (ex-message e))

--- a/test/metabase/warehouses_rest/api_test.clj
+++ b/test/metabase/warehouses_rest/api_test.clj
@@ -1571,14 +1571,15 @@
                    :model/FieldValues values-1 {:field_id (u/the-id field-1), :values [1 2 3 4]}
                    :model/FieldValues values-2 {:field_id (u/the-id field-2), :values [1 2 3 4]}]
 
-      (snowplow-test/with-fake-snowplow-collector
-        (is (= {:status "ok"}
-               (mt/user-http-request :crowberto :post 200 (format "database/%d/discard_values" (u/the-id db)))))
+      (mt/test-helpers-set-global-values!
+        (snowplow-test/with-fake-snowplow-collector
+          (is (= {:status "ok"}
+                 (mt/user-http-request :crowberto :post 200 (format "database/%d/discard_values" (u/the-id db)))))
 
-        (testing "triggers snowplow event"
-          (is (=?
-               {"event" "database_discard_field_values", "target_id" (u/the-id db)}
-               (:data (last (snowplow-test/pop-event-data-and-user-id!)))))))
+          (testing "triggers snowplow event"
+            (is (=?
+                 {"event" "database_discard_field_values", "target_id" (u/the-id db)}
+                 (:data (last (snowplow-test/pop-event-data-and-user-id!))))))))
 
       (testing "values-1 still exists?"
         (is (= false


### PR DESCRIPTION
### Description

I noticed a large chunk of tests I was writing couldn't be made parallel because mt/with-temporary-setting-values shares state between threads. 

The settings cache now supports thread-local isolation via dynamic vars. This enables thread-safe temporary setting values in tests by binding isolated cache state per-thread rather than modifying global state.

The thread-safe implementation:
1. Snapshots current DB settings into an isolated cache atom
2. Wraps execution in a rollback-only transaction
3. Binds thread-local cache, lock, and timestamp
4. Changes are visible only to the current thread

Use test-helpers-set-global-values! to opt into the old non-thread-safe behavior when needed


### Checklist

- [x] Tests have been added/updated to cover changes in this PR