### PR TITLE
fix: logo in email is not centered

### DIFF
--- a/src/metabase/channel/email/_logo.hbs
+++ b/src/metabase/channel/email/_logo.hbs
@@ -1,3 +1,3 @@
 {{#if applicationLogoUrl}}
-  <img width="32" height="40" src="{{{applicationLogoUrl}}}"/>
+  <img style="max-height: 40px; max-width: 100%;" src="{{{applicationLogoUrl}}}"/>
 {{/if}}

--- a/src/metabase/channel/email/comment_created.hbs
+++ b/src/metabase/channel/email/comment_created.hbs
@@ -4,8 +4,8 @@
       <tr>
         <td>
           <div class="container" style="background-color: white; max-width: 555px; border-radius: 24px; margin: 0 auto; padding: 40px; border: 1px solid rgba(7, 23, 34, 0.14)">
-            <div style="text-align: center; height: 45px; margin-bottom: 32px;">
-              <img width="35.55" height="45" src="{{context.application_logo_url}}" alt="Metabase logo"/>
+            <div style="text-align: center; margin-bottom: 32px;">
+              <img style="max-height: 45px; max-width: 100%;" src="{{context.application_logo_url}}" alt="{{context.application_name}} logo"/>
             </div>
 
             <h1 style="text-align: center; font-size: 27px; line-height: 36px; font-weight: 400; margin: 0 0 8px 0; color: #2F3C45;">

--- a/src/metabase/channel/email/logo.clj
+++ b/src/metabase/channel/email/logo.clj
@@ -1,0 +1,41 @@
+ (ns metabase.channel.email.logo
+   (:require
+    [clojure.string :as str]
+    [metabase.channel.render.core :as channel.render]
+    [metabase.util.jvm :as u.jvm]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private data-uri-pattern
+  #"^data:([^;]+);base64,(.+)$")
+
+(defn- parse-data-uri
+  "Parse a data URI and return {:content-type <string> :bytes <byte-array>}, or nil if not a data URI."
+  [data-uri]
+  (when-let [[_ content-type base64-data] (re-matches data-uri-pattern data-uri)]
+    {:content-type content-type
+     :bytes        (u.jvm/decode-base64-to-bytes base64-data)}))
+
+(defn logo-bundle
+  "Create a logo bundle from the application logo URL.
+   Returns {:image-src <url-or-cid> :attachment <attachment-map-or-nil>}.
+   For data URIs, converts to an embedded attachment for email compatibility.
+   For the default logo asset path, uses the static Metabase logo URL."
+  [logo-url]
+  (cond
+    (nil? logo-url)
+    nil
+
+    (= logo-url "app/assets/img/logo.svg")
+    {:image-src  "http://static.metabase.com/email_logo.png"
+     :attachment nil}
+
+    (str/starts-with? logo-url "data:")
+    (when-let [{:keys [bytes]} (parse-data-uri logo-url)]
+      (let [bundle (channel.render/make-image-bundle :attachment bytes)]
+        {:image-src  (:image-src bundle)
+         :attachment (channel.render/image-bundle->attachment bundle)}))
+
+    :else
+    {:image-src logo-url
+     :attachment nil}))

--- a/src/metabase/channel/email/messages.clj
+++ b/src/metabase/channel/email/messages.clj
@@ -11,6 +11,7 @@
    [metabase.app-db.core :as app-db]
    [metabase.appearance.core :as appearance]
    [metabase.channel.email :as email]
+   [metabase.channel.email.logo :as email.logo]
    [metabase.channel.render.core :as channel.render]
    [metabase.channel.settings :as channel.settings]
    [metabase.channel.template.core :as channel.template]
@@ -39,18 +40,21 @@
   (or (appearance/application-name)
       (trs "Metabase")))
 
-(defn logo-url
-  "Return the URL for the application logo. If the logo is the default, return a URL to the Metabase logo."
+(defn- logo-bundle
+  "Get the logo bundle for the current application logo."
   []
-  (let [url (appearance/application-logo-url)]
-    (cond
-      (= url "app/assets/img/logo.svg") "http://static.metabase.com/email_logo.png"
+  (email.logo/logo-bundle (appearance/application-logo-url)))
 
-      :else nil)))
-      ;; NOTE: disabling whitelabeled URLs for now since some email clients don't render them correctly
-      ;; We need to extract them and embed as attachments like we do in metabase.channel.render.image-bundle
-      ;; (data-uri-svg? url)               (themed-image-url url color)
-      ;; :else                             url
+(defn logo-url
+  "Return the URL for the application logo. If the logo is the default, return a URL to the Metabase logo.
+   For data URIs, returns the cid: reference (requires logo-attachment to be included in email)."
+  []
+  (:image-src (logo-bundle)))
+
+(defn logo-attachment
+  "Return the logo attachment map for embedding in emails, or nil if not needed."
+  []
+  (:attachment (logo-bundle)))
 
 (defn button-style
   "Return a CSS style string for a button with the given color."
@@ -81,6 +85,27 @@
    :colorTextDark      channel.render/color-text-dark
    :siteUrl            (system/site-url)})
 
+(defn- make-message-attachment
+  "Convert a content-id/url pair to an email attachment map."
+  [[content-id url]]
+  {:type         :inline
+   :content-id   content-id
+   :content-type "image/png"
+   :content      url})
+
+(defn- send-email-with-logo!
+  "Send an email, including the logo as an attachment if it's a data URI.
+   Takes the same args as email/send-message! but handles logo attachments automatically."
+  [{:keys [message] :as email-args}]
+  (if-let [attachment (logo-attachment)]
+    (email/send-message!
+     (assoc email-args
+            :message-type :attachments
+            :message      (vec (cons {:type    "text/html; charset=utf-8"
+                                      :content message}
+                                     [(make-message-attachment (first attachment))]))))
+    (email/send-message! email-args)))
+
 ;;; ### Public Interface
 
 (defn- all-admin-recipients
@@ -98,7 +123,7 @@
   [new-user & {:keys [google-auth?]}]
   {:pre [(map? new-user)]}
   (let [recipients (all-admin-recipients)]
-    (email/send-message!
+    (send-email-with-logo!
      {:subject      (str (if google-auth?
                            (trs "{0} created a {1} account" (:common_name new-user) (app-name-trs))
                            (trs "{0} accepted their {1} invite" (:common_name new-user) (app-name-trs))))
@@ -131,7 +156,7 @@
                               :isActive         is-active?
                               :adminEmail       (system/admin-email)
                               :adminEmailSet    (boolean (system/admin-email))}))]
-    (email/send-message!
+    (send-email-with-logo!
      {:subject      (trs "[{0}] Password Reset Request" (app-name-trs))
       :recipients   [email]
       :message-type :html
@@ -235,11 +260,11 @@
                         :heading      (trs "We hope you''ve been enjoying Metabase.")
                         :callToAction (trs "Would you mind taking a quick 5 minute survey to tell us how it’s going?")
                         :link         "https://metabase.com/feedback/active"})
-        email {:subject      (trs "[{0}] Tell us how things are going." (app-name-trs))
-               :recipients   [email]
-               :message-type :html
-               :message      (channel.template/render "metabase/channel/email/follow_up_email.hbs" context)}]
-    (email/send-message! email)))
+        email-msg {:subject      (trs "[{0}] Tell us how things are going." (app-name-trs))
+                   :recipients   [email]
+                   :message-type :html
+                   :message      (channel.template/render "metabase/channel/email/follow_up_email.hbs" context)}]
+    (send-email-with-logo! email-msg)))
 
 (defn send-creator-sentiment-email!
   "Format and send an email to a creator with a link to a survey. If a [[blob]] is included, it will be turned into json
@@ -263,7 +288,7 @@
                  :recipients   [email]
                  :message-type :html
                  :message      (channel.template/render "metabase/channel/email/creator_sentiment_email.hbs" context)}]
