### PR TITLE
[Mutation Testing] Kill mutations in metabase.lib.segment/check-segment-overwrite

### DIFF
--- a/test/metabase/lib/segment_test.cljc
+++ b/test/metabase/lib/segment_test.cljc
@@ -190,18 +190,18 @@
            (lib/check-segment-overwrite 1 segment-1-def))))))
 
 (deftest ^:parallel check-segment-overwrite-cycle-ex-data-test
-    (testing "Cycle exception includes segment-id and cycle-path in ex-data"
-      (let [mp            (lib.tu/mock-metadata-provider meta/metadata-provider {})
-            segment-1-def (segment-definition-referencing mp 1)
-            ex            (try
-                            (lib/check-segment-overwrite 1 segment-1-def)
-                            (catch #?(:clj Exception :cljs js/Error) e e))
-            data          (ex-data ex)]
-        (is (= 1 (:segment-id data)))
-        (is (contains? data :cycle-path))
-        (is (vector? (:cycle-path data)))
-        (is (some #{1} (:cycle-path data)))
-        (is (re-find #"1" (ex-message ex))))))
+  (testing "Cycle exception includes segment-id and cycle-path in ex-data"
+    (let [mp            (lib.tu/mock-metadata-provider meta/metadata-provider {})
+          segment-1-def (segment-definition-referencing mp 1)
+          ex            (try
+                          (lib/check-segment-overwrite 1 segment-1-def)
+                          (catch #?(:clj Exception :cljs js/Error) e e))
+          data          (ex-data ex)]
+      (is (= 1 (:segment-id data)))
+      (is (contains? data :cycle-path))
+      (is (vector? (:cycle-path data)))
+      (is (some #{1} (:cycle-path data)))
+      (is (re-find #"1" (ex-message ex))))))
 
 (deftest ^:parallel check-segment-overwrite-self-reference-in-mp-test
   (testing "Segment referencing itself (segment exists in mp) - should throw cycle"

--- a/test/metabase/lib/segment_test.cljc
+++ b/test/metabase/lib/segment_test.cljc
@@ -189,7 +189,7 @@
            #"[Cc]ycle"
            (lib/check-segment-overwrite 1 segment-1-def))))))
 
-  (deftest ^:parallel check-segment-overwrite-cycle-ex-data-test
+(deftest ^:parallel check-segment-overwrite-cycle-ex-data-test
     (testing "Cycle exception includes segment-id and cycle-path in ex-data"
       (let [mp            (lib.tu/mock-metadata-provider meta/metadata-provider {})
             segment-1-def (segment-definition-referencing mp 1)

--- a/test/metabase/lib/segment_test.cljc
+++ b/test/metabase/lib/segment_test.cljc
@@ -189,8 +189,6 @@
            #"[Cc]ycle"
            (lib/check-segment-overwrite 1 segment-1-def))))))
 
-(deftest ^:parallel check-segment-overwrite-self-reference-in-mp-test
-
   (deftest ^:parallel check-segment-overwrite-cycle-ex-data-test
     (testing "Cycle exception includes segment-id and cycle-path in ex-data"
       (let [mp            (lib.tu/mock-metadata-provider meta/metadata-provider {})
@@ -204,6 +202,8 @@
         (is (vector? (:cycle-path data)))
         (is (some #{1} (:cycle-path data)))
         (is (re-find #"1" (ex-message ex))))))
+
+(deftest ^:parallel check-segment-overwrite-self-reference-in-mp-test
   (testing "Segment referencing itself (segment exists in mp) - should throw cycle"
     (let [simple-def (segment-definition-with-filter
                       meta/metadata-provider


### PR DESCRIPTION
Part of the mutation testing project for `metabase.lib.segment`.

Closes QUE-3067

### Functions
- `metabase.lib.segment/check-segment-cycles`
- `metabase.lib.segment/segment-graph`

### Stats
- **Surviving mutations before:** 9
- **Tests added:** 2
- **Mutations killed by this PR:** 8
- **Mutations remaining:** 1

### Mutations killed
- Replace cycle-path with nil in str/join (check-segment-cycles)
- Replace :segment-id with :segment-id__ in ex-data (check-segment-cycles)
- Replace segment-id value with nil in ex-data (check-segment-cycles)
- Replace :cycle-path with :cycle-path__ in ex-data (check-segment-cycles)
- Replace cycle-path value with nil in ex-data (check-segment-cycles)
- Replace segment-id with nil in error message (segment-graph)
- Replace :segment-id with :segment-id__ in ex-data (segment-graph)
- Replace segment-id value with nil in ex-data (segment-graph)

### Mutations not killed (with rationale)
- Replace acc with nil in reduce (segment-graph) — find-cycle always calls children-of with a single node, so the reduce always has one iteration. (assoc nil k v) ≡ (assoc {} k v).
