### PR TITLE
Fix broken eslint tests

### DIFF
--- a/frontend/lint/tests/jtag-missing-key.unit.spec.js
+++ b/frontend/lint/tests/jtag-missing-key.unit.spec.js
@@ -1,6 +1,6 @@
 import { RuleTester } from "eslint";
 
-import jtagKey from "../eslint-rules/jtag-missing-key";
+import rule from "../eslint-plugin-metabase/rules/jtag-missing-key";
 
 const ruleTester = new RuleTester({
   languageOptions: {
@@ -95,7 +95,7 @@ const message = jt\`Fragment \${(<><Icon name="test" /><span>content</span></>)}
   },
 ];
 
-ruleTester.run("jtag-key", jtagKey, {
+ruleTester.run("jtag-key", rule, {
   valid: VALID_CASES,
   invalid: INVALID_CASES.map((invalidCase) => {
     const errorCount = invalidCase.errorCount || 1;

--- a/frontend/lint/tests/no-literal-metabase-strings.unit.spec.js
+++ b/frontend/lint/tests/no-literal-metabase-strings.unit.spec.js
@@ -1,6 +1,6 @@
 import { RuleTester } from "eslint";
 
-import noLiteralMetabaseString from "../eslint-rules/no-literal-metabase-strings";
+import rule from "../eslint-plugin-metabase/rules/no-literal-metabase-strings";
 
 const ruleTester = new RuleTester({
   languageOptions: {
@@ -120,7 +120,7 @@ const INVALID_CASES = [
   },
 ];
 
-ruleTester.run("no-literal-metabase-strings", noLiteralMetabaseString, {
+ruleTester.run("no-literal-metabase-strings", rule, {
   valid: VALID_CASES,
   invalid: INVALID_CASES.map((invalidCase) => ({
     code: invalidCase.code,

--- a/frontend/lint/tests/no-locale-with-intl-functions.unit.spec.js
+++ b/frontend/lint/tests/no-locale-with-intl-functions.unit.spec.js
@@ -1,6 +1,6 @@
 import { RuleTester } from "eslint";
 
-import noLocaleWithIntlFunctions from "../eslint-rules/no-locale-with-intl-functions";
+import rule from "../eslint-plugin-metabase/rules/no-locale-with-intl-functions";
 
 const ruleTester = new RuleTester({
   languageOptions: {
@@ -79,7 +79,7 @@ const INVALID_CASES = [
   },
 ];
 
-ruleTester.run("no-locale-with-intl-functions", noLocaleWithIntlFunctions, {
+ruleTester.run("no-locale-with-intl-functions", rule, {
   valid: VALID_CASES,
   invalid: INVALID_CASES.map((invalidCase) => {
     return {

--- a/frontend/lint/tests/no-unconditional-metabase-links-render.unit.spec.js
+++ b/frontend/lint/tests/no-unconditional-metabase-links-render.unit.spec.js
@@ -1,6 +1,6 @@
 import { RuleTester } from "eslint";
 
-import noUnconditionalMetabaseLinksRender from "../eslint-rules/no-unconditional-metabase-links-render";
+import rule from "../eslint-plugin-metabase/rules/no-unconditional-metabase-links-render";
 
 const ruleTester = new RuleTester({
   languageOptions: {
@@ -148,14 +148,10 @@ const { url: docsUrl } = useDocsUrl("permissions/data");`,
   },
 ];
 
-ruleTester.run(
-  "no-unconditional-metabase-links-render",
-  noUnconditionalMetabaseLinksRender,
-  {
-    valid: VALID_CASES,
-    invalid: INVALID_CASES.map((invalidCase) => ({
-      code: invalidCase.code,
-      errors: [{ message: invalidCase.error }],
-    })),
-  },
-);
+ruleTester.run("no-unconditional-metabase-links-render", rule, {
+  valid: VALID_CASES,
+  invalid: INVALID_CASES.map((invalidCase) => ({
+    code: invalidCase.code,
+    errors: [{ message: invalidCase.error }],
+  })),
+});

--- a/frontend/lint/tests/no-unordered-test-helpers.unit.spec.js
+++ b/frontend/lint/tests/no-unordered-test-helpers.unit.spec.js
@@ -1,6 +1,6 @@
 import { RuleTester } from "eslint";
 
-import rule from "../eslint-rules/no-unordered-test-helpers";
+import rule from "../eslint-plugin-metabase/rules/no-unordered-test-helpers";
 
 const ruleTester = new RuleTester({ languageOptions: { ecmaVersion: 2015 } });
 

--- a/frontend/lint/tests/no-unsafe-element-filtering.unit.spec.js
+++ b/frontend/lint/tests/no-unsafe-element-filtering.unit.spec.js
@@ -1,6 +1,6 @@
 import { RuleTester } from "eslint";
 
-import rule from "../eslint-rules/no-unsafe-element-filtering";
+import rule from "../eslint-plugin-metabase/rules/no-unsafe-element-filtering";
 
 const ruleTester = new RuleTester({ languageOptions: { ecmaVersion: 2015 } });
 

--- a/frontend/lint/tests/no-unscoped-text-selectors.unit.spec.js
+++ b/frontend/lint/tests/no-unscoped-text-selectors.unit.spec.js
@@ -1,6 +1,6 @@
 import { RuleTester } from "eslint";
 
-import rule from "../eslint-rules/no-unscoped-text-selectors";
+import rule from "../eslint-plugin-metabase/rules/no-unscoped-text-selectors";
 
 const ruleTester = new RuleTester({ languageOptions: { ecmaVersion: 2015 } });
 


### PR DESCRIPTION
Resolves DEV-1378 by fixing broken eslint custom rules tests. Most likely introduced in https://github.com/metabase/metabase/pull/68772 but not caught because #68947 isn't yet implemented.


### Before

```
Test Suites: 7 failed, 7 total
Tests:       0 total
Snapshots:   0 total
Time:        0.492 s, estimated 1 s
Ran all test suites matching /frontend\/lint\/tests/i.
```

### Now

```
 PASS   lint-rules  frontend/lint/tests/no-locale-with-intl-functions.unit.spec.js
 PASS   lint-rules  frontend/lint/tests/no-unscoped-text-selectors.unit.spec.js
 PASS   lint-rules  frontend/lint/tests/no-unsafe-element-filtering.unit.spec.js
 PASS   lint-rules  frontend/lint/tests/no-unordered-test-helpers.unit.spec.js
 PASS   lint-rules  frontend/lint/tests/no-unconditional-metabase-links-render.unit.spec.js
 PASS   lint-rules  frontend/lint/tests/jtag-missing-key.unit.spec.js
 PASS   lint-rules  frontend/lint/tests/no-literal-metabase-strings.unit.spec.js

Test Suites: 7 passed, 7 total
Tests:       251 passed, 251 total
Snapshots:   0 total
Time:        0.848 s, estimated 1 s
Ran all test suites matching /frontend\/lint\/tests/i.
Done in 20.25s.
```