### PR TITLE
feat: enable transform setting on first import

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
@@ -23,35 +23,51 @@
    [toucan2.core :as t2])
   (:import (metabase_enterprise.remote_sync.source.protocol SourceSnapshot)))
 
+(def ^:private transform-models
+  "Models that indicate transforms content in a snapshot."
+  #{"Transform" "TransformTag" "PythonLibrary"})
+
+(defn- snapshot-has-transforms?
+  "Checks if the snapshot contains any Transform, TransformTag, or PythonLibrary entities.
+   Used to auto-enable remote-sync-transforms setting during import.
+
+   Uses the ingestable to list all entities and checks their :model metadata."
+  [ingestable]
+  (let [serdes-paths (serialization/ingest-list ingestable)]
+    (some (fn [path]
+            (some #(transform-models (:model %)) path))
+          serdes-paths)))
+
 (defn- sync-objects!
   "Populates the remote-sync-object table with imported entities. Deletes all existing RemoteSyncObject records and
   inserts new ones for each imported entity, marking them as 'synced' with the given timestamp.
 
-  Takes a timestamp instant, a map of imported entities grouped by model name (for standard models with entity_id),
-  and separate path collections for Table and Field models which use name-based identity.
+  Takes a timestamp instant and imported-data map from spec/extract-imported-entities.
 
   Uses the spec system to determine how to query and build sync objects for each model type."
-  [timestamp imported-entities-by-model table-paths field-paths]
+  [timestamp imported-data]
   (t2/delete! :model/RemoteSyncObject)
-  (let [all-inserts (spec/sync-all-entities! timestamp imported-entities-by-model table-paths field-paths)]
+  (let [all-inserts (spec/sync-all-entities! timestamp imported-data)]
     (when (seq all-inserts)
       (t2/insert! :model/RemoteSyncObject all-inserts))))
 
 (defn- remove-unsynced!
   "Deletes any remote sync content that was NOT part of the import.
 
-  Takes a sequence of remote-synced collection IDs and a map of imported entities grouped by model name. For each
-  entity-id based model, deletes entities whose entity_id is not in the imported set.
+  Takes a sequence of remote-synced collection IDs and imported-data map from spec/extract-imported-entities.
+  For each entity-id based model, deletes entities whose entity_id is not in the imported set.
 
   Models with :scope-key in their spec are scoped to synced collections (using :id for Collection, :collection_id
   for others). Models without :scope-key (like TransformTag) are deleted globally by entity_id.
 
+  Path-based models (Table, Field) are not removed here - they are controlled by published table settings.
+
   Uses specs-for-deletion to process models in dependency order (models with FK references to
   Collection are deleted before Collection itself)."
-  [synced-collection-ids imported-entities-by-model]
+  [synced-collection-ids {:keys [by-entity-id]}]
   (doseq [[model-key model-spec] (spec/specs-for-deletion)
           :let [serdes-model (:model-type model-spec)
-                entity-ids (get imported-entities-by-model serdes-model [])
+                entity-ids (get by-entity-id serdes-model [])
                 entity-id-clause (if (seq entity-ids)
                                    [:not-in entity-ids]
                                    :entity_id)
@@ -142,55 +158,31 @@
                       :version (source.p/version snapshot)
                       :message (format "Skipping import: snapshot version %s matches last imported version" snapshot-version)}
               (log/infof (:message <>)))
-            (let [path-filters (cond-> [#"collections/.*" #"databases/.*" #"actions/.*"]
-                                 (settings/remote-sync-transforms)
-                                 (conj #"transforms/.*" #"python-libraries/.*")
-                                 (settings/library-is-remote-synced?)
-                                 (conj #"snippets/.*"))
-                  ingestable-snapshot (->> (source.p/->ingestable snapshot {:path-filters path-filters})
-                                           (source.ingestable/wrap-progress-ingestable task-id 0.7))
-                  load-result (serdes/with-cache
-                                (serialization/load-metabase! ingestable-snapshot))
-                  seen-paths (:seen load-result)
-                  data-model-models #{"Table" "Field"}
-                  ;; For standard models (Collection, Card, Segment, etc.), extract entity_id as before
-                  imported-entities-by-model (->> seen-paths
-                                                  (remove #(data-model-models (:model (last %))))
-                                                  (map last)
-                                                  (group-by :model)
-                                                  (map (fn [[model entities]]
-                                                         [model (set (map :id entities))]))
-                                                  (into {}))
-                  ;; For Tables, capture full path for unique identification
-                  ;; Path format: [{:model "Database" :id db-name} {:model "Schema" :id schema}? {:model "Table" :id table-name}]
-                  table-paths (->> seen-paths
-                                   (filter #(= "Table" (:model (last %))))
-                                   (map (fn [path]
-                                          {:db_name    (-> path first :id)
-                                           :schema     (when (= 3 (count path)) (-> path second :id))
-                                           :table_name (-> path last :id)})))
-                  ;; For Fields, path format includes Table
-                  ;; [{:model "Database"} {:model "Schema"}? {:model "Table"} {:model "Field" :id field-name}]
-                  field-paths (->> seen-paths
-                                   (filter #(= "Field" (:model (last %))))
-                                   (map (fn [path]
-                                          (let [table-idx (dec (count path))]
-                                            {:db_name    (-> path first :id)
-                                             :schema     (when (> (count path) 3) (-> path second :id))
-                                             :table_name (-> path (nth (dec table-idx)) :id)
-                                             :field_name (-> path last :id)}))))]
-              (remote-sync.task/update-progress! task-id 0.8)
-              (t2/with-transaction [_conn]
-                (remove-unsynced! (spec/all-syncable-collection-ids) imported-entities-by-model)
-                (sync-objects! sync-timestamp imported-entities-by-model table-paths field-paths))
-              (remote-sync.task/update-progress! task-id 0.95)
-              (remote-sync.task/set-version!
-               task-id
-               (source.p/version snapshot))
-              (log/info "Successfully reloaded entities from git repository")
-              {:status :success
-               :version (source.p/version snapshot)
-               :message "Successfully reloaded from git repository"})))
+            (let [path-filters [#"collections/.*" #"databases/.*" #"actions/.*"
+                                #"transforms/.*" #"python-libraries/.*" #"snippets/.*"]
+                  base-ingestable (source.p/->ingestable snapshot {:path-filters path-filters})
+                  has-transforms? (snapshot-has-transforms? base-ingestable)
+                  ingestable-snapshot (source.ingestable/wrap-progress-ingestable task-id 0.7 base-ingestable)]
+              (when (and has-transforms?
+                         (not (settings/remote-sync-transforms)))
+                (log/info "Detected transforms in remote source, enabling remote-sync-transforms setting")
+                (settings/remote-sync-transforms! true))
+              (let [load-result (serdes/with-cache
+                                  (serialization/load-metabase! ingestable-snapshot))
+                    seen-paths (:seen load-result)
+                    imported-data (spec/extract-imported-entities seen-paths)]
+                (remote-sync.task/update-progress! task-id 0.8)
+                (t2/with-transaction [_conn]
+                  (remove-unsynced! (spec/all-syncable-collection-ids) imported-data)
+                  (sync-objects! sync-timestamp imported-data))
+                (remote-sync.task/update-progress! task-id 0.95)
+                (remote-sync.task/set-version!
+                 task-id
+                 (source.p/version snapshot))
+                (log/info "Successfully reloaded entities from git repository")
+                {:status :success
+                 :version (source.p/version snapshot)
+                 :message "Successfully reloaded from git repository"}))))
         (catch Exception e
           (handle-import-exception e snapshot))
         (finally

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/settings.clj
@@ -123,7 +123,11 @@
 (defn- sync-transform-tracking-on-change
   "Called when remote-sync-transforms setting changes."
   [_old-value new-value]
-  (sync-transform-tracking! (boolean new-value)))
+  ;; new-value may be a string "true"/"false" or a boolean, so we need to parse it
+  (let [enabled? (if (string? new-value)
+                   (parse-boolean new-value)
+                   (boolean new-value))]
+    (sync-transform-tracking! enabled?)))
 
 (defsetting remote-sync-transforms
   (deferred-tru "Whether to sync transforms via remote-sync. When enabled, all transforms, transform tags, and transform jobs are synced as a single unit (all-or-nothing).")

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/spec.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/spec.clj
@@ -601,9 +601,8 @@
   [seen-paths]
   (reduce
    (fn [acc path]
-     (let [model-type (-> path last :model)
-           spec (spec-for-model-type model-type)]
-       (if (and spec (spec-enabled? spec))
+     (let [model-type (-> path last :model)]
+       (if-let [spec (spec-for-model-type model-type)]
          (let [identity-type (:identity spec)
                identity-data (extract-identity-from-serdes-path spec path)]
            (if identity-data

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/spec.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/spec.clj
@@ -559,6 +559,68 @@
   {:entity-id (:entity_id instance)
    :path      (select-keys instance path-keys)})
 
+;;; ----------------------------------------- Serdes Path Identity Extraction ------------------------------------------
+
+(def ^:private serdes-path-identity-hierarchy
+  "Hierarchy for extract-identity-from-serdes-path dispatch. Both :entity-id and :hybrid models
+   extract identity the same way (entity_id from last path element)."
+  (-> (make-hierarchy)
+      (derive :entity-id ::entity-id-extractor)
+      (derive :hybrid ::entity-id-extractor)))
+
+(defmulti extract-identity-from-serdes-path
+  "Extracts identity data from a serdes path based on the spec's identity strategy. For entity-id
+   and hybrid models, returns the entity_id string from the last path element. For path-based models
+   like Table and Field, returns a map with database, schema, and table/field names that can be used
+   to look up the entity."
+  {:arglists '([spec serdes-path])}
+  (fn [spec _path] (:identity spec))
+  :hierarchy #'serdes-path-identity-hierarchy)
+
+(defmethod extract-identity-from-serdes-path ::entity-id-extractor
+  [_ serdes-path]
+  (:id (last serdes-path)))
+
+(defmethod extract-identity-from-serdes-path :path
+  [_ serdes-path]
+  (let [path-map (into {} (map (fn [elem] [(keyword (u/lower-case-en (:model elem))) (:id elem)]) serdes-path))]
+    (cond-> {}
+      (contains? path-map :database) (assoc :db_name (:database path-map))
+      (contains? path-map :schema)   (assoc :schema (:schema path-map))
+      (contains? path-map :table)    (assoc :table_name (:table path-map))
+      (contains? path-map :field)    (assoc :field_name (:field path-map)))))
+
+(defmethod extract-identity-from-serdes-path :default
+  [_ _]
+  nil)
+
+(defn extract-imported-entities
+  "Processes serdes paths from an import and extracts entity identities grouped by how they should be looked up.
+   Returns a map with :by-entity-id containing entity_ids grouped by model type, and :by-path containing
+   path lookup maps for models like Table and Field that use path-based identity."
+  [seen-paths]
+  (reduce
+   (fn [acc path]
+     (let [model-type (-> path last :model)
+           spec (spec-for-model-type model-type)]
+       (if (and spec (spec-enabled? spec))
+         (let [identity-type (:identity spec)
+               identity-data (extract-identity-from-serdes-path spec path)]
+           (if identity-data
+             (case identity-type
+               (:entity-id :hybrid)
+               (update-in acc [:by-entity-id model-type] (fnil conj #{}) identity-data)
+
+               :path
+               (update-in acc [:by-path (:model-key spec)] (fnil conj []) identity-data)
+
+               acc)
+             acc))
+         acc)))
+   {:by-entity-id {}
+    :by-path {}}
+   seen-paths))
+
 ;;; --------------------------------------------- Export Path Construction ---------------------------------------------
 
 (defn- transform-entity-for-serdes
@@ -799,25 +861,18 @@
   nil)
 
 (defn sync-all-entities!
-  "Syncs all entities based on specs. Takes:
-   - timestamp: The sync timestamp
-   - imported-entities-by-model: Map of model-type string -> set of entity_ids
-   - table-paths: Collection of table path maps
-   - field-paths: Collection of field path maps
-
-   Returns a sequence of all sync objects to insert."
-  [timestamp imported-entities-by-model table-paths field-paths]
+  "Builds RemoteSyncObject entries for all imported entities based on their specs. Iterates over enabled
+   specs and queries the database to hydrate the fields needed for each sync object. Returns a sequence
+   of maps ready for insertion into the RemoteSyncObject table."
+  [timestamp {:keys [by-entity-id by-path]}]
   (into []
         (for [[model-key spec] (enabled-specs)
               :let [identity-type (:identity spec)
                     model-type (:model-type spec)
                     data (case identity-type
-                           :entity-id (get imported-entities-by-model model-type)
-                           :path (case model-key
-                                   :model/Table table-paths
-                                   :model/Field field-paths
-                                   nil)
-                           :hybrid (get imported-entities-by-model model-type))]
+                           :entity-id (get by-entity-id model-type)
+                           :path (get by-path model-key)
+                           :hybrid (get by-entity-id model-type))]
               :when (seq data)
               entity (query-entities-for-sync spec data timestamp)]
           entity)))
@@ -835,7 +890,6 @@
   [{:keys [export-scope]}]
   (case (or export-scope :derived)
     :root-collections
-    ;; Collection model: query for root-level remote-synced + transforms-namespace + snippets-namespace collections
     ;; Excludes archived collections - their files are handled by the removal logic
     (concat
      (t2/select-fn-set (juxt (constantly "Collection") :id)
@@ -859,7 +913,6 @@
                                   [:= :location "/"]
                                   [:not :archived]]})))
     :derived
-    ;; Other collection-based models: no root query, derived from collection expansion
     nil))
 
 (defmethod query-export-roots :setting
@@ -867,27 +920,22 @@
   (when (spec-enabled? spec)
     (case export-scope
       :root-only
-      ;; Transform: root transforms (collection_id = nil)
       (t2/select-fn-set (juxt (constantly model-type) :id) model-key :collection_id nil)
       :all
-      ;; TransformTag: all instances
       (t2/select-fn-set (juxt (constantly model-type) :id) model-key)
-      ;; Default: no root query
       nil)))
 
-(defmethod query-export-roots :published-table [_] nil)  ; Derived via serdes/descendants
-(defmethod query-export-roots :parent-table [_] nil)     ; Derived via serdes/descendants
+(defmethod query-export-roots :published-table [_] nil)
+(defmethod query-export-roots :parent-table [_] nil)
 
 (defmethod query-export-roots :library-synced
   [{:keys [export-scope model-key model-type archived-key] :as spec}]
   (when (spec-enabled? spec)
     (case export-scope
       :all
-      ;; NativeQuerySnippet: all non-archived instances
       (if archived-key
         (t2/select-fn-set (juxt (constantly model-type) :id) model-key archived-key false)
         (t2/select-fn-set (juxt (constantly model-type) :id) model-key))
-      ;; Default: no root query
       nil)))
 
 (defmethod query-export-roots :default [_] nil)

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/events_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/events_test.clj
@@ -513,7 +513,7 @@
                    :model/Card card {:name "Test Card"
                                      :dataset_query (mt/mbql-query venues)
                                      :collection_id (:id remote-sync-collection)}]
-      (#'impl/sync-objects! (t/instant) {"Card" #{(:entity_id card)}} nil nil)
+      (#'impl/sync-objects! (t/instant) {:by-entity-id {"Card" #{(:entity_id card)}}})
 
       (let [initial-entry (t2/select-one :model/RemoteSyncObject :model_type "Card" :model_id (:id card))]
         (is (= "synced" (:status initial-entry)))
@@ -551,7 +551,7 @@
                    :model/Collection normal-collection {:name "Normal"}
                    :model/Dashboard dashboard {:name "Test Dashboard"
                                                :collection_id (:id remote-sync-collection)}]
-      (#'impl/sync-objects! (t/instant) {"Dashboard" #{(:entity_id dashboard)}} nil nil)
+      (#'impl/sync-objects! (t/instant) {:by-entity-id {"Dashboard" #{(:entity_id dashboard)}}})
 
       (let [initial-entry (t2/select-one :model/RemoteSyncObject :model_type "Dashboard" :model_id (:id dashboard))]
         (is (= "synced" (:status initial-entry)))
@@ -585,7 +585,7 @@
     (mt/with-temp [:model/Collection remote-sync-collection {:is_remote_synced true :name "Remote-Sync"}
                    :model/Collection normal-collection {:name "Normal"}
                    :model/Document document {:collection_id (u/the-id remote-sync-collection)}]
-      (#'impl/sync-objects! (t/instant) {"Document" #{(:entity_id document)}} nil nil)
+      (#'impl/sync-objects! (t/instant) {:by-entity-id {"Document" #{(:entity_id document)}}})
 
       (let [initial-entry (t2/select-one :model/RemoteSyncObject :model_type "Document" :model_id (:id document))]
         (is (= "synced" (:status initial-entry)))
@@ -616,7 +616,7 @@
 (deftest existing-collection-type-changed-from-remote-synced-test
   (testing "existing collection type changed from remote-synced is marked as removed"
     (mt/with-temp [:model/Collection collection {:is_remote_synced true :name "Remote-Sync"}]
-      (#'impl/sync-objects! (t/instant) {"Collection" #{(:entity_id collection)}} nil nil)
+      (#'impl/sync-objects! (t/instant) {:by-entity-id {"Collection" #{(:entity_id collection)}}})
       (let [initial-entry (t2/select-one :model/RemoteSyncObject :model_type "Collection" :model_id (:id collection))]
         (is (= "synced" (:status initial-entry)))
         (events/publish-event! :event/collection-update
@@ -765,7 +765,7 @@
                    :model/Collection normal-collection {:name "Normal Collection"}
                    :model/Timeline timeline {:name "Test Timeline"
                                              :collection_id (:id remote-sync-collection)}]
-      (#'impl/sync-objects! (t/instant) {"Timeline" #{(:entity_id timeline)}} nil nil)
+      (#'impl/sync-objects! (t/instant) {:by-entity-id {"Timeline" #{(:entity_id timeline)}}})
       (is (= 1 (count (t2/select :model/RemoteSyncObject))))
       (events/publish-event! :event/timeline-update
                              {:object (assoc timeline :collection_id (:id normal-collection))

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
@@ -1061,7 +1061,7 @@
           (let [task-id (t2/insert-returning-pk! :model/RemoteSyncTask {:sync_task_type "import" :initiated_by (mt/user->id :rasta)})
                 lib-entity-id "auto-enable-lib-xxxxx"
                 test-files {"main" {(str "python-libraries/" lib-entity-id ".yaml")
-                                    (format "path: common.py
+                                    (format "path: uncommon.py
 source: |
   # shared code
   def shared_func():
@@ -1076,7 +1076,7 @@ serdes/meta:
             (is (false? (remote-sync.settings/remote-sync-transforms))
                 "remote-sync-transforms should be initially disabled")
             (let [result (impl/import! (source.p/snapshot mock-source) task-id)]
-              (is (= :success (:status #p result))
+              (is (= :success (:status result))
                   "Import should succeed")
               (is (true? (remote-sync.settings/remote-sync-transforms))
                   "remote-sync-transforms should be auto-enabled after successful import with python-libraries"))))))))

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/test_helpers.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/test_helpers.clj
@@ -555,6 +555,40 @@ serdes/meta:
           entity-id
           (str/replace (u/lower-case-en name) #"\s+" "_")))
 
+(defn generate-transform-yaml
+  "Generates YAML content for a transform.
+
+  Args:
+    entity-id: The unique identifier for the transform.
+    name: The name of the transform.
+
+  Returns:
+    A string containing the YAML representation of the transform."
+  [entity-id name]
+  (format "name: %s
+description: null
+entity_id: %s
+collection_id: null
+created_at: '2024-08-28T09:46:18.671622Z'
+creator_id: rasta@metabase.com
+source:
+  type: query
+  query:
+    database: 1
+    type: query
+    query:
+      source-table: 1
+target:
+  type: table
+  name: test_output
+  schema: PUBLIC
+serdes/meta:
+- id: %s
+  label: %s
+  model: Transform
+"
+          name entity-id entity-id (str/replace (u/lower-case-en name) #"\s+" "_")))
+
 (defn generate-measure-yaml
   "Generates YAML content for a measure with the given `measure-name`, `table-name`, and `db-name`.
   Optional keyword args include `:schema`, `:description`, `:entity-id`, and `:agg-field-name`

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/test_helpers.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/test_helpers.clj
@@ -8,15 +8,8 @@
    [toucan2.core :as t2]))
 
 (defn generate-collection-yaml
-  "Generates YAML content for a collection.
-
-  Args:
-    entity-id: The unique identifier for the collection.
-    name: The name of the collection.
-    parent-id: Optional parent collection ID.
-
-  Returns:
-    A string containing the YAML representation of the collection."
+  "Generate YAML content for a collection with the given `entity-id` and `name`.
+  Optionally accepts `:parent-id` for nested collections."
   [entity-id name & {:keys [parent-id]}]
   (format "name: %s
 description: null
@@ -41,20 +34,10 @@ is_sample: false
           (or parent-id "null") entity-id (str/replace (u/lower-case-en name) #"\s+" "_")))
 
 (defn generate-v57-collection-yaml
-  "Generates YAML content for a collection in v57 format.
-
-  In v57, remote-synced collections used `type: remote-synced` instead of
-  `is_remote_synced: true`. This helper is used to test backward compatibility
-  when importing exports from v57 Metabase instances.
-
-  Args:
-    entity-id: The unique identifier for the collection.
-    name: The name of the collection.
-    parent-id: Optional parent collection ID.
-    type: Optional type value (e.g., \"remote-synced\" for v57 remote-synced collections).
-
-  Returns:
-    A string containing the v57-format YAML representation of the collection."
+  "Generate YAML content for a collection in v57 format. In v57, remote-synced collections
+  used `type: remote-synced` instead of `is_remote_synced: true`. Used to test backward
+  compatibility when importing exports from v57 Metabase instances. Optionally accepts
+  `:parent-id` and `:type` (e.g., `\"remote-synced\"`)."
   [entity-id name & {:keys [parent-id type]}]
   (format "name: %s
 description: null
@@ -79,15 +62,8 @@ is_sample: false
           (or type "null") (or parent-id "null") entity-id (str/replace (u/lower-case-en name) #"\s+" "_")))
 
 (defn generate-card-yaml
-  "Generates YAML content for a card.
-
-  Args:
-    entity-id: The unique identifier for the card.
-    name: The name of the card.
-    collection-id: The ID of the collection containing this card.
-
-  Returns:
-    A string containing the YAML representation of the card."
+  "Generate YAML content for a card with the given `entity-id`, `name`, and `collection-id`.
+  Optionally accepts a `type` (defaults to `\"question\"`)."
   [entity-id name collection-id & [type]]
   (format "name: %s
 description: null
@@ -127,16 +103,8 @@ document_id: null
           name entity-id collection-id entity-id (str/replace (u/lower-case-en name) #"\s+" "_") (or type "question")))
 
 (defn generate-dashboard-yaml
-  "Generates YAML content for a dashboard.
-
-  Args:
-    entity-id: The unique identifier for the dashboard.
-    name: The name of the dashboard.
-    collection-id: The ID of the collection containing this dashboard.
-    dashcards: Optional collection of dashboard cards to include.
-
-  Returns:
-    A string containing the YAML representation of the dashboard."
+  "Generate YAML content for a dashboard with the given `entity-id`, `name`, and `collection-id`.
+  Optionally accepts `:dashcards` to include dashboard cards."
   [entity-id name collection-id & {:keys [dashcards]}]
   (let [dashcards-yaml (if dashcards
                          (str/join "\n" (map (fn [dc]
@@ -261,7 +229,7 @@ width: fixed
     (->MockSourceSnapshot source-id base-url branch fail-mode files-atom)))
 
 (defn create-mock-source
-  "Create a mock Source for testing"
+  "Create a mock Source for testing. Optionally accepts `:branch`, `:fail-mode`, and `:initial-files`."
   [& {:keys [branch fail-mode initial-files]
       :or {branch "main"
            fail-mode nil
@@ -287,7 +255,8 @@ width: fixed
     (->MockSource "test-source" "https://test.example.com" branch fail-mode files-atom branches-atom)))
 
 (defn clean-object
-  "Reset the object table before running tests to prevent existing extries from affecting dirty state checks"
+  "Test fixture that resets the RemoteSyncObject table before running tests to prevent existing
+  entries from affecting dirty state checks."
   [f]
   (let [old-models (t2/select :model/RemoteSyncObject)]
     (try
@@ -299,12 +268,12 @@ width: fixed
           (t2/insert! :model/RemoteSyncObject old-models))))))
 
 (defmacro with-clean-object
-  "Macro to wrap a body to execute in a clean change log table"
+  "Execute `body` with a clean RemoteSyncObject table."
   [& body]
   `(clean-object (fn [] ~@body)))
 
 (defn clean-task-table
-  "Reset the task table to an empty state before running tests."
+  "Test fixture that resets the RemoteSyncTask table to an empty state before running tests."
   [f]
   (let [old-models (t2/select :model/RemoteSyncTask)]
     (try
@@ -316,18 +285,12 @@ width: fixed
           (t2/insert! :model/RemoteSyncTask old-models))))))
 
 (def clean-remote-sync-state
-  "Fixture to make sure sync state is clean"
+  "Composed test fixture that ensures both RemoteSyncObject and RemoteSyncTask tables are clean."
   (t/compose-fixtures clean-object clean-task-table))
 
 (defn generate-table-yaml
-  "Generates YAML content for a table.
-
-  Args:
-    table-name: The name of the table (used as entity_id).
-    db-name: The name of the database containing this table.
-
-  Returns:
-    A string containing the YAML representation of the table."
+  "Generate YAML content for a table with the given `table-name` and `db-name`.
+  Optionally accepts `:schema`, `:is-published` (defaults to true), and `:description`."
   [table-name db-name & {:keys [schema is-published description]
                          :or {is-published true
                               description nil}}]
@@ -375,15 +338,8 @@ serdes/meta:
           table-name))
 
 (defn generate-field-yaml
-  "Generates YAML content for a field.
-
-  Args:
-    field-name: The name of the field (used as entity_id).
-    table-name: The name of the table containing this field.
-    db-name: The name of the database containing this field.
-
-  Returns:
-    A string containing the YAML representation of the field."
+  "Generate YAML content for a field with the given `field-name`, `table-name`, and `db-name`.
+  Optionally accepts `:schema`, `:base-type`, `:description`, and `:database-type`."
   [field-name table-name db-name & {:keys [schema base-type description database-type]
                                     :or {base-type "type/Text"
                                          database-type "VARCHAR"
@@ -446,16 +402,8 @@ database_partitioned: null
           field-name))
 
 (defn generate-segment-yaml
-  "Generates YAML content for a segment.
-
-  Args:
-    segment-name: The name of the segment (used as entity_id).
-    table-name: The name of the table containing this segment.
-    db-name: The name of the database containing this segment.
-    filter-field-name: The name of the field to use in the filter clause.
-
-  Returns:
-    A string containing the YAML representation of the segment."
+  "Generate YAML content for a segment with the given `segment-name`, `table-name`, and `db-name`.
+  Optionally accepts `:schema`, `:description`, `:entity-id`, and `:filter-field-name`."
   [segment-name table-name db-name & {:keys [schema description entity-id filter-field-name]
                                       :or {description "Test segment"
                                            filter-field-name "Some Field"}}]
@@ -513,15 +461,8 @@ serdes/meta:
             (str/replace (u/lower-case-en segment-name) #"\s+" "_"))))
 
 (defn generate-action-yaml
-  "Generates YAML content for an action.
-
-  Args:
-    entity-id: The unique identifier for the action.
-    name: The name of the action.
-    model-id: The entity ID of the model (Card) this action belongs to.
-
-  Returns:
-    A string containing the YAML representation of the action."
+  "Generate YAML content for an action with the given `entity-id`, `name`, and `model-id`.
+  Optionally accepts `:type` (defaults to `\"implicit\"`) and `:kind` (defaults to `\"row/create\"`)."
   [entity-id name model-id & {:keys [type kind]
                               :or {type "implicit"
                                    kind "row/create"}}]
@@ -556,28 +497,26 @@ serdes/meta:
           (str/replace (u/lower-case-en name) #"\s+" "_")))
 
 (defn generate-transform-yaml
-  "Generates YAML content for a transform.
-
-  Args:
-    entity-id: The unique identifier for the transform.
-    name: The name of the transform.
-
-  Returns:
-    A string containing the YAML representation of the transform."
-  [entity-id name]
+  "Generate YAML content for a transform with the given `entity-id` and `name`.
+  Optionally accepts `:collection-id` for transforms inside a collection."
+  [entity-id name & {:keys [collection-id]}]
   (format "name: %s
 description: null
 entity_id: %s
-collection_id: null
+collection_id: %s
 created_at: '2024-08-28T09:46:18.671622Z'
 creator_id: rasta@metabase.com
+source_database_id: test-data (h2)
 source:
   type: query
   query:
-    database: 1
+    database: test-data (h2)
     type: query
     query:
-      source-table: 1
+      source-table:
+      - test-data (h2)
+      - PUBLIC
+      - VENUES
 target:
   type: table
   name: test_output
@@ -587,12 +526,11 @@ serdes/meta:
   label: %s
   model: Transform
 "
-          name entity-id entity-id (str/replace (u/lower-case-en name) #"\s+" "_")))
+          name entity-id (or collection-id "null") entity-id (str/replace (u/lower-case-en name) #"\s+" "_")))
 
 (defn generate-measure-yaml
-  "Generates YAML content for a measure with the given `measure-name`, `table-name`, and `db-name`.
-  Optional keyword args include `:schema`, `:description`, `:entity-id`, and `:agg-field-name`
-  for the aggregation field. Returns a string containing the YAML representation of the measure."
+  "Generate YAML content for a measure with the given `measure-name`, `table-name`, and `db-name`.
+  Optionally accepts `:schema`, `:description`, `:entity-id`, and `:agg-field-name`."
   [measure-name table-name db-name & {:keys [schema description entity-id agg-field-name]
                                       :or {description "Test measure"
                                            agg-field-name "Some Field"}}]

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/transforms_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/transforms_test.clj
@@ -277,33 +277,6 @@
                   (is (not (some #(str/includes? % "transforms/") (keys files-after-export)))
                       "Export should NOT include transform files when setting is disabled"))))))))))
 
-(defn- generate-transform-yaml
-  "Generates YAML content for a transform."
-  [entity-id name database-id table-id]
-  (format "name: %s
-description: null
-entity_id: %s
-collection_id: null
-created_at: '2024-08-28T09:46:18.671622Z'
-creator_id: rasta@metabase.com
-source:
-  type: query
-  query:
-    database: %d
-    type: query
-    query:
-      source-table: %d
-target:
-  type: table
-  name: test_output
-  schema: PUBLIC
-serdes/meta:
-- id: %s
-  label: %s
-  model: Transform
-"
-          name entity-id database-id table-id entity-id (str/replace (u/lower-case-en name) #"\s+" "_")))
-
 (defn- generate-transforms-namespace-collection-yaml
   "Generates YAML content for a transforms-namespace collection."
   [entity-id name]
@@ -337,12 +310,12 @@ is_sample: false
           (let [task-id             (t2/insert-returning-pk! :model/RemoteSyncTask {:sync_task_type "import" :initiated_by (mt/user->id :rasta)})
                 coll-entity-id      "transforms-coll-xxx"
                 transform-entity-id "test-transform-xxxxx"
-                test-files          {"main" {(str "collections/" coll-entity-id "_transforms/" coll-entity-id "_transforms.yaml")
-                                             (generate-transforms-namespace-collection-yaml coll-entity-id "Transforms")
-                                             (str "collections/" coll-entity-id "_transforms/transforms/" transform-entity-id "_test_transform.yaml")
-                                             (generate-transform-yaml transform-entity-id "Test Transform" (mt/id) (mt/id :venues))}}
-                mock-source         (test-helpers/create-mock-source :initial-files test-files)
-                result              (impl/import! (source.p/snapshot mock-source) task-id)]
+                test-files {"main" {(str "collections/" coll-entity-id "_transforms/" coll-entity-id "_transforms.yaml")
+                                    (generate-transforms-namespace-collection-yaml coll-entity-id "Transforms")
+                                    (str "collections/" coll-entity-id "_transforms/transforms/" transform-entity-id "_test_transform.yaml")
+                                    (test-helpers/generate-transform-yaml transform-entity-id "Test Transform")}}
+                mock-source (test-helpers/create-mock-source :initial-files test-files)
+                result (impl/import! (source.p/snapshot mock-source) task-id)]
             (is (= :success (:status result)))
             (is (t2/exists? :model/Collection :entity_id coll-entity-id :namespace "transforms")
                 "Transforms-namespace collection should be imported")
@@ -390,7 +363,7 @@ is_sample: false
               (let [initial-files {"main" {(str "collections/" coll-eid "_transforms_collection/" coll-eid "_transforms_collection.yaml")
                                            (generate-transforms-namespace-collection-yaml coll-eid "Transforms Collection")
                                            (str "collections/" coll-eid "_transforms_collection/transforms/" transform-eid "_child_transform.yaml")
-                                           (generate-transform-yaml transform-eid "Child Transform" (mt/id) (mt/id :venues))}}
+                                           (test-helpers/generate-transform-yaml transform-eid "Child Transform")}}
                     mock-source (test-helpers/create-mock-source :initial-files initial-files)]
                 (is (some #(str/includes? % coll-eid) (keys (get @(:files-atom mock-source) "main"))))
                 (is (some #(str/includes? % transform-eid) (keys (get @(:files-atom mock-source) "main"))))
@@ -404,7 +377,6 @@ is_sample: false
                   (let [files-after-export (get @(:files-atom mock-source) "main")]
                     (is (not (some #(str/includes? % coll-eid) (keys files-after-export))))
                     (is (not (some #(str/includes? % transform-eid) (keys files-after-export))))
-                    ;; Root transform should still be exported
                     (is (some #(str/includes? % root-transform-eid) (keys files-after-export))
                         "Root transform should be exported")))))))))))
 
@@ -477,8 +449,8 @@ is_sample: false
               (is (t2/exists? :model/Transform :id local-transform-id))
               (let [test-files {"main" {(str "collections/" coll-entity-id "_transforms/" coll-entity-id "_transforms.yaml")
                                         (generate-transforms-namespace-collection-yaml coll-entity-id "Transforms Collection")
-                                        (str "collections/" coll-entity-id "_transforms/transforms/" remote-transform-entity-id "_remote_transform.yaml")
-                                        (generate-transform-yaml remote-transform-entity-id "Remote Transform" (mt/id) (mt/id :venues))}}
+                                        (str "collections/" coll-entity-id "_transforms/transforms/" remote-transform-entity-id "_remote_transform.yaml")}}
+                                        (test-helpers/generate-transform-yaml remote-transform-entity-id "Remote Transform")}}
                     mock-source (test-helpers/create-mock-source :initial-files test-files)
                     result (impl/import! (source.p/snapshot mock-source) task-id)]
                 (is (= :success (:status result))
@@ -673,7 +645,6 @@ serdes/meta:
                     local-entity-id (:entity_id local-library)]
                 (is (t2/exists? :model/PythonLibrary :path "common.py")
                     "Local PythonLibrary should exist before import")
-                ;; Use the same entity_id as the local library so it gets updated
                 (let [test-files {"main" {(str "python-libraries/" local-entity-id ".yaml")
                                           (generate-python-library-yaml local-entity-id "common.py" "# remote version\ndef new_func():\n    pass")}}
                       mock-source (test-helpers/create-mock-source :initial-files test-files)
@@ -684,3 +655,159 @@ serdes/meta:
                     (is (some? library) "PythonLibrary should still exist")
                     (is (str/includes? (:source library) "# remote version")
                         "PythonLibrary source should be updated with remote version")))))))))))
+
+;;; ------------------------------------------- Transform Sync Behavior Tests -------------------------------------------
+
+(deftest import-preserves-local-transforms-when-setting-disabled-and-remote-has-none-test
+  (testing "When remote-sync-transforms is disabled and remote has no transforms, local transforms are preserved"
+    (mt/with-premium-features #{:transforms}
+      (mt/with-temporary-setting-values [remote-sync-transforms false
+                                         remote-sync-enabled true]
+        (mt/with-model-cleanup [:model/RemoteSyncTask :model/Transform :model/TransformTag]
+          (let [task-id (t2/insert-returning-pk! :model/RemoteSyncTask {:sync_task_type "import" :initiated_by (mt/user->id :rasta)})
+                local-transform-entity-id (u/generate-nano-id)
+                local-tag-entity-id (u/generate-nano-id)]
+            (mt/with-temp [:model/Collection {coll-id :id} {:name "Transforms Collection"
+                                                            :namespace collection/transforms-ns
+                                                            :location "/"}
+                           :model/Transform {local-transform-id :id} {:name "Local Transform"
+                                                                      :entity_id local-transform-entity-id
+                                                                      :collection_id coll-id}
+                           :model/TransformTag {local-tag-id :id} {:name "Local Tag"
+                                                                   :entity_id local-tag-entity-id}]
+              (is (t2/exists? :model/Transform :id local-transform-id)
+                  "Local transform should exist before import")
+              (is (t2/exists? :model/TransformTag :id local-tag-id)
+                  "Local tag should exist before import")
+              (is (t2/exists? :model/Collection :id coll-id)
+                  "Local transforms collection should exist before import")
+              (let [remote-coll-entity-id (u/generate-nano-id)
+                    test-files {"main" {(str "collections/" remote-coll-entity-id "_remote_collection/" remote-coll-entity-id "_remote_collection.yaml")
+                                        (test-helpers/generate-collection-yaml remote-coll-entity-id "Remote Collection")}}
+                    mock-source (test-helpers/create-mock-source :initial-files test-files)
+                    result (impl/import! (source.p/snapshot mock-source) task-id)]
+                (is (= :success (:status result))
+                    (str "Import should succeed. Result: " result))
+                (is (t2/exists? :model/Transform :id local-transform-id)
+                    "Local transform should still exist after import when setting is disabled")
+                (is (t2/exists? :model/TransformTag :id local-tag-id)
+                    "Local tag should still exist after import when setting is disabled")
+                (is (t2/exists? :model/Collection :id coll-id)
+                    "Local transforms collection should still exist after import when setting is disabled")))))))))
+
+(deftest import-replaces-local-transforms-when-remote-has-transforms-test
+  (testing "When remote has transforms, local transforms are replaced with remote content (setting auto-enabled)"
+    (mt/with-premium-features #{:transforms}
+      (mt/with-temporary-setting-values [remote-sync-transforms false
+                                         remote-sync-enabled true]
+        (mt/with-model-cleanup [:model/RemoteSyncTask :model/Transform :model/TransformTag]
+          (let [task-id (t2/insert-returning-pk! :model/RemoteSyncTask {:sync_task_type "import" :initiated_by (mt/user->id :rasta)})
+                local-transform-entity-id (u/generate-nano-id)
+                local-tag-entity-id (u/generate-nano-id)
+                remote-transform-entity-id (u/generate-nano-id)
+                remote-coll-entity-id (u/generate-nano-id)]
+            (mt/with-temp [:model/Collection {coll-id :id coll-eid :entity_id} {:name "Local Transforms Collection"
+                                                                                :namespace collection/transforms-ns
+                                                                                :location "/"}
+                           :model/Transform {local-transform-id :id} {:name "Local Transform"
+                                                                      :entity_id local-transform-entity-id
+                                                                      :collection_id coll-id}
+                           :model/TransformTag {local-tag-id :id} {:name "Local Tag"
+                                                                   :entity_id local-tag-entity-id}]
+              (is (t2/exists? :model/Transform :id local-transform-id)
+                  "Local transform should exist before import")
+              (is (t2/exists? :model/TransformTag :id local-tag-id)
+                  "Local tag should exist before import")
+              (let [test-files {"main" {(str "collections/" remote-coll-entity-id "_transforms/" remote-coll-entity-id "_transforms.yaml")
+                                        (generate-transforms-namespace-collection-yaml remote-coll-entity-id "Remote Transforms")
+                                        (str "collections/" remote-coll-entity-id "_transforms/transforms/" remote-transform-entity-id "_remote_transform.yaml")
+                                        (test-helpers/generate-transform-yaml remote-transform-entity-id "Remote Transform")}}
+                    mock-source (test-helpers/create-mock-source :initial-files test-files)
+                    result (impl/import! (source.p/snapshot mock-source) task-id)]
+                (is (= :success (:status result))
+                    (str "Import should succeed. Result: " result))
+                (is (settings/remote-sync-transforms)
+                    "remote-sync-transforms setting should be auto-enabled when remote has transforms")
+                (is (not (t2/exists? :model/Transform :id local-transform-id))
+                    "Local transform should be deleted after import when remote has different transforms")
+                (is (not (t2/exists? :model/TransformTag :id local-tag-id))
+                    "Local tag should be deleted after import when remote has different tags")
+                (is (t2/exists? :model/Transform :entity_id remote-transform-entity-id)
+                    "Remote transform should be imported")
+                (is (t2/exists? :model/Collection :entity_id remote-coll-entity-id :namespace "transforms")
+                    "Remote transforms collection should be imported")
+                (is (not (t2/exists? :model/Collection :entity_id coll-eid))
+                    "Local transforms collection should be removed when not on remote")))))))))
+
+(deftest import-removes-all-local-transforms-when-setting-enabled-and-remote-has-none-test
+  (testing "When remote-sync-transforms is enabled and remote has no transforms, all local transforms are removed"
+    (mt/with-premium-features #{:transforms}
+      (mt/with-temporary-setting-values [remote-sync-transforms true
+                                         remote-sync-enabled true]
+        (mt/with-model-cleanup [:model/RemoteSyncTask :model/Transform :model/TransformTag]
+          (let [task-id (t2/insert-returning-pk! :model/RemoteSyncTask {:sync_task_type "import" :initiated_by (mt/user->id :rasta)})
+                local-transform-entity-id (u/generate-nano-id)
+                local-tag-entity-id (u/generate-nano-id)]
+            (mt/with-temp [:model/Collection {coll-id :id coll-eid :entity_id} {:name "Local Transforms Collection"
+                                                                                :namespace collection/transforms-ns
+                                                                                :entity_id (u/generate-nano-id)
+                                                                                :location "/"}
+                           :model/Transform {local-transform-id :id} {:name "Local Transform"
+                                                                      :entity_id local-transform-entity-id
+                                                                      :collection_id coll-id}
+                           :model/TransformTag {local-tag-id :id} {:name "Local Tag"
+                                                                   :entity_id local-tag-entity-id}]
+              (is (t2/exists? :model/Transform :id local-transform-id)
+                  "Local transform should exist before import")
+              (is (t2/exists? :model/TransformTag :id local-tag-id)
+                  "Local tag should exist before import")
+              (is (t2/exists? :model/Collection :id coll-id)
+                  "Local transforms collection should exist before import")
+              (let [remote-coll-entity-id (u/generate-nano-id)
+                    test-files {"main" {(str "collections/" remote-coll-entity-id "_remote_collection/" remote-coll-entity-id "_remote_collection.yaml")
+                                        (test-helpers/generate-collection-yaml remote-coll-entity-id "Remote Collection")}}
+                    mock-source (test-helpers/create-mock-source :initial-files test-files)
+                    result (impl/import! (source.p/snapshot mock-source) task-id)]
+                (is (= :success (:status result))
+                    (str "Import should succeed. Result: " result))
+                (is (not (t2/exists? :model/Transform :id local-transform-id))
+                    "Local transform should be deleted when setting enabled and remote has no transforms")
+                (is (not (t2/exists? :model/TransformTag :id local-tag-id))
+                    "Local tag should be deleted when setting enabled and remote has no transforms")
+                (is (not (t2/exists? :model/Collection :entity_id coll-eid))
+                    "Local transforms collection should be deleted when setting enabled and remote has none")))))))))
+
+(deftest import-auto-enables-setting-when-remote-has-transforms-test
+  (testing "When setting is disabled and remote has transforms, setting is auto-enabled and transforms are synced"
+    (mt/with-premium-features #{:transforms}
+      (mt/with-temporary-setting-values [remote-sync-transforms false
+                                         remote-sync-enabled true]
+        (mt/with-model-cleanup [:model/RemoteSyncTask :model/Transform]
+          (let [task-id (t2/insert-returning-pk! :model/RemoteSyncTask {:sync_task_type "import" :initiated_by (mt/user->id :rasta)})
+                local-transform-entity-id (u/generate-nano-id)
+                remote-transform-entity-id (u/generate-nano-id)
+                remote-coll-entity-id (u/generate-nano-id)]
+            (mt/with-temp [:model/Collection {coll-id :id} {:name "Local Transforms Collection"
+                                                            :namespace collection/transforms-ns
+                                                            :location "/"}
+                           :model/Transform {local-transform-id :id} {:name "Local Transform"
+                                                                      :entity_id local-transform-entity-id
+                                                                      :collection_id coll-id}]
+              (is (not (settings/remote-sync-transforms))
+                  "remote-sync-transforms should be disabled initially")
+              (is (t2/exists? :model/Transform :id local-transform-id)
+                  "Local transform should exist before import")
+              (let [test-files {"main" {(str "collections/" remote-coll-entity-id "_transforms/" remote-coll-entity-id "_transforms.yaml")
+                                        (generate-transforms-namespace-collection-yaml remote-coll-entity-id "Remote Transforms")
+                                        (str "collections/" remote-coll-entity-id "_transforms/transforms/" remote-transform-entity-id "_remote_transform.yaml")
+                                        (test-helpers/generate-transform-yaml remote-transform-entity-id "Remote Transform")}}
+                    mock-source (test-helpers/create-mock-source :initial-files test-files)
+                    result (impl/import! (source.p/snapshot mock-source) task-id)]
+                (is (= :success (:status result))
+                    (str "Import should succeed. Result: " result))
+                (is (settings/remote-sync-transforms)
+                    "remote-sync-transforms setting should be auto-enabled when remote has transforms")
+                (is (t2/exists? :model/Transform :entity_id remote-transform-entity-id)
+                    "Remote transform should be imported")
+                (is (not (t2/exists? :model/Transform :id local-transform-id))
+                    "Local transform should be removed because it's not on the remote")))))))))


### PR DESCRIPTION
## Description

When a we import a remote that has transforms set the `remote-sync-transforms` setting to true.

Update the remote sync object table clean up to be driven by the spec configuration.

Add tests showing that transforms are consistently synced and erased according to the following rules:

1. if the instance has `remote-sync-transforms` off and local transforms and the remote does not have transforms content they are preserved after an import
2. if the instance has `remote-sync-transforms` off and local transforms and the remote has transforms content, the local transforms are completely replaced by the remote.
3. if the instance has `remote-sync-transforms` on and the remote has transforms content any local transforms are completely replaced by the remote.
4. if the instance has `remote-sync-transforms` on has local transforms, but the remote has no transforms, the local transforms are removed on import.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

