### PR TITLE
Remove links from all alerts/subscriptions related emails in modular embeddings

### DIFF
--- a/src/metabase/channel/email/_header.hbs
+++ b/src/metabase/channel/email/_header.hbs
@@ -1,7 +1,8 @@
 <html>
 <head>
-  <link href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,900;1,100;1,300;1,400;1,700;1,900" rel="stylesheet">
   <style>
+    @import url("https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,900;1,100;1,300;1,400;1,700;1,900");
+
     * {
       mso-line-height-rule: exactly;
     }

--- a/src/metabase/channel/email/broken_subscription_notification.hbs
+++ b/src/metabase/channel/email/broken_subscription_notification.hbs
@@ -65,6 +65,7 @@
     {{/each}}
   </table>
 
+  {{#unless disable_links}}
   <div style="text-align: center;">
     <a
       href="{{{dashboardUrl}}}"
@@ -77,5 +78,6 @@
   <div
     style="height: 1px; width: 100%; background-color: #F0F0F0; margin-top: 2em;"
   ></div>
+  {{/unless}}
 </div>
 {{> metabase/channel/email/_footer.hbs }}

--- a/src/metabase/channel/email/card_notification_archived.hbs
+++ b/src/metabase/channel/email/card_notification_archived.hbs
@@ -1,4 +1,4 @@
 {{> metabase/channel/email/_header.hbs }}
   <p>Alerts about {{card.name}} (#{{card.id}}) have stopped because the question was archived by {{actor.first_name}} {{actor.last_name}}.</p>
-  <p>If you want to restore the alert, go to the <a href="{{{trash-url}}}">trash</a>, restore the question and re-create the alert.</p>
+  {{#unless disable_links}}<p>If you want to restore the alert, go to the <a href="{{{trash-url}}}">trash</a>, restore the question and re-create the alert.</p>{{/unless}}
 {{> metabase/channel/email/_footer.hbs }}

--- a/src/metabase/channel/email/card_notification_changed_stopped.hbs
+++ b/src/metabase/channel/email/card_notification_changed_stopped.hbs
@@ -1,3 +1,3 @@
 {{> metabase/channel/email/_header.hbs }}
-    <p>Alerts about <a href="{{{card-url card.id}}}">{{card.name}}</a> have stopped because the question was edited by {{actor.first_name}} {{actor.last_name}}.</p>
+    <p>Alerts about <a {{#unless disable_links}}href="{{{card-url card.id}}}"{{/unless}}>{{card.name}}</a> have stopped because the question was edited by {{actor.first_name}} {{actor.last_name}}.</p>
 {{> metabase/channel/email/_footer.hbs }}

--- a/src/metabase/channel/email/messages.clj
+++ b/src/metabase/channel/email/messages.clj
@@ -368,7 +368,7 @@
 
 (defn send-broken-subscription-notification!
   "Email dashboard and subscription creators information about a broken subscription due to bad parameters"
-  [{:keys [dashboard-id dashboard-name pulse-creator dashboard-creator affected-users bad-parameters]}]
+  [{:keys [dashboard-id dashboard-name pulse-creator dashboard-creator affected-users bad-parameters disable_links]}]
   (let [{:keys [siteUrl] :as context} (common-context)]
     (email/send-message!
      :subject (trs "Subscription to {0} removed" dashboard-name)
@@ -399,4 +399,5 @@
                                                      :recipient         (:common_name pulse-creator)
                                                      :role              "Subscription Creator"}]
                                                    (map #(assoc % :role "Subscriber") affected-users)))
-                       :dashboardUrl             (format "%s/dashboard/%s" siteUrl dashboard-id)})))))
+                       :dashboardUrl             (format "%s/dashboard/%s" siteUrl dashboard-id)
+                       :disable_links            disable_links})))))

