### PR TITLE
Add support for `auto-refresh-interval` in modular embedding

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-iframe-embedding.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-iframe-embedding.cy.spec.ts
@@ -8,7 +8,7 @@ import {
 
 const { H } = cy;
 
-describe("scenarios > embedding > sdk iframe embedding", () => {
+describe("scenarios > embedding > modular embedding", () => {
   beforeEach(() => {
     H.prepareSdkIframeEmbedTest({ signOut: true });
   });
@@ -305,134 +305,134 @@ describe("scenarios > embedding > sdk iframe embedding", () => {
       cy.findByRole("button", { name: "Cancel" }).click();
     });
   });
-});
 
-describe("scenarios > embedding > Modular embedding", () => {
-  beforeEach(() => {
-    H.resetSnowplow();
-    H.prepareSdkIframeEmbedTest({
-      enabledAuthMethods: ["jwt"],
-      signOut: false,
+  describe("analytics", () => {
+    beforeEach(() => {
+      H.resetSnowplow();
+      H.prepareSdkIframeEmbedTest({
+        enabledAuthMethods: ["jwt"],
+        signOut: false,
+      });
+      H.enableTracking();
     });
-    H.enableTracking();
-  });
 
-  it("should send an modular embedding usage event", () => {
-    cy.signOut();
-    cy.visit("http://localhost:4000");
-    const frame = H.loadSdkIframeEmbedTestPage({
-      origin: "http://different-than-metabase-instance.com",
-      elements: [
-        {
-          component: "metabase-dashboard",
-          attributes: {
-            dashboardId: ORDERS_DASHBOARD_ID,
-            "with-subscriptions": true,
+    it("should send an modular embedding usage event", () => {
+      cy.signOut();
+      cy.visit("http://localhost:4000");
+      const frame = H.loadSdkIframeEmbedTestPage({
+        origin: "http://different-than-metabase-instance.com",
+        elements: [
+          {
+            component: "metabase-dashboard",
+            attributes: {
+              dashboardId: ORDERS_DASHBOARD_ID,
+              "with-subscriptions": true,
+            },
           },
-        },
-        {
-          component: "metabase-question",
-          attributes: {
-            questionId: ORDERS_QUESTION_ID,
+          {
+            component: "metabase-question",
+            attributes: {
+              questionId: ORDERS_QUESTION_ID,
+            },
           },
-        },
-        {
-          component: "metabase-question",
-          attributes: {
-            questionId: "new",
+          {
+            component: "metabase-question",
+            attributes: {
+              questionId: "new",
+            },
           },
-        },
-        {
-          component: "metabase-browser",
-          attributes: {},
-        },
-      ],
-      selector: `[dashboard-id="${ORDERS_DASHBOARD_ID}"] > iframe`, // get only the first iframe
-    });
+          {
+            component: "metabase-browser",
+            attributes: {},
+          },
+        ],
+        selector: `[dashboard-id="${ORDERS_DASHBOARD_ID}"] > iframe`, // get only the first iframe
+      });
 
-    frame.within(() => {
-      cy.findByText("Orders in a dashboard").should("be.visible");
-      cy.findByText("Orders").should("be.visible");
-      H.assertTableRowsCount(2000);
-    });
+      frame.within(() => {
+        cy.findByText("Orders in a dashboard").should("be.visible");
+        cy.findByText("Orders").should("be.visible");
+        H.assertTableRowsCount(2000);
+      });
 
-    H.expectUnstructuredSnowplowEvent({
-      event: "setup",
-      global: {
-        auth_method: "sso",
-      },
-      dashboard: {
-        with_title: {
-          false: 0,
-          true: 1,
-        },
-        with_downloads: {
-          false: 1,
-          true: 0,
-        },
-        drills: {
-          false: 0,
-          true: 1,
-        },
-        with_subscriptions: {
-          false: 0,
-          true: 1,
-        },
-      },
-      question: {
-        drills: {
-          false: 0,
-          true: 1,
-        },
-        with_downloads: {
-          false: 1,
-          true: 0,
-        },
-        with_title: {
-          false: 0,
-          true: 1,
-        },
-        is_save_enabled: {
-          false: 1,
-          true: 0,
-        },
-      },
-      exploration: {
-        is_save_enabled: {
-          false: 1,
-          true: 0,
-        },
-      },
-      browser: {
-        read_only: {
-          false: 0,
-          true: 1,
-        },
-      },
-    });
-  });
-
-  it("should not send an modular embedding usage event in the preview", () => {
-    cy.visit(`/question/${ORDERS_QUESTION_ID}`);
-
-    H.openEmbedJsModal();
-    H.embedModalEnableEmbedding();
-
-    H.waitForSimpleEmbedIframesToLoad();
-    H.getSimpleEmbedIframeContent().within(() => {
-      cy.findByText("Orders").should("be.visible");
-    });
-
-    H.expectUnstructuredSnowplowEvent(
-      {
+      H.expectUnstructuredSnowplowEvent({
         event: "setup",
         global: {
-          auth_method: "session",
+          auth_method: "sso",
         },
-      },
-      // Expect that the usage event shouldn't be sent
-      0,
-    );
+        dashboard: {
+          with_title: {
+            false: 0,
+            true: 1,
+          },
+          with_downloads: {
+            false: 1,
+            true: 0,
+          },
+          drills: {
+            false: 0,
+            true: 1,
+          },
+          with_subscriptions: {
+            false: 0,
+            true: 1,
+          },
+        },
+        question: {
+          drills: {
+            false: 0,
+            true: 1,
+          },
+          with_downloads: {
+            false: 1,
+            true: 0,
+          },
+          with_title: {
+            false: 0,
+            true: 1,
+          },
+          is_save_enabled: {
+            false: 1,
+            true: 0,
+          },
+        },
+        exploration: {
+          is_save_enabled: {
+            false: 1,
+            true: 0,
+          },
+        },
+        browser: {
+          read_only: {
+            false: 0,
+            true: 1,
+          },
+        },
+      });
+    });
+
+    it("should not send an modular embedding usage event in the preview", () => {
+      cy.visit(`/question/${ORDERS_QUESTION_ID}`);
+
+      H.openEmbedJsModal();
+      H.embedModalEnableEmbedding();
+
+      H.waitForSimpleEmbedIframesToLoad();
+      H.getSimpleEmbedIframeContent().within(() => {
+        cy.findByText("Orders").should("be.visible");
+      });
+
+      H.expectUnstructuredSnowplowEvent(
+        {
+          event: "setup",
+          global: {
+            auth_method: "session",
+          },
+        },
+        // Expect that the usage event shouldn't be sent
+        0,
+      );
+    });
   });
 });
 

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
@@ -171,6 +171,7 @@ const SdkIframeEmbedView = ({
               key={rerenderKey}
               className={SdkIframeEmbedRouteS.Dashboard}
               {...entityProps}
+              autoRefreshInterval={settings.autoRefreshInterval}
               withTitle={settings.withTitle}
               withDownloads={settings.withDownloads}
               initialParameters={settings.initialParameters}
@@ -192,6 +193,7 @@ const SdkIframeEmbedView = ({
             className={SdkIframeEmbedRouteS.Dashboard}
             dashboardId={settings.dashboardId ?? null}
             token={settings.token}
+            autoRefreshInterval={settings.autoRefreshInterval}
             withTitle={settings.withTitle}
             withDownloads={settings.withDownloads}
             withSubscriptions={settings.withSubscriptions}

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/constants.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/constants.ts
@@ -30,6 +30,7 @@ export const ALLOWED_EMBED_SETTING_KEYS_MAP = {
   ] satisfies (keyof SdkIframeEmbedBaseSettings)[],
   dashboard: [
     "dashboardId",
+    "autoRefreshInterval",
     "withTitle",
     "withDownloads",
     "withSubscriptions",
@@ -66,6 +67,7 @@ export const ALLOWED_EMBED_SETTING_KEYS_MAP = {
   ] satisfies (keyof BrowserEmbedOptions)[],
   metabot: ["layout"] satisfies (keyof MetabotEmbedOptions)[],
 } as const;
+
 export const ALLOWED_GUEST_EMBED_SETTING_KEYS_MAP = {
   base: [
     "apiKey",
@@ -76,6 +78,7 @@ export const ALLOWED_GUEST_EMBED_SETTING_KEYS_MAP = {
   ] satisfies (keyof SdkIframeEmbedBaseSettings)[],
   dashboard: [
     "token",
+    "autoRefreshInterval",
     "withTitle",
     "withDownloads",
     "initialParameters",

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
@@ -497,6 +497,7 @@ function createCustomElement<Arr extends readonly string[]>(
 const MetabaseDashboardElement = createCustomElement("metabase-dashboard", [
   "dashboard-id",
   "token",
+  "auto-refresh-interval",
   "with-title",
   "with-downloads",
   "with-subscriptions",

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
@@ -74,6 +74,7 @@ export type DashboardEmbedOptions = StrictUnion<
   componentName: "metabase-dashboard";
 
   drills?: boolean;
+  autoRefreshInterval?: number;
   withTitle?: boolean;
   withDownloads?: boolean;
   withSubscriptions?: boolean;


### PR DESCRIPTION
closes EMB-1254

> [!note]
> I'll remove the checkbox in the modular embedding wizard for testing before merging

### Description

This PR adds support for `auto-refresh-interval` in modular embedding.

### How to verify

For testing purposes, I have exposed a new checkbox that will enable the 5-second auto-refresh for easy testing.

1. Go to any saved dashboard.
2. Click the sharing icon > Embed
3. Test both guest authentication and SSO authentication
4. Check the new checkbox that will enable the 5-second auto-refresh.
5. Open the devtool to see that there should be card query requests every 5 seconds.
6. Alternatively, test the embed for real by clicking "Get code"
7. Copy the code and run the embed normally. Here, you can try to play with `auto-refresh-interval` value like 0, negative numbers, positive numbers, decimals, or strings.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
