### PR TITLE
Interrupt threads stuck after query cancellation

### DIFF
--- a/src/metabase/server/settings.clj
+++ b/src/metabase/server/settings.clj
@@ -74,3 +74,17 @@ x.com")
   :default    false
   :visibility :admin
   :export?    false)
+
+;; This is normally set via the env var `MB_THREAD_INTERRUPT_ESCALATION_TIMEOUT_MS`
+(defsetting thread-interrupt-escalation-timeout-ms
+  "By default, this is 0 and the thread interrupt escalation does not run."
+  :visibility :internal
+  :export?    false
+  :type       :integer
+  :default    0
+  :doc "Timeout in milliseconds to wait after query cancellation before escalating to Thread.interrupt().
+        This is used to free up threads that are stuck waiting for a DB response after a query has been cancelled.")
+
+(def ^:dynamic ^Long *thread-interrupt-escalation-timeout-ms*
+  "Maximum amount of time to wait after query cancellation before escalating to Thread.interrupt(), in ms."
+  (thread-interrupt-escalation-timeout-ms))

--- a/src/metabase/server/settings.clj
+++ b/src/metabase/server/settings.clj
@@ -82,9 +82,9 @@ x.com")
   :export?    false
   :type       :integer
   :default    0
-  :doc "Timeout in milliseconds to wait after query cancellation before escalating to Thread.interrupt().
+  :doc "Timeout in milliseconds to wait after query cancellation before escalating to thread interruption.
         This is used to free up threads that are stuck waiting for a DB response after a query has been cancelled.")
 
 (def ^:dynamic ^Long *thread-interrupt-escalation-timeout-ms*
-  "Maximum amount of time to wait after query cancellation before escalating to Thread.interrupt(), in ms."
+  "Timeout in milliseconds to wait after query cancellation before escalating to thread interruption."
   (thread-interrupt-escalation-timeout-ms))

--- a/src/metabase/server/streaming_response.clj
+++ b/src/metabase/server/streaming_response.clj
@@ -100,7 +100,7 @@
         (let [timeout-chan (a/timeout server.settings/*thread-interrupt-escalation-timeout-ms*)
               [_ port]     (a/alts! [finished-chan timeout-chan])]
           (when (= port timeout-chan)
-            (log/infof "Task still running %s after cancellation, escalating to Thread.interrupt()"
+            (log/infof "Task still running %s after cancellation, escalating to thread interruption"
                        (u/format-milliseconds server.settings/*thread-interrupt-escalation-timeout-ms*))
             (.cancel fut true)))))))
 
@@ -117,8 +117,8 @@
                    (a/>!! finished-chan :unexpected-error)
                    (write-error! os e nil))
                  (finally
-                   ;; Clear the interrupted flag before any blocking ops (a/>!!) to prevent
-                   ;; the thread from carrying stale interrupted state to the next task.
+                   ;; Clear the interrupted flag to prevent the thread from
+                   ;; carrying stale interrupted state to the next task.
                    (Thread/interrupted)
                    (a/>!! finished-chan (if (a/poll! canceled-chan)
                                           :canceled

--- a/test/metabase/server/streaming_response_test.clj
+++ b/test/metabase/server/streaming_response_test.clj
@@ -9,6 +9,7 @@
    [metabase.query-processor.pipeline :as qp.pipeline]
    [metabase.server.instance :as server.instance]
    [metabase.server.protocols :as server.protocols]
+   [metabase.server.settings :as server.settings]
    [metabase.server.streaming-response :as streaming-response]
    [metabase.server.streaming-response.thread-pool :as thread-pool]
    [metabase.test :as mt]
@@ -20,7 +21,7 @@
    (jakarta.servlet AsyncContext ServletOutputStream)
    (jakarta.servlet.http HttpServletResponse)
    (java.io Closeable InputStream)
-   (java.util.concurrent Executors)
+   (java.util.concurrent Executors Future)
    (org.apache.commons.lang3.concurrent BasicThreadFactory$Builder)))
 
 (set! *warn-on-reflection* true)
@@ -343,3 +344,92 @@
         (is (not (mr/validate schema {:data "not a streaming response"})))
         (is (= ["Non-streaming response returned from streaming endpoint"]
                (me/humanize (mr/explain schema {:data "not a streaming response"}))))))))
+
+;;; ---------------------------------------- interrupt escalation tests ----------------------------------------
+
+(deftest start-interrupt-escalation-cancels-future-test
+  (testing ".cancel is called when the task is still running after the interruption timeout"
+    (with-redefs [server.settings/*thread-interrupt-escalation-timeout-ms* 100]
+      (let [cancel-called? (promise)
+            mock-future    (reify Future
+                             (cancel [_ interrupt?]
+                               (deliver cancel-called? interrupt?)
+                               true)
+                             (isCancelled [_] false)
+                             (isDone [_] false)
+                             (get [_] nil))
+            finished-chan   (a/promise-chan)
+            canceled-chan   (a/promise-chan)]
+        (#'streaming-response/start-interrupt-escalation! mock-future finished-chan canceled-chan)
+        (a/>!! canceled-chan ::request-canceled)
+        (let [result (deref cancel-called? 2000 ::timed-out)]
+          (is (true? result)))))))
+
+(deftest start-interrupt-escalation-no-cancel-when-task-finishes-test
+  (testing ".cancel is not called when the task finishes before the escalation timeout"
+    (with-redefs [server.settings/*thread-interrupt-escalation-timeout-ms* 2000]
+      (let [cancel-called? (atom false)
+            mock-future    (reify Future
+                             (cancel [_ _]
+                               (reset! cancel-called? true)
+                               true)
+                             (isCancelled [_] false)
+                             (isDone [_] false)
+                             (get [_] nil))
+            finished-chan   (a/promise-chan)
+            canceled-chan   (a/promise-chan)]
+        (#'streaming-response/start-interrupt-escalation! mock-future finished-chan canceled-chan)
+        (a/>!! canceled-chan ::request-canceled)
+        (Thread/sleep 50)
+        (a/>!! finished-chan :completed)
+        (Thread/sleep 200)
+        (is (false? @cancel-called?)
+            "Future.cancel() should NOT be called when the task finishes before timeout")))))
+
+(deftest start-interrupt-escalation-noop-when-disabled-test
+  (testing "no-op when interrupt-escalation-timeout-ms is 0"
+    (with-redefs [server.settings/*thread-interrupt-escalation-timeout-ms* 0]
+      (let [cancel-called? (atom false)
+            mock-future    (reify Future
+                             (cancel [_ _]
+                               (reset! cancel-called? true)
+                               true)
+                             (isCancelled [_] false)
+                             (isDone [_] false)
+                             (get [_] nil))
+            finished-chan   (a/promise-chan)
+            canceled-chan   (a/promise-chan)]
+        (is (nil? (#'streaming-response/start-interrupt-escalation! mock-future finished-chan canceled-chan)))
+        (a/>!! canceled-chan ::request-canceled)
+        (Thread/sleep 200)
+        (is (false? @cancel-called?)
+            "Future.cancel() should NOT be called when escalation is disabled")))))
+
+(deftest interrupt-escalation-integration-test
+  (testing "A stuck streaming response thread is interrupted via escalation after cancellation"
+    (with-redefs [server.settings/*thread-interrupt-escalation-timeout-ms* 200]
+      (with-streaming-response-thread-pool!
+        (let [interrupted?     (promise)
+              task-started?    (promise)
+              complete-promise (promise)
+              finished-chan    (a/promise-chan)
+              canceled-chan    (a/promise-chan)]
+          (with-open [os (java.io.ByteArrayOutputStream.)]
+            (#'streaming-response/do-f-async
+             (reify AsyncContext
+               (complete [_]
+                 (deliver complete-promise true)))
+             (fn [_os _canceled-chan]
+               (deliver task-started? true)
+               (try
+                 ;; Simulate a stuck JDBC driver that blocks indefinitely
+                 (Thread/sleep 60000)
+                 (catch InterruptedException _e
+                   (deliver interrupted? true))))
+             os
+             finished-chan
+             canceled-chan)
+            (is (true? (deref task-started? 5000 ::timed-out)))
+            (a/>!! canceled-chan ::request-canceled)
+            (is (true? (deref interrupted? 5000 ::timed-out)))
+            (is (true? (deref complete-promise 5000 ::timed-out)))))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/66656

### Description

Based on the report in https://github.com/metabase/metabase/issues/66656, threads seem to be leaking due to JDBC drivers that continue to block despite cancellation attempts (`unreturnedConnectionTimeout`, `.setNetworkTimeout`, and `cancelAutomaticallyClosedStatements`). This attempts to interrupt those threads if it is not marked as finished after being marked as cancelled after `thread-interrupt-escalation-timeout-ms` milliseconds. It is `start-async-cancel-loop!` that would be marking the request as cancelled, and `do-f*` that is blocking.

### How to verify

See tests

### Demo



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
