### PR TITLE
fix: mini picker loader style

### DIFF
--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
@@ -1,7 +1,9 @@
+import { useMemo } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
 import {
+  searchApi,
   skipToken,
   useGetCollectionQuery,
   useListCollectionItemsQuery,
@@ -16,9 +18,14 @@ import { VirtualizedList } from "metabase/common/components/VirtualizedList";
 import { useSetting } from "metabase/common/hooks";
 import { useDebouncedValue } from "metabase/common/hooks/use-debounced-value";
 import { getIcon } from "metabase/lib/icon";
+import { useSelector } from "metabase/lib/redux";
 import { PLUGIN_DATA_STUDIO } from "metabase/plugins";
-import { Box, Flex, Icon, Repeat, Skeleton, Text } from "metabase/ui";
-import type { SchemaName, SearchModel } from "metabase-types/api";
+import { Box, Flex, Icon, Repeat, Skeleton, Stack, Text } from "metabase/ui";
+import type {
+  SchemaName,
+  SearchModel,
+  SearchRequest,
+} from "metabase-types/api";
 
 import { useMiniPickerContext } from "../context";
 import type {
@@ -299,32 +306,49 @@ function SearchItemList({ query }: { query: string }) {
   const { onChange, models, isHidden } = useMiniPickerContext();
   const debouncedQuery = useDebouncedValue(query, 500);
 
-  const { data: searchResponse, isFetching } = useSearchQuery({
-    q: debouncedQuery,
+  const makeQueryArgs = (
+    query: string,
+    models: MiniPickerPickableItem["model"][],
+  ): SearchRequest => ({
+    q: query,
     models: models as SearchModel[],
     limit: 50,
     // FIXME: optionally pass table_db_id so we filter on the backend to valid joins
   });
 
+  const rawQueryArgs = useMemo(
+    () => makeQueryArgs(query, models),
+    [query, models],
+  );
+
+  const cachedSearch = useSelector(
+    searchApi.endpoints.search.select(rawQueryArgs),
+  );
+  const hasCachedResults = Boolean(cachedSearch?.data);
+
+  const effectiveQuery = hasCachedResults ? query : debouncedQuery;
+  const searchQueryArgs = useMemo(
+    () => makeQueryArgs(effectiveQuery, models),
+    [effectiveQuery, models],
+  );
+
+  const { data: searchResponse, isFetching } = useSearchQuery(searchQueryArgs);
+
+  const isSearching =
+    isFetching || (!hasCachedResults && query !== debouncedQuery);
   const searchResults: MiniPickerPickableItem[] = (
     searchResponse?.data ?? []
   ).filter((i) => !isHidden(i));
 
-  const isFetchingDebounced = useDebouncedValue(
-    isFetching,
-    500,
-    (_lastValue, newValue) => newValue === true,
-  );
-
   return (
     <ItemList>
-      {!isFetchingDebounced && searchResults.length === 0 && (
+      {!isSearching && searchResults.length === 0 && (
         <Box>
           <Text px="md" py="sm" c="text-secondary">{t`No search results`}</Text>
         </Box>
       )}
-      {isFetchingDebounced && <MiniPickerListLoader />}
-      {!isFetchingDebounced &&
+      {isSearching && <MiniPickerListLoader />}
+      {!isSearching &&
         searchResults.map((item) => {
           return (
             <MiniPickerItem
@@ -343,11 +367,16 @@ function SearchItemList({ query }: { query: string }) {
 }
 
 export const MiniPickerListLoader = () => (
-  <Repeat times={3}>
-    <Box px="sm" py="2px">
-      <Skeleton height="2rem" />
-    </Box>
-  </Repeat>
+  <Stack px="1rem" pt="0.5rem" pb="13px" gap="1rem">
+    <Repeat times={3}>
+      <Skeleton
+        height="1.5rem"
+        width="100%"
+        radius="0.5rem"
+        bg="background-secondary"
+      />
+    </Repeat>
+  </Stack>
 );
 
 const isTableInDb = (


### PR DESCRIPTION
[Discussion](https://metaboat.slack.com/archives/C096M2BBGHH/p1770055487417849?thread_ts=1766489677.072949&cid=C096M2BBGHH)

### Description

Update the style and behaviour of mini picker loaders (shows loader immediately when typed, unless the results are cached).

### How to verify

1. New -> New Question
2. Type something in the source picker.

### Demo


https://github.com/user-attachments/assets/fdc9f6a2-f092-4d75-9ade-331ef70cf25a



### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
