### PR TITLE
Convert PermissionsEditBar to TypeScript

### DIFF
--- a/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsEditBar.tsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsEditBar.tsx
@@ -1,22 +1,27 @@
 import { useDisclosure } from "@mantine/hooks";
 import cx from "classnames";
-import PropTypes from "prop-types";
 import { t } from "ttag";
 
 import { Button } from "metabase/common/components/Button";
 import { ConfirmModal } from "metabase/common/components/ConfirmModal";
 import { EditBar } from "metabase/common/components/EditBar";
+import type { PermissionsGraph } from "metabase-types/api";
 
 import { PermissionsConfirm } from "../PermissionsConfirm";
 
-const propTypes = {
-  diff: PropTypes.object,
-  isDirty: PropTypes.bool.isRequired,
-  onCancel: PropTypes.func.isRequired,
-  onSave: PropTypes.func.isRequired,
-};
+interface PermissionsEditBarProps {
+  diff?: PermissionsGraph;
+  isDirty: boolean;
+  onCancel: () => void;
+  onSave?: () => void;
+}
 
-export function PermissionsEditBar({ diff, isDirty, onCancel, onSave }) {
+export function PermissionsEditBar({
+  diff,
+  isDirty,
+  onCancel,
+  onSave,
+}: PermissionsEditBarProps) {
   const [modelOpened, { open: openModal, close: closeModal }] = useDisclosure();
   const saveButton = (
     <Button
@@ -42,9 +47,9 @@ export function PermissionsEditBar({ diff, isDirty, onCancel, onSave }) {
       <ConfirmModal
         title={t`Save permissions?`}
         opened={modelOpened}
-        content={diff ? <PermissionsConfirm diff={diff} /> : null}
+        message={diff ? <PermissionsConfirm diff={diff} /> : undefined}
         onConfirm={() => {
-          onSave();
+          onSave?.();
           closeModal();
         }}
         onClose={closeModal}
@@ -52,5 +57,3 @@ export function PermissionsEditBar({ diff, isDirty, onCancel, onSave }) {
     </>
   );
 }
-
-PermissionsEditBar.propTypes = propTypes;

--- a/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsEditBar.tsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsEditBar.tsx
@@ -5,6 +5,7 @@ import { t } from "ttag";
 import { Button } from "metabase/common/components/Button";
 import { ConfirmModal } from "metabase/common/components/ConfirmModal";
 import { EditBar } from "metabase/common/components/EditBar";
+import { Flex, Text } from "metabase/ui";
 import type { PermissionsGraph } from "metabase-types/api";
 
 import { PermissionsConfirm } from "../PermissionsConfirm";
@@ -47,7 +48,14 @@ export function PermissionsEditBar({
       <ConfirmModal
         title={t`Save permissions?`}
         opened={modelOpened}
-        message={diff ? <PermissionsConfirm diff={diff} /> : undefined}
+        message={
+          diff ? (
+            <Flex direction="column" gap="lg">
+              <PermissionsConfirm diff={diff} />
+              <Text>{t`Are you sure you want to do this?`}</Text>
+            </Flex>
+          ) : undefined
+        }
         onConfirm={() => {
           onSave?.();
           closeModal();


### PR DESCRIPTION
Convert `PermissionsEditBar.jsx` to TypeScript.

Closes DEV-1424