### PR TITLE
feat: add dimension computation

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -778,6 +778,7 @@
 
   lib-metric
   {:team "UX West"
+   :api  #{metabase.lib-metric.core}
    :uses #{lib
            util}}
 
@@ -829,6 +830,7 @@
            events
            lib
            lib-be
+           lib-metric
            models
            permissions
            remote-sync

--- a/resources/migrations/059_update_migrations.yaml
+++ b/resources/migrations/059_update_migrations.yaml
@@ -999,6 +999,82 @@ databaseChangeLog:
             tableName: notification_card
             columnName: disable_links
 
+  - changeSet:
+      id: v59.2026-02-03T21:43:00
+      author: epaget
+      comment: Add dimensions column to measure table
+      changes:
+        - addColumn:
+            tableName: measure
+            columns:
+              - column:
+                  name: dimensions
+                  type: ${text.type}
+                  remarks: JSON array of persisted dimension definitions (id, display-name, types)
+                  constraints:
+                    nullable: true
+      rollback:
+        - dropColumn:
+            tableName: measure
+            columnName: dimensions
+
+  - changeSet:
+      id: v59.2026-02-03T21:43:01
+      author: epaget
+      comment: Add dimension_mappings column to measure table
+      changes:
+        - addColumn:
+            tableName: measure
+            columns:
+              - column:
+                  name: dimension_mappings
+                  type: ${text.type}
+                  remarks: JSON array of dimension-to-field mappings (dimension-id, target, table-id)
+                  constraints:
+                    nullable: true
+      rollback:
+        - dropColumn:
+            tableName: measure
+            columnName: dimension_mappings
+
+  - changeSet:
+      id: v59.2026-02-03T21:43:02
+      author: epaget
+      comment: Add dimensions column to report_card table for metrics
+      changes:
+        - addColumn:
+            tableName: report_card
+            columns:
+              - column:
+                  name: dimensions
+                  type: ${text.type}
+                  remarks: JSON array of persisted dimension definitions (id, display-name, types)
+                  constraints:
+                    nullable: true
+      rollback:
+        - dropColumn:
+            tableName: report_card
+            columnName: dimensions
+
+  - changeSet:
+      id: v59.2026-02-03T21:43:03
+      author: epaget
+      comment: Add dimension_mappings column to report_card table for metrics
+      changes:
+        - addColumn:
+            tableName: report_card
+            columns:
+              - column:
+                  name: dimension_mappings
+                  type: ${text.type}
+                  remarks: JSON array of dimension-to-field mappings (dimension-id, target, table-id)
+                  constraints:
+                    nullable: true
+      rollback:
+        - dropColumn:
+            tableName: report_card
+            columnName: dimension_mappings
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/lib_metric/core.cljc
+++ b/src/metabase/lib_metric/core.cljc
@@ -9,4 +9,17 @@
    Dimensions are UUID-referenced columns available for filtering and grouping.
    They provide stable identifiers that survive query changes, unlike field refs
    or column aliases. Dimension refs `[:dimension {} \"uuid\"]` are resolved to
-   concrete field refs when the definition is converted to an executable MBQL query.")
+   concrete field refs when the definition is converted to an executable MBQL query."
+  (:require
+   [metabase.lib-metric.dimension :as lib-metric.dimension]
+   [potemkin :as p]))
+
+(comment lib-metric.dimension/keep-me)
+
+(p/import-vars
+ [lib-metric.dimension
+  dimensionable-query
+  get-persisted-dimension-mappings
+  get-persisted-dimensions
+  hydrate-dimensions
+  save-dimensions!])

--- a/src/metabase/lib_metric/schema.cljc
+++ b/src/metabase/lib_metric/schema.cljc
@@ -32,7 +32,7 @@
   "Schema for a dimension mapping."
   [:map
    [:type ::dimension-mapping.type]
-   [:table-id ::lib.schema.id/table]
+   [:table-id {:optional true} [:maybe ::lib.schema.id/table]]
    [:dimension-id ::dimension-id]
    [:target ::dimension-mapping.target]])
 
@@ -50,3 +50,30 @@
    [:= :dimension]
    ::dimension-reference.options
    ::dimension-id])
