### PR TITLE
Hide transforms from metabot if source is not readable

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
@@ -88,7 +88,8 @@
   [results]
   (let [transform-ids (->> results
                            (filter #(= "transform" (:type %)))
-                           (map :id))]
+                           (map :id)
+                           set)]
     (if-not (seq transform-ids)
       results
       (let [readable-ids (->> (t2/select :model/Transform :id [:in transform-ids])

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
@@ -3,7 +3,7 @@
    [clojure.set :as set]
    [metabase-enterprise.metabot-v3.config :as metabot-v3.config]
    [metabase-enterprise.metabot-v3.reactions]
-   [metabase-enterprise.transforms.util :as transforms.util]
+   [metabase-enterprise.transforms.core :as transforms]
    [metabase.api.common :as api]
    [metabase.permissions.core :as perms]
    [metabase.search.core :as search]
@@ -93,7 +93,7 @@
     (if-not (seq transform-ids)
       results
       (let [readable-ids (->> (t2/select :model/Transform :id [:in transform-ids])
-                              transforms.util/add-source-readable
+                              transforms/add-source-readable
                               (filter :source_readable)
                               (map :id)
                               set)]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
@@ -3,11 +3,11 @@
    [clojure.set :as set]
    [metabase-enterprise.metabot-v3.config :as metabot-v3.config]
    [metabase-enterprise.metabot-v3.reactions]
-   [metabase-enterprise.transforms.core :as transforms]
    [metabase.api.common :as api]
    [metabase.permissions.core :as perms]
    [metabase.search.core :as search]
    [metabase.search.engine :as search.engine]
+   [metabase.transforms.core :as transforms]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [toucan2.core :as t2]))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
@@ -88,9 +88,8 @@
   [results]
   (let [transform-ids (->> results
                            (filter #(= "transform" (:type %)))
-                           (map :id)
-                           seq)]
-    (if-not transform-ids
+                           (map :id))]
+    (if-not (seq transform-ids)
       results
       (let [readable-ids (->> (t2/select :model/Transform :id [:in transform-ids])
                               transforms.util/add-source-readable

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
@@ -3,6 +3,7 @@
    [clojure.set :as set]
    [metabase-enterprise.metabot-v3.config :as metabot-v3.config]
    [metabase-enterprise.metabot-v3.reactions]
+   [metabase-enterprise.transforms.util :as transforms.util]
    [metabase.api.common :as api]
    [metabase.permissions.core :as perms]
    [metabase.search.core :as search]
@@ -80,6 +81,26 @@
                   (assoc-in result [:collection :description] (get descriptions coll-id))
                   result))
               results)))))
+
+(defn- remove-unreadable-transforms
+  "Remove transforms from search results that the user cannot read.
+  This filters out transforms where the user doesn't have access to the source tables/database."
+  [results]
+  (let [transform-ids (->> results
+                           (filter #(= "transform" (:type %)))
+                           (map :id)
+                           seq)]
+    (if-not transform-ids
+      results
+      (let [readable-ids (->> (t2/select :model/Transform :id [:in transform-ids])
+                              transforms.util/add-source-readable
+                              (filter :source_readable)
+                              (map :id)
+                              set)]
+        (filterv (fn [result]
+                   (or (not= "transform" (:type result))
+                       (contains? readable-ids (:id result))))
+                 results)))))
 
 (defn- search-result-id
   "Generate a unique identifier for a search result based on its id and model."
@@ -218,7 +239,8 @@
     (->> fused-results
          (take limit)
          (map postprocess-search-result)
-         enrich-with-collection-descriptions)))
+         enrich-with-collection-descriptions
+         remove-unreadable-transforms)))
 
 (defn search-tool
   "Handler for the /search and /search_v2 tool endpoints.

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/transforms.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/transforms.clj
@@ -15,9 +15,10 @@
   (try
     {:structured_output
      (->> (api.transforms/get-transforms)
-          (into [] (comp (map #(select-keys % [:id :entity_id :name :type :description :source]))
-                         (filter #(or (transforms/python-transform? %)
-                                      (transforms/native-query-transform? %))))))}
+          (into [] (comp (filter #(or (transforms/python-transform? %)
+                                      (transforms/native-query-transform? %)))
+                         (filter :source_readable)
+                         (map #(select-keys % [:id :entity_id :name :type :description :source])))))}
     (catch Exception e
       (metabot-v3.tools.u/handle-agent-error e))))
 

--- a/enterprise/backend/src/metabase_enterprise/transforms/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/core.clj
@@ -1,51 +1,9 @@
 (ns metabase-enterprise.transforms.core
-  "API namespace for the `metabase-enterprise.transform` module."
-  (:require
-   [java-time.api :as t]
-   [metabase-enterprise.transforms.models.transform]
-   [metabase-enterprise.transforms.models.transform-run]
-   [metabase-enterprise.transforms.settings]
-   [metabase-enterprise.transforms.util]
-   [metabase.premium-features.core :refer [defenterprise]]
-   [potemkin :as p]
-   [toucan2.core :as t2]))
+  "Enterprise module placeholder for transforms.
 
-(p/import-vars
- [metabase-enterprise.transforms.settings
-  transform-timeout]
- [metabase-enterprise.transforms.util
-  add-source-readable
-  native-query-transform?
-  python-transform?
-  query-transform?
-  transform-source-database
-  transform-source-type
-  transform-type
-  has-db-transforms-permission?]
- [metabase-enterprise.transforms.models.transform-run
-  timeout-run!]
- [metabase-enterprise.transforms.models.transform
-  update-transform-tags!])
+  Transforms are weird: they have different behavior on OSS vs EE. We need to test this, so we need tests
+  in `enterprise/backend/test/metabase_enterprise/transforms/api_test.clj`.
 
-(defenterprise transform-stats
-  "Calculate successful transform runs over a window of the previous UTC day 00:00-23:59.
-  Rolling stats are included under :transform-rolling (up to date totals for today)"
-  :feature :none
-  []
-  (let [today-utc     (t/offset-date-time (t/zone-offset "+00"))
-        yesterday-utc (t/minus today-utc (t/days 1))
-        count-runs    (fn [source-types date]
-                        (or (:cnt (t2/query-one {:select [[[:count :r.id] :cnt]]
-                                                 :from   [[:transform_run :r]]
-                                                 :join   [[:transform :t] [:= :t.id :r.transform_id]]
-                                                 :where  [:and
-                                                          [:= :r.status "succeeded"]
-                                                          [:in :t.source_type source-types]
-                                                          [:= [:cast :r.end_time :date] [:cast date :date]]]}))
-                            0))]
-    {:transform-native-runs         (count-runs ["native" "mbql"] yesterday-utc)
-     :transform-python-runs         (count-runs ["python"] yesterday-utc)
-     :transform-usage-date          (str (t/local-date yesterday-utc))
-     :transform-rolling-native-runs (count-runs ["native" "mbql"] today-utc)
-     :transform-rolling-python-runs (count-runs ["python"] today-utc)
-     :transform-rolling-usage-date  (str (t/local-date today-utc))}))
+  But we need a 'real' module, because all tests must belong to a module.
+
+  Hence, this placeholder.")

--- a/enterprise/backend/src/metabase_enterprise/transforms/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/core.clj
@@ -1,9 +1,51 @@
 (ns metabase-enterprise.transforms.core
-  "Enterprise module placeholder for transforms.
+  "API namespace for the `metabase-enterprise.transform` module."
+  (:require
+   [java-time.api :as t]
+   [metabase-enterprise.transforms.models.transform]
+   [metabase-enterprise.transforms.models.transform-run]
+   [metabase-enterprise.transforms.settings]
+   [metabase-enterprise.transforms.util]
+   [metabase.premium-features.core :refer [defenterprise]]
+   [potemkin :as p]
+   [toucan2.core :as t2]))
 
-  Transforms are weird: they have different behavior on OSS vs EE. We need to test this, so we need tests
-  in `enterprise/backend/test/metabase_enterprise/transforms/api_test.clj`.
+(p/import-vars
+ [metabase-enterprise.transforms.settings
+  transform-timeout]
+ [metabase-enterprise.transforms.util
+  add-source-readable
+  native-query-transform?
+  python-transform?
+  query-transform?
+  transform-source-database
+  transform-source-type
+  transform-type
+  has-db-transforms-permission?]
+ [metabase-enterprise.transforms.models.transform-run
+  timeout-run!]
+ [metabase-enterprise.transforms.models.transform
+  update-transform-tags!])
 
-  But we need a 'real' module, because all tests must belong to a module.
-
-  Hence, this placeholder.")
+(defenterprise transform-stats
+  "Calculate successful transform runs over a window of the previous UTC day 00:00-23:59.
+  Rolling stats are included under :transform-rolling (up to date totals for today)"
+  :feature :none
+  []
+  (let [today-utc     (t/offset-date-time (t/zone-offset "+00"))
+        yesterday-utc (t/minus today-utc (t/days 1))
+        count-runs    (fn [source-types date]
+                        (or (:cnt (t2/query-one {:select [[[:count :r.id] :cnt]]
+                                                 :from   [[:transform_run :r]]
+                                                 :join   [[:transform :t] [:= :t.id :r.transform_id]]
+                                                 :where  [:and
+                                                          [:= :r.status "succeeded"]
+                                                          [:in :t.source_type source-types]
+                                                          [:= [:cast :r.end_time :date] [:cast date :date]]]}))
+                            0))]
+    {:transform-native-runs         (count-runs ["native" "mbql"] yesterday-utc)
+     :transform-python-runs         (count-runs ["python"] yesterday-utc)
+     :transform-usage-date          (str (t/local-date yesterday-utc))
+     :transform-rolling-native-runs (count-runs ["native" "mbql"] today-utc)
+     :transform-rolling-python-runs (count-runs ["python"] today-utc)
+     :transform-rolling-usage-date  (str (t/local-date today-utc))}))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/transforms_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/transforms_test.clj
@@ -1,0 +1,71 @@
+(ns metabase-enterprise.metabot-v3.tools.transforms-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.metabot-v3.tools.transforms :as metabot-v3.tools.transforms]
+   [metabase.api.common :as api]
+   [metabase.permissions.models.permissions-group :as perms-group]
+   [metabase.test :as mt]))
+
+(deftest get-transforms-test
+  (testing "get-transforms filters out transforms the user cannot read"
+    (mt/with-premium-features #{:metabot-v3 :transforms}
+      (mt/with-temp [:model/Database {db-id :id} {}
+                     :model/Transform transform
+                     {:name   "Test Transform"
+                      :source {:type  "query"
+                               :query {:database db-id
+                                       :type     "native"
+                                       :native   {:query "SELECT 1"}}}}]
+        (testing "returns transform when user can query the source database"
+          (mt/with-test-user :crowberto
+            (let [result   (:structured_output (metabot-v3.tools.transforms/get-transforms {}))
+                  returned (first (filter #(= (:id transform) (:id %)) result))]
+              (is (some? returned)))))
+        (testing "filters out transform when user cannot query the source database"
+          (mt/with-user-in-groups [group {:name "No Query Access"}
+                                   user [group]]
+            (mt/with-db-perm-for-group! (perms-group/all-users) db-id :perms/create-queries :no
+              (mt/with-db-perm-for-group! group db-id :perms/create-queries :no
+                (binding [api/*current-user-id*  (:id user)
+                          api/*is-superuser?*    false
+                          api/*is-data-analyst?* true]
+                  (let [result   (:structured_output (metabot-v3.tools.transforms/get-transforms {}))
+                        returned (first (filter #(= (:id transform) (:id %)) result))]
+                    (is (nil? returned))))))))))))
+
+(deftest get-transform-details-test
+  (testing "get-transform-details returns transform when user can query the source database"
+    (mt/with-premium-features #{:metabot-v3 :transforms}
+      (mt/with-temp [:model/Transform transform
+                     {:name   "Test Transform"
+                      :source {:type  "query"
+                               :query {:database (mt/id)
+                                       :type     "native"
+                                       :native   {:query "SELECT 1"}}}}]
+        (mt/with-test-user :crowberto
+          (let [result (:structured_output (metabot-v3.tools.transforms/get-transform-details
+                                            {:transform-id (:id transform)}))]
+            (is (= (:id transform) (:id result)))))))))
+
+(deftest get-transform-details-blocked-test
+  (testing "get-transform-details throws when user cannot query the source database"
+    (mt/with-premium-features #{:metabot-v3 :transforms}
+      (mt/with-temp [:model/Database {db-id :id} {}
+                     :model/Transform transform
+                     {:name   "Blocked Transform"
+                      :source {:type  "query"
+                               :query {:database db-id
+                                       :type     "native"
+                                       :native   {:query "SELECT 1"}}}}]
+        (mt/with-user-in-groups [group {:name "No Query Access"}
+                                 user [group]]
+          (mt/with-db-perm-for-group! (perms-group/all-users) db-id :perms/create-queries :no
+            (mt/with-db-perm-for-group! group db-id :perms/create-queries :no
+              (binding [api/*current-user-id*  (:id user)
+                        api/*is-superuser?*    false
+                        api/*is-data-analyst?* true]
+                (is (thrown-with-msg?
+                     clojure.lang.ExceptionInfo
+                     #"You don't have permissions to do that"
+                     (metabot-v3.tools.transforms/get-transform-details
+                      {:transform-id (:id transform)})))))))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/transforms_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/transforms_test.clj
@@ -27,34 +27,34 @@
                   (mt/with-test-user :rasta
                     (let [result   (:structured_output (metabot-v3.tools.transforms/get-transforms {}))
                           returned (first (filter #(= (:id transform) (:id %)) result))]
-                      (is (nil? returned))))))))))))
+                      (is (nil? returned)))))))))))))
 
-  (deftest get-transform-details-test
-    (testing "get-transform-details returns transform when user can query the source database"
-      (mt/with-premium-features #{:metabot-v3 :transforms}
-        (mt/with-temp [:model/Transform transform
-                       {:name   "Test Transform"
-                        :source {:type  "query"
-                                 :query (lib/native-query (mt/metadata-provider) "SELECT 1")}}]
-          (mt/with-test-user :crowberto
-            (let [result (:structured_output (metabot-v3.tools.transforms/get-transform-details
-                                              {:transform-id (:id transform)}))]
-              (is (= (:id transform) (:id result)))))))))
+(deftest get-transform-details-test
+  (testing "get-transform-details returns transform when user can query the source database"
+    (mt/with-premium-features #{:metabot-v3 :transforms}
+      (mt/with-temp [:model/Transform transform
+                     {:name   "Test Transform"
+                      :source {:type  "query"
+                               :query (lib/native-query (mt/metadata-provider) "SELECT 1")}}]
+        (mt/with-test-user :crowberto
+          (let [result (:structured_output (metabot-v3.tools.transforms/get-transform-details
+                                            {:transform-id (:id transform)}))]
+            (is (= (:id transform) (:id result)))))))))
 
-  (deftest get-transform-details-blocked-test
-    (testing "get-transform-details throws when user cannot query the source database"
-      (mt/with-premium-features #{:metabot-v3 :transforms}
-        (mt/with-temp [:model/Database {db-id :id} {}]
-          (let [mp (lib-be/application-database-metadata-provider db-id)]
-            (mt/with-temp [:model/Transform transform
-                           {:name   "Blocked Transform"
-                            :source {:type  "query"
-                                     :query (lib/native-query mp "SELECT 1")}}]
-              (mt/with-data-analyst-role! (mt/user->id :rasta)
-                (mt/with-db-perm-for-group! (perms-group/all-users) db-id :perms/create-queries :no
-                  (mt/with-test-user :rasta
-                    (is (thrown-with-msg?
-                         clojure.lang.ExceptionInfo
-                         #"You don't have permissions to do that"
-                         (metabot-v3.tools.transforms/get-transform-details
-                          {:transform-id (:id transform)})))))))))))))
+(deftest get-transform-details-blocked-test
+  (testing "get-transform-details throws when user cannot query the source database"
+    (mt/with-premium-features #{:metabot-v3 :transforms}
+      (mt/with-temp [:model/Database {db-id :id} {}]
+        (let [mp (lib-be/application-database-metadata-provider db-id)]
+          (mt/with-temp [:model/Transform transform
+                         {:name   "Blocked Transform"
+                          :source {:type  "query"
+                                   :query (lib/native-query mp "SELECT 1")}}]
+            (mt/with-data-analyst-role! (mt/user->id :rasta)
+              (mt/with-db-perm-for-group! (perms-group/all-users) db-id :perms/create-queries :no
+                (mt/with-test-user :rasta
+                  (is (thrown-with-msg?
+                       clojure.lang.ExceptionInfo
+                       #"You don't have permissions to do that"
+                       (metabot-v3.tools.transforms/get-transform-details
+                        {:transform-id (:id transform)}))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/transforms_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/transforms_test.clj
@@ -2,70 +2,59 @@
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.metabot-v3.tools.transforms :as metabot-v3.tools.transforms]
-   [metabase.api.common :as api]
+   [metabase.lib-be.metadata.jvm :as lib-be]
+   [metabase.lib.core :as lib]
    [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.test :as mt]))
 
 (deftest get-transforms-test
-  (testing "get-transforms filters out transforms the user cannot read"
+  (testing "get-transforms correctly returns transform when the user has access to the source database"
     (mt/with-premium-features #{:metabot-v3 :transforms}
-      (mt/with-temp [:model/Database {db-id :id} {}
-                     :model/Transform transform
-                     {:name   "Test Transform"
-                      :source {:type  "query"
-                               :query {:database db-id
-                                       :type     "native"
-                                       :native   {:query "SELECT 1"}}}}]
-        (testing "returns transform when user can query the source database"
+      (mt/with-temp [:model/Database {db-id :id} {}]
+        (let [mp (lib-be/application-database-metadata-provider db-id)]
+          (mt/with-temp [:model/Transform transform
+                         {:name   "Test Transform"
+                          :source {:type  "query"
+                                   :query (lib/native-query mp "SELECT 1")}}]
+            (testing "returns transform when user can query the source database"
+              (mt/with-test-user :crowberto
+                (let [result   (:structured_output (metabot-v3.tools.transforms/get-transforms {}))
+                      returned (first (filter #(= (:id transform) (:id %)) result))]
+                  (is (some? returned)))))
+            (testing "filters out transform when user cannot query the source database"
+              (mt/with-data-analyst-role! (mt/user->id :rasta)
+                (mt/with-db-perm-for-group! (perms-group/all-users) db-id :perms/create-queries :no
+                  (mt/with-test-user :rasta
+                    (let [result   (:structured_output (metabot-v3.tools.transforms/get-transforms {}))
+                          returned (first (filter #(= (:id transform) (:id %)) result))]
+                      (is (nil? returned))))))))))))
+
+  (deftest get-transform-details-test
+    (testing "get-transform-details returns transform when user can query the source database"
+      (mt/with-premium-features #{:metabot-v3 :transforms}
+        (mt/with-temp [:model/Transform transform
+                       {:name   "Test Transform"
+                        :source {:type  "query"
+                                 :query (lib/native-query (mt/metadata-provider) "SELECT 1")}}]
           (mt/with-test-user :crowberto
-            (let [result   (:structured_output (metabot-v3.tools.transforms/get-transforms {}))
-                  returned (first (filter #(= (:id transform) (:id %)) result))]
-              (is (some? returned)))))
-        (testing "filters out transform when user cannot query the source database"
-          (mt/with-user-in-groups [group {:name "No Query Access"}
-                                   user [group]]
-            (mt/with-db-perm-for-group! (perms-group/all-users) db-id :perms/create-queries :no
-              (mt/with-db-perm-for-group! group db-id :perms/create-queries :no
-                (binding [api/*current-user-id*  (:id user)
-                          api/*is-superuser?*    false
-                          api/*is-data-analyst?* true]
-                  (let [result   (:structured_output (metabot-v3.tools.transforms/get-transforms {}))
-                        returned (first (filter #(= (:id transform) (:id %)) result))]
-                    (is (nil? returned))))))))))))
+            (let [result (:structured_output (metabot-v3.tools.transforms/get-transform-details
+                                              {:transform-id (:id transform)}))]
+              (is (= (:id transform) (:id result)))))))))
 
-(deftest get-transform-details-test
-  (testing "get-transform-details returns transform when user can query the source database"
-    (mt/with-premium-features #{:metabot-v3 :transforms}
-      (mt/with-temp [:model/Transform transform
-                     {:name   "Test Transform"
-                      :source {:type  "query"
-                               :query {:database (mt/id)
-                                       :type     "native"
-                                       :native   {:query "SELECT 1"}}}}]
-        (mt/with-test-user :crowberto
-          (let [result (:structured_output (metabot-v3.tools.transforms/get-transform-details
-                                            {:transform-id (:id transform)}))]
-            (is (= (:id transform) (:id result)))))))))
-
-(deftest get-transform-details-blocked-test
-  (testing "get-transform-details throws when user cannot query the source database"
-    (mt/with-premium-features #{:metabot-v3 :transforms}
-      (mt/with-temp [:model/Database {db-id :id} {}
-                     :model/Transform transform
-                     {:name   "Blocked Transform"
-                      :source {:type  "query"
-                               :query {:database db-id
-                                       :type     "native"
-                                       :native   {:query "SELECT 1"}}}}]
-        (mt/with-user-in-groups [group {:name "No Query Access"}
-                                 user [group]]
-          (mt/with-db-perm-for-group! (perms-group/all-users) db-id :perms/create-queries :no
-            (mt/with-db-perm-for-group! group db-id :perms/create-queries :no
-              (binding [api/*current-user-id*  (:id user)
-                        api/*is-superuser?*    false
-                        api/*is-data-analyst?* true]
-                (is (thrown-with-msg?
-                     clojure.lang.ExceptionInfo
-                     #"You don't have permissions to do that"
-                     (metabot-v3.tools.transforms/get-transform-details
-                      {:transform-id (:id transform)})))))))))))
+  (deftest get-transform-details-blocked-test
+    (testing "get-transform-details throws when user cannot query the source database"
+      (mt/with-premium-features #{:metabot-v3 :transforms}
+        (mt/with-temp [:model/Database {db-id :id} {}]
+          (let [mp (lib-be/application-database-metadata-provider db-id)]
+            (mt/with-temp [:model/Transform transform
+                           {:name   "Blocked Transform"
+                            :source {:type  "query"
+                                     :query (lib/native-query mp "SELECT 1")}}]
+              (mt/with-data-analyst-role! (mt/user->id :rasta)
+                (mt/with-db-perm-for-group! (perms-group/all-users) db-id :perms/create-queries :no
+                  (mt/with-test-user :rasta
+                    (is (thrown-with-msg?
+                         clojure.lang.ExceptionInfo
+                         #"You don't have permissions to do that"
+                         (metabot-v3.tools.transforms/get-transform-details
+                          {:transform-id (:id transform)})))))))))))))

--- a/src/metabase/transforms/core.clj
+++ b/src/metabase/transforms/core.clj
@@ -13,6 +13,7 @@
  [metabase.transforms.settings
   transform-timeout]
  [metabase.transforms.util
+  add-source-readable
   native-query-transform?
   python-transform?
   query-transform?


### PR DESCRIPTION
Resolves [BOT-900: Respect transform source_readable permissions in Metabot](https://linear.app/metabase/issue/BOT-900/respect-transform-source-readable-permissions-in-metabot)

* Filters out transforms in the `get-transforms` metabot tool if `source_readable` is false
* Filters out transforms in the search tool if `source_readable` is false. This requires some extra work (`transforms.util/add-source-readable`) since this information isn't available directly in the search index.
* Adds some relevant tests, including some happy-path tests for the transform tools that we didn't have before