### PR TITLE
Hardening around transform.target-db-id

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/transforms/models/transform.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/models/transform.clj
@@ -81,7 +81,11 @@
   (when collection_id
     (collection/check-allowed-content :model/Transform collection_id))
   ;; Populate computed fields
-  (let [target-db-id (transforms.i/target-db-id transform)]
+  (let [target-db-id (transforms.i/target-db-id transform)
+        ;; This is a work-around for remote-sync tests we have which contain invalid database references.
+        ;; TODO (Chris 2026-02-02 Fix tests. Perhaps throw an error here, or at least log a warning.
+        target-db-id (when (and target-db-id (t2/exists? :model/Database :id target-db-id))
+                       target-db-id)]
     (-> transform
         (assoc-in [:target :database] target-db-id)
         (assoc

--- a/enterprise/backend/src/metabase_enterprise/transforms/models/transform.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/models/transform.clj
@@ -93,9 +93,12 @@
   (when-let [new-collection (:collection_id (t2/changes transform))]
     (collection/check-collection-namespace :model/Transform new-collection)
     (collection/check-allowed-content :model/Transform new-collection))
-  (if source
-    (assoc transform :source_type (transforms.util/transform-source-type source))
-    transform))
+  (cond-> transform
+    source
+    (assoc :source_type (transforms.util/transform-source-type source))
+
+    (or (:source (t2/changes transform)) (:target (t2/changes transform)))
+    (assoc :target_db_id (transforms.i/target-db-id transform))))
 
 (t2/define-after-select :model/Transform
   [{:keys [source] :as transform}]

--- a/enterprise/backend/src/metabase_enterprise/transforms/models/transform.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/models/transform.clj
@@ -83,7 +83,7 @@
   ;; Populate computed fields
   (let [target-db-id (transforms.i/target-db-id transform)
         ;; This is a work-around for remote-sync tests we have which contain invalid database references.
-        ;; TODO (Chris 2026-02-02 Fix tests. Perhaps throw an error here, or at least log a warning.
+        ;; TODO (Chris 2026-02-02) Fix tests. Perhaps throw an error here, or at least log a warning.
         target-db-id (when (and target-db-id (t2/exists? :model/Database :id target-db-id))
                        target-db-id)]
     (-> transform

--- a/enterprise/backend/src/metabase_enterprise/transforms/models/transform.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/models/transform.clj
@@ -83,7 +83,7 @@
   ;; Populate computed fields
   (let [target-db-id (transforms.i/target-db-id transform)
         ;; This is a work-around for remote-sync tests we have which contain invalid database references.
-        ;; TODO (Chris 2026-02-02) Fix tests. Perhaps throw an error here, or at least log a warning.
+        ;; TODO (Chris 2026-02-02) -- Fix tests. Perhaps throw an error here, or at least log a warning.
         target-db-id (when (and target-db-id (t2/exists? :model/Database :id target-db-id))
                        target-db-id)]
     (-> transform

--- a/enterprise/backend/src/metabase_enterprise/transforms/models/transform.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/models/transform.clj
@@ -89,7 +89,7 @@
         ;; TODO (Chris 2026-02-02) -- Update tests so this workaround is unnecessary.
         valid-db-id? (and target-db-id (t2/exists? :model/Database :id target-db-id))]
     (when-not valid-db-id?
-      (log/warnf "Invalid target database id (%d) ignored for new transform (%s)" target-db-id (:name transform)))
+      (log/warnf "Invalid target database id (%s) ignored for new transform (%s)" target-db-id (:name transform)))
     (-> transform
         (assoc-in [:target :database] target-db-id)
         (assoc

--- a/enterprise/backend/src/metabase_enterprise/transforms/models/transform.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/models/transform.clj
@@ -87,14 +87,14 @@
         ;; In practice, our serialized representation should not contain any database ids, and this should
         ;; not be required.
         ;; TODO (Chris 2026-02-02) -- Update tests so this workaround is unnecessary.
-        valid-db-id? (when target-db-id (t2/exists? :model/Database :id target-db-id))]
+        valid-db-id? (and target-db-id (t2/exists? :model/Database :id target-db-id))]
     (when-not valid-db-id?
       (log/warnf "Invalid target database id (%d) ignored for new transform (%s)" target-db-id (:name transform)))
     (-> transform
-        (assoc-in [:target :database] (when valid-db-id? target-db-id))
+        (assoc-in [:target :database] target-db-id)
         (assoc
          :source_type (transforms.util/transform-source-type source)
-         :target_db_id target-db-id))))
+         :target_db_id (when valid-db-id? target-db-id)))))
 
 (t2/define-before-update :model/Transform
   [{:keys [source] :as transform}]

--- a/enterprise/backend/src/metabase_enterprise/transforms/ordering.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/ordering.clj
@@ -75,11 +75,11 @@
   the transforms in the original list -- if a transform depends on some transform not in the list, the 'extra'
   dependency is ignored. Both query and Python transforms can have dependencies on tables produced by other transforms."
   [transforms]
-  (let [;; Group all transforms by their database
+  (let [;; Group all transforms by their database, skipping transforms with no target db
         transforms-by-db (->> transforms
-                              (map (fn [transform]
-                                     (let [db-id (transforms.i/target-db-id transform)]
-                                       {db-id [transform]})))
+                              (keep (fn [transform]
+                                      (when-let [db-id (transforms.i/target-db-id transform)]
+                                        {db-id [transform]})))
                               (apply merge-with into))
         transform-ids    (into #{} (map :id) transforms)
         target-refs      (target-ref-map transforms)
@@ -92,9 +92,11 @@
                                              {:output-tables (output-table-map mp db-transforms)
                                               :dependencies  (dependency-map db-transforms)})))
                                     (apply merge-with merge))]
-    (update-vals dependencies #(into #{}
-                                     (keep (fn [dep] (resolve-dependency dep output-tables transform-ids target-refs)))
-                                     %))))
+    ;; Transforms with nil target_db_id get empty dependency sets
+    (into (zipmap (map :id transforms) (repeat #{}))
+          (update-vals dependencies #(into #{}
+                                           (keep (fn [dep] (resolve-dependency dep output-tables transform-ids target-refs)))
+                                           %)))))
 
 (defn find-cycle
   "Finds a path containing a cycle in the directed graph `node->children`.

--- a/enterprise/backend/src/metabase_enterprise/transforms/ordering.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/ordering.clj
@@ -92,7 +92,8 @@
                                              {:output-tables (output-table-map mp db-transforms)
                                               :dependencies  (dependency-map db-transforms)})))
                                     (apply merge-with merge))]
