### PR TITLE
fix: memoize getDefaultModelFilters and getDefaultMetricFilters selectors

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/content_verification/metrics.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/content_verification/metrics.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { t } from "ttag";
+import { createSelector } from "reselect";
 
 import type {
   MetricFilterControlsProps,
@@ -13,11 +14,13 @@ import { VerifiedToggle } from "./VerifiedFilter/VerifiedToggle";
 
 const USER_SETTING_KEY = "browse-filter-only-verified-metrics";
 
-export function getDefaultMetricFilters(state: State): MetricFilterSettings {
-  return {
-    verified: getSetting(state, USER_SETTING_KEY) ?? false,
-  };
-}
+const getVerifiedMetricSetting = (state: State) =>
+  getSetting(state, USER_SETTING_KEY) ?? false;
+
+export const getDefaultMetricFilters = createSelector(
+  [getVerifiedMetricSetting],
+  (verified): MetricFilterSettings => ({ verified }),
+);
 
 /**
  * This was originally designed to support multiple filters but it currently

--- a/enterprise/frontend/src/metabase-enterprise/content_verification/models.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/content_verification/models.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { t } from "ttag";
+import { createSelector } from "reselect";
 
 import type {
   ModelFilterControlsProps,
@@ -13,11 +14,13 @@ import { VerifiedToggle } from "./VerifiedFilter/VerifiedToggle";
 
 const USER_SETTING_KEY = "browse-filter-only-verified-models";
 
-export function getDefaultModelFilters(state: State): ModelFilterSettings {
-  return {
-    verified: getSetting(state, USER_SETTING_KEY) ?? false,
-  };
-}
+const getVerifiedModelSetting = (state: State) =>
+  getSetting(state, USER_SETTING_KEY) ?? false;
+
+export const getDefaultModelFilters = createSelector(
+  [getVerifiedModelSetting],
+  (verified): ModelFilterSettings => ({ verified }),
+);
 
 /**
  * This was originally designed to support multiple filters but it currently


### PR DESCRIPTION
Use createSelector from reselect to prevent returning new object references on every call, which was causing unnecessary re-renderings.

Fixes #52312