### PR TITLE
[deps] Ignore "soft" refs (in `:fields` clauses) in deps analysis

### DIFF
--- a/e2e/test/scenarios/dependencies/dependency-broken-list.cy.spec.ts
+++ b/e2e/test/scenarios/dependencies/dependency-broken-list.cy.spec.ts
@@ -28,7 +28,9 @@ const MODEL_BASED_MODEL_BROKEN_AGGREGATION =
 
 const BROKEN_TABLE_DEPENDENCIES = [TABLE_DISPLAY_NAME];
 const BROKEN_TABLE_DEPENDENTS = [
-  TABLE_BASED_QUESTION_BROKEN_FIELD,
+  // NOTE: TABLE_BASED_QUESTION_BROKEN_FIELD is *not* listed here because it's only broken in the `:fields` ref.
+  // These are considered "soft" refs that don't break the query, since the QP will quietly drop a bad ref from a
+  // `:fields` clause and the query will run successfully.
   TABLE_BASED_QUESTION_BROKEN_EXPRESSION,
   TABLE_BASED_QUESTION_BROKEN_FILTER,
   TABLE_BASED_QUESTION_BROKEN_BREAKOUT,
@@ -61,7 +63,7 @@ const BROKEN_DEPENDENCIES_SORTED_BY_LOCATION = [
 const BROKEN_DEPENDENTS_SORTED_BY_DEPENDENTS_ERRORS = [
   TABLE_BASED_QUESTION, // 1 error: PRICE
   TABLE_BASED_MODEL, // 1 error: AMOUNT
-  TABLE_DISPLAY_NAME, // 2 errors: SCORE, STATUS
+  TABLE_DISPLAY_NAME, // 1 error: SCORE; plus 1 "soft" error on STATUS, which is only in a `:fields` list.
 ];
 
 const BROKEN_DEPENDENTS_SORTED_BY_DEPENDENTS_WITH_ERRORS = [
@@ -107,7 +109,7 @@ describe("scenarios > dependencies > broken list", () => {
       checkSidebar({
         title: TABLE_DISPLAY_NAME,
         transform: TABLE_TRANSFORM,
-        missingColumns: ["score", "status"],
+        missingColumns: ["score"],
         brokenDependents: BROKEN_TABLE_DEPENDENTS,
       });
 

--- a/e2e/test/scenarios/dependencies/dependency-checks.cy.spec.ts
+++ b/e2e/test/scenarios/dependencies/dependency-checks.cy.spec.ts
@@ -456,7 +456,7 @@ function createMbqlTransformWithDependentMbqlTransforms() {
                   type: "query",
                   query: {
                     "source-table": tableId,
-                    fields: [["field", fieldId, null]],
+                    filter: [">", ["field", fieldId, null], 1],
                   },
                 },
               },

--- a/enterprise/backend/src/metabase_enterprise/dependencies/analysis.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/analysis.clj
@@ -24,7 +24,7 @@
    query  :- ::lib.schema/query]
   (if (lib/any-native-stage? query)
     (deps.native/validate-native-query driver query)
-    (lib/find-bad-refs-with-source query)))
+    (into #{} (remove :soft?) (lib/find-bad-refs-with-source query))))
 
 (defmulti check-entity
   "Given a metadata provider, an entity type and an entity id, find any bad refs in that entity."


### PR DESCRIPTION
Fixes QUE-3044.

### Description

I added some commented tests that are now captured as part of QUE-3081
rather than part of this PR.

### How to verify

Bad refs in `:fields` do not cause analysis findings anymore.

You need to contrive to have a bad `:field` ref in your `:fields` list.
That's easiest at the REPL, but there are ways to do it in the UI:

1. Create a model that is just a `Orders` passed along
2. Create a question based on the model, and select only the ID, SUBTOTAL and QUANTITY fields.
3. Edit the model to only return ID, SUBTOTAL and TOTAL.
4. The `QUANTITY` ref is now dangling!
5. But the QP can still run this query, since it drops unresolvable `:fields` refs.

Before this PR, your model and question now appear in the broken deps list.
With this PR, it does not.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