--- a/src/metabase/channel/email/messages.clj
+++ b/src/metabase/channel/email/messages.clj
@@ -352,18 +352,28 @@
 
 (defn send-alert-stopped-because-archived-email!
   "Email to notify users when a card associated to their alert has been archived"
-  [card recipient-emails archiver]
+  [card recipient-emails recipient-emails-with-no-links archiver]
   (send-email! recipient-emails not-working-subject archived-template
                {:card card
                 :actor archiver}
+               true)
+  (send-email! recipient-emails-with-no-links not-working-subject archived-template
+               {:card card
+                :actor archiver
+                :disable_links true}
                true))
 
 (defn send-alert-stopped-because-changed-email!
   "Email to notify users when a card associated to their alert changed in a way that invalidates their alert"
-  [card recipient-emails archiver]
+  [card recipient-emails recipient-emails-with-no-links archiver]
   (send-email! recipient-emails not-working-subject changed-stopped-template
                {:card card
                 :actor archiver}
+               true)
+  (send-email! recipient-emails-with-no-links not-working-subject changed-stopped-template
+               {:card card
+                :actor archiver
+                :disable_links true}
                true))
 
 (defn send-broken-subscription-notification!

--- a/src/metabase/channel/email/notification_card_new_confirmation.hbs
+++ b/src/metabase/channel/email/notification_card_new_confirmation.hbs
@@ -1,4 +1,4 @@
 {{> metabase/channel/email/_header.hbs }}
-    <p>This is just a confirmation that your alert about <a href="{{{card-url payload.event_info.object.payload.card_id}}}">{{payload.event_info.object.payload.card.name}}</a> has been set up.</p>
+    <p>This is just a confirmation that your alert about <a {{#unless payload.event_info.object.payload.disable_links}}href="{{{card-url payload.event_info.object.payload.card_id}}}"{{/unless}}>{{payload.event_info.object.payload.card.name}}</a> has been set up.</p>
     <p>This alert will be sent {{> metabase/channel/email/_notification_card_condition.hbs send_condition=payload.event_info.object.payload.send_condition}}.</p>
 {{> metabase/channel/email/_footer.hbs}}

--- a/src/metabase/channel/email/notification_card_you_were_removed.hbs
+++ b/src/metabase/channel/email/notification_card_you_were_removed.hbs
@@ -1,3 +1,3 @@
 {{> metabase/channel/email/_header.hbs }}
-    <p>Just letting you know that {{actor_name}} unsubscribed you from alerts about <a href="{{{card-url payload.card_id}}}">{{payload.card.name}}</a>.</p>
+    <p>Just letting you know that {{actor_name}} unsubscribed you from alerts about <a {{#unless payload.disable_links}}href="{{{card-url payload.card_id}}}"{{/unless}}>{{payload.card.name}}</a>.</p>
 {{> metabase/channel/email/_footer.hbs }}

--- a/src/metabase/dashboards_rest/api.clj
+++ b/src/metabase/dashboards_rest/api.clj
@@ -939,7 +939,9 @@
          :dashboard-id dashboard-id
          :dashboard-name dashboard-name
          :dashboard-description dashboard-description
-         :dashboard-creator (select-keys dashboard-creator [:first_name :last_name :email :common_name]))))))
+         :dashboard-creator (select-keys dashboard-creator [:first_name :last_name :email :common_name])
+         ;; We will not include links to Metabase for subscriptions created in modular embeddings
+         :disable_links (:disable_links broken-pulse))))))
 
 (defn- handle-broken-subscriptions
   "Given a dashboard id and original parameters, determine if any of the subscriptions are broken (we've removed params

--- a/test/metabase/dashboards_rest/api_test.clj
+++ b/test/metabase/dashboards_rest/api_test.clj
@@ -4622,8 +4622,8 @@
                                                             :rasta :put 200 (str "dashboard/" dash-id)
                                                             {:parameters []}))
                   title            (format "Subscription to %s removed" dashboard-name)
