### PR TITLE
`./bin/mage dev-repl`

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -139,6 +139,27 @@
           (let [[db version] (:arguments parsed)]
             (start-db/start-db (:db-info (current-task)) db version)))}
 
+  dev-repl
+  {:doc "Launch Metabase dev environment (frontend + backend) with interactive configuration"
+   :examples [["./bin/mage dev-repl" "Interactive TUI to configure and launch"]
+              ["./bin/mage dev-repl -e ee -t all-features -d postgres"
+               "Launch with specific config (skip prompts)"]
+              ["./bin/mage dev-repl --no-frontend" "Backend only (skip frontend dev server)"]
+              ["./bin/mage dev-repl --fresh" "Recreate database container from scratch"]]
+   :requires [[mage.dev-repl :as dev-repl]]
+   :options [["-e" "--edition EDITION" "ee or oss"]
+             ["-t" "--token TOKEN" "Token type: all-features, starter-cloud, pro-cloud, pro-self-hosted, none"]
+             ["-d" "--db DB" "Database: postgres, mysql, mariadb, h2"]
+             ["-c" "--config FILE" "Config file path (default: dev/config.yml)"]
+             ["-v" "--db-version VERSION" "Database version: latest or oldest (default: latest)"]
+             ["-p" "--port PORT" "Backend port (default: 3000)" :parse-fn Integer/parseInt]
+             ["-f" "--fresh" "Recreate database container (destroy existing data)"]
+             ["-F" "--no-frontend" "Skip starting the frontend dev server"]]
+   :db-info {:postgres {:ports {:oldest 5432 :latest 5433} :eol-url "https://endoflife.date/api/postgres.json"}
+             :mysql {:ports {:oldest 3308 :latest 3309} :eol-url "https://endoflife.date/api/mysql.json"}
+             :mariadb {:ports {:oldest 3306 :latest 3307} :eol-url "https://endoflife.date/api/mariadb.json"}}
+   :task (task! (dev-repl/dev-repl parsed (select-keys (current-task) [:db-info])))}
+
   nrepl
   {:doc "Starts the babashka nrepl: helpful for mage development"
    :requires [[babashka.nrepl.server :as nrepl.server]

--- a/deps.edn
+++ b/deps.edn
@@ -827,6 +827,12 @@
    :exec-fn     dev.h2/shell
    :jvm-opts    ["-Dfile.encoding=UTF-8"]}
 
+  ;; connect to an H2 TCP listener:
+  ;; clojure -M:connect-to-h2-tcp --port 9092 --db-file /path/to/metabase
+  :connect-to-h2-tcp
+  {:extra-paths ["dev/src"]
+   :main-opts   ["-m" "dev.h2"]}
+
   :generate-automagic-dashboards-pot
   {:main-opts ["-m" "metabase.xrays.automagic-dashboards.dashboard-templates"]}
 

--- a/dev/src/dev/h2.clj
+++ b/dev/src/dev/h2.clj
@@ -1,5 +1,6 @@
 (ns dev.h2
   (:require
+   [clojure.tools.cli :as cli]
    [environ.core :as env]
    [metabase.app-db.data-source :as mdb.data-source]
    [metabase.app-db.env :as mdb.env])
@@ -24,9 +25,51 @@
 (def ^:private tcp-listener (atom nil))
 
 (defn tcp-listen
-  "Starts a TCP server for the H2 app-db database on port 9092."
-  []
-  (when @tcp-listener
-    (throw (ex-info "TCP listener is already running" {:port 9092})))
-  (reset! tcp-listener (.start (Server/createTcpServer (into-array ["-tcp" "-tcpAllowOthers" "-tcpPort" "9092"]))))
-  (println (str "H2 TCP server started (no username or password): jdbc:h2:tcp://localhost:9092/" (#'metabase.app-db.env/env->db-file metabase.app-db.env/env))))
+  "Starts a TCP server for the H2 app-db database on the specified port."
+  [port]
+  (when-not (= "h2" (:mb-db-type env/env))
+    (throw (ex-info "The database type is not H2" {:db-type (:mb-db-type env/env)})))
+  (when-let [listener @tcp-listener]
+    (throw (ex-info "TCP listener is already running" {:port (:port listener)})))
+  (let [server (.start (Server/createTcpServer (into-array ["-tcp" "-tcpAllowOthers" "-tcpPort" (str port)])))]
+    (reset! tcp-listener {:server server :port port})
+    (println (str "H2 TCP server started (no username or password): jdbc:h2:tcp://localhost:" port "/"
+                  (#'metabase.app-db.env/env->db-file metabase.app-db.env/env)))))
+
+(defn connect-tcp
+  "Open an H2 shell connected to a TCP listener."
+  [{:keys [port db-file]}]
+  (let [url (str "jdbc:h2:tcp://localhost:" port "/" db-file)]
+    (println "Connecting to database at URL" url)
+    (org.h2.tools.Shell/main (into-array String ["-url" url]))))
+
+(def ^:private connect-cli-spec
+  [["-h" "--help" "Show this help text"]
+   ["-p" "--port PORT" "H2 TCP listener port"
+    :parse-fn #(Integer/parseInt %)]
+   ["-f" "--db-file PATH" "H2 database file path"]])
+
+(defn -main
+  "CLI entry point for connecting to an H2 TCP listener."
+  [& args]
+  (let [{:keys [options errors summary]} (cli/parse-opts args connect-cli-spec)
+        {:keys [help port db-file]} options]
+    (when help
+      #_:clj-kondo/ignore
+      (do
+        (println "Usage: clojure -M:connect-to-h2-tcp --port PORT --db-file PATH")
+        (println "Options:")
+        (println summary))
+      (System/exit 0))
+    (when (seq errors)
+      #_:clj-kondo/ignore
+      (doseq [error errors]
+        (println error))
+      (System/exit 1))
+    (when-not (and port db-file)
+      #_:clj-kondo/ignore
+      (do
+        (println "Both --port and --db-file are required.")
+        (println "Usage: clojure -M:connect-to-h2-tcp --port PORT --db-file PATH"))
+      (System/exit 1))
+    (connect-tcp {:port port :db-file db-file})))

--- a/dev/src/user.clj
+++ b/dev/src/user.clj
@@ -64,6 +64,8 @@
 
 (def cli-spec [["-h" "--help" "Show this help text"]
                ["-H" "--hot" "Enable hot reloading"] ;
+               [nil "--h2-tcp-port PORT" "Start an H2 TCP listener on the specified port"
+                :parse-fn #(Integer/parseInt %)]
                ["-p" "--port PORT" "Port to run the nREPL server on"
                 :default 50605
                 :parse-fn #(Integer/parseInt %)]])
@@ -75,9 +77,10 @@
 
   Command Line Args:
 
-  `--hot` - Checks for modified files and reloads them during a request."
+  `--hot` - Checks for modified files and reloads them during a request.
+  `--h2-tcp-port` - Starts an H2 TCP listener on the specified port."
   [& args]
-  (let [{:keys [help hot port]} (:options (cli/parse-opts args cli-spec))]
+  (let [{:keys [help hot h2-tcp-port port]} (:options (cli/parse-opts args cli-spec))]
     (when help
       #_:clj-kondo/ignore
       (do
@@ -89,6 +92,8 @@
       #_:clj-kondo/ignore
       (println "Enabling hot reloading of code. Backend code will reload on every request.")
       (alter-var-root #'*enable-hot-reload* (constantly true)))
+    (when h2-tcp-port
+      ((requiring-resolve 'dev.h2/tcp-listen) h2-tcp-port))
     (future
       #_:clj-kondo/ignore
       (println "Starting Metabase cider repl on port" port)

--- a/mage/src/mage/dev_repl.clj
+++ b/mage/src/mage/dev_repl.clj
@@ -1,0 +1,334 @@
+(ns mage.dev-repl
+  (:require
+   [babashka.http-client :as http]
+   [babashka.process :as p]
+   [clojure.string :as str]
+   [mage.color :as c]
+   [mage.shell :as shell]
+   [mage.util :as u])
+  (:import
+   (java.net ServerSocket)))
+
+(set! *warn-on-reflection* true)
+
+;; Port utilities
+(defn- find-free-port
+  "Find a free port by binding to port 0 and reading the assigned port."
+  []
+  (with-open [socket (ServerSocket. 0)]
+    (.getLocalPort socket)))
+
+;; Token env var mapping (expects MBDEV_*_TOKEN in env)
+(def token-env-vars
+  {:all-features    "MBDEV_ALL_FEATURES_TOKEN"
+   :starter-cloud   "MBDEV_STARTER_CLOUD_TOKEN"
+   :pro-cloud       "MBDEV_PRO_CLOUD_TOKEN"
+   :pro-self-hosted "MBDEV_PRO_SELF_HOSTED_TOKEN"})
+
+;; Container management with dynamic ports and reuse
+(defn- container-name [db-type version]
+  (format "mb-dev-%s-%s" (name db-type) (name version)))
+
+(defn- container-internal-port [db-type]
+  (case db-type
+    :postgres 5432
+    (:mysql :mariadb) 3306))
+
+(defn- docker-image [db-type version]
+  (str (name db-type) ":" (name version)))
+
+(defn- docker-env-vars [db-type]
+  (case db-type
+    :postgres ["-e" "POSTGRES_USER=metabase"
+               "-e" "POSTGRES_PASSWORD=password"
+               "-e" "POSTGRES_DB=metabase"]
+    (:mysql :mariadb) ["-e" "MYSQL_DATABASE=metabase_test"
+                       "-e" "MYSQL_ALLOW_EMPTY_PASSWORD=yes"]))
+
+(defn- container-running? [name]
+  (let [output (u/sh "docker" "ps" "-q" "--filter" (str "name=^" name "$"))]
+    (not (str/blank? output))))
+
+(defn- container-exists? [name]
+  (let [output (u/sh "docker" "ps" "-aq" "--filter" (str "name=^" name "$"))]
+    (not (str/blank? output))))
+
+(defn- get-container-port
+  "Get the host port for a running container."
+  [name internal-port]
+  (let [output (u/sh "docker" "port" name (str internal-port))]
+    (when-let [[_ port] (re-find #":(\d+)$" output)]
+      (Integer/parseInt port))))
+
+(defn- create-db-container!
+  "Create a new DB container with a random port. Returns the host port."
+  [db-type version name]
+  (let [internal-port (container-internal-port db-type)
+        image (docker-image db-type version)
+        env-vars (docker-env-vars db-type)]
+    (println (c/green "Creating database container:") name)
+    (println (c/cyan "  Image:") image)
+    (apply shell/sh* "docker" "run" "-d"
+           "--name" name
+           "-p" (str "0:" internal-port) ; 0 = random port
+           (concat env-vars [image]))
+    ;; Wait a moment for container to start
+    (Thread/sleep 1000)
+    (let [port (get-container-port name internal-port)]
+      (println (c/cyan "  Port:") port)
+      port)))
+
+(defn- ask-reuse-container?
+  "Ask user whether to reuse existing container."
+  [name running?]
+  (println (c/yellow "Found existing container:") name
+           (if running? "(running)" "(stopped)"))
+  (let [choice (u/fzf-select! ["Reuse existing" "Create fresh"]
+                              "--height=10 --layout=reverse --prompt='Database container: '")]
+    (= choice "Reuse existing")))
+
+(defn- ensure-db!
+  "Ensure DB container is running. Returns {:port :stop-on-exit? :name}.
+   - If fresh?, remove existing and create new with random port
+   - If container exists, ask user whether to reuse
+   - If missing, create new with random port
+
+   :stop-on-exit? is true if we created or started the container (so we should stop it on exit)"
+  [db-type db-version fresh?]
+  (let [name (container-name db-type db-version)
+        internal-port (container-internal-port db-type)
+        running? (container-running? name)
+        exists? (or running? (container-exists? name))]
+    (cond
+      ;; --fresh flag: always create new
+      fresh?
+      (do
+        (println (c/yellow "Fresh database requested, creating new container..."))
+        (when exists?
+          (shell/sh* {:quiet? true} "docker" "rm" "-f" name))
+        {:port (create-db-container! db-type db-version name)
+         :stop-on-exit? true
+         :name name})
+
+      ;; Container exists: ask user whether to reuse
+      (and exists? (ask-reuse-container? name running?))
+      (do
+        (when-not running?
+          (println (c/green "Starting stopped container:") name)
+          (shell/sh* "docker" "start" name)
+          (Thread/sleep 1000))
+        {:port (get-container-port name internal-port)
+         :stop-on-exit? (not running?) ; stop if we started it, leave alone if was already running
+         :name name})
+
+      ;; User chose fresh, or no container exists
+      :else
+      (do
+        (when exists?
+          (println (c/yellow "Removing existing container..."))
+          (shell/sh* {:quiet? true} "docker" "rm" "-f" name))
+        {:port (create-db-container! db-type db-version name)
+         :stop-on-exit? true
+         :name name}))))
+
+(defn- stop-container! [name]
+  (println)
+  (println (c/yellow "Stopping database container:") name)
+  (shell/sh* {:quiet? true} "docker" "stop" name))
+
+(defn- wait-for-backend!
+  "Poll the health endpoint until the backend is ready."
+  [port]
+  (let [url (str "http://localhost:" port "/api/health")]
+    (print (c/cyan "Waiting for backend to start..."))
+    (flush)
+    (loop [attempts 0]
+      (Thread/sleep 2000)
+      (let [healthy? (try
+                       (let [resp (http/get url {:throw false :timeout 2000})]
+                         (and (= 200 (:status resp))
+                              (str/includes? (:body resp) "\"status\":\"ok\"")))
+                       (catch Exception _ false))]
+        (if healthy?
+          (println (c/green " ready!"))
+          (do
+            (print ".")
+            (flush)
+            (when (< attempts 120) ; ~4 minutes max
+              (recur (inc attempts)))))))))
+
+;; Token validation
+(defn- validate-token! [token]
+  (when (and token (not= token :none))
+    (let [env-var (get token-env-vars token)
+          value   (System/getenv env-var)]
+      (when (str/blank? value)
+        (println (c/red "WARNING:") (c/yellow env-var) "is not set!")
+        (println "Set this env var with your" (name token) "token, or use --token none")
+        (u/exit 1)))))
+
+(def ^:private fzf-opts "--height=10 --layout=reverse")
+
+;; FZF prompts (or use CLI args)
+(defn- select-edition [opts]
+  (or (some-> (:edition opts) keyword)
+      (keyword (u/fzf-select! ["ee" "oss"] (str fzf-opts " --prompt='Edition: '")))))
+
+(defn- select-token [opts]
+  (or (some-> (:token opts) keyword)
+      (keyword (u/fzf-select!
+                ["all-features" "starter-cloud" "pro-cloud" "pro-self-hosted" "none"]
+                (str fzf-opts " --prompt='Token: '")))))
+
+(defn- select-db [opts]
+  (or (some-> (:db opts) keyword)
+      (keyword (u/fzf-select! ["postgres" "mysql" "mariadb" "h2"] (str fzf-opts " --prompt='Database: '")))))
+
+(defn- select-config [opts]
+  (or (:config opts)
+      (let [files (u/shl "find" "dev" "-name" "*.yml" "-o" "-name" "*.yaml")
+            selected (if (seq files)
+                       (u/fzf-select! (conj files "none") (str fzf-opts " --prompt='Config file: '"))
+                       (u/fzf-select! ["dev/config.yml" "none"] (str fzf-opts " --prompt='Config file: '")))]
+        (when-not (= selected "none")
+          selected))))
+
+(defn- select-port [opts]
+  (or (:port opts)
+      (let [;; become() replaces fzf with shell cmd - echo selection if exists, else query
+            input (u/fzf-select! ["3000" "3001" "3002" "3003" "3004"]
+                                 (str fzf-opts " --prompt='Backend port: '"
+                                      " --bind 'enter:become([ -n {} ] && echo {} || echo {q})'"))]
+        (Integer/parseInt (str/trim input)))))
+
+;; Build env map
+(defn- build-env [edition token config-file db-type db-port frontend-port backend-port]
+  (cond-> {"MB_EDITION" (name edition)
+           "MB_ENABLE_TEST_ENDPOINTS" "true"
+           "MB_DANGEROUS_UNSAFE_ENABLE_TESTING_H2_CONNECTIONS_DO_NOT_ENABLE" "true"}
+
+    ;; Backend port
+    backend-port
+    (assoc "MB_JETTY_PORT" (str backend-port))
+
+    ;; Frontend port
+    frontend-port
+    (assoc "MB_FRONTEND_DEV_PORT" (str frontend-port))
+
+    ;; EE token
+    (and (= edition :ee) (not= token :none))
+    (assoc "MB_PREMIUM_EMBEDDING_TOKEN" (System/getenv (get token-env-vars token))
+           "METASTORE_DEV_SERVER_URL" "https://token-check.staging.metabase.com"
+           "MB_CONFIG_FILE_PATH" config-file)
+
+    ;; Database (non-H2)
+    (not= db-type :h2)
+    (assoc "MB_DB_TYPE" (if (= db-type :mariadb) "mysql" (name db-type))
+           "MB_DB_CONNECTION_URI"
+           (case db-type
+             :postgres (format "postgresql://metabase:password@localhost:%s/metabase" db-port)
+             (:mysql :mariadb) (format "mysql://root@localhost:%s/metabase_test" db-port)))
+
+    ;; H2
+    (= db-type :h2)
+    (assoc "MB_DB_TYPE" "h2"
+           "MB_DB_FILE" (format "/tmp/metabase_%d" (System/currentTimeMillis)))))
+
+;; Frontend dev server
+(defn- start-frontend!
+  "Start the frontend dev server in the background. Returns {:port :log-file}."
+  [edition port]
+  (let [log-file (str "/tmp/metabase-frontend-" port ".log")]
+    (println (c/green "Starting frontend dev server on port") (c/cyan port))
+    (println (c/cyan "  Log file:") log-file)
+    (println (c/cyan "  Tail with:") (str "tail -f " log-file))
+    (let [log (java.io.File. log-file)]
+      (p/process {:dir u/project-root-directory
+                  :out log
+                  :err log
+                  :extra-env {"MB_FRONTEND_DEV_PORT" (str port)
+                              "MB_EDITION" (name edition)}}
+                 "yarn" "build-hot"))
+    {:port port :log-file log-file}))
+
+;; Build aliases
+;; Uses :dev-start which runs user/-main - starts nREPL + Metabase
+(defn- build-aliases [edition]
+  (str ":dev:dev-start:drivers:drivers-dev"
+       (when (= edition :ee) ":ee:ee-dev")))
+
+;; Main entry point
+(defn dev-repl [{:keys [options]} _task-opts]
+  (let [edition    (select-edition options)
+        token      (when (= edition :ee) (select-token options))
+        _          (validate-token! token)
+        config     (when (and (= edition :ee) (not= token :none))
+                     (select-config options))
+        db-type    (select-db options)
+        db-version (keyword (or (:db-version options) "latest"))
+        fresh?     (:fresh options)
+        no-frontend? (:no-frontend options)
+        backend-port (select-port options)
+
+        ;; Start frontend dev server (unless --no-frontend)
+        frontend (when-not no-frontend?
+                   (start-frontend! edition (find-free-port)))
+        frontend-port (:port frontend)
+        frontend-log (:log-file frontend)
+
+        ;; Ensure DB container (reuse if exists, unless --fresh)
+        db-info    (when (not= db-type :h2)
+                     (ensure-db! db-type db-version fresh?))
+        db-port    (:port db-info)
+
+        env-map    (build-env edition token config db-type db-port frontend-port backend-port)
+        aliases    (build-aliases edition)
+        nrepl-port (find-free-port)
+        cmd        ["clojure" (str "-M" aliases) "-p" (str nrepl-port)]
+        backend-log (str "/tmp/metabase-backend-" backend-port ".log")]
+
+    ;; Show config
+    (println)
+    (println (c/green "Starting Metabase:"))
+    (println (c/cyan "  Edition:") (name edition))
+    (when token (println (c/cyan "  Token:") (name token)))
+    (when config (println (c/cyan "  Config:") config))
+    (println (c/cyan "  Database:") (str (name db-type) (when db-port (str " on port " db-port))))
+    (println (c/cyan "  nREPL:") (str "port " nrepl-port " (cider-connect)"))
+    (println (c/cyan "  Aliases:") aliases)
+    (when frontend-port
+      (println (c/cyan "  Frontend:") (str "http://localhost:" frontend-port))
+      (println (c/cyan "  FE logs:") (str "tail -f " frontend-log)))
+    (println (c/cyan "  BE logs:") (str "tail -f " backend-log))
+    (println (c/cyan "  Backend:") (str "http://localhost:" backend-port))
+    (println)
+
+    ;; Launch backend (output to log file)
+    (let [log-file (java.io.File. backend-log)
+          proc (apply p/process {:dir u/project-root-directory
+                                 :out log-file
+                                 :err log-file
+                                 :extra-env env-map}
+                      cmd)
+          cleanup! (fn []
+                     (p/destroy-tree proc)
+                     (when (:stop-on-exit? db-info)
+                       (stop-container! (:name db-info))))]
+
+      ;; Register SIGINT handler for Ctrl+C cleanup
+      (sun.misc.Signal/handle
+       (sun.misc.Signal. "INT")
+       (reify sun.misc.SignalHandler
+         (handle [_ _]
+           (cleanup!)
+           (System/exit 0))))
+
+      (println)
+      (println (c/cyan "Press Ctrl+C to stop."))
+      (println)
+      ;; Poll health endpoint in background
+      (future (wait-for-backend! backend-port))
+      ;; Wait for backend process to exit
+      @proc
+      ;; Normal exit cleanup
+      (cleanup!))))


### PR DESCRIPTION
The goal here is to have a single command that gives you a full Metabase instance that is:
- setup for development (you have a REPL, FE hot reloads, etc)
- isolated from other running Metabase instances (only a single port is chosen by the user - the one Metabase will be exposed on. All others are selected as random open ports)
- configurable (you can select what appdb type/edition, metabase edition/token, config file, and port to start up on)

You can just run `./bin/mage dev-repl` and get an interactive CLI that will ask you about these settings, launch the database, start the frontend (on a random port), and start Metabase configured to talk to that database/frontend.

Or you can specify options from the command line, like `./bin/mage dev-repl -e ee -t all-features -d postgres`.

![demo-2x](https://github.com/user-attachments/assets/0a2356fe-6a23-482e-a9db-00014789ddbe)
