### PR TITLE
Unmatched rows lens: return cards for both LHS or RHS null scenarios

### DIFF
--- a/frontend/src/metabase-lib/transforms-inspector.ts
+++ b/frontend/src/metabase-lib/transforms-inspector.ts
@@ -79,3 +79,15 @@ export const computeCardStats = (
   rows: unknown[][] | undefined,
 ): CardStats | null =>
   convertKeysToSnakeCase(INSPECTOR.computeCardResult(lensId, card, rows ?? []));
+
+export type DegeneracyResult = {
+  degenerate: boolean;
+  reason: string | null;
+};
+
+export const isDegenerate = (
+  cardId: string,
+  displayType: string,
+  cardsStats: Record<string, CardStats>,
+): DegeneracyResult =>
+  INSPECTOR.isDegenerate(cardId, displayType, convertCardsStatsToKebabCase(cardsStats));

--- a/src/metabase/transforms/inspector/card_result.cljc
+++ b/src/metabase/transforms/inspector/card_result.cljc
@@ -23,8 +23,9 @@
     [lens-id (keyword (get-in card [:metadata :card-type]))]))
 
 (defmethod compute-card-result :default
-  [_ _ _]
-  nil)
+  [_ _ row]
+  (when (nil? row)
+    {"no-data" true}))
 
 (defmethod compute-card-result [:join-analysis :join-step]
   [_ _card row]

--- a/src/metabase/transforms/inspector/core.cljc
+++ b/src/metabase/transforms/inspector/core.cljc
@@ -59,4 +59,4 @@
    - {:degenerate? true :reason :no-data|:single-value|:null-value|:all-same-value|...}
    - {:degenerate? false}"
   [card-id display-type card-results]
-  (degeneracy/degenerate-for-display? card-id (get card-results card-id) display-type card-results))
+  (degeneracy/degenerate-for-display? card-id display-type card-results))

--- a/src/metabase/transforms/inspector/degeneracy.cljc
+++ b/src/metabase/transforms/inspector/degeneracy.cljc
@@ -1,57 +1,15 @@
 (ns metabase.transforms.inspector.degeneracy
   "Multimethod for detecting degenerate card results.
    A degenerate result is one that doesn't provide useful information
-   and should be hidden or deprioritized in the UI.
-
-   Examples of degenerate results:
-   - Bar chart with only 1 bar (no comparison possible)
-   - Pie chart with only 1 slice (100% of one value)
-   - Line chart with only 1 point (no trend visible)
-   - Any chart with 0 rows (no data)
-   - Scalar with null value
-   - Bar chart where all bars have the same height
-
-   Card results use string keys from compute-card-result:
-   - \"row-count\" - number of rows
-   - \"output-count\" - output count (for joins)
-   - \"matched-count\" - matched count (for joins)
-   - \"null-count\" - null count
-   - \"null-rate\" - null rate (0.0-1.0)
-   - \"first-row\" - first row of data")
+   and should be hidden or deprioritized in the UI.")
 
 ;;; -------------------------------------------------- Basic Checks --------------------------------------------------
 
 (defn- no-data?
   "Check if the result has no data at all."
   [card-result]
-  (let [row-count (or (get card-result "row-count")
-                      (get card-result "output-count"))]
-    (or (nil? row-count) (zero? row-count))))
-
-(defn- single-value?
-  "Check if the result has only a single value (1 row for breakout queries)."
-  [card-result]
-  (let [row-count (or (get card-result "row-count")
-                      (get card-result "output-count"))]
-    (= row-count 1)))
-
-(defn- null-scalar?
-  "Check if a scalar result is null."
-  [card-result]
-  (let [first-row (get card-result "first-row")]
-    (or (nil? first-row)
-        (empty? first-row)
-        (nil? (first first-row)))))
-
-(defn- all-same-value?
-  "Check if all values in the result are the same (for breakout queries).
-   Looks for a companion stats card with ID '{card-id}-stats' that returns
-   distinct-count. If distinct-count = 1, all values are same."
-  [card-id card-results]
-  (when card-results
-    (when-let [stats-result (get card-results (str card-id "-stats"))]
-      (= 1 (or (get stats-result "distinct-count")
-               (-> (get stats-result "first-row") first))))))
+  (or (get card-result "no-data")
+      (= 0 (get card-result "row-count"))))
 
 ;;; -------------------------------------------------- Display-specific Checks --------------------------------------------------
 
