### PR TITLE
Fix broken containerize workflow

### DIFF
--- a/.github/actions/fetch-artifact/action.yml
+++ b/.github/actions/fetch-artifact/action.yml
@@ -8,6 +8,10 @@ inputs:
   edition:
     description: Metabase edition (ee or oss)
     required: true
+  release:
+    description: Whether this is a release artifact (uses metabase-release- prefix)
+    required: false
+    default: "false"
   output-name:
     description: Optional custom name for the output jar file (defaults to metabase.jar)
     required: false
@@ -28,7 +32,9 @@ runs:
         script: | # js
           const fs = require('fs');
 
-          const artifactName = `metabase-${{ inputs.edition }}-${{ inputs.commit }}-uberjar`;
+          const isRelease = "${{ inputs.release }}" === "true";
+          const prefix = isRelease ? "metabase-release" : "metabase";
+          const artifactName = `${prefix}-${{ inputs.edition }}-${{ inputs.commit }}-uberjar`;
           console.log(`Looking for artifact: ${artifactName}`);
 
           const artifacts = await github.rest.actions.listArtifactsForRepo({

--- a/.github/workflows/containerize-jar.yml
+++ b/.github/workflows/containerize-jar.yml
@@ -17,7 +17,7 @@ on:
         type: string
       release:
         type: string
-        default: 'true'
+        default: 'false'
       build-args:
         type: string
   workflow_dispatch:

--- a/.github/workflows/containerize-jar.yml
+++ b/.github/workflows/containerize-jar.yml
@@ -38,6 +38,13 @@ on:
       commit:
         description: the full commit hash
         type: string
+      release:
+        description: Whether this is a release artifact (uses metabase-release- prefix)
+        type: choice
+        options:
+          - "false"
+          - "true"
+        default: "false"
 
 jobs:
   containerize:

--- a/.github/workflows/containerize-jar.yml
+++ b/.github/workflows/containerize-jar.yml
@@ -4,8 +4,10 @@ run-name: Containerize ${{ inputs.tag }} Uberjar
 on:
   workflow_call:
     inputs:
-      artifact-name:
+      edition:
+        description: Metabase edition (ee or oss)
         type: string
+        required: true
       repo:
         description: owner and repo like "metabase/metabase"
         type: string
@@ -20,9 +22,13 @@ on:
         type: string
   workflow_dispatch:
     inputs:
-      artifact-name:
-        description: usually something like "metabase-release-{{ edition }}-{{ hash }}-uberjar"
-        type: string
+      edition:
+        description: Metabase edition (ee or oss)
+        type: choice
+        options:
+          - ee
+          - oss
+        required: true
       repo:
         description: docker owner and repo like "metabase/metabase"
         type: string
@@ -45,10 +51,12 @@ jobs:
         fetch-depth: 0
       # we want the dockerfile from the commit we're building
     - run: git checkout ${{ inputs.commit }} -- bin/docker
-    - name: Retrieve test build uberjar artifact
+    - name: Retrieve uberjar artifact
       uses: ./.github/actions/fetch-artifact
       with:
-        name: ${{ inputs.artifact-name }}
+        commit: ${{ inputs.commit }}
+        edition: ${{ inputs.edition }}
+        release: ${{ inputs.release }}
     - name: Prepare build scripts
       run: cd ${{ github.workspace }}/release && yarn && yarn build
     - name: Get platforms

--- a/.github/workflows/containerize-uberjar.yml
+++ b/.github/workflows/containerize-uberjar.yml
@@ -55,7 +55,7 @@ jobs:
     uses: ./.github/workflows/containerize-jar.yml
     secrets: inherit
     with:
-      artifact-name: metabase-${{ matrix.edition }}-${{ github.event.inputs.commit || github.event.pull_request.head.sha || github.sha }}-uberjar
+      edition: ${{ matrix.edition }}
       commit: ${{ github.event.inputs.commit || github.sha }}
       repo: ${{ fromJson(needs.get-container-info.outputs[matrix.edition]).repo }}
       tag: ${{ fromJson(needs.get-container-info.outputs[matrix.edition]).tag }}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -234,6 +234,7 @@ jobs:
       commit: ${{ inputs.commit }}
       repo: ${{ vars.DOCKERHUB_OWNER }}/${{ vars.DOCKERHUB_STAGING_REPO }}
       tag: ${{ needs.release-artifact.outputs.oss_version }}-${{ inputs.commit }}
+      release: "true"
 
   containerize-ee:
     needs: release-artifact
@@ -244,6 +245,7 @@ jobs:
       commit: ${{ inputs.commit }}
       repo: ${{ vars.DOCKERHUB_OWNER }}/${{ vars.DOCKERHUB_STAGING_REPO }}
       tag: ${{ needs.release-artifact.outputs.ee_version }}-${{ inputs.commit }}
+      release: "true"
 
   tests-complete-message:
     if: always()

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -71,10 +71,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           sparse-checkout: .github
-      - name: Retrieve test build uberjar artifact for ${{ matrix.edition }}
+      - name: Retrieve release uberjar artifact for ${{ matrix.edition }}
         uses: ./.github/actions/fetch-artifact
         with:
-          name: metabase-release-${{ matrix.edition }}-${{ inputs.commit }}-uberjar
+          commit: ${{ inputs.commit }}
+          edition: ${{ matrix.edition }}
+          release: "true"
 
       - name: Extract version number from  version.properties
         id: version-properties
@@ -228,7 +230,7 @@ jobs:
     uses: ./.github/workflows/containerize-jar.yml
     secrets: inherit
     with:
-      artifact-name: metabase-release-oss-${{ inputs.commit }}-uberjar
+      edition: oss
       commit: ${{ inputs.commit }}
       repo: ${{ vars.DOCKERHUB_OWNER }}/${{ vars.DOCKERHUB_STAGING_REPO }}
       tag: ${{ needs.release-artifact.outputs.oss_version }}-${{ inputs.commit }}
@@ -238,7 +240,7 @@ jobs:
     uses: ./.github/workflows/containerize-jar.yml
     secrets: inherit
     with:
-      artifact-name: metabase-release-ee-${{ inputs.commit }}-uberjar
+      edition: ee
       commit: ${{ inputs.commit }}
       repo: ${{ vars.DOCKERHUB_OWNER }}/${{ vars.DOCKERHUB_STAGING_REPO }}
       tag: ${{ needs.release-artifact.outputs.ee_version }}-${{ inputs.commit }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,6 +265,7 @@ jobs:
       commit: ${{ inputs.commit }}
       repo: ${{ vars.DOCKERHUB_OWNER }}/${{ vars.DOCKERHUB_REPO }}
       tag: ${{ needs.check-version.outputs.oss }}
+      release: "true"
 
   containerize-ee:
     needs: check-version
@@ -275,6 +276,7 @@ jobs:
       commit: ${{ inputs.commit }}
       repo: ${{ vars.DOCKERHUB_OWNER }}/${{ vars.DOCKERHUB_REPO }}-enterprise
       tag: ${{ needs.check-version.outputs.ee }}
+      release: "true"
 
   push-tags:
     permissions: write-all

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,10 +140,12 @@ jobs:
     - uses: actions/checkout@v4
       with:
         sparse-checkout: .github
-    - name: Retrieve test build uberjar artifact for ${{ matrix.edition }}
+    - name: Retrieve release uberjar artifact for ${{ matrix.edition }}
       uses: ./.github/actions/fetch-artifact
       with:
-        name: metabase-release-${{ matrix.edition }}-${{ inputs.commit }}-uberjar
+        commit: ${{ inputs.commit }}
+        edition: ${{ matrix.edition }}
+        release: "true"
     - name: Check JAR version properties
       run: |
         # ensure actual jar checksum matches checksum file
@@ -259,7 +261,7 @@ jobs:
     uses: ./.github/workflows/containerize-jar.yml
     secrets: inherit
     with:
-      artifact-name: metabase-release-oss-${{ inputs.commit }}-uberjar
+      edition: oss
       commit: ${{ inputs.commit }}
       repo: ${{ vars.DOCKERHUB_OWNER }}/${{ vars.DOCKERHUB_REPO }}
       tag: ${{ needs.check-version.outputs.oss }}
@@ -269,7 +271,7 @@ jobs:
     uses: ./.github/workflows/containerize-jar.yml
     secrets: inherit
     with:
-      artifact-name: metabase-release-ee-${{ inputs.commit }}-uberjar
+      edition: ee
       commit: ${{ inputs.commit }}
       repo: ${{ vars.DOCKERHUB_OWNER }}/${{ vars.DOCKERHUB_REPO }}-enterprise
       tag: ${{ needs.check-version.outputs.ee }}


### PR DESCRIPTION
Resolves DEV-1451

## Summary

- Commit 8143e32165d unified artifact naming but left release workflows intact because they use a different naming pattern (metabase-release- prefix vs metabase-)
- This broke containerize-jar.yml which still expected an artifact-name input that no longer exists in fetch-artifact
- The fix extends the unified naming approach to support both patterns via a release flag, rather than maintaining two separate code paths

### Artifact Naming Convention
| Workflow Type | `release` Flag | Artifact Name Pattern |
|---------------|----------------|----------------------|
| Release builds | `true` | `metabase-release-{edition}-{commit}-uberjar` |
| PR/Test builds | `false` | `metabase-{edition}-{commit}-uberjar` |


> [!NOTE]
> Historical reason why we need different naming strategy for releases: https://github.com/metabase/metabase/pull/36663
