### PR TITLE
Improved message for job failure due to routing

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/database_routing/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/database_routing/common.clj
@@ -24,7 +24,10 @@
         nil
 
         is-anonymous-user?
-        (throw (ex-info (tru "Anonymous users cannot access a database with routing enabled.") {:status-code 400}))
+        (throw (ex-info (tru "Anonymous users cannot access a database with routing enabled.") {:status-code 400
+                                                                                                :database-routing-enabled true
+                                                                                                :database-or-id db-or-id
+                                                                                                :database-name (t2/select-one-fn :name :model/Database (u/the-id db-or-id))}))
 
         (= database-name "__METABASE_ROUTER__")
         nil

--- a/enterprise/backend/src/metabase_enterprise/transforms/jobs.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/jobs.clj
@@ -240,7 +240,9 @@
               (try
                 (transforms.job-run/fail-started-run! run-id {:message (.getMessage t)})
                 (when (= :cron run-method)
-                  (notify-job-failure job-id (.getMessage t)))
+                  (if (::transform-failure (ex-data t))
+                    (notify-transform-failures job-id (::failures (ex-data t)))
+                    (notify-job-failure job-id (.getMessage t))))
                 (catch Exception e
                   (log/error e "Error when failing a transform job run.")))
               (throw t))))

--- a/enterprise/backend/src/metabase_enterprise/transforms/ordering.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/ordering.clj
@@ -12,25 +12,42 @@
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.query-processor.preprocess :as qp.preprocess]
+   [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
+(defn- database-routing-error-ex-data [^Throwable e]
+  (when e
+    (if (:database-routing-enabled (ex-data e))
+      (ex-data e)
+      (recur (.getCause e)))))
+
 (defmethod transforms.i/table-dependencies :query
-  [{:keys [source]}]
-  (let [query (-> (:query source)
-                  transforms.util/massage-sql-query
-                  qp.preprocess/preprocess)
-        driver (-> query
-                   lib.metadata/database
-                   :engine)]
-    (if (lib/native-only-query? query)
-      (driver/native-query-deps driver query)
-      (into #{}
-            (map (fn [table-id]
-                   {:table table-id}))
-            (lib/all-source-table-ids query)))))
+  [{:keys [source] :as transform}]
+  (try
+    (let [query (-> (:query source)
+                    transforms.util/massage-sql-query
+                    qp.preprocess/preprocess)
+          driver (-> query
+                     lib.metadata/database
+                     :engine)]
+      (if (lib/native-only-query? query)
+        (driver/native-query-deps driver query)
+        (into #{}
+              (map (fn [table-id]
+                     {:table table-id}))
+              (lib/all-source-table-ids query))))
+    (catch clojure.lang.ExceptionInfo e
+      (if-some [data (database-routing-error-ex-data e)]
+        (let [message (i18n/trs "Failed to run transform because the database {0} has database routing turned on. Running transforms on databases with db routing enabled is not supported." (:database-name data))]
+          (throw (ex-info message
+                          {:metabase-enterprise.transforms.jobs/transform-failure true
+                           :metabase-enterprise.transforms.jobs/failures [{:metabase-enterprise.transforms.jobs/transform transform
+                                                                           :metabase-enterprise.transforms.jobs/message message}]}
+                          e)))
+        (throw e)))))
 
 (defn- dependency-map [transforms]
   (into {}


### PR DESCRIPTION
Closes GDGT-1588
Closes https://github.com/metabase/metabase/issues/68757

### Description

Catch the db routing exception and rethrow one with a better message. Then handle a special case bit of ex-data to capture the transform that is the cause.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR