### PR TITLE
Fix flake in native test 

### DIFF
--- a/e2e/support/helpers/e2e-browser-helpers.ts
+++ b/e2e/support/helpers/e2e-browser-helpers.ts
@@ -27,3 +27,6 @@ export function readClipboard() {
     return win.navigator.clipboard.readText();
   });
 }
+
+const isMac = Cypress.platform === "darwin";
+export const metaKey = isMac ? "Meta" : "Control";

--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
@@ -40,7 +40,7 @@ describe("issue 11727", { tags: "@external" }, () => {
     cy.findByTestId("query-builder-main")
       .findByText("Doing science...")
       .should("be.visible");
-    cy.get("body").type("{cmd}{enter}");
+    cy.realPress([H.metaKey, "Enter"]);
     cy.findByTestId("query-builder-main")
       .findByText("Here's where your results will appear")
       .should("be.visible");


### PR DESCRIPTION
Closes QUE-3051

Uses `cy.realPress` as a more reliable way to trigger the shortcut.

[stress test](https://github.com/metabase/metabase/actions/runs/21617347204)