### PR TITLE
Fix jest-haste-map duplicate manual mock warning

### DIFF
--- a/frontend/src/metabase/common/components/ExplicitSize/__mocks__/index.ts
+++ b/frontend/src/metabase/common/components/ExplicitSize/__mocks__/index.ts
@@ -1,1 +1,0 @@
-export { ExplicitSize } from "./ExplicitSize";

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/__mocks__/index.ts
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/__mocks__/index.ts
@@ -1,1 +1,0 @@
-export { NativeQueryEditor } from "./NativeQueryEditor";

--- a/frontend/test/register-visualizations.js
+++ b/frontend/test/register-visualizations.js
@@ -1,8 +1,12 @@
 // We need to mock this *before* registering the visualizations. Otherwise
 // `ChartWithLegend` with already load the real one.
-jest.mock("metabase/common/components/ExplicitSize");
+jest.mock("metabase/common/components/ExplicitSize", () =>
+  require("metabase/common/components/ExplicitSize/__mocks__/ExplicitSize"),
+);
 
 // We need to mock this *before* registering the visualizations.
 // Otherwise ActionViz loads the NativeQueryEditor (via ActionCreator)
 // and tests fail because ace is not properly mocked
-jest.mock("metabase/query_builder/components/NativeQueryEditor");
+jest.mock("metabase/query_builder/components/NativeQueryEditor", () =>
+  require("metabase/query_builder/components/NativeQueryEditor/__mocks__/NativeQueryEditor"),
+);


### PR DESCRIPTION
Resolves DEV-1377

This pull request updates how mocks are imported in the test setup to ensure the correct mocked modules are used, and removes unnecessary barrel exports from the mocks directories.

**Testing and Mocking Improvements:**

* Updated the way `ExplicitSize` and `NativeQueryEditor` are mocked in `register-visualizations.js` to directly require the specific mock implementations, ensuring that tests use the intended mocks and preventing accidental loading of real components.

**Code Cleanup:**

* Removed the barrel export for `ExplicitSize` in `frontend/src/metabase/common/components/ExplicitSize/__mocks__/index.ts`, as it is no longer needed due to the updated mocking approach.
* Removed the barrel export for `NativeQueryEditor` in `frontend/src/metabase/query_builder/components/NativeQueryEditor/__mocks__/index.ts`, for the same reason.

### Before
<img width="838" height="76" alt="Screenshot From 2026-02-03 10-11-15" src="https://github.com/user-attachments/assets/4cad2003-c143-4356-bbec-b01af0f2f21c" />

### Now
Warning should be gone.
