### PR TITLE
fixes for email clients in dark mode

### DIFF
--- a/src/metabase/channel/email/_dashsub_alert_header.hbs
+++ b/src/metabase/channel/email/_dashsub_alert_header.hbs
@@ -5,10 +5,16 @@
   </head>
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="color-scheme" content="light only">
+    <meta name="supported-color-schemes" content="light only">
     <style>
       @import url('https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,400;0,700;0,900;1,400;1,700;1,900&display=swap');
 
       {{!-- Styles are mostly inline for maximum compatibility with email clients.  --}}
+
+      :root {
+        color-scheme: light only;
+      }
 
       body {
         font-size: 14px;

--- a/src/metabase/channel/render/js/svg.clj
+++ b/src/metabase/channel/render/js/svg.clj
@@ -169,6 +169,11 @@
   "Height to render svg images. If not bound, will preserve aspect ratio of original image."
   nil)
 
+(def ^:dynamic ^:private *svg-background-color*
+  "Background color for rendered PNG images. Set to nil for transparent background.
+  Defaults to white to ensure charts are readable in dark mode email clients."
+  java.awt.Color/WHITE)
+
 (defn- render-svg
   ^bytes [^SVGOMDocument svg-document]
   (style/register-fonts-if-needed!)
@@ -180,6 +185,8 @@
       (.addTranscodingHint transcoder PNGTranscoder/KEY_WIDTH *svg-render-width*)
       (when *svg-render-height*
         (.addTranscodingHint transcoder PNGTranscoder/KEY_HEIGHT *svg-render-height*))
+      (when *svg-background-color*
+        (.addTranscodingHint transcoder PNGTranscoder/KEY_BACKGROUND_COLOR *svg-background-color*))
       (.transcode transcoder in out))
     (.toByteArray os)))
 
@@ -253,6 +260,7 @@
   "Entrypoint for rendering an SVG icon as a PNG, with a specific color"
   [icon-name color]
   (let [svg-string (icon-svg-string icon-name color)]
-    (binding [*svg-render-width*  (float 33)
-              *svg-render-height* (float 33)]
+    (binding [*svg-render-width*       (float 33)
+              *svg-render-height*      (float 33)
+              *svg-background-color*   nil]
       (svg-string->bytes svg-string))))


### PR DESCRIPTION
Closes #68165

### Description

Dashboard/question subscriptions are difficult to see in email clients with dark mode enabled because charts are PNGs with a transparent background. Email clients in dark mode automatically change the background color, making the chart very difficult to read.

This PR solves this in two different ways:

- Adds `<meta name="color-scheme" content="light only">` to the email template to instruct email clients that dark mode is not supported
- Since not all email clients support `<meta name="color-scheme" content="light only">`, changes the PNGs for charts to have a white rather than transparent background

More context in this [thread](https://metaboat.slack.com/archives/C096M2BBGHH/p1770061785283479). 

### How to verify

Send a dashboard or question subscription and view it with an email client in dark mode.

### Demo

Before:
<img width="1196" height="852" alt="image" src="https://github.com/user-attachments/assets/e4148756-576e-4d9e-b2be-f0051e540fa8" />

After, in email clients that do support `<meta name="color-scheme" content="light only">` (Apple mail, Gmail on web). Emails are identical to light mode:
<img width="661" height="665" alt="image" src="https://github.com/user-attachments/assets/69440ab5-873a-4aa8-af5d-29b975bc77d1" />

After, in email clients that don't support `<meta name="color-scheme" content="light only">` (Gmail on iOS, Outlook all platforms):
<img width="992" height="876" alt="image" src="https://github.com/user-attachments/assets/3d0fedf4-a44a-48f1-931b-f185d0038451" />

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