-    (email/send-message! message)))
+    (send-email-with-logo! message)))
 
 (defn generate-pulse-unsubscribe-hash
   "Generates hash to allow for non-users to unsubscribe from pulses/subscriptions.

--- a/src/metabase/channel/email/new_user_invite.hbs
+++ b/src/metabase/channel/email/new_user_invite.hbs
@@ -1,8 +1,8 @@
 {{> metabase/channel/email/_header.hbs }}
 {{#with payload.event_info.details.invitor as |invitor|}}
   <div style="padding-top: 40px; padding-left: 16px; padding-bottom: 96px; padding-right: 16px; box-sizing: border-box; width: 100%; max-width: 600px; background-color: #FFFFFF; border-radius: 24px; border: 1px solid #dcdfe0; margin-top: 32px; margin-left: auto; margin-right: auto;">
-    <div style="margin-bottom: 32px; text-align: center; width: 56px; height: 56px; padding-top: 5px; box-sizing: border-box; padding-bottom: 5px; margin-left: auto; margin-right: auto;">
-      <img height="46" src="{{context.application_logo_url}}" alt="{{context.application_name}} logo" />
+    <div style="margin-bottom: 32px; text-align: center; padding-top: 5px; box-sizing: border-box; padding-bottom: 5px;">
+      <img style="max-height: 46px; max-width: 100%;" src="{{context.application_logo_url}}" alt="{{context.application_name}} logo" />
     </div>
     <div>
       {{#if payload.event_info.object.is_from_setup}}

--- a/src/metabase/channel/email/slack_token_error.hbs
+++ b/src/metabase/channel/email/slack_token_error.hbs
@@ -1,6 +1,6 @@
 {{> metabase/channel/email/_header.hbs }}
   <div style="padding-bottom: 2em; padding-top: 1em; text-align: center;">
-    <img width="32" height="40" src="{{context.application_logo_url}}"/>
+    <img style="max-height: 40px; max-width: 100%;" src="{{context.application_logo_url}}" alt="{{context.application_name}} logo"/>
   </div>
   <div style="text-align: center; margin: 0 auto; max-width: 500px">
     <div style="text-align: left">

--- a/src/metabase/channel/email/support_access_grant.hbs
+++ b/src/metabase/channel/email/support_access_grant.hbs
@@ -4,8 +4,8 @@
       <tr>
         <td>
           <div class="container" style="background-color: white; max-width: 555px; border-radius: 24px; margin: 0 auto; padding: 40px; border: 1px solid rgba(7, 23, 34, 0.14)">
-            <div style="text-align: center; height: 45px; margin-bottom: 32px;">
-              <img width="35.55" height="45" src="{{context.application_logo_url}}" alt="Metabase logo"/>
+            <div style="text-align: center; margin-bottom: 32px;">
+              <img style="max-height: 45px; max-width: 100%;" src="{{context.application_logo_url}}" alt="{{context.application_name}} logo"/>
             </div>
 
             <h1 style="text-align: center; font-size: 27px; line-height: 36px; font-weight: 400; margin: 0 0 8px 0; color: #2F3C45;">

--- a/src/metabase/channel/email/transform_failed.hbs
+++ b/src/metabase/channel/email/transform_failed.hbs
@@ -4,8 +4,8 @@
       <tr>
         <td>
           <div class="container" style="background-color: white; max-width: 555px; border-radius: 24px; margin: 0 auto; padding: 40px; border: 1px solid rgba(7, 23, 34, 0.14)">
-            <div style="text-align: center; height: 45px; margin-bottom: 32px;">
-              <img width="35.55" height="45" src="{{context.application_logo_url}}" alt="Metabase logo"/>
+            <div style="text-align: center; margin-bottom: 32px;">
+              <img style="max-height: 45px; max-width: 100%;" src="{{context.application_logo_url}}" alt="{{context.application_name}} logo"/>
             </div>
 
             <h1 style="text-align: center; font-size: 27px; line-height: 36px; font-weight: 400; margin: 0 0 8px 0; color: #2F3C45;">


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #68452
Closes [UXW-2860: Custom Logo isn't loaded properly on User Invite Email](https://linear.app/metabase/issue/UXW-2860/custom-logo-isnt-loaded-properly-on-user-invite-email)

### Description

Logo image in emails wasn't centered if it was rectangular. Now it is.

### How to verify

1. Change the logo image to be rectangular
2. Go to Admin -> People
3. Invite someone
4. Get the email

### Demo

Before:
<img width="1840" height="1106" alt="image" src="https://github.com/user-attachments/assets/8ea1a0a8-4de9-419f-806e-73df0cdbcecf" />

After:
<img width="1840" height="1106" alt="image" src="https://github.com/user-attachments/assets/80450f57-9cd7-46f0-ae11-76ebcfdecec6" />

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
