### PR TITLE
Add additional tables to Lib test metadata

### DIFF
--- a/test/metabase/lib/test_metadata.cljc
+++ b/test/metabase/lib/test_metadata.cljc
@@ -1,3 +1,4 @@
+;; -*- comment-column: 55; -*-
 (ns metabase.lib.test-metadata
   "Test metadata that we can test the new Metadata lib with. This was captured from the same API endpoints that the frontend
   Query Builder hits to power its UI.
@@ -48,107 +49,152 @@
   ([table-name]
    (+ random-id-offset
       (case table-name
-        :categories   10
-        :checkins     20
-        :users        30
-        :venues       40
-        :products     50
-        :orders       60
-        :people       70
-        :reviews      80
-        :ic/accounts  90
-        :ic/reports  100
-        :gh/issues   110
-        :gh/users    120
-        :gh/comments 130)))
+        :categories      10
+        :checkins        20
+        :users           30
+        :venues          40
+        :products        50
+        :orders          60
+        :people          70
+        :reviews         80
+        :ic/accounts     90
+        :ic/reports      100
+        :gh/issues       110
+        :gh/users        120
+        :gh/comments     130
+        ;; extra tables added to customer-facing Sample Dataset somewhat recently but not present in backend
+        ;; `test-data`
+        :feedback        140
+        :accounts        150
+        :analytic-events 160
+        :invoices        170)))
 
   ([table-name field-name]
    (+ random-id-offset
       (case table-name
-        :categories (case field-name         ;
-                      :id   100              ; :type/BigInteger
-                      :name 101)             ; :type/Text
-        :checkins   (case field-name         ;
-                      :id       200          ; :type/BigInteger
-                      :date     201          ; :type/Date
-                      :user-id  202          ; :type/Integer
-                      :venue-id 203)         ; :type/Integer
-        :users      (case field-name         ;
-                      :id         300        ; :type/BigInteger
-                      :name       301        ; :type/Text
-                      :last-login 302        ; :type/DateTime
-                      :password   303)       ; :type/Text
-        :venues     (case field-name         ;
-                      :id          400       ; :type/BigInteger
-                      :name        401       ; :type/Text
-                      :category-id 402       ; :type/Integer
-                      :latitude    403       ; :type/Float
-                      :longitude   404       ; :type/Float
-                      :price       405)      ; :type/Integer
-        :products   (case field-name         ;
-                      :id         500        ; :type/BigInteger
-                      :rating     501        ; :type/Float
-                      :category   502        ; :type/Text
-                      :price      503        ; :type/Float
-                      :title      504        ; :type/Text
-                      :created-at 505        ; :type/DateTimeWithLocalTZ
-                      :vendor     506        ; :type/Text
-                      :ean        507)       ; :type/Text
-        :orders     (case field-name         ;
-                      :id         600        ; :type/BigInteger
-                      :subtotal   601        ; :type/Float
-                      :total      602        ; :type/Float
-                      :tax        603        ; :type/Float
-                      :discount   604        ; :type/Float
-                      :quantity   605        ; :type/Integer
-                      :created-at 606        ; :type/DateTimeWithLocalTZ
-                      :product-id 607        ; :type/Integer
-                      :user-id    608)       ; :type/Integer
-        :people     (case field-name         ;
-                      :id         700        ; :type/BigInteger
-                      :state      701        ; :type/Text
-                      :city       702        ; :type/Text
-                      :address    703        ; :type/Text
-                      :name       704        ; :type/Text
-                      :source     705        ; :type/Text
-                      :zip        706        ; :type/Text
-                      :latitude   707        ; :type/Float
-                      :password   708        ; :type/Text
-                      :birth-date 709        ; :type/Date
-                      :longitude  710        ; :type/Float
-                      :email      711        ; :type/Text
-                      :created-at 712)       ; :type/DateTimeWithLocalTZ
-        :reviews    (case field-name         ;
-                      :id         800        ; :type/BigInteger
-                      :created-at 801        ; :type/DateTimeWithLocalTZ
-                      :rating     802        ; :type/Integer
-                      :reviewer   803        ; :type/Text
-                      :body       804        ; :type/Text
-                      :product-id 805)       ; :type/Integer
-        :ic/accounts (case field-name        ;
-                       :id        900        ; :type/Integer
-                       :name      901)       ; :type/Text
-        :ic/reports  (case field-name        ;
-                       :id         1000      ; :type/Integer
-                       :created-by 1001      ; :type/Integer
-                       :updated-by 1002)     ; :type/Integer
-        :gh/issues   (case field-name
-                       :id          1100     ; :type/UUID
-                       :reporter-id 1101     ; :type/Text (FK to :gh/users)
-                       :assignee-id 1102     ; :type/Text (FK to :gh/users)
-                       :is-open     1103     ; :type/Integer (but it wants to be :type/Boolean)
-                       :reported-at 1104     ; :type/DateTime
-                       :closed-at   1105)    ; :type/DateTime
-        :gh/users    (case field-name
-                       :id           1200    ; :type/Text (Github usernames eg. camsaul, bshepherdson)
-                       :birthday     1202    ; :type/Date
-                       :email        1203)   ; :type/Text
-        :gh/comments (case field-name
-                       :id            1300   ; :type/UUID
-                       :author-id     1301   ; :type/Text
-                       :posted-at     1302   ; :type/DateTime
-                       :reply-to      1303   ; :type/UUID (FK to the same table)
-                       :body-markdown 1304))))) ;type/Text
+        :categories      (case field-name              ;
+                           :id   100                   ; :type/BigInteger
+                           :name 101)                  ; :type/Text
+        :checkins        (case field-name              ;
+                           :id       200               ; :type/BigInteger
+                           :date     201               ; :type/Date
+                           :user-id  202               ; :type/Integer
+                           :venue-id 203)              ; :type/Integer
+        :users           (case field-name              ;
+                           :id         300             ; :type/BigInteger
+                           :name       301             ; :type/Text
+                           :last-login 302             ; :type/DateTime
+                           :password   303)            ; :type/Text
+        :venues          (case field-name              ;
+                           :id          400            ; :type/BigInteger
+                           :name        401            ; :type/Text
+                           :category-id 402            ; :type/Integer
+                           :latitude    403            ; :type/Float
+                           :longitude   404            ; :type/Float
+                           :price       405)           ; :type/Integer
+        :products        (case field-name              ;
+                           :id         500             ; :type/BigInteger
+                           :rating     501             ; :type/Float
+                           :category   502             ; :type/Text
+                           :price      503             ; :type/Float
+                           :title      504             ; :type/Text
+                           :created-at 505             ; :type/DateTimeWithLocalTZ
+                           :vendor     506             ; :type/Text
+                           :ean        507)            ; :type/Text
+        :orders          (case field-name              ;
+                           :id         600             ; :type/BigInteger
+                           :subtotal   601             ; :type/Float
+                           :total      602             ; :type/Float
+                           :tax        603             ; :type/Float
+                           :discount   604             ; :type/Float
+                           :quantity   605             ; :type/Integer
+                           :created-at 606             ; :type/DateTimeWithLocalTZ
+                           :product-id 607             ; :type/Integer
+                           :user-id    608)            ; :type/Integer
+        :people          (case field-name              ;
+                           :id         700             ; :type/BigInteger
+                           :state      701             ; :type/Text
+                           :city       702             ; :type/Text
+                           :address    703             ; :type/Text
+                           :name       704             ; :type/Text
+                           :source     705             ; :type/Text
+                           :zip        706             ; :type/Text
+                           :latitude   707             ; :type/Float
+                           :password   708             ; :type/Text
+                           :birth-date 709             ; :type/Date
+                           :longitude  710             ; :type/Float
+                           :email      711             ; :type/Text
+                           :created-at 712)            ; :type/DateTimeWithLocalTZ
+        :reviews         (case field-name              ;
+                           :id         800             ; :type/BigInteger
+                           :created-at 801             ; :type/DateTimeWithLocalTZ
+                           :rating     802             ; :type/Integer
+                           :reviewer   803             ; :type/Text
+                           :body       804             ; :type/Text
+                           :product-id 805)            ; :type/Integer
+        :ic/accounts     (case field-name              ;
+                           :id   900                   ; :type/Integer
+                           :name 901)                  ; :type/Text
+        :ic/reports      (case field-name              ;
+                           :id         1000            ; :type/Integer
+                           :created-by 1001            ; :type/Integer
+                           :updated-by 1002)           ; :type/Integer
+        :gh/issues       (case field-name
+                           :id          1100           ; :type/UUID
+                           :reporter-id 1101           ; :type/Text (FK to :gh/users)
+                           :assignee-id 1102           ; :type/Text (FK to :gh/users)
+                           :is-open     1103           ; :type/Integer (but it wants to be :type/Boolean)
+                           :reported-at 1104           ; :type/DateTime
+                           :closed-at   1105)          ; :type/DateTime
+        :gh/users        (case field-name
+                           :id       1200              ; :type/Text (Github usernames eg. camsaul, bshepherdson)
+                           :birthday 1202              ; :type/Date
+                           :email    1203)             ; :type/Text
+        :gh/comments     (case field-name
+                           :id            1300         ; :type/UUID
+                           :author-id     1301         ; :type/Text
+                           :posted-at     1302         ; :type/DateTime
+                           :reply-to      1303         ; :type/UUID (FK to the same table)
+                           :body-markdown 1304)        ; :type/Text
+        :feedback        (case field-name
+                           :id            1400         ; :type/BigInteger
+                           :account-id    1401         ; :type/BigInteger (FK to accounts.id; remapped to accounts.email)
+                           :email         1402         ; :type/Email
+                           :date-received 1403         ; :type/DateTime
+                           :rating        1404         ; :type/Integer
+                           :rating-mapped 1405         ; :type/Text
+                           :body          1406)        ; :type/Text
+        :accounts        (case field-name
+                           :id                  1500   ; :type/BigInteger
+                           :email               1501   ; :type/Text
+                           :first-name          1502   ; :type/Text
+                           :last-name           1503   ; :type/Text
+                           :plan                1504   ; :type/Text
+                           :source              1505   ; :type/Text
+                           :seats               1506   ; :type/Integer
+                           :created-at          1507   ; :type/DateTime
+                           :trial-ends-at       1508   ; :type/DateTime
+                           :canceled-at         1509   ; :type/DateTime
+                           :trial-converted     1510   ; :type/Boolean
+                           :active-subscription 1511   ; :type/Boolean
+                           :legacy-plan         1512   ; :type/Boolean
+                           :latitude            1513   ; :type/Float
+                           :longitude           1514   ; :type/Float
+                           :country             1515)  ; :type/Text
+        :analytic-events (case field-name
+                           :id           1600          ; :type/BigInteger
+                           :account-id   1601          ; :type/BigInteger (FK to accounts.id; remapped to accounts.email)
+                           :event        1602          ; :type/Text
+                           :timestamp    1603          ; :type/DateTime
+                           :page-url     1604          ; :type/Text
+                           :button-label 1605)         ; :type/Text
+        :invoices        (case field-name
+                           :id               1700      ; :type/BigInteger
+                           :account-id       1701      ; :type/BigInteger (FK to accounts.id; remapped to accounts.email)
+                           :payment          1702      ; :type/Float
+                           :expected-invoice 1703      ; :type/Boolean
+                           :plan             1704      ; :type/Text
+                           :date-received    1705))))) ; :type/DateTime
 
 (defmulti ^:private table-metadata-method
   {:arglists '([table-name])}
@@ -307,7 +353,7 @@
    :database-position   1
    :database-required   false
    :fingerprint         {:global {:distinct-count 618, :nil% 0.0}
-                         :type   #:type{:DateTime {:earliest "2013-01-03", :latest "2015-12-29"}}}
+                         :type   {:type/DateTime {:earliest "2013-01-03", :latest "2015-12-29"}}}
    :base-type           :type/Date
    :points-of-interest  nil
    :lib/type            :metadata/column})
