### PR TITLE
Add option to remove X-axis padding in charts

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
@@ -243,6 +243,8 @@ export const buildNumericDimensionAxis = (
 
   const [min, max] = extent;
   const axisPadding = interval / 2;
+  const removeAxisPadding = settings["graph.x_axis.remove_padding"] ?? false;
+  const shouldPad = isPadded && !removeAxisPadding;
 
   return {
     ...getCommonDimensionAxisOptions(
@@ -256,13 +258,13 @@ export const buildNumericDimensionAxis = (
       margin: CHART_STYLE.axisTicksMarginX,
       ...getDimensionTicksDefaultOption(settings, renderingContext),
       formatter: (rawValue: number) => {
-        if (isPadded && (rawValue < min || rawValue > max)) {
+        if (shouldPad && (rawValue < min || rawValue > max)) {
           return "";
         }
         return getPaddedAxisLabel(formatter(fromEChartsAxisValue(rawValue)));
       },
     },
-    ...(isPadded
+    ...(shouldPad
       ? {
           min: () => min - axisPadding,
           max: () => max + axisPadding,
@@ -281,8 +283,9 @@ export const buildTimeSeriesDimensionAxis = (
   chartMeasurements: ChartMeasurements,
   renderingContext: RenderingContext,
 ): XAXisOption => {
+  const removeAxisPadding = settings["graph.x_axis.remove_padding"] ?? false;
   const { formatter, maxInterval, minInterval, canRender, xDomainPadded } =
-    getTicksOptions(xAxisModel, width);
+    getTicksOptions(xAxisModel, width, removeAxisPadding);
 
   return {
     ...getCommonDimensionAxisOptions(
@@ -330,6 +333,8 @@ export const buildCategoricalDimensionAxis = (
     "graph.x_axis.axis_enabled": autoAxisEnabled,
   };
 
+  const removeAxisPadding = settings["graph.x_axis.remove_padding"] ?? false;
+
   return {
     ...getCommonDimensionAxisOptions(
       chartMeasurements,
@@ -337,6 +342,7 @@ export const buildCategoricalDimensionAxis = (
       renderingContext,
     ),
     type: "category",
+    boundaryGap: !removeAxisPadding,
     axisLabel: {
       margin: CHART_STYLE.axisTicksMarginX,
       ...getDimensionTicksDefaultOption(settings, renderingContext),

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/ticks.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/ticks.ts
@@ -17,7 +17,11 @@ import {
 // For example, when a dataset has two days and minInterval is 1 day in milliseconds datasets like ["2022-01-01", "2022-01-02"]
 // will be rendered without the second tick. However, for ["2022-01-02", "2022-01-03"] ECharts would correctly render two ticks as needed.
 // The workaround is to add more padding on sides for this corner case.
-const getPadding = (intervalsCount: number) => {
+const getPadding = (intervalsCount: number, removePadding: boolean) => {
+  if (removePadding) {
+    return 0;
+  }
+
   if (intervalsCount <= 1) {
     return 5 / 6;
   }
@@ -28,6 +32,7 @@ const getPadding = (intervalsCount: number) => {
 export const getTicksOptions = (
   xAxisModel: TimeSeriesXAxisModel,
   chartWidth: number,
+  removePadding = false,
 ) => {
   const { range, toEChartsAxisValue, interval, intervalsCount } = xAxisModel;
 
@@ -44,7 +49,7 @@ export const getTicksOptions = (
   }) as ContinuousDomain;
 
   const isSingleItem = xDomain[0] === xDomain[1];
-  const padding = getPadding(intervalsCount);
+  const padding = getPadding(intervalsCount, removePadding);
   const xDomainPadded = [
     xDomain[0] - getTimeSeriesIntervalDuration(interval) * padding,
     xDomain[1] + getTimeSeriesIntervalDuration(interval) * padding,

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -898,6 +898,21 @@ export const GRAPH_AXIS_SETTINGS = {
       placeholder: getDefaultDimensionLabel(series),
     }),
   },
+  "graph.x_axis.remove_padding": {
+    get section() {
+      return t`Axes`;
+    },
+    get group() {
+      return t`X-axis`;
+    },
+    get title() {
+      return t`Remove axis padding`;
+    },
+    widget: "toggle",
+    index: 4,
+    inline: true,
+    default: false,
+  },
   "graph.y_axis.labels_enabled": {
     get section() {
       return t`Axes`;


### PR DESCRIPTION
## Summary

Fixes #66754

Adds a new visualization setting "Remove axis padding" that allows users to control whether charts have padding at the start and end of the X-axis. When enabled, data points align flush with the axis boundaries instead of having a visual offset.

## Changes

- Added `graph.x_axis.remove_padding` toggle setting in the Axes → X-axis section
- Updated time series, categorical, and numeric axis builders to respect the setting
- Setting defaults to `false` to maintain current padding behavior
- Works for both interactive visualizations and static renders (emails/exports)

## Test plan

1. Create a line, area, or bar chart with time series, categorical, or numeric X-axis data
2. Open visualization settings → Axes → X-axis
3. Toggle "Remove axis padding" on/off
4. Verify data points align with axis boundaries when enabled
5. Verify default padding behavior when disabled