### PR TITLE
Fix infinite hang caused by selecting drop down in conditional formatting settings

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting/RuleEditor.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting/RuleEditor.tsx
@@ -135,7 +135,12 @@ export const RuleEditor = ({
             </Text>
             <Box>
               <Select<ColumnFormattingOperator>
-                comboboxProps={{ withinPortal: false }}
+                comboboxProps={{
+                  withinPortal: false,
+                  middlewares: {
+                    flip: false,
+                  },
+                }}
                 value={rule.operator}
                 onChange={(operator) => onChange({ ...rule, operator })}
                 data={_.pairs(operators).map(([value, label]) => ({


### PR DESCRIPTION
Closes #69106
Closes [UXW-3026](https://linear.app/metabase/issue/UXW-3026/selecting-drop-down-in-conditional-formatting-settings-causes-metabase)

### Description

Mantine has a bug where, in certain conditions, the floating `placement` of a Popover will infinitely flip from "top" to "bottom", causing the browser to hang. This PR disables the Popover's flip middleware as a fix, though I'll also create an issue with Mantine which will hopefully lead to a more robust solution.

### How to verify

See #69106. The bug is very layout dependent so might be hard to reproduce. If I zoom in, zoom out, or slightly change my window size, it no longer happens. I wasn't able to recreate the bug in an E2E test.

### Demo

Before: [Loom](https://www.loom.com/share/47aa2c926d8b4b7f92623aed14a74b51)
After: the dropdown opens as expected

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
