### PR TITLE
Implement DB-level caching of premium features

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1024,7 +1024,6 @@
            config
            events
            internal-stats
-           models
            settings
            startup
            task

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1024,7 +1024,9 @@
            config
            events
            internal-stats
+           models
            settings
+           startup
            task
            util}}
 

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
@@ -97,6 +97,7 @@
    "PermissionsGroupMembership"
    "PermissionsRevision"
    "PersistedInfo"
+   "PremiumFeaturesCache"
    "Pulse"
    "PulseCard"
    "PulseChannel"

--- a/enterprise/backend/test/metabase_enterprise/serialization/models/entity_id_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/models/entity_id_test.clj
@@ -72,6 +72,7 @@
     :model/PermissionsGroupMembership
     :model/PermissionsRevision
     :model/PersistedInfo
+    :model/PremiumFeaturesCache
     :model/Pulse
     :model/PulseCard
     :model/PulseChannel

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotPurchasePage/MetabotPurchasePage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotPurchasePage/MetabotPurchasePage.unit.spec.tsx
@@ -7,6 +7,7 @@ import {
   setupStoreEEBillingEndpoint,
   setupStoreEECloudAddOnsEndpoint,
   setupStoreEETieredMetabotAI,
+  setupTokenRefreshEndpoint,
 } from "__support__/server-mocks";
 import { renderWithProviders, screen } from "__support__/ui";
 import {
@@ -103,6 +104,7 @@ const setup = async ({
     simulate_http_get_error,
   );
   setupStoreEETieredMetabotAI(simulate_http_post_error);
+  setupTokenRefreshEndpoint();
 
   renderWithProviders(<MetabotPurchasePage />, {
     // Calling `setupPropertiesEndpoints` above is not enough; we also need to set `storeInitialState`:

--- a/frontend/src/metabase/api/index.ts
+++ b/frontend/src/metabase/api/index.ts
@@ -29,6 +29,7 @@ export * from "./notification";
 export * from "./parameters";
 export * from "./permission";
 export * from "./persist";
+export * from "./premium-features";
 export * from "./revision";
 export * from "./search";
 export * from "./segment";

--- a/frontend/src/metabase/api/premium-features.ts
+++ b/frontend/src/metabase/api/premium-features.ts
@@ -1,0 +1,19 @@
+import type { TokenStatus } from "metabase-types/api";
+
+import { Api } from "./api";
+import { invalidateTags, tag } from "./tags";
+
+export const premiumFeaturesApi = Api.injectEndpoints({
+  endpoints: (builder) => ({
+    refreshTokenStatus: builder.mutation<TokenStatus, void>({
+      query: () => ({
+        method: "POST",
+        url: "/api/premium-features/token/refresh",
+      }),
+      invalidatesTags: (_, error) =>
+        invalidateTags(error, [tag("session-properties")]),
+    }),
+  }),
+});
+
+export const { useRefreshTokenStatusMutation } = premiumFeaturesApi;

--- a/frontend/src/metabase/api/utils/use-token-refresh.ts
+++ b/frontend/src/metabase/api/utils/use-token-refresh.ts
@@ -1,6 +1,10 @@
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
 
-import { Api, useGetSettingsQuery } from "metabase/api";
+import {
+  Api,
+  useGetSettingsQuery,
+  useRefreshTokenStatusMutation,
+} from "metabase/api";
 import { useDispatch } from "metabase/lib/redux";
 import type { TokenStatusFeature } from "metabase-types/api";
 
@@ -47,6 +51,18 @@ export function useTokenRefreshUntil(
   /* in order to force this hook to re-run on every request, even if the response data is the same, we can't destructure only the data prop from this hook, as is the pattern in many components */
   const res = useGetSettingsQuery();
   const dispatch = useDispatch();
+  const [refreshTokenStatus] = useRefreshTokenStatusMutation();
+
+  const refreshToken = useCallback(async () => {
+    // Bust the server-side cache first; the mutation's invalidatesTags will
+    // also invalidate session-properties on success, but we do it in finally
+    // too so the UI updates even if the request fails.
+    try {
+      await refreshTokenStatus().unwrap();
+    } finally {
+      dispatch(Api.util.invalidateTags(["session-properties"]));
+    }
+  }, [dispatch, refreshTokenStatus]);
 
   useEffect(() => {
     if (skip) {
@@ -57,10 +73,8 @@ export function useTokenRefreshUntil(
     const isTokenFeatureMissing = !tokenStatusFeatures?.includes(tokenFeature);
 
     if (isTokenFeatureMissing) {
-      const timeout = setTimeout(() => {
-        dispatch(Api.util.invalidateTags(["session-properties"]));
-      }, intervalMs);
+      const timeout = setTimeout(refreshToken, intervalMs);
       return () => clearTimeout(timeout);
     }
-  }, [res, dispatch, tokenFeature, intervalMs, skip]);
+  }, [res, dispatch, tokenFeature, intervalMs, skip, refreshToken]);
 }

--- a/frontend/test/__support__/server-mocks/premium-features.ts
+++ b/frontend/test/__support__/server-mocks/premium-features.ts
@@ -26,6 +26,12 @@ export const setupTokenStatusEndpointEmpty = () => {
   });
 };
 
+export const setupTokenRefreshEndpoint = () => {
+  fetchMock.post("path:/api/premium-features/token/refresh", 200, {
+    name: "premium-token-refresh",
+  });
+};
+
 export const setupTokenActivationEndpoint = ({
   success,
   status,

--- a/resources/migrations/059_update_migrations.yaml
+++ b/resources/migrations/059_update_migrations.yaml
@@ -3003,9 +3003,9 @@ databaseChangeLog:
                     primaryKey: true
                     nullable: false
               - column:
-                  name: token_status
-                  type: ${text.type}
-                  remarks: JSON-encoded token status response from MetaStore
+                  name: token_status_hash
+                  type: varchar(64)
+                  remarks: SHA-256 hex hash of the JSON-encoded token status
                   constraints:
                     nullable: false
               - column:

--- a/resources/migrations/059_update_migrations.yaml
+++ b/resources/migrations/059_update_migrations.yaml
@@ -2986,6 +2986,35 @@ databaseChangeLog:
                   constraints:
                     nullable: true
 
+  - changeSet:
+      id: v59.2026-02-07T17:00:00
+      author: johnswanson
+      comment: Create premium_features_token_cache table for cross-instance token cache
+      changes:
+        - createTable:
+            tableName: premium_features_token_cache
+            remarks: Caches premium features token check results, shared across instances
+            columns:
+              - column:
+                  name: token_hash
+                  type: varchar(64)
+                  remarks: SHA-256 hex hash of the premium token
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: token_status
+                  type: ${text.type}
+                  remarks: JSON-encoded token status response from MetaStore
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: ${timestamp_type}
+                  remarks: When this cache entry was last refreshed
+                  constraints:
+                    nullable: false
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/models/resolution.clj
+++ b/src/metabase/models/resolution.clj
@@ -73,6 +73,7 @@
     :model/PermissionsGroupMembership        metabase.permissions.models.permissions-group-membership
     :model/PermissionsRevision               metabase.permissions.models.permissions-revision
     :model/PersistedInfo                     metabase.model-persistence.models.persisted-info
+    :model/PremiumFeaturesCache              metabase.premium-features.models.premium-features-cache
     :model/PythonLibrary                     metabase-enterprise.transforms-python.models.python-library
     :model/Pulse                             metabase.pulse.models.pulse
     :model/PulseCard                         metabase.pulse.models.pulse-card

--- a/src/metabase/premium_features/api.clj
+++ b/src/metabase/premium_features/api.clj
@@ -2,7 +2,9 @@
   (:require
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
-   [metabase.premium-features.core :as premium-features]))
+   [metabase.premium-features.core :as premium-features]
+   [metabase.premium-features.token-check :as token-check]
+   [ring.util.response :as response]))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
@@ -13,6 +15,17 @@
   `features`, when it is `valid-thru`, and the `status` of the account."
   []
   (api/check-404 (premium-features/token-status)))
