### PR TITLE
fix: Fix selector memoization for getDefaultModelFilters and getDefaultMetricFilters

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/content_verification/metrics.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/content_verification/metrics.tsx
@@ -7,17 +7,19 @@ import type {
 } from "metabase/browse/metrics";
 import { useUserSetting } from "metabase/common/hooks";
 import { getSetting } from "metabase/selectors/settings";
+import { createSelector } from "metabase/lib/redux";
 import type { State } from "metabase-types/store";
 
 import { VerifiedToggle } from "./VerifiedFilter/VerifiedToggle";
 
 const USER_SETTING_KEY = "browse-filter-only-verified-metrics";
 
-export function getDefaultMetricFilters(state: State): MetricFilterSettings {
-  return {
-    verified: getSetting(state, USER_SETTING_KEY) ?? false,
-  };
-}
+export const getDefaultMetricFilters = createSelector(
+  (state: State) => getSetting(state, USER_SETTING_KEY),
+  (verified): MetricFilterSettings => ({
+    verified: verified ?? false,
+  }),
+);
 
 /**
  * This was originally designed to support multiple filters but it currently

--- a/enterprise/frontend/src/metabase-enterprise/content_verification/models.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/content_verification/models.tsx
@@ -7,17 +7,19 @@ import type {
 } from "metabase/browse/models";
 import { useUserSetting } from "metabase/common/hooks";
 import { getSetting } from "metabase/selectors/settings";
+import { createSelector } from "metabase/lib/redux";
 import type { State } from "metabase-types/store";
 
 import { VerifiedToggle } from "./VerifiedFilter/VerifiedToggle";
 
 const USER_SETTING_KEY = "browse-filter-only-verified-models";
 
-export function getDefaultModelFilters(state: State): ModelFilterSettings {
-  return {
-    verified: getSetting(state, USER_SETTING_KEY) ?? false,
-  };
-}
+export const getDefaultModelFilters = createSelector(
+  (state: State) => getSetting(state, USER_SETTING_KEY),
+  (verified): ModelFilterSettings => ({
+    verified: verified ?? false,
+  }),
+);
 
 /**
  * This was originally designed to support multiple filters but it currently

--- a/frontend/src/metabase/plugins/oss/content-verification.ts
+++ b/frontend/src/metabase/plugins/oss/content-verification.ts
@@ -12,6 +12,10 @@ export type MetricFilterSettings = {
   verified: boolean;
 };
 
+// Memoized filter objects to prevent unnecessary re-renders
+const DEFAULT_MODEL_FILTERS: ModelFilterSettings = { verified: false };
+const DEFAULT_METRIC_FILTERS: MetricFilterSettings = { verified: false };
+
 const getDefaultPluginContentVerification = () => ({
   contentVerificationEnabled: false,
   VerifiedFilter: {} as SearchFilterComponent<"verified">,
@@ -21,13 +25,11 @@ const getDefaultPluginContentVerification = () => ({
   ) => 0,
 
   ModelFilterControls: (_props: ModelFilterControlsProps) => null,
-  getDefaultModelFilters: (_state: State): ModelFilterSettings => ({
-    verified: false,
-  }),
+  getDefaultModelFilters: (_state: State): ModelFilterSettings =>
+    DEFAULT_MODEL_FILTERS,
 
-  getDefaultMetricFilters: (_state: State): MetricFilterSettings => ({
-    verified: false,
-  }),
+  getDefaultMetricFilters: (_state: State): MetricFilterSettings =>
+    DEFAULT_METRIC_FILTERS,
   MetricFilterControls: (_props: MetricFilterControlsProps) => null,
 });
 


### PR DESCRIPTION
Use createSelector for enterprise selectors to ensure memoization works properly. Use constant objects for OSS default filters to prevent new object creation.

This prevents unnecessary re-renderings caused by selectors returning new object references with every function call.

Fixes #52312