### PR TITLE
Fix data studio guard

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data-studio/selectors.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/selectors.ts
@@ -1,9 +1,5 @@
-import {
-  PLUGIN_FEATURE_LEVEL_PERMISSIONS,
-  PLUGIN_TRANSFORMS,
-} from "metabase/plugins";
 import { getIsEmbeddingIframe } from "metabase/selectors/embed";
-import { getUserIsAdmin } from "metabase/selectors/user";
+import { getUserIsAdmin, getUserIsAnalyst } from "metabase/selectors/user";
 import { getIsRemoteSyncReadOnly } from "metabase-enterprise/remote_sync/selectors";
 import type { State } from "metabase-types/store";
 
@@ -12,11 +8,7 @@ export function canAccessDataStudio(state: State) {
   if (getIsEmbeddingIframe(state)) {
     return false;
   }
-  return (
-    getUserIsAdmin(state) ||
-    PLUGIN_TRANSFORMS.canAccessTransforms(state) ||
-    PLUGIN_FEATURE_LEVEL_PERMISSIONS.canAccessDataModel(state)
-  );
+  return getUserIsAdmin(state) || getUserIsAnalyst(state);
 }
 
 export const getUserCanWriteSegments = (

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/selectors.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/selectors.unit.spec.ts
@@ -1,0 +1,59 @@
+import { createMockUser } from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks";
+
+import { canAccessDataStudio } from "./selectors";
+
+jest.mock("metabase/selectors/embed", () => ({
+  getIsEmbeddingIframe: jest.fn(() => false),
+}));
+
+const { getIsEmbeddingIframe } = jest.requireMock("metabase/selectors/embed");
+
+describe("canAccessDataStudio", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getIsEmbeddingIframe.mockReturnValue(false);
+  });
+
+  it("returns false when in embedding iframe", () => {
+    getIsEmbeddingIframe.mockReturnValue(true);
+    const state = createMockState({
+      currentUser: createMockUser({ is_superuser: true }),
+    });
+
+    expect(canAccessDataStudio(state)).toBe(false);
+  });
+
+  it("returns true when user is admin", () => {
+    const state = createMockState({
+      currentUser: createMockUser({
+        is_superuser: true,
+        is_data_analyst: false,
+      }),
+    });
+
+    expect(canAccessDataStudio(state)).toBe(true);
+  });
+
+  it("returns true when user is analyst", () => {
+    const state = createMockState({
+      currentUser: createMockUser({
+        is_superuser: false,
+        is_data_analyst: true,
+      }),
+    });
+
+    expect(canAccessDataStudio(state)).toBe(true);
+  });
+
+  it("returns false when user is neither admin nor analyst", () => {
+    const state = createMockState({
+      currentUser: createMockUser({
+        is_superuser: false,
+        is_data_analyst: false,
+      }),
+    });
+
+    expect(canAccessDataStudio(state)).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes UXW-2865

### Description

Updates canAccessDataStudio logic.

[Slack thread](https://metaboat.slack.com/archives/C09HKPWRG4B/p1769552037382339)

[1 Pager - Permissions & Access](https://linear.app/metabase/document/1-pager-permissions-and-access-c2e9ccfee3e3)

> Other users can be given access [to the data studio] by using the Data Analyst role/group ... No other users can be given access to the Data Studio

### How to verify

You should only be able to access the data studio if you belong to the admin group or the data analysts group.

Just having access to table metadata isn't sufficient to access the data studio.

### Demo

**BEFORE (wrong)**

https://github.com/user-attachments/assets/dc2134e2-7473-44ee-9158-ccbe74ff4158

**AFTER (right)**

https://github.com/user-attachments/assets/b3e7d6a8-5a64-433c-ba92-9199aefb944b

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [n/a] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
