### PR TITLE
fix: cannot save dashboard when dashboard was reverted to one with deleted filter

### DIFF
--- a/src/metabase/revisions/impl/dashboard.clj
+++ b/src/metabase/revisions/impl/dashboard.clj
@@ -100,7 +100,7 @@
 (defmethod revision/revert-to-revision! :model/Dashboard
   [model dashboard-id user-id serialized-dashboard]
   ;; Clean invalid parameter card references before reverting (cards may have been deleted since the revision)
-  (let [cleaned-parameters   (clean-invalid-parameter-card-references (:parameters serialized-dashboard))
+  (let [cleaned-parameters   (clean-invalid-parameter-card-references (or (:parameters serialized-dashboard) []))
         serialized-dashboard (assoc serialized-dashboard :parameters cleaned-parameters)]
     ;; Update the dashboard description / name / permissions
     ((get-method revision/revert-to-revision! :default) model dashboard-id user-id (dissoc serialized-dashboard :cards :tabs))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #66670
Closes [UXW-2494: Cannot save dashboard or change filter value source any longer after deleting original value-source question](https://linear.app/metabase/issue/UXW-2494/cannot-save-dashboard-or-change-filter-value-source-any-longer-after)

### Description

When restoring dashboard to a revision with a filter that was archived, it wasn't checking if the filter still exists and wasn't removing said filter from the dashboard.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create a new dashboard.
2. Add a question to the dashboard (Question A).
3. Create another question (Question B) and save it, but do not add it to the dashboard.
4. Edit the dashboard and add a dashboard filter, set the filter’s value source (Where values should come from) to Question B.
5. Save the dashboard.
6. Move Question B to the trash.
7. See that the value source is now set back to “Connected questions.”
8. Revert the dashboard to its earlier version where the filter used Question B.
9. Permanently delete Question B from the trash.

Now:  
10. Try to add another filter and save the dashboard → Save fails.  
11. Edit the existing filter and click Edit under “How should people filter on this column?” → modal loads indefinitely.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
