### PR TITLE
Add cancelAutomaticallyClosedStatements option to c3p0

### DIFF
--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -155,6 +155,10 @@
                                                         "com.mchange namespace. You must raise the log level for"
                                                         "com.mchange to INFO via a custom log4j config in order to"
                                                         "see stacktraces in the logs.")))
+   ;; [From c3p0 docs] If true, Statement.cancel() will be called prior to Statement.close() when c3p0
+   ;; automatically closes statements because a Connection with open Statements has exceeded its
+   ;; unreturnedConnectionTimeout. This can help terminate hanging queries on the database server side. (#66656)
+   "cancelAutomaticallyClosedStatements" true
    ;; Set the data source name so that the c3p0 JMX bean has a useful identifier, which incorporates the DB ID, driver,
    ;; and name from the details
    "dataSourceName"               (format "db-%d-%s-%s"

--- a/test/metabase/driver/sql_jdbc/connection_test.clj
+++ b/test/metabase/driver/sql_jdbc/connection_test.clj
@@ -269,6 +269,12 @@
                (sql-jdbc.conn/jdbc-data-warehouse-debug-unreturned-connection-stack-traces))
             (str "setting=" setting))))))
 
+(deftest ^:parallel include-cancel-automatically-closed-statements-test
+  (testing "We should be setting cancelAutomaticallyClosedStatements to help terminate hung queries (#66656)"
+    (is (true?
+         (get (sql-jdbc.conn/data-warehouse-connection-pool-properties :h2 (mt/db))
+              "cancelAutomaticallyClosedStatements")))))
+
 (deftest debug-unreturned-connection-stack-traces-misconfigured-c3p0-log-warning-test
   (testing "We should log a warning if debug stack traces are enabled but c3p0 INFO logs are not (#47981)\n"
     ;; kondo thinks the c3p0-log-level binding is unused


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/66656

### Description

Use the c3p0 option suggested in the reported issue

### How to verify

todo

### Demo

todo

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