@@ -456,7 +502,7 @@
    :database-position   1
    :database-required   false
    :fingerprint         {:global {:distinct-count 15, :nil% 0.0}
-                         :type   #:type{:Text
+                         :type   {:type/Text
                                         {:percent-json   0.0
                                          :percent-url    0.0
                                          :percent-email  0.0
@@ -493,7 +539,7 @@
    :database-position   2
    :database-required   false
    :fingerprint         {:global {:distinct-count 15, :nil% 0.0}
-                         :type   #:type{:DateTime {:earliest "2014-01-01T08:30:00Z", :latest "2014-12-05T15:15:00Z"}}}
+                         :type   {:type/DateTime {:earliest "2014-01-01T08:30:00Z", :latest "2014-12-05T15:15:00Z"}}}
    :base-type           :type/DateTime
    :points-of-interest  nil
    :lib/type            :metadata/column})
@@ -525,7 +571,7 @@
    :database-position   3
    :database-required   false
    :fingerprint         {:global {:distinct-count 15, :nil% 0.0}
-                         :type   #:type{:Text
+                         :type   {:type/Text
                                         {:percent-json   0.0
                                          :percent-url    0.0
                                          :percent-email  0.0
@@ -617,7 +663,7 @@
    :database-position   1
    :database-required   false
    :fingerprint         {:global {:distinct-count 100, :nil% 0.0}
-                         :type   #:type{:Text
+                         :type   {:type/Text
                                         {:percent-json   0.0
                                          :percent-url    0.0
                                          :percent-email  0.0
@@ -685,7 +731,7 @@
    :database-position   3
    :database-required   false
    :fingerprint         {:global {:distinct-count 94, :nil% 0.0}
-                         :type   #:type{:Number
+                         :type   {:type/Number
                                         {:min 10.0646
                                          :q1  34.06098873016278
                                          :q3  37.77185
@@ -722,16 +768,15 @@
    :display-name        "Longitude"
    :database-position   4
    :database-required   false
-   :fingerprint
-   {:global {:distinct-count 84, :nil% 0.0}
-    :type
-    #:type{:Number
-           {:min -165.374
-            :q1  -122.40857106781186
-            :q3  -118.2635
-            :max -73.9533
-            :sd  14.162810671348238
-            :avg -115.99848699999998}}}
+   :fingerprint         {:global {:distinct-count 84, :nil% 0.0}
+                         :type
+                         {:type/Number
+                                {:min -165.374
+                                 :q1  -122.40857106781186
+                                 :q3  -118.2635
+                                 :max -73.9533
+                                 :sd  14.162810671348238
+                                 :avg -115.99848699999998}}}
    :base-type           :type/Float
    :points-of-interest  nil
    :lib/type            :metadata/column})
@@ -763,7 +808,7 @@
    :database-position   5
    :database-required   false
    :fingerprint         {:global {:distinct-count 4, :nil% 0.0}
-                         :type   #:type{:Number
+                         :type   {:type/Number
                                         {:min 1.0
                                          :q1  1.4591129021415095
                                          :q3  2.493086095768049
@@ -1795,9 +1840,8 @@
    :display-name               "Birth Date"
    :database-position          9
    :database-required          false
-   :fingerprint
-   {:global {:distinct-count 2308, :nil% 0.0}
-    :type   {:type/DateTime {:earliest "1958-04-26", :latest "2000-04-03"}}}
+   :fingerprint                {:global {:distinct-count 2308, :nil% 0.0}
+                                :type   {:type/DateTime {:earliest "1958-04-26", :latest "2000-04-03"}}}
    :base-type                  :type/Date
    :points-of-interest         nil
    :lib/type                   :metadata/column})
@@ -2232,8 +2276,8 @@
                                                      :percent-url    0.0
                                                      :percent-email  0.0
                                                      :percent-state  0.0
-                                                     :average-length 5.5}}},
-   :base-type                  :type/Text,
+                                                     :average-length 5.5}}}
+   :base-type                  :type/Text
    :points-of-interest         nil
    :lib/type                   :metadata/column})
 
