### PR TITLE
Add an auto-refresh indicator

### DIFF
--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/EditableDashboard/EditableDashboard.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/EditableDashboard/EditableDashboard.tsx
@@ -32,6 +32,7 @@ export const EditableDashboardInner = (props: EditableDashboardProps) => {
           DASHBOARD_ACTION.EDIT_DASHBOARD,
           DASHBOARD_ACTION.DASHBOARD_SUBSCRIPTIONS,
           DASHBOARD_ACTION.DOWNLOAD_PDF,
+          DASHBOARD_ACTION.REFRESH_INDICATOR,
         ];
 
   const getClickActionMode: SdkDashboardInnerProps["getClickActionMode"] = ({

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/InteractiveDashboard/InteractiveDashboard.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/InteractiveDashboard/InteractiveDashboard.tsx
@@ -47,6 +47,7 @@ const InteractiveDashboardInner = (props: InteractiveDashboardProps) => {
       dashboardActions={[
         DASHBOARD_ACTION.DASHBOARD_SUBSCRIPTIONS,
         DASHBOARD_ACTION.DOWNLOAD_PDF,
+        DASHBOARD_ACTION.REFRESH_INDICATOR,
       ]}
       dashcardMenu={({ dashcard, result, downloadsEnabled }) =>
         downloadsEnabled?.results &&

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/StaticDashboard/StaticDashboard.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/StaticDashboard/StaticDashboard.tsx
@@ -47,6 +47,7 @@ const StaticDashboardInner = (props: StaticDashboardProps) => {
       dashboardActions={[
         DASHBOARD_ACTION.DASHBOARD_SUBSCRIPTIONS,
         DASHBOARD_ACTION.DOWNLOAD_PDF,
+        DASHBOARD_ACTION.REFRESH_INDICATOR,
       ]}
       navigateToNewCardFromDashboard={null}
       dashcardMenu={({ dashcard, result }) =>

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderButtonRow/DashboardHeaderButtonRow.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderButtonRow/DashboardHeaderButtonRow.tsx
@@ -42,6 +42,7 @@ export const DashboardHeaderButtonRow = ({
     downloadsEnabled,
     withSubscriptions,
     dashboardActions,
+    refreshPeriod,
   } = useDashboardContext();
 
   const hasModelActionsEnabled = useSelector(getHasModelActionsEnabled);
@@ -80,6 +81,7 @@ export const DashboardHeaderButtonRow = ({
               onFullscreenChange,
               downloadsEnabled,
               withSubscriptions,
+              refreshPeriod,
               ...buttonComponentProps,
             })
           ) {

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderButtonRow/DashboardHeaderButtonRow.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderButtonRow/DashboardHeaderButtonRow.unit.spec.tsx
@@ -100,10 +100,8 @@ const DASHBOARD_EXPECTED_DATA_MAP: Record<
     icon: "download",
     tooltip: "Download as PDF",
   },
-  DASHBOARD_SUBSCRIPTIONS: {
-    icon: "subscription",
-    tooltip: "Subscriptions",
-  },
+  DASHBOARD_SUBSCRIPTIONS: {},
+  REFRESH_INDICATOR: {},
 };
 
 const setup = ({

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderButtonRow/action-buttons.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderButtonRow/action-buttons.tsx
@@ -20,6 +20,7 @@ import {
 } from "../buttons";
 import { AddLinkOrEmbedButton } from "../buttons/AddLinkOrEmbedButton";
 import { DashboardSubscriptionsButton } from "../buttons/DashboardSubscriptionsButton";
+import { RefreshIndicator } from "../buttons/RefreshIndicator";
 
 import { DASHBOARD_ACTION } from "./dashboard-action-keys";
 import type { DashboardActionButton, DashboardActionKey } from "./types";
@@ -134,5 +135,9 @@ export const dashboardActionButtons: Record<
   [DASHBOARD_ACTION.DASHBOARD_SUBSCRIPTIONS]: {
     enabled: ({ withSubscriptions }) => withSubscriptions,
     component: () => <DashboardSubscriptionsButton />,
+  },
+  [DASHBOARD_ACTION.REFRESH_INDICATOR]: {
+    enabled: () => true,
+    component: () => <RefreshIndicator />,
   },
 };

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderButtonRow/action-buttons.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderButtonRow/action-buttons.tsx
@@ -137,7 +137,7 @@ export const dashboardActionButtons: Record<
     component: () => <DashboardSubscriptionsButton />,
   },
   [DASHBOARD_ACTION.REFRESH_INDICATOR]: {
-    enabled: () => true,
+    enabled: ({ refreshPeriod }) => refreshPeriod != null && refreshPeriod > 0,
     component: () => <RefreshIndicator />,
   },
 };

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderButtonRow/dashboard-action-keys.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderButtonRow/dashboard-action-keys.tsx
@@ -19,6 +19,7 @@ export const DASHBOARD_ACTION = {
   DOWNLOAD_PDF: "DOWNLOAD_PDF",
   // Modular embeddings (modular embedding, modular embedding SDK)
   DASHBOARD_SUBSCRIPTIONS: "DASHBOARD_SUBSCRIPTIONS",
+  REFRESH_INDICATOR: "REFRESH_INDICATOR",
 } as const;
 
 type DashboardActionKey = keyof typeof DASHBOARD_ACTION;

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderButtonRow/types.ts
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderButtonRow/types.ts
@@ -38,6 +38,7 @@ export type DashboardActionButton = {
         | "isFullscreen"
         | "onFullscreenChange"
         | "withSubscriptions"
+        | "refreshPeriod"
       >,
   ) => boolean;
 };

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/RefreshIndicator.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/RefreshIndicator.tsx
@@ -16,9 +16,6 @@ export function RefreshIndicator() {
     setRefreshElapsedHook(setElapsed);
   }, [setRefreshElapsedHook]);
 
-  if (refreshPeriod == null || refreshPeriod <= 0) {
-    return null;
-  }
   return (
     <RefreshWidgetTarget
       elapsed={elapsed}

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/RefreshIndicator.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/RefreshIndicator.tsx
@@ -1,9 +1,29 @@
+import { useEffect, useState } from "react";
+
+import CS from "metabase/css/core/index.css";
 import { useDashboardContext } from "metabase/dashboard/context";
 
+import { RefreshWidgetTarget } from "../../RefreshWidget/RefreshWidgetTarget";
+
+/**
+ * This is only used in modular embeddings
+ */
 export function RefreshIndicator() {
-  const { refreshPeriod } = useDashboardContext();
+  const { refreshPeriod, setRefreshElapsedHook } = useDashboardContext();
+  const [elapsed, setElapsed] = useState<number | null>(null);
+
+  useEffect(() => {
+    setRefreshElapsedHook(setElapsed);
+  }, [setRefreshElapsedHook]);
+
   if (refreshPeriod == null || refreshPeriod <= 0) {
     return null;
   }
-  return "refresh indicator";
+  return (
+    <RefreshWidgetTarget
+      elapsed={elapsed}
+      period={refreshPeriod}
+      className={CS.cursorDefault}
+    />
+  );
 }

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/RefreshIndicator.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/RefreshIndicator.tsx
@@ -1,0 +1,9 @@
+import { useDashboardContext } from "metabase/dashboard/context";
+
+export function RefreshIndicator() {
+  const { refreshPeriod } = useDashboardContext();
+  if (refreshPeriod == null || refreshPeriod <= 0) {
+    return null;
+  }
+  return "refresh indicator";
+}

--- a/frontend/src/metabase/dashboard/components/RefreshWidget/RefreshWidgetTarget.tsx
+++ b/frontend/src/metabase/dashboard/components/RefreshWidget/RefreshWidgetTarget.tsx
@@ -44,6 +44,7 @@ export const RefreshWidgetTarget = ({
       }
       name="clock"
       aria-label={t`Auto Refresh`}
+      {...buttonProps}
     >
       <CountdownIcon
         width={16}

--- a/frontend/src/metabase/dashboard/types/embed-display-options.ts
+++ b/frontend/src/metabase/dashboard/types/embed-display-options.ts
@@ -30,6 +30,6 @@ export type EmbedDisplayParams = {
   getClickActionMode: ClickActionModeGetter | undefined;
   downloadsEnabled: EmbedResourceDownloadOptions;
   withFooter: boolean;
-  // TODO: (Kelvin 2025-11-17) move this to a new type in EMB-1025
+  // TODO: (Kelvin 2026-01-29) move this to a new type in EMB-1025 (canceled at moment)
   withSubscriptions: boolean;
 };


### PR DESCRIPTION
closes EMB-1259

### Description

This PR adds an auto-refresh visual indicator. It uses the same icon we use on the core app, but without the ability to change the refresh interval via the UI.

### How to verify

#### Modular embedding SDK
This works on all dashboard components by passing `autoRefreshInterval`, the value could be anything, but only positive integers would work and show the auto refresh indicator.

#### Modular embedding
Works on both the guest authentication and normal modular embedding. Passing `auto-refresh-interval` property to the `metabase-dashboard` to enable auto refresh. The value still needs to be a positive integer for the auto-refresh to work.

### Demo

<img width="1218" height="327" alt="image" src="https://github.com/user-attachments/assets/91acf665-3291-4f0a-8541-4803d7306f33" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
