### PR TITLE
Fixes and improvements for staleness tracking

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -429,6 +429,7 @@
   metabase-enterprise.transforms.api-test/with-worker-runs                              clojure.core/let
   metabase-enterprise.transforms.test-util/with-transform-cleanup!                      clojure.core/let
   metabase-enterprise.transforms.execute/with-transform-lifecycle                       clojure.core/let
+  metabase-enterprise.workspaces.test-util/with-resources!                              clojure.core/let
   metabase-enterprise.workspaces.test-util/with-workspaces!                             clojure.core/let
   metabase.actions.test-util/with-actions                                               clojure.core/let
   metabase.api.common/let-404                                                           clojure.core/let

--- a/enterprise/backend/src/metabase_enterprise/workspaces/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/api.clj
@@ -513,10 +513,11 @@
    _query-params
    ;; Hmmm, I wonder why this isn't a boolean? T_T
    {:keys [stale_only]} :- [:map [:stale_only {:optional true} [:or [:= 1] :boolean]]]]
-  (let [workspace (t2/select-one :model/Workspace :id ws-id)]
-    (api/check-404 workspace)
-    (api/check-400 (not= :archived (:base_status workspace)) "Cannot execute archived workspace")
-    (ws.impl/execute-workspace! workspace (ws.impl/get-or-calculate-graph! workspace) {:stale-only stale_only})))
+  (let [workspace (t2/select-one :model/Workspace :id ws-id)
+        _         (api/check-404 workspace)
+        _         (api/check-400 (not= :archived (:base_status workspace)) "Cannot execute archived workspace")
+        graph     (ws.impl/get-or-calculate-graph! workspace)]
+    (ws.impl/execute-workspace! workspace graph {:stale-only stale_only})))
 
 (mr/def ::graph-node-type [:enum :input-table :external-transform :workspace-transform])
 
@@ -916,11 +917,12 @@
   App DB changes are rolled back. Warehouse DB changes persist."
   {:access :workspace}
   [{:keys [ws-id tx-id]} :- [:map [:ws-id ::ws.t/appdb-id] [:tx-id ::ws.t/ref-id]]]