@@ -2939,6 +2983,987 @@
                              (field-metadata-method :gh/comments :reply-to)
                              (field-metadata-method :gh/comments :body-markdown)]})
 
+(defmethod field-metadata-method [:feedback :id]
+  [_table-name _field-name]
+  {:active               true
+   :base-type            :type/BigInteger
+   :coercion-strategy    nil
+   :database-partitioned nil
+   :database-type        "BIGINT"
+   :description          nil
+   :display-name         "ID"
+   :effective-type       :type/BigInteger
+   :fingerprint          nil
+   :fk-target-field-id   nil
+   :id                   (id :feedback :id)
+   :name                 "ID"
+   :nfc-path             nil
+   :parent-id            nil
+   :position             0
+   :semantic-type        :type/PK
+   :settings             nil
+   :table-id             (id :feedback)
+   :visibility-type      :normal
+   :lib/type             :metadata/column})
+
+(defmethod field-metadata-method [:feedback :account-id]
+  [_table-name _field-name]
+  {:active               true
+   :base-type            :type/BigInteger
+   :coercion-strategy    nil
+   :database-partitioned nil
+   :database-type        "BIGINT"
+   :description          nil
+   :display-name         "Account ID"
+   :effective-type       :type/BigInteger
+   :fingerprint          {:global {:distinct-count 642, :nil% 0.0}}
+   :fk-target-field-id   (id :accounts :id)
+   :id                   (id :feedback :account-id)
+   :name                 "ACCOUNT_ID"
+   :nfc-path             nil
+   :parent-id            nil
+   :position             1
+   :semantic-type        :type/FK
+   :settings             nil
+   :table-id             (id :feedback)
+   :visibility-type      :normal
+   :lib/type             :metadata/column})
+
+(defmethod field-metadata-method [:feedback :email]
+  [_table-name _field-name]
+  {:active               true
+   :base-type            :type/Text
+   :coercion-strategy    nil
+   :database-partitioned nil
+   :database-type        "CHARACTER VARYING"
+   :description          nil
+   :display-name         "Email"
+   :effective-type       :type/Text
+   :fingerprint          {:global {:distinct-count 642, :nil% 0.0}
+                          :type   {:type/Text {:percent-json   0.0
+                                               :percent-url    0.0
+                                               :percent-email  1.0
+                                               :percent-state  0.0
+                                               :average-length 28.327102803738317}}}
+   :fk-target-field-id   nil
+   :id                   (id :feedback :email)
+   :name                 "EMAIL"
+   :nfc-path             nil
+   :parent-id            nil
+   :position             2
+   :semantic-type        :type/Email
+   :settings             nil
+   :table-id             (id :feedback)
+   :visibility-type      :normal
+   :lib/type             :metadata/column})
+
+(defmethod field-metadata-method [:feedback :date-received]
+  [_table-name _field-name]
+  {:active               true
+   :base-type            :type/DateTime
+   :coercion-strategy    nil
+   :database-partitioned nil
+   :database-type        "TIMESTAMP"
+   :description          nil
+   :display-name         "Date Received"
+   :effective-type       :type/DateTime
+   :fingerprint          {:global {:distinct-count 576, :nil% 0.0}
+                          :type   {:type/DateTime {:earliest "2020-11-20T00:00:00Z", :latest "2031-12-01T00:00:00Z"}}}
+   :fk-target-field-id   nil
+   :id                   (id :feedback :date-received)
+   :name                 "DATE_RECEIVED"
+   :nfc-path             nil
+   :parent-id            nil
+   :position             3
+   :semantic-type        nil
+   :settings             nil
+   :table-id             (id :feedback)
+   :visibility-type      :normal
+   :lib/type             :metadata/column})
+
+(defmethod field-metadata-method [:feedback :rating]
+  [_table-name _field-name]
+  {:active               true
+   :base-type            :type/Integer
+   :coercion-strategy    nil
+   :database-partitioned nil
+   :database-type        "SMALLINT"
+   :description          nil
+   :display-name         "Rating"
+   :effective-type       :type/Integer
+   :fingerprint          {:global {:distinct-count 5, :nil% 0.0}
+                          :type   {:type/Number {:min 1.0
+                                                 :q1  2.7545289729206877
+                                                 :q3  4.004191340512663
+                                                 :max 5.0
+                                                 :sd  0.8137255616667736
+                                                 :avg 3.3629283489096573}}}
+   :fk-target-field-id   nil
+   :id                   (id :feedback :rating)
+   :name                 "RATING"
+   :nfc-path             nil
+   :parent-id            nil
+   :position             4
+   :semantic-type        :type/Score
+   :settings             nil
+   :table-id             (id :feedback)
+   :visibility-type      :normal
+   :lib/type             :metadata/column})
+
+(defmethod field-metadata-method [:feedback :rating-mapped]
+  [_table-name _field-name]
+  {:active               true
+   :base-type            :type/Text
+   :coercion-strategy    nil
+   :database-partitioned nil
+   :database-type        "CHARACTER VARYING"
+   :description          nil
+   :display-name         "Rating Mapped"
+   :effective-type       :type/Text
+   :fingerprint          {:global {:distinct-count 5, :nil% 0.0}
+                          :type   {:type/Text {:percent-json   0.0
+                                               :percent-url    0.0
+                                               :percent-email  0.0
+                                               :percent-state  0.0
+                                               :average-length 6.453271028037383}}}
+   :fk-target-field-id   nil
+   :id                   (id :feedback :rating-mapped)
+   :name                 "RATING_MAPPED"
+   :nfc-path             nil
+   :parent-id            nil
+   :position             5
+   :semantic-type        :type/Category
+   :settings             nil
+   :table-id             (id :feedback)
+   :visibility-type      :normal
+   :lib/type             :metadata/column})
+
+(defmethod field-metadata-method [:feedback :body]
+  [_table-name _field-name]
+  {:active               true
+   :base-type            :type/Text
+   :coercion-strategy    nil
+   :database-partitioned nil
+   :database-type        "CHARACTER LARGE OBJECT"
+   :description          nil
+   :display-name         "Body"
+   :effective-type       :type/Text
+   :fingerprint          {:global {:distinct-count 642, :nil% 0.0}
+                          :type   {:type/Text {:percent-json   0.0
+                                               :percent-url    0.0
+                                               :percent-email  0.0
+                                               :percent-state  0.0
+                                               :average-length 438.15264797507785}}}
+   :fk-target-field-id   nil
+   :id                   (id :feedback :body)
+   :name                 "BODY"
+   :nfc-path             nil
+   :parent-id            nil
+   :position             6
+   :semantic-type        nil
+   :settings             nil
+   :table-id             (id :feedback)
+   :visibility-type      :normal
+   :lib/type             :metadata/column})
+
+(defmethod table-metadata-method :feedback
+  [_table-name]
+  {:active                  true
+   :database-require-filter nil
+   :db-id                   (id)
+   :display-name            "Feedback"
+   :fields                  [(field-metadata-method :feedback :id)
+                             (field-metadata-method :feedback :account-id)
+                             (field-metadata-method :feedback :email)
+                             (field-metadata-method :feedback :date-received)
+                             (field-metadata-method :feedback :rating)
+                             (field-metadata-method :feedback :rating-mapped)
+                             (field-metadata-method :feedback :body)]
+   :id                      (id :feedback)
+   :name                    "FEEDBACK"
+   :schema                  "PUBLIC"
+   :visibility-type         nil
+   :lib/type                :metadata/table})
+
+(defmethod field-metadata-method [:accounts :id]
+  [_table-name _field-name]
+  {:active               true
+   :base-type            :type/BigInteger
+   :coercion-strategy    nil
+   :database-partitioned nil
+   :database-type        "BIGINT"
+   :description          nil
+   :display-name         "ID"
+   :effective-type       :type/BigInteger
+   :fingerprint          nil
+   :fk-target-field-id   nil
+   :id                   (id :accounts :id)
+   :name                 "ID"
+   :nfc-path             nil
+   :parent-id            nil
+   :position             0
+   :semantic-type        :type/PK
+   :settings             nil
+   :table-id             (id :accounts)
+   :visibility-type      :normal
+   :lib/type             :metadata/column})
+
+(defmethod field-metadata-method [:accounts :email]
+  [_table-name _field-name]
+  {:active               true
+   :base-type            :type/Text
+   :coercion-strategy    nil
+   :database-partitioned nil
+   :database-type        "CHARACTER VARYING"
+   :description          nil
+   :display-name         "Email"
+   :effective-type       :type/Text
+   :fingerprint          {:global {:distinct-count 2494, :nil% 0.0}
+                          :type   {:type/Text {:percent-json   0.0
+                                               :percent-url    0.0
+                                               :percent-email  1.0
+                                               :percent-state  0.0
+                                               :average-length 28.185971943887775}}}
+   :fk-target-field-id   nil
+   :id                   (id :accounts :email)
+   :name                 "EMAIL"
+   :nfc-path             nil
+   :parent-id            nil
+   :position             1
+   :semantic-type        :type/Email
+   :settings             nil
+   :table-id             (id :accounts)
+   :visibility-type      :normal
+   :lib/type             :metadata/column})
+
+(defmethod field-metadata-method [:accounts :first-name]
+  [_table-name _field-name]
+  {:active               true
+   :base-type            :type/Text
+   :coercion-strategy    nil
+   :database-partitioned nil
+   :database-type        "CHARACTER VARYING"
+   :description          nil
+   :display-name         "First Name"
+   :effective-type       :type/Text
+   :fingerprint          {:global {:distinct-count 1687, :nil% 0.0}
+                          :type   {:type/Text {:percent-json   0.0
+                                               :percent-url    0.0
+                                               :percent-email  0.0
+                                               :percent-state  0.001603206412825651
+                                               :average-length 5.997595190380761}}}
+   :fk-target-field-id   nil
+   :id                   (id :accounts :first-name)
+   :name                 "FIRST_NAME"
+   :nfc-path             nil
+   :parent-id            nil
+   :position             2
+   :semantic-type        :type/Name
+   :settings             nil
+   :table-id             (id :accounts)
+   :visibility-type      :normal
+   :lib/type             :metadata/column})
+
+(defmethod field-metadata-method [:accounts :last-name]
+  [_table-name _field-name]
+  {:active               true
+   :base-type            :type/Text
+   :coercion-strategy    nil
+   :database-partitioned nil
+   :database-type        "CHARACTER VARYING"
+   :description          nil
+   :display-name         "Last Name"
+   :effective-type       :type/Text
+   :fingerprint          {:global {:distinct-count 473, :nil% 0.0}
+                          :type   {:type/Text {:percent-json   0.0
+                                               :percent-url    0.0
+                                               :percent-email  0.0
+                                               :percent-state  0.0
+                                               :average-length 6.536673346693386}}}
+   :fk-target-field-id   nil
+   :id                   (id :accounts :last-name)
+   :name                 "LAST_NAME"
+   :nfc-path             nil
+   :parent-id            nil
+   :position             3
+   :semantic-type        :type/Name
+   :settings             nil
+   :table-id             (id :accounts)
+   :visibility-type      :normal
+   :lib/type             :metadata/column})
+
+(defmethod field-metadata-method [:accounts :plan]
+  [_table-name _field-name]
+  {:active               true
+   :base-type            :type/Text
+   :coercion-strategy    nil
+   :database-partitioned nil
+   :database-type        "CHARACTER VARYING"
+   :description          nil
+   :display-name         "Plan"
+   :effective-type       :type/Text
+   :fingerprint          {:global {:distinct-count 3, :nil% 0.0}
+                          :type   {:type/Text {:percent-json   0.0
+                                               :percent-url    0.0
+                                               :percent-email  0.0
+                                               :percent-state  0.0
+                                               :average-length 5.1062124248497}}}
+   :fk-target-field-id   nil
+   :id                   (id :accounts :plan)
+   :name                 "PLAN"
+   :nfc-path             nil
+   :parent-id            nil
+   :position             4
+   :semantic-type        :type/Category
+   :settings             nil
+   :table-id             (id :accounts)
+   :visibility-type      :normal
+   :lib/type             :metadata/column})
+
+(defmethod field-metadata-method [:accounts :source]
+  [_table-name _field-name]
+  {:active               true
+   :base-type            :type/Text
+   :coercion-strategy    nil
+   :database-partitioned nil
+   :database-type        "CHARACTER VARYING"
+   :description          nil
+   :display-name         "Source"
+   :effective-type       :type/Text
+   :fingerprint          {:global {:distinct-count 5, :nil% 0.3346693386773547}
+                          :type   {:type/Text {:percent-json   0.0
+                                               :percent-url    0.0
+                                               :percent-email  0.0
+                                               :percent-state  0.0
+                                               :average-length 4.4705410821643286}}}
+   :fk-target-field-id   nil
+   :id                   (id :accounts :source)
+   :name                 "SOURCE"
+   :nfc-path             nil
+   :parent-id            nil
+   :position             5
+   :semantic-type        :type/Source
+   :settings             nil
+   :table-id             (id :accounts)
+   :visibility-type      :normal
+   :lib/type             :metadata/column})
+
+(defmethod field-metadata-method [:accounts :seats]
+  [_table-name _field-name]
+  {:active               true
+   :base-type            :type/Integer
+   :coercion-strategy    nil
+   :database-partitioned nil
+   :database-type        "INTEGER"
+   :description          nil
+   :display-name         "Seats"
+   :effective-type       :type/Integer
+   :fingerprint          {:global {:distinct-count 102, :nil% 0.0}
+                          :type   {:type/Number {:min 1.0
+                                                 :q1  2.4309856865966593
+                                                 :q3  10.553778422458695
+                                                 :max 1325.0
+                                                 :sd  51.198301031505444
+                                                 :avg 16.21763527054108}}}
+   :fk-target-field-id   nil
+   :id                   (id :accounts :seats)
+   :name                 "SEATS"
+   :nfc-path             nil
+   :parent-id            nil
+   :position             6
+   :semantic-type        nil
+   :settings             nil
+   :table-id             (id :accounts)
+   :visibility-type      :normal
+   :lib/type             :metadata/column})
+
+(defmethod field-metadata-method [:accounts :created-at]
+  [_table-name _field-name]
+  {:active               true
+   :base-type            :type/DateTime
+   :coercion-strategy    nil
+   :database-partitioned nil
+   :database-type        "TIMESTAMP"
+   :description          nil
+   :display-name         "Created At"
+   :effective-type       :type/DateTime
+   :fingerprint          {:global {:distinct-count 2495, :nil% 0.0}
+                          :type   {:type/DateTime {:earliest "2020-09-15T16:11:50Z", :latest "2031-10-10T19:14:48Z"}}}
+   :fk-target-field-id   nil
+   :id                   (id :accounts :created-at)
+   :name                 "CREATED_AT"
+   :nfc-path             nil
+   :parent-id            nil
+   :position             7
+   :semantic-type        :type/CreationTimestamp
+   :settings             nil
+   :table-id             (id :accounts)
+   :visibility-type      :normal
+   :lib/type             :metadata/column})
+
+(defmethod field-metadata-method [:accounts :trial-ends-at]
+  [_table-name _field-name]
+  {:active               true
+   :base-type            :type/DateTime
+   :coercion-strategy    nil
+   :database-partitioned nil
+   :database-type        "TIMESTAMP"
+   :description          nil
+   :display-name         "Trial Ends At"
+   :effective-type       :type/DateTime
+   :fingerprint          {:global {:distinct-count 1712, :nil% 0.001202404809619238}
+                          :type   {:type/DateTime {:earliest "2020-09-30T12:00:00Z", :latest "2031-10-25T12:00:00Z"}}}
+   :fk-target-field-id   nil
+   :id                   (id :accounts :trial-ends-at)
+   :name                 "TRIAL_ENDS_AT"
+   :nfc-path             nil
+   :parent-id            nil
+   :position             8
+   :semantic-type        nil
+   :settings             nil
+   :table-id             (id :accounts)
+   :visibility-type      :normal
+   :lib/type             :metadata/column})
+
+(defmethod field-metadata-method [:accounts :canceled-at]
+  [_table-name _field-name]
+  {:active               true
+   :base-type            :type/DateTime
+   :coercion-strategy    nil
+   :database-partitioned nil
+   :database-type        "TIMESTAMP"
+   :description          nil
+   :display-name         "Canceled At"
+   :effective-type       :type/DateTime
+   :fingerprint          {:global {:distinct-count 2021, :nil% 0.1859719438877756}
+                          :type   {:type/DateTime {:earliest "2020-10-01T15:43:40Z", :latest "2032-06-03T14:01:15Z"}}}
+   :fk-target-field-id   nil
+   :id                   (id :accounts :canceled-at)
+   :name                 "CANCELED_AT"
+   :nfc-path             nil
+   :parent-id            nil
+   :position             9
+   :semantic-type        :type/CancelationTimestamp
+   :settings             nil
+   :table-id             (id :accounts)
+   :visibility-type      :normal
+   :lib/type             :metadata/column})
+
+(defmethod field-metadata-method [:accounts :trial-converted]
+  [_table-name _field-name]
+  {:active               true
+   :base-type            :type/Boolean
+   :coercion-strategy    nil
+   :database-partitioned nil
+   :database-type        "BOOLEAN"
+   :description          nil
+   :display-name         "Trial Converted"
+   :effective-type       :type/Boolean
+   :fingerprint          {:global {:distinct-count 2, :nil% 0.0}}
+   :fk-target-field-id   nil
+   :id                   (id :accounts :trial-converted)
+   :name                 "TRIAL_CONVERTED"
+   :nfc-path             nil
+   :parent-id            nil
+   :position             10
+   :semantic-type        nil
+   :settings             nil
+   :table-id             (id :accounts)
+   :visibility-type      :normal
+   :lib/type             :metadata/column})
+
+(defmethod field-metadata-method [:accounts :active-subscription]
+  [_table-name _field-name]
+  {:active               true
+   :base-type            :type/Boolean
+   :coercion-strategy    nil
+   :database-partitioned nil
+   :database-type        "BOOLEAN"
+   :description          nil
+   :display-name         "Active Subscription"
+   :effective-type       :type/Boolean
+   :fingerprint          {:global {:distinct-count 2, :nil% 0.0}}
+   :fk-target-field-id   nil
+   :id                   (id :accounts :active-subscription)
+   :name                 "ACTIVE_SUBSCRIPTION"
+   :nfc-path             nil
+   :parent-id            nil
+   :position             11
+   :semantic-type        nil
+   :settings             nil
+   :table-id             (id :accounts)
+   :visibility-type      :normal
+   :lib/type             :metadata/column})
+
+(defmethod field-metadata-method [:accounts :legacy-plan]
+  [_table-name _field-name]
+  {:active               true
+   :base-type            :type/Boolean
+   :coercion-strategy    nil
+   :database-partitioned nil
+   :database-type        "BOOLEAN"
+   :description          nil
+   :display-name         "Legacy Plan"
+   :effective-type       :type/Boolean
+   :fingerprint          {:global {:distinct-count 2, :nil% 0.0}}
+   :fk-target-field-id   nil
+   :id                   (id :accounts :legacy-plan)
+   :name                 "LEGACY_PLAN"
+   :nfc-path             nil
+   :parent-id            nil
+   :position             12
+   :semantic-type        nil
+   :settings             nil
+   :table-id             (id :accounts)
+   :visibility-type      :normal
+   :lib/type             :metadata/column})
+
+(defmethod field-metadata-method [:accounts :latitude]
+  [_table-name _field-name]
+  {:active               true
+   :base-type            :type/Float
+   :coercion-strategy    nil
+   :database-partitioned nil
+   :database-type        "DOUBLE PRECISION"
+   :description          nil
+   :display-name         "Latitude"
+   :effective-type       :type/Float
+   :fingerprint          {:global {:distinct-count 2472, :nil% 4.008016032064128E-4}
+                          :type   {:type/Number {:min -48.75
+                                                 :q1  19.430679334308675
+                                                 :q3  47.24585743676113
+                                                 :max 69.23111
+                                                 :sd  23.492041679980137
+                                                 :avg 31.35760681046913}}}
+   :fk-target-field-id   nil
+   :id                   (id :accounts :latitude)
+   :name                 "LATITUDE"
+   :nfc-path             nil
+   :parent-id            nil
+   :position             13
+   :semantic-type        :type/Latitude
+   :settings             nil
+   :table-id             (id :accounts)
+   :visibility-type      :normal
+   :lib/type             :metadata/column})
+
+(defmethod field-metadata-method [:accounts :longitude]
+  [_table-name _field-name]
+  {:active               true
+   :base-type            :type/Float
+   :coercion-strategy    nil
+   :database-partitioned nil
+   :database-type        "DOUBLE PRECISION"
+   :description          nil
+   :display-name         "Longitude"
+   :effective-type       :type/Float
+   :fingerprint          {:global {:distinct-count 2484, :nil% 4.008016032064128E-4}
+                          :type   {:type/Number {:min -175.06667
+                                                 :q1  -55.495929410727236
+                                                 :q3  28.627359769389155
+                                                 :max 176.21667
+                                                 :sd  68.51011002740533
+                                                 :avg 2.6042336031796345}}}
+   :fk-target-field-id   nil
+   :id                   (id :accounts :longitude)
+   :name                 "LONGITUDE"
+   :nfc-path             nil
+   :parent-id            nil
+   :position             14
+   :semantic-type        :type/Longitude
+   :settings             nil
+   :table-id             (id :accounts)
+   :visibility-type      :normal
+   :lib/type             :metadata/column})
+
+(defmethod field-metadata-method [:accounts :country]
+  [_table-name _field-name]
+  {:active               true
+   :base-type            :type/Text
+   :coercion-strategy    nil
+   :database-partitioned nil
+   :database-type        "CHARACTER"
+   :description          nil
+   :display-name         "Country"
+   :effective-type       :type/Text
+   :fingerprint          {:global {:distinct-count 134, :nil% 8.016032064128256E-4}
+                          :type   {:type/Text {:percent-json   0.0
+                                               :percent-url    0.0
+                                               :percent-email  0.0
+                                               :percent-state  0.1130260521042084
+                                               :average-length 1.9983967935871743}}}
+   :fk-target-field-id   nil
+   :id                   (id :accounts :country)
+   :name                 "COUNTRY"
+   :nfc-path             nil
+   :parent-id            nil
+   :position             15
+   :semantic-type        :type/Country
+   :settings             nil
+   :table-id             (id :accounts)
+   :visibility-type      :normal
+   :lib/type             :metadata/column})
+
+(defmethod table-metadata-method :accounts
+  [_table-name]
+  {:active                  true
+   :database-require-filter nil
+   :db-id                   (id)
+   :display-name            "Accounts"
+   :fields                  [(field-metadata-method :accounts :id)
+                             (field-metadata-method :accounts :email)
+                             (field-metadata-method :accounts :first-name)
+                             (field-metadata-method :accounts :last-name)
+                             (field-metadata-method :accounts :plan)
+                             (field-metadata-method :accounts :source)
+                             (field-metadata-method :accounts :seats)
+                             (field-metadata-method :accounts :created-at)
+                             (field-metadata-method :accounts :trial-ends-at)
+                             (field-metadata-method :accounts :canceled-at)
+                             (field-metadata-method :accounts :trial-converted)
+                             (field-metadata-method :accounts :active-subscription)
+                             (field-metadata-method :accounts :legacy-plan)
+                             (field-metadata-method :accounts :latitude)
+                             (field-metadata-method :accounts :longitude)
+                             (field-metadata-method :accounts :country)]
+   :id                      (id :accounts)
+   :name                    "ACCOUNTS"
+   :schema                  "PUBLIC"
+   :visibility-type         nil
+   :lib/type                :metadata/table})
+
+(defmethod field-metadata-method [:analytic-events :id]
+  [_table-name _field-name]
+  {:active               true
+   :base-type            :type/BigInteger
+   :coercion-strategy    nil
+   :database-partitioned nil
+   :database-type        "BIGINT"
+   :description          nil
+   :display-name         "ID"
+   :effective-type       :type/BigInteger
+   :fingerprint          nil
+   :fk-target-field-id   nil
+   :id                   (id :analytic-events :id)
+   :name                 "ID"
+   :nfc-path             nil
+   :parent-id            nil
+   :position             0
+   :semantic-type        :type/PK
+   :settings             nil
+   :table-id             (id :analytic-events)
+   :visibility-type      :normal
+   :lib/type             :metadata/column})
+
+(defmethod field-metadata-method [:analytic-events :account-id]
+  [_table-name _field-name]
+  {:active               true
+   :base-type            :type/BigInteger
+   :coercion-strategy    nil
+   :database-partitioned nil
+   :database-type        "BIGINT"
+   :description          nil
+   :display-name         "Account ID"
+   :effective-type       :type/BigInteger
+   :fingerprint          {:global {:distinct-count 589, :nil% 0.0}}
+   :fk-target-field-id   (id :accounts :id)
+   :id                   (id :analytic-events :account-id)
+   :name                 "ACCOUNT_ID"
+   :nfc-path             nil
+   :parent-id            nil
+   :position             1
+   :semantic-type        :type/FK
+   :settings             nil
+   :table-id             (id :analytic-events)
+   :visibility-type      :normal
+   :lib/type             :metadata/column})
+
+(defmethod field-metadata-method [:analytic-events :event]
+  [_table-name _field-name]
+  {:active               true
+   :base-type            :type/Text
+   :coercion-strategy    nil
+   :database-partitioned nil
+   :database-type        "CHARACTER VARYING"
+   :description          nil
+   :display-name         "Event"
+   :effective-type       :type/Text
+   :fingerprint          {:global {:distinct-count 2, :nil% 0.0}
+                          :type   {:type/Text {:percent-json   0.0
+                                               :percent-url    0.0
+                                               :percent-email  0.0
+                                               :percent-state  0.0
+                                               :average-length 11.3906}}}
+   :fk-target-field-id   nil
+   :id                   (id :analytic-events :event)
+   :name                 "EVENT"
+   :nfc-path             nil
+   :parent-id            nil
+   :position             2
+   :semantic-type        :type/Category
+   :settings             nil
+   :table-id             (id :analytic-events)
+   :visibility-type      :normal
+   :lib/type             :metadata/column})
+
+(defmethod field-metadata-method [:analytic-events :timestamp]
+  [_table-name _field-name]
+  {:active               true
+   :base-type            :type/DateTime
+   :coercion-strategy    nil
+   :database-partitioned nil
+   :database-type        "TIMESTAMP"
+   :description          nil
+   :display-name         "Timestamp"
+   :effective-type       :type/DateTime
+   :fingerprint          {:global {:distinct-count 8576, :nil% 0.0}
+                          :type   {:type/DateTime {:earliest "2022-03-15T00:18:25Z", :latest "2022-04-11T20:24:02Z"}}}
+   :fk-target-field-id   nil
+   :id                   (id :analytic-events :timestamp)
+   :name                 "TIMESTAMP"
+   :nfc-path             nil
+   :parent-id            nil
+   :position             3
+   :semantic-type        nil
+   :settings             nil
+   :table-id             (id :analytic-events)
+   :visibility-type      :normal
+   :lib/type             :metadata/column})
+
+(defmethod field-metadata-method [:analytic-events :page-url]
+  [_table-name _field-name]
+  {:active               true
+   :base-type            :type/Text
+   :coercion-strategy    nil
+   :database-partitioned nil
+   :database-type        "CHARACTER VARYING"
+   :description          nil
+   :display-name         "Page URL"
+   :effective-type       :type/Text
+   :fingerprint          {:global {:distinct-count 6, :nil% 0.1302}
+                          :type   {:type/Text {:percent-json   0.0
+                                               :percent-url    0.0
+                                               :percent-email  0.0
+                                               :percent-state  0.0
+                                               :average-length 22.2674}}}
+   :fk-target-field-id   nil
+   :id                   (id :analytic-events :page-url)
+   :name                 "PAGE_URL"
+   :nfc-path             nil
+   :parent-id            nil
+   :position             4
+   :semantic-type        :type/URL
+   :settings             nil
+   :table-id             (id :analytic-events)
+   :visibility-type      :normal
+   :lib/type             :metadata/column})
+
+(defmethod field-metadata-method [:analytic-events :button-label]
+  [_table-name _field-name]
+  {:active               true
+   :base-type            :type/Text
+   :coercion-strategy    nil
+   :database-partitioned nil
+   :database-type        "CHARACTER VARYING"
+   :description          nil
+   :display-name         "Button Label"
+   :effective-type       :type/Text
+   :fingerprint          {:global {:distinct-count 6, :nil% 0.8698}
+                          :type   {:type/Text {:percent-json 0.0, :percent-url 0.0, :percent-email 0.0, :percent-state 0.0, :average-length 1.0552}}}
+   :fk-target-field-id   nil
+   :id                   (id :analytic-events :button-label)
+   :name                 "BUTTON_LABEL"
+   :nfc-path             nil
+   :parent-id            nil
+   :position             5
+   :semantic-type        :type/Category
+   :settings             nil
+   :table-id             (id :analytic-events)
+   :visibility-type      :normal
+   :lib/type             :metadata/column})
+
+(defmethod table-metadata-method :analytic-events
+  [_table-name]
+  {:active                  true
+   :database-require-filter nil
+   :db-id                   (id)
+   :display-name            "Analytic Events"
+   :fields                  [(field-metadata-method :analytic-events :id)
+                             (field-metadata-method :analytic-events :account-id)
+                             (field-metadata-method :analytic-events :event)
+                             (field-metadata-method :analytic-events :timestamp)
+                             (field-metadata-method :analytic-events :page-url)
+                             (field-metadata-method :analytic-events :button-label)]
+   :id                      (id :analytic-events)
+   :name                    "ANALYTIC_EVENTS"
+   :schema                  "PUBLIC"
+   :visibility-type         nil
+   :lib/type                :metadata/table})
+
+(defmethod field-metadata-method [:invoices :id]
+  [_table-name _field-name]
+  {:active               true
+   :base-type            :type/BigInteger
+   :coercion-strategy    nil
+   :database-partitioned nil
+   :database-type        "BIGINT"
+   :description          nil
+   :display-name         "ID"
+   :effective-type       :type/BigInteger
+   :fingerprint          nil
+   :fk-target-field-id   nil
+   :id                   (id :invoices :id)
+   :name                 "ID"
+   :nfc-path             nil
+   :parent-id            nil
+   :position             0
+   :semantic-type        :type/PK
+   :settings             nil
+   :table-id             (id :invoices)
+   :visibility-type      :normal
+   :lib/type             :metadata/column})
+
+(defmethod field-metadata-method [:invoices :account-id]
+  [_table-name _field-name]
+  {:active               true
+   :base-type            :type/BigInteger
+   :coercion-strategy    nil
+   :database-partitioned nil
+   :database-type        "BIGINT"
+   :description          nil
+   :display-name         "Account ID"
+   :effective-type       :type/BigInteger
+   :fingerprint          {:global {:distinct-count 1449, :nil% 0.0}}
+   :fk-target-field-id   (id :accounts :id)
+   :id                   (id :invoices :account-id)
+   :name                 "ACCOUNT_ID"
+   :nfc-path             nil
+   :parent-id            nil
+   :position             1
+   :semantic-type        :type/FK
+   :settings             nil
+   :table-id             (id :invoices)
+   :visibility-type      :normal
+   :lib/type             :metadata/column})
+
+(defmethod field-metadata-method [:invoices :payment]
+  [_table-name _field-name]
+  {:active               true
+   :base-type            :type/Float
+   :coercion-strategy    nil
+   :database-partitioned nil
+   :database-type        "DOUBLE PRECISION"
+   :description          nil
+   :display-name         "Payment"
+   :effective-type       :type/Float
+   :fingerprint          {:global {:distinct-count 707, :nil% 0.0}
+                          :type   {:type/Number {:min 13.7
+                                                 :q1  233.1870107122195
+                                                 :q3  400.5965814842149
+                                                 :max 33714.6
+                                                 :sd  763.7961603932441
+                                                 :avg 519.4153400000004}}}
+   :fk-target-field-id   nil
+   :id                   (id :invoices :payment)
+   :name                 "PAYMENT"
+   :nfc-path             nil
+   :parent-id            nil
+   :position             2
+   :semantic-type        nil
+   :settings             nil
+   :table-id             (id :invoices)
+   :visibility-type      :normal
+   :lib/type             :metadata/column})
+
+(defmethod field-metadata-method [:invoices :expected-invoice]
+  [_table-name _field-name]
+  {:active               true
+   :base-type            :type/Boolean
+   :coercion-strategy    nil
+   :database-partitioned nil
+   :database-type        "BOOLEAN"
+   :description          nil
+   :display-name         "Expected Invoice"
+   :effective-type       :type/Boolean
+   :fingerprint          {:global {:distinct-count 2, :nil% 0.0}}
+   :fk-target-field-id   nil
+   :id                   (id :invoices :expected-invoice)
+   :name                 "EXPECTED_INVOICE"
+   :nfc-path             nil
+   :parent-id            nil
+   :position             3
+   :semantic-type        nil
+   :settings             nil
+   :table-id             (id :invoices)
+   :visibility-type      :normal
+   :lib/type             :metadata/column})
+
+(defmethod field-metadata-method [:invoices :plan]
+  [_table-name _field-name]
+  {:active               true
+   :base-type            :type/Text
+   :coercion-strategy    nil
+   :database-partitioned nil
+   :database-type        "CHARACTER VARYING"
+   :description          nil
+   :display-name         "Plan"
+   :effective-type       :type/Text
+   :fingerprint          {:global {:distinct-count 3, :nil% 0.0}
+                          :type   {:type/Text {:percent-json 0.0, :percent-url 0.0, :percent-email 0.0, :percent-state 0.0, :average-length 5.2931}}}
+   :fk-target-field-id   nil
+   :id                   (id :invoices :plan)
+   :name                 "PLAN"
+   :nfc-path             nil
+   :parent-id            nil
+   :position             4
+   :semantic-type        :type/Category
+   :settings             nil
+   :table-id             (id :invoices)
+   :visibility-type      :normal
+   :lib/type             :metadata/column})
+
+(defmethod field-metadata-method [:invoices :date-received]
+  [_table-name _field-name]
+  {:active               true
+   :base-type            :type/DateTime
+   :coercion-strategy    nil
+   :database-partitioned nil
+   :database-type        "TIMESTAMP"
+   :description          nil
+   :display-name         "Date Received"
+   :effective-type       :type/DateTime
+   :fingerprint          {:global {:distinct-count 714, :nil% 0.0}
+                          :type   {:type/DateTime {:earliest "2020-09-30T00:00:00Z", :latest "2027-05-02T00:00:00Z"}}}
+   :fk-target-field-id   nil
+   :id                   (id :invoices :date-received)
+   :name                 "DATE_RECEIVED"
+   :nfc-path             nil
+   :parent-id            nil
+   :position             5
+   :semantic-type        nil
+   :settings             nil
+   :table-id             (id :invoices)
+   :visibility-type      :normal
+   :lib/type             :metadata/column})
+
+(defmethod table-metadata-method :invoices
+  [_table-name]
+  {:active                  true
+   :database-require-filter nil
+   :db-id                   (id)
+   :display-name            "Invoices"
+   :fields                  [(field-metadata-method :invoices :id)
+                             (field-metadata-method :invoices :account-id)
+                             (field-metadata-method :invoices :payment)
+                             (field-metadata-method :invoices :expected-invoice)
+                             (field-metadata-method :invoices :plan)
+                             (field-metadata-method :invoices :date-received)]
+   :id                      (id :invoices)
+   :name                    "INVOICES"
+   :schema                  "PUBLIC"
+   :visibility-type         nil
+   :lib/type                :metadata/table})
+
 (def metadata
   "Complete Database metadata for testing, captured from a call to `GET /api/database/:id/metadata`. For the H2 version
   of `test-data`. This is a representative example of the metadata the FE Query Builder would have available to it.
@@ -2991,7 +4016,11 @@
                                  (table-metadata-method :ic/reports)
                                  (table-metadata-method :gh/issues)
                                  (table-metadata-method :gh/users)
-                                 (table-metadata-method :gh/comments)]
+                                 (table-metadata-method :gh/comments)
+                                 (table-metadata-method :feedback)
+                                 (table-metadata-method :accounts)
+                                 (table-metadata-method :analytic-events)
+                                 (table-metadata-method :invoices)]
    :creator-id                  nil
    :is-full-sync                true
    :cache-ttl                   nil

