### PR TITLE
Throw db-routing error on anonymous transform call

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/transforms/query_impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/query_impl.clj
@@ -7,6 +7,7 @@
    [metabase.driver.util :as driver.u]
    [metabase.lib.schema.common :as schema.common]
    [metabase.query-processor.compile :as qp.compile]
+   [metabase.util.i18n :as i18n]
    [metabase.util.log :as log]
    [metabase.util.malli.registry :as mr]
    [toucan2.core :as t2]))
@@ -39,12 +40,21 @@
     ;; once we have more than just append, dispatch on :target-incremental-strategy
     :table-incremental {}))
 
+(defn- throw-if-db-routing-enabled [transform driver database]
+  (when (transforms.util/db-routing-enabled? database)
+    (throw (ex-info (i18n/tru "Failed to run the transform ({0}) because the database ({1}) has database routing turned on. Running transforms on databases with db routing enabled is not supported."
+                              (:name transform)
+                              (:name database))
+                    {:driver driver, :database database}))))
+
 (defn- run-mbql-transform!
   ([transform] (run-mbql-transform! transform nil))
   ([{:keys [id source target owner_user_id creator_id] :as transform} {:keys [run-method start-promise user-id]}]
    (try
      (let [db (get-in source [:query :database])
            {driver :engine :as database} (t2/select-one :model/Database db)
+           ;; important to test routing before calling compile-source (whose qp middleware will also throw)
+           _ (throw-if-db-routing-enabled transform driver database)
            transform-details {:db-id db
                               :database database
                               :transform-id   id
@@ -60,9 +70,6 @@
                          user-id
                          (or owner_user_id creator_id))]
 
-       (when (transforms.util/db-routing-enabled? database)
-         (throw (ex-info "Transforms are not supported on databases with DB routing enabled."
-                         {:driver driver, :database database})))
        (when-not (every? (fn [feature] (driver.u/supports? (:engine database) feature database)) features)
          (throw (ex-info "The database does not support the requested transform target type."
                          {:driver driver, :database database, :features features})))

--- a/enterprise/backend/test/metabase_enterprise/transforms/execute_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/execute_test.clj
@@ -258,12 +258,38 @@
                                                        :details {:destination_database true}}
                          :model/DatabaseRouter _ {:database_id (mt/id)
                                                   :user_attribute "db_name"}
-                         :model/Transform transform {:name   "transform"
+                         :model/Transform transform {:name   "Test transform"
                                                      :source {:type  :query
                                                               :query query}
                                                      :target target-table}]
             (is (thrown-with-msg?
                  clojure.lang.ExceptionInfo
-                 #"Transforms are not supported on databases with DB routing enabled."
+                 #"Failed to run the transform \(Test transform\) because the database \(.+\) has database routing turned on. Running transforms on databases with db routing enabled is not supported."
                  (mt/with-current-user (mt/user->id :crowberto)
                    (transforms.execute/execute! transform {:run-method :manual}))))))))))
+
+(deftest run-mbql-transform-anonymous-user-routing-error-test
+  (mt/test-drivers (mt/normal-driver-select {:+features [:transforms/table]})
+    (mt/with-premium-features #{:database-routing}
+      (with-transform-cleanup! [target-table {:type   :table
+                                              :schema (t2/select-one-fn :schema :model/Table (mt/id :products))
+                                              :name   "products"}]
+        (let [mp (mt/metadata-provider)
+              products (lib.metadata/table mp (mt/id :products))
+              query (lib/query mp products)]
+          (mt/with-temp [:model/Database _destination {:engine driver/*driver*
+                                                       :router_database_id (mt/id)
+                                                       :details {:destination_database true}}
+                         :model/DatabaseRouter _ {:database_id (mt/id)
+                                                  :user_attribute "db_name"}
+                         :model/Transform transform {:name   "Test transform"
+                                                     :source {:type  :query
+                                                              :query query}
+                                                     :target target-table}]
+            ;; NOTE: No `with-current-user` wrapper - this simulates running the transform
+            ;; without a user context (e.g., from a cron job or background task).
+            ;; previously this could produce the wrong error message from the QP routing middleware.
+            (is (thrown-with-msg?
+                 clojure.lang.ExceptionInfo
+                 #"Failed to run the transform \(Test transform\) because the database \(.+\) has database routing turned on. Running transforms on databases with db routing enabled is not supported."
+                 (transforms.execute/execute! transform {:run-method :cron})))))))))


### PR DESCRIPTION
Before you would incidentally get an error about being an anonymous user due to qp middleware asserts firing before the custom error message.

Also changes the error message to be more informative in a cron-type situation

Fixes GDGT-1588