-                                   ;; Keep only the relevant messages. If not, you might get some other side-effecting email, such
-                                   ;; as "We've Noticed a New Metabase Login, Rasta".
+                  ;; Keep only the relevant messages. If not, you might get some other side-effecting email, such
+                  ;; as "We've Noticed a New Metabase Login, Rasta".
                   inbox            (update-vals
                                     @mt/inbox
                                     (fn [messages]

--- a/test/metabase/dashboards_rest/api_test.clj
+++ b/test/metabase/dashboards_rest/api_test.clj
@@ -4541,7 +4541,7 @@
 
 (deftest handle-broken-subscriptions-due-to-bad-parameters-test
   (defn- test-handle-broken-subscription-notification!
-    [{:keys [disable-links? email-body-re match-email-body-re?]}]
+    [{:keys [disable-links? email-body-pattern match-email-body-pattern?]}]
     (let [param {:name "Source"
                  :slug "source"
                  :id   "_SOURCE_PARAM_ID_"
@@ -4633,8 +4633,8 @@
                                        (is (true? (some-> (get-in inbox [recipient-email 0 :body 0 :content])
                                                           (str/includes? title)))))
                                      (testing "The second email (about the broken slack pulse) was received"
-                                       (is (= match-email-body-re? (some-> (get-in inbox [recipient-email 1 :body 0 :content])
-                                                                           (str/includes? email-body-re))))))]
+                                       (is (= match-email-body-pattern? (some-> (get-in inbox [recipient-email 1 :body 0 :content])
+                                                                                (str/includes? email-body-pattern))))))]
               (testing "The dashboard parameters were removed"
                 (is (empty? parameters)))
               (testing "The broken pulse was archived"
@@ -4650,21 +4650,21 @@
 
   (testing "When a subscriptions is broken, archive it and notify the dashboard and subscription creator (#30100)"
     (test-handle-broken-subscription-notification!
-     {:disable-links?       false
-      :email-body-re        "#my-channel"
-      :match-email-body-re? true}))
+     {:disable-links?            false
+      :email-body-pattern        "#my-channel"
+      :match-email-body-pattern? true}))
 
   (testing "When a subscriptions is broken, archive it and notify the dashboard and subscription creator (#30100) with email links when disable_links: false"
     (test-handle-broken-subscription-notification!
-     {:disable-links?       false
-      :email-body-re        "href="
-      :match-email-body-re? true}))
+     {:disable-links?            false
+      :email-body-pattern        "href="
+      :match-email-body-pattern? true}))
 
   (testing "When a subscriptions is broken, archive it and notify the dashboard and subscription creator (#30100) without email links when disable_links: true"
     (test-handle-broken-subscription-notification!
-     {:disable-links?       true
-      :email-body-re        "href="
-      :match-email-body-re? false})))
+     {:disable-links?            true
+      :email-body-pattern        "href="
+      :match-email-body-pattern? false})))
 
 (deftest run-mlv2-dashcard-query-test
   (testing "POST /api/dashboard/:dashboard-id/dashcard/:dashcard-id/card/:card-id"

--- a/test/metabase/dashboards_rest/api_test.clj
+++ b/test/metabase/dashboards_rest/api_test.clj
@@ -4588,7 +4588,7 @@
                                            :user_id          (mt/user->id :rasta)}
            :model/PulseChannelRecipient _ {:pulse_channel_id pulse-channel-id
                                            :user_id          (mt/user->id :crowberto)}
-                     ;; Broken slack pulse
+           ;; Broken slack pulse
            :model/Pulse {bad-slack-pulse-id :id} {:name          "Bad Slack Pulse"
                                                   :dashboard_id  dash-id
                                                   :creator_id    (mt/user->id :trashbird)
@@ -4601,7 +4601,7 @@
                                   :pulse_id     bad-slack-pulse-id
                                   :details      {:channel "#my-channel"}
                                   :enabled      true}
-                     ;; Non broken pulse
+           ;; Non broken pulse
            :model/Pulse {good-pulse-id :id} {:name         "Good Pulse"
                                              :dashboard_id dash-id
                                              :creator_id   (mt/user->id :trashbird)}
@@ -4623,8 +4623,8 @@
                                                             :rasta :put 200 (str "dashboard/" dash-id)
                                                             {:parameters []}))
                   title            (format "Subscription to %s removed" dashboard-name)
-                            ;; Keep only the relevant messages. If not, you might get some other side-effecting email, such
-                            ;; as "We've Noticed a New Metabase Login, Rasta".
+                                   ;; Keep only the relevant messages. If not, you might get some other side-effecting email, such
+                                   ;; as "We've Noticed a New Metabase Login, Rasta".
                   inbox            (update-vals
                                     @mt/inbox
                                     (fn [messages]

--- a/test/metabase/dashboards_rest/api_test.clj
+++ b/test/metabase/dashboards_rest/api_test.clj
@@ -4540,8 +4540,7 @@
               (is (true? (:archived (models.pulse/update-pulse! {:id bad-pulse-id :archived true})))))))))))
 
 (deftest handle-broken-subscriptions-due-to-bad-parameters-test
-  (defn handle-broken-subscription-notification!
-    "Handles the notification logic for broken subscriptions.i"
+  (defn- test-handle-broken-subscription-notification!
     [{:keys [disable-links? email-body-re match-email-body-re?]}]
     (let [param {:name "Source"
                  :slug "source"
@@ -4650,19 +4649,19 @@
                 (emails-received? "trashbird@metabase.com"))))))))
 
   (testing "When a subscriptions is broken, archive it and notify the dashboard and subscription creator (#30100)"
-    (handle-broken-subscription-notification!
+    (test-handle-broken-subscription-notification!
      {:disable-links?       false
       :email-body-re        "#my-channel"
       :match-email-body-re? true}))
 
   (testing "When a subscriptions is broken, archive it and notify the dashboard and subscription creator (#30100) with email links when disable_links: false"
-    (handle-broken-subscription-notification!
+    (test-handle-broken-subscription-notification!
      {:disable-links?       false
       :email-body-re        "href="
       :match-email-body-re? true}))
 
   (testing "When a subscriptions is broken, archive it and notify the dashboard and subscription creator (#30100) without email links when disable_links: true"
-    (handle-broken-subscription-notification!
+    (test-handle-broken-subscription-notification!
      {:disable-links?       true
       :email-body-re        "href="
       :match-email-body-re? false})))

--- a/test/metabase/notification/api/notification_test.clj
+++ b/test/metabase/notification/api/notification_test.clj
@@ -1021,6 +1021,21 @@
                              :expected-subject "You’ve been unsubscribed from an alert"
                              :card-url-tag card-url-tag))))
 
