### PR TITLE
Convert BaseSidebar to TypeScript

### DIFF
--- a/frontend/src/metabase/reference/guide/BaseSidebar.tsx
+++ b/frontend/src/metabase/reference/guide/BaseSidebar.tsx
@@ -1,5 +1,4 @@
 import cx from "classnames";
-import type { CSSProperties } from "react";
 import { memo } from "react";
 import { t } from "ttag";
 
@@ -8,13 +7,8 @@ import S from "metabase/common/components/Sidebar.module.css";
 import { SidebarItem } from "metabase/common/components/SidebarItem";
 import CS from "metabase/css/core/index.css";
 
-interface BaseSidebarProps {
-  className?: string;
-  style?: CSSProperties;
-}
-
-const BaseSidebar = ({ style, className }: BaseSidebarProps) => (
-  <div className={cx(S.sidebar, className)} style={style}>
+const BaseSidebar = () => (
+  <div className={S.sidebar}>
     <div>
       <Breadcrumbs
         className={cx(CS.py4, CS.ml3)}

--- a/frontend/src/metabase/reference/guide/BaseSidebar.tsx
+++ b/frontend/src/metabase/reference/guide/BaseSidebar.tsx
@@ -1,6 +1,5 @@
-/* eslint "react/prop-types": "warn" */
 import cx from "classnames";
-import PropTypes from "prop-types";
+import type { CSSProperties } from "react";
 import { memo } from "react";
 import { t } from "ttag";
 
@@ -9,7 +8,12 @@ import S from "metabase/common/components/Sidebar.module.css";
 import { SidebarItem } from "metabase/common/components/SidebarItem";
 import CS from "metabase/css/core/index.css";
 
-const BaseSidebar = ({ style, className }) => (
+interface BaseSidebarProps {
+  className?: string;
+  style?: CSSProperties;
+}
+
+const BaseSidebar = ({ style, className }: BaseSidebarProps) => (
   <div className={cx(S.sidebar, className)} style={style}>
     <div>
       <Breadcrumbs
@@ -41,11 +45,6 @@ const BaseSidebar = ({ style, className }) => (
     </ol>
   </div>
 );
-
-BaseSidebar.propTypes = {
-  className: PropTypes.string,
-  style: PropTypes.object,
-};
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export default memo(BaseSidebar);


### PR DESCRIPTION
Convert `BaseSidebar.jsx` to TypeScript.

Closes DEV-1434