### PR TITLE
Add :transform-rolling stats to allow for up-to-date metering

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/transforms/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/core.clj
@@ -23,20 +23,24 @@
   timeout-run!])
 
 (defenterprise transform-stats
-  "Calculate successful transform runs over a window of the previous UTC day 00:00-23:59"
+  "Calculate successful transform runs over a window of the previous UTC day 00:00-23:59.
+  Rolling stats are included under :transform-rolling (up to date totals for today)"
   :feature :none
   []
-  (let [yesterday-utc (-> (t/offset-date-time (t/zone-offset "+00"))
-                          (t/minus (t/days 1)))
-        count-runs    (fn [source-types]
+  (let [today-utc     (t/offset-date-time (t/zone-offset "+00"))
+        yesterday-utc (t/minus today-utc (t/days 1))
+        count-runs    (fn [source-types date]
                         (or (:cnt (t2/query-one {:select [[[:count :r.id] :cnt]]
                                                  :from   [[:transform_run :r]]
                                                  :join   [[:transform :t] [:= :t.id :r.transform_id]]
                                                  :where  [:and
                                                           [:= :r.status "succeeded"]
                                                           [:in :t.source_type source-types]
-                                                          [:= [:cast :r.end_time :date] [:cast yesterday-utc :date]]]}))
+                                                          [:= [:cast :r.end_time :date] [:cast date :date]]]}))
                             0))]
-    {:transform-native-runs (count-runs ["native" "mbql"])
-     :transform-python-runs (count-runs ["python"])
-     :transform-usage-date  (str (t/local-date yesterday-utc))}))
+    {:transform-native-runs         (count-runs ["native" "mbql"] yesterday-utc)
+     :transform-python-runs         (count-runs ["python"] yesterday-utc)
+     :transform-usage-date          (str (t/local-date yesterday-utc))
+     :transform-rolling-native-runs (count-runs ["native" "mbql"] today-utc)
+     :transform-rolling-python-runs (count-runs ["python"] today-utc)
+     :transform-rolling-usage-date  (str (t/local-date today-utc))}))

--- a/src/metabase/premium_features/token_check.clj
+++ b/src/metabase/premium_features/token_check.clj
@@ -111,6 +111,11 @@
       t/local-date
       str))
 
+(defn- today []
+  (-> (t/offset-date-time (t/zone-offset "+00"))
+      t/local-date
+      str))
+
 (defenterprise metabot-stats
   "Stats for Metabot"
   metabase-enterprise.metabot-v3.core
@@ -124,9 +129,12 @@
   "Stats for Transforms"
   metabase-enterprise.transforms.core
   []
-  {:transform-native-runs    0
-   :transform-python-runs    0
-   :transform-usage-date     (yesterday)})
+  {:transform-native-runs         0
+   :transform-python-runs         0
+   :transform-usage-date          (yesterday)
+   :transform-rolling-native-runs 0
+   :transform-rolling-python-runs 0
+   :transform-rolling-usage-date  (today)})
 
 (defn metering-stats
   "Collect metering statistics for billing purposes. Used by both token check and metering task. "


### PR DESCRIPTION
Companion with https://github.com/metabase/harbormaster/pull/6880 

Allows up to date metering alongside the existing 'yesterday' totals.

As its a new key and otherwise we have not made any changes should be safe to deploy at any time (no deploy dependency on HM)
