### PR TITLE
[FEATURE] Add Snowflake secondary roles support to impersonation

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModal.tsx
@@ -86,6 +86,10 @@ const ImpersonationModalInner = ({
   const selectedAttribute =
     draftImpersonation?.attribute ?? impersonation?.attribute;
 
+  const selectedSecondaryRolesAttribute =
+    draftImpersonation?.secondary_roles_attribute ??
+    impersonation?.secondary_roles_attribute;
+
   const dispatch = useDispatch();
 
   const close = useCallback(() => {
@@ -93,7 +97,10 @@ const ImpersonationModalInner = ({
   }, [dispatch, route]);
 
   const handleSave = useCallback(
-    (attribute: UserAttributeKey) => {
+    (
+      attribute: UserAttributeKey,
+      secondaryRolesAttribute?: UserAttributeKey,
+    ) => {
       dispatch(
         updateDataPermission({
           groupId,
@@ -106,10 +113,14 @@ const ImpersonationModalInner = ({
         }),
       );
 
-      if (attribute !== selectedAttribute) {
+      if (
+        attribute !== selectedAttribute ||
+        secondaryRolesAttribute !== selectedSecondaryRolesAttribute
+      ) {
         dispatch(
           updateImpersonation({
             attribute,
+            secondary_roles_attribute: secondaryRolesAttribute,
             db_id: databaseId,
             group_id: groupId,
           }),
@@ -118,7 +129,14 @@ const ImpersonationModalInner = ({
 
       close();
     },
-    [close, databaseId, dispatch, groupId, selectedAttribute],
+    [
+      close,
+      databaseId,
+      dispatch,
+      groupId,
+      selectedAttribute,
+      selectedSecondaryRolesAttribute,
+    ],
   );
 
   const handleCancel = useCallback(() => {
@@ -148,6 +166,7 @@ const ImpersonationModalInner = ({
   return (
     <ImpersonationModalView
       selectedAttribute={selectedAttribute}
+      selectedSecondaryRolesAttribute={selectedSecondaryRolesAttribute}
       attributes={attributes}
       database={database}
       onSave={handleSave}

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModalView.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModalView.tsx
@@ -26,13 +26,18 @@ import {
 
 const ROLE_ATTRIBUTION_MAPPING_SCHEMA = Yup.object({
   attribute: Yup.string().required(Errors.required).default(""),
+  secondary_roles_attribute: Yup.string().optional().default(""),
 });
 
 type ImpersonationModalViewProps = {
   attributes: UserAttributeKey[];
   selectedAttribute?: UserAttributeKey;
+  selectedSecondaryRolesAttribute?: UserAttributeKey;
   database: Database;
-  onSave: (attribute: UserAttributeKey) => void;
+  onSave: (
+    attribute: UserAttributeKey,
+    secondaryRolesAttribute?: UserAttributeKey,
+  ) => void;
   onCancel: () => void;
 };
 
@@ -40,6 +45,7 @@ export const ImpersonationModalView = ({
   attributes,
   database,
   selectedAttribute,
+  selectedSecondaryRolesAttribute,
   onSave,
   onCancel,
 }: ImpersonationModalViewProps) => {
@@ -47,7 +53,10 @@ export const ImpersonationModalView = ({
     attribute:
       selectedAttribute ??
       (attributes.length === 1 ? attributes[0] : undefined),
+    secondary_roles_attribute: selectedSecondaryRolesAttribute ?? "",
   };
+
+  const isSnowflake = database.engine === "snowflake";
 
   const attributeOptions = useMemo(() => {
     const selectableAttributes =
@@ -60,9 +69,18 @@ export const ImpersonationModalView = ({
 
   const hasAttributes = attributeOptions.length > 0;
 
-  const handleSubmit = ({ attribute }: { attribute?: UserAttributeKey }) => {
+  const handleSubmit = ({
+    attribute,
+    secondary_roles_attribute,
+  }: {
+    attribute?: UserAttributeKey;
+    secondary_roles_attribute?: UserAttributeKey;
+  }) => {
     if (attribute != null) {
-      onSave(attribute);
+      onSave(
+        attribute,
+        secondary_roles_attribute || undefined,
+      );
     }
   };
 
@@ -128,6 +146,19 @@ export const ImpersonationModalView = ({
                 mb="1.25rem"
                 renderOption={renderUserAttributesForSelect}
               />
+
+              {isSnowflake && (
+                <FormSelect
+                  name="secondary_roles_attribute"
+                  placeholder={t`Pick a user attribute (optional)`}
+                  label={t`Secondary roles attribute`}
+                  data={[
+                    { value: "", label: t`None` },
+                    ...attributeOptions,
+                  ]}
+                  mb="1.25rem"
+                />
+              )}
 
               <ImpersonationWarning database={database} />
 

--- a/frontend/src/metabase-types/api/permissions.ts
+++ b/frontend/src/metabase-types/api/permissions.ts
@@ -136,4 +136,5 @@ export type Impersonation = {
   db_id: DatabaseId;
   group_id: GroupId;
   attribute: UserAttributeKey;
+  secondary_roles_attribute?: UserAttributeKey;
 };

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -893,6 +893,18 @@
       (format "USE ROLE \"%s\";" role)
       (format "USE ROLE %s;" role))))
 
+(defmethod driver.sql/set-secondary-roles-statement :snowflake
+  [_ secondary-roles]
+  (let [upper (str/upper-case (str/trim secondary-roles))]
+    (if (or (= upper "ALL") (= upper "NONE"))
+      (format "USE SECONDARY ROLES %s;" upper)
+      (let [roles       (map str/trim (str/split secondary-roles #","))
+            quote-role  (fn [r]
+                          (if (re-find #"[^a-zA-Z0-9_]" r)
+                            (format "\"%s\"" r)
+                            r))]
+        (format "USE SECONDARY ROLES %s;" (str/join ", " (map quote-role roles)))))))
+
 (defmethod driver.sql/default-database-role :snowflake
   [_ database]
   (-> database :details :role))

--- a/resources/migrations/059_update_migrations.yaml
+++ b/resources/migrations/059_update_migrations.yaml
@@ -2971,6 +2971,19 @@ databaseChangeLog:
             constraintName: fk_metabase_table_transform_id
             onDelete: SET NULL
 
+  - changeSet:
+      id: v59.2026-02-06T00:00:01
+      author: troyharvey
+      comment: Add secondary_roles_attribute column to connection_impersonations for Snowflake secondary roles
+      changes:
+        - addColumn:
+            tableName: connection_impersonations
+            columns:
+              - column:
+                  name: secondary_roles_attribute
+                  type: ${text.type}
+                  remarks: User attribute for Snowflake secondary roles (USE SECONDARY ROLES). Nullable - only used for Snowflake.
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/driver/sql.clj
+++ b/src/metabase/driver/sql.clj
@@ -108,6 +108,15 @@
   [_ _ _]
   nil)
 
+(defmulti set-secondary-roles-statement
+  "Return a SQL statement to set secondary roles (e.g. Snowflake USE SECONDARY ROLES).
+   Returns nil by default (most drivers don't support this)."
+  {:added "0.59.0" :arglists '([driver secondary-roles])}
+  driver/dispatch-on-initialized-driver
+  :hierarchy #'driver/hierarchy)
+
+(defmethod set-secondary-roles-statement :default [_ _] nil)
+
 (defmulti default-database-role
   "The name of the default role for a given database, used for queries that do not have custom user
   impersonation rules configured for them. This must be implemented for each driver that supports user impersonation."


### PR DESCRIPTION
![Untitled 3](https://github.com/user-attachments/assets/a03981f6-6e23-4fcc-a823-2c26d8074475)

## Summary

- Add `secondary_roles_attribute` column to `connection_impersonations` table
- Implement `set-secondary-roles-statement` driver multimethod with Snowflake support (ALL/NONE/comma-separated roles)
- Resolve secondary roles from user attributes and execute `USE SECONDARY ROLES` during impersonation
- Add secondary roles attribute field to impersonation modal (Snowflake-only)

## Test plan

- [ ] Verify migration creates `secondary_roles_attribute` column
- [ ] Confirm impersonation modal shows secondary roles field only for Snowflake databases
- [ ] Test query execution sends both `USE ROLE` and `USE SECONDARY ROLES` statements
- [ ] Verify secondary roles attribute persists and retrieves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)