### PR TITLE
export back button, test that it shows up with title=false, align button

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
@@ -167,41 +167,6 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
   });
 
   describe("BackButton component", () => {
-    it("should show BackButton after drilling and allow navigating back", () => {
-      mountSdkContent(
-        <InteractiveQuestion questionId={ORDERS_QUESTION_ID}>
-          <div>
-            <InteractiveQuestion.BackButton />
-            <InteractiveQuestion.Title />
-            <InteractiveQuestion.QuestionVisualization />
-          </div>
-        </InteractiveQuestion>,
-      );
-
-      getSdkRoot().within(() => {
-        cy.findByText("Orders").should("be.visible");
-
-        // BackButton should not be visible initially (no navigation history)
-        cy.findByText(/Back to/).should("not.exist");
-
-        // Perform a drill on the first row's Product ID
-        H.tableInteractiveBody().findAllByText("14").first().click();
-        H.popover().findByText("View this Product's Orders").click();
-
-        // BackButton should now be visible
-        cy.findByText("Back to Orders").should("be.visible");
-
-        // Click the back button to return to the original question
-        cy.findByText("Back to Orders").click();
-
-        // Should be back at the original question
-        cy.findByText("Orders").should("be.visible");
-
-        // BackButton should be hidden again
-        cy.findByText(/Back to/).should("not.exist");
-      });
-    });
-
     it("should show BackButton after drilling even with title=false (metabase#68556)", () => {
       mountSdkContent(
         <InteractiveQuestion questionId={ORDERS_QUESTION_ID} title={false} />,

--- a/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
@@ -1,6 +1,7 @@
 const { H } = cy;
 import { InteractiveQuestion } from "@metabase/embedding-sdk-react";
 
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 import { modal, popover } from "e2e/support/helpers";
 import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
 import { mountSdkContent } from "e2e/support/helpers/embedding-sdk-component-testing/component-embedding-sdk-helpers";
@@ -162,6 +163,70 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
       cy.log("the alert is deleted");
       getSdkRoot().button("Alerts").should("be.visible").click();
       modal().findByRole("heading", { name: "New alert" }).should("be.visible");
+    });
+  });
+
+  describe("BackButton component", () => {
+    it("should show BackButton after drilling and allow navigating back", () => {
+      mountSdkContent(
+        <InteractiveQuestion questionId={ORDERS_QUESTION_ID}>
+          <div>
+            <InteractiveQuestion.BackButton />
+            <InteractiveQuestion.Title />
+            <InteractiveQuestion.QuestionVisualization />
+          </div>
+        </InteractiveQuestion>,
+      );
+
+      getSdkRoot().within(() => {
+        cy.findByText("Orders").should("be.visible");
+
+        // BackButton should not be visible initially (no navigation history)
+        cy.findByText(/Back to/).should("not.exist");
+
+        // Perform a drill on the first row's Product ID
+        H.tableInteractiveBody().findAllByText("14").first().click();
+        H.popover().findByText("View this Product's Orders").click();
+
+        // BackButton should now be visible
+        cy.findByText("Back to Orders").should("be.visible");
+
+        // Click the back button to return to the original question
+        cy.findByText("Back to Orders").click();
+
+        // Should be back at the original question
+        cy.findByText("Orders").should("be.visible");
+
+        // BackButton should be hidden again
+        cy.findByText(/Back to/).should("not.exist");
+      });
+    });
+
+    it("should show BackButton after drilling even with title=false (metabase#68556)", () => {
+      mountSdkContent(
+        <InteractiveQuestion questionId={ORDERS_QUESTION_ID} title={false} />,
+      );
+
+      getSdkRoot().within(() => {
+        // Title should not be visible
+        cy.findByText("Orders").should("not.exist");
+
+        // BackButton should not be visible initially
+        cy.findByText(/Back to/).should("not.exist");
+
+        // Perform a drill on the first row's Product ID
+        H.tableInteractiveBody().findAllByText("14").first().click();
+        H.popover().findByText("View this Product's Orders").click();
+
+        // BackButton should be visible after drill
+        cy.findByText("Back to Orders").should("be.visible");
+
+        // Click back
+        cy.findByText("Back to Orders").click();
+
+        // BackButton should be hidden again
+        cy.findByText(/Back to/).should("not.exist");
+      });
     });
   });
 });