-  (let [workspace  (api/check-404 (t2/select-one :model/Workspace ws-id))
-        transform  (api/check-404 (t2/select-one :model/WorkspaceTransform :ref_id tx-id :workspace_id ws-id))]
-    (api/check-400 (not= :archived (:base_status workspace)) "Cannot execute archived workspace")
-    (check-transforms-enabled! (:database_id workspace))
-    (ws.impl/run-transform! workspace (ws.impl/get-or-calculate-graph! workspace) transform)))
+  (let [workspace (api/check-404 (t2/select-one :model/Workspace ws-id))
+        transform (api/check-404 (t2/select-one :model/WorkspaceTransform :ref_id tx-id :workspace_id ws-id))
+        _         (api/check-400 (not= :archived (:base_status workspace)) "Cannot execute archived workspace")
+        _         (check-transforms-enabled! (:database_id workspace))
+        graph     (ws.impl/get-or-calculate-graph! workspace)]
+    (ws.impl/run-transform! workspace graph transform)))
 
 (api.macros/defendpoint :post "/:ws-id/transform/:tx-id/dry-run"
   :- ::ws.t/dry-run-result
@@ -930,11 +932,12 @@
   Does not update last_run_at or create any database tables."
   {:access :workspace}
   [{:keys [ws-id tx-id]} :- [:map [:ws-id ::ws.t/appdb-id] [:tx-id ::ws.t/ref-id]]]
-  (let [workspace  (api/check-404 (t2/select-one :model/Workspace ws-id))
-        transform  (api/check-404 (t2/select-one :model/WorkspaceTransform :ref_id tx-id :workspace_id ws-id))]
-    (api/check-400 (not= :archived (:base_status workspace)) "Cannot execute archived workspace")
-    (check-transforms-enabled! (:database_id workspace))
-    (ws.impl/dry-run-transform workspace (ws.impl/get-or-calculate-graph! workspace) transform)))
+  (let [workspace (api/check-404 (t2/select-one :model/Workspace ws-id))
+        transform (api/check-404 (t2/select-one :model/WorkspaceTransform :ref_id tx-id :workspace_id ws-id))
+        _         (api/check-400 (not= :archived (:base_status workspace)) "Cannot execute archived workspace")
+        _         (check-transforms-enabled! (:database_id workspace))
+        graph     (ws.impl/get-or-calculate-graph! workspace)]
+    (ws.impl/dry-run-transform workspace graph transform)))
 
 (def ^:private CheckoutTransformLegacy
   "Legacy format for workspace checkout transforms (DEPRECATED)."

--- a/enterprise/backend/src/metabase_enterprise/workspaces/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/impl.clj
@@ -215,7 +215,7 @@
   [graph ref-id]
   (when-let [deps-map (:dependencies graph)]
     (ws.dag/bfs-reduce deps-map [{:node-type :workspace-transform :id ref-id}]
-                       :rf (workspace-transform-id-xf conj!))))
+                       :rf (workspace-transform-id-xf conj))))
 
 (defn downstream-descendants
   "Given a graph and a ref-id, find all downstream workspace transform descendants.
@@ -226,7 +226,7 @@
   (when-let [deps-map (:dependencies graph)]
     (let [forward-edges (ws.dag/reverse-graph deps-map)]
       (ws.dag/bfs-reduce forward-edges [{:node-type :workspace-transform :id ref-id}]
-                         :rf (workspace-transform-id-xf conj!)))))
+                         :rf (workspace-transform-id-xf conj)))))
 
 (defn- any-internal-ancestor-stale?
   "Check if any in-workspace entity ancestor is stale.

--- a/enterprise/backend/src/metabase_enterprise/workspaces/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/impl.clj
@@ -335,6 +335,8 @@
 (defn increment-analysis-version!
   "Atomically increment analysis_version for a transform. Used to invalidate cached analysis."
   [workspace-id ref-id]
+  ;; definition_changed is also set by the WorkspaceTransform before-update hook when source/target changes,
+  ;; but we set it here as well since this function is also called for unarchive (where source/target don't change).
   (t2/update! :model/WorkspaceTransform
               {:workspace_id workspace-id, :ref_id ref-id}
               {:analysis_version [:+ :analysis_version 1]

--- a/enterprise/backend/src/metabase_enterprise/workspaces/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/impl.clj
@@ -215,7 +215,7 @@
   [graph ref-id]
   (when-let [deps-map (:dependencies graph)]
     (ws.dag/bfs-reduce deps-map [{:node-type :workspace-transform :id ref-id}]
-                       :rf (workspace-transform-id-xf conj))))
+                       :rf (workspace-transform-id-xf conj!))))
 
 (defn downstream-descendants
   "Given a graph and a ref-id, find all downstream workspace transform descendants.
@@ -226,7 +226,7 @@
   (when-let [deps-map (:dependencies graph)]
     (let [forward-edges (ws.dag/reverse-graph deps-map)]
       (ws.dag/bfs-reduce forward-edges [{:node-type :workspace-transform :id ref-id}]
-                         :rf (workspace-transform-id-xf conj)))))
+                         :rf (workspace-transform-id-xf conj!)))))
 
 (defn- any-internal-ancestor-stale?
   "Check if any in-workspace entity ancestor is stale.

--- a/enterprise/backend/src/metabase_enterprise/workspaces/models/workspace_transform.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/models/workspace_transform.clj
@@ -62,4 +62,10 @@
                        :ref_id        (:ref_id original)
                        :old_global_id (:global_id original)
                        :new_global_id (:global_id instance)}))))
