### PR TITLE
Fix: Respect query sort order for X-axis scale default (#68496)

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.js
@@ -1321,3 +1321,65 @@ describe("issue 63671", () => {
       .should("have.length", 1);
   });
 });
+
+describe("chart should respect query sort order", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should default to ordinal scale when query has explicit sort order (metabase#68496)", () => {
+    H.createQuestion(
+      {
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"]],
+          breakout: [
+            ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+          ],
+          "order-by": [["desc", ["aggregation", 0]]],
+          limit: 6,
+        },
+        display: "bar",
+      },
+      { visitQuestion: true },
+    );
+
+    H.openVizSettingsSidebar();
+    H.leftSidebar().findByText("Axes").click();
+
+    H.leftSidebar()
+      .findByText("Scale")
+      .closest("label")
+      .parent()
+      .findByTestId("chart-setting-select")
+      .should("have.value", "ordinal");
+  });
+
+  it("should default to timeseries scale when query has no explicit sort order", () => {
+    H.createQuestion(
+      {
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"]],
+          breakout: [
+            ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+          ],
+          limit: 6,
+        },
+        display: "bar",
+      },
+      { visitQuestion: true },
+    );
+
+    H.openVizSettingsSidebar();
+    H.leftSidebar().findByText("Axes").click();
+
+    H.leftSidebar()
+      .findByText("Scale")
+      .closest("label")
+      .parent()
+      .findByTestId("chart-setting-select")
+      .should("have.value", "timeseries");
+  });
+});

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -673,7 +673,7 @@ export const GRAPH_AXIS_SETTINGS = {
     ],
     isValid: isXAxisScaleValid,
     getDefault: (series, vizSettings) =>
-      getDefaultXAxisScale(vizSettings, series[0]?.card?.display),
+      getDefaultXAxisScale(vizSettings, series[0]?.card?.display, series),
     getProps: (series, vizSettings) => ({
       options: getAvailableXAxisScales(series, vizSettings),
     }),

--- a/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.unit.spec.ts
@@ -6,6 +6,8 @@ import {
   isXAxisScaleValid,
   queryHasExplicitSort,
 } from "metabase/visualizations/shared/settings/cartesian-chart";
