### PR TITLE
Add snowplow events to oss sqlgen endpoints

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -779,7 +779,8 @@
   {:team "Metabot"
    :api  #{metabase.llm.api
            metabase.llm.init}
-   :uses #{api
+   :uses #{analytics
+           api
            lib
            lib-be
            models

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/token_usage/jsonschema/1-0-0
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/token_usage/jsonschema/1-0-0
@@ -1,0 +1,62 @@
+{
+    "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+    "self": {
+      "vendor": "com.metabase",
+      "name": "token_usage",
+      "format": "jsonschema",
+      "version": "1-0-0"
+    },
+    "type": "object",
+    "description": "Event to capture the token usage of individual LLM invocations. Created for billing purposes.",
+    "properties": {
+      "hashed_metabase_license_token": {
+        "type": "string",
+        "description": "The hashed value of the Metabase license token",
+        "maxLength": 255
+      },
+      "request_id": {
+        "type": "string",
+        "description": "Unique ID that is assigned to each incoming request. Can be used to aggregate usage for a single request.",
+        "maxLength": 255
+      },
+      "model_id": {
+        "type": "string",
+        "description": "The ID of the model that was used to generate the tokens",
+        "maxLength": 255
+      },
+      "total_tokens": {
+        "type": "integer",
+        "description": "The total number of tokens",
+        "minimum": 0,
+        "maximum": 2147483647
+      },
+      "prompt_tokens": {
+        "type": "integer",
+        "description": "The number of prompt tokens",
+        "minimum": 0,
+        "maximum": 2147483647
+      },
+      "completion_tokens": {
+        "type": "integer",
+        "description": "The number of completion tokens",
+        "minimum": 0,
+        "maximum": 2147483647
+      },
+      "estimated_costs_usd": {
+        "type": "number",
+        "description": "The estimated cost of for the tokens in USD",
+        "minimum": 0,
+        "maximum": 2147483647
+      }
+    },
+    "required": [
+      "hashed_metabase_license_token",
+      "request_id",
+      "model_id",
+      "total_tokens",
+      "prompt_tokens",
+      "completion_tokens",
+      "estimated_costs_usd"
+    ],
+    "additionalProperties": false
+  }

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/token_usage/jsonschema/1-0-1
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/token_usage/jsonschema/1-0-1
@@ -1,0 +1,80 @@
+{
+    "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+    "self": {
+      "vendor": "com.metabase",
+      "name": "token_usage",
+      "format": "jsonschema",
+      "version": "1-0-1"
+    },
+    "type": "object",
+    "description": "Event to capture the token usage of individual LLM invocations. Created for billing purposes.",
+    "properties": {
+      "hashed_metabase_license_token": {
+        "type": "string",
+        "description": "The hashed value of the Metabase license token",
+        "maxLength": 255
+      },
+      "user_id": {
+        "type": [
+          "integer",
+          "null"
+        ],
+        "description": "The ID of the user that send the request",
+        "minimum": 0,
+        "maximum": 2147483647
+      },
+      "request_id": {
+        "type": "string",
+        "description": "Unique ID that is assigned to each incoming request. Can be used to aggregate usage for a single request.",
+        "maxLength": 255
+      },
+      "model_id": {
+        "type": "string",
+        "description": "The ID of the model that was used to generate the tokens",
+        "maxLength": 255
+      },
+      "total_tokens": {
+        "type": "integer",
+        "description": "The total number of tokens",
+        "minimum": 0,
+        "maximum": 2147483647
+      },
+      "prompt_tokens": {
+        "type": "integer",
+        "description": "The number of prompt tokens",
+        "minimum": 0,
+        "maximum": 2147483647
+      },
+      "completion_tokens": {
+        "type": "integer",
+        "description": "The number of completion tokens",
+        "minimum": 0,
+        "maximum": 2147483647
+      },
+      "estimated_costs_usd": {
+        "type": "number",
+        "description": "The estimated cost of for the tokens in USD",
+        "minimum": 0,
+        "maximum": 2147483647
+      },
+      "duration_ms": {
+        "type": [
+          "integer",
+          "null"
+        ],
+        "description": "The time it took to (in milliseconds) to receive an answer from the LLM.",
+        "minimum": 0,
+        "maximum": 2147483647
+      }
+    },
+    "required": [
+      "hashed_metabase_license_token",
+      "request_id",
+      "model_id",
+      "total_tokens",
+      "prompt_tokens",
+      "completion_tokens",
+      "estimated_costs_usd"
+    ],
+    "additionalProperties": false
+  }

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/token_usage/jsonschema/1-0-2
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/token_usage/jsonschema/1-0-2
@@ -1,0 +1,88 @@
+{
+    "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+    "self": {
+        "vendor": "com.metabase",
+        "name": "token_usage",
+        "format": "jsonschema",
+        "version": "1-0-2"
+    },
+    "type": "object",
+    "description": "Event to capture the token usage of individual LLM invocations. Created for billing purposes.",
+    "properties": {
+        "hashed_metabase_license_token": {
+            "type": "string",
+            "description": "The hashed value of the Metabase license token",
+            "maxLength": 255
+        },
+        "user_id": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "description": "The ID of the user that send the request",
+            "minimum": 0,
+            "maximum": 2147483647
+        },
+        "request_id": {
+            "type": "string",
+            "description": "Unique ID that is assigned to each incoming request. Can be used to aggregate usage for a single request.",
+            "maxLength": 255
+        },
+        "model_id": {
+            "type": "string",
+            "description": "The ID of the model that was used to generate the tokens",
+            "maxLength": 255
+        },
+        "total_tokens": {
+            "type": "integer",
+            "description": "The total number of tokens",
+            "minimum": 0,
+            "maximum": 2147483647
+        },
+        "prompt_tokens": {
+            "type": "integer",
+            "description": "The number of prompt tokens",
+            "minimum": 0,
+            "maximum": 2147483647
+        },
+        "completion_tokens": {
+            "type": "integer",
+            "description": "The number of completion tokens",
+            "minimum": 0,
+            "maximum": 2147483647
+        },
+        "estimated_costs_usd": {
+            "type": "number",
+            "description": "The estimated cost of for the tokens in USD",
+            "minimum": 0,
+            "maximum": 2147483647
+        },
+        "duration_ms": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "description": "The time it took to (in milliseconds) to receive an answer from the LLM.",
+            "minimum": 0,
+            "maximum": 2147483647
+        },
+        "tag": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "A classifier indicating the specific purpose or functionality for which the tokens were used.",
+            "maxLength": 255
+        }
+    },
+    "required": [
+        "hashed_metabase_license_token",
+        "request_id",
+        "model_id",
+        "total_tokens",
+        "prompt_tokens",
+        "completion_tokens",
+        "estimated_costs_usd"
+    ],
+    "additionalProperties": false
+}

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/token_usage/jsonschema/1-0-3
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/token_usage/jsonschema/1-0-3
@@ -11,7 +11,7 @@
     "properties": {
         "hashed_metabase_license_token": {
             "type": "string",
-            "description": "The hashed value of the Metabase license token",
+            "description": "The hashed value of the Metabase license token for instances with a token. For Open Source instances, this will use the snowplow anonymous uuid in the form `oss_<anonymous_uuid>` to allow unique counts of instances.",
             "maxLength": 255
         },
         "user_id": {

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/token_usage/jsonschema/1-0-3
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/token_usage/jsonschema/1-0-3
@@ -1,0 +1,96 @@
+{
+    "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+    "self": {
+        "vendor": "com.metabase",
+        "name": "token_usage",
+        "format": "jsonschema",
+        "version": "1-0-3"
+    },
+    "type": "object",
+    "description": "Event to capture the token usage of individual LLM invocations. Created for billing purposes.",
+    "properties": {
+        "hashed_metabase_license_token": {
+            "type": "string",
+            "description": "The hashed value of the Metabase license token",
+            "maxLength": 255
+        },
+        "user_id": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "description": "The ID of the user that send the request",
+            "minimum": 0,
+            "maximum": 2147483647
+        },
+        "request_id": {
+            "type": "string",
+            "description": "Unique ID that is assigned to each incoming request. Can be used to aggregate usage for a single request.",
+            "maxLength": 255
+        },
+        "session_id": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "An identifier for the conversation or session in which the tokens were used. This can help group related requests together. Can be null for non-conversational use cases.",
+            "maxLength": 255
+        },
+        "model_id": {
+            "type": "string",
+            "description": "The ID of the model that was used to generate the tokens",
+            "maxLength": 255
+        },
+        "total_tokens": {
+            "type": "integer",
+            "description": "The total number of tokens",
+            "minimum": 0,
+            "maximum": 2147483647
+        },
+        "prompt_tokens": {
+            "type": "integer",
+            "description": "The number of prompt tokens",
+            "minimum": 0,
+            "maximum": 2147483647
+        },
+        "completion_tokens": {
+            "type": "integer",
+            "description": "The number of completion tokens",
+            "minimum": 0,
+            "maximum": 2147483647
+        },
+        "estimated_costs_usd": {
+            "type": "number",
+            "description": "The estimated cost of for the tokens in USD",
+            "minimum": 0,
+            "maximum": 2147483647
+        },
+        "duration_ms": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "description": "The time it took to (in milliseconds) to receive an answer from the LLM.",
+            "minimum": 0,
+            "maximum": 2147483647
+        },
+        "tag": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "A classifier indicating the specific purpose or functionality for which the tokens were used.",
+            "maxLength": 255
+        }
+    },
+    "required": [
+        "hashed_metabase_license_token",
+        "request_id",
+        "model_id",
+        "total_tokens",
+        "prompt_tokens",
+        "completion_tokens",
+        "estimated_costs_usd"
+    ],
+    "additionalProperties": false
+}

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/token_usage/jsonschema/1-0-4
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/token_usage/jsonschema/1-0-4
@@ -11,7 +11,7 @@
     "properties": {
         "hashed_metabase_license_token": {
             "type": "string",
-            "description": "The hashed value of the Metabase license token",
+            "description": "The hashed value of the Metabase license token for instances with a token. For Open Source instances, this will use the snowplow anonymous uuid in the form `oss_<anonymous_uuid>` to allow unique counts of instances.",
             "maxLength": 255
         },
         "user_id": {

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/token_usage/jsonschema/1-0-4
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/token_usage/jsonschema/1-0-4
@@ -1,0 +1,112 @@
+{
+    "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+    "self": {
+        "vendor": "com.metabase",
+        "name": "token_usage",
+        "format": "jsonschema",
+        "version": "1-0-4"
+    },
+    "type": "object",
+    "description": "Event to capture the token usage of individual LLM invocations. Created for billing purposes.",
+    "properties": {
+        "hashed_metabase_license_token": {
+            "type": "string",
+            "description": "The hashed value of the Metabase license token",
+            "maxLength": 255
+        },
+        "user_id": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "description": "The ID of the user that send the request",
+            "minimum": 0,
+            "maximum": 2147483647
+        },
+        "request_id": {
+            "type": "string",
+            "description": "Unique ID that is assigned to each incoming request. Can be used to aggregate usage for a single request.",
+            "maxLength": 255
+        },
+        "session_id": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "An identifier for the conversation or session in which the tokens were used. This can help group related requests together. Can be null for non-conversational use cases.",
+            "maxLength": 255
+        },
+        "model_id": {
+            "type": "string",
+            "description": "The ID of the model that was used to generate the tokens",
+            "maxLength": 255
+        },
+        "total_tokens": {
+            "type": "integer",
+            "description": "The total number of tokens",
+            "minimum": 0,
+            "maximum": 2147483647
+        },
+        "prompt_tokens": {
+            "type": "integer",
+            "description": "The number of prompt tokens",
+            "minimum": 0,
+            "maximum": 2147483647
+        },
+        "completion_tokens": {
+            "type": "integer",
+            "description": "The number of completion tokens",
+            "minimum": 0,
+            "maximum": 2147483647
+        },
+        "estimated_costs_usd": {
+            "type": "number",
+            "description": "The estimated cost of for the tokens in USD",
+            "minimum": 0,
+            "maximum": 2147483647
+        },
+        "duration_ms": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "description": "The time it took to (in milliseconds) to receive an answer from the LLM.",
+            "minimum": 0,
+            "maximum": 2147483647
+        },
+        "tag": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "A classifier indicating the specific purpose or functionality for which the tokens were used.",
+            "maxLength": 255
+        },
+        "profile": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "The profile/configuration variant used for the request. Allows distinguishing different configuration variants and usage patterns.",
+            "maxLength": 255
+        },
+        "source": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "The source/trigger of the request (e.g., 'metabot_agent', 'sql_generation_workflow', 'analyze_chart'). Indicates which API endpoint or workflow initiated the LLM call.",
+            "maxLength": 255
+        }
+    },
+    "required": [
+        "hashed_metabase_license_token",
+        "request_id",
+        "model_id",
+        "total_tokens",
+        "prompt_tokens",
+        "completion_tokens",
+        "estimated_costs_usd"
+    ],
+    "additionalProperties": false
+}

