### PR TITLE
Fix rules of hooks violations

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModal.tsx
@@ -45,7 +45,10 @@ const parseParams = (params: ImpersonationModalParams): ImpersonationParams => {
   };
 };
 
-const _ImpersonationModal = ({ route, params }: ImpersonationModalProps) => {
+const ImpersonationModalInner = ({
+  route,
+  params,
+}: ImpersonationModalProps) => {
   const [
     {
       loading: isImpersonationLoading,
@@ -153,4 +156,4 @@ const _ImpersonationModal = ({ route, params }: ImpersonationModalProps) => {
   );
 };
 
-export const ImpersonationModal = withRouter(_ImpersonationModal);
+export const ImpersonationModal = withRouter(ImpersonationModalInner);

--- a/enterprise/frontend/src/metabase-enterprise/clean_up/CleanupCollectionModal/CleanupCollectionModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/clean_up/CleanupCollectionModal/CleanupCollectionModal.tsx
@@ -39,7 +39,7 @@ interface CleanupCollectionModalProps {
   params: { slug: string };
 }
 
-const _CleanupCollectionModal = ({
+const CleanupCollectionModalInner = ({
   onClose: handleClose,
   params: { slug },
 }: CleanupCollectionModalProps) => {
@@ -224,4 +224,4 @@ const _CleanupCollectionModal = ({
   );
 };
 
-export const CleanupCollectionModal = withRouter(_CleanupCollectionModal);
+export const CleanupCollectionModal = withRouter(CleanupCollectionModalInner);

--- a/enterprise/frontend/src/metabase-enterprise/collections/use-get-default-collection-id/use-get-default-collection-id.ts
+++ b/enterprise/frontend/src/metabase-enterprise/collections/use-get-default-collection-id/use-get-default-collection-id.ts
@@ -1,5 +1,5 @@
 import { skipToken, useGetCollectionQuery } from "metabase/api";
-import { _useGetDefaultCollectionId as useOSSGetDefaultCollectionId } from "metabase/collections/hooks";
+import { useOSSGetDefaultCollectionId } from "metabase/collections/hooks";
 import { useGetAuditInfoQuery } from "metabase-enterprise/api";
 import { isInstanceAnalyticsCollection } from "metabase-enterprise/collections/utils";
 import type { CollectionId } from "metabase-types/api";

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/SdkSaveQuestionForm.stories.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/SdkSaveQuestionForm.stories.tsx
@@ -20,7 +20,7 @@ export default {
 };
 
 export const Default = {
-  render(args: SdkQuestionProps) {
+  render: function Render(args: SdkQuestionProps) {
     const [isSaveModalOpen, { toggle, close }] = useDisclosure(false);
 
     const [isBeforeSaveCalled, setBeforeSaveCalled] = useState(false);

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/VisualizationButton/VisualizationButton.stories.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/VisualizationButton/VisualizationButton.stories.tsx
@@ -20,7 +20,7 @@ export default {
 };
 
 export const QuestionVisualizationButton = {
-  render() {
+  render: function Render() {
     const [count, setCount] = useState(0);
     return (
       <Box p="lg">
@@ -43,7 +43,7 @@ export const QuestionVisualizationButton = {
 };
 
 export const CustomVisualizationButton = {
-  render() {
+  render: function Render() {
     const OisinsRandomButton = () => {
       const { visualizeQuestion } = useRunVisualization();
       return (

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/util/BadgeList/BadgeList.stories.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/util/BadgeList/BadgeList.stories.tsx
@@ -15,7 +15,7 @@ export default {
 };
 
 export const DefaultLayoutBadgeList = {
-  render() {
+  render: function Render() {
     const [items, setItems] = useState(
       Array.from(Array(5).keys()).map((i) => ({
         name: `item ${i}`,

--- a/frontend/src/embedding-sdk-bundle/components/private/util/MultiStepPopover/MultiStepPopover.stories.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/util/MultiStepPopover/MultiStepPopover.stories.tsx
@@ -15,7 +15,7 @@ export default {
 };
 
 export const MultiStepPopoverStory = {
-  render() {
+  render: function Render() {
     const [count, handlers] = useCounter(0, {
       min: 0,
       max: 3,

--- a/frontend/src/metabase/admin/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobModal.tsx
+++ b/frontend/src/metabase/admin/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobModal.tsx
@@ -37,7 +37,7 @@ const mapDispatchToProps = {
     PersistedModels.objectActions.refreshCache(job),
 };
 
-function _ModelCacheRefreshJobModal({
+function ModelCacheRefreshJobModalInner({
   persistedModel,
   onClose,
   onRefresh,
@@ -90,4 +90,4 @@ export const ModelCacheRefreshJobModal = _.compose(
       props.params.jobId,
     loadingAndErrorWrapper: false,
   }),
-)(_ModelCacheRefreshJobModal);
+)(ModelCacheRefreshJobModalInner);

--- a/frontend/src/metabase/admin/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx
+++ b/frontend/src/metabase/admin/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx
@@ -112,7 +112,7 @@ const mapDispatchToProps = {
     PersistedModels.objectActions.refreshCache(job),
 };
 
-function _ModelCacheRefreshJobs({ onRefresh }: Props) {
+function ModelCacheRefreshJobsInner({ onRefresh }: Props) {
   const { page, handleNextPage, handlePreviousPage } = usePagination();
   const { data, error, isFetching } = useListPersistedInfoQuery({
     limit: PAGE_SIZE,
@@ -188,7 +188,7 @@ function _ModelCacheRefreshJobs({ onRefresh }: Props) {
 export const ModelCacheRefreshJobs = connect(
   null,
   mapDispatchToProps,
-)(_ModelCacheRefreshJobs);
+)(ModelCacheRefreshJobsInner);
 
 export function ModelCachePage({ children }: { children?: React.ReactNode }) {
   return (

--- a/frontend/src/metabase/admin/upsells/components/UpsellBanner.stories.tsx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellBanner.stories.tsx
@@ -5,7 +5,7 @@ import { ReduxProvider } from "__support__/storybook";
 import { ExternalLink } from "metabase/common/components/ExternalLink";
 import { Box } from "metabase/ui";
 
-import { _UpsellBanner } from "./UpsellBanner";
+import { UpsellBannerInner } from "./UpsellBanner";
 import S from "./Upsells.module.css";
 
 const args = {
@@ -42,12 +42,12 @@ const argTypes = {
   },
 };
 
-type UpsellBannerProps = ComponentProps<typeof _UpsellBanner>;
+type UpsellBannerProps = ComponentProps<typeof UpsellBannerInner>;
 
 const DefaultTemplate = (args: UpsellBannerProps) => (
   <ReduxProvider>
     <Box>
-      <_UpsellBanner {...args} />
+      <UpsellBannerInner {...args} />
     </Box>
   </ReduxProvider>
 );
@@ -55,7 +55,7 @@ const DefaultTemplate = (args: UpsellBannerProps) => (
 const SecondaryTemplate = ({ children, ...args }: UpsellBannerProps) => (
   <ReduxProvider>
     <Box>
-      <_UpsellBanner {...args}>
+      <UpsellBannerInner {...args}>
         {children}
         <ExternalLink
           className={S.SecondaryCTALink}
@@ -63,14 +63,14 @@ const SecondaryTemplate = ({ children, ...args }: UpsellBannerProps) => (
         >
           Learn more
         </ExternalLink>
-      </_UpsellBanner>
+      </UpsellBannerInner>
     </Box>
   </ReduxProvider>
 );
 
 export default {
   title: "Patterns/Upsells/Banner",
-  component: _UpsellBanner,
+  component: UpsellBannerInner,
   args,
   argTypes,
 };
@@ -96,7 +96,7 @@ export const WithOnClick = {
   render: (args: UpsellBannerProps) => (
     <ReduxProvider>
       <Box>
-        <_UpsellBanner {...args} onClick={action("clicked")} />
+        <UpsellBannerInner {...args} onClick={action("clicked")} />
       </Box>
     </ReduxProvider>
   ),
@@ -106,7 +106,7 @@ export const Dismissible = {
   render: (args: UpsellBannerProps) => (
     <ReduxProvider>
       <Box>
-        <_UpsellBanner {...args} dismissible />
+        <UpsellBannerInner {...args} dismissible />
       </Box>
     </ReduxProvider>
   ),

--- a/frontend/src/metabase/admin/upsells/components/UpsellBanner.tsx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellBanner.tsx
@@ -50,7 +50,7 @@ export type UpsellBannerProps =
   | (UpsellBannerPropsBase & CardLinkProps)
   | (UpsellBannerPropsBase & CardLinkProps & DismissibleProps);
 
-export const _UpsellBanner: React.FC<UpsellBannerProps> = ({
+export const UpsellBannerInner: React.FC<UpsellBannerProps> = ({
   title,
   buttonText,
   buttonLink,
@@ -124,5 +124,5 @@ export const _UpsellBanner: React.FC<UpsellBannerProps> = ({
 };
 
 export const UpsellBanner = UpsellWrapperDismissible(
-  UpsellWrapper(_UpsellBanner),
+  UpsellWrapper(UpsellBannerInner),
 );

--- a/frontend/src/metabase/admin/upsells/components/UpsellBigCard.stories.tsx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellBigCard.stories.tsx
@@ -4,7 +4,7 @@ import { ReduxProvider } from "__support__/storybook";
 import { ExternalLink } from "metabase/common/components/ExternalLink";
 import { Box, Modal } from "metabase/ui";
 
-import { type UpsellBigCardProps, _UpsellBigCard } from "./UpsellBigCard";
+import { UpsellBigCardInner, type UpsellBigCardProps } from "./UpsellBigCard";
 import S from "./Upsells.module.css";
 
 const args = {
@@ -38,7 +38,7 @@ const argTypes = {
 const DefaultTemplate = (args: Omit<UpsellBigCardProps, "onClick">) => (
   <ReduxProvider>
     <Box>
-      <_UpsellBigCard {...args} buttonLink="https://www.metabase.com" />
+      <UpsellBigCardInner {...args} buttonLink="https://www.metabase.com" />
     </Box>
   </ReduxProvider>
 );
@@ -50,7 +50,7 @@ const SecondaryTemplate = ({
 }: Omit<UpsellBigCardProps, "onClick">) => (
   <ReduxProvider>
     <Box>
-      <_UpsellBigCard {...args} buttonLink="https://www.metabase.com">
+      <UpsellBigCardInner {...args} buttonLink="https://www.metabase.com">
         {children}
         <ExternalLink
           className={S.SecondaryCTALink}
@@ -58,7 +58,7 @@ const SecondaryTemplate = ({
         >
           Learn more
         </ExternalLink>
-      </_UpsellBigCard>
+      </UpsellBigCardInner>
     </Box>
   </ReduxProvider>
 );
@@ -78,7 +78,7 @@ const ModalTemplate = ({
         I am just a basic Mantine modal.
       </Modal>
       <Box>
-        <_UpsellBigCard {...args} onClick={() => setOpened(true)}>
+        <UpsellBigCardInner {...args} onClick={() => setOpened(true)}>
           {children}
           <ExternalLink
             className={S.SecondaryCTALink}
@@ -86,7 +86,7 @@ const ModalTemplate = ({
           >
             Learn more
           </ExternalLink>
-        </_UpsellBigCard>
+        </UpsellBigCardInner>
       </Box>
     </ReduxProvider>
   );
@@ -94,7 +94,7 @@ const ModalTemplate = ({
 
 export default {
   title: "Patterns/Upsells/BigCard",
-  component: _UpsellBigCard,
+  component: UpsellBigCardInner,
   args,
   argTypes,
 };

--- a/frontend/src/metabase/admin/upsells/components/UpsellBigCard.tsx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellBigCard.tsx
@@ -33,7 +33,7 @@ export type UpsellBigCardProps = React.PropsWithChildren<{
       }
   );
 
-export const _UpsellBigCard: React.FC<UpsellBigCardProps> = ({
+export const UpsellBigCardInner: React.FC<UpsellBigCardProps> = ({
   title,
   buttonText,
   buttonLink,
@@ -111,4 +111,4 @@ export const _UpsellBigCard: React.FC<UpsellBigCardProps> = ({
   );
 };
 
-export const UpsellBigCard = UpsellWrapper(_UpsellBigCard);
+export const UpsellBigCard = UpsellWrapper(UpsellBigCardInner);

--- a/frontend/src/metabase/admin/upsells/components/UpsellPill.stories.tsx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellPill.stories.tsx
@@ -4,7 +4,7 @@ import type { ComponentProps } from "react";
 import { ReduxProvider } from "__support__/storybook";
 import { Box } from "metabase/ui";
 
-import { _UpsellPill } from "./UpsellPill";
+import { UpsellPillInner } from "./UpsellPill";
 
 const args = {
   children: "Metabase Enterprise is so great",
@@ -28,12 +28,12 @@ const argTypes = {
   },
 };
 
-type UpsellPillProps = ComponentProps<typeof _UpsellPill>;
+type UpsellPillProps = ComponentProps<typeof UpsellPillInner>;
 
 const DefaultTemplate = (args: UpsellPillProps) => (
   <ReduxProvider>
     <Box>
-      <_UpsellPill {...args} />
+      <UpsellPillInner {...args} />
     </Box>
   </ReduxProvider>
 );
@@ -41,14 +41,14 @@ const DefaultTemplate = (args: UpsellPillProps) => (
 const NarrowTemplate = (args: UpsellPillProps) => (
   <ReduxProvider>
     <Box style={{ maxWidth: "10rem" }}>
-      <_UpsellPill {...args} />
+      <UpsellPillInner {...args} />
     </Box>
   </ReduxProvider>
 );
 
 export default {
   title: "Patterns/Upsells/Pill",
-  component: _UpsellPill,
+  component: UpsellPillInner,
   args,
   argTypes,
 };

--- a/frontend/src/metabase/admin/upsells/components/UpsellPill.tsx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellPill.tsx
@@ -9,7 +9,7 @@ import { UpsellWrapper } from "./UpsellWrapper";
 import { trackUpsellClicked, trackUpsellViewed } from "./analytics";
 import { useUpsellLink } from "./use-upsell-link";
 
-export function _UpsellPill({
+export function UpsellPillInner({
   children,
   link,
   campaign,
@@ -60,4 +60,4 @@ export function _UpsellPill({
   );
 }
 
-export const UpsellPill = UpsellWrapper(_UpsellPill);
+export const UpsellPill = UpsellWrapper(UpsellPillInner);

--- a/frontend/src/metabase/admin/utils.js
+++ b/frontend/src/metabase/admin/utils.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import { useLayoutEffect } from "react";
 import { push, replace, routerActions } from "react-router-redux";
 import { connectedReduxRedirect } from "redux-auth-wrapper/history3/redirect";
@@ -30,7 +31,7 @@ const mapDispatchToProps = {
   replace,
 };
 
-const _RedirectToAllowedSettings = ({ adminItems, replace }) => {
+const RedirectToAllowedSettingsInner = ({ adminItems, replace }) => {
   useLayoutEffect(() => {
     replace(adminItems.length === 0 ? "/unauthorized" : adminItems[0].path);
   }, [adminItems, replace]);
@@ -38,10 +39,15 @@ const _RedirectToAllowedSettings = ({ adminItems, replace }) => {
   return null;
 };
 
+RedirectToAllowedSettingsInner.propTypes = {
+  adminItems: PropTypes.arrayOf(PropTypes.shape({ path: PropTypes.string })),
+  replace: PropTypes.func.isRequired,
+};
+
 export const RedirectToAllowedSettings = connect(
   mapStateToProps,
   mapDispatchToProps,
-)(_RedirectToAllowedSettings);
+)(RedirectToAllowedSettingsInner);
 
 export const createTenantsRouteGuard = () => {
   const Wrapper = connectedReduxRedirect({

--- a/frontend/src/metabase/collections/hooks.ts
+++ b/frontend/src/metabase/collections/hooks.ts
@@ -3,7 +3,7 @@ import { useSelector } from "metabase/lib/redux";
 import { PLUGIN_COLLECTIONS } from "metabase/plugins";
 import type { CollectionId } from "metabase-types/api";
 
-export const _useGetDefaultCollectionId = (
+export const useOSSGetDefaultCollectionId = (
   sourceCollectionId?: CollectionId | null,
 ): CollectionId | null => {
   // TODO: refactor this selector to be this hook and fetch the necessary collections
@@ -25,5 +25,6 @@ export const useGetDefaultCollectionId = (
     // eslint-disable-next-line react-hooks/rules-of-hooks -- this won't change at runtime, so it's safe
     return PLUGIN_COLLECTIONS.useGetDefaultCollectionId(sourceCollectionId);
   }
-  return _useGetDefaultCollectionId(sourceCollectionId);
+  // eslint-disable-next-line react-hooks/rules-of-hooks -- this won't change at runtime, so it's safe
+  return useOSSGetDefaultCollectionId(sourceCollectionId);
 };

--- a/frontend/src/metabase/common/components/ErrorPages/ErrorPages.tsx
+++ b/frontend/src/metabase/common/components/ErrorPages/ErrorPages.tsx
@@ -100,7 +100,7 @@ export const SmallGenericError = forwardRef<
     message?: string;
     bordered?: boolean;
   }
->(function _SmallGenericError(
+>(function SmallGenericErrorInner(
   { message = t`Something’s gone wrong.`, bordered = true, ...props },
   ref,
 ) {

--- a/frontend/src/metabase/common/components/LeaveConfirmModal/LeaveRouteConfirmModal.tsx
+++ b/frontend/src/metabase/common/components/LeaveConfirmModal/LeaveRouteConfirmModal.tsx
@@ -17,7 +17,7 @@ interface LeaveRouteConfirmModalProps {
   onOpenChange?: (opened: boolean) => void;
 }
 
-const _LeaveRouteConfirmModal = ({
+const LeaveRouteConfirmModalInner = ({
   isEnabled,
   isLocationAllowed,
   route,
@@ -53,4 +53,4 @@ const _LeaveRouteConfirmModal = ({
   );
 };
 
-export const LeaveRouteConfirmModal = withRouter(_LeaveRouteConfirmModal);
+export const LeaveRouteConfirmModal = withRouter(LeaveRouteConfirmModalInner);

--- a/frontend/src/metabase/common/components/LoadingAndErrorWrapper/LoadingAndErrorWrapper.tsx
+++ b/frontend/src/metabase/common/components/LoadingAndErrorWrapper/LoadingAndErrorWrapper.tsx
@@ -32,7 +32,7 @@ export interface LoadingAndErrorWrapperProps {
 export const LoadingAndErrorWrapper = forwardRef<
   HTMLDivElement,
   LoadingAndErrorWrapperProps
->(function _LoadingAndErrorWrapper(
+>(function LoadingAndErrorWrapperInner(
   {
     loading = false,
     error,

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.tsx
@@ -47,7 +47,7 @@ export interface BaseBucketPickerPopoverProps {
   };
 }
 
-function _BaseBucketPickerPopover({
+function BaseBucketPickerPopoverInner({
   query,
   stageIndex,
   items,
@@ -224,7 +224,10 @@ const TriggerButton = forwardRef(function TriggerButton(
   );
 });
 
-export const BaseBucketPickerPopover = Object.assign(_BaseBucketPickerPopover, {
-  displayName: "BucketPickerPopover",
-  TriggerButton,
-});
+export const BaseBucketPickerPopover = Object.assign(
+  BaseBucketPickerPopoverInner,
+  {
+    displayName: "BucketPickerPopover",
+    TriggerButton,
+  },
+);

--- a/frontend/src/metabase/common/components/ReorderableTagsInput/ReorderableTagsInput.stories.tsx
+++ b/frontend/src/metabase/common/components/ReorderableTagsInput/ReorderableTagsInput.stories.tsx
@@ -65,7 +65,9 @@ export default {
 };
 
 export const Default = {
-  render: (storyArgs: ComponentProps<typeof ReorderableTagsInput>) => {
+  render: function Render(
+    storyArgs: ComponentProps<typeof ReorderableTagsInput>,
+  ) {
     const [value, setValue] = useState<string[]>(
       [storyArgs.data[0]?.value, storyArgs.data[1]?.value].filter(Boolean),
     );
@@ -78,7 +80,7 @@ export const Default = {
 
 export const DragBetweenTwoInputs = {
   name: "Drag between two inputs",
-  render: () => {
+  render: function Render() {
     const allOptions = useMemo(() => makeOptions(), []);
 
     // Two controlled lists

--- a/frontend/src/metabase/common/components/UpsellCard/UpsellCard.stories.tsx
+++ b/frontend/src/metabase/common/components/UpsellCard/UpsellCard.stories.tsx
@@ -3,7 +3,7 @@ import { action } from "@storybook/addon-actions";
 import { ReduxProvider } from "__support__/storybook";
 import { Flex } from "metabase/ui";
 
-import { type UpsellCardProps, _UpsellCard } from "./UpsellCard";
+import { UpsellCardInner, type UpsellCardProps } from "./UpsellCard";
 
 const args = {
   title: "Ice Cream",
@@ -60,13 +60,13 @@ const Wrapper = (args: {
 
 const DefaultTemplate = (args: UpsellCardProps) => (
   <Wrapper>
-    <_UpsellCard {...args} />
+    <UpsellCardInner {...args} />
   </Wrapper>
 );
 
 export default {
   title: "Patterns/Upsells/Card",
-  component: _UpsellCard,
+  component: UpsellCardInner,
   args,
   argTypes,
 };

--- a/frontend/src/metabase/common/components/UpsellCard/UpsellCard.tsx
+++ b/frontend/src/metabase/common/components/UpsellCard/UpsellCard.tsx
@@ -53,7 +53,7 @@ export type UpsellCardProps = {
 } & CardWidthProps &
   CardLinkProps;
 
-export const _UpsellCard: React.FC<UpsellCardProps> = ({
+export const UpsellCardInner: React.FC<UpsellCardProps> = ({
   title,
   buttonText,
   buttonLink,
@@ -125,4 +125,4 @@ export const _UpsellCard: React.FC<UpsellCardProps> = ({
   );
 };
 
-export const UpsellCard = UpsellWrapper(_UpsellCard);
+export const UpsellCard = UpsellWrapper(UpsellCardInner);

--- a/frontend/src/metabase/common/components/UserHasSeen/UserHasSeenAll.tsx
+++ b/frontend/src/metabase/common/components/UserHasSeen/UserHasSeenAll.tsx
@@ -15,7 +15,7 @@ interface UserHasSeenAllProps {
   }) => JSX.Element;
 }
 
-const _UserHasSeenAll = ({ children }: UserHasSeenAllProps) => {
+const UserHasSeenAllInner = ({ children }: UserHasSeenAllProps) => {
   const ctx = useContext(UserHasSeenAllContext);
 
   if (!ctx) {
@@ -32,6 +32,6 @@ export const UserHasSeenAll = ({
   ...rest
 }: UserHasSeenAllProps & { id: string }) => (
   <UserHasSeenAllProvider id={id}>
-    <_UserHasSeenAll {...rest} />
+    <UserHasSeenAllInner {...rest} />
   </UserHasSeenAllProvider>
 );

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
@@ -713,7 +713,7 @@ const getUndoReplaceCardMessage = ({ type }: Card) => {
 const DashboardGrid = forwardRef<
   HTMLDivElement,
   DashboardGridForwardedRefProps
->(function _DashboardGrid({ width = 0, ...restProps }, ref) {
+>(function DashboardGridBase({ width = 0, ...restProps }, ref) {
   const {
     dashboard,
     selectedTabId,

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardModal.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardModal.unit.spec.tsx
@@ -235,8 +235,8 @@ describe("CreateDashboardModal", () => {
       await userEvent.click(collDropdown());
       await waitFor(() => expect(newCollBtn()).toBeInTheDocument());
       await userEvent.click(newCollBtn());
-      await screen.findByTestId("create-collection-on-the-go"),
-        await screen.findByText("Give it a name");
+      await screen.findByTestId("create-collection-on-the-go");
+      await screen.findByText("Give it a name");
     });
   });
 });

--- a/frontend/src/metabase/visualizations/components/EChartsRenderer/ResponsiveEChartsRenderer.tsx
+++ b/frontend/src/metabase/visualizations/components/EChartsRenderer/ResponsiveEChartsRenderer.tsx
@@ -11,10 +11,10 @@ export interface ResponsiveEChartsRendererProps
   onResize?: (width: number, height: number) => void;
 }
 
-const _ResponsiveEChartsRenderer = forwardRef<
+const ResponsiveEChartsRendererInner = forwardRef<
   HTMLDivElement,
   ResponsiveEChartsRendererProps
->(function _ResponsiveEChartsRenderer(
+>(function ResponsiveEChartsRendererBase(
   {
     onResize,
     width,
@@ -51,4 +51,4 @@ export const ResponsiveEChartsRendererExplicitSize =
   ExplicitSize<ResponsiveEChartsRendererProps>({
     wrapped: true,
     refreshMode: "debounceLeading",
-  })(_ResponsiveEChartsRenderer);
+  })(ResponsiveEChartsRendererInner);

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
@@ -29,7 +29,7 @@ const HIDE_X_AXIS_LABEL_HEIGHT_THRESHOLD = 200;
 const HIDE_Y_AXIS_HEIGHT_THRESHOLD = 150;
 const INTERPOLATE_LINE_THRESHOLD = 150;
 
-function _CartesianChart(props: VisualizationProps) {
+function CartesianChartInner(props: VisualizationProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   // The width and height from props reflect the dimensions of the entire container which includes legend,
   // however, for correct ECharts option calculation we need to use the dimensions of the chart viewport
@@ -218,7 +218,7 @@ function _CartesianChart(props: VisualizationProps) {
 export function CartesianChart(props: VisualizationProps) {
   return (
     <ChartRenderingErrorBoundary onRenderError={props.onRenderError}>
-      <_CartesianChart {...props} />
+      <CartesianChartInner {...props} />
     </ChartRenderingErrorBoundary>
   );
 }


### PR DESCRIPTION
The `react-hooks/rules-of-hooks` rule, which becomes default in Eslint v9, identifies React components by checking if the function name starts with an uppercase letter. This PR fixes two issues:
1. Components starting with underscore `_` violate this
2. Anonymous arrow function like render: () => {...}, which we use in storybook files,  has no name for the linter to check. Fixed by using function Render() {...}