### PR TITLE
Gdgt 1669 make cards clickable

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformInspectPage/components/LensSections/DefaultLensSections/components/VisualizationCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformInspectPage/components/LensSections/DefaultLensSections/components/VisualizationCard.tsx
@@ -4,7 +4,7 @@ import { useGetAdhocQueryMetadataQuery } from "metabase/api";
 import { useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { getMetadata } from "metabase/selectors/metadata";
-import { Box, Card, Icon, Loader, Stack, Tooltip } from "metabase/ui";
+import { Box, Card, Icon, Loader, Stack } from "metabase/ui";
 import Visualization from "metabase/visualizations/components/Visualization";
 import * as Lib from "metabase-lib";
 import type {
@@ -82,11 +82,9 @@ export const VisualizationCard = ({
     : undefined;
 
   const actionButtons = questionUrl ? (
-    <Tooltip label="Open question">
-      <Link to={questionUrl} target="_blank">
-        <Icon name="external" />
-      </Link>
-    </Tooltip>
+    <Link to={questionUrl} target="_blank">
+      <Icon name="external" />
+    </Link>
   ) : null;
 
   return (

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformInspectPage/components/LensSections/DefaultLensSections/components/VisualizationCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformInspectPage/components/LensSections/DefaultLensSections/components/VisualizationCard.tsx
@@ -72,8 +72,10 @@ export const VisualizationCard = ({
   const isLoading = isMetadataLoading || isDataLoading;
 
   const questionUrl = rawSeries?.[0]?.card
-    ? Urls.question(rawSeries[0].card)
+    ? Urls.serializedQuestion(rawSeries[0].card)
     : undefined;
+
+  const getHref = questionUrl ? () => questionUrl : undefined;
 
   const actionButtons = questionUrl ? (
     <Tooltip label="Open question">
@@ -96,6 +98,7 @@ export const VisualizationCard = ({
               rawSeries={rawSeries}
               showTitle={true}
               actionButtons={actionButtons}
+              getHref={getHref}
             />
           </Box>
         )}

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformInspectPage/components/LensSections/DefaultLensSections/components/VisualizationCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformInspectPage/components/LensSections/DefaultLensSections/components/VisualizationCard.tsx
@@ -1,7 +1,10 @@
+import { Link } from "react-router";
+
 import { useGetAdhocQueryMetadataQuery } from "metabase/api";
 import { useSelector } from "metabase/lib/redux";
+import * as Urls from "metabase/lib/urls";
 import { getMetadata } from "metabase/selectors/metadata";
-import { Box, Card, Loader, Stack, Title } from "metabase/ui";
+import { Box, Card, Icon, Loader, Stack, Tooltip } from "metabase/ui";
 import Visualization from "metabase/visualizations/components/Visualization";
 import * as Lib from "metabase-lib";
 import type {
@@ -68,20 +71,32 @@ export const VisualizationCard = ({
   const rawSeries = buildRawSeries(data, card, displayType, displaySettings);
   const isLoading = isMetadataLoading || isDataLoading;
 
+  const questionUrl = rawSeries?.[0]?.card
+    ? Urls.question(rawSeries[0].card)
+    : undefined;
+
+  const actionButtons = questionUrl ? (
+    <Tooltip label="Open question">
+      <Link to={questionUrl} target="_blank">
+        <Icon name="external" c="brand" />
+      </Link>
+    </Tooltip>
+  ) : null;
+
   return (
     <Card p="md" shadow="none" withBorder>
       <Stack gap="sm">
-        <Title order={5} lineClamp={1}>
-          {card.title}
-        </Title>
-
         {isLoading || !rawSeries ? (
           <Stack gap="sm" align="center" justify="center" h={height}>
             <Loader size="sm" />
           </Stack>
         ) : (
           <Box h={height}>
-            <Visualization rawSeries={rawSeries} />
+            <Visualization
+              rawSeries={rawSeries}
+              showTitle={true}
+              actionButtons={actionButtons}
+            />
           </Box>
         )}
 

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformInspectPage/components/LensSections/DefaultLensSections/components/VisualizationCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformInspectPage/components/LensSections/DefaultLensSections/components/VisualizationCard.tsx
@@ -77,10 +77,14 @@ export const VisualizationCard = ({
 
   const getHref = questionUrl ? () => questionUrl : undefined;
 
+  const onChangeCardAndRun = questionUrl
+    ? () => window.open(questionUrl, "_blank")
+    : undefined;
+
   const actionButtons = questionUrl ? (
     <Tooltip label="Open question">
       <Link to={questionUrl} target="_blank">
-        <Icon name="external" c="brand" />
+        <Icon name="external" />
       </Link>
     </Tooltip>
   ) : null;
@@ -99,6 +103,7 @@ export const VisualizationCard = ({
               showTitle={true}
               actionButtons={actionButtons}
               getHref={getHref}
+              onChangeCardAndRun={onChangeCardAndRun}
             />
           </Box>
         )}


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-1669/make-cards-clickable

### Description

Cards in the are now linked and can be build in the fu ll mode.


### How to verify

### Demo

<img width="2510" height="2830" alt="96164" src="https://github.com/user-attachments/assets/762f1bf6-b75e-49a8-a407-a86ae9b64034" />