+
+;;; ------------------------------------------------- Persisted Dimensions -------------------------------------------------
+;;; These schemas are used for storage format in the database.
+
+(mr/def ::dimension-status
+  "Status of a dimension indicating whether it's active or has issues.
+   - :status/active   - Column exists, dimension is usable
+   - :status/orphaned - Column was removed from schema, dimension preserved for reference"
+  [:enum :status/active :status/orphaned])
+
+(mr/def ::persisted-dimension
+  "Schema for a persisted dimension definition with status tracking.
+   Persisted dimensions include additional metadata about their status
+   and any issues that prevent them from being used.
+   Note: target field references are stored in dimension-mappings, not here."
+  [:map
+   [:id ::dimension-id]
+   [:name {:optional true} [:maybe :string]]
+   [:display-name {:optional true} [:maybe ::lib.schema.common/non-blank-string]]
+   [:effective-type {:optional true} [:maybe ::lib.schema.common/base-type]]
+   [:semantic-type {:optional true} [:maybe ::lib.schema.common/semantic-or-relation-type]]
+   [:status {:optional true} [:maybe ::dimension-status]]
+   [:status-message {:optional true} [:maybe :string]]])
+
+(mr/def ::persisted-dimensions
+  "Schema for a sequence of persisted dimensions."
+  [:sequential ::persisted-dimension])

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -1286,6 +1286,8 @@
           :cache_ttl
           ;; dependencies aren't serialized, so the version of dependency analysis done shouldn't be serialized
           :dependency_analysis_version
+          ;; dimensions are computed from the query and reconciled on read, not serialized
+          :dimensions :dimension_mappings
           ;; temporary column to power rollback from v57 to v56; we can remove it in v58
           :legacy_query]
    :transform

--- a/src/metabase/revisions/impl/card.clj
+++ b/src/metabase/revisions/impl/card.clj
@@ -7,6 +7,8 @@
   #{:cache_invalidated_at
     :created_at
     :creator_id
+    :dimension_mappings
+    :dimensions
     :document_id
     :entity_id
     :id

