### PR TITLE
Add &parents to match-lite and rewrite remaining match/match-one usages

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -253,6 +253,7 @@
     (metabase.driver-api.core/match)
     (metabase.driver-api.core/match-one)
     (metabase.driver-api.core/match-lite)
+    (metabase.driver-api.core/match-many)
     (metabase.driver-api.core/replace)
     (metabase.driver-api.core/replace-in)
     (metabase.query-processor.middleware.cache-backend.interface/with-cached-results)
@@ -306,6 +307,8 @@
    metabase.lib.convert/->legacy-MBQL                 {:message "Conversion to legacy MBQL is discouraged, please use Lib to manipulate MBQL queries"}
    metabase.lib.core/->legacy-MBQL                    {:message "Conversion to legacy MBQL is discouraged, please use Lib to manipulate MBQL queries"}
    metabase.lib.equality/find-column-indexes-for-refs {:message "Use lib.equality/closest-matches-in-metadata or lib.equality/find-closest-matches-for-refs instead of lib.equality/find-column-indexes-for-refs"}
+   metabase.lib.util.match/match                      {:message "Use lib.util.match/match-many instead of lib.util.match/match."}
+   metabase.lib.util.match/match-one                  {:message "Use lib.util.match/match-lite instead of lib.util.match/match-one."}
    metabase-enterprise.transforms.interface/execute!  {:message "Use metabase-enterprise.transforms.execute/execute! instead of metabase-enterprise.transforms.interface/execute!"}
    next.jdbc/active-tx?                               {:message "Use metabase.app-db.core/in-transaction? to see if we are in a transaction"}
    toucan2.core/debug                                 {:message "Don't commit code using t2/debug"}

--- a/.cljfmt.edn
+++ b/.cljfmt.edn
@@ -121,6 +121,7 @@
   metabase.driver-api.core/match                                                              [[:inner 0]]
   metabase.driver-api.core/match-one                                                          [[:inner 0]]
   metabase.driver-api.core/match-lite                                                         [[:inner 0]]
