### PR TITLE
Fix no unused expression violations

### DIFF
--- a/e2e/runner/run_cypress_local.ts
+++ b/e2e/runner/run_cypress_local.ts
@@ -138,9 +138,11 @@ const cleanup = async (exitCode: string | number = SUCCESS_EXIT_CODE) => {
     "🧹 Containers are running in background. If you wish to stop them, run:\n`docker compose -f ./e2e/test/scenarios/docker-compose.yml down`",
   );
 
-  typeof exitCode === "number"
-    ? process.exit(exitCode)
-    : process.exit(SUCCESS_EXIT_CODE);
+  if (typeof exitCode === "number") {
+    process.exit(exitCode);
+  } else {
+    process.exit(SUCCESS_EXIT_CODE);
+  }
 };
 
 init()

--- a/e2e/support/helpers/e2e-permissions-helpers.js
+++ b/e2e/support/helpers/e2e-permissions-helpers.js
@@ -33,7 +33,9 @@ export function modifyPermission(
             }
           });
       }
-      value && cy.findByText(value).click();
+      if (value) {
+        cy.findByText(value).click();
+      }
     });
 }
 

--- a/e2e/test/scenarios/admin/databases.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases.cy.spec.js
@@ -609,7 +609,9 @@ describe("scenarios > admin > databases > exceptions", () => {
   it("should handle a failure to `GET` the list of all databases (metabase#20471)", () => {
     const errorMessage = "Lorem ipsum dolor sit amet, consectetur adip";
 
-    IS_ENTERPRISE && H.activateToken("pro-self-hosted");
+    if (IS_ENTERPRISE) {
+      H.activateToken("pro-self-hosted");
+    }
 
     cy.intercept(
       {

--- a/e2e/test/scenarios/admin/tools/help.cy.spec.ts
+++ b/e2e/test/scenarios/admin/tools/help.cy.spec.ts
@@ -68,8 +68,12 @@ describe("scenarios > admin > tools > help > helping hand", () => {
           .click();
       }
 
-      ticket && cy.findByLabelText("Ticket").type(ticket);
-      notes && cy.findByLabelText("Notes").type(notes);
+      if (ticket) {
+        cy.findByLabelText("Ticket").type(ticket);
+      }
+      if (notes) {
+        cy.findByLabelText("Notes").type(notes);
+      }
 
       cy.button("Grant access").click();
     });

--- a/e2e/test/scenarios/binning/binning-options.cy.spec.js
+++ b/e2e/test/scenarios/binning/binning-options.cy.spec.js
@@ -335,10 +335,10 @@ function getAllOptions({ options, isSelected, shouldExpandList } = {}) {
         cy.findByText(option);
       });
 
-      isSelected &&
-        cy
-          .findByText(selectedOption)
+      if (isSelected) {
+        cy.findByText(selectedOption)
           .closest("li")
           .should("have.attr", "aria-selected", "true");
+      }
     });
 }

--- a/e2e/test/scenarios/binning/qb-explicit-joins.cy.spec.js
+++ b/e2e/test/scenarios/binning/qb-explicit-joins.cy.spec.js
@@ -305,7 +305,11 @@ function assertQueryBuilderState({
   mode = null,
   values,
 } = {}) {
-  mode === "notebook" ? H.visualize() : waitAndAssertOnRequest("@dataset");
+  if (mode === "notebook") {
+    H.visualize();
+  } else {
+    waitAndAssertOnRequest("@dataset");
+  }
 
   const visualizationSelector = columnType === "time" ? "circle" : "bar";
 
@@ -319,10 +323,11 @@ function assertQueryBuilderState({
 
   H.echartsContainer().get("text").should("contain", "Count");
 
-  values &&
+  if (values) {
     H.echartsContainer().within(() => {
       values.forEach((value) => {
         cy.findByText(value);
       });
     });
+  }
 }

--- a/e2e/test/scenarios/binning/qb-implicit-joins.cy.spec.js
+++ b/e2e/test/scenarios/binning/qb-implicit-joins.cy.spec.js
@@ -155,7 +155,11 @@ function waitAndAssertOnRequest(requestAlias) {
 function assertQueryBuilderState({ title, mode = null, values } = {}) {
   const [firstValue, lastValue] = values;
 
-  mode === "notebook" ? H.visualize() : waitAndAssertOnRequest("@dataset");
+  if (mode === "notebook") {
+    H.visualize();
+  } else {
+    waitAndAssertOnRequest("@dataset");
+  }
 
   cy.findByText(title);
   cy.get("[data-testid=cell-data]")

--- a/e2e/test/scenarios/filters/relative-datetime.cy.spec.js
+++ b/e2e/test/scenarios/filters/relative-datetime.cy.spec.js
@@ -262,7 +262,9 @@ const openCreatedAt = (tab) => {
   H.popover().within(() => {
     cy.findByText("Filter by this column").click();
     cy.findByText("Relative date range…").click();
-    tab && cy.findByText(tab).click();
+    if (tab) {
+      cy.findByText(tab).click();
+    }
   });
 };
 

--- a/e2e/test/scenarios/native-filters/sql-field-filter-types.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-field-filter-types.cy.spec.js
@@ -243,9 +243,11 @@ describe("scenarios > filters > sql filters > field filter > String", () => {
       ([subType, { searchTerm, value, representativeResult }], index) => {
         FieldFilter.setWidgetType(subType);
 
-        searchTerm
-          ? FieldFilter.pickDefaultValue(searchTerm, value, "Update filter")
-          : FieldFilter.addDefaultStringFilter(value);
+        if (searchTerm) {
+          FieldFilter.pickDefaultValue(searchTerm, value, "Update filter");
+        } else {
+          FieldFilter.addDefaultStringFilter(value);
+        }
 
         SQLFilter.runQuery();
 

--- a/e2e/test/scenarios/organization/official-collections.cy.spec.js
+++ b/e2e/test/scenarios/organization/official-collections.cy.spec.js
@@ -161,7 +161,9 @@ function testOfficialBadgePresence(expectBadge = true) {
       collection_id: collectionId,
     });
 
-    !expectBadge && H.deleteToken();
+    if (!expectBadge) {
+      H.deleteToken();
+    }
     cy.visit(`/collection/${collectionId}`);
   });
 
@@ -221,7 +223,9 @@ function testOfficialQuestionBadgeInRegularDashboard(expectBadge = true) {
     });
   });
 
-  !expectBadge && H.deleteToken();
+  if (!expectBadge) {
+    H.deleteToken();
+  }
 
   cy.visit("/collection/root");
   cy.findByText("Regular Dashboard").click();

--- a/e2e/test/scenarios/permissions/permissions-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/permissions-reproductions.cy.spec.js
@@ -64,8 +64,11 @@ describe("issue 13347", { tags: ["@external", "@skip"] }, () => {
       // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Saved Questions").click();
 
-      // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage
-      test === "QB" ? cy.findByText("Q1").click() : cy.findByText("Q2").click();
+      if (test === "QB") {
+        cy.findByText("Q1").click();
+      } else {
+        cy.findByText("Q2").click();
+      }
 
       cy.wait("@dataset", { timeout: 5000 });
       // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage

--- a/e2e/test/scenarios/question/nested.cy.spec.js
+++ b/e2e/test/scenarios/question/nested.cy.spec.js
@@ -555,7 +555,9 @@ function createNestedQuestion(
   }
 
   createBaseQuestion(baseQuestionDetails).then(({ body: { id } }) => {
-    loadBaseQuestionMetadata && H.visitQuestion(id);
+    if (loadBaseQuestionMetadata) {
+      H.visitQuestion(id);
+    }
 
     const { query: nestedQuery, ...details } = nestedQuestionDetails;
 

--- a/e2e/validate-e2e-test-files.js
+++ b/e2e/validate-e2e-test-files.js
@@ -97,6 +97,10 @@ function init() {
   if (!payload.length) {
     validateAllFiles();
   } else {
-    scope === "--staged" ? validateStagedFiles() : validateStagedFiles(payload);
+    if (scope === "--staged") {
+      validateStagedFiles();
+    } else {
+      validateStagedFiles(payload);
+    }
   }
 }

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.tsx
@@ -139,7 +139,11 @@ export const StrategyEditorForQuestionsAndDashboards = () => {
           setTargetModel(newTargetModel);
           setIsStrategyFormDirty(false);
         };
-        isFormDirty ? askBeforeDiscardingChanges(update) : update();
+        if (isFormDirty) {
+          askBeforeDiscardingChanges(update);
+        } else {
+          update();
+        }
       }
     },
     [

--- a/enterprise/frontend/src/metabase-enterprise/clean_up/CleanupCollectionModal/CleanupCollectionModalFilters.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/clean_up/CleanupCollectionModal/CleanupCollectionModalFilters.tsx
@@ -34,7 +34,9 @@ export const CleanupCollectionModalFilters = ({
           data={dateFilterOptions}
           value={dateFilter}
           onChange={(option) => {
-            option && isDateFilter(option) && onDateFilterChange(option);
+            if (option && isDateFilter(option)) {
+              onDateFilterChange(option);
+            }
           }}
           mx=".5rem"
           data-testid="cleanup-date-filter"

--- a/enterprise/frontend/src/metabase-enterprise/content_translation/components/ContentTranslationConfiguration/ContentTranslationConfiguration.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/content_translation/components/ContentTranslationConfiguration/ContentTranslationConfiguration.tsx
@@ -106,10 +106,14 @@ export const ContentTranslationConfiguration = () => {
         timeout = setTimeout(() => setShowDownloadingIndicator(true), DELAY);
       } else {
         setShowDownloadingIndicator(false);
-        timeout && clearTimeout(timeout);
+        if (timeout) {
+          clearTimeout(timeout);
+        }
       }
       return () => {
-        timeout && clearTimeout(timeout);
+        if (timeout) {
+          clearTimeout(timeout);
+        }
       };
     },
     [isDownloadInProgress],

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/bulk-selection.utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/data-model/components/TablePicker/bulk-selection.utils.ts
@@ -106,9 +106,11 @@ export function markAllSchemas(
   for (const schema of database.children) {
     const schemaId = getSchemaId(schema);
     if (schema.children.length === 0) {
-      targetChecked === "all"
-        ? schemas.add(schemaId)
-        : schemas.delete(schemaId);
+      if (targetChecked === "all") {
+        schemas.add(schemaId);
+      } else {
+        schemas.delete(schemaId);
+      }
     } else {
       markAllTables(schema, targetChecked, tables);
     }
@@ -127,9 +129,11 @@ function markAllTables(
   tablesSelection: Set<TableId>,
 ) {
   for (const tableId of getSchemaChildrenTableIds(schema)) {
-    targetChecked === "all"
-      ? tablesSelection.add(tableId)
-      : tablesSelection.delete(tableId);
+    if (targetChecked === "all") {
+      tablesSelection.add(tableId);
+    } else {
+      tablesSelection.delete(tableId);
+    }
   }
 }
 
@@ -171,7 +175,11 @@ export function toggleSchemaSelection(
 
 export function toggleInSet<T>(set: Set<T>, item: T): Set<T> {
   const newSet = new Set(set);
-  newSet.has(item) ? newSet.delete(item) : newSet.add(item);
+  if (newSet.has(item)) {
+    newSet.delete(item);
+  } else {
+    newSet.add(item);
+  }
   return newSet;
 }
 

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/glossary/pages/GlossaryPage/GlossaryPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/glossary/pages/GlossaryPage/GlossaryPage.tsx
@@ -38,7 +38,9 @@ export function GlossaryPage() {
             glossary={glossary}
             onCreate={async (term, definition) => {
               const { data } = await createGlossary({ term, definition });
-              data?.id && trackDataStudioGlossaryTermCreated(data.id);
+              if (data?.id) {
+                trackDataStudioGlossaryTermCreated(data.id);
+              }
             }}
             onEdit={async (id, term, definition) => {
               await updateGlossary({ id, term, definition });

--- a/enterprise/frontend/src/metabase-enterprise/database_replication/DatabaseReplicationModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/database_replication/DatabaseReplicationModal.tsx
@@ -47,9 +47,9 @@ export const DatabaseReplicationModal = ({
   const [error, setError] = useState<string>();
   const handleError = (error: unknown) => {
     setSetupStep("error");
-    isRTKQueryError(error) &&
-      typeof error.data === "string" &&
+    if (isRTKQueryError(error) && typeof error.data === "string") {
       setError(error.data);
+    }
   };
   const onModalClose = () => {
     setSetupStep("form");

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotAgentSuggestionMessage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotAgentSuggestionMessage.tsx
@@ -83,7 +83,9 @@ const useGetOldTransform = ({
 }: MetabotAgentEditSuggestionChatMessage["payload"]) => {
   const [trigger, result] = useLazyGetTransformQuery();
   useMount(() => {
-    !editorTransform && suggestedTransform.id && trigger(suggestedTransform.id);
+    if (!editorTransform && suggestedTransform.id) {
+      trigger(suggestedTransform.id);
+    }
   });
 
   if (editorTransform) {

--- a/frontend/src/metabase-lib/v1/Question.ts
+++ b/frontend/src/metabase-lib/v1/Question.ts
@@ -182,8 +182,9 @@ class Question {
 
     const isVirtualDashcard = !this._card.id;
     // The `dataset_query` is null for questions on a dashboard the user doesn't have access to
-    !isVirtualDashcard &&
+    if (!isVirtualDashcard) {
       console.warn("Unknown query type: " + datasetQuery?.type);
+    }
   });
 
   legacyNativeQuery(): NativeQuery | undefined {

--- a/frontend/src/metabase/admin/performance/components/StrategyEditorForDatabases.tsx
+++ b/frontend/src/metabase/admin/performance/components/StrategyEditorForDatabases.tsx
@@ -78,7 +78,11 @@ export const StrategyEditorForDatabases: React.FC = () => {
   const updateTargetId: UpdateTargetId = (newTargetId, isFormDirty) => {
     if (targetId !== newTargetId) {
       const update = () => setTargetId(newTargetId);
-      isFormDirty ? askBeforeDiscardingChanges(update) : update();
+      if (isFormDirty) {
+        askBeforeDiscardingChanges(update);
+      } else {
+        update();
+      }
     }
   };
 

--- a/frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.tsx
@@ -25,7 +25,11 @@ export function HttpsOnlyWidget() {
     setStatus(Status.CHECKING);
     fetchWithTimeout(siteUrl + "/api/health", { timeout: 10000 })
       .then((response) => {
-        response.ok ? setStatus(Status.VERIFIED) : setStatus(Status.FAILED);
+        if (response.ok) {
+          setStatus(Status.VERIFIED);
+        } else {
+          setStatus(Status.FAILED);
+        }
       })
       .catch(() => {
         setStatus(Status.FAILED);

--- a/frontend/src/metabase/common/components/ActionButton/ActionButton.tsx
+++ b/frontend/src/metabase/common/components/ActionButton/ActionButton.tsx
@@ -57,7 +57,9 @@ export const ActionButton = forwardRef<ActionButtonHandle, ActionButtonProps>(
     const isMountedRef = useRef(true);
 
     const resetTimeout = () => {
-      timeout.current && clearTimeout(timeout.current);
+      if (timeout.current) {
+        clearTimeout(timeout.current);
+      }
     };
 
     useEffect(() => {

--- a/frontend/src/metabase/common/components/DashboardSelector/DashboardSelector.tsx
+++ b/frontend/src/metabase/common/components/DashboardSelector/DashboardSelector.tsx
@@ -52,7 +52,7 @@ export const DashboardSelector = ({
       </Group>
     );
   }
-  ``;
+
   return (
     <Flex>
       <DashboardPickerButton

--- a/frontend/src/metabase/common/components/FileInput/FileInput.tsx
+++ b/frontend/src/metabase/common/components/FileInput/FileInput.tsx
@@ -28,7 +28,7 @@ export const FileInput = forwardRef(function FileInput(
     (event: ChangeEvent<HTMLInputElement>) => {
       const { files } = event.target;
       setHasValue(files != null && files?.length > 0);
-      onChange && onChange(event);
+      onChange?.(event);
     },
     [onChange],
   );

--- a/frontend/src/metabase/common/components/Pickers/EntityPicker/components/EntityPickerModal.tsx
+++ b/frontend/src/metabase/common/components/Pickers/EntityPicker/components/EntityPickerModal.tsx
@@ -104,7 +104,9 @@ export function EntityPickerModal({
     (event) => {
       if (event.key === "Escape") {
         event.stopPropagation();
-        !isDialogOpen && onClose();
+        if (!isDialogOpen) {
+          onClose();
+        }
       }
     },
     { capture: true },

--- a/frontend/src/metabase/common/components/Radio/Radio.tsx
+++ b/frontend/src/metabase/common/components/Radio/Radio.tsx
@@ -146,11 +146,11 @@ const RadioItem = <TValue,>({
   const { RadioLabel, RadioContainer } = VARIANTS[variant];
 
   const handleChange = useCallback(() => {
-    onChange && onChange(value);
+    onChange?.(value);
   }, [value, onChange]);
 
   const handleClick = useCallback(() => {
-    onOptionClick && onOptionClick(value);
+    onOptionClick?.(value);
   }, [value, onOptionClick]);
 
   return (

--- a/frontend/src/metabase/common/components/Toggle/Toggle.tsx
+++ b/frontend/src/metabase/common/components/Toggle/Toggle.tsx
@@ -19,7 +19,7 @@ export const Toggle = forwardRef(function Toggle(
 ): JSX.Element {
   const handleChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
-      onChange && onChange(event.currentTarget.checked);
+      onChange?.(event.currentTarget.checked);
     },
     [onChange],
   );

--- a/frontend/src/metabase/common/components/tree/TreeNode.tsx
+++ b/frontend/src/metabase/common/components/tree/TreeNode.tsx
@@ -42,10 +42,14 @@ const BaseTreeNode = React.forwardRef<HTMLLIElement, TreeNodeProps>(
           onSelect?.();
           break;
         case "ArrowRight":
-          !isExpanded && onToggleExpand();
+          if (!isExpanded) {
+            onToggleExpand();
+          }
           break;
         case "ArrowLeft":
-          isExpanded && onToggleExpand();
+          if (isExpanded) {
+            onToggleExpand();
+          }
           break;
       }
     };

--- a/frontend/src/metabase/dashboard/actions/cards-typed.ts
+++ b/frontend/src/metabase/dashboard/actions/cards-typed.ts
@@ -273,7 +273,9 @@ export const replaceCard =
     await dispatch(loadMetadataForCard(card));
     dispatch(showAutoWireToastNewCard({ dashcard_id: dashcardId }));
 
-    dashboardId && trackQuestionReplaced(dashboardId);
+    if (dashboardId) {
+      trackQuestionReplaced(dashboardId);
+    }
   };
 
 export const addCardWithVisualization =

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/DashboardInfoButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/DashboardInfoButton.tsx
@@ -18,9 +18,11 @@ export const DashboardInfoButton = (
   );
 
   const handleClick = () => {
-    isShowingDashboardInfoSidebar
-      ? closeSidebar()
-      : setSidebar({ name: SIDEBAR_NAME.info });
+    if (isShowingDashboardInfoSidebar) {
+      closeSidebar();
+    } else {
+      setSidebar({ name: SIDEBAR_NAME.info });
+    }
   };
 
   useRegisterShortcut(

--- a/frontend/src/metabase/documents/components/DocumentPage.tsx
+++ b/frontend/src/metabase/documents/components/DocumentPage.tsx
@@ -278,9 +278,11 @@ export const DocumentPage = ({
       trackDocumentBookmark();
     }
 
-    isBookmarked
-      ? deleteBookmark({ type: "document", id: documentId })
-      : createBookmark({ type: "document", id: documentId });
+    if (isBookmarked) {
+      deleteBookmark({ type: "document", id: documentId });
+    } else {
+      createBookmark({ type: "document", id: documentId });
+    }
   }, [isBookmarked, deleteBookmark, createBookmark, documentId]);
 
   const handleShowHistory = useCallback(() => {
@@ -400,7 +402,11 @@ export const DocumentPage = ({
           return;
         }
 
-        isNewDocument ? setCollectionPickerMode("save") : handleSave();
+        if (isNewDocument) {
+          setCollectionPickerMode("save");
+        } else {
+          handleSave();
+        }
       }
     };
 

--- a/frontend/src/metabase/lib/colors/groups.ts
+++ b/frontend/src/metabase/lib/colors/groups.ts
@@ -15,9 +15,15 @@ export const getAccentColors = (
   palette?: ColorPalette,
 ): string[] => {
   const ranges: string[][] = [];
-  main && ranges.push(getMainAccentColors(palette, gray));
-  light && ranges.push(getLightAccentColors(palette, gray));
-  dark && ranges.push(getDarkAccentColors(palette, gray));
+  if (main) {
+    ranges.push(getMainAccentColors(palette, gray));
+  }
+  if (light) {
+    ranges.push(getLightAccentColors(palette, gray));
+  }
+  if (dark) {
+    ranges.push(getDarkAccentColors(palette, gray));
+  }
 
   return harmony ? _.unzip(ranges).flat() : ranges.flat();
 };

--- a/frontend/src/metabase/lib/redux/hooks.unit.spec.tsx
+++ b/frontend/src/metabase/lib/redux/hooks.unit.spec.tsx
@@ -54,7 +54,11 @@ describe("useDispatch", () => {
       setup({
         thunk: () => (_dispatch: any, getState: () => State) => {
           const email = getState().currentUser?.email;
-          email ? foundEmailState() : didNotFindEmailState();
+          if (email) {
+            foundEmailState();
+          } else {
+            didNotFindEmailState();
+          }
         },
       });
       expect(foundEmailState).toHaveBeenCalled();

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/tests/premium-hosting-upload.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/tests/premium-hosting-upload.unit.spec.tsx
@@ -196,9 +196,11 @@ async function assertSheetsOpened({
 } = {}) {
   await userEvent.click(screen.getByRole("tab", { name: /Google Sheets$/ }));
 
-  isAdmin
-    ? expect(await screen.findByText("Manage imports")).toBeInTheDocument()
-    : expect(screen.queryByText("Manage imports")).not.toBeInTheDocument();
+  if (isAdmin) {
+    expect(await screen.findByText("Manage imports")).toBeInTheDocument();
+  } else {
+    expect(screen.queryByText("Manage imports")).not.toBeInTheDocument();
+  }
 
   expect(
     await screen.findByRole("heading", { name: title }),

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarCollectionLink.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarCollectionLink.tsx
@@ -77,10 +77,14 @@ const SidebarCollectionLink = forwardRef<HTMLLIElement, Props>(
         }
         switch (event.key) {
           case "ArrowRight":
-            !isExpanded && onToggleExpand();
+            if (!isExpanded) {
+              onToggleExpand();
+            }
             break;
           case "ArrowLeft":
-            isExpanded && onToggleExpand();
+            if (isExpanded) {
+              onToggleExpand();
+            }
             break;
         }
       },

--- a/frontend/src/metabase/query_builder/actions/zoom.ts
+++ b/frontend/src/metabase/query_builder/actions/zoom.ts
@@ -13,5 +13,7 @@ export const zoomInRow =
 
     // don't show object id in url if it is a row index
     const hasPK = getPKColumnIndex(getState()) !== -1;
-    hasPK && dispatch(updateUrl(null, { objectId, replaceState: false }));
+    if (hasPK) {
+      dispatch(updateUrl(null, { objectId, replaceState: false }));
+    }
   };

--- a/frontend/src/metabase/query_builder/components/view/QuestionTimelineWidget/QuestionTimelineWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionTimelineWidget/QuestionTimelineWidget.tsx
@@ -51,7 +51,11 @@ export const QuestionTimelineWidget = ({
   const handleCloseTimelines = () => dispatch(onCloseTimelines());
 
   function handleClick(isShowingTimelineSidebar: boolean, ack: () => void) {
-    isShowingTimelineSidebar ? handleCloseTimelines() : handleOpenTimelines();
+    if (isShowingTimelineSidebar) {
+      handleCloseTimelines();
+    } else {
+      handleOpenTimelines();
+    }
     ack();
   }
 

--- a/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
@@ -46,7 +46,9 @@ export const NotebookContainer = ({
   const { width: windowWidth } = useWindowSize();
 
   useEffect(() => {
-    isOpen && setShouldShowNotebook(isOpen);
+    if (isOpen) {
+      setShouldShowNotebook(isOpen);
+    }
   }, [isOpen]);
 
   const { isShowingNotebookNativePreview, notebookNativePreviewSidebarWidth } =

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SingleDatePicker/SingleDatePickerBody/SingleDatePickerBody.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SingleDatePicker/SingleDatePickerBody/SingleDatePickerBody.tsx
@@ -21,11 +21,15 @@ export function SingleDatePickerBody({
   const [date, setDate] = useState<Date>(value);
 
   const handleDateChange = (newDate: DateStringValue | null) => {
-    newDate && onChange(setDatePart(value, dayjs(newDate).toDate()));
+    if (newDate) {
+      onChange(setDatePart(value, dayjs(newDate).toDate()));
+    }
   };
 
   const handleTimeChange = (newTime: Date | null) => {
-    newTime && onChange(setTimePart(value, newTime));
+    if (newTime) {
+      onChange(setTimePart(value, newTime));
+    }
   };
 
   return (

--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/SupportingText/SupportingText.tsx
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/SupportingText/SupportingText.tsx
@@ -218,7 +218,9 @@ const SupportingTextComponent = ({
           className={S.handle}
           onClick={() => {
             const pos = getPos();
-            pos && editor.commands.setNodeSelection(pos);
+            if (pos) {
+              editor.commands.setNodeSelection(pos);
+            }
           }}
           onKeyDown={(e) => {
             if (e.key === "Backspace" || e.key === "Delete") {

--- a/frontend/src/metabase/timelines/collections/containers/EditEventModal/EditEventModal.tsx
+++ b/frontend/src/metabase/timelines/collections/containers/EditEventModal/EditEventModal.tsx
@@ -33,11 +33,15 @@ const timelineEventProps = {
 const mapDispatchToProps = (dispatch: any) => ({
   onSubmit: async (event: TimelineEvent, timeline?: Timeline) => {
     await dispatch(TimelineEvents.actions.update(event));
-    timeline && dispatch(push(Urls.timelineInCollection(timeline)));
+    if (timeline) {
+      dispatch(push(Urls.timelineInCollection(timeline)));
+    }
   },
   onArchive: async (event: TimelineEvent, timeline?: Timeline) => {
     await dispatch(TimelineEvents.actions.setArchived(event, true));
-    timeline && dispatch(push(Urls.timelineInCollection(timeline)));
+    if (timeline) {
+      dispatch(push(Urls.timelineInCollection(timeline)));
+    }
   },
 });
 

--- a/frontend/src/metabase/timelines/questions/components/TimelineCard/TimelineCard.tsx
+++ b/frontend/src/metabase/timelines/questions/components/TimelineCard/TimelineCard.tsx
@@ -67,10 +67,12 @@ const TimelineCard = ({
 
   const handleChangeVisibility = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
-      if (e.target.checked) {
-        timeline.events && onShowTimelineEvents(timeline.events);
-      } else {
-        timeline.events && onHideTimelineEvents(timeline.events);
+      if (timeline.events) {
+        if (e.target.checked) {
+          onShowTimelineEvents(timeline.events);
+        } else {
+          onHideTimelineEvents(timeline.events);
+        }
       }
     },
     [timeline, onShowTimelineEvents, onHideTimelineEvents],

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailView.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailView.tsx
@@ -249,9 +249,9 @@ export function ObjectDetailView({
 
   const onFollowForeignKey = useCallback(
     (fk: ForeignKey) => {
-      zoomedRowID !== undefined
-        ? followForeignKey({ objectId: zoomedRowID, fk })
-        : _.noop();
+      if (zoomedRowID !== undefined) {
+        followForeignKey({ objectId: zoomedRowID, fk });
+      }
     },
     [zoomedRowID, followForeignKey],
   );

--- a/frontend/src/metabase/visualizer/components/DataImporter/DatasetsList/DatasetsListItem.tsx
+++ b/frontend/src/metabase/visualizer/components/DataImporter/DatasetsList/DatasetsListItem.tsx
@@ -35,7 +35,11 @@ export const DatasetsListItem = (props: DatasetsListItemProps) => {
       aria-pressed={selected}
       size="xs"
       onClick={() => {
-        selected ? onRemove?.(item) : onToggle?.(item);
+        if (selected) {
+          onRemove?.(item);
+        } else {
+          onToggle?.(item);
+        }
       }}
       leftSection={
         <Box>


### PR DESCRIPTION
Eslint v9 errors on no-unused-expressions by default:
```
// errors because the result of the expression is ignored
ticket && cy.findByLabelText("Ticket").type(ticket);

// works
if (ticket) {
  cy.findByLabelText("Ticket").type(ticket);
}

// works because the result of the expression is used
const a = predicate && doSomething()
```

It is configurable, but the [Slack consensus](https://metaboat.slack.com/archives/C505ZNNH4/p1769746568850879?thread_ts=1769745100.200739&cid=C505ZNNH4) was to abide by the new rules