### PR TITLE
Fix broken `Link` mock

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/QuestionDataSource.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/QuestionDataSource.unit.spec.js
@@ -1,4 +1,4 @@
-/* eslint-disable react/display-name, react/prop-types */
+/* eslint-disable react/prop-types */
 import { Component } from "react";
 
 import { createMockMetadata } from "__support__/metadata";
@@ -254,9 +254,9 @@ function setup({
   return { onError, question };
 }
 
-jest.mock("metabase/common/components/Link", () => ({ to: href, ...props }) => (
-  <a href={href} {...props} />
-));
+jest.mock("metabase/common/components/Link", () => ({
+  Link: ({ to: href, ...props }) => <a href={href} {...props} />,
+}));
 
 function getQuestionFromUrl(relativeUrl) {
   const url = new URL(relativeUrl, document.location.href);


### PR DESCRIPTION
Resolves DEV-1379

The fix was changing the mock from returning a function directly (which would be a default export) to returning an object with a Link property (named export), matching how the actual module exports the component.

Most likely introduced in #67780

### Before

```
    You are trying to create a styled element with an undefined component.
    You may have forgotten to import it.

      65 | `;
      66 |
    > 67 | export const UndoButton = styled(Link)`
         |                           ^
      68 |   font-weight: bold;
      69 |   background-color: ${() => alpha("background-primary", 0.1)};
      70 |   padding: 4px 12px;

      at createStyled (node_modules/@emotion/styled/base/dist/emotion-styled-base.cjs.dev.js:99:13)
      at Object.<anonymous> (frontend/src/metabase/common/components/UndoListing.styled.tsx:67:27)
      at Object.require (frontend/src/metabase/common/components/UndoListing.tsx:31:1)
      at Object.require (frontend/test/__support__/ui.tsx:23:1)
      at Object.require (frontend/test/__support__/utils.ts:3:1)
      at Object.require (frontend/test/__support__/server-mocks/dashboard.ts:3:1)
      at Object.require (frontend/test/__support__/server-mocks/index.ts:15:1)
      at Object.require (frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/QuestionDataSource.unit.spec.js:5:1)

Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        2.093 s, estimated 4 s
Ran all test suites matching /frontend\/src\/metabase\/query_builder\/components\/view\/ViewHeader\/components\/QuestionDataSource\/QuestionDataSource.unit.spec.js/i.

```

### After

```
Test Suites: 1 passed, 1 total
Tests:       68 passed, 68 total
Snapshots:   0 total
Time:        3.898 s, estimated 6 s
Ran all test suites matching /frontend\/src\/metabase\/query_builder\/components\/view\/ViewHeader\/components\/QuestionDataSource\/QuestionDataSource.unit.spec.js/i.
```