### PR TITLE
Add enable tenants and create shared collection button

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
@@ -56,6 +56,11 @@
 (defn- has-user-created-tenants? []
   (t2/exists? :model/Tenant :is_active true))
 
+(defn- has-shared-tenant-collections? []
+  (t2/exists? :model/Collection {:where [:and
+                                         [:= :namespace "shared-tenant-collection"]
+                                         [:= :archived false]]}))
+
 (defn- has-configured-data-segregation-strategy? []
   ;; Check if any of the 3 data segregation strategies are enabled:
   ;; 1. Row and Column Level Security (Sandboxing)
@@ -66,8 +71,9 @@
       (t2/exists? :model/DatabaseRouter)))
 
 (defn- embedding-hub-checklist []
-  (let [enable-tenants?                 (perms/use-tenants)
-        create-tenants?                 (has-user-created-tenants?)
+  (let [enable-tenants?                  (and (perms/use-tenants)
+                                              (has-shared-tenant-collections?))
+        create-tenants?                  (has-user-created-tenants?)
         setup-data-segregation-strategy? (has-configured-data-segregation-strategy?)]
     ;; for the main embedding hub checklist
     {"add-data"                          (has-user-added-database?)


### PR DESCRIPTION
Closes EMB-1290

### Description

Implements enabling tenants and creating shared tenant collections.

### How to verify

- Go to embedding hub > setup permissions and tenants card
- Click on "Enable tenants and create shared collection", it should do so.
- Click on the completed step, the button should be disabled.
- If tenants are enabled AND there are at least ONE shared collection, the button should be disabled.

### Demo

<img width="1352" height="1528" alt="CleanShot 2569-02-05 at 04 15 36@2x" src="https://github.com/user-attachments/assets/bb2dacca-01c3-46bd-a510-188136ac8ecb" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR - e2e

