### PR TITLE
Add clean screenshot mode for charts and dashboards

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.unit.spec.tsx
@@ -240,6 +240,7 @@ describe("DashCardMenu", () => {
     setup();
 
     await userEvent.click(getIcon("ellipsis"));
+    expect(await screen.findByText("Save screenshot")).toBeInTheDocument();
     await userEvent.click(await screen.findByText("Download results"));
 
     expect(

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenuItems.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenuItems.tsx
@@ -20,7 +20,9 @@ type DashCardMenuItemsProps = {
   question: Question;
   result: Dataset;
   isDownloadingData: boolean;
+  isSavingPresentationScreenshot: boolean;
   onDownload: () => void;
+  onSavePresentationScreenshot: () => void;
   onEditVisualization?: () => void;
   dashcardId?: DashCardId;
   canEdit?: boolean;
@@ -29,7 +31,9 @@ export const DashCardMenuItems = ({
   question,
   result,
   isDownloadingData,
+  isSavingPresentationScreenshot,
   onDownload,
+  onSavePresentationScreenshot,
   onEditVisualization,
   dashcardId,
   canEdit,
@@ -94,6 +98,16 @@ export const DashCardMenuItems = ({
 
     if (withDownloads && canDownloadResults(result)) {
       items.push({
+        key: "MB_SAVE_PRESENTATION_SCREENSHOT",
+        iconName: "camera",
+        label: isSavingPresentationScreenshot
+          ? t`Saving screenshot…`
+          : t`Save screenshot`,
+        onClick: onSavePresentationScreenshot,
+        disabled: isSavingPresentationScreenshot,
+      });
+
+      items.push({
         key: "MB_DOWNLOAD_RESULTS",
         iconName: "download",
         label: isDownloadingData ? t`Downloading…` : t`Download results`,
@@ -129,7 +143,9 @@ export const DashCardMenuItems = ({
   }, [
     customItems,
     isDownloadingData,
+    isSavingPresentationScreenshot,
     onDownload,
+    onSavePresentationScreenshot,
     onEditQuestion,
     question,
     result,

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionMoreActionsMenu/tests/QuestionMoreActionsMenu.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionMoreActionsMenu/tests/QuestionMoreActionsMenu.unit.spec.tsx
@@ -43,6 +43,18 @@ describe("QuestionMoreActionsMenu >", () => {
       await userEvent.click(screen.getByText("Edit alerts"));
       expect(await screen.findByTestId("alert-list-modal")).toBeInTheDocument();
     });
+
+    it("should show the 'Save screenshot' menu item", async () => {
+      setup({
+        alerts: [],
+        canManageSubscriptions: false,
+        isAdmin: true,
+        isEmailSetup: true,
+        isEnterprise: false,
+      });
+      await openMenu();
+      expect(screen.getByText("Save screenshot")).toBeInTheDocument();
+    });
   });
 
   describe("non-admins", () => {

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionMoreActionsMenu/tests/setup.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionMoreActionsMenu/tests/setup.tsx
@@ -12,12 +12,14 @@ import { QuestionAlertListModal } from "metabase/notifications/modals";
 import Question from "metabase-lib/v1/Question";
 import type {
   Card,
+  Dataset,
   ModerationReview,
   Notification,
   User,
 } from "metabase-types/api";
 import {
   createMockCard,
+  createMockDataset,
   createMockSettings,
   createMockTokenFeatures,
   createMockUser,
@@ -33,6 +35,7 @@ type SetupOpts = {
   isEmailSetup: boolean;
   isEnterprise: boolean;
   moderationReviews?: ModerationReview[];
+  result?: Dataset;
 };
 
 export function setup({
@@ -42,6 +45,7 @@ export function setup({
   isEmailSetup = false,
   isEnterprise = false,
   moderationReviews,
+  result = createMockDataset(),
 }: SetupOpts) {
   const card = createMockCard(
     isEnterprise ? { moderation_reviews: moderationReviews ?? [] } : {},
@@ -72,6 +76,9 @@ export function setup({
         card,
       },
     } as User,
+    qb: {
+      queryResults: [result],
+    },
   });
 
   fetchMock.get("path:/api/user/recipients", { data: [] });

--- a/frontend/src/metabase/redux/downloads.ts
+++ b/frontend/src/metabase/redux/downloads.ts
@@ -40,6 +40,7 @@ export interface DownloadQueryResultsOpts {
   type: string;
   question: Question;
   result: Dataset;
+  imageExportStyle?: "default" | "presentation";
   enableFormatting?: boolean;
   enablePivot?: boolean;
   dashboardId?: DashboardId;
@@ -154,12 +155,10 @@ const getDownloadedResourceType = ({
 export const downloadToImage = createAsyncThunk(
   "metabase/downloads/downloadToImage",
   async (
-    {
-      opts: { question, dashcardId },
-      id,
-    }: { opts: DownloadQueryResultsOpts; id: number },
+    { opts, id }: { opts: DownloadQueryResultsOpts; id: number },
     { getState },
   ) => {
+    const { question, dashcardId } = opts;
     const isWhitelabeled = getTokenFeature(getState(), "whitelabel");
     const includeBranding = !isWhitelabeled;
     const fileName = getChartFileName(question, includeBranding);
@@ -176,6 +175,7 @@ export const downloadToImage = createAsyncThunk(
       selector: chartSelector,
       fileName,
       includeBranding,
+      presentationMode: opts.imageExportStyle === "presentation",
     });
 
     return { id, fileName };

--- a/frontend/src/metabase/visualizations/lib/save-chart-image.ts
+++ b/frontend/src/metabase/visualizations/lib/save-chart-image.ts
@@ -205,6 +205,9 @@ const appendPresentationExportStyles = (
   const { legendText, valueText, tableText, tableLineHeight } = typography;
 
   const css = `
+    .${PRESENTATION_EXPORT_CLASS} .dc-chart .y-axis-label {
+      display: none !important;
+    }
     .${PRESENTATION_EXPORT_CLASS} .DashboardChartLegend {
       font-size: ${legendText}px !important;
       line-height: 1.3 !important;

--- a/frontend/src/metabase/visualizations/lib/save-chart-image.ts
+++ b/frontend/src/metabase/visualizations/lib/save-chart-image.ts
@@ -15,12 +15,259 @@ interface Opts {
   selector: string;
   fileName: string;
   includeBranding: boolean;
+  presentationMode?: boolean;
 }
+
+const PRESENTATION_EXPORT_CLASS = "saving-dom-image-presentation";
+const PRESENTATION_EXPORT_STYLE_ID = "mb-saving-dom-image-presentation-style";
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.max(min, Math.min(value, max));
+
+type PresentationTypography = {
+  legendText: number;
+  valueText: number;
+  tableText: number;
+  tableLineHeight: number;
+};
+
+type ChartKind = "table" | "donut" | "cartesian" | "other";
+
+const getChartKind = (node: HTMLElement): ChartKind => {
+  if (node.querySelector("table")) {
+    return "table";
+  }
+  if (
+    node.querySelector(
+      ".dc-chart .pie-slice, .dc-chart .pie-label, .dc-chart .donut, .dc-chart .arc",
+    )
+  ) {
+    return "donut";
+  }
+  if (
+    node.querySelector(
+      ".dc-chart .axis .tick text, .dc-chart .x-axis-label, .dc-chart .y-axis-label",
+    )
+  ) {
+    return "cartesian";
+  }
+  return "other";
+};
+
+type CaptureBounds = {
+  width: number;
+  height: number;
+};
+
+const getPresentationCaptureBounds = (
+  node: HTMLElement,
+  chartKind: ChartKind,
+): CaptureBounds => {
+  const rootRect = node.getBoundingClientRect();
+  // Keep native capture bounds for charts to avoid clipping legends/branding/axes.
+  // We only tighten bounds for table-like renders where empty canvas is common.
+  if (chartKind !== "table") {
+    return {
+      width: rootRect.width,
+      height: rootRect.height,
+    };
+  }
+
+  const rootArea = rootRect.width * rootRect.height;
+
+  let maxRight = rootRect.left;
+  let maxBottom = rootRect.top;
+  let found = false;
+
+  const elements = Array.from(node.querySelectorAll("*"));
+  for (const element of elements) {
+    if (!(element instanceof Element)) {
+      continue;
+    }
+    const rect = element.getBoundingClientRect();
+    if (rect.width <= 1 || rect.height <= 1) {
+      continue;
+    }
+
+    const style = window.getComputedStyle(element);
+    if (
+      style.display === "none" ||
+      style.visibility === "hidden" ||
+      Number(style.opacity) === 0
+    ) {
+      continue;
+    }
+
+    const area = rect.width * rect.height;
+    const areaRatio = rootArea > 0 ? area / rootArea : 1;
+    const isLikelyBackgroundWrapper =
+      areaRatio > 0.92 &&
+      !element.matches("table, svg, canvas, .dc-chart, .Visualization");
+    if (isLikelyBackgroundWrapper) {
+      continue;
+    }
+
+    const clampedRight = Math.min(rect.right, rootRect.right);
+    const clampedBottom = Math.min(rect.bottom, rootRect.bottom);
+    if (clampedRight <= rootRect.left || clampedBottom <= rootRect.top) {
+      continue;
+    }
+
+    found = true;
+    maxRight = Math.max(maxRight, clampedRight);
+    maxBottom = Math.max(maxBottom, clampedBottom);
+  }
+
+  if (!found) {
+    return {
+      width: rootRect.width,
+      height: rootRect.height,
+    };
+  }
+
+  const rightPadding = chartKind === "table" ? 12 : 24;
+  const bottomPadding = chartKind === "cartesian" ? 48 : 24;
+
+  return {
+    width: clamp(maxRight - rootRect.left + rightPadding, 240, rootRect.width),
+    height: clamp(
+      maxBottom - rootRect.top + bottomPadding,
+      160,
+      rootRect.height,
+    ),
+  };
+};
+
+const getPresentationTypography = (
+  node: HTMLElement,
+  contentWidth: number,
+  contentHeight: number,
+  chartKind: ChartKind,
+): PresentationTypography => {
+  const referenceWidth = 1600;
+  const referenceHeight = 900;
+
+  const widthScale = clamp(contentWidth / referenceWidth, 0.85, 1.35);
+  const heightScale = clamp(contentHeight / referenceHeight, 0.9, 1.25);
+  const sizeScale = Math.min(widthScale, heightScale);
+
+  const axisTickCount = node.querySelectorAll(
+    ".dc-chart .axis .tick text",
+  ).length;
+  const valueLabelCount = node.querySelectorAll(
+    "text.value-label, text.value-label-white",
+  ).length;
+  const densityCount = axisTickCount + valueLabelCount;
+
+  let densityScale = 1;
+  if (densityCount > 60) {
+    densityScale = 0.9;
+  } else if (densityCount > 40) {
+    densityScale = 0.95;
+  } else if (densityCount > 24) {
+    densityScale = 1;
+  } else if (densityCount < 12) {
+    densityScale = 1.12;
+  }
+
+  const scale = sizeScale * densityScale;
+
+  let legendText = 28;
+  let valueText = 28;
+  let tableText = 20;
+
+  if (chartKind === "table") {
+    legendText = 20;
+    valueText = 18;
+    tableText = 22;
+  } else if (chartKind === "donut") {
+    legendText = 28;
+    valueText = 26;
+    tableText = 18;
+  } else if (chartKind === "other") {
+    legendText = 24;
+    valueText = 24;
+    tableText = 19;
+  }
+
+  return {
+    legendText: clamp(Math.round(legendText * scale), 20, 40),
+    valueText: clamp(Math.round(valueText * scale), 18, 42),
+    tableText: clamp(Math.round(tableText * scale), 16, 30),
+    tableLineHeight: clamp(1.45 * (1 / densityScale), 1.35, 1.65),
+  };
+};
+
+const appendPresentationExportStyles = (
+  doc: Document,
+  typography: PresentationTypography,
+) => {
+  const { legendText, valueText, tableText, tableLineHeight } = typography;
+
+  const css = `
+    .${PRESENTATION_EXPORT_CLASS} .DashboardChartLegend {
+      font-size: ${legendText}px !important;
+      line-height: 1.3 !important;
+      font-weight: 700 !important;
+    }
+    .${PRESENTATION_EXPORT_CLASS} text.value-label,
+    .${PRESENTATION_EXPORT_CLASS} text.value-label-white {
+      font-size: ${valueText}px !important;
+      font-weight: 700 !important;
+    }
+    .${PRESENTATION_EXPORT_CLASS} table th,
+    .${PRESENTATION_EXPORT_CLASS} table td {
+      font-size: ${tableText}px !important;
+      line-height: ${tableLineHeight} !important;
+    }
+  `;
+
+  let style = doc.getElementById(
+    PRESENTATION_EXPORT_STYLE_ID,
+  ) as HTMLStyleElement | null;
+
+  if (!style) {
+    style = doc.createElement("style");
+    style.id = PRESENTATION_EXPORT_STYLE_ID;
+    doc.head.appendChild(style);
+  }
+
+  style.textContent = css;
+};
+
+const applyInlinePresentationTypography = (
+  node: HTMLElement,
+  typography: PresentationTypography,
+) => {
+  const { legendText, valueText, tableText, tableLineHeight } = typography;
+
+  node
+    .querySelectorAll<SVGTextElement>(
+      "text.value-label, text.value-label-white",
+    )
+    .forEach((el) => {
+      el.style.fontSize = `${valueText}px`;
+      el.style.fontWeight = "700";
+      el.setAttribute("font-size", `${valueText}px`);
+    });
+
+  node.querySelectorAll<HTMLElement>(".DashboardChartLegend").forEach((el) => {
+    el.style.fontSize = `${legendText}px`;
+    el.style.lineHeight = "1.3";
+    el.style.fontWeight = "700";
+  });
+
+  node.querySelectorAll<HTMLElement>("table th, table td").forEach((el) => {
+    el.style.fontSize = `${tableText}px`;
+    el.style.lineHeight = `${tableLineHeight}`;
+  });
+};
 
 export const saveChartImage = async ({
   selector,
   fileName,
   includeBranding,
+  presentationMode = false,
 }: Opts) => {
   const node = document.querySelector(selector);
 
@@ -31,25 +278,43 @@ export const saveChartImage = async ({
 
   const contentHeight = node.getBoundingClientRect().height;
   const contentWidth = node.getBoundingClientRect().width;
+  const chartKind = presentationMode ? getChartKind(node) : "other";
+  const captureBounds = presentationMode
+    ? getPresentationCaptureBounds(node, chartKind)
+    : { width: contentWidth, height: contentHeight };
 
-  const size = getBrandingSize(contentWidth);
+  const size = getBrandingSize(captureBounds.width);
   const brandingHeight = getBrandingConfig(size).h;
   const verticalOffset = includeBranding ? brandingHeight : 0;
 
   // Appending any element to the node does not automatically increase the canvas height.
-  const canvasHeight = contentHeight + verticalOffset;
+  const canvasHeight = captureBounds.height + verticalOffset;
 
   const { default: html2canvas } = await import("html2canvas-pro");
   const canvas = await html2canvas(node, {
     scale: 2,
     useCORS: true,
+    width: captureBounds.width,
     height: canvasHeight,
     onclone: (_doc: Document, node: HTMLElement) => {
       node.classList.add(SAVING_DOM_IMAGE_CLASS);
       node.classList.add(EmbedFrameS.WithThemeBackground);
+      node.style.width = `${captureBounds.width}px`;
 
       node.style.borderRadius = "0px";
       node.style.border = "none";
+
+      if (presentationMode) {
+        const typography = getPresentationTypography(
+          node,
+          captureBounds.width,
+          captureBounds.height,
+          chartKind,
+        );
+        appendPresentationExportStyles(_doc, typography);
+        applyInlinePresentationTypography(node, typography);
+        node.classList.add(PRESENTATION_EXPORT_CLASS);
+      }
 
       if (includeBranding) {
         const branding = createBrandingElement(size);


### PR DESCRIPTION
### Description

This PR adds a new **Save screenshot** action for charts to generate presentation-ready PNGs directly from Metabase.

Implemented:
- Added **Save screenshot** in:
  - Dashboard chart card menu (`DashCardMenu`)
  - Question page “more actions” menu
- Added screenshot export mode for chart images with:
  - larger/readable text for values and legend
  - branding footer (`Made with Metabase`) by default (when not whitelabeled)
- Added chart-type-aware screenshot behavior:
  - safe capture bounds for chart exports
  - tighter crop behavior for table-like exports to reduce large empty space
- Preserved native axis-title rendering to avoid y-axis text distortion in cartesian charts.

Notes:
- This is focused on screenshot usability for presentations/reports/social sharing.
- No backend/API changes.

### How to verify

1. Start Metabase frontend locally (`yarn build-hot`) and open `http://localhost:3000`.
2. Open a **saved question** with a chart (e.g. line/bar/stacked bar).
3. Open the top-right **more actions** menu and click **Save screenshot**.
4. Verify downloaded PNG:
   - includes chart content and footer branding (non-whitelabel)
   - has improved readability (legend/value labels)
   - does **not** squash y-axis title text
5. Open a **dashboard** with chart cards.
6. In a chart card menu (`...`), click **Save screenshot** and verify same behavior.
7. Validate with multiple chart types:
   - cartesian chart (line/bar/stacked bar)
   - donut/pie
   - table-like visualization (check crop does not include excessive empty area)

### Demo

- Before/after screenshots attached in PR comments.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] If adding new Loki tests: they pass stress testing