### PR TITLE
fix: dark Theme Hides values in Gauge Chart

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/Gauge/Gauge.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Gauge/Gauge.jsx
@@ -8,8 +8,9 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import CS from "metabase/css/core/index.css";
-import { color } from "metabase/lib/colors";
+import { color as colorHex } from "metabase/lib/colors";
 import { formatValue } from "metabase/lib/formatting";
+import { color } from "metabase/ui/utils/colors";
 import { ChartSettingSegmentsEditor } from "metabase/visualizations/components/settings/ChartSettingSegmentsEditor";
 import { columnSettings } from "metabase/visualizations/lib/settings/column";
 import { segmentIsValid } from "metabase/visualizations/lib/utils";
@@ -126,9 +127,9 @@ export class Gauge extends Component {
         try {
           value = series[0].data.rows[0][0] || 0;
         } catch (e) {}
-        const errorColor = Color(color("error")).hex();
-        const warningColor = Color(color("warning")).hex();
-        const successColor = Color(color("success")).hex();
+        const errorColor = Color(colorHex("error")).hex();
+        const warningColor = Color(colorHex("warning")).hex();
+        const successColor = Color(colorHex("success")).hex();
         return [
           { min: 0, max: value / 2, color: errorColor, label: "" },
           { min: value / 2, max: value, color: warningColor, label: "" },


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/69223

### Description

Gauge was using invalid color functions for parts that need to be theme-specific.

### How to verify

1. Go Account -> Make sure you have Dark Theme Enabled
2. Go to New Question -> Orders -> Count -> Plot as Gauge Chart

### Demo

Before:
<img width="911" height="988" alt="image" src="https://github.com/user-attachments/assets/321e1d84-1908-4d35-87ed-d29618721748" />

After:
<img width="903" height="985" alt="image" src="https://github.com/user-attachments/assets/e13e75d1-3072-4410-972f-df36473cfd5d" />

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