--- a/src/metabase/analytics/core.clj
+++ b/src/metabase/analytics/core.clj
@@ -43,6 +43,7 @@
 
  [metabase.analytics.settings
 
+  analytics-uuid
   anon-tracking-enabled
   anon-tracking-enabled!
   instance-creation]

--- a/src/metabase/analytics/snowplow.clj
+++ b/src/metabase/analytics/snowplow.clj
@@ -50,6 +50,7 @@
    :snowplow/action         "1-0-0"
    :snowplow/embed_share    "1-0-2"
    :snowplow/llm_usage      "1-0-0"
+   :snowplow/token_usage    "1-0-4"
    :snowplow/serialization  "1-0-1"
    :snowplow/simple_event   "1-0-0"
    :snowplow/cleanup        "1-0-0"})

--- a/src/metabase/llm/anthropic.clj
+++ b/src/metabase/llm/anthropic.clj
@@ -168,8 +168,10 @@
 (defn chat-completion-stream
   "Send a streaming chat completion request to Anthropic.
 
-   Returns a core.async channel that emits AI SDK v5 formatted text delta chunks:
-   {:type :text-delta :delta \"text chunk\"}
+   Returns a core.async channel that emits AI SDK v5 formatted chunks:
+   - {:type :text-delta :delta \"text chunk\"} for content
+   - {:type :usage :id \"anthropic/model\" :usage {:promptTokens N}} from message_start
+   - {:type :usage :id \"anthropic/model\" :usage {:completionTokens N}} from message_delta
 
    The channel closes when the stream completes or on error.
 
@@ -182,9 +184,14 @@
     (when-not api-key
       (throw (ex-info "LLM is not configured. Please set an Anthropic API key via MB_LLM_ANTHROPIC_API_KEY."
                       {:type :llm-not-configured})))
-    (let [model        (or model (llm-settings/llm-anthropic-model) default-model)
-          request      {:model model :system system :messages messages}
-          request-body (build-streaming-request-body request)]
+    (let [model              (or model (llm-settings/llm-anthropic-model) default-model)
+          ;; Transform the :id field on usage parts to simplified provider model format
+          simplify-model-xf (map (fn [chunk]
+                                   (if (and (= :usage (:type chunk)) (:id chunk))
+                                     (update chunk :id model->simplified-provider-model)
+                                     chunk)))
+          request            {:model model :system system :messages messages}
+          request-body       (build-streaming-request-body request)]
       (try
         (let [response (http/post anthropic-messages-url
                                   {:as                 :stream
@@ -195,7 +202,8 @@
                                    :connection-timeout (llm-settings/llm-connection-timeout-ms)})]
           (if (<= 200 (:status response) 299)
             (a/pipe (streaming/anthropic-sse-chan (:body response))
-                    (a/chan 64 streaming/anthropic-chat->aisdk-xf))
+                    (a/chan 64 (comp streaming/anthropic-chat->aisdk-xf
+                                     simplify-model-xf)))
             (handle-streaming-error (:status response) (:body response))))
         (catch Exception e
           (log/error e "Anthropic streaming request failed with exception")

--- a/src/metabase/llm/api.clj
+++ b/src/metabase/llm/api.clj
@@ -7,7 +7,7 @@
    [clojure.java.io :as io]
    [clojure.set :as set]
    [clojure.string :as str]
-   [metabase.analytics.settings :as analytics.settings]
+   [metabase.analytics.core :as analytics]
    [metabase.analytics.snowplow :as snowplow]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
@@ -209,7 +209,7 @@
                                 buddy-hash/sha256
                                 codecs/bytes->hex)
         token-or-uuid   (or hashed-token
-                            (str "oss__" (analytics.settings/analytics-uuid)))
+                            (str "oss__" (analytics/analytics-uuid)))
         estimated-costs (llm.costs/estimate {:model      model
                                              :prompt     prompt
                                              :completion completion})]

--- a/src/metabase/llm/api.clj
+++ b/src/metabase/llm/api.clj
@@ -222,7 +222,7 @@
                             :completion-tokens             completion
                             :estimated-costs-usd           estimated-costs
                             :user-id                       user-id
-                            :duration-ms                   duration-ms
+                            :duration-ms                   (some-> duration-ms long)
                             :source                        source
                             :tag                           tag}
                            user-id)))
@@ -231,10 +231,10 @@
   "Track SQL generation usage via Snowplow simple_event."
   [{:keys [duration-ms result engine]}]
   (snowplow/track-event! :snowplow/simple_event
-                         {:event "metabot_oss_sqlgen_used"
-                          :duration_ms duration-ms
-                          :result result
-                          :event_detail (some-> engine name)}
+                         {:event        "metabot_oss_sqlgen_used"
+                          :event_detail (some-> engine name)
+                          :duration_ms  (some-> duration-ms long)
+                          :result       result}
                          api/*current-user-id*))
 
 ;;; ------------------------------------------ Extract Tables Endpoint ------------------------------------------

--- a/src/metabase/llm/costs.clj
+++ b/src/metabase/llm/costs.clj
@@ -1,0 +1,23 @@
+(ns metabase.llm.costs
+  "LLM cost estimation utils.")
+
+(def ^:private model-pricing
+  "Model pricing by model family. Prices are in USD. :input and :output are per :scale tokens."
+  {"anthropic/claude-opus-4-5"   {:input  5.00 :output 25.00 :scale 1000000}
+   "anthropic/claude-opus-4-1"   {:input 15.00 :output 75.00 :scale 1000000}
+   "anthropic/claude-opus-4"     {:input 15.00 :output 75.00 :scale 1000000}
+   "anthropic/claude-sonnet-4-5" {:input  3.00 :output 15.00 :scale 1000000}
+   "anthropic/claude-sonnet-4"   {:input  3.00 :output 15.00 :scale 1000000}
+   "anthropic/claude-haiku-4-5"  {:input  1.00 :output  5.00 :scale 1000000}
+   "anthropic/claude-haiku-3-5"  {:input  0.80 :output  4.00 :scale 1000000}
+   "anthropic/claude-haiku-3"    {:input  0.25 :output  1.25 :scale 1000000}})
+
+(defn estimate
+  "Estimate the cost in USD for token usage.
+
+  Returns 0.0 for unknown models."
+  [{:keys [model prompt completion]}]
+  (if-let [{:keys [input output scale]} (get model-pricing model)]
+    (+ (* (/ (double prompt) scale) input)
+       (* (/ (double completion) scale) output))
+    0.0))

--- a/test/metabase/llm/anthropic_test.clj
+++ b/test/metabase/llm/anthropic_test.clj
@@ -1,10 +1,13 @@
 (ns metabase.llm.anthropic-test
   (:require
    [clj-http.client :as http]
+   [clojure.core.async :as a]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.llm.anthropic :as anthropic]
-   [metabase.test :as mt]))
+   [metabase.test :as mt])
+  (:import
+   (java.io ByteArrayInputStream)))
 
 (set! *warn-on-reflection* true)
 
@@ -159,3 +162,52 @@
 (deftest ^:parallel model->simplified-provider-model-nil-model-test
   (testing "returns nil for nil input"
     (is (nil? (#'anthropic/model->simplified-provider-model nil)))))
+
+;;; ------------------------------------------- chat-completion-stream Tests -------------------------------------------
+
+(deftest chat-completion-stream-usage-parts-test
+  (testing "chat-completion-stream emits usage parts with model id"
+    (let [sse-data (str "event: message_start\n"
+                        "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_123\",\"model\":\"claude-sonnet-4-20250514\",\"usage\":{\"input_tokens\":1500}}}\n\n"
+                        "event: content_block_start\n"
+                        "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"name\":\"generate_sql\"}}\n\n"
+                        "event: content_block_delta\n"
+                        "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"sql\\\":\\\"SELECT 1\\\"}\"}}\n\n"
+                        "event: content_block_stop\n"
+                        "data: {\"type\":\"content_block_stop\",\"index\":0}\n\n"
+                        "event: message_delta\n"
+                        "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":250}}\n\n"
+                        "event: message_stop\n"
+                        "data: {\"type\":\"message_stop\"}\n\n")
+          mock-response {:status 200
+                         :body (ByteArrayInputStream. (.getBytes sse-data "UTF-8"))}]
+      (mt/with-temporary-setting-values [llm-anthropic-api-key "sk-test-key"
+                                         llm-anthropic-model "claude-sonnet-4-20250514"]
+        (with-redefs [http/post (constantly mock-response)]
+          (let [ch (anthropic/chat-completion-stream {:system "You are a SQL expert"
+                                                      :messages [{:role "user" :content "test"}]})
+                results (loop [acc []]
+                          (if-let [v (a/<!! ch)]
+                            (recur (conj acc v))
+                            acc))
+                usage-parts (filter #(= :usage (:type %)) results)
+                text-parts (filter #(= :text-delta (:type %)) results)]
+            ;; Should have two usage parts (prompt and completion)
+            (is (= [{:type :usage
+                     :id "anthropic/claude-sonnet-4"
+                     :usage {:promptTokens 1500}}
+                    {:type :usage
+                     :id "anthropic/claude-sonnet-4"
+                     :usage {:completionTokens 250}}]
+                   usage-parts))
+            (is (= [{:type :text-delta
+                     :delta "{\"sql\":\"SELECT 1\"}"}]
+                   text-parts))))))))
+
+(deftest chat-completion-stream-not-configured-test
+  (testing "throws when API key not configured"
+    (mt/with-temporary-setting-values [llm-anthropic-api-key nil]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"not configured"
+           (anthropic/chat-completion-stream {:messages [{:role "user" :content "test"}]}))))))

--- a/test/metabase/llm/anthropic_test.clj
+++ b/test/metabase/llm/anthropic_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.llm.anthropic-test
   (:require
+   [clj-http.client :as http]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.llm.anthropic :as anthropic]
@@ -101,7 +102,7 @@
       (is (contains? (get-in tool [:input_schema :properties]) :sql))
       (is (= ["sql"] (get-in tool [:input_schema :required]))))))
 
-;;; ------------------------------------------- chat-completion error handling Tests -------------------------------------------
+;;; ------------------------------------------- chat-completion Tests -------------------------------------------
 
 (deftest chat-completion-not-configured-test
   (testing "throws when API key not configured"
@@ -110,6 +111,29 @@
            clojure.lang.ExceptionInfo
            #"not configured"
            (anthropic/chat-completion {:messages [{:role "user" :content "test"}]}))))))
+
+(deftest chat-completion-returns-usage-test
+  (testing "chat-completion returns result, usage, and duration"
+    (let [mock-response {:body {:id "msg_123"
+                                :model "claude-sonnet-4-5-20250929"
+                                :content [{:type "tool_use"
+                                           :id "tool_123"
+                                           :name "generate_sql"
+                                           :input {:sql "SELECT * FROM users"
+                                                   :explanation "Fetches all users"}}]
+                                :usage {:input_tokens 1500
+                                        :output_tokens 250}}}]
+      (mt/with-temporary-setting-values [llm-anthropic-api-key "sk-test-key"]
+        (with-redefs [http/post (constantly mock-response)]
+          (let [result (anthropic/chat-completion {:system "You are a SQL expert"
+                                                   :messages [{:role "user" :content "get all users"}]})]
+            (is (=? {:result {:sql "SELECT * FROM users"
+                              :explanation "Fetches all users"}
+                     :duration-ms #(and (number? %) (pos? %))
+                     :usage {:model "anthropic/claude-sonnet-4-5"
+                             :prompt 1500
+                             :completion 250}}
+                    result))))))))
 
 ;;; ------------------------------------------- default-model Tests -------------------------------------------
 

--- a/test/metabase/llm/anthropic_test.clj
+++ b/test/metabase/llm/anthropic_test.clj
@@ -117,3 +117,21 @@
   (testing "default model is defined and reasonable"
     (is (string? anthropic/default-model))
     (is (str/includes? anthropic/default-model "claude"))))
+
+;;; ------------------------------------------- model->simplified-provider-model Tests -------------------------------------------
+
+(deftest ^:parallel model->simplified-provider-model-test
+  (testing "strips date suffix and adds provider prefix"
+    (is (= "anthropic/claude-sonnet-4-5"
+           (#'anthropic/model->simplified-provider-model "claude-sonnet-4-5-20250929")))
+    (is (= "anthropic/claude-opus-4-5"
+           (#'anthropic/model->simplified-provider-model "claude-opus-4-5-20250514")))))
+
+(deftest ^:parallel model->simplified-provider-model-no-suffix-test
+  (testing "handles model without date suffix"
+    (is (= "anthropic/claude-sonnet-4-5"
+           (#'anthropic/model->simplified-provider-model "claude-sonnet-4-5")))))
+
+(deftest ^:parallel model->simplified-provider-model-nil-model-test
+  (testing "returns nil for nil input"
+    (is (nil? (#'anthropic/model->simplified-provider-model nil)))))

--- a/test/metabase/llm/api_test.clj
+++ b/test/metabase/llm/api_test.clj
@@ -226,7 +226,7 @@
                 (let [simple-events (filter #(= :snowplow/simple_event (:schema %)) @tracked-events)]
                   (is (=? [{:schema :snowplow/simple_event
                             :data {:event "metabot_oss_sqlgen_used"
-                                   :duration_ms pos?
+                                   :duration_ms int?
                                    :result "success"
                                    :event_detail "postgres"}}]
                           simple-events)))))))))))
@@ -254,7 +254,7 @@
               (let [simple-events (filter #(= :snowplow/simple_event (:schema %)) @tracked-events)]
                 (is (=? [{:schema :snowplow/simple_event
                           :data {:event "metabot_oss_sqlgen_used"
-                                 :duration_ms pos?
+                                 :duration_ms int?
                                  :result "failure"
                                  :event_detail "postgres"}}]
                         simple-events))))))))))
@@ -292,7 +292,7 @@
                                    :prompt-tokens 1500
                                    :completion-tokens 250
                                    :total-tokens 1750
-                                   :duration-ms pos?
+                                   :duration-ms int?
                                    :source "oss_metabot"
                                    :tag "oss-sqlgen-streaming"}}]
                           token-events))))
@@ -300,7 +300,7 @@
                 (let [simple-events (filter #(= :snowplow/simple_event (:schema %)) @tracked-events)]
                   (is (=? [{:schema :snowplow/simple_event
                             :data {:event "metabot_oss_sqlgen_used"
-                                   :duration_ms pos?
+                                   :duration_ms int?
                                    :result "success"
                                    :event_detail "postgres"}}]
                           simple-events)))))))))))
@@ -334,7 +334,7 @@
                 (let [simple-events (filter #(= :snowplow/simple_event (:schema %)) @tracked-events)]
                   (is (=? [{:schema :snowplow/simple_event
                             :data {:event "metabot_oss_sqlgen_used"
-                                   :duration_ms pos?
+                                   :duration_ms int?
                                    :result "failure"
                                    :event_detail "postgres"}}]
                           simple-events)))))))))))

--- a/test/metabase/llm/api_test.clj
+++ b/test/metabase/llm/api_test.clj
@@ -5,7 +5,7 @@
    [clojure.set :as set]
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [metabase.analytics.settings :as analytics.settings]
+   [metabase.analytics.core :as analytics]
    [metabase.analytics.snowplow :as snowplow]
    [metabase.llm.anthropic :as llm.anthropic]
    [metabase.llm.api :as api]
@@ -350,7 +350,7 @@
                                                                         :data data
                                                                         :user-id user-id}))
                     premium-features/premium-embedding-token (constantly nil)
-                    analytics.settings/analytics-uuid (constantly test-analytics-uuid)]
+                    analytics/analytics-uuid (constantly test-analytics-uuid)]
         (#'api/track-token-usage! {:model "anthropic/claude-sonnet-4-5"
                                    :prompt 1000
                                    :completion 500

--- a/test/metabase/llm/api_test.clj
+++ b/test/metabase/llm/api_test.clj
@@ -240,15 +240,16 @@
               (tu/poll-until 2000 (seq @tracked-events))
               (is (string? response))
               (is (str/includes? response "SELECT * FROM users"))
-              (is (=? [{:schema :snowplow/token_usage
-                        :data {:model-id "anthropic/claude-sonnet-4"
-                               :prompt-tokens 1500
-                               :completion-tokens 250
-                               :total-tokens 1750
-                               :duration-ms pos?
-                               :source "oss_metabot"
-                               :tag "oss-sqlgen-streaming"}}]
-                      @tracked-events)))))))))
+              (let [token-usage-events (filter #(= :snowplow/token_usage (:schema %)) @tracked-events)]
+                (is (=? [{:schema :snowplow/token_usage
+                          :data {:model-id "anthropic/claude-sonnet-4"
+                                 :prompt-tokens 1500
+                                 :completion-tokens 250
+                                 :total-tokens 1750
+                                 :duration-ms pos?
+                                 :source "oss_metabot"
+                                 :tag "oss-sqlgen-streaming"}}]
+                        token-usage-events))))))))))
 
 ;;; ------------------------------------------- Token Usage Tracking Tests -------------------------------------------
 
@@ -304,3 +305,122 @@
           ;; Should be a SHA-256 hash (64 hex chars), not "oss__*"
           (is (=? {:hashed-metabase-license-token #"[0-9a-f]{64}"}
                   data)))))))
+
+;;; ------------------------------------------- Simple Event Tracking Tests -------------------------------------------
+
+(deftest generate-sql-tracks-simple-event-test
+  (testing "successful /generate-sql call tracks simple_event"
+    (mt/with-temp [:model/Database db {:engine :postgres}
+                   :model/Table table {:db_id (:id db) :name "users" :schema "public"}
+                   :model/Field _ {:table_id (:id table) :name "id" :base_type :type/Integer}]
+      (let [tracked-events (atom [])
+            mock-chat-response {:result {:sql "SELECT * FROM users"}
+                                :usage {:model "anthropic/claude-sonnet-4-5"
+                                        :prompt 1000
+                                        :completion 200}
+                                :duration-ms 500}]
+        (mt/with-temporary-setting-values [llm-anthropic-api-key "sk-test"]
+          (with-redefs [llm.anthropic/chat-completion (constantly mock-chat-response)
+                        snowplow/track-event! (fn [schema data user-id]
+                                                (swap! tracked-events conj {:schema schema
+                                                                            :data data
+                                                                            :user-id user-id}))]
+            (let [response (mt/user-http-request :rasta :post 200 "llm/generate-sql"
+                                                 {:prompt "get all users"
+                                                  :database_id (:id db)
+                                                  :referenced_entities [{:model "table" :id (:id table)}]})]
+              (is (= "SELECT * FROM users" (:sql response)))
+              (let [simple-events (filter #(= :snowplow/simple_event (:schema %)) @tracked-events)]
+                (is (=? [{:schema :snowplow/simple_event
+                          :data {:event "metabot_oss_sqlgen_used"
+                                 :duration_ms pos?
+                                 :result "success"
+                                 :event_detail "postgres"}}]
+                        simple-events))))))))))
+
+(deftest generate-sql-tracks-simple-event-on-failure-test
+  (testing "failed /generate-sql call tracks simple_event with failure result"
+    (mt/with-temp [:model/Database db {:engine :postgres}
+                   :model/Table table {:db_id (:id db) :name "users" :schema "public"}
+                   :model/Field _ {:table_id (:id table) :name "id" :base_type :type/Integer}]
+      (let [tracked-events (atom [])]
+        (mt/with-temporary-setting-values [llm-anthropic-api-key "sk-test"]
+          (with-redefs [llm.anthropic/chat-completion (fn [_] (throw (Exception. "API error")))
+                        snowplow/track-event! (fn [schema data user-id]
+                                                (swap! tracked-events conj {:schema schema
+                                                                            :data data
+                                                                            :user-id user-id}))]
+            (mt/user-http-request :rasta :post 500 "llm/generate-sql"
+                                  {:prompt "get all users"
+                                   :database_id (:id db)
+                                   :referenced_entities [{:model "table" :id (:id table)}]})
+            (let [simple-events (filter #(= :snowplow/simple_event (:schema %)) @tracked-events)]
+              (is (=? [{:schema :snowplow/simple_event
+                        :data {:event "metabot_oss_sqlgen_used"
+                               :duration_ms pos?
+                               :result "failure"
+                               :event_detail "postgres"}}]
+                      simple-events)))))))))
+
+(deftest generate-sql-streaming-tracks-simple-event-test
+  (testing "successful /generate-sql-streaming call tracks simple_event"
+    (mt/with-temp [:model/Database db {:engine :postgres}
+                   :model/Table table {:db_id (:id db) :name "users" :schema "public"}
+                   :model/Field _ {:table_id (:id table) :name "id" :base_type :type/Integer}]
+      (let [tracked-events (atom [])
+            mock-chan (a/chan 10)]
+        (a/>!! mock-chan {:type :usage :id "anthropic/claude-sonnet-4" :usage {:promptTokens 1500}})
+        (a/>!! mock-chan {:type :text-delta :delta "{\"sql\":\"SELECT * FROM users\"}"})
+        (a/>!! mock-chan {:type :usage :id "anthropic/claude-sonnet-4" :usage {:completionTokens 250}})
+        (a/close! mock-chan)
+        (mt/with-temporary-setting-values [llm-anthropic-api-key "sk-test"]
+          (with-redefs [llm.anthropic/chat-completion-stream (constantly mock-chan)
+                        snowplow/track-event! (fn [schema data user-id]
+                                                (swap! tracked-events conj {:schema schema
+                                                                            :data data
+                                                                            :user-id user-id}))]
+            (let [response (mt/user-http-request :rasta :post 202 "llm/generate-sql-streaming"
+                                                 {:prompt "get all users"
+                                                  :database_id (:id db)
+                                                  :referenced_entities [{:model "table" :id (:id table)}]})]
+              ;; Wait for the background thread to complete tracking
+              (tu/poll-until 2000 (>= (count @tracked-events) 2))
+              (is (string? response))
+              (is (str/includes? response "SELECT * FROM users"))
+              (let [simple-events (filter #(= :snowplow/simple_event (:schema %)) @tracked-events)]
+                (is (=? [{:schema :snowplow/simple_event
+                          :data {:event "metabot_oss_sqlgen_used"
+                                 :duration_ms pos?
+                                 :result "success"
+                                 :event_detail "postgres"}}]
+                        simple-events))))))))))
+
+(deftest generate-sql-streaming-tracks-simple-event-on-error-test
+  (testing "streaming error chunk tracks simple_event with failure result"
+    (mt/with-temp [:model/Database db {:engine :postgres}
+                   :model/Table table {:db_id (:id db) :name "users" :schema "public"}
+                   :model/Field _ {:table_id (:id table) :name "id" :base_type :type/Integer}]
+      (let [tracked-events (atom [])
+            mock-chan (a/chan 10)]
+        (a/>!! mock-chan {:type :error :error "API rate limit exceeded"})
+        (a/close! mock-chan)
+        (mt/with-temporary-setting-values [llm-anthropic-api-key "sk-test"]
+          (with-redefs [llm.anthropic/chat-completion-stream (constantly mock-chan)
+                        snowplow/track-event! (fn [schema data user-id]
+                                                (swap! tracked-events conj {:schema schema
+                                                                            :data data
+                                                                            :user-id user-id}))]
+            (let [response (mt/user-http-request :rasta :post 202 "llm/generate-sql-streaming"
+                                                 {:prompt "get all users"
+                                                  :database_id (:id db)
+                                                  :referenced_entities [{:model "table" :id (:id table)}]})]
+              ;; Wait for the background thread to complete
+              (tu/poll-until 2000 (seq @tracked-events))
+              (is (string? response))
+              (let [simple-events (filter #(= :snowplow/simple_event (:schema %)) @tracked-events)]
+                (is (=? [{:schema :snowplow/simple_event
+                          :data {:event "metabot_oss_sqlgen_used"
+                                 :duration_ms pos?
+                                 :result "failure"
+                                 :event_detail "postgres"}}]
+                        simple-events))))))))))

--- a/test/metabase/llm/api_test.clj
+++ b/test/metabase/llm/api_test.clj
@@ -393,5 +393,3 @@
           ;; Should be a SHA-256 hash (64 hex chars), not "oss__*"
           (is (=? {:hashed-metabase-license-token #"[0-9a-f]{64}"}
                   data)))))))
-
-

--- a/test/metabase/llm/costs_test.clj
+++ b/test/metabase/llm/costs_test.clj
@@ -1,0 +1,52 @@
+(ns metabase.llm.costs-test
+  (:require
+   [clojure.test :refer :all]
+   [mb.hawk.assert-exprs.approximately-equal :as =?]
+   [metabase.llm.costs :as costs]))
+
+(set! *warn-on-reflection* true)
+
+(deftest ^:parallel estimate-sanity-test
+  (testing "known models calculate correct costs"
+    (is (=? (=?/approx [0.030 0.0001])
+            (costs/estimate {:model "anthropic/claude-opus-4-5"
+                             :prompt 1000
+                             :completion 1000})))
+    (is (=? (=?/approx [0.018 0.0001])
+            (costs/estimate {:model "anthropic/claude-sonnet-4-5"
+                             :prompt 1000
+                             :completion 1000})))))
+
+(deftest ^:parallel estimate-zero-tokens-test
+  (testing "zero tokens returns zero cost"
+    (is (= 0.0
+           (costs/estimate {:model "anthropic/claude-sonnet-4-5"
+                            :prompt 0
+                            :completion 0})))))
+
+(deftest ^:parallel estimate-unknown-model-test
+  (testing "unknown model returns 0.0"
+    (is (= 0.0
+           (costs/estimate {:model "unknown-model-xyz"
+                            :prompt 1000
+                            :completion 1000})))))
+
+(deftest ^:parallel estimate-nil-model-test
+  (testing "nil model returns 0.0"
+    (is (= 0.0
+           (costs/estimate {:model nil
+                            :prompt 1000
+                            :completion 1000})))))
+
+(deftest ^:parallel estimate-all-models-test
+  (testing "all known models have valid pricing"
+    (doseq [model (keys @#'costs/model-pricing)]
+      (testing (str "model: " model)
+        (is (pos? (costs/estimate {:model model
+                                   :prompt 1000
+                                   :completion 1000}))
+            "should have positive cost for non-zero tokens")
+        (is (= 0.0 (costs/estimate {:model model
+                                    :prompt 0
+                                    :completion 0}))
+            "should have zero cost for zero tokens")))))


### PR DESCRIPTION
Closes BOT-748

### Description

https://metaboat.slack.com/archives/C07SJT1P0ET/p1769493176349639

Add snowplow token usage and request success / failure events to the oss metabot `generate-sql` and `generate-sql-streaming` endpoints.

* Copy the `token_usage` snowplow schema from ai-service into the metabase repo (see https://github.com/metabase/ai-service/pull/602).
* Add `:snowplow/token_usage` to `metabase.analytics.snowplow/schema->version`
* Add basic anthropic cost estimation based on static tables
* Return `:usage` and `:duration-ms` from `llm.anthropic/chat-completion`
* Add snowplow `token_usage` tracking to oss `generate-sql` endpoint
* Add snowplow `token_usage` tracking to oss `generate-sql-streaming` endpoint
* Add snowplow `simple_event` tracking for sqlgen success and failure events

### How to verify

Startup snowplow collector
* `cd snowplow && docker compose up`

Startup metabase in OSS mode with snowplow enabled
* `MB_EDITION=oss`
* `MB_LLM_ANTHROPIC_API_KEY` (ask in slack if you don't have one)
* `MB_SNOWPLOW_AVAILABLE=true`
* `MB_SNOWPLOW_URL="http://localhost:9090"`
* no `MB_PREMIUM_EMBEDDING_TOKEN`
* no ee on classpath

1. New -> SQL Query
2. `CMD + Shift + i` to bring up SQLgen prompt
3. Ask for some SQL
4. Send

See snowplow events at `http://localhost:9090/micro/{all,good,bad}`


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
