### PR TITLE
Case statements with/without defaults

### DIFF
--- a/src/metabase/query_processor/middleware/format_rows.clj
+++ b/src/metabase/query_processor/middleware/format_rows.clj
@@ -71,7 +71,7 @@
 (defn- format-rows-xform [rf metadata]
   {:pre [(fn? rf)]}
   (log/debugf "Formatting rows with results timezone ID %s" (qp.timezone/results-timezone-id))
-  (let [cols-converted-timezones (perf/mapv :converted_timezone metadata)
+  (let [cols-converted-timezones (perf/mapv :converted_timezone (:cols metadata))
         timezone-id (t/zone-id (qp.timezone/results-timezone-id))
         format (fn [value converted-timezone]
                  (cond-> value

--- a/src/metabase/query_processor/middleware/format_rows.clj
+++ b/src/metabase/query_processor/middleware/format_rows.clj
@@ -57,33 +57,34 @@
   (format-value [t timezone-id]
     (t/format :iso-offset-date-time (u.date/with-time-zone-same-instant t timezone-id))))
 
+(defn- strip-timezone [t]
+  (cond
+    (instance? OffsetDateTime t)
+    (.toLocalDateTime ^OffsetDateTime t)
+
+    (instance? ZonedDateTime t)
+    (.toLocalDateTime ^ZonedDateTime t)
+
+    :else
+    t))
+
 (defn- format-rows-xform [rf metadata]
   {:pre [(fn? rf)]}
   (log/debugf "Formatting rows with results timezone ID %s" (qp.timezone/results-timezone-id))
-  (let [timezone-id  (t/zone-id (qp.timezone/results-timezone-id))
-        ;; a column will have `converted_timezone` metadata if it is the result of `convert-timezone` expression
-        ;; in that case, we'll format the results with the target timezone.
-        ;; Otherwise format it with results-timezone
-        cols-zone-id (perf/mapv #(t/zone-id (get % :converted_timezone timezone-id)) (:cols metadata))
-        ;; For columns with converted_timezone, if the driver returns an
-        ;; OffsetDateTime/ZonedDateTime, the value has already been timezone-converted
-        ;; in SQL but the db may have re-cast it as timestamp with tz. We need to
-        ;; strip the offset and treat it as a LocalDateTime so format-value attaches
-        ;; the target zone instead of shifting from UTC. (#68712)
-        converted?   (perf/mapv #(boolean (:converted_timezone %)) (:cols metadata))
-        normalize    (fn [v converted-col?]
-                       (cond
-                         (not converted-col?)
-                         v
-
-                         (instance? OffsetDateTime v)
-                         (.toLocalDateTime ^OffsetDateTime v)
-
-                         (instance? ZonedDateTime v)
-                         (.toLocalDateTime ^ZonedDateTime v)
-
-                         :else
-                         v))]
+  (let [cols-converted-timezones (perf/mapv :converted_timezone metadata)
+        timezone-id (t/zone-id (qp.timezone/results-timezone-id))
+        format (fn [value converted-timezone]
+                 (cond-> value
+                   ;; For columns with converted_timezone, if the driver returns an
+                   ;; OffsetDateTime/ZonedDateTime, the value has already been timezone-converted
+                   ;; in SQL but the db may have re-cast it as timestamp with tz. We need to
+                   ;; strip the offset and treat it as a LocalDateTime so format-value attaches
+                   ;; the target zone instead of shifting from UTC. (#68712)
+                   converted-timezone strip-timezone
+                   ;; a column will have `converted_timezone` metadata if it is the result of `convert-timezone`
+                   ;; expression in that case, we'll format the results with the target timezone.  Otherwise
+                   ;; format it with results-timezone
+                   true (format-value (t/zone-id (or converted-timezone timezone-id)))))]
     (fn
       ([]
        (rf))
@@ -92,9 +93,7 @@
        (rf result))
 
       ([result row]
-       (rf result (perf/mapv format-value
-                             (perf/mapv normalize row converted?)
-                             cols-zone-id))))))
+       (rf result (perf/mapv format row cols-converted-timezones))))))
 
 (defn format-rows
   "Format individual query result values as needed.  Ex: format temporal values as ISO-8601 strings w/ timezone offset."

--- a/test/metabase/query_processor/native_test.clj
+++ b/test/metabase/query_processor/native_test.clj
@@ -6,7 +6,6 @@
    [metabase.lib.options :as lib.options]
    [metabase.lib.test-util :as lib.tu]
    [metabase.query-processor :as qp]
-   [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.date-time-zone-functions-test :as dt-fn-test]
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test-util :as qp.test-util]
@@ -123,12 +122,8 @@
                       (as-> q (lib/with-fields q [index-col
                                                   (lib/expression-ref q "with-default")
                                                   (lib/expression-ref q "without-default")])))
-                [idx with-default-val without-default-val :as first-row] (first (mt/rows (qp/process-query q)))]
+                results (qp/process-query q)
+                [_idx with-default-val without-default-val] (first (mt/rows results))]
             (testing "MBQL: case with and without default should produce the same result for matching rows"
-              (is (= without-default-val with-default-val)))
-            (testing "native SQL compiled from the MBQL query should return equal results for both columns"
-              (let [compiled (qp.compile/compile q)
-                    native-rows (mt/rows (qp/process-query (mt/native-query compiled)))
-                    first-native-row (first native-rows)]
-                (is (= first-native-row first-row))))))))))
+              (is (= without-default-val with-default-val)))))))))
 

