### PR TITLE
Unify the JAR artifact naming strategy

### DIFF
--- a/.github/actions/fetch-artifact/action.yml
+++ b/.github/actions/fetch-artifact/action.yml
@@ -2,8 +2,11 @@ name: Fetch artifact
 description: Fetches a specific artifact and downloads it to the current directory
 
 inputs:
-  name:
-    description: The name of the artifact to fetch
+  commit:
+    description: Commit SHA for the artifact
+    required: true
+  edition:
+    description: Metabase edition (ee or oss)
     required: true
   output-name:
     description: Optional custom name for the output jar file (defaults to metabase.jar)
@@ -25,15 +28,18 @@ runs:
         script: | # js
           const fs = require('fs');
 
+          const artifactName = `metabase-${{ inputs.edition }}-${{ inputs.commit }}-uberjar`;
+          console.log(`Looking for artifact: ${artifactName}`);
+
           const artifacts = await github.rest.actions.listArtifactsForRepo({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            name: "${{ inputs.name }}",
+            name: artifactName,
             per_page: 1,
           });
 
           if (!artifacts.data?.artifacts?.[0]?.id) {
-            throw new Error(`No artifacts found for ${{ inputs.name }}`);
+            throw new Error(`No artifacts found for ${artifactName}`);
           }
 
           const artifact_id = artifacts.data.artifacts[0].id;

--- a/.github/actions/prepare-uberjar-artifact/action.yml
+++ b/.github/actions/prepare-uberjar-artifact/action.yml
@@ -2,9 +2,10 @@ name: Prepare Uberjar Artifact
 description: Prepare and upload Metabase JAR as a GitHub artifact.
 
 inputs:
-  name:
-    required: true
-    description: Artifact name
+  edition:
+    required: false
+    default: "ee"
+    description: Metabase edition (ee or oss)
 
 runs:
   using: "composite"
@@ -18,7 +19,7 @@ runs:
     - name: Upload JARs as artifact
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ inputs.name }}
+        name: metabase-${{ inputs.edition }}-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
         path: |
           ./target/uberjar/metabase.jar
           ./COMMIT-ID

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -79,7 +79,8 @@ jobs:
       - name: Retrieve uberjar artifact for ${{ inputs.edition }}
         uses: ./.github/actions/fetch-artifact
         with:
-          name: metabase-${{ inputs.edition }}-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
+          commit: ${{ github.event.pull_request.head.sha || github.sha }}
+          edition: ${{ inputs.edition }}
           extract-path: "target/uberjar"
           output-name: "metabase.jar"
 

--- a/.github/workflows/embedding-sdk-component-tests.yml
+++ b/.github/workflows/embedding-sdk-component-tests.yml
@@ -45,7 +45,8 @@ jobs:
       - name: Retrieve uberjar artifact for ee
         uses: ./.github/actions/fetch-artifact
         with:
-          name: metabase-ee-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
+          commit: ${{ github.event.pull_request.head.sha || github.sha }}
+          edition: ee
           extract-path: "target/uberjar"
           output-name: "metabase.jar"
 
@@ -194,7 +195,8 @@ jobs:
         id: download-uberjar
         uses: ./.github/actions/fetch-artifact
         with:
-          name: metabase-ee-${{ steps.get-commit-sha.outputs.sha }}-uberjar
+          commit: ${{ steps.get-commit-sha.outputs.sha }}
+          edition: ee
           extract-path: "target/uberjar"
           output-name: "metabase.jar"
         continue-on-error: true # do not break the whole job if this step doesn't succeed

--- a/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
+++ b/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
@@ -137,7 +137,8 @@ jobs:
       - name: Retrieve uberjar artifact for ee
         uses: ./.github/actions/fetch-artifact
         with:
-          name: metabase-ee-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
+          commit: ${{ github.event.pull_request.head.sha || github.sha }}
+          edition: ee
           extract-path: "target/uberjar"
           output-name: "metabase.jar"
 
@@ -252,7 +253,8 @@ jobs:
       - name: Retrieve uberjar artifact for ee
         uses: ./.github/actions/fetch-artifact
         with:
