### PR TITLE
Reduce bundle size by removing import of enormous character sizes constant

### DIFF
--- a/frontend/src/metabase/static-viz/components/FunnelChart/FunnelChart.tsx
+++ b/frontend/src/metabase/static-viz/components/FunnelChart/FunnelChart.tsx
@@ -8,14 +8,16 @@ import type {
 } from "metabase/static-viz/components/FunnelChart/types";
 import {
   calculateFunnelPolygonPoints,
-  calculateFunnelSteps,
-  calculateStepOpacity,
   getFormattedStep,
   groupData,
   reorderData,
 } from "metabase/static-viz/components/FunnelChart/utils/funnel";
 import { Text } from "metabase/static-viz/components/Text";
 import { measureTextHeight } from "metabase/static-viz/lib/text";
+import {
+  calculateFunnelSteps,
+  calculateStepOpacity,
+} from "metabase/visualizations/lib/funnel/utils";
 
 import Watermark from "../../watermark.svg?component";
 

--- a/frontend/src/metabase/static-viz/components/FunnelChart/utils/funnel.ts
+++ b/frontend/src/metabase/static-viz/components/FunnelChart/utils/funnel.ts
@@ -9,34 +9,6 @@ import type { TextWidthMeasurer } from "metabase/visualizations/shared/types/mea
 
 import type { FunnelDatum, FunnelSettings, FunnelStep, Step } from "../types";
 
-export const calculateFunnelSteps = (
-  data: FunnelDatum[],
-  stepWidth: number,
-  funnelHeight: number,
-): FunnelStep[] => {
-  const firstMeasure = data[0][1];
-  const maxMeasure = Math.max(...data.map((datum) => datum[1]));
-  return data.map((datum, index) => {
-    const [step, measure] = datum;
-    const left = index * stepWidth;
-    const height = (measure * funnelHeight) / maxMeasure;
-    const top = (funnelHeight - height) / 2;
-    const percent = firstMeasure > 0 ? measure / firstMeasure : 0;
-
-    return {
-      step: step.toString(),
-      measure,
-      percent,
-      top,
-      left,
-      height,
-    };
-  });
-};
-
-export const calculateStepOpacity = (index: number, stepsCount: number) =>
-  1 - index * (0.9 / (stepsCount + 1));
-
 type StepDimensions = Pick<FunnelStep, "top" | "left" | "height">;
 
 export const calculateFunnelPolygonPoints = (

--- a/frontend/src/metabase/static-viz/components/FunnelChart/utils/funnel.unit.spec.ts
+++ b/frontend/src/metabase/static-viz/components/FunnelChart/utils/funnel.unit.spec.ts
@@ -1,12 +1,10 @@
 import { merge } from "icepick";
 
+import { calculateFunnelSteps } from "metabase/visualizations/lib/funnel/utils";
+
 import type { FunnelDatum, FunnelSettings } from "../types";
 
-import {
-  calculateFunnelPolygonPoints,
-  calculateFunnelSteps,
-  reorderData,
-} from "./funnel";
+import { calculateFunnelPolygonPoints, reorderData } from "./funnel";
 
 describe("calculateFunnelSteps", () => {
   it("calculates funnel steps from data", () => {

--- a/frontend/src/metabase/visualizations/components/FunnelNormal.tsx
+++ b/frontend/src/metabase/visualizations/components/FunnelNormal.tsx
@@ -13,10 +13,6 @@ import {
 import { formatNullable } from "metabase/lib/formatting/nullable";
 import { isNotNull } from "metabase/lib/types";
 import {
-  calculateFunnelSteps,
-  calculateStepOpacity,
-} from "metabase/static-viz/components/FunnelChart/utils/funnel";
-import {
   FunnelNormalRoot,
   FunnelStart,
   FunnelStep,
@@ -25,6 +21,10 @@ import {
   Subtitle,
   Title,
 } from "metabase/visualizations/components/FunnelNormal.styled";
+import {
+  calculateFunnelSteps,
+  calculateStepOpacity,
+} from "metabase/visualizations/lib/funnel/utils";
 import type {
   ClickObject,
   HoveredObject,

--- a/frontend/src/metabase/visualizations/lib/funnel/utils.ts
+++ b/frontend/src/metabase/visualizations/lib/funnel/utils.ts
@@ -1,0 +1,32 @@
+import type {
+  FunnelDatum,
+  FunnelStep,
+} from "metabase/static-viz/components/FunnelChart/types";
+
+export const calculateFunnelSteps = (
+  data: FunnelDatum[],
+  stepWidth: number,
+  funnelHeight: number,
+): FunnelStep[] => {
+  const firstMeasure = data[0][1];
+  const maxMeasure = Math.max(...data.map((datum) => datum[1]));
+  return data.map((datum, index) => {
+    const [step, measure] = datum;
+    const left = index * stepWidth;
+    const height = (measure * funnelHeight) / maxMeasure;
+    const top = (funnelHeight - height) / 2;
+    const percent = firstMeasure > 0 ? measure / firstMeasure : 0;
+
+    return {
+      step: step.toString(),
+      measure,
+      percent,
+      top,
+      left,
+      height,
+    };
+  });
+};
+
+export const calculateStepOpacity = (index: number, stepsCount: number) =>
+  1 - index * (0.9 / (stepsCount + 1));


### PR DESCRIPTION
### Description

#68031 increased bundle size by 1 MB, entirely driven by inadvertently importing "metabase/static-viz/constants/char-sizes", which is a 1MB file.

This has happened before and was fixed in #47159, so it's worth considering the best way to prevent this happening again.

### How to verify

1. Checkout master and run `yarn build-release`. You'll see something like: `app-main.c50792edab37dc83.js (7.253 MiB)`
2. Checkout this branch and run `yarn build-release`. You'll see something like: `app-main.3c2bd31a763b8649.js (6.292 MiB)`