### PR TITLE
Fix Dockerfile build when VERSION is unset

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN npm install -g bun
 # install frontend dependencies
 RUN bun install --frozen-lockfile
 
-RUN INTERACTIVE=false CI=true MB_EDITION=$MB_EDITION bin/build.sh :version ${VERSION}
+RUN INTERACTIVE=false CI=true MB_EDITION=$MB_EDITION bin/build.sh ${VERSION:+:version} ${VERSION:+$VERSION}
 
 # ###################
 # # STAGE 2: runner

--- a/bin/build/src/build/version_properties.clj
+++ b/bin/build/src/build/version_properties.clj
@@ -38,7 +38,7 @@
                    (str (name k) \= v))))
 
 (defn- most-recent-tag []
-  (shell-output-when-nonzero "git" "describe" "--abbrev=0" "--tags"))
+  (shell-output-when-nonzero "git" "describe" "--abbrev=0" "--tags" "--match" "v[01].[0-9]*.[0-9]*"))
 
 (defn- tag-parts [tag]
   (when tag

--- a/bin/build/test/build/version_properties_test.clj
+++ b/bin/build/test/build/version_properties_test.clj
@@ -1,7 +1,33 @@
 (ns build.version-properties-test
   (:require
    [build.version-properties :as version-properties]
-   [clojure.test :refer :all]))
+   [clojure.test :refer :all]
+   [clojure.tools.build.api :as b]
+   [metabuild-common.core :as u])
+  (:import
+   (java.nio.file Files)
+   (java.nio.file.attribute FileAttribute)))
+
+(deftest most-recent-tag-test
+  (let [repo (str (Files/createTempDirectory "metabase-version-properties-test-" (make-array FileAttribute 0)))
+        git! (fn [& args]
+               (apply u/sh {:dir repo, :quiet? true} "git" args))
+        sh*  u/sh*]
+    (try
+      (git! "init" "--quiet")
+      (git! "config" "user.email" "test@metabase.com")
+      (git! "config" "user.name" "Metabase Test")
+      (git! "commit" "--quiet" "--allow-empty" "--message" "Metabase release")
+      (git! "tag" "v0.60.0-beta")
+      (git! "commit" "--quiet" "--allow-empty" "--message" "Custom viz release")
+      (git! "tag" "custom-viz-v2.0.0-canary.0")
+      (with-redefs [u/sh* (fn [& args]
+                            (apply sh* {:dir repo, :quiet? true} args))]
+        (is (= "v0.60.0-beta"
+               (#'version-properties/most-recent-tag))
+            "Metabase version detection should ignore component release tags"))
+      (finally
+        (b/delete {:path repo})))))
 
 (deftest tag-parts-test
   (doseq [[tag expected] {nil          nil


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/58322

### Description

The command defined in the docs section [Build a Metabase Uberjar in a containerized environment](https://www.metabase.com/docs/latest/developers-guide/build#build-a-metabase-uberjar-in-a-containerized-environment) does not work because the docker argument `VERSION` must be set.

Adding a specific version as an argument solved solved the issue:
```bash
DOCKER_BUILDKIT=1 docker build --build-arg VERSION=v1.54.9 --output container-output/ .
```

However, a cleaner solution is to make the argument optional. The container build no longer fails when `VERSION` isn’t provided; it now only passes `:version` to `bin/build.sh` when `VERSION` is non-empty, allowing the default git-derived snapshot version to be used.

### How to verify

Now if you run the command specified in the docs, you should be able to generate the uberjar:
```
DOCKER_BUILDKIT=1 docker build --output container-output/ .
```

Additionally you can also set the version if you want to manually select one.

### Demo

After executing the command and running the generated jar file, the metabase version information was set to the git-derived snapshot automatically.

<img width="563" height="385" alt="image" src="https://github.com/user-attachments/assets/7c961046-3ea0-4ce6-acec-ca412391ca9e" />

