### PR TITLE
[wip] Stupidest Possible e2e Partitioning

### DIFF
--- a/.github/scripts/build-e2e-matrix.unit.spec.js
+++ b/.github/scripts/build-e2e-matrix.unit.spec.js
@@ -1,4 +1,4 @@
-const { buildMatrix } = require("./build-e2e-matrix");
+const { buildMatrix, getRelevantSpecs } = require("./build-e2e-matrix");
 
 describe("buildMatrix", () => {
   const options = {
@@ -93,5 +93,23 @@ describe("buildMatrix", () => {
 
     expect(result.config.length).toBe(1);
     expect(result.config[0].name).toBe("e2e-group-1");
+  });
+
+  describe("getRelevantSpecs", () => {
+    it("should return correct spec folders for changed files", () => {
+      const changedFiles = [
+        "frontend/src/metabase/search/some-file.js",
+        "src/metabase/internal_stats/stats.clj",
+        "some/other/file.txt",
+      ].join("\n");
+
+      const matchedSpecs = getRelevantSpecs(changedFiles);
+
+      console.log({ matchedSpecs });
+
+      expect(matchedSpecs).toContain("search");
+      expect(matchedSpecs).toContain("stats");
+      expect(matchedSpecs).not.toContain("sharing");
+    });
   });
 });

--- a/.github/scripts/e2e-matrix-map.js
+++ b/.github/scripts/e2e-matrix-map.js
@@ -1,0 +1,373 @@
+const e2eMatrixMap = [
+  {
+    specFolder: "actions",
+    globs: [
+      "frontend/src/metabase/actions/**",
+      "src/metabase/actions/**",
+    ],
+  },
+  {
+    specFolder: "admin",
+    globs: [
+      "frontend/src/metabase/admin/**",
+      "src/metabase/settings/**",
+      "src/metabase/settings_rest/**",
+      "src/metabase/api/database.clj",
+      "src/metabase/api/user.clj",
+    ],
+  },
+  {
+    specFolder: "admin-2",
+    globs: [
+      "frontend/src/metabase/admin/**",
+      "src/metabase/settings/**",
+      "src/metabase/settings_rest/**",
+      "src/metabase/api/database.clj",
+      "src/metabase/api/user.clj",
+    ],
+  },
+  {
+    specFolder: "binning",
+    globs: [
+      "frontend/src/metabase/query_builder/**",
+      "src/metabase/query_processor/**",
+      "src/metabase/lib/**",
+    ],
+  },
+  {
+    specFolder: "collections",
+    globs: [
+      "frontend/src/metabase/collections/**",
+      "src/metabase/collections/**",
+      "src/metabase/collections_rest/**",
+      "src/metabase/api/collection.clj",
+    ],
+  },
+  {
+    specFolder: "custom-column",
+    globs: [
+      "frontend/src/metabase/query_builder/**",
+      "src/metabase/query_processor/**",
+      "src/metabase/lib/**",
+    ],
+  },
+  {
+    specFolder: "dashboard",
+    globs: [
+      "frontend/src/metabase/dashboard/**",
+      "src/metabase/dashboards/**",
+      "src/metabase/dashboards_rest/**",
+      "src/metabase/api/dashboard.clj",
+    ],
+  },
+  {
+    specFolder: "dashboard-cards",
+    globs: [
+      "frontend/src/metabase/dashboard/**",
+      "src/metabase/dashboards/**",
+      "src/metabase/dashboards_rest/**",
+      "src/metabase/api/dashboard.clj",
+      "src/metabase/api/card.clj",
+    ],
+  },
+  {
+    specFolder: "dashboard-filters",
+    globs: [
+      "frontend/src/metabase/dashboard/**",
+      "frontend/src/metabase/parameters/**",
+      "src/metabase/dashboards/**",
+      "src/metabase/parameters/**",
+      "src/metabase/api/dashboard.clj",
+    ],
+  },
+  {
+    specFolder: "dashboard-filters-2",
+    globs: [
+      "frontend/src/metabase/dashboard/**",
+      "frontend/src/metabase/parameters/**",
+      "src/metabase/dashboards/**",
+      "src/metabase/parameters/**",
+    ],
+  },
+  {
+    specFolder: "dashboard-filters-matrix",
+    globs: [
+      "frontend/src/metabase/dashboard/**",
+      "frontend/src/metabase/parameters/**",
+      "src/metabase/dashboards/**",
+      "src/metabase/parameters/**",
+    ],
+  },
+  {
+    specFolder: "data-model",
+    globs: [
+      "frontend/src/metabase/admin/**",
+      "frontend/src/metabase-lib/**",
+      "src/metabase/models/**",
+      "src/metabase/api/field.clj",
+      "src/metabase/api/table.clj",
+    ],
+  },
+  {
+    specFolder: "data-reference",
+    globs: [
+      "frontend/src/metabase/reference/**",
+      "src/metabase/api/database.clj",
+      "src/metabase/api/table.clj",
+      "src/metabase/api/field.clj",
+    ],
+  },
+  {
+    specFolder: "data-studio",
+    globs: [
+      "frontend/src/metabase/data-studio/**",
+      "frontend/src/metabase/query_builder/**",
+      "frontend/src/metabase/querying/**",
+      "src/metabase/query_processor/**",
+      "src/metabase/lib/**",
+    ],
+  },
+  {
+    specFolder: "dependencies",
+    globs: [
+      "package.json",
+      "yarn.lock",
+    ],
+  },
+  {
+    specFolder: "detail-view",
+    globs: [
+      "frontend/src/metabase/detail-view/**",
+      "src/metabase/query_processor/**",
+    ],
+  },
+  {
+    specFolder: "docker-compose.yml",
+    globs: [
+      "dev/docker-compose.yml",
+    ],
+  },
+  {
+    specFolder: "documents",
+    globs: [
+      "frontend/src/metabase/documents/**",
+      "src/metabase/documents/**",
+      "src/metabase/api/document.clj",
+    ],
+  },
+  {
+    specFolder: "embedding",
+    globs: [
+      "frontend/src/metabase/embedding/**",
+      "frontend/src/metabase/public/**",
+      "src/metabase/embedding/**",
+      "src/metabase/embedding_rest/**",
+      "src/metabase/public_sharing/**",
+      "src/metabase/public_sharing_rest/**",
+      "src/metabase/api/embed.clj",
+      "src/metabase/api/public.clj",
+    ],
+  },
+  {
+    specFolder: "filters",
+    globs: [
+      "frontend/src/metabase/parameters/**",
+      "frontend/src/metabase/query_builder/**",
+      "src/metabase/parameters/**",
+      "src/metabase/query_processor/**",
+    ],
+  },
+  {
+    specFolder: "filters-reproductions",
+    globs: [
+      "frontend/src/metabase/parameters/**",
+      "frontend/src/metabase/query_builder/**",
+      "src/metabase/parameters/**",
+      "src/metabase/query_processor/**",
+    ],
+  },
+  {
+    specFolder: "i18n",
+    globs: [
+      "frontend/src/metabase/i18n/**",
+      "locales/**",
+    ],
+  },
+  {
+    specFolder: "joins",
+    globs: [
+      "frontend/src/metabase/query_builder/**",
+      "src/metabase/query_processor/**",
+      "src/metabase/lib/**",
+    ],
+  },
+  {
+    specFolder: "maildev-keys",
+    globs: [
+      "dev/**",
+    ],
+  },
+  {
+    specFolder: "metabot",
+    globs: [
+      "frontend/src/metabase/metabot/**",
+      "src/metabase/llm/**",
+      "src/metabase/api/metabot.clj",
+    ],
+  },
+  {
+    specFolder: "metrics",
+    globs: [
+      "frontend/src/metabase/admin/**",
+      "frontend/src/metabase/query_builder/**",
+      "src/metabase/models/**",
+      "src/metabase/measures/**",
+      "src/metabase/api/metric.clj",
+    ],
+  },
+  {
+    specFolder: "models",
+    globs: [
+      "frontend/src/metabase/models/**",
+      "frontend/src/metabase/query_builder/**",
+      "src/metabase/models/**",
+      "src/metabase/api/card.clj",
+    ],
+  },
+  {
+    specFolder: "native",
+    globs: [
+      "frontend/src/metabase/query_builder/**",
+      "src/metabase/query_processor/**",
+      "src/metabase/driver/**",
+    ],
+  },
+  {
+    specFolder: "native-filters",
+    globs: [
+      "frontend/src/metabase/parameters/**",
+      "frontend/src/metabase/query_builder/**",
+      "src/metabase/parameters/**",
+      "src/metabase/query_processor/**",
+      "src/metabase/native_query_snippets/**",
+    ],
+  },
+  {
+    specFolder: "navigation",
+    globs: [
+      "frontend/src/metabase/nav/**",
+      "frontend/src/metabase/home/**",
+      "frontend/src/metabase/browse/**",
+    ],
+  },
+  {
+    specFolder: "onboarding",
+    globs: [
+      "frontend/src/metabase/setup/**",
+      "src/metabase/setup/**",
+      "src/metabase/setup_rest/**",
+    ],
+  },
+  {
+    specFolder: "organization",
+    globs: [
+      "frontend/src/metabase/browse/**",
+      "frontend/src/metabase/collections/**",
+      "src/metabase/collections/**",
+    ],
+  },
+  {
+    specFolder: "permissions",
+    globs: [
+      "frontend/src/metabase/admin/**",
+      "src/metabase/permissions/**",
+      "src/metabase/permissions_rest/**",
+      "src/metabase/api/permissions.clj",
+    ],
+  },
+  {
+    specFolder: "question",
+    globs: [
+      "frontend/src/metabase/query_builder/**",
+      "frontend/src/metabase/questions/**",
+      "src/metabase/query_processor/**",
+      "src/metabase/api/card.clj",
+    ],
+  },
+  {
+    specFolder: "question-reproductions",
+    globs: [
+      "frontend/src/metabase/query_builder/**",
+      "src/metabase/query_processor/**",
+    ],
+  },
+  {
+    specFolder: "search",
+    globs: [
+      "frontend/src/metabase/search/**",
+      "src/metabase/search/**",
+      "src/metabase/api/search.clj",
+    ],
+  },
+  {
+    specFolder: "sharing",
+    globs: [
+      "frontend/src/metabase/public/**",
+      "frontend/src/metabase/dashboard/**",
+      "src/metabase/public_sharing/**",
+      "src/metabase/public_sharing_rest/**",
+      "src/metabase/pulse/**",
+      "src/metabase/api/public.clj",
+    ],
+  },
+  {
+    specFolder: "stats",
+    globs: [
+      "src/metabase/internal_stats/**",
+      "src/metabase/analytics/**",
+    ],
+  },
+  {
+    specFolder: "table-editing",
+    globs: [
+      "frontend/src/metabase/admin/**",
+      "src/metabase/api/table.clj",
+      "src/metabase/api/field.clj",
+    ],
+  },
+  {
+    specFolder: "visualizations-charts",
+    globs: [
+      "frontend/src/metabase/visualizations/**",
+      "src/metabase/query_processor/**",
+    ],
+  },
+  {
+    specFolder: "visualizations-tabular",
+    globs: [
+      "frontend/src/metabase/visualizations/**",
+      "src/metabase/query_processor/**",
+    ],
+  },
+  {
+    // run all e2e tests if anything in these folders change
+    specFolder: "**",
+    globs: [
+      "e2e/support/**",
+      "frontend/src/metabase/*",
+      "src/metabase/core/**",
+      "src/metabase/server/**",
+      "src/metabase/api_routes/**",
+      "src/metabase/driver.clj",
+      "src/metabase/config/**",
+      "src/metabase/plugins/**",
+      "rspack.config.js",
+      "jest.config.js",
+      "cypress.env.json",
+    ]
+  }
+];
+
+module.exports = {
+  e2eMatrixMap,
+};

--- a/.github/workflows/e2e-matrix-builder.yml
+++ b/.github/workflows/e2e-matrix-builder.yml
@@ -11,6 +11,9 @@ on:
         required: false
         type: string
         default: "./e2e/test/scenarios/**/*.cy.spec.*"
+      run-all:
+        type: boolean
+        default: false
     outputs:
       matrix:
         value: ${{ jobs.build-matrix.outputs.matrix }}
@@ -29,13 +32,12 @@ jobs:
       isDefaultSpecPattern: ${{ steps.matrix.outputs.isDefaultSpecPattern }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          sparse-checkout: |
-            .github
-          sparse-checkout-cone-mode: false
       - uses: actions/setup-node@v4
         with:
           node-version: lts/Jod # 22.x.x
+      - run: |
+          git diff --name-only master > changed-files.txt
+      - run: npm i minimatch
       - name: Build e2e matrix
         uses: actions/github-script@v7
         id: matrix

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -19,8 +19,9 @@ jobs:
   e2e-matrix-builder:
     uses: ./.github/workflows/e2e-matrix-builder.yml
     with:
-      chunks: 50
+      chunks: 10 # this should be dynamic. querying runs more tests than admin
       specs: ${{ inputs.specs }}
+      run-all: false # TODO: make this work based on a label or branch name
 
   reset-e2e-test-comment:
     if: ${{ github.event_name == 'pull_request' }}

--- a/frontend/src/metabase/actions/actions.ts
+++ b/frontend/src/metabase/actions/actions.ts
@@ -14,6 +14,8 @@ export interface ExecuteActionOpts {
   parameters: ParametersForActionExecution;
 }
 
+// FIXME: code change to trigger tests
+
 export const executeAction =
   ({ action, parameters }: ExecuteActionOpts) =>
   async (dispatch: Dispatch): Promise<ActionFormSubmitResult> => {

--- a/package.json
+++ b/package.json
@@ -301,6 +301,7 @@
     "lint-staged": "^14",
     "loki": "^0.35.1",
     "mini-css-extract-plugin": "2.7.2",
+    "minimatch": "^10.1.2",
     "mocha": "^10.8.1",
     "mocha-junit-reporter": "^2.2.1",
     "mochawesome": "^7.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2630,6 +2630,13 @@
   dependencies:
     "@isaacs/balanced-match" "^4.0.1"
 
+"@isaacs/brace-expansion@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz#0ef5a92d91f2fff2a37646ce54da9e5f599f6eff"
+  integrity sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==
+  dependencies:
+    "@isaacs/balanced-match" "^4.0.1"
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -16034,6 +16041,13 @@ minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
+
+minimatch@^10.1.2:
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.1.2.tgz#6c3f289f9de66d628fa3feb1842804396a43d81c"
+  integrity sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==
+  dependencies:
+    "@isaacs/brace-expansion" "^5.0.1"
 
 minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"


### PR DESCRIPTION
## Problem

e2e tests take _forever_ to run, and often flake, which feels extra bad when you get a flake that doesn't even relate to anything your PR did. In a lot of situations, our e2e coverage is more trouble than it's worth.

## Extremely Dumb solution

Attempt to only run relevant e2e tests for a given set of code changes by:

1. use the e2e-matrix-map to define reasonable heuristics for which folders of code should trigger which folders of e2e tests.
2. for PRs, automatically run the subset of tests that are very likely to be relevant to the changes
3. allow you to run all changes with a `run-all-e2e` label (not implemented)
4. run all e2e tests on master and release branches (not implemented)


## Todo
1. Take a good pass on the map to improve the likelihood of running the right tests
2. make the run-all-e2e flag actually work
3. make the number of chunks dynamic

## Hypotheses
1. Everyone will love this for like 3 days, and then
2. There are enough complex dependencies that this heuristic will not run the right tests, and we'll merge some legitimately test-failing code to master and will have to go back and fix things a bunch
