### PR TITLE
No turning on DB routing for DB w/ Transforms

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/transforms/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/core.clj
@@ -2,6 +2,7 @@
   "API namespace for the `metabase-enterprise.transform` module."
   (:require
    [java-time.api :as t]
+   [metabase-enterprise.transforms.models.transform]
    [metabase-enterprise.transforms.models.transform-run]
    [metabase-enterprise.transforms.settings]
    [metabase-enterprise.transforms.util]
@@ -19,7 +20,9 @@
   transform-source-database
   transform-type]
  [metabase-enterprise.transforms.models.transform-run
-  timeout-run!])
+  timeout-run!]
+ [metabase-enterprise.transforms.models.transform
+  transform->db-id])
 
 (defenterprise transform-stats
   "Calculate successful transform runs over a window of the previous UTC day 00:00-23:59"

--- a/enterprise/backend/src/metabase_enterprise/transforms/models/transform.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/models/transform.clj
@@ -320,7 +320,7 @@
     (when query-text
       (subs query-text 0 (min (count query-text) search/max-searchable-value-length)))))
 
-(defn- extract-transform-db-id
+(defn transform->db-id
   "Return the database ID from transform source; else nil."
   [{:keys [source]}]
   (let [parsed-source (transform-source-out source)]
@@ -342,7 +342,7 @@
                   :view-count    false
                   :native-query  {:fn maybe-extract-transform-query-text
                                   :fields [:source :source_type]}
-                  :database-id   {:fn extract-transform-db-id
+                  :database-id   {:fn transform->db-id
                                   :fields [:source]}}
    :search-terms [:name :description]
    :render-terms {:transform-name :name

--- a/enterprise/backend/test/metabase_enterprise/database_routing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/database_routing/api_test.clj
@@ -129,6 +129,18 @@
                  :model/Database {db-id :id} {:router_database_id router-db-id}]
     (is (= "Cannot make a destination database a router database"
            (mt/user-http-request :crowberto :put 400 (str "ee/database-routing/router-database/" db-id)
+                                 {:user_attribute "db_name"}))))
+  (mt/with-temp [:model/Database {db-id :id} {}
+                 :model/Transform _ {:name   "test transform"
+                                     :source {:type  "query"
+                                              :query {:database db-id
+                                                      :type     "native"
+                                                      :native   {:query "SELECT 1"}}}
+                                     :target {:type   "table"
+                                              :schema "transforms"
+                                              :name   "test_table"}}]
+    (is (= "Cannot enable database routing for a database that has transforms"
+           (mt/user-http-request :crowberto :put 400 (str "ee/database-routing/router-database/" db-id)
                                  {:user_attribute "db_name"})))))
 
 (deftest can-delete-router-databases


### PR DESCRIPTION
The Database Routing and Transforms features are mutually exclusive — routing a database that has transforms (or vice versa) would produce nonsensical results. The transforms→routing direction was already guarded (transforms/api.clj:88), but the reverse was not. This adds a check in the PUT /api/ee/database-routing/router-database/:id endpoint that rejects the request with a 400 if the target database has any associated transforms.
