### PR TITLE
Gdgt 1675 disable unmatched rows view details button in inspector

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformInspectPage/components/LensSections/DefaultLensSections/components/VisualizationCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformInspectPage/components/LensSections/DefaultLensSections/components/VisualizationCard.tsx
@@ -17,6 +17,7 @@ import type {
   CardDisplayType,
   Dataset,
   InspectorCard,
+  InspectorCardDisplayType,
   RawSeries,
 } from "metabase-types/api";
 import { createMockCard } from "metabase-types/api/mocks";
@@ -99,6 +100,7 @@ export const VisualizationCard = ({
             <Visualization
               rawSeries={rawSeries}
               showTitle={true}
+              // we want to have dashboard like experience: e.g. leaner UI, no column reordering, prevent row detail clicks
               isDashboard={true}
               actionButtons={actionButtons}
               getHref={getHref}
@@ -142,14 +144,16 @@ function getDisplayConfig(
 function buildRawSeries(
   dataset: Dataset | undefined,
   card: InspectorCard,
-  displayType: string,
+  displayType: InspectorCardDisplayType,
   displaySettings: Record<string, unknown>,
 ): RawSeries | undefined {
   if (!dataset) {
     return;
   }
+
   const vizDisplay: CardDisplayType =
-    displayType === "hidden" ? "table" : (displayType as CardDisplayType);
+    displayType === "hidden" ? "table" : displayType;
+
   return [
     {
       card: createMockCard({
@@ -159,7 +163,7 @@ function buildRawSeries(
         visualization_settings: {
           "graph.y_axis.labels_enabled": false,
           "graph.x_axis.labels_enabled": false,
-          "table.row_index": false,
+          "table.row_index": false, // hide row index column
           ...displaySettings,
           ...card.visualization_settings,
         },

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformInspectPage/components/LensSections/DefaultLensSections/components/VisualizationCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformInspectPage/components/LensSections/DefaultLensSections/components/VisualizationCard.tsx
@@ -99,6 +99,7 @@ export const VisualizationCard = ({
             <Visualization
               rawSeries={rawSeries}
               showTitle={true}
+              isDashboard={true}
               actionButtons={actionButtons}
               getHref={getHref}
               onChangeCardAndRun={onChangeCardAndRun}
@@ -158,6 +159,7 @@ function buildRawSeries(
         visualization_settings: {
           "graph.y_axis.labels_enabled": false,
           "graph.x_axis.labels_enabled": false,
+          "table.row_index": false,
           ...displaySettings,
           ...card.visualization_settings,
         },

--- a/frontend/src/metabase-types/api/transform.ts
+++ b/frontend/src/metabase-types/api/transform.ts
@@ -458,17 +458,7 @@ export type InspectorSection = {
   layout?: InspectorLayoutType;
 };
 
-export type InspectorCardDisplayType =
-  | "bar"
-  | "row"
-  | "line"
-  | "area"
-  | "pie"
-  | "scalar"
-  | "gauge"
-  | "progress"
-  | "table"
-  | "hidden";
+export type InspectorCardDisplayType = CardDisplayType | "hidden";
 
 export type InspectorCard = {
   id: string;


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-1675/disable-unmatched-rows-view-details-button-in-inspector

### Description

- Use `dashboard` preset that matches more the behavior we're looking for in Visualization in Transform's Inspector.
- Disable index row column.

### Demo

<img width="917" height="517" alt="image" src="https://github.com/user-attachments/assets/853a5032-8e98-4e7e-acbb-63e6ac4ff9c7" />
