### PR TITLE
Convert Grid to TypeScript

### DIFF
--- a/frontend/src/metabase/common/components/Grid/Grid.jsx
+++ b/frontend/src/metabase/common/components/Grid/Grid.jsx
@@ -1,5 +1,0 @@
-import { GridItemRoot, GridRoot } from "./Grid.styled";
-
-export const Grid = (props) => <GridRoot {...props} />;
-
-export const GridItem = (props) => <GridItemRoot {...props} />;

--- a/frontend/src/metabase/common/components/Grid/Grid.tsx
+++ b/frontend/src/metabase/common/components/Grid/Grid.tsx
@@ -1,11 +1,11 @@
-import type { ComponentProps } from "react";
+import type { ReactNode } from "react";
 
 import { GridItemRoot, GridRoot } from "./Grid.styled";
 
-export const Grid = (props: ComponentProps<typeof GridRoot>) => (
-  <GridRoot {...props} />
+export const Grid = (props: { children: ReactNode }) => (
+  <GridRoot>{props.children}</GridRoot>
 );
 
-export const GridItem = (props: ComponentProps<typeof GridItemRoot>) => (
-  <GridItemRoot {...props} />
+export const GridItem = (props: { children: ReactNode }) => (
+  <GridItemRoot>{props.children}</GridItemRoot>
 );

--- a/frontend/src/metabase/common/components/Grid/Grid.tsx
+++ b/frontend/src/metabase/common/components/Grid/Grid.tsx
@@ -1,0 +1,11 @@
+import type { ComponentProps } from "react";
+
+import { GridItemRoot, GridRoot } from "./Grid.styled";
+
+export const Grid = (props: ComponentProps<typeof GridRoot>) => (
+  <GridRoot {...props} />
+);
+
+export const GridItem = (props: ComponentProps<typeof GridItemRoot>) => (
+  <GridItemRoot {...props} />
+);


### PR DESCRIPTION
Convert `Grid.jsx` to TypeScript.

Closes DEV-1403