### PR TITLE
Add completion checks for data segregation and tenants

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
@@ -262,44 +262,6 @@ describe("scenarios - embedding hub", () => {
         .should("not.exist");
     });
 
-    it('"Pick a user strategy" card should open the edit strategy modal', () => {
-      H.restore("setup");
-      cy.signInAsAdmin();
-      H.activateToken("bleeding-edge");
-
-      cy.request("PUT", "/api/setting/embedding-homepage", {
-        value: "visible",
-      });
-
-      cy.visit("/");
-
-      H.main()
-        .findByText("Pick a user strategy")
-        .scrollIntoView()
-        .should("be.visible")
-        .click();
-
-      H.modal().within(() => {
-        cy.findByText("Pick a user strategy").should("be.visible");
-        cy.findByText("Multi tenant").click();
-        cy.button("Apply").click();
-      });
-
-      cy.log("the internal prefix should show up on the page");
-      H.main().findByText("Internal users").should("be.visible");
-      H.main().findByText("Internal groups").should("be.visible");
-
-      cy.visit("/");
-
-      cy.log("'Pick a user strategy' should now be marked as done");
-      H.main()
-        .findByText("Pick a user strategy")
-        .closest("button")
-        .scrollIntoView()
-        .findByText("Done", { timeout: 10_000 })
-        .should("be.visible");
-    });
-
     it("should link to user strategy when tenants are disabled", () => {
       H.restore("setup");
       cy.signInAsAdmin();

--- a/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
@@ -56,6 +56,15 @@
 (defn- has-user-created-tenants? []
   (t2/exists? :model/Tenant :is_active true))
 
+(defn- has-configured-data-segregation-strategy? []
+  ;; Check if any of the 3 data segregation strategies are enabled:
+  ;; 1. Row and Column Level Security (Sandboxing)
+  ;; 2. Connection Impersonation
+  ;; 3. Database Routing
+  (or (has-configured-sandboxes?)
+      (t2/exists? :model/ConnectionImpersonation)
+      (t2/exists? :model/DatabaseRouter)))
+
 (defn- embedding-hub-checklist []
   {"add-data"                       (has-user-added-database?)
    "create-dashboard"               (has-user-created-dashboard?)
@@ -66,7 +75,7 @@
    "secure-embeds"                  (has-configured-sso?)
    "enable-tenants"                 (perms/use-tenants)
    "create-tenants"                 (has-user-created-tenants?)
-   "setup-data-segregation-strategy" false})
+   "setup-data-segregation-strategy" (has-configured-data-segregation-strategy?)})
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen

--- a/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
@@ -86,11 +86,22 @@
      "create-tenants"                    create-tenants?
      "setup-data-segregation-strategy"   setup-data-segregation-strategy?}))
 
