### PR TITLE
Allow non-admins to see timezone on Runs page tooltip

### DIFF
--- a/src/metabase/system/settings.clj
+++ b/src/metabase/system/settings.clj
@@ -120,7 +120,7 @@
 
 (defsetting system-timezone
   "The timezone used by the system by default. AKA the JVM timezone."
-  :visibility :admin
+  :visibility :authenticated
   :export?    true
   :setter     :none
   :getter     (comp str t/zone-id)


### PR DESCRIPTION
Closes [UXW-2909](https://linear.app/metabase/issue/UXW-2909/runs-page-timezone-tooltip-does-not-show-timezone)

### Description

Non-admins don't have access to the system-timezone setting, resulting in a missing timezone on the Runs page tooltip (among other possible issues).

### How to verify

Log in as a non-admin user -> Data Studio -> Runs -> verify you can see the timezone in the tooltip.

### Demo

Before:
<img width="378" height="178" alt="image" src="https://github.com/user-attachments/assets/6ce02017-2595-42a9-b178-b003a02c45dd" />

After:
<img width="184" height="95" alt="image" src="https://github.com/user-attachments/assets/8c88d126-07d8-4443-888a-ea50fce4fea9" />

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
