### PR TITLE
Add Metabot card on cloud for embedding hub

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
@@ -346,5 +346,45 @@ describe("scenarios - embedding hub", () => {
         .scrollIntoView()
         .should("be.visible");
     });
+
+    describe("Metabot card", () => {
+      it("should show the Metabot card on Cloud and navigate to /admin/metabot", () => {
+        H.restore("setup");
+        cy.signInAsAdmin();
+
+        // bleeding-edge contains both `hosted` and `metabot` features enabled
+        H.activateToken("bleeding-edge");
+
+        cy.visit("/admin/embedding/setup-guide");
+
+        cy.log("metabot card should be visible");
+        cy.findByTestId("admin-layout-content")
+          .findByText("Set up AI")
+          .scrollIntoView()
+          .should("be.visible");
+
+        cy.findByTestId("admin-layout-content")
+          .findByText("Embed natural language querying")
+          .scrollIntoView()
+          .should("be.visible")
+          .click();
+
+        cy.log("should navigate to Metabot admin page");
+        cy.url().should("include", "/admin/metabot");
+      });
+
+      it("should not show the Metabot card on self-hosted", () => {
+        H.restore("setup");
+        cy.signInAsAdmin();
+        H.activateToken("pro-self-hosted");
+
+        cy.visit("/admin/embedding/setup-guide");
+
+        cy.log("metabot card should not be visible on self-hosted");
+        cy.findByTestId("admin-layout-content")
+          .findByText("Embed natural language querying")
+          .should("not.exist");
+      });
+    });
   });
 });

--- a/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
@@ -259,44 +259,6 @@ describe("scenarios - embedding hub", () => {
         .should("not.exist");
     });
 
-    it('"Pick a user strategy" card should open the edit strategy modal', () => {
-      H.restore("setup");
-      cy.signInAsAdmin();
-      H.activateToken("bleeding-edge");
-
-      cy.request("PUT", "/api/setting/embedding-homepage", {
-        value: "visible",
-      });
-
-      cy.visit("/");
-
-      H.main()
-        .findByText("Pick a user strategy")
-        .scrollIntoView()
-        .should("be.visible")
-        .click();
-
-      H.modal().within(() => {
-        cy.findByText("Pick a user strategy").should("be.visible");
-        cy.findByText("Multi tenant").click();
-        cy.button("Apply").click();
-      });
-
-      cy.log("the internal prefix should show up on the page");
-      H.main().findByText("Internal users").should("be.visible");
-      H.main().findByText("Internal groups").should("be.visible");
-
-      cy.visit("/");
-
-      cy.log("'Pick a user strategy' should now be marked as done");
-      H.main()
-        .findByText("Pick a user strategy")
-        .closest("button")
-        .scrollIntoView()
-        .findByText("Done", { timeout: 10_000 })
-        .should("be.visible");
-    });
-
     it("should link to user strategy when tenants are disabled", () => {
       H.restore("setup");
       cy.signInAsAdmin();

--- a/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
@@ -61,7 +61,8 @@
    "create-test-embed"             (embedding.settings/embedding-hub-test-embed-snippet-created)
    "embed-production"              (embedding.settings/embedding-hub-production-embed-snippet-created)
    "secure-embeds"                 (has-configured-sso?)
-   "setup-tenants"                 (perms/use-tenants)})
+   "setup-tenants"                 (perms/use-tenants)
+   "embed-metabot"                 false})
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminPage.tsx
@@ -1,7 +1,7 @@
 import { useDisclosure } from "@mantine/hooks";
 import { useEffect, useMemo } from "react";
 import { IndexRoute, Route } from "react-router";
-import { push } from "react-router-redux";
+import { replace } from "react-router-redux";
 import { P, match } from "ts-pattern";
 import { c, jt, t } from "ttag";
 import _ from "underscore";
@@ -128,7 +128,9 @@ function MetabotNavPane() {
     const hasMetabotId = metabots?.some((metabot) => metabot.id === metabotId);
 
     if (!hasMetabotId && metabots?.length) {
-      dispatch(push(`/admin/metabot/${metabots[0]?.id}`));
+      // Use replace to avoid breaking the back button - `/admin/metabot` (without ID)
+      // is not a standalone page, so we don't want it in browser history
+      dispatch(replace(`/admin/metabot/${metabots[0]?.id}`));
     }
   }, [metabots, metabotId, dispatch]);
 

