### PR TITLE
[Mutation Testing] Kill mutations in metabase.lib.segment/check-segment-cycles

### DIFF
--- a/test/metabase/lib/segment_test.cljc
+++ b/test/metabase/lib/segment_test.cljc
@@ -16,15 +16,15 @@
 (def ^:private segment-definition
   (:query (lib.tu.macros/mbql-query venues
             {:aggregation [[:count]]
-             :filter      [:and
-                           [:> $id [:* $price 11]]
-                           [:contains $name "BBQ" {:case-sensitive true}]]})))
+             :filter [:and
+                      [:> $id [:* $price 11]]
+                      [:contains $name "BBQ" {:case-sensitive true}]]})))
 
 (def ^:private segments-db
-  {:segments [{:id          segment-id
-               :name        "PriceID-BBQ"
-               :table-id    (meta/id :venues)
-               :definition  segment-definition
+  {:segments [{:id segment-id
+               :name "PriceID-BBQ"
+               :table-id (meta/id :venues)
+               :definition segment-definition
                :description "The ID is greater than 11 times the price and the name contains \"BBQ\"."}]})
 
 (def ^:private metadata-provider
@@ -52,39 +52,39 @@
          (lib.metadata.calculation/suggested-name query-with-segment))))
 
 (deftest ^:parallel display-info-test
-  (are [segment] (=? {:name              "priceid_bbq",
-                      :display-name      "PriceID-BBQ",
+  (are [segment] (=? {:name "priceid_bbq",
+                      :display-name "PriceID-BBQ",
                       :long-display-name "PriceID-BBQ",
-                      :effective-type    :type/Boolean,
-                      :description       "The ID is greater than 11 times the price and the name contains \"BBQ\"."}
+                      :effective-type :type/Boolean,
+                      :description "The ID is greater than 11 times the price and the name contains \"BBQ\"."}
                      (lib.metadata.calculation/display-info query-with-segment segment))
     segment-clause
     segment-metadata))
 
 (deftest ^:parallel unknown-display-info-test
-  (is (=? {:effective-type    :type/Boolean
-           :display-name      "[Unknown Segment]"
+  (is (=? {:effective-type :type/Boolean
+           :display-name "[Unknown Segment]"
            :long-display-name "[Unknown Segment]"}
           (lib.metadata.calculation/display-info query-with-segment [:segment {} (inc segment-id)]))))
 
 (deftest ^:parallel available-segments-test
   (testing "Should return Segments with the same Table ID as query's `:source-table`"
-    (is (=? [{:lib/type    :metadata/segment
-              :id          segment-id
-              :name        "PriceID-BBQ"
-              :table-id    (meta/id :venues)
-              :definition  segment-definition
+    (is (=? [{:lib/type :metadata/segment
+              :id segment-id
+              :name "PriceID-BBQ"
+              :table-id (meta/id :venues)
+              :definition segment-definition
               :description "The ID is greater than 11 times the price and the name contains \"BBQ\"."}]
             (lib/available-segments (lib/query metadata-provider (meta/table-metadata :venues))))))
   (testing "Should return filter-positions"
-    (let [query              (-> (lib/query metadata-provider (meta/table-metadata :venues))
-                                 (lib/filter segment-clause))
+    (let [query (-> (lib/query metadata-provider (meta/table-metadata :venues))
+                    (lib/filter segment-clause))
           available-segments (lib/available-segments query)]
-      (is (=? [{:lib/type    :metadata/segment
-                :id          segment-id
-                :name        "PriceID-BBQ"
-                :table-id    (meta/id :venues)
-                :definition  segment-definition
+      (is (=? [{:lib/type :metadata/segment
+                :id segment-id
+                :name "PriceID-BBQ"
+                :table-id (meta/id :venues)
+                :definition segment-definition
                 :description "The ID is greater than 11 times the price and the name contains \"BBQ\"."
                 :filter-positions [0]}]
               available-segments))
@@ -122,7 +122,7 @@
 
 (deftest ^:parallel filter-with-segment-test
   (testing "Should be able to pass a Segment metadata to `filter`"
-    (let [query    (lib/query metadata-provider (meta/table-metadata :venues))
+    (let [query (lib/query metadata-provider (meta/table-metadata :venues))
           segments (lib/available-segments query)]
       (is (= 1
              (count segments)))
@@ -133,17 +133,17 @@
           (let [query' (lib/filter query segment)]
             (is (lib/uses-segment? query' segment-id))
             (is (=? {:lib/type :mbql/query
-                     :stages   [{:lib/type     :mbql.stage/mbql
-                                 :source-table (meta/id :venues)
-                                 :filters  [[:segment {:lib/uuid string?} segment-id]]}]}
+                     :stages [{:lib/type :mbql.stage/mbql
+                               :source-table (meta/id :venues)
+                               :filters [[:segment {:lib/uuid string?} segment-id]]}]}
                     query'))
             (is (=? [[:segment {:lib/uuid string?} segment-id]]
                     (lib/filters query')))
-            (is (=? [{:name              "priceid_bbq",
-                      :display-name      "PriceID-BBQ",
+            (is (=? [{:name "priceid_bbq",
+                      :display-name "PriceID-BBQ",
                       :long-display-name "PriceID-BBQ",
-                      :effective-type    :type/Boolean,
-                      :description       "The ID is greater than 11 times the price and the name contains \"BBQ\"."}]
+                      :effective-type :type/Boolean,
+                      :description "The ID is greater than 11 times the price and the name contains \"BBQ\"."}]
                     (map (partial lib/display-info query')
                          (lib/filters query'))))))))))
 
@@ -160,7 +160,7 @@
 
 (deftest ^:parallel check-segment-overwrite-no-refs-test
   (testing "Segment with no segment references - should pass"
-    (let [mp         (lib.tu/mock-metadata-provider meta/metadata-provider {})
+    (let [mp (lib.tu/mock-metadata-provider meta/metadata-provider {})
           definition (segment-definition-with-filter mp (lib/> (meta/field-metadata :venues :price) 2))]
       (is (nil? (lib/check-segment-overwrite 1 definition))))))
 
@@ -170,36 +170,50 @@
           segment-2-def (segment-definition-with-filter
                          meta/metadata-provider
                          (lib/> (meta/field-metadata :venues :price) 2))
-          mp            (lib.tu/mock-metadata-provider
-                         meta/metadata-provider
-                         {:segments [{:id         2
-                                      :name       "Segment 2"
-                                      :table-id   (meta/id :venues)
-                                      :definition segment-2-def}]})
+          mp (lib.tu/mock-metadata-provider
+              meta/metadata-provider
+              {:segments [{:id 2
+                           :name "Segment 2"
+                           :table-id (meta/id :venues)
+                           :definition segment-2-def}]})
           ;; Segment 1 references Segment 2 - use mp so it can find segment 2
           segment-1-def (segment-definition-referencing mp 2)]
       (is (nil? (lib/check-segment-overwrite 1 segment-1-def))))))
 
 (deftest ^:parallel check-segment-overwrite-self-reference-not-in-mp-test
   (testing "Segment referencing itself - should throw cycle (even if segment is not in mp)"
-    (let [mp            (lib.tu/mock-metadata-provider meta/metadata-provider {})
+    (let [mp (lib.tu/mock-metadata-provider meta/metadata-provider {})
           segment-1-def (segment-definition-referencing mp 1)]
       (is (thrown-with-msg?
            #?(:clj Exception :cljs js/Error)
            #"[Cc]ycle"
            (lib/check-segment-overwrite 1 segment-1-def))))))
 
+(deftest ^:parallel check-segment-overwrite-cycle-ex-data-test
+  (testing "Cycle exception includes segment-id and cycle-path in ex-data"
+    (let [mp (lib.tu/mock-metadata-provider meta/metadata-provider {})
+          segment-1-def (segment-definition-referencing mp 1)
+          ex (try
+               (lib/check-segment-overwrite 1 segment-1-def)
+               (catch #?(:clj Exception :cljs js/Error) e e))
+          data (ex-data ex)]
+      (is (= 1 (:segment-id data)))
+      (is (contains? data :cycle-path))
+      (is (vector? (:cycle-path data)))
+      (is (some #{1} (:cycle-path data)))
+      (is (re-find #"1" (ex-message ex))))))
+
 (deftest ^:parallel check-segment-overwrite-self-reference-in-mp-test
   (testing "Segment referencing itself (segment exists in mp) - should throw cycle"
     (let [simple-def (segment-definition-with-filter
                       meta/metadata-provider
                       (lib/> (meta/field-metadata :venues :price) 2))
-          mp         (lib.tu/mock-metadata-provider
-                      meta/metadata-provider
-                      {:segments [{:id         1
-                                   :name       "Segment 1"
-                                   :table-id   (meta/id :venues)
-                                   :definition simple-def}]})
+          mp (lib.tu/mock-metadata-provider
+              meta/metadata-provider
+              {:segments [{:id 1
+                           :name "Segment 1"
+                           :table-id (meta/id :venues)
+                           :definition simple-def}]})
           segment-1-def (segment-definition-referencing mp 1)]
       (is (thrown-with-msg?
            #?(:clj Exception :cljs js/Error)
@@ -209,21 +223,21 @@
 (deftest ^:parallel check-segment-overwrite-indirect-cycle-test
   (testing "Segment A -> Segment B -> Segment A - should throw"
     (let [;; Segment 1 exists with a simple definition (will be overwritten)
-          simple-def    (segment-definition-with-filter
-                         meta/metadata-provider
-                         (lib/> (meta/field-metadata :venues :price) 2))
+          simple-def (segment-definition-with-filter
+                      meta/metadata-provider
+                      (lib/> (meta/field-metadata :venues :price) 2))
           ;; Segment 2 references Segment 1
           segment-2-def (segment-definition-referencing meta/metadata-provider 1)
-          mp            (lib.tu/mock-metadata-provider
-                         meta/metadata-provider
-                         {:segments [{:id         1
-                                      :name       "Segment 1"
-                                      :table-id   (meta/id :venues)
-                                      :definition simple-def}
-                                     {:id         2
-                                      :name       "Segment 2"
-                                      :table-id   (meta/id :venues)
-                                      :definition segment-2-def}]})
+          mp (lib.tu/mock-metadata-provider
+              meta/metadata-provider
+              {:segments [{:id 1
+                           :name "Segment 1"
+                           :table-id (meta/id :venues)
+                           :definition simple-def}
+                          {:id 2
+                           :name "Segment 2"
+                           :table-id (meta/id :venues)
+                           :definition segment-2-def}]})
           ;; New definition for Segment 1 references Segment 2 -> creates cycle: 1 -> 2 -> 1
           segment-1-def (segment-definition-referencing mp 2)]
       (is (thrown-with-msg?
@@ -234,27 +248,27 @@
 (deftest ^:parallel check-segment-overwrite-longer-cycle-test
   (testing "Segment A -> B -> C -> A - should throw"
     (let [;; Segment 1 exists with a simple definition (will be overwritten)
-          simple-def    (segment-definition-with-filter
-                         meta/metadata-provider
-                         (lib/> (meta/field-metadata :venues :price) 2))
+          simple-def (segment-definition-with-filter
+                      meta/metadata-provider
+                      (lib/> (meta/field-metadata :venues :price) 2))
           ;; Segment 3 references Segment 1
           segment-3-def (segment-definition-referencing meta/metadata-provider 1)
           ;; Segment 2 references Segment 3
           segment-2-def (segment-definition-referencing meta/metadata-provider 3)
-          mp            (lib.tu/mock-metadata-provider
-                         meta/metadata-provider
-                         {:segments [{:id         1
-                                      :name       "Segment 1"
-                                      :table-id   (meta/id :venues)
-                                      :definition simple-def}
-                                     {:id         2
-                                      :name       "Segment 2"
-                                      :table-id   (meta/id :venues)
-                                      :definition segment-2-def}
-                                     {:id         3
-                                      :name       "Segment 3"
-                                      :table-id   (meta/id :venues)
-                                      :definition segment-3-def}]})
+          mp (lib.tu/mock-metadata-provider
+              meta/metadata-provider
+              {:segments [{:id 1
+                           :name "Segment 1"
+                           :table-id (meta/id :venues)
+                           :definition simple-def}
+                          {:id 2
+                           :name "Segment 2"
+                           :table-id (meta/id :venues)
+                           :definition segment-2-def}
+                          {:id 3
+                           :name "Segment 3"
+                           :table-id (meta/id :venues)
+                           :definition segment-3-def}]})
           ;; New definition for Segment 1 references Segment 2 -> creates cycle: 1 -> 2 -> 3 -> 1
           segment-1-def (segment-definition-referencing mp 2)]
       (is (thrown-with-msg?
@@ -264,9 +278,20 @@
 
 (deftest ^:parallel check-segment-overwrite-unknown-segment-test
   (testing "Segment referencing unknown segment - should throw"
-    (let [mp            (lib.tu/mock-metadata-provider meta/metadata-provider {})
+    (let [mp (lib.tu/mock-metadata-provider meta/metadata-provider {})
           segment-1-def (segment-definition-referencing mp 999)]
       (is (thrown-with-msg?
            #?(:clj Exception :cljs js/Error)
            #"does not exist"
            (lib/check-segment-overwrite 1 segment-1-def))))))
+
+(deftest ^:parallel check-segment-overwrite-unknown-segment-ex-data-test
+  (testing "Unknown segment exception includes segment-id in ex-data and message"
+    (let [mp (lib.tu/mock-metadata-provider meta/metadata-provider {})
+          segment-1-def (segment-definition-referencing mp 999)
+          ex (try
+               (lib/check-segment-overwrite 1 segment-1-def)
+               (catch #?(:clj Exception :cljs js/Error) e e))
+          data (ex-data ex)]
+      (is (= 999 (:segment-id data)))
+      (is (re-find #"999" (ex-message ex))))))


### PR DESCRIPTION
Part of the mutation testing project for `metabase.lib.segment`.

Linear: QUE-3066

### Function
`metabase.lib.segment/check-segment-cycles`

### Stats
- **Surviving mutations before:** 9
- **Tests added:** 2
- **Mutations killed by this PR:** 8
- **Mutations remaining:** 1

### Mutations killed
- Replace cycle-path with nil (in str/join)
- Replace :segment-id with :segment-id__ (check-segment-cycles ex-data)
- Replace segment-id value with nil (check-segment-cycles ex-data)
- Replace :cycle-path with :cycle-path__ (check-segment-cycles ex-data)
- Replace cycle-path value with nil (check-segment-cycles ex-data)
- Replace segment-id with nil (segment-graph error message)
- Replace :segment-id with :segment-id__ (segment-graph ex-data)
- Replace segment-id value with nil (segment-graph ex-data)

### Mutations not killed (with rationale)
- Replace acc with nil (segment-graph reduce) — find-cycle always calls children-of with a single node, so the reduce always has one iteration. (assoc nil k v) ≡ (assoc {} k v).
- Replace {:min 1} with {:min 0} (available-segments schema) — Schema annotation only — the function returns nil (not empty seq) when no segments. Runtime behavior identical.
