### PR TITLE
Hide Guest embedding status bar when guest embedding is disabled

### DIFF
--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeGuestEmbedStatusBar.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeGuestEmbedStatusBar.tsx
@@ -13,6 +13,7 @@ export const SdkIframeGuestEmbedStatusBar = () => {
     embeddingParameters,
     isFetching,
     initialEmbeddingParameters,
+    isGuestEmbedsEnabled,
   } = useSdkIframeEmbedSetupContext();
 
   const toggleEmbedding = useToggleResourceEmbedding();
@@ -23,7 +24,12 @@ export const SdkIframeGuestEmbedStatusBar = () => {
     toggleEmbedding?.resourceType === "dashboard" ||
     toggleEmbedding?.resourceType === "question";
 
-  if (!isGuestEmbed || !shouldShowForStep || !shouldShowForResource) {
+  if (
+    !isGuestEmbed ||
+    !isGuestEmbedsEnabled ||
+    !shouldShowForStep ||
+    !shouldShowForResource
+  ) {
     return null;
   }
 

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/EmbedModalContentStatusBar.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/EmbedModalContentStatusBar.tsx
@@ -34,6 +34,7 @@ export const EmbedModalContentStatusBar = ({
       direction="row"
       align="center"
       gap="0.5rem"
+      data-testid="embed-modal-content-status-bar"
     >
       <Text>
         {!isPublished

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/StaticEmbedSetupPane.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/StaticEmbedSetupPane.tsx
@@ -209,13 +209,7 @@ export const StaticEmbedSetupPane = ({
 
   return (
     <Stack gap={0}>
-      <Paper
-        withBorder
-        shadow="sm"
-        m="1.5rem 2rem"
-        p="0.75rem 1rem"
-        data-testid="embed-modal-content-status-bar"
-      >
+      <Paper withBorder shadow="sm" m="1.5rem 2rem" p="0.75rem 1rem">
         <EmbedModalContentStatusBar
           resourceType={resourceType}
           isPublished={resource.enable_embedding}


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #68835
Hide Guest embedding status bar when guest embedding is disabled

Fixes https://linear.app/metabase/issue/EMB-1261/if-guest-embedding-is-disabled-the-publish-toolbar-is-still-visible

<img width="1672" height="198" alt="image" src="https://github.com/user-attachments/assets/1f64db24-321e-4d35-aec3-93144b5da57f" />

How to verify:
- disable guest embedding
- via an entity page (dashboard/question) open EmbedJS wizard.
- the `guest` embed Auth type should be selected
- you should see `enable guest embed` card
- you should not see `guest embedding status panel`