### PR TITLE
fix: prompt suggestions should left-align with the input box

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.module.css
@@ -1,8 +1,6 @@
 /* TODO: rtl support */
 
 .container {
-  --padding-x: 1.5rem;
-
   width: 100%;
   height: 100%;
   display: flex;
@@ -11,7 +9,7 @@
 
 .header {
   /* top padding is set to visually align w/ the dashboard action buttons */
-  padding: 1.25rem var(--padding-x) 1rem;
+  padding: 1.25rem 1.5rem 1rem;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -37,7 +35,7 @@
 }
 
 .messagesContainer {
-  padding: 1rem var(--padding-x) 1.5rem;
+  padding: 1rem 1rem 1.5rem;
   height: 100%;
   display: flex;
   flex-direction: column;
@@ -47,6 +45,7 @@
 .messages {
   display: flex;
   flex-direction: column;
+  padding-inline: 0.5rem;
 }
 
 .messageContainer {


### PR DESCRIPTION
Closes [BOT-467](https://linear.app/metabase/issue/BOT-467/prompt-suggestions-should-left-align-with-the-input-box-and-should)

### Description

Prompt suggestions in the Metabot chat empty state were slightly offset from the chat input because the suggestions container used a larger horizontal padding than the input area.

This change aligns prompt suggestions with the input by reducing the message area horizontal padding to match the input, while adding compensating inner padding to the conversation message list so existing message spacing stays consistent.

### How to verify

1. Open Metabase locally and sign in.
2. Click `Chat with Metabot (⌘+E)` in the top app bar.
3. Click the reset/clear conversation button (revert icon) so the empty state + prompt suggestions are visible.
4. Verify the left edge of the suggestion buttons lines up with the left edge of the input box, and suggestions don't exceed the input width.

### Demo

Before (master): 

<img width="1280" height="720" alt="before-master" src="https://github.com/user-attachments/assets/4e08024b-685a-430a-8fa5-47ce3734cb11" />
After (this branch): 

<img width="1280" height="720" alt="after-branch" src="https://github.com/user-attachments/assets/565ba2b0-cfdf-4434-9946-70dc94a9ef9e" />

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
