### PR TITLE
Fix #66446 - Disambiguate errors when moving content to remote synced collections

### DIFF
--- a/e2e/test/scenarios/admin/remote-sync.cy.spec.ts
+++ b/e2e/test/scenarios/admin/remote-sync.cy.spec.ts
@@ -104,6 +104,9 @@ describe("Remote Sync", () => {
 
       H.getSyncStatusIndicators().should("have.length", 0);
 
+      const expectedError = "Uses content that is not remote synced.";
+
+      cy.log("Test moving via 'Move' modal");
       H.openCollectionItemMenu("Orders in a dashboard");
       H.popover().findByText("Move").click();
 
@@ -115,12 +118,20 @@ describe("Remote Sync", () => {
 
       cy.wait("@updateDashboard").then((req) => {
         expect(req.response?.statusCode).to.eq(400);
-        expect(req.response?.body.message).to.contain(
-          "content that is not remote synced",
-        );
+        expect(req.response?.body.message).to.contain(expectedError);
+        H.entityPickerModal().findByText(expectedError).should("exist");
+        H.entityPickerModal().button("Cancel").click();
       });
 
-      H.entityPickerModal().button("Cancel").click();
+      cy.log("Test moving via drag-and-drop");
+      H.collectionTable().findByText("Orders in a dashboard").as("dragSubject");
+      H.navigationSidebar()
+        .findByText("Test Synced Collection")
+        .as("dropTarget");
+      H.dragAndDrop("dragSubject", "dropTarget");
+      H.undoToast().should("contain.text", expectedError);
+
+      cy.log("Test positive case");
       H.openCollectionItemMenu("Orders, Count");
       H.popover().findByText("Move").click();
 

--- a/frontend/src/metabase/common/components/dnd/ItemDragSource.jsx
+++ b/frontend/src/metabase/common/components/dnd/ItemDragSource.jsx
@@ -87,9 +87,9 @@ const DragSourceComponent = DragSource(
 
 export function ItemDragSource(props) {
   const [sendToast] = useToast();
-  const onMoveError = (e) =>
+  const onMoveError = (error) =>
     sendToast({
-      message: getErrorMessage(e),
+      message: getErrorMessage(error),
       icon: "warning_triangle_filled",
       iconColor: "warning",
     });

--- a/frontend/src/metabase/common/components/dnd/ItemDragSource.jsx
+++ b/frontend/src/metabase/common/components/dnd/ItemDragSource.jsx
@@ -3,7 +3,9 @@ import { Component } from "react";
 import { DragSource } from "react-dnd";
 import { getEmptyImage } from "react-dnd-html5-backend";
 
+import { getErrorMessage } from "metabase/api/utils";
 import { isRootTrashCollection } from "metabase/collections/utils";
+import { useToast } from "metabase/common/hooks";
 
 import { dragTypeForItem } from ".";
 
@@ -30,7 +32,7 @@ class ItemDragSourceInner extends Component {
   }
 }
 
-export const ItemDragSource = DragSource(
+const DragSourceComponent = DragSource(
   (props) => dragTypeForItem(props.item),
   {
     canDrag({ isSelected, selected, collection, item }, monitor) {
@@ -50,7 +52,7 @@ export const ItemDragSource = DragSource(
     beginDrag(props, monitor, component) {
       return { item: props.item };
     },
-    async endDrag({ selected, onDrop }, monitor, component) {
+    async endDrag({ selected, onDrop, onMoveError }, monitor, component) {
       if (!monitor.didDrop()) {
         return;
       }
@@ -71,7 +73,7 @@ export const ItemDragSource = DragSource(
 
           onDrop && onDrop();
         } catch (e) {
-          console.error("There was a problem moving these items: ", e);
+          onMoveError?.(e);
         }
       }
     },
@@ -82,3 +84,14 @@ export const ItemDragSource = DragSource(
     isDragging: monitor.isDragging(),
   }),
 )(ItemDragSourceInner);
+
+export function ItemDragSource(props) {
+  const [sendToast] = useToast();
+  const onMoveError = (e) =>
+    sendToast({
+      message: getErrorMessage(e),
+      icon: "warning_triangle_filled",
+      iconColor: "warning",
+    });
+  return <DragSourceComponent {...props} onMoveError={onMoveError} />;
+}

--- a/frontend/src/metabase/dashboard/actions/tabs.ts
+++ b/frontend/src/metabase/dashboard/actions/tabs.ts
@@ -546,6 +546,9 @@ export const tabsReducer = createReducer<DashboardState>(
     );
 
     builder.addCase(Dashboards.actionTypes.UPDATE, (state, { payload }) => {
+      if (!payload.dashboard) {
+        return;
+      }
       const { dashcards: newDashcards, tabs: newTabs } = payload.dashboard;
 
       const { prevDash, prevTabs } = getPrevDashAndTabs({

--- a/frontend/src/metabase/dashboard/reducers-typed.ts
+++ b/frontend/src/metabase/dashboard/reducers-typed.ts
@@ -327,7 +327,7 @@ export const dashboards = createReducer(
         };
       })
       .addCase(Dashboards.actionTypes.UPDATE, (state, { payload }) => {
-        const draftDashboard = state[payload.dashboard.id];
+        const draftDashboard = state[payload.dashboard?.id];
         if (draftDashboard) {
           draftDashboard.collection_id = payload.dashboard.collection_id;
           draftDashboard.collection = payload.dashboard.collection;

--- a/frontend/src/metabase/redux/user.ts
+++ b/frontend/src/metabase/redux/user.ts
@@ -52,6 +52,7 @@ export const currentUser = createReducer<User | null>(null, (builder) => {
     .addCase(Dashboards.actionTypes.UPDATE, (state, { payload }) => {
       const { dashboard } = payload;
       if (
+        dashboard &&
         state != null &&
         state.custom_homepage?.dashboard_id === dashboard.id &&
         dashboard.archived


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/66446 / UXW-2442

### Description

1. Removes client-side runtime errors so the BE error message can surface to the Move modal
2. Updates ItemDragSource so errors appear in toasts rather than the console

### How to verify

See https://github.com/metabase/metabase/issues/66446 for repro steps

### Demo

https://www.loom.com/share/456d7aa0f68448c0b96be4f22f11b1a4

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [n/a] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