-;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
-;; use our API + we will need it when we make auto-TypeScript-signature generation happen
-;;
-#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
-(api.macros/defendpoint :get "/checklist"
+(def ^:private EmbeddingHubChecklist
+  "Schema for the embedding hub checklist response."
+  [:map {:closed true}
+   ["add-data"                             :boolean]
+   ["create-dashboard"                     :boolean]
+   ["create-models"                        :boolean]
+   ["configure-row-column-security"        :boolean]
+   ["create-test-embed"                    :boolean]
+   ["embed-production"                     :boolean]
+   ["secure-embeds"                        :boolean]
+   ["data-permissions-and-enable-tenants"  :boolean]
+   ["enable-tenants"                       :boolean]
+   ["create-tenants"                       :boolean]
+   ["setup-data-segregation-strategy"      :boolean]])
+
+(api.macros/defendpoint :get "/checklist" :- EmbeddingHubChecklist
   "Get the embedding hub checklist status, indicating which setup steps have been completed."
   []
   (embedding-hub-checklist))

--- a/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
@@ -66,16 +66,25 @@
       (t2/exists? :model/DatabaseRouter)))
 
 (defn- embedding-hub-checklist []
-  {"add-data"                       (has-user-added-database?)
-   "create-dashboard"               (has-user-created-dashboard?)
-   "create-models"                  (has-user-created-models?)
-   "configure-row-column-security"  (has-configured-sandboxes?)
-   "create-test-embed"              (embedding.settings/embedding-hub-test-embed-snippet-created)
-   "embed-production"               (embedding.settings/embedding-hub-production-embed-snippet-created)
-   "secure-embeds"                  (has-configured-sso?)
-   "enable-tenants"                 (perms/use-tenants)
-   "create-tenants"                 (has-user-created-tenants?)
-   "setup-data-segregation-strategy" (has-configured-data-segregation-strategy?)})
+  (let [enable-tenants?                 (perms/use-tenants)
+        create-tenants?                 (has-user-created-tenants?)
+        setup-data-segregation-strategy? (has-configured-data-segregation-strategy?)]
+    ;; for the main embedding hub checklist
+    {"add-data"                          (has-user-added-database?)
+     "create-dashboard"                  (has-user-created-dashboard?)
+     "create-models"                     (has-user-created-models?)
+     "configure-row-column-security"     (has-configured-sandboxes?)
+     "create-test-embed"                 (embedding.settings/embedding-hub-test-embed-snippet-created)
+     "embed-production"                  (embedding.settings/embedding-hub-production-embed-snippet-created)
+     "secure-embeds"                     (has-configured-sso?)
+     "data-permissions-and-enable-tenants" (and enable-tenants?
+                                                create-tenants?
+                                                setup-data-segregation-strategy?)
+
+     ;; for the "configure data permissions and enable tenants" sub-checklist page
+     "enable-tenants"                    enable-tenants?
+     "create-tenants"                    create-tenants?
+     "setup-data-segregation-strategy"   setup-data-segregation-strategy?}))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen

--- a/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
@@ -53,15 +53,20 @@
                                                               :where  [:= :is_sample true]}]]
                                     [:is :collection_id nil]]]}))
 
+(defn- has-user-created-tenants? []
+  (t2/exists? :model/Tenant :is_active true))
+
 (defn- embedding-hub-checklist []
-  {"add-data"                      (has-user-added-database?)
-   "create-dashboard"              (has-user-created-dashboard?)
-   "create-models"                 (has-user-created-models?)
-   "configure-row-column-security" (has-configured-sandboxes?)
-   "create-test-embed"             (embedding.settings/embedding-hub-test-embed-snippet-created)
-   "embed-production"              (embedding.settings/embedding-hub-production-embed-snippet-created)
-   "secure-embeds"                 (has-configured-sso?)
-   "setup-tenants"                 (perms/use-tenants)})
+  {"add-data"                       (has-user-added-database?)
+   "create-dashboard"               (has-user-created-dashboard?)
+   "create-models"                  (has-user-created-models?)
+   "configure-row-column-security"  (has-configured-sandboxes?)
+   "create-test-embed"              (embedding.settings/embedding-hub-test-embed-snippet-created)
+   "embed-production"               (embedding.settings/embedding-hub-production-embed-snippet-created)
+   "secure-embeds"                  (has-configured-sso?)
+   "enable-tenants"                 (perms/use-tenants)
+   "create-tenants"                 (has-user-created-tenants?)
+   "setup-data-segregation-strategy" false})
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen

--- a/enterprise/backend/test/metabase_enterprise/embedding_hub/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/embedding_hub/api_test.clj
@@ -91,3 +91,14 @@
     (mt/with-premium-features #{:embedding}
       (let [response (mt/user-http-request :crowberto :get 200 "/ee/embedding-hub/checklist")]
         (is (false? (:setup-data-segregation-strategy response)))))))
+
+(deftest data-permissions-and-enable-tenants-test
+  (testing "data-permissions-and-enable-tenants returns true when all three conditions are met"
+    (mt/with-premium-features #{:embedding :sandboxes :tenants}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (mt/with-temp [:model/Tenant _ {:name "Test Tenant" :slug "test-tenant"}
+                       :model/PermissionsGroup {group-id :id} {}
+                       :model/Sandbox _ {:group_id group-id
+                                         :table_id (mt/id :venues)}]
+          (let [response (mt/user-http-request :crowberto :get 200 "/ee/embedding-hub/checklist")]
+            (is (true? (:data-permissions-and-enable-tenants response)))))))))

