### PR TITLE
Fix colors and strings in the deps sidebar

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListSidebar/BrokenDependentsSection/BrokenDependentsSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListSidebar/BrokenDependentsSection/BrokenDependentsSection.tsx
@@ -84,7 +84,7 @@ export function BrokenDependentsSection({
     <Stack role="region" aria-label={getDependentErrorNodesLabel()}>
       <Group justify="space-between" wrap="nowrap">
         <Group gap="sm" wrap="nowrap">
-          <Badge c="text-selected" bg="error">
+          <Badge variant="filled" bg="error">
             {count}
           </Badge>
           <Title order={5}>

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListSidebar/ErrorsSection/ErrorsSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListSidebar/ErrorsSection/ErrorsSection.tsx
@@ -73,7 +73,7 @@ function ErrorList({ title, items, "aria-label": ariaLabel }: ErrorListProps) {
   return (
     <Stack role="region" aria-label={ariaLabel}>
       <Group gap="sm" wrap="nowrap">
-        <Badge c="text-selected" bg="error">
+        <Badge variant="filled" bg="error">
           {items.length}
         </Badge>
         <Title order={5}>{title}</Title>

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListSidebar/FieldsSection/FieldsSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyList/ListSidebar/FieldsSection/FieldsSection.tsx
@@ -32,7 +32,7 @@ export function FieldsSection({ node }: FieldsSectionProps) {
   return (
     <Stack role="region" aria-label={t`Fields`}>
       <Group gap="sm" wrap="nowrap">
-        <Badge c="text-selected" bg="brand">
+        <Badge variant="filled" bg="brand">
           {fields.length}
         </Badge>
         <Title order={5}>{getNodeFieldsLabel(fields.length)}</Title>

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/utils.ts
@@ -151,18 +151,18 @@ export function getNodeLink(node: DependencyNode): NodeLink | null {
       };
     case "dashboard":
       return {
-        label: `View this dashboard`,
+        label: t`View this dashboard`,
         url: Urls.dashboard({ id: node.id, name: node.data.name }),
       };
     case "document":
       return {
-        label: `View this document`,
+        label: t`View this document`,
         url: Urls.document({ id: node.id }),
       };
     case "sandbox":
       if (node.data.table != null) {
         return {
-          label: `View this permission`,
+          label: t`View this permission`,
           url: Urls.tableDataPermissions(
             node.data.table.db_id,
             node.data.table.schema,


### PR DESCRIPTION
Fixes https://linear.app/metabase/issue/QUE-3047/fe-fix-colors-in-the-dependency-list-sidebar-after-recent-color

Before
<img width="505" height="161" alt="Screenshot 2026-01-30 at 09 42 00" src="https://github.com/user-attachments/assets/ab2b1cad-a33b-4fa2-bf59-245026f8278c" />

After
<img width="528" height="299" alt="Screenshot 2026-01-30 at 09 41 48" src="https://github.com/user-attachments/assets/251329ee-e752-4476-af43-c479b960ebbf" />
