### PR TITLE
Lock steps 2 to 5 in data permissions setup checklist

### DIFF
--- a/frontend/src/metabase/common/components/OnboardingStepper/types.ts
+++ b/frontend/src/metabase/common/components/OnboardingStepper/types.ts
@@ -22,6 +22,11 @@ export interface OnboardingStepperProps {
   onChange?: (value: string | null) => void;
 }
 
+export interface OnboardingStepperHandle {
+  /** Navigate to the next incomplete step */
+  goToNextIncompleteStep: () => void;
+}
+
 export interface OnboardingStepperStepProps {
   /** Unique identifier for this step */
   stepId: string;


### PR DESCRIPTION
Closes EMB-1291

### Description

The "Configure data permissions and enable tenants" page should:

- Completing step 2 unlocks steps 3 and 4.
- Completing step 2 - 4 unlocks steps 5 (summary).

### How to verify

- E2E test that verifies step completions should pass
- Completing step 2 (selecting a data segregation strategy in the UI) should unlock steps 3 and 4.
- Completing step 2 to 4 should unlock step 5 (summary)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR - E2E