@@ -59,97 +17,23 @@
   "Check if a card result is degenerate for a given display type.
 
    Arguments:
-   - card-id: the card's ID (for looking up companion cards)
-   - card-result: the card's computed result (string keys)
+   - card-id: the card's ID (for looking up in card-results)
    - display-type: keyword like :bar, :line, etc.
-   - card-results: map of all card results (for companion card lookup)
+   - card-results: map of all card results (card-id -> result map)
 
    Returns {:degenerate? bool :reason keyword}."
-  {:arglists '([card-id card-result display-type card-results])}
-  (fn [_card-id _card-result display-type _card-results] display-type))
+  {:arglists '([card-id display-type card-results])}
+  (fn [_card-id display-type _card-results] display-type))
 
 (defmethod degenerate-for-display? :default
-  [_card-id card-result _display-type _card-results]
+  [card-id _display-type card-results]
   (cond
-    (no-data? card-result)
+    (no-data? (get card-results card-id))
     {:degenerate? true :reason :no-data}
 
     :else
-    {:degenerate? false}))
-
-(defmethod degenerate-for-display? :bar
-  [card-id card-result _ card-results]
-  (cond
-    (no-data? card-result)
-    {:degenerate? true :reason :no-data}
-
-    (single-value? card-result)
-    {:degenerate? true :reason :single-value}
-
-    (all-same-value? card-id card-results)
-    {:degenerate? true :reason :all-same-value}
-
-    :else
-    {:degenerate? false}))
-
-(defmethod degenerate-for-display? :row
-  [card-id card-result _ card-results]
-  (degenerate-for-display? card-id card-result :bar card-results))
-
-(defmethod degenerate-for-display? :pie
-  [_card-id card-result _ _card-results]
-  (cond
-    (no-data? card-result)
-    {:degenerate? true :reason :no-data}
-
-    (single-value? card-result)
-    {:degenerate? true :reason :single-slice}
-
-    :else
-    {:degenerate? false}))
-
-(defmethod degenerate-for-display? :line
-  [_card-id card-result _ _card-results]
-  (cond
-    (no-data? card-result)
-    {:degenerate? true :reason :no-data}
-
-    (single-value? card-result)
-    {:degenerate? true :reason :single-point}
-
-    :else
-    {:degenerate? false}))
-
-(defmethod degenerate-for-display? :area
-  [card-id card-result _ card-results]
-  (degenerate-for-display? card-id card-result :line card-results))
-
-(defmethod degenerate-for-display? :scalar
-  [_card-id card-result _ _card-results]
-  (cond
-    (no-data? card-result)
-    {:degenerate? true :reason :no-data}
-
-    (null-scalar? card-result)
-    {:degenerate? true :reason :null-value}
-
-    :else
-    {:degenerate? false}))
-
-(defmethod degenerate-for-display? :gauge
-  [card-id card-result _ card-results]
-  (degenerate-for-display? card-id card-result :scalar card-results))
-
-(defmethod degenerate-for-display? :progress
-  [card-id card-result _ card-results]
-  (degenerate-for-display? card-id card-result :scalar card-results))
-
-(defmethod degenerate-for-display? :table
-  [_card-id card-result _ _card-results]
-  (if (no-data? card-result)
-    {:degenerate? true :reason :no-data}
     {:degenerate? false}))
 
 (defmethod degenerate-for-display? :hidden
-  [_card-id _card-result _ _card-results]
-  {:degenerate? false})
+  [_card-id _display-type _card-results]
+  {:degenerate? true})

--- a/src/metabase/transforms/inspector/js.cljs
+++ b/src/metabase/transforms/inspector/js.cljs
@@ -56,3 +56,13 @@
     (clj->js (inspector/interesting-fields fields
                                            :threshold (or threshold 0.3)
                                            :limit limit))))
+
+(defn ^:export isDegenerate
+  "Check if a card result is degenerate and shouldn't be displayed.
+   Returns {degenerate: bool, reason: string|null}."
+  [card-id display-type card-results-js]
+  (let [card-results (js->clj card-results-js)
+        display-kw (keyword display-type)
+        result (inspector/degenerate? card-id display-kw card-results)]
+    (clj->js {:degenerate (:degenerate? result)
+              :reason (some-> (:reason result) name)})))


### PR DESCRIPTION
Also hooks to simple degeneracy check, as some of those cards may be empty

Closes https://linear.app/metabase/issue/GDGT-1719/unmatched-rows-lens-return-cards-for-both-lhs-or-rhs-null-scenarios