### PR TITLE
Do not delete built-in transform tags on sync

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/remote_sync/spec.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/spec.clj
@@ -279,7 +279,8 @@
     :archived-key   nil  ; no archived field
     :tracking       {:select-fields  [:name]
                      :field-mappings {:model_name :name}}
-    :removal        {:statuses #{"removed" "delete"}}  ; no scope-key = global deletion
+    :removal        {:statuses   #{"removed" "delete"}  ; no scope-key = global deletion
+                     :conditions {:built_in_type nil}}  ; protect built-in tags from removal
     :export-path    {:type :transform-tag-path}
     :export-scope   :all  ; query for all instances
     :enabled?       :remote-sync-transforms}})

--- a/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
@@ -220,7 +220,7 @@
                     io/input-stream)
             ba  (#'api.serialization/ba-copy res)]
         (testing "Archive contains correct number of files with proper log entries"
-          (is (= 8
+          (is (= 12
                  (with-open [tar (open-tar ba)]
                    (count
                     (for [^TarArchiveEntry e (u.compress/entries tar)
@@ -228,7 +228,7 @@
                       (do
                         (condp re-find (.getName e)
                           #"/export.log$" (testing "Log contains extract and store entries"
-                                            (is (= (+ #_extract 7 #_store 7)
+                                            (is (= (+ #_extract 11 #_store 11)
                                                    (count (line-seq (io/reader tar))))))
                           nil)
                         (.getName e))))))))
@@ -242,7 +242,7 @@
                    "settings"        false
                    "field_values"    false
                    "duration_ms"     (every-pred number? pos?)
-                   "count"           7
+                   "count"           11
                    "error_count"     0
                    "source"          "api"
                    "secrets"         false
@@ -272,7 +272,7 @@
                                                   {:request-options {:headers {"content-type" "multipart/form-data"}}}
                                                   {:file ba}))]
           (testing "Log contains imported entity types"
-            (is (= #{"Collection" "Dashboard" "Card" "TransformJob"}
+            (is (= #{"Collection" "Dashboard" "Card" "TransformJob" "TransformTag"}
                    (log-types (line-seq (io/reader (io/input-stream res)))))))
 
           (testing "Entities are restored in the database"
@@ -284,8 +284,8 @@
                      "direction"     "import"
                      "duration_ms"   pos?
                      "source"        "api"
-                     "models"        "Card,Collection,Dashboard,TransformJob"
-                     "count"         7
+                     "models"        "Card,Collection,Dashboard,TransformJob,TransformTag"
+                     "count"         11
                      "error_count"   0
                      "success"       true
                      "error_message" nil}
@@ -348,7 +348,7 @@
                                           :continue_on_error true)
                 log (slurp (io/input-stream res))]
             (testing "Log shows loaded entities and error"
-              (is (= #{"Dashboard" "Card" "Collection" "TransformJob"}
+              (is (= #{"Dashboard" "Card" "Collection" "TransformJob" "TransformTag"}
                      (log-types (str/split-lines log))))
               (is (re-find #"Failed to read file \{:path \"Collection DoesNotExist\"}" log)))
 
@@ -358,9 +358,9 @@
                        "direction"   "import"
                        "source"      "api"
                        "duration_ms" int?
-                       "count"       6
+                       "count"       10
                        "error_count" 1
-                       "models"      "Collection,Dashboard,TransformJob"}
+                       "models"      "Collection,Dashboard,TransformJob,TransformTag"}
                       (-> (snowplow-test/pop-event-data-and-user-id!) last :data))))))))))
 
 (deftest import-invalid-archive-test
@@ -428,7 +428,7 @@
             (doseq [^TarArchiveEntry e (u.compress/entries tar)]
               (condp re-find (.getName e)
                 #"/export.log$" (testing "Log shows extract entries, error, and store entries"
-                                  (is (= (+ #_extract 7 #_error 1 #_store 6)
+                                  (is (= (+ #_extract 11 #_error 1 #_store 10)
                                          (count (line-seq (io/reader tar))))))
                 nil))))
 
@@ -441,7 +441,7 @@
                    "settings"        false
                    "field_values"    false
                    "duration_ms"     pos?
-                   "count"           6
+                   "count"           10
                    "error_count"     1
                    "source"          "api"
                    "secrets"         false


### PR DESCRIPTION
I found that some tests were failing intermittently - sometimes TransformTags were present, and sometimes they were missing. I tracked it down to this test, which enables and then disables remote syncing transforms.

The issue is that if we sync transforms (... and transform tags), then unsync them, then we delete everything that was synced - including the built-in tags.

We should exclude these from deletion.