+          (testing "when notification is archived (active -> inactive) with disable_links value:"
+            (let [has-link? (fn [disable_links]
+                              (notification.tu/with-card-notification
+                                [{noti-id :id :as notification} (assoc-in base-notification [:notification-card :disable_links] disable_links)]
+                                (->> (update-notification! noti-id notification {:active false})
+                                     first :body first :content
+                                     (re-find #"href=")
+                                     (= "href="))))]
+              (testing "false will keep links in the alert unsubscribe email"
+                (is (true? (has-link? false))))
+              (testing "nil will keep links in the alert unsubscribe email"
+                (is (true? (has-link? nil))))
+              (testing "true will remove all links in the alert unsubscribe email"
+                (is (false? (has-link? true))))))
+
           (testing "when notification is unarchived (inactive -> active)"
             (notification.tu/with-card-notification
               [{noti-id :id :as notification} (assoc-in base-notification [:notification :active] false)]

--- a/test/metabase/queries_rest/api/card_test.clj
+++ b/test/metabase/queries_rest/api/card_test.clj
@@ -2131,8 +2131,6 @@
                                                                          [:query :breakout] [[:field (mt/id :checkins :date) {:temporal-unit :month}]
                                                                                              [:field (mt/id :checkins :date) {:temporal-unit :year}]])}))}))
 
-;; XXX: Add new tests here.
-
 (deftest changing-the-display-type-from-line-to-area-bar-is-fine-and-doesnt-delete-the-alert
   (doseq [{:keys [message display]}
           [{:message "Changing display type from line to area should not delete alert"


### PR DESCRIPTION
Closes EMB-1280

### Description

There are 5 emails for alerts/dashboards that modular embedding users could get. We remove links from those 5 emails. I'll list the emails in the next section.

### How to verify
1. Subscriptions: broken from parameter change
    1. Set up a dashboard with a card and a parameter connected to the card
    2. Subscribe to the dashboard in modular embedding or modular embedding SDK and ensure you set the parameter value in the subscription
    3. Remove the parameter from the dashboard and save. You should get an email.
4. Alerts: setup confirmation
    1. Create a question
    2. Create an alert for the question in modular embedding or modular embedding SDK.
    3. You should get an email
6. Alerts: alert deleted
    1. Create a question
    2. Create an alert for the question in modular embedding or modular embedding SDK.
    3. Delete the alert (not the card)
    4. You should get an email
8. Alerts: display type changed from table -> line (there are other scenarios, but this is just an example)
    1. Create a question with table visualization
    2. Create an alert for the question in modular embedding or modular embedding SDK.
    3. Change the visualization to line, you may need to modify the query for the chart to display
    4. You should get an email
10. Alerts: original card trashed
    1. Create a question
    2. Create an alert for the question in modular embedding or modular embedding SDK.
    3. Delete the card
    4. You should get an email

### Demo
#### 1. Subscriptions: broken from parameter change
After: 
<img width="735" height="583" alt="image" src="https://github.com/user-attachments/assets/e09cb336-d898-44a0-b654-b52a1e0ab2ec" />


Before:
<img width="1442" height="1346" alt="image" src="https://github.com/user-attachments/assets/55775505-98de-41ef-83f2-8d90980ed346" />

#### 2. Alerts: setup confirmation

After:
<img width="560" height="209" alt="image" src="https://github.com/user-attachments/assets/07fcbeb8-200e-4db0-bbb6-238e667f09b1" />

Before:
<img width="1312" height="388" alt="image" src="https://github.com/user-attachments/assets/527cf62a-022d-4f93-9878-d4b71d60b865" />

#### 3. Alerts: alert deleted

After:
<img width="640" height="195" alt="image" src="https://github.com/user-attachments/assets/4ec40dc2-e508-4f5d-a8a0-6b0ea7af9ba6" />


Before:
<img width="1300" height="354" alt="image" src="https://github.com/user-attachments/assets/e3ca39d5-fae4-481b-bffb-3dc3f88fa9e2" />

#### 4. Alerts: display type changed from table -> line (there are other scenarios, but this is just an example)

After:
<img width="648" height="169" alt="image" src="https://github.com/user-attachments/assets/71e8df21-2393-450e-bbb0-d1b86a9baa9e" />


Before:
<img width="1470" height="378" alt="image" src="https://github.com/user-attachments/assets/9c0e0c7d-7c0d-4cbb-aab4-93e462ca78d5" />

#### 5. Alerts: original card trashed

After (the second line is removed completely):
<img width="734" height="207" alt="image" src="https://github.com/user-attachments/assets/dbc89a6d-d3e7-4f5e-be60-c39890cdd783" />

Before:
<img width="1750" height="504" alt="image" src="https://github.com/user-attachments/assets/ba0023b1-17a4-42f2-895e-d75f74590278" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
