### PR TITLE
add support for ct to sdk back button

### DIFF
--- a/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/SdkInternalNavigationBackButton.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/SdkInternalNavigationBackButton.tsx
@@ -1,6 +1,7 @@
 import cx from "classnames";
 import { t } from "ttag";
 
+import { useTranslateContent } from "metabase/i18n/hooks";
 import { Button, Icon } from "metabase/ui";
 
 import S from "./SdkInternalNavigationBackButton.module.css";
@@ -18,6 +19,7 @@ export const SdkInternalNavigationBackButton = ({
   className?: string;
 }) => {
   const navigation = useSdkInternalNavigationOptional();
+  const tc = useTranslateContent();
 
   if (!navigation?.canGoBack) {
     return null;
@@ -26,7 +28,9 @@ export const SdkInternalNavigationBackButton = ({
   const { previousEntry, pop } = navigation;
 
   const previousName =
-    previousEntry && "name" in previousEntry ? previousEntry.name : undefined;
+    previousEntry && "name" in previousEntry
+      ? tc(previousEntry.name)
+      : undefined;
 
   const label = previousName ? t`Back to ${previousName}` : t`Back`;
 


### PR DESCRIPTION
Had a conflict during a rebase on the default title component, where Timofei added content translation to the name of the previous question, but I moved that name to the back button in this branch.