### PR TITLE
Allow source-readable to be null in response schema

### DIFF
--- a/src/metabase/transforms/api/transform.clj
+++ b/src/metabase/transforms/api/transform.clj
@@ -96,7 +96,7 @@
    [:target :any]
    [:source_type :keyword]
    [:source_database_id {:optional true} [:maybe pos-int?]]
-   [:source_readable {:optional true} :boolean]
+   [:source_readable {:optional true} [:maybe :boolean]]
    [:entity_id [:maybe :string]]
    [:created_at :any]
    [:updated_at :any]


### PR DESCRIPTION
### Description

The recently merged #68256 wasn't correctly listing that source_readable can be nil.

Redshift test was failing because of it

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
