### PR TITLE
Update the latest docker tag when the latest major version matches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -326,10 +326,11 @@ jobs:
             const { getExtraTagsForVersion } = require('${{ github.workspace }}/release/dist/index.cjs');
 
             const version = '${{ inputs.version }}';
+            const latestMajorVersion = '${{ vars.LATEST_MAJOR_VERSION }}';
 
-            const extra_tags = getExtraTagsForVersion({ version });
+            const extra_tags = getExtraTagsForVersion({ version, latestMajorVersion });
 
-            console.log({ extra_tags });
+            console.log({ extra_tags, latestMajorVersion });
             core.setOutput('extra_tags', JSON.stringify(extra_tags));
 
   add-extra-tags:
@@ -347,9 +348,11 @@ jobs:
     with:
       version: ${{ inputs.version }}
       tag_name: ${{ matrix.tag }}
-      tag_ee: ${{ contains(matrix.tag, 'v1') }}
-      tag_oss: ${{ contains(matrix.tag, 'v0') }}
-      dot-x-tag: true
+      # For version tags (v0.x, v1.x), apply to matching edition only
+      # For non-version tags like "latest", apply to both editions
+      tag_ee: ${{ contains(matrix.tag, 'v1') || !startsWith(matrix.tag, 'v') }}
+      tag_oss: ${{ contains(matrix.tag, 'v0') || !startsWith(matrix.tag, 'v') }}
+      dot-x-tag: ${{ startsWith(matrix.tag, 'v') }}
 
   trigger-cloud-issues:
     if: ${{ !inputs.auto }}

