### PR TITLE
fix(SDK): fixed bugged scrolling in embedded metabot (second version)

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/metabot-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/metabot-question.cy.spec.tsx
@@ -35,6 +35,10 @@ const metabotResponseWithNavigateTo = `${metabotResponse}
 
 const metabotRetryResponse = `0:"Retry: Here is the [question link](${adHocQuestionPath})"`;
 
+const mockTextOnlyResponse = (text: string) =>
+  `0:"${text}"
+d:{"finishReason":"stop","usage":{"promptTokens":100,"completionTokens":10}}`;
+
 describe("scenarios > embedding-sdk > metabot-question", () => {
   const setup = (response: string) => {
     signInAsAdminAndEnableEmbeddingSdk();
@@ -115,6 +119,25 @@ describe("scenarios > embedding-sdk > metabot-question", () => {
             "Orders, Max of Quantity, Grouped by Product ID, 2 rows",
           ).should("be.visible");
         });
+      });
+    });
+  });
+
+  it.only("should handle scrolling", () => {
+    const question = "mlem ".repeat(100);
+    setup(
+      mockTextOnlyResponse(
+        "You're absolutely right, let me rephrase that for you: " + question,
+      ),
+    );
+
+    cy.get("@collectionId").then((collectionId) => {
+      mountSdkContent(
+        <MetabotQuestion isSaveEnabled targetCollection={collectionId} />,
+      );
+
+      getSdkRoot().within(() => {
+        cy.findByTestId("metabot-chat-input").type(question + " {enter}");
       });
     });
   });

--- a/e2e/test-component/scenarios/embedding-sdk/metabot-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/metabot-question.cy.spec.tsx
@@ -35,10 +35,6 @@ const metabotResponseWithNavigateTo = `${metabotResponse}
 
 const metabotRetryResponse = `0:"Retry: Here is the [question link](${adHocQuestionPath})"`;
 
