### PR TITLE
fix: better display for transforms sync changes

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
@@ -72,7 +72,7 @@
                                    [:not-in entity-ids]
                                    :entity_id)
                 scope-key (get-in model-spec [:removal :scope-key])
-                extra-conditions (into [] cat (get-in model-spec [:removal :conditions]))]]
+                extra-conditions (into [] cat (:conditions model-spec))]]
     (if scope-key
       ;; Collection-scoped: delete only within synced collections
       (when (seq synced-collection-ids)

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/schema.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/schema.clj
@@ -29,9 +29,11 @@
 ;;; ------------------------------------------- Dirty Item Schemas -------------------------------------------
 
 (def DirtyItem
-  "Schema for a dirty sync item."
+  "Schema for a dirty sync item.
+   Note: id is :int instead of pos-int? because the Transforms root collection uses
+   a sentinel value of -1 as its model_id."
   [:map
-   [:id pos-int?]
+   [:id :int]
    [:name [:maybe :string]]
    [:model :string]
    [:sync_status :string]

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/spec.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/spec.clj
@@ -51,12 +51,16 @@
                        :select-fields  - Fields to select for hydration
                        :hydrate-query  - Optional custom query for joins (overrides select-fields)
                        :field-mappings - Map of RemoteSyncObject column -> source field or [field transform-fn]
+   - :conditions     - Optional map of conditions for filtering syncable entities.
+                       Only entities matching these conditions are eligible for sync
+                       (export, import cleanup, removal). Example: {:built_in_type nil}
+                       to exclude built-in items from sync.
    - :removal        - Removal/cleanup configuration:
                        :statuses   - Set of statuses to check for removal (e.g., #{\"removed\" \"delete\"})
                        :scope-key  - Optional key for scoping deletions (e.g., :collection_id, :id).
                                      If nil, deletions are global (by entity_id only).
-                       :conditions - Optional map of extra conditions for filtering removals
-                                     (e.g., {:built_in_type nil} to protect built-in items)
+                       :all-on-setting-disable - Optional setting keyword; when this setting's sentinel
+                                     RSO exists with 'delete' status, remove ALL entities of this type
    - :export-scope   - Export scope for query-export-roots:
                        :root-collections - Query root-level remote-synced + namespace collections (Collection)
                        :root-only        - Query root instances with collection_id = nil (Transform)
@@ -267,7 +271,8 @@
     :tracking       {:select-fields  [:name :collection_id]
                      :field-mappings {:model_name          :name
                                       :model_collection_id :collection_id}}
-    :removal        {:statuses #{"removed" "delete"}}  ; no scope-key = global deletion
+    :removal        {:statuses #{"removed" "delete"}  ; no scope-key = global deletion
+                     :all-on-setting-disable :remote-sync-transforms}
     :export-scope   :root-only  ; query for root transforms (collection_id = nil)
     :enabled?       :remote-sync-transforms}
 
@@ -282,8 +287,9 @@
     :archived-key   nil  ; no archived field
     :tracking       {:select-fields  [:name]
                      :field-mappings {:model_name :name}}
-    :removal        {:statuses   #{"removed" "delete"}  ; no scope-key = global deletion
-                     :conditions {:built_in_type nil}}  ; protect built-in tags from removal
+    :conditions     {:built_in_type nil}  ; exclude built-in tags from sync
+    :removal        {:statuses #{"removed" "delete"}  ; no scope-key = global deletion
+                     :all-on-setting-disable :remote-sync-transforms}
     :export-scope   :all  ; query for all instances
     :enabled?       :remote-sync-transforms}
 
@@ -298,7 +304,8 @@
     :archived-key   nil  ; no archived field
     :tracking       {:select-fields  [:path]
                      :field-mappings {:model_name :path}}
-    :removal        {:statuses #{"removed" "delete"}}  ; no scope-key = global deletion
+    :removal        {:statuses #{"removed" "delete"}  ; no scope-key = global deletion
+                     :all-on-setting-disable :remote-sync-transforms}
     :export-scope   :all  ; query for all instances
     :enabled?       :remote-sync-transforms}})
 
@@ -759,6 +766,30 @@
       ;; Select all columns since different models need different fields for serdes paths
       (t2/select model-key :id [:in removed-ids]))))
 