--- a/test/metabase/lib/test_metadata.cljc
+++ b/test/metabase/lib/test_metadata.cljc
@@ -8,8 +8,6 @@
   will not be reflected here, for example if we add new information to the metadata. We'll have to manually update
   these things if that happens and Metabase lib is meant to consume it."
   (:require
-   #?@(:clj
-       ([flatland.ordered.set :as ordered-set]))
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.lib.test-metadata.graph-provider :as meta.graph-provider]
    [metabase.util.malli :as mu]))
@@ -4066,10 +4064,12 @@
                               a-field-name))
                           (keys (methods field-metadata-method)))]
     (into
-     #?(:clj (ordered-set/ordered-set) :cljs #{})
-     (sort-by (fn [field]
-                (:position (field-metadata-method table-name field)))
-              field-names))))
+     (sorted-set-by
+      (letfn [(position [field]
+                (:position (field-metadata-method table-name field)))]
+        (fn [x y]
+          (compare (position x) (position y)))))
+     field-names)))
 
 (mu/defn table-metadata :- ::lib.schema.metadata/table
   "Get Table metadata for a one of the `test-data` Tables in the test metadata, e.g. `:venues`. This is here so you can

--- a/test/metabase/lib/test_metadata.cljc
+++ b/test/metabase/lib/test_metadata.cljc
@@ -503,11 +503,11 @@
    :database-required   false
    :fingerprint         {:global {:distinct-count 15, :nil% 0.0}
                          :type   {:type/Text
-                                        {:percent-json   0.0
-                                         :percent-url    0.0
-                                         :percent-email  0.0
-                                         :percent-state  0.0
-                                         :average-length 13.266666666666667}}}
+                                  {:percent-json   0.0
+                                   :percent-url    0.0
+                                   :percent-email  0.0
+                                   :percent-state  0.0
+                                   :average-length 13.266666666666667}}}
    :base-type           :type/Text
    :points-of-interest  nil
    :lib/type            :metadata/column})
