### PR TITLE
update edit table metadata button link to stay in data studio

### DIFF
--- a/frontend/src/metabase/transforms/pages/TransformSettingsPage/TransformSettingsSection/TargetSection.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformSettingsPage/TransformSettingsSection/TargetSection.unit.spec.tsx
@@ -16,6 +16,7 @@ import type {
 } from "metabase-types/api";
 import {
   createMockDatabase,
+  createMockTable,
   createMockTokenFeatures,
   createMockTransform,
   createMockTransformOwner,
@@ -163,5 +164,36 @@ describe("OwnerSection", () => {
       }),
     });
     expect(screen.getByText("Ownership")).toBeInTheDocument();
+  });
+});
+
+describe("TargetSection", () => {
+  it("should not render a edit table metadata button when the target table does not exist", async () => {
+    setup({});
+
+    expect(
+      await screen.findByRole("button", { name: /Change target/ }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole("link", { name: /Edit this table/ }),
+    ).not.toBeInTheDocument();
+  });
+  it("should link you to a page where you can edit the target tables metadata", async () => {
+    setup({
+      transform: createMockTransform({
+        table: createMockTable(),
+      }),
+    });
+
+    expect(
+      await screen.findByRole("button", { name: /Change target/ }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("link", { name: /Edit this table/ }),
+    ).toHaveAttribute(
+      "href",
+      expect.stringContaining("/data-studio/data/database"),
+    );
   });
 });

--- a/frontend/src/metabase/transforms/pages/TransformSettingsPage/TransformSettingsSection/TransformSettingsSection.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformSettingsPage/TransformSettingsSection/TransformSettingsSection.tsx
@@ -237,7 +237,7 @@ function EditMetadataButton({ transform }: EditMetadataButtonProps) {
   return (
     <Button
       component={Link}
-      to={Urls.dataModel({
+      to={Urls.dataStudioData({
         databaseId: table.db_id,
         schemaName: table.schema,
         tableId: table.id,


### PR DESCRIPTION
### Description
Small change to update the URL that the "Edit this table's metadata" button points to to keep users in the data studio, rather than link to the metadata editor in Admin

### How to verify
1. Set up a transform and run it
2. in the settings tab of the transform, there should be a button to edit the target table's metadata
3. Click the button, and you should be brought to the data tab in the data studio

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] ~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~
