### PR TITLE
fix: the timing of the shimmer loading indicator effect should be 2x as fast

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotThinking.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotThinking.module.css
@@ -23,7 +23,7 @@
   background-image: var(--bg),
     linear-gradient(var(--base-color), var(--base-color));
   background-position: 50%;
-  animation: rotate-background 3000ms ease infinite;
+  animation: rotate-background 1500ms ease infinite;
 }
 
 @keyframes rotate-background {


### PR DESCRIPTION
Closes [BOT-464: The timing of the shimmer loading indicator effect should be 2x as fast](https://linear.app/metabase/issue/BOT-464/the-timing-of-the-shimmer-loading-indicator-effect-should-be-2x-as)

### Description

Reduced the animation duration in half so it's more clear that it's loading.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Ask metabot to search something
2. Observe the loader for the tool "Searching"

### Demo

Before:

https://github.com/user-attachments/assets/3acea19e-82ea-4f26-b806-ed6fbae7a784


After:

https://github.com/user-attachments/assets/a5e9f349-9d6e-47e6-843c-e690c0c004e5



### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
