### PR TITLE
Move app switcher into Dependency Graph

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyGraph/DependencyGraph.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyGraph/DependencyGraph.module.css
@@ -25,9 +25,3 @@
     }
   }
 }
-
-.appSwitcher {
-  margin-left: auto;
-  margin-right: 2.5rem;
-  background-color: var(--mb-color-background-secondary);
-}

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyGraph/DependencyGraph.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyGraph/DependencyGraph.module.css
@@ -8,6 +8,7 @@
   flex-direction: column;
   bottom: 0;
   pointer-events: none;
+  z-index: 20;
 }
 
 .panelContent {
@@ -24,4 +25,12 @@
       background-color: var(--mb-color-background);
     }
   }
+}
+
+.appSwitcher {
+  position: absolute;
+  top: 1.25rem;
+  right: 3.5rem;
+  background-color: var(--mb-color-background-secondary);
+  z-index: 10;
 }

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyGraph/DependencyGraph.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyGraph/DependencyGraph.module.css
@@ -8,7 +8,6 @@
   flex-direction: column;
   bottom: 0;
   pointer-events: none;
-  z-index: 20;
 }
 
 .panelContent {
@@ -28,9 +27,7 @@
 }
 
 .appSwitcher {
-  position: absolute;
-  top: 1.25rem;
-  right: 3.5rem;
+  margin-left: auto;
+  margin-right: 2.5rem;
   background-color: var(--mb-color-background-secondary);
-  z-index: 10;
 }

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyGraph/DependencyGraph.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyGraph/DependencyGraph.tsx
@@ -12,7 +12,6 @@ import { useEffect, useMemo, useState } from "react";
 import { t } from "ttag";
 
 import { useMetadataToasts } from "metabase/metadata/hooks";