-          name: metabase-ee-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
+          commit: ${{ github.event.pull_request.head.sha || github.sha }}
+          edition: ee
           extract-path: "target/uberjar"
           output-name: "metabase.jar"
 

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -29,7 +29,8 @@ jobs:
       - name: Retrieve uberjar artifact for ee
         uses: ./.github/actions/fetch-artifact
         with:
-          name: metabase-ee-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
+          commit: ${{ github.event.pull_request.head.sha || github.sha }}
+          edition: ee
           extract-path: "target/uberjar"
           output-name: "metabase.jar"
       - name: Move uberjar to bin/docker

--- a/.github/workflows/pr-env.yml
+++ b/.github/workflows/pr-env.yml
@@ -40,7 +40,8 @@ jobs:
       - name: Retrieve uberjar artifact for ee
         uses: ./.github/actions/fetch-artifact
         with:
-          name: metabase-ee-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
+          commit: ${{ github.event.pull_request.head.sha || github.sha }}
+          edition: ee
           extract-path: "target/uberjar"
           output-name: "metabase.jar"
       - name: Move uberjar to bin/docker

--- a/.github/workflows/tag-for-release.yml
+++ b/.github/workflows/tag-for-release.yml
@@ -156,7 +156,8 @@ jobs:
     - name: Retrieve test build uberjar artifact for ${{ matrix.edition }}
       uses: ./.github/actions/fetch-artifact
       with:
-        name: metabase-${{ matrix.edition }}-${{ inputs.commit }}-uberjar
+        commit: ${{ inputs.commit }}
+        edition: ${{ matrix.edition }}
 
     - name: Update version.properties in jar
       run: | # sh

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -44,7 +44,8 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/fetch-artifact
         with:
-          name: metabase-ee-${{ github.event.inputs.commit || github.event.pull_request.head.sha || github.sha }}-uberjar
+          commit: ${{ github.event.inputs.commit || github.event.pull_request.head.sha || github.sha }}
+          edition: ee
           output-name: metabase-ee.jar
 
       - name: Try to fetch existing OSS artifact
@@ -52,7 +53,8 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/fetch-artifact
         with:
-          name: metabase-oss-${{ github.event.inputs.commit || github.event.pull_request.head.sha || github.sha }}-uberjar
+          commit: ${{ github.event.inputs.commit || github.event.pull_request.head.sha || github.sha }}
+          edition: oss
           output-name: metabase-oss.jar
 
       - name: Decide if build is needed
@@ -140,7 +142,7 @@ jobs:
       - name: Prepare uberjar artifact
         uses: ./.github/actions/prepare-uberjar-artifact
         with:
-          name: metabase-${{ matrix.edition }}-${{ github.event.inputs.commit || github.event.pull_request.head.sha || github.sha }}-uberjar
+          edition: ${{ matrix.edition }}
 
   check-jar-health:
     runs-on: ubuntu-22.04
@@ -171,7 +173,8 @@ jobs:
       - name: Retrieve uberjar artifact
         uses: ./.github/actions/fetch-artifact
         with:
-          name: metabase-${{ matrix.edition }}-${{ github.event.inputs.commit || github.event.pull_request.head.sha || github.sha }}-uberjar
+          commit: ${{ github.event.inputs.commit || github.event.pull_request.head.sha || github.sha }}
+          edition: ${{ matrix.edition }}
       - name: Launch uberjar
         run: >-
           java --add-opens java.base/java.nio=ALL-UNNAMED -jar ./metabase.jar &


### PR DESCRIPTION
Resolves DEV-1102

**Actions updated (2)**:
- prepare-uberjar-artifact - now takes edition input (default: ee) instead of name
- fetch-artifact - now takes commit and edition inputs instead of name

**Workflows updated (7)**:
- uberjar.yml - 3 call sites
- e2e-test.yml
- perf-test.yml
- pr-env.yml
- embedding-sdk-component-tests.yml - 2 call sites
- embedding-sdk-host-sample-apps-tests.yml - 2 call sites
- tag-for-release.yml

**Artifact naming convention:**
`metabase-{edition}-{commit}-uberjar`

> [!Note]
> Release workflows remain unchanged and can continue using their metabase-release-{edition}-{commit}-uberjar pattern.
