### PR TITLE
feat: allow empty min and max for scalar conditional colors

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/scalar.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-charts/scalar.cy.spec.ts
@@ -1,0 +1,58 @@
+const { H } = cy;
+import Color from "color";
+
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+
+const { ORDERS_ID } = SAMPLE_DATABASE;
+
+describe("scenarios > visualizations > scalar", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should allow open-ended conditional color ranges", () => {
+    H.createQuestion({
+      query: {
+        "source-table": ORDERS_ID,
+        aggregation: [["count"]],
+      },
+      display: "scalar",
+    }).then(({ body: { id } }) => {
+      cy.visit(`/question/${id}`);
+      cy.findByTestId("query-visualization-root", { timeout: 20000 })
+        .findByTestId("scalar-value")
+        .should("be.visible");
+    });
+
+    H.openVizSettingsSidebar();
+    H.sidebar().findByText("Conditional colors").click();
+
+    cy.findByRole("button", { name: /add a range/i }).click();
+
+    cy.findAllByPlaceholderText("Min").eq(0).clear().blur();
+    cy.findAllByPlaceholderText("Max").eq(0).clear().type("1000").blur();
+
+    cy.findByRole("button", { name: /add a range/i }).click();
+
+    cy.findAllByPlaceholderText("Min").eq(1).clear().type("1000").blur();
+    cy.findAllByPlaceholderText("Max").eq(1).clear().blur();
+
+    cy.findAllByTestId("color-selector-button").eq(1).click();
+    H.popover()
+      .findAllByRole("button")
+      .eq(4)
+      .then(($button) => {
+        const color = $button.attr("aria-label");
+        cy.wrap($button).click();
+        cy.findByTestId("scalar-value").should(
+          "have.css",
+          "color",
+          Color(color).rgb().string(),
+        );
+      });
+
+    cy.findByTestId("scalar-value").realHover();
+    H.tooltip().should("contain.text", "≤ 1000").and("contain.text", "≥ 1000");
+  });
+});

--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -498,8 +498,8 @@ export type ListViewColumns = {
 };
 
 export type ScalarSegment = {
-  min: number;
-  max: number;
+  min: number | null;
+  max: number | null;
   color: string;
   label?: string;
 };

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingSegmentsEditor/ChartSettingSegmentsEditor.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingSegmentsEditor/ChartSettingSegmentsEditor.tsx
@@ -27,7 +27,7 @@ export const ChartSettingSegmentsEditor = ({
   const onChangeProperty = (
     index: number,
     property: keyof ScalarSegment,
-    value: number | string,
+    value: number | string | null,
   ) =>
     onChange([
       ...segments.slice(0, index),
@@ -71,9 +71,11 @@ export const ChartSettingSegmentsEditor = ({
                 <td>
                   <NumberInput
                     className={CS.full}
-                    value={segment.min}
+                    value={segment.min ?? ""}
                     onBlur={(e) => {
-                      const newValue = parseFloat(e.target.value);
+                      const rawValue = e.target.value;
+                      const newValue =
+                        rawValue === "" ? null : parseFloat(rawValue);
                       if (newValue !== segment.min) {
                         onChangeProperty(index, "min", newValue);
                       }
@@ -85,9 +87,11 @@ export const ChartSettingSegmentsEditor = ({
                 <td>
                   <NumberInput
                     className={CS.full}
-                    value={segment.max}
+                    value={segment.max ?? ""}
                     onBlur={(e) => {
-                      const newValue = parseFloat(e.target.value);
+                      const rawValue = e.target.value;
+                      const newValue =
+                        rawValue === "" ? null : parseFloat(rawValue);
                       if (newValue !== segment.max) {
                         onChangeProperty(index, "max", newValue);
                       }
@@ -144,6 +148,10 @@ function getColorPalette() {
 function newSegment(segments: ScalarSegment[]) {
   const palette = getColorPalette();
   const lastSegment = segments[segments.length - 1];
+  const lastMax =
+    typeof lastSegment?.max === "number" && Number.isFinite(lastSegment.max)
+      ? lastSegment.max
+      : null;
   const lastColorIndex = lastSegment
     ? _.findIndex(palette, (color) => color === lastSegment.color)
     : -1;
@@ -153,8 +161,8 @@ function newSegment(segments: ScalarSegment[]) {
       : palette[0];
 
   return {
-    min: lastSegment ? lastSegment.max : 0,
-    max: lastSegment ? lastSegment.max * 2 : 1,
+    min: lastMax !== null ? lastMax : 0,
+    max: lastMax !== null ? lastMax * 2 : 1,
     color: nextColor,
     label: "",
   };

--- a/frontend/src/metabase/visualizations/lib/utils.js
+++ b/frontend/src/metabase/visualizations/lib/utils.js
@@ -518,5 +518,11 @@ export function findSensibleSankeyColumns(data) {
   };
 }
 
-export const segmentIsValid = ({ min, max }) =>
-  !isNaN(min) && !isNaN(max) && min !== null && max !== null;
+export const segmentIsValid = (
+  { min, max },
+  { allowOpenEnded = false } = {},
+) => {
+  const hasMin = typeof min === "number" && Number.isFinite(min);
+  const hasMax = typeof max === "number" && Number.isFinite(max);
+  return allowOpenEnded ? hasMin || hasMax : hasMin && hasMax;
+};

--- a/frontend/src/metabase/visualizations/visualizations/Scalar/Scalar.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Scalar/Scalar.tsx
@@ -195,7 +195,9 @@ export class Scalar extends Component<
       jsx: true,
     };
 
-    const segments = settings["scalar.segments"]?.filter(segmentIsValid);
+    const segments = settings["scalar.segments"]?.filter((segment) =>
+      segmentIsValid(segment, { allowOpenEnded: true }),
+    );
 
     const color = getColor(value, segments);
     const tooltipContent = getTooltipContent(segments);

--- a/src/metabase/channel/render/body.clj
+++ b/src/metabase/channel/render/body.clj
@@ -88,9 +88,11 @@
 (defn get-color-from-segment
   "Returns the color of the first segment who's max is higher than value and min is lower than value"
   [viz-settings value]
-  (let [{segments :scalar.segments} viz-settings]
+  (let [{segments :scalar.segments} viz-settings
+        ->min (fn [min] (if (number? min) min Double/NEGATIVE_INFINITY))
+        ->max (fn [max] (if (number? max) max Double/POSITIVE_INFINITY))]
     (some (fn [{:keys [min max color]}]
-            (when (and (some? min) (some? max) (<= min value max))
+            (when (<= (->min min) value (->max max))
               color))
           segments)))
 


### PR DESCRIPTION
Closes [UXW-2849: Allow empty min and max for scalar conditional colors](https://linear.app/metabase/issue/UXW-2849/allow-empty-min-and-max-for-scalar-conditional-colors)

### Description

Treat empty min and max as -Infinity and +Infinity instead of as incorrect.

### How to verify

1. New question -> Visualize -> Number
2. Set some conditions with empty max or min

### Demo

https://github.com/user-attachments/assets/76cdf8a6-1a9d-4739-b7a0-d73ae640aa84

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