+(defn- setting-sentinel-delete?
+  "Returns true if the setting's sentinel RSO exists with 'delete' status.
+   Used to detect when a setting (like :remote-sync-transforms) has been disabled
+   and all entities of the controlled types should be removed."
+  [setting-key]
+  (when (= setting-key :remote-sync-transforms)
+    (t2/exists? :model/RemoteSyncObject
+                :model_type "Collection"
+                :model_id rs-settings/transforms-root-id
+                :status "delete")))
+
+(defn- build-bulk-removal-paths
+  "Builds removal paths for ALL entities of a spec's model type.
+   Used when the controlling setting is disabled (sentinel RSO has 'delete' status).
+   Respects :conditions from the spec to exclude ineligible entities."
+  [spec ctx]
+  (let [{:keys [model-type model-key conditions]} spec]
+    (for [entity (if conditions
+                   (apply t2/select model-key (into [] cat conditions))
+                   (t2/select model-key))
+          :let [path (entity->serdes-path model-type entity ctx)]
+          :when path]
+      path)))
+
 (defn build-all-removal-paths
   "Builds full file paths for all entities marked for removal in RemoteSyncObject.
    Uses serdes/storage-path to generate paths that exactly match the file structure.
@@ -768,19 +799,31 @@
    2. Query actual entities by those IDs
    3. Use serdes/storage-path to build the exact file path
 
+   Also handles bulk removal for specs with :all-on-setting-disable when the
+   controlling setting's sentinel RSO has 'delete' status.
+
    Returns paths without file extensions - the git source adds .yaml as needed."
   []
-  (let [ctx (serdes/storage-base-context)]
-    (into []
-          (for [[_model-key spec] (enabled-specs)
-                :when (spec-enabled? spec)
-                :let [{:keys [statuses]} (:removal spec)
-                      model-type (:model-type spec)]
-                :when (seq statuses)
-                entity (query-removed-entities spec)
-                :let [path (entity->serdes-path model-type entity ctx)]
-                :when path]
-            path))))
+  (let [ctx (serdes/storage-base-context)
+        ;; Standard removal paths from enabled specs
+        standard-paths (into []
+                             (for [[_model-key spec] (enabled-specs)
+                                   :when (spec-enabled? spec)
+                                   :let [{:keys [statuses]} (:removal spec)
+                                         model-type (:model-type spec)]
+                                   :when (seq statuses)
+                                   entity (query-removed-entities spec)
+                                   :let [path (entity->serdes-path model-type entity ctx)]
+                                   :when path]
+                               path))
+        ;; Bulk removal paths for specs with :all-on-setting-disable
+        bulk-paths (into []
+                         (for [[_model-key spec] remote-sync-specs
+                               :let [setting-key (get-in spec [:removal :all-on-setting-disable])]
+                               :when (and setting-key (setting-sentinel-delete? setting-key))
+                               path (build-bulk-removal-paths spec ctx)]
+                           path))]
+    (into standard-paths bulk-paths)))
 
 ;;; ----------------------------------------- Sync Object Query Functions --------------------------------------------
 
@@ -958,13 +1001,16 @@
     nil))
 
 (defmethod query-export-roots :setting
-  [{:keys [export-scope model-key model-type] :as spec}]
+  [{:keys [export-scope model-key model-type conditions] :as spec}]
   (when (spec-enabled? spec)
     (case export-scope
       :root-only
-      (t2/select-fn-set (juxt (constantly model-type) :id) model-key :collection_id nil)
+      (apply t2/select-fn-set (juxt (constantly model-type) :id) model-key
+             :collection_id nil
+             (into [] cat conditions))
       :all
-      (t2/select-fn-set (juxt (constantly model-type) :id) model-key)
+      (apply t2/select-fn-set (juxt (constantly model-type) :id) model-key
+             (into [] cat conditions))
       nil)))
 
 (defmethod query-export-roots :published-table [_] nil)

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/ChangesLists/AllChangesView.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/ChangesLists/AllChangesView.tsx
@@ -1,9 +1,7 @@
 import { Fragment, useMemo } from "react";
 import { t } from "ttag";
-import _ from "underscore";
 
 import { useListCollectionsTreeQuery } from "metabase/api";
