### PR TITLE
don't render data studio button for non admins or analysts

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data-studio/query-builder/components/DataStudioToolbarButton/DataStudioToolbarButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/query-builder/components/DataStudioToolbarButton/DataStudioToolbarButton.tsx
@@ -2,22 +2,24 @@ import { useCallback } from "react";
 import { t } from "ttag";
 
 import { ToolbarButton } from "metabase/common/components/ToolbarButton";
-import { useDispatch } from "metabase/lib/redux";
+import { useDispatch, useSelector } from "metabase/lib/redux";
 import type { DataStudioToolbarButtonProps } from "metabase/plugins";
 import { openUrl } from "metabase/redux/app";
+import { canAccessDataStudio } from "metabase-enterprise/data-studio/selectors";
 import { Urls } from "metabase-enterprise/urls";
 
 export const DataStudioToolbarButton = ({
   question,
 }: DataStudioToolbarButtonProps) => {
   const dispatch = useDispatch();
+  const hasDataStuioAccess = useSelector(canAccessDataStudio);
   const isMetric = question.type() === "metric";
 
   const handleClick = useCallback(() => {
     dispatch(openUrl(Urls.dataStudioMetric(question.id())));
   }, [question, dispatch]);
 
-  if (!isMetric) {
+  if (!isMetric || !hasDataStuioAccess) {
     return null;
   }
 

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/query-builder/components/DataStudioToolbarButton/DataStudioToolbarButton.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/query-builder/components/DataStudioToolbarButton/DataStudioToolbarButton.unit.spec.tsx
@@ -1,0 +1,71 @@
+import { renderWithProviders, screen } from "__support__/ui";
+import Question from "metabase-lib/v1/Question";
+import type { CardType } from "metabase-types/api";
+import { createMockCard, createMockUser } from "metabase-types/api/mocks";
+
+import { DataStudioToolbarButton } from "./DataStudioToolbarButton";
+
+const setup = ({
+  type = "metric",
+  is_superuser = false,
+  is_data_analyst = true,
+}: {
+  type?: CardType;
+  is_data_analyst?: boolean;
+  is_superuser?: boolean;
+} = {}) => {
+  const question = new Question(
+    createMockCard({
+      type,
+    }),
+  );
+
+  renderWithProviders(<DataStudioToolbarButton question={question} />, {
+    storeInitialState: {
+      currentUser: createMockUser({
+        is_data_analyst,
+        is_superuser,
+      }),
+    },
+  });
+};
+
+it("should render a button if the card is a metric and the user has data studio access", async () => {
+  setup();
+
+  expect(
+    await screen.findByRole("button", { name: "Open in Data Studio" }),
+  ).toBeInTheDocument();
+});
+
+it("should render a button if the card is a metric and the user is an admin", async () => {
+  setup({ is_superuser: true, is_data_analyst: false });
+
+  expect(
+    await screen.findByRole("button", { name: "Open in Data Studio" }),
+  ).toBeInTheDocument();
+});
+
+it("should not render a button if the card is a metric and the user is not a data analyst", async () => {
+  setup({ is_data_analyst: false });
+
+  expect(
+    screen.queryByRole("button", { name: "Open in Data Studio" }),
+  ).not.toBeInTheDocument();
+});
+
+it("should not render a button if the card is a model", async () => {
+  setup({ type: "model" });
+
+  expect(
+    screen.queryByRole("button", { name: "Open in Data Studio" }),
+  ).not.toBeInTheDocument();
+});
+
+it("should not render a button if the card is a question", async () => {
+  setup({ type: "question" });
+
+  expect(
+    screen.queryByRole("button", { name: "Open in Data Studio" }),
+  ).not.toBeInTheDocument();
+});


### PR DESCRIPTION
### Description
Adds a check to the <DataStudioTolbarButton /> component to ensure that the user has access to the data studio before rendering the button, along with unit tests

### How to verify
1. Set up a user that has access to the library (through the main app), but not the data studio (not an admin or part of the data analyst group)
2. Go to the a metric in the library
3. There should no longer be a data studio button shown next to the info button in the query builder header

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] ~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~