@@ -572,11 +572,11 @@
    :database-required   false
    :fingerprint         {:global {:distinct-count 15, :nil% 0.0}
                          :type   {:type/Text
-                                        {:percent-json   0.0
-                                         :percent-url    0.0
-                                         :percent-email  0.0
-                                         :percent-state  0.0
-                                         :average-length 36.0}}}
+                                  {:percent-json   0.0
+                                   :percent-url    0.0
+                                   :percent-email  0.0
+                                   :percent-state  0.0
+                                   :average-length 36.0}}}
    :base-type           :type/Text
    :points-of-interest  nil
    :lib/type            :metadata/column})
@@ -664,11 +664,11 @@
    :database-required   false
    :fingerprint         {:global {:distinct-count 100, :nil% 0.0}
                          :type   {:type/Text
-                                        {:percent-json   0.0
-                                         :percent-url    0.0
-                                         :percent-email  0.0
-                                         :percent-state  0.0
-                                         :average-length 15.63}}}
+                                  {:percent-json   0.0
+                                   :percent-url    0.0
+                                   :percent-email  0.0
+                                   :percent-state  0.0
+                                   :average-length 15.63}}}
    :base-type           :type/Text
    :points-of-interest  nil
    :lib/type            :metadata/column})
@@ -732,12 +732,12 @@
    :database-required   false
    :fingerprint         {:global {:distinct-count 94, :nil% 0.0}
                          :type   {:type/Number
-                                        {:min 10.0646
-                                         :q1  34.06098873016278
-                                         :q3  37.77185
-                                         :max 40.7794
-                                         :sd  3.4346725397190827
-                                         :avg 35.505891999999996}}}
+                                  {:min 10.0646
+                                   :q1  34.06098873016278
+                                   :q3  37.77185
+                                   :max 40.7794
+                                   :sd  3.4346725397190827
+                                   :avg 35.505891999999996}}}
    :base-type           :type/Float
    :points-of-interest  nil
    :lib/type            :metadata/column})