-  instance)
+  ;; Mark the definition as changed when source or target is updated.
+  ;; This is also set redundantly by [[metabase-enterprise.workspaces.impl/increment-analysis-version!]] in the API
+  ;; layer, but having it here ensures correctness regardless of the code path used to update the transform.
+  (cond-> instance
+    (or (contains? (t2/changes instance) :source)
+        (contains? (t2/changes instance) :target))
+    (assoc :definition_changed true)))

--- a/enterprise/backend/test/metabase_enterprise/transforms/models_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/models_test.clj
@@ -339,4 +339,3 @@
                                 (t2/insert! :model/Card (merge (mt/with-temp-defaults :model/Card) {:type :model :collection_id (:id transforms)}))))
           (is (thrown-with-msg? clojure.lang.ExceptionInfo #"A Transform can only go in Collections in the :transforms namespace."
                                 (t2/insert! :model/Transform (assoc (mt/with-temp-defaults :model/Transform) :collection_id (:id regular-col))))))))))
-

--- a/enterprise/backend/test/metabase_enterprise/workspaces/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/api_test.clj
@@ -30,19 +30,9 @@
 
 (use-fixtures :once (fn [thunk] (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table) (thunk))))
 
-(defn- append-part [url part]
-  (case [(str/starts-with? part "/")
-         (str/ends-with? url "/")]
-    [false false] (str url \/ part)
-    ([true false]
-     [false true]) (str url part)
-    (str url (subs part 1))))
-
-(defn ws-url [id & path]
-  (when (some nil? (cons id path))
-    (throw (ex-info "Cannot build workspace URL without key resources"
-                    {:id id, :path path})))
-  (reduce append-part (str "ee/workspace/" id) (map str path)))
+(def ws-url
+  "Alias for ws.tu/ws-url for convenience."
+  ws.tu/ws-url)
 
 (def ^:private ->native
   "It's convenient to construct queries using MBQL helper, but only native queries can be used in workspaces."

--- a/enterprise/backend/test/metabase_enterprise/workspaces/dag_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/dag_test.clj
@@ -207,7 +207,7 @@
           tbl {:node-type :table :id "tbl"}
           graph {tx1 [tx2 tbl], tx2 [], tbl []}
           xf (keep #(when (= :workspace-transform (:node-type %)) (:id %)))]
-      (is (= ["t2"] (ws.dag/bfs-reduce graph [tx1] :rf (xf conj!)))))))
+      (is (= ["t2"] (ws.dag/bfs-reduce graph [tx1] :rf (xf conj)))))))
 
 (deftest collapse-test
   (is (= {:x1 [:x2 :x3]

--- a/enterprise/backend/test/metabase_enterprise/workspaces/dag_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/dag_test.clj
@@ -207,7 +207,7 @@
           tbl {:node-type :table :id "tbl"}
           graph {tx1 [tx2 tbl], tx2 [], tbl []}
           xf (keep #(when (= :workspace-transform (:node-type %)) (:id %)))]
-      (is (= ["t2"] (ws.dag/bfs-reduce graph [tx1] :rf (xf conj)))))))
+      (is (= ["t2"] (ws.dag/bfs-reduce graph [tx1] :rf (xf conj!)))))))
 
 (deftest collapse-test
   (is (= {:x1 [:x2 :x3]

--- a/enterprise/backend/test/metabase_enterprise/workspaces/dag_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/dag_test.clj
@@ -144,27 +144,27 @@
     (is (= {:a [:x], :b [:x], :c [:x]}
            (ws.dag/reverse-graph {:x [:a :b :c]})))))
 
-(deftest bfs-descendants-test
+(deftest bfs-reduce-test
   (testing "empty adjacency returns empty"
-    (is (= [] (ws.dag/bfs-descendants {} :a))))
+    (is (= [] (ws.dag/bfs-reduce {} [:a]))))
 
   (testing "no neighbors returns empty"
-    (is (= [] (ws.dag/bfs-descendants {:a []} :a))))
+    (is (= [] (ws.dag/bfs-reduce {:a []} [:a]))))
 
   (testing "single hop"
     (is (= [:b :c]
-           (ws.dag/bfs-descendants {:a [:b :c]} :a))))
+           (ws.dag/bfs-reduce {:a [:b :c]} [:a]))))
 
   (testing "chain traversal - collects all reachable nodes"
     (let [graph {:a [:b], :b [:c], :c [:d], :d []}]
-      (is (= [:b :c :d] (ws.dag/bfs-descendants graph :a)))
-      (is (= [:c :d] (ws.dag/bfs-descendants graph :b)))
-      (is (= [:d] (ws.dag/bfs-descendants graph :c)))
-      (is (= [] (ws.dag/bfs-descendants graph :d)))))
+      (is (= [:b :c :d] (ws.dag/bfs-reduce graph [:a])))
+      (is (= [:c :d] (ws.dag/bfs-reduce graph [:b])))
+      (is (= [:d] (ws.dag/bfs-reduce graph [:c])))
+      (is (= [] (ws.dag/bfs-reduce graph [:d])))))
 
   (testing "diamond graph - no duplicates (a -> b -> d, a -> c -> d)"
     (let [graph {:a [:b :c], :b [:d], :c [:d], :d []}]
-      (is (= [:b :c :d] (ws.dag/bfs-descendants graph :a)))))
+      (is (= [:b :c :d] (ws.dag/bfs-reduce graph [:a])))))
 
   (testing "works with map nodes (like workspace transform nodes)"
     (let [tx1 {:node-type :workspace-transform :id "tx1"}
@@ -172,29 +172,42 @@
           tx3 {:node-type :workspace-transform :id "tx3"}
           tbl {:node-type :table :id {:db 1 :schema "public" :table "foo"}}
           graph {tx1 [tx2 tbl], tx2 [tx3], tx3 [], tbl []}]
-      (is (= [tx2 tbl tx3] (ws.dag/bfs-descendants graph tx1)))
-      (is (= [tx3] (ws.dag/bfs-descendants graph tx2)))))
+      (is (= [tx2 tbl tx3] (ws.dag/bfs-reduce graph [tx1])))
+      (is (= [tx3] (ws.dag/bfs-reduce graph [tx2])))))
 
   (testing "handles cycles gracefully - a -> b -> c -> a (cycle), should not infinite loop"
     (let [graph {:a [:b], :b [:c], :c [:a]}]
-      (is (= [:b :c :a] (ws.dag/bfs-descendants graph :a)))))
+      (is (= [:b :c :a] (ws.dag/bfs-reduce graph [:a])))))
 
   (testing "include-start? option"
     (let [graph {:a [:b], :b [:c], :c []}]
-      (is (= [:a :b :c] (ws.dag/bfs-descendants graph :a :include-start? true)))
-      (is (= [:b :c] (ws.dag/bfs-descendants graph :a :include-start? false)))))
+      (is (= [:a :b :c] (ws.dag/bfs-reduce graph [:a] :include-start? true)))
+      (is (= [:b :c] (ws.dag/bfs-reduce graph [:a] :include-start? false)))))
 
   (testing "multiple start nodes"
     (let [graph {:a [:x], :b [:y], :x [], :y []}]
-      (is (= [:x :y] (ws.dag/bfs-descendants graph [:a :b])))
-      (is (= [:a :b :x :y] (ws.dag/bfs-descendants graph [:a :b] :include-start? true)))))
+      (is (= [:x :y] (ws.dag/bfs-reduce graph [:a :b])))
+      (is (= [:a :b :x :y] (ws.dag/bfs-reduce graph [:a :b] :include-start? true)))))
 
   (testing "traverses through different node types"
     (let [tx1 {:node-type :workspace-transform :id "tx1"}
           tx2 {:node-type :workspace-transform :id "tx2"}
           ext {:node-type :external-transform :id "ext"}
           graph {tx1 [ext], ext [tx2], tx2 []}]
-      (is (= [ext tx2] (ws.dag/bfs-descendants graph tx1))))))
+      (is (= [ext tx2] (ws.dag/bfs-reduce graph [tx1])))))
+
+  (testing "custom :init collects into a set"
+    (let [graph {:a [:b :c], :b [:d], :c [:d], :d []}]
+      (is (= #{:b :c :d} (ws.dag/bfs-reduce graph [:a] :init #{})))
+      (is (= #{:a :b :c :d} (ws.dag/bfs-reduce graph [:a] :init #{} :include-start? true)))))
+
+  (testing "custom :rf filters during traversal"
+    (let [tx1 {:node-type :workspace-transform :id "t1"}
+          tx2 {:node-type :workspace-transform :id "t2"}
+          tbl {:node-type :table :id "tbl"}
+          graph {tx1 [tx2 tbl], tx2 [], tbl []}
+          xf (keep #(when (= :workspace-transform (:node-type %)) (:id %)))]
+      (is (= ["t2"] (ws.dag/bfs-reduce graph [tx1] :rf (xf conj)))))))
 
 (deftest collapse-test
   (is (= {:x1 [:x2 :x3]

--- a/enterprise/backend/test/metabase_enterprise/workspaces/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/e2e_test.clj
@@ -53,7 +53,7 @@
 
               (testing "changing the query without granting access will fail"
                 (t2/update! :model/WorkspaceTransform
-                            {:ref_id (:ref_id isolated-transform)}
+                            {:workspace_id (:id workspace) :ref_id (:ref_id isolated-transform)}
                             {:source {:type  "query"
                                       :query (mt/native-query (ws.tu/mbql->native (mt/mbql-query venues {:limit 1})))}})
                 (let [ref-id    (:ref_id isolated-transform)

--- a/enterprise/backend/test/metabase_enterprise/workspaces/models/workspace_transform_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/models/workspace_transform_test.clj
@@ -12,12 +12,13 @@
   (testing "WorkspaceTransform definition_changed is marked based on source/target changes"
     (ws.tu/with-resources! [{ws-id :workspace-id, :keys [workspace-map]}
                             {:workspace {:definitions {:x1 [:t0]}}}]
-      (let [t1-ref (workspace-map :x1)
-            ws+ref {:workspace_id ws-id, :ref_id t1-ref}
-            tx-url (ws.tu/ws-url ws-id "/transform/" t1-ref)
+      (let [t1-ref    (workspace-map :x1)
+            ws+ref    {:workspace_id ws-id, :ref_id t1-ref}
+            unchanged {:definition_changed false, :input_data_changed false}
             change!   (fn [updates]
-                        (t2/update! :model/WorkspaceTransform ws+ref {:definition_changed false})
-                        (mt/user-http-request :crowberto :put 200 tx-url updates))]
+                        ;; First reset the stale tracking
+                        (t2/update! :model/WorkspaceTransform ws+ref unchanged)
+                        (t2/update! :model/WorkspaceTransform ws+ref updates))]
         (testing "initially definition is stale - as we've never been run"
           (is (= {t1-ref {:definition_changed true, :input_data_changed false}} (ws.tu/staleness-flags ws-id))))
         (testing "marks as stale when source changes"

--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -4684,36 +4684,6 @@ databaseChangeLog:
       rollback: # will be removed along with the table
 
   - changeSet:
-      id: v58.2026-01-09T12:00:00
-      author: johnswanson
-      comment: Create data-analyst magic permissions group
-      changes:
-        - sql:
-            sql: INSERT INTO permissions_group (name, magic_group_type) VALUES ('Data Analysts', 'data-analyst')
-      rollback:
-        - sql:
-            sql: DELETE FROM permissions_group WHERE magic_group_type = 'data-analyst';
-
-  - changeSet:
-      id: v58.2026-01-09T12:00:01
-      author: johnswanson
-      comment: Grant read permissions on existing Library collections to Data Analysts group
-      changes:
-        - sql:
-            sql: >-
-              INSERT INTO permissions (group_id, object)
-              SELECT pg.id, '/collection/' || c.id || '/'
-              FROM permissions_group pg, collection c
-              WHERE pg.magic_group_type = 'data-analyst'
-                AND c.type IN ('library', 'library-data', 'library-metrics')
-      rollback:
-        - sql:
-            # We can safely delete ALL permissions for this group because it will be deleted in the rollback above
-            sql: >-
-              DELETE FROM permissions
-              WHERE group_id IN (SELECT id FROM permissions_group WHERE magic_group_type = 'data-analyst');
-
-  - changeSet:
       id: v58.2026-01-09T10:00:00
       author: qnkhuat
       comment: Drop stale column from workspace_transform
@@ -4754,24 +4724,34 @@ databaseChangeLog:
             columnName: definition_changed
 
   - changeSet:
-      id: v58.2026-01-16T10:00:00
-      author: qnkhuat
-      comment: Add input_data_changed column to workspace_transform table
+      id: v58.2026-01-09T12:00:00
+      author: johnswanson
+      comment: Create data-analyst magic permissions group
       changes:
-        - addColumn:
-            tableName: workspace_transform
-            columns:
-              - column:
-                  name: input_data_changed
-                  type: ${boolean.type}
-                  defaultValueBoolean: false
-                  remarks: Indicates if upstream data has changed and transform needs re-execution
-                  constraints:
-                    nullable: false
+        - sql:
+            sql: INSERT INTO permissions_group (name, magic_group_type) VALUES ('Data Analysts', 'data-analyst')
       rollback:
-        - dropColumn:
-            tableName: workspace_transform
-            columnName: input_data_changed
+        - sql:
+            sql: DELETE FROM permissions_group WHERE magic_group_type = 'data-analyst';
+
+  - changeSet:
+      id: v58.2026-01-09T12:00:01
+      author: johnswanson
+      comment: Grant read permissions on existing Library collections to Data Analysts group
+      changes:
+        - sql:
+            sql: >-
+              INSERT INTO permissions (group_id, object)
+              SELECT pg.id, '/collection/' || c.id || '/'
+              FROM permissions_group pg, collection c
+              WHERE pg.magic_group_type = 'data-analyst'
+                AND c.type IN ('library', 'library-data', 'library-metrics')
+      rollback:
+        - sql:
+            # We can safely delete ALL permissions for this group because it will be deleted in the rollback above
+            sql: >-
+              DELETE FROM permissions
+              WHERE group_id IN (SELECT id FROM permissions_group WHERE magic_group_type = 'data-analyst');
 
   - changeSet:
       id: v58.2026-01-12T10:47:48
@@ -5204,6 +5184,26 @@ databaseChangeLog:
         - dropColumn:
             tableName: metabase_database
             columnName: workspace_permissions_status
+
+  - changeSet:
+      id: v58.2026-01-16T10:00:00
+      author: qnkhuat
+      comment: Add input_data_changed column to workspace_transform table
+      changes:
+        - addColumn:
+            tableName: workspace_transform
+            columns:
+              - column:
+                  name: input_data_changed
+                  type: ${boolean.type}
+                  defaultValueBoolean: false
+                  remarks: Indicates if upstream data has changed and transform needs re-execution
+                  constraints:
+                    nullable: false
+      rollback:
+        - dropColumn:
+            tableName: workspace_transform
+            columnName: input_data_changed
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 


### PR DESCRIPTION
o Bring back transients
o Fix migration order
o Add redundancy around staleness marking. Makes testing easier too
o More efficient and generic bfs walking
o Make tests more terse, more powerful
o Tweak logic to be more conservative. Skip redundant graph retrieval which could calculate an inconsistent graph.