### PR TITLE
Fix formatting and spacing in quartz.properties. Add check in intervals to clusters

### DIFF
--- a/resources/quartz.properties
+++ b/resources/quartz.properties
@@ -11,11 +11,13 @@ org.quartz.scheduler.skipUpdateCheck = true
 #     https://www.quartz-scheduler.org/documentation/quartz-2.3.0/configuration/ConfigJobStoreTX.html
 #     https://www.quartz-scheduler.org/documentation/quartz-2.3.0/configuration/ConfigDataSources.html
 #     https://github.com/clojurewerkz/quartzite.docs/blob/master/articles/durable_quartz_stores.md
-org.quartz.jobStore.class=org.quartz.impl.jdbcjobstore.JobStoreTX
-org.quartz.jobStore.driverDelegateClass=org.quartz.impl.jdbcjobstore.StdJDBCDelegate
-org.quartz.jobStore.dataSource=db
+org.quartz.jobStore.class = org.quartz.impl.jdbcjobstore.JobStoreTX
+org.quartz.jobStore.driverDelegateClass = org.quartz.impl.jdbcjobstore.StdJDBCDelegate
+org.quartz.jobStore.dataSource = db
 
 org.quartz.jobStore.isClustered = true
+# Added to see if we can prevent multiple firings (which should never happen). Source https://www.quartz-scheduler.org/documentation/quartz-1.8.6/configuration/ConfigJDBCJobStoreClustering.html
+org.quartz.jobStore.clusterCheckinInterval = 20000
 
 # By default, Quartz will fire triggers up to a minute late without considering them to be misfired; if it cannot fire
 # anything within that period for one reason or another (such as all threads in the thread pool being tied up), the
@@ -25,7 +27,7 @@ org.quartz.jobStore.isClustered = true
 # We'll bump it up to 15 minutes (900,000) because the sorts of things we're scheduling aren't extremely time-sensitive,
 # for example Pulses and Sync can be sent out more than a minute late without issue. (In fact, 15 minutes late is better
 # than not at all for such things)
-org.quartz.jobStore.misfireThreshold=900000
+org.quartz.jobStore.misfireThreshold = 900000
 
 # Useful for debugging when Quartz jobs run and when they misfire
 #org.quartz.plugin.triggHistory.class = org.quartz.plugins.history.LoggingTriggerHistoryPlugin


### PR DESCRIPTION
Adding a new line for Quartz to check in on clusters and fix formatting