### PR TITLE
GDGT-1356: Alert Notification Cron Syntax is misleading

### DIFF
--- a/frontend/src/metabase/lib/cron.ts
+++ b/frontend/src/metabase/lib/cron.ts
@@ -65,6 +65,7 @@ export function explainCronExpression(cronExpression: string) {
     verbose: false,
     locale: MetabaseSettings.get("site-locale"),
     use24HourTimeFormat: has24HourModeSetting(),
+    dayOfWeekStartIndexZero: false,
   });
 }
 

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/NotificationSchedule.unit.spec.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/NotificationSchedule.unit.spec.tsx
@@ -4,6 +4,26 @@ import type { ScheduleDisplayType } from "metabase-types/api";
 import { setup } from "./setup.spec";
 
 describe("NotificationSchedule", () => {
+  it("raw - should correctly parse day of week from cron expression", () => {
+    // In Quartz cron format, days are 1-based: 1=SUN, 2=MON, ..., 7=SAT
+    // "0 0 9 ? * 2,4,6 *" means Monday, Wednesday, Friday at 9:00 AM
+    setup({
+      subscription: {
+        id: 1,
+        notification_id: 1,
+        type: "notification-subscription/cron",
+        event_name: null,
+        cron_schedule: "0 0 9 ? * 2,4,6 *",
+        created_at: "2025-03-14T16:11:12Z",
+        ui_display_type: "cron/raw",
+      },
+    });
+
+    expect(
+      screen.getByText(/Monday, Wednesday, and Friday/),
+    ).toBeInTheDocument();
+  });
+
   ["builder", "raw"].forEach((uiDisplayType) => {
     it(`${uiDisplayType} - should show warning when notification schedule is set to less than 10 minutes`, () => {
       setup({


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #66422
Closes [GDGT-1356](https://linear.app/metabase/issue/GDGT-1356/alert-notification-cron-syntax-is-misleading)

### Description

Adjust config for cron expressions parsing to conform to Quartz format. In Quartz week day numbers start from 1, not 0, that's why the actual schedules differed from what was displayed in cron explanation string (see Linear issue).

### How to verify

1. New question -> Create an alert
2. Select "Custom" check
3. Enter `0 7 ? * 2-6`
4. Check that explanation says: "Alerts will be sent at 07:00 AM, Monday through Friday, according to your Metabase timezone (UTC)."

### Demo

<img width="682" height="747" alt="image" src="https://github.com/user-attachments/assets/ecdfd882-c149-4ae7-ad16-4fc94ce8745c" />
### Checklist

- [x] Tests have been added/updated to cover changes in this PR
