### PR TITLE
Add link to documentation for database routing in the onboarding step

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
@@ -541,5 +541,32 @@ describe("scenarios - embedding hub", () => {
         })
         .should("be.disabled");
     });
+
+    it("selecting database routing strategy should show documentation link in step 3", () => {
+      H.restore("setup");
+      cy.signInAsAdmin();
+      H.activateToken("bleeding-edge");
+      H.updateSetting("use-tenants", true);
+
+      cy.visit("/admin/embedding/setup-guide/permissions");
+
+      cy.log("select database routing strategy");
+      H.main()
+        .findByRole("radio", { name: /Database routing/ })
+        .click();
+
+      cy.log("confirm the strategy selection");
+      H.main().findByRole("button", { name: "Use database routing" }).click();
+
+      cy.log("should show database routing content with docs link");
+      H.main()
+        .findByText("Manage data permissions with database routing")
+        .should("be.visible");
+
+      H.main()
+        .findByRole("link", { name: /View the guide/i })
+        .should("have.attr", "href")
+        .and("include", "database-routing");
+    });
   });
 });

--- a/frontend/src/metabase/common/components/OnboardingStepper/OnboardingStepper.module.css
+++ b/frontend/src/metabase/common/components/OnboardingStepper/OnboardingStepper.module.css
@@ -50,11 +50,11 @@
   font-size: 1.0625rem;
 }
 
