### PR TITLE
Unify table visibility with can-query semantics

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1314,8 +1314,7 @@
            startup
            task
            transforms
-           util
-           warehouses}}
+           util}}
 
   secrets
   {:team "Drivers"

--- a/enterprise/backend/src/metabase_enterprise/data_studio/permissions/published_tables.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_studio/permissions/published_tables.clj
@@ -49,7 +49,7 @@
 
 (defenterprise published-table-visible-clause
   "Returns a HoneySQL clause matching published tables that are readable via collection permissions."
-  :feature :data-studio
+  :feature :library
   [table-id-column {:keys [user-id is-superuser?]}]
   [:in table-id-column
    {:select [:id]

--- a/enterprise/backend/src/metabase_enterprise/data_studio/permissions/published_tables.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_studio/permissions/published_tables.clj
@@ -46,3 +46,18 @@
   [table]
   (when (:is_published table)
     (mi/current-user-has-full-permissions? (perms/perms-objects-set-for-parent-collection table :read))))
+
+(defenterprise published-table-visible-clause
+  "Returns a HoneySQL clause matching published tables that are readable via collection permissions."
+  :feature :data-studio
+  [table-id-column {:keys [user-id is-superuser?]}]
+  [:in table-id-column
+   {:select [:id]
+    :from   [:metabase_table]
+    :where  [:and
+             [:= :is_published true]
+             (collection/visible-collection-filter-clause
+              :collection_id
+              {}
+              {:current-user-id user-id
+               :is-superuser?   is-superuser?})]}])

--- a/enterprise/backend/test/metabase_enterprise/data_studio/api/collection_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_studio/api/collection_test.clj
@@ -52,7 +52,7 @@
 
 (deftest collection-items-table-permissions-test
   (mt/with-premium-features #{:library}
-    (testing "GET /api/collection/:id/items - published tables only require collection read permissions"
+    (testing "GET /api/collection/:id/items - published tables require view-data plus query access"
       (mt/with-no-data-perms-for-all-users!
         (mt/with-temp [:model/Collection collection {}
                        :model/Table      {table-id :id :as table} {:collection_id (u/the-id collection)
@@ -61,9 +61,15 @@
           (perms/add-user-to-group! (mt/user->id :rasta) group-id)
           (t2/delete! :model/DataPermissions :db_id (mt/id))
           (perms/grant-collection-read-permissions! (perms/all-users-group) collection)
-          (testing "with collection read but NO data permissions, user should see published table"
+          (testing "with collection read but no view-data, user should not see published table"
             (data-perms/set-database-permission! group-id (mt/id) :perms/view-data :blocked)
             (data-perms/set-database-permission! group-id (mt/id) :perms/create-queries :no)
+            (let [items (:data (mt/user-http-request :rasta :get 200
+                                                     (str "collection/" (u/the-id collection) "/items")))]
+              (is (empty? (filter #(= "table" (:model %)) items))
+                  "User without view-data should not see published tables")))
+          (testing "with collection read and view-data, user should see published table"
+            (data-perms/set-table-permission! group-id table :perms/view-data :unrestricted)
             (let [items (:data (mt/user-http-request :rasta :get 200
                                                      (str "collection/" (u/the-id collection) "/items")))]
               (is (=? [{:id          table-id
@@ -72,8 +78,8 @@
                         :database_id (mt/id)
                         :archived    false}]
                       (filter #(= "table" (:model %)) items))
-                  "User with collection read permissions should see published tables (even without data permissions)")))
-          (testing "with collection read AND data permissions, user should still see published table"
+                  "User with view-data and collection access should see published tables")))
+          (testing "with collection read and direct data query perms, user should still see published table"
             (data-perms/set-table-permission! group-id table :perms/view-data :unrestricted)
             (data-perms/set-table-permission! group-id table :perms/create-queries :query-builder)
             (let [items (:data (mt/user-http-request :rasta :get 200
@@ -98,16 +104,21 @@
           (data-perms/set-table-permission! group-id table :perms/create-queries :query-builder)
           (testing "user cannot access collection at all without collection permissions"
             (mt/user-http-request :rasta :get 403 (str "collection/" (u/the-id collection) "/items"))))))
-    (testing "GET /api/collection/root/items - published tables in root do NOT require data permissions"
+    (testing "GET /api/collection/root/items - published tables in root still require view-data"
       (mt/with-no-data-perms-for-all-users!
         (mt/with-temp [:model/Table {table-id :id :as table} {:collection_id nil
                                                               :is_published  true}
                        :model/PermissionsGroup {group-id :id} {}]
           (perms/add-user-to-group! (mt/user->id :rasta) group-id)
           (t2/delete! :model/DataPermissions :db_id (mt/id))
-          (testing "with NO data permissions, user should see published table in root"
+          (testing "with no view-data, user should not see published table in root"
             (data-perms/set-database-permission! group-id (mt/id) :perms/view-data :blocked)
             (data-perms/set-database-permission! group-id (mt/id) :perms/create-queries :no)
+            (let [items (:data (mt/user-http-request :rasta :get 200 "collection/root/items"))]
+              (is (empty? (filter #(= table-id (:id %)) (filter #(= "table" (:model %)) items)))
+                  "Users without view-data should not see published tables in root")))
+          (testing "with view-data permissions, user should see published table in root"
+            (data-perms/set-table-permission! group-id table :perms/view-data :unrestricted)
             (let [items (:data (mt/user-http-request :rasta :get 200 "collection/root/items"))]
               (is (=? [{:id          table-id
                         :name        (:display_name table)
@@ -115,8 +126,8 @@
                         :database_id (mt/id)
                         :archived    false}]
                       (filter #(= table-id (:id %)) (filter #(= "table" (:model %)) items)))
-                  "Users should see published tables in root collection (even without data permissions)")))
-          (testing "with data permissions, user should still see published table in root"
+                  "User with view-data should see published tables in root")))
+          (testing "with direct query permissions, user should still see published table in root"
             (data-perms/set-table-permission! group-id table :perms/view-data :unrestricted)
             (data-perms/set-table-permission! group-id table :perms/create-queries :query-builder)
             (let [items (:data (mt/user-http-request :rasta :get 200 "collection/root/items"))]

--- a/enterprise/backend/test/metabase_enterprise/data_studio/api/query_metadata_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_studio/api/query_metadata_test.clj
@@ -76,7 +76,7 @@
                   (mt/user-http-request :rasta :get 200 (format "table/card__%d/query_metadata" (u/the-id card))))))))))
 
 (deftest card-query-metadata-published-table-collection-perms-test
-  (testing "GET /api/card/:id/query_metadata should include published tables accessible via collection permissions"
+  (testing "GET /api/card/:id/query_metadata should include published tables that are queryable"
     (mt/with-premium-features #{:library}
       (mt/with-temp [:model/Collection table-coll {}
                      :model/Database db {}
@@ -90,7 +90,7 @@
                      :model/PermissionsGroup {group-id :id} {}
                      :model/PermissionsGroupMembership _ {:user_id (mt/user->id :rasta) :group_id group-id}]
         (mt/with-no-data-perms-for-all-users!
-          (data-perms/set-database-permission! group-id db :perms/view-data :blocked)
+          (data-perms/set-database-permission! group-id db :perms/view-data :unrestricted)
           (data-perms/set-database-permission! group-id db :perms/create-queries :no)
           (perms/grant-collection-read-permissions! group-id (u/the-id table-coll))
           (perms/grant-collection-read-permissions! group-id (u/the-id card-coll))
@@ -118,7 +118,7 @@
                      :model/PermissionsGroup {group-id :id} {}
                      :model/PermissionsGroupMembership _ {:user_id (mt/user->id :rasta) :group_id group-id}]
         (mt/with-no-data-perms-for-all-users!
-          (data-perms/set-database-permission! group-id db :perms/view-data :blocked)
+          (data-perms/set-database-permission! group-id db :perms/view-data :unrestricted)
           (data-perms/set-database-permission! group-id db :perms/create-queries :no)
           (perms/grant-collection-read-permissions! group-id (u/the-id table-coll))
           (perms/grant-collection-read-permissions! group-id (u/the-id card-coll))

--- a/enterprise/backend/test/metabase_enterprise/data_studio/permissions/published_tables_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_studio/permissions/published_tables_test.clj
@@ -62,7 +62,7 @@
 
 (deftest published-table-visible-clause-filters-by-collection-perms-test
   (testing "Returns clause that only includes published tables in readable collections"
-    (mt/with-premium-features #{:data-studio}
+    (mt/with-premium-features #{:library}
       (mt/with-temp [:model/Collection {allowed-coll-id :id} {}
                      :model/Collection {blocked-coll-id :id} {}
                      :model/PermissionsGroup {group-id :id} {}

--- a/enterprise/backend/test/metabase_enterprise/data_studio/permissions/published_tables_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_studio/permissions/published_tables_test.clj
@@ -71,12 +71,13 @@
                      :model/Table {allowed-table-id :id} {:is_published true :collection_id allowed-coll-id}
                      :model/Table {blocked-table-id :id} {:is_published true :collection_id blocked-coll-id}
                      :model/Table _ {:is_published false :collection_id allowed-coll-id}]
-        (perms/grant-collection-read-permissions! group-id allowed-coll-id)
-        (perms/revoke-collection-permissions! group-id blocked-coll-id)
-        (perms/revoke-collection-permissions! (perms/all-users-group) blocked-coll-id)
-        (let [clause (published-tables/published-table-visible-clause
-                      :id
-                      {:user-id user-id
-                       :is-superuser? false})]
-          (is (= #{allowed-table-id}
-                 (t2/select-pks-set :model/Table {:where [:and clause [:in :id [allowed-table-id blocked-table-id]]]}))))))))
+        (mt/with-no-data-perms-for-all-users!
+          (perms/grant-collection-read-permissions! group-id allowed-coll-id)
+          (perms/revoke-collection-permissions! group-id blocked-coll-id)
+          (perms/revoke-collection-permissions! (perms/all-users-group) blocked-coll-id)
+          (let [clause (published-tables/published-table-visible-clause
+                        :id
+                        {:user-id user-id
+                         :is-superuser? false})]
+            (is (= #{allowed-table-id}
+                   (t2/select-pks-set :model/Table {:where [:and clause [:in :id [allowed-table-id blocked-table-id]]]})))))))))

--- a/enterprise/backend/test/metabase_enterprise/data_studio/permissions/published_tables_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_studio/permissions/published_tables_test.clj
@@ -5,7 +5,8 @@
    [metabase.permissions.core :as perms]
    [metabase.permissions.published-tables :as published-tables]
    [metabase.test :as mt]
-   [metabase.test.fixtures :as fixtures]))
+   [metabase.test.fixtures :as fixtures]
+   [toucan2.core :as t2]))
 
 (use-fixtures :once (fixtures/initialize :db))
 
@@ -58,3 +59,24 @@
         (perms/grant-collection-read-permissions! group-id (:id collection))
         (mt/with-current-user user-id
           (is (false? (boolean (published-tables/can-access-via-collection? table)))))))))
+
+(deftest published-table-visible-clause-filters-by-collection-perms-test
+  (testing "Returns clause that only includes published tables in readable collections"
+    (mt/with-premium-features #{:data-studio}
+      (mt/with-temp [:model/Collection {allowed-coll-id :id} {}
+                     :model/Collection {blocked-coll-id :id} {}
+                     :model/PermissionsGroup {group-id :id} {}
+                     :model/User {user-id :id} {}
+                     :model/PermissionsGroupMembership _ {:user_id user-id :group_id group-id}
+                     :model/Table {allowed-table-id :id} {:is_published true :collection_id allowed-coll-id}
+                     :model/Table {blocked-table-id :id} {:is_published true :collection_id blocked-coll-id}
+                     :model/Table _ {:is_published false :collection_id allowed-coll-id}]
+        (perms/grant-collection-read-permissions! group-id allowed-coll-id)
+        (perms/revoke-collection-permissions! group-id blocked-coll-id)
+        (perms/revoke-collection-permissions! (perms/all-users-group) blocked-coll-id)
+        (let [clause (published-tables/published-table-visible-clause
+                      :id
+                      {:user-id user-id
+                       :is-superuser? false})]
+          (is (= #{allowed-table-id}
+                 (t2/select-pks-set :model/Table {:where [:and clause [:in :id [allowed-table-id blocked-table-id]]]}))))))))

--- a/enterprise/backend/test/metabase_enterprise/data_studio/search_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_studio/search_test.clj
@@ -4,6 +4,8 @@
    [clojure.test :refer :all]
    [medley.core :as m]
    [metabase.collections.models.collection :as collection]
+   [metabase.permissions.core :as perms]
+   [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.search.core :as search]
    [metabase.test :as mt]
    [metabase.util.random :refer [random-name]]))
@@ -115,20 +117,44 @@
                           :collection {:id nil}
                           :database_name "Context Test DB"}]
                         our-result))))))))
-    (testing "Collection does not matter for permissions for unpublished tables"
+    (testing "Users without query permissions cannot discover tables in search"
       (let [search-term (random-name)
             name-1 (str search-term " 1")
             name-2 (str search-term " 2")]
-        (mt/with-temp [:model/Table {unpub-table :id} {:collection_id nil :is_published false :name name-1}
-                       :model/Table {pub-table :id} {:collection_id nil :is_published true :name name-2}]
+        (mt/with-no-data-perms-for-all-users!
+          (mt/with-temp [:model/Table {unpub-table :id} {:collection_id nil :is_published false :name name-1}
+                         :model/Table {pub-table :id} {:collection_id nil :is_published true :name name-2}]
+            ;; Explicitly deny both view and query perms so this assertion doesn't depend on global defaults.
+            (data-perms/set-database-permission! (perms/all-users-group) (mt/id) :perms/view-data :blocked)
+            (data-perms/set-database-permission! (perms/all-users-group) (mt/id) :perms/create-queries :no)
+            (doseq [engine ["in-place" "appdb"]]
+              (search/reindex! {:async? false :in-place? true})
+              (mt/with-non-admin-groups-no-root-collection-perms
+                (let [results (mt/user-http-request :rasta :get 200 "search"
+                                                    :q search-term :models "table" :search_engine engine)
+                      our-result (->> (filter (comp #{pub-table unpub-table} :id) (:data results))
+                                      (sort-by :id)
+                                      (map #(select-keys % [:id])))]
+                  (testing "no tables appear"
+                    (is (= []
+                           our-result))))))))))))
+
+(deftest unpublished-table-visible-with-data-perms-test
+  (testing "Unpublished tables are discoverable when the user has data/query permissions"
+    (let [search-term (random-name)
+          table-name  (str search-term " unpublished")]
+      (mt/with-no-data-perms-for-all-users!
+        (mt/with-temp [:model/Table {unpub-table :id} {:collection_id nil :is_published false :name table-name}]
+          ;; Explicitly grant data/query perms so this does not rely on global test defaults.
+          (data-perms/set-database-permission! (perms/all-users-group) (mt/id) :perms/view-data :unrestricted)
+          (data-perms/set-database-permission! (perms/all-users-group) (mt/id) :perms/create-queries :query-builder)
           (doseq [engine ["in-place" "appdb"]]
             (search/reindex! {:async? false :in-place? true})
             (mt/with-non-admin-groups-no-root-collection-perms
-              (let [results (mt/user-http-request :rasta :get 200 "search"
-                                                  :q search-term :models "table" :search_engine engine)
-                    our-result (->> (filter (comp #{pub-table unpub-table} :id) (:data results))
-                                    (sort-by :id)
-                                    (map #(select-keys % [:id])))]
-                (testing "only the unpublished table appears"
-                  (is (= [{:id unpub-table}]
-                         our-result)))))))))))
+              (let [result-ids (->> (mt/user-http-request :rasta :get 200 "search"
+                                                          :q search-term :models "table" :search_engine engine)
+                                    :data
+                                    (map :id)
+                                    (into #{}))]
+                (is (contains? result-ids unpub-table)
+                    (format "Unpublished table should be visible with data permissions (engine=%s)" engine))))))))))

--- a/src/metabase/collections_rest/api.clj
+++ b/src/metabase/collections_rest/api.clj
@@ -22,7 +22,6 @@
    [metabase.models.interface :as mi]
    [metabase.notification.core :as notification]
    [metabase.permissions.core :as perms]
-   [metabase.permissions.published-tables :as published-tables]
    [metabase.premium-features.core :as premium-features :refer [defenterprise]]
    [metabase.queries.core :as queries]
    [metabase.request.core :as request]
@@ -773,7 +772,7 @@
   [_ collection {:keys [archived? pinned-state]}]
   (let [user-info {:user-id       api/*current-user-id*
                    :is-superuser? api/*is-superuser?*}
-        published-clause (published-tables/published-table-visible-clause :t.id user-info)
+        published-clause (perms/published-table-visible-clause :t.id user-info)
         queryable-clause (cond-> [:or
                                   [:in :t.id (perms/visible-table-filter-select
                                               :id

--- a/src/metabase/permissions/core.clj
+++ b/src/metabase/permissions/core.clj
@@ -133,7 +133,8 @@
   can-access-via-collection?
   user-published-table-permission
   user-has-any-published-table-permission?
-  user-has-published-table-permission-for-database?])
+  user-has-published-table-permission-for-database?
+  published-table-visible-clause])
 
 (p/import-vars [metabase.permissions.settings use-tenants])
 

--- a/src/metabase/permissions/published_tables.clj
+++ b/src/metabase/permissions/published_tables.clj
@@ -37,3 +37,10 @@
   metabase-enterprise.data-studio.permissions.published-tables
   [_table]
   false)
+
+(defenterprise published-table-visible-clause
+  "Returns a HoneySQL clause for published tables visible via collection permissions.
+  OSS implementation returns nil."
+  metabase-enterprise.data-studio.permissions.published-tables
+  [_table-id-column _user-info]
+  nil)

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -36,18 +36,19 @@
   variables. This might require updating `can-read?` and `can-write?` to take explicit perms sets instead of relying
   on dynamic variables."
   {:style/indent 0}
-  [current-user-perms & body]
-  `(with-bindings {(requiring-resolve 'metabase.api.common/*current-user-permissions-set*) (atom ~current-user-perms)}
+  [current-user-id current-user-perms & body]
+  `(with-bindings {(requiring-resolve 'metabase.api.common/*current-user-id*)              ~current-user-id
+                   (requiring-resolve 'metabase.api.common/*current-user-permissions-set*) (atom ~current-user-perms)}
      ~@body))
 
-(defn- can-write? [{:keys [current-user-perms]} instance]
-  (ensure-current-user-perms-set-is-bound current-user-perms (mi/can-write? instance)))
+(defn- can-write? [{:keys [current-user-id current-user-perms]} instance]
+  (ensure-current-user-perms-set-is-bound current-user-id current-user-perms (mi/can-write? instance)))
 
-(defn- can-read? [{:keys [current-user-perms]} instance]
-  (ensure-current-user-perms-set-is-bound current-user-perms (mi/can-read? instance)))
+(defn- can-read? [{:keys [current-user-id current-user-perms]} instance]
+  (ensure-current-user-perms-set-is-bound current-user-id current-user-perms (mi/can-read? instance)))
 
-(defn- can-query? [{:keys [current-user-perms]} instance]
-  (ensure-current-user-perms-set-is-bound current-user-perms (mi/can-query? instance)))
+(defn- can-query? [{:keys [current-user-id current-user-perms]} instance]
+  (ensure-current-user-perms-set-is-bound current-user-id current-user-perms (mi/can-query? instance)))
 
 (defmethod check-permissions-for-model :default
   [search-ctx instance]

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -19,7 +19,6 @@
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]
-   [metabase.warehouses.models.database :as database]
    [toucan2.core :as t2]
    [toucan2.instance :as t2.instance]
    [toucan2.realize :as t2.realize]))
@@ -47,6 +46,9 @@
 (defn- can-read? [{:keys [current-user-perms]} instance]
   (ensure-current-user-perms-set-is-bound current-user-perms (mi/can-read? instance)))
 
+(defn- can-query? [{:keys [current-user-perms]} instance]
+  (ensure-current-user-perms-set-is-bound current-user-perms (mi/can-query? instance)))
+
 (defmethod check-permissions-for-model :default
   [search-ctx instance]
   (if (:archived? search-ctx)
@@ -64,13 +66,7 @@
 ;; issue with new pure sql implementation
 (defmethod check-permissions-for-model :table
   [search-ctx instance]
-  ;; we've already filtered out tables w/o collection permissions in the query itself.
-  (let [instance-id (:id instance)
-        user-id     (:current-user-id search-ctx)
-        db-id       (database/table-id->database-id instance-id)]
-    (and
-     (perms/user-has-permission-for-table? user-id :perms/view-data :unrestricted db-id instance-id)
-     (perms/user-has-permission-for-table? user-id :perms/create-queries :query-builder db-id instance-id))))
+  (can-query? search-ctx (assoc instance :db_id (:database_id instance))))
 
 (defmethod check-permissions-for-model :indexed-entity
   [search-ctx instance]

--- a/src/metabase/search/permissions.clj
+++ b/src/metabase/search/permissions.clj
@@ -57,4 +57,5 @@
     :is-superuser? is-superuser?
     :is-data-analyst? is-data-analyst?}
    {:perms/view-data :unrestricted
-    :perms/create-queries :query-builder}))
+    :perms/create-queries :query-builder}
+   {:include-published-via-collection? true}))

--- a/src/metabase/warehouse_schema/models/table.clj
+++ b/src/metabase/warehouse_schema/models/table.clj
@@ -8,7 +8,6 @@
    [metabase.models.interface :as mi]
    [metabase.models.serialization :as serdes]
    [metabase.permissions.core :as perms]
-   [metabase.permissions.published-tables :as published-tables]
    [metabase.premium-features.core :refer [defenterprise]]
    [metabase.remote-sync.core :as remote-sync]
    [metabase.search.spec :as search.spec]
@@ -384,7 +383,7 @@
    & [{:keys [include-published-via-collection?]}]]
   (let [{:keys [clause with]} (perms/visible-table-filter-with-cte column-or-exp user-info permission-mapping)]
     (if-let [published-clause (and include-published-via-collection?
-                                   (published-tables/published-table-visible-clause column-or-exp user-info))]
+                                   (perms/published-table-visible-clause column-or-exp user-info))]
       {:clause [:or clause
                 [:and
                  [:in column-or-exp (perms/visible-table-filter-select

--- a/src/metabase/warehouse_schema/models/table.clj
+++ b/src/metabase/warehouse_schema/models/table.clj
@@ -291,23 +291,22 @@
   ;; - view-data permission and either create-queries permission or published-collection access (EE feature)
   ([instance]
    (boolean
-    (or
-     ;; Has both view-data and create-queries permissions
-     (and (perms/user-has-permission-for-table?
+    ;; Has both view-data and create-queries permissions
+    (and (perms/user-has-permission-for-table?
+          api/*current-user-id*
+          :perms/view-data
+          :unrestricted
+          (:db_id instance)
+          (:id instance))
+         (or
+          (perms/user-has-permission-for-table?
            api/*current-user-id*
-           :perms/view-data
-           :unrestricted
+           :perms/create-queries
+           :query-builder
            (:db_id instance)
            (:id instance))
-          (or
-           (perms/user-has-permission-for-table?
-            api/*current-user-id*
-            :perms/create-queries
-            :query-builder
-            (:db_id instance)
-            (:id instance))
-           ;; Can access via published collection (EE feature)
-           (perms/can-access-via-collection? instance))))))
+          ;; Can access via published collection (EE feature)
+          (perms/can-access-via-collection? instance)))))
   ([_ pk]
    (mi/can-query? (t2/select-one :model/Table pk))))
 

--- a/test/metabase/search/filter_test.clj
+++ b/test/metabase/search/filter_test.clj
@@ -8,6 +8,7 @@
    [metabase.search.in-place.filter :as search.in-place.filter]
    [metabase.search.ingestion :as search.ingestion]
    [metabase.search.test-util :as search.tu]
+   [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]))
 
 (use-fixtures :once (fixtures/initialize :db))
@@ -103,61 +104,62 @@
    :enabled-transform-source-types #{"mbql"}})
 
 (deftest with-filters-test
-  (testing "The kitchen sink context is complete"
-    (is (empty? (remove kitchen-sink-filter-context (filter-keys)))))
+  (mt/with-premium-features #{}
+    (testing "The kitchen sink context is complete"
+      (is (empty? (remove kitchen-sink-filter-context (filter-keys)))))
 
-  (testing "In the general case, we simply filter by models, and exclude dashboard cards"
-    (is (= {:select [:some :stuff],
-            :from :somewhere,
-            :where
-            [:and
-             [:= 1 2]
-             [:or [:= nil :search_index.dashboard_id] nil]]}
-           (search.filter/with-filters {:models []} {:select [:some :stuff], :from :somewhere})))
-    (is (= {:select [:some :stuff],
-            :from :somewhere,
-            :where
-            [:and
-             [:in :search_index.model ["a"]]
-             [:or [:= nil :search_index.dashboard_id] nil]]}
-           (search.filter/with-filters {:models ["a"]} {:select [:some :stuff], :from :somewhere}))))
+    (testing "In the general case, we simply filter by models, and exclude dashboard cards"
+      (is (= {:select [:some :stuff],
+              :from :somewhere,
+              :where
+              [:and
+               [:= 1 2]
+               [:or [:= nil :search_index.dashboard_id] nil]]}
+             (search.filter/with-filters {:models []} {:select [:some :stuff], :from :somewhere})))
+      (is (= {:select [:some :stuff],
+              :from :somewhere,
+              :where
+              [:and
+               [:in :search_index.model ["a"]]
+               [:or [:= nil :search_index.dashboard_id] nil]]}
+             (search.filter/with-filters {:models ["a"]} {:select [:some :stuff], :from :somewhere}))))
 
-  (testing "We can insert appropriate constraints for all the filters"
-    (is (= {:select [:some :stuff],
-            :from :somewhere,
-            :where
-            #{[:in :search_index.last_editor_id [321]]
-              [:in :search_index.creator_id [123]]
-              [:or [:= :search_index.collection_id 5] [:like :collection.location "%/5/%"]]
-              [:not= :search_index.model [:inline "table"]]
-              [:= :search_index.archived true]
-              [:in :search_index.model ["card" "dataset" "metric" "dashboard" "action"]]
-              [:or
-               [:= nil :search_index.dashboard_id]
-               [:not= [:inline 0] [:coalesce :search_index.dashboardcard_count [:inline 0]]]]
-              [:in
-               :search_index.model
-               #{"dashboard"
-                 "table"
-                 "segment"
-                 "collection"
-                 "measure"
-                 "transform"
-                 "document"
-                 "database"
-                 "action"
-                 "indexed-entity"
-                 "metric"
-                 "card"}]
-              [:< [:cast :search_index.model_created_at :date] #t "2024-10-02"]
-              [:in :search_index.model_id ["1" "2" "3" "4"]]
-              [:< [:cast :search_index.last_edited_at :date] #t "2024-10-03"]
-              [:>= [:cast :search_index.model_created_at :date] #t "2024-10-01"]
-              [:= :search_index.non_temporal_dim_ids "[1]"]
-              [:= :search_index.has_temporal_dim true]
-              :and
-              [:= :search_index.database_id 231]
-              [:in :search_index.display_type ["line"]]
-              [:>= [:cast :search_index.last_edited_at :date] #t "2024-10-02"]}}
-           (-> (search.filter/with-filters kitchen-sink-filter-context {:select [:some :stuff], :from :somewhere})
-               (update :where set))))))
+    (testing "We can insert appropriate constraints for all the filters"
+      (is (= {:select [:some :stuff],
+              :from :somewhere,
+              :where
+              #{[:in :search_index.last_editor_id [321]]
+                [:in :search_index.creator_id [123]]
+                [:or [:= :search_index.collection_id 5] [:like :collection.location "%/5/%"]]
+                [:not= :search_index.model [:inline "table"]]
+                [:= :search_index.archived true]
+                [:in :search_index.model ["card" "dataset" "metric" "dashboard" "action"]]
+                [:or
+                 [:= nil :search_index.dashboard_id]
+                 [:not= [:inline 0] [:coalesce :search_index.dashboardcard_count [:inline 0]]]]
+                [:in
+                 :search_index.model
+                 #{"dashboard"
+                   "table"
+                   "segment"
+                   "collection"
+                   "measure"
+                   "transform"
+                   "document"
+                   "database"
+                   "action"
+                   "indexed-entity"
+                   "metric"
+                   "card"}]
+                [:< [:cast :search_index.model_created_at :date] #t "2024-10-02"]
+                [:in :search_index.model_id ["1" "2" "3" "4"]]
+                [:< [:cast :search_index.last_edited_at :date] #t "2024-10-03"]
+                [:>= [:cast :search_index.model_created_at :date] #t "2024-10-01"]
+                [:= :search_index.non_temporal_dim_ids "[1]"]
+                [:= :search_index.has_temporal_dim true]
+                :and
+                [:= :search_index.database_id 231]
+                [:in :search_index.display_type ["line"]]
+                [:>= [:cast :search_index.last_edited_at :date] #t "2024-10-02"]}}
+             (-> (search.filter/with-filters kitchen-sink-filter-context {:select [:some :stuff], :from :somewhere})
+                 (update :where set)))))))


### PR DESCRIPTION
Fixes [UXW-2931: Hide blocked tables from Data Library and collection](https://linear.app/metabase/issue/UXW-2931/hide-blocked-tables-from-data-library-and-collection)

Table visibility checks had drifted across different APIs.

- `(can-query? table)` checked whether you had view access and create-queries access OR the table was published. This is incorrect: the table is queryable if you have view access AND either the table is published OR you have create-queries.

- the collections API included tables that were not queryable.

- the search API allowed you to view tables if a) you had data permissions on the table, AND b) the table was unpublished or published in a collection you had access to. This is incorrect, since publishing a table shouldn't hide a previously visible table from search results. Search should return tables for which you have view-data permissions PLUS the table is either published or you have create-queries permissions.

Fundamentally this change:

- correctly defines what `(can-query? table)` means, and
- uses that new definition of `can-query` to determine table visibility across the collection, search, and table APIs.

Note that I did not change some existing usages of `(mi/visible-filter-clause :model/Table ...)`, which will continue to exclude tables for which the user does not have explicit data permissions set (but could otherwise query due to being published). That should be a simple followup PR.

- align SQL table visibility with mi/can-query? semantics for search paths

- add enterprise `published-table-visible-clause` and wire optional

- `published-via-collection` support into `(mi/visible-filter-clause :model/Table ...)`

- update search table fallback permission check to use canonical `mi/can-query?`

- fix collection table children filtering to include `published-via-collection` queryability

- make `(mi/can-query? :model/Table)` return explicit booleans

- add/adjust EE tests for:
  - published-table SQL clause behavior
  - collection items visibility under view/query perms
  - search visibility when user lacks query perms
  - search visibility for unpublished tables when user has data perms
  - stabilize appdb negation test by avoiding brittle exact count for "customer" in shared index data