+  metabase.driver-api.core/match-many                                                         [[:inner 0]]
   metabase.driver-api.core/replace                                                            [[:inner 0]]
   metabase.driver-api.core/replace-in                                                         [[:inner 0]]
   metabase.driver.bigquery-cloud-sdk.query-processor/with-temporal-type                       [[:default]]

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -1076,8 +1076,8 @@ function(bin) {
         source-field-mappings (get-field-mappings source-query projections)
         ;; Find the fields the join condition refers to that are not coming from the joined query.
         ;; These have to be bound in the :let property of the $lookup stage, they cannot be referred to directly.
-        own-fields (driver-api/match condition
-                     [:field _ (_ :guard #(not= (:join-alias %) alias))])
+        own-fields (driver-api/match-many condition
+                     [:field _ (opts :guard (not= (:join-alias opts) alias))] &match)
         ;; Map the own fields to a fresh alias and to its rvalue.
         mapping (map (fn [f] (let [alias (-> (format "let_%s_" (->lvalue f))
                                              ;; ~ in let aliases provokes a parse error in Mongo. For correct function,
@@ -1663,13 +1663,12 @@ function(bin) {
 (defn- query->collection-name
   "Return `:collection` from a source query, if it exists."
   [query]
-  (driver-api/match-one query
-    (_ :guard (every-pred map? :collection))
+  (driver-api/match-lite query
+    {:collection (collection :guard identity)}
     ;; ignore source queries inside `:joins` or `:collection` outside of a `:source-query`
-    (when (let [parents (set &parents)]
-            (and (contains? parents :source-query)
-                 (not (contains? parents :joins))))
-      (:collection &match))))
+    (when (and (some #{:source-query} &parents)
+               (not (some #{:joins} &parents)))
+      collection)))
 
 (defn- log-aggregation-pipeline [form]
   (when-not driver-api/*disable-qp-logging*

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -550,9 +550,9 @@
                 (if (contains? param :name)
                   [(:name param) (:value param)]
 
-                  (when-let [field-id (driver-api/match-one param
+                  (when-let [field-id (driver-api/match-lite param
                                         [:field (field-id :guard integer?) _]
-                                        (when (contains? (set &parents) :dimension)
+                                        (when (perf/some #{:dimension} &parents)
                                           field-id))]
                     [(:name (driver-api/field (driver-api/metadata-provider) field-id))
                      (:value param)]))))

--- a/src/metabase/driver_api/core.clj
+++ b/src/metabase/driver_api/core.clj
@@ -108,6 +108,7 @@
  lib.util.match/match
  lib.util.match/match-one
  lib.util.match/match-lite
+ lib.util.match/match-many
  lib.util.match/replace
  lib/truncate-alias
  lib/->legacy-MBQL

--- a/src/metabase/lib/expression.cljc
+++ b/src/metabase/lib/expression.cljc
@@ -587,7 +587,7 @@
 
 (defn- referred-aggregations
   [agg]
-  (set (lib.util.match/match agg [:aggregation _opts x & _] x)))
+  (set (lib.util.match/match-many agg [:aggregation _opts x & _] x)))
 
 (defn- cyclic-definition
   ([node->children]

--- a/src/metabase/lib/query.cljc
+++ b/src/metabase/lib/query.cljc
@@ -127,10 +127,10 @@
   "Add `:base-type` and `:effective-type` to options of fields in `x` using `metadata-provider`. Works on pmbql fields.
   `:effective-type` is required for coerced fields to pass schema checks."
   [x metadata-provider :- ::lib.schema.metadata/metadata-provider]
-  (if-let [field-ids (lib.util.match/match x
+  (if-let [field-ids (lib.util.match/match-many x
                        [:field
-                        (_options :guard (every-pred map? (complement (every-pred :base-type :effective-type))))
-                        (id :guard integer? pos?)]
+                        (_opts :guard (and (map? _opts) (not (and (:base-type _opts) (:effective-type _opts)))))
+                        (id :guard (and (integer? id) (pos? id)))]
                        (when-not (some #{:mbql/stage-metadata} &parents)
                          id))]
     ;; "pre-warm" the metadata provider

--- a/test/metabase/channel/render/card_test.clj
+++ b/test/metabase/channel/render/card_test.clj
@@ -311,7 +311,7 @@
                                                                                 (qp/process-query (:dataset_query card))
                                                                                 {:channel.render/include-title? true}))
               expected-href         (format "https://mb.com/dashboard/%d#scrollTo=%d" (:dashboard_id dc1) (:id dc1))]
-          (is (every? true? (map #(= (:href %) expected-href) (lib.util.match/match rendered-card-content  {:href _}))))))))
+          (is (every? #(= % expected-href) (lib.util.match/match-many rendered-card-content {:href href} href)))))))
   (testing "the title and body hrefs for visualizer cards should be of the form '.../dashboard/<DASHBOARD_ID>#scrollTo=<DASHBOARD_CARD_ID>'"
     (mt/with-temp [:model/Card           card {:name          "A Card"
                                                :dataset_query (mt/mbql-query venues {:limit 1})}
@@ -325,4 +325,4 @@
                                                                                 (qp/process-query (:dataset_query card))
                                                                                 {:channel.render/include-title? true}))
               expected-href         (format "https://mb.com/dashboard/%d#scrollTo=%d" (:dashboard_id dc1) (:id dc1))]
-          (is (every? true? (map #(= (:href %) expected-href) (lib.util.match/match rendered-card-content  {:href _})))))))))
+          (is (every? #(= % expected-href) (lib.util.match/match-many rendered-card-content {:href href} href))))))))

--- a/test/metabase/lib/util/match_test.cljc
+++ b/test/metabase/lib/util/match_test.cljc
@@ -1,4 +1,7 @@
 (ns metabase.lib.util.match-test
+  {:clj-kondo/config '{:linters
+                       {:discouraged-var {metabase.lib.util.match/match {:level :off}
+                                          metabase.lib.util.match/match-one {:level :off}}}}}
   (:require
    [clojure.test :as t]
    [metabase.lib.util.match :as lib.util.match]))
@@ -430,3 +433,12 @@
     (t/is (= [15] (lib.util.match/match-many [[1 2 3] [4 5 6]]
                     [a b c] (when (> a 1)
                               (+ a b c)))))))
+
+(t/deftest ^:parallel parents-tests
+  (t/is (= [:foo :bar :baz :qux]
+           (lib.util.match/match-lite [:foo [:bar [:baz {:qux 42}]]]
+             42 &parents)))
+  (t/is (= [[:foo :bar :baz :qux]
+            [:foo :bar :baz :corge]]
+           (lib.util.match/match-many [:foo [:bar [:baz {:qux 42 :corge 42}]]]
+             42 &parents))))

--- a/test/metabase/query_processor/util/add_alias_info_test.clj
+++ b/test/metabase/query_processor/util/add_alias_info_test.clj
@@ -1098,10 +1098,10 @@
                                    :condition    [:= $product-id &PRODUCTS__via__PRODUCT_ID.products.id]}]}))]
       (is (=? [[:expression {::add/source-table ::add/none, ::add/desired-alias "pivot-grouping"} "pivot-grouping"]
                [:expression {::add/source-table ::add/none, ::add/desired-alias "pivot-grouping"} "pivot-grouping"]]
-              (lib.util.match/match (-> query
-                                        add/add-alias-info
-                                        qp.preprocess/preprocess)
-                :expression))))))
+              (lib.util.match/match-many (-> query
+                                             add/add-alias-info
+                                             qp.preprocess/preprocess)
+                [:expression & _] &match))))))
 
 (deftest ^:parallel remapped-columns-in-joined-source-queries-test
   (testing "Make sure remapped columns are given correct aliases and escaped correctly for drivers like Oracle"

--- a/test/metabase/xrays/automagic_dashboards/core_test.clj
+++ b/test/metabase/xrays/automagic_dashboards/core_test.clj
@@ -623,8 +623,8 @@
                             :let     [query (get-in dashcard [:card :dataset_query])]
                             :when    query
                             :let     [breakouts (lib/breakouts query)]
-                            id       (lib.util.match/match breakouts
-                                       [:field (_opts :guard :binning) (id :guard pos-int?)]
+                            id       (lib.util.match/match-many breakouts
+                                       [:field {:binning _} (id :guard pos-int?)]
                                        id)]
                         id)))))))))))
 
@@ -657,8 +657,8 @@
                                            :let     [query (get-in dashcard [:card :dataset_query])]
                                            :when    query
                                            :let     [breakouts (lib/breakouts query)]
-                                           id       (lib.util.match/match breakouts
-                                                      [:field (_opts :guard :temporal-unit) (id :guard pos-int?)]
+                                           id       (lib.util.match/match-many breakouts
+                                                      [:field {:temporal-unit _} (id :guard pos-int?)]
                                                       id)]
                                        id)]
               (ensure-single-table-sourced (mt/id :products) dashboard)


### PR DESCRIPTION
This removes the last feature disparity between `match-lite` and the old `match`. Now, `match-lite`/`match-many` is compatible with all of the usecases that `match-one`/`match-many` covered. The remaining usages were converted.

Additionally, this PR adds Kondo rules to suggest `match-lite` instead of `match`.