-import { isLibraryCollection } from "metabase/collections/utils";
 import { useSetting } from "metabase/common/hooks";
 import {
   Box,
@@ -16,31 +14,23 @@ import {
   Title,
 } from "metabase/ui";
 import {
+  type CollectionGroup,
+  TRANSFORMS_ROOT_ID,
+  buildNamespaceCollectionMap,
+  findLibraryCollectionId,
+  getGroupIcon,
+  groupEntitiesByCollection,
+} from "metabase-enterprise/remote_sync/displayGroups";
+import {
   buildCollectionMap,
   getCollectionPathSegments,
   getSyncStatusColor,
   getSyncStatusIcon,
-  isTableChildModel,
 } from "metabase-enterprise/remote_sync/utils";
-import type { Collection, RemoteSyncEntity } from "metabase-types/api";
+import type { RemoteSyncEntity } from "metabase-types/api";
 
 import { CollectionPath } from "./CollectionPath";
 import { EntityLink } from "./EntityLink";
-
-/** A table group with optional entity (when table itself is dirty) and its nested children */
-type TableGroup = {
-  tableId: number;
-  tableName: string;
-  table?: RemoteSyncEntity;
-  children: RemoteSyncEntity[];
-};
-
-const SYNC_STATUS_ORDER: RemoteSyncEntity["sync_status"][] = [
-  "create",
-  "update",
-  "touch",
-  "delete",
-];
 
 interface AllChangesViewProps {
   entities: RemoteSyncEntity[];
@@ -65,45 +55,28 @@ export const AllChangesView = ({ entities, title }: AllChangesViewProps) => {
     namespace: "snippets",
   });
 
-  // Build a set of snippet collection IDs for icon selection
-  // Only include collections with namespace "snippets" to avoid false positives
-  const snippetCollectionIds = useMemo(() => {
-    const ids = new Set<number>();
-    const collectIds = (collections: typeof snippetCollectionTree) => {
-      for (const collection of collections) {
-        if (
-          typeof collection.id === "number" &&
-          collection.namespace === "snippets"
-        ) {
-          ids.add(collection.id);
-        }
-        if (collection.children) {
-          collectIds(collection.children);
-        }
-      }
-    };
-    collectIds(snippetCollectionTree);
-    return ids;
-  }, [snippetCollectionTree]);
+  // Build namespace-to-collection-ids map in a single pass
+  const namespaceCollectionMap = useMemo(
+    () =>
+      buildNamespaceCollectionMap([
+        ...collectionTree,
+        ...snippetCollectionTree,
+      ]),
+    [collectionTree, snippetCollectionTree],
+  );
+
+  // Find the Transforms root entity (id=-1) if it exists
+  const transformsRootEntity = useMemo(() => {
+    return entities.find(
+      (e) => e.model === "collection" && e.id === TRANSFORMS_ROOT_ID,
+    );
+  }, [entities]);
 
   // Find the library collection ID for placing snippets without a collection_id
-  const libraryCollectionId = useMemo(() => {
-    const findLibrary = (collections: Collection[]): number | null => {
-      for (const col of collections) {
-        if (isLibraryCollection(col)) {
-          return typeof col.id === "number" ? col.id : null;
-        }
-        if (col.children?.length) {
-          const found = findLibrary(col.children);
-          if (found !== null) {
-            return found;
-          }
-        }
-      }
-      return null;
-    };
-    return findLibrary(collectionTree);
-  }, [collectionTree]);
+  const libraryCollectionId = useMemo(
+    () => findLibraryCollectionId(collectionTree),
+    [collectionTree],
+  );
 
   const collectionMap = useMemo(() => {
     // Merge regular collections with snippet collections
@@ -118,118 +91,24 @@ export const AllChangesView = ({ entities, title }: AllChangesViewProps) => {
     );
   }, [entities]);
 
-  const groupedData = useMemo(() => {
-    const byCollection = _.groupBy(entities, (e) => {
-      if (e.collection_id != null) {
-        return e.collection_id;
-      }
-      // Snippets without a collection_id should go under the Library collection
-      if (e.model === "nativequerysnippet" && libraryCollectionId != null) {
-        return libraryCollectionId;
-      }
-      // Default to Root for other entities without a collection_id
-      return 0;
-    });
-
-    const sortByStatus = (items: RemoteSyncEntity[]) =>
-      items.sort((a, b) => {
-        const statusOrderA = SYNC_STATUS_ORDER.indexOf(a.sync_status);
-        const statusOrderB = SYNC_STATUS_ORDER.indexOf(b.sync_status);
-        if (statusOrderA !== statusOrderB) {
-          return statusOrderA - statusOrderB;
-        }
-        return a.name.localeCompare(b.name);
-      });
-
-    return Object.entries(byCollection)
-      .map(([collectionId, items]) => {
-        const collectionEntity = items.find(
-          (item) =>
-            item.model === "collection" && item.id === Number(collectionId),
-        );
-
-        // Separate tables, table children, and other items
-        const tables = items.filter((item) => item.model === "table");
-        const tableChildren = items.filter((item) =>
-          isTableChildModel(item.model),
-        );
-        const otherItems = items.filter(
-          (item) =>
-            item.model !== "table" &&
-            !isTableChildModel(item.model) &&
-            !(item.model === "collection" && item.id === Number(collectionId)),
-        );
-
-        // Group table children by their parent table_id
-        const childrenByTableId = _.groupBy(
-          tableChildren,
-          (e) => e.table_id || 0,
-        );
-
-        // Create table groups for dirty tables
-        const tableIds = new Set(tables.map((t) => t.id));
-        const dirtyTableGroups: TableGroup[] = tables.map((table) => ({
-          tableId: table.id,
-          tableName: table.name,
-          table,
-          children: sortByStatus(childrenByTableId[table.id] || []),
-        }));
-
-        // Create table groups for orphan children (children whose parent table is not dirty)
-        const orphanTableGroups: TableGroup[] = Object.entries(
-          childrenByTableId,
-        )
-          .filter(([tableId]) => !tableIds.has(Number(tableId)))
-          .map(([tableId, children]) => ({
-            tableId: Number(tableId),
-            tableName: children[0]?.table_name ?? t`Unknown table`,
-            children: sortByStatus(children),
-          }));
-
-        // Combine and sort all table groups
-        const tableGroups = [...dirtyTableGroups, ...orphanTableGroups].sort(
-          (a, b) => a.tableName.localeCompare(b.tableName),
-        );
-
-        const numericCollectionId = Number(collectionId) || undefined;
-        const isSnippetCollection =
-          numericCollectionId !== undefined &&
-          snippetCollectionIds.has(numericCollectionId);
-
-        // Get base path segments for this collection
-        let pathSegments = getCollectionPathSegments(
-          numericCollectionId,
-          collectionMap,
-        );
-
-        // For snippet collections, prepend the Library collection path
-        // This makes them appear as descendants of the Library collection
-        if (isSnippetCollection && libraryCollectionId != null) {
-          const libraryCollection = collectionMap.get(libraryCollectionId);
-          if (libraryCollection) {
-            pathSegments = [
-              { id: libraryCollection.id, name: libraryCollection.name },
-              ...pathSegments,
-            ];
-          }
-        }
-
-        return {
-          pathSegments,
-          collectionId: numericCollectionId,
-          collectionEntity,
-          tableGroups,
-          items: sortByStatus(otherItems),
-          isSnippetCollection,
-        };
-      })
-      .sort((a, b) =>
-        a.pathSegments
-          .map((s) => s.name)
-          .join(" / ")
-          .localeCompare(b.pathSegments.map((s) => s.name).join(" / ")),
-      );
-  }, [entities, collectionMap, snippetCollectionIds, libraryCollectionId]);
+  const groupedData: CollectionGroup[] = useMemo(
+    () =>
+      groupEntitiesByCollection({
+        entities,
+        transformsRootEntity,
+        namespaceCollectionMap,
+        collectionMap,
+        libraryCollectionId,
+        getCollectionPathSegments,
+      }),
+    [
+      entities,
+      collectionMap,
+      namespaceCollectionMap,
+      libraryCollectionId,
+      transformsRootEntity,
+    ],
+  );
 
   return (
     <Box>
@@ -266,11 +145,7 @@ export const AllChangesView = ({ entities, title }: AllChangesViewProps) => {
                     bdrs="md"
                   >
                     <Icon
-                      name={
-                        group.isSnippetCollection
-                          ? "snippet"
-                          : "synced_collection"
-                      }
+                      name={getGroupIcon(group.spec)}
                       size={16}
                       c="text-secondary"
                     />

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/displayGroups.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/displayGroups.ts
@@ -1,0 +1,501 @@
+import { t } from "ttag";
+import _ from "underscore";
+
+import { isLibraryCollection } from "metabase/collections/utils";
+import type { IconName } from "metabase/ui";
+import type {
+  Collection,
+  CollectionId,
+  RemoteSyncEntity,
+  RemoteSyncEntityModel,
+  RemoteSyncEntityStatus,
+} from "metabase-types/api";
+
+/**
+ * Sentinel value for the virtual Transforms root collection.
+ * Used to represent the entire transforms feature being enabled/disabled.
+ */
+export const TRANSFORMS_ROOT_ID = -1;
+
+/**
+ * Configuration for how entities are grouped and displayed in the changes view.
+ * Similar to the backend remote-sync-specs pattern.
+ */
+export type DisplayGroupSpec = {
+  /** Unique identifier for this group */
+  id: string;
+  /** Collection namespace to match (e.g., "transforms", "snippets") */
+  namespace?: string;
+  /** Model types that belong to this group */
+  models?: Set<RemoteSyncEntityModel>;
+  /** Virtual root ID for groups that have a synthetic root (e.g., -1 for Transforms) */
+  virtualRootId?: number;
+  /** i18n function for virtual root name */
+  virtualRootName?: () => string;
+  /** Icon to display for this group's collections */
+  icon: IconName;
+  /** ID of another group whose path should be prepended */
+  pathPrefixGroupId?: string;
+  /** Priority for matching (higher values checked first) */
+  priority: number;
+};
+
+/**
+ * Display group specifications ordered by priority (highest first).
+ * Each spec defines how a category of entities should be grouped and displayed.
+ */
+const displayGroupSpecs: DisplayGroupSpec[] = [
+  {
+    id: "transforms",
+    namespace: "transforms",
+    models: new Set(["transform", "transformtag", "pythonlibrary"]),
+    virtualRootId: TRANSFORMS_ROOT_ID,
+    virtualRootName: () => t`Transforms`,
+    icon: "transform",
+    priority: 100,
+  },
+  {
+    id: "snippets",
+    namespace: "snippets",
+    models: new Set(["nativequerysnippet"]),
+    icon: "snippet",
+    pathPrefixGroupId: "library",
+    priority: 90,
+  },
+  {
+    id: "tables",
+    models: new Set(["table", "field", "segment", "measure"]),
+    icon: "synced_collection",
+    priority: 50,
+  },
+  {
+    id: "default",
+    icon: "synced_collection",
+    priority: 0,
+  },
+];
+
+/**
+ * Map of namespace string to set of collection IDs in that namespace.
+ */
+export type NamespaceCollectionMap = Map<string, Set<number>>;
+
+/**
+ * Build a map from namespace to collection IDs in a single pass.
+ */
+export const buildNamespaceCollectionMap = (
+  collectionTree: Collection[],
+): NamespaceCollectionMap => {
+  const map = new Map<string, Set<number>>();
+
+  const collectIds = (collections: Collection[]) => {
+    for (const collection of collections) {
+      if (
+        typeof collection.id === "number" &&
+        collection.namespace &&
+        typeof collection.namespace === "string"
+      ) {
+        const existing = map.get(collection.namespace);
+        if (existing) {
+          existing.add(collection.id);
+        } else {
+          map.set(collection.namespace, new Set([collection.id]));
+        }
+      }
+      if (collection.children) {
+        collectIds(collection.children);
+      }
+    }
+  };
+
+  collectIds(collectionTree);
+  return map;
+};
+
+/**
+ * Find the display group spec that matches an entity.
+ * Checks in priority order: model match, then namespace match (for collections).
+ */
+const getSpecForEntity = (
+  entity: RemoteSyncEntity,
+  namespaceCollectionMap: NamespaceCollectionMap,
+): DisplayGroupSpec => {
+  for (const spec of displayGroupSpecs) {
+    if (spec.models?.has(entity.model)) {
+      return spec;
+    }
+    if (entity.model === "collection" && spec.namespace) {
+      const namespaceIds = namespaceCollectionMap.get(spec.namespace);
+      if (namespaceIds?.has(entity.id)) {
+        return spec;
+      }
+    }
+    if (entity.collection_id != null && spec.namespace) {
+      const namespaceIds = namespaceCollectionMap.get(spec.namespace);
+      if (namespaceIds?.has(entity.collection_id)) {
+        return spec;
+      }
+    }
+  }
+  return displayGroupSpecs[displayGroupSpecs.length - 1];
+};
+
+/**
+ * Result of getGroupKeyInfo containing both the group key and the matched spec.
+ */
+type GroupKeyInfo = {
+  groupKey: string | number;
+  spec: DisplayGroupSpec;
+};
+
+/**
+ * Determine the group key for an entity based on its spec.
+ * Returns both the key and the spec for use in rendering.
+ */
+const getGroupKeyInfo = (
+  entity: RemoteSyncEntity,
+  spec: DisplayGroupSpec,
+  libraryCollectionId: number | null,
+  transformsRootExists: boolean,
+): GroupKeyInfo => {
+  if (entity.model === "collection" && entity.id === TRANSFORMS_ROOT_ID) {
+    return { groupKey: "transforms-root", spec };
+  }
+  if (spec.id === "transforms") {
+    if (transformsRootExists || entity.collection_id == null) {
+      return { groupKey: "transforms-root", spec };
+    }
+    return { groupKey: entity.collection_id, spec };
+  }
+  if (entity.collection_id != null) {
+    return { groupKey: entity.collection_id, spec };
+  }
+  if (spec.id === "snippets" && libraryCollectionId != null) {
+    return { groupKey: libraryCollectionId, spec };
+  }
+  return { groupKey: 0, spec };
+};
+
+/**
+ * Get the icon name for a display group.
+ */
+export const getGroupIcon = (spec: DisplayGroupSpec): IconName => {
+  return spec.icon;
+};
+
+/**
+ * Check if a collection is in a specific namespace.
+ */
+const isCollectionInNamespace = (
+  collectionId: number,
+  namespace: string,
+  namespaceCollectionMap: NamespaceCollectionMap,
+): boolean => {
+  const namespaceIds = namespaceCollectionMap.get(namespace);
+  return namespaceIds?.has(collectionId) ?? false;
+};
+
+/**
+ * Find the Library collection in the collection tree.
+ */
+export const findLibraryCollectionId = (
+  collectionTree: Collection[],
+): number | null => {
+  const findLibrary = (collections: Collection[]): number | null => {
+    for (const col of collections) {
+      if (isLibraryCollection(col)) {
+        return typeof col.id === "number" ? col.id : null;
+      }
+      if (col.children?.length) {
+        const found = findLibrary(col.children);
+        if (found !== null) {
+          return found;
+        }
+      }
+    }
+    return null;
+  };
+  return findLibrary(collectionTree);
+};
+
+export type CollectionPathSegment = {
+  id: CollectionId;
+  name: string;
+};
+
+/**
+ * Get path prefix segments for entities that need a virtual parent path.
+ * For example, snippet collections get "Library" prepended, transforms collections get "Transforms" prepended.
+ */
+const getPathPrefixSegments = (
+  spec: DisplayGroupSpec,
+  collectionId: number | undefined,
+  namespaceCollectionMap: NamespaceCollectionMap,
+  collectionMap: Map<number, Collection>,
+  libraryCollectionId: number | null,
+): CollectionPathSegment[] => {
+  if (spec.id === "transforms" && spec.virtualRootId != null) {
+    return [{ id: spec.virtualRootId, name: spec.virtualRootName?.() ?? "" }];
+  }
+  if (
+    spec.pathPrefixGroupId === "library" &&
+    libraryCollectionId != null &&
+    collectionId !== libraryCollectionId &&
+    collectionId != null &&
+    isCollectionInNamespace(collectionId, "snippets", namespaceCollectionMap)
+  ) {
+    const libraryCollection = collectionMap.get(libraryCollectionId);
+    if (libraryCollection) {
+      return [{ id: libraryCollection.id, name: libraryCollection.name }];
+    }
+  }
+  return [];
+};
+
+/**
+ * Get the spec by ID.
+ */
+const getSpecById = (id: string): DisplayGroupSpec | undefined => {
+  return displayGroupSpecs.find((spec) => spec.id === id);
+};
+
+/**
+ * Models that are children of tables (get their collection from a parent table)
+ */
+const TABLE_CHILD_MODELS: Set<RemoteSyncEntityModel> = new Set([
+  "field",
+  "segment",
+  "measure",
+]);
+
+/**
+ * Check if a model type is a child of a table (field, segment, or measure)
+ */
+export const isTableChildModel = (model: RemoteSyncEntityModel): boolean => {
+  return TABLE_CHILD_MODELS.has(model);
+};
+
+/** A table group with optional entity (when table itself is dirty) and its nested children */
+export type TableGroup = {
+  tableId: number;
+  tableName: string;
+  table?: RemoteSyncEntity;
+  children: RemoteSyncEntity[];
+};
+
+/** A collection group with display metadata */
+export type CollectionGroup = {
+  pathSegments: CollectionPathSegment[];
+  collectionId: number | undefined;
+  collectionEntity: RemoteSyncEntity | undefined;
+  tableGroups: TableGroup[];
+  items: RemoteSyncEntity[];
+  spec: DisplayGroupSpec;
+  isTransformsRoot: boolean;
+};
+
+/** Order for sorting entities by sync status */
+const SYNC_STATUS_ORDER: RemoteSyncEntityStatus[] = [
+  "create",
+  "update",
+  "touch",
+  "delete",
+];
+
+/**
+ * Sort entities by sync status (create, update, touch, delete) then by name.
+ * Returns a new sorted array.
+ */
+const sortEntitiesByStatus = (
+  items: RemoteSyncEntity[],
+): RemoteSyncEntity[] => {
+  return [...items].sort((a, b) => {
+    const statusOrderA = SYNC_STATUS_ORDER.indexOf(a.sync_status);
+    const statusOrderB = SYNC_STATUS_ORDER.indexOf(b.sync_status);
+    if (statusOrderA !== statusOrderB) {
+      return statusOrderA - statusOrderB;
+    }
+    return a.name.localeCompare(b.name);
+  });
+};
+
+/**
+ * Build table groups from a list of entities.
+ * Groups table children under their parent tables, creating groups for both
+ * dirty tables and orphan children (children whose parent table is not dirty).
+ */
+const buildTableGroups = (items: RemoteSyncEntity[]): TableGroup[] => {
+  const tables = items.filter((item) => item.model === "table");
+  const tableChildren = items.filter((item) => isTableChildModel(item.model));
+  const childrenByTableId = _.groupBy(tableChildren, (e) => e.table_id || 0);
+  const tableIds = new Set(tables.map((tbl) => tbl.id));
+
+  const dirtyTableGroups: TableGroup[] = tables.map((table) => ({
+    tableId: table.id,
+    tableName: table.name,
+    table,
+    children: sortEntitiesByStatus(childrenByTableId[table.id] || []),
+  }));
+
+  const orphanTableGroups: TableGroup[] = Object.entries(childrenByTableId)
+    .filter(([tableId]) => !tableIds.has(Number(tableId)))
+    .map(([tableId, children]) => ({
+      tableId: Number(tableId),
+      tableName: children[0]?.table_name ?? t`Unknown table`,
+      children: sortEntitiesByStatus(children),
+    }));
+
+  return [...dirtyTableGroups, ...orphanTableGroups].sort((a, b) =>
+    a.tableName.localeCompare(b.tableName),
+  );
+};
+
+/**
+ * Filter items to get non-table, non-table-child entities.
+ * Excludes the collection entity itself and the transforms root if applicable.
+ */
+const filterOtherItems = (
+  items: RemoteSyncEntity[],
+  collectionId: string,
+  isTransformsRoot: boolean,
+): RemoteSyncEntity[] => {
+  return items.filter((item) => {
+    if (
+      isTransformsRoot &&
+      item.model === "collection" &&
+      item.id === TRANSFORMS_ROOT_ID
+    ) {
+      return false;
+    }
+    return (
+      item.model !== "table" &&
+      !isTableChildModel(item.model) &&
+      !(item.model === "collection" && item.id === Number(collectionId))
+    );
+  });
+};
+
+/** Parameters for building a collection group */
+type BuildCollectionGroupParams = {
+  collectionId: string;
+  items: RemoteSyncEntity[];
+  transformsRootEntity: RemoteSyncEntity | undefined;
+  namespaceCollectionMap: NamespaceCollectionMap;
+  collectionMap: Map<number, Collection>;
+  libraryCollectionId: number | null;
+  getCollectionPathSegments: (
+    collectionId: number | undefined,
+    collectionMap: Map<number, Collection>,
+  ) => CollectionPathSegment[];
+};
+
+/**
+ * Build a single collection group from a collection ID and its items.
+ */
+const buildCollectionGroup = ({
+  collectionId,
+  items,
+  transformsRootEntity,
+  namespaceCollectionMap,
+  collectionMap,
+  libraryCollectionId,
+  getCollectionPathSegments,
+}: BuildCollectionGroupParams): CollectionGroup => {
+  const isTransformsRoot = collectionId === "transforms-root";
+  const collectionEntity = isTransformsRoot
+    ? transformsRootEntity
+    : items.find(
+        (item) =>
+          item.model === "collection" && item.id === Number(collectionId),
+      );
+  const firstItem = items[0];
+  const groupSpec = firstItem
+    ? getSpecForEntity(firstItem, namespaceCollectionMap)
+    : getSpecById("default")!;
+  const tableGroups = buildTableGroups(items);
+  const otherItems = filterOtherItems(items, collectionId, isTransformsRoot);
+  const numericCollectionId = isTransformsRoot
+    ? TRANSFORMS_ROOT_ID
+    : Number(collectionId) || undefined;
+
+  let pathSegments = isTransformsRoot
+    ? [{ id: TRANSFORMS_ROOT_ID, name: t`Transforms` }]
+    : getCollectionPathSegments(numericCollectionId, collectionMap);
+  const prefixSegments = getPathPrefixSegments(
+    groupSpec,
+    numericCollectionId,
+    namespaceCollectionMap,
+    collectionMap,
+    libraryCollectionId,
+  );
+  if (prefixSegments.length > 0 && !isTransformsRoot) {
+    pathSegments = [...prefixSegments, ...pathSegments];
+  }
+
+  return {
+    pathSegments,
+    collectionId: numericCollectionId,
+    collectionEntity,
+    tableGroups,
+    items: sortEntitiesByStatus(otherItems),
+    spec: groupSpec,
+    isTransformsRoot,
+  };
+};
+
+/** Parameters for grouping entities into collection groups */
+type GroupEntitiesParams = {
+  entities: RemoteSyncEntity[];
+  transformsRootEntity: RemoteSyncEntity | undefined;
+  namespaceCollectionMap: NamespaceCollectionMap;
+  collectionMap: Map<number, Collection>;
+  libraryCollectionId: number | null;
+  getCollectionPathSegments: (
+    collectionId: number | undefined,
+    collectionMap: Map<number, Collection>,
+  ) => CollectionPathSegment[];
+};
+
+/**
+ * Group entities by collection and build collection groups.
+ * This is the main orchestration function for the changes view grouping logic.
+ */
+export const groupEntitiesByCollection = ({
+  entities,
+  transformsRootEntity,
+  namespaceCollectionMap,
+  collectionMap,
+  libraryCollectionId,
+  getCollectionPathSegments,
+}: GroupEntitiesParams): CollectionGroup[] => {
+  const transformsRootExists = transformsRootEntity != null;
+  const byCollection = _.groupBy(entities, (e) => {
+    const spec = getSpecForEntity(e, namespaceCollectionMap);
+    const { groupKey } = getGroupKeyInfo(
+      e,
+      spec,
+      libraryCollectionId,
+      transformsRootExists,
+    );
+    return groupKey;
+  });
+
+  return Object.entries(byCollection)
+    .map(([collectionId, items]) =>
+      buildCollectionGroup({
+        collectionId,
+        items,
+        transformsRootEntity,
+        namespaceCollectionMap,
+        collectionMap,
+        libraryCollectionId,
+        getCollectionPathSegments,
+      }),
+    )
+    .sort((a, b) =>
+      a.pathSegments
+        .map((s) => s.name)
+        .join(" / ")
+        .localeCompare(b.pathSegments.map((s) => s.name).join(" / ")),
+    );
+};

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/hooks/use-has-transform-dirty-changes.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/hooks/use-has-transform-dirty-changes.unit.spec.ts
@@ -7,6 +7,7 @@ import {
 } from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
 import { renderHookWithProviders, waitFor } from "__support__/ui";
+import { TRANSFORMS_ROOT_ID } from "metabase-enterprise/remote_sync/utils";
 import type { Collection, RemoteSyncEntity } from "metabase-types/api";
 import {
   createMockCollection,
@@ -189,6 +190,58 @@ describe("useHasTransformDirtyChanges", () => {
 
     await waitFor(() => {
       expect(result.current).toBe(false);
+    });
+  });
+
+  it("returns true when Transforms root collection (id=-1) is dirty with create status", async () => {
+    const transformsRootEntity = createMockRemoteSyncEntity({
+      id: TRANSFORMS_ROOT_ID,
+      name: "Transforms",
+      model: "collection",
+      sync_status: "create",
+    });
+    const { result } = setup({
+      collections: [createMockTransformsCollection()],
+      dirty: [transformsRootEntity],
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBe(true);
+    });
+  });
+
+  it("returns true when Transforms root collection (id=-1) is dirty with delete status", async () => {
+    const transformsRootEntity = createMockRemoteSyncEntity({
+      id: TRANSFORMS_ROOT_ID,
+      name: "Transforms",
+      model: "collection",
+      sync_status: "delete",
+    });
+    const { result } = setup({
+      collections: [createMockTransformsCollection()],
+      dirty: [transformsRootEntity],
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBe(true);
+    });
+  });
+
+  it("returns true when Transforms root collection (id=-1) is dirty even when transforms setting is disabled", async () => {
+    const transformsRootEntity = createMockRemoteSyncEntity({
+      id: TRANSFORMS_ROOT_ID,
+      name: "Transforms",
+      model: "collection",
+      sync_status: "delete",
+    });
+    const { result } = setup({
+      isTransformsSyncEnabled: false,
+      collections: [],
+      dirty: [transformsRootEntity],
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBe(true);
     });
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/utils.ts
@@ -2,17 +2,16 @@ import { t } from "ttag";
 
 import type { ColorName } from "metabase/lib/colors/types";
 import type { IconName } from "metabase/ui";
-import type {
-  Collection,
-  CollectionId,
-  RemoteSyncEntityModel,
-  RemoteSyncEntityStatus,
-} from "metabase-types/api";
+import type { Collection, RemoteSyncEntityStatus } from "metabase-types/api";
 
-export type CollectionPathSegment = {
-  id: CollectionId;
-  name: string;
-};
+import type { CollectionPathSegment } from "./displayGroups";
+
+// Re-export from displayGroups for backwards compatibility
+export {
+  TRANSFORMS_ROOT_ID,
+  isTableChildModel,
+  type CollectionPathSegment,
+} from "./displayGroups";
 
 type ErrorData = {
   message?: string;
@@ -176,20 +175,4 @@ export const getCollectionPathSegments = (
 
   segments.push({ id: collection.id, name: collection.name });
   return segments;
-};
-
-/**
- * Models that are children of tables (get their collection from a parent table)
- */
-const TABLE_CHILD_MODELS: Set<RemoteSyncEntityModel> = new Set([
-  "field",
-  "segment",
-  "measure",
-]);
-
-/**
- * Check if a model type is a child of a table (field, segment, or measure)
- */
-export const isTableChildModel = (model: RemoteSyncEntityModel): boolean => {
-  return TABLE_CHILD_MODELS.has(model);
 };


### PR DESCRIPTION
### Description

Better display for transform sync changes where we treat toggling the `remote-sync-transforms` as though we are toggling the `is_remote_synced` setting on Root transforms collection. This then creates a 'collection' typed remote sync object entry for the Root collection and uses that to drive dirty state display (or non-display) on the frontend.

This object also drives how items are deleted from the sync so when this 'collection' is in a deleted state it removes all transforms related content from the sync but preserves it locally.

The code to handle all the pathing logic in AllChangesView was getting hairy, so I turned it into data-driven specs similar to the backend and broke it into smaller functions. 

### Demo

Adding Transforms for the first time:
<img width="571" height="81" alt="Screenshot 2026-01-30 at 2 56 01 PM" src="https://github.com/user-attachments/assets/fcc527c9-1700-4e98-9167-e7d140226c5a" />

Removing all transforms from the sync:
<img width="576" height="136" alt="Screenshot 2026-01-30 at 2 55 40 PM" src="https://github.com/user-attachments/assets/c71cb975-8338-4bcf-89d5-889d999a4644" />

Making changes to synced transforms.
<img width="580" height="223" alt="Screenshot 2026-01-30 at 2 52 29 PM" src="https://github.com/user-attachments/assets/65aa1a24-c91f-4509-aaec-734826e906d4" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
