### PR TITLE
Check if we connect to SingleStore in mysql driver

### DIFF
--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -143,6 +143,21 @@
   [conn :- (lib.schema.common/instance-of-class Connection)]
   (= (connection-flavor conn) "MariaDB"))
 
+(defn- singlestore-connection?
+  "Returns true if the database is SingleStore by checking for memsql_version variable."
+  [driver db]
+  (sql-jdbc.execute/do-with-connection-with-options
+   driver
+   db
+   nil
+   (fn [^java.sql.Connection conn]
+     (try
+       (let [stmt (.prepareStatement conn "SHOW VARIABLES LIKE 'memsql_version';")
+             rset (.executeQuery stmt)]
+         (.next rset))
+       (catch Exception _
+         false)))))
+
 (defn- partial-revokes-enabled?
   [driver db]
   (sql-jdbc.execute/do-with-connection-with-options
@@ -165,6 +180,7 @@
   [driver _feat db]
   (and (= driver :mysql)
        (mysql? db)
+       (not (singlestore-connection? driver db))
        (not (try
               (partial-revokes-enabled? driver db)
               (catch Exception e
@@ -225,7 +241,8 @@
   [_driver conn-spec & {:as _options}]
   ;; MariaDB doesn't allow users to query the privileges of roles a user might have (unless they have select privileges
   ;; for the mysql database), so we can't query the full privileges of the current user.
-  (when-not (some-> conn-spec :connection mariadb-connection?)
+  (when-not (or (some-> conn-spec :connection mariadb-connection?)
+                (some-> conn-spec :connection singlestore-connection?))
     (let [sql->tuples (fn [sql] (drop 1 (jdbc/query conn-spec sql {:as-arrays? true})))
           db-name     (ffirst (sql->tuples "SELECT DATABASE()"))
           table-names (map first (sql->tuples "SHOW TABLES"))]


### PR DESCRIPTION
> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform). Also, if you're attempting to fix a translation issue, please submit your changes to our [Crowdin project](https://crowdin.com/project/metabase-i18n) instead of opening a PR.

Closes https://github.com/metabase/metabase/issues/68309

### Description

#### Problem                                                                                                                                                                                                                      
SingleStore (formerly MemSQL) is MySQL-compatible but doesn't support certain MySQL-specific features like the `partial_revokes` system variable and role-based privilege queries. This causes connection and sync errors when connecting to SingleStore through Metabase's MySQL driver.

#### Solution
Add SingleStore detection (via the `memsql_version` server variable) and skip incompatible MySQL-specific checks, following the same pattern as existing MariaDB support.

#### Changes

  1. Added singlestore-connection? function to detect SingleStore databases
  2. Skip partial_revokes check for SingleStore in :metadata/table-writable-check
  3. Skip privilege queries for SingleStore in current-user-table-privileges
  4. Fixed typo in mariadb? docstring (:dbms_version → :dbms-version)
 
### How to verify
Spin up MySQL, ran driver tests `clojure -X:dev:drivers:drivers-dev:test :only metabase.driver.mysql-test`. Also checked that connection to SingleStore can be established and sample data can be loaded.

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
