### PR TITLE
Add a note about the Metabase config

### DIFF
--- a/docs/developers-guide/devenv.md
+++ b/docs/developers-guide/devenv.md
@@ -33,6 +33,8 @@ This runs both the [frontend](#frontend) and [backend](#backend). Alternatively,
 
 To use any other database beside the default ones please take a look at [Building Drivers](#building-drivers) further down in this document.
 
+**Hint:** If you often reset your Metabase instance and start from scratch, a predefined [Metabase config](https://www.metabase.com/docs/latest/configuring-metabase/config-file) can save you a lot of time.
+
 ### Frontend
 
 Metabase depends on third-party libraries to run, so you'll need to keep those up to date. The Clojure CLI will automatically fetch the dependencies when needed. With JavaScript dependencies, however, you'll need to kick off the installation process manually.

--- a/docs/developers-guide/devenv.md
+++ b/docs/developers-guide/devenv.md
@@ -33,7 +33,7 @@ This runs both the [frontend](#frontend) and [backend](#backend). Alternatively,
 
 To use any other database beside the default ones please take a look at [Building Drivers](#building-drivers) further down in this document.
 
-To skip the setup wizard and pre-configure users, database connections, and settings, add a [`config.yml`](https://www.metabase.com/docs/latest/configuring-metabase/config-file) to the directory where you run Metabase.
+To skip the setup wizard and pre-configure users, database connections, and settings, add a [Metabase config file](https://www.metabase.com/docs/latest/configuring-metabase/config-file) to the directory where you run Metabase.
 
 ### Frontend
 

--- a/docs/developers-guide/devenv.md
+++ b/docs/developers-guide/devenv.md
@@ -33,7 +33,7 @@ This runs both the [frontend](#frontend) and [backend](#backend). Alternatively,
 
 To use any other database beside the default ones please take a look at [Building Drivers](#building-drivers) further down in this document.
 
-**Hint:** If you often reset your Metabase instance and start from scratch, a predefined [Metabase config](https://www.metabase.com/docs/latest/configuring-metabase/config-file) can save you a lot of time.
+To skip the setup wizard and pre-configure users, database connections, and settings, add a [`config.yml`](https://www.metabase.com/docs/latest/configuring-metabase/config-file) to the directory where you run Metabase.
 
 ### Frontend
 


### PR DESCRIPTION
Resolves DEV-1323

This pull request adds a helpful hint to the developer guide for Metabase. The new hint suggests using a predefined Metabase config file to save time when frequently resetting the Metabase instance.