--- a/release/src/version-helpers.ts
+++ b/release/src/version-helpers.ts
@@ -161,23 +161,20 @@ export const getExtraTagsForVersion = ({
   version: string;
   latestMajorVersion?: string;
 }) => {
-  const ossVerion = getOSSVersion(version);
+  const ossVersion = getOSSVersion(version);
   const eeVersion = getEnterpriseVersion(version);
   const versionType = getVersionType(version);
 
-  // eg. v0.23.x / v1.23.x
-  const tags = [getDotXs(ossVerion, 1), getDotXs(eeVersion, 1)];
+  const baseTags = [getDotXs(ossVersion, 1), getDotXs(eeVersion, 1)];
+  const minorTags = versionType !== "major"
+    ? [getDotXs(ossVersion, 2), getDotXs(eeVersion, 2)]
+    : [];
 
-  if (versionType !== "major") {
-    // eg. v0.23.4.x / v1.23.4.x
-    tags.push(getDotXs(ossVerion, 2), getDotXs(eeVersion, 2));
-  }
-
-  if (shouldAddLatestTag({ version, latestMajorVersion })) {
-    tags.push("latest");
-  }
-
-  return tags;
+  return [
+    ...baseTags,
+    ...minorTags,
+    ...(shouldAddLatestTag({ version, latestMajorVersion }) ? ["latest"] : []),
+  ];
 };
 
 /**

--- a/release/src/version-helpers.ts
+++ b/release/src/version-helpers.ts
@@ -143,6 +143,17 @@ export const getDotXVersion = (version: string) => {
   return getDotXs(version, 2);
 };
 
+const shouldAddLatestTag = ({
+  version,
+  latestMajorVersion,
+}: {
+  version: string;
+  latestMajorVersion?: string;
+}) => {
+  const majorVersion = getMajorVersion(version);
+  return majorVersion === latestMajorVersion;
+};
+
 export const getExtraTagsForVersion = ({
   version,
   latestMajorVersion,
@@ -157,37 +168,13 @@ export const getExtraTagsForVersion = ({
   // eg. v0.23.x / v1.23.x
   const tags = [getDotXs(ossVerion, 1), getDotXs(eeVersion, 1)];
 
-  if (versionType === "major") {
-    return maybeAddLatestTag({ tags, version, latestMajorVersion });
+  if (versionType !== "major") {
+    // eg. v0.23.4.x / v1.23.4.x
+    tags.push(getDotXs(ossVerion, 2), getDotXs(eeVersion, 2));
   }
 
-  // eg. v0.23.4.x / v1.23.4.x
-  return maybeAddLatestTag({
-    tags: [...tags, getDotXs(ossVerion, 2), getDotXs(eeVersion, 2)],
-    version,
-    latestMajorVersion,
-  });
-};
-
-const maybeAddLatestTag = ({
-  tags,
-  version,
-  latestMajorVersion,
-}: {
-  tags: string[];
-  version: string;
-  latestMajorVersion?: string;
-}) => {
-  if (!latestMajorVersion) {
-    return tags;
-  }
-
-  const versionMajor = getMajorVersion(version);
-  const isLatestMajor = versionMajor === latestMajorVersion;
-  const isPreRelease = isPreReleaseVersion(version);
-
-  if (isLatestMajor && !isPreRelease) {
-    return [...tags, "latest"];
+  if (shouldAddLatestTag({ version, latestMajorVersion })) {
+    tags.push("latest");
   }
 
   return tags;

--- a/release/src/version-helpers.ts
+++ b/release/src/version-helpers.ts
@@ -143,7 +143,13 @@ export const getDotXVersion = (version: string) => {
   return getDotXs(version, 2);
 };
 
-export const getExtraTagsForVersion = ({ version }: { version: string }) => {
+export const getExtraTagsForVersion = ({
+  version,
+  latestMajorVersion,
+}: {
+  version: string;
+  latestMajorVersion?: string;
+}) => {
   const ossVerion = getOSSVersion(version);
   const eeVersion = getEnterpriseVersion(version);
   const versionType = getVersionType(version);
@@ -152,11 +158,39 @@ export const getExtraTagsForVersion = ({ version }: { version: string }) => {
   const tags = [getDotXs(ossVerion, 1), getDotXs(eeVersion, 1)];
 
   if (versionType === "major") {
-    return tags;
+    return maybeAddLatestTag({ tags, version, latestMajorVersion });
   }
 
   // eg. v0.23.4.x / v1.23.4.x
-  return [...tags, getDotXs(ossVerion, 2), getDotXs(eeVersion, 2)];
+  return maybeAddLatestTag({
+    tags: [...tags, getDotXs(ossVerion, 2), getDotXs(eeVersion, 2)],
+    version,
+    latestMajorVersion,
+  });
+};
+
+const maybeAddLatestTag = ({
+  tags,
+  version,
+  latestMajorVersion,
+}: {
+  tags: string[];
+  version: string;
+  latestMajorVersion?: string;
+}) => {
+  if (!latestMajorVersion) {
+    return tags;
+  }
+
+  const versionMajor = getMajorVersion(version);
+  const isLatestMajor = versionMajor === latestMajorVersion;
+  const isPreRelease = isPreReleaseVersion(version);
+
+  if (isLatestMajor && !isPreRelease) {
+    return [...tags, "latest"];
+  }
+
+  return tags;
 };
 
 /**

--- a/release/src/version-helpers.ts
+++ b/release/src/version-helpers.ts
@@ -165,7 +165,9 @@ export const getExtraTagsForVersion = ({
   const eeVersion = getEnterpriseVersion(version);
   const versionType = getVersionType(version);
 
+  // eg. v0.23.x / v1.23.x
   const baseTags = [getDotXs(ossVersion, 1), getDotXs(eeVersion, 1)];
+  // eg. v0.23.4.x / v1.23.4.x
   const minorTags = versionType !== "major"
     ? [getDotXs(ossVersion, 2), getDotXs(eeVersion, 2)]
     : [];

--- a/release/src/version-helpers.unit.spec.ts
+++ b/release/src/version-helpers.unit.spec.ts
@@ -838,20 +838,20 @@ describe("version-helpers", () => {
       ).toEqual(["v0.59.x", "v1.59.x"]);
     });
 
-    it("should NOT add latest tag for pre-release versions even when major matches", () => {
+    it("should add latest tag for pre-release versions when major matches", () => {
       expect(
         getExtraTagsForVersion({
           version: "v0.58.1-rc1",
           latestMajorVersion: "58",
         }),
-      ).toEqual(["v0.58.x", "v1.58.x", "v0.58.1.x", "v1.58.1.x"]);
+      ).toEqual(["v0.58.x", "v1.58.x", "v0.58.1.x", "v1.58.1.x", "latest"]);
 
       expect(
         getExtraTagsForVersion({
           version: "v0.58.0-beta",
           latestMajorVersion: "58",
         }),
-      ).toEqual(["v0.58.x", "v1.58.x"]);
+      ).toEqual(["v0.58.x", "v1.58.x", "latest"]);
     });
 
     it("should NOT add latest tag when latestMajorVersion is not provided", () => {

--- a/release/src/version-helpers.unit.spec.ts
+++ b/release/src/version-helpers.unit.spec.ts
@@ -802,6 +802,70 @@ describe("version-helpers", () => {
         "v1.75.1.x",
       ]);
     });
+
+    it("should add latest tag when version major matches latestMajorVersion", () => {
+      expect(
+        getExtraTagsForVersion({ version: "v0.58.1", latestMajorVersion: "58" }),
+      ).toEqual(["v0.58.x", "v1.58.x", "v0.58.1.x", "v1.58.1.x", "latest"]);
+
+      expect(
+        getExtraTagsForVersion({ version: "v1.58.2", latestMajorVersion: "58" }),
+      ).toEqual(["v0.58.x", "v1.58.x", "v0.58.2.x", "v1.58.2.x", "latest"]);
+    });
+
+    it("should add latest tag for major versions when major matches latestMajorVersion", () => {
+      expect(
+        getExtraTagsForVersion({ version: "v0.58.0", latestMajorVersion: "58" }),
+      ).toEqual(["v0.58.x", "v1.58.x", "latest"]);
+    });
+
+    it("should add latest tag for patch versions when major matches latestMajorVersion", () => {
+      expect(
+        getExtraTagsForVersion({
+          version: "v0.58.1.3",
+          latestMajorVersion: "58",
+        }),
+      ).toEqual(["v0.58.x", "v1.58.x", "v0.58.1.x", "v1.58.1.x", "latest"]);
+    });
+
+    it("should NOT add latest tag when version major does not match latestMajorVersion", () => {
+      expect(
+        getExtraTagsForVersion({ version: "v0.57.5", latestMajorVersion: "58" }),
+      ).toEqual(["v0.57.x", "v1.57.x", "v0.57.5.x", "v1.57.5.x"]);
+
+      expect(
+        getExtraTagsForVersion({ version: "v0.59.0", latestMajorVersion: "58" }),
+      ).toEqual(["v0.59.x", "v1.59.x"]);
+    });
+
+    it("should NOT add latest tag for pre-release versions even when major matches", () => {
+      expect(
+        getExtraTagsForVersion({
+          version: "v0.58.1-rc1",
+          latestMajorVersion: "58",
+        }),
+      ).toEqual(["v0.58.x", "v1.58.x", "v0.58.1.x", "v1.58.1.x"]);
+
+      expect(
+        getExtraTagsForVersion({
+          version: "v0.58.0-beta",
+          latestMajorVersion: "58",
+        }),
+      ).toEqual(["v0.58.x", "v1.58.x"]);
+    });
+
+    it("should NOT add latest tag when latestMajorVersion is not provided", () => {
+      expect(getExtraTagsForVersion({ version: "v0.58.1" })).toEqual([
+        "v0.58.x",
+        "v1.58.x",
+        "v0.58.1.x",
+        "v1.58.1.x",
+      ]);
+
+      expect(
+        getExtraTagsForVersion({ version: "v0.58.1", latestMajorVersion: "" }),
+      ).toEqual(["v0.58.x", "v1.58.x", "v0.58.1.x", "v1.58.1.x"]);
+    });
   });
 
   describe("filterOutNonSupportedPrereleaseIdentifier", () => {


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #68909
Resolves DEV-1334

tl;dr 
The latest tag will now be properly recognized if the current tag's major edition matches *manually set* GitHub var's `LATEST_MAJOR_EDITION` value.

This pull request updates the version tagging logic for releases to support automatically adding the "latest" tag when the released version matches the current latest major version. It also improves the flexibility of tag assignment in the release workflow and adds comprehensive unit tests to verify the new behavior.

**Tagging logic improvements:**

* Enhanced `getExtraTagsForVersion` in `release/src/version-helpers.ts` to accept an optional `latestMajorVersion` parameter and append the "latest" tag when the released version's major matches the latest major version and is not a pre-release. [[1]](diffhunk://#diff-c48ad4563e8f842f368b0e28e7333610cefa2a1c579b888b066057a621d63f23L146-R152) [[2]](diffhunk://#diff-c48ad4563e8f842f368b0e28e7333610cefa2a1c579b888b066057a621d63f23L155-R193)
* Refactored the release workflow in `.github/workflows/release.yml` to pass `latestMajorVersion` into the tag generation step and improved tag assignment logic for OSS and EE editions. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R329-R333) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L350-R355)

**Testing improvements:**

- [x] Tests have been added/updated to cover changes in this PR

* Added extensive unit tests in `release/src/version-helpers.unit.spec.ts` to cover scenarios for when the "latest" tag should and should not be added, including major, patch, and pre-release versions, and cases where `latestMajorVersion` is not provided.