### PR TITLE
feat: add library/transforms toggles to modal

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/DataStudioLayout/DataStudioLayout.setup.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/app/pages/DataStudioLayout/DataStudioLayout.setup.spec.tsx
@@ -1,6 +1,7 @@
 import { setupEnterprisePlugins } from "__support__/enterprise";
 import {
   setupCollectionsEndpoints,
+  setupLibraryEndpoints,
   setupPropertiesEndpoints,
   setupRemoteSyncEndpoints,
   setupSettingsEndpoints,
@@ -201,6 +202,7 @@ export const setup = ({
   setupRemoteSyncSettingsEndpoints(remoteSyncSettings);
   setupDirtyEndpoints({ dirty, collections });
   setupNavbarEndpoints(isNavbarOpened);
+  setupLibraryEndpoints(false);
 
   renderDataStudioLayout({
     isAdmin,

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/CollectionSyncList/CollectionSyncList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/CollectionSyncList/CollectionSyncList.tsx
@@ -1,10 +1,8 @@
 import { useFormikContext } from "formik";
 import { useCallback, useEffect, useMemo } from "react";
 import { usePrevious } from "react-use";
-import { t } from "ttag";
 
-import CS from "metabase/css/core/bordered.module.css";
-import { Box, Flex, Icon, Loader, Switch, Text } from "metabase/ui";
+import { Box, Flex, Loader, Text } from "metabase/ui";
 import type {
   CollectionItem,
   CollectionSyncPreferences,
@@ -13,6 +11,7 @@ import type {
 
 import { COLLECTIONS_KEY, TYPE_KEY } from "../../constants";
 import { CollectionSyncRow } from "../CollectionSyncRow";
+import { LibrarySyncRow } from "../LibrarySyncRow";
 import { TransformsSyncRow } from "../TransformsSyncRow";
 
 import S from "./CollectionSyncList.module.css";
@@ -27,14 +26,6 @@ interface CollectionSyncListProps {
    * When true and no library collection exists, show a placeholder row for library.
    */
   showLibraryPlaceholder?: boolean;
-  /**
-   * Callback when the library pending toggle changes (when library doesn't exist).
-   */
-  onLibraryPendingChange?: (checked: boolean) => void;
-  /**
-   * Current state of the library pending toggle.
-   */
-  isLibraryPendingChecked?: boolean;
 }
 
 export const CollectionSyncList = ({
@@ -44,8 +35,6 @@ export const CollectionSyncList = ({
   isLoading,
   showTransformsRow,
   showLibraryPlaceholder,
-  onLibraryPendingChange,
-  isLibraryPendingChecked,
 }: CollectionSyncListProps) => {
   const { values, setFieldValue, initialValues } =
     useFormikContext<RemoteSyncConfigurationSettings>();
@@ -81,30 +70,10 @@ export const CollectionSyncList = ({
       />
     ));
 
-    if (showLibraryPlaceholder && onLibraryPendingChange) {
-      const libraryPlaceholderRow = (
-        <Box key="library-placeholder" p="md" className={CS.borderRowDivider}>
-          <Flex justify="space-between" align="center">
-            <Flex align="center" gap="sm">
-              <Icon name="repository" c="text-secondary" />
-              <Text fw="medium">{t`Library`}</Text>
-            </Flex>
-            <Flex align="center" gap="sm">
-              <Switch
-                size="sm"
-                checked={isLibraryPendingChecked ?? false}
-                onChange={(e) =>
-                  onLibraryPendingChange(e.currentTarget.checked)
-                }
-                disabled={isReadOnly}
-                aria-label={t`Sync Library`}
-              />
-              <Text>{t`Sync`}</Text>
-            </Flex>
-          </Flex>
-        </Box>
+    if (showLibraryPlaceholder) {
+      rowsItems.unshift(
+        <LibrarySyncRow key="library-placeholder" isReadOnly={isReadOnly} />,
       );
-      rowsItems.unshift(libraryPlaceholderRow);
     }
 
     if (showTransformsRow) {
@@ -134,8 +103,6 @@ export const CollectionSyncList = ({
     showTransformsRow,
     values,
     showLibraryPlaceholder,
-    onLibraryPendingChange,
-    isLibraryPendingChecked,
   ]);
 
   if (isLoading) {

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/LibrarySyncRow/LibrarySyncRow.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/LibrarySyncRow/LibrarySyncRow.tsx
@@ -1,0 +1,46 @@
+import { useFormikContext } from "formik";
+import { t } from "ttag";
+
+import CS from "metabase/css/core/bordered.module.css";
+import { Box, Flex, Icon, Switch, Text } from "metabase/ui";
+import type { RemoteSyncConfigurationSettings } from "metabase-types/api";
+
+import { SYNC_LIBRARY_PENDING_KEY } from "../../constants";
+
+type FormValues = RemoteSyncConfigurationSettings & {
+  [SYNC_LIBRARY_PENDING_KEY]?: boolean;
+};
+
+interface LibrarySyncRowProps {
+  isReadOnly: boolean;
+}
+
+export const LibrarySyncRow = ({ isReadOnly }: LibrarySyncRowProps) => {
+  const { values, setFieldValue } = useFormikContext<FormValues>();
+  const isChecked = values[SYNC_LIBRARY_PENDING_KEY] ?? false;
+
+  const handleToggle = (checked: boolean) => {
+    setFieldValue(SYNC_LIBRARY_PENDING_KEY, checked);
+  };
+
+  return (
+    <Box p="md" className={CS.borderRowDivider}>
+      <Flex justify="space-between" align="center">
+        <Flex align="center" gap="sm">
+          <Icon name="repository" c="text-secondary" />
+          <Text fw="medium">{t`Library`}</Text>
+        </Flex>
+        <Flex align="center" gap="sm">
+          <Switch
+            size="sm"
+            checked={isChecked}
+            onChange={(e) => handleToggle(e.currentTarget.checked)}
+            disabled={isReadOnly}
+            aria-label={t`Sync Library`}
+          />
+          <Text>{t`Sync`}</Text>
+        </Flex>
+      </Flex>
+    </Box>
+  );
+};

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/LibrarySyncRow/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/LibrarySyncRow/index.ts
@@ -1,0 +1,1 @@
+export { LibrarySyncRow } from "./LibrarySyncRow";

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.tsx
@@ -20,17 +20,15 @@ import {
   FormTextInput,
 } from "metabase/forms";
 import { useSelector } from "metabase/lib/redux";
-import { PLUGIN_COLLECTIONS, PLUGIN_TRANSFORMS } from "metabase/plugins";
+import { PLUGIN_TRANSFORMS } from "metabase/plugins";
 import { getApplicationName } from "metabase/selectors/whitelabel";
 import {
   Box,
   Button,
   Flex,
   Icon,
-  type IconName,
   Radio,
   Stack,
-  Switch,
   Text,
   Tooltip,
 } from "metabase/ui";
@@ -506,68 +504,17 @@ export const RemoteSyncSettingsForm = (props: RemoteSyncSettingsFormProps) => {
                   title={t`Content to sync`}
                   variant={variant}
                 >
-                  <Box
-                    style={{
-                      border: "1px solid var(--mb-color-border)",
-                      borderRadius: "var(--mantine-radius-md)",
-                    }}
-                  >
-                    {/* Library toggle - show even if library doesn't exist yet */}
-                    {libraryCollection ? (
-                      <ModalSyncToggleRow
-                        icon={
-                          PLUGIN_COLLECTIONS.getIcon({
-                            model: "collection",
-                            type: libraryCollection.type,
-                            is_remote_synced:
-                              values[COLLECTIONS_KEY]?.[libraryCollection.id] ??
-                              false,
-                          }).name as IconName
-                        }
-                        label={libraryCollection.name}
-                        isChecked={
-                          values[COLLECTIONS_KEY]?.[libraryCollection.id] ??
-                          false
-                        }
-                        onToggle={(checked) =>
-                          setFieldValue(
-                            `${COLLECTIONS_KEY}.${libraryCollection.id}`,
-                            checked,
-                          )
-                        }
-                        isLast={!PLUGIN_TRANSFORMS.isEnabled}
-                        ariaLabel={t`Sync ${libraryCollection.name}`}
-                      />
-                    ) : (
-                      <ModalSyncToggleRow
-                        icon="repository"
-                        label={t`Library`}
-                        isChecked={
-                          (values as Record<string, unknown>)[
-                            SYNC_LIBRARY_PENDING_KEY
-                          ] === true
-                        }
-                        onToggle={(checked) =>
-                          setFieldValue(SYNC_LIBRARY_PENDING_KEY, checked)
-                        }
-                        isLast={!PLUGIN_TRANSFORMS.isEnabled}
-                        ariaLabel={t`Sync Library`}
-                      />
-                    )}
-                    {/* Transforms toggle */}
-                    {PLUGIN_TRANSFORMS.isEnabled && (
-                      <ModalSyncToggleRow
-                        icon="transform"
-                        label={t`Transforms`}
-                        isChecked={values[TRANSFORMS_KEY] ?? false}
-                        onToggle={(checked) =>
-                          setFieldValue(TRANSFORMS_KEY, checked)
-                        }
-                        isLast
-                        ariaLabel={t`Sync Transforms`}
-                      />
-                    )}
-                  </Box>
+                  <TopLevelCollectionsList
+                    skipCollections
+                    onLibraryPendingChange={(checked) =>
+                      setFieldValue(SYNC_LIBRARY_PENDING_KEY, checked)
+                    }
+                    isLibraryPendingChecked={
+                      (values as Record<string, unknown>)[
+                        SYNC_LIBRARY_PENDING_KEY
+                      ] === true
+                    }
+                  />
                 </RemoteSyncSettingsSection>
               )}
 
@@ -654,47 +601,4 @@ const getEnvSettingProps = (setting?: SettingDefinition) => {
     };
   }
   return {};
-};
-
-interface ModalSyncToggleRowProps {
-  icon: IconName;
-  label: string;
-  isChecked: boolean;
-  onToggle: (checked: boolean) => void;
-  isLast: boolean;
-  ariaLabel: string;
-}
-
-const ModalSyncToggleRow = ({
-  icon,
-  label,
-  isChecked,
-  onToggle,
-  isLast,
-  ariaLabel,
-}: ModalSyncToggleRowProps) => {
-  return (
-    <Box
-      p="md"
-      style={{
-        borderBottom: isLast ? undefined : "1px solid var(--mb-color-border)",
-      }}
-    >
-      <Flex justify="space-between" align="center">
-        <Flex align="center" gap="sm">
-          <Icon name={icon} c="text-secondary" />
-          <Text fw="medium">{label}</Text>
-        </Flex>
-        <Flex align="center" gap="sm">
-          <Switch
-            size="sm"
-            checked={isChecked}
-            onChange={(e) => onToggle(e.currentTarget.checked)}
-            aria-label={ariaLabel}
-          />
-          <Text>{t`Sync`}</Text>
-        </Flex>
-      </Flex>
-    </Box>
-  );
 };

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.tsx
@@ -74,7 +74,7 @@ export type RemoteSyncSettingsFormProps = {
 };
 
 type RemoteSyncSettingsFormState = RemoteSyncConfigurationSettings & {
-  "sync-library-pending"?: boolean;
+  [SYNC_LIBRARY_PENDING_KEY]?: boolean;
 };
 
 export const RemoteSyncSettingsForm = (props: RemoteSyncSettingsFormProps) => {
@@ -346,7 +346,7 @@ export const RemoteSyncSettingsForm = (props: RemoteSyncSettingsFormProps) => {
         validationContext={settingValues}
         onSubmit={handleSubmit}
       >
-        {({ dirty, values, setFieldValue }) => (
+        {({ dirty, values }) => (
           <Form disabled={!dirty}>
             <Stack gap="xl" maw="52rem">
               {!isModalVariant && !isRemoteSyncEnabled && (
@@ -497,13 +497,7 @@ export const RemoteSyncSettingsForm = (props: RemoteSyncSettingsFormProps) => {
                   title={t`Content to sync`}
                   variant={variant}
                 >
-                  <TopLevelCollectionsList
-                    skipCollections
-                    onLibraryPendingChange={(checked) =>
-                      setFieldValue(SYNC_LIBRARY_PENDING_KEY, checked)
-                    }
-                    isLibraryPendingChecked={values[SYNC_LIBRARY_PENDING_KEY]}
-                  />
+                  <TopLevelCollectionsList skipCollections />
                 </RemoteSyncSettingsSection>
               )}
 

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.tsx
@@ -163,27 +163,21 @@ export const RemoteSyncSettingsForm = (props: RemoteSyncSettingsFormProps) => {
         }
       }
 
-      // Build settings to save, excluding the pending library key
-      const valuesWithUpdatedCollections = {
-        ...values,
-        [COLLECTIONS_KEY]: collectionsMap,
-      };
-
       // Don't send collections when in read-only mode
       // Also filter out the sync-library-pending key as it's not a real setting
-      const isReadOnly = valuesWithUpdatedCollections[TYPE_KEY] === "read-only";
+      const isReadOnly = values[TYPE_KEY] === "read-only";
       const settingsToSave: RemoteSyncConfigurationSettings = {
-        [REMOTE_SYNC_KEY]: valuesWithUpdatedCollections[REMOTE_SYNC_KEY],
-        [URL_KEY]: valuesWithUpdatedCollections[URL_KEY],
-        [TOKEN_KEY]: valuesWithUpdatedCollections[TOKEN_KEY],
-        [TYPE_KEY]: valuesWithUpdatedCollections[TYPE_KEY],
-        [BRANCH_KEY]: valuesWithUpdatedCollections[BRANCH_KEY],
-        [AUTO_IMPORT_KEY]: valuesWithUpdatedCollections[AUTO_IMPORT_KEY],
-        [TRANSFORMS_KEY]: valuesWithUpdatedCollections[TRANSFORMS_KEY],
+        [REMOTE_SYNC_KEY]: values[REMOTE_SYNC_KEY],
+        [URL_KEY]: values[URL_KEY],
+        [TOKEN_KEY]: values[TOKEN_KEY],
+        [TYPE_KEY]: values[TYPE_KEY],
+        [BRANCH_KEY]: values[BRANCH_KEY],
+        [AUTO_IMPORT_KEY]: values[AUTO_IMPORT_KEY],
+        [TRANSFORMS_KEY]: values[TRANSFORMS_KEY],
         ...(isReadOnly
           ? {}
           : {
-              [COLLECTIONS_KEY]: valuesWithUpdatedCollections[COLLECTIONS_KEY],
+              [COLLECTIONS_KEY]: collectionsMap,
             }),
       };
 
@@ -347,7 +341,7 @@ export const RemoteSyncSettingsForm = (props: RemoteSyncSettingsFormProps) => {
   return (
     <>
       <FormProvider
-        initialValues={initialValues as RemoteSyncConfigurationSettings}
+        initialValues={initialValues}
         enableReinitialize
         validationSchema={REMOTE_SYNC_SCHEMA}
         validationContext={settingValues}
@@ -509,11 +503,7 @@ export const RemoteSyncSettingsForm = (props: RemoteSyncSettingsFormProps) => {
                     onLibraryPendingChange={(checked) =>
                       setFieldValue(SYNC_LIBRARY_PENDING_KEY, checked)
                     }
-                    isLibraryPendingChecked={
-                      (values as Record<string, unknown>)[
-                        SYNC_LIBRARY_PENDING_KEY
-                      ] === true
-                    }
+                    isLibraryPendingChecked={values[SYNC_LIBRARY_PENDING_KEY]}
                   />
                 </RemoteSyncSettingsSection>
               )}

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.tsx
@@ -315,8 +315,7 @@ export const RemoteSyncSettingsForm = (props: RemoteSyncSettingsFormProps) => {
           ? true
           : values[TRANSFORMS_KEY],
       // For modal variant when library doesn't exist, default to wanting to create and sync it
-      [SYNC_LIBRARY_PENDING_KEY]:
-        shouldDefaultToChecked && !libraryCollection ? true : false,
+        [SYNC_LIBRARY_PENDING_KEY]: shouldDefaultToChecked && !libraryCollection,
     };
   }, [
     settingValues,

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.tsx
@@ -315,7 +315,7 @@ export const RemoteSyncSettingsForm = (props: RemoteSyncSettingsFormProps) => {
           ? true
           : values[TRANSFORMS_KEY],
       // For modal variant when library doesn't exist, default to wanting to create and sync it
-        [SYNC_LIBRARY_PENDING_KEY]: shouldDefaultToChecked && !libraryCollection,
+      [SYNC_LIBRARY_PENDING_KEY]: shouldDefaultToChecked && !libraryCollection,
     };
   }, [
     settingValues,

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.unit.spec.tsx
@@ -143,21 +143,285 @@ describe("RemoteSyncSettingsForm", () => {
   });
 
   describe("settings-modal variant", () => {
-    it("should show info text when read-write mode is selected", async () => {
-      setup({ remoteSyncType: "read-write", variant: "settings-modal" });
-
-      await waitFor(() => {
-        expect(
-          screen.getByText(/Library collection will be enabled for syncing/i),
-        ).toBeInTheDocument();
-      });
-    });
-
-    it("should now show set up help link", async () => {
+    it("should not show set up help link", async () => {
       setup({ variant: "settings-modal" });
       expect(
         screen.queryByRole("link", { name: "setup guide" }),
       ).not.toBeInTheDocument();
+    });
+
+    it("should show 'Content to sync' section when read-write mode is selected", async () => {
+      const libraryCollection = createMockLibraryCollection({ id: 999 });
+
+      setup({
+        remoteSyncType: "read-write",
+        variant: "settings-modal",
+        libraryCollection,
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Content to sync")).toBeInTheDocument();
+      });
+    });
+
+    it("should not show 'Content to sync' section when read-only mode is selected", async () => {
+      const libraryCollection = createMockLibraryCollection({ id: 999 });
+
+      setup({
+        remoteSyncType: "read-only",
+        variant: "settings-modal",
+        libraryCollection,
+      });
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("Read-only")).toBeChecked();
+      });
+
+      expect(screen.queryByText("Content to sync")).not.toBeInTheDocument();
+    });
+
+    describe("library toggle", () => {
+      it("should show library toggle in modal variant when read-write mode is selected", async () => {
+        const libraryCollection = createMockLibraryCollection({
+          id: 999,
+          name: "Library",
+        });
+
+        setup({
+          remoteSyncType: "read-write",
+          variant: "settings-modal",
+          libraryCollection,
+        });
+
+        await waitFor(() => {
+          expect(screen.getByText("Content to sync")).toBeInTheDocument();
+        });
+
+        expect(screen.getByLabelText("Sync Library")).toBeInTheDocument();
+      });
+
+      it("should have library toggle checked by default during first-time setup", async () => {
+        const libraryCollection = createMockLibraryCollection({
+          id: 999,
+          name: "Library",
+          is_remote_synced: false,
+        });
+
+        setup({
+          remoteSyncType: "read-write",
+          remoteSyncEnabled: false,
+          variant: "settings-modal",
+          libraryCollection,
+        });
+
+        await waitFor(() => {
+          expect(screen.getByText("Content to sync")).toBeInTheDocument();
+        });
+
+        const libraryToggle = screen.getByLabelText("Sync Library");
+        expect(libraryToggle).toBeChecked();
+      });
+
+      it("should respect existing sync state when remote sync is already enabled", async () => {
+        const libraryCollection = createMockLibraryCollection({
+          id: 999,
+          name: "Library",
+          is_remote_synced: false,
+        });
+
+        setup({
+          remoteSyncType: "read-write",
+          remoteSyncEnabled: true,
+          remoteSyncUrl: "https://github.com/test/repo.git",
+          variant: "settings-modal",
+          libraryCollection,
+        });
+
+        await waitFor(() => {
+          expect(screen.getByText("Content to sync")).toBeInTheDocument();
+        });
+
+        const libraryToggle = screen.getByLabelText("Sync Library");
+        expect(libraryToggle).not.toBeChecked();
+      });
+
+      it("should allow toggling library sync state", async () => {
+        const libraryCollection = createMockLibraryCollection({
+          id: 999,
+          name: "Library",
+        });
+
+        setup({
+          remoteSyncType: "read-write",
+          variant: "settings-modal",
+          libraryCollection,
+        });
+
+        await waitFor(() => {
+          expect(screen.getByText("Content to sync")).toBeInTheDocument();
+        });
+
+        const libraryToggle = screen.getByLabelText("Sync Library");
+        expect(libraryToggle).toBeChecked();
+
+        await userEvent.click(libraryToggle);
+        expect(libraryToggle).not.toBeChecked();
+      });
+    });
+
+    describe("library toggle when library does not exist", () => {
+      it("should show library toggle even when library collection does not exist", async () => {
+        setup({
+          remoteSyncType: "read-write",
+          variant: "settings-modal",
+          libraryCollection: null,
+        });
+
+        await waitFor(() => {
+          expect(screen.getByText("Content to sync")).toBeInTheDocument();
+        });
+
+        expect(screen.getByLabelText("Sync Library")).toBeInTheDocument();
+        expect(screen.getByText("Library")).toBeInTheDocument();
+      });
+
+      it("should have library toggle checked by default when library does not exist", async () => {
+        setup({
+          remoteSyncType: "read-write",
+          remoteSyncEnabled: false,
+          variant: "settings-modal",
+          libraryCollection: null,
+        });
+
+        await waitFor(() => {
+          expect(screen.getByText("Content to sync")).toBeInTheDocument();
+        });
+
+        const libraryToggle = screen.getByLabelText("Sync Library");
+        expect(libraryToggle).toBeChecked();
+      });
+
+      it("should allow toggling library sync state when library does not exist", async () => {
+        setup({
+          remoteSyncType: "read-write",
+          variant: "settings-modal",
+          libraryCollection: null,
+        });
+
+        await waitFor(() => {
+          expect(screen.getByText("Content to sync")).toBeInTheDocument();
+        });
+
+        const libraryToggle = screen.getByLabelText("Sync Library");
+        expect(libraryToggle).toBeChecked();
+
+        await userEvent.click(libraryToggle);
+        expect(libraryToggle).not.toBeChecked();
+      });
+    });
+
+    describe("transforms toggle", () => {
+      afterEach(() => {
+        PLUGIN_TRANSFORMS.isEnabled = false;
+      });
+
+      it("should show transforms toggle in modal variant when feature is enabled", async () => {
+        PLUGIN_TRANSFORMS.isEnabled = true;
+        const libraryCollection = createMockLibraryCollection({ id: 999 });
+
+        setup({
+          remoteSyncType: "read-write",
+          variant: "settings-modal",
+          libraryCollection,
+        });
+
+        await waitFor(() => {
+          expect(screen.getByText("Content to sync")).toBeInTheDocument();
+        });
+
+        expect(screen.getByLabelText("Sync Transforms")).toBeInTheDocument();
+      });
+
+      it("should not show transforms toggle in modal variant when feature is disabled", async () => {
+        PLUGIN_TRANSFORMS.isEnabled = false;
+        const libraryCollection = createMockLibraryCollection({ id: 999 });
+
+        setup({
+          remoteSyncType: "read-write",
+          variant: "settings-modal",
+          libraryCollection,
+        });
+
+        await waitFor(() => {
+          expect(screen.getByText("Content to sync")).toBeInTheDocument();
+        });
+
+        expect(
+          screen.queryByLabelText("Sync Transforms"),
+        ).not.toBeInTheDocument();
+      });
+
+      it("should have transforms toggle checked by default during first-time setup when feature is enabled", async () => {
+        PLUGIN_TRANSFORMS.isEnabled = true;
+        const libraryCollection = createMockLibraryCollection({ id: 999 });
+
+        setup({
+          remoteSyncType: "read-write",
+          remoteSyncEnabled: false,
+          remoteSyncTransforms: false,
+          variant: "settings-modal",
+          libraryCollection,
+        });
+
+        await waitFor(() => {
+          expect(screen.getByText("Content to sync")).toBeInTheDocument();
+        });
+
+        const transformsToggle = screen.getByLabelText("Sync Transforms");
+        expect(transformsToggle).toBeChecked();
+      });
+
+      it("should respect existing sync state when remote sync is already enabled", async () => {
+        PLUGIN_TRANSFORMS.isEnabled = true;
+        const libraryCollection = createMockLibraryCollection({ id: 999 });
+
+        setup({
+          remoteSyncType: "read-write",
+          remoteSyncEnabled: true,
+          remoteSyncUrl: "https://github.com/test/repo.git",
+          remoteSyncTransforms: false,
+          variant: "settings-modal",
+          libraryCollection,
+        });
+
+        await waitFor(() => {
+          expect(screen.getByText("Content to sync")).toBeInTheDocument();
+        });
+
+        const transformsToggle = screen.getByLabelText("Sync Transforms");
+        expect(transformsToggle).not.toBeChecked();
+      });
+
+      it("should allow toggling transforms sync state", async () => {
+        PLUGIN_TRANSFORMS.isEnabled = true;
+        const libraryCollection = createMockLibraryCollection({ id: 999 });
+
+        setup({
+          remoteSyncType: "read-write",
+          variant: "settings-modal",
+          libraryCollection,
+        });
+
+        await waitFor(() => {
+          expect(screen.getByText("Content to sync")).toBeInTheDocument();
+        });
+
+        const transformsToggle = screen.getByLabelText("Sync Transforms");
+        expect(transformsToggle).toBeChecked();
+
+        await userEvent.click(transformsToggle);
+        expect(transformsToggle).not.toBeChecked();
+      });
     });
   });
 
@@ -195,14 +459,16 @@ describe("RemoteSyncSettingsForm", () => {
       expect(screen.getByLabelText("Sync Transforms")).toBeInTheDocument();
     });
 
-    it("should not display transforms row in modal variant (collections section is hidden)", async () => {
+    it("should display transforms toggle in modal variant 'Content to sync' section when feature is enabled", async () => {
       PLUGIN_TRANSFORMS.isEnabled = true;
+      const libraryCollection = createMockLibraryCollection({ id: 999 });
 
       setup({
         remoteSyncEnabled: true,
         remoteSyncType: "read-write",
         remoteSyncUrl: "https://github.com/test/repo.git",
         variant: "settings-modal",
+        libraryCollection,
       });
 
       // Wait for the form to be fully rendered with read-write mode
@@ -210,10 +476,9 @@ describe("RemoteSyncSettingsForm", () => {
         expect(screen.getByLabelText("Read-write")).toBeChecked();
       });
 
-      // In modal variant, collections section is hidden, so transforms row is also hidden
-      expect(
-        screen.queryByLabelText("Sync Transforms"),
-      ).not.toBeInTheDocument();
+      // In modal variant, transforms toggle is shown in "Content to sync" section
+      expect(screen.getByText("Content to sync")).toBeInTheDocument();
+      expect(screen.getByLabelText("Sync Transforms")).toBeInTheDocument();
     });
   });
 

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/TopLevelCollectionsList/TopLevelCollectionsList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/TopLevelCollectionsList/TopLevelCollectionsList.tsx
@@ -14,22 +14,10 @@ interface TopLevelCollectionsListProps {
    * Useful for modal variant where only these options should be shown.
    */
   skipCollections?: boolean;
-  /**
-   * Callback when the library pending toggle changes.
-   * Only used when library doesn't exist and skipCollections is true.
-   */
-  onLibraryPendingChange?: (checked: boolean) => void;
-  /**
-   * Current state of the library pending toggle.
-   * Only used when library doesn't exist and skipCollections is true.
-   */
-  isLibraryPendingChecked?: boolean;
 }
 
 export const TopLevelCollectionsList = ({
   skipCollections,
-  onLibraryPendingChange,
-  isLibraryPendingChecked,
 }: TopLevelCollectionsListProps = {}) => {
   const { data, isLoading, error } = useListCollectionItemsQuery(
     {
@@ -75,8 +63,6 @@ export const TopLevelCollectionsList = ({
       isLoading={isLoading || isLoadingLibrary}
       showTransformsRow={PLUGIN_TRANSFORMS.isEnabled}
       showLibraryPlaceholder={skipCollections && !libraryCollection}
-      onLibraryPendingChange={onLibraryPendingChange}
-      isLibraryPendingChecked={isLibraryPendingChecked}
     />
   );
 };

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/constants.ts
@@ -11,6 +11,8 @@ export const REMOTE_SYNC_KEY = "remote-sync-enabled";
 export const AUTO_IMPORT_KEY = "remote-sync-auto-import";
 export const TRANSFORMS_KEY = "remote-sync-transforms";
 export const COLLECTIONS_KEY = "collections";
+// Used in modal variant when library doesn't exist yet but user wants to sync it
+export const SYNC_LIBRARY_PENDING_KEY = "sync-library-pending";
 
 export const REMOTE_SYNC_SCHEMA = Yup.object({
   [REMOTE_SYNC_KEY]: Yup.boolean().nullable().default(true),
@@ -24,6 +26,7 @@ export const REMOTE_SYNC_SCHEMA = Yup.object({
     .default("read-only"),
   [BRANCH_KEY]: Yup.string().nullable().default("main"),
   [COLLECTIONS_KEY]: Yup.object().nullable().default({}),
+  [SYNC_LIBRARY_PENDING_KEY]: Yup.boolean().nullable().default(false),
 });
 
 export const REMOTE_SYNC_INVALIDATION_TAGS: TagDescription<EnterpriseTagType>[] =

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/constants.ts
@@ -1,6 +1,11 @@
 import type { TagDescription } from "@reduxjs/toolkit/query";
 import * as Yup from "yup";
 
+import {
+  REMOTE_SYNC_TYPES,
+  type RemoteSyncType,
+} from "metabase-types/api/settings";
+
 import { type EnterpriseTagType, tag } from "../api/tags";
 
 export const URL_KEY = "remote-sync-url";
@@ -20,10 +25,10 @@ export const REMOTE_SYNC_SCHEMA = Yup.object({
   [TOKEN_KEY]: Yup.string().nullable().default(null),
   [AUTO_IMPORT_KEY]: Yup.boolean().nullable().default(false),
   [TRANSFORMS_KEY]: Yup.boolean().nullable().default(false),
-  [TYPE_KEY]: Yup.string()
-    .oneOf(["read-only", "read-write"] as const)
+  [TYPE_KEY]: Yup.mixed<RemoteSyncType>()
+    .oneOf([...REMOTE_SYNC_TYPES])
     .nullable()
-    .default("read-only"),
+    .default("read-only" as const),
   [BRANCH_KEY]: Yup.string().nullable().default("main"),
   [COLLECTIONS_KEY]: Yup.object().nullable().default({}),
   [SYNC_LIBRARY_PENDING_KEY]: Yup.boolean().nullable().default(false),

--- a/frontend/src/metabase-types/api/remote-sync.ts
+++ b/frontend/src/metabase-types/api/remote-sync.ts
@@ -84,6 +84,7 @@ export type RemoteSyncConfigurationSettings = Pick<
   | "remote-sync-token"
   | "remote-sync-type"
   | "remote-sync-branch"
+  | "remote-sync-auto-import"
   | "remote-sync-transforms"
 > & {
   collections?: CollectionSyncPreferences;

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -282,6 +282,9 @@ const tokenStatusFeatures = [
 
 export type TokenStatusFeature = (typeof tokenStatusFeatures)[number];
 
+export const REMOTE_SYNC_TYPES = ["read-only", "read-write"] as const;
+export type RemoteSyncType = (typeof REMOTE_SYNC_TYPES)[number];
+
 interface TokenStatusStoreUsers {
   email: string;
 }
@@ -676,7 +679,7 @@ export interface EnterpriseSettings extends Settings {
   "remote-sync-token"?: string | null;
   "remote-sync-url"?: string | null;
   "remote-sync-branch"?: string | null;
-  "remote-sync-type"?: "read-only" | "read-write" | null;
+  "remote-sync-type"?: RemoteSyncType | null;
   "remote-sync-auto-import"?: boolean | null;
   "remote-sync-transforms"?: boolean | null;
   "login-page-illustration"?: IllustrationSettingValue;


### PR DESCRIPTION
### Description

In the 'Set up git sync' modal in data studio this adds pre-selected toggles to sync the library and transforms. This also creates the library if you select it to sync, but it has not yet been created.

### Demo

<img width="815" height="1128" alt="Screenshot 2026-01-29 at 9 31 22 AM" src="https://github.com/user-attachments/assets/9d599946-0de2-4a30-97c1-e8b3216484cd" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
