### PR TITLE
fix: dashboard card becomes uneditable after reordering funnel steps

### DIFF
--- a/e2e/test/scenarios/dashboard/visualizer/funnel-title-navigation.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/funnel-title-navigation.cy.spec.ts
@@ -1,0 +1,100 @@
+export {};
+
+const { H } = cy;
+
+describe("scenarios > dashboard > visualizer > funnel title navigation", () => {
+  beforeEach(() => {
+    H.restore();
+
+    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
+      "dashcardQuery",
+    );
+
+    cy.signInAsNormalUser();
+  });
+
+  it("should open the underlying question when clicking the title of a single-question visualizer funnel (UXW-2692)", () => {
+    const visualizerTitle = "UXW-2692 Visualizer Funnel";
+
+    H.createNativeQuestion({
+      name: "UXW-2692 Funnel Base",
+      display: "funnel",
+      native: {
+        query: `
+          SELECT 73 AS "Val", 'Downloads' AS "Step"
+          UNION ALL
+          SELECT 52 AS "Val", 'Followers' AS "Step"
+        `,
+      },
+      visualization_settings: {
+        "funnel.metric": "Val",
+        "funnel.dimension": "Step",
+      },
+    }).then(({ body: { id: questionId } }) => {
+      H.createDashboard({ name: "UXW-2692 Dashboard" }).then(
+        ({ body: { id: dashboardId } }) => {
+          cy.request("PUT", `/api/dashboard/${dashboardId}`, {
+            dashcards: [
+              {
+                id: -1,
+                card_id: questionId,
+                dashboard_tab_id: null,
+                row: 0,
+                col: 0,
+                size_x: 12,
+                size_y: 8,
+                visualization_settings: {
+                  visualization: {
+                    display: "funnel",
+                    columnValuesMapping: {
+                      COLUMN_1: [
+                        {
+                          name: "COLUMN_1",
+                          originalName: "Step",
+                          sourceId: `card:${questionId}`,
+                        },
+                      ],
+                      COLUMN_2: [
+                        {
+                          name: "COLUMN_2",
+                          originalName: "Val",
+                          sourceId: `card:${questionId}`,
+                        },
+                      ],
+                    },
+                    settings: {
+                      "card.title": visualizerTitle,
+                      "funnel.metric": "COLUMN_2",
+                      "funnel.dimension": "COLUMN_1",
+                      "funnel.rows": [
+                        {
+                          key: "Followers",
+                          name: "Followers",
+                          enabled: true,
+                        },
+                        {
+                          key: "Downloads",
+                          name: "Downloads",
+                          enabled: true,
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            ],
+          });
+
+          H.visitDashboard(dashboardId);
+
+          cy.wait("@dashcardQuery");
+          H.getDashboardCard(0).findByTestId("funnel-chart").should("exist");
+
+          H.clickOnCardTitle(0);
+
+          cy.location("pathname").should("contain", `/question/${questionId}`);
+        },
+      );
+    });
+  });
+});

--- a/frontend/src/metabase/visualizations/visualizations/Funnel/Funnel.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Funnel/Funnel.tsx
@@ -195,6 +195,7 @@ export function Funnel(props: VisualizationProps) {
     className,
     onChangeCardAndRun,
     rawSeries,
+    visualizerRawSeries,
     fontFamily,
     getHref,
     isDashboard,
@@ -232,6 +233,7 @@ export function Funnel(props: VisualizationProps) {
       {hasTitle && (
         <ChartCaption
           series={groupedRawSeries}
+          visualizerRawSeries={visualizerRawSeries}
           settings={settings}
           icon={headerIcon}
           getHref={canSelectTitle ? getHref : undefined}


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #67980
Closes [UXW-2692: Funnel viz - dashboard card becomes uneditable after reordering funnel steps via Visualize another way](https://linear.app/metabase/issue/UXW-2692/funnel-viz-dashboard-card-becomes-uneditable-after-reordering-funnel)

### Description

visualizerRawSeries wasn't passed to `ChartCaption`, which then tried to navigate to visualizer card without `dataset_query` which crashed instead of saved question.

### How to verify

1. Create a native question

```sql
select 73 val, 'Downloads' step
union all
select 52, 'Followers'
```

2. Visualize as Funnel
3. Save and add it to a dashboard
4. Edit the dashboard, select Visualize another way, reorder the Followers and Downloads steps. Save.
5. The card can no longer be opened by clicking on its title.

### Demo


https://github.com/user-attachments/assets/d285710b-7959-473a-8a7c-cf1f321f11da


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
