### PR TITLE
Convert DisclosureTriangle to TypeScript

### DIFF
--- a/frontend/src/metabase/common/components/DisclosureTriangle/DisclosureTriangle.tsx
+++ b/frontend/src/metabase/common/components/DisclosureTriangle/DisclosureTriangle.tsx
@@ -1,7 +1,14 @@
-/* eslint-disable react/prop-types */
 import { Icon } from "metabase/ui";
 
-export const DisclosureTriangle = ({ open, className }) => (
+interface DisclosureTriangleProps {
+  open: boolean;
+  className?: string;
+}
+
+export const DisclosureTriangle = ({
+  open,
+  className,
+}: DisclosureTriangleProps) => (
   <Icon
     className={className}
     name="expand_arrow"


### PR DESCRIPTION
Convert `DisclosureTriangle.jsx` to TypeScript.

Closes DEV-1402