### PR TITLE
Don't use the deprecated enable-query-caching value

### DIFF
--- a/src/metabase/cache/core.clj
+++ b/src/metabase/cache/core.clj
@@ -16,6 +16,5 @@
   root-strategy]
  [metabase.cache.settings
   enable-query-caching
-  enable-query-caching!
   query-caching-max-kb
   query-caching-max-ttl])

--- a/src/metabase/cache/settings.clj
+++ b/src/metabase/cache/settings.clj
@@ -2,14 +2,17 @@
   (:require
    [metabase.settings.core :as setting :refer [defsetting]]
    [metabase.util :as u]
-   [metabase.util.i18n :refer [deferred-tru tru]]))
+   [metabase.util.i18n :refer [deferred-tru tru]]
+   [toucan2.core :as t2]))
 
 (defsetting enable-query-caching
   (deferred-tru "Allow caching results of queries that take a long time to run.")
   :type       :boolean
   :default    true
   :visibility :authenticated
-  :audit      :getter)
+  :audit      :getter
+  :getter     #(t2/exists? :model/CacheConfig)
+  :setter     :none)
 
 (def ^:private ^:const global-max-caching-kb
   "Although depending on the database, we can support much larger cached values (1GB for PG, 2GB for H2 and 4GB for

--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -223,9 +223,6 @@
               (fn [metadata]
                 (save-results-xform start-time-ns metadata query-hash cache-strategy (rff metadata)))))))))
 
-(defn- caching-enabled? []
-  (cache/enable-query-caching))
-
 (defn- has-cache-strategy? [cache-strategy]
   (some? cache-strategy))
 
@@ -233,26 +230,22 @@
   (not= (:type cache-strategy) :nocache))
 
 (defn- is-cacheable?
-  "Returns true if query caching is enabled and the query has a valid cache strategy."
+  "Returns true if the query has a valid cache strategy."
   [{:keys [cache-strategy], :as _query}]
-  (let [enabled?    (caching-enabled?)
-        has-strat?  (has-cache-strategy? cache-strategy)
+  (let [has-strat?  (has-cache-strategy? cache-strategy)
         not-nocache? (strategy-not-nocache? cache-strategy)]
-    (and enabled? has-strat? not-nocache?)))
+    (and has-strat? not-nocache?)))
 
 (defn- get-cache-eligibility-description
   "Returns a descriptive string explaining why a query is or isn't cacheable."
   [{:keys [cache-strategy], :as _query}]
-  (let [enabled?    (caching-enabled?)
-        has-strat?  (has-cache-strategy? cache-strategy)
+  (let [has-strat?  (has-cache-strategy? cache-strategy)
         not-nocache? (strategy-not-nocache? cache-strategy)]
-    (if (and enabled? has-strat? not-nocache?)
-      (str "query caching is enabled; "
-           "cache strategy provided: " (pr-str cache-strategy) "; "
+    (if (and has-strat? not-nocache?)
+      (str "cache strategy provided: " (pr-str cache-strategy) "; "
            "cache strategy type is not :nocache")
       (str/join ", "
                 (cond-> []
-                  (not enabled?)     (conj "query caching is disabled")
                   (not has-strat?)   (conj "no cache strategy provided")
                   (not not-nocache?) (conj "cache strategy is :nocache"))))))
 

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -44,7 +44,6 @@
 #_{:clj-kondo/ignore [:metabase/validate-deftest]}
 (use-fixtures :once (fn [thunk]
                       (initialize/initialize-if-needed! :db)
-                      (metabase.cache.core/enable-query-caching! true)
                       (thunk)))
 
 (def ^:private ^:dynamic *save-chan*
@@ -184,11 +183,7 @@
                                          nil              false}]
         (testing (format "cache strategy = %s" (pr-str cache-strategy))
           (is (= expected
-                 (boolean (#'cache/is-cacheable? {:cache-strategy cache-strategy}))))))
-      (testing "but enable-query-caching setting is still respected"
-        (mt/with-temporary-setting-values [enable-query-caching false]
-          (is (= false
-                 (boolean (#'cache/is-cacheable? {:cache-strategy (ttl-strategy)})))))))))
+                 (boolean (#'cache/is-cacheable? {:cache-strategy cache-strategy})))))))))
 
 (deftest empty-cache-test
   (testing "if there's nothing in the cache, cached results should *not* be returned"


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #68398
### Description

If you explicitly disabled the cache in the the past using the old `enable-query-caching` setting, that value still overrides other cache settings even though you can no longer set it through the UI.

This further removes the usage of the enable-query-caching setting by making the value be computed based on whether there are cache configurations defined and disabling the setter.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
