### PR TITLE
Scalar viz ensure field to select has a section

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/Scalar/Scalar.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Scalar/Scalar.tsx
@@ -70,6 +70,9 @@ export class Scalar extends Component<
 
   static settings = {
     ...fieldSetting("scalar.field", {
+      get section() {
+        return t`Formatting`;
+      },
       get title() {
         return t`Field to show`;
       },

--- a/frontend/src/metabase/visualizations/visualizations/Scalar/Scalar.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Scalar/Scalar.unit.spec.tsx
@@ -1,8 +1,17 @@
+import userEvent from "@testing-library/user-event";
 import type { ComponentProps } from "react";
 
-import { render, screen } from "__support__/ui";
+import { render, renderWithProviders, screen, within } from "__support__/ui";
+import { registerVisualization } from "metabase/visualizations";
+import { QuestionChartSettings } from "metabase/visualizations/components/ChartSettings";
 import type { Series } from "metabase-types/api";
-import { createMockCard, createMockColumn } from "metabase-types/api/mocks";
+import {
+  createMockCard,
+  createMockColumn,
+  createMockDataset,
+  createMockDatasetData,
+  createMockSingleSeries,
+} from "metabase-types/api/mocks";
 
 import { Scalar } from "./Scalar";
 
@@ -82,5 +91,81 @@ describe("Scalar", () => {
     // The container should not have text-overflow: ellipsis
     // as the ScalarValue component handles sizing to fit
     expect(styles.textOverflow).not.toBe("ellipsis");
+  });
+});
+
+describe("scalar viz settings", () => {
+  beforeAll(() => {
+    // @ts-expect-error: incompatible prop types with registerVisualization
+    registerVisualization(Scalar);
+  });
+
+  it("should render the field to show input in the formatting section if there are 2 or more columns", async () => {
+    const series = [
+      createMockSingleSeries(
+        createMockCard({ display: "scalar" }),
+        createMockDataset({
+          data: createMockDatasetData({
+            cols: [
+              createMockColumn({
+                display_name: "FOO",
+                source: "native",
+                name: "FOO",
+              }),
+              createMockColumn({
+                display_name: "BAR",
+                source: "native",
+                name: "BAR",
+              }),
+            ],
+          }),
+        }),
+      ),
+    ];
+    renderWithProviders(<QuestionChartSettings series={series} />);
+
+    expect(
+      await screen.findByRole("radio", { name: "Formatting" }),
+    ).toBeChecked();
+    expect(await screen.findByText("Field to show")).toBeInTheDocument();
+
+    const getFieldSelect = async () =>
+      await within(
+        await screen.findByTestId("chart-settings-widget-scalar.field"),
+      ).findByRole("textbox");
+
+    expect(await getFieldSelect()).toHaveDisplayValue("FOO");
+    await userEvent.click(await getFieldSelect());
+
+    expect(await screen.findByRole("listbox")).toHaveTextContent("FOO");
+    expect(await screen.findByRole("listbox")).toHaveTextContent("BAR");
+  });
+
+  it("should not render the field to show input in the formatting section if there is only 1 columns", async () => {
+    const series = [
+      createMockSingleSeries(
+        createMockCard({ display: "scalar" }),
+        createMockDataset({
+          data: createMockDatasetData({
+            cols: [
+              createMockColumn({
+                display_name: "BAR",
+                source: "native",
+                name: "BAR",
+              }),
+            ],
+          }),
+        }),
+      ),
+    ];
+    renderWithProviders(<QuestionChartSettings series={series} />);
+
+    expect(
+      await screen.findByRole("radio", { name: "Formatting" }),
+    ).toBeChecked();
+
+    expect(
+      screen.queryByTestId("chart-settings-widget-scalar.field"),
+    ).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
### Description
When Conditional formatting was introduced to Scalar viz types, it also introduced an additional section in the chart settings props. That meant that the "Field to show" setting needed to have a specific section defined, or else it could end up where we don't want it (which it did). This setting only appears when there is more than 1 column in the series, which is why it wasn't caught before

### How to verify
1. Set up a question that has 2 aggregations (Count and Sum, for example)
2. Visualize as a Number
3. Note that the field to show settings shows up int he formatting section, not the conditional colors section

### Demo
<img width="1015" height="893" alt="image" src="https://github.com/user-attachments/assets/cfd65ede-2d4e-4423-a7a7-89730a116ac2" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] ~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~