--- a/frontend/src/metabase/api/embedding-hub.ts
+++ b/frontend/src/metabase/api/embedding-hub.ts
@@ -10,7 +10,9 @@ type CheckListApiStep =
   | "create-test-embed"
   | "embed-production"
   | "secure-embeds"
-  | "setup-tenants";
+  | "enable-tenants"
+  | "create-tenants"
+  | "setup-data-segregation-strategy";
 export type EmbeddingHubChecklist = Record<CheckListApiStep, boolean>;
 
 export const embeddingHubApi = Api.injectEndpoints({

--- a/frontend/src/metabase/api/embedding-hub.ts
+++ b/frontend/src/metabase/api/embedding-hub.ts
@@ -12,7 +12,8 @@ type CheckListApiStep =
   | "secure-embeds"
   | "enable-tenants"
   | "create-tenants"
-  | "setup-data-segregation-strategy";
+  | "setup-data-segregation-strategy"
+  | "data-permissions-and-enable-tenants";
 export type EmbeddingHubChecklist = Record<CheckListApiStep, boolean>;
 
 export const embeddingHubApi = Api.injectEndpoints({

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.unit.spec.tsx
@@ -166,7 +166,7 @@ describe("EmbeddingHub", () => {
         "configure-row-column-security": false,
         "embed-production": false,
         "secure-embeds": false,
-        "setup-tenants": false,
+        "data-permissions-and-enable-tenants": false,
       },
     });
 

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.unit.spec.tsx
@@ -142,20 +142,6 @@ describe("EmbeddingHub", () => {
     );
   });
 
-  it("has correct href link for Configure data permissions card", async () => {
-    setup();
-
-    const configureDataPermissionsLink = screen.getByRole("link", {
-      name: /configure data permissions/i,
-    });
-    expect(configureDataPermissionsLink).toBeInTheDocument();
-
-    expect(configureDataPermissionsLink).toHaveAttribute(
-      "href",
-      "https://www.metabase.com/docs/latest/permissions/embedding.html?utm_source=product&utm_medium=docs&utm_campaign=embedding_hub&utm_content=configure-row-column-security&source_plan=oss#one-database-for-all-customers-commingled-setups",
-    );
-  });
-
   it("shows success banner when first 3 steps are completed", async () => {
     setup({
       checklist: {

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/SetupPermissionsAndTenantsPage.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/SetupPermissionsAndTenantsPage.tsx
@@ -1,8 +1,10 @@
 /* eslint-disable metabase/no-literal-metabase-strings -- This string only shows for admins */
 
+import { useMemo, useState } from "react";
 import { Link } from "react-router";
 import { t } from "ttag";
 
+import { useGetEmbeddingHubChecklistQuery } from "metabase/api/embedding-hub";
 import { OnboardingStepper } from "metabase/common/components/OnboardingStepper";
 import { Button, Group, Icon, Stack, Text, Title } from "metabase/ui";
 
@@ -11,6 +13,24 @@ import S from "./SetupPermissionsAndTenantsPage.module.css";
 const SETUP_GUIDE_PATH = "/admin/embedding/setup-guide";
 
 export const SetupPermissionsAndTenantsPage = () => {
+  const { data: checklist } = useGetEmbeddingHubChecklistQuery();
+  const [isDataSegregationSelected, _setIsDataSegregationSelected] =
+    useState(false);
+
+  const completedSteps = useMemo(() => {
+    const isDataSegregationComplete =
+      isDataSegregationSelected ||
+      checklist?.["setup-data-segregation-strategy"];
+
+    return {
+      "enable-tenants": checklist?.["enable-tenants"] ?? false,
+      "data-segregation": isDataSegregationComplete ?? false,
+      "select-data": isDataSegregationComplete ?? false,
+      "create-tenants": checklist?.["create-tenants"] ?? false,
+      summary: false,
+    };
+  }, [checklist, isDataSegregationSelected]);
+
   return (
     <Stack mx="auto" gap="sm" maw={800}>
       <Link to={SETUP_GUIDE_PATH} className={S.backLink}>
@@ -24,8 +44,7 @@ export const SetupPermissionsAndTenantsPage = () => {
         {t`Configure data permissions and enable tenants`}
       </Title>
 
-      {/* TODO(EMB-1266): implement completed and locked steps logic */}
-      <OnboardingStepper completedSteps={{}} lockedSteps={{}}>
+      <OnboardingStepper completedSteps={completedSteps} lockedSteps={{}}>
         <OnboardingStepper.Step
           stepId="enable-tenants"
           title={t`Enable multi-tenant user strategy`}

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/SetupPermissionsAndTenantsPage.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/SetupPermissionsAndTenantsPage.tsx
@@ -21,18 +21,24 @@ export const SetupPermissionsAndTenantsPage = () => {
     useState(false);
 
   const completedSteps = useMemo(() => {
-    // When data segregation is finally configured, we permanently
-    // mark this step as done. Otherwise rely on UI state.
     const isDataSegregationComplete =
-      checklist?.["setup-data-segregation-strategy"] ||
-      isDataSegregationSelected;
+      checklist?.["setup-data-segregation-strategy"] ?? false;
+    const isTenantsEnabled = checklist?.["enable-tenants"] ?? false;
+    const isTenantsCreated = checklist?.["create-tenants"] ?? false;
 
     return {
-      "enable-tenants": checklist?.["enable-tenants"] ?? false,
-      "data-segregation": isDataSegregationComplete ?? false,
-      "select-data": isDataSegregationComplete ?? false,
-      "create-tenants": checklist?.["create-tenants"] ?? false,
-      summary: false,
+      "enable-tenants": isTenantsEnabled,
+
+      // When data segregation is finally configured, we permanently
+      // mark this step as done. Otherwise rely on UI state.
+      "select-data-segregation-strategy":
+        isDataSegregationSelected || isDataSegregationComplete,
+
+      "select-data-for-segregation": isDataSegregationComplete,
+      "create-tenants": isTenantsCreated,
+
+      summary:
+        isTenantsEnabled && isDataSegregationComplete && isTenantsCreated,
     };
   }, [checklist, isDataSegregationSelected]);
 

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/SetupPermissionsAndTenantsPage.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/SetupPermissionsAndTenantsPage.tsx
@@ -14,13 +14,18 @@ const SETUP_GUIDE_PATH = "/admin/embedding/setup-guide";
 
 export const SetupPermissionsAndTenantsPage = () => {
   const { data: checklist } = useGetEmbeddingHubChecklistQuery();
+
+  // The "Which data segregation strategy does your database use?"
+  // is a purely UI step for choosing which strategy to use.
   const [isDataSegregationSelected, _setIsDataSegregationSelected] =
     useState(false);
 
   const completedSteps = useMemo(() => {
+    // When data segregation is finally configured, we permanently
+    // mark this step as done. Otherwise rely on UI state.
     const isDataSegregationComplete =
-      isDataSegregationSelected ||
-      checklist?.["setup-data-segregation-strategy"];
+      checklist?.["setup-data-segregation-strategy"] ||
+      isDataSegregationSelected;
 
     return {
       "enable-tenants": checklist?.["enable-tenants"] ?? false,

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/SetupPermissionsAndTenantsPage.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/SetupPermissionsAndTenantsPage.tsx
@@ -31,10 +31,10 @@ export const SetupPermissionsAndTenantsPage = () => {
 
       // When data segregation is finally configured, we permanently
       // mark this step as done. Otherwise rely on UI state.
-      "select-data-segregation-strategy":
+      "data-segregation":
         isDataSegregationSelected || isDataSegregationComplete,
 
-      "select-data-for-segregation": isDataSegregationComplete,
+      "select-data": isDataSegregationComplete,
       "create-tenants": isTenantsCreated,
 
       summary:

--- a/frontend/src/metabase/embedding/embedding-hub/hooks/use-completed-embedding-hub-steps.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/hooks/use-completed-embedding-hub-steps.ts
@@ -26,7 +26,10 @@ export const useCompletedEmbeddingHubSteps = (): {
         "secure-embeds": false,
         "embed-production": false,
         "create-models": false,
-        "setup-tenants": false,
+        "create-tenants": false,
+        "enable-tenants": false,
+        "setup-data-segregation-strategy": false,
+        "data-permissions-and-enable-tenants": false,
       };
     }
 

--- a/frontend/src/metabase/embedding/embedding-hub/hooks/use-completed-embedding-hub-steps.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/hooks/use-completed-embedding-hub-steps.ts
@@ -19,6 +19,7 @@ export const useCompletedEmbeddingHubSteps = (): {
   const data = useMemo(() => {
     if (isLoading || !embeddingHubChecklist) {
       return {
+        // main checklist
         "create-test-embed": false,
         "add-data": false,
         "create-dashboard": false,
@@ -26,10 +27,12 @@ export const useCompletedEmbeddingHubSteps = (): {
         "secure-embeds": false,
         "embed-production": false,
         "create-models": false,
+        "data-permissions-and-enable-tenants": false,
+
+        // "configure data permissions and enable tenants" sub-checklist
         "create-tenants": false,
         "enable-tenants": false,
         "setup-data-segregation-strategy": false,
-        "data-permissions-and-enable-tenants": false,
       };
     }
 

--- a/frontend/src/metabase/embedding/embedding-hub/hooks/use-get-embedding-hub-steps.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/hooks/use-get-embedding-hub-steps.ts
@@ -81,8 +81,8 @@ export const useGetEmbeddingHubSteps = (): EmbeddingHubStep[] => {
       ],
     };
 
-    const SETUP_TENANTS: EmbeddingHubStep = {
-      id: "setup-tenants",
+    const DATA_PERMISSIONS_AND_ENABLE_TENANTS: EmbeddingHubStep = {
+      id: "data-permissions-and-enable-tenants",
       title: t`Pick a strategy for users and permissions`,
       actions: [
         {
@@ -90,9 +90,7 @@ export const useGetEmbeddingHubSteps = (): EmbeddingHubStep[] => {
           description: t`Set granular permissions for multi-tenancy to control data access. Share dashboards, questions, and models with external users and allow them to create content, while restricting access to internal or other tenants' data.`,
           to: "/admin/embedding/setup-guide/permissions",
           variant: "outline",
-
-          // TODO(EMB-1265): update this to "setup-permissions-and-tenants"
-          stepId: "setup-tenants",
+          stepId: "data-permissions-and-enable-tenants",
         },
       ],
     };
@@ -136,7 +134,9 @@ export const useGetEmbeddingHubSteps = (): EmbeddingHubStep[] => {
       ADD_DATA,
       CREATE_DASHBOARD,
       TEST_EMBED,
-      ...(isTenantsFeatureAvailable ? [SETUP_TENANTS] : []),
+      ...(isTenantsFeatureAvailable
+        ? [DATA_PERMISSIONS_AND_ENABLE_TENANTS]
+        : []),
       SECURE_EMBEDS,
       EMBED_PRODUCTION,
     ];

--- a/frontend/src/metabase/embedding/embedding-hub/types/embedding-checklist.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/types/embedding-checklist.ts
@@ -8,7 +8,7 @@ export type EmbeddingHubStepId =
   | "secure-embeds"
   | "embed-production"
   | "create-models"
-  | "setup-tenants";
+  | "data-permissions-and-enable-tenants";
 
 export interface EmbeddingHubStep {
   id: EmbeddingHubStepId;


### PR DESCRIPTION
Closes EMB-1266

### Description

Adds the backend completion checks for the data segregation and tenants card and page, as well as adding it to the frontend:

```clj
;; for the main "configure data permissions and enable tenants" card
  (and enable-tenants?
       create-tenants?
       setup-data-segregation-strategy?)

;; for the "configure data permissions and enable tenants" sub-checklist page
"enable-tenants"                    enable-tenants?
"create-tenants"                    create-tenants?
"setup-data-segregation-strategy"   setup-data-segregation-strategy?

```

### How to verify

- Go to `/admin/embedding/setup-guide/permissions`. If you have created tenants and enabled tenants, those steps should be green. If you have configured RLS or other data segregation, the two steps should also be green. Note that the step content is a placeholder right now.

<img width="2472" height="1662" alt="CleanShot 2569-01-30 at 10 50 25@2x" src="https://github.com/user-attachments/assets/d44eac1a-bb93-4513-9b0d-21ccdd610eff" />

- The backend test in `enterprise/backend/test/metabase_enterprise/embedding_hub/api_test.clj` should be passing. See the test cases there. 
- The e2e test in `e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts` should be passing. See the test cases there.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR - E2E and Backend Tests