-.StepRoot[data-active="true"] .StepHeader {
+.StepRoot[data-active="true"] .StepHeaderWithTitle {
   margin-bottom: 1rem;
 }
 
-.StepRoot[data-active="false"] .StepHeader {
+.StepRoot[data-active="false"] .StepHeaderWithTitle {
   margin: 0;
 }
 
@@ -108,7 +108,7 @@
   color: var(--mb-color-text-tertiary);
 }
 
-/* Step content (only shown when active) */
-.StepContent {
+/* Step content with title (only shown when active) */
+.StepContentWithTitle {
   margin-top: 1rem;
 }

--- a/frontend/src/metabase/common/components/OnboardingStepper/OnboardingStepperStep.tsx
+++ b/frontend/src/metabase/common/components/OnboardingStepper/OnboardingStepperStep.tsx
@@ -1,3 +1,4 @@
+import cx from "classnames";
 import { useContext } from "react";
 
 import { Box, Icon } from "metabase/ui";
@@ -10,6 +11,7 @@ export function OnboardingStepperStep({
   stepId,
   title,
   children,
+  hideTitleOnActive = false,
   "data-testid": testId,
 }: OnboardingStepperStepProps) {
   const {
@@ -26,6 +28,8 @@ export function OnboardingStepperStep({
   const isCompleted = completedSteps[stepId] ?? false;
   const isLocked = lockedSteps[stepId] ?? false;
   const stepNumber = stepNumbers[stepId] ?? 0;
+
+  const shouldShowTitle = !isActive || !hideTitleOnActive;
 
   return (
     <Box
@@ -55,17 +59,25 @@ export function OnboardingStepperStep({
         )}
       </div>
 
-      <div className={S.StepHeader}>
-        <div className={S.StepTitle} data-completed={isCompleted}>
-          {title}
-        </div>
+      <div
+        className={cx(S.StepHeader, shouldShowTitle && S.StepHeaderWithTitle)}
+      >
+        {shouldShowTitle && (
+          <div className={S.StepTitle} data-completed={isCompleted}>
+            {title}
+          </div>
+        )}
 
-        {isLocked && (
+        {isLocked && !isActive && (
           <Icon name="lock" className={S.StepLockIcon} aria-label="Locked" />
         )}
       </div>
 
-      {isActive && <div className={S.StepContent}>{children}</div>}
+      {isActive && (
+        <div className={cx(shouldShowTitle && S.StepContentWithTitle)}>
+          {children}
+        </div>
+      )}
     </Box>
   );
 }

--- a/frontend/src/metabase/common/components/OnboardingStepper/types.ts
+++ b/frontend/src/metabase/common/components/OnboardingStepper/types.ts
@@ -34,6 +34,9 @@ export interface OnboardingStepperStepProps {
   /** Title displayed in the step header */
   title: string;
 
+  /** Whether to hide the step title on step active */
+  hideTitleOnActive?: boolean;
+
   /** Content to show when the step is active */
   children: ReactNode;
 

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/DatabaseRoutingStepContent.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/DatabaseRoutingStepContent.tsx
@@ -1,0 +1,45 @@
+/* eslint-disable metabase/no-unconditional-metabase-links-render */
+
+import { t } from "ttag";
+
+import { ExternalLink } from "metabase/common/components/ExternalLink";
+import { useDocsUrl } from "metabase/common/hooks";
+import { Button, Group, Icon, Paper, Stack, Text, Title } from "metabase/ui";
+
+export const DatabaseRoutingStepContent = () => {
+  const { url: docsUrl } = useDocsUrl("permissions/database-routing", {
+    utm: { utm_content: "embedding-hub" },
+  });
+
+  return (
+    <Stack>
+      <Text c="text-secondary" lh="xl" mt="xs">
+        {t`Follow the steps in the documentation to manage data permissions with database routing.`}
+      </Text>
+
+      <Paper bg="background-brand" p="lg" radius="md" withBorder>
+        <Stack gap="sm">
+          <Title order={4} c="text-primary">
+            {t`Manage data permissions with database routing`}
+          </Title>
+
+          <Text c="text-secondary" lh="xl">
+            {t`Follow the guide in the docs to enable database routing at the data source level, add destination databases and configure the relevant tenant attributes.`}
+          </Text>
+
+          <Group justify="flex-end">
+            <Button
+              component={ExternalLink}
+              href={docsUrl}
+              variant="outline"
+              rightSection={<Icon name="external" size={16} />}
+              mt="sm"
+            >
+              {t`View the guide`}
+            </Button>
+          </Group>
+        </Stack>
+      </Paper>
+    </Stack>
+  );
+};

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/SetupPermissionsAndTenantsPage.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/SetupPermissionsAndTenantsPage.tsx
@@ -20,6 +20,7 @@ import {
   type DataSegregationStrategy,
   DataSegregationStrategyPicker,
 } from "./DataSegregationStrategyPicker";
+import { DatabaseRoutingStepContent } from "./DatabaseRoutingStepContent";
 import S from "./SetupPermissionsAndTenantsPage.module.css";
 
 const SETUP_GUIDE_PATH = "/admin/embedding/setup-guide";
@@ -192,10 +193,15 @@ export const SetupPermissionsAndTenantsPage = () => {
         <OnboardingStepper.Step
           stepId="select-data"
           title={t`Select data to make available`}
+          hideTitleOnActive
         >
-          <Text c="text-secondary" size="sm" lh="lg">
-            {t`Choose which tables and columns are available for embedding.`}
-          </Text>
+          {selectedStrategy === "database-routing" ? (
+            <DatabaseRoutingStepContent />
+          ) : (
+            <Text c="text-secondary" size="sm" lh="lg">
+              {t`Choose which tables and columns are available for embedding.`}
+            </Text>
+          )}
         </OnboardingStepper.Step>
 
         <OnboardingStepper.Step


### PR DESCRIPTION
Closes EMB-1273

### Description

Database routing is not trivial to setup, so we show a card with link to database routing docs whenever that data segregation step is selected.

### How to verify

- Go to embedding hub > `Configure data permissions and enable tenants` > `Pick data segregation strategy`
- Choose `Database routing` > `Use database routing`
- You should see "Manage data permissions with database routing"
- Clicking "View the guide" takes you to DB routing docs

### Demo

<img width="1572" height="986" alt="CleanShot 2569-02-05 at 06 17 51@2x" src="https://github.com/user-attachments/assets/bfd33dc9-ddc4-44d6-94b6-437db17e3992" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
