### PR TITLE
Update table email styles to match frontend

### DIFF
--- a/src/metabase/channel/render/style.clj
+++ b/src/metabase/channel/render/style.clj
@@ -56,6 +56,10 @@
   "Color for dark text."
   "#4C5773")
 
+(def ^:const color-text-primary
+  "Color that matches text-primary used in the frontend"
+  "#303D46")
+
 (def ^:const color-border
   "Used as color for the border of table, table header, and table body rows for charts with `:table` visualization."
   "#F0F0F0")

--- a/src/metabase/channel/render/table.clj
+++ b/src/metabase/channel/render/table.clj
@@ -16,7 +16,7 @@
    (style/font-style)
    {:font-size       (format "%spx" style/font-size)
     :font-weight     700
-    :color           style/color-text-dark
+    :color           style/color-text-primary
     :border-bottom   (str "2px solid " style/color-border)
     :border-right    0}))
 
@@ -24,9 +24,9 @@
   (merge
    (style/font-style)
    {:font-size      (format "%spx" style/font-size)
-    :font-weight    400
+    :font-weight    700
     :text-align     :left
-    :color          style/color-text-dark
+    :color          style/color-text-primary
     :border-bottom  (str "1px solid " style/color-border)
     :border-right   (str "1px solid " style/color-border)
     :padding        (format "%sem %sem" style/td-y-padding-em style/td-x-padding-em)}))


### PR DESCRIPTION
Closes #66833

### Description

When sending a table via email, the backend uses a lighter font for table cells than the frontend, which could make the table unreadable in the email if a dark conditional formatting is applied. This PR updates the backend to use the same styles as the frontend

### How to verify

Follow the steps in #66833

### Demo

Before:
<img width="179" height="184" alt="image" src="https://github.com/user-attachments/assets/e999996d-2b19-47ca-a2d4-2fd15bfac771" />

After. This is an extreme example and obviously isn't that readable. But it matches the frontend, and presumably the user is happy with how the formatting looks in the frontend before sending via email - the key is that the backend just needs to match the frontend:
<img width="180" height="182" alt="image" src="https://github.com/user-attachments/assets/a6c91713-a4bf-4c60-ab68-3d971f5396a8" />

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
