### PR TITLE
Fix sync-fields redundant app DB queries

### DIFF
--- a/src/metabase/sync/sync_metadata/fields.clj
+++ b/src/metabase/sync/sync_metadata/fields.clj
@@ -63,6 +63,9 @@
   [database    :- i/DatabaseInstance
    table       :- i/TableInstance
    db-metadata :- [:set i/TableMetadataField]]
+  ;; `our-metadata` returned by `sync-instances!` includes newly created/reactivated fields but may also
+  ;; contain fields that were retired. This is fine because `update-metadata!` only processes fields present
+  ;; in `db-metadata`, so retired entries are ignored.
   (let [{:keys [num-updates our-metadata]} (sync-instances/sync-instances! table db-metadata (fields.our-metadata/our-metadata table))]
     (+ num-updates
        (sync-metadata/update-metadata! database table db-metadata our-metadata))))

--- a/src/metabase/sync/sync_metadata/fields.clj
+++ b/src/metabase/sync/sync_metadata/fields.clj
@@ -63,11 +63,9 @@
   [database    :- i/DatabaseInstance
    table       :- i/TableInstance
    db-metadata :- [:set i/TableMetadataField]]
-  (+ (sync-instances/sync-instances! table db-metadata (fields.our-metadata/our-metadata table))
-     ;; Now that tables are synced and fields created as needed make sure field properties are in sync.
-     ;; Re-fetch our metadata because there might be some things that have changed after calling
-     ;; `sync-instances`
-     (sync-metadata/update-metadata! database table db-metadata (fields.our-metadata/our-metadata table))))
+  (let [{:keys [num-updates our-metadata]} (sync-instances/sync-instances! table db-metadata (fields.our-metadata/our-metadata table))]
+    (+ num-updates
+       (sync-metadata/update-metadata! database table db-metadata our-metadata))))
 
 (defn- select-best-matching-name
   "Returns a key function for use with [[sort-by]] that ranks items based on how closely their `:schema` and `:name` match the given target values.

--- a/src/metabase/sync/sync_metadata/fields.clj
+++ b/src/metabase/sync/sync_metadata/fields.clj
@@ -63,12 +63,12 @@
   [database    :- i/DatabaseInstance
    table       :- i/TableInstance
    db-metadata :- [:set i/TableMetadataField]]
-  ;; `our-metadata` returned by `sync-instances!` includes newly created/reactivated fields but may also
+  ;; `updated-metadata` returned by `sync-instances!` includes newly created/reactivated fields but may also
   ;; contain fields that were retired. This is fine because `update-metadata!` only processes fields present
   ;; in `db-metadata`, so retired entries are ignored.
-  (let [{:keys [num-updates our-metadata]} (sync-instances/sync-instances! table db-metadata (fields.our-metadata/our-metadata table))]
+  (let [{:keys [num-updates updated-metadata]} (sync-instances/sync-instances! table db-metadata (fields.our-metadata/our-metadata table))]
     (+ num-updates
-       (sync-metadata/update-metadata! database table db-metadata our-metadata))))
+       (sync-metadata/update-metadata! database table db-metadata updated-metadata))))
 
 (defn- select-best-matching-name
   "Returns a key function for use with [[sort-by]] that ranks items based on how closely their `:schema` and `:name` match the given target values.


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/38941

### Description

During field sync, `sync-and-update!` calls `fields.our-metadata/our-metadata` twice per table — once for `sync-instances!` and again for `update-metadata!`. The second call exists because `sync-instances!` might create/reactivate fields, but internally it already maintains updated metadata via an atom in `sync-active-instances!` and just discards it when returning.

This PR changes `sync-instances!` to return `{:num-updates, :our-metadata}` instead of just a count, so the caller reuses the updated metadata directly. Eliminates N redundant `SELECT metabase_field.* FROM metabase_field WHERE table_id = ? AND active = TRUE` queries per sync cycle (one per table).

### How to verify

1. Run the new test: `./bin/mage run-tests metabase.sync.sync-metadata.fields-test/our-metadata-fetched-once-per-table-test`
   - Before the fix, `our-metadata` was called 2x per table (test fails with `expected: 1, actual: 2`)
   - After the fix, called exactly 1x (test passes)
2. Run existing sync field tests for regressions:
   - `./bin/mage run-tests metabase.sync.sync-metadata.fields.sync-instances-test/sync-fields-test`
   - `./bin/mage run-tests metabase.sync.sync-metadata.fields.sync-instances-test/resync-nested-fields-test`
   - `./bin/mage run-tests metabase.sync.sync-metadata.fields.sync-instances-test/reactivate-field-test`
   - `./bin/mage run-tests metabase.sync.sync-metadata.fields-test/mark-inactive-test`
   - `./bin/mage run-tests metabase.sync.sync-metadata.fields-test/renaming-fields-test`

### Checklist

- [x] Tests have been added/updated to cover changes in this PR