### PR TITLE
fix: stacked bar chart crashes when card has multiple same-type aggregations

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.unit.spec.js
+++ b/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.unit.spec.js
@@ -27,7 +27,14 @@ function getSeries(display, index, changeSeriesName) {
         ["a", 1],
         ["b", 2],
       ],
-      cols: [{ name: "foo" }, { name: "bar" }],
+      cols: [
+        { name: "foo", display_name: "Foo", source: "breakout" },
+        {
+          name: `Test ${index}`,
+          display_name: `Test ${index}`,
+          source: "aggregation",
+        },
+      ],
     },
   };
 }

--- a/frontend/src/metabase/visualizations/lib/utils.js
+++ b/frontend/src/metabase/visualizations/lib/utils.js
@@ -292,12 +292,6 @@ export function getSingleSeriesDimensionsAndMetrics(
   );
   if (
     dimensionNotMetricColumns.length <= maxDimensions &&
-    metricColumns.length === 1
-  ) {
-    dimensions = dimensionNotMetricColumns;
-    metrics = metricColumns;
-  } else if (
-    dimensionNotMetricColumns.length === 1 &&
     metricColumns.length <= maxMetrics
   ) {
     dimensions = dimensionNotMetricColumns;

--- a/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
@@ -62,22 +62,28 @@ export function getDefaultDimensions(
 ) {
   const [{ card, data }] = rawSeries;
   const mainSeriesColumns = data?.cols ?? [];
+  const hasData = mainSeriesColumns.length > 0;
   const prevDimensionsRaw = (settings["graph.dimensions"] ?? []).filter(
     isNotNull,
   );
-  const prevDimensions = prevDimensionsRaw.filter((columnName: string) =>
-    mainSeriesColumns.some((col: DatasetColumn) => col.name === columnName),
-  );
+  const prevDimensions = hasData
+    ? prevDimensionsRaw.filter((columnName: string) =>
+        mainSeriesColumns.some((col: DatasetColumn) => col.name === columnName),
+      )
+    : prevDimensionsRaw;
   const defaultDimensions = getDefaultColumns(rawSeries).dimensions;
   const canReusePrevious =
     prevDimensions.length > 0 &&
     defaultDimensions.length > 0 &&
     defaultDimensions[0] == null &&
-    columnsAreValid(
-      prevDimensionsRaw,
-      data,
-      getDefaultDimensionFilter(card.display),
-    );
+    (!hasData ||
+      (columnsAreValid(
+        prevDimensionsRaw,
+        data,
+        getDefaultDimensionFilter(card.display),
+      ) &&
+        prevDimensionsRaw.filter((colName) => colName !== null).length ===
+          prevDimensionsRaw.length));
 
   if (canReusePrevious) {
     return prevDimensions;
@@ -91,13 +97,21 @@ export function getDefaultMetrics(
   settings: ComputedVisualizationSettings,
 ) {
   const [{ card, data }] = rawSeries;
+  const hasData = (data?.cols ?? []).length > 0;
   const prevMetrics = settings["graph.metrics"] ?? [];
   const defaultMetrics = getDefaultColumns(rawSeries).metrics;
   const canReusePrevious =
     prevMetrics.length > 0 &&
     defaultMetrics.length > 0 &&
     defaultMetrics[0] == null &&
-    columnsAreValid(prevMetrics, data, getDefaultMetricFilter(card.display));
+    (!hasData ||
+      (columnsAreValid(
+        prevMetrics,
+        data,
+        getDefaultMetricFilter(card.display),
+      ) &&
+        prevMetrics.filter((metric) => metric !== null).length ===
+          prevMetrics.length));
 
   if (canReusePrevious) {
     return prevMetrics;

--- a/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
@@ -60,18 +60,26 @@ export function getDefaultDimensions(
   rawSeries: RawSeries,
   settings: ComputedVisualizationSettings,
 ) {
-  const mainSeriesColumns = rawSeries[0]?.data?.cols;
-  const prevDimensions = (settings["graph.dimensions"] ?? [])
-    .filter(isNotNull)
-    .filter((columnName) =>
-      mainSeriesColumns.some((col) => col.name === columnName),
-    );
+  const [{ card, data }] = rawSeries;
+  const mainSeriesColumns = data?.cols ?? [];
+  const prevDimensionsRaw = (settings["graph.dimensions"] ?? []).filter(
+    isNotNull,
+  );
+  const prevDimensions = prevDimensionsRaw.filter((columnName: string) =>
+    mainSeriesColumns.some((col: DatasetColumn) => col.name === columnName),
+  );
   const defaultDimensions = getDefaultColumns(rawSeries).dimensions;
-  if (
+  const canReusePrevious =
     prevDimensions.length > 0 &&
     defaultDimensions.length > 0 &&
-    defaultDimensions[0] == null
-  ) {
+    defaultDimensions[0] == null &&
+    columnsAreValid(
+      prevDimensionsRaw,
+      data,
+      getDefaultDimensionFilter(card.display),
+    );
+
+  if (canReusePrevious) {
     return prevDimensions;
   }
 
@@ -82,14 +90,16 @@ export function getDefaultMetrics(
   rawSeries: RawSeries,
   settings: ComputedVisualizationSettings,
 ) {
-  const [{ card }] = rawSeries;
+  const [{ card, data }] = rawSeries;
   const prevMetrics = settings["graph.metrics"] ?? [];
   const defaultMetrics = getDefaultColumns(rawSeries).metrics;
-  if (
+  const canReusePrevious =
     prevMetrics.length > 0 &&
     defaultMetrics.length > 0 &&
-    defaultMetrics[0] == null
-  ) {
+    defaultMetrics[0] == null &&
+    columnsAreValid(prevMetrics, data, getDefaultMetricFilter(card.display));
+
+  if (canReusePrevious) {
     return prevMetrics;
   }
   return defaultMetrics.slice(0, getMaxMetricsSupported(card.display));

--- a/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.unit.spec.ts
@@ -1,9 +1,138 @@
 import {
+  getDefaultColumns,
+  getDefaultDimensions,
+  getDefaultMetrics,
+} from "metabase/visualizations/shared/settings/cartesian-chart";
+import type { DatasetData, VisualizationDisplay } from "metabase-types/api";
+import {
+  createMockCard,
   createMockColumn,
+  createMockDatasetData,
   createMockSingleSeries,
 } from "metabase-types/api/mocks";
 
-import { getDefaultColumns } from "./cartesian-chart";
+const createSeries = ({
+  display,
+  cols,
+  rows = [
+    [1, "a", 10],
+    [2, "b", 20],
+  ],
+}: {
+  display: VisualizationDisplay;
+  cols: DatasetData["cols"];
+  rows?: DatasetData["rows"];
+}) => {
+  return [
+    {
+      card: createMockCard({ display }),
+      data: createMockDatasetData({
+        cols,
+        rows,
+      }),
+    },
+  ];
+};
+
+describe("cartesian-chart defaults", () => {
+  it("ignores previous metrics that reference missing columns", () => {
+    const cols = [
+      createMockColumn({
+        name: "created_at",
+        display_name: "Created At",
+        source: "breakout",
+      }),
+      createMockColumn({
+        name: "sum",
+        display_name: "Sum",
+        base_type: "type/Integer",
+        source: "aggregation",
+      }),
+    ];
+    const series = createSeries({ display: "bar", cols });
+
+    const result = getDefaultMetrics(series, {
+      "graph.metrics": ["missing_metric"],
+    });
+
+    expect(result).toEqual(["sum"]);
+  });
+
+  it("ignores previous dimensions that reference missing columns", () => {
+    const cols = [
+      createMockColumn({
+        name: "created_at",
+        display_name: "Created At",
+        source: "breakout",
+      }),
+      createMockColumn({
+        name: "sum",
+        display_name: "Sum",
+        base_type: "type/Integer",
+        source: "aggregation",
+      }),
+    ];
+    const series = createSeries({ display: "bar", cols });
+
+    const result = getDefaultDimensions(series, {
+      "graph.dimensions": ["missing_dimension"],
+    });
+
+    expect(result).toEqual(["created_at"]);
+  });
+
+  it("reuses previous dimensions when defaults are unavailable but columns are valid", () => {
+    const cols = [
+      createMockColumn({
+        name: "dim",
+        display_name: "Dim",
+        source: "breakout",
+      }),
+      createMockColumn({
+        name: "m1",
+        display_name: "M1",
+        base_type: "type/Integer",
+        source: "aggregation",
+      }),
+      createMockColumn({
+        name: "m2",
+        display_name: "M2",
+        base_type: "type/Integer",
+        source: "aggregation",
+      }),
+    ];
+    const series = createSeries({ display: "scatter", cols });
+
+    const result = getDefaultDimensions(series, {
+      "graph.dimensions": ["dim"],
+    });
+
+    expect(result).toEqual(["dim"]);
+  });
+
+  it("reuses previous metrics when defaults are unavailable but columns are valid", () => {
+    const cols = [
+      createMockColumn({
+        name: "dim",
+        display_name: "Dim",
+        source: "breakout",
+      }),
+      createMockColumn({
+        name: "m1",
+        display_name: "M1",
+        base_type: "type/Integer",
+        source: "aggregation",
+      }),
+    ];
+    const series = createSeries({ display: "scatter", cols });
+
+    const result = getDefaultMetrics(series, {
+      "graph.metrics": ["m1"],
+    });
+
+    expect(result).toEqual(["m1"]);
+  });
+});
 
 const COLS = [
   createMockColumn({


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #68819
Closes [UXW-2870: Stacked bar chart crashes after upgrade when card has multiple same-type aggregations](https://linear.app/metabase/issue/UXW-2870/stacked-bar-chart-crashes-after-upgrade-when-card-has-multiple-same)

### Description

`getDefaultMetrics` was returning previous results without checking if the columns actually exist. Now it checks for if they are valid, and if not uses the default and not incorrect previous ones.

### How to verify

1. Create a new question (Custom question) using any table with a numeric column (e.g., Sample Database → Orders → Total)
2. Add two aggregations of the same type: both Sum of Total, then Save
At this point, the result columns are deduplicated: "sum" and "sum_2"
3. Add two breakouts: Created At (by month) and Product → Category
4. Click Visualize
5. Change display type to Bar. In chart settings:
6. Set X-axis to Created At
7. Set Y-axis to both Sum of Total columns
8. Under Display, enable Stacked
9. Save the question — verify the chart renders correctly
10. Open the notebook editor and rename the first aggregation to "Sum" (capital S)
11. This changes column.name for the first aggregation to "Sum". Because "Sum" and "sum" are case-sensitively different, the second aggregation no longer needs deduplication — its result_metadata.name changes from "sum_2" to "sum". But graph.metrics still contains "sum_2" from the previous save
12. Save — chart crashes with TypeError: cannot read properties of undefined (reading 'name')

### Demo

Before:
<img width="1177" height="737" alt="image" src="https://github.com/user-attachments/assets/f970f97a-290e-42b5-a8ef-40384038d794" />

After:
<img width="1177" height="734" alt="image" src="https://github.com/user-attachments/assets/78b5c2d8-5373-40c8-972f-29fd0c61ba92" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
