### PR TITLE
fix(selectors): use constant objects for default filter settings to enable memoization

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/content_verification/metrics.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/content_verification/metrics.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { t } from "ttag";
+import { createSelector } from "@reduxjs/toolkit";
 
 import type {
   MetricFilterControlsProps,
@@ -13,11 +14,13 @@ import { VerifiedToggle } from "./VerifiedFilter/VerifiedToggle";
 
 const USER_SETTING_KEY = "browse-filter-only-verified-metrics";
 
-export function getDefaultMetricFilters(state: State): MetricFilterSettings {
-  return {
-    verified: getSetting(state, USER_SETTING_KEY) ?? false,
-  };
-}
+const getVerifiedSetting = (state: State): boolean =>
+  getSetting(state, USER_SETTING_KEY) ?? false;
+
+export const getDefaultMetricFilters = createSelector(
+  [getVerifiedSetting],
+  (verified): MetricFilterSettings => ({ verified }),
+);
 
 /**
  * This was originally designed to support multiple filters but it currently

--- a/enterprise/frontend/src/metabase-enterprise/content_verification/models.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/content_verification/models.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { t } from "ttag";
+import { createSelector } from "@reduxjs/toolkit";
 
 import type {
   ModelFilterControlsProps,
@@ -13,11 +14,13 @@ import { VerifiedToggle } from "./VerifiedFilter/VerifiedToggle";
 
 const USER_SETTING_KEY = "browse-filter-only-verified-models";
 
-export function getDefaultModelFilters(state: State): ModelFilterSettings {
-  return {
-    verified: getSetting(state, USER_SETTING_KEY) ?? false,
-  };
-}
+const getVerifiedSetting = (state: State): boolean =>
+  getSetting(state, USER_SETTING_KEY) ?? false;
+
+export const getDefaultModelFilters = createSelector(
+  [getVerifiedSetting],
+  (verified): ModelFilterSettings => ({ verified }),
+);
 
 /**
  * This was originally designed to support multiple filters but it currently

--- a/frontend/src/metabase/plugins/oss/content-verification.ts
+++ b/frontend/src/metabase/plugins/oss/content-verification.ts
@@ -12,6 +12,10 @@ export type MetricFilterSettings = {
   verified: boolean;
 };
 
+// Constant objects to ensure reference equality for memoization
+const DEFAULT_MODEL_FILTERS: ModelFilterSettings = { verified: false };
+const DEFAULT_METRIC_FILTERS: MetricFilterSettings = { verified: false };
+
 const getDefaultPluginContentVerification = () => ({
   contentVerificationEnabled: false,
   VerifiedFilter: {} as SearchFilterComponent<"verified">,
@@ -21,13 +25,11 @@ const getDefaultPluginContentVerification = () => ({
   ) => 0,
 
   ModelFilterControls: (_props: ModelFilterControlsProps) => null,
-  getDefaultModelFilters: (_state: State): ModelFilterSettings => ({
-    verified: false,
-  }),
+  getDefaultModelFilters: (_state: State): ModelFilterSettings =>
+    DEFAULT_MODEL_FILTERS,
 
-  getDefaultMetricFilters: (_state: State): MetricFilterSettings => ({
-    verified: false,
-  }),
+  getDefaultMetricFilters: (_state: State): MetricFilterSettings =>
+    DEFAULT_METRIC_FILTERS,
   MetricFilterControls: (_props: MetricFilterControlsProps) => null,
 });
 


### PR DESCRIPTION
## Context
The `getDefaultModelFilters` and `getDefaultMetricFilters` selectors return new `{verified: false}` objects on every function call, causing new references that prevent memoization at the reselect level.

## Solution
Define constant `DEFAULT_MODEL_FILTERS` and `DEFAULT_METRIC_FILTERS` objects outside the function scope and return those instead. This ensures referential equality across calls, allowing proper memoization.

## Changes
- Added constant `DEFAULT_MODEL_FILTERS` and `DEFAULT_METRIC_FILTERS` objects
- Updated `getDefaultModelFilters` to return the constant
- Updated `getDefaultMetricFilters` to return the constant

Fixes #52312