--- a/e2e/test-component/scenarios/embedding-sdk/internal-navigation.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/internal-navigation.cy.spec.tsx
@@ -1,6 +1,7 @@
 import {
   InteractiveDashboard,
   InteractiveQuestion,
+  StaticDashboard,
 } from "@metabase/embedding-sdk-react";
 
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
@@ -486,6 +487,30 @@ describe("scenarios > embedding-sdk > internal-navigation", () => {
         cy.findByTestId("visualization-root").should("be.visible");
 
         cy.findByTestId("question-download-widget-button").should("be.visible");
+      });
+    });
+
+    it("should not be able to navigate when using StaticDashboard even if click behaviors are configured", () => {
+      cy.get<number>("@dashboardAId").then((dashboardAId) => {
+        mountSdkContent(
+          <StaticDashboard
+            dashboardId={dashboardAId}
+            // this prop isn't actually accepted
+            enableEntityNavigation
+          />,
+        );
+      });
+
+      cy.wait("@dashcardQuery");
+
+      getSdkRoot().within(() => {
+        // Verify we're on Dashboard A
+        cy.findByText("Dashboard A").should("be.visible");
+
+        // Click behavior link text should not be rendered in static mode
+        H.getDashboardCard()
+          .findByText("Go to Dashboard B")
+          .should("not.exist");
       });
     });
 

--- a/e2e/test-component/scenarios/embedding-sdk/internal-navigation.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/internal-navigation.cy.spec.tsx
@@ -464,6 +464,31 @@ describe("scenarios > embedding-sdk > internal-navigation", () => {
       });
     });
 
