### PR TITLE
Filter out questions from other dashboards in section question picker (#68612)

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/dashboard-sections.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-sections.cy.spec.js
@@ -133,6 +133,46 @@ describe("scenarios > dashboard cards > sections > read only collections", () =>
   });
 });
 
+describe("scenarios > dashboard cards > sections > questions from other dashboards (metabase#68612)", () => {
+  const questionInDashboardDetails = {
+    name: "Question In Dashboard",
+    query: { "source-table": 1, limit: 10 },
+    display: "table",
+  };
+
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should not show questions from other dashboards in the recents tab", () => {
+    H.createDashboardWithQuestions({
+      dashboardDetails: { name: "Dashboard with question" },
+      questions: [questionInDashboardDetails],
+    }).then(({ dashboard }) => {
+      H.visitDashboard(dashboard.id);
+
+      H.createDashboard({ name: "New Dashboard" }).then(
+        ({ body: newDashboard }) => {
+          H.visitDashboard(newDashboard.id);
+
+          H.editDashboard();
+          addSection("KPIs w/ large chart below");
+
+          H.dashboardGrid()
+            .findAllByText("Select question")
+            .first()
+            .click({ force: true });
+
+          H.entityPickerModal()
+            .findByRole("tabpanel")
+            .should("not.contain", "Question In Dashboard");
+        },
+      );
+    });
+  });
+});
+
 function addSection(name) {
   cy.findByLabelText("Add section").click();
   H.menu().findByLabelText(name).click();

--- a/frontend/src/metabase/visualizations/visualizations/DashCardPlaceholder.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/DashCardPlaceholder.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { t } from "ttag";
 
 import {
@@ -8,7 +8,12 @@ import {
 import { replaceCard } from "metabase/dashboard/actions";
 import { useDispatch } from "metabase/lib/redux";
 import { Button, Flex } from "metabase/ui";
-import type { Dashboard, VirtualDashboardCard } from "metabase-types/api";
+import {
+  type Dashboard,
+  type RecentItem,
+  type VirtualDashboardCard,
+  isRecentCollectionItem,
+} from "metabase-types/api";
 
 import type { VisualizationProps } from "../types";
 
@@ -32,6 +37,20 @@ function DashCardPlaceholderInner({
     dispatch(replaceCard({ dashcardId: dashcard.id, nextCardId: nextCard.id }));
     setQuestionPickerOpen(false);
   };
+
+  const recentFilter = useCallback(
+    (items: RecentItem[]) => {
+      return items.filter((item) => {
+        if (isRecentCollectionItem(item) && item.dashboard) {
+          if (item.dashboard.id !== dashboard.id) {
+            return false;
+          }
+        }
+        return true;
+      });
+    },
+    [dashboard.id],
+  );
 
   if (!isDashboard) {
     return null;
@@ -76,6 +95,7 @@ function DashCardPlaceholderInner({
           models={["card", "dataset", "metric"]}
           onChange={handleSelectQuestion}
           onClose={() => setQuestionPickerOpen(false)}
+          recentFilter={recentFilter}
         />
       )}
     </>


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/68612

### Description

When using the "Add Section" feature in dashboards and clicking "Select question", questions saved inside other dashboards were appearing in the Recents tab. Selecting these questions would cause a save failure with "Invalid Request" (400 error) since questions inside dashboards cannot be referenced from a different dashboard.

This PR adds a `recentFilter` to the `QuestionPickerModal` in `DashCardPlaceholder` that filters out questions belonging to dashboards other than the current one. This matches the existing behavior already implemented in the "Replace card" modal in `DashboardGrid`.

### How to verify

1. Create a dashboard (Dashboard A) and add a new question to it, saving the question **inside the dashboard** (not to a collection)
2. Visit that dashboard so the question appears in your recents
3. Create a new dashboard (Dashboard B)
4. Edit Dashboard B → Click "Add section" → Choose any layout
5. Click "Select question" on a placeholder card
6. Check the **Recents** tab - the question from Dashboard A should NOT appear
7. (Before fix) The question would appear and selecting it would cause save to fail
8. (After fix) The question is filtered out and doesn't appear in Recents

### Demo

_N/A - behavior change in filtering, no visual UI changes_

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)