### PR TITLE
fix: gauge chart breaks when sent via email/slack

### DIFF
--- a/frontend/src/metabase/static-viz/components/Gauge/Gauge.tsx
+++ b/frontend/src/metabase/static-viz/components/Gauge/Gauge.tsx
@@ -133,7 +133,10 @@ export default function Gauge({
                       return (
                         arcPath && (
                           <g key={`pie-arc-${index}`}>
-                            <path d={arcPath} fill={colorGetter(arc)} />
+                            <path
+                              d={arcPath}
+                              fill={colorGetter(arc, getColor)}
+                            />
                           </g>
                         )
                       );

--- a/frontend/src/metabase/static-viz/components/Gauge/utils.tsx
+++ b/frontend/src/metabase/static-viz/components/Gauge/utils.tsx
@@ -3,6 +3,8 @@ import Color from "color";
 
 import type { NumberFormatOptions } from "metabase/static-viz/lib/numbers";
 import { measureTextWidth } from "metabase/static-viz/lib/text";
+import { resolveColorFromCssVariable } from "metabase/ui/utils/colors";
+import type { ColorGetter } from "metabase/visualizations/types";
 
 import {
   BASE_FONT_SIZE,
@@ -157,9 +159,18 @@ export function fixSwappedMinMax(segment: GaugeSegment): GaugeSegment {
   return segment;
 }
 
-export function colorGetter(pieArcDatum: PieArcDatum<GaugeSegment>) {
+export function colorGetter(
+  pieArcDatum: PieArcDatum<GaugeSegment>,
+  getColor: ColorGetter,
+) {
   // Convert to hex due to Apache Batik limitations (SVG renderer for static viz)
-  return Color(pieArcDatum.data.color).hex();
+  // Also resolve CSS variables to their hex values since they can't be parsed
+  // in the static viz context.
+  const resolvedColor = resolveColorFromCssVariable(
+    pieArcDatum.data.color,
+    getColor,
+  );
+  return Color(resolvedColor).hex();
 }
 
 /**

--- a/frontend/src/metabase/static-viz/components/Gauge/utils.unit.spec.ts
+++ b/frontend/src/metabase/static-viz/components/Gauge/utils.unit.spec.ts
@@ -1,12 +1,17 @@
+import type { PieArcDatum } from "@visx/shape/lib/shapes/Pie";
+
+import { createColorGetter } from "metabase/static-viz/lib/colors";
 import type { NumberFormatOptions } from "metabase/static-viz/lib/numbers";
 
 import {
   GAUGE_ARC_ANGLE,
   SEGMENT_LABEL_ANCHOR_THRESHOLD_ANGLE,
 } from "./constants";
+import type { GaugeSegment } from "./types";
 import {
   calculateRelativeValueAngle,
   calculateSegmentLabelTextAnchor,
+  colorGetter,
   getCirclePositionInSvgCoordinate,
   limit,
   populateDefaultColumnSettings,
@@ -173,6 +178,48 @@ describe("Static gauge utils", () => {
           SEGMENT_LABEL_ANCHOR_THRESHOLD_ANGLE - 0.001,
         ),
       ).toEqual("middle");
+    });
+  });
+
+  describe("colorGetter", () => {
+    const getColor = createColorGetter();
+    const createPieArcDatum = (color: string): PieArcDatum<GaugeSegment> => ({
+      data: { min: 0, max: 100, color, label: "test" },
+      value: 100,
+      index: 0,
+      startAngle: 0,
+      endAngle: Math.PI,
+      padAngle: 0,
+    });
+
+    it("converts hex color to hex format", () => {
+      const arcDatum = createPieArcDatum("#ED6E6E");
+      expect(colorGetter(arcDatum, getColor)).toBe("#ED6E6E");
+    });
+
+    it("converts rgb color to hex format", () => {
+      const arcDatum = createPieArcDatum("rgb(237, 110, 110)");
+      expect(colorGetter(arcDatum, getColor)).toBe("#ED6E6E");
+    });
+
+    it("converts named color to hex format", () => {
+      const arcDatum = createPieArcDatum("red");
+      expect(colorGetter(arcDatum, getColor)).toBe("#FF0000");
+    });
+
+    it("handles CSS variable color for error", () => {
+      const arcDatum = createPieArcDatum("var(--mb-color-error)");
+      expect(colorGetter(arcDatum, getColor)).toMatch(/^#[0-9A-F]{6}$/i);
+    });
+
+    it("handles CSS variable color for warning", () => {
+      const arcDatum = createPieArcDatum("var(--mb-color-warning)");
+      expect(colorGetter(arcDatum, getColor)).toMatch(/^#[0-9A-F]{6}$/i);
+    });
+
+    it("handles CSS variable color for success", () => {
+      const arcDatum = createPieArcDatum("var(--mb-color-success)");
+      expect(colorGetter(arcDatum, getColor)).toMatch(/^#[0-9A-F]{6}$/i);
     });
   });
 });

--- a/frontend/src/metabase/ui/utils/colors.ts
+++ b/frontend/src/metabase/ui/utils/colors.ts
@@ -78,3 +78,23 @@ export const isColorName = (name?: string | null): name is ColorName => {
 export const maybeColor = (maybeColorName: ColorName | string): string => {
   return isColorName(maybeColorName) ? color(maybeColorName) : maybeColorName;
 };
+
+const CSS_VAR_REGEX = /^var\(--mb-color-(.+)\)$/;
+
+/**
+ * Resolves CSS variable color values (created by `color()`) to their actual values.
+ * This is the inverse of `color()` - use it when you need actual color values
+ * instead of CSS variable references (e.g., in static viz contexts like email/Slack
+ * exports where CSS variables cannot be resolved by the browser).
+ */
+export function resolveColorFromCssVariable(
+  colorValue: string,
+  getColor: (colorName: string) => string,
+): string {
+  const match = colorValue.match(CSS_VAR_REGEX);
+  if (match) {
+    const colorName = match[1];
+    return getColor(colorName);
+  }
+  return colorValue;
+}

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingSegmentsEditor/ChartSettingSegmentsEditor.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingSegmentsEditor/ChartSettingSegmentsEditor.tsx
@@ -1,3 +1,4 @@
+import Color from "color";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -133,10 +134,10 @@ export const ChartSettingSegmentsEditor = ({
 function getColorPalette() {
   return [
     ...getAccentColors(),
-    color("error"),
-    color("warning"),
-    color("success"),
-    color("background-tertiary"),
+    Color(color("error")).hex(),
+    Color(color("warning")).hex(),
+    Color(color("success")).hex(),
+    Color(color("background-tertiary")).hex(),
   ];
 }
 

--- a/frontend/src/metabase/visualizations/visualizations/Gauge/Gauge.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Gauge/Gauge.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/prop-types */
 import cx from "classnames";
+import Color from "color";
 import * as d3 from "d3";
 import { Component, useCallback, useEffect, useRef, useState } from "react";
 import * as React from "react";
@@ -7,8 +8,8 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import CS from "metabase/css/core/index.css";
+import { color } from "metabase/lib/colors";
 import { formatValue } from "metabase/lib/formatting";
-import { color } from "metabase/ui/utils/colors";
 import { ChartSettingSegmentsEditor } from "metabase/visualizations/components/settings/ChartSettingSegmentsEditor";
 import { columnSettings } from "metabase/visualizations/lib/settings/column";
 import { segmentIsValid } from "metabase/visualizations/lib/utils";
@@ -125,10 +126,13 @@ export class Gauge extends Component {
         try {
           value = series[0].data.rows[0][0] || 0;
         } catch (e) {}
+        const errorColor = Color(color("error")).hex();
+        const warningColor = Color(color("warning")).hex();
+        const successColor = Color(color("success")).hex();
         return [
-          { min: 0, max: value / 2, color: color("error"), label: "" },
-          { min: value / 2, max: value, color: color("warning"), label: "" },
-          { min: value, max: value * 2, color: color("success"), label: "" },
+          { min: 0, max: value / 2, color: errorColor, label: "" },
+          { min: value / 2, max: value, color: warningColor, label: "" },
+          { min: value, max: value * 2, color: successColor, label: "" },
         ];
       },
       widget: ChartSettingSegmentsEditor,


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #68668
Closes [UXW-2839: Gauge chart breaks when sent via email/slack](https://linear.app/metabase/issue/UXW-2839/gauge-chart-breaks-when-sent-via-emailslack)

### Description

In static-viz context, there is no CSS variables support, and the color resolver was not converting it correctly to hex. Fixed by extracting color name from CSS variable and passing it to `getColor` (created by `createColorGetter`) which converts said color to hex.

### How to verify

1. Create new gauge question
2. Click on three dots menu in the header
3. Click "Create an alert"
4. Click "Send now"

### Demo

Before:
<img width="1840" height="1113" alt="image" src="https://github.com/user-attachments/assets/a2aa2052-3ffe-4bb8-9557-7b742cd4178a" />

After: 
<img width="1840" height="1113" alt="image" src="https://github.com/user-attachments/assets/1c7b84bd-4f86-411c-b0e6-4dd660189497" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
