### PR TITLE
CI: query-processor module should trigger driver tests

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -327,12 +327,13 @@
                          "Cloud driver + its files changed"
                          "RUN"
                          (str "any of " (pr-str driver-triggers) " affected by cloud-driver module changes")]
-                        ["7"    "Cloud driver, no relevant changes"       "SKIP" "no relevant changes for cloud driver"]
-                        ["8"
+                        ["7"    "Cloud driver + query-processor updated"  "RUN"  "query-processor module updated"]
+                        ["8"    "Cloud driver, no relevant changes"       "SKIP" "no relevant changes for cloud driver"]
+                        ["9"
                          (str (pr-str driver-triggers) " module deps affected")
                          "RUN"
                          (str "any of " (pr-str driver-triggers) " affected by module changes")]
-                        ["9"    "Self-hosted driver, not affected"        "SKIP" "driver module not affected"]])))))
+                        ["10"   "Self-hosted driver, not affected"        "SKIP" "driver module not affected"]])))))
    :options [[nil "--git-ref REF" "The git ref to compute changed modules against"]
              [nil "--is-master-or-release MASTER_OR_RELEASE"]
              [nil "--pr-labels PR_LABELS" "Comma delimited labels on the pr"]

--- a/mage/src/mage/modules.clj
+++ b/mage/src/mage/modules.clj
@@ -387,19 +387,23 @@
     {:should-run true
      :reason (str "driver files changed (modules/drivers/" (name driver) "/**)")}
 
-    ;; Priority 7: Cloud driver, no relevant changes
+    ;; Priority 7: Cloud driver + query-processor updated → run it
     (and (contains? cloud-drivers driver)
-         (or (contains? updated 'query-processor)
-             (contains? particular-driver-changed? driver)))
+         (contains? updated 'query-processor))
+    {:should-run true
+     :reason "query-processor module updated"}
+
+    ;; Priority 8: Cloud driver, no relevant changes → skip
+    (contains? cloud-drivers driver)
     {:should-run false
      :reason "no relevant changes for cloud driver"}
 
-    ;; Priority 8: Driver deps affected by shared code changes
+    ;; Priority 9: Driver deps affected by shared code changes
     driver-deps-affected?
     {:should-run true
      :reason "driver module affected by shared code changes"}
 
-    ;; Priority 9: Self-hosted driver, not affected
+    ;; Priority 10: Self-hosted driver, not affected
     :else
     {:should-run false
      :reason "driver module not affected"}))

--- a/mage/src/mage/modules.clj
+++ b/mage/src/mage/modules.clj
@@ -14,7 +14,7 @@
 
 (def default-modules-which-trigger-drivers
   "Modules that, when affected by changes, should trigger driver tests."
-  ['driver 'enterprise/transforms])
+  ['driver 'enterprise/transforms 'query-processor])
 
 ;;; TODO (Cam 2025-11-07) changes to test files should only cause us to run tests for that module as well, not
 ;;; everything that depends on that module directly or indirectly in `src`

--- a/mage/test/mage/modules_test.clj
+++ b/mage/test/mage/modules_test.clj
@@ -27,7 +27,8 @@
     (let [result (mage.modules/driver-decision :mysql
                                                (make-ctx {})
                                                false ; driver-module-affected?
-                                               #{:mysql})] ; quarantined
+                                               #{:mysql} ; quarantined
+                                               #{})] ; updated
       (is (false? (:should-run result)))
       (is (= "driver is quarantined" (:reason result))))))
 
@@ -36,7 +37,8 @@
     (let [result (mage.modules/driver-decision :mysql
                                                (make-ctx {:pr-labels #{"break-quarantine-mysql"}})
                                                false
-                                               #{:mysql})]
+                                               #{:mysql}
+                                               #{})]
       (is (true? (:should-run result)))
       (is (re-find #"anti-quarantine label" (:reason result))))))
 
@@ -45,7 +47,8 @@
     (let [result (mage.modules/driver-decision :mysql
                                                (make-ctx {:is-master-or-release true})
                                                true ; driver-deps-affected?
-                                               #{:mysql})] ; quarantined
+                                               #{:mysql} ; quarantined
+                                               #{})] ; updated
       (is (false? (:should-run result)))
       (is (= "driver is quarantined" (:reason result))))))
 
@@ -59,7 +62,8 @@
       (let [result (mage.modules/driver-decision driver
                                                  (make-ctx {:skip true})
                                                  true ; even if affected
-                                                 #{})]
+                                                 #{} ; quarantined
+                                                 #{})] ; updated
         (is (false? (:should-run result))
             (str driver " should be skipped"))
         (is (= "workflow skip (no backend changes)" (:reason result)))))))
@@ -69,7 +73,8 @@
     (let [result (mage.modules/driver-decision :mysql
                                                (make-ctx {:skip true})
                                                false
-                                               #{:mysql})]
+                                               #{:mysql}
+                                               #{})]
       (is (false? (:should-run result)))
       (is (= "workflow skip (no backend changes)" (:reason result))))))
 
@@ -83,7 +88,8 @@
       (let [result (mage.modules/driver-decision driver
                                                  (make-ctx {:is-master-or-release false})
                                                  false ; driver module not affected
-                                                 #{})]
+                                                 #{} ; quarantined
+                                                 #{})] ; updated
         (is (true? (:should-run result))
             (str driver " should always run"))
         (is (= "H2/Postgres always run" (:reason result)))))))
@@ -94,7 +100,8 @@
       (let [result (mage.modules/driver-decision driver
                                                  (make-ctx {:skip true})
                                                  false
-                                                 #{})]
+                                                 #{} ; quarantined
+                                                 #{})] ; updated
         (is (false? (:should-run result))
             (str driver " should be skipped on global skip"))
         (is (= "workflow skip (no backend changes)" (:reason result)))))))
@@ -110,13 +117,14 @@
       (let [result (mage.modules/driver-decision driver
                                                  (make-ctx {:is-master-or-release true})
                                                  false ; even if not affected
-                                                 #{})]
+                                                 #{} ; quarantined
+                                                 #{})] ; updated
         (is (true? (:should-run result))
             (str driver " should run on master"))
         (is (= "master/release branch" (:reason result)))))))
 
 ;;; =============================================================================
-;;; Priority 8: Driver deps affected (self-hosted only)
+;;; Priority 9: Driver deps affected (self-hosted only)
 ;;; =============================================================================
 
 (deftest driver-deps-affected-runs-self-hosted-drivers
@@ -126,13 +134,14 @@
       (let [result (mage.modules/driver-decision driver
                                                  (make-ctx {})
                                                  true ; driver-deps-affected
-                                                 #{})]
+                                                 #{} ; quarantined
+                                                 #{})] ; updated
         (is (true? (:should-run result))
             (str driver " should run when driver module affected"))
         (is (= "driver module affected by shared code changes" (:reason result)))))))
 
 ;;; =============================================================================
-;;; Priority 5-7: Cloud driver special rules
+;;; Priority 5-8: Cloud driver special rules
 ;;; =============================================================================
 
 (deftest cloud-driver-with-label-runs
@@ -141,7 +150,8 @@
       (let [result (mage.modules/driver-decision driver
                                                  (make-ctx {:pr-labels #{"ci:all-cloud-drivers"}})
                                                  false ; not affected
-                                                 #{})]
+                                                 #{} ; quarantined
+                                                 #{})] ; updated
         (is (true? (:should-run result))
             (str driver " should run with label"))
         (is (= "ci:all-cloud-drivers label" (:reason result)))))))
@@ -151,9 +161,22 @@
     (let [result (mage.modules/driver-decision :athena
                                                (make-ctx {:particular-driver-changed? #{:athena}})
                                                false
-                                               #{})]
+                                               #{} ; quarantined
+                                               #{})] ; updated
       (is (true? (:should-run result)))
       (is (re-find #"driver files changed" (:reason result))))))
+
+(deftest cloud-driver-with-query-processor-changes-runs
+  (testing "Cloud driver runs when query-processor module is updated"
+    (doseq [driver [:athena :bigquery :databricks :redshift :snowflake]]
+      (let [result (mage.modules/driver-decision driver
+                                                 (make-ctx {})
+                                                 false ; not affected
+                                                 #{} ; quarantined
+                                                 #{'query-processor})] ; updated
+        (is (true? (:should-run result))
+            (str driver " should run when query-processor updated"))
+        (is (= "query-processor module updated" (:reason result)))))))
 
 (deftest cloud-driver-without-changes-skips
   (testing "Cloud driver skips when no relevant changes"
@@ -161,13 +184,14 @@
       (let [result (mage.modules/driver-decision driver
                                                  (make-ctx {})
                                                  false ; not affected
-                                                 #{})]
+                                                 #{} ; quarantined
+                                                 #{})] ; updated
         (is (false? (:should-run result))
             (str driver " should skip without changes"))
         (is (= "no relevant changes for cloud driver" (:reason result)))))))
 
 ;;; =============================================================================
-;;; Priority 9: Self-hosted drivers
+;;; Priority 10: Self-hosted drivers
 ;;; =============================================================================
 
 (deftest self-hosted-driver-not-affected-skips
@@ -177,7 +201,8 @@
       (let [result (mage.modules/driver-decision driver
                                                  (make-ctx {})
                                                  false ; not affected
-                                                 #{})]
+                                                 #{} ; quarantined
+                                                 #{})] ; updated
         (is (false? (:should-run result))
             (str driver " should skip when not affected"))
         (is (= "driver module not affected" (:reason result)))))))

--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -114,3 +114,4 @@
    (-> query
        (userland-query info)
        (assoc-in [:middleware :add-default-userland-constraints?] true))))
+;; test

--- a/src/metabase/query_processor/execute.clj
+++ b/src/metabase/query_processor/execute.clj
@@ -97,3 +97,5 @@
    rff            :- ::qp.schema/rff]
   (qp.setup/with-qp-setup [compiled-query compiled-query]
     (execute* compiled-query rff)))
+
+;; Test change for cloud driver trigger

--- a/src/metabase/query_processor/execute.clj
+++ b/src/metabase/query_processor/execute.clj
@@ -97,5 +97,3 @@
    rff            :- ::qp.schema/rff]
   (qp.setup/with-qp-setup [compiled-query compiled-query]
     (execute* compiled-query rff)))
-
-;; Test change for cloud driver trigger


### PR DESCRIPTION
## Summary

When query-processor code changes, run cloud driver tests (BigQuery, Snowflake, Athena, Databricks, Redshift) to catch driver-specific regressions before they hit master.

## Why

Previously, PRs modifying query-processor code had cloud driver tests **skipped** because QP changes weren't triggering them. This allowed QP changes to merge without running cloud driver tests, causing failures to leak to master.

### Recent examples
- #68740 had QP changes but cloud drivers were skipped in CI
- #68762 (fixing cloud tests) also had failures that leaked to master

From today's Slack thread: *"Merging qp changes into master without running cloud drivers at least once definitely feels like a bad idea to me."* - William

## The fix

Instead of adding `query-processor` to the "always trigger drivers" list (which would run ALL drivers on every QP change), we add a new priority rule specifically for cloud drivers:

**Priority 7: Cloud driver + query-processor updated → RUN**

This means:
- Cloud drivers run when QP code changes (catching cloud-specific regressions)
- Self-hosted drivers (MySQL, Postgres, etc.) still follow the existing rules
- No unnecessary CI cost for self-hosted drivers on QP-only changes

### Updated priority order

| Priority | Condition | Result |
|----------|-----------|--------|
| 1 | Global skip (no backend changes) | SKIP |
| 2 | Driver is :h2 or :postgres | RUN |
| 3 | Driver is quarantined | SKIP |
| 3(a) | ...and has break-quarantine-X label | RUN |
| 4 | On master or release branch | RUN |
| 5 | Cloud driver + ci:all-cloud-drivers label | RUN |
| 6 | Cloud driver + its files changed | RUN |
| **7** | **Cloud driver + query-processor updated** | **RUN** |
| 8 | Cloud driver, no relevant changes | SKIP |
| 9 | Driver deps affected by module changes | RUN |
| 10 | Self-hosted driver, not affected | SKIP |

## Test plan

- [x] `./bin/mage -test modules` passes
- [ ] CI runs cloud drivers on this PR (since it includes a QP file change)