-    ;; Transforms with nil target_db_id get empty dependency sets
+    ;; Transforms without a target database are invalid and shouldn't form part of the dependency graph.
+    ;; Give them empty dependency sets so they don't interfere with ordering.
     (into (zipmap (map :id transforms) (repeat #{}))
           (update-vals dependencies #(into #{}
                                            (keep (fn [dep] (resolve-dependency dep output-tables transform-ids target-refs)))

--- a/enterprise/backend/src/metabase_enterprise/transforms/ordering.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/ordering.clj
@@ -96,10 +96,11 @@
     ;; Give them empty dependency sets so they don't interfere with ordering.
     (into (zipmap (map :id transforms) (repeat #{}))
           (update-vals dependencies
-                       #(into #{}
-                              (keep (fn [dep]
-                                      (resolve-dependency dep output-tables transform-ids target-refs)))
-                              %)))))
+                       (fn [deps]
+                         (into #{}
+                               (keep (fn [dep]
+                                       (resolve-dependency dep output-tables transform-ids target-refs)))
+                               deps))))))
 
 (defn find-cycle
   "Finds a path containing a cycle in the directed graph `node->children`.

--- a/enterprise/backend/src/metabase_enterprise/transforms/ordering.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/ordering.clj
@@ -95,9 +95,11 @@
     ;; Transforms without a target database are invalid and shouldn't form part of the dependency graph.
     ;; Give them empty dependency sets so they don't interfere with ordering.
     (into (zipmap (map :id transforms) (repeat #{}))
-          (update-vals dependencies #(into #{}
-                                           (keep (fn [dep] (resolve-dependency dep output-tables transform-ids target-refs)))
-                                           %)))))
+          (update-vals dependencies
+                       #(into #{}
+                              (keep (fn [dep]
+                                      (resolve-dependency dep output-tables transform-ids target-refs)))
+                              %)))))
 
 (defn find-cycle
   "Finds a path containing a cycle in the directed graph `node->children`.

--- a/enterprise/backend/src/metabase_enterprise/transforms/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/util.clj
@@ -209,10 +209,13 @@
     (let [target (update target :type keyword)
           database-id (transforms.i/target-db-id transform)]
       (when database-id
-        (let [{driver :engine :as database} (t2/select-one :model/Database database-id)]
-          (driver/drop-transform-target! driver database target)
-          (log/info "Deactivating  target " (pr-str target) "for transform" id)
-          (deactivate-table! database target))))))
+        (if-let [{driver :engine :as database} (t2/select-one :model/Database database-id)]
+          (do
+            (driver/drop-transform-target! driver database target)
+            (log/info "Deactivating  target " (pr-str target) "for transform" id)
+            (deactivate-table! database target))
+          (log/warnf "Skipping drop of transform target %s for transform %d: database %d not found"
+                     (pr-str target) id database-id))))))
 
 (defn delete-target-table-by-id!
   "Delete the target table of the transform specified by `transform-id`."

--- a/enterprise/backend/src/metabase_enterprise/transforms/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/util.clj
@@ -207,11 +207,12 @@
   [{:keys [id target], :as transform}]
   (when target
     (let [target (update target :type keyword)
-          database-id (transforms.i/target-db-id transform)
-          {driver :engine :as database} (t2/select-one :model/Database database-id)]
-      (driver/drop-transform-target! driver database target)
-      (log/info "Deactivating  target " (pr-str target) "for transform" id)
-      (deactivate-table! database target))))
+          database-id (transforms.i/target-db-id transform)]
+      (when database-id
+        (let [{driver :engine :as database} (t2/select-one :model/Database database-id)]
+          (driver/drop-transform-target! driver database target)
+          (log/info "Deactivating  target " (pr-str target) "for transform" id)
+          (deactivate-table! database target))))))
 
 (defn delete-target-table-by-id!
   "Delete the target table of the transform specified by `transform-id`."

--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -5205,6 +5205,58 @@ databaseChangeLog:
             tableName: workspace_transform
             columnName: input_data_changed
 
+  - changeSet:
+      id: v58.2026-01-31T10:00:00
+      author: christruter
+      comment: Backfill target_db_id for existing transforms
+      changes:
+        - customChange:
+            class: "metabase.app_db.custom_migrations.BackfillTransformTargetDbId"
+
+  - changeSet:
+      id: v58.2026-01-31T10:00:01
+      author: christruter
+      comment: Add index on transform.target_db_id
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - indexExists:
+                tableName: transform
+                indexName: idx_transform_target_db_id
+      changes:
+        - createIndex:
+            tableName: transform
+            indexName: idx_transform_target_db_id
+            columns:
+              - column:
+                  name: target_db_id
+      rollback:
+        - dropIndex:
+            tableName: transform
+            indexName: idx_transform_target_db_id
+
+  - changeSet:
+      id: v58.2026-01-31T10:00:02
+      author: christruter
+      comment: Add foreign key constraint from transform.target_db_id to metabase_database
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - foreignKeyConstraintExists:
+                foreignKeyTableName: transform
+                foreignKeyName: fk_transform_target_db_id
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: transform
+            baseColumnNames: target_db_id
+            referencedTableName: metabase_database
+            referencedColumnNames: id
+            constraintName: fk_transform_target_db_id
+      rollback:
+        - dropForeignKeyConstraint:
+            baseTableName: transform
+            constraintName: fk_transform_target_db_id
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -5239,6 +5239,7 @@ databaseChangeLog:
       id: v58.2026-01-31T10:00:02
       author: christruter
       comment: Add foreign key constraint from transform.target_db_id to metabase_database
+      validCheckSum: ANY
       preConditions:
         - onFail: MARK_RAN
         - not:
@@ -5252,6 +5253,7 @@ databaseChangeLog:
             referencedTableName: metabase_database
             referencedColumnNames: id
             constraintName: fk_transform_target_db_id
+            onDelete: SET NULL
       rollback:
         - dropForeignKeyConstraint:
             baseTableName: transform

--- a/src/metabase/app_db/custom_migrations.clj
+++ b/src/metabase/app_db/custom_migrations.clj
@@ -1822,17 +1822,26 @@
           (t2/update! :transform id {:source_type transform-type})))))
 
 (define-migration BackfillTransformTargetDbId
-  (doseq [{:keys [id source target]} (t2/query {:select [:id :source :target]
-                                                :from   [:transform]
-                                                :where  [:= :target_db_id nil]})]
-    (let [source-map (json/decode source)
-          target-map (json/decode target)
-          ;; Mirror the app-code logic: for query transforms, source.query.database is the source of truth;
-          ;; for python transforms, target.database is the only option.
-          db-id      (or (get-in source-map ["query" "database"])
-                         (get target-map "database"))]
-      (when db-id
-        (t2/update! :transform id {:target_db_id db-id})))))
+  ;; Backfills the target_db_id column for existing transform records.
+  ;;
+  ;; For query transforms, uses source.query.database as the source of truth.
+  ;; For python transforms, uses target.database. Records with no database
+  ;; information are left with nil target_db_id.
+  ;;
+  ;; Skips transforms whose referenced database no longer exists (leaves target_db_id NULL),
+  ;; since the subsequent FK constraint migration would fail if stale DB references were set.
+  (let [existing-db-ids (into #{} (map :id) (t2/query {:select [:id] :from [:metabase_database]}))]
+    (doseq [{:keys [id source target]} (t2/query {:select [:id :source :target]
+                                                  :from   [:transform]
+                                                  :where  [:= :target_db_id nil]})]
+      (let [source-map (json/decode source)
+            target-map (json/decode target)
+            ;; Mirror the app-code logic: for query transforms, source.query.database is the source of truth;
+            ;; for python transforms, target.database is the only option.
+            db-id      (or (get-in source-map ["query" "database"])
+                           (get target-map "database"))]
+        (when (and db-id (existing-db-ids db-id))
+          (t2/update! :transform id {:target_db_id db-id}))))))
 
 (define-migration MoveExistingAtSymbolUserAttributes
   (reserve-at-symbol-user-attributes/migrate!))

--- a/src/metabase/app_db/custom_migrations.clj
+++ b/src/metabase/app_db/custom_migrations.clj
@@ -1834,8 +1834,8 @@
     (doseq [{:keys [id source target]} (t2/query {:select [:id :source :target]
                                                   :from   [:transform]
                                                   :where  [:= :target_db_id nil]})]
-      (let [source-map (json-out source)
-            target-map (json-out target)
+      (let [source-map (json-out source false)
+            target-map (json-out target false)
             ;; Mirror the app-code logic: for query transforms, source.query.database is the source of truth;
             ;; for python transforms, target.database is the only option.
             db-id      (or (get-in source-map ["query" "database"])

--- a/src/metabase/app_db/custom_migrations.clj
+++ b/src/metabase/app_db/custom_migrations.clj
@@ -1834,8 +1834,8 @@
     (doseq [{:keys [id source target]} (t2/query {:select [:id :source :target]
                                                   :from   [:transform]
                                                   :where  [:= :target_db_id nil]})]
-      (let [source-map (json/decode source)
-            target-map (json/decode target)
+      (let [source-map (json-out source)
+            target-map (json-out target)
             ;; Mirror the app-code logic: for query transforms, source.query.database is the source of truth;
             ;; for python transforms, target.database is the only option.
             db-id      (or (get-in source-map ["query" "database"])

--- a/test/metabase/app_db/custom_migrations_test.clj
+++ b/test/metabase/app_db/custom_migrations_test.clj
@@ -2731,7 +2731,7 @@
   (testing "v58.2026-01-31T10:00:00 : backfill target_db_id from target and source JSON"
     (impl/test-migrations ["v58.2026-01-31T10:00:00"] [migrate!]
       (let [db-id       (:id (new-instance-with-default :metabase_database))
-            ;; Transform with database in source.query and target JSON — backfilled from source.query.database
+            ;; Transform with database in both source.query and target JSON — source.query.database takes precedence
             with-target-db (t2/insert-returning-instance!
                             :transform
                             {:name        "target-db"
@@ -2749,6 +2749,15 @@
                              :source_type "mbql"
                              :created_at  :%now
                              :updated_at  :%now})
+            ;; Python transform with database only in target — should be backfilled from target.database
+            with-target-only (t2/insert-returning-instance!
+                              :transform
+                              {:name        "target-only-db"
+                               :source      (json/encode {:type "python" :script "x = 1"})
+                               :target      (json/encode {:database db-id :schema "public" :table "out_target" :type "append"})
+                               :source_type "python"
+                               :created_at  :%now
+                               :updated_at  :%now})
             ;; Transform with no database anywhere — should stay NULL
             without-db (t2/insert-returning-instance!
                         :transform
@@ -2771,6 +2780,7 @@
         (testing "before migration, target_db_id is nil for all"
           (is (nil? (:target_db_id with-target-db)))
           (is (nil? (:target_db_id with-source-db)))
+          (is (nil? (:target_db_id with-target-only)))
           (is (nil? (:target_db_id without-db)))
           (is (nil? (:target_db_id with-deleted-db))))
         (migrate!)
@@ -2778,6 +2788,8 @@
           (is (= db-id (:target_db_id (t2/select-one :transform :id (:id with-target-db))))))
         (testing "after migration, target_db_id is backfilled from source.query.database as fallback"
           (is (= db-id (:target_db_id (t2/select-one :transform :id (:id with-source-db))))))
+        (testing "after migration, target_db_id is backfilled from target.database for python transforms"
+          (is (= db-id (:target_db_id (t2/select-one :transform :id (:id with-target-only))))))
         (testing "after migration, target_db_id stays nil when no database anywhere"
           (is (nil? (:target_db_id (t2/select-one :transform :id (:id without-db))))))
         (testing "after migration, target_db_id stays nil when referenced database no longer exists"

--- a/test/metabase/app_db/custom_migrations_test.clj
+++ b/test/metabase/app_db/custom_migrations_test.clj
@@ -2756,19 +2756,19 @@
             none-id       (insert! "python" python-source (target))
             ;; deleted database reference — stays nil
             deleted-id    (insert! "mbql" (query-source deleted-db-id) (target :database deleted-db-id))
-            target->id    #(t2/select-one-fn :target_db_id :transform :id %)]
+            id->target    #(t2/select-one-fn :target_db_id :transform :id %)]
         (testing "Before backfill, the field is uniformly empty"
           ;; Haven't turned this into a loop, as it would obscure which case failed.
-          (is (nil? (target->id both-id)))
-          (is (nil? (target->id source-id)))
-          (is (nil? (target->id target->id)))
-          (is (nil? (target->id none-id)))
-          (is (nil? (target->id deleted-id))))
+          (is (nil? (id->target both-id)))
+          (is (nil? (id->target source-id)))
+          (is (nil? (id->target target-id)))
+          (is (nil? (id->target none-id)))
+          (is (nil? (id->target deleted-id))))
         (migrate!)
         (testing "Valid database ids are backfilled"
           ;; Ditto, since the IDs are opaque in CI, give each case its own line for transparent failures.
-          (is (= db-id (target->id both-id)))
-          (is (= db-id (target->id source-id)))
-          (is (= db-id (target->id target->id)))
-          (is (nil? (target->id none-id)))
-          (is (nil? (target->id deleted-id))))))))
+          (is (= db-id (id->target both-id)))
+          (is (= db-id (id->target source-id)))
+          (is (= db-id (id->target target-id)))
+          (is (nil? (id->target none-id)))
+          (is (nil? (id->target deleted-id))))))))


### PR DESCRIPTION
Handle missing, invalid, and changing target databases.