### PR TITLE
flake: wait for card query after revert

### DIFF
--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-with-question-revert.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-with-question-revert.cy.spec.js
@@ -96,6 +96,7 @@ describe("issue 35954", () => {
 
           cy.log("Revert the question to its original (GUI) version");
           cy.intercept("POST", "/api/revision/revert").as("revertQuestion");
+          cy.intercept("POST", "/api/card/*/query").as("cardQuery");
           H.questionInfoButton().click();
           cy.findByRole("tab", { name: "History" }).click();
 
@@ -105,6 +106,7 @@ describe("issue 35954", () => {
             .findByTestId("question-revert-button")
             .click();
           cy.wait("@revertQuestion");
+          cy.wait("@cardQuery");
           // Mid-test assertions to root out the flakiness
           cy.findByRole("tab", { name: "History" }).click();
           cy.findByTestId("saved-question-history-list").should(


### PR DESCRIPTION
The revert operation triggers a chain: revert API -> reload card page.

Test was only waiting for the revert API, then sometimes it would manage to click the History tab *before* the page reload. Then the page reloads and we're not on the History tab anymore.

Waiting for the card query request to finish means that we've reloaded the page and ready to roll.