--- a/frontend/src/metabase/api/embedding-hub.ts
+++ b/frontend/src/metabase/api/embedding-hub.ts
@@ -10,7 +10,9 @@ type CheckListApiStep =
   | "create-test-embed"
   | "embed-production"
   | "secure-embeds"
-  | "setup-tenants";
+  | "setup-tenants"
+  | "embed-metabot";
+
 export type EmbeddingHubChecklist = Record<CheckListApiStep, boolean>;
 
 export const embeddingHubApi = Api.injectEndpoints({

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.unit.spec.tsx
@@ -142,20 +142,6 @@ describe("EmbeddingHub", () => {
     );
   });
 
-  it("has correct href link for Configure data permissions card", async () => {
-    setup();
-
-    const configureDataPermissionsLink = screen.getByRole("link", {
-      name: /configure data permissions/i,
-    });
-    expect(configureDataPermissionsLink).toBeInTheDocument();
-
-    expect(configureDataPermissionsLink).toHaveAttribute(
-      "href",
-      "https://www.metabase.com/docs/latest/permissions/embedding.html?utm_source=product&utm_medium=docs&utm_campaign=embedding_hub&utm_content=configure-row-column-security&source_plan=oss#one-database-for-all-customers-commingled-setups",
-    );
-  });
-
   it("shows success banner when first 3 steps are completed", async () => {
     setup({
       checklist: {

--- a/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.tsx
@@ -84,7 +84,15 @@ export const StepperWithCards = ({ steps }: { steps: StepperStep[] }) => {
       iconSize={28}
     >
       {steps.map((step) => {
-        const isDone = step.cards.every((card) => card.done || card.optional);
+        const requiredCards = step.cards.filter((card) => !card.optional);
+
+        // For steps with required cards, only consider required cards.
+        // For steps with ONLY optional cards, consider optional cards too.
+        const isDone =
+          requiredCards.length > 0
+            ? requiredCards.every((card) => card.done)
+            : step.cards.some((card) => card.done);
+
         const hasOnlyOneCard = step.cards.length === 1;
 
         return (

--- a/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.tsx
@@ -129,7 +129,11 @@ export const StepperWithCards = ({ steps }: { steps: StepperStep[] }) => {
                             <Stack justify="space-between" h="100%">
                               <Stack gap="xs" h="100%">
                                 <Text
-                                  size={card.optional ? "md" : "lg"}
+                                  size={
+                                    card.optional && !hasOnlyOptionalCards
+                                      ? "md"
+                                      : "lg"
+                                  }
                                   fw="bold"
                                   c={
                                     card.done

--- a/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.tsx
@@ -85,6 +85,7 @@ export const StepperWithCards = ({ steps }: { steps: StepperStep[] }) => {
     >
       {steps.map((step) => {
         const isDone = step.cards.every((card) => card.done || card.optional);
+        const hasOnlyOptionalCards = step.cards.every((card) => card.optional);
 
         return (
           <Stepper.Step
@@ -103,9 +104,12 @@ export const StepperWithCards = ({ steps }: { steps: StepperStep[] }) => {
 
                     const isNextCard = nextCard && nextCard.id === card.id;
 
+                    const getColSpan = () =>
+                      !card.optional || hasOnlyOptionalCards ? 8 : 4;
+
                     return (
                       <Grid.Col
-                        span={{ xs: 12, md: card.optional ? 4 : 8 }}
+                        span={{ xs: 12, md: getColSpan() }}
                         key={card.id}
                       >
                         <CardAction card={card}>

--- a/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.tsx
@@ -85,7 +85,7 @@ export const StepperWithCards = ({ steps }: { steps: StepperStep[] }) => {
     >
       {steps.map((step) => {
         const isDone = step.cards.every((card) => card.done || card.optional);
-        const hasOnlyOptionalCards = step.cards.every((card) => card.optional);
+        const hasOnlyOneCard = step.cards.length === 1;
 
         return (
           <Stepper.Step
@@ -103,15 +103,10 @@ export const StepperWithCards = ({ steps }: { steps: StepperStep[] }) => {
                         : undefined;
 
                     const isNextCard = nextCard && nextCard.id === card.id;
-
-                    const getColSpan = () =>
-                      !card.optional || hasOnlyOptionalCards ? 8 : 4;
+                    const colSpan = !card.optional || hasOnlyOneCard ? 8 : 4;
 
                     return (
-                      <Grid.Col
-                        span={{ xs: 12, md: getColSpan() }}
-                        key={card.id}
-                      >
+                      <Grid.Col span={{ xs: 12, md: colSpan }} key={card.id}>
                         <CardAction card={card}>
                           <Card
                             h="100%"
@@ -130,7 +125,7 @@ export const StepperWithCards = ({ steps }: { steps: StepperStep[] }) => {
                               <Stack gap="xs" h="100%">
                                 <Text
                                   size={
-                                    card.optional && !hasOnlyOptionalCards
+                                    card.optional && !hasOnlyOneCard
                                       ? "md"
                                       : "lg"
                                   }

--- a/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.unit.spec.tsx
@@ -160,7 +160,7 @@ describe("StepperWithCards", () => {
     );
   });
 
-  it("should disable locked cards", () => {
+  it("should disable locked cards", async () => {
     const mockClickAction = jest.fn();
     const steps = createMockSteps([
       {

--- a/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.unit.spec.tsx
@@ -129,7 +129,7 @@ describe("StepperWithCards", () => {
     expect(allSteps[0]).toHaveAttribute("data-done", "false");
 
     // no check icons should be present
-    expect(screen.queryAllByLabelText("check icon")).toHaveLength(0);
+    expect(screen.queryByLabelText("check icon")).not.toBeInTheDocument();
   });
 
   it("marks step as done when it only has optional cards and at least one is done", async () => {

--- a/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.unit.spec.tsx
@@ -189,7 +189,7 @@ describe("StepperWithCards", () => {
     expect(lockedCard).toBeDisabled();
 
     // clicking the card should not trigger the action
-    userEvent.click(lockedCard);
+    await userEvent.click(lockedCard);
     expect(mockClickAction).not.toHaveBeenCalled();
 
     // step should not be marked as done

--- a/frontend/src/metabase/embedding/embedding-hub/hooks/use-completed-embedding-hub-steps.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/hooks/use-completed-embedding-hub-steps.ts
@@ -27,6 +27,7 @@ export const useCompletedEmbeddingHubSteps = (): {
         "embed-production": false,
         "create-models": false,
         "setup-tenants": false,
+        "embed-metabot": false,
       };
     }
 

--- a/frontend/src/metabase/embedding/embedding-hub/hooks/use-get-embedding-hub-steps.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/hooks/use-get-embedding-hub-steps.ts
@@ -135,7 +135,7 @@ export const useGetEmbeddingHubSteps = (): EmbeddingHubStep[] => {
       ],
     };
 
-    // Show Metabot step only on Cloud when Metabot is available or trial is offered
+    // Show Metabot step only on Cloud when Metabot is available
     const isMetabotFeatureAvailable = PLUGIN_METABOT.isEnabled();
     const shouldShowMetabotStep = isHosted && isMetabotFeatureAvailable;
 

--- a/frontend/src/metabase/embedding/embedding-hub/types/embedding-checklist.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/types/embedding-checklist.ts
@@ -8,7 +8,8 @@ export type EmbeddingHubStepId =
   | "secure-embeds"
   | "embed-production"
   | "create-models"
-  | "setup-tenants";
+  | "setup-tenants"
+  | "embed-metabot";
 
 export interface EmbeddingHubStep {
   id: EmbeddingHubStepId;


### PR DESCRIPTION
Closes EMB-1264

### Description

Adds the Metabot card ("Embed natural language querying") only if we are in Cloud.

### How to verify

- Run Metabase with the `MB_ALL_FEATURES_TOKEN` which has both hosted and metabot feature
- Go to the embedding hub in `admin settings > embedding > setup guide`
- You should see the Metabot card on embedding hub now
- Clicking on Metabot card should take you to the Metabot settings page.
- You can also run the e2e locally to see the result of this flow

### Demo

<img width="2934" height="1676" alt="CleanShot 2569-01-30 at 08 17 38@2x" src="https://github.com/user-attachments/assets/6644aa3f-a19e-412b-82c4-ea1d854622d7" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
