### PR TITLE
Fix reindex connection management

### DIFF
--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -291,32 +291,35 @@
         (log/warnf "Unable to find table %s and no longer tracking it as pending", table)
         (swap! *indexes* assoc :pending nil))))
 
-  (let [active-table (active-table)
-        entries (map document->entry documents)
-        ;; No need to update the active index if we are doing a full index and it will be swapped out soon. Most updates are no-ops anyway.
-        active-updated? (when-not (and active-table (pending-table) (= context :search/reindexing)) (safe-batch-upsert! active-table entries))
-        pending-updated? (safe-batch-upsert! (pending-table) entries)]
-    (when (or active-updated? pending-updated?)
-      (u/prog1 (->> entries (map :model) frequencies)
-        (when (and (= :search/reindexing context) (not search.ingestion/*force-sync*))
-          (t2/query ["commit"]))
-        (log/trace "indexed documents for " <>)
-        (when active-updated?
-          (analytics/set! :metabase-search/appdb-index-size (t2/count (name active-table))))))))
+  (let [reindexing? (and (= :search/reindexing context) (not search.ingestion/*force-sync*))
+        do-writes   (fn []
+                      (let [active-table    (active-table)
+                            entries          (map document->entry documents)
+                            ;; No need to update the active index if we are doing a full index and it will be swapped out soon. Most updates are no-ops anyway.
+                            active-updated?  (when-not (and active-table (pending-table) reindexing?)
+                                               (safe-batch-upsert! active-table entries))
+                            pending-updated? (safe-batch-upsert! (pending-table) entries)]
+                        (when (or active-updated? pending-updated?)
+                          (u/prog1 (->> entries (map :model) frequencies)
+                            (when reindexing?
+                              (t2/query ["commit"]))
+                            (log/trace "indexed documents for " <>)
+                            (when active-updated?
+                              (analytics/set! :metabase-search/appdb-index-size (t2/count (name active-table))))))))]
+    (if reindexing?
+      ;; New connection used for performing the updates which commit periodically without impacting any outer transactions.
+      (t2/with-connection [_conn (mdb/data-source)]
+        (do-writes))
+      (do-writes))))
 
 (defn index-docs!
   "Indexes the documents. The context should be :search/updating or :search/reindexing.
    Context should be :search/updating or :search/reindexing to help control how to manage the updates"
   [context document-reducible]
-  ;; New connection used for performing the updates which commit periodically without impacting any outer transactions.
-  (letfn [(do-index []
-            (transduce (comp (partition-all insert-batch-size)
-                             (map (partial batch-update! context)))
-                       (partial merge-with +)
-                       document-reducible))]
-    (if (and (= :search/reindexing context) (not search.ingestion/*force-sync*))
-      (t2/with-connection [_conn (mdb/data-source)] (do-index))
-      (do-index))))
+  (transduce (comp (partition-all insert-batch-size)
+                   (map (partial batch-update! context)))
+             (partial merge-with +)
+             document-reducible))
 
 (defmethod search.engine/update! :search.engine/appdb [_engine document-reducible]
   (index-docs! :search/updating document-reducible))


### PR DESCRIPTION
Closes #68130

### Description

We had moved reindexing to use a separate connection so it can periodically commit without impacting any surrounding transactions, including lock holders.

BUT: After each batch, `batch-update!` does a `commit` on that transaction, and in postgre, that commit closes the server-side cursor that the read side is still using for the next batch. So when the transducer tries to pull row 151 from the ResultSet, it fails with "ResultSet is closed."   

This changes around the connection management so the writes get their own transaction and will not impact the connections used for reading.



### Example problem stacktrace

```
clojure.lang.ExceptionInfo: This ResultSet is closed.
	at org.postgresql.jdbc.PgResultSet.checkClosed(PgResultSet.java:3259)
	at org.postgresql.jdbc.PgResultSet.next(PgResultSet.java:2272)
	at com.mchange.v2.c3p0.impl.NewProxyResultSet.next(NewProxyResultSet.java:4589)
	at toucan2.jdbc.result_set$reduce_result_set.invokeStatic(result_set.clj:149)
	at toucan2.jdbc.result_set$reduce_result_set.invoke(result_set.clj:125)
	at toucan2.jdbc.query$reduce_jdbc_query.invokeStatic(query.clj:51)
	at toucan2.jdbc.query$reduce_jdbc_query.invoke(query.clj:22)
	at toucan2.jdbc.pipeline$transduce_execute_with_connection_primary_method_java_sql_Connection_default_default.invokeStatic(pipeline.clj:19)
	at toucan2.jdbc.pipeline$transduce_execute_with_connection_primary_method_java_sql_Connection_default_default.invoke(pipeline.clj:9)
	at methodical.impl.combo.common$partial_STAR_$fn__29282.invoke(common.clj:15)
	at methodical.impl.combo.threaded$combine_methods_thread_last$fn__29592$combined_method_thread_last__29593.invoke(threaded.clj:64)
	at methodical.util.FnWithMeta.invoke(util.clj:46)
	at methodical.impl.standard$invoke_multifn.invokeStatic(standard.clj:65)
	at methodical.impl.standard$invoke_multifn.invoke(standard.clj:47)
	at methodical.impl.standard.StandardMultiFn.invoke(standard.clj:216)
	at toucan2.pipeline$transduce_execute$with_connection_STAR___31765.invoke(pipeline.clj:78)
	at toucan2.connection$bind_current_connectable_fn$fn__31439.invoke(connection.clj:104)
	at toucan2.connection$bind_current_connectable_fn$fn__31439.invoke(connection.clj:104)
	at toucan2.jdbc.connection$do_with_connection_primary_method_java_sql_Connection.invokeStatic(connection.clj:13)
	at toucan2.jdbc.connection$do_with_connection_primary_method_java_sql_Connection.invoke(connection.clj:11)
	at methodical.impl.combo.common$partial_STAR_$fn__29282.invoke(common.clj:12)
	at methodical.util.FnWithMeta.invoke(util.clj:46)
	at toucan2.connection$do_with_connection_around_method_toucan2_connection_default.invokeStatic(connection.clj:118)
	at toucan2.connection$do_with_connection_around_method_toucan2_connection_default.invoke(connection.clj:106)
	at methodical.impl.combo.common$partial_STAR_$fn__29282.invoke(common.clj:12)
	at methodical.util.FnWithMeta.invoke(util.clj:46)
	at methodical.impl.standard$invoke_multifn.invokeStatic(standard.clj:55)
	at methodical.impl.standard$invoke_multifn.invoke(standard.clj:47)
	at methodical.impl.standard.StandardMultiFn.invoke(standard.clj:210)
	at toucan2.connection$do_with_connection_primary_method_.invokeStatic(connection.clj:204)
	at toucan2.connection$do_with_connection_primary_method_.invoke(connection.clj:194)
	at methodical.impl.combo.common$partial_STAR_$fn__29282.invoke(common.clj:12)
	at methodical.util.FnWithMeta.invoke(util.clj:46)
	at toucan2.connection$do_with_connection_around_method_toucan2_connection_default.invokeStatic(connection.clj:118)
	at toucan2.connection$do_with_connection_around_method_toucan2_connection_default.invoke(connection.clj:106)
	at methodical.impl.combo.common$partial_STAR_$fn__29282.invoke(common.clj:12)
	at methodical.util.FnWithMeta.invoke(util.clj:46)
	at methodical.impl.standard$invoke_multifn.invokeStatic(standard.clj:55)
	at methodical.impl.standard$invoke_multifn.invoke(standard.clj:47)
	at methodical.impl.standard.StandardMultiFn.invoke(standard.clj:210)
	at toucan2.pipeline$transduce_execute.invokeStatic(pipeline.clj:77)
	at toucan2.pipeline$transduce_execute.invoke(pipeline.clj:64)
	at clojure.lang.Var.invoke(Var.java:401)
	at toucan2.pipeline$transduce_compiled_query.invokeStatic(pipeline.clj:244)
	at toucan2.pipeline$transduce_compiled_query.invoke(pipeline.clj:240)
	at toucan2.pipeline$transduce_built_query.invokeStatic(pipeline.clj:252)
	at toucan2.pipeline$transduce_built_query.invoke(pipeline.clj:246)
	at toucan2.pipeline$transduce_query_primary_method_default.invokeStatic(pipeline.clj:272)
	at toucan2.pipeline$transduce_query_primary_method_default.invoke(pipeline.clj:269)
	at methodical.impl.combo.common$partial_STAR_$fn__29282.invoke(common.clj:15)
	at methodical.impl.combo.threaded$combine_methods_thread_last$fn__29592$combined_method_thread_last__29593.invoke(threaded.clj:64)
	at methodical.util.FnWithMeta.invoke(util.clj:46)
	at methodical.impl.standard$invoke_multifn.invokeStatic(standard.clj:65)
	at methodical.impl.standard$invoke_multifn.invoke(standard.clj:47)
	at methodical.impl.standard.StandardMultiFn.invoke(standard.clj:216)
	at toucan2.pipeline$transduce_query_STAR_.invokeStatic(pipeline.clj:278)
	at toucan2.pipeline$transduce_query_STAR_.invoke(pipeline.clj:274)
	at toucan2.pipeline$transduce_with_model.invokeStatic(pipeline.clj:293)
	at toucan2.pipeline$transduce_with_model.invoke(pipeline.clj:280)
	at toucan2.pipeline$transduce_parsed.invokeStatic(pipeline.clj:309)
	at toucan2.pipeline$transduce_parsed.invoke(pipeline.clj:295)
	at clojure.lang.AFn.applyToHelper(AFn.java:160)
	at clojure.lang.AFn.applyTo(AFn.java:144)
	at clojure.core$apply.invokeStatic(core.clj:669)
	at clojure.core$apply.invoke(core.clj:662)
	at toucan2.pipeline$reducible_fn$reify__31872.reduce(pipeline.clj:404)
	at clojure.core$transduce.invokeStatic(core.clj:7025)
	at clojure.core.Eduction.reduce(core.clj:7874)
	at clojure.core$reduce.invokeStatic(core.clj:6964)
	at clojure.core$reduce.invoke(core.clj:6947)
	at metabase.util$rconcat$reify__9657.coll_reduce(util.cljc:1235)
	at clojure.core$reduce.invokeStatic(core.clj:6965)
	at clojure.core$reduce.invoke(core.clj:6947)
	at metabase.util$rconcat$reify__9657.coll_reduce(util.cljc:1234)
	at clojure.core$transduce.invokeStatic(core.clj:7026)
	at clojure.core.Eduction.reduce(core.clj:7874)
	at clojure.core$transduce.invokeStatic(core.clj:7025)
	at clojure.core$transduce.invokeStatic(core.clj:7021)
	at clojure.core$transduce.invoke(core.clj:7012)
	at metabase.search.appdb.index$index_docs_BANG_$do_index__124146.invoke(index.clj:319)
	at metabase.search.appdb.index$index_docs_BANG_$with_connection_STAR___124148.invoke(index.clj:324)
	at toucan2.connection$bind_current_connectable_fn$fn__31439.invoke(connection.clj:104)
	at toucan2.jdbc.connection$do_with_connection_primary_method_javax_sql_DataSource.invokeStatic(connection.clj:18)
	at toucan2.jdbc.connection$do_with_connection_primary_method_javax_sql_DataSource.invoke(connection.clj:15)
	at methodical.impl.combo.common$partial_STAR_$fn__29282.invoke(common.clj:12)
	at methodical.ut…
```

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
