### PR TITLE
Fully test source-model-card

### DIFF
--- a/src/metabase/lib/card.cljc
+++ b/src/metabase/lib/card.cljc
@@ -190,6 +190,8 @@
    card                  :- ::lib.schema.metadata/card]
   (when-let [card-query (some->> (:dataset-query card) not-empty (lib.query/query metadata-providerable))]
     (when-let [source-card-id (lib.util/source-card-id card-query)]
+      ;; TODO (eric 2026-01-29): this self-reference check is not reachable from the current callers.
+      ;; I suggest we delete this check.
       (when-not (= source-card-id (:id card))
         (let [source-card (lib.metadata/card metadata-providerable source-card-id)]
           (when (= (:type source-card) :model)

--- a/test/metabase/lib/card_test.cljc
+++ b/test/metabase/lib/card_test.cljc
@@ -465,7 +465,31 @@
     (let [mp (lib.tu/mock-metadata-provider
               meta/metadata-provider
               {:cards [{:id 1, :name "Card 1", :database-id (meta/id)}]})]
-      (is (nil? (#'lib.card/source-model-card mp (lib.metadata/card mp 1)))))))
+      (is (nil? (lib.card/card-returned-columns mp (lib.metadata/card mp 1))))))
+  (testing "question sourcing a model gets model metadata merged in"
+    (let [venues-query (lib/query meta/metadata-provider (meta/table-metadata :venues))
+          model-result-metadata (mapv #(assoc % :display-name "Custom" :description "model desc")
+                                      (lib/returned-columns venues-query))
+          mp (lib.tu/mock-metadata-provider
+              meta/metadata-provider
+              {:cards [{:id 1
+                        :name "Source Model"
+                        :type :model
+                        :database-id (meta/id)
+                        :dataset-query venues-query
+                        :result-metadata model-result-metadata}]})
+          card-2-query (lib/query mp (lib.metadata/card mp 1))
+          mp2 (lib.tu/mock-metadata-provider
+               mp
+               {:cards [{:id 2
+                         :name "Question"
+                         :type :question
+                         :database-id (meta/id)
+                         :dataset-query card-2-query
+                         :result-metadata (lib/returned-columns card-2-query)}]})
+          cols (lib.card/card-returned-columns mp2 (lib.metadata/card mp2 2))]
+      (is (every? #(= "Custom" (:display-name %)) cols))
+      (is (every? #(= "model desc" (:description %)) cols)))))
 
 (deftest ^:parallel do-not-include-join-aliases-in-original-display-names-test
   (let [query (lib.tu.mocks-31368/query-with-legacy-source-card true)]


### PR DESCRIPTION
Closes QUE-3056

### Description

lib.card/source-model-card is a private function. It had one simple test on it. This PR expands the tests, and also makes sure that the private function isn't tested directly. This one goes through `lib.card/card-returned-columns`, which is public.