### PR TITLE
trigger cloud driver tests on certain modules

### DIFF
--- a/mage/src/mage/modules.clj
+++ b/mage/src/mage/modules.clj
@@ -393,7 +393,7 @@
     {:should-run true
      :reason (str "driver files changed (modules/drivers/" (name driver) "/**)")}
 
-    ;; Priority 7: Cloud driver + query-processor updated → run it
+    ;; Priority 7: Cloud driver + module triggering cloud dbs updated → run it
     (and (contains? cloud-drivers driver)
          (seq (set/intersection updated modules-triggering-cloud-drivers)))
     {:should-run true

--- a/mage/test/mage/modules_test.clj
+++ b/mage/test/mage/modules_test.clj
@@ -166,17 +166,20 @@
       (is (true? (:should-run result)))
       (is (re-find #"driver files changed" (:reason result))))))
 
-(deftest cloud-driver-with-query-processor-changes-runs
-  (testing "Cloud driver runs when query-processor module is updated"
-    (doseq [driver [:athena :bigquery :databricks :redshift :snowflake]]
+(deftest modules-can-trigger-cloud-drivers
+  (doseq [module '#{query-processor transforms
+                    enterprise/transforms enterprise/transforms-python}
+          driver [:athena :bigquery :databricks :redshift :snowflake]]
+    (testing (format "Cloud driver runs when %s module is updated" module)
       (let [result (mage.modules/driver-decision driver
                                                  (make-ctx {})
-                                                 false ; not affected
-                                                 #{} ; quarantined
-                                                 #{'query-processor})] ; updated
+                                                 false       ; not affected
+                                                 #{}         ; quarantined
+                                                 #{module})] ; updated
         (is (true? (:should-run result))
             (str driver " should run when query-processor updated"))
-        (is (= "query-processor module updated" (:reason result)))))))
+        (is (= "Module updated which explicitly triggers cloud drivers"
+               (:reason result)))))))
 
 (deftest cloud-driver-without-changes-skips
   (testing "Cloud driver skips when no relevant changes"
@@ -250,7 +253,7 @@
     (let [modules-triggering-drivers (modules-affecting-drivers)
           ;; This count was 33 as of 2026-01-20. Update this number ONLY if you
           ;; intentionally want more modules to trigger driver tests.
-          max-allowed-count 33]
+          max-allowed-count 35]
       (is (<= (count modules-triggering-drivers) max-allowed-count)
           (format "Too many modules trigger driver tests! Expected <= %d, got %d.
                    Modules triggering driver tests: %s


### PR DESCRIPTION
Motivating example:
https://github.com/metabase/metabase/pull/68256/changes added some schemas to transform apis. Transforms run when drivers run. But it didn't trigger cloud dbs. And of course, there was an issue with redshift transform tests.

https://github.com/metabase/metabase/actions/runs/21718378450/job/62645866080 is the determine driver skips link:

```
=== Module Analysis ===
Changed modules: #{models transforms}
Driver module affected: true
Important file changed: false
Drivers with file changes: #{}

=== Driver Decisions ===
h2                        RUN  - H2/Postgres always run
athena                    SKIP - no relevant changes for cloud driver
bigquery                  SKIP - no relevant changes for cloud driver
clickhouse                RUN  - driver module affected by shared code changes
databricks                SKIP - no relevant changes for cloud driver
druid                     RUN  - driver module affected by shared code changes
druid-jdbc                RUN  - driver module affected by shared code changes
mongo                     RUN  - driver module affected by shared code changes
mongo-ssl                 RUN  - driver module affected by shared code changes
mongo-sharded-cluster     RUN  - driver module affected by shared code changes
mysql-mariadb             RUN  - driver module affected by shared code changes
oracle                    RUN  - driver module affected by shared code changes
postgres                  RUN  - H2/Postgres always run
presto-jdbc               RUN  - driver module affected by shared code changes
redshift                  SKIP - no relevant changes for cloud driver
snowflake                 SKIP - no relevant changes for cloud driver
sparksql                  RUN  - driver module affected by shared code changes
sqlite                    RUN  - driver module affected by shared code changes
sqlserver                 RUN  - driver module affected by shared code changes
vertica                   RUN  - driver module affected by shared code changes
```

Important part is `Changed modules: #{models transforms}` and `redshift SKIP - no relevant changes for cloud driver`. This intends to change that.
