### PR TITLE
feat(modular): support relative paths for jwtProviderUri

### DIFF
--- a/enterprise/frontend/src/embedding/auth-common/jwt.ts
+++ b/enterprise/frontend/src/embedding/auth-common/jwt.ts
@@ -90,7 +90,8 @@ const runFetchRequestToken = async (
 const refreshUserJwt = async (url: string) => {
   let clientBackendResponse;
   try {
-    const urlWithSource = new URL(url);
+    // Use window.location.origin as base to support relative URLs like "/api/sso"
+    const urlWithSource = new URL(url, window.location.origin);
     urlWithSource.searchParams.set("response", "json");
     clientBackendResponse = await fetch(urlWithSource.toString(), {
       method: "GET",


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/EMB-1293/allow-relative-urls-for-jwtprovideruri