-const mockTextOnlyResponse = (text: string) =>
-  `0:"${text}"
-d:{"finishReason":"stop","usage":{"promptTokens":100,"completionTokens":10}}`;
-
 describe("scenarios > embedding-sdk > metabot-question", () => {
   const setup = (response: string) => {
     signInAsAdminAndEnableEmbeddingSdk();
@@ -119,25 +115,6 @@ describe("scenarios > embedding-sdk > metabot-question", () => {
             "Orders, Max of Quantity, Grouped by Product ID, 2 rows",
           ).should("be.visible");
         });
-      });
-    });
-  });
-
-  it.only("should handle scrolling", () => {
-    const question = "mlem ".repeat(100);
-    setup(
-      mockTextOnlyResponse(
-        "You're absolutely right, let me rephrase that for you: " + question,
-      ),
-    );
-
-    cy.get("@collectionId").then((collectionId) => {
-      mountSdkContent(
-        <MetabotQuestion isSaveEnabled targetCollection={collectionId} />,
-      );
-
-      getSdkRoot().within(() => {
-        cy.findByTestId("metabot-chat-input").type(question + " {enter}");
       });
     });
   });

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
@@ -390,6 +390,36 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
   });
 
   describe("<metabase-metabot>", () => {
+    it("should handle scrolling gracefully (metabase#67399)", () => {
+      const question = `
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+      `;
+
+      H.visitCustomHtmlPage(`
+      ${H.getNewEmbedScriptTag()}
+      ${H.getNewEmbedConfigurationScript()}
+      <metabase-metabot />
+      `);
+
+      H.getSimpleEmbedIframeContent().within(() => {
+        cy.log("metabot chat should be interactive");
+        cy.findByText("Ask questions to AI.").should("be.visible");
+
+        cy.findByPlaceholderText("Ask AI a question...")
+          .paste(question)
+          .type("{enter}");
+
+        // Making sure the ChatInput is still within the viewport
+        cy.findByPlaceholderText("Ask AI a question...").should("be.visible");
+      });
+    });
+
     it("should load the embedded Metabot component", () => {
       H.visitCustomHtmlPage(`
       ${H.getNewEmbedScriptTag()}

--- a/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotChatInput.tsx
+++ b/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotChatInput.tsx
@@ -50,7 +50,7 @@ export function MetabotChatInput() {
         ref={metabot.promptInputRef as LegacyRef<HTMLTextAreaElement>}
         autoFocus
         value={metabot.prompt}
-        disabled={metabot.isDoingScience}
+        readOnly={metabot.isDoingScience}
         placeholder={placeholder}
         onChange={(e) => metabot.setPrompt(e.target.value)}
         classNames={{ input: S.chatInput }}

--- a/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotQuestion.tsx
@@ -2,8 +2,8 @@ import { useElementSize } from "@mantine/hooks";
 import { useId, useMemo } from "react";
 import { P, match } from "ts-pattern";
 
-import { FlexibleSizeComponent } from "embedding-sdk-bundle/components/private/FlexibleSizeComponent";
 import { withPublicComponentWrapper } from "embedding-sdk-bundle/components/private/PublicComponentWrapper";
+import { ResizeWrapper } from "embedding-sdk-bundle/components/private/ResizeWrapper";
 import { SdkAdHocQuestion } from "embedding-sdk-bundle/components/private/SdkAdHocQuestion";
 import { SdkQuestionDefaultView } from "embedding-sdk-bundle/components/private/SdkQuestionDefaultView";
 import { METABOT_SDK_EE_PLUGIN } from "embedding-sdk-bundle/components/public/MetabotQuestion/MetabotQuestion";
@@ -87,13 +87,13 @@ const MetabotQuestionInner = ({
     );
   }
 
+  // avoids initial flickering
+  if (!derivedLayout || containerWidth == null) {
+    return null;
+  }
+
   return (
-    <FlexibleSizeComponent
-      height={height}
-      width={width}
-      className={className}
-      style={style}
-    >
+    <ResizeWrapper h={height} w={width} className={className} style={style}>
       <div
         ref={containerRef}
         className={S.container}
@@ -114,7 +114,7 @@ const MetabotQuestionInner = ({
           </Stack>
         </div>
       </div>
-    </FlexibleSizeComponent>
+    </ResizeWrapper>
   );
 };
 

--- a/frontend/src/embedding-sdk-bundle/components/private/ResizeWrapper.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/ResizeWrapper.tsx
@@ -3,6 +3,11 @@ import type { ReactNode, RefObject } from "react";
 
 import { Box, type BoxProps } from "metabase/ui";
 
+import {
+  FLEXIBLE_SIZE_DEFAULT_HEIGHT,
+  FLEXIBLE_SIZE_DEFAULT_WIDTH,
+} from "./FlexibleSizeComponent";
+
 /**
  * Props for the ResizeWrapper component.
  * @extends BoxProps
@@ -36,12 +41,14 @@ interface ResizeWrapperProps extends BoxProps {
 export function ResizeWrapper({
   children,
   ref: divRef,
+  h = FLEXIBLE_SIZE_DEFAULT_HEIGHT,
+  w = FLEXIBLE_SIZE_DEFAULT_WIDTH,
   ...props
 }: ResizeWrapperProps) {
   const [ref, rect] = useResizeObserver();
 
   return (
-    <Box ref={ref} w="100%" h="100%" {...props}>
+    <Box ref={ref} w={w} h={h} {...props}>
       <div
         ref={divRef}
         style={{

--- a/frontend/src/embedding-sdk-bundle/components/private/ResizeWrapper.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/ResizeWrapper.tsx
@@ -1,0 +1,56 @@
+import { useResizeObserver } from "@mantine/hooks";
+import type { ReactNode, RefObject } from "react";
+
+import { Box, type BoxProps } from "metabase/ui";
+
+/**
+ * Props for the ResizeWrapper component.
+ * @extends BoxProps
+ */
+interface ResizeWrapperProps extends BoxProps {
+  /** Content to be wrapped and resized */
+  children: ReactNode;
+  /** Optional ref to attach to the inner div that receives the measured dimensions */
+  ref?: RefObject<HTMLDivElement>;
+}
+
+/**
+ * A wrapper component that measures available space and applies those dimensions to its children.
+ *
+ * Uses a resize observer on the outer container to track size changes, then applies
+ * the measured dimensions to an inner div wrapping the children. This ensures children
+ * render with explicit dimensions matching their available space.
+ *
+ * @param props - Component props
+ * @param props.children - Content to render inside the measured container
+ * @param props.ref - Optional ref for the inner div (renamed to divRef internally to avoid conflict)
+ * @param props...props - Additional BoxProps passed to the outer Box container
+ *
+ * @example
+ * ```tsx
+ * <ResizeWrapper>
+ *   <MyChart />
+ * </ResizeWrapper>
+ * ```
+ */
+export function ResizeWrapper({
+  children,
+  ref: divRef,
+  ...props
+}: ResizeWrapperProps) {
+  const [ref, rect] = useResizeObserver();
+
+  return (
+    <Box ref={ref} w="100%" h="100%" {...props}>
+      <div
+        ref={divRef}
+        style={{
+          width: rect.width,
+          height: rect.height,
+        }}
+      >
+        {children}
+      </div>
+    </Box>
+  );
+}


### PR DESCRIPTION
closes https://github.com/metabase/metabase/issues/67399

Closes [EMB-1154: Embedded metabot preview doesn't scroll independently of query results](https://linear.app/metabase/issue/EMB-1154/embedded-metabot-preview-doesnt-scroll-independently-of-query-results)
Description

This PR adds proper measuring to the SDK Metabot question, so it scrolls normally (as in, not the entire MetabotQuestion scrolls, only its "chat" part).

Instead of using `FlexibleSizeComponent` like other SDK/EAJS components, it now uses the new `ResizeWrapper`. In other words, instead of being wrapped in a 100% height div, it's wrapped in a div that measures it's available height to allow for proper scrolling.

The other SDK/EAJS components work fine with `FlexibleSizeComponent` because they either don't need inner scrolling (like `MetabaseBrowser`) or because they handle their own sizing (`InteractiveQuestion` with, deep down, the use of the `ExplicitSize` HOC).

Before:
[loom.com/share/f98b723bbd9644f58de0ab0bcb349f00](https://www.loom.com/share/f98b723bbd9644f58de0ab0bcb349f00)

After:
[loom.com/share/4a38ccf671af448198ccd3e6656015e5](https://www.loom.com/share/4a38ccf671af448198ccd3e6656015e5)