### PR TITLE
fix: Use setting/get instead of read-setting in discard-setting-changes

### DIFF
--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -629,7 +629,9 @@
   ((reduce
     (fn [thunk setting-k]
       (fn []
-        (let [value (setting/read-setting setting-k)]
+        ;; Use setting/get instead of setting/read-setting to ensure :init functions
+        ;; are called and we get the actual computed value, not nil
+        (let [value (setting/get setting-k)]
           (do-with-temporary-setting-value! setting-k value thunk :skip-init? true))))
     thunk
     settings)))


### PR DESCRIPTION
## Problem
The `discard-setting-changes` test helper was broken for settings that use `:init` functions. When evaluating a setting for the first time in tests, it would return `nil` instead of the correct initialized value.

Example from the issue:
```clojure
(defsetting query-analysis-native-disabled
  (deferred-tru "Whether we should disable analysis of all native queries")
  :visibility :internal
  :export?    false
  :init       (comp not sql-parsing-enabled)
  :type       :boolean)

;; In tests:
(mt/with-discard-setting-changes [sql-parsing-enabled query-analysis-native-disabled]
  (query-analysis-native-disabled)) ;; => nil (WRONG - should be false)
```

## Root Cause
The `do-with-discarded-setting-changes!` function used `setting/read-setting` which binds `*disable-init*` to `true`, bypassing the `:init` function entirely.

## Solution
Changed to use `setting/get` which properly evaluates `:init` functions before returning the value.

## Testing
- Settings with `:init` functions now return correct values within `discard-setting-changes` blocks
- Settings without `:init` functions continue to work as before

Fixes #45707