### PR TITLE
Uxw 2973 admin toggle for transforms global

### DIFF
--- a/e2e/support/helpers/e2e-data-studio-helpers.ts
+++ b/e2e/support/helpers/e2e-data-studio-helpers.ts
@@ -52,6 +52,7 @@ export const DataStudio = {
       DataStudio.Transforms.list().should("be.visible");
     },
     pythonResults: () => cy.findByTestId("python-results"),
+    enableTransformPage: () => cy.findByTestId("enable-transform-page"),
   },
   Jobs: {
     header: () => cy.findByTestId("jobs-header"),

--- a/e2e/test/scenarios/data-studio/transforms/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms/transforms.cy.spec.ts
@@ -4162,6 +4162,14 @@ describe("scenarios > data studio > transforms > permissions > oss", () => {
     "should be able to enable transforms in OSS without upsell gem icon",
     { tags: "@OSS" },
     () => {
+      cy.log("ensure that transform permissions are not shown");
+      cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP_ID}`);
+
+      //Check that a known header is present
+      cy.findByRole("columnheader", { name: "Database name" }).should("exist");
+      //Ensure transform permissions are not displayed
+      cy.findByRole("columnheader", { name: /Transforms/ }).should("not.exist");
+
       cy.log("Visit data studio page");
       cy.visit("/data-studio");
       H.DataStudio.nav().should("be.visible");
@@ -4193,6 +4201,16 @@ describe("scenarios > data studio > transforms > permissions > oss", () => {
       H.popover()
         .findByText(/Python/i)
         .should("not.exist");
+
+      cy.log("transform permissions should still not");
+      H.goToAdmin();
+      H.appBar().findByRole("link", { name: "Permissions" }).click();
+      cy.findByRole("menuitem", { name: "All Users" }).click();
+
+      //Check that a known header is present
+      cy.findByRole("columnheader", { name: "Database name" }).should("exist");
+      //Ensure transform permissions are not displayed
+      cy.findByRole("columnheader", { name: /Transforms/ }).should("not.exist");
     },
   );
 });
@@ -4204,7 +4222,7 @@ describe("scenarios > data studio > transforms > permissions > pro-self-hosted",
   });
 
   // TODO [OSS]: fix this test. It works in isolation and local setup, but fails consistently on CI
-  it.only("should have transforms available in self-hosted pro without upsell gem icon", () => {
+  it("should have transforms available in self-hosted pro without upsell gem icon", () => {
     H.activateToken("pro-self-hosted").then(() => {
       cy.log("ensure that transform permissions are not shown");
       cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP_ID}`);

--- a/e2e/test/scenarios/data-studio/transforms/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms/transforms.cy.spec.ts
@@ -4166,7 +4166,9 @@ describe("scenarios > data studio > transforms > permissions > oss", () => {
       cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP_ID}`);
 
       //Check that a known header is present
-      cy.findByRole("columnheader", { name: "Database name" }).should("exist");
+      cy.findByRole("columnheader", { name: "Database name" }).should(
+        "be.visible",
+      );
       //Ensure transform permissions are not displayed
       cy.findByRole("columnheader", { name: /Transforms/ }).should("not.exist");
 
@@ -4208,7 +4210,9 @@ describe("scenarios > data studio > transforms > permissions > oss", () => {
       cy.findByRole("menuitem", { name: "All Users" }).click();
 
       //Check that a known header is present
-      cy.findByRole("columnheader", { name: "Database name" }).should("exist");
+      cy.findByRole("columnheader", { name: "Database name" }).should(
+        "be.visible",
+      );
       //Ensure transform permissions are not displayed
       cy.findByRole("columnheader", { name: /Transforms/ }).should("not.exist");
     },
@@ -4221,14 +4225,15 @@ describe("scenarios > data studio > transforms > permissions > pro-self-hosted",
     cy.signInAsAdmin();
   });
 
-  // TODO [OSS]: fix this test. It works in isolation and local setup, but fails consistently on CI
   it("should have transforms available in self-hosted pro without upsell gem icon", () => {
     H.activateToken("pro-self-hosted").then(() => {
       cy.log("ensure that transform permissions are not shown");
       cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP_ID}`);
 
       //Check that a known header is present
-      cy.findByRole("columnheader", { name: "Database name" }).should("exist");
+      cy.findByRole("columnheader", { name: "Database name" }).should(
+        "be.visible",
+      );
       //Ensure transform permissions are not displayed
       cy.findByRole("columnheader", { name: /Transforms/ }).should("not.exist");
 
@@ -4263,9 +4268,13 @@ describe("scenarios > data studio > transforms > permissions > pro-self-hosted",
       cy.findByRole("menuitem", { name: "All Users" }).click();
 
       //Check that a known header is present
-      cy.findByRole("columnheader", { name: "Database name" }).should("exist");
-      //Ensure transform permissions are not displayed
-      cy.findByRole("columnheader", { name: /Transforms/ }).should("exist");
+      cy.findByRole("columnheader", { name: "Database name" }).should(
+        "be.visible",
+      );
+      //Ensure transform permissions are displayed
+      cy.findByRole("columnheader", { name: /Transforms/ })
+        .scrollIntoView()
+        .should("be.visible");
     });
   });
 });

--- a/e2e/test/scenarios/data-studio/transforms/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms/transforms.cy.spec.ts
@@ -4204,7 +4204,7 @@ describe("scenarios > data studio > transforms > permissions > pro-self-hosted",
   });
 
   // TODO [OSS]: fix this test. It works in isolation and local setup, but fails consistently on CI