+
+#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
+(api.macros/defendpoint :post "/token/refresh"
+  "Clear all token caches and re-check the premium features token against the MetaStore.
+  Returns the fresh token status. Useful for the frontend after a purchase so that new features
+  are recognized without waiting for the cache TTL."
+  []
+  (token-check/clear-cache!)
+  (-> (api/check-404 (premium-features/token-status))
+      response/response
+      (assoc-in [:mb/cookies :cookie/premium-features-cache-timestamp] true)))
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/premium-features` routes."

--- a/src/metabase/premium_features/core.clj
+++ b/src/metabase/premium_features/core.clj
@@ -31,8 +31,7 @@
   plan-alias
   quotas
   TokenStatus
-  clear-cache!
-  clear-local-cache!]
+  clear-cache!]
 
  (metabase.premium-features.settings
   active-users-count

--- a/src/metabase/premium_features/core.clj
+++ b/src/metabase/premium_features/core.clj
@@ -31,7 +31,8 @@
   plan-alias
   quotas
   TokenStatus
-  clear-cache!]
+  clear-cache!
+  clear-local-cache!]
 
  (metabase.premium-features.settings
   active-users-count

--- a/src/metabase/premium_features/init.clj
+++ b/src/metabase/premium_features/init.clj
@@ -2,4 +2,5 @@
   (:require
    [metabase.premium-features.core]
    [metabase.premium-features.settings]
+   [metabase.premium-features.task.clear-token-cache]
    [metabase.premium-features.task.send-metering]))

--- a/src/metabase/premium_features/models/premium_features_cache.clj
+++ b/src/metabase/premium_features/models/premium_features_cache.clj
@@ -1,0 +1,15 @@
+(ns metabase.premium-features.models.premium-features-cache
+  "Model for the `premium_features_token_cache` table, which caches premium features token check results
+  across instances."
+  (:require
+   [metabase.models.interface :as mi]
+   [methodical.core :as methodical]
+   [toucan2.core :as t2]))
+
+(methodical/defmethod t2/table-name :model/PremiumFeaturesCache [_model] :premium_features_token_cache)
+
+(doto :model/PremiumFeaturesCache
+  (derive :metabase/model))
+
+(t2/deftransforms :model/PremiumFeaturesCache
+  {:token_status mi/transform-json})

--- a/src/metabase/premium_features/models/premium_features_cache.clj
+++ b/src/metabase/premium_features/models/premium_features_cache.clj
@@ -1,8 +1,7 @@
 (ns metabase.premium-features.models.premium-features-cache
-  "Model for the `premium_features_token_cache` table, which caches premium features token check results
-  across instances."
+  "Model for the `premium_features_token_cache` table, which stores hashes of premium features token check
+  results for cross-instance cache coordination. The actual token status is only held in memory."
   (:require
-   [metabase.models.interface :as mi]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
@@ -10,6 +9,3 @@
 
 (doto :model/PremiumFeaturesCache
   (derive :metabase/model))
-
-(t2/deftransforms :model/PremiumFeaturesCache
-  {:token_status mi/transform-json})

--- a/src/metabase/premium_features/task/clear_token_cache.clj
+++ b/src/metabase/premium_features/task/clear_token_cache.clj
@@ -1,0 +1,9 @@
+(ns metabase.premium-features.task.clear-token-cache
+  "Clears the premium features token cache on startup so the first token check always hits MetaStore fresh.
+  Without this, the cache table (which survives restarts) could serve stale feature data."
+  (:require
+   [metabase.premium-features.token-check :as token-check]
+   [metabase.startup.core :as startup]))
+
+(defmethod startup/def-startup-logic! ::clear-token-cache [_]
+  (token-check/clear-cache!))

--- a/src/metabase/server/handler.clj
+++ b/src/metabase/server/handler.clj
@@ -12,6 +12,7 @@
    [metabase.server.middleware.metadata-provider-cache :as mw.mp-cache]
    [metabase.server.middleware.misc :as mw.misc]
    [metabase.server.middleware.offset-paging :as mw.offset-paging]
+   [metabase.server.middleware.premium-features-cache :as mw.pf-cache]
    [metabase.server.middleware.request-id :as mw.request-id]
    [metabase.server.middleware.security :as mw.security]
    [metabase.server.middleware.session :as mw.session]
@@ -83,6 +84,7 @@
         #'mw.session/reset-session-timeout           ; Resets the timeout cookie for user activity to [[metabase.request.cookies/session-timeout]]
         #'mw.session/bind-current-user               ; Binds *current-user* and *current-user-id* if :metabase-user-id is non-nil
         #'mw.session/wrap-current-user-info          ; looks for :metabase-session-key and sets :metabase-user-id and other info if Session ID is valid
+        #'mw.pf-cache/wrap-premium-features-cache-check ; check cookie to refresh premium features cache if needed
         #'mw.settings-cache/wrap-settings-cache-check ; check cookie to refresh settings cache if needed
         #'analytics/embedding-mw                     ; reads sdk client headers, binds them to *client* and *version*, and tracks sdk-response metrics
         #'mw.session/wrap-session-key                ; looks for a Metabase Session ID and assoc as :metabase-session-key

--- a/src/metabase/server/middleware/premium_features_cache.clj
+++ b/src/metabase/server/middleware/premium_features_cache.clj
@@ -1,0 +1,57 @@
+(ns metabase.server.middleware.premium-features-cache
+  "Ring middleware to propagate premium-features cache invalidation across instances via a cookie.
+  When one instance refreshes features (via POST /api/premium-features/token/refresh), it sets a cookie
+  with the current timestamp. Other instances see this cookie and clear their local token caches so the
+  next feature check reads fresh data from the shared DB cache table."
+  (:require
+   [metabase.premium-features.core :as premium-features]
+   [metabase.util.log :as log]
+   [ring.util.response :as response]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private cookie-name "metabase.PREMIUM_FEATURES_LAST_UPDATED")
+
+(def ^:private last-known-invalidation (atom nil))
+
+(defn- check-and-invalidate-features-cache
+  "Check if the cookie timestamp is newer than our last known invalidation, and if so, clear the cache."
+  [request]
+  (when-let [cookie-timestamp (get-in request [:cookies cookie-name :value])]
+    (let [last-known @last-known-invalidation]
+      (when (and cookie-timestamp
+                 (or (nil? last-known)
+                     (try (pos? (compare cookie-timestamp last-known))
+                          (catch Exception _e
+                            (log/infof "Strange premium features cookie value: %s" cookie-timestamp)
+                            false))))
+        (log/info "Premium features cookie indicates cache is out of date. Clearing...")
+        (premium-features/clear-local-cache!)
+        (reset! last-known-invalidation cookie-timestamp)
+        ::invalidated))))
+
+(defn- maybe-set-premium-features-cookie
+  "Set the premium features last-updated cookie if this request triggered a refresh or propagated an invalidation."
+  [invalidated? response]
+  (if (or invalidated?
+          (-> response :mb/cookies :cookie/premium-features-cache-timestamp))
+    (let [timestamp (str (java.time.Instant/now))]
+      (reset! last-known-invalidation timestamp)
+      (response/set-cookie (update response :mb/cookies dissoc :cookie/premium-features-cache-timestamp)
+                           cookie-name
+                           timestamp
+                           {:path      "/"
+                            :max-age   (* 5 60)
+                            :same-site :lax}))
+    response))
+
+(defn wrap-premium-features-cache-check
+  "Middleware that checks if the premium features cache needs to be invalidated based on a cookie.
+
+  When premium features are refreshed on one instance, the API sets a cookie with the current timestamp.
+  This middleware checks that cookie on subsequent requests and clears the local cache if needed,
+  ensuring consistency in multi-instance deployments."
+  [handler]
+  (fn [request respond raise]
+    (let [invalidated? (check-and-invalidate-features-cache request)]
+      (handler request (comp respond #(maybe-set-premium-features-cookie invalidated? %)) raise))))

--- a/src/metabase/server/middleware/premium_features_cache.clj
+++ b/src/metabase/server/middleware/premium_features_cache.clj
@@ -1,8 +1,8 @@
 (ns metabase.server.middleware.premium-features-cache
   "Ring middleware to propagate premium-features cache invalidation across instances via a cookie.
   When one instance refreshes features (via POST /api/premium-features/token/refresh), it sets a cookie
-  with the current timestamp. Other instances see this cookie and clear their local token caches so the
-  next feature check reads fresh data from the shared DB cache table."
+  with the current timestamp. Other instances see this cookie and clear all token caches so the
+  next feature check re-fetches from the MetaStore."
   (:require
    [metabase.premium-features.core :as premium-features]
    [metabase.util.log :as log]
@@ -26,7 +26,7 @@
                             (log/infof "Strange premium features cookie value: %s" cookie-timestamp)
                             false))))
         (log/info "Premium features cookie indicates cache is out of date. Clearing...")
-        (premium-features/clear-local-cache!)
+        (premium-features/clear-cache!)
         (reset! last-known-invalidation cookie-timestamp)
         ::invalidated))))
 

--- a/test/metabase/cmd/copy_test.clj
+++ b/test/metabase/cmd/copy_test.clj
@@ -36,6 +36,7 @@
     :model/DatabaseRouter
     :model/Dependency
     :model/PythonLibrary
+    :model/PremiumFeaturesCache
     :model/Query
     :model/QueryCache
     :model/QueryExecution

--- a/test/metabase/premium_features/api_test.clj
+++ b/test/metabase/premium_features/api_test.clj
@@ -1,6 +1,8 @@
 (ns metabase.premium-features.api-test
   (:require
+   [clj-http.cookies :as cookies]
    [clojure.test :refer :all]
+   [metabase.premium-features.token-check :as token-check]
    [metabase.test :as mt]))
 
 (set! *warn-on-reflection* true)
@@ -23,3 +25,33 @@
       (testing "returns 404 if no token is set"
         (is (= "Not found."
                (mt/user-http-request :crowberto :get 404 "premium-features/token/status")))))))
+
+(deftest post-token-refresh-test
+  (testing "POST /api/premium-features/token/refresh"
+    (mt/with-random-premium-token! [_token]
+      (testing "clears cache and returns fresh token status"
+        (let [cleared? (atom false)]
+          (with-redefs [token-check/clear-cache! (fn [] (reset! cleared? true))]
+            (is (=? {:valid    true
+                     :status   "fake"
+                     :features ["test" "fixture"]}
+                    (mt/user-http-request :crowberto :post 200 "premium-features/token/refresh")))
+            (is (true? @cleared?)))))
+
+      (testing "requires superusers"
+        (is (= "You don't have permissions to do that."
+               (mt/user-http-request :rasta :post 403 "premium-features/token/refresh")))))
+
+    (mt/with-temporary-setting-values [:premium-embedding-token nil]
+      (testing "returns 404 if no token is set"
+        (is (= "Not found."
+               (mt/user-http-request :crowberto :post 404 "premium-features/token/refresh")))))))
+
+(deftest token-refresh-sets-premium-features-cookie-test
+  (testing "POST /api/premium-features/token/refresh sets the premium-features-last-updated cookie"
+    (mt/with-random-premium-token! [_token]
+      (let [cs (cookies/cookie-store)]
+        (mt/user-real-request :crowberto :post 200 "premium-features/token/refresh"
+                              {:request-options {:cookie-store cs}})
+        (let [pf-cookie (get (cookies/get-cookies cs) "metabase.PREMIUM_FEATURES_LAST_UPDATED")]
+          (is (some? pf-cookie) "No premium-features-last-updated cookie set"))))))

--- a/test/metabase/premium_features/token_check_test.clj
+++ b/test/metabase/premium_features/token_check_test.clj
@@ -3,19 +3,21 @@
    [clj-http.client :as http]
    [clj-http.core :as http.core]
    [clojure.test :refer :all]
+   [java-time.api :as t]
    [mb.hawk.parallel]
    [metabase.app-db.connection :as mdb.connection]
    [metabase.app-db.core :as mdb]
    [metabase.premium-features.core :as premium-features]
+   [metabase.premium-features.task.clear-token-cache]
    [metabase.premium-features.test-util :as tu]
    [metabase.premium-features.token-check :as token-check]
+   [metabase.startup.core :as startup]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
+   [metabase.util :as u]
    [metabase.util.json :as json]
    [metabase.util.malli.registry :as mr]
-   [toucan2.core :as t2])
-  (:import
-   (java.util.concurrent TimeUnit)))
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -48,9 +50,10 @@
         response   (atom :error)
         ;; i've removed the circuit breaker from the stack. that sometimes shuts down the tests in a way we don't want
         ;; to exercise here
-        checker (binding [token-check/*customize-checker* true]
-                  (token-check/make-checker {:ttl-ms 500
-                                             :grace-period (token-check/guava-cache-grace-period 36 TimeUnit/HOURS)}))]
+        checker    (binding [token-check/*customize-checker* true]
+                     (token-check/make-checker {:local-ttl (t/seconds 5)
+                                                :soft-ttl  (t/minutes 1)
+                                                :hard-ttl  (t/minutes 2)}))]
     (with-redefs [token-check/http-fetch (fn [& _]
                                            (swap! call-count inc)
                                            (case @response
@@ -71,17 +74,15 @@
             (token-check/check-token (tu/random-token))))))
 
 (deftest fetch-token-does-not-call-db-when-cached
-  (testing "No DB calls are made when checking token status if the status is cached"
+  (testing "No DB calls are made when checking token status if the status is in local cache"
     (let [token (tu/random-token)
           _ (token-check/check-token token)
-          ;; Sigh. This is really quite horrific. But we need some wiggle room here: any endpoint that gets some setting
-          ;; inside it is going to check to see whether it's time for an update check. If it is, it'll hit the DB to see
-          ;; when settings were last updated, and the count will be incremented. Therefore, let's do this a few times...
+          ;; The local cache has a 5s TTL, so repeated checks within that window should not hit the DB.
           call-counts (repeatedly 3 (fn []
                                       (t2/with-call-count [call-count]
                                         (token-check/check-token token)
                                         (call-count))))]
-      ;; ... and then make sure that *some* of the times, we didn't hit the DB again.
+      ;; At least some of these should be zero (served from local in-memory cache)
       (is (some zero? call-counts)))))
 
 (deftest token-checker-test
@@ -89,9 +90,8 @@
         behavior       (atom :success)
         call-count     (atom 0)
         good-response  {:valid    true
-                        :status   :fake
-                        :features [:feature1 :feature2]}
-        no-features    {:valid false :status "Unable to validate token" :error-details "network issues!"}
+                        :status   "fake"
+                        :features ["feature1" "feature2"]}
         token-response (fn [_token]
                          (swap! call-count inc)
                          (case @behavior
@@ -102,13 +102,15 @@
                         {:base            (reify token-check/TokenChecker
                                             (-check-token [_ token]
                                               (token-response token))
-                                            (-clear-cache! [_]))
+                                            (-clear-cache! [_])
+                                            (-clear-local-cache! [_]))
                          :circuit-breaker {:failure-threshold-ratio-in-period [4 4 1000]
                                            :delay-ms                          50
                                            :success-threshold                 1}
                          :timeout-ms      100
-                         :ttl-ms          200
-                         :grace-period    (token-check/guava-cache-grace-period 1000 TimeUnit/MILLISECONDS)})]
+                         :local-ttl       (t/millis 50)
+                         :soft-ttl        (t/millis 200)
+                         :hard-ttl        (t/seconds 1)})]
     (testing "when no information is present, hits the underlying"
       (is (= good-response (token-check/-check-token checker token)))
       (is (= 1 @call-count)))
@@ -119,12 +121,7 @@
       (reset! behavior :error)
       (Thread/sleep 200)
       (dotimes [_ 1000] (token-check/-check-token checker token))
-      (is (< @call-count 50))
-      (testing "But we always get a good response from the grace period"
-        (is (= good-response (token-check/-check-token checker token)))))
-    (testing "But eventually grace period elapses"
-      (Thread/sleep 1000)
-      (is (= no-features (token-check/-check-token checker token))))
+      (is (< @call-count 50)))
     (testing "When connectivity is restored we get successful token checks"
       (reset! behavior :success)
       (Thread/sleep 100) ;; wait for circuit breaker to open back up
@@ -132,21 +129,23 @@
   (testing "App db not setup yet does not invoke the circuit breaker (#65294)"
     (let [token          (tu/random-token)
           good-response  {:valid    true
-                          :status   :fake
-                          :features [:feature1 :feature2]}
+                          :status   "fake"
+                          :features ["feature1" "feature2"]}
           token-response (fn [_token]
                            good-response)
           checker        (token-check/make-checker
                           {:base            (reify token-check/TokenChecker
                                               (-check-token [_ token]
                                                 (token-response token))
-                                              (-clear-cache! [_]))
+                                              (-clear-cache! [_])
+                                              (-clear-local-cache! [_]))
                            :circuit-breaker {:failure-threshold-ratio-in-period [4 4 1000]
                                              :delay-ms                          5000
                                              :success-threshold                 1}
                            :timeout-ms      100
-                           :ttl-ms          200
-                           :grace-period    (token-check/guava-cache-grace-period 1000 TimeUnit/MILLISECONDS)})]
+                           :local-ttl       (t/millis 50)
+                           :soft-ttl        (t/millis 200)
+                           :hard-ttl        (t/seconds 1)})]
       (with-redefs [mdb/db-is-set-up? (constantly false)]
         (is (= {:valid false
                 :status "Unable to validate token"
@@ -161,73 +160,56 @@
         (with-redefs [mdb/db-is-set-up? (constantly true)]
           (is (= good-response (token-check/-check-token checker token))))))))
 
-(deftest grace-period-test
-  (testing "implementation check"
-    (let [token          (tu/random-token)
-          behavior       (atom :success)
-          success-token  {:valid true :status :fake :features [:feature1 :feature2]}
-          restored-token {:valid true :status :fake :features [:new-feature]}
-          invalid        {:valid false, :status "Unable to validate token", :error-details nil}
-          underlying     (reify token-check/TokenChecker
-                           (-check-token [_ t]
-                             (when (= t token)
-                               (case @behavior
-                                 :success          success-token
-                                 :error            (throw (ex-info "network troubles!" {:ka :boom}))
-                                 :network-restored restored-token)))
-                           (-clear-cache! [_]))
-          grace          (binding [token-check/*customize-checker* true]
-                           (token-check/make-checker
-                            {:base         underlying
-                             :grace-period (token-check/guava-cache-grace-period 20 TimeUnit/MILLISECONDS)}))]
-      (is (= success-token (token-check/check-token grace token)))
-      (is (= invalid (token-check/check-token grace (tu/random-token))))
-      (testing "During errors"
-        (reset! behavior :error)
-        (is (= success-token (token-check/check-token grace token)))
-        (is (= invalid (token-check/check-token grace (tu/random-token))))
-        (Thread/sleep 40) ;; our simple one here has a grace period of 20 milliseconds
-        (testing "but it expires"
-          (is (= {:valid false :status "Unable to validate token" :error-details "network troubles!"}
-                 (token-check/check-token grace token)))))
-      (testing "When good"
-        (reset! behavior :success)
-        (is (= success-token (token-check/check-token grace token))))
-      (testing "We can enter the grace period"
-        (reset! behavior :error)
-        (is (= success-token (token-check/check-token grace token))))
-      (testing "And then we immediately get new token when network restores"
-        (reset! behavior :network-restored)
-        (is (= restored-token (token-check/check-token grace token)))))))
+(defn- age-cache-entry!
+  "Rewrite the `updated_at` timestamp for `token` in the cache table to be `age-ms` milliseconds in the past."
+  [token age-ms]
+  (let [token-hash (#'token-check/hash-token token)
+        new-ts     (t/minus (t/offset-date-time) (t/millis age-ms))]
+    (t2/update! :model/PremiumFeaturesCache :token_hash token-hash {:updated_at new-ts})))
 
-(deftest e2e
-  (testing "token check hits the network"
-    (let [token                 (tu/random-token)
-          ;; todo: need to check that we use the grace period
-          time-passes!          token-check/clear-cache!
-          call-count            (atom 0)]
-      (with-redefs [token-check/http-fetch (fn [& _]
-                                             (swap! call-count inc)
-                                             {:status 200
-                                              :body   "{\"valid\":true,\"status\":\"fake\",\"features\":[\"fake\",\"features\"]}"})]
-        (= {:valid true, :status "fake", :features ["fake" "features"]}
-           (token-check/check-token token))
-        (is (= 1 @call-count)))
-      (with-redefs [token-check/http-fetch (fn [& _]
-                                             (swap! call-count inc)
-                                             (throw (ex-info "network failure!" {})))]
-        (testing "Doesn't hit the network inside of cache duration"
-          (is (= {:valid true, :status "fake", :features ["fake" "features"]}
-                 (token-check/check-token token)))
+(deftest e2e-test
+  (testing "full stack: HTTP fetch → table cache → error handling"
+    (let [token      (tu/random-token)
+          call-count (atom 0)
+          good-body  "{\"valid\":true,\"status\":\"fake\",\"features\":[\"fake\",\"features\"]}"
+          good-resp  {:valid true, :status "fake", :features ["fake" "features"]}
+          ;; no circuit breaker — it carries state between runs and causes flakes
+          checker    (binding [token-check/*customize-checker* true]
+                       (token-check/make-checker {:local-ttl (t/millis 50)
+                                                  :soft-ttl  (t/hours 12)
+                                                  :hard-ttl  (t/hours 36)}))]
+      (try
+        (with-redefs [token-check/http-fetch (fn [& _]
+                                               (swap! call-count inc)
+                                               {:status 200 :body good-body})]
+          (is (= good-resp (token-check/check-token checker token)))
           (is (= 1 @call-count)))
-        (time-passes!) ;; we can clear the cache but don't have a great way to expire the grace period
-        (testing "Hits the network periodically (12 hours)"
-          (let [response (token-check/check-token token)]
-            ;; called but we got network failure from redefs
-            (is (= 2 @call-count))
-            (testing "Grace period supplements errors"
-              (is (= {:valid true, :status "fake", :features ["fake" "features"]}
-                     response)))))))))
+        (with-redefs [token-check/http-fetch (fn [& _]
+                                               (swap! call-count inc)
+                                               (throw (ex-info "network failure!" {})))]
+          (testing "Doesn't hit the network inside of cache duration"
+            ;; Wait for local cache to expire, but DB cache is still fresh
+            (Thread/sleep 60)
+            (is (= good-resp (token-check/check-token checker token)))
+            (is (= 1 @call-count)))
+          (testing "Stale cache (past soft TTL, within hard TTL) still serves cached result"
+            (age-cache-entry! token (+ (u/hours->ms 12) 1000))
+            (Thread/sleep 60) ;; expire local cache
+            (let [refresh-done (promise)]
+              (binding [token-check/*testing-only-call-after-refresh* #(deliver refresh-done true)]
+                (is (= good-resp (token-check/check-token checker token))))
+              ;; async refresh was attempted (and failed), but stale value was returned
+              (is (true? (deref refresh-done 5000 :timeout))))
+            (is (= 2 @call-count)))
+          (testing "Expired cache (past hard TTL) surfaces the error"
+            (age-cache-entry! token (+ (u/hours->ms 36) 1000))
+            (Thread/sleep 60) ;; expire local cache
+            (is (= {:valid         false
+                    :status        "Unable to validate token"
+                    :error-details "network failure!"}
+                   (token-check/check-token checker token)))))
+        (finally
+          (token-check/-clear-cache! checker))))))
 
 (deftest token-status-setting-test
   (testing "If a `premium-embedding-token` has been set, the `token-status` setting should return the response
@@ -372,3 +354,213 @@
       (is (contains? stats :domains))
       (is (contains? stats :embedding-dashboard-count))
       (is (contains? stats :embedding-question-count)))))
+
+;;; ------------------------------------------------ table-backed-token-checker ------------------------------------------------
+
+(defn- make-table-backed-checker
+  "Helper: wraps a base token-response fn with table-backed caching. Returns the checker."
+  [token-response-fn {:keys [local-ttl soft-ttl hard-ttl]
+                      :or   {local-ttl (t/millis 50)}}]
+  (binding [token-check/*customize-checker* true]
+    (token-check/make-checker
+     {:base      (reify token-check/TokenChecker
+                   (-check-token [_ token] (token-response-fn token))
+                   (-clear-cache! [_])
+                   (-clear-local-cache! [_]))
+      :local-ttl local-ttl
+      :soft-ttl  soft-ttl
+      :hard-ttl  hard-ttl})))
+
+(deftest table-backed-token-checker-fresh-hit-test
+  (testing "Fresh cache entry (< soft-ttl) is returned without hitting the underlying checker"
+    (let [call-count    (atom 0)
+          good-response {:valid true :status "OK" :features ["sandboxes"]}
+          checker       (make-table-backed-checker
+                         (fn [_token]
+                           (swap! call-count inc)
+                           good-response)
+                         {:soft-ttl (t/minutes 1) :hard-ttl (t/minutes 2)})
+          token         (tu/random-token)]
+      (try
+        ;; First call: cache miss → delegate
+        (is (= good-response (token-check/-check-token checker token)))
+        (is (= 1 @call-count))
+        ;; Second call: fresh cache hit → no delegate
+        (is (= good-response (token-check/-check-token checker token)))
+        (is (= 1 @call-count))
+        (finally
+          (token-check/-clear-cache! checker))))))
+
+(deftest table-backed-token-checker-stale-async-refresh-test
+  (testing "Stale entry (soft..hard) returns cached value and triggers async refresh"
+    (let [call-count       (atom 0)
+          good-response    {:valid true :status "OK" :features ["sandboxes"]}
+          updated-response {:valid true :status "OK" :features ["sandboxes" "audit-app"]}
+          response-atom    (atom good-response)
+          refresh-done     (promise)
+          checker          (make-table-backed-checker
+                            (fn [_token]
+                              (swap! call-count inc)
+                              @response-atom)
+                            ;; soft=1ms so it's immediately stale, hard=10s so not expired
+                            {:local-ttl (t/millis 1) :soft-ttl (t/millis 1) :hard-ttl (t/seconds 10)})
+          token            (tu/random-token)]
+      (try
+        ;; First call: cache miss → delegate
+        (is (= good-response (token-check/-check-token checker token)))
+        (is (= 1 @call-count))
+        ;; Let the entry become stale (both local and DB)
+        (Thread/sleep 10)
+        ;; Switch to updated response for the async refresh
+        (reset! response-atom updated-response)
+        ;; Second call: stale → returns old cached value, kicks off async refresh
+        (binding [token-check/*testing-only-call-after-refresh* #(deliver refresh-done true)]
+          (is (= good-response (token-check/-check-token checker token)))
+          (is (true? @refresh-done)))
+        ;; Wait for the async refresh to complete
+        (is (not= :timeout (deref refresh-done 5000 :timeout)))
+        ;; Expire local cache
+        (Thread/sleep 10)
+        ;; Third call: should now see the refreshed value
+        (is (= updated-response (token-check/-check-token checker token)))
+        (finally
+          (token-check/-clear-cache! checker))))))
+
+(deftest table-backed-token-checker-expired-sync-test
+  (testing "Expired entry (> hard-ttl) delegates synchronously"
+    (let [call-count    (atom 0)
+          good-response {:valid true :status "OK" :features ["sandboxes"]}
+          checker       (make-table-backed-checker
+                         (fn [_token]
+                           (swap! call-count inc)
+                           good-response)
+                         ;; Both TTLs = 1ms so entry expires immediately
+                         {:local-ttl (t/millis 1) :soft-ttl (t/millis 1) :hard-ttl (t/millis 1)})
+          token         (tu/random-token)]
+      (try
+        ;; First call: miss
+        (token-check/-check-token checker token)
+        (is (= 1 @call-count))
+        (Thread/sleep 5)
+        ;; Second call: expired → synchronous delegate
+        (token-check/-check-token checker token)
+        (is (= 2 @call-count))
+        (finally
+          (token-check/-clear-cache! checker))))))
+
+(deftest table-backed-token-checker-multi-token-test
+  (testing "Different tokens are cached independently"
+    (let [call-count (atom 0)
+          checker    (make-table-backed-checker
+                      (fn [token]
+                        (swap! call-count inc)
+                        {:valid true :status "OK" :features [(str "feat-" token)]})
+                      {:soft-ttl (t/minutes 1) :hard-ttl (t/minutes 2)})
+          token-a    (tu/random-token)
+          token-b    (tu/random-token)]
+      (try
+        (let [result-a (token-check/-check-token checker token-a)]
+          (is (= [(str "feat-" token-a)] (:features result-a))))
+        (let [result-b (token-check/-check-token checker token-b)]
+          (is (= [(str "feat-" token-b)] (:features result-b))))
+        (is (= 2 @call-count))
+        ;; Both cached now
+        (token-check/-check-token checker token-a)
+        (token-check/-check-token checker token-b)
+        (is (= 2 @call-count))
+        (finally
+          (token-check/-clear-cache! checker))))))
+
+(deftest table-backed-token-checker-clear-cache-test
+  (testing "clear-cache! removes both local and DB cache"
+    (let [checker (make-table-backed-checker
+                   (fn [_token]
+                     {:valid true :status "OK" :features ["sandboxes"]})
+                   {:soft-ttl (t/minutes 1) :hard-ttl (t/minutes 2)})
+          token   (tu/random-token)]
+      (token-check/-check-token checker token)
+      (let [token-hash (#'token-check/hash-token token)]
+        (is (some? (t2/select-one :model/PremiumFeaturesCache :token_hash token-hash)))
+        (token-check/-clear-cache! checker)
+        (is (nil? (t2/select-one :model/PremiumFeaturesCache :token_hash token-hash)))))))
+
+(deftest table-backed-token-checker-invalid-cached-test
+  (testing "Invalid token responses are also cached in table to avoid hammering MetaStore"
+    (let [call-count (atom 0)
+          checker    (make-table-backed-checker
+                      (fn [_token]
+                        (swap! call-count inc)
+                        {:valid false :status "Token does not exist."})
+                      {:soft-ttl (t/minutes 1) :hard-ttl (t/minutes 2)})
+          token      (tu/random-token)]
+      (try
+        (is (= {:valid false :status "Token does not exist."}
+               (token-check/-check-token checker token)))
+        (is (= 1 @call-count))
+        ;; Second call should use cache
+        (is (= {:valid false :status "Token does not exist."}
+               (token-check/-check-token checker token)))
+        (is (= 1 @call-count))
+        (finally
+          (token-check/-clear-cache! checker))))))
+
+(deftest table-backed-token-checker-cross-instance-sync-test
+  (testing "Entry written by another instance (simulated via direct table write) is read without delegate call"
+    (let [call-count    (atom 0)
+          checker       (make-table-backed-checker
+                         (fn [_token]
+                           (swap! call-count inc)
+                           {:valid false :status "should not be called"})
+                         {:local-ttl (t/millis 1) :soft-ttl (t/minutes 1) :hard-ttl (t/minutes 2)})
+          token         (tu/random-token)
+          token-hash    (#'token-check/hash-token token)
+          fake-features {:valid    true
+                         :status   "OK"
+                         :features ["sandboxes" "audit-app"]}]
+      (try
+        ;; Simulate another instance writing to the table
+        (t2/insert! :model/PremiumFeaturesCache {:token_hash   token-hash
+                                                 :token_status fake-features
+                                                 :updated_at   (t/offset-date-time)})
+        ;; This instance should read the entry from table, not hit delegate
+        (Thread/sleep 5) ;; ensure local cache is expired
+        (is (= fake-features (token-check/-check-token checker token)))
+        (is (= 0 @call-count))
+        (finally
+          (token-check/-clear-cache! checker))))))
+
+(deftest table-backed-token-checker-exception-propagation-test
+  (testing "When delegate throws on expired/missing, exception propagates through error-catching"
+    (let [checker (make-table-backed-checker
+                   (fn [_token]
+                     (throw (ex-info "MetaStore unreachable" {})))
+                   {:soft-ttl (t/minutes 1) :hard-ttl (t/minutes 2)})
+          token   (tu/random-token)]
+      ;; error-catching wraps it, so we get the error-details response
+      (is (= {:valid false
+              :status "Unable to validate token"
+              :error-details "MetaStore unreachable"}
+             (token-check/-check-token checker token))))))
+
+(deftest startup-clears-token-cache-test
+  (testing "The startup hook clears the token cache table so the first check after boot hits MetaStore"
+    (let [call-count    (atom 0)
+          good-response {:valid true :status "OK" :features ["sandboxes"]}
+          checker       (make-table-backed-checker
+                         (fn [_token]
+                           (swap! call-count inc)
+                           good-response)
+                         {:soft-ttl (t/minutes 10) :hard-ttl (t/minutes 20)})
+          token         (tu/random-token)]
+      (try
+        ;; Populate the cache
+        (token-check/-check-token checker token)
+        (is (= 1 @call-count))
+        (let [token-hash (#'token-check/hash-token token)]
+          (is (some? (t2/select-one :model/PremiumFeaturesCache :token_hash token-hash)))
+          ;; Run the startup hook (clears the global token-checker's cache, including the table)
+          (startup/def-startup-logic! :metabase.premium-features.task.clear-token-cache/clear-token-cache)
+          ;; Table should be cleared
+          (is (nil? (t2/select-one :model/PremiumFeaturesCache :token_hash token-hash))))
+        (finally
+          (token-check/-clear-cache! checker))))))

--- a/test/metabase/premium_features/token_check_test.clj
+++ b/test/metabase/premium_features/token_check_test.clj
@@ -102,8 +102,7 @@
                         {:base            (reify token-check/TokenChecker
                                             (-check-token [_ token]
                                               (token-response token))
-                                            (-clear-cache! [_])
-                                            (-clear-local-cache! [_]))
+                                            (-clear-cache! [_]))
                          :circuit-breaker {:failure-threshold-ratio-in-period [4 4 1000]
                                            :delay-ms                          50
                                            :success-threshold                 1}
@@ -137,8 +136,7 @@
                           {:base            (reify token-check/TokenChecker
                                               (-check-token [_ token]
                                                 (token-response token))
-                                              (-clear-cache! [_])
-                                              (-clear-local-cache! [_]))
+                                              (-clear-cache! [_]))
                            :circuit-breaker {:failure-threshold-ratio-in-period [4 4 1000]
                                              :delay-ms                          5000
                                              :success-threshold                 1}
@@ -372,8 +370,7 @@
     (token-check/make-checker
      {:base      (reify token-check/TokenChecker
                    (-check-token [_ token] (token-response-fn token))
-                   (-clear-cache! [_])
-                   (-clear-local-cache! [_]))
+                   (-clear-cache! [_]))
       :local-ttl local-ttl
       :soft-ttl  soft-ttl
       :hard-ttl  hard-ttl})))


### PR DESCRIPTION
Premium feature token checks are cached per-instance in memory with a 12h TTL. During rolling deploys after a plan upgrade, different instances can disagree about which features are available:

   1. Request hits instance A (old cache) → reports old features
   2. Request hits instance B (freshly started, no cache) → reports new features
   3. Frontend says "upgrade successful!"
   4. Request hits instance A again → old features are back

This flapping means the frontend can't reliably detect when an upgrade has landed.

## Solution

### DB-hash-aware cross-instance cache

Replace the per-instance in-memory TTL cache with a two-layer caching scheme coordinated through the DB:

 - A **local in-memory cache** holds the full token status (features, validity, etc.)
 - A **DB table** (`premium_features_token_cache`) stores only a SHA-256 hash of the token status, keyed by a hash of the token itself. The DB never stores actual features — just enough to coordinate freshness across instances.

When a token check comes in:
- If the local cache matches the DB hash and is < 12h old: serve it immediately
- If it matches the DB hash and is < 36h old: serve the stale data and refresh asynchronously in the background
- If the DB hash doesn't match (another instance refreshed), or the cache is > 36h old, or this is a cold start: synchronous MetaStore fetch

This ensures all instances converge quickly after a plan change while keeping MetaStore traffic low. Cold-starting instances always hit the MetaStore — there's no way to bootstrap features from the DB alone, since it only stores hashes.

### Checker stack (inner to outer)

1. **`store-and-airgap-token-checker`** — hits MetaStore or validates airgap token
2. **`circuit-breaker-token-checker`** — circuit breaking + timeout
3. **`db-hash-aware-token-checker`** — the core caching layer (described above)
4. **`local-cached-token-checker`** — 5s TTL memoization to avoid hitting the DB on every request
5. **`error-catching-token-checker`** — wraps exceptions into `{:valid false}` responses

The 5s local cache means we hit the DB at most once every 5s, even during the grace period.

### Force-refresh endpoint

`POST /api/premium-features/token/refresh` clears all caches and synchronously re-checks against the MetaStore. The frontend uses this when polling for new features after a purchase (`useTokenRefreshUntil` in `UpgradeModalLoading`, `MetabotSettingUpModal`, `TransformsSettingUpModal`). A cookie-based mechanism propagates the invalidation to other instances so they clear their local caches on the next request.