### PR TITLE
make sure database is initialized

### DIFF
--- a/test/metabase/upload/db_test.clj
+++ b/test/metabase/upload/db_test.clj
@@ -2,8 +2,11 @@
   (:require
    [clojure.test :refer :all]
    [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
    [metabase.upload.db :as upload.db]
    [toucan2.core :as t2]))
+
+(use-fixtures :once (fixtures/initialize :db))
 
 (deftest current-database-test
   (mt/with-discard-model-updates! [:model/Database]


### PR DESCRIPTION
seeing error in CI:

```
ERROR in metabase.upload.db-test/current-database-test (DbException.java:502)
Uncaught exception, not in assertion.

             clojure.lang.ExceptionInfo: Table "METABASE_DATABASE" not found (this database is empty); SQL statement:
                                         SELECT * FROM "METABASE_DATABASE" WHERE "UPLOADS_ENABLED" = TRUE [42104-214]
```

https://github.com/metabase/metabase/actions/runs/21711162702/job/62620032674

we just need to ensure that the db is initialized first