### PR TITLE
flake: fix temporal pollution

### DIFF
--- a/src/metabase/testing_api/api.clj
+++ b/src/metabase/testing_api/api.clj
@@ -130,6 +130,8 @@
   "Restore a database snapshot for testing purposes."
   [{snapshot-name :name} :- [:map
                              [:name ms/NonBlankString]]]
+  ;; reset the system clock, in case `/set-time` was called without cleanup
+  (alter-var-root #'java-time.clock/*clock* (constantly nil))
   (.clear ^Queue @#'search.ingestion/queue)
   (restore-snapshot! snapshot-name)
   (search/reindex! {:async? false})


### PR DESCRIPTION
We have a testing endpoint that sets/freezes the clock.

Some e2e tests were doing this, and not cleaning up after themselves. Time stayed frozen, which caused issues for subsequent tests.

This fixes the `/api/testing/restore/:name` endpoint to always reset the clock.