### PR TITLE
flake: empty schemas in target schemas

### DIFF
--- a/e2e/test/scenarios/data-studio/transforms/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms/reproductions.cy.spec.ts
@@ -1,5 +1,4 @@
 const { H } = cy;
-import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
 
 describe("issue #68378", () => {
   beforeEach(() => {
@@ -7,13 +6,13 @@ describe("issue #68378", () => {
     H.resetTestTable({ type: "postgres", table: "empty_schema" });
     cy.signInAsAdmin();
     H.activateToken("bleeding-edge");
-    cy.request("POST", `/api/database/${WRITABLE_DB_ID}/sync_schema`);
   });
 
   it("should show empty schema's when picking a target schema (metabase#68378)", () => {
     visitTransformListPage();
     cy.button("Create a transform").click();
     H.popover().findByText("SQL query").click();
+    H.popover().findByText("Writable Postgres12").click();
     H.NativeEditor.type("SELECT 42", { allowFastSet: true });
 
     cy.log("Save with empty_schema as target schema");


### PR DESCRIPTION
The test was missing an explicit database selection step which sometimes resulted in the Save button being disabled.

Also removed the unnecessary sync_schema call — the syncable_schemas endpoint queries Postgres directly via the driver, so no metadata sync is needed.
