### PR TITLE
Added link to doc for full app embedding

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/embedding/components/InteractiveEmbeddingSettingsCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding/components/InteractiveEmbeddingSettingsCard.tsx
@@ -23,7 +23,7 @@ export function InteractiveEmbeddingSettingsCard() {
         {
           icon: "reference",
           title: t`Documentation`,
-          href: fullAppEmbeddingDocumentationUrl?.url,
+          href: fullAppEmbeddingDocumentationUrl.url,
         },
       ]}
     >

--- a/enterprise/frontend/src/metabase-enterprise/embedding/components/InteractiveEmbeddingSettingsCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding/components/InteractiveEmbeddingSettingsCard.tsx
@@ -1,7 +1,7 @@
 import { t } from "ttag";
 
 import { EmbeddingSettingsCard } from "metabase/admin/settings/components/EmbeddingSettings";
-import { useSetting } from "metabase/common/hooks";
+import { useDocsUrl, useSetting } from "metabase/common/hooks";
 import { Stack } from "metabase/ui/components";
 import { InteractiveEmbeddingAuthorizedOriginsWidget } from "metabase-enterprise/embedding/components/InteractiveEmbeddingAuthorizedOriginsWidget";
 
@@ -10,11 +10,22 @@ export function InteractiveEmbeddingSettingsCard() {
     "enable-embedding-interactive",
   );
 
+  const fullAppEmbeddingDocumentationUrl = useDocsUrl(
+    "embedding/full-app-embedding",
+  );
+
   return (
     <EmbeddingSettingsCard
       title={t`Enable full app embedding`}
       description={t`Embed the full Metabase application or individual pages into your app. Best for complex, BI-focused scenarios where you want to embed all of Metabase's capabilities into your app. If you are looking for stability of UX, flexibility or control, or don't have a complex use case that requires a full-blown BI solution, we recommend using Modular embedding instead.`}
       settingKey="enable-embedding-interactive"
+      links={[
+        {
+          icon: "reference",
+          title: t`Documentation`,
+          href: fullAppEmbeddingDocumentationUrl?.url,
+        },
+      ]}
     >
       {isInteractiveEmbeddingEnabled && (
         <Stack gap="xl" px="xl" pb="lg">

--- a/enterprise/frontend/src/metabase-enterprise/embedding/components/InteractiveEmbeddingSettingsCard.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding/components/InteractiveEmbeddingSettingsCard.unit.spec.tsx
@@ -43,14 +43,13 @@ describe("InteractiveEmbeddingSettingsCard", () => {
   it("should show a link to the doc", async () => {
     await setup({ enabled: true });
 
-    expect(await screen.findByText("Documentation")).toBeInTheDocument();
+    const linkToDoc = await screen.findByRole("link", {
+      name: "Documentation",
+    });
 
-    // eslint-disable-next-line testing-library/no-node-access
-    const linkToDoc = (await screen.findByText("Documentation")).closest("a");
-
-    expect(linkToDoc).not.toBeNull();
-
-    expect(linkToDoc?.href).toBe(
+    expect(linkToDoc).toBeVisible();
+    expect(linkToDoc).toHaveAttribute(
+      "href",
       "https://www.metabase.com/docs/latest/embedding/full-app-embedding.html",
     );
   });

--- a/enterprise/frontend/src/metabase-enterprise/embedding/components/InteractiveEmbeddingSettingsCard.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding/components/InteractiveEmbeddingSettingsCard.unit.spec.tsx
@@ -40,6 +40,21 @@ describe("InteractiveEmbeddingSettingsCard", () => {
     ).toBeInTheDocument();
   });
 
+  it("should show a link to the doc", async () => {
+    await setup({ enabled: true });
+
+    expect(await screen.findByText("Documentation")).toBeInTheDocument();
+
+    // eslint-disable-next-line testing-library/no-node-access
+    const linkToDoc = (await screen.findByText("Documentation")).closest("a");
+
+    expect(linkToDoc).not.toBeNull();
+
+    expect(linkToDoc?.href).toBe(
+      "https://www.metabase.com/docs/latest/embedding/full-app-embedding.html",
+    );
+  });
+
   it("should toggle interactive embedding on", async () => {
     await setup({ enabled: false });
     const toggle = await screen.findByLabelText(


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #68152
Closes [EMB-1194: Full app embedding doesn't have a documentation link, but the other embedding types do](https://linear.app/metabase/issue/EMB-1194/full-app-embedding-doesnt-have-a-documentation-link-but-the-other)

### Description

Adds a link to docs

<img width="1649" height="954" alt="image" src="https://github.com/user-attachments/assets/cf956c5a-a7ce-4243-af0d-3ddf9c68e691" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
