### PR TITLE
Bigquery and snowflake failing test QUE-3013

### DIFF
--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -590,7 +590,8 @@
                          (h2x/is-of-type? hsql-form "timestamptz"))]
     (sql.u/validate-convert-timezone-args timestamptz? target-timezone source-timezone)
     (-> (if timestamptz?
-          [:convert_timezone target-timezone hsql-form]
+          [:to_timestamp_ntz
+           [:convert_timezone target-timezone hsql-form]]
           [:to_timestamp_ntz
            [:convert_timezone (or source-timezone (driver-api/results-timezone-id)) target-timezone hsql-form]])
         (h2x/with-database-type-info "timestampntz"))))

--- a/test/metabase/query_processor/native_test.clj
+++ b/test/metabase/query_processor/native_test.clj
@@ -1,5 +1,6 @@
 (ns ^:mb/driver-tests metabase.query-processor.native-test
   (:require
+   [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
@@ -112,17 +113,41 @@
                 convert-tz (fn [col]
                              (lib.options/ensure-uuid
                               [:convert-timezone {} col "Asia/Seoul"]))
-                with-default (lib/case [[(lib/= index-col 1) (convert-tz dt-tz-col)]]
-                               dt-tz-col)
                 without-default (lib/case [[(lib/= index-col 1) (convert-tz dt-tz-col)]])
                 q (-> query
-                      (lib/expression "with-default" with-default)
                       (lib/expression "without-default" without-default)
                       (lib/filter (lib/= index-col 1))
                       (as-> q (lib/with-fields q [index-col
-                                                  (lib/expression-ref q "with-default")
                                                   (lib/expression-ref q "without-default")])))
                 results (qp/process-query q)
-                [_idx with-default-val without-default-val] (first (mt/rows results))]
+                [_idx original-without-default-val] (first (mt/rows results))]
             (testing "MBQL: case with and without default should produce the same result for matching rows"
-              (is (= without-default-val with-default-val)))))))))
+              ;; Should not have a timezone
+              (is (not (str/ends-with? original-without-default-val "Z"))))
+            (mt/test-drivers (disj (mt/normal-drivers-with-feature :convert-timezone)
+                                   ;; Don't test bigquery because it can't do the case with a default. It requires all
+                                   ;; case branches to return the same type while others will coerce if they can.
+                                   ;; The assertion above should be enough for BigQuery.
+                                   #_:clj-kondo/ignore
+                                   :bigquery-cloud-sdk)
+              (let [mp (mt/metadata-provider)
+                    query (lib/query mp (lib.metadata/table mp (mt/id :times)))
+                    dt-tz-col (lib.metadata/field mp (mt/id :times :dt_tz))
+                    index-col (lib.metadata/field mp (mt/id :times :index))
+                    convert-tz (fn [col]
+                                 (lib.options/ensure-uuid
+                                  [:convert-timezone {} col "Asia/Seoul"]))
+                    with-default (lib/case [[(lib/= index-col 1) (convert-tz dt-tz-col)]]
+                                   dt-tz-col)
+                    without-default (lib/case [[(lib/= index-col 1) (convert-tz dt-tz-col)]])
+                    q (-> query
+                          (lib/expression "with-default" with-default)
+                          (lib/expression "without-default" without-default)
+                          (lib/filter (lib/= index-col 1))
+                          (as-> q (lib/with-fields q [index-col
+                                                      (lib/expression-ref q "with-default")
+                                                      (lib/expression-ref q "without-default")])))
+                    results (qp/process-query q)
+                    [_idx with-default-val without-default-val] (first (mt/rows results))]
+                (testing "MBQL: case with and without default should produce the same result for matching rows"
+                  (is (= without-default-val with-default-val original-without-default-val)))))))))))

--- a/test/metabase/query_processor/native_test.clj
+++ b/test/metabase/query_processor/native_test.clj
@@ -102,14 +102,14 @@
           (is (= [["Gizmo" "Swaniawski, Casper and Hilll"]]
                  (mt/rows (qp/process-query (mt/native-query query))))))))))
 
-(defmethod driver/database-supports? [::driver/driver ::case-branch-coersion]
+(defmethod driver/database-supports? [::driver/driver ::case-branch-coercion]
   [_driver _feature _database]
   true)
 
 ;; Don't test bigquery because it can't do the case with a default. It requires all
 ;; case branches to return the same type while others will coerce if they can.
 ;; The assertion above should be enough for BigQuery.
-(defmethod driver/database-supports? [:bigquery-cloud-sdk ::case-branch-coersion]
+(defmethod driver/database-supports? [:bigquery-cloud-sdk ::case-branch-coercion]
   [_driver _feature _database]
   false)
 
@@ -136,7 +136,7 @@
             (testing "MBQL: case with and without default should produce the same result for matching rows"
               ;; Should not have a timezone
               (is (not (str/ends-with? original-without-default-val "Z"))))
-            (mt/test-drivers (mt/normal-drivers-with-feature :convert-timezone ::case-branch-coersion)
+            (mt/test-drivers (mt/normal-drivers-with-feature :convert-timezone ::case-branch-coercion)
               (let [mp (mt/metadata-provider)
                     query (lib/query mp (lib.metadata/table mp (mt/id :times)))
                     dt-tz-col (lib.metadata/field mp (mt/id :times :dt_tz))


### PR DESCRIPTION
Closes QUE-3052
Closes QUE-3049
Closes QUE-3050
Closes #68712

### Description

BigQuery can't do case statements with different types in each branch. Other dbs can. This fixes a test that ran a case statement with different types to skip BigQuery, but it adds a new assertion to check correct behavior without it.

This also corrects a fault in the SnowFlake driver that incorrectly assumed that `convertTimezone()` returned a timestamp_ntz but it returns a timestamp_tz. This wraps it in a cast back to timestamp_ntz.