-  it("should have transforms available in self-hosted pro without upsell gem icon", () => {
+  it.only("should have transforms available in self-hosted pro without upsell gem icon", () => {
     H.activateToken("pro-self-hosted").then(() => {
       cy.log("ensure that transform permissions are not shown");
       cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP_ID}`);

--- a/e2e/test/scenarios/data-studio/transforms/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms/transforms.cy.spec.ts
@@ -4115,6 +4115,17 @@ describe("scenarios > data studio > transforms > permissions", () => {
     });
     H.setUserAsAnalyst(NORMAL_USER_ID);
 
+    cy.log(
+      "Ensure that transform permissions are visible when instance is hosted and transform feature is present",
+    );
+
+    cy.findByRole("radio", { name: "Data" }).click({ force: true });
+    cy.findByRole("menuitem", { name: "All Users" }).click();
+
+    cy.findByRole("columnheader", { name: /Transforms/ })
+      .scrollIntoView()
+      .should("be.visible");
+
     cy.log("sign in as normal user and create a transform");
     cy.signInAsNormalUser();
     visitTransformListPage();

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/index.ts
@@ -6,7 +6,6 @@ import type {
   SpecialGroupType,
 } from "metabase/admin/permissions/types";
 import { isNotNull } from "metabase/lib/types";
-import { PLUGIN_TRANSFORMS } from "metabase/plugins";
 import type { Group, GroupsPermissions } from "metabase-types/api";
 
 import { buildDataModelPermission } from "./data-model-permission";
@@ -23,7 +22,7 @@ export const getFeatureLevelDataPermissions = ({
   defaultGroup,
   permissionSubject,
   permissionView,
-  transformsEnabled,
+  showTransformPermissions = false,
 }: {
   entityId: EntityId;
   groupId: number;
@@ -33,7 +32,7 @@ export const getFeatureLevelDataPermissions = ({
   defaultGroup: Group;
   permissionSubject: PermissionSubject;
   permissionView?: "group" | "database";
-  transformsEnabled?: boolean;
+  showTransformPermissions?: boolean;
 }): PermissionSectionConfig[] => {
   const isAdmin = groupType === "admin";
   const isExternal = groupType === "external";
@@ -72,17 +71,16 @@ export const getFeatureLevelDataPermissions = ({
         )
       : null;
 
-  const transformsPermission =
-    PLUGIN_TRANSFORMS.isEnabled && transformsEnabled
-      ? buildTransformsPermission(
-          entityId,
-          groupId,
-          isAdmin,
-          permissions,
-          defaultGroup,
-          permissionSubject,
-        )
-      : null;
+  const transformsPermission = showTransformPermissions
+    ? buildTransformsPermission(
+        entityId,
+        groupId,
+        isAdmin,
+        permissions,
+        defaultGroup,
+        permissionSubject,
+      )
+    : null;
 
   return [
     downloadPermission,

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/index.ts
@@ -23,7 +23,7 @@ export const getFeatureLevelDataPermissions = ({
   defaultGroup,
   permissionSubject,
   permissionView,
-  tenantsEnabled,
+  transformsEnabled,
 }: {
   entityId: EntityId;
   groupId: number;
@@ -33,7 +33,7 @@ export const getFeatureLevelDataPermissions = ({
   defaultGroup: Group;
   permissionSubject: PermissionSubject;
   permissionView?: "group" | "database";
-  tenantsEnabled?: boolean;
+  transformsEnabled?: boolean;
 }): PermissionSectionConfig[] => {
   const isAdmin = groupType === "admin";
   const isExternal = groupType === "external";
@@ -73,7 +73,7 @@ export const getFeatureLevelDataPermissions = ({
       : null;
 
   const transformsPermission =
-    PLUGIN_TRANSFORMS.isEnabled && tenantsEnabled
+    PLUGIN_TRANSFORMS.isEnabled && transformsEnabled
       ? buildTransformsPermission(
           entityId,
           groupId,

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/index.ts
@@ -14,16 +14,27 @@ import { buildDetailsPermission } from "./details-permission";
 import { buildDownloadPermission } from "./download-permission";
 import { buildTransformsPermission } from "./transforms-permission";
 
-export const getFeatureLevelDataPermissions = (
-  entityId: EntityId,
-  groupId: number,
-  groupType: SpecialGroupType,
-  permissions: GroupsPermissions,
-  dataAccessPermissionValue: DataPermissionValue,
-  defaultGroup: Group,
-  permissionSubject: PermissionSubject,
-  permissionView?: "group" | "database",
-): PermissionSectionConfig[] => {
+export const getFeatureLevelDataPermissions = ({
+  entityId,
+  groupId,
+  groupType,
+  permissions,
+  dataAccessPermissionValue,
+  defaultGroup,
+  permissionSubject,
+  permissionView,
+  tenantsEnabled,
+}: {
+  entityId: EntityId;
+  groupId: number;
+  groupType: SpecialGroupType;
+  permissions: GroupsPermissions;
+  dataAccessPermissionValue: DataPermissionValue;
+  defaultGroup: Group;
+  permissionSubject: PermissionSubject;
+  permissionView?: "group" | "database";
+  tenantsEnabled?: boolean;
+}): PermissionSectionConfig[] => {
   const isAdmin = groupType === "admin";
   const isExternal = groupType === "external";
   const downloadPermission = buildDownloadPermission(
@@ -61,16 +72,17 @@ export const getFeatureLevelDataPermissions = (
         )
       : null;
 
-  const transformsPermission = PLUGIN_TRANSFORMS.isEnabled
-    ? buildTransformsPermission(
-        entityId,
-        groupId,
-        isAdmin,
-        permissions,
-        defaultGroup,
-        permissionSubject,
-      )
-    : null;
+  const transformsPermission =
+    PLUGIN_TRANSFORMS.isEnabled && tenantsEnabled
+      ? buildTransformsPermission(
+          entityId,
+          groupId,
+          isAdmin,
+          permissions,
+          defaultGroup,
+          permissionSubject,
+        )
+      : null;
 
   return [
     downloadPermission,

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/index.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/index.unit.spec.ts
@@ -49,15 +49,15 @@ describe("getFeatureLevelDataPermissions", () => {
     it("returns 4 permissions including transforms when PLUGIN_TRANSFORMS.isEnabled is true", () => {
       PLUGIN_TRANSFORMS.isEnabled = true;
 
-      const permissions = getFeatureLevelDataPermissions(
-        { databaseId },
+      const permissions = getFeatureLevelDataPermissions({
+        entityId: { databaseId },
         groupId,
         groupType,
-        getPermissionGraph(),
-        DataPermissionValue.UNRESTRICTED,
+        permissions: getPermissionGraph(),
+        dataAccessPermissionValue: DataPermissionValue.UNRESTRICTED,
         defaultGroup,
-        "schemas",
-      );
+        permissionSubject: "schemas",
+      });
 
       expect(permissions).toHaveLength(4);
       expect(permissions[0]).toMatchObject({ permission: "download" });
@@ -74,15 +74,15 @@ describe("getFeatureLevelDataPermissions", () => {
     it("returns 3 permissions without transforms when PLUGIN_TRANSFORMS.isEnabled is false", () => {
       PLUGIN_TRANSFORMS.isEnabled = false;
 
-      const permissions = getFeatureLevelDataPermissions(
-        { databaseId },
+      const permissions = getFeatureLevelDataPermissions({
+        entityId: { databaseId },
         groupId,
         groupType,
-        getPermissionGraph(),
-        DataPermissionValue.UNRESTRICTED,
+        permissions: getPermissionGraph(),
+        dataAccessPermissionValue: DataPermissionValue.UNRESTRICTED,
         defaultGroup,
-        "schemas",
-      );
+        permissionSubject: "schemas",
+      });
 
       expect(permissions).toHaveLength(3);
       expect(permissions[0]).toMatchObject({ permission: "download" });
@@ -95,15 +95,15 @@ describe("getFeatureLevelDataPermissions", () => {
     it("returns 2 permissions without transforms regardless of PLUGIN_TRANSFORMS.isEnabled", () => {
       PLUGIN_TRANSFORMS.isEnabled = true;
 
-      const permissions = getFeatureLevelDataPermissions(
-        { databaseId, schemaName: "public" },
+      const permissions = getFeatureLevelDataPermissions({
+        entityId: { databaseId, schemaName: "public" },
         groupId,
         groupType,
-        getPermissionGraph(),
-        DataPermissionValue.UNRESTRICTED,
+        permissions: getPermissionGraph(),
+        dataAccessPermissionValue: DataPermissionValue.UNRESTRICTED,
         defaultGroup,
-        "tables",
-      );
+        permissionSubject: "tables",
+      });
 
       expect(permissions).toHaveLength(2);
       expect(permissions[0]).toMatchObject({ permission: "download" });
@@ -115,15 +115,15 @@ describe("getFeatureLevelDataPermissions", () => {
     it("returns 2 permissions without transforms regardless of PLUGIN_TRANSFORMS.isEnabled", () => {
       PLUGIN_TRANSFORMS.isEnabled = true;
 
-      const permissions = getFeatureLevelDataPermissions(
-        { databaseId, schemaName: "public", tableId: 1 },
+      const permissions = getFeatureLevelDataPermissions({
+        entityId: { databaseId, schemaName: "public", tableId: 1 },
         groupId,
         groupType,
-        getPermissionGraph(),
-        DataPermissionValue.UNRESTRICTED,
+        permissions: getPermissionGraph(),
+        dataAccessPermissionValue: DataPermissionValue.UNRESTRICTED,
         defaultGroup,
-        "fields",
-      );
+        permissionSubject: "fields",
+      });
 
       expect(permissions).toHaveLength(2);
       expect(permissions[0]).toMatchObject({ permission: "download" });

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/index.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/index.unit.spec.ts
@@ -57,7 +57,7 @@ describe("getFeatureLevelDataPermissions", () => {
         dataAccessPermissionValue: DataPermissionValue.UNRESTRICTED,
         defaultGroup,
         permissionSubject: "schemas",
-        transformsEnabled: true,
+        showTransformPermissions: true,
       });
 
       expect(permissions).toHaveLength(4);
@@ -83,47 +83,6 @@ describe("getFeatureLevelDataPermissions", () => {
         dataAccessPermissionValue: DataPermissionValue.UNRESTRICTED,
         defaultGroup,
         permissionSubject: "schemas",
-        transformsEnabled: false,
-      });
-
-      expect(permissions).toHaveLength(3);
-      expect(permissions[0]).toMatchObject({ permission: "download" });
-      expect(permissions[1]).toMatchObject({ permission: "data-model" });
-      expect(permissions[2]).toMatchObject({ permission: "details" });
-    });
-
-    it("returns 3 permissions when the transform token feature is present, but transforms are disabled", () => {
-      PLUGIN_TRANSFORMS.isEnabled = true;
-
-      const permissions = getFeatureLevelDataPermissions({
-        entityId: { databaseId },
-        groupId,
-        groupType,
-        permissions: getPermissionGraph(),
-        dataAccessPermissionValue: DataPermissionValue.UNRESTRICTED,
-        defaultGroup,
-        permissionSubject: "schemas",
-        transformsEnabled: false,
-      });
-
-      expect(permissions).toHaveLength(3);
-      expect(permissions[0]).toMatchObject({ permission: "download" });
-      expect(permissions[1]).toMatchObject({ permission: "data-model" });
-      expect(permissions[2]).toMatchObject({ permission: "details" });
-    });
-
-    it("returns 3 permissions when the transform token feature is missing, but transforms are enabled (possible downgrade screnario)", () => {
-      PLUGIN_TRANSFORMS.isEnabled = false;
-
-      const permissions = getFeatureLevelDataPermissions({
-        entityId: { databaseId },
-        groupId,
-        groupType,
-        permissions: getPermissionGraph(),
-        dataAccessPermissionValue: DataPermissionValue.UNRESTRICTED,
-        defaultGroup,
-        permissionSubject: "schemas",
-        transformsEnabled: true,
       });
 
       expect(permissions).toHaveLength(3);
@@ -134,7 +93,7 @@ describe("getFeatureLevelDataPermissions", () => {
   });
 
   describe("tables subject (schema level)", () => {
-    it("returns 2 permissions without transforms regardless of PLUGIN_TRANSFORMS.isEnabled", () => {
+    it("returns 2 permissions without transforms regardless of showTransformPermissions", () => {
       PLUGIN_TRANSFORMS.isEnabled = true;
 
       const permissions = getFeatureLevelDataPermissions({
@@ -145,7 +104,7 @@ describe("getFeatureLevelDataPermissions", () => {
         dataAccessPermissionValue: DataPermissionValue.UNRESTRICTED,
         defaultGroup,
         permissionSubject: "tables",
-        transformsEnabled: true,
+        showTransformPermissions: true,
       });
 
       expect(permissions).toHaveLength(2);
@@ -155,9 +114,7 @@ describe("getFeatureLevelDataPermissions", () => {
   });
 
   describe("fields subject (table level)", () => {
-    it("returns 2 permissions without transforms regardless of PLUGIN_TRANSFORMS.isEnabled", () => {
-      PLUGIN_TRANSFORMS.isEnabled = true;
-
+    it("returns 2 permissions without transforms regardless of showTransformPermissions", () => {
       const permissions = getFeatureLevelDataPermissions({
         entityId: { databaseId, schemaName: "public", tableId: 1 },
         groupId,
@@ -166,7 +123,7 @@ describe("getFeatureLevelDataPermissions", () => {
         dataAccessPermissionValue: DataPermissionValue.UNRESTRICTED,
         defaultGroup,
         permissionSubject: "fields",
-        transformsEnabled: true,
+        showTransformPermissions: true,
       });
 
       expect(permissions).toHaveLength(2);

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/index.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/index.unit.spec.ts
@@ -46,7 +46,7 @@ describe("getFeatureLevelDataPermissions", () => {
   });
 
   describe("schemas subject (database level)", () => {
-    it("returns 4 permissions including transforms when PLUGIN_TRANSFORMS.isEnabled is true", () => {
+    it("returns 4 permissions including transforms when PLUGIN_TRANSFORMS.isEnabled is true and transforms are enabled on the instance", () => {
       PLUGIN_TRANSFORMS.isEnabled = true;
 
       const permissions = getFeatureLevelDataPermissions({
@@ -57,6 +57,7 @@ describe("getFeatureLevelDataPermissions", () => {
         dataAccessPermissionValue: DataPermissionValue.UNRESTRICTED,
         defaultGroup,
         permissionSubject: "schemas",
+        transformsEnabled: true,
       });
 
       expect(permissions).toHaveLength(4);
@@ -71,7 +72,7 @@ describe("getFeatureLevelDataPermissions", () => {
       });
     });
 
-    it("returns 3 permissions without transforms when PLUGIN_TRANSFORMS.isEnabled is false", () => {
+    it("returns 3 permissions when the transform token feature is disabled", () => {
       PLUGIN_TRANSFORMS.isEnabled = false;
 
       const permissions = getFeatureLevelDataPermissions({
@@ -82,6 +83,47 @@ describe("getFeatureLevelDataPermissions", () => {
         dataAccessPermissionValue: DataPermissionValue.UNRESTRICTED,
         defaultGroup,
         permissionSubject: "schemas",
+        transformsEnabled: false,
+      });
+
+      expect(permissions).toHaveLength(3);
+      expect(permissions[0]).toMatchObject({ permission: "download" });
+      expect(permissions[1]).toMatchObject({ permission: "data-model" });
+      expect(permissions[2]).toMatchObject({ permission: "details" });
+    });
+
+    it("returns 3 permissions when the transform token feature is present, but transforms are disabled", () => {
+      PLUGIN_TRANSFORMS.isEnabled = true;
+
+      const permissions = getFeatureLevelDataPermissions({
+        entityId: { databaseId },
+        groupId,
+        groupType,
+        permissions: getPermissionGraph(),
+        dataAccessPermissionValue: DataPermissionValue.UNRESTRICTED,
+        defaultGroup,
+        permissionSubject: "schemas",
+        transformsEnabled: false,
+      });
+
+      expect(permissions).toHaveLength(3);
+      expect(permissions[0]).toMatchObject({ permission: "download" });
+      expect(permissions[1]).toMatchObject({ permission: "data-model" });
+      expect(permissions[2]).toMatchObject({ permission: "details" });
+    });
+
+    it("returns 3 permissions when the transform token feature is missing, but transforms are enabled (possible downgrade screnario)", () => {
+      PLUGIN_TRANSFORMS.isEnabled = false;
+
+      const permissions = getFeatureLevelDataPermissions({
+        entityId: { databaseId },
+        groupId,
+        groupType,
+        permissions: getPermissionGraph(),
+        dataAccessPermissionValue: DataPermissionValue.UNRESTRICTED,
+        defaultGroup,
+        permissionSubject: "schemas",
+        transformsEnabled: true,
       });
 
       expect(permissions).toHaveLength(3);
@@ -103,6 +145,7 @@ describe("getFeatureLevelDataPermissions", () => {
         dataAccessPermissionValue: DataPermissionValue.UNRESTRICTED,
         defaultGroup,
         permissionSubject: "tables",
+        transformsEnabled: true,
       });
 
       expect(permissions).toHaveLength(2);
@@ -123,6 +166,7 @@ describe("getFeatureLevelDataPermissions", () => {
         dataAccessPermissionValue: DataPermissionValue.UNRESTRICTED,
         defaultGroup,
         permissionSubject: "fields",
+        transformsEnabled: true,
       });
 
       expect(permissions).toHaveLength(2);

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/utils.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/utils.tsx
@@ -34,11 +34,17 @@ export const databaseManagementPermissionAllowedPathGetter = (
   return canUserAccessDatabaseManagement(user) ? ["databases"] : [];
 };
 
-export const getDataColumns = (
-  subject: PermissionSubject,
-  groupType?: SpecialGroupType,
-  isExternal?: boolean,
-) => {
+export const getDataColumns = ({
+  subject,
+  groupType,
+  isExternal,
+  transformsEnabled,
+}: {
+  subject: PermissionSubject;
+  groupType?: SpecialGroupType;
+  isExternal?: boolean;
+  transformsEnabled?: boolean;
+}) => {
   const allSubjectsColumns: { name: string; hint?: ReactNode }[] = [
     {
       name: t`Download results`,
@@ -57,7 +63,7 @@ export const getDataColumns = (
       name: t`Manage database`,
     });
 
-    if (PLUGIN_TRANSFORMS.isEnabled) {
+    if (PLUGIN_TRANSFORMS.isEnabled && transformsEnabled) {
       allSubjectsColumns.push({
         name: t`Transforms`,
         hint:

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/utils.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/utils.tsx
@@ -6,7 +6,6 @@ import type {
   PermissionSubject,
   SpecialGroupType,
 } from "metabase/admin/permissions/types";
-import { PLUGIN_TRANSFORMS } from "metabase/plugins";
 import { getUser } from "metabase/selectors/user";
 import type { User } from "metabase-types/api";
 import type { AdminPathKey, State } from "metabase-types/store";
@@ -38,12 +37,12 @@ export const getDataColumns = ({
   subject,
   groupType,
   isExternal,
-  transformsEnabled,
+  showTransformPermissions = false,
 }: {
   subject: PermissionSubject;
   groupType?: SpecialGroupType;
   isExternal?: boolean;
-  transformsEnabled?: boolean;
+  showTransformPermissions?: boolean;
 }) => {
   const allSubjectsColumns: { name: string; hint?: ReactNode }[] = [
     {
@@ -63,7 +62,7 @@ export const getDataColumns = ({
       name: t`Manage database`,
     });
 
-    if (PLUGIN_TRANSFORMS.isEnabled && transformsEnabled) {
+    if (showTransformPermissions) {
       allSubjectsColumns.push({
         name: t`Transforms`,
         hint:

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/utils.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/utils.unit.spec.ts
@@ -10,11 +10,15 @@ describe("getDataColumns", () => {
   });
 
   describe("schemas subject (database level)", () => {
-    it("returns 4 columns with Transforms when PLUGIN_TRANSFORMS.isEnabled is true", () => {
+    it("returns 4 permissions including transforms when PLUGIN_TRANSFORMS.isEnabled is true and transforms are enabled on the instance", () => {
       PLUGIN_TRANSFORMS.isEnabled = true;
 
       expect(
-        getDataColumns({ subject: "schemas", groupType: "admin" }),
+        getDataColumns({
+          subject: "schemas",
+          groupType: "admin",
+          transformsEnabled: true,
+        }),
       ).toStrictEqual([
         {
           name: "Download results",
@@ -26,10 +30,40 @@ describe("getDataColumns", () => {
       ]);
     });
 
-    it("returns 3 columns without Transforms when PLUGIN_TRANSFORMS.isEnabled is false", () => {
+    it("returns 3 permissions when the transform token feature is disabled", () => {
       PLUGIN_TRANSFORMS.isEnabled = false;
 
       expect(getDataColumns({ subject: "schemas" })).toStrictEqual([
+        {
+          name: "Download results",
+          hint: "Downloads of native queries are only allowed if a group has download permissions for the entire database.",
+        },
+        { name: "Manage table metadata" },
+        { name: "Manage database" },
+      ]);
+    });
+
+    it("returns 3 permissions when the transform token feature is present, but transforms are disabled", () => {
+      PLUGIN_TRANSFORMS.isEnabled = true;
+
+      expect(
+        getDataColumns({ subject: "schemas", transformsEnabled: false }),
+      ).toStrictEqual([
+        {
+          name: "Download results",
+          hint: "Downloads of native queries are only allowed if a group has download permissions for the entire database.",
+        },
+        { name: "Manage table metadata" },
+        { name: "Manage database" },
+      ]);
+    });
+
+    it("returns 3 permissions when the transform token feature is missing, but transforms are enabled (possible downgrade screnario)", () => {
+      PLUGIN_TRANSFORMS.isEnabled = false;
+
+      expect(
+        getDataColumns({ subject: "schemas", transformsEnabled: true }),
+      ).toStrictEqual([
         {
           name: "Download results",
           hint: "Downloads of native queries are only allowed if a group has download permissions for the entire database.",

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/utils.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/utils.unit.spec.ts
@@ -13,7 +13,9 @@ describe("getDataColumns", () => {
     it("returns 4 columns with Transforms when PLUGIN_TRANSFORMS.isEnabled is true", () => {
       PLUGIN_TRANSFORMS.isEnabled = true;
 
-      expect(getDataColumns("schemas", "admin")).toStrictEqual([
+      expect(
+        getDataColumns({ subject: "schemas", groupType: "admin" }),
+      ).toStrictEqual([
         {
           name: "Download results",
           hint: "Downloads of native queries are only allowed if a group has download permissions for the entire database.",
@@ -27,7 +29,7 @@ describe("getDataColumns", () => {
     it("returns 3 columns without Transforms when PLUGIN_TRANSFORMS.isEnabled is false", () => {
       PLUGIN_TRANSFORMS.isEnabled = false;
 
-      expect(getDataColumns("schemas")).toStrictEqual([
+      expect(getDataColumns({ subject: "schemas" })).toStrictEqual([
         {
           name: "Download results",
           hint: "Downloads of native queries are only allowed if a group has download permissions for the entire database.",
@@ -49,10 +51,14 @@ describe("getDataColumns", () => {
       ];
 
       PLUGIN_TRANSFORMS.isEnabled = true;
-      expect(getDataColumns("tables")).toStrictEqual(expectedColumns);
+      expect(getDataColumns({ subject: "tables" })).toStrictEqual(
+        expectedColumns,
+      );
 
       PLUGIN_TRANSFORMS.isEnabled = false;
-      expect(getDataColumns("tables")).toStrictEqual(expectedColumns);
+      expect(getDataColumns({ subject: "tables" })).toStrictEqual(
+        expectedColumns,
+      );
     });
   });
 
@@ -67,10 +73,14 @@ describe("getDataColumns", () => {
       ];
 
       PLUGIN_TRANSFORMS.isEnabled = true;
-      expect(getDataColumns("fields")).toStrictEqual(expectedColumns);
+      expect(getDataColumns({ subject: "fields" })).toStrictEqual(
+        expectedColumns,
+      );
 
       PLUGIN_TRANSFORMS.isEnabled = false;
-      expect(getDataColumns("fields")).toStrictEqual(expectedColumns);
+      expect(getDataColumns({ subject: "fields" })).toStrictEqual(
+        expectedColumns,
+      );
     });
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/utils.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/utils.unit.spec.ts
@@ -17,7 +17,7 @@ describe("getDataColumns", () => {
         getDataColumns({
           subject: "schemas",
           groupType: "admin",
-          transformsEnabled: true,
+          showTransformPermissions: true,
         }),
       ).toStrictEqual([
         {
@@ -31,39 +31,7 @@ describe("getDataColumns", () => {
     });
 
     it("returns 3 permissions when the transform token feature is disabled", () => {
-      PLUGIN_TRANSFORMS.isEnabled = false;
-
       expect(getDataColumns({ subject: "schemas" })).toStrictEqual([
-        {
-          name: "Download results",
-          hint: "Downloads of native queries are only allowed if a group has download permissions for the entire database.",
-        },
-        { name: "Manage table metadata" },
-        { name: "Manage database" },
-      ]);
-    });
-
-    it("returns 3 permissions when the transform token feature is present, but transforms are disabled", () => {
-      PLUGIN_TRANSFORMS.isEnabled = true;
-
-      expect(
-        getDataColumns({ subject: "schemas", transformsEnabled: false }),
-      ).toStrictEqual([
-        {
-          name: "Download results",
-          hint: "Downloads of native queries are only allowed if a group has download permissions for the entire database.",
-        },
-        { name: "Manage table metadata" },
-        { name: "Manage database" },
-      ]);
-    });
-
-    it("returns 3 permissions when the transform token feature is missing, but transforms are enabled (possible downgrade screnario)", () => {
-      PLUGIN_TRANSFORMS.isEnabled = false;
-
-      expect(
-        getDataColumns({ subject: "schemas", transformsEnabled: true }),
-      ).toStrictEqual([
         {
           name: "Download results",
           hint: "Downloads of native queries are only allowed if a group has download permissions for the entire database.",

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -377,6 +377,7 @@ export const createMockSettings = (
   "subscription-allowed-domains": null,
   "token-features": createMockTokenFeatures(),
   "token-status": null,
+  "transforms-enabled": false,
   version: createMockVersion(),
   "version-info": createMockVersionInfo(),
   "version-info-last-checked": null,

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -582,6 +582,7 @@ interface PublicSettings {
   "snowplow-url": string;
   "start-of-week": DayOfWeekId;
   "token-features": TokenFeatures;
+  "transforms-enabled": boolean;
   version: Version;
   "version-info-last-checked": string | null;
   "airgap-enabled": boolean;

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/fields.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/fields.ts
@@ -191,15 +191,25 @@ const buildNativePermission = (
   };
 };
 
-export const buildFieldsPermissions = (
-  entityId: TableEntityId,
-  groupId: number,
-  groupType: SpecialGroupType,
-  permissions: GroupsPermissions,
-  originalPermissions: GroupsPermissions,
-  defaultGroup: Group,
-  database: Database,
-): PermissionSectionConfig[] => {
+export const buildFieldsPermissions = ({
+  entityId,
+  groupId,
+  groupType,
+  permissions,
+  originalPermissions,
+  defaultGroup,
+  database,
+  transformsEnabled,
+}: {
+  entityId: TableEntityId;
+  groupId: number;
+  groupType: SpecialGroupType;
+  permissions: GroupsPermissions;
+  originalPermissions: GroupsPermissions;
+  defaultGroup: Group;
+  database: Database;
+  transformsEnabled: boolean;
+}): PermissionSectionConfig[] => {
   const isAdmin = groupType === "admin";
 
   const accessPermission = buildAccessPermission(
@@ -227,14 +237,15 @@ export const buildFieldsPermissions = (
   return _.compact([
     shouldShowViewDataColumn && accessPermission,
     nativePermission,
-    ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.getFeatureLevelDataPermissions(
+    ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.getFeatureLevelDataPermissions({
       entityId,
       groupId,
       groupType,
       permissions,
-      accessPermission.value,
+      dataAccessPermissionValue: accessPermission.value,
       defaultGroup,
-      "fields",
-    ),
+      permissionSubject: "fields",
+      transformsEnabled,
+    }),
   ]);
 };

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/fields.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/fields.ts
@@ -199,7 +199,7 @@ export const buildFieldsPermissions = ({
   originalPermissions,
   defaultGroup,
   database,
-  transformsEnabled,
+  showTransformPermissions,
 }: {
   entityId: TableEntityId;
   groupId: number;
@@ -208,7 +208,7 @@ export const buildFieldsPermissions = ({
   originalPermissions: GroupsPermissions;
   defaultGroup: Group;
   database: Database;
-  transformsEnabled: boolean;
+  showTransformPermissions: boolean;
 }): PermissionSectionConfig[] => {
   const isAdmin = groupType === "admin";
 
@@ -245,7 +245,7 @@ export const buildFieldsPermissions = ({
       dataAccessPermissionValue: accessPermission.value,
       defaultGroup,
       permissionSubject: "fields",
-      transformsEnabled,
+      showTransformPermissions,
     }),
   ]);
 };

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.tsx
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.tsx
@@ -177,7 +177,7 @@ type EntityWithPermissions = {
   callout?: string;
 };
 
-const getShouldShowTransformPermissions = createSelector(
+export const getShouldShowTransformPermissions = createSelector(
   (state: State) => getPlan(getSetting(state, "token-features")),
   getIsHosted,
   (state: State) => getSetting(state, "transforms-enabled"),

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.tsx
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.tsx
@@ -182,7 +182,8 @@ export const getDatabasesPermissionEditor = createSelector(
   getGroup,
   Groups.selectors.getList,
   getIsLoadingDatabaseTables,
-  (state: State) => getSetting(state, "transforms-enabled"),
+  (state: State) =>
+    getSetting(state, "transforms-enabled") || getSetting(state, "is-hosted?"),
   (
     metadata,
     params,
@@ -393,7 +394,9 @@ export const getGroupsDataPermissionEditor: GetGroupsDataPermissionEditorSelecto
     getDataPermissions,
     getOriginalDataPermissions,
     getOrderedGroups,
-    (state: State) => getSetting(state, "transforms-enabled"),
+    (state: State) =>
+      getSetting(state, "transforms-enabled") ||
+      getSetting(state, "is-hosted?"),
     (
       metadata,
       params,

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.unit.spec.tsx
@@ -1,0 +1,86 @@
+import { createMockTokenFeatures } from "metabase-types/api/mocks";
+import {
+  createMockSettingsState,
+  createMockState,
+} from "metabase-types/store/mocks";
+
+import { getShouldShowTransformPermissions } from "./permission-editor";
+
+describe("getShouldShowTransformPermissions", () => {
+  describe("OSS version", () => {
+    it("should return false for OSS version regardless of other settings", () => {
+      const state = createMockState({
+        settings: createMockSettingsState({
+          "is-hosted?": false,
+          "transforms-enabled": true,
+        }),
+      });
+
+      expect(getShouldShowTransformPermissions(state)).toBe(false);
+    });
+  });
+
+  describe("Pro Self-Hosted", () => {
+    it("should return true when transforms feature and setting are both enabled", () => {
+      const state = createMockState({
+        settings: createMockSettingsState({
+          "is-hosted?": false,
+          "transforms-enabled": true,
+          "token-features": createMockTokenFeatures({ transforms: true }),
+        }),
+      });
+
+      expect(getShouldShowTransformPermissions(state)).toBe(true);
+    });
+
+    it("should return false when transforms feature is enabled but setting is disabled", () => {
+      const state = createMockState({
+        settings: createMockSettingsState({
+          "is-hosted?": false,
+          "transforms-enabled": false,
+          "token-features": createMockTokenFeatures({ transforms: true }),
+        }),
+      });
+
+      expect(getShouldShowTransformPermissions(state)).toBe(false);
+    });
+  });
+
+  describe("Pro Cloud", () => {
+    it("should return true when transforms feature is enabled (ignores setting)", () => {
+      const state = createMockState({
+        settings: createMockSettingsState({
+          "is-hosted?": true,
+          "transforms-enabled": false,
+          "token-features": createMockTokenFeatures({ transforms: true }),
+        }),
+      });
+
+      expect(getShouldShowTransformPermissions(state)).toBe(true);
+    });
+
+    it("should return false when transforms feature is disabled", () => {
+      const state = createMockState({
+        settings: createMockSettingsState({
+          "is-hosted?": true,
+          "transforms-enabled": false,
+          "token-features": createMockTokenFeatures({ transforms: false }),
+        }),
+      });
+
+      expect(getShouldShowTransformPermissions(state)).toBe(false);
+    });
+
+    it("should return false when transforms feature is disabled even when the setting is enabled", () => {
+      const state = createMockState({
+        settings: createMockSettingsState({
+          "is-hosted?": true,
+          "transforms-enabled": true,
+          "token-features": createMockTokenFeatures({ transforms: false }),
+        }),
+      });
+
+      expect(getShouldShowTransformPermissions(state)).toBe(false);
+    });
+  });
+});

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/schemas.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/schemas.ts
@@ -192,16 +192,27 @@ const buildNativePermission = (
   };
 };
 
-export const buildSchemasPermissions = (
-  entityId: DatabaseEntityId,
-  groupId: number,
-  groupType: SpecialGroupType,
-  permissions: GroupsPermissions,
-  originalPermissions: GroupsPermissions,
-  defaultGroup: Group,
-  database: Database,
-  permissionView: "group" | "database",
-): PermissionSectionConfig[] => {
+export const buildSchemasPermissions = ({
+  entityId,
+  groupId,
+  groupType,
+  permissions,
+  originalPermissions,
+  defaultGroup,
+  database,
+  permissionView,
+  transformsEnabled,
+}: {
+  entityId: DatabaseEntityId;
+  groupId: number;
+  groupType: SpecialGroupType;
+  permissions: GroupsPermissions;
+  originalPermissions: GroupsPermissions;
+  defaultGroup: Group;
+  database: Database;
+  permissionView: "group" | "database";
+  transformsEnabled: boolean;
+}): PermissionSectionConfig[] => {
   const isAdmin = groupType === "admin";
 
   const accessPermission = buildAccessPermission(
@@ -231,15 +242,16 @@ export const buildSchemasPermissions = (
   return _.compact([
     shouldShowViewDataColumn && accessPermission,
     nativePermission,
-    ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.getFeatureLevelDataPermissions(
+    ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.getFeatureLevelDataPermissions({
       entityId,
       groupId,
       groupType,
       permissions,
-      accessPermission.value,
+      dataAccessPermissionValue: accessPermission.value,
       defaultGroup,
-      "schemas",
+      permissionSubject: "schemas",
       permissionView,
-    ),
+      transformsEnabled,
+    }),
   ]);
 };

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/schemas.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/schemas.ts
@@ -201,7 +201,7 @@ export const buildSchemasPermissions = ({
   defaultGroup,
   database,
   permissionView,
-  transformsEnabled,
+  showTransformPermissions,
 }: {
   entityId: DatabaseEntityId;
   groupId: number;
@@ -211,7 +211,7 @@ export const buildSchemasPermissions = ({
   defaultGroup: Group;
   database: Database;
   permissionView: "group" | "database";
-  transformsEnabled: boolean;
+  showTransformPermissions: boolean;
 }): PermissionSectionConfig[] => {
   const isAdmin = groupType === "admin";
 
@@ -251,7 +251,7 @@ export const buildSchemasPermissions = ({
       defaultGroup,
       permissionSubject: "schemas",
       permissionView,
-      transformsEnabled,
+      showTransformPermissions,
     }),
   ]);
 };

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
@@ -192,7 +192,7 @@ export const buildTablesPermissions = ({
   originalPermissions,
   defaultGroup,
   database,
-  transformsEnabled,
+  showTransformPermissions,
 }: {
   entityId: SchemaEntityId;
   groupId: number;
@@ -201,7 +201,7 @@ export const buildTablesPermissions = ({
   originalPermissions: GroupsPermissions;
   defaultGroup: Group;
   database: Database;
-  transformsEnabled: boolean;
+  showTransformPermissions: boolean;
 }): PermissionSectionConfig[] => {
   const isAdmin = groupType === "admin";
 
@@ -239,7 +239,7 @@ export const buildTablesPermissions = ({
       dataAccessPermissionValue: accessPermission.value,
       defaultGroup,
       permissionSubject: "tables",
-      transformsEnabled,
+      showTransformPermissions,
     }),
   ]);
 };

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
@@ -184,15 +184,25 @@ const buildNativePermission = (
   };
 };
 
-export const buildTablesPermissions = (
-  entityId: SchemaEntityId,
-  groupId: number,
-  groupType: SpecialGroupType,
-  permissions: GroupsPermissions,
-  originalPermissions: GroupsPermissions,
-  defaultGroup: Group,
-  database: Database,
-): PermissionSectionConfig[] => {
+export const buildTablesPermissions = ({
+  entityId,
+  groupId,
+  groupType,
+  permissions,
+  originalPermissions,
+  defaultGroup,
+  database,
+  transformsEnabled,
+}: {
+  entityId: SchemaEntityId;
+  groupId: number;
+  groupType: SpecialGroupType;
+  permissions: GroupsPermissions;
+  originalPermissions: GroupsPermissions;
+  defaultGroup: Group;
+  database: Database;
+  transformsEnabled: boolean;
+}): PermissionSectionConfig[] => {
   const isAdmin = groupType === "admin";
 
   const accessPermission = buildAccessPermission(
@@ -221,14 +231,15 @@ export const buildTablesPermissions = (
   return _.compact([
     shouldShowViewDataColumn && accessPermission,
     nativePermission,
-    ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.getFeatureLevelDataPermissions(
+    ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.getFeatureLevelDataPermissions({
       entityId,
       groupId,
       groupType,
       permissions,
-      accessPermission.value,
+      dataAccessPermissionValue: accessPermission.value,
       defaultGroup,
-      "tables",
-    ),
+      permissionSubject: "tables",
+      transformsEnabled,
+    }),
   ]);
 };

--- a/frontend/src/metabase/data-studio/app/pages/TransformsSectionLayout/TransformsSectionLayout.tsx
+++ b/frontend/src/metabase/data-studio/app/pages/TransformsSectionLayout/TransformsSectionLayout.tsx
@@ -1,8 +1,7 @@
-import type { Location } from "history";
 import type { ReactNode } from "react";
 import { t } from "ttag";
 
-import { useHasTokenFeature, useSetting } from "metabase/common/hooks";
+import { useSetting } from "metabase/common/hooks";
 import { usePageTitle } from "metabase/hooks/use-page-title";
 import { useSelector } from "metabase/lib/redux";
 import { PLUGIN_TRANSFORMS } from "metabase/plugins";
@@ -21,7 +20,7 @@ export function TransformsSectionLayout({
   usePageTitle(t`Transforms`);
   const shouldShowUpsell = useSelector(getShouldShowTransformsUpsell);
   const isTransformsEnabled = useSetting("transforms-enabled");
-  const isHosted = useHasTokenFeature("hosting");
+  const isHosted = useSetting("is-hosted?");
 
   if (shouldShowUpsell) {
     return <PLUGIN_TRANSFORMS.TransformsUpsellPage />;

--- a/frontend/src/metabase/data-studio/app/pages/TransformsSectionLayout/TransformsSectionLayout.tsx
+++ b/frontend/src/metabase/data-studio/app/pages/TransformsSectionLayout/TransformsSectionLayout.tsx
@@ -2,7 +2,7 @@ import type { Location } from "history";
 import type { ReactNode } from "react";
 import { t } from "ttag";
 
-import { useSetting } from "metabase/common/hooks";
+import { useHasTokenFeature, useSetting } from "metabase/common/hooks";
 import { usePageTitle } from "metabase/hooks/use-page-title";
 import { useSelector } from "metabase/lib/redux";
 import { PLUGIN_TRANSFORMS } from "metabase/plugins";
@@ -12,7 +12,6 @@ import { getShouldShowTransformsUpsell } from "metabase/transforms/selectors";
 import { SectionLayout } from "../../components/SectionLayout";
 
 type TransformsSectionLayoutProps = {
-  location: Location;
   children?: ReactNode;
 };
 
@@ -22,10 +21,11 @@ export function TransformsSectionLayout({
   usePageTitle(t`Transforms`);
   const shouldShowUpsell = useSelector(getShouldShowTransformsUpsell);
   const isTransformsEnabled = useSetting("transforms-enabled");
+  const isHosted = useHasTokenFeature("hosting");
 
   if (shouldShowUpsell) {
     return <PLUGIN_TRANSFORMS.TransformsUpsellPage />;
-  } else if (!isTransformsEnabled) {
+  } else if (!isTransformsEnabled && !isHosted) {
     return <EnableTransformsPage />;
   }
 

--- a/frontend/src/metabase/data-studio/app/pages/TransformsSectionLayout/TransformsSectionLayout.tsx
+++ b/frontend/src/metabase/data-studio/app/pages/TransformsSectionLayout/TransformsSectionLayout.tsx
@@ -2,9 +2,11 @@ import type { Location } from "history";
 import type { ReactNode } from "react";
 import { t } from "ttag";
 
+import { useSetting } from "metabase/common/hooks";
 import { usePageTitle } from "metabase/hooks/use-page-title";
 import { useSelector } from "metabase/lib/redux";
 import { PLUGIN_TRANSFORMS } from "metabase/plugins";
+import { EnableTransformsPage } from "metabase/transforms/pages/EnableTransformsPage/EnableTransformsPage";
 import { getShouldShowTransformsUpsell } from "metabase/transforms/selectors";
 
 import { SectionLayout } from "../../components/SectionLayout";
@@ -19,9 +21,12 @@ export function TransformsSectionLayout({
 }: TransformsSectionLayoutProps) {
   usePageTitle(t`Transforms`);
   const shouldShowUpsell = useSelector(getShouldShowTransformsUpsell);
+  const isTransformsEnabled = useSetting("transforms-enabled");
 
   if (shouldShowUpsell) {
     return <PLUGIN_TRANSFORMS.TransformsUpsellPage />;
+  } else if (!isTransformsEnabled) {
+    return <EnableTransformsPage />;
   }
 
   return <SectionLayout>{children}</SectionLayout>;

--- a/frontend/src/metabase/data-studio/app/pages/TransformsSectionLayout/TransformsSectionLayout.unit.spec.tsx
+++ b/frontend/src/metabase/data-studio/app/pages/TransformsSectionLayout/TransformsSectionLayout.unit.spec.tsx
@@ -1,0 +1,41 @@
+import { setupEnterpriseOnlyPlugin } from "__support__/enterprise";
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders } from "__support__/ui";
+import { createMockTokenFeatures } from "metabase-types/api/mocks";
+import { TransformsSectionLayout } from "./TransformsSectionLayout";
+import { createMockState } from "metabase-types/store/mocks";
+
+const setup = ({
+  isHosted,
+  hasTransformFeature,
+  transformsEnabled,
+}: {
+  isHosted: boolean;
+  hasTransformFeature: boolean;
+  transformsEnabled: boolean;
+}) => {
+  const settings = mockSettings({
+    "token-features": createMockTokenFeatures({
+      transforms: hasTransformFeature,
+      hosting: isHosted,
+    }),
+    "transforms-enabled": transformsEnabled,
+  });
+
+  if (isHosted || hasTransformFeature) {
+    setupEnterpriseOnlyPlugin("transforms");
+  }
+
+  renderWithProviders(
+    <TransformsSectionLayout>List of transforms</TransformsSectionLayout>,
+    {
+      storeInitialState: createMockState({
+        settings,
+      }),
+    },
+  );
+};
+
+describe("TransformSectionLayout", () => {
+  it("should show you an enable button in OSS", () => {});
+});

--- a/frontend/src/metabase/data-studio/app/pages/TransformsSectionLayout/TransformsSectionLayout.unit.spec.tsx
+++ b/frontend/src/metabase/data-studio/app/pages/TransformsSectionLayout/TransformsSectionLayout.unit.spec.tsx
@@ -1,4 +1,8 @@
 import { setupEnterpriseOnlyPlugin } from "__support__/enterprise";
+import {
+  setupStoreEEBillingEndpoint,
+  setupStoreEECloudAddOnsEndpoint,
+} from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
 import { renderWithProviders, screen } from "__support__/ui";
 import {
@@ -84,6 +88,11 @@ describe("TransformSectionLayout", () => {
   });
 
   describe("Pro Hosted", () => {
+    beforeEach(() => {
+      setupStoreEECloudAddOnsEndpoint(5);
+      setupStoreEEBillingEndpoint(5);
+    });
+
     it("Should only allow you into transforms if you have the transform token feature", async () => {
       setup({ isHosted: true });
       await assertDataStudioUpsellPage();

--- a/frontend/src/metabase/data-studio/app/pages/TransformsSectionLayout/TransformsSectionLayout.unit.spec.tsx
+++ b/frontend/src/metabase/data-studio/app/pages/TransformsSectionLayout/TransformsSectionLayout.unit.spec.tsx
@@ -119,5 +119,5 @@ const assertEnableScreen = async () =>
 
 const assertDataStudioUpsellPage = async () =>
   expect(
-    await screen.findByText("Tidy up your data right from Metabase"),
+    await screen.findByText("Start transforming your data in Metabase"),
   ).toBeInTheDocument();

--- a/frontend/src/metabase/data-studio/app/pages/TransformsSectionLayout/TransformsSectionLayout.unit.spec.tsx
+++ b/frontend/src/metabase/data-studio/app/pages/TransformsSectionLayout/TransformsSectionLayout.unit.spec.tsx
@@ -1,25 +1,36 @@
 import { setupEnterpriseOnlyPlugin } from "__support__/enterprise";
 import { mockSettings } from "__support__/settings";
-import { renderWithProviders } from "__support__/ui";
-import { createMockTokenFeatures } from "metabase-types/api/mocks";
-import { TransformsSectionLayout } from "./TransformsSectionLayout";
+import { renderWithProviders, screen } from "__support__/ui";
+import {
+  createMockTokenFeatures,
+  createMockUser,
+} from "metabase-types/api/mocks";
 import { createMockState } from "metabase-types/store/mocks";
 
+import { TransformsSectionLayout } from "./TransformsSectionLayout";
+
+jest.mock("metabase/nav/components/AppSwitcher", () => ({
+  AppSwitcher: () => "App Switcher",
+}));
+
 const setup = ({
-  isHosted,
-  hasTransformFeature,
-  transformsEnabled,
+  isHosted = false,
+  hasTransformFeature = false,
+  transformsEnabled = false,
+  isAdmin = false,
 }: {
-  isHosted: boolean;
-  hasTransformFeature: boolean;
-  transformsEnabled: boolean;
-}) => {
+  isHosted?: boolean;
+  hasTransformFeature?: boolean;
+  transformsEnabled?: boolean;
+  isAdmin?: boolean;
+} = {}) => {
   const settings = mockSettings({
     "token-features": createMockTokenFeatures({
       transforms: hasTransformFeature,
       hosting: isHosted,
     }),
     "transforms-enabled": transformsEnabled,
+    "is-hosted?": isHosted,
   });
 
   if (isHosted || hasTransformFeature) {
@@ -31,11 +42,73 @@ const setup = ({
     {
       storeInitialState: createMockState({
         settings,
+        currentUser: createMockUser({ is_superuser: isAdmin }),
       }),
     },
   );
 };
 
 describe("TransformSectionLayout", () => {
-  it("should show you an enable button in OSS", () => {});
+  describe("OSS", () => {
+    it("should show you an enable button in OSS if transforms are not enabled", async () => {
+      setup();
+      await assertEnableScreen();
+    });
+    it("should show you an enable button in OSS if transforms are not enabled, and an enable button if you are an admin", async () => {
+      setup({ isAdmin: true });
+      await assertEnableScreen();
+
+      expect(
+        await screen.findByRole("button", { name: "Enable transforms" }),
+      ).toBeInTheDocument();
+    });
+    it("should show allow you into transforms if transforms are enabled", async () => {
+      setup({
+        transformsEnabled: true,
+      });
+
+      await assertInApp();
+    });
+  });
+
+  describe("Pro Self Hosted", () => {
+    it("Should show you enable screen if transforms are not enabled", async () => {
+      setup({ hasTransformFeature: true });
+      await assertEnableScreen();
+    });
+
+    it("Should only allow you into transforms if you transforms are enabled", async () => {
+      setup({ hasTransformFeature: true, transformsEnabled: true });
+      await assertInApp();
+    });
+  });
+
+  describe("Pro Hosted", () => {
+    it("Should only allow you into transforms if you have the transform token feature", async () => {
+      setup({ isHosted: true });
+      await assertDataStudioUpsellPage();
+    });
+
+    it("We should only allow you into transforms if the token feature is true, not transformsEnabled", async () => {
+      setup({ isHosted: true, transformsEnabled: true });
+      await assertDataStudioUpsellPage();
+    });
+
+    it("If the transform featuure is enabled, we should show you the app", async () => {
+      setup({ isHosted: true, hasTransformFeature: true });
+      await assertInApp();
+    });
+  });
 });
+
+const assertInApp = async () =>
+  expect(await screen.findByText("List of transforms")).toBeInTheDocument();
+const assertEnableScreen = async () =>
+  expect(
+    await screen.findByText("Customize and clean up your data"),
+  ).toBeInTheDocument();
+
+const assertDataStudioUpsellPage = async () =>
+  expect(
+    await screen.findByText("Tidy up your data right from Metabase"),
+  ).toBeInTheDocument();

--- a/frontend/src/metabase/data-studio/app/pages/TransformsSectionLayout/TransformsSectionLayout.unit.spec.tsx
+++ b/frontend/src/metabase/data-studio/app/pages/TransformsSectionLayout/TransformsSectionLayout.unit.spec.tsx
@@ -54,11 +54,11 @@ const setup = ({
 
 describe("TransformSectionLayout", () => {
   describe("OSS", () => {
-    it("should show you an enable button in OSS if transforms are not enabled", async () => {
+    it("should show you an enable transforms screen in OSS if transforms are not enabled", async () => {
       setup();
       await assertEnableScreen();
     });
-    it("should show you an enable button in OSS if transforms are not enabled, and an enable button if you are an admin", async () => {
+    it("should show you an enable transforms screen with an enable button if you are an admin and transforms are not enabled", async () => {
       setup({ isAdmin: true });
       await assertEnableScreen();
 
@@ -93,17 +93,17 @@ describe("TransformSectionLayout", () => {
       setupStoreEEBillingEndpoint(5);
     });
 
-    it("Should only allow you into transforms if you have the transform token feature", async () => {
+    it("should show you an upsell page if you are hosted and the transform feature is not present", async () => {
       setup({ isHosted: true });
       await assertDataStudioUpsellPage();
     });
 
-    it("We should only allow you into transforms if the token feature is true, not transformsEnabled", async () => {
+    it("should show you an upsell page if you are hosted and the transform feature is not present, even when transforms are enabled on the instance", async () => {
       setup({ isHosted: true, transformsEnabled: true });
       await assertDataStudioUpsellPage();
     });
 
-    it("If the transform featuure is enabled, we should show you the app", async () => {
+    it("should show you the app if the instance is hosted and the transform feature is present", async () => {
       setup({ isHosted: true, hasTransformFeature: true });
       await assertInApp();
     });

--- a/frontend/src/metabase/plugins/oss/permissions.ts
+++ b/frontend/src/metabase/plugins/oss/permissions.ts
@@ -141,7 +141,7 @@ const getDefaultFeatureLevelPermissions = () => ({
     defaultGroup: _defaultGroup,
     permissionSubject: _permissionSubject,
     permissionView: _permissionView,
-    transformsEnabled: _transformsEnabled,
+    showTransformPermissions: _showTransformPermissions,
   }: {
     entityId: DatabaseEntityId;
     groupId: number;
@@ -151,7 +151,7 @@ const getDefaultFeatureLevelPermissions = () => ({
     defaultGroup: Group;
     permissionSubject: PermissionSubject;
     permissionView?: "group" | "database";
-    transformsEnabled: boolean;
+    showTransformPermissions?: boolean;
   }) => {
     return [] as any;
   },
@@ -159,12 +159,12 @@ const getDefaultFeatureLevelPermissions = () => ({
     subject: _subject,
     groupType: _groupType,
     isExternal: _isExternal,
-    transformsEnabled: _transformsEnabled,
+    showTransformPermissions: _showTransformPermissions,
   }: {
     subject: PermissionSubject;
     groupType?: SpecialGroupType;
     isExternal?: boolean;
-    transformsEnabled?: boolean;
+    showTransformPermissions?: boolean;
   }) => [] as any,
   getDownloadWidgetMessageOverride: (_result: Dataset): string | null => null,
   canDownloadResults: (_result: Dataset): boolean => true,

--- a/frontend/src/metabase/plugins/oss/permissions.ts
+++ b/frontend/src/metabase/plugins/oss/permissions.ts
@@ -132,23 +132,40 @@ const getDefaultAdvancedPermissions = () => ({
 export const PLUGIN_ADVANCED_PERMISSIONS = getDefaultAdvancedPermissions();
 
 const getDefaultFeatureLevelPermissions = () => ({
-  getFeatureLevelDataPermissions: (
-    _entityId: DatabaseEntityId,
-    _groupId: number,
-    _groupType: SpecialGroupType,
-    _permissions: GroupsPermissions,
-    _dataAccessPermissionValue: DataPermissionValue,
-    _defaultGroup: Group,
-    _permissionSubject: PermissionSubject,
-    _permissionView?: "group" | "database",
-  ) => {
+  getFeatureLevelDataPermissions: ({
+    entityId: _entityId,
+    groupId: _groupId,
+    groupType: _groupType,
+    permissions: _permissions,
+    dataAccessPermissionValue: _dataAccessPermissionValue,
+    defaultGroup: _defaultGroup,
+    permissionSubject: _permissionSubject,
+    permissionView: _permissionView,
+    transformsEnabled: _transformsEnabled,
+  }: {
+    entityId: DatabaseEntityId;
+    groupId: number;
+    groupType: SpecialGroupType;
+    permissions: GroupsPermissions;
+    dataAccessPermissionValue: DataPermissionValue;
+    defaultGroup: Group;
+    permissionSubject: PermissionSubject;
+    permissionView?: "group" | "database";
+    transformsEnabled: boolean;
+  }) => {
     return [] as any;
   },
-  getDataColumns: (
-    _subject: PermissionSubject,
-    _groupType?: SpecialGroupType,
-    _isExternal?: boolean,
-  ) => [] as any,
+  getDataColumns: ({
+    subject: _subject,
+    groupType: _groupType,
+    isExternal: _isExternal,
+    transformsEnabled: _transformsEnabled,
+  }: {
+    subject: PermissionSubject;
+    groupType?: SpecialGroupType;
+    isExternal?: boolean;
+    transformsEnabled?: boolean;
+  }) => [] as any,
   getDownloadWidgetMessageOverride: (_result: Dataset): string | null => null,
   canDownloadResults: (_result: Dataset): boolean => true,
   canAccessDataModel: (state: State): boolean => getUserIsAdmin(state),

--- a/frontend/src/metabase/transforms/pages/EnableTransformsPage/EnableTransformsPage.tsx
+++ b/frontend/src/metabase/transforms/pages/EnableTransformsPage/EnableTransformsPage.tsx
@@ -1,5 +1,6 @@
 import { t } from "ttag";
 
+import { useUpdateSettingMutation } from "metabase/api";
 import { DataStudioBreadcrumbs } from "metabase/data-studio/common/components/DataStudioBreadcrumbs";
 import { PageContainer } from "metabase/data-studio/common/components/PageContainer";
 import { PaneHeader } from "metabase/data-studio/common/components/PaneHeader";
@@ -20,6 +21,15 @@ import {
 export const EnableTransformsPage = () => {
   const isAdmin = useSelector(getUserIsAdmin);
 
+  const [updateSetting, { isLoading: updateSettingLoading }] =
+    useUpdateSettingMutation();
+
+  const enableTransforms = () =>
+    updateSetting({
+      key: "transforms-enabled",
+      value: true,
+    });
+
   return (
     <PageContainer>
       <PaneHeader
@@ -38,7 +48,11 @@ export const EnableTransformsPage = () => {
                   fw="bold"
                   lh="1.25rem"
                 >{t`Because transforms require write access to your database, make sure you know what you’re doing and that you understand the risks.`}</Text>
-                <Button variant="primary">{t`Enable transforms`}</Button>
+                <Button
+                  loading={updateSettingLoading}
+                  variant="primary"
+                  onClick={enableTransforms}
+                >{t`Enable transforms`}</Button>
               </>
             )}
           </Stack>

--- a/frontend/src/metabase/transforms/pages/EnableTransformsPage/EnableTransformsPage.tsx
+++ b/frontend/src/metabase/transforms/pages/EnableTransformsPage/EnableTransformsPage.tsx
@@ -1,0 +1,95 @@
+import { t } from "ttag";
+
+import { DataStudioBreadcrumbs } from "metabase/data-studio/common/components/DataStudioBreadcrumbs";
+import { PageContainer } from "metabase/data-studio/common/components/PageContainer";
+import { PaneHeader } from "metabase/data-studio/common/components/PaneHeader";
+import { useSelector } from "metabase/lib/redux";
+import { getUserIsAdmin } from "metabase/selectors/user";
+import {
+  Button,
+  Card,
+  Center,
+  Group,
+  Icon,
+  type IconName,
+  SimpleGrid,
+  Stack,
+  Text,
+  Title,
+} from "metabase/ui";
+export const EnableTransformsPage = () => {
+  const isAdmin = useSelector(getUserIsAdmin);
+
+  return (
+    <PageContainer>
+      <PaneHeader
+        breadcrumbs={
+          <DataStudioBreadcrumbs>{t`Transforms`}</DataStudioBreadcrumbs>
+        }
+      />
+      <Center>
+        <Card withBorder p="3rem" w="40rem">
+          <Stack gap="md" align="start">
+            <Title order={2}>{t`Customize and clean up your data`}</Title>
+            <Text lh="1.25rem">{t`Transforms let you create new tables within your connected databases, helping you make nicer and more self-explanatory datasets for your end users to look at and explore.`}</Text>
+            {isAdmin && (
+              <>
+                <Text
+                  fw="bold"
+                  lh="1.25rem"
+                >{t`Because transforms require write access to your database, make sure you know what you’re doing and that you understand the risks.`}</Text>
+                <Button variant="primary">{t`Enable transforms`}</Button>
+              </>
+            )}
+          </Stack>
+          <SimpleGrid cols={2} mt="3rem" spacing="sm">
+            <SimpleCard
+              icon="sql"
+              title={t`Custom tables`}
+              description={t`Create the tables your end users need with SQL queries`}
+            />
+            <SimpleCard
+              icon="clock"
+              title={t`Smart scheduling`}
+              description={t`Tell your transformd when to run by assigning tags`}
+            />
+            <SimpleCard
+              icon="eye"
+              title={t`Observability`}
+              description={t`See which transforms ran, and when`}
+            />
+            <SimpleCard
+              icon="lock"
+              title={t`Permissioned`}
+              description={t`Only Admins can create and run transforms`}
+            />
+          </SimpleGrid>
+        </Card>
+      </Center>
+    </PageContainer>
+  );
+};
+
+const SimpleCard = ({
+  icon,
+  title,
+  description,
+}: {
+  icon: IconName;
+  title: string;
+  description: string;
+}) => (
+  <Card bg="background-secondary" shadow="none">
+    <Group wrap="nowrap" align="start" gap="sm">
+      <Icon name={icon} c="brand" size={16} flex="0 0 1rem" />
+      <Stack gap="xs">
+        <Text fw="bold" lh="1rem">
+          {title}
+        </Text>
+        <Text fz="sm" lh="1rem">
+          {description}
+        </Text>
+      </Stack>
+    </Group>
+  </Card>
+);

--- a/frontend/src/metabase/transforms/pages/EnableTransformsPage/EnableTransformsPage.tsx
+++ b/frontend/src/metabase/transforms/pages/EnableTransformsPage/EnableTransformsPage.tsx
@@ -31,7 +31,7 @@ export const EnableTransformsPage = () => {
     });
 
   return (
-    <PageContainer>
+    <PageContainer data-testid="enable-transform-page">
       <PaneHeader
         breadcrumbs={
           <DataStudioBreadcrumbs>{t`Transforms`}</DataStudioBreadcrumbs>

--- a/src/metabase/transforms/settings.clj
+++ b/src/metabase/transforms/settings.clj
@@ -21,5 +21,4 @@
   :type       :boolean
   :visibility :authenticated
   :default    false
-  :feature    :transforms
   :audit      :getter)

--- a/src/metabase/transforms/settings.clj
+++ b/src/metabase/transforms/settings.clj
@@ -21,4 +21,5 @@
   :type       :boolean
   :visibility :authenticated
   :default    false
+  :export?    false
   :audit      :getter)

--- a/src/metabase/transforms/settings.clj
+++ b/src/metabase/transforms/settings.clj
@@ -15,3 +15,11 @@
   :export?    false
   :encryption :no
   :audit      :getter)
+
+(setting/defsetting transforms-enabled
+  (deferred-tru "Enable transforms for instances that have not explicetly purchased the transform add-on")
+  :type       :boolean
+  :visibility :authenticated
+  :default    false
+  :feature    :transforms
+  :audit      :getter)


### PR DESCRIPTION
### Description
Adds a instance setting that can tell if transforms are enabled or not, which is used in cases where the transforms token feature is not set. 

### How to verify
#### In OSS
- Verify that transforms need to be enabled before they can be accessed. This can be done by going to the transforms page in Data Studio

#### In Pro Self Hosted
- Same as OSS, except after enabling, you should should have the ability to adjust transform permissions after enabling

#### In Starter and Pro Cloud
- You should have the same upsell experience as before, but after purchasing the transforms add on, we should not require you to explicitly enable transforms


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
