### PR TITLE
GDGT-898: Make 'Connected to' items look clickable in Detail view

### DIFF
--- a/frontend/src/metabase/detail-view/components/Relationships/Relationship/Relationship.module.css
+++ b/frontend/src/metabase/detail-view/components/Relationships/Relationship/Relationship.module.css
@@ -1,9 +1,17 @@
+.root {
+  padding: var(--mantine-spacing-sm) var(--mantine-spacing-md);
+  border-radius: var(--mantine-radius-md);
+}
+
 .clickable {
-  color: var(--mb-color-text-primary) !important;
+  cursor: pointer;
 
   &:hover {
-    .text {
-      color: var(--mb-color-brand) !important;
+    background-color: var(--mb-color-background-hover);
+
+    .text,
+    .icon {
+      color: var(--mb-color-brand-hover) !important;
     }
   }
 }

--- a/frontend/src/metabase/detail-view/components/Relationships/Relationship/Relationship.tsx
+++ b/frontend/src/metabase/detail-view/components/Relationships/Relationship/Relationship.tsx
@@ -56,7 +56,8 @@ export const Relationship = ({ fk, rowId, onClick }: Props) => {
 
     return dataset.data.rows[0]?.[0] ?? 0; // rows array can be empty (metabase#62156)
   }, [dataset]);
-  const clickable = typeof count === "number" && count > 0;
+  const clickable =
+    typeof count === "number" && count > 0 && fkQuestionUrl != null;
   const originTableName = fk.origin?.table?.display_name ?? "";
   const relationName =
     typeof count === "number"
@@ -66,17 +67,8 @@ export const Relationship = ({ fk, rowId, onClick }: Props) => {
   const textColor =
     count === 0 ? "text-tertiary" : clickable ? "brand" : "text-secondary";
 
-  return (
-    <Flex
-      className={cx(S.root, {
-        [S.clickable]: clickable,
-      })}
-      align="center"
-      justify="space-between"
-      {...(clickable
-        ? { component: Link, to: fkQuestionUrl, onClick }
-        : undefined)}
-    >
+  const content = (
+    <>
       <Stack gap={rem(12)}>
         {isFetching && <Loader data-testid="loading-indicator" size="md" />}
 
@@ -94,6 +86,29 @@ export const Relationship = ({ fk, rowId, onClick }: Props) => {
       {clickable && (
         <Icon className={S.icon} name="chevronright" c="brand" aria-hidden />
       )}
+    </>
+  );
+
+  const className = cx(S.root, { [S.clickable]: clickable });
+
+  if (clickable) {
+    return (
+      <Flex
+        component={Link}
+        to={fkQuestionUrl}
+        onClick={onClick}
+        className={className}
+        align="center"
+        justify="space-between"
+      >
+        {content}
+      </Flex>
+    );
+  }
+
+  return (
+    <Flex className={className} align="center" justify="space-between">
+      {content}
     </Flex>
   );
 };

--- a/frontend/src/metabase/detail-view/components/Relationships/Relationship/Relationship.tsx
+++ b/frontend/src/metabase/detail-view/components/Relationships/Relationship/Relationship.tsx
@@ -8,7 +8,7 @@ import { t } from "ttag";
 import { skipToken, useGetAdhocQueryQuery } from "metabase/api";
 import { useSelector } from "metabase/lib/redux";
 import { getMetadata } from "metabase/selectors/metadata";
-import { Loader, Stack, Text, rem } from "metabase/ui";
+import { Flex, Icon, Loader, Stack, Text, rem } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import type { ForeignKey } from "metabase-types/api";
 
@@ -63,38 +63,37 @@ export const Relationship = ({ fk, rowId, onClick }: Props) => {
       ? inflect(originTableName, count)
       : originTableName;
 
+  const textColor =
+    count === 0 ? "text-tertiary" : clickable ? "brand" : "text-secondary";
+
   return (
-    <Stack
-      className={cx({
+    <Flex
+      className={cx(S.root, {
         [S.clickable]: clickable,
       })}
-      gap={rem(12)}
+      align="center"
+      justify="space-between"
       {...(clickable
         ? { component: Link, to: fkQuestionUrl, onClick }
         : undefined)}
     >
-      {isFetching && <Loader data-testid="loading-indicator" size="md" />}
+      <Stack gap={rem(12)}>
+        {isFetching && <Loader data-testid="loading-indicator" size="md" />}
 
-      {!isFetching && (
-        <Text
-          c={count === 0 ? "text-tertiary" : "text-secondary"}
-          className={S.text}
-          fw="bold"
-          fz={rem(24)}
-          lh={1}
-        >
-          {error ? t`Unknown` : String(count)}
+        {!isFetching && (
+          <Text c={textColor} className={S.text} fw="bold" fz={rem(24)} lh={1}>
+            {error ? t`Unknown` : String(count)}
+          </Text>
+        )}
+
+        <Text c={textColor} className={S.text} fw="bold" lh={1}>
+          {relationName}
         </Text>
-      )}
+      </Stack>
 
-      <Text
-        c={count === 0 ? "text-tertiary" : "text-secondary"}
-        className={S.text}
-        fw="bold"
-        lh={1}
-      >
-        {relationName}
-      </Text>
-    </Stack>
+      {clickable && (
+        <Icon className={S.icon} name="chevronright" c="brand" aria-hidden />
+      )}
+    </Flex>
   );
 };


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-898

### Description

The "Connected to" items in Detail views (showing related records like "93 Orders", "8 Reviews") looked like plain text without any visual indication they were clickable. This PR adds visual cues to make them appear interactive:

- Brand color for text when item is clickable (count > 0)
- Chevron icon on the right side
- Hover state with background highlight and cursor pointer
- Non-clickable items (count = 0) remain gray without icon

### How to verify

1. Open any table with foreign key relationships (e.g., Products table in Sample Database)
2. Click on a row to open the Detail view sidesheet
3. Look at the "Connected to" section on the right
4. Verify items with count > 0 show in brand color with a chevron icon
5. Hover over them to see the background highlight
6. Items with count = 0 should appear gray without chevron

### Demo

<img width="712" height="863" alt="image" src="https://github.com/user-attachments/assets/30748f73-a335-4ed0-8efa-89b7075ad885" />