--- a/test/metabase/lib_metric/dimension_test.cljc
+++ b/test/metabase/lib_metric/dimension_test.cljc
@@ -1,0 +1,222 @@
+(ns metabase.lib-metric.dimension-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [metabase.lib-metric.dimension :as lib-metric.dimension]))
+
+;;; -------------------------------------------------- Test Data --------------------------------------------------
+
+(def ^:private uuid-1 "550e8400-e29b-41d4-a716-446655440001")
+(def ^:private uuid-2 "550e8400-e29b-41d4-a716-446655440002")
+(def ^:private uuid-3 "550e8400-e29b-41d4-a716-446655440003")
+(def ^:private uuid-4 "550e8400-e29b-41d4-a716-446655440004")
+(def ^:private uuid-orphaned "550e8400-e29b-41d4-a716-446655440099")
+
+(def ^:private target-1 [:field {:lib/uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"} 1])
+(def ^:private target-2 [:field {:lib/uuid "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"} 2])
+(def ^:private target-99 [:field {:lib/uuid "cccccccc-cccc-cccc-cccc-cccccccccccc"} 99])
+
+(defn- make-computed-pair
+  "Helper to create a computed pair for testing."
+  ([name target]
+   {:dimension {:id nil :name name}
+    :mapping   {:type :table :target target}})
+  ([name target table-id]
+   {:dimension {:id nil :name name}
+    :mapping   {:type :table :table-id table-id :target target}}))
+
+;;; -------------------------------------------------- Target Comparison --------------------------------------------------
+
+(deftest ^:parallel targets-equal?-same-field-id-test
+  (let [target-a [:field {:lib/uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"} 100]
+        target-b [:field {:lib/uuid "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"} 100]]
+    (is (lib-metric.dimension/targets-equal? target-a target-b)
+        "targets with same field ID are equal regardless of lib/uuid")))
+
+(deftest ^:parallel targets-equal?-different-field-ids-test
+  (let [target-a [:field {:lib/uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"} 100]
+        target-b [:field {:lib/uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"} 101]]
+    (is (not (lib-metric.dimension/targets-equal? target-a target-b))
+        "targets with different field IDs are not equal")))
+
+(deftest ^:parallel targets-equal?-different-join-aliases-test
+  (let [target-base [:field {:lib/uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"} 100]
+        target-with-alias [:field {:lib/uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" :join-alias "Products"} 100]]
+    (is (not (lib-metric.dimension/targets-equal? target-base target-with-alias))
+        "targets with different join aliases are not equal")))
+
+(deftest ^:parallel targets-equal?-expression-targets-test
+  (let [target-a [:expression {:lib/uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"} "my_expr"]
+        target-b [:expression {:lib/uuid "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"} "my_expr"]]
+    (is (lib-metric.dimension/targets-equal? target-a target-b)
+        "expression targets are compared correctly")))
+
+(deftest ^:parallel targets-equal?-ignores-types-test
+  (let [target-a [:field {:lib/uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" :effective-type :type/Integer} 100]
+        target-b [:field {:lib/uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" :effective-type :type/Text :base-type :type/BigInteger} 100]]
+    (is (lib-metric.dimension/targets-equal? target-a target-b)
+        "effective-type and base-type are ignored")))
+
+;;; -------------------------------------------------- Reconciliation --------------------------------------------------
+
+(deftest ^:parallel reconcile-new-dimensions-get-random-uuids-test
+  (let [computed-pairs [(make-computed-pair "col1" target-1)
+                        (make-computed-pair "col2" target-2)]
+        {:keys [dimensions dimension-mappings]}
+        (lib-metric.dimension/reconcile-dimensions-and-mappings computed-pairs nil nil)]
+    (is (= 2 (count dimensions)))
+    (is (every? #(re-matches #"[a-f0-9-]{36}" (:id %)) dimensions))
+    (is (= 2 (count dimension-mappings)))
+    (is (= (set (map :id dimensions))
+           (set (map :dimension-id dimension-mappings))))))
+
+(deftest ^:parallel reconcile-matched-dimensions-preserve-id-test
+  (let [computed-pairs [(make-computed-pair "col1" target-1)]
+        persisted-dims [{:id uuid-1 :name "col1" :status :status/active}]
+        persisted-mappings [{:type :table :table-id 1 :dimension-id uuid-1 :target target-1}]
+        {:keys [dimensions]}
+        (lib-metric.dimension/reconcile-dimensions-and-mappings
+         computed-pairs persisted-dims persisted-mappings)]
+    (is (= uuid-1 (:id (first dimensions))))))
+
+(deftest ^:parallel reconcile-matched-dimensions-preserve-modifications-test
+  (let [computed-pairs [(make-computed-pair "col1" target-1)]
+        persisted-dims [{:id uuid-1 :name "col1" :display-name "Custom Name"
+                         :semantic-type :type/Category :status :status/active}]
+        persisted-mappings [{:type :table :table-id 1 :dimension-id uuid-1 :target target-1}]
+        {:keys [dimensions]}
+        (lib-metric.dimension/reconcile-dimensions-and-mappings
+         computed-pairs persisted-dims persisted-mappings)
+        dim (first dimensions)]
+    (is (= "Custom Name" (:display-name dim)))
+    (is (= :type/Category (:semantic-type dim)))
+    (is (= :status/active (:status dim)))))
+
+(deftest ^:parallel reconcile-matching-ignores-lib-uuid-test
+  (let [target-different-uuid [:field {:lib/uuid "dddddddd-dddd-dddd-dddd-dddddddddddd"} 1]
+        computed-pairs [(make-computed-pair "col1" target-different-uuid)]
+        persisted-dims [{:id uuid-1 :name "col1" :display-name "Persisted Name" :status :status/active}]
+        persisted-mappings [{:type :table :table-id 1 :dimension-id uuid-1 :target target-1}]
+        {:keys [dimensions]}
+        (lib-metric.dimension/reconcile-dimensions-and-mappings
+         computed-pairs persisted-dims persisted-mappings)]
+    (is (= uuid-1 (:id (first dimensions))) "should match despite different lib/uuid")
+    (is (= "Persisted Name" (:display-name (first dimensions))))))
+
+(deftest ^:parallel reconcile-orphaned-dimensions-detected-test
+  (let [computed-pairs [(make-computed-pair "col1" target-1)]
+        persisted-dims [{:id uuid-1 :name "col1" :status :status/active}
+                        {:id uuid-orphaned :name "old_column" :status :status/active}]
+        persisted-mappings [{:type :table :table-id 1 :dimension-id uuid-1 :target target-1}
+                            {:type :table :table-id 1 :dimension-id uuid-orphaned :target target-99}]
+        {:keys [dimensions dimension-mappings]}
+        (lib-metric.dimension/reconcile-dimensions-and-mappings
+         computed-pairs persisted-dims persisted-mappings)
+        orphaned (first (filter #(= uuid-orphaned (:id %)) dimensions))]
+    (is (= 2 (count dimensions)) "should have 2 dimensions")
+    (is (= :status/orphaned (:status orphaned)))
+    (is (= "Column 'old_column' no longer exists in the data source" (:status-message orphaned)))
+    (is (= 1 (count dimension-mappings)) "orphaned dimensions have no mappings")))
+
+(deftest ^:parallel reconcile-non-persisted-dims-not-tracked-as-orphaned-test
+  (let [computed-pairs [(make-computed-pair "col1" target-1)]
+        persisted-dims [{:id uuid-2 :name "col2"}]
+        persisted-mappings [{:type :table :table-id 1 :dimension-id uuid-2 :target target-2}]
+        {:keys [dimensions]}
+        (lib-metric.dimension/reconcile-dimensions-and-mappings
+         computed-pairs persisted-dims persisted-mappings)]
+    (is (= 1 (count dimensions)) "only the computed dimension should exist")))
+
+(deftest ^:parallel reconcile-orphaned-becomes-active-if-target-reappears-test
+  (let [computed-pairs [(make-computed-pair "col1" target-1)]
+        persisted-dims [{:id uuid-1 :name "col1" :display-name "Custom Name"
+                         :status :status/orphaned
+                         :status-message "Column 'col1' no longer exists"}]
+        persisted-mappings [{:type :table :table-id 1 :dimension-id uuid-1 :target target-1}]
+        {:keys [dimensions]}
+        (lib-metric.dimension/reconcile-dimensions-and-mappings
+         computed-pairs persisted-dims persisted-mappings)
+        dim (first dimensions)]
+    (is (= 1 (count dimensions)))
+    (is (= uuid-1 (:id dim)))
+    (is (= :status/active (:status dim)))
+    (is (nil? (:status-message dim)))
+    (is (= "Custom Name" (:display-name dim)))))
+
+;;; -------------------------------------------------- Persistence Helpers --------------------------------------------------
+
+(deftest ^:parallel extract-persisted-dimensions-filters-by-status-test
+  (let [dimensions [{:id uuid-1 :name "col1" :status :status/active}
+                    {:id uuid-2 :name "col2"}
+                    {:id uuid-3 :name "col3" :status :status/orphaned}
+                    {:id uuid-4 :name "col4" :status :status/active}]]
+    (is (= [{:id uuid-1 :name "col1" :status :status/active}
+            {:id uuid-3 :name "col3" :status :status/orphaned}
+            {:id uuid-4 :name "col4" :status :status/active}]
+           (lib-metric.dimension/extract-persisted-dimensions dimensions)))))
+
+(deftest ^:parallel extract-persisted-dimensions-empty-when-no-status-test
+  (let [dimensions [{:id uuid-1 :name "col1"}
+                    {:id uuid-2 :name "col2"}]]
+    (is (= [] (lib-metric.dimension/extract-persisted-dimensions dimensions)))))
+
+(deftest ^:parallel dimensions-changed?-true-when-dimensions-differ-test
+  (is (lib-metric.dimension/dimensions-changed?
+       [{:id uuid-1 :name "old" :status :status/active}]
+       [{:id uuid-1 :name "new" :status :status/active}])))
+
+(deftest ^:parallel dimensions-changed?-true-when-dimension-added-test
+  (is (lib-metric.dimension/dimensions-changed?
+       [{:id uuid-1 :status :status/active}]
+       [{:id uuid-1 :status :status/active} {:id uuid-2 :status :status/active}])))
+
+(deftest ^:parallel dimensions-changed?-true-when-dimension-removed-test
+  (is (lib-metric.dimension/dimensions-changed?
+       [{:id uuid-1 :status :status/active} {:id uuid-2 :status :status/active}]
+       [{:id uuid-1 :status :status/active}])))
+
+(deftest ^:parallel dimensions-changed?-true-when-status-changes-test
+  (is (lib-metric.dimension/dimensions-changed?
+       [{:id uuid-1 :name "col1" :status :status/active}]
+       [{:id uuid-1 :name "col1" :status :status/orphaned}])))
+
+(deftest ^:parallel dimensions-changed?-false-when-equal-test
+  (is (not (lib-metric.dimension/dimensions-changed?
+            [{:id uuid-1 :name "col1" :status :status/active}]
+            [{:id uuid-1 :name "col1" :status :status/active}]))))
+
+(deftest ^:parallel dimensions-changed?-false-when-order-differs-test
+  (is (not (lib-metric.dimension/dimensions-changed?
+            [{:id uuid-1 :status :status/active} {:id uuid-2 :status :status/active}]
+            [{:id uuid-2 :status :status/active} {:id uuid-1 :status :status/active}]))))
+
+(deftest ^:parallel dimensions-changed?-ignores-extra-keys-test
+  (is (not (lib-metric.dimension/dimensions-changed?
+            [{:id uuid-1 :name "col1" :status :status/active :lib/source :source/table}]
+            [{:id uuid-1 :name "col1" :status :status/active :lib/source :source/other}]))))
+
+(deftest ^:parallel dimensions-changed?-handles-nil-old-dimensions-test
+  (is (lib-metric.dimension/dimensions-changed?
+       nil
+       [{:id uuid-1 :status :status/active}])))
+
+(deftest ^:parallel dimensions-changed?-handles-empty-dimensions-test
+  (is (not (lib-metric.dimension/dimensions-changed? [] [])))
+  (is (lib-metric.dimension/dimensions-changed? [] [{:id uuid-1 :status :status/active}]))
+  (is (lib-metric.dimension/dimensions-changed? [{:id uuid-1 :status :status/active}] [])))
+
+(deftest ^:parallel mappings-changed?-true-when-mappings-differ-test
+  (is (lib-metric.dimension/mappings-changed?
+       [{:type :table :table-id 1 :dimension-id uuid-1 :target target-1}]
+       [{:type :table :table-id 1 :dimension-id uuid-1 :target target-2}])))
+
+(deftest ^:parallel mappings-changed?-false-when-only-lib-uuid-differs-test
+  (let [target-a [:field {:lib/uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"} 1]
+        target-b [:field {:lib/uuid "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"} 1]]
+    (is (not (lib-metric.dimension/mappings-changed?
+              [{:type :table :table-id 1 :dimension-id uuid-1 :target target-a}]
+              [{:type :table :table-id 1 :dimension-id uuid-1 :target target-b}])))))
+
+(deftest ^:parallel mappings-changed?-handles-nil-old-mappings-test
+  (is (lib-metric.dimension/mappings-changed?
+       nil
+       [{:type :table :table-id 1 :dimension-id uuid-1 :target target-1}])))


### PR DESCRIPTION
### Description

Adds dimension computation/reconciliation. This assumes we only save dimensions when they are consumed by using a metric with dimensions in a card, by having a metric be used by another metric, or by setting custom values for dimension display_name/type in the metrics configuration.

This will mean that dimension mappings _must_ be passed with adhoc metric queries to resolve transient dimensions to the desired target, but also means that transient dimensions are never stale.

Additionally, when we reconcile persistent dimensions with the target query we will set a status on persistent dimensions to mark ones that will no longer work (because the table or target query has changed). This is supplied as a dimension status enum and the backend can supply a configurable message for it.

Also includes UXW-2796, including dimensions/dimension-mappings in measures api response.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

