### PR TITLE
fix kerberos tests

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,7 +4,8 @@ FROM mcr.microsoft.com/vscode/devcontainers/java:21
 
 RUN ( curl -fsSL https://deb.nodesource.com/setup_22.x | bash ) \
   && export DEBIAN_FRONTEND=noninteractive \
-  && apt-get update && apt-get -y install --no-install-recommends nodejs yarn rlwrap fontconfig
+  && apt-get update && apt-get -y install --no-install-recommends nodejs rlwrap fontconfig \
+  && npm install --global yarn
 
 # install Clojure
 RUN curl https://download.clojure.org/install/linux-install-1.12.0.1488.sh | bash

--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -85,7 +85,9 @@ backend_ci: &backend_ci
 
 backend_presto_kerberos:
   - "**/presto_jdbc/**"
+  - "**/presto-jdbc/**" # the driver module has a hyphen. underscores are classpaths
   - "**/presto_jdbc.clj"
+  - "**/presto_ject_test.clj"
   - ".github/workflows/presto-kerberos-integration-test.yml"
 
 backend_sources: &backend_sources

--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -87,7 +87,7 @@ backend_presto_kerberos:
   - "**/presto_jdbc/**"
   - "**/presto-jdbc/**" # the driver module has a hyphen. underscores are classpaths
   - "**/presto_jdbc.clj"
-  - "**/presto_ject_test.clj"
+  - "**/presto_jdbc_test.clj"
   - ".github/workflows/presto-kerberos-integration-test.yml"
 
 backend_sources: &backend_sources

--- a/modules/drivers/presto-jdbc/test/metabase/driver/presto_jdbc_test.clj
+++ b/modules/drivers/presto-jdbc/test/metabase/driver/presto_jdbc_test.clj
@@ -121,7 +121,7 @@
     (is (= "UTC"
            (driver/db-default-timezone :presto-jdbc (mt/db))))))
 
-(deftest ^:synchronized template-tag-timezone-test
+(deftest template-tag-timezone-test
   (mt/test-driver :presto-jdbc
     (testing "Make sure date params work correctly when report timezones are set (#10487)"
       (mt/with-temporary-setting-values [report-timezone "Asia/Hong_Kong"]

--- a/modules/drivers/presto-jdbc/test/metabase/driver/presto_jdbc_test.clj
+++ b/modules/drivers/presto-jdbc/test/metabase/driver/presto_jdbc_test.clj
@@ -121,7 +121,7 @@
     (is (= "UTC"
            (driver/db-default-timezone :presto-jdbc (mt/db))))))
 
-(deftest template-tag-timezone-test
+(deftest ^:synchronized template-tag-timezone-test
   (mt/test-driver :presto-jdbc
     (testing "Make sure date params work correctly when report timezones are set (#10487)"
       (mt/with-temporary-setting-values [report-timezone "Asia/Hong_Kong"]


### PR DESCRIPTION
in CI we're running:

```
[2/3] RUN ( curl -fsSL https://deb.nodesource.com/setup_22.x | bash )   && export DEBIAN_FRONTEND=noninteractive   && apt-get update && apt-get -y install --no-install-recommends nodejs yarn rlwrap fontconfig

...

3.579 Hit:1 http://deb.debian.org/debian trixie InRelease
(#6 3.579 Hit:2 http://deb.debian.org/debian trixie-updates InRelease
(#6 3.588 Hit:3 http://deb.debian.org/debian-security trixie-security InRelease
(#6 3.651 Hit:4 https://deb.nodesource.com/node_22.x nodistro InRelease
(#6 3.661 Reading package lists...
(#6 4.185 Reading package lists...
(#6 4.691 Building dependency tree...
(#6 4.834 Reading state information...
Dockerfile:5

--------------------

   4 |

   5 | >>> RUN ( curl -fsSL https://deb.nodesource.com/setup_22.x | bash ) \

   6 | >>>   && export DEBIAN_FRONTEND=noninteractive \

   7 | >>>   && apt-get update && apt-get -y install --no-install-recommends nodejs yarn rlwrap fontconfig

   8 |

--------------------

failed to solve: process "/bin/sh -c ( curl -fsSL https://deb.nodesource.com/setup_22.x | bash )   && export DEBIAN_FRONTEND=noninteractive   && apt-get update && apt-get -y install --no-install-recommends nodejs yarn rlwrap fontconfig" did not complete successfully: exit code: 100

(#6 4.850 E: Unable to locate package yarn
(#6 ERROR: process "/bin/sh -c ( curl -fsSL https://deb.nodesource.com/setup_22.x | bash )   && export DEBIAN_FRONTEND=noninteractive   && apt-get update && apt-get -y install --no-install-recommends nodejs yarn rlwrap fontconfig" did not complete successfully: exit code: 100
------
 > [2/3] RUN ( curl -fsSL https://deb.nodesource.com/setup_22.x | bash )   && export DEBIAN_FRONTEND=noninteractive   && apt-get update && apt-get -y install --no-install-recommends nodejs yarn rlwrap fontconfig:
3.517 2026-02-03 18:01:51 - To install N|solid Runtime, run: apt install nsolid -y
3.517
3.579 Hit:1 http://deb.debian.org/debian trixie InRelease
3.579 Hit:2 http://deb.debian.org/debian trixie-updates InRelease
3.588 Hit:3 http://deb.debian.org/debian-security trixie-security InRelease
3.651 Hit:4 https://deb.nodesource.com/node_22.x nodistro InRelease

4.850 E: Unable to locate package yarn

```

and it seems like debian doesn't host yarn (anymore?) which is understandable. So we just do:

```
&& npm install --global yarn
```

And we should be good.

LLM diagnosed this. The setup here is a bit strange to me but it cats it's resulting dockerfile:

```yaml
      - name: Print compose config
        run: cat mba-compose.yml
```

which was helpful. That dockerfile references:

```yaml
  metabase:
    build:
      context: /home/runner/work/metabase/metabase/.devcontainer/
      dockerfile: Dockerfile
```

And it's that devcontainer we are fixing here