### PR TITLE
Convert FieldSidebar to TypeScript

### DIFF
--- a/frontend/src/metabase/reference/databases/FieldSidebar.tsx
+++ b/frontend/src/metabase/reference/databases/FieldSidebar.tsx
@@ -1,6 +1,5 @@
-/* eslint "react/prop-types": "warn" */
 import cx from "classnames";
-import PropTypes from "prop-types";
+import type { CSSProperties } from "react";
 import { memo } from "react";
 import { t } from "ttag";
 
@@ -9,10 +8,25 @@ import S from "metabase/common/components/Sidebar.module.css";
 import { SidebarItem } from "metabase/common/components/SidebarItem";
 import CS from "metabase/css/core/index.css";
 import MetabaseSettings from "metabase/lib/settings";
+import type { Database, Field, Table } from "metabase-types/api";
 
 import { trackReferenceXRayClicked } from "../analytics";
 
-const FieldSidebar = ({ database, table, field, style, className }) => (
+interface FieldSidebarProps {
+  database: Database;
+  table: Table;
+  field: Field;
+  className?: string;
+  style?: CSSProperties;
+}
+
+const FieldSidebar = ({
+  database,
+  table,
+  field,
+  style,
+  className,
+}: FieldSidebarProps) => (
   <div className={cx(S.sidebar, className)} style={style}>
     <ul>
       <div>
@@ -51,14 +65,6 @@ const FieldSidebar = ({ database, table, field, style, className }) => (
     </ul>
   </div>
 );
-
-FieldSidebar.propTypes = {
-  database: PropTypes.object,
-  table: PropTypes.object,
-  field: PropTypes.object,
-  className: PropTypes.string,
-  style: PropTypes.object,
-};
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export default memo(FieldSidebar);

--- a/frontend/src/metabase/reference/databases/FieldSidebar.tsx
+++ b/frontend/src/metabase/reference/databases/FieldSidebar.tsx
@@ -1,5 +1,4 @@
 import cx from "classnames";
-import type { CSSProperties } from "react";
 import { memo } from "react";
 import { t } from "ttag";
 
@@ -16,18 +15,10 @@ interface FieldSidebarProps {
   database: Database;
   table: Table;
   field: Field;
-  className?: string;
-  style?: CSSProperties;
 }
 
-const FieldSidebar = ({
-  database,
-  table,
-  field,
-  style,
-  className,
-}: FieldSidebarProps) => (
-  <div className={cx(S.sidebar, className)} style={style}>
+const FieldSidebar = ({ database, table, field }: FieldSidebarProps) => (
+  <div className={S.sidebar}>
     <ul>
       <div>
         <Breadcrumbs


### PR DESCRIPTION
Convert `FieldSidebar.jsx` to TypeScript.

Closes DEV-1432