### PR TITLE
allow getting transforms in root collection

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/transforms/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/api_test.clj
@@ -1192,36 +1192,36 @@
         (mt/with-temp [:model/Transform {transform-id :id}
                        {:name "Root Transform"
                         :description "A transform at root"}]
-          ;; Test 1: Transform appears in unfiltered results
-          (let [items (->> (:data (mt/user-http-request :crowberto :get 200
-                                                        "collection/root/items"
-                                                        :namespace "transforms"))
-                           (filter #(= "transform" (:model %))))]
-            (is (= 1 (count items)))
-            (is (= "transform" (:model (first items))))
-            (is (= "Root Transform" (:name (first items)))))
+          (testing "Transform appears in unfiltered results"
+            (let [items (->> (:data (mt/user-http-request :crowberto :get 200
+                                                          "collection/root/items"
+                                                          :namespace "transforms"))
+                             (filter #(= "transform" (:model %))))]
+              (is (= 1 (count items)))
+              (is (= "transform" (:model (first items))))
+              (is (= "Root Transform" (:name (first items))))))
+          (testing "Transform appears when filtered by models=trans form"
 
-          ;; Test 2: Transform appears when filtered by models=transform
-          (let [items (:data (mt/user-http-request :crowberto :get 200
-                                                   "collection/root/items"
-                                                   :namespace "transforms"
-                                                   :models "transform"))]
-            (is (= 1 (count items)))
-            (is (= transform-id (:id (first items)))))
+            (let [items (:data (mt/user-http-request :crowberto :get 200
+                                                     "collection/root/items"
+                                                     :namespace "transforms"
+                                                     :models "transform"))]
+              (is (= 1 (count items)))
+              (is (= transform-id (:id (first items))))))
 
-          ;; Test 3: Transform NOT returned when filtering for other models only
-          (let [items (:data (mt/user-http-request :crowberto :get 200
-                                                   "collection/root/items"
-                                                   :namespace "transforms"
-                                                   :models "card"))]
-            (is (empty? items)))
+          (testing "Transform NOT returned when filtering for other models only"
+            (let [items (:data (mt/user-http-request :crowberto :get 200
+                                                     "collection/root/items"
+                                                     :namespace "transforms"
+                                                     :models "card"))]
+              (is (empty? items))))
 
-          ;; Test 4: Non-admin users don't see transforms
-          (let [items (->> (:data (mt/user-http-request :rasta :get 200
-                                                        "collection/root/items"
-                                                        :namespace "transforms"))
-                           (filter #(= "transform" (:model %))))]
-            (is (empty? items))))))))
+          (testing "Non-admin users don't see transforms"
+            (let [items (->> (:data (mt/user-http-request :rasta :get 200
+                                                          "collection/root/items"
+                                                          :namespace "transforms"))
+                             (filter #(= "transform" (:model %))))]
+              (is (empty? items)))))))))
 
 (deftest transforms-appear-in-here-test
   (testing "GET /api/collection/:id/items"

--- a/enterprise/backend/test/metabase_enterprise/transforms/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/api_test.clj
@@ -1185,6 +1185,44 @@
                                                    (format "collection/%d/items" collection-id)))]
             (is (empty? items))))))))
 