@@ -771,12 +771,12 @@
    :fingerprint         {:global {:distinct-count 84, :nil% 0.0}
                          :type
                          {:type/Number
-                                {:min -165.374
-                                 :q1  -122.40857106781186
-                                 :q3  -118.2635
-                                 :max -73.9533
-                                 :sd  14.162810671348238
-                                 :avg -115.99848699999998}}}
+                          {:min -165.374
+                           :q1  -122.40857106781186
+                           :q3  -118.2635
+                           :max -73.9533
+                           :sd  14.162810671348238
+                           :avg -115.99848699999998}}}
    :base-type           :type/Float
    :points-of-interest  nil
    :lib/type            :metadata/column})
@@ -809,12 +809,12 @@
    :database-required   false
    :fingerprint         {:global {:distinct-count 4, :nil% 0.0}
                          :type   {:type/Number
-                                        {:min 1.0
-                                         :q1  1.4591129021415095
-                                         :q3  2.493086095768049
-                                         :max 4.0
-                                         :sd  0.7713951678941896
-                                         :avg 2.03}}}
+                                  {:min 1.0
+                                   :q1  1.4591129021415095
+                                   :q3  2.493086095768049
+                                   :max 4.0
+                                   :sd  0.7713951678941896
+                                   :avg 2.03}}}
    :base-type           :type/Integer
    :points-of-interest  nil
    :lib/type            :metadata/column})

--- a/test/metabase/lib/test_util/generators/filters.cljc
+++ b/test/metabase/lib/test_util/generators/filters.cljc
@@ -12,6 +12,9 @@
 (defn- gen-int []
   (- (tu.rng/rand-int 2000000) 1000000))
 
+(defn- gen-boolean []
+  (boolean (pos? (tu.rng/rand-int 2))))
+
 (def ^:private valid-ascii
   (mapv char (range 0x20 0x7f)))
 
@@ -79,6 +82,7 @@
     (lib.types.isa/time? column)                       (gen-time)
     (lib.types.isa/date-without-time? column)          (gen-date)
     (lib.types.isa/date-or-datetime? column)           (gen-datetime)
+    (isa? effective-type :type/Boolean)                (gen-boolean)
     :else (throw (ex-info " !!! Not sure what values to generate for column" {:effective-type effective-type
                                                                               :column         column}))))
 


### PR DESCRIPTION
Also add the four newer tables from the Sample Dataset to the Lib mock metadata.

This makes it easier for us to write backend tests in Lib or the QP when the repro steps in issues use these tables; it also adds a boolean column to the mock metadata so we can more easily test with that 