### PR TITLE
Updating text color for filter counter chip

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewTitleHeader.module.css
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewTitleHeader.module.css
@@ -48,7 +48,7 @@
     &:hover,
     &[data-expanded="true"] {
       .FilterCountChip {
-        color: var(--mb-color-text-selected);
+        color: var(--mb-color-text-primary-inverse);
         background-color: var(--mb-color-filter);
       }
     }


### PR DESCRIPTION
### Description
Fixes the color of the counter chip for filters in the query builder

### How to verify
1. Go to a question and add at least 1 filter
2. notice that the counter beside the filter button shows the number in `text-primary-inverse`, not `text-selected`

#### Before
<img width="148" height="63" alt="image" src="https://github.com/user-attachments/assets/5eedd7b4-94c6-4507-a44e-28857398b235" />
<img width="160" height="60" alt="image" src="https://github.com/user-attachments/assets/15f01e18-8b78-435d-9ff6-abb40f216dff" />

#### After
<img width="163" height="72" alt="image" src="https://github.com/user-attachments/assets/b44eb06f-1945-43b3-958e-d5a604fbd6a5" />
<img width="181" height="76" alt="image" src="https://github.com/user-attachments/assets/46e2c0ba-d66c-47a7-8a55-50cbac5f5fe7" />


