### PR TITLE
[deps] Split "supported" entities into analyzable and dependable

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/dependencies/findings.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/findings.clj
@@ -59,13 +59,24 @@
            (log/errorf e "Analyzing entity %s %s failed"
                        (t2/model instance) (:id instance))))))
 
-(def supported-entities
-  "Entities supported by the analysis findings code"
-  #{:card :transform :segment :table})
+(def analyzable-entities
+  "Entities for which we can compute analysis findings."
+  #{:card :transform :segment})
 
-(def ^:private SupportedEntityType
+(def ^:private AnalyzableEntityType
   "Schema for entity types supported by analysis findings."
-  (into [:enum] supported-entities))
+  (into [:enum] analyzable-entities))
+
+(def dependable-entities
+  "Entities which can be depended on by other entities, even if they cannot themselves be analyzed.
+
+  For example, `:table`s can be passed to [[mark-dependents-stale!]] as the upstream entity whose dependents are now
+  stale, but we cannot analyze tables themselves."
+  (conj analyzable-entities :table))
+
+(def ^:private DependableEntityType
+  "Schema for entity types supported by analysis findings."
+  (into [:enum] dependable-entities))
 
 (defn- mark-supported-dependents-stale!
   "Given a map of {entity-type [entity-ids]}, mark all supported types as stale.
@@ -73,7 +84,7 @@
   [dependents]
   (let [supported-dependents (into {}
                                    (filter (fn [[dep-type dep-ids]]
-                                             (and (supported-entities dep-type)
+                                             (and (analyzable-entities dep-type)
                                                   (seq dep-ids))))
                                    dependents)]
     (doseq [[dep-type dep-ids] supported-dependents]
@@ -87,7 +98,7 @@
   Uses `transitive-dependents` (not `transitive-mbql-dependents`) because:
   1. It's faster - doesn't need to fetch entities to check for native-ness
   2. Native dependents marked stale will just be quickly re-validated as valid"
-  [entity-type :- SupportedEntityType
+  [entity-type :- DependableEntityType
    entity-id   :- pos-int?]
   (let [dependents (models.dependency/transitive-dependents {entity-type [{:id entity-id}]})]
     (mark-supported-dependents-stale! dependents)))
@@ -106,7 +117,7 @@
 
   Takes in an entity type and batch size, and looks for a batch of entities with missing or out of date
   AnalysisFindings and then upsert new analyses for them."
-  [type :- SupportedEntityType
+  [type :- AnalyzableEntityType
    batch-size :- pos-int?]
   (let [instances (deps.analysis-finding/instances-for-analysis type batch-size)]
     (lib-be/with-metadata-provider-cache

--- a/enterprise/backend/src/metabase_enterprise/dependencies/task/entity_check.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/task/entity_check.clj
@@ -21,7 +21,7 @@
                       (log/info "Updated" processed "entities of type" entity-type))
                     (- batch-size processed))))
               (deps.settings/dependency-entity-check-batch-size)
-              deps.findings/supported-entities)
+              deps.findings/analyzable-entities)
       (< 1)))
 
 (defn- check-entities!


### PR DESCRIPTION
Fixes QUE-3070.

### Description

This splits the vague, dual-purpose `supported-entities` into two:
- those entities which can be depended on, whose dependents get marked
  stale when they're updated (eg. a table during sync)
- those entities which we can analyze, and should check for staleness

I added `:table` to the old `supported-entities` since they're a valid
*upstream* dependency that might needs its downstream dependents to be
marked as stale, and it failed the schema.

The trouble is that we don't run analysis on tables, but the same set of
"supported" types was used to check for what entities need reanalysis.

That led to a chain like this:
- Something changed, and the entity-check job is scheduled immediately.
- It runs, and checks each `supported-entities` for any entity with
  a missing, `stale` or outdated analysis finding.
- That list now includes tables, and since tables are not analyzed none
  of them have entries - so there's apparently lots of work to do!
- On trying to analyze tables, it fails because they're not supported,
  and it silently does nothing.
- But the batch draining logic still thinks the whole batch was used, so
  it reschedules.
- No real progress is getting made, since the tables cannot really be
  analyzed, therefore they never get marked as done.
- Infinite loop spinning forever!


### How to verify

I can't reproduce the infinite loop of reanalysis locally, with this change
in place.

1. The deps analysis job runs some minutes after startup, and then every hour-ish.
2. But you can trigger it by editing a card.
3. It never stops trying to analyze batch after batch, because it always thinks there are missing analyses for tables.

With this change, the latter doesn't happen anymore.

### Checklist

- ~~Tests have been added/updated to cover changes in this PR~~
    - I don't think it's practical to write a test for this.
