### PR TITLE
Automate js/ts stats update

### DIFF
--- a/.github/scripts/csv-to-mb.js
+++ b/.github/scripts/csv-to-mb.js
@@ -1,0 +1,41 @@
+/**
+ * jsonData must be in the format:
+ * [
+ *   { column1: value1, column2: value2, ... },
+ *   { column1: value3, column2: value4, ... },
+ *   ...
+ * ]
+ */
+function jsonToCsvFormData(jsonData) {
+  const formData = new FormData();
+  const csvHeader = Object.keys(jsonData[0]).join(',') + '\n';
+  const csvContent = jsonData.map(row =>
+    Object.values(row).map(value => `"${String(value).replace(/"/g, '""')}"`).join(',')
+  ).join('\n');
+
+  const blob = new Blob([csvHeader + csvContent], { type: 'text/csv' });
+  formData.append('file', blob, 'data.csv');
+
+  return formData;
+}
+
+function uploadCsvToMb({ baseUrl, tableID, jsonData, mode = 'append' }) {
+  const formData = jsonToCsvFormData(jsonData);
+  const operation = mode === 'replace' ? 'replace-csv' : 'append-csv';
+
+  return fetch(`${baseUrl}/api/table/${tableID}/${operation}`, {
+    method: 'POST',
+    headers: {
+      "x-api-key": process.env.API_KEY
+    },
+    body: formData
+  })
+  .then(response => {
+    if (!response.ok) {
+      throw new Error(`Upload failed`);
+    }
+    return { success: true };
+  });
+}
+
+module.exports = { uploadCsvToMb };

--- a/.github/scripts/csv-to-mb.js
+++ b/.github/scripts/csv-to-mb.js
@@ -19,11 +19,11 @@ function jsonToCsvFormData(jsonData) {
   return formData;
 }
 
-function uploadCsvToMb({ baseUrl, tableID, jsonData, mode = 'append' }) {
+function uploadCsvToMb({ baseUrl, tableId, jsonData, mode = 'append' }) {
   const formData = jsonToCsvFormData(jsonData);
   const operation = mode === 'replace' ? 'replace-csv' : 'append-csv';
 
-  return fetch(`${baseUrl}/api/table/${tableID}/${operation}`, {
+  return fetch(`${baseUrl}/api/table/${tableId}/${operation}`, {
     method: 'POST',
     headers: {
       "x-api-key": process.env.API_KEY

--- a/.github/workflows/js-stats-update.yml
+++ b/.github/workflows/js-stats-update.yml
@@ -1,0 +1,50 @@
+name: JS Stats Update
+
+on:
+  pull_request: ## FIXME: for testing
+  schedule:
+    - cron: 40 1 * * 4 # every Thursday at 1:40
+
+jobs:
+  js-stats:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: get JS file count
+        run: |
+          oss=$(find ./frontend/src/metabase -type f -name "*.js" -o -name "*.jsx" | wc -l)
+          ee=$(find ./enterprise/frontend/src/metabase-enterprise -type f -name "*.js" -o -name "*.jsx" | wc -l)
+
+          echo $(($oss+$ee)) javascript files
+
+          echo "JS_FILES=$(($oss+$ee))" >> $GITHUB_OUTPUT
+      - name: Upload count to Stats
+        uses: actions/github-script@v7
+        env:
+          JS_FILES: ${{ steps.get-js-file-count.outputs.JS_FILES }}
+          API_KEY: ${{ secrets.STATS_API_KEY }}
+        with:
+          script: | # js
+            const { uploadCsvToMb } = require('${{ github.workspace }}/.github/scripts/csv-to-mb.js');
+
+            console.log("JS_FILES", process.env.JS_FILES);
+
+            const data = [
+              {
+                'Date': new Date().toISOString().slice(0, 10), // YYYY-MM-DD
+                'Js files': Number(process.env.JS_FILES),
+              }
+            ];
+
+            uploadCsvToMb({
+              baseUrl: 'https://stats.metabase.com',
+              jsonData: data,
+              tableId: 73270,
+              mode: 'append',
+            }).then(() => {
+              console.log('Data uploaded successfully');
+            }).catch((error) => {
+              console.error('Error uploading data:', error);
+              process.exit(1);
+            });

--- a/.github/workflows/js-stats-update.yml
+++ b/.github/workflows/js-stats-update.yml
@@ -12,6 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: get JS file count
+        id: get-js-file-count
         run: |
           oss=$(find ./frontend/src/metabase -type f -name "*.js" -o -name "*.jsx" | wc -l)
           ee=$(find ./enterprise/frontend/src/metabase-enterprise -type f -name "*.js" -o -name "*.jsx" | wc -l)

--- a/.github/workflows/js-stats-update.yml
+++ b/.github/workflows/js-stats-update.yml
@@ -2,6 +2,7 @@ name: JS Stats Update
 
 on:
   pull_request: ## FIXME: for testing
+  workflow_dispatch:
   schedule:
     - cron: 40 1 * * 4 # every Thursday at 1:40
 
@@ -29,7 +30,7 @@ jobs:
           script: | # js
             const { uploadCsvToMb } = require('${{ github.workspace }}/.github/scripts/csv-to-mb.js');
 
-            console.log("JS_FILES", process.env.JS_FILES);
+            console.log("JS_FILES", Number(process.env.JS_FILES));
 
             const data = [
               {
@@ -40,8 +41,8 @@ jobs:
 
             uploadCsvToMb({
               baseUrl: 'https://stats.metabase.com',
-              jsonData: data,
               tableId: 73270,
+              jsonData: data,
               mode: 'append',
             }).then(() => {
               console.log('Data uploaded successfully');

--- a/.github/workflows/js-stats-update.yml
+++ b/.github/workflows/js-stats-update.yml
@@ -1,7 +1,6 @@
 name: JS Stats Update
 
 on:
-  pull_request: ## FIXME: for testing
   workflow_dispatch:
   schedule:
     - cron: 40 1 * * 4 # every Thursday at 1:40


### PR DESCRIPTION
Closes UXW-2969

### Description

Every Thursday, this will count our total JS files and upload it to this table on stats:
http://localhost:3000/model/1727-javascript-eradication-progress-2026-02-02t15-41-58-490826646-08-00

Adds a reusable JS function that we can use to either append or replace data on any already-existing CSV-upload table on any metabase instance via API key

✅ [Successful Upload](https://github.com/metabase/metabase/actions/runs/21715315030/job/62629465175?pr=69167)