### PR TITLE
fix: y axis not shown even if it would fit

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
@@ -22,10 +22,12 @@ import { useChartEvents } from "metabase/visualizations/visualizations/Cartesian
 
 import { useChartDebug } from "./use-chart-debug";
 import { useModelsAndOption } from "./use-models-and-option";
-import { getGridSizeAdjustedSettings } from "./utils";
 
-const HIDE_X_AXIS_LABEL_WIDTH_THRESHOLD = 360;
-const HIDE_Y_AXIS_LABEL_WIDTH_THRESHOLD = 200;
+const HIDE_Y_AXIS_LABEL_WIDTH_THRESHOLD = 360;
+const HIDE_X_AXIS_LABEL_HEIGHT_THRESHOLD = 200;
+
+const HIDE_Y_AXIS_HEIGHT_THRESHOLD = 150;
+const INTERPOLATE_LINE_THRESHOLD = 150;
 
 function _CartesianChart(props: VisualizationProps) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -41,7 +43,6 @@ function _CartesianChart(props: VisualizationProps) {
     settings: originalSettings,
     card,
     getHref,
-    gridSize,
     width: outerWidth,
     height: outerHeight,
     showTitle,
@@ -61,17 +62,29 @@ function _CartesianChart(props: VisualizationProps) {
   } = props;
 
   const settings = useMemo(() => {
-    const settings = getGridSizeAdjustedSettings(originalSettings, gridSize);
+    const settings = { ...originalSettings };
     if (isDashboard) {
-      if (outerWidth <= HIDE_X_AXIS_LABEL_WIDTH_THRESHOLD) {
+      if (
+        outerWidth <= INTERPOLATE_LINE_THRESHOLD ||
+        outerHeight <= INTERPOLATE_LINE_THRESHOLD
+      ) {
+        settings["line.interpolate"] = "cardinal";
+      }
+
+      if (outerWidth <= HIDE_Y_AXIS_LABEL_WIDTH_THRESHOLD) {
         settings["graph.y_axis.labels_enabled"] = false;
       }
-      if (outerHeight <= HIDE_Y_AXIS_LABEL_WIDTH_THRESHOLD) {
+
+      if (outerHeight <= HIDE_X_AXIS_LABEL_HEIGHT_THRESHOLD) {
         settings["graph.x_axis.labels_enabled"] = false;
+      }
+
+      if (outerHeight <= HIDE_Y_AXIS_HEIGHT_THRESHOLD) {
+        settings["graph.y_axis.axis_enabled"] = false;
       }
     }
     return settings;
-  }, [originalSettings, gridSize, isDashboard, outerWidth, outerHeight]);
+  }, [originalSettings, isDashboard, outerWidth, outerHeight]);
 
   const { chartModel, timelineEventsModel, option } = useModelsAndOption(
     {

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/utils.ts
@@ -5,53 +5,7 @@ import type {
   DataKey,
   SeriesModel,
 } from "metabase/visualizations/echarts/cartesian/model/types";
-import type {
-  ComputedVisualizationSettings,
-  HoveredObject,
-  VisualizationGridSize,
-} from "metabase/visualizations/types";
-
-const getFidelity = (gridSize?: VisualizationGridSize) => {
-  const fidelity = { x: 0, y: 0 };
-  const size = gridSize || { width: Infinity, height: Infinity };
-  if (size.width >= 5) {
-    fidelity.x = 2;
-  } else if (size.width >= 4) {
-    fidelity.x = 1;
-  }
-  if (size.height >= 5) {
-    fidelity.y = 2;
-  } else if (size.height >= 4) {
-    fidelity.y = 1;
-  }
-
-  return fidelity;
-};
-
-export const getGridSizeAdjustedSettings = (
-  settings: ComputedVisualizationSettings,
-  gridSize?: VisualizationGridSize,
-) => {
-  const fidelity = getFidelity(gridSize);
-  const newSettings = { ...settings };
-
-  // smooth interpolation at smallest x/y fidelity
-  if (fidelity.x === 0 && fidelity.y === 0) {
-    newSettings["line.interpolate"] = "cardinal";
-  }
-
-  // no axis in < 1 fidelity
-  if (fidelity.x < 1 || fidelity.y < 1) {
-    newSettings["graph.y_axis.axis_enabled"] = false;
-  }
-
-  // no labels in < 2 fidelity
-  if (fidelity.x < 2 || fidelity.y < 2) {
-    newSettings["graph.y_axis.labels_enabled"] = false;
-  }
-
-  return newSettings;
-};
+import type { HoveredObject } from "metabase/visualizations/types";
 
 export const getHoveredSeriesDataKey = (
   seriesModels: SeriesModel[],


### PR DESCRIPTION
### Description

Y axis wasn't visible on charts that have enough space to display it because it was relying on grid size (which is in units) instead of pixel size. Since the unit size of the grid might change (like making the dashboard full-width), it makes more sense to rely on pixel size instead.

### How to verify

1. Add a chart to a dashboard (bar chart for example)
2. Resize it to be 3 grid units tall
3. Toggle full-width dashboard and set your browser scaling to a lower value (like 60%)

### Demo

https://github.com/user-attachments/assets/5d40908f-17b2-4f04-bab3-15809ecc913e

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [x] ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~