-import { AppSwitcher } from "metabase/nav/components/AppSwitcher";
 import { Group, useColorScheme } from "metabase/ui";
 import { useGetDependencyGraphQuery } from "metabase-enterprise/api";
 import type {
@@ -51,7 +50,7 @@ type DependencyGraphProps = {
   error?: any;
   getGraphUrl: (entry?: any) => string;
   withEntryPicker?: boolean;
-  withAppSwitcher?: boolean;
+  headerRightSide?: React.ReactNode;
   entry?: any;
   nodeTypes?: typeof NODE_TYPES;
   edgeTypes?: typeof EDGE_TYPES;
@@ -65,7 +64,7 @@ export function DependencyGraph({
   error: externalError,
   getGraphUrl,
   withEntryPicker,
-  withAppSwitcher = false,
+  headerRightSide = null,
   nodeTypes = NODE_TYPES,
   edgeTypes = EDGE_TYPES,
   openLinksInNewTab = true,
@@ -148,7 +147,7 @@ export function DependencyGraph({
               />
             )}
             {nodes.length > 1 && <GraphSelectInput nodes={nodes} />}
-            {withAppSwitcher && <AppSwitcher className={S.appSwitcher} />}
+            {headerRightSide}
           </Group>
         </Panel>
         {selection != null && selectedNode != null && (

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyGraph/DependencyGraph.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyGraph/DependencyGraph.tsx
@@ -12,6 +12,7 @@ import { useEffect, useMemo, useState } from "react";
 import { t } from "ttag";
 
 import { useMetadataToasts } from "metabase/metadata/hooks";
+import { AppSwitcher } from "metabase/nav/components/AppSwitcher";
 import { Group, useColorScheme } from "metabase/ui";
 import { useGetDependencyGraphQuery } from "metabase-enterprise/api";
 import type {
@@ -50,6 +51,7 @@ type DependencyGraphProps = {
   error?: any;
   getGraphUrl: (entry?: any) => string;
   withEntryPicker?: boolean;
+  withAppSwitcher?: boolean;
   entry?: any;
   nodeTypes?: typeof NODE_TYPES;
   edgeTypes?: typeof EDGE_TYPES;
@@ -63,6 +65,7 @@ export function DependencyGraph({
   error: externalError,
   getGraphUrl,
   withEntryPicker,
+  withAppSwitcher = false,
   nodeTypes = NODE_TYPES,
   edgeTypes = EDGE_TYPES,
   openLinksInNewTab = true,
@@ -165,6 +168,7 @@ export function DependencyGraph({
             )}
           </Panel>
         )}
+        {withAppSwitcher && <AppSwitcher className={S.appSwitcher} />}
       </ReactFlow>
     </GraphContext.Provider>
   );

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyGraph/DependencyGraph.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyGraph/DependencyGraph.tsx
@@ -148,6 +148,7 @@ export function DependencyGraph({
               />
             )}
             {nodes.length > 1 && <GraphSelectInput nodes={nodes} />}
+            {withAppSwitcher && <AppSwitcher className={S.appSwitcher} />}
           </Group>
         </Panel>
         {selection != null && selectedNode != null && (
@@ -168,7 +169,6 @@ export function DependencyGraph({
             )}
           </Panel>
         )}
-        {withAppSwitcher && <AppSwitcher className={S.appSwitcher} />}
       </ReactFlow>
     </GraphContext.Provider>
   );

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyGraphPage/DependencyGraphPage.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyGraphPage/DependencyGraphPage.module.css
@@ -1,0 +1,5 @@
+.appSwitcher {
+  margin-left: auto;
+  margin-right: 2.5rem;
+  background-color: var(--mb-color-background-secondary);
+}

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyGraphPage/DependencyGraphPage.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyGraphPage/DependencyGraphPage.module.css
@@ -1,6 +1,0 @@
-.ProfileLink {
-  position: absolute;
-  top: 1.25rem;
-  right: 3.5rem;
-  background-color: var(--mb-color-background-secondary);
-}

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyGraphPage/DependencyGraphPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyGraphPage/DependencyGraphPage.tsx
@@ -3,7 +3,6 @@ import { useContext } from "react";
 
 import { skipToken } from "metabase/api";
 import * as Urls from "metabase/lib/urls";
-import { AppSwitcher } from "metabase/nav/components/AppSwitcher";
 import { PLUGIN_DEPENDENCIES } from "metabase/plugins";
 import { Stack } from "metabase/ui";
 import { useGetDependencyGraphQuery } from "metabase-enterprise/api";
@@ -11,7 +10,6 @@ import { useGetDependencyGraphQuery } from "metabase-enterprise/api";
 import { DependencyGraph } from "../../components/DependencyGraph";
 import { isSameNode } from "../../utils";
 
-import S from "./DependencyGraphPage.module.css";
 import { parseDependencyEntry } from "./utils";
 
 export type DependencyGraphPageQuery = {
@@ -46,8 +44,8 @@ export function DependencyGraphPage({ location }: DependencyGraphPageProps) {
         error={error}
         getGraphUrl={(entry) => Urls.dependencyGraph({ entry, baseUrl })}
         withEntryPicker={withEntryPicker}
+        withAppSwitcher={baseUrl === undefined}
       />
-      {baseUrl === undefined && <AppSwitcher className={S.ProfileLink} />}
     </Stack>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyGraphPage/DependencyGraphPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyGraphPage/DependencyGraphPage.tsx
@@ -3,6 +3,7 @@ import { useContext } from "react";
 
 import { skipToken } from "metabase/api";
 import * as Urls from "metabase/lib/urls";
+import { AppSwitcher } from "metabase/nav/components/AppSwitcher";
 import { PLUGIN_DEPENDENCIES } from "metabase/plugins";
 import { Stack } from "metabase/ui";
 import { useGetDependencyGraphQuery } from "metabase-enterprise/api";
@@ -10,6 +11,7 @@ import { useGetDependencyGraphQuery } from "metabase-enterprise/api";
 import { DependencyGraph } from "../../components/DependencyGraph";
 import { isSameNode } from "../../utils";
 
+import S from "./DependencyGraphPage.module.css";
 import { parseDependencyEntry } from "./utils";
 
 export type DependencyGraphPageQuery = {
@@ -44,7 +46,11 @@ export function DependencyGraphPage({ location }: DependencyGraphPageProps) {
         error={error}
         getGraphUrl={(entry) => Urls.dependencyGraph({ entry, baseUrl })}
         withEntryPicker={withEntryPicker}
-        withAppSwitcher={baseUrl === undefined}
+        headerRightSide={
+          baseUrl === undefined ? (
+            <AppSwitcher className={S.appSwitcher} />
+          ) : null
+        }
       />
     </Stack>
   );

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyGraphPage/DependencyGraphPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyGraphPage/DependencyGraphPage.unit.spec.tsx
@@ -1,26 +1,26 @@
 import { Route } from "react-router";
 
-import { setupDependecyGraphEndpoint } from "__support__/server-mocks";
+import {
+  setupDependecyGraphEndpoint,
+  setupRecentViewsAndSelectionsEndpoints,
+} from "__support__/server-mocks";
 import { renderWithProviders, screen } from "__support__/ui";
 import { PLUGIN_DEPENDENCIES } from "metabase/plugins";
 import { createMockDependencyGraph } from "metabase-types/api/mocks";
 
 import { DependencyGraphPage } from "./DependencyGraphPage";
 
-jest.mock("../../components/DependencyGraph", () => ({
-  DependencyGraph: () => <p>Dependency Graph</p>,
-}));
-
 describe("DependencyGraphPage", () => {
   beforeEach(() => {
     setupDependecyGraphEndpoint(createMockDependencyGraph());
+    setupRecentViewsAndSelectionsEndpoints([], ["selections"]);
   });
   it("should show an app switcher if there is no context", async () => {
     renderWithProviders(<Route path="/" component={DependencyGraphPage} />, {
       withRouter: true,
     });
 
-    expect(await screen.findByText("Dependency Graph")).toBeInTheDocument();
+    expect(await screen.findByTestId("dependency-graph")).toBeInTheDocument();
     expect(screen.getByTestId("app-switcher-target")).toBeInTheDocument();
   });
 
@@ -44,7 +44,7 @@ describe("DependencyGraphPage", () => {
       },
     );
 
-    expect(await screen.findByText("Dependency Graph")).toBeInTheDocument();
+    expect(await screen.findByTestId("dependency-graph")).toBeInTheDocument();
     expect(screen.queryByTestId("app-switcher-target")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/ui/components/inputs/Select/SelectItem/DefaultSelectItem.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Select/SelectItem/DefaultSelectItem.tsx
@@ -17,7 +17,7 @@ export const DefaultSelectItem = forwardRef(function DefaultSelectItem(
 ) {
   return (
     <SelectItem ref={ref} {...props}>
-      {icon && <Icon name={icon} />}
+      {icon && <Icon name={icon} flex="0 0 1rem" />}
 
       <Text c="inherit" lh="inherit">
         {label ?? value}


### PR DESCRIPTION
### Description
Moves the app switcher into the DependecyGraph so that it can be rendered below the Right Panel when open, but still be clickable otherwise

### Demo
<img width="1254" height="973" alt="image" src="https://github.com/user-attachments/assets/6cc96cd5-8bd1-4b6a-9494-ad873d7ccf04" />
<img width="1257" height="965" alt="image" src="https://github.com/user-attachments/assets/8b5229d7-edc8-4a9a-8314-4d00f466febe" />
<img width="1261" height="967" alt="image" src="https://github.com/user-attachments/assets/05d0e311-809e-4b0e-8d18-3bb48f90fef4" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
