### PR TITLE
internal navigation: change back button cover on hover

### DIFF
--- a/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/SdkInternalNavigationBackButton.module.css
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/SdkInternalNavigationBackButton.module.css
@@ -1,0 +1,5 @@
+.backButton:not([data-css-specificity-hack]) {
+  &:hover {
+    color: var(--mb-color-brand);
+  }
+}

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/SdkInternalNavigationBackButton.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/SdkInternalNavigationBackButton.tsx
@@ -1,7 +1,9 @@
+import cx from "classnames";
 import { t } from "ttag";
 
 import { Button, Icon } from "metabase/ui";
 
+import S from "./SdkInternalNavigationBackButton.module.css";
 import { useSdkInternalNavigationOptional } from "./context";
 
 /**
@@ -37,7 +39,7 @@ export const SdkInternalNavigationBackButton = ({
       onClick={pop}
       pl={0}
       style={style}
-      className={className}
+      className={cx(className, S.backButton)}
       aria-label={label}
     >
       {label}


### PR DESCRIPTION
Closes [EMB-1289: change back button hover color to brand](https://linear.app/metabase/issue/EMB-1289/change-back-button-hover-color-to-brand)
Got this feedback to change it in DM from Alessio when I showed him the current UI and button position