### PR TITLE
Fix flake in transform repro

### DIFF
--- a/e2e/test/scenarios/data-studio/transforms/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms/reproductions.cy.spec.ts
@@ -8,7 +8,7 @@ describe("issue #68378", () => {
     H.activateToken("bleeding-edge");
   });
 
-  it("should show empty schema's when picking a target schema (metabase#68378)", () => {
+  it("should show empty schemas when picking a target schema (metabase#68378)", () => {
     visitTransformListPage();
     cy.button("Create a transform").click();
     H.popover().findByText("SQL query").click();

--- a/e2e/test/scenarios/data-studio/transforms/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms/reproductions.cy.spec.ts
@@ -13,7 +13,7 @@ describe("issue #68378", () => {
     cy.button("Create a transform").click();
     H.popover().findByText("SQL query").click();
     H.popover().findByText("Writable Postgres12").click();
-    H.NativeEditor.type("SELECT 42", { allowFastSet: true });
+    H.NativeEditor.type("SELECT 42", { allowFastSet: true }).blur();
 
     cy.log("Save with empty_schema as target schema");
     getQueryEditor().button("Save").click();


### PR DESCRIPTION
Fix flake in transforms reproduction intorduced by https://github.com/metabase/metabase/pull/68592.

The changes from the input don't trigger always if we don't blur after `allowFastSet`.
[stress test master](https://github.com/metabase/metabase/actions/runs/21430621615)
[stress test PR](https://github.com/metabase/metabase/actions/runs/21417027403)