### PR TITLE
fix(plugins): memoize selector return values to prevent unnecessary re-renders

### DIFF
--- a/frontend/src/metabase/plugins/oss/content-verification.ts
+++ b/frontend/src/metabase/plugins/oss/content-verification.ts
@@ -12,6 +12,10 @@ export type MetricFilterSettings = {
   verified: boolean;
 };
 
+// Static default filter objects to prevent unnecessary re-renders
+const DEFAULT_MODEL_FILTERS: ModelFilterSettings = { verified: false };
+const DEFAULT_METRIC_FILTERS: MetricFilterSettings = { verified: false };
+
 const getDefaultPluginContentVerification = () => ({
   contentVerificationEnabled: false,
   VerifiedFilter: {} as SearchFilterComponent<"verified">,
@@ -21,13 +25,11 @@ const getDefaultPluginContentVerification = () => ({
   ) => 0,
 
   ModelFilterControls: (_props: ModelFilterControlsProps) => null,
-  getDefaultModelFilters: (_state: State): ModelFilterSettings => ({
-    verified: false,
-  }),
+  getDefaultModelFilters: (_state: State): ModelFilterSettings =>
+    DEFAULT_MODEL_FILTERS,
 
-  getDefaultMetricFilters: (_state: State): MetricFilterSettings => ({
-    verified: false,
-  }),
+  getDefaultMetricFilters: (_state: State): MetricFilterSettings =>
+    DEFAULT_METRIC_FILTERS,
   MetricFilterControls: (_props: MetricFilterControlsProps) => null,
 });
 


### PR DESCRIPTION
Fixes #52312

The getDefaultModelFilters and getDefaultMetricFilters selectors were returning new object references on every call, preventing proper memoization in reselect.

Changes:
- Add static DEFAULT_MODEL_FILTERS and DEFAULT_METRIC_FILTERS constants
- Return these constants instead of creating new objects

This ensures that selectors return the same reference when called with the same arguments, enabling proper memoization and preventing unnecessary re-renders.