+(deftest root-collection-items-include-transforms-test
+  (testing "GET /api/collection/root/items"
+    (testing "Includes transforms in root collection items"
+      (mt/with-premium-features #{:transforms}
+        (mt/with-temp [:model/Transform {transform-id :id}
+                       {:name "Root Transform"
+                        :description "A transform at root"}]
+          ;; Test 1: Transform appears in unfiltered results
+          (let [items (->> (:data (mt/user-http-request :crowberto :get 200
+                                                        "collection/root/items"
+                                                        :namespace "transforms"))
+                           (filter #(= "transform" (:model %))))]
+            (is (= 1 (count items)))
+            (is (= "transform" (:model (first items))))
+            (is (= "Root Transform" (:name (first items)))))
+
+          ;; Test 2: Transform appears when filtered by models=transform
+          (let [items (:data (mt/user-http-request :crowberto :get 200
+                                                   "collection/root/items"
+                                                   :namespace "transforms"
+                                                   :models "transform"))]
+            (is (= 1 (count items)))
+            (is (= transform-id (:id (first items)))))
+
+          ;; Test 3: Transform NOT returned when filtering for other models only
+          (let [items (:data (mt/user-http-request :crowberto :get 200
+                                                   "collection/root/items"
+                                                   :namespace "transforms"
+                                                   :models "card"))]
+            (is (empty? items)))
+
+          ;; Test 4: Non-admin users don't see transforms
+          (let [items (->> (:data (mt/user-http-request :rasta :get 200
+                                                        "collection/root/items"
+                                                        :namespace "transforms"))
+                           (filter #(= "transform" (:model %))))]
+            (is (empty? items))))))))
+
 (deftest transforms-appear-in-here-test
   (testing "GET /api/collection/:id/items"
     (testing "Transforms in a collection appear in its :here field"

--- a/src/metabase/collections_rest/api.clj
+++ b/src/metabase/collections_rest/api.clj
@@ -1293,6 +1293,15 @@
       #{:collection}
       #{:no_models})))
 
+(def ^:private namespaces-holding-non-collection-types
+  "We can't really *know* what namespace something with a `nil` `collection_id` is in, unless it's one of the special
+  types that can only live in one namespace.
+
+  If you're looking in the root collection of one of these namespaces, we'll allow you to list any type of model.
+
+  Otherwise, we'll just show you collections."
+  #{nil "snippets" "transforms"})
+
 ;; TODO (Cam 10/28/25) -- fix this endpoint so it uses kebab-case for query parameters for consistency with the rest
 ;; of the REST API
 ;;
@@ -1347,7 +1356,7 @@
       :show-dashboard-questions?   (boolean show_dashboard_questions)
       :collection-type             collection_type
       :include-library?            include_library
-      :models                      (if-not (contains? #{nil "snippets" "transforms"} namespace)
+      :models                      (if-not (contains? namespaces-holding-non-collection-types namespace)
                                      #{:collection}
                                      model-kwds)
       :pinned-state                (keyword pinned_state)

--- a/src/metabase/collections_rest/api.clj
+++ b/src/metabase/collections_rest/api.clj
@@ -1347,7 +1347,9 @@
       :show-dashboard-questions?   (boolean show_dashboard_questions)
       :collection-type             collection_type
       :include-library?            include_library
-      :models                      (if-not (or (nil? namespace) (= namespace "snippets")) #{:collection} model-kwds)
+      :models                      (if-not (contains? #{nil "snippeets" "transforms"} namespace)
+                                     #{:collection}
+                                     model-kwds)
       :pinned-state                (keyword pinned_state)
       :sort-info                   {:sort-column                 (or (some-> sort_column normalize-sort-choice) :name)
                                     :sort-direction              (or (some-> sort_direction normalize-sort-choice) :asc)

--- a/src/metabase/collections_rest/api.clj
+++ b/src/metabase/collections_rest/api.clj
@@ -1347,7 +1347,7 @@
       :show-dashboard-questions?   (boolean show_dashboard_questions)
       :collection-type             collection_type
       :include-library?            include_library
-      :models                      (if-not (contains? #{nil "snippeets" "transforms"} namespace)
+      :models                      (if-not (contains? #{nil "snippets" "transforms"} namespace)
                                      #{:collection}
                                      model-kwds)
       :pinned-state                (keyword pinned_state)


### PR DESCRIPTION
- The `GET /api/collection/root/items?namespace=transforms` endpoint was only returning collections, never transforms themselves. The root endpoint's model filter excluded all non-nil namespaces except "snippets" from passing through requested model types, so the transforms namespace was restricted to `#{:collection}`.
- Added "transforms" to the set of namespaces that pass through model-kwds instead of being restricted to collections only.