### PR TITLE
Fix Dependency Graph icon

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/TableSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TableSection/TableSection.tsx
@@ -243,7 +243,7 @@ const TableSectionBase = ({
               entry: { id: Number(table.id), type: "table" },
             })}
             p="sm"
-            leftSection={<Icon name="network" />}
+            leftSection={<Icon name="dependencies" />}
             style={{
               flexGrow: 0,
               width: 40,


### PR DESCRIPTION
Closes UXW-2856

### Description

Fixes outdated Dependency Graph icon.

### How to verify

1. Navigate to a table's metadata in the data studio
2. Verify the icon for the "Dependency graph" button is correct

### Demo

<img width="1712" height="1016" alt="Screenshot 2026-01-29 at 11 52 50 AM" src="https://github.com/user-attachments/assets/ed2b03a8-0291-4aef-9256-cf63539fd01a" />

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR
- [n/a] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
