### PR TITLE
Fix empty tooltips

### DIFF
--- a/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.jsx
@@ -107,7 +107,7 @@ export function PermissionsTable({
               <span className={cx(CS.flex, CS.alignCenter)}>
                 <Ellipsified>{entity.name}</Ellipsified>
                 {typeof entity.hint === "string" && (
-                  <Tooltip tooltip={entity.hint}>
+                  <Tooltip label={entity.hint}>
                     <HintIcon />
                   </Tooltip>
                 )}

--- a/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp/SuggestionsSidebar.tsx
+++ b/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp/SuggestionsSidebar.tsx
@@ -75,14 +75,16 @@ const SuggestionsList = ({
                       className={CS.mr1}
                     />
                     <h4 className={CS.textWrap}>{item.title}</h4>
-                    <Box ml="auto" className={CS.hoverChild}>
-                      <Tooltip label={item.description}>
-                        <Icon
-                          name="info_outline"
-                          c="background-tertiary-inverse"
-                        />
-                      </Tooltip>
-                    </Box>
+                    {!!item.description && (
+                      <Box ml="auto" className={CS.hoverChild}>
+                        <Tooltip label={item.description}>
+                          <Icon
+                            name="info_outline"
+                            c="background-tertiary-inverse"
+                          />
+                        </Tooltip>
+                      </Box>
+                    )}
                   </Flex>
                 </Card>
               </Link>

--- a/frontend/src/metabase/visualizations/components/LegendItem.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendItem.jsx
@@ -120,7 +120,7 @@ export class LegendItem extends Component {
                   CS.textMedium,
                 )}
               >
-                <Tooltip tooltip={description} maxWidth="22em">
+                <Tooltip label={description} maxWidth="22em">
                   <Icon className={infoClassName} name="info" />
                 </Tooltip>
               </div>


### PR DESCRIPTION
Closes [UXW-2850](https://linear.app/metabase/issue/UXW-2850/permission-group-tooltips-show-block-character-instead-of-text)

### Description

Fixes a few different tooltip issues:

- Empty tooltip in the permissions table due to passing `tooltip` rather than `label`
- Empty tooltip in the "More X-rays" view due to empty tooltip text
- I wrote a regex to search for any other cases where we were passing `tooltip` instead of `label` to `Tooltip`. I found only one instance in `LegendItem`, which is only used in static-viz so there was no impact, but I updated it anyway.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Admin -> Permissions -> Databases -> Sample Database. Verify the tooltip over Administrators is working as expected
2. Databases -> Sample Database -> Orders -> X-Ray. The suggested X-rays in the "More X-rays" section under "Compare" should not have tooltips, since we shouldn't show a tooltip when its text would be empty.

### Demo

Before - permissions table:
<img width="170" height="77" alt="image" src="https://github.com/user-attachments/assets/1e2fc26c-be7e-4444-aa0c-819bead50d12" />

After - permissions table:
<img width="375" height="116" alt="image" src="https://github.com/user-attachments/assets/7d9fa89c-f72a-494d-a82b-a0f29bbe8c1c" />

Before - more x-rays view:
<img width="320" height="133" alt="image" src="https://github.com/user-attachments/assets/3b080f9d-9147-41d4-b1cd-f02e975d24b1" />

After - more x-rays view:
<img width="327" height="143" alt="image" src="https://github.com/user-attachments/assets/d90d158a-c5df-4644-94a2-c826ae548905" />