--- a/test/metabase/query_processor/native_test.clj
+++ b/test/metabase/query_processor/native_test.clj
@@ -2,8 +2,12 @@
   (:require
    [clojure.test :refer :all]
    [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.options :as lib.options]
    [metabase.lib.test-util :as lib.tu]
    [metabase.query-processor :as qp]
+   [metabase.query-processor.compile :as qp.compile]
+   [metabase.query-processor.date-time-zone-functions-test :as dt-fn-test]
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test-util :as qp.test-util]
    [metabase.test :as mt]
@@ -96,3 +100,35 @@
                                          :card-id      2}}}]
           (is (= [["Gizmo" "Swaniawski, Casper and Hilll"]]
                  (mt/rows (qp/process-query (mt/native-query query))))))))))
+
+(deftest convert-timezone-in-case-with-default-test
+  (testing "convert-timezone inside case with a default value should not double-convert (#68712)"
+    (mt/test-drivers (mt/normal-drivers-with-feature :convert-timezone)
+      (mt/with-report-timezone-id! "UTC"
+        (mt/dataset dt-fn-test/times-mixed
+          (let [mp (mt/metadata-provider)
+                query (lib/query mp (lib.metadata/table mp (mt/id :times)))
+                dt-tz-col (lib.metadata/field mp (mt/id :times :dt_tz))
+                index-col (lib.metadata/field mp (mt/id :times :index))
+                convert-tz (fn [col]
+                             (lib.options/ensure-uuid
+                              [:convert-timezone {} col "Asia/Seoul"]))
+                with-default (lib/case [[(lib/= index-col 1) (convert-tz dt-tz-col)]]
+                               dt-tz-col)
+                without-default (lib/case [[(lib/= index-col 1) (convert-tz dt-tz-col)]])
+                q (-> query
+                      (lib/expression "with-default" with-default)
+                      (lib/expression "without-default" without-default)
+                      (lib/filter (lib/= index-col 1))
+                      (as-> q (lib/with-fields q [index-col
+                                                  (lib/expression-ref q "with-default")
+                                                  (lib/expression-ref q "without-default")])))
+                [idx with-default-val without-default-val :as first-row] (first (mt/rows (qp/process-query q)))]
+            (testing "MBQL: case with and without default should produce the same result for matching rows"
+              (is (= without-default-val with-default-val)))
+            (testing "native SQL compiled from the MBQL query should return equal results for both columns"
+              (let [compiled (qp.compile/compile q)
+                    native-rows (mt/rows (qp/process-query (mt/native-query compiled)))
+                    first-native-row (first native-rows)]
+                (is (= first-native-row first-row))))))))))
+

--- a/test/metabase/query_processor/native_test.clj
+++ b/test/metabase/query_processor/native_test.clj
@@ -126,4 +126,3 @@
                 [_idx with-default-val without-default-val] (first (mt/rows results))]
             (testing "MBQL: case with and without default should produce the same result for matching rows"
               (is (= without-default-val with-default-val)))))))))
-


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/68712

### Description

In the case statement, the default case did not TIMEZONE() to alter the timezone. The cases with TIMEZONE() returned a timestamp. The default case without TIMEZONE() returned timestamptz. Postgres reconciled the different types by converting all of them to timestamptz. So the timestamp was altered (by `TIMEZONE()`), but a new UTC timestamp was added (by the cast).

When the post-processor formats the rows, it checks that the metadata for the column has `:converted_timezone`. If it has that, it is formatted in the converted timezone, and since it's UTC, it will convert it again, a second time, which is incorrect.

The fix here is to check if the returned column is a timestamptz and strip it before formatting. We assume the database has already done the conversion. This avoids the second conversion.

### How to verify

Same steps as in the original bug.

<img width="647" height="169" alt="Screenshot 2026-01-27 at 2 34 59 PM" src="https://github.com/user-attachments/assets/7193d942-1012-4677-8624-f5970aa629b4" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

