### PR TITLE
feat(sdk, embed-js): Add joined tables/temporal/bins content translations for aggregations and breakouts and question title

### DIFF
--- a/e2e/support/helpers/e2e-notebook-helpers.ts
+++ b/e2e/support/helpers/e2e-notebook-helpers.ts
@@ -503,3 +503,19 @@ function getSortItems(stageIndex: number) {
 export function clauseStepPopover() {
   return popover({ testId: "clause-popover" });
 }
+
+export function openPopoverFromDefaultBucketSize(
+  column: string,
+  bucket: string,
+) {
+  cy.findAllByTestId("dimension-list-item")
+    .filter(`:contains("${column}")`)
+    .as("targetListItem")
+    .realHover()
+    .within(() => {
+      cy.findByTestId("dimension-list-item-binning")
+        .as("listItemSelectedBinning")
+        .should("contain", bucket)
+        .click();
+    });
+}

--- a/e2e/test-component/scenarios/embedding-sdk/content-translations.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/content-translations.cy.spec.tsx
@@ -95,6 +95,7 @@ describe("scenarios > embedding-sdk > content-translations", () => {
         // Table translations
         { locale: "de", msgid: "Orders", msgstr: "DE-Orders" },
         { locale: "de", msgid: "Products", msgstr: "DE-Products" },
+        { locale: "de", msgid: "Product", msgstr: "DE-Product" },
         { locale: "de", msgid: "People", msgstr: "DE-People" },
         { locale: "de", msgid: "Reviews", msgstr: "DE-Reviews" },
         // Column translations
@@ -339,7 +340,11 @@ describe("scenarios > embedding-sdk > content-translations", () => {
           cy.findByText("DE-Latitude").click();
         });
 
-        cy.findByText("Eindeutige Werte von DE-Latitude").should("be.visible");
+        cy.findByTestId("step-summarize-0-0").within(() => {
+          cy.findByText("Eindeutige Werte von DE-Latitude").should(
+            "be.visible",
+          );
+        });
 
         cy.findByText("Wähle eine Spalte für die Gruppierung").click();
 
@@ -374,6 +379,97 @@ describe("scenarios > embedding-sdk > content-translations", () => {
 
         cy.findByTestId("table-header").within(() => {
           cy.findByText("DE-Latitude: 10°").should("be.visible");
+        });
+      });
+    });
+
+    it("should translate aggregation-related columns for joined tables", () => {
+      setupEditor();
+      mountEditor();
+
+      getSdkRoot().within(() => {
+        popover().within(() => {
+          cy.findByText("DE-Orders").click();
+        });
+
+        // "Join data" in German locale
+        cy.button("Daten verknüpfen").click();
+
+        popover().within(() => {
+          cy.findByText("DE-People").click();
+        });
+
+        cy.findByText("DE-User ID").click();
+
+        popover().within(() => {
+          cy.findByText("DE-Product ID").click();
+        });
+
+        cy.findByText("DE-ID").click();
+
+        popover().within(() => {
+          cy.findByText("DE-ID").click();
+        });
+
+        cy.findByText("Wähle eine Funktion oder Metrik aus").click();
+
+        popover().within(() => {
+          cy.findByText("Anzahl eindeutiger Werte von...").click();
+          cy.findByText("DE-People").click();
+
+          cy.findByText("DE-Created At").click();
+        });
+
+        cy.findByTestId("step-summarize-0-0").within(() => {
+          cy.findByText(
+            "Eindeutige Werte von DE-People - DE-Product → DE-Created At: Monat",
+          ).should("be.visible");
+        });
+
+        cy.findByText("Wähle eine Spalte für die Gruppierung").click();
+
+        popover().within(() => {
+          cy.findByText("DE-People").click();
+          cy.findByText("DE-Created At").click();
+        });
+
+        cy.findByText("DE-People - DE-Product → DE-Created At: Monat").should(
+          "be.visible",
+        );
+
+        // "Visualize" in German locale
+        cy.button("Darstellen").click();
+
+        cy.findByTestId("interactive-question-top-toolbar").within(() => {
+          cy.findByText(
+            "Eindeutige Werte von DE-People - DE-Product → DE-Created At: Monat von DE-People - DE-Product → DE-Created At: Monat",
+          ).should("be.visible");
+        });
+
+        cy.findByTestId("interactive-question-result-toolbar").within(() => {
+          // "1 grouping" in German locale
+          cy.findByText("1 Gruppierung").click();
+        });
+
+        popover().within(() => {
+          cy.findByText("DE-People - DE-Product → DE-Created At").should(
+            "be.visible",
+          );
+        });
+
+        cy.findByTestId("chart-type-selector-button").click();
+
+        popover().within(() => {
+          cy.findByText("Tabelle").click();
+        });
+
+        cy.findByTestId("table-header").within(() => {
+          cy.findByText("DE-People - DE-Product → DE-Created At: Monat").should(
+            "be.visible",
+          );
+          cy.findByText(
+            "Eindeutige Werte von DE-People - DE-Product → DE-Created At: Monat",
+          ).should("be.visible");
         });
       });
     });

--- a/e2e/test-component/scenarios/embedding-sdk/content-translations.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/content-translations.cy.spec.tsx
@@ -4,7 +4,11 @@ import {
 } from "@metabase/embedding-sdk-react";
 
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { createQuestion, popover } from "e2e/support/helpers";
+import {
+  createQuestion,
+  openPopoverFromDefaultBucketSize,
+  popover,
+} from "e2e/support/helpers";
 import { uploadTranslationDictionaryViaAPI } from "e2e/support/helpers/e2e-content-translation-helpers";
 import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
 import {
@@ -104,6 +108,8 @@ describe("scenarios > embedding-sdk > content-translations", () => {
         { locale: "de", msgid: "User ID", msgstr: "DE-User ID" },
         { locale: "de", msgid: "Subtotal", msgstr: "DE-Subtotal" },
         { locale: "de", msgid: "Address", msgstr: "DE-Address" },
+        { locale: "de", msgid: "Latitude", msgstr: "DE-Latitude" },
+        { locale: "de", msgid: "Longitude", msgstr: "DE-Longitude" },
       ]);
 
       cy.signOut();
@@ -131,25 +137,25 @@ describe("scenarios > embedding-sdk > content-translations", () => {
       setupEditor();
       mountEditor();
 
-      popover().within(() => {
-        // Use .should("exist") instead of .should("be.visible") because
-        // elements in scrollable popovers might be below the fold
-        cy.findByText("DE-Products").should("exist");
-
-        cy.findByText("DE-Orders").click();
-      });
-
       getSdkRoot().within(() => {
+        popover().within(() => {
+          // Use .should("exist") instead of .should("be.visible") because
+          // elements in scrollable popovers might be below the fold
+          cy.findByText("DE-Products").should("exist");
+
+          cy.findByText("DE-Orders").click();
+        });
+
         // "Add a filter to narrow down your answer" in German locale
         cy.findByText(
           "Füge Filter hinzu, um deine Antwort einzugrenzen",
         ).click();
-      });
 
-      popover().within(() => {
-        cy.findByText("DE-Total").should("exist");
-        cy.findByText("DE-Tax").should("exist");
-        cy.findByText("DE-Quantity").should("exist");
+        popover().within(() => {
+          cy.findByText("DE-Total").should("exist");
+          cy.findByText("DE-Tax").should("exist");
+          cy.findByText("DE-Quantity").should("exist");
+        });
       });
     });
 
@@ -157,33 +163,29 @@ describe("scenarios > embedding-sdk > content-translations", () => {
       setupEditor();
       mountEditor();
 
-      popover().within(() => {
-        cy.findByText("DE-Orders").click();
-      });
-
       getSdkRoot().within(() => {
+        popover().within(() => {
+          cy.findByText("DE-Orders").click();
+        });
+
         cy.findByText(
           "Füge Filter hinzu, um deine Antwort einzugrenzen",
         ).click();
-      });
 
-      popover().within(() => {
-        cy.findByText("DE-Total").click();
-      });
+        popover().within(() => {
+          cy.findByText("DE-Total").click();
 
-      popover().within(() => {
-        cy.findByTestId("number-filter-picker").within(() => {
-          cy.findByText("DE-Total").should("be.visible");
+          cy.findByTestId("number-filter-picker").within(() => {
+            cy.findByText("DE-Total").should("be.visible");
 
-          cy.findByPlaceholderText("Min").type("100");
-          cy.findByPlaceholderText("Max").type("200");
+            cy.findByPlaceholderText("Min").type("100");
+            cy.findByPlaceholderText("Max").type("200");
 
-          // "Add filter" in German locale
-          cy.button("Füge einen Filter hinzu").click();
+            // "Add filter" in German locale
+            cy.button("Füge einen Filter hinzu").click();
+          });
         });
-      });
 
-      getSdkRoot().within(() => {
         // "DE-Total is between 100 and 200" - filter display with translated column name
         cy.findByText("DE-Total ist zwischen 100 und 200").should("be.visible");
       });
@@ -193,37 +195,33 @@ describe("scenarios > embedding-sdk > content-translations", () => {
       setupEditor();
       mountEditor();
 
-      popover().within(() => {
-        cy.findByText("DE-Orders").click();
-      });
-
       getSdkRoot().within(() => {
+        popover().within(() => {
+          cy.findByText("DE-Orders").click();
+        });
+
         // "Pick a function or metric" in German locale
         cy.findByText("Wähle eine Funktion oder Metrik aus").click();
-      });
 
-      popover().within(() => {
-        // "Sum of..." in German locale
-        cy.findByText("Summe von...").click();
+        popover().within(() => {
+          // "Sum of..." in German locale
+          cy.findByText("Summe von...").click();
 
-        cy.findByText("DE-Orders").should("exist");
-        cy.findByText("DE-Discount").should("exist");
-      });
+          cy.findByText("DE-Orders").should("exist");
+          cy.findByText("DE-Discount").should("exist");
 
-      popover().within(() => {
-        cy.findByText("DE-Total").click();
-      });
+          cy.findByText("DE-Total").click();
+        });
 
-      getSdkRoot().within(() => {
         // "Pick a column to group by" in German locale
         cy.findByText("Wähle eine Spalte für die Gruppierung").click();
-      });
 
-      popover().within(() => {
-        cy.findByText("DE-Orders").should("exist");
-        cy.findByText("DE-Product ID").should("exist");
+        popover().within(() => {
+          cy.findByText("DE-Orders").should("exist");
+          cy.findByText("DE-Product ID").should("exist");
 
-        cy.findByText("DE-Total").click();
+          cy.findByText("DE-Total").click();
+        });
       });
     });
 
@@ -231,28 +229,24 @@ describe("scenarios > embedding-sdk > content-translations", () => {
       setupEditor();
       mountEditor();
 
-      popover().within(() => {
-        cy.findByText("DE-Orders").click();
-      });
-
       getSdkRoot().within(() => {
+        popover().within(() => {
+          cy.findByText("DE-Orders").click();
+        });
+
         cy.findByText("Wähle eine Funktion oder Metrik aus").click();
-      });
 
-      popover().within(() => {
-        cy.findByText("Summe von...").click();
-        cy.findByText("DE-Total").click();
-      });
+        popover().within(() => {
+          cy.findByText("Summe von...").click();
+          cy.findByText("DE-Total").click();
+        });
 
-      getSdkRoot().within(() => {
         cy.findByText("Wähle eine Spalte für die Gruppierung").click();
-      });
 
-      popover().within(() => {
-        cy.findByText("DE-Product ID").click();
-      });
+        popover().within(() => {
+          cy.findByText("DE-Product ID").click();
+        });
 
-      getSdkRoot().within(() => {
         // "Visualize" in German locale
         cy.button("Darstellen").click();
 
@@ -282,26 +276,126 @@ describe("scenarios > embedding-sdk > content-translations", () => {
       });
     });
 
+    it("should translate columns with temporal bucket patterns", () => {
+      setupEditor();
+      mountEditor();
+
+      getSdkRoot().within(() => {
+        popover().within(() => {
+          cy.findByText("DE-Orders").click();
+        });
+
+        cy.findByText("Wähle eine Funktion oder Metrik aus").click();
+
+        popover().within(() => {
+          cy.findByText("Anzahl eindeutiger Werte von...").click();
+          cy.findByText("DE-Total").click();
+        });
+
+        cy.findByText("Wähle eine Spalte für die Gruppierung").click();
+
+        popover().within(() => {
+          cy.findByText("DE-Created At").click();
+        });
+
+        // "Visualize" in German locale
+        cy.button("Darstellen").click();
+
+        cy.findByTestId("interactive-question-result-toolbar").within(() => {
+          // "1 grouping" in German locale
+          cy.findByText("1 Gruppierung").click();
+        });
+
+        popover().within(() => {
+          cy.findByText("DE-Created At").should("be.visible");
+        });
+
+        cy.findByTestId("chart-type-selector-button").click();
+
+        popover().within(() => {
+          cy.findByText("Tabelle").click();
+        });
+
+        cy.findByTestId("table-header").within(() => {
+          cy.findByText("DE-Created At: Monat").should("be.visible");
+        });
+      });
+    });
+
+    it("should translate columns with binning patterns", () => {
+      setupEditor();
+      mountEditor();
+
+      getSdkRoot().within(() => {
+        popover().within(() => {
+          // Select People table which has Latitude/Longitude fields
+          cy.findByText("DE-People").click();
+        });
+
+        cy.findByText("Wähle eine Funktion oder Metrik aus").click();
+
+        popover().within(() => {
+          cy.findByText("Anzahl eindeutiger Werte von...").click();
+          cy.findByText("DE-Latitude").click();
+        });
+
+        cy.findByText("Eindeutige Werte von DE-Latitude").should("be.visible");
+
+        cy.findByText("Wähle eine Spalte für die Gruppierung").click();
+
+        popover().within(() => {
+          openPopoverFromDefaultBucketSize(
+            "DE-Latitude",
+            "Automatische Klasseneinteilung",
+          );
+
+          cy.findByText("Eine Klasse pro 10 Grad").click();
+        });
+
+        cy.findByText("DE-Latitude: 10°").should("be.visible");
+
+        // "Visualize" in German locale
+        cy.button("Darstellen").click();
+
+        cy.findByTestId("interactive-question-result-toolbar").within(() => {
+          // "1 grouping" in German locale
+          cy.findByText("1 Gruppierung").click();
+        });
+
+        popover().within(() => {
+          cy.findByText("DE-Latitude").should("be.visible");
+        });
+
+        cy.findByTestId("chart-type-selector-button").click();
+
+        popover().within(() => {
+          cy.findByText("Tabelle").click();
+        });
+
+        cy.findByTestId("table-header").within(() => {
+          cy.findByText("DE-Latitude: 10°").should("be.visible");
+        });
+      });
+    });
+
     it("should translate content in sort step", () => {
       setupEditor();
       mountEditor();
 
-      popover().within(() => {
-        cy.findByText("DE-Orders").click();
-      });
-
       getSdkRoot().within(() => {
+        popover().within(() => {
+          cy.findByText("DE-Orders").click();
+        });
+
         // "Sort" in German locale
         cy.button("Sortieren").click();
-      });
 
-      popover().within(() => {
-        cy.findByText("DE-User ID").should("exist");
+        popover().within(() => {
+          cy.findByText("DE-User ID").should("exist");
 
-        cy.findByText("DE-Total").click();
-      });
+          cy.findByText("DE-Total").click();
+        });
 
-      getSdkRoot().within(() => {
         cy.findByText("DE-Total").should("be.visible");
       });
     });
@@ -310,44 +404,36 @@ describe("scenarios > embedding-sdk > content-translations", () => {
       setupEditor();
       mountEditor();
 
-      popover().within(() => {
-        cy.findByText("DE-Orders").click();
-      });
-
       getSdkRoot().within(() => {
+        popover().within(() => {
+          cy.findByText("DE-Orders").click();
+        });
+
         // "Join data" in German locale
         cy.button("Daten verknüpfen").click();
-      });
 
-      getSdkRoot().within(() => {
         // "Left table" in German locale
         cy.findByLabelText("Linke Tabelle").should("have.text", "DE-Orders");
-      });
 
-      popover().within(() => {
-        cy.findByText("DE-People").click();
-      });
+        popover().within(() => {
+          cy.findByText("DE-People").click();
+        });
 
-      getSdkRoot().within(() => {
         cy.findByText("DE-User ID").click();
-      });
 
-      popover().within(() => {
-        cy.findByText("DE-Orders").should("exist");
+        popover().within(() => {
+          cy.findByText("DE-Orders").should("exist");
 
-        cy.findByText("DE-Product ID").click();
-      });
+          cy.findByText("DE-Product ID").click();
+        });
 
-      getSdkRoot().within(() => {
         cy.findByText("DE-ID").click();
-      });
 
-      popover().within(() => {
-        cy.findByText("DE-People").should("exist");
-        cy.findByText("DE-Address").click();
-      });
+        popover().within(() => {
+          cy.findByText("DE-People").should("exist");
+          cy.findByText("DE-Address").click();
+        });
 
-      getSdkRoot().within(() => {
         cy.findByText("DE-Product ID").should("be.visible");
         cy.findByText("DE-Address").should("be.visible");
       });

--- a/e2e/test/scenarios/binning/correctness/longitude.cy.spec.js
+++ b/e2e/test/scenarios/binning/correctness/longitude.cy.spec.js
@@ -1,3 +1,5 @@
+import { openPopoverFromDefaultBucketSize } from "e2e/support/helpers";
+
 const { H } = cy;
 
 import { LONGITUDE_OPTIONS } from "./shared/constants";
@@ -58,19 +60,6 @@ describe("scenarios > binning > correctness > longitude", () => {
       .and("contain", "1");
   });
 });
-
-function openPopoverFromDefaultBucketSize(column, bucket) {
-  cy.findAllByTestId("dimension-list-item")
-    .filter(`:contains("${column}")`)
-    .as("targetListItem")
-    .realHover()
-    .within(() => {
-      cy.findByTestId("dimension-list-item-binning")
-        .as("listItemSelectedBinning")
-        .should("contain", bucket)
-        .click();
-    });
-}
 
 function getTitle(title) {
   cy.findByText(title);

--- a/enterprise/frontend/src/embedding-sdk-ee/metabot/QuestionTitle.tsx
+++ b/enterprise/frontend/src/embedding-sdk-ee/metabot/QuestionTitle.tsx
@@ -1,10 +1,12 @@
-import { getQuestionTitle } from "embedding-sdk-bundle/components/private/QuestionTitle";
 import { useSdkQuestionContext } from "embedding-sdk-bundle/components/private/SdkQuestion/context";
+import { getQuestionTitle } from "embedding-sdk-bundle/lib/sdk-question/get-question-title";
+import { useTranslateContent } from "metabase/i18n/hooks";
 import { Text } from "metabase/ui";
 
 export function QuestionTitle() {
   const { question } = useSdkQuestionContext();
-  const titleText = getQuestionTitle({ question });
+  const tc = useTranslateContent();
+  const titleText = getQuestionTitle(question, tc);
 
   if (titleText === null) {
     return null;

--- a/enterprise/frontend/src/metabase-enterprise/content_translation/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/content_translation/index.ts
@@ -9,7 +9,7 @@ import {
 import { useTranslateContent } from "./use-translate-content";
 import {
   getTranslatedFilterDisplayName,
-  translateAggregationDisplayName,
+  translateColumnDisplayName,
   translateDisplayNames,
   useSortByContentTranslation,
   useTranslateFieldValuesInHoveredObject,
@@ -47,7 +47,7 @@ export function initializePlugin() {
         );
       },
       translateDisplayNames,
-      translateAggregationDisplayName,
+      translateColumnDisplayName,
       getTranslatedFilterDisplayName,
       ContentTranslationConfiguration,
     });

--- a/enterprise/frontend/src/metabase-enterprise/content_translation/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/content_translation/utils.ts
@@ -7,6 +7,7 @@ import _ from "underscore";
 import type { ContentTranslationFunction } from "metabase/i18n/types";
 import { isCartesianChart } from "metabase/visualizations";
 import type { HoveredObject } from "metabase/visualizations/types";
+import * as Lib from "metabase-lib";
 import type {
   DictionaryArray,
   MaybeTranslatedSeries,
@@ -65,15 +66,22 @@ export const translateContentString: TranslateContentStringFunction = (
   return msgstr;
 };
 
-export type AggregationPattern = (value: string) => string;
+export type ColumnDisplayNamePattern = (value: string) => string;
 
 /**
- * Patterns for aggregation display names.
- * These must match the patterns used in the backend (metabase.lib.aggregation).
+ * Patterns for column display names.
+ * These must match the patterns used in the backend:
+ * - Aggregations: metabase.lib.aggregation
+ * - Binning: metabase.lib.binning
+ * - Temporal buckets: metabase.lib.temporal_bucket
+ *
  * Each pattern is a function that takes a column name and returns the full display name.
  * More specific patterns must come before less specific ones.
  */
-const AGGREGATION_PATTERNS: AggregationPattern[] = [
+const COLUMN_DISPLAY_NAME_PATTERNS: ColumnDisplayNamePattern[] = [
+  // Aggregation patterns (from metabase.lib.aggregation)
+  // More specific patterns must come first
+  (value: string) => t`Sum of ${value} matching condition`,
   (value: string) => t`Average of ${value}`,
   (value: string) => t`Count of ${value}`,
   (value: string) => t`Cumulative count of ${value}`,
@@ -83,17 +91,27 @@ const AGGREGATION_PATTERNS: AggregationPattern[] = [
   (value: string) => t`Median of ${value}`,
   (value: string) => t`Min of ${value}`,
   (value: string) => t`Standard deviation of ${value}`,
-  (value: string) => t`Sum of ${value} matching condition`,
   (value: string) => t`Sum of ${value}`,
   (value: string) => t`Variance of ${value}`,
+
+  // Binning patterns (from metabase.lib.binning)
+  // Note: "Auto binned" uses t`` because it may be translated on the FE
+  (value: string) => t`${value}: Auto binned`,
+
+  // Temporal bucket patterns (from metabase.lib.temporal_bucket)
+  // Generated dynamically using the same Lib functions the backend uses,
+  // ensuring the translated suffixes match (e.g., "Month" → "Monat" in German)
+  ...Lib.availableTemporalUnits().map(
+    (unit) => (value: string) => `${value}: ${Lib.describeTemporalUnit(unit)}`,
+  ),
 ];
 
 // Unique marker to find where the value placeholder is in a pattern
 const VALUE_MARKER = "\u0000";
 
 /**
- * Translates an aggregation column display name by recursively parsing the
- * aggregation pattern and translating the inner column name.
+ * Translates a column display name by recursively parsing known patterns
+ * (aggregations, binning, temporal buckets) and translating the inner column name.
  *
  * Handles patterns where the value can be:
  * - At the start: "{value} של סכום" (Hebrew, right-to-left)
@@ -101,14 +119,49 @@ const VALUE_MARKER = "\u0000";
  * - Wrapped: "Somme de {value} totale" (hypothetical)
  *
  * Examples:
- * - "Total" => tc("Total") (no aggregation pattern matched)
+ * - "Total" => tc("Total") (no pattern matched)
  * - "Sum of Total" => t`Sum of ${tc("Total")}`
  * - "Sum of Min of Total" => t`Sum of ${t`Min of ${tc("Total")}`}`
+ * - "Created At: Month" => t`${tc("Created At")}: Month`
+ * - "Total: Auto binned" => t`${tc("Total")}: Auto binned`
  */
-export const translateAggregationDisplayName = (
+// Separator used for binning and temporal bucket suffixes (e.g., "Total: Day", "Total: 10 bins")
+const COLON_SEPARATOR = ": ";
+
+/**
+ * Regex patterns that match known binning suffixes that are NOT covered by
+ * the explicit COLUMN_DISPLAY_NAME_PATTERNS (which handle locale-translated strings).
+ *
+ * These patterns match dynamic numeric suffixes:
+ * - "10 bins", "50 bins", "100 bins" (num-bins strategy)
+ * - "0.1°", "1°", "10°" (bin-width for coordinates)
+ * - "0.1", "1", "10" (bin-width for non-coordinates)
+ */
+const DYNAMIC_BINNING_SUFFIX_PATTERNS = [
+  // Matches "{number} bin" or "{number} bins" (English)
+  // Note: other locales may have different translations
+  /^\d+\s+bins?$/i,
+  // Matches "{number}°" (coordinate bin-width with degree symbol)
+  /^[\d.]+°$/,
+  // Matches plain number (non-coordinate bin-width)
+  // Only match if it looks like a decimal (has a dot) to avoid false positives
+  /^\d+\.\d+$/,
+];
+
+/**
+ * Checks if a suffix looks like a dynamic binning pattern that should trigger
+ * the colon-separator fallback for content translation.
+ */
+const isDynamicBinningSuffix = (suffix: string): boolean => {
+  return DYNAMIC_BINNING_SUFFIX_PATTERNS.some((pattern) =>
+    pattern.test(suffix),
+  );
+};
+
+export const translateColumnDisplayName = (
   displayName: string,
   tc: ContentTranslationFunction,
-  patterns: AggregationPattern[] = AGGREGATION_PATTERNS,
+  patterns: ColumnDisplayNamePattern[] = COLUMN_DISPLAY_NAME_PATTERNS,
 ): string => {
   if (!hasTranslations(tc)) {
     return displayName;
@@ -131,10 +184,40 @@ export const translateAggregationDisplayName = (
       if (innerStart <= innerEnd) {
         const innerPart = displayName.substring(innerStart, innerEnd);
 
-        return pattern(
-          translateAggregationDisplayName(innerPart, tc, patterns),
-        );
+        return pattern(translateColumnDisplayName(innerPart, tc, patterns));
       }
+    }
+  }
+
+  // Fallback: handle colon-separated patterns like "Total: 10 bins", "Latitude: 0.1°",
+  // or "Created At: Monat" (temporal buckets with backend-translated suffixes).
+  const colonIndex = displayName.lastIndexOf(COLON_SEPARATOR);
+
+  if (colonIndex > 0) {
+    const columnPart = displayName.substring(0, colonIndex);
+    const suffixPart = displayName.substring(
+      colonIndex + COLON_SEPARATOR.length,
+    );
+
+    // For recognized dynamic binning suffixes, always split and translate column part
+    if (isDynamicBinningSuffix(suffixPart)) {
+      return (
+        translateColumnDisplayName(columnPart, tc, patterns) +
+        COLON_SEPARATOR +
+        suffixPart
+      );
+    }
+
+    // For other suffixes (e.g., temporal buckets like "Monat", "Day of week"),
+    // only split if the column part actually has a translation.
+    // This avoids incorrectly splitting column names that contain ": " literally.
+    const translatedColumn = translateColumnDisplayName(
+      columnPart,
+      tc,
+      patterns,
+    );
+    if (translatedColumn !== columnPart) {
+      return translatedColumn + COLON_SEPARATOR + suffixPart;
     }
   }
 
@@ -165,13 +248,13 @@ export const translateDisplayNames = <T>(
           fieldsToTranslate.includes(key as string) &&
           typeof value === "string";
 
-        // We can't detect if an element is an aggregation-related or not here.
+        // We can't detect if an element has a special pattern (aggregation, binning, temporal bucket) or not here.
         // We can't rely on the `source` field as for cases when a question containing aggregations is a base for another question,
         // the `source` field contains the `fields` value, not the `aggregation` one.
-        // As the solution, we always try to translate the display name as an aggregation one,
-        // and inside `translateAggregationDisplayName` we fallback to regular tc() call if no aggregation pattern is matched.
+        // As the solution, we always try to translate the display name using pattern matching,
+        // and inside `translateColumnDisplayName` we fallback to regular tc() call if no pattern is matched.
         const newValue = shouldTranslate
-          ? translateAggregationDisplayName(value as string, tc)
+          ? translateColumnDisplayName(value as string, tc)
           : traverse(value as T);
 
         return I.assoc(acc, key, newValue);

--- a/enterprise/frontend/src/metabase-enterprise/content_translation/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/content_translation/utils.ts
@@ -197,7 +197,7 @@ export const translateColumnDisplayName = (
     }
   }
 
-  // Fallback: handle colon-separated patterns like "Total: 10 bins", "Latitude: 0.1°",
+  // Handle colon-separated patterns like "Total: 10 bins", "Latitude: 0.1°",
   // or "Created At: Monat" (temporal buckets with backend-translated suffixes).
   const colonIndex = displayName.lastIndexOf(COLON_SEPARATOR);
 
@@ -229,7 +229,7 @@ export const translateColumnDisplayName = (
     }
   }
 
-  // Fallback: handle joined table column names like "Products → Created At"
+  // Handle joined table column names like "Products → Created At"
   // or nested joins like "Orders → Products → Created At: Monat"
   // We split on the FIRST arrow to preserve nested patterns in the column part.
   const arrowIndex = displayName.indexOf(JOIN_SEPARATOR);

--- a/frontend/src/embedding-sdk-bundle/components/private/QuestionTitle.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/QuestionTitle.tsx
@@ -1,56 +1,21 @@
 import cx from "classnames";
 
+import { getQuestionTitle } from "embedding-sdk-bundle/lib/sdk-question/get-question-title";
 import type { CommonStylingProps } from "embedding-sdk-bundle/types/props";
 import CS from "metabase/css/core/index.css";
 import { useTranslateContent } from "metabase/i18n/hooks";
-import {
-  getAdHocQuestionDescription,
-  shouldRenderAdhocDescription,
-} from "metabase/query_builder/components/view/ViewHeader/components/AdHocQuestionDescription/AdHocQuestionDescription";
-import * as Lib from "metabase-lib";
-import type Question from "metabase-lib/v1/Question";
 
-type GetQuestionTitleProps = {
-  question?: Question;
-};
-
-export const getQuestionTitle = ({
-  question,
-}: GetQuestionTitleProps): string | null => {
-  if (!question) {
-    return null;
-  }
-
-  const isSaved = question.isSaved();
-  const displayName = question.displayName();
-
-  if (isSaved && displayName) {
-    return displayName ?? null;
-  }
-
-  const query = question.query();
-  const { isNative } = Lib.queryDisplayInfo(query);
-  const adhocDescription = getAdHocQuestionDescription({ question });
-  if (
-    !isNative &&
-    shouldRenderAdhocDescription({ question }) &&
-    adhocDescription
-  ) {
-    return adhocDescription;
-  }
-
-  return null;
-};
-
-type QuestionTitleProps = GetQuestionTitleProps & CommonStylingProps;
+type QuestionTitleProps = {
+  question?: Parameters<typeof getQuestionTitle>[0];
+} & CommonStylingProps;
 
 export const QuestionTitle = ({
   question,
   className,
   style,
 }: QuestionTitleProps) => {
-  const questionTitle = getQuestionTitle({ question });
   const tc = useTranslateContent();
+  const questionTitle = getQuestionTitle(question, tc);
 
   if (questionTitle === null) {
     return null;
@@ -58,7 +23,7 @@ export const QuestionTitle = ({
 
   return (
     <h2 className={cx(CS.h2, CS.textWrap, className)} style={style}>
-      {tc(questionTitle)}
+      {questionTitle}
     </h2>
   );
 };

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Breakout/BreakoutBadgeList.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Breakout/BreakoutBadgeList.tsx
@@ -6,6 +6,7 @@ import {
 } from "embedding-sdk-bundle/components/private/SdkQuestion/components/Breakout/use-breakout-data";
 import { useSdkQuestionContext } from "embedding-sdk-bundle/components/private/SdkQuestion/context";
 import { useTranslateContent } from "metabase/i18n/hooks";
+import { PLUGIN_CONTENT_TRANSLATION } from "metabase/plugins";
 
 import { BadgeList } from "../util/BadgeList";
 
@@ -25,7 +26,10 @@ export const BreakoutBadgeListInner = ({
     <BadgeList
       items={breakoutItems.map((item) => ({
         item,
-        name: tc(item.longDisplayName),
+        name: PLUGIN_CONTENT_TRANSLATION.translateColumnDisplayName(
+          item.longDisplayName,
+          tc,
+        ),
       }))}
       addButtonLabel={t`Add another grouping`}
       onSelectItem={onSelectItem}

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Summarize/use-summarize-data.ts
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Summarize/use-summarize-data.ts
@@ -59,7 +59,7 @@ export const useSummarizeData = () => {
             return {
               ...aggregationItem,
               displayName:
-                PLUGIN_CONTENT_TRANSLATION.translateAggregationDisplayName(
+                PLUGIN_CONTENT_TRANSLATION.translateColumnDisplayName(
                   aggregationItem.displayName,
                   tc,
                 ),

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/DefaultViewTitle.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/DefaultViewTitle.tsx
@@ -1,9 +1,9 @@
 import { c, t } from "ttag";
 
+import { getQuestionTitle } from "embedding-sdk-bundle/lib/sdk-question/get-question-title";
 import { useTranslateContent } from "metabase/i18n/hooks";
 import { Anchor, Stack, Text } from "metabase/ui";
 
-import { getQuestionTitle } from "../QuestionTitle";
 import { useSdkQuestionContext } from "../SdkQuestion/context";
 
 import type { SdkQuestionDefaultViewProps } from "./SdkQuestionDefaultView";
@@ -60,7 +60,7 @@ export const DefaultViewTitle = ({
   if (title === undefined || title === true) {
     const originalName = tc(originalQuestion?.displayName());
 
-    const titleText = tc(getQuestionTitle({ question }));
+    const titleText = getQuestionTitle(question, tc);
 
     return (
       <DefaultViewTitleText

--- a/frontend/src/embedding-sdk-bundle/lib/sdk-question/get-question-title.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/sdk-question/get-question-title.ts
@@ -1,0 +1,44 @@
+import type { ContentTranslationFunction } from "metabase/i18n/types";
+import { PLUGIN_CONTENT_TRANSLATION } from "metabase/plugins";
+import {
+  getAdHocQuestionDescription,
+  shouldRenderAdhocDescription,
+} from "metabase/query_builder/components/view/ViewHeader/components/AdHocQuestionDescription/AdHocQuestionDescription";
+import * as Lib from "metabase-lib";
+import type Question from "metabase-lib/v1/Question";
+
+export const getQuestionTitle = (
+  question: Question | undefined,
+  tc?: ContentTranslationFunction,
+): string | null => {
+  if (!question) {
+    return null;
+  }
+
+  const isSaved = question.isSaved();
+  const displayName = question.displayName();
+
+  if (isSaved && displayName) {
+    return tc ? tc(displayName) : displayName;
+  }
+
+  const query = question.query();
+  const { isNative } = Lib.queryDisplayInfo(query);
+  const adhocDescription = getAdHocQuestionDescription({
+    question,
+    translateDisplayName: tc
+      ? (name: string) =>
+          PLUGIN_CONTENT_TRANSLATION.translateColumnDisplayName(name, tc)
+      : undefined,
+  });
+
+  if (
+    !isNative &&
+    shouldRenderAdhocDescription({ question }) &&
+    adhocDescription
+  ) {
+    return adhocDescription;
+  }
+
+  return null;
+};

--- a/frontend/src/metabase/plugins/oss/content-translation.ts
+++ b/frontend/src/metabase/plugins/oss/content-translation.ts
@@ -21,7 +21,7 @@ const getDefaultPluginContentTranslation = () => ({
     obj: T,
     _tc: ContentTranslationFunction,
   ) => obj,
-  translateAggregationDisplayName: (
+  translateColumnDisplayName: (
     displayName: string,
     _tc: ContentTranslationFunction,
   ): string => displayName,

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/AdHocQuestionDescription/AdHocQuestionDescription.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/AdHocQuestionDescription/AdHocQuestionDescription.tsx
@@ -11,6 +11,8 @@ type AdHocQuestionDescriptionProps = {
 
 type GetAdhocQuestionDescriptionProps = {
   question: Question;
+  /** Optional function to translate longDisplayName values */
+  translateDisplayName?: (displayName: string) => string;
 };
 
 export const shouldRenderAdhocDescription = ({
@@ -26,6 +28,7 @@ export const shouldRenderAdhocDescription = ({
 
 export const getAdHocQuestionDescription = ({
   question,
+  translateDisplayName = (name: string) => name,
 }: GetAdhocQuestionDescriptionProps) => {
   const query = question.query();
   const stageIndex = getInfoStageIndex(query);
@@ -41,9 +44,10 @@ export const getAdHocQuestionDescription = ({
             aggregations.length,
           )
         : aggregations
-            .map(
-              (aggregation) =>
+            .map((aggregation) =>
+              translateDisplayName(
                 Lib.displayInfo(query, stageIndex, aggregation).longDisplayName,
+              ),
             )
             .join(t` and `);
   const breakoutDescription =
@@ -56,9 +60,10 @@ export const getAdHocQuestionDescription = ({
             breakouts.length,
           )
         : breakouts
-            .map(
-              (breakout) =>
+            .map((breakout) =>
+              translateDisplayName(
                 Lib.displayInfo(query, stageIndex, breakout).longDisplayName,
+              ),
             )
             .join(t` and `);
 

--- a/frontend/src/metabase/querying/notebook/components/AggregateStep/AggregateStep.tsx
+++ b/frontend/src/metabase/querying/notebook/components/AggregateStep/AggregateStep.tsx
@@ -3,6 +3,7 @@ import { t } from "ttag";
 
 import { AggregationPicker } from "metabase/common/components/AggregationPicker";
 import { useTranslateContent } from "metabase/i18n/hooks";
+import { PLUGIN_CONTENT_TRANSLATION } from "metabase/plugins";
 import * as Lib from "metabase-lib";
 
 import type { NotebookStepProps } from "../../types";
@@ -46,7 +47,10 @@ export function AggregateStep({
   };
 
   const renderAggregationName = (aggregation: Lib.AggregationClause) =>
-    tc(Lib.displayInfo(query, stageIndex, aggregation).longDisplayName);
+    PLUGIN_CONTENT_TRANSLATION.translateColumnDisplayName(
+      Lib.displayInfo(query, stageIndex, aggregation).longDisplayName,
+      tc,
+    );
 
   return (
     <ClauseStep

--- a/frontend/src/metabase/querying/notebook/components/BreakoutStep/BreakoutStep.tsx
+++ b/frontend/src/metabase/querying/notebook/components/BreakoutStep/BreakoutStep.tsx
@@ -3,6 +3,7 @@ import { t } from "ttag";
 
 import { QueryColumnPicker } from "metabase/common/components/QueryColumnPicker";
 import { useTranslateContent } from "metabase/i18n/hooks";
+import { PLUGIN_CONTENT_TRANSLATION } from "metabase/plugins";
 import * as Lib from "metabase-lib";
 
 import type { NotebookStepProps } from "../../types";
@@ -35,7 +36,10 @@ export function BreakoutStep({
   const isAddButtonDisabled = isMetric && metricColumns.length === 0;
 
   const renderBreakoutName = (clause: Lib.BreakoutClause) =>
-    tc(Lib.displayInfo(query, stageIndex, clause).longDisplayName);
+    PLUGIN_CONTENT_TRANSLATION.translateColumnDisplayName(
+      Lib.displayInfo(query, stageIndex, clause).longDisplayName,
+      tc,
+    );
 
   const handleAddBreakout = (column: Lib.ColumnMetadata) => {
     const nextQuery = Lib.breakout(query, stageIndex, column);


### PR DESCRIPTION
Add joined tables/temporal/bins content translations for aggregations and breakouts and question title
- temporal values
- bins
- joined tables

How to test:
- add content translations
```
Locale Code,String,Translation
de,Accounts,DE ACCOUNTS
de,Plan,DE PLANS
de,Orders,DE ORDERS
de,Revenue per quarter,DE REVENUE PER QUARTER
de,Overall Business Health,DE AMAZING DASHBOARD NAME
de,Checkout funnel,DE AMAZING QUESTION NAME
de,Our analytics,DE OUR ANALYTICS
de,Examples,DE EXAMPLES
de,Foo,DE FOO
de,Bar,DE BAR
de,Bar Description,DE BAR DESCRIPTION
de,Created At,DE CREATED AT
de,Latitude,DE LATITUDE
```

- Embed EmbedJS into a page

1). Setup the following query in the editor, and check proper content translations:
<img width="2824" height="1712" alt="image" src="https://github.com/user-attachments/assets/f807f080-3db6-460c-911d-bbd0166dbff0" />

Check table columns after clicking `visualize` and selecting the table viz type:
<img width="2088" height="390" alt="image" src="https://github.com/user-attachments/assets/fdb6dd2a-6b3b-4635-9559-8788c29180e4" />


2) Setup the following query in the editor, and check proper content translations:
<img width="2638" height="1338" alt="image" src="https://github.com/user-attachments/assets/972286b9-d0df-4b34-9993-a58776c194bb" />

Check table columns after clicking `visualize` and selecting the table viz type:
<img width="2066" height="452" alt="image" src="https://github.com/user-attachments/assets/5bc3df75-5794-4bf0-b72f-0f76cd15f229" />

3) Setup the following query in the editor, and check proper content translations:
<img width="2652" height="1272" alt="image" src="https://github.com/user-attachments/assets/3b435e6f-76f0-4f14-80fb-4be5a9a25e3d" />

Check table columns after clicking `visualize` and selecting the table viz type:
<img width="2160" height="454" alt="image" src="https://github.com/user-attachments/assets/dc839f7c-bebe-4102-808b-ca420c0b243e" />
<img width="1044" height="354" alt="image" src="https://github.com/user-attachments/assets/b1e1d111-8ed2-46dd-9ef3-5f2186dbc2a7" />

