### PR TITLE
Only show an app switcher in the dependency page, not the tabs

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyGraphPage/DependencyGraphPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyGraphPage/DependencyGraphPage.tsx
@@ -47,7 +47,7 @@ export function DependencyGraphPage({ location }: DependencyGraphPageProps) {
         getGraphUrl={(entry) => Urls.dependencyGraph({ entry, baseUrl })}
         withEntryPicker={withEntryPicker}
       />
-      <AppSwitcher className={S.ProfileLink} />
+      {baseUrl === undefined && <AppSwitcher className={S.ProfileLink} />}
     </Stack>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyGraphPage/DependencyGraphPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyGraphPage/DependencyGraphPage.unit.spec.tsx
@@ -1,8 +1,9 @@
-import React from "react";
 import { Route } from "react-router";
 
+import { setupDependecyGraphEndpoint } from "__support__/server-mocks";
 import { renderWithProviders, screen } from "__support__/ui";
 import { PLUGIN_DEPENDENCIES } from "metabase/plugins";
+import { createMockDependencyGraph } from "metabase-types/api/mocks";
 
 import { DependencyGraphPage } from "./DependencyGraphPage";
 
@@ -11,6 +12,9 @@ jest.mock("../../components/DependencyGraph", () => ({
 }));
 
 describe("DependencyGraphPage", () => {
+  beforeEach(() => {
+    setupDependecyGraphEndpoint(createMockDependencyGraph());
+  });
   it("should show an app switcher if there is no context", async () => {
     renderWithProviders(<Route path="/" component={DependencyGraphPage} />, {
       withRouter: true,

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyGraphPage/DependencyGraphPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyGraphPage/DependencyGraphPage.unit.spec.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { Route } from "react-router";
+
+import { renderWithProviders, screen } from "__support__/ui";
+import { PLUGIN_DEPENDENCIES } from "metabase/plugins";
+
+import { DependencyGraphPage } from "./DependencyGraphPage";
+
+jest.mock("../../components/DependencyGraph", () => ({
+  DependencyGraph: () => <p>Dependency Graph</p>,
+}));
+
+describe("DependencyGraphPage", () => {
+  it("should show an app switcher if there is no context", async () => {
+    renderWithProviders(<Route path="/" component={DependencyGraphPage} />, {
+      withRouter: true,
+    });
+
+    expect(await screen.findByText("Dependency Graph")).toBeInTheDocument();
+    expect(screen.getByTestId("app-switcher-target")).toBeInTheDocument();
+  });
+
+  it("should not show an app switcher if the context contains a base url", async () => {
+    renderWithProviders(
+      <Route
+        path="/"
+        component={() => (
+          <PLUGIN_DEPENDENCIES.DependencyGraphPageContext.Provider
+            value={{
+              baseUrl: "any-url",
+              defaultEntry: { id: 2, type: "transform" },
+            }}
+          >
+            <DependencyGraphPage />
+          </PLUGIN_DEPENDENCIES.DependencyGraphPageContext.Provider>
+        )}
+      />,
+      {
+        withRouter: true,
+      },
+    );
+
+    expect(await screen.findByText("Dependency Graph")).toBeInTheDocument();
+    expect(screen.queryByTestId("app-switcher-target")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase-types/api/mocks/dependencies.ts
+++ b/frontend/src/metabase-types/api/mocks/dependencies.ts
@@ -156,7 +156,7 @@ export function createMockDependencyEdge(
 }
 
 export function createMockDependencyGraph(
-  opts?: Partial<DependencyGraph>,
+  opts: Partial<DependencyGraph> = {},
 ): DependencyGraph {
   return {
     nodes: [],

--- a/frontend/test/__support__/server-mocks/dependencies.ts
+++ b/frontend/test/__support__/server-mocks/dependencies.ts
@@ -2,6 +2,7 @@ import fetchMock from "fetch-mock";
 
 import type {
   CheckDependenciesResponse,
+  DependencyGraph,
   DependencyNode,
   ListBreakingGraphNodesResponse,
   ListUnreferencedGraphNodesResponse,
@@ -47,4 +48,8 @@ export function setupListUnreferencedGraphNodesEndpoint(
   response: ListUnreferencedGraphNodesResponse,
 ) {
   fetchMock.get("path:/api/ee/dependencies/graph/unreferenced", response);
+}
+
+export function setupDependecyGraphEndpoint(response: DependencyGraph) {
+  fetchMock.get("path:/api/ee/dependencies/graph", response);
 }


### PR DESCRIPTION
### Description
Updates the Dependency Graph Page to only show the app swticher where there is no baseUrl in the context, meaning that the page isn't embedded in another page. This implementation makes some assumptions, an alternative would be to have an explicit setting in the context if needed

### How to verify
1. Go to data studio -> dependencies page
2. See the app switcher
3. Go to the library, click on an entity, then click the dependencies tab
4. there should be no app switcher in the dependencies graph

### Demo
<img width="1333" height="968" alt="image" src="https://github.com/user-attachments/assets/19cff718-4aef-4f06-99b4-dc2b3af5cb6f" />
<img width="1332" height="968" alt="image" src="https://github.com/user-attachments/assets/a4b4627b-4d97-4407-8e74-7e50a1ef8554" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
