### PR TITLE
Convert routes-public to TypeScript

### DIFF
--- a/frontend/src/metabase/routes-public.tsx
+++ b/frontend/src/metabase/routes-public.tsx
@@ -7,7 +7,7 @@ import { PublicDocument } from "metabase/public/containers/PublicDocument";
 import { PublicOrEmbeddedDashboardPage } from "metabase/public/containers/PublicOrEmbeddedDashboard";
 import { PublicOrEmbeddedQuestion } from "metabase/public/containers/PublicOrEmbeddedQuestion";
 
-export const getRoutes = (store) => {
+export const getRoutes = () => {
   return (
     <Route>
       <Route path="public" component={PublicApp}>


### PR DESCRIPTION
Convert `routes-public.jsx` to TypeScript.

Closes DEV-1438