### PR TITLE
Fix "View as table" in visualizer

### DIFF
--- a/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
@@ -993,4 +993,17 @@ describe("scenarios > dashboard > visualizer > basics", () => {
       );
     });
   });
+
+  it("should allow viewing the table preview (metabase#69038)", () => {
+    createDashboardWithVisualizerDashcards();
+    H.editDashboard();
+
+    H.showDashcardVisualizerModal(0);
+
+    cy.findByTestId("visualizer-view-as-table-button").click();
+
+    cy.findByTestId("visualizer-tabular-preview-modal").within(() => {
+      cy.findByText("Count").should("exist");
+    });
+  });
 });

--- a/frontend/src/metabase/visualizations/components/TableInteractive/cells/HeaderCellWithColumnInfo.tsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/cells/HeaderCellWithColumnInfo.tsx
@@ -44,9 +44,6 @@ export const HeaderCellWithColumnInfo = memo(
     className,
     renderTableHeader,
   }: HeaderCellWithColumnInfoProps) {
-    const query = question?.query();
-    const stageIndex = -1;
-
     const headerCellOverride = useMemo(() => {
       return renderTableHeader != null
         ? renderTableHeader(column, columnIndex, theme)
@@ -63,23 +60,33 @@ export const HeaderCellWithColumnInfo = memo(
       </div>
     );
 
+    let headerContent: React.ReactNode;
+
+    if (getInfoPopoversDisabled()) {
+      headerContent = cellContent;
+    } else {
+      // question.query will throw when used in the visualizer
+      // we don't go down this code path in the visualizer because isDashboard is true
+      const query = question?.query();
+      const stageIndex = -1;
+      headerContent = (
+        <QueryColumnInfoPopover
+          position="bottom-start"
+          query={query}
+          stageIndex={stageIndex}
+          column={query && Lib.fromLegacyColumn(query, stageIndex, column)}
+          timezone={timezone}
+          openDelay={500}
+          showFingerprintInfo
+        >
+          {cellContent}
+        </QueryColumnInfoPopover>
+      );
+    }
+
     return (
       <HeaderCellWrapper className={className} variant={variant} align={align}>
-        {getInfoPopoversDisabled() ? (
-          cellContent
-        ) : (
-          <QueryColumnInfoPopover
-            position="bottom-start"
-            query={query}
-            stageIndex={-1}
-            column={query && Lib.fromLegacyColumn(query, stageIndex, column)}
-            timezone={timezone}
-            openDelay={500}
-            showFingerprintInfo
-          >
-            {cellContent}
-          </QueryColumnInfoPopover>
-        )}
+        {headerContent}
       </HeaderCellWrapper>
     );
   },

--- a/frontend/src/metabase/visualizations/visualizations/Table/Table.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table/Table.tsx
@@ -129,10 +129,17 @@ export class Table extends Component<TableProps, TableState> {
         settings: ComputedVisualizationSettings,
       ) => data && data.cols.length !== 3 && !settings["table.pivot"],
       getDefault: ([{ card, data }]: Series) => {
+        let native: boolean;
+        try {
+          native = isNative(card);
+        } catch (error) {
+          // isNative throws when used in the visualizer
+          native = false;
+        }
         if (
           !data ||
           data.cols.length !== 3 ||
-          isNative(card) ||
+          native ||
           data.cols.filter(isMetric).length !== 1 ||
           data.cols.filter(isDimension).length !== 2
         ) {


### PR DESCRIPTION
Closes #69038

### Description

Clicking the "View as table" button in visualizer was broken (I believe) by #63913, because the visualizer creates an empty `dataset_query` object (see `getTabularPreviewSeries`) which causes an error whenever it's used to construct a `Lib.Query` (see `from-js-query`).

This PR works around the issue by preventing `Table` from every trying to construct a `Query` when used in the visualizer, but this seems a little hacky. Perhaps there's a way visualizer can create non-empty `dataset_query` objects instead.

### How to verify

See #69038

### Demo

Before:
<img width="1011" height="677" alt="image" src="https://github.com/user-attachments/assets/57e425f3-d8ea-4721-91ce-6866f4895799" />

After:
<img width="921" height="592" alt="image" src="https://github.com/user-attachments/assets/28e9bc4e-261a-4a2b-af5c-ba311d081c15" />

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