+import * as Lib from "metabase-lib";
+import { createQuery, createQueryWithClauses } from "metabase-lib/test-helpers";
 import type { DatasetData, VisualizationDisplay } from "metabase-types/api";
 import {
   createMockCard,
@@ -244,18 +246,14 @@ describe("getDefaultColumns", () => {
 
 describe("queryHasExplicitSort", () => {
   it("should return true when query has order-by clause", () => {
+    const queryWithSort = createQueryWithClauses({
+      orderBys: [{ tableName: "ORDERS", columnName: "ID" }],
+    });
     const series = [
       createMockSingleSeries(
         {
           display: "bar",
-          dataset_query: {
-            type: "query",
-            database: 1,
-            query: {
-              "source-table": 1,
-              "order-by": [["desc", ["field", 2, null]]],
-            },
-          },
+          dataset_query: Lib.toJsQuery(queryWithSort),
         },
         {
           data: {
@@ -272,45 +270,12 @@ describe("queryHasExplicitSort", () => {
   });
 
   it("should return false when query has no order-by clause", () => {
+    const queryWithoutSort = createQuery();
     const series = [
       createMockSingleSeries(
         {
           display: "bar",
-          dataset_query: {
-            type: "query",
-            database: 1,
-            query: {
-              "source-table": 1,
-            },
-          },
-        },
-        {
-          data: {
-            rows: [[0, 1]],
-            cols: [
-              createMockDatetimeColumn({ name: "col1" }),
-              createMockNumericColumn({ name: "col2" }),
-            ],
-          },
-        },
-      ),
-    ];
-    expect(queryHasExplicitSort(series)).toBe(false);
-  });
-
-  it("should return false when query has empty order-by clause", () => {
-    const series = [
-      createMockSingleSeries(
-        {
-          display: "bar",
-          dataset_query: {
-            type: "query",
-            database: 1,
-            query: {
-              "source-table": 1,
-              "order-by": [],
-            },
-          },
+          dataset_query: Lib.toJsQuery(queryWithoutSort),
         },
         {
           data: {
@@ -353,57 +318,10 @@ describe("queryHasExplicitSort", () => {
     expect(queryHasExplicitSort(series)).toBe(false);
   });
 
-  it("should return true when MBQL v2 query has order-by clause in stages", () => {
+  it("should return false when card has no dataset_query", () => {
     const series = [
       createMockSingleSeries(
-        {
-          display: "bar",
-          dataset_query: {
-            "lib/type": "mbql/query",
-            database: 1,
-            stages: [
-              {
-                "lib/type": "mbql.stage/mbql",
-                "source-table": 1,
-                aggregation: [["count", {}]],
-                breakout: [["field", {}, 13]],
-                "order-by": [["desc", {}, ["aggregation", {}, "uuid-123"]]],
-              },
-            ],
-          } as any,
-        },
-        {
-          data: {
-            rows: [[0, 1]],
-            cols: [
-              createMockDatetimeColumn({ name: "col1" }),
-              createMockNumericColumn({ name: "col2" }),
-            ],
-          },
-        },
-      ),
-    ];
-    expect(queryHasExplicitSort(series)).toBe(true);
-  });
-
-  it("should return false when MBQL v2 query has no order-by clause in stages", () => {
-    const series = [
-      createMockSingleSeries(
-        {
-          display: "bar",
-          dataset_query: {
-            "lib/type": "mbql/query",
-            database: 1,
-            stages: [
-              {
-                "lib/type": "mbql.stage/mbql",
-                "source-table": 1,
-                aggregation: [["count", {}]],
-                breakout: [["field", {}, 13]],
-              },
-            ],
-          } as any,
-        },
+        { display: "bar" },
         {
           data: {
             rows: [[0, 1]],
@@ -439,18 +357,14 @@ describe("getDefaultXAxisScale", () => {
   };
 
   it("should default to ordinal when query has explicit sort order (metabase#68496)", () => {
+    const queryWithSort = createQueryWithClauses({
+      orderBys: [{ tableName: "ORDERS", columnName: "ID" }],
+    });
     const seriesWithSort = [
       createMockSingleSeries(
         {
           display: "bar",
-          dataset_query: {
-            type: "query",
-            database: 1,
-            query: {
-              "source-table": 1,
-              "order-by": [["desc", ["aggregation", 0]]],
-            },
-          },
+          dataset_query: Lib.toJsQuery(queryWithSort),
         },
         {
           data: {
@@ -469,17 +383,12 @@ describe("getDefaultXAxisScale", () => {
   });
 
   it("should default to timeseries when query has no explicit sort order", () => {
+    const queryWithoutSort = createQuery();
     const seriesWithoutSort = [
       createMockSingleSeries(
         {
           display: "bar",
-          dataset_query: {
-            type: "query",
-            database: 1,
-            query: {
-              "source-table": 1,
-            },
-          },
+          dataset_query: Lib.toJsQuery(queryWithoutSort),
         },
         {
           data: {
@@ -504,18 +413,14 @@ describe("getDefaultXAxisScale", () => {
   });
 
   it("should default to histogram when histogram setting is true", () => {
+    const queryWithSort = createQueryWithClauses({
+      orderBys: [{ tableName: "ORDERS", columnName: "ID" }],
+    });
     const seriesWithSort = [
       createMockSingleSeries(
         {
           display: "bar",
-          dataset_query: {
-            type: "query",
-            database: 1,
-            query: {
-              "source-table": 1,
-              "order-by": [["desc", ["aggregation", 0]]],
-            },
-          },
+          dataset_query: Lib.toJsQuery(queryWithSort),
         },
         {},
       ),
@@ -526,17 +431,12 @@ describe("getDefaultXAxisScale", () => {
   });
 
   it("should default to linear for numeric columns without explicit sort", () => {
+    const queryWithoutSort = createQuery();
     const seriesWithoutSort = [
       createMockSingleSeries(
         {
           display: "bar",
-          dataset_query: {
-            type: "query",
-            database: 1,
-            query: {
-              "source-table": 1,
-            },
-          },
+          dataset_query: Lib.toJsQuery(queryWithoutSort),
         },
         {},
       ),
@@ -549,18 +449,14 @@ describe("getDefaultXAxisScale", () => {
 
 describe("isXAxisScaleValid", () => {
   it("should return false for timeseries scale when query has explicit sort order (metabase#68496)", () => {
+    const queryWithSort = createQueryWithClauses({
+      orderBys: [{ tableName: "ORDERS", columnName: "ID" }],
+    });
     const seriesWithSort = [
       createMockSingleSeries(
         {
           display: "bar",
-          dataset_query: {
-            type: "query",
-            database: 1,
-            query: {
-              "source-table": 1,
-              "order-by": [["desc", ["aggregation", 0]]],
-            },
-          },
+          dataset_query: Lib.toJsQuery(queryWithSort),
         },
         {
           data: {
@@ -583,18 +479,14 @@ describe("isXAxisScaleValid", () => {
   });
 
   it("should return true for ordinal scale when query has explicit sort order", () => {
+    const queryWithSort = createQueryWithClauses({
+      orderBys: [{ tableName: "ORDERS", columnName: "ID" }],
+    });
     const seriesWithSort = [
       createMockSingleSeries(
         {
           display: "bar",
-          dataset_query: {
-            type: "query",
-            database: 1,
-            query: {
-              "source-table": 1,
-              "order-by": [["desc", ["aggregation", 0]]],
-            },
-          },
+          dataset_query: Lib.toJsQuery(queryWithSort),
         },
         {
           data: {
@@ -617,17 +509,12 @@ describe("isXAxisScaleValid", () => {
   });
 
   it("should return true for timeseries scale when query has no explicit sort order", () => {
+    const queryWithoutSort = createQuery();
     const seriesWithoutSort = [
       createMockSingleSeries(
         {
           display: "bar",
-          dataset_query: {
-            type: "query",
-            database: 1,
-            query: {
-              "source-table": 1,
-            },
-          },
+          dataset_query: Lib.toJsQuery(queryWithoutSort),
         },
         {
           data: {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/68496

### Description
This PR fixes an issue where bar/line charts with date dimensions would always default to "timeseries" X-axis scale, even when the user has explicitly sorted the data by a different column (e.g., ORDER BY count DESC).

#### The Problem:
When a query has an explicit `order-by` clause, the chart should respect that ordering. However, the X-axis scale was defaulting to `timeseries` which re-orders the data chronologically, overriding the user's intended sort order.

#### The Solution:
1. Added `queryHasExplicitSort(series)` helper that detects if the query has an explicit `order-by` clause (supporting both MBQL v1 and v2 formats).
2. Modified `getDefaultXAxisScale()` to return `ordinal` when an explicit sort order is detected.
3. Modified `isXAxisScaleValid()` to invalidate `timeseries/linear/pow/log` scales when an explicit sort exists, forcing recalculation of the default (handles `persistDefault: true` behavior).

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question → Sample Database → Orders
2. Summarize: Count, grouped by Created At: Month
3. Add Sort: Count (descending)
4. Click Visualize
5. Open Visualization Settings → Axes
6. Before fix: Scale shows `Timeseries` and bars are ordered chronologically
7. After fix: Scale shows "Ordinal" and bars are ordered by count (highest first)

Also verify the reverse case:

1. Same query but remove the Sort step
2. Scale should default to `Timeseries` (original behavior preserved)

### Demo
| Before | After |
|----------|----------|
| <img width="1726" height="962" alt="Screenshot 2026-01-29 at 6 04 12 PM" src="https://github.com/user-attachments/assets/4eade064-1c40-4c71-ad25-cd7997ebda7b" /> |  <img width="1727" height="964" alt="Screenshot 2026-01-29 at 5 56 26 PM" src="https://github.com/user-attachments/assets/dd4a183f-d7da-43d3-a151-33fc51d09e99" /> |


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
