### PR TITLE
fix Back button on eajs browser component

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/eajs-internal-navigation.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/eajs-internal-navigation.cy.spec.ts
@@ -417,5 +417,67 @@ describe("scenarios > embedding > sdk iframe embedding > internal-navigation", (
         .findByText(/Back to/)
         .should("not.exist");
     });
+
+    it("should clean up navigation stack when clicking a collection breadcrumb after navigating back", () => {
+      H.visitCustomHtmlPage(`
+        ${H.getNewEmbedScriptTag()}
+        ${H.getNewEmbedConfigurationScript({})}
+        <metabase-browser initial-collection="root" enable-entity-navigation />
+      `);
+
+      cy.log("open First Dashboard from the browser");
+      H.getSimpleEmbedIframeContent()
+        .findByText("First Dashboard")
+        .should("be.visible")
+        .click();
+
+      cy.wait("@getDashCardQuery");
+
+      cy.log("navigate to Target Dashboard via click behavior link");
+      H.getSimpleEmbedIframeContent()
+        .findAllByText("Go to Target Dashboard")
+        .first()
+        .click();
+
+      cy.wait("@getDashboard");
+
+      cy.log("click back to return to First Dashboard");
+      H.getSimpleEmbedIframeContent()
+        .findByText("Back to First Dashboard")
+        .should("be.visible")
+        .click();
+
+      cy.log(
+        "click 'Our analytics' breadcrumb to go back to the collection browser",
+      );
+      H.getSimpleEmbedIframeContent()
+        .findByTestId("sdk-breadcrumbs")
+        .findByText("Our analytics")
+        .click();
+
+      cy.log("verify the collection browser is showing items again");
+      H.getSimpleEmbedIframeContent()
+        .findByText("First Dashboard")
+        .should("be.visible");
+
+      cy.log(
+        "verify no back button is present (navigation stack should be clean)",
+      );
+      H.getSimpleEmbedIframeContent()
+        .findByText(/Back to/)
+        .should("not.exist");
+
+      cy.log(
+        "verify we can navigate to a dashboard again (no stale virtual entries)",
+      );
+      H.getSimpleEmbedIframeContent().findByText("First Dashboard").click();
+
+      cy.wait("@getDashCardQuery");
+
+      H.getSimpleEmbedIframeContent()
+        .findByTestId("sdk-breadcrumbs")
+        .findByText("First Dashboard")
+        .should("be.visible");
+    });
   });
 });

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/eajs-internal-navigation.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/eajs-internal-navigation.cy.spec.ts
@@ -381,16 +381,11 @@ describe("scenarios > embedding > sdk iframe embedding > internal-navigation", (
 
       cy.log("back button should be visible");
       H.getSimpleEmbedIframeContent()
-        .findByText("Back to First Dashboard")
+        .findByText(/Back to/)
         .should("be.visible")
         .click();
 
-      cy.log("verify we returned to First Dashboard");
-      H.getSimpleEmbedIframeContent()
-        .findByText("First Dashboard")
-        .should("be.visible");
-
-      cy.log("breadcrumbs should be visible again");
+      cy.log("breadcrumbs should return after going back");
       H.getSimpleEmbedIframeContent()
         .findByTestId("sdk-breadcrumbs")
         .should("be.visible");

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/eajs-internal-navigation.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/eajs-internal-navigation.cy.spec.ts
@@ -381,11 +381,16 @@ describe("scenarios > embedding > sdk iframe embedding > internal-navigation", (
 
       cy.log("back button should be visible");
       H.getSimpleEmbedIframeContent()
-        .findByText(/Back to/)
+        .findByText("Back to First Dashboard")
         .should("be.visible")
         .click();
 
-      cy.log("breadcrumbs should return after going back");
+      cy.log("verify we returned to First Dashboard");
+      H.getSimpleEmbedIframeContent()
+        .findByText("First Dashboard")
+        .should("be.visible");
+
+      cy.log("breadcrumbs should be visible again");
       H.getSimpleEmbedIframeContent()
         .findByTestId("sdk-breadcrumbs")
         .should("be.visible");

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/SdkInternalNavigationProvider.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/SdkInternalNavigationProvider.tsx
@@ -33,6 +33,8 @@ type Props = {
   renderDrillThroughQuestion?: () => ReactNode;
   /** Props to pass to drill-through question components */
   drillThroughQuestionProps?: DrillThroughQuestionProps;
+  /** When true, children are kept mounted (hidden) during navigation instead of being unmounted */
+  keepMounted?: boolean;
   style?: CSSProperties;
   className?: string;
 };
@@ -44,11 +46,16 @@ const SdkInternalNavigationProviderInner = ({
   dashboardProps,
   renderDrillThroughQuestion: RenderDrillThroughQuestion,
   drillThroughQuestionProps,
+  keepMounted = false,
 }: Props) => {
   const [stack, setStack] = useState<SdkInternalNavigationEntry[]>([]);
 
   const push = useCallback((entry: SdkInternalNavigationEntry) => {
     setStack((prev) => [...prev, entry]);
+  }, []);
+
+  const reset = useCallback(() => {
+    setStack([]);
   }, []);
 
   const pop = useCallback(() => {
@@ -79,12 +86,13 @@ const SdkInternalNavigationProviderInner = ({
       stack,
       push,
       pop,
+      reset,
       currentEntry: stack.at(-1),
       previousEntry: stack.at(-2),
-      canGoBack: stack.length > 1,
+      canGoBack: stack.filter((e) => e.type !== "metabase-browser").length > 1,
       initWithDashboard,
     }),
-    [stack, push, pop, initWithDashboard],
+    [stack, push, pop, reset, initWithDashboard],
   );
 
   // "Virtual" entries are entries that are rendered by the previous entity (ie: drills, new question from dashboard)
@@ -96,8 +104,7 @@ const SdkInternalNavigationProviderInner = ({
 
   const entryToRender = nonVirtualEntries.at(-1);
   const entryIndex = entryToRender ? stack.indexOf(entryToRender) : -1;
-  // If the entry is the original entry, we just need to return the children.
-  const entryIsOriginalEntity = stack.length === 0 || entryIndex === 0;
+  const entryIsOriginalEntity = !entryToRender || entryIndex === 0;
 
   const shouldRenderBackButton = match(stack.at(-1)?.type ?? null)
     .with(null, () => false)
@@ -144,9 +151,24 @@ const SdkInternalNavigationProviderInner = ({
     })
     .otherwise(() => children);
 
-  // When we don't render the children directly, we need to render a wrapper with the styles applied.
-  // Otherwise we don pass `style` and `className` to anything, we can't always wrap it otherwise we may render
-  // paddings and borders twice.
+  if (keepMounted) {
+    // Keep children always mounted at the same DOM position to prevent unmount/remount.
+    // Use display:contents when visible (transparent wrapper) and display:none when hidden.
+    return (
+      <SdkInternalNavigationContext.Provider value={value}>
+        <div style={{ display: entryIsOriginalEntity ? "contents" : "none" }}>
+          {children}
+        </div>
+        {!entryIsOriginalEntity && (
+          <SdkDashboardStyledWrapper className={className} style={style}>
+            {maybeButton}
+            {content}
+          </SdkDashboardStyledWrapper>
+        )}
+      </SdkInternalNavigationContext.Provider>
+    );
+  }
+
   return (
     <SdkInternalNavigationContext.Provider value={value}>
       {entryIsOriginalEntity ? (

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/SdkInternalNavigationProvider.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/SdkInternalNavigationProvider.tsx
@@ -84,7 +84,7 @@ const SdkInternalNavigationProviderInner = ({
       pop,
       currentEntry: stack.at(-1),
       previousEntry: stack.at(-2),
-      // When starting form the `metabase-browser`, we need to have > 2 items in
+      // When starting from the `metabase-browser`, we need to have > 2 items in
       // the stack to be able to go back, as the first navigation is handled by
       // the breadcrumbs.
       canGoBack: stack.filter((e) => e.type !== "metabase-browser").length > 1,
@@ -152,7 +152,7 @@ const SdkInternalNavigationProviderInner = ({
 
   return (
     <SdkInternalNavigationContext.Provider value={value}>
-      {/* When `keepChildrenMounted` is true, we week the children mounted but hide them */}
+      {/* When `keepChildrenMounted` is true, we keep the children mounted but hide them */}
       <div style={{ display: entryIsOriginalEntity ? "contents" : "none" }}>
         {entryIsOriginalEntity || keepChildrenMounted ? children : null}
       </div>

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/SdkInternalNavigationProvider.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/SdkInternalNavigationProvider.tsx
@@ -158,7 +158,7 @@ const SdkInternalNavigationProviderInner = ({
       </div>
       {entryIsOriginalEntity ? null : (
         // When we don't render the children directly, we need to render a wrapper with the styles applied.
-        // Otherwise we don pass `style` and `className` to anything, we can't always wrap it otherwise we may render
+        // Otherwise we don't pass `style` and `className` to anything, we can't always wrap it otherwise we may render
         // paddings and borders twice.
         <SdkDashboardStyledWrapper className={className} style={style}>
           {maybeButton}

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/SdkInternalNavigationProvider.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/SdkInternalNavigationProvider.tsx
@@ -33,6 +33,8 @@ type Props = {
   renderDrillThroughQuestion?: () => ReactNode;
   /** Props to pass to drill-through question components */
   drillThroughQuestionProps?: DrillThroughQuestionProps;
+  /** When true, children are kept mounted (but hidden) during navigation instead of being unmounted */
+  keepChildrenMounted?: boolean;
   style?: CSSProperties;
   className?: string;
 };
@@ -44,6 +46,7 @@ const SdkInternalNavigationProviderInner = ({
   dashboardProps,
   renderDrillThroughQuestion: RenderDrillThroughQuestion,
   drillThroughQuestionProps,
+  keepChildrenMounted = false,
 }: Props) => {
   const [stack, setStack] = useState<SdkInternalNavigationEntry[]>([]);
 
@@ -81,7 +84,10 @@ const SdkInternalNavigationProviderInner = ({
       pop,
       currentEntry: stack.at(-1),
       previousEntry: stack.at(-2),
-      canGoBack: stack.length > 1,
+      // When starting form the `metabase-browser`, we need to have > 2 items in
+      // the stack to be able to go back, as the first navigation is handled by
+      // the breadcrumbs.
+      canGoBack: stack.filter((e) => e.type !== "metabase-browser").length > 1,
       initWithDashboard,
     }),
     [stack, push, pop, initWithDashboard],
@@ -90,7 +96,7 @@ const SdkInternalNavigationProviderInner = ({
   // "Virtual" entries are entries that are rendered by the previous entity (ie: drills, new question from dashboard)
   // we don't have to render them, but we need them in the stack to make the back button work correctly
   const nonVirtualEntries = useMemo(
-    () => stack.filter((entry) => !entry.type.startsWith("virtual")),
+    () => stack.filter((entry) => !entry.virtual),
     [stack],
   );
 
@@ -144,14 +150,16 @@ const SdkInternalNavigationProviderInner = ({
     })
     .otherwise(() => children);
 
-  // When we don't render the children directly, we need to render a wrapper with the styles applied.
-  // Otherwise we don pass `style` and `className` to anything, we can't always wrap it otherwise we may render
-  // paddings and borders twice.
   return (
     <SdkInternalNavigationContext.Provider value={value}>
-      {entryIsOriginalEntity ? (
-        children
-      ) : (
+      {/* When `keepChildrenMounted` is true, we week the children mounted but hide them */}
+      <div style={{ display: entryIsOriginalEntity ? "contents" : "none" }}>
+        {entryIsOriginalEntity || keepChildrenMounted ? children : null}
+      </div>
+      {entryIsOriginalEntity ? null : (
+        // When we don't render the children directly, we need to render a wrapper with the styles applied.
+        // Otherwise we don pass `style` and `className` to anything, we can't always wrap it otherwise we may render
+        // paddings and borders twice.
         <SdkDashboardStyledWrapper className={className} style={style}>
           {maybeButton}
           {content}

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/context.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/context.tsx
@@ -4,48 +4,56 @@ import type { SdkDashboardId } from "embedding-sdk-bundle/types/dashboard";
 import type { SdkQuestionId } from "embedding-sdk-bundle/types/question";
 import type { ParameterValues } from "metabase/embedding-sdk/types/dashboard";
 
+// This type exists only to have a global place where to put the JSDoc for virtual
+type BaseEntry = {
+  /** "Virtual" entries are entries that are rendered by the previous entity and not by the SdkInternalNavigationProvider directly (ie: drills, new question from dashboard)
+   * We still need the entry object in the stack to keep track of them and make the back button work correctly
+   */
+  virtual?: boolean;
+};
+
 export type SdkInternalNavigationEntry =
-  | {
+  | (BaseEntry & {
       type: "dashboard";
       id: SdkDashboardId;
       name: string;
       virtual?: true;
       parameters?: ParameterValues;
       onPop?: () => void;
-    }
-  | {
+    })
+  | (BaseEntry & {
       type: "question";
       id: SdkQuestionId;
       name: string;
       virtual?: true;
       parameters?: ParameterValues;
       onPop?: () => void;
-    }
-  | {
+    })
+  | (BaseEntry & {
       type: "metabase-browser";
       virtual: false;
       onPop?: () => void;
-    }
-  | {
+    })
+  | (BaseEntry & {
       /** Parent component handles rendering, this just tracks navigation depth */
       type: "question-drill";
       virtual: true;
       name: string;
       onPop?: () => void;
-    }
-  | {
+    })
+  | (BaseEntry & {
       /** Opening a card from dashboard (clicking card title or click behavior) */
       type: "open-card";
       virtual: true;
       name: string;
       onPop?: () => void;
-    }
-  | {
+    })
+  | (BaseEntry & {
       /** New question creation from dashboard */
       type: "new-question";
       virtual: true;
       onPop?: () => void;
-    };
+    });
 
 export type SdkInternalNavigationContextValue = {
   stack: SdkInternalNavigationEntry[];

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/context.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/context.tsx
@@ -10,19 +10,12 @@ export type SdkInternalNavigationEntry =
       id: SdkDashboardId;
       name: string;
       parameters?: ParameterValues;
-      onPop?: () => void;
     }
   | {
       type: "question";
       id: SdkQuestionId;
       name: string;
       parameters?: ParameterValues;
-      onPop?: () => void;
-    }
-  | {
-      /** Virtual entry for the metabase-browser collection view */
-      type: "metabase-browser";
-      onPop?: () => void;
     }
   | {
       /** Virtual entry for question drills - parent component handles rendering, this just tracks navigation depth */
@@ -40,27 +33,12 @@ export type SdkInternalNavigationEntry =
       /** Virtual entry for new question creation from dashboard */
       type: "virtual-new-question";
       onPop?: () => void;
-    }
-  | {
-      /** Virtual entry for dashboard opened from MetabaseBrowser — browser handles rendering */
-      type: "virtual-dashboard";
-      id: SdkDashboardId;
-      name: string;
-      onPop?: () => void;
-    }
-  | {
-      /** Virtual entry for question/model/metric opened from MetabaseBrowser — browser handles rendering */
-      type: "virtual-question";
-      id: SdkQuestionId;
-      name: string;
-      onPop?: () => void;
     };
 
 export type SdkInternalNavigationContextValue = {
   stack: SdkInternalNavigationEntry[];
   push: (entry: SdkInternalNavigationEntry) => void;
   pop: () => void;
-  reset: () => void;
   currentEntry: SdkInternalNavigationEntry | undefined;
   canGoBack: boolean;
   previousEntry: SdkInternalNavigationEntry | undefined;

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/context.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/context.tsx
@@ -10,12 +10,19 @@ export type SdkInternalNavigationEntry =
       id: SdkDashboardId;
       name: string;
       parameters?: ParameterValues;
+      onPop?: () => void;
     }
   | {
       type: "question";
       id: SdkQuestionId;
       name: string;
       parameters?: ParameterValues;
+      onPop?: () => void;
+    }
+  | {
+      /** Virtual entry for the metabase-browser collection view */
+      type: "metabase-browser";
+      onPop?: () => void;
     }
   | {
       /** Virtual entry for question drills - parent component handles rendering, this just tracks navigation depth */
@@ -33,12 +40,27 @@ export type SdkInternalNavigationEntry =
       /** Virtual entry for new question creation from dashboard */
       type: "virtual-new-question";
       onPop?: () => void;
+    }
+  | {
+      /** Virtual entry for dashboard opened from MetabaseBrowser — browser handles rendering */
+      type: "virtual-dashboard";
+      id: SdkDashboardId;
+      name: string;
+      onPop?: () => void;
+    }
+  | {
+      /** Virtual entry for question/model/metric opened from MetabaseBrowser — browser handles rendering */
+      type: "virtual-question";
+      id: SdkQuestionId;
+      name: string;
+      onPop?: () => void;
     };
 
 export type SdkInternalNavigationContextValue = {
   stack: SdkInternalNavigationEntry[];
   push: (entry: SdkInternalNavigationEntry) => void;
   pop: () => void;
+  reset: () => void;
   currentEntry: SdkInternalNavigationEntry | undefined;
   canGoBack: boolean;
   previousEntry: SdkInternalNavigationEntry | undefined;

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/context.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/context.tsx
@@ -9,29 +9,41 @@ export type SdkInternalNavigationEntry =
       type: "dashboard";
       id: SdkDashboardId;
       name: string;
+      virtual?: true;
       parameters?: ParameterValues;
+      onPop?: () => void;
     }
   | {
       type: "question";
       id: SdkQuestionId;
       name: string;
+      virtual?: true;
       parameters?: ParameterValues;
+      onPop?: () => void;
     }
   | {
-      /** Virtual entry for question drills - parent component handles rendering, this just tracks navigation depth */
-      type: "virtual-question-drill";
+      type: "metabase-browser";
+      virtual: false;
+      onPop?: () => void;
+    }
+  | {
+      /** Parent component handles rendering, this just tracks navigation depth */
+      type: "question-drill";
+      virtual: true;
       name: string;
       onPop?: () => void;
     }
   | {
-      /** Virtual entry for opening a card from dashboard (clicking card title or click behavior) */
-      type: "virtual-open-card";
+      /** Opening a card from dashboard (clicking card title or click behavior) */
+      type: "open-card";
+      virtual: true;
       name: string;
       onPop?: () => void;
     }
   | {
-      /** Virtual entry for new question creation from dashboard */
-      type: "virtual-new-question";
+      /** New question creation from dashboard */
+      type: "new-question";
+      virtual: true;
       onPop?: () => void;
     };
 

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/context/SdkQuestionProvider.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/context/SdkQuestionProvider.tsx
@@ -186,9 +186,10 @@ export const SdkQuestionProvider = ({
 
       // Push virtual entry if last entry is NOT already a question drill
       const currentEntry = navigation?.stack.at(-1);
-      if (currentEntry?.type !== "virtual-question-drill") {
+      if (currentEntry?.type !== "question-drill") {
         navigation?.push({
-          type: "virtual-question-drill",
+          type: "question-drill",
+          virtual: true,
           name: question?.displayName() ?? t`Question`,
           onPop: () => loadAndQueryQuestion(),
         });

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
@@ -317,16 +317,18 @@ const SdkDashboardInner = ({
         // For drills, only push if not already a question drill
         // One press of back button should undo all of them
         const currentEntry = sdkNavigation?.stack.at(-1);
-        if (currentEntry?.type !== "virtual-question-drill") {
+        if (currentEntry?.type !== "question-drill") {
           sdkNavigation?.push({
-            type: "virtual-question-drill",
+            type: "question-drill",
+            virtual: true,
             name: opts.previousCard.name ?? t`Question`,
             onPop: () => onNavigateBackToDashboard(),
           });
         }
       } else {
         sdkNavigation?.push({
-          type: "virtual-open-card",
+          type: "open-card",
+          virtual: true,
           name: opts.previousCard.name ?? t`Question`,
           onPop: () => onNavigateBackToDashboard(),
         });
@@ -410,7 +412,8 @@ const SdkDashboardInner = ({
                  * @see {@link https://github.com/metabase/metabase/blob/4453fa8363eb37062a159f398050d050d91397a9/frontend/src/metabase/dashboard/components/DashboardLeaveConfirmationModal/DashboardLeaveConfirmationModal.tsx#L30-L34}
                  */
                 sdkNavigation?.push({
-                  type: "virtual-new-question",
+                  type: "new-question",
+                  virtual: true,
                   onPop: () => setRenderMode("dashboard"),
                 });
                 setRenderMode("queryBuilder");
@@ -425,7 +428,8 @@ const SdkDashboardInner = ({
             });
           } else {
             sdkNavigation?.push({
-              type: "virtual-new-question",
+              type: "new-question",
+              virtual: true,
               onPop: () => setRenderMode("dashboard"),
             });
             setRenderMode("queryBuilder");

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/components/MetabaseBrowser.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/components/MetabaseBrowser.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
+import { useMount } from "react-use";
 import { P, match } from "ts-pattern";
 import { t } from "ttag";
 import _ from "underscore";
 
 import { SdkBreadcrumbs } from "embedding-sdk-bundle/components/private/SdkBreadcrumbs";
+import { useSdkInternalNavigation } from "embedding-sdk-bundle/components/private/SdkInternalNavigation/context";
 import { CollectionBrowser } from "embedding-sdk-bundle/components/public/CollectionBrowser";
 import { CreateDashboardModal } from "embedding-sdk-bundle/components/public/CreateDashboardModal";
 import { InteractiveQuestion } from "embedding-sdk-bundle/components/public/InteractiveQuestion";
@@ -30,11 +32,13 @@ type MetabaseBrowserView =
   | { type: "dashboard"; id: number | string }
   | { type: "question" | "metric" | "model"; id: number | string }
   | { type: "exploration" }
-  | { type: "create-dashboard" };
+  | { type: "create-dashboard" }
+  | { type: "suspended" };
 
 const BREADCRUMB_HEIGHT = "3.5rem";
 
 export function MetabaseBrowser({ settings }: MetabaseBrowserProps) {
+  const navigationContext = useSdkInternalNavigation();
   const { initialCollection } = settings;
 
   const isReadOnly = settings.readOnly ?? true;
@@ -48,6 +52,21 @@ export function MetabaseBrowser({ settings }: MetabaseBrowserProps) {
     type: "collection",
     id: initialCollection,
   });
+
+  useMount(() => {
+    if (navigationContext.stack.length === 0) {
+      // Populate the initial entry of the stack when this is the root/starting point
+      navigationContext.push({ type: "metabase-browser", virtual: false });
+    }
+  });
+
+  const hasNavigatedAway = useMemo(() => {
+    // If we've opened a dashboard and we navigate away with drills/SdkNavigationProvider, we need to unmount the dashboard.
+    // Otherwise if we navigate to another dashboard we'll have two dashboards trying to access the same Redux state.
+    return navigationContext.stack.some(
+      (entry) => entry.type !== "metabase-browser" && !entry.virtual,
+    );
+  }, [navigationContext.stack]);
 
   // Use the last collection in the breadcrumb as the target for saving new questions.
   const targetCollection = useMemo(() => {
@@ -67,102 +86,125 @@ export function MetabaseBrowser({ settings }: MetabaseBrowserProps) {
     }
   }, [currentLocation]);
 
-  const viewContent = match(currentView)
-    .with({ type: "exploration" }, () => (
-      <Box px="xl" h="100%">
-        <InteractiveQuestion
-          questionId="new"
-          height="100%"
-          withDownloads
-          isSaveEnabled={!isReadOnly}
-          entityTypes={settings.dataPickerEntityTypes}
-          targetCollection={targetCollection}
-        />
-      </Box>
-    ))
-    .with({ type: "create-dashboard" }, () => (
-      <CreateDashboardModal
-        onCreate={(dashboard) => {
-          // Update the breadcrumbs to reflect the collection where the dashboard was saved
-          if (dashboard.collection) {
-            reportLocation({
-              type: "collection",
-              id: dashboard.collection.id,
-              name: dashboard.collection.name,
-            });
-          }
+  const viewContent = hasNavigatedAway
+    ? null
+    : match(currentView)
+        .with({ type: "exploration" }, () => (
+          <Box px="xl" h="100%">
+            <InteractiveQuestion
+              questionId="new"
+              height="100%"
+              withDownloads
+              isSaveEnabled={!isReadOnly}
+              entityTypes={settings.dataPickerEntityTypes}
+              targetCollection={targetCollection}
+            />
+          </Box>
+        ))
+        .with({ type: "create-dashboard" }, () => (
+          <CreateDashboardModal
+            onCreate={(dashboard) => {
+              // Update the breadcrumbs to reflect the collection where the dashboard was saved
+              if (dashboard.collection) {
+                reportLocation({
+                  type: "collection",
+                  id: dashboard.collection.id,
+                  name: dashboard.collection.name,
+                });
+              }
 
-          // On the next tick, update the current view.
-          // This is needed for when we create new collections.
-          setTimeout(() => {
-            setCurrentView({ type: "dashboard", id: dashboard.id });
-          }, 0);
-        }}
-        onClose={() =>
-          setCurrentView({ type: "collection", id: targetCollection })
-        }
-        initialCollectionId={targetCollection}
-      />
-    ))
-    .with({ type: "dashboard", id: P.nonNullable }, ({ id }) => {
-      const dashboardView = isReadOnly ? (
-        <InteractiveDashboard
-          dashboardId={id}
-          withDownloads
-          style={{ height: "100%" }}
-          drillThroughQuestionProps={{ isSaveEnabled: false }}
-          enableEntityNavigation={settings.enableEntityNavigation}
-        />
-      ) : (
-        <EditableDashboard
-          withCardTitle
-          dashboardId={id}
-          style={{ height: "100%" }}
-          enableEntityNavigation={settings.enableEntityNavigation}
-        />
-      );
-
-      // The overflow-scroll is needed otherwise the editable
-      // dashboard header gets scrolled out of view.
-      return (
-        <Group h="100%" style={{ overflowY: "scroll" }}>
-          {dashboardView}
-        </Group>
-      );
-    })
-    .with(
-      { type: P.union("question", "metric", "model"), id: P.nonNullable },
-      ({ id }) => (
-        <Box px="xl" h="100%">
-          <InteractiveQuestion
-            questionId={id}
-            height="100%"
-            withDownloads
-            isSaveEnabled={!isReadOnly}
-            targetCollection={targetCollection}
+              // On the next tick, update the current view.
+              // This is needed for when we create new collections.
+              setTimeout(() => {
+                setCurrentView({ type: "dashboard", id: dashboard.id });
+              }, 0);
+            }}
+            onClose={() =>
+              setCurrentView({ type: "collection", id: targetCollection })
+            }
+            initialCollectionId={targetCollection}
           />
-        </Box>
-      ),
-    )
-    .with({ type: "collection" }, (view) => (
-      <Box px="xl" pt="lg" style={{ overflowY: "auto" }}>
-        <CollectionBrowser
-          collectionId={view.id}
-          visibleColumns={settings.collectionVisibleColumns}
-          visibleEntityTypes={settings.collectionEntityTypes}
-          pageSize={settings.collectionPageSize}
-          onClick={(item) => {
-            const type = match<string, SdkBreadcrumbItemType>(item.model)
-              .with("card", () => "question")
-              .with("dataset", () => "model")
-              .otherwise((model) => model as SdkBreadcrumbItemType);
+        ))
+        .with({ type: "dashboard", id: P.nonNullable }, ({ id }) => {
+          const dashboardView = isReadOnly ? (
+            <InteractiveDashboard
+              dashboardId={id}
+              withDownloads
+              style={{ height: "100%" }}
+              drillThroughQuestionProps={{ isSaveEnabled: false }}
+              enableEntityNavigation={settings.enableEntityNavigation}
+            />
+          ) : (
+            <EditableDashboard
+              withCardTitle
+              dashboardId={id}
+              style={{ height: "100%" }}
+              enableEntityNavigation={settings.enableEntityNavigation}
+            />
+          );
 
-            setCurrentView({ type, id: item.id });
-          }}
-        />
-      </Box>
-    ))
-    .otherwise(() => null);
+          // The overflow-scroll is needed otherwise the editable
+          // dashboard header gets scrolled out of view.
+          return (
+            <Group h="100%" style={{ overflowY: "scroll" }}>
+              {dashboardView}
+            </Group>
+          );
+        })
+        .with(
+          { type: P.union("question", "metric", "model"), id: P.nonNullable },
+          ({ id }) => (
+            <Box px="xl" h="100%">
+              <InteractiveQuestion
+                questionId={id}
+                height="100%"
+                withDownloads
+                isSaveEnabled={!isReadOnly}
+                targetCollection={targetCollection}
+              />
+            </Box>
+          ),
+        )
+        .with({ type: "collection" }, (view) => (
+          <Box px="xl" pt="lg" style={{ overflowY: "auto" }}>
+            <CollectionBrowser
+              collectionId={view.id}
+              visibleColumns={settings.collectionVisibleColumns}
+              visibleEntityTypes={settings.collectionEntityTypes}
+              pageSize={settings.collectionPageSize}
+              onClick={(item) => {
+                const type = match<string, SdkBreadcrumbItemType>(item.model)
+                  .with("card", () => "question")
+                  .with("dataset", () => "model")
+                  .otherwise((model) => model as SdkBreadcrumbItemType);
+
+                setCurrentView({ type, id: item.id });
+
+                if (type !== "collection") {
+                  // If we're navigating to something other than a collection, we need to keep the navigation stack updated
+                  // to make the back button work correctly
+                  navigationContext.push({
+                    type: match(type)
+                      .with("dashboard", () => "dashboard" as const)
+                      .with(
+                        "question",
+                        "metric",
+                        "model",
+                        () => "question" as const,
+                      )
+                      .exhaustive(),
+                    virtual: true,
+                    id: item.id,
+                    name: item.name,
+                    onPop: () =>
+                      setCurrentView({ type: "collection", id: view.id }),
+                  });
+                }
+              }}
+            />
+          </Box>
+        ))
+        .otherwise(() => null);
 
   const handleNewExploration = () => {
     setCurrentView({ type: "exploration" });

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/components/MetabaseBrowser.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/components/MetabaseBrowser.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useMount } from "react-use";
 import { P, match } from "ts-pattern";
 import { t } from "ttag";
@@ -43,7 +43,7 @@ export function MetabaseBrowser({ settings }: MetabaseBrowserProps) {
 
   const isReadOnly = settings.readOnly ?? true;
 
-  const { breadcrumbs, currentLocation, reportLocation } = useSdkBreadcrumbs();
+  const { breadcrumbs, reportLocation } = useSdkBreadcrumbs();
 
   const { canWrite: canWriteToInitialCollection } =
     useCollectionData(initialCollection);
@@ -78,13 +78,6 @@ export function MetabaseBrowser({ settings }: MetabaseBrowserProps) {
 
     return lastCollectionItem?.id ?? initialCollection;
   }, [breadcrumbs, initialCollection]);
-
-  // If a user clicks on a collection breadcrumb, switch the view.
-  useEffect(() => {
-    if (currentLocation?.type === "collection") {
-      setCurrentView({ type: currentLocation.type, id: currentLocation.id });
-    }
-  }, [currentLocation]);
 
   const viewContent = hasNavigatedAway
     ? null
@@ -234,7 +227,20 @@ export function MetabaseBrowser({ settings }: MetabaseBrowserProps) {
           w="100%"
         >
           <Group>
-            <SdkBreadcrumbs />
+            <SdkBreadcrumbs
+              onBreadcrumbClick={(item) => {
+                if (item.type === "collection") {
+                  setCurrentView({ type: item.type, id: item.id });
+
+                  // If we selected a collection, we go back to the browser component, we need to clear the stack
+                  // metabase-browser is always at index 0, so we can pop length-1 times
+                  const count = navigationContext.stack.length - 1;
+                  for (let i = 0; i < count; i++) {
+                    navigationContext.pop();
+                  }
+                }
+              }}
+            />
           </Group>
 
           {currentView.type === "collection" && (

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/components/MetabaseBrowser.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/components/MetabaseBrowser.tsx
@@ -1,10 +1,9 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { P, match } from "ts-pattern";
 import { t } from "ttag";
 import _ from "underscore";
 
 import { SdkBreadcrumbs } from "embedding-sdk-bundle/components/private/SdkBreadcrumbs";
-import { useSdkInternalNavigation } from "embedding-sdk-bundle/components/private/SdkInternalNavigation/context";
 import { CollectionBrowser } from "embedding-sdk-bundle/components/public/CollectionBrowser";
 import { CreateDashboardModal } from "embedding-sdk-bundle/components/public/CreateDashboardModal";
 import { InteractiveQuestion } from "embedding-sdk-bundle/components/public/InteractiveQuestion";
@@ -31,13 +30,11 @@ type MetabaseBrowserView =
   | { type: "dashboard"; id: number | string }
   | { type: "question" | "metric" | "model"; id: number | string }
   | { type: "exploration" }
-  | { type: "create-dashboard" }
-  | { type: "suspended" };
+  | { type: "create-dashboard" };
 
 const BREADCRUMB_HEIGHT = "3.5rem";
 
 export function MetabaseBrowser({ settings }: MetabaseBrowserProps) {
-  const navigationContext = useSdkInternalNavigation();
   const { initialCollection } = settings;
 
   const isReadOnly = settings.readOnly ?? true;
@@ -51,32 +48,6 @@ export function MetabaseBrowser({ settings }: MetabaseBrowserProps) {
     type: "collection",
     id: initialCollection,
   });
-
-  useEffect(() => {
-    if (navigationContext.stack.length === 0) {
-      navigationContext.push({ type: "metabase-browser" });
-    }
-  }, []);
-
-  // When the provider renders a non-virtual entry (click behavior navigation),
-  // unmount our dashboard to free the shared Redux state.
-  // When navigation returns, restore the view so the dashboard re-fetches.
-  const previousViewRef = useRef<MetabaseBrowserView | null>(null);
-
-  useEffect(() => {
-    const hasProviderEntry = navigationContext.stack.some(
-      (entry) =>
-        entry.type !== "metabase-browser" && !entry.type.startsWith("virtual"),
-    );
-
-    if (hasProviderEntry && currentView.type !== "suspended") {
-      previousViewRef.current = currentView;
-      setCurrentView({ type: "suspended" });
-    } else if (!hasProviderEntry && previousViewRef.current) {
-      setCurrentView(previousViewRef.current);
-      previousViewRef.current = null;
-    }
-  }, [navigationContext.stack, currentView, initialCollection]);
 
   // Use the last collection in the breadcrumb as the target for saving new questions.
   const targetCollection = useMemo(() => {
@@ -92,10 +63,6 @@ export function MetabaseBrowser({ settings }: MetabaseBrowserProps) {
   // If a user clicks on a collection breadcrumb, switch the view.
   useEffect(() => {
     if (currentLocation?.type === "collection") {
-      // Pop virtual entries pushed by browser navigation (e.g., virtual-dashboard)
-      if (navigationContext.stack.length > 1) {
-        navigationContext.pop();
-      }
       setCurrentView({ type: currentLocation.type, id: currentLocation.id });
     }
   }, [currentLocation]);
@@ -190,31 +157,7 @@ export function MetabaseBrowser({ settings }: MetabaseBrowserProps) {
               .with("dataset", () => "model")
               .otherwise((model) => model as SdkBreadcrumbItemType);
 
-            if (type === "dashboard") {
-              setCurrentView({ type: "dashboard", id: item.id });
-              navigationContext.push({
-                type: "virtual-dashboard",
-                id: item.id,
-                name: item.name,
-                onPop: () =>
-                  setCurrentView({ type: "collection", id: view.id }),
-              });
-            } else if (
-              type === "question" ||
-              type === "model" ||
-              type === "metric"
-            ) {
-              setCurrentView({ type, id: item.id });
-              navigationContext.push({
-                type: "virtual-question",
-                id: item.id,
-                name: item.name,
-                onPop: () =>
-                  setCurrentView({ type: "collection", id: view.id }),
-              });
-            } else {
-              setCurrentView({ type, id: item.id });
-            }
+            setCurrentView({ type, id: item.id });
           }}
         />
       </Box>

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/components/MetabaseBrowser.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/components/MetabaseBrowser.tsx
@@ -32,8 +32,7 @@ type MetabaseBrowserView =
   | { type: "dashboard"; id: number | string }
   | { type: "question" | "metric" | "model"; id: number | string }
   | { type: "exploration" }
-  | { type: "create-dashboard" }
-  | { type: "suspended" };
+  | { type: "create-dashboard" };
 
 const BREADCRUMB_HEIGHT = "3.5rem";
 

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
@@ -140,7 +140,7 @@ const SdkIframeEmbedView = ({
           componentName: "metabase-browser",
         },
         (settings) => (
-          <SdkInternalNavigationProvider>
+          <SdkInternalNavigationProvider keepChildrenMounted>
             {/*  re-mount breadcrumbs when initial collection changes */}
             <SdkBreadcrumbsProvider key={settings.initialCollection}>
               <MetabaseBrowser settings={settings} />

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
@@ -140,7 +140,7 @@ const SdkIframeEmbedView = ({
           componentName: "metabase-browser",
         },
         (settings) => (
-          <SdkInternalNavigationProvider keepMounted>
+          <SdkInternalNavigationProvider>
             {/*  re-mount breadcrumbs when initial collection changes */}
             <SdkBreadcrumbsProvider key={settings.initialCollection}>
               <MetabaseBrowser settings={settings} />

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
@@ -140,7 +140,7 @@ const SdkIframeEmbedView = ({
           componentName: "metabase-browser",
         },
         (settings) => (
-          <SdkInternalNavigationProvider>
+          <SdkInternalNavigationProvider keepMounted>
             {/*  re-mount breadcrumbs when initial collection changes */}
             <SdkBreadcrumbsProvider key={settings.initialCollection}>
               <MetabaseBrowser settings={settings} />


### PR DESCRIPTION
Fixes the bug that Kelvin found here: https://github.com/metabase/metabase/pull/69185#discussion_r2774862076
The back button was saying "Back to [Dashboard]" but instead navigated back to the browser collection.

## Changes
Added a `keepChildrenMounted` prop, this makes the browser collection stay mounted and not lose its state, this makes the "Back to ${dashboard}" button work, this fixes the original issue.
Another fix was cleaning the stack when clicking on the breaadcrumbs, this fixes an issue that's only visible after the first one got fixed


## How to reproduce
- Create a dashboard that uses click behavior to link to another
- open it via `<metabase-browser enable-entity-navigation />` in EAJS
- do the click behavior to navigate to the second dashboard
- click the back button, you should need to do it twice to go back to the starting point