### PR TITLE
Fix broken Metabase icon in SDK banner when using EE with license

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -520,7 +520,7 @@ const configs = [
       "no-restricted-imports": [
         "error",
         {
-          ...baseMetabaseRestrictedConfig,
+          paths: baseMetabaseRestrictedConfig.paths,
           patterns: [
             ...baseMetabaseRestrictedConfig.patterns,
             {
@@ -716,7 +716,7 @@ const configs = [
       "no-restricted-imports": [
         "error",
         {
-          ...baseMetabaseRestrictedConfig,
+          paths: baseMetabaseRestrictedConfig.paths,
           patterns: [
             ...baseMetabaseRestrictedConfig.patterns,
             {
@@ -755,7 +755,7 @@ const configs = [
       "no-restricted-imports": [
         "error",
         {
-          ...baseMetabaseRestrictedConfig,
+          paths: baseMetabaseRestrictedConfig.paths,
           patterns: [
             ...baseMetabaseRestrictedConfig.patterns,
             {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -723,6 +723,12 @@ const configs = [
               group: ["__support__/**", "!__support__/metadata"],
               message: TEST_FILES_NAME_PATTERN_ERROR_MESSAGE,
             },
+            {
+              group: ["metabase/common/components/LogoIcon"],
+              importNames: ["LogoIcon"],
+              message:
+                "Do not use LogoIcon in the core app. With custom Icon, it doesn't work because it relies on Metabase path",
+            },
           ],
         },
       ],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -727,7 +727,7 @@ const configs = [
               group: ["metabase/common/components/LogoIcon"],
               importNames: ["LogoIcon"],
               message:
-                "Do not use LogoIcon in the core app. With custom Icon, it doesn't work because it relies on Metabase path",
+                "Do not use LogoIcon in the SDK. With custom Icon, it doesn't work because it uses the Metabase instance's relative path.",
             },
           ],
         },

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkUsageProblem/SdkUsageProblemBanner.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkUsageProblem/SdkUsageProblemBanner.tsx
@@ -8,7 +8,7 @@ import { useSdkDispatch } from "embedding-sdk-bundle/store";
 import { setUsageProblem } from "embedding-sdk-bundle/store/reducer";
 import type { SdkUsageProblem } from "embedding-sdk-bundle/types/usage-problem";
 import { ExternalLink } from "metabase/common/components/ExternalLink";
-import { LogoIcon as MetabaseLogo } from "metabase/common/components/LogoIcon";
+import { DefaultLogoIcon } from "metabase/common/components/LogoIcon";
 import { originalColors } from "metabase/lib/colors";
 import { Button, Card, Flex, Icon, Popover, Stack, Text } from "metabase/ui";
 
@@ -59,7 +59,7 @@ export const SdkUsageProblemBanner = ({
           i-should-be-flex="true"
         >
           <Flex bg="white" px="sm" className={S.Logo} align="center">
-            <MetabaseLogo height={24} />
+            <DefaultLogoIcon height={24} />
           </Flex>
 
           <Flex justify="center" align="center" className={S.Content}>


### PR DESCRIPTION
Closes EMB-1298

### Description

This happens because EE instance with whitelabel token will load the custom Logo component, and this component uses relative logo path, so it doesn't work on the SDK.

The fix is to just keep showing the Metabase icon. I think we don't need to do whitelabel here, as we only warn users with this banner on localhosts.

### How to verify

1. Run Metabase with EE license (any license should do, as they all should have `whitelabel`)
1. Use API key authentication
1. Embed any SDK coponent.
1. Click the Metabase icon in the lower left corner, the popup should shoow up and the Metabase icon should continue to work

### Demo

#### After
<img width="409" height="282" alt="image" src="https://github.com/user-attachments/assets/eff4b3f6-d274-4fb2-a969-0c92ca77affd" />

#### Before
<img width="740" height="562" alt="image" src="https://github.com/user-attachments/assets/553db514-151d-491d-81df-6e22e698bef9" />


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
