### PR TITLE
Fix collisions in test log file uploads

### DIFF
--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -52,7 +52,7 @@ runs:
       if: always() && steps.run-test.outcome != 'success'
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ format('test-logs-{0}{1}', github.job, (inputs.logs-artifact-suffix == '' || inputs.logs-artifact-suffix == null) && '' || format('-{0}', inputs.logs-artifact-suffix)) }}
+        name: ${{ format('test-logs-{0}{1}', github.job, inputs.logs-artifact-suffix && format('-{0}', inputs.logs-artifact-suffix) || '') }}
         path: logs/test-log.json
         retention-days: 1
       # Failing to upload the artifact should never affect the outcome of the whole test run.

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -1020,6 +1020,7 @@ jobs:
         uses: ./.github/actions/test-driver
         with:
           junit-name: 'be-tests-${{ matrix.version.junit-name }}'
+          logs-artifact-suffix: ${{ matrix.version.name }}-${{ matrix.job.name }}
           test-args: >-
             ${{ matrix.job.test-args }}
             :exclude-tags '[ ${{ matrix.job.exclude-tag }} ${{ env.__ADDITIONAL_EXCLUDED_TAG__ }}]'


### PR DESCRIPTION
1. if the `log-artifact-suffix` is empty, just do `test-logs-{github-job}`.

2. include a `log-artifact-suffix` argument for the driver tests

This way we don't get 409 conflict errors when uploading logs on test failures for driver tests.
