### PR TITLE
Convert PermissionsTabs to TypeScript

### DIFF
--- a/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsPageLayout.tsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsPageLayout.tsx
@@ -40,7 +40,7 @@ import { ToolbarButton } from "../ToolbarButton";
 import { PermissionsEditBar } from "./PermissionsEditBar";
 import { PermissionsTabs } from "./PermissionsTabs";
 
-type PermissionsPageTab =
+export type PermissionsPageTab =
   | "data"
   | "collections"
   | "application"

--- a/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx
@@ -1,5 +1,4 @@
 import cx from "classnames";
-import PropTypes from "prop-types";
 import { t } from "ttag";
 
 import { Radio } from "metabase/common/components/Radio";
@@ -10,12 +9,14 @@ import {
   PLUGIN_APPLICATION_PERMISSIONS,
 } from "metabase/plugins";
 
-const propTypes = {
-  tab: PropTypes.string.isRequired,
-  onChangeTab: PropTypes.func.isRequired,
-};
+import type { PermissionsPageTab } from "./PermissionsPageLayout";
 
-export const PermissionsTabs = ({ tab, onChangeTab }) => {
+interface PermissionsTabsProps {
+  tab: PermissionsPageTab;
+  onChangeTab: (tab: PermissionsPageTab) => void;
+}
+
+export const PermissionsTabs = ({ tab, onChangeTab }: PermissionsTabsProps) => {
   const isUsingTenants = useSetting("use-tenants");
 
   const adminPermissionsTabs = isUsingTenants
@@ -32,8 +33,8 @@ export const PermissionsTabs = ({ tab, onChangeTab }) => {
         colorScheme="accent7"
         value={tab}
         options={[
-          { name: t`Data`, value: `data` },
-          { name: t`Collections`, value: `collections` },
+          { name: t`Data`, value: "data" },
+          { name: t`Collections`, value: "collections" },
           ...adminPermissionsTabs,
           ...PLUGIN_APPLICATION_PERMISSIONS.tabs,
         ]}
@@ -43,5 +44,3 @@ export const PermissionsTabs = ({ tab, onChangeTab }) => {
     </div>
   );
 };
-
-PermissionsTabs.propTypes = propTypes;


### PR DESCRIPTION
Convert `PermissionsTabs.jsx` to TypeScript.

Closes DEV-1425