### PR TITLE
feat: snippets under 'library' in changes view

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/ChangesLists/AllChangesView.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/ChangesLists/AllChangesView.tsx
@@ -3,6 +3,7 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import { useListCollectionsTreeQuery } from "metabase/api";
+import { isLibraryCollection } from "metabase/collections/utils";
 import { useSetting } from "metabase/common/hooks";
 import {
   Box,
@@ -21,7 +22,7 @@ import {
   getSyncStatusIcon,
   isTableChildModel,
 } from "metabase-enterprise/remote_sync/utils";
-import type { RemoteSyncEntity } from "metabase-types/api";
+import type { Collection, RemoteSyncEntity } from "metabase-types/api";
 
 import { CollectionPath } from "./CollectionPath";
 import { EntityLink } from "./EntityLink";
@@ -65,11 +66,15 @@ export const AllChangesView = ({ entities, title }: AllChangesViewProps) => {
   });
 
   // Build a set of snippet collection IDs for icon selection
+  // Only include collections with namespace "snippets" to avoid false positives
   const snippetCollectionIds = useMemo(() => {
     const ids = new Set<number>();
     const collectIds = (collections: typeof snippetCollectionTree) => {
       for (const collection of collections) {
-        if (typeof collection.id === "number") {
+        if (
+          typeof collection.id === "number" &&
+          collection.namespace === "snippets"
+        ) {
           ids.add(collection.id);
         }
         if (collection.children) {
@@ -80,6 +85,25 @@ export const AllChangesView = ({ entities, title }: AllChangesViewProps) => {
     collectIds(snippetCollectionTree);
     return ids;
   }, [snippetCollectionTree]);
+
+  // Find the library collection ID for placing snippets without a collection_id
+  const libraryCollectionId = useMemo(() => {
+    const findLibrary = (collections: Collection[]): number | null => {
+      for (const col of collections) {
+        if (isLibraryCollection(col)) {
+          return typeof col.id === "number" ? col.id : null;
+        }
+        if (col.children?.length) {
+          const found = findLibrary(col.children);
+          if (found !== null) {
+            return found;
+          }
+        }
+      }
+      return null;
+    };
+    return findLibrary(collectionTree);
+  }, [collectionTree]);
 
   const collectionMap = useMemo(() => {
     // Merge regular collections with snippet collections
@@ -95,7 +119,17 @@ export const AllChangesView = ({ entities, title }: AllChangesViewProps) => {
   }, [entities]);
 
   const groupedData = useMemo(() => {
-    const byCollection = _.groupBy(entities, (e) => e.collection_id || 0);
+    const byCollection = _.groupBy(entities, (e) => {
+      if (e.collection_id != null) {
+        return e.collection_id;
+      }
+      // Snippets without a collection_id should go under the Library collection
+      if (e.model === "nativequerysnippet" && libraryCollectionId != null) {
+        return libraryCollectionId;
+      }
+      // Default to Root for other entities without a collection_id
+      return 0;
+    });
 
     const sortByStatus = (items: RemoteSyncEntity[]) =>
       items.sort((a, b) => {
@@ -158,18 +192,35 @@ export const AllChangesView = ({ entities, title }: AllChangesViewProps) => {
         );
 
         const numericCollectionId = Number(collectionId) || undefined;
+        const isSnippetCollection =
+          numericCollectionId !== undefined &&
+          snippetCollectionIds.has(numericCollectionId);
+
+        // Get base path segments for this collection
+        let pathSegments = getCollectionPathSegments(
+          numericCollectionId,
+          collectionMap,
+        );
+
+        // For snippet collections, prepend the Library collection path
+        // This makes them appear as descendants of the Library collection
+        if (isSnippetCollection && libraryCollectionId != null) {
+          const libraryCollection = collectionMap.get(libraryCollectionId);
+          if (libraryCollection) {
+            pathSegments = [
+              { id: libraryCollection.id, name: libraryCollection.name },
+              ...pathSegments,
+            ];
+          }
+        }
+
         return {
-          pathSegments: getCollectionPathSegments(
-            numericCollectionId,
-            collectionMap,
-          ),
+          pathSegments,
           collectionId: numericCollectionId,
           collectionEntity,
           tableGroups,
           items: sortByStatus(otherItems),
-          isSnippetCollection:
-            numericCollectionId !== undefined &&
-            snippetCollectionIds.has(numericCollectionId),
+          isSnippetCollection,
         };
       })
       .sort((a, b) =>
@@ -178,7 +229,7 @@ export const AllChangesView = ({ entities, title }: AllChangesViewProps) => {
           .join(" / ")
           .localeCompare(b.pathSegments.map((s) => s.name).join(" / ")),
       );
-  }, [entities, collectionMap, snippetCollectionIds]);
+  }, [entities, collectionMap, snippetCollectionIds, libraryCollectionId]);
 
   return (
     <Box>

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/middleware/register-listeners.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/middleware/register-listeners.ts
@@ -78,6 +78,11 @@ function shouldInvalidateForCollection(
     return true;
   }
 
+  // Also invalidate for snippets namespace collections
+  if (newCollection.namespace === "snippets") {
+    return true;
+  }
+
   return false;
 }
 

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/middleware/remote-sync-listener-middleware.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/middleware/remote-sync-listener-middleware.unit.spec.ts
@@ -354,6 +354,50 @@ describe("remote-sync-listener-middleware", () => {
         expect(callsAfter).toBe(callsBefore);
       });
 
+      it("should invalidate tags when creating a snippets namespace collection", async () => {
+        const snippetsCollection = createMockCollection({
+          id: 100,
+          name: "My Snippets Collection",
+          namespace: "snippets",
+          is_remote_synced: false,
+        });
+
+        setupCreateCollectionEndpoint(snippetsCollection);
+        setupRemoteSyncDirtyEndpoint();
+
+        const store = createTestStore();
+
+        // Subscribe to the dirty query first so RTK Query will refetch when tags are invalidated
+        store.dispatch(
+          remoteSyncApi.endpoints.getRemoteSyncChanges.initiate(undefined),
+        );
+
+        // Wait for initial dirty query to complete
+        await waitForCondition(() =>
+          fetchMock.callHistory.done("remote-sync-dirty"),
+        );
+
+        // Dispatch the create collection mutation
+        store.dispatch(
+          collectionApi.endpoints.createCollection.initiate({
+            name: "My Snippets Collection",
+            namespace: "snippets",
+          }),
+        );
+
+        // Wait for the request to complete
+        await waitForCondition(() =>
+          fetchMock.callHistory.done("create-collection"),
+        );
+
+        // Give middleware time to process and trigger invalidation
+        await new Promise((resolve) => setTimeout(resolve, 100));
+
+        // Verify the dirty endpoint was called more than once (initial + refetch after invalidation)
+        const dirtyCalls = fetchMock.callHistory.calls("remote-sync-dirty");
+        expect(dirtyCalls.length).toBeGreaterThan(1);
+      });
+
       it("should invalidate tags when creating a remote-synced collection", async () => {
         const remoteSyncedCollection = createMockCollection({
           id: 100,


### PR DESCRIPTION
### Description

Display dirty snippets and snippets collections as children of the library collection in the list of dirty changes for push. This just changes how we build the path to snippets and snippets collections so they are shown as children of the Library rather than children of Root since conceptually they are 'inside' the library. 

### Demo

<img width="591" height="137" alt="Screenshot 2026-01-30 at 11 03 40 AM" src="https://github.com/user-attachments/assets/31290e06-7be4-4612-b1c5-6967b75efb7e" />
<img width="589" height="124" alt="Screenshot 2026-01-30 at 10 53 22 AM" src="https://github.com/user-attachments/assets/d9838100-73da-4ad5-8b31-a7b101b8e3ed" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
