### PR TITLE
feat(viz): allow displaying additional column values on chart labels #68767

### DIFF
--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -318,6 +318,9 @@ export type VisualizationSettings = {
   "scalar.compact_primary_number"?: boolean;
   "scalar.segments"?: ScalarSegment[];
 
+  // Data labels
+  "graph.display_columns"?: string[];
+
   // Pie Settings
   "pie.dimension"?: string | string[];
   "pie.middle_dimension"?: string;
@@ -328,6 +331,7 @@ export type VisualizationSettings = {
   "pie.show_legend"?: boolean;
   "pie.show_total"?: boolean;
   "pie.show_labels"?: boolean;
+  "pie.show_data_values"?: boolean;
   "pie.percent_visibility"?: "off" | "legend" | "inside" | "both";
   "pie.decimal_places"?: number;
   "pie.slice_threshold"?: number;

--- a/frontend/src/metabase/visualizations/echarts/cartesian/chart-measurements/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/chart-measurements/index.ts
@@ -497,12 +497,16 @@ export const getChartPadding = (
 
   // 1. Top Padding
 
-  // Prevent data labels from being rendered outside the chart
   if (
     settings["graph.show_values"] ||
     (settings["graph.show_goal"] && settings["graph.goal_label"])
   ) {
     padding.top += seriesLabelFontSize + CHART_STYLE.seriesLabels.offset;
+
+    const displayColumns = settings["graph.display_columns"] ?? [];
+    if (displayColumns.length > 0) {
+      padding.top += seriesLabelFontSize * displayColumns.length * 1.2;
+    }
   }
 
   // 2. Bottom Padding

--- a/frontend/src/metabase/visualizations/echarts/pie/option.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/option.ts
@@ -165,23 +165,42 @@ function getSliceLabel(
   settings: ComputedVisualizationSettings,
   formatters: PieChartFormatters,
 ) {
-  const name = settings["pie.show_labels"] ? slice.name : undefined;
-  const percent =
-    settings["pie.percent_visibility"] === "inside" ||
-    settings["pie.percent_visibility"] === "both"
-      ? formatters.formatPercent(slice.normalizedPercentage, "chart")
-      : undefined;
+  const parts: string[] = [];
 
-  if (name != null && percent != null) {
-    return `${name}: ${percent}`;
+  // Add slice name if enabled
+  if (settings["pie.show_labels"]) {
+    parts.push(slice.name);
   }
-  if (name != null) {
-    return name;
+
+  // Add metric value if enabled
+  if (settings["pie.show_data_values"]) {
+    parts.push(formatters.formatMetric(slice.rawValue));
   }
-  if (percent != null) {
-    return percent;
+
+  // Add percentage if enabled
+  const showPercent =
+    settings["pie.percent_visibility"] === "inside" ||
+    settings["pie.percent_visibility"] === "both";
+  if (showPercent) {
+    parts.push(formatters.formatPercent(slice.normalizedPercentage, "chart"));
   }
-  return " ";
+
+  if (parts.length === 0) {
+    return " ";
+  }
+
+  // Join parts with appropriate separators
+  if (parts.length === 1) {
+    return parts[0];
+  }
+
+  // If we have name and other values, use colon separator
+  if (settings["pie.show_labels"] && parts.length > 1) {
+    const [name, ...rest] = parts;
+    return `${name}: ${rest.join(" ")}`;
+  }
+
+  return parts.join(" ");
 }
 
 function getSeriesDataFromSlices(

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -21,6 +21,7 @@ import {
   getAvailableAdditionalColumns,
   getAvailableXAxisScales,
   getComputedAdditionalColumnsValue,
+  getComputedDisplayColumnsValue,
   getDefaultColumns,
   getDefaultDataLabelsFrequency,
   getDefaultDimensionFilter,
@@ -382,6 +383,46 @@ export const TOOLTIP_SETTINGS = {
       };
     },
     readDependencies: ["graph.metrics", "graph.dimensions"],
+  },
+  "graph.display_columns": {
+    get section() {
+      return t`Display`;
+    },
+    get title() {
+      return t`Additional data label columns`;
+    },
+    get placeholder() {
+      return t`Select columns to display on chart`;
+    },
+    widget: "multiselect",
+    useRawSeries: true,
+    getValue: getComputedDisplayColumnsValue,
+    getHidden: (rawSeries, vizSettings) => {
+      if (!vizSettings["graph.show_values"]) {
+        return true;
+      }
+      return getAvailableAdditionalColumns(rawSeries, vizSettings).length === 0;
+    },
+    getProps: (rawSeries, vizSettings) => {
+      const isAggregatedChart = rawSeries[0].card.display !== "scatter";
+      const options = getAvailableAdditionalColumns(
+        rawSeries,
+        vizSettings,
+        isAggregatedChart,
+      ).map((col) => ({
+        label: col.display_name,
+        value: getColumnKey(col),
+      }));
+
+      return {
+        options,
+      };
+    },
+    readDependencies: [
+      "graph.metrics",
+      "graph.dimensions",
+      "graph.show_values",
+    ],
   },
 };
 

--- a/frontend/src/metabase/visualizations/lib/settings/graph.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.unit.spec.js
@@ -648,3 +648,173 @@ describe("graph.tooltip_columns", () => {
     });
   });
 });
+
+describe("graph.display_columns", () => {
+  const displayColumnsSetting = TOOLTIP_SETTINGS["graph.display_columns"];
+
+  describe("getHidden", () => {
+    it("should be hidden when graph.show_values is false", () => {
+      const mockSeries = [
+        createMockSingleSeries(
+          createMockCard(),
+          createMockDataset({
+            data: createMockDatasetData({
+              cols: [
+                createMockColumn({ name: "dim", base_type: "type/Text" }),
+                createMockColumn({ name: "metric1", base_type: "type/Number" }),
+                createMockColumn({ name: "metric2", base_type: "type/Number" }),
+              ],
+            }),
+          }),
+        ),
+      ];
+
+      const isHidden = displayColumnsSetting.getHidden(mockSeries, {
+        "graph.show_values": false,
+        "graph.dimensions": ["dim"],
+        "graph.metrics": ["metric1"],
+      });
+
+      expect(isHidden).toBe(true);
+    });
+
+    it("should be hidden when there are no available additional columns", () => {
+      const mockSeries = [
+        createMockSingleSeries(
+          createMockCard(),
+          createMockDataset({
+            data: createMockDatasetData({
+              cols: [
+                createMockColumn({ name: "dim", base_type: "type/Text" }),
+                createMockColumn({ name: "metric", base_type: "type/Number" }),
+              ],
+            }),
+          }),
+        ),
+      ];
+
+      const isHidden = displayColumnsSetting.getHidden(mockSeries, {
+        "graph.show_values": true,
+        "graph.dimensions": ["dim"],
+        "graph.metrics": ["metric"],
+      });
+
+      expect(isHidden).toBe(true);
+    });
+
+    it("should not be hidden when graph.show_values is true and there are available columns", () => {
+      const mockSeries = [
+        createMockSingleSeries(
+          createMockCard(),
+          createMockDataset({
+            data: createMockDatasetData({
+              cols: [
+                createMockColumn({ name: "dim", base_type: "type/Text" }),
+                createMockColumn({ name: "metric1", base_type: "type/Number" }),
+                createMockColumn({ name: "metric2", base_type: "type/Number" }),
+              ],
+            }),
+          }),
+        ),
+      ];
+
+      const isHidden = displayColumnsSetting.getHidden(mockSeries, {
+        "graph.show_values": true,
+        "graph.dimensions": ["dim"],
+        "graph.metrics": ["metric1"],
+      });
+
+      expect(isHidden).toBe(false);
+    });
+  });
+
+  describe("getValue", () => {
+    it("should return empty array by default", () => {
+      const mockSeries = [
+        createMockSingleSeries(
+          createMockCard({ display: "bar" }),
+          createMockDataset({
+            data: createMockDatasetData({
+              cols: [
+                createMockColumn({ name: "dim", base_type: "type/Text" }),
+                createMockColumn({ name: "metric1", base_type: "type/Number" }),
+                createMockColumn({ name: "metric2", base_type: "type/Number" }),
+              ],
+            }),
+          }),
+        ),
+      ];
+
+      const value = displayColumnsSetting.getValue(mockSeries, {
+        "graph.dimensions": ["dim"],
+        "graph.metrics": ["metric1"],
+      });
+
+      expect(value).toHaveLength(0);
+    });
+
+    it("should filter out invalid column keys", () => {
+      const mockSeries = [
+        createMockSingleSeries(
+          createMockCard({ display: "bar" }),
+          createMockDataset({
+            data: createMockDatasetData({
+              cols: [
+                createMockColumn({ name: "dim", base_type: "type/Text" }),
+                createMockColumn({ name: "metric1", base_type: "type/Number" }),
+                createMockColumn({ name: "metric2", base_type: "type/Number" }),
+              ],
+            }),
+          }),
+        ),
+      ];
+
+      const value = displayColumnsSetting.getValue(mockSeries, {
+        "graph.dimensions": ["dim"],
+        "graph.metrics": ["metric1"],
+        "graph.display_columns": [
+          '["name","metric2"]',
+          '["name","invalid_column"]',
+        ],
+      });
+
+      expect(value).toStrictEqual(['["name","metric2"]']);
+    });
+  });
+
+  describe("getProps", () => {
+    it("should return options for available additional columns", () => {
+      const mockSeries = [
+        createMockSingleSeries(
+          createMockCard(),
+          createMockDataset({
+            data: createMockDatasetData({
+              cols: [
+                createMockColumn({ name: "dim", base_type: "type/Text" }),
+                createMockColumn({
+                  name: "metric1",
+                  display_name: "Metric 1",
+                  base_type: "type/Number",
+                }),
+                createMockColumn({
+                  name: "metric2",
+                  display_name: "Metric 2",
+                  base_type: "type/Number",
+                }),
+              ],
+            }),
+          }),
+        ),
+      ];
+
+      const props = displayColumnsSetting.getProps(mockSeries, {
+        "graph.dimensions": ["dim"],
+        "graph.metrics": ["metric1"],
+      });
+
+      expect(props.options).toEqual([
+        { label: "Metric 2", value: '["name","metric2"]' },
+      ]);
+    });
+  });
+});

--- a/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
@@ -449,6 +449,23 @@ export function getComputedAdditionalColumnsValue(
   return filteredStoredColumns;
 }
 
+export function getComputedDisplayColumnsValue(
+  rawSeries: RawSeries,
+  settings: ComputedVisualizationSettings,
+) {
+  const availableAdditionalColumnKeys = new Set(
+    getAvailableAdditionalColumns(rawSeries, settings).map((column) =>
+      getColumnKey(column),
+    ),
+  );
+
+  const filteredStoredColumns = (
+    settings["graph.display_columns"] ?? []
+  ).filter((columnKey: string) => availableAdditionalColumnKeys.has(columnKey));
+
+  return filteredStoredColumns;
+}
+
 export function getSeriesModelsForSettings(
   rawSeries: RawSeries,
   settings: ComputedVisualizationSettings,

--- a/frontend/src/metabase/visualizations/visualizations/PieChart/chart-definition.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart/chart-definition.ts
@@ -238,6 +238,17 @@ export const PIE_CHART_DEFINITION: VisualizationDefinition = {
       getDefault: (_rawSeries, settings) => getDefaultShowLabels(settings),
       inline: true,
     },
+    "pie.show_data_values": {
+      get section() {
+        return t`Display`;
+      },
+      get title() {
+        return t`Show data values`;
+      },
+      widget: "toggle",
+      getDefault: () => false,
+      inline: true,
+    },
     "pie.percent_visibility": {
       get section() {
         return t`Display`;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/68767

### Description
This PR allows users to display additional metric values directly on chart elements (bars, pie slices) rather than only in tooltips. This is valuable for static viewing scenarios like executive dashboards, TV displays, and exported screenshots where hover interactions are unavailable.

**Implementation approach (Hybrid of Approach 2 + 6 from issue discussion):**

**Bar/Line/Area charts:**
- Added `graph.display_columns` multiselect setting (parallel to existing `graph.tooltip_columns`)
- Appears in Display tab when "Show values on data points" is enabled
- Users can select which additional columns to display on data labels
- Leverages existing label formatter infrastructure

**Pie charts:**
- Added `pie.show_data_values` toggle setting
- Shows the metric value on slice labels alongside dimension name and percentage
- Simple toggle that integrates with existing label visibility settings

### How to verify
**Bar chart:**
1. New question → Native query → Sample Database
2. Run: `SELECT 'Product A' as category, 100 as sales, 25 as profit UNION ALL SELECT 'Product B', 150, 40 UNION ALL SELECT 'Product C', 80, 15`
3. Visualize as Bar chart
4. Set dimension: `category`, metric: `sales`
5. In Display tab, enable "Show values on data points"
6. A new "Additional label columns" dropdown appears → select `profit`
7. Verify that bar labels now show both sales value and profit value

**Pie chart:**
1. Using the same query, visualize as Pie chart
2. Set dimension: `category`, metric: `sales`
3. In Display tab, enable "Show labels"
4. Enable "Show data values"
5. Verify that slice labels now include the metric value (e.g., "Product A: 100")

### Demo
| Before | After |
|--------|-------|
| <img width="1726" height="963" alt="Screenshot 2026-02-01 at 11 54 11 AM" src="https://github.com/user-attachments/assets/bc5201d9-6592-4710-9bcc-e6281d4693bc" /> | <img width="1728" height="964" alt="Screenshot 2026-02-01 at 11 46 49 AM" src="https://github.com/user-attachments/assets/1ec87586-fd0a-493d-a348-46d409d2ca3f" /> |
| <img width="1726" height="963" alt="Bar before" src="https://github.com/user-attachments/assets/3995c879-f879-41f1-a5a6-88e5f9b6016d" /> | <img width="1724" height="962" alt="Screenshot 2026-02-01 at 12 04 20 PM" src="https://github.com/user-attachments/assets/a132cfaf-791e-40b0-b6be-bb2987fc3433" /> |
| <img width="1728" height="962" alt="Area before" src="https://github.com/user-attachments/assets/4e2c3ce3-f709-4584-9f6b-3b86a514b7e8" /> | <img width="1724" height="964" alt="Screenshot 2026-02-01 at 12 21 42 PM" src="https://github.com/user-attachments/assets/f5cb03c7-e306-4781-b94c-94d7abe25759" /> |
### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