+    it("should forward `withDownloads` prop from the dashboard to the question", () => {
+      cy.get<number>("@dashboardAId").then((dashboardAId) => {
+        mountSdkContent(
+          <InteractiveDashboard
+            dashboardId={dashboardAId}
+            enableEntityNavigation
+            withDownloads
+          />,
+        );
+      });
+
+      cy.wait("@dashcardQuery");
+
+      getSdkRoot().within(() => {
+        H.getDashboardCard()
+          .findAllByText("Go to Native Question")
+          .first()
+          .click();
+
+        cy.findByTestId("visualization-root").should("be.visible");
+
+        cy.findByTestId("question-download-widget-button").should("be.visible");
+      });
+    });
+
     it("should support nested navigations dashboard -> dashboard -> question -> multiple drills -> back through all", () => {
       cy.get<number>("@dashboardAId").then((dashboardAId) => {
         mountSdkContent(

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/SdkInternalNavigationProvider.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/SdkInternalNavigationProvider.tsx
@@ -13,7 +13,10 @@ import type { SdkDashboardId } from "embedding-sdk-bundle/types/dashboard";
 import { Stack } from "metabase/ui";
 
 import { SdkQuestion } from "../../public/SdkQuestion";
-import type { DrillThroughQuestionProps } from "../../public/SdkQuestion/SdkQuestion";
+import type {
+  DrillThroughQuestionProps,
+  SdkQuestionProps,
+} from "../../public/SdkQuestion/SdkQuestion";
 import { InteractiveDashboardContent } from "../../public/dashboard/InteractiveDashboard/InteractiveDashboard";
 import type { SdkDashboardInnerProps } from "../../public/dashboard/SdkDashboard";
 
@@ -119,16 +122,25 @@ const SdkInternalNavigationProviderInner = ({
         initialParameters={activeEntry.parameters}
       />
     ))
-    .with({ activeEntry: { type: "question" } }, ({ activeEntry }) => (
-      <SdkQuestion
-        questionId={activeEntry.id}
-        onNavigateBack={pop}
-        initialSqlParameters={activeEntry.parameters}
-        {...drillThroughQuestionProps}
-      >
-        {RenderDrillThroughQuestion && <RenderDrillThroughQuestion />}
-      </SdkQuestion>
-    ))
+    .with({ activeEntry: { type: "question" } }, ({ activeEntry }) => {
+      // We try to infer question props from the starting dashboard when they have a 1:1 mapping
+      const questionPropsInferredFromDashboard: Partial<SdkQuestionProps> = {
+        withDownloads: dashboardProps?.withDownloads,
+      };
+
+      return (
+        <SdkQuestion
+          questionId={activeEntry.id}
+          onNavigateBack={pop}
+          initialSqlParameters={activeEntry.parameters}
+          isSaveEnabled
+          {...questionPropsInferredFromDashboard}
+          {...drillThroughQuestionProps}
+        >
+          {RenderDrillThroughQuestion && <RenderDrillThroughQuestion />}
+        </SdkQuestion>
+      );
+    })
     .otherwise(() => children);
 
   // When we don't render the children directly, we need to render a wrapper with the styles applied.

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/BackButton/BackButton.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/BackButton/BackButton.tsx
@@ -1,42 +1,24 @@
-import type { HTMLAttributes } from "react";
-
-import { useSdkBreadcrumbs } from "embedding-sdk-bundle/hooks/private/use-sdk-breadcrumb";
-import { QueryBuilderBackButton } from "metabase/query_builder/components/view/ViewHeader/components";
-import type { ActionIconProps } from "metabase/ui";
-
-import { useSdkQuestionContext } from "../../context";
+import { SdkInternalNavigationBackButton } from "embedding-sdk-bundle/components/private/SdkInternalNavigation/SdkInternalNavigationBackButton";
 
 /**
  * @expand
  * @category InteractiveQuestion
  */
-export type BackButtonProps = Omit<
-  ActionIconProps & HTMLAttributes<HTMLButtonElement>,
-  "noLink" | "onClick"
->;
+export type BackButtonProps = {
+  style?: React.CSSProperties;
+  className?: string;
+};
 
 /**
- * A navigation button that returns to the previous view.
- * Only visible when rendered within the {@link InteractiveDashboardProps.renderDrillThroughQuestion} prop.
+ * A navigation button that allows users to go back to the previous view.
+ * Visible after performing navigations such as drills or click behaviors.
+ *
+ * Displays "Back to {name}" where name is the title of the previous dashboard or question.
  *
  * @function
  * @category InteractiveQuestion
  * @param props
  */
-export const BackButton = ({ ...actionIconProps }: BackButtonProps) => {
-  const { onNavigateBack, backToDashboard } = useSdkQuestionContext();
-  const { isBreadcrumbEnabled } = useSdkBreadcrumbs();
-
-  if (!onNavigateBack || isBreadcrumbEnabled) {
-    return null;
-  }
-
-  return (
-    <QueryBuilderBackButton
-      noLink
-      onClick={onNavigateBack}
-      parentOverride={backToDashboard}
-      {...actionIconProps}
-    />
-  );
+export const BackButton = (props: BackButtonProps) => {
+  return <SdkInternalNavigationBackButton {...props} />;
 };

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/BackButton/BackButton.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/BackButton/BackButton.tsx
@@ -1,24 +1,42 @@
-import { SdkInternalNavigationBackButton } from "embedding-sdk-bundle/components/private/SdkInternalNavigation/SdkInternalNavigationBackButton";
+import type { HTMLAttributes } from "react";
+
+import { useSdkBreadcrumbs } from "embedding-sdk-bundle/hooks/private/use-sdk-breadcrumb";
+import { QueryBuilderBackButton } from "metabase/query_builder/components/view/ViewHeader/components";
+import type { ActionIconProps } from "metabase/ui";
+
+import { useSdkQuestionContext } from "../../context";
 
 /**
  * @expand
  * @category InteractiveQuestion
  */
-export type BackButtonProps = {
-  style?: React.CSSProperties;
-  className?: string;
-};
+export type BackButtonProps = Omit<
+  ActionIconProps & HTMLAttributes<HTMLButtonElement>,
+  "noLink" | "onClick"
+>;
 
 /**
- * A navigation button that allows users to go back to the previous view.
- * Visible after performing navigations such as drills or click behaviors.
- *
- * Displays "Back to {name}" where name is the title of the previous dashboard or question.
+ * A navigation button that returns to the previous view.
+ * Only visible when rendered within the {@link InteractiveDashboardProps.renderDrillThroughQuestion} prop.
  *
  * @function
  * @category InteractiveQuestion
  * @param props
  */
-export const BackButton = (props: BackButtonProps) => {
-  return <SdkInternalNavigationBackButton {...props} />;
+export const BackButton = ({ ...actionIconProps }: BackButtonProps) => {
+  const { onNavigateBack, backToDashboard } = useSdkQuestionContext();
+  const { isBreadcrumbEnabled } = useSdkBreadcrumbs();
+
+  if (!onNavigateBack || isBreadcrumbEnabled) {
+    return null;
+  }
+
+  return (
+    <QueryBuilderBackButton
+      noLink
+      onClick={onNavigateBack}
+      parentOverride={backToDashboard}
+      {...actionIconProps}
+    />
+  );
 };

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/DefaultViewTitle.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/DefaultViewTitle.tsx
@@ -27,6 +27,10 @@ export const DefaultViewTitle = ({ title }: SdkQuestionDefaultViewProps) => {
   if (title === undefined || title === true) {
     const titleText = getQuestionTitle(question, tc);
 
+    if (titleText === null) {
+      return null;
+    }
+
     return (
       <DefaultViewTitleText
         title={


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #68556
Closes https://linear.app/metabase/issue/EMB-1243/sdk-after-drilling-from-a-question-with-title=false-its-impossible-to
Closes https://linear.app/metabase/issue/EMB-1275/map-dashboard-props-to-question-props-when-navigating-to-questions
Closes https://linear.app/metabase/issue/EMB-1277/export-the-navigation-button-as-sub-component-and-add-jsdoc-to-it
Closes [EMB-1299: align back button with "save" in the question editing mode](https://linear.app/metabase/issue/EMB-1299/align-back-button-with-save-in-the-question-editing-mode)
Closes https://linear.app/metabase/issue/EMB-1278/e2e-tests-for-sdk-internal-navigation

Batching small linear issues to the same PR to avoid lots of context switch, rebases, failing ci etc
Should be pretty easy to review it [commit by commit](https://github.com/metabase/metabase/pull/69222/commits)