### PR TITLE
fix(sdk): fix failing tests for white-labeled colors

### DIFF
--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-embedding-theme-override.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-embedding-theme-override.ts
@@ -34,7 +34,11 @@ export function useEmbeddingThemeOverride(
       // This must be done before ThemeProvider calls getThemeOverrides.
       setGlobalEmbeddingColors(themeWithPreset?.colors, appColors ?? {});
 
-      return getEmbeddingThemeOverride(themeWithPreset || {}, font, appColors);
+      return getEmbeddingThemeOverride(
+        themeWithPreset || {},
+        font,
+        appColors ?? {},
+      );
     }
 
     // We must include Modular Embedding specific overrides for portals (e.g. popover and modal) to target the correct portal id

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-embedding-theme-override.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-embedding-theme-override.ts
@@ -27,14 +27,14 @@ export function useEmbeddingThemeOverride(
   const appColors = useSetting("application-colors");
 
   return useMemo(() => {
-    if (isEmbeddingThemeV1(theme)) {
+    if (!theme || isEmbeddingThemeV1(theme)) {
       const themeWithPreset = applyThemePreset(theme);
 
       // !! Mutate the global colors object to apply the new colors.
       // This must be done before ThemeProvider calls getThemeOverrides.
       setGlobalEmbeddingColors(themeWithPreset?.colors, appColors ?? {});
 
-      return getEmbeddingThemeOverride(themeWithPreset || {}, font);
+      return getEmbeddingThemeOverride(themeWithPreset || {}, font, appColors);
     }
 
     // We must include Modular Embedding specific overrides for portals (e.g. popover and modal) to target the correct portal id

--- a/frontend/src/embedding-sdk-bundle/lib/theme/get-embedding-theme.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/theme/get-embedding-theme.ts
@@ -68,12 +68,20 @@ export function getEmbeddingThemeOverride(
 
   // Apply whitelabeled colors from appearance settings
   for (const key in whitelabeledColors) {
+    if (!override.colors) {
+      override.colors = {};
+    }
+
     override.colors[key as MetabaseColorKey] = colorTuple(
       whitelabeledColors[key],
     );
   }
 
   if (theme.colors) {
+    if (!override.colors) {
+      override.colors = {};
+    }
+
     const userColors = { ...theme.colors };
 
     // Apply fallback colors for missing colors that the user forgot to define.

--- a/frontend/src/embedding-sdk-bundle/lib/theme/get-embedding-theme.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/theme/get-embedding-theme.ts
@@ -18,9 +18,13 @@ import {
   SDK_TO_MAIN_APP_COLORS_MAPPING,
   SDK_TO_MAIN_APP_TOOLTIP_COLORS_MAPPING,
 } from "metabase/embedding-sdk/theme/embedding-color-palette";
-import type { MetabaseAccentColorKey } from "metabase/lib/colors";
+import type {
+  MetabaseAccentColorKey,
+  MetabaseColorKey,
+} from "metabase/lib/colors";
 import { mapChartColorsToAccents } from "metabase/lib/colors/accents";
 import type { MantineThemeOverride } from "metabase/ui";
+import type { ColorSettings } from "metabase-types/api";
 
 import { colorTuple } from "./color-tuple";
 
@@ -39,6 +43,7 @@ const stripUndefinedKeys = <T>(x: T): unknown =>
 export function getEmbeddingThemeOverride(
   theme: MetabaseTheme,
   font: string | undefined,
+  whitelabeledColors?: ColorSettings | undefined,
 ): MantineThemeOverride {
   const components: MetabaseComponentTheme = merge(
     DEFAULT_EMBEDDED_COMPONENT_THEME,
@@ -58,11 +63,17 @@ export function getEmbeddingThemeOverride(
     },
 
     components: getEmbeddingComponentOverrides(),
+    colors: {},
   };
 
-  if (theme.colors) {
-    override.colors = {};
+  // Apply whitelabeled colors from appearance settings
+  for (const key in whitelabeledColors) {
+    override.colors[key as MetabaseColorKey] = colorTuple(
+      whitelabeledColors[key],
+    );
+  }
 
+  if (theme.colors) {
     const userColors = { ...theme.colors };
 
     // Apply fallback colors for missing colors that the user forgot to define.


### PR DESCRIPTION
### Description

Fixes the failing `"should use the brand color from the app settings as fallback if they're present"` SDK test. The tests were failing for a very good reason: https://github.com/metabase/metabase/pull/68169 actually broke the whitelabeled colors on the SDK!

Reason is that in the unified colors PR, I removed the `colorsConfig` mutation because I wanted to get rid of the global mutation. Little did I know that the `getEmbeddingThemeOverride` function on the V1 theme was relying on that global mutation all along, as it auto-populates the Mantine theme with the correct appearance settings color.

The fix is straightforward: pass `whitelabeledColors` to `getEmbeddingThemeOverride`, and you no longer need any global variable hacks.

### How to verify

The test `"should use the brand color from the app settings as fallback if they're present"` should not fail.

### Demo

Tests passes and the whitelabel colors are applied.

<img width="2958" height="1682" alt="CleanShot 2569-01-28 at 23 22 50@2x" src="https://github.com/user-attachments/assets/760ff072-8e5d-4863-98c7-832a33222e1f" />
