### PR TITLE
feat(sdk, embedjs): support saving and editing questions created with metabot

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/metabot-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/metabot-question.cy.spec.tsx
@@ -73,7 +73,7 @@ describe("scenarios > embedding-sdk > metabot-question", () => {
     });
   });
 
-  it.only("should allow to save a question", () => {
+  it("should allow to save a question", () => {
     cy.intercept("POST", "http://localhost:4000/api/card").as("postCard");
 
     setup(metabotResponseWithNavigateTo);

--- a/e2e/test-component/scenarios/embedding-sdk/metabot-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/metabot-question.cy.spec.tsx
@@ -62,7 +62,6 @@ describe("scenarios > embedding-sdk > metabot-question", () => {
     cy.request("POST", "/api/collection", {
       name: "first_collection",
       description: "First collection",
-      parent_id: undefined,
     }).then(({ body }) => {
       cy.wrap(body.id).as("collectionId");
     });
@@ -84,7 +83,7 @@ describe("scenarios > embedding-sdk > metabot-question", () => {
   });
 
   it("should allow saving a question", () => {
-    cy.intercept("POST", "http://localhost:4000/api/card").as("postCard");
+    cy.intercept("POST", "/api/card").as("postCard");
 
     setup(metabotResponseWithNavigateTo);
 

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
@@ -437,6 +437,88 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
         .findAllByText("AI isn't perfect. Double-check results.")
         .should("be.visible");
     });
+
+    describe("saving a metabot question", () => {
+      const query = {
+        "source-table": ORDERS_ID,
+        aggregation: [["max", ["field", ORDERS.QUANTITY, null]]],
+        breakout: [["field", ORDERS.PRODUCT_ID, null]],
+        limit: 2,
+      };
+      const adHocQuestionPath = `/question#${btoa(
+        JSON.stringify({
+          dataset_query: { database: 1, type: "query", query },
+          display: "table",
+          displayIsLocked: true,
+          visualization_settings: {},
+        }),
+      )}`;
+
+      const metabotResponse = `0:"Here is the [question link](${adHocQuestionPath})"`;
+      const metabotResponseWithNavigateTo = `${metabotResponse}
+    2:{"type":"navigate_to","version":1,"value":"${adHocQuestionPath}"}`;
+
+      it("should allow to save a new question", () => {
+        H.mockMetabotResponse({
+          statusCode: 200,
+          body: metabotResponseWithNavigateTo,
+        });
+
+        cy.intercept("POST", "http://localhost:4000/api/card").as("postCard");
+
+        cy.log("Create a collection");
+        cy.request("POST", "/api/collection", {
+          name: "first_collection",
+          description: "First collection",
+          parent_id: undefined,
+        }).then(({ body }) => {
+          cy.log("Visit an embed metabase-metabot");
+          H.visitCustomHtmlPage(`
+            ${H.getNewEmbedScriptTag()}
+            ${H.getNewEmbedConfigurationScript()}
+            <metabase-metabot is-save-enabled="true" target-collection="${body.id}" />
+          `);
+
+          H.getSimpleEmbedIframeContent().within(() => {
+            cy.log("Ask a Metabot to create a question");
+            // the question doesn't matter, we're stubbing the response
+            cy.findByPlaceholderText("Ask AI a question...").type(
+              "Show me something{enter}",
+            );
+
+            cy.findByText("question link").click();
+
+            cy.findByText("Max of Quantity by Product ID").should("be.visible");
+
+            cy.log("Save the question");
+            cy.findByRole("button", { name: "Save" })
+              .should("be.visible")
+              .click();
+
+            H.modal().within(() => {
+              cy.findByText("Save new question").should("be.visible");
+              cy.findByRole("button", { name: "Save" }).click();
+            });
+          });
+
+          cy.wait("@postCard").then((interception) => {
+            const response = interception.response?.body;
+            const questionId = response.id;
+
+            cy.log("Open the question");
+            H.visitQuestion(questionId)?.then(() => {
+              // Name of the collection should be visible at the top of the page
+              // findAllBy because there are two "first_collection", one in the sidebar and one at the top
+              cy.findAllByText("first_collection").first().should("be.visible");
+              // Name of the new question should be visible too
+              cy.findByText(
+                "Orders, Max of Quantity, Grouped by Product ID, 2 rows",
+              ).should("be.visible");
+            });
+          });
+        });
+      });
+    });
   });
 
   describe("common checks", () => {

--- a/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotQuestion.schema.ts
+++ b/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotQuestion.schema.ts
@@ -12,6 +12,8 @@ const propsSchema: Yup.SchemaOf<MetabotQuestionProps> = Yup.object({
   layout: Yup.mixed<"auto" | "sidebar" | "stacked">()
     .oneOf(["auto", "sidebar", "stacked"])
     .optional(),
+  isSaveEnabled: Yup.mixed().optional(),
+  targetCollection: Yup.mixed().optional(),
 });
 
 export const metabotQuestionSchema: FunctionSchema = { input: [propsSchema] };

--- a/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotQuestion.tsx
@@ -36,7 +36,7 @@ const MetabotQuestionInner = ({
   className,
   style,
   layout = "auto",
-  isSaveEnabled,
+  isSaveEnabled = false,
   targetCollection,
 }: MetabotQuestionProps) => {
   const { isLocaleLoading } = useLocale();

--- a/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotQuestion.tsx
@@ -36,6 +36,8 @@ const MetabotQuestionInner = ({
   className,
   style,
   layout = "auto",
+  isSaveEnabled,
+  targetCollection,
 }: MetabotQuestionProps) => {
   const { isLocaleLoading } = useLocale();
   const { navigateToPath } = useMetabotReactions();
@@ -68,7 +70,8 @@ const MetabotQuestionInner = ({
       <SdkAdHocQuestion
         questionPath={navigateToPath}
         title={false}
-        isSaveEnabled={false}
+        isSaveEnabled={isSaveEnabled}
+        targetCollection={targetCollection}
       >
         <SdkQuestionDefaultView
           height="100%"

--- a/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/types.ts
+++ b/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/types.ts
@@ -1,5 +1,6 @@
 import type { CSSProperties } from "react";
 
+import type { SdkCollectionId } from "embedding-sdk-bundle/types/collection";
 import type { CommonStylingProps } from "embedding-sdk-bundle/types/props";
 
 /**
@@ -28,4 +29,14 @@ export interface MetabotQuestionProps extends CommonStylingProps {
    * A number or string specifying a CSS size value that specifies the width of the component
    */
   width?: CSSProperties["width"];
+
+  /**
+   * Whether to show the save button.
+   **/
+  isSaveEnabled?: boolean;
+
+  /**
+   * The collection to save the question to. This will hide the collection picker from the save modal. Only applicable to interactive questions.
+   */
+  targetCollection?: SdkCollectionId;
 }

--- a/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/types.ts
+++ b/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/types.ts
@@ -32,11 +32,11 @@ export interface MetabotQuestionProps extends CommonStylingProps {
 
   /**
    * Whether to show the save button.
-   **/
+   */
   isSaveEnabled?: boolean;
 
   /**
-   * The collection to save the question to. This will hide the collection picker from the save modal. Only applicable to interactive questions.
+   * The collection to save the question to. This will hide the collection picker from the save modal.
    */
   targetCollection?: SdkCollectionId;
 }

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
@@ -271,6 +271,8 @@ const SdkIframeEmbedView = ({
           <MetabotQuestion
             key={rerenderKey}
             layout={settings.layout}
+            isSaveEnabled={settings.isSaveEnabled}
+            targetCollection={settings.targetCollection}
             height="100%"
           />
         ),

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/constants.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/constants.ts
@@ -64,7 +64,11 @@ export const ALLOWED_EMBED_SETTING_KEYS_MAP = {
     "withNewQuestion",
     "withNewDashboard",
   ] satisfies (keyof BrowserEmbedOptions)[],
-  metabot: ["layout"] satisfies (keyof MetabotEmbedOptions)[],
+  metabot: [
+    "layout",
+    "isSaveEnabled",
+    "targetCollection",
+  ] satisfies (keyof MetabotEmbedOptions)[],
 } as const;
 export const ALLOWED_GUEST_EMBED_SETTING_KEYS_MAP = {
   base: [

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
@@ -531,6 +531,8 @@ const MetabaseManageContentElement = createCustomElement("metabase-browser", [
 
 const MetabaseMetabotElement = createCustomElement("metabase-metabot", [
   "layout",
+  "is-save-enabled",
+  "target-collection",
 ]);
 
 // Expose the old API that's still used in the tests, we'll probably remove this api unless customers prefer it

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
@@ -161,6 +161,16 @@ export interface MetabotEmbedOptions {
   /** Layout mode for the metabot interface */
   layout?: "auto" | "sidebar" | "stacked";
 
+  /**
+   * The collection to save a question to
+   */
+  targetCollection?: CollectionId;
+
+  /**
+   * Is the save button enabled
+   */
+  isSaveEnabled?: boolean;
+
   // incompatible options
   template?: never;
   questionId?: never;

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
@@ -167,7 +167,7 @@ export interface MetabotEmbedOptions {
   targetCollection?: CollectionId;
 
   /**
-   * Is the save button enabled
+   * Whether the save button is enabled
    */
   isSaveEnabled?: boolean;
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #66073
Closes [EMB-1058: Support saving and editing Questions created with metabot SDK/EmbedJS](https://linear.app/metabase/issue/EMB-1058/support-saving-and-editing-questions-created-with-metabot-sdkembedjs)

### Description

When using a Metabot question in an embed context (SDK or modular/EAJS), users can now save the question they created, just like they can modify and save questions using InteractiveQuestion for example (assuming they have the right to do so).

### How to verify

1. Use MetabaseMetabot (either in an SDK app or with EAJS)
2. Set `isSaveEnabled` to `true` and give it a `targetCollection`
3. Ask Metabot to make a question for you
4. Notice how you can now save ther question

### Demo

https://www.loom.com/share/7b5c2967d225498c9baccce70bae38ef

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
