### PR TITLE
Remove deprecated unit test helpers

### DIFF
--- a/e2e/test/scenarios/dashboard-filters-2/shared/dashboard-filters-query-stages.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/shared/dashboard-filters-query-stages.ts
@@ -325,31 +325,31 @@ export function createQ9Query(source: Card): StructuredQuery {
 type CreateQuery = (source: Card) => StructuredQuery;
 
 export function createAndVisitDashboardWithCardMatrix(
-  createQuery: CreateQuery,
+  createQueryFromCard: CreateQuery,
 ) {
   cy.then(function () {
     H.createQuestion({
       type: "question",
-      query: createQuery(this.baseQuestion),
+      query: createQueryFromCard(this.baseQuestion),
       name: "Question-based Question",
     }).then((response) => cy.wrap(response.body).as("qbq"));
 
     H.createQuestion({
       type: "question",
-      query: createQuery(this.baseModel),
+      query: createQueryFromCard(this.baseModel),
       name: "Model-based Question",
     }).then((response) => cy.wrap(response.body).as("mbq"));
 
     H.createQuestion({
       type: "model",
       name: "Question-based Model",
-      query: createQuery(this.baseQuestion),
+      query: createQueryFromCard(this.baseQuestion),
     }).then((response) => cy.wrap(response.body).as("qbm"));
 
     H.createQuestion({
       type: "model",
       name: "Model-based Model",
-      query: createQuery(this.baseModel),
+      query: createQueryFromCard(this.baseModel),
     }).then((response) => cy.wrap(response.body).as("mbm"));
   });
 

--- a/frontend/src/metabase-lib/breakout.unit.spec.ts
+++ b/frontend/src/metabase-lib/breakout.unit.spec.ts
@@ -1,11 +1,16 @@
 import { checkNotNull } from "metabase/lib/types";
 import * as Lib from "metabase-lib";
 
-import { columnFinder, createQuery, findTemporalBucket } from "./test-helpers";
+import {
+  DEFAULT_TEST_QUERY,
+  SAMPLE_PROVIDER,
+  columnFinder,
+  findTemporalBucket,
+} from "./test-helpers";
 
 describe("breakout", () => {
   describe("add breakout", () => {
-    const query = createQuery();
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY);
     const findBreakoutableColumn = columnFinder(
       query,
       Lib.breakoutableColumns(query, 0),
@@ -27,7 +32,7 @@ describe("breakout", () => {
     });
 
     it("should preserve breakout positions between v1-v2 roundtrip", () => {
-      const query = createQuery();
+      const query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY);
       const taxColumn = findBreakoutableColumn("ORDERS", "TAX");
       const nextQuery = Lib.breakout(query, 0, taxColumn);
       const nextQueryColumns = Lib.breakoutableColumns(nextQuery, 0);
@@ -40,9 +45,10 @@ describe("breakout", () => {
         breakoutPositions: [0],
       });
 
-      const roundtripQuery = createQuery({
-        query: Lib.toJsQuery(nextQuery),
-      });
+      const roundtripQuery = Lib.fromJsQuery(
+        SAMPLE_PROVIDER,
+        Lib.toJsQuery(nextQuery),
+      );
       const roundtripQueryColumns = Lib.breakoutableColumns(roundtripQuery, 0);
       const roundtripTaxColumn = columnFinder(
         roundtripQuery,
@@ -98,7 +104,7 @@ describe("breakout", () => {
   });
 
   describe("replace breakout", () => {
-    const query = createQuery();
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY);
     const findBreakoutableColumn = columnFinder(
       query,
       Lib.breakoutableColumns(query, 0),
@@ -127,7 +133,7 @@ describe("breakout", () => {
   });
 
   describe("remove breakout", () => {
-    const query = createQuery();
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY);
     const findBreakoutableColumn = columnFinder(
       query,
       Lib.breakoutableColumns(query, 0),

--- a/frontend/src/metabase-lib/breakout.unit.spec.ts
+++ b/frontend/src/metabase-lib/breakout.unit.spec.ts
@@ -5,8 +5,26 @@ import {
   DEFAULT_TEST_QUERY,
   SAMPLE_PROVIDER,
   columnFinder,
-  findTemporalBucket,
 } from "./test-helpers";
+
+const findTemporalBucket = (
+  query: Lib.Query,
+  column: Lib.ColumnMetadata,
+  bucketName: string,
+) => {
+  if (bucketName === "Don't bin") {
+    return null;
+  }
+
+  const buckets = Lib.availableTemporalBuckets(query, 0, column);
+  const bucket = buckets.find(
+    (bucket) => Lib.displayInfo(query, 0, bucket).displayName === bucketName,
+  );
+  if (!bucket) {
+    throw new Error(`Could not find temporal bucket ${bucketName}`);
+  }
+  return bucket;
+};
 
 describe("breakout", () => {
   describe("add breakout", () => {

--- a/frontend/src/metabase-lib/comparison.unit.spec.ts
+++ b/frontend/src/metabase-lib/comparison.unit.spec.ts
@@ -1,5 +1,6 @@
 import * as Lib from "metabase-lib";
 import { ORDERS_ID } from "metabase-types/api/mocks/presets";
+
 import { SAMPLE_PROVIDER } from "./test-helpers";
 
 describe("findColumnIndexesFromLegacyRefs", () => {

--- a/frontend/src/metabase-lib/comparison.unit.spec.ts
+++ b/frontend/src/metabase-lib/comparison.unit.spec.ts
@@ -1,22 +1,32 @@
 import * as Lib from "metabase-lib";
-
-import { createQueryWithClauses } from "./test-helpers";
+import { ORDERS_ID } from "metabase-types/api/mocks/presets";
+import { SAMPLE_PROVIDER } from "./test-helpers";
 
 describe("findColumnIndexesFromLegacyRefs", () => {
   const stageIndex = -1;
 
   it("should match columns that differ only by temporal buckets", () => {
-    const query = createQueryWithClauses({
-      breakouts: [
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
+      stages: [
         {
-          tableName: "ORDERS",
-          columnName: "CREATED_AT",
-          temporalBucketName: "Year",
-        },
-        {
-          tableName: "ORDERS",
-          columnName: "CREATED_AT",
-          temporalBucketName: "Month",
+          source: {
+            type: "table",
+            id: ORDERS_ID,
+          },
+          breakouts: [
+            {
+              type: "column",
+              sourceName: "ORDERS",
+              name: "CREATED_AT",
+              unit: "year",
+            },
+            {
+              type: "column",
+              sourceName: "ORDERS",
+              name: "CREATED_AT",
+              unit: "month",
+            },
+          ],
         },
       ],
     });
@@ -31,17 +41,27 @@ describe("findColumnIndexesFromLegacyRefs", () => {
   });
 
   it("should match columns that differ only by binning", () => {
-    const query = createQueryWithClauses({
-      breakouts: [
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
+      stages: [
         {
-          tableName: "ORDERS",
-          columnName: "TOTAL",
-          binningStrategyName: "10 bins",
-        },
-        {
-          tableName: "ORDERS",
-          columnName: "TOTAL",
-          binningStrategyName: "50 bins",
+          source: {
+            type: "table",
+            id: ORDERS_ID,
+          },
+          breakouts: [
+            {
+              type: "column",
+              sourceName: "ORDERS",
+              name: "TOTAL",
+              bins: 10,
+            },
+            {
+              type: "column",
+              sourceName: "ORDERS",
+              name: "TOTAL",
+              bins: 50,
+            },
+          ],
         },
       ],
     });

--- a/frontend/src/metabase-lib/order_by.unit.spec.ts
+++ b/frontend/src/metabase-lib/order_by.unit.spec.ts
@@ -2,16 +2,35 @@ import { createMockMetadata } from "__support__/metadata";
 import * as Lib from "metabase-lib";
 import { createMockCard } from "metabase-types/api/mocks";
 import {
+  ORDERS_ID,
   SAMPLE_DB_ID,
   createProductsTitleField,
   createSampleDatabase,
 } from "metabase-types/api/mocks/presets";
 
-import { columnFinder, createQuery } from "./test-helpers";
+import {
+  SAMPLE_DATABASE,
+  SAMPLE_PROVIDER,
+  columnFinder,
+  createMetadataProvider,
+  createQuery,
+  createTestQuery,
+} from "./test-helpers";
 
 describe("order by", () => {
   describe("orderableColumns", () => {
-    const query = createQuery();
+    const query = createTestQuery(SAMPLE_PROVIDER, {
+      databaseId: SAMPLE_DATABASE.id,
+      stages: [
+        {
+          source: {
+            type: "table",
+            id: ORDERS_ID,
+          },
+        },
+      ],
+    });
+
     const findOrderableColumn = columnFinder(
       query,
       Lib.orderableColumns(query, 0),
@@ -79,6 +98,7 @@ describe("order by", () => {
         databases: [createSampleDatabase()],
         questions: [card],
       });
+      const provider = createMetadataProvider(metadata);
 
       const query = createQuery({
         databaseId: SAMPLE_DB_ID,

--- a/frontend/src/metabase-lib/order_by.unit.spec.ts
+++ b/frontend/src/metabase-lib/order_by.unit.spec.ts
@@ -8,19 +8,11 @@ import {
   createSampleDatabase,
 } from "metabase-types/api/mocks/presets";
 
-import {
-  SAMPLE_DATABASE,
-  SAMPLE_PROVIDER,
-  columnFinder,
-  createMetadataProvider,
-  createQuery,
-  createTestQuery,
-} from "./test-helpers";
+import { SAMPLE_PROVIDER, columnFinder, createQuery } from "./test-helpers";
 
 describe("order by", () => {
   describe("orderableColumns", () => {
-    const query = createTestQuery(SAMPLE_PROVIDER, {
-      databaseId: SAMPLE_DATABASE.id,
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
       stages: [
         {
           source: {
@@ -98,7 +90,6 @@ describe("order by", () => {
         databases: [createSampleDatabase()],
         questions: [card],
       });
-      const provider = createMetadataProvider(metadata);
 
       const query = createQuery({
         databaseId: SAMPLE_DB_ID,

--- a/frontend/src/metabase-lib/query.unit.spec.ts
+++ b/frontend/src/metabase-lib/query.unit.spec.ts
@@ -65,6 +65,7 @@ describe("stageIndexes", () => {
           },
         },
         {},
+        {},
       ],
     });
     expect(Lib.stageIndexes(query)).toEqual([0, 1, 2]);

--- a/frontend/src/metabase-lib/query.unit.spec.ts
+++ b/frontend/src/metabase-lib/query.unit.spec.ts
@@ -1,4 +1,5 @@
 import * as Lib from "metabase-lib";
+import type { DatasetQuery } from "metabase-types/api";
 import {
   ORDERS_ID,
   PEOPLE_ID,
@@ -7,12 +8,19 @@ import {
 } from "metabase-types/api/mocks/presets";
 
 import {
-  DEFAULT_QUERY,
   DEFAULT_TEST_QUERY,
   SAMPLE_DATABASE,
   SAMPLE_METADATA,
   SAMPLE_PROVIDER,
 } from "./test-helpers";
+
+const DEFAULT_QUERY: DatasetQuery = {
+  database: SAMPLE_DATABASE.id,
+  type: "query",
+  query: {
+    "source-table": ORDERS_ID,
+  },
+};
 
 describe("fromJsQuery", () => {
   // this is a very important optimization that the FE heavily relies upon

--- a/frontend/src/metabase-lib/query.unit.spec.ts
+++ b/frontend/src/metabase-lib/query.unit.spec.ts
@@ -8,10 +8,10 @@ import {
 
 import {
   DEFAULT_QUERY,
+  DEFAULT_TEST_QUERY,
   SAMPLE_DATABASE,
   SAMPLE_METADATA,
   SAMPLE_PROVIDER,
-  createQuery,
 } from "./test-helpers";
 
 describe("fromJsQuery", () => {
@@ -29,26 +29,36 @@ describe("fromJsQuery", () => {
 
 describe("toLegacyQuery", () => {
   it("should serialize a query", () => {
-    const query = createQuery();
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY);
     expect(Lib.toLegacyQuery(query)).toEqual(DEFAULT_QUERY);
   });
 });
 
 describe("suggestedName", () => {
   it("should suggest a query name", () => {
-    const query = createQuery();
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY);
     expect(Lib.suggestedName(query)).toBe("Orders");
   });
 });
 
 describe("stageIndexes", () => {
   it("should return stage indexes for a single-stage query", () => {
-    const query = createQuery();
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY);
     expect(Lib.stageIndexes(query)).toEqual([0]);
   });
 
   it("should return stage indexes for a multi-stage query", () => {
-    const query = Lib.appendStage(Lib.appendStage(createQuery()));
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
+      stages: [
+        {
+          source: {
+            type: "table",
+            id: PRODUCTS_ID,
+          },
+        },
+        {},
+      ],
+    });
     expect(Lib.stageIndexes(query)).toEqual([0, 1, 2]);
   });
 });

--- a/frontend/src/metabase-lib/test-helpers.ts
+++ b/frontend/src/metabase-lib/test-helpers.ts
@@ -83,24 +83,6 @@ export const columnFinder =
     return column;
   };
 
-export const findBinningStrategy = (
-  query: Lib.Query,
-  column: Lib.ColumnMetadata,
-  bucketName: string,
-) => {
-  if (bucketName === "Don't bin") {
-    return null;
-  }
-  const buckets = Lib.availableBinningStrategies(query, 0, column);
-  const bucket = buckets.find(
-    (bucket) => Lib.displayInfo(query, 0, bucket).displayName === bucketName,
-  );
-  if (!bucket) {
-    throw new Error(`Could not find binning strategy ${bucketName}`);
-  }
-  return bucket;
-};
-
 export const findTemporalBucket = (
   query: Lib.Query,
   column: Lib.ColumnMetadata,
@@ -147,121 +129,11 @@ export const findSegment = (query: Lib.Query, segmentName: string) => {
   return segment;
 };
 
-function withTemporalBucketAndBinningStrategy(
-  query: Lib.Query,
-  column: Lib.ColumnMetadata,
-  temporalBucketName = "Don't bin",
-  binningStrategyName = "Don't bin",
-) {
-  return Lib.withTemporalBucket(
-    Lib.withBinning(
-      column,
-      findBinningStrategy(query, column, binningStrategyName),
-    ),
-    findTemporalBucket(query, column, temporalBucketName),
-  );
-}
-
-type AggregationClauseOpts =
-  | {
-      operatorName: string;
-      tableName?: never;
-      columnName?: never;
-    }
-  | {
-      operatorName: string;
-      tableName: string;
-      columnName: string;
-    };
-
-interface BreakoutClauseOpts {
-  columnName: string;
-  tableName?: string;
-  temporalBucketName?: string;
-  binningStrategyName?: string;
-}
-
 export interface ExpressionClauseOpts {
   name: string;
   operator: Lib.ExpressionOperator;
   args: (Lib.ExpressionArg | Lib.ExpressionClause)[];
   options?: Lib.ExpressionOptions | null;
-}
-
-interface OrderByClauseOpts {
-  columnName: string;
-  tableName: string;
-  direction: Lib.OrderByDirection;
-}
-
-interface QueryWithClausesOpts {
-  query?: Lib.Query;
-  expressions?: ExpressionClauseOpts[];
-  aggregations?: AggregationClauseOpts[];
-  breakouts?: BreakoutClauseOpts[];
-  orderBys?: OrderByClauseOpts[];
-}
-
-export function createQueryWithClauses({
-  query = createQuery(),
-  expressions = [],
-  aggregations = [],
-  breakouts = [],
-  orderBys = [],
-}: QueryWithClausesOpts) {
-  const queryWithExpressions = expressions.reduce((query, expression) => {
-    return Lib.expression(
-      query,
-      -1,
-      expression.name,
-      Lib.expressionClause(
-        expression.operator,
-        expression.args,
-        expression.options,
-      ),
-    );
-  }, query);
-
-  const queryWithAggregations = aggregations.reduce((query, aggregation) => {
-    return Lib.aggregate(
-      query,
-      -1,
-      Lib.aggregationClause(
-        findAggregationOperator(query, aggregation.operatorName),
-        aggregation.columnName && aggregation.tableName
-          ? columnFinder(query, Lib.visibleColumns(query, -1))(
-              aggregation.tableName,
-              aggregation.columnName,
-            )
-          : undefined,
-      ),
-    );
-  }, queryWithExpressions);
-
-  const queryWithBreakouts = breakouts.reduce((query, breakout) => {
-    const breakoutColumn = columnFinder(
-      query,
-      Lib.breakoutableColumns(query, -1),
-    )(breakout.tableName, breakout.columnName);
-    return Lib.breakout(
-      query,
-      -1,
-      withTemporalBucketAndBinningStrategy(
-        query,
-        breakoutColumn,
-        breakout.temporalBucketName,
-        breakout.binningStrategyName,
-      ),
-    );
-  }, queryWithAggregations);
-
-  return orderBys.reduce((query, orderBy) => {
-    const orderByColumn = columnFinder(query, Lib.orderableColumns(query, -1))(
-      orderBy.tableName,
-      orderBy.columnName,
-    );
-    return Lib.orderBy(query, -1, orderByColumn, orderBy.direction);
-  }, queryWithBreakouts);
 }
 
 export const queryDrillThru = (

--- a/frontend/src/metabase-lib/test-helpers.ts
+++ b/frontend/src/metabase-lib/test-helpers.ts
@@ -53,19 +53,6 @@ export const DEFAULT_QUERY: DatasetQuery = {
   },
 };
 
-type QueryOpts = MetadataProviderOpts & {
-  query?: DatasetQuery;
-};
-
-export function createQuery({
-  databaseId = SAMPLE_DATABASE.id,
-  metadata = SAMPLE_METADATA,
-  query = DEFAULT_QUERY,
-}: QueryOpts = {}) {
-  const metadataProvider = createMetadataProvider({ databaseId, metadata });
-  return Lib.fromJsQuery(metadataProvider, query);
-}
-
 export const columnFinder =
   (query: Lib.Query, columns: Lib.ColumnMetadata[]) =>
   (

--- a/frontend/src/metabase-lib/test-helpers.ts
+++ b/frontend/src/metabase-lib/test-helpers.ts
@@ -68,52 +68,6 @@ export const columnFinder =
     return column;
   };
 
-export const findTemporalBucket = (
-  query: Lib.Query,
-  column: Lib.ColumnMetadata,
-  bucketName: string,
-) => {
-  if (bucketName === "Don't bin") {
-    return null;
-  }
-
-  const buckets = Lib.availableTemporalBuckets(query, 0, column);
-  const bucket = buckets.find(
-    (bucket) => Lib.displayInfo(query, 0, bucket).displayName === bucketName,
-  );
-  if (!bucket) {
-    throw new Error(`Could not find temporal bucket ${bucketName}`);
-  }
-  return bucket;
-};
-
-export const findAggregationOperator = (
-  query: Lib.Query,
-  operatorShortName: string,
-) => {
-  const operators = Lib.availableAggregationOperators(query, 0);
-  const operator = operators.find(
-    (operator) =>
-      Lib.displayInfo(query, 0, operator).shortName === operatorShortName,
-  );
-  if (!operator) {
-    throw new Error(`Could not find aggregation operator ${operatorShortName}`);
-  }
-  return operator;
-};
-
-export const findSegment = (query: Lib.Query, segmentName: string) => {
-  const stageIndex = 0;
-  const segment = Lib.availableSegments(query, stageIndex).find(
-    (segment) =>
-      Lib.displayInfo(query, stageIndex, segment).displayName === segmentName,
-  );
-  if (!segment) {
-    throw new Error(`Could not find segment ${segmentName}`);
-  }
-  return segment;
-};
-
 export interface ExpressionClauseOpts {
   name: string;
   operator: Lib.ExpressionOperator;

--- a/frontend/src/metabase-lib/test-helpers.ts
+++ b/frontend/src/metabase-lib/test-helpers.ts
@@ -10,6 +10,7 @@ import type {
   DatasetQuery,
   RowValue,
   TableId,
+  TestQuerySpec,
 } from "metabase-types/api";
 import {
   ORDERS_ID,
@@ -35,6 +36,14 @@ export function createMetadataProvider({
 }: MetadataProviderOpts = {}) {
   return Lib.metadataProvider(databaseId, metadata);
 }
+
+export const DEFAULT_TEST_QUERY: TestQuerySpec = {
+  stages: [
+    {
+      source: { type: "table", id: ORDERS_ID },
+    },
+  ],
+};
 
 export const DEFAULT_QUERY: DatasetQuery = {
   database: SAMPLE_DATABASE.id,

--- a/frontend/src/metabase-lib/test-helpers.ts
+++ b/frontend/src/metabase-lib/test-helpers.ts
@@ -29,7 +29,7 @@ type MetadataProviderOpts = {
   metadata?: Metadata;
 };
 
-function createMetadataProvider({
+export function createMetadataProvider({
   databaseId = SAMPLE_DATABASE.id,
   metadata = SAMPLE_METADATA,
 }: MetadataProviderOpts = {}) {

--- a/frontend/src/metabase-lib/test-helpers.ts
+++ b/frontend/src/metabase-lib/test-helpers.ts
@@ -6,7 +6,6 @@ import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type {
   DatabaseId,
   DatasetColumn,
-  DatasetQuery,
   RowValue,
   TestQuerySpec,
 } from "metabase-types/api";
@@ -41,14 +40,6 @@ export const DEFAULT_TEST_QUERY: TestQuerySpec = {
       source: { type: "table", id: ORDERS_ID },
     },
   ],
-};
-
-export const DEFAULT_QUERY: DatasetQuery = {
-  database: SAMPLE_DATABASE.id,
-  type: "query",
-  query: {
-    "source-table": ORDERS_ID,
-  },
 };
 
 export const columnFinder =

--- a/frontend/src/metabase-lib/test-helpers.ts
+++ b/frontend/src/metabase-lib/test-helpers.ts
@@ -1,7 +1,6 @@
 /* istanbul ignore file */
 
 import { createMockMetadata } from "__support__/metadata";
-import { checkNotNull } from "metabase/lib/types";
 import * as Lib from "metabase-lib";
 import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type {
@@ -9,7 +8,6 @@ import type {
   DatasetColumn,
   DatasetQuery,
   RowValue,
-  TableId,
   TestQuerySpec,
 } from "metabase-types/api";
 import {
@@ -173,44 +171,6 @@ export const findDrillThru = (
 interface ColumnClickObjectOpts {
   column: DatasetColumn;
 }
-
-export const getJoinQueryHelpers = (
-  query: Lib.Query,
-  stageIndex: number,
-  tableId: TableId,
-) => {
-  const table = checkNotNull(Lib.tableOrCardMetadata(query, tableId));
-
-  const findLHSColumn = columnFinder(
-    query,
-    Lib.joinConditionLHSColumns(query, stageIndex),
-  );
-  const findRHSColumn = columnFinder(
-    query,
-    Lib.joinConditionRHSColumns(query, stageIndex, table),
-  );
-
-  const defaultStrategy = Lib.availableJoinStrategies(query, stageIndex).find(
-    (strategy) => Lib.displayInfo(query, stageIndex, strategy).default,
-  );
-
-  if (!defaultStrategy) {
-    throw new Error("No default strategy found");
-  }
-
-  const defaultOperator = Lib.joinConditionOperators(query, stageIndex)[0];
-  if (!defaultOperator) {
-    throw new Error("No default operator found");
-  }
-
-  return {
-    table,
-    defaultStrategy,
-    defaultOperator,
-    findLHSColumn,
-    findRHSColumn,
-  };
-};
 
 export function createColumnClickObject({
   column,

--- a/frontend/src/metabase-lib/v1/parameters/utils/targets.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/targets.unit.spec.ts
@@ -2,9 +2,9 @@ import { createMockMetadata } from "__support__/metadata";
 import { checkNotNull } from "metabase/lib/types";
 import * as Lib from "metabase-lib";
 import {
-  SAMPLE_DATABASE,
+  DEFAULT_TEST_QUERY,
   SAMPLE_PROVIDER,
-  createQuery,
+  createMetadataProvider,
 } from "metabase-lib/test-helpers";
 import Question from "metabase-lib/v1/Question";
 import type Database from "metabase-lib/v1/metadata/Database";
@@ -55,10 +55,14 @@ const metadata = createMockMetadata({
 
 const db = metadata.database(SAMPLE_DB_ID) as Database;
 const productsTable = metadata.table(PRODUCTS_ID) as Table;
+const provider = createMetadataProvider({
+  databaseId: db.id,
+  metadata,
+});
 
-const queryOrders = createQuery();
+const queryOrders = Lib.createTestQuery(provider, DEFAULT_TEST_QUERY);
 
-const queryNonDateBreakout = Lib.createTestQuery(SAMPLE_PROVIDER, {
+const queryNonDateBreakout = Lib.createTestQuery(provider, {
   stages: [
     {
       source: { type: "table", id: ORDERS_ID },

--- a/frontend/src/metabase-lib/v1/parameters/utils/targets.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/targets.unit.spec.ts
@@ -71,7 +71,7 @@ const queryNonDateBreakout = Lib.createTestQuery(provider, {
         {
           type: "column",
           name: "QUANTITY",
-          sourceName: "Orders",
+          sourceName: "ORDERS",
         },
       ],
     },
@@ -82,12 +82,12 @@ const query1DateBreakout = Lib.createTestQuery(SAMPLE_PROVIDER, {
   stages: [
     {
       source: { type: "table", id: ORDERS_ID },
-      aggregations: [{ type: "operator", operator: "count", args: [] }],
+      aggregations: [{ type: "operator", operator: "count" }],
       breakouts: [
         {
           type: "column",
           name: "CREATED_AT",
-          sourceName: "Orders",
+          sourceName: "ORDERS",
           unit: "month",
         },
       ],
@@ -99,18 +99,18 @@ const query2DateBreakouts = Lib.createTestQuery(SAMPLE_PROVIDER, {
   stages: [
     {
       source: { type: "table", id: ORDERS_ID },
-      aggregations: [{ type: "operator", operator: "count", args: [] }],
+      aggregations: [{ type: "operator", operator: "count" }],
       breakouts: [
         {
           type: "column",
           name: "CREATED_AT",
-          sourceName: "Orders",
+          sourceName: "ORDERS",
           unit: "month",
         },
         {
           type: "column",
           name: "CREATED_AT",
-          sourceName: "Product",
+          sourceName: "PRODUCTS",
           unit: "month",
         },
       ],
@@ -122,21 +122,22 @@ const queryDateBreakoutsMultiStage = Lib.createTestQuery(SAMPLE_PROVIDER, {
   stages: [
     {
       source: { type: "table", id: ORDERS_ID },
-      aggregations: [{ type: "operator", operator: "count", args: [] }],
+      aggregations: [{ type: "operator", operator: "count" }],
       breakouts: [
         {
           type: "column",
           name: "CREATED_AT",
-          sourceName: "Orders",
+          sourceName: "ORDERS",
           unit: "month",
         },
       ],
     },
     {
-      aggregations: [{ type: "operator", operator: "count", args: [] }],
+      aggregations: [{ type: "operator", operator: "count" }],
       breakouts: [
         {
           type: "column",
+          sourceName: "ORDERS",
           name: "CREATED_AT",
           unit: "year",
         },
@@ -622,12 +623,12 @@ function createComplex1StageQuery() {
                 left: {
                   type: "column",
                   name: "PRODUCT_ID",
-                  sourceName: "Orders",
+                  sourceName: "ORDERS",
                 },
                 right: {
                   type: "column",
                   name: "PRODUCT_ID",
-                  sourceName: "Reviews",
+                  sourceName: "REVIEWS",
                 },
               },
             ],
@@ -640,7 +641,7 @@ function createComplex1StageQuery() {
               type: "operator",
               operator: "datetime-add",
               args: [
-                { type: "column", name: "BIRTH_DATE", sourceName: "User" },
+                { type: "column", name: "BIRTH_DATE", sourceName: "PEOPLE" },
                 { type: "literal", value: 18 },
                 { type: "literal", value: "year" },
               ],
@@ -648,30 +649,31 @@ function createComplex1StageQuery() {
           },
         ],
         aggregations: [
-          { type: "operator", operator: "count", args: [] },
+          { type: "operator", operator: "count" },
           {
             type: "operator",
             operator: "sum",
-            args: [{ type: "column", name: "TOTAL", sourceName: "Orders" }],
+            args: [{ type: "column", name: "TOTAL", sourceName: "ORDERS" }],
           },
         ],
         breakouts: [
           {
             type: "column",
             name: "CREATED_AT",
-            sourceName: "Orders",
+            sourceName: "ORDERS",
             unit: "month",
           },
           {
             type: "column",
             name: "CREATED_AT",
-            sourceName: "Product",
+            sourceName: "PRODUCTS",
             unit: "year",
+            index: 0,
           },
           {
             type: "column",
             name: "CREATED_AT",
-            sourceName: "Reviews",
+            sourceName: "REVIEWS",
             unit: "quarter",
           },
           {
@@ -699,12 +701,12 @@ function createComplex2StageQuery() {
                 left: {
                   type: "column",
                   name: "PRODUCT_ID",
-                  sourceName: "Orders",
+                  sourceName: "ORDERS",
                 },
                 right: {
                   type: "column",
                   name: "PRODUCT_ID",
-                  sourceName: "Reviews",
+                  sourceName: "REVIEWS",
                 },
               },
             ],
@@ -717,7 +719,7 @@ function createComplex2StageQuery() {
               type: "operator",
               operator: "datetime-add",
               args: [
-                { type: "column", name: "BIRTH_DATE", sourceName: "User" },
+                { type: "column", name: "BIRTH_DATE", sourceName: "PEOPLE" },
                 { type: "literal", value: 18 },
                 { type: "literal", value: "year" },
               ],
@@ -729,23 +731,32 @@ function createComplex2StageQuery() {
           {
             type: "operator",
             operator: "sum",
-            args: [{ type: "column", name: "TOTAL", sourceName: "Orders" }],
+            args: [
+              {
+                type: "column",
+                name: "TOTAL",
+                sourceName: "ORDERS",
+              },
+            ],
           },
         ],
         breakouts: [
           {
             type: "column",
             name: "CREATED_AT",
+            sourceName: "ORDERS",
             unit: "month",
           },
           {
             type: "column",
             name: "CREATED_AT",
+            sourceName: "ORDERS",
             unit: "year",
           },
           {
             type: "column",
             name: "CREATED_AT",
+            sourceName: "REVIEWS",
             unit: "quarter",
           },
           {
@@ -765,12 +776,13 @@ function createComplex2StageQuery() {
                 left: {
                   type: "column",
                   name: "CREATED_AT",
-                  sourceName: "Summaries",
+                  sourceName: "ORDERS",
+                  index: 0,
                 },
                 right: {
                   type: "column",
                   name: "CREATED_AT",
-                  sourceName: "Reviews",
+                  sourceName: "REVIEWS",
                 },
               },
             ],
@@ -789,7 +801,7 @@ function createComplex2StageQuery() {
             },
           },
         ],
-        aggregations: [{ type: "operator", operator: "count", args: [] }],
+        aggregations: [{ type: "operator", operator: "count" }],
         breakouts: [
           {
             type: "column",

--- a/frontend/src/metabase-lib/v1/parameters/utils/targets.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/targets.unit.spec.ts
@@ -5,7 +5,6 @@ import {
   SAMPLE_DATABASE,
   SAMPLE_PROVIDER,
   createQuery,
-  createTestQuery,
 } from "metabase-lib/test-helpers";
 import Question from "metabase-lib/v1/Question";
 import type Database from "metabase-lib/v1/metadata/Database";
@@ -59,27 +58,32 @@ const productsTable = metadata.table(PRODUCTS_ID) as Table;
 
 const queryOrders = createQuery();
 
-const queryNonDateBreakout = createTestQuery(SAMPLE_PROVIDER, {
-  databaseId: SAMPLE_DATABASE.id,
-  stages: [
-    {
-      source: { type: "table", id: ORDERS_ID },
-      aggregations: [{ type: "operator", operator: "count", args: [] }],
-      breakouts: [{ name: "QUANTITY", groupName: "Orders" }],
-    },
-  ],
-});
-
-const query1DateBreakout = createTestQuery(SAMPLE_PROVIDER, {
-  databaseId: SAMPLE_DATABASE.id,
+const queryNonDateBreakout = Lib.createTestQuery(SAMPLE_PROVIDER, {
   stages: [
     {
       source: { type: "table", id: ORDERS_ID },
       aggregations: [{ type: "operator", operator: "count", args: [] }],
       breakouts: [
         {
+          type: "column",
+          name: "QUANTITY",
+          sourceName: "Orders",
+        },
+      ],
+    },
+  ],
+});
+
+const query1DateBreakout = Lib.createTestQuery(SAMPLE_PROVIDER, {
+  stages: [
+    {
+      source: { type: "table", id: ORDERS_ID },
+      aggregations: [{ type: "operator", operator: "count", args: [] }],
+      breakouts: [
+        {
+          type: "column",
           name: "CREATED_AT",
-          groupName: "Orders",
+          sourceName: "Orders",
           unit: "month",
         },
       ],
@@ -87,21 +91,22 @@ const query1DateBreakout = createTestQuery(SAMPLE_PROVIDER, {
   ],
 });
 
-const query2DateBreakouts = createTestQuery(SAMPLE_PROVIDER, {
-  databaseId: SAMPLE_DATABASE.id,
+const query2DateBreakouts = Lib.createTestQuery(SAMPLE_PROVIDER, {
   stages: [
     {
       source: { type: "table", id: ORDERS_ID },
       aggregations: [{ type: "operator", operator: "count", args: [] }],
       breakouts: [
         {
+          type: "column",
           name: "CREATED_AT",
-          groupName: "Orders",
+          sourceName: "Orders",
           unit: "month",
         },
         {
+          type: "column",
           name: "CREATED_AT",
-          groupName: "Product",
+          sourceName: "Product",
           unit: "month",
         },
       ],
@@ -109,16 +114,16 @@ const query2DateBreakouts = createTestQuery(SAMPLE_PROVIDER, {
   ],
 });
 
-const queryDateBreakoutsMultiStage = createTestQuery(SAMPLE_PROVIDER, {
-  databaseId: SAMPLE_DATABASE.id,
+const queryDateBreakoutsMultiStage = Lib.createTestQuery(SAMPLE_PROVIDER, {
   stages: [
     {
       source: { type: "table", id: ORDERS_ID },
       aggregations: [{ type: "operator", operator: "count", args: [] }],
       breakouts: [
         {
+          type: "column",
           name: "CREATED_AT",
-          groupName: "Orders",
+          sourceName: "Orders",
           unit: "month",
         },
       ],
@@ -127,6 +132,7 @@ const queryDateBreakoutsMultiStage = createTestQuery(SAMPLE_PROVIDER, {
       aggregations: [{ type: "operator", operator: "count", args: [] }],
       breakouts: [
         {
+          type: "column",
           name: "CREATED_AT",
           unit: "year",
         },
@@ -598,8 +604,7 @@ describe("parameters/utils/targets", () => {
 });
 
 function createComplex1StageQuery() {
-  return createTestQuery(SAMPLE_PROVIDER, {
-    databaseId: SAMPLE_DATABASE.id,
+  return Lib.createTestQuery(SAMPLE_PROVIDER, {
     stages: [
       {
         source: { type: "table", id: ORDERS_ID },
@@ -613,12 +618,12 @@ function createComplex1StageQuery() {
                 left: {
                   type: "column",
                   name: "PRODUCT_ID",
-                  groupName: "Orders",
+                  sourceName: "Orders",
                 },
                 right: {
                   type: "column",
                   name: "PRODUCT_ID",
-                  groupName: "Reviews",
+                  sourceName: "Reviews",
                 },
               },
             ],
@@ -631,7 +636,7 @@ function createComplex1StageQuery() {
               type: "operator",
               operator: "datetime-add",
               args: [
-                { type: "column", name: "BIRTH_DATE", groupName: "User" },
+                { type: "column", name: "BIRTH_DATE", sourceName: "User" },
                 { type: "literal", value: 18 },
                 { type: "literal", value: "year" },
               ],
@@ -643,26 +648,30 @@ function createComplex1StageQuery() {
           {
             type: "operator",
             operator: "sum",
-            args: [{ type: "column", name: "TOTAL", groupName: "Orders" }],
+            args: [{ type: "column", name: "TOTAL", sourceName: "Orders" }],
           },
         ],
         breakouts: [
           {
+            type: "column",
             name: "CREATED_AT",
-            groupName: "Orders",
+            sourceName: "Orders",
             unit: "month",
           },
           {
+            type: "column",
             name: "CREATED_AT",
-            groupName: "Product",
+            sourceName: "Product",
             unit: "year",
           },
           {
+            type: "column",
             name: "CREATED_AT",
-            groupName: "Reviews",
+            sourceName: "Reviews",
             unit: "quarter",
           },
           {
+            type: "column",
             name: "User's 18th birthday",
           },
         ],
@@ -672,8 +681,7 @@ function createComplex1StageQuery() {
 }
 
 function createComplex2StageQuery() {
-  return createTestQuery(SAMPLE_PROVIDER, {
-    databaseId: SAMPLE_DATABASE.id,
+  return Lib.createTestQuery(SAMPLE_PROVIDER, {
     stages: [
       {
         source: { type: "table", id: ORDERS_ID },
@@ -687,12 +695,12 @@ function createComplex2StageQuery() {
                 left: {
                   type: "column",
                   name: "PRODUCT_ID",
-                  groupName: "Orders",
+                  sourceName: "Orders",
                 },
                 right: {
                   type: "column",
                   name: "PRODUCT_ID",
-                  groupName: "Reviews",
+                  sourceName: "Reviews",
                 },
               },
             ],
@@ -705,7 +713,7 @@ function createComplex2StageQuery() {
               type: "operator",
               operator: "datetime-add",
               args: [
-                { type: "column", name: "BIRTH_DATE", groupName: "User" },
+                { type: "column", name: "BIRTH_DATE", sourceName: "User" },
                 { type: "literal", value: 18 },
                 { type: "literal", value: "year" },
               ],
@@ -717,23 +725,27 @@ function createComplex2StageQuery() {
           {
             type: "operator",
             operator: "sum",
-            args: [{ type: "column", name: "TOTAL", groupName: "Orders" }],
+            args: [{ type: "column", name: "TOTAL", sourceName: "Orders" }],
           },
         ],
         breakouts: [
           {
+            type: "column",
             name: "CREATED_AT",
             unit: "month",
           },
           {
+            type: "column",
             name: "CREATED_AT",
             unit: "year",
           },
           {
+            type: "column",
             name: "CREATED_AT",
             unit: "quarter",
           },
           {
+            type: "column",
             name: "User's 18th birthday",
           },
         ],
@@ -749,12 +761,12 @@ function createComplex2StageQuery() {
                 left: {
                   type: "column",
                   name: "CREATED_AT",
-                  groupName: "Summaries",
+                  sourceName: "Summaries",
                 },
                 right: {
                   type: "column",
                   name: "CREATED_AT",
-                  groupName: "Reviews",
+                  sourceName: "Reviews",
                 },
               },
             ],
@@ -774,7 +786,12 @@ function createComplex2StageQuery() {
           },
         ],
         aggregations: [{ type: "operator", operator: "count", args: [] }],
-        breakouts: [{ name: "User's 18th birthday" }],
+        breakouts: [
+          {
+            type: "column",
+            name: "User's 18th birthday",
+          },
+        ],
       },
     ],
   });

--- a/frontend/src/metabase-lib/viz/display.unit.spec.ts
+++ b/frontend/src/metabase-lib/viz/display.unit.spec.ts
@@ -1,5 +1,5 @@
-import * as Lib from "metabase-lib";
 import { createMockMetadata } from "__support__/metadata";
+import * as Lib from "metabase-lib";
 import type { Field, Table } from "metabase-types/api";
 import { createMockField, createMockTable } from "metabase-types/api/mocks";
 import {
@@ -8,7 +8,7 @@ import {
   createSampleDatabase,
 } from "metabase-types/api/mocks/presets";
 
-import { createQuery, createMetadataProvider } from "../test-helpers";
+import { DEFAULT_TEST_QUERY, createMetadataProvider } from "../test-helpers";
 
 import { defaultDisplay } from "./display";
 
@@ -61,7 +61,7 @@ describe("defaultDisplay", () => {
   });
 
   it("returns 'table' display for queries with no aggregations and no breakouts", () => {
-    const query = createQuery();
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY);
 
     expect(defaultDisplay(query)).toEqual({ display: "table" });
   });

--- a/frontend/src/metabase-lib/viz/display.unit.spec.ts
+++ b/frontend/src/metabase-lib/viz/display.unit.spec.ts
@@ -1,12 +1,14 @@
+import * as Lib from "metabase-lib";
 import { createMockMetadata } from "__support__/metadata";
 import type { Field, Table } from "metabase-types/api";
 import { createMockField, createMockTable } from "metabase-types/api/mocks";
 import {
+  ORDERS_ID,
   SAMPLE_DB_ID,
   createSampleDatabase,
 } from "metabase-types/api/mocks/presets";
 
-import { createQuery, createQueryWithClauses } from "../test-helpers";
+import { createQuery, createMetadataProvider } from "../test-helpers";
 
 import { defaultDisplay } from "./display";
 
@@ -42,19 +44,18 @@ const SAMPLE_DATABASE = createSampleDatabase({
 });
 
 const SAMPLE_METADATA = createMockMetadata({ databases: [SAMPLE_DATABASE] });
+const SAMPLE_PROVIDER = createMetadataProvider({
+  databaseId: SAMPLE_DATABASE.id,
+  metadata: SAMPLE_METADATA,
+});
 
 describe("defaultDisplay", () => {
   it("returns 'table' display for native queries", () => {
-    const query = createQuery({
-      metadata: SAMPLE_METADATA,
-      query: {
-        database: SAMPLE_DATABASE.id,
-        type: "native",
-        native: {
-          query: "SELECT * FROM ACCOUNTS",
-        },
-      },
-    });
+    const query = Lib.nativeQuery(
+      SAMPLE_DATABASE.id,
+      SAMPLE_PROVIDER,
+      "SELECT * FROM ACCOUNTS",
+    );
 
     expect(defaultDisplay(query)).toEqual({ display: "table" });
   });
@@ -66,17 +67,30 @@ describe("defaultDisplay", () => {
   });
 
   it("returns 'scalar' display for queries with 1 aggregation and no breakouts", () => {
-    const query = createQueryWithClauses({
-      aggregations: [{ operatorName: "count" }],
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
+      stages: [
+        {
+          source: {
+            type: "table",
+            id: ORDERS_ID,
+          },
+          aggregations: [{ type: "operator", operator: "count", args: [] }],
+        },
+      ],
     });
 
     expect(defaultDisplay(query)).toEqual({ display: "scalar" });
   });
 
   it("returns 'map' display for queries with 1 aggregation and 1 breakout by state", () => {
-    const query = createQueryWithClauses({
-      aggregations: [{ operatorName: "count" }],
-      breakouts: [{ columnName: "STATE", tableName: "PEOPLE" }],
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
+      stages: [
+        {
+          source: { type: "table", id: ORDERS_ID },
+          aggregations: [{ type: "operator", operator: "count", args: [] }],
+          breakouts: [{ type: "column", name: "STATE", sourceName: "PEOPLE" }],
+        },
+      ],
     });
 
     expect(defaultDisplay(query)).toEqual({
@@ -89,19 +103,19 @@ describe("defaultDisplay", () => {
   });
 
   it("returns 'map' display for queries with 1 aggregation and 1 breakout by country", () => {
-    const query = createQueryWithClauses({
-      query: createQuery({
-        metadata: SAMPLE_METADATA,
-        query: {
-          database: SAMPLE_DATABASE.id,
-          type: "query",
-          query: {
-            "source-table": ACCOUNTS_ID,
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
+      stages: [
+        {
+          source: {
+            type: "table",
+            id: ACCOUNTS_ID,
           },
+          aggregations: [{ type: "operator", operator: "count", args: [] }],
+          breakouts: [
+            { type: "column", name: "COUNTRY", sourceName: "ACCOUNTS" },
+          ],
         },
-      }),
-      aggregations: [{ operatorName: "count" }],
-      breakouts: [{ columnName: "COUNTRY", tableName: "ACCOUNTS" }],
+      ],
     });
 
     expect(defaultDisplay(query)).toEqual({
@@ -114,13 +128,22 @@ describe("defaultDisplay", () => {
   });
 
   it("returns 'bar' display for queries with aggregations and 1 breakout by date with temporal bucketing", () => {
-    const query = createQueryWithClauses({
-      aggregations: [{ operatorName: "count" }],
-      breakouts: [
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
+      stages: [
         {
-          columnName: "CREATED_AT",
-          tableName: "ORDERS",
-          temporalBucketName: "Day of month",
+          source: {
+            type: "table",
+            id: ACCOUNTS_ID,
+          },
+          aggregations: [{ type: "operator", operator: "count", args: [] }],
+          breakouts: [
+            {
+              type: "column",
+              name: "CREATED_AT",
+              sourceName: "ORDERS",
+              unit: "day-of-month",
+            },
+          ],
         },
       ],
     });
@@ -129,22 +152,35 @@ describe("defaultDisplay", () => {
   });
 
   it("returns 'line' display for queries with aggregations and 1 breakout by date without temporal bucketing", () => {
-    const query = createQueryWithClauses({
-      aggregations: [{ operatorName: "count" }],
-      breakouts: [{ columnName: "CREATED_AT", tableName: "ORDERS" }],
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
+      stages: [
+        {
+          source: { type: "table", id: ORDERS_ID },
+          aggregations: [{ type: "operator", operator: "count", args: [] }],
+          breakouts: [
+            { type: "column", name: "CREATED_AT", sourceName: "ORDERS" },
+          ],
+        },
+      ],
     });
 
     expect(defaultDisplay(query)).toEqual({ display: "line" });
   });
 
   it("returns 'bar' display for queries with aggregations and 1 breakout with binning", () => {
-    const query = createQueryWithClauses({
-      aggregations: [{ operatorName: "count" }],
-      breakouts: [
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
+      stages: [
         {
-          columnName: "TOTAL",
-          tableName: "ORDERS",
-          binningStrategyName: "10 bins",
+          source: { type: "table", id: ORDERS_ID },
+          aggregations: [{ type: "operator", operator: "count", args: [] }],
+          breakouts: [
+            {
+              type: "column",
+              name: "TOTAL",
+              sourceName: "ORDERS",
+              bins: 10,
+            },
+          ],
         },
       ],
     });
@@ -153,29 +189,46 @@ describe("defaultDisplay", () => {
   });
 
   it("returns 'table' display for queries with aggregations and 1 breakout without binning", () => {
-    const query = createQueryWithClauses({
-      aggregations: [{ operatorName: "count" }],
-      breakouts: [{ columnName: "TOTAL", tableName: "ORDERS" }],
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
+      stages: [
+        {
+          source: { type: "table", id: ORDERS_ID },
+          aggregations: [{ type: "operator", operator: "count", args: [] }],
+          breakouts: [{ type: "column", name: "TOTAL", sourceName: "ORDERS" }],
+        },
+      ],
     });
 
     expect(defaultDisplay(query)).toEqual({ display: "table" });
   });
 
   it("returns 'bar' display for queries with aggregations and 1 breakout by category", () => {
-    const query = createQueryWithClauses({
-      aggregations: [{ operatorName: "count" }],
-      breakouts: [{ columnName: "CATEGORY", tableName: "PRODUCTS" }],
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
+      stages: [
+        {
+          source: { type: "table", id: ORDERS_ID },
+          aggregations: [{ type: "operator", operator: "count", args: [] }],
+          breakouts: [
+            { type: "column", name: "CATEGORY", sourceName: "PRODUCTS" },
+          ],
+        },
+      ],
     });
 
     expect(defaultDisplay(query)).toEqual({ display: "bar" });
   });
 
   it("returns 'line' display for queries with 1 aggregation and 2 breakouts, at least 1 of which is by date", () => {
-    const query = createQueryWithClauses({
-      aggregations: [{ operatorName: "count" }],
-      breakouts: [
-        { columnName: "CREATED_AT", tableName: "ORDERS" },
-        { columnName: "TOTAL", tableName: "ORDERS" },
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
+      stages: [
+        {
+          source: { type: "table", id: ORDERS_ID },
+          aggregations: [{ type: "operator", operator: "count", args: [] }],
+          breakouts: [
+            { type: "column", name: "CREATED_AT", sourceName: "ORDERS" },
+            { type: "column", name: "TOTAL", sourceName: "ORDERS" },
+          ],
+        },
       ],
     });
 
@@ -183,18 +236,25 @@ describe("defaultDisplay", () => {
   });
 
   it("returns 'map' display with 'grid' type for queries with 1 aggregation and 2 binned breakouts by coordinates", () => {
-    const query = createQueryWithClauses({
-      aggregations: [{ operatorName: "count" }],
-      breakouts: [
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
+      stages: [
         {
-          columnName: "LATITUDE",
-          tableName: "PEOPLE",
-          binningStrategyName: "Auto bin",
-        },
-        {
-          columnName: "LONGITUDE",
-          tableName: "PEOPLE",
-          binningStrategyName: "Auto bin",
+          source: { type: "table", id: ORDERS_ID },
+          aggregations: [{ type: "operator", operator: "count", args: [] }],
+          breakouts: [
+            {
+              type: "column",
+              name: "LATITUDE",
+              sourceName: "PEOPLE",
+              bins: "auto",
+            },
+            {
+              type: "column",
+              name: "LONGITUDE",
+              sourceName: "PEOPLE",
+              bins: "auto",
+            },
+          ],
         },
       ],
     });
@@ -208,11 +268,16 @@ describe("defaultDisplay", () => {
   });
 
   it("returns 'map' display with 'pin' type for queries with 1 aggregation and 2 un-binned breakouts by coordinates", () => {
-    const query = createQueryWithClauses({
-      aggregations: [{ operatorName: "count" }],
-      breakouts: [
-        { columnName: "LATITUDE", tableName: "PEOPLE" },
-        { columnName: "LONGITUDE", tableName: "PEOPLE" },
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
+      stages: [
+        {
+          source: { type: "table", id: ORDERS_ID },
+          aggregations: [{ type: "operator", operator: "count", args: [] }],
+          breakouts: [
+            { type: "column", name: "LATITUDE", sourceName: "PEOPLE" },
+            { type: "column", name: "LONGITUDE", sourceName: "PEOPLE" },
+          ],
+        },
       ],
     });
 
@@ -225,15 +290,21 @@ describe("defaultDisplay", () => {
   });
 
   it("returns 'map' display with 'pin' type for queries with 1 aggregation and 2 breakouts by coordinates - 1 binned, 1 unbinned", () => {
-    const query = createQueryWithClauses({
-      aggregations: [{ operatorName: "count" }],
-      breakouts: [
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
+      stages: [
         {
-          columnName: "LATITUDE",
-          tableName: "PEOPLE",
-          binningStrategyName: "Auto bin",
+          source: { type: "table", id: ORDERS_ID },
+          aggregations: [{ type: "operator", operator: "count", args: [] }],
+          breakouts: [
+            {
+              type: "column",
+              name: "LATITUDE",
+              sourceName: "PEOPLE",
+              bins: "auto",
+            },
+            { type: "column", name: "LONGITUDE", sourceName: "PEOPLE" },
+          ],
         },
-        { columnName: "LONGITUDE", tableName: "PEOPLE" },
       ],
     });
 
@@ -246,11 +317,16 @@ describe("defaultDisplay", () => {
   });
 
   it("returns 'bar' display for queries with 1 aggregation and 2 breakouts by category", () => {
-    const query = createQueryWithClauses({
-      aggregations: [{ operatorName: "count" }],
-      breakouts: [
-        { columnName: "CATEGORY", tableName: "PRODUCTS" },
-        { columnName: "VENDOR", tableName: "PRODUCTS" },
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
+      stages: [
+        {
+          source: { type: "table", id: ORDERS_ID },
+          aggregations: [{ type: "operator", operator: "count", args: [] }],
+          breakouts: [
+            { type: "column", name: "CATEGORY", sourceName: "PRODUCTS" },
+            { type: "column", name: "VENDOR", sourceName: "PRODUCTS" },
+          ],
+        },
       ],
     });
 
@@ -258,11 +334,19 @@ describe("defaultDisplay", () => {
   });
 
   it("returns 'table' display by default", () => {
-    const query = createQueryWithClauses({
-      aggregations: [{ operatorName: "count" }, { operatorName: "cum-count" }],
-      breakouts: [
-        { columnName: "LATITUDE", tableName: "PEOPLE" },
-        { columnName: "LONGITUDE", tableName: "PEOPLE" },
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
+      stages: [
+        {
+          source: { type: "table", id: ORDERS_ID },
+          aggregations: [
+            { type: "operator", operator: "count", args: [] },
+            { type: "operator", operator: "cum-count", args: [] },
+          ],
+          breakouts: [
+            { type: "column", name: "LATITUDE", sourceName: "PEOPLE" },
+            { type: "column", name: "LONGITUDE", sourceName: "PEOPLE" },
+          ],
+        },
       ],
     });
 

--- a/frontend/src/metabase-types/api/query.ts
+++ b/frontend/src/metabase-types/api/query.ts
@@ -458,6 +458,10 @@ export type TestColumnSpec = {
   name: string;
   sourceName?: string;
   displayName?: string;
+
+  // When the columns cannot be disambiguated with name, sourceName and displayName
+  // use this index to pick one.
+  index?: number;
 };
 
 export type TestExpressionSpec =

--- a/frontend/src/metabase-types/api/query.ts
+++ b/frontend/src/metabase-types/api/query.ts
@@ -490,11 +490,11 @@ export type TestTemporalBucketSpec = {
 };
 
 export type TestBinCountSpec = {
-  bins?: number;
+  bins?: number | "auto";
 };
 
 export type TestBinWidthSpec = {
-  binWidth?: number;
+  binWidth?: number | "auto";
 };
 
 type TestBinningSpec =

--- a/frontend/src/metabase/common/components/AdHocQuestionLoader.unit.spec.js
+++ b/frontend/src/metabase/common/components/AdHocQuestionLoader.unit.spec.js
@@ -1,7 +1,11 @@
 import { render } from "__support__/ui";
 import { delay } from "__support__/utils";
 import * as Lib from "metabase-lib";
-import { SAMPLE_METADATA, createQuery } from "metabase-lib/test-helpers";
+import {
+  DEFAULT_TEST_QUERY,
+  SAMPLE_METADATA,
+  SAMPLE_PROVIDER,
+} from "metabase-lib/test-helpers";
 import Question from "metabase-lib/v1/Question";
 import * as ML_Urls from "metabase-lib/v1/urls";
 
@@ -23,7 +27,7 @@ describe("AdHocQuestionLoader", () => {
 
   it("should load a question given a questionHash", async () => {
     const q = Question.create({ metadata: SAMPLE_METADATA }).setQuery(
-      createQuery(),
+      Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY),
     );
     const questionHash = ML_Urls.getUrl(q).match(/(#.*)/)[1];
 

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
@@ -5,7 +5,12 @@ import { createMockMetadata } from "__support__/metadata";
 import { createMockEntitiesState } from "__support__/store";
 import { renderWithProviders, screen } from "__support__/ui";
 import * as Lib from "metabase-lib";
-import { createQuery, createQueryWithClauses } from "metabase-lib/test-helpers";
+import {
+  SAMPLE_DATABASE,
+  SAMPLE_PROVIDER,
+  createQuery,
+  createTestQuery,
+} from "metabase-lib/test-helpers";
 import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import {
   COMMON_DATABASE_FEATURES,
@@ -13,6 +18,7 @@ import {
 } from "metabase-types/api/mocks";
 import {
   ORDERS,
+  ORDERS_ID,
   SAMPLE_DB_ID,
   createOrdersTable,
   createPeopleTable,
@@ -29,15 +35,38 @@ import {
 import { AggregationPicker } from "./AggregationPicker";
 
 function createQueryWithCountAggregation() {
-  return createQueryWithClauses({
-    aggregations: [{ operatorName: "count" }],
+  return createTestQuery(SAMPLE_PROVIDER, {
+    databaseId: SAMPLE_DATABASE.id,
+    stages: [
+      {
+        source: {
+          type: "table",
+          id: ORDERS_ID,
+        },
+        aggregations: [{ type: "operator", operator: "count", args: [] }],
+      },
+    ],
   });
 }
 
 function createQueryWithMaxAggregation() {
-  return createQueryWithClauses({
-    aggregations: [
-      { operatorName: "max", tableName: "ORDERS", columnName: "QUANTITY" },
+  return createTestQuery(SAMPLE_PROVIDER, {
+    databaseId: SAMPLE_DATABASE.id,
+    stages: [
+      {
+        source: {
+          type: "table",
+          id: ORDERS_ID,
+        },
+
+        aggregations: [
+          {
+            type: "operator",
+            operator: "max",
+            args: [{ type: "column", name: "QUANTITY" }],
+          },
+        ],
+      },
     ],
   });
 }

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
@@ -9,7 +9,6 @@ import {
   SAMPLE_DATABASE,
   SAMPLE_PROVIDER,
   createQuery,
-  createTestQuery,
 } from "metabase-lib/test-helpers";
 import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import {
@@ -35,8 +34,7 @@ import {
 import { AggregationPicker } from "./AggregationPicker";
 
 function createQueryWithCountAggregation() {
-  return createTestQuery(SAMPLE_PROVIDER, {
-    databaseId: SAMPLE_DATABASE.id,
+  return Lib.createTestQuery(SAMPLE_PROVIDER, {
     stages: [
       {
         source: {
@@ -50,8 +48,7 @@ function createQueryWithCountAggregation() {
 }
 
 function createQueryWithMaxAggregation() {
-  return createTestQuery(SAMPLE_PROVIDER, {
-    databaseId: SAMPLE_DATABASE.id,
+  return Lib.createTestQuery(SAMPLE_PROVIDER, {
     stages: [
       {
         source: {

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
@@ -5,20 +5,14 @@ import { createMockMetadata } from "__support__/metadata";
 import { createMockEntitiesState } from "__support__/store";
 import { renderWithProviders, screen } from "__support__/ui";
 import * as Lib from "metabase-lib";
-import {
-  SAMPLE_DATABASE,
-  SAMPLE_PROVIDER,
-  createQuery,
-} from "metabase-lib/test-helpers";
+import { DEFAULT_TEST_QUERY, SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
 import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import {
   COMMON_DATABASE_FEATURES,
   createMockCard,
 } from "metabase-types/api/mocks";
 import {
-  ORDERS,
   ORDERS_ID,
-  SAMPLE_DB_ID,
   createOrdersTable,
   createPeopleTable,
   createProductsTable,
@@ -69,38 +63,46 @@ function createQueryWithMaxAggregation() {
 }
 
 function createQueryWithInlineExpression() {
-  return createQuery({
-    query: {
-      database: SAMPLE_DB_ID,
-      type: "query",
-      query: {
-        aggregation: [
-          [
-            "aggregation-options",
-            ["avg", ["field", ORDERS.QUANTITY, null]],
-            { name: "Avg Q", "display-name": "Avg Q" },
-          ],
+  return Lib.createTestQuery(SAMPLE_PROVIDER, {
+    stages: [
+      {
+        source: {
+          type: "table",
+          id: ORDERS_ID,
+        },
+        aggregations: [
+          {
+            name: "Avg Q",
+            value: {
+              type: "operator",
+              operator: "avg",
+              args: [
+                { type: "column", name: "QUANTITY", sourceName: "ORDERS" },
+              ],
+            },
+          },
         ],
       },
-    },
+    ],
   });
 }
 
 function createQueryWithInlineExpressionWithOperator() {
-  return createQuery({
-    query: {
-      database: SAMPLE_DB_ID,
-      type: "query",
-      query: {
-        aggregation: [
-          [
-            "aggregation-options",
-            ["count"],
-            { name: "My count", "display-name": "My count" },
-          ],
+  return Lib.createTestQuery(SAMPLE_PROVIDER, {
+    stages: [
+      {
+        source: { type: "table", id: ORDERS_ID },
+        aggregations: [
+          {
+            name: "My count",
+            value: {
+              type: "operator",
+              operator: "count",
+            },
+          },
         ],
       },
-    },
+    ],
   });
 }
 
@@ -141,7 +143,7 @@ function setup({
     }),
   }),
   metadata = createMetadata(),
-  query = createQuery({ metadata }),
+  query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY),
   allowCustomExpressions,
 }: SetupOpts = {}) {
   const stageIndex = 0;

--- a/frontend/src/metabase/common/components/MetadataInfo/ColumnInfo/ColumnInfo.unit.spec.js
+++ b/frontend/src/metabase/common/components/MetadataInfo/ColumnInfo/ColumnInfo.unit.spec.js
@@ -7,7 +7,7 @@ import {
   DEFAULT_TEST_QUERY,
   SAMPLE_PROVIDER,
   columnFinder,
-} from "metabase-lib/queries";
+} from "metabase-lib/test-helpers";
 import {
   PRODUCTS,
   PRODUCT_CATEGORY_VALUES,

--- a/frontend/src/metabase/common/components/MetadataInfo/ColumnInfo/ColumnInfo.unit.spec.js
+++ b/frontend/src/metabase/common/components/MetadataInfo/ColumnInfo/ColumnInfo.unit.spec.js
@@ -3,7 +3,11 @@ import { createMockEntitiesState } from "__support__/store";
 import { renderWithProviders, screen } from "__support__/ui";
 import { getMetadata } from "metabase/selectors/metadata";
 import * as Lib from "metabase-lib";
-import { columnFinder, createQuery } from "metabase-lib/test-helpers";
+import {
+  DEFAULT_TEST_QUERY,
+  SAMPLE_PROVIDER,
+  columnFinder,
+} from "metabase-lib/queries";
 import {
   PRODUCTS,
   PRODUCT_CATEGORY_VALUES,
@@ -29,7 +33,7 @@ function setup(field) {
 }
 
 function setupMLv2(table, column) {
-  const query = createQuery();
+  const query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY);
   const columns = Lib.visibleColumns(query, 0);
   const findColumn = columnFinder(query, columns);
   const col = findColumn(table, column);

--- a/frontend/src/metabase/common/components/MetadataInfo/ColumnInfoIcon/ColumnInfoIcon.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/MetadataInfo/ColumnInfoIcon/ColumnInfoIcon.unit.spec.tsx
@@ -1,11 +1,15 @@
 import { fireEvent, render, screen, waitFor } from "__support__/ui";
 import * as Lib from "metabase-lib";
-import { columnFinder, createQuery } from "metabase-lib/test-helpers";
+import {
+  DEFAULT_TEST_QUERY,
+  SAMPLE_PROVIDER,
+  columnFinder,
+} from "metabase-lib/test-helpers";
 
 import { QueryColumnInfoIcon } from "./ColumnInfoIcon";
 
 function setup(table: string, column: string) {
-  const query = createQuery();
+  const query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY);
   const columns = Lib.visibleColumns(query, 0);
   const findColumn = columnFinder(query, columns);
   const col = findColumn(table, column);

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BucketPickerPopover.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BucketPickerPopover.unit.spec.tsx
@@ -2,11 +2,15 @@ import userEvent from "@testing-library/user-event";
 
 import { render, screen, waitFor } from "__support__/ui";
 import * as Lib from "metabase-lib";
-import { columnFinder, createQuery } from "metabase-lib/test-helpers";
+import {
+  DEFAULT_TEST_QUERY,
+  SAMPLE_PROVIDER,
+  columnFinder,
+} from "metabase-lib/test-helpers";
 
 import { BucketPickerPopover } from "./BucketPickerPopover";
 
-const query = createQuery();
+const query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY);
 const findColumn = columnFinder(query, Lib.breakoutableColumns(query, 0));
 const dateColumn = findColumn("ORDERS", "CREATED_AT");
 const numericColumn = findColumn("ORDERS", "TOTAL");

--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.unit.spec.tsx
@@ -2,7 +2,12 @@ import userEvent from "@testing-library/user-event";
 
 import { fireEvent, renderWithProviders, screen, within } from "__support__/ui";
 import * as Lib from "metabase-lib";
-import { columnFinder, createQuery } from "metabase-lib/test-helpers";
+import {
+  DEFAULT_TEST_QUERY,
+  SAMPLE_PROVIDER,
+  columnFinder,
+} from "metabase-lib/test-helpers";
+import { ORDERS_ID } from "metabase-types/api/mocks/presets";
 
 import type { QueryColumnPickerProps } from "./QueryColumnPicker";
 import { QueryColumnPicker } from "./QueryColumnPicker";
@@ -17,16 +22,28 @@ type SetupOpts = Partial<
 };
 
 function createQueryWithBreakout() {
-  const plainQuery = createQuery();
-  const [column] = Lib.breakoutableColumns(plainQuery, 0);
-  const query = Lib.breakout(plainQuery, 0, column);
+  const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
+    stages: [
+      {
+        source: { type: "table", id: ORDERS_ID },
+        breakouts: [
+          {
+            type: "column",
+            name: "CREATED_AT",
+            sourceName: "ORDERS",
+          },
+        ],
+      },
+    ],
+  });
+
   const [clause] = Lib.breakouts(query, 0);
   const clauseInfo = Lib.displayInfo(query, 0, clause);
   return { query, clause, clauseInfo };
 }
 
 function setup({
-  query = createQuery(),
+  query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY),
   stageIndex = 0,
   columns = Lib.breakoutableColumns(query, stageIndex),
   hasBinning = true,

--- a/frontend/src/metabase/common/utils/columns.unit.spec.ts
+++ b/frontend/src/metabase/common/utils/columns.unit.spec.ts
@@ -1,10 +1,14 @@
 import * as Lib from "metabase-lib";
-import { columnFinder, createQuery } from "metabase-lib/test-helpers";
+import {
+  DEFAULT_TEST_QUERY,
+  SAMPLE_PROVIDER,
+  columnFinder,
+} from "metabase-lib/test-helpers";
 
 import { getColumnIcon } from "./columns";
 
 describe("common/utils/columns", () => {
-  const query = createQuery();
+  const query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY);
   const columns = Lib.orderableColumns(query, 0);
   const getColumn = columnFinder(query, columns);
 

--- a/frontend/src/metabase/data-studio/measures/components/MeasureEditor/MeasureEditor.unit.spec.tsx
+++ b/frontend/src/metabase/data-studio/measures/components/MeasureEditor/MeasureEditor.unit.spec.tsx
@@ -1,10 +1,11 @@
 import { renderWithProviders, screen } from "__support__/ui";
-import { createQuery } from "metabase-lib/test-helpers";
+import * as Lib from "metabase-lib";
+import { DEFAULT_TEST_QUERY, SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
 
 import { MeasureEditor } from "./MeasureEditor";
 
 describe("MeasureEditor", () => {
-  const query = createQuery();
+  const query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY);
   const description = "A sample description";
   const onQueryChange = jest.fn();
   const onDescriptionChange = jest.fn();

--- a/frontend/src/metabase/parameters/utils/mapping-options.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/mapping-options.unit.spec.js
@@ -1,8 +1,9 @@
 import { createMockMetadata } from "__support__/metadata";
-import * as Lib from "metabase-lib";
 import {
+  SAMPLE_DATABASE,
   SAMPLE_METADATA,
-  createQueryWithClauses,
+  SAMPLE_PROVIDER,
+  createTestQuery,
 } from "metabase-lib/test-helpers";
 import Question from "metabase-lib/v1/Question";
 import {
@@ -778,17 +779,21 @@ describe("getMappingOptionByTarget", () => {
     });
 
     it("should not confuse columns from different stages", () => {
-      const query = Lib.appendStage(
-        createQueryWithClauses({
-          breakouts: [
-            {
-              columnName: "CREATED_AT",
-              tableName: "ORDERS",
-              temporalBucketName: "Month",
-            },
-          ],
-        }),
-      );
+      const query = createTestQuery(SAMPLE_PROVIDER, {
+        databaseId: SAMPLE_DATABASE.id,
+        stages: [
+          {
+            source: { type: "table", id: ORDERS_ID },
+            breakouts: [
+              {
+                name: "CREATED_AT",
+                unit: "month",
+              },
+            ],
+          },
+          {},
+        ],
+      });
       const question = Question.create({ metadata: SAMPLE_METADATA }).setQuery(
         query,
       );

--- a/frontend/src/metabase/parameters/utils/mapping-options.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/mapping-options.unit.spec.js
@@ -1,9 +1,6 @@
 import { createMockMetadata } from "__support__/metadata";
-import {
-  SAMPLE_DATABASE,
-  SAMPLE_METADATA,
-  SAMPLE_PROVIDER,
-} from "metabase-lib/test-helpers";
+import * as Lib from "metabase-lib";
+import { SAMPLE_METADATA, SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
 import Question from "metabase-lib/v1/Question";
 import {
   createMockCard,

--- a/frontend/src/metabase/parameters/utils/mapping-options.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/mapping-options.unit.spec.js
@@ -3,7 +3,6 @@ import {
   SAMPLE_DATABASE,
   SAMPLE_METADATA,
   SAMPLE_PROVIDER,
-  createTestQuery,
 } from "metabase-lib/test-helpers";
 import Question from "metabase-lib/v1/Question";
 import {
@@ -779,13 +778,13 @@ describe("getMappingOptionByTarget", () => {
     });
 
     it("should not confuse columns from different stages", () => {
-      const query = createTestQuery(SAMPLE_PROVIDER, {
-        databaseId: SAMPLE_DATABASE.id,
+      const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
         stages: [
           {
             source: { type: "table", id: ORDERS_ID },
             breakouts: [
               {
+                type: "column",
                 name: "CREATED_AT",
                 unit: "month",
               },

--- a/frontend/src/metabase/parameters/utils/mapping-options.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/mapping-options.unit.spec.js
@@ -782,6 +782,7 @@ describe("getMappingOptionByTarget", () => {
             breakouts: [
               {
                 type: "column",
+                sourceName: "ORDERS",
                 name: "CREATED_AT",
                 unit: "month",
               },

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/CodeMirrorEditor.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/CodeMirrorEditor.unit.spec.tsx
@@ -2,7 +2,8 @@ import fetchMock from "fetch-mock";
 
 import { createMockMetadata } from "__support__/metadata";
 import { renderWithProviders, screen } from "__support__/ui";
-import { createQuery } from "metabase-lib/test-helpers";
+import * as Lib from "metabase-lib";
+import { createMetadataProvider } from "metabase-lib/test-helpers";
 import type { NativeQuerySnippet } from "metabase-types/api";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
 
@@ -30,16 +31,12 @@ function setup({
   const metadata = createMockMetadata({
     databases: [database],
   });
-  const query = createQuery({
+  const provider = createMetadataProvider({
+    databaseId: database.id,
     metadata,
-    query: {
-      database: database.id,
-      type: "native",
-      native: {
-        query: text,
-      },
-    },
   });
+
+  const query = Lib.createTestNativeQuery(provider, { query: text });
 
   renderWithProviders(
     <CodeMirrorEditor

--- a/frontend/src/metabase/query_builder/components/expressions/CombineColumns/util.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/components/expressions/CombineColumns/util.unit.spec.ts
@@ -1,6 +1,9 @@
 import { createMockMetadata } from "__support__/metadata";
 import * as Lib from "metabase-lib";
-import { columnFinder, createQuery } from "metabase-lib/test-helpers";
+import {
+  columnFinder,
+  createMetadataProvider,
+} from "metabase-lib/test-helpers";
 import {
   createMockDatabase,
   createMockField,
@@ -69,16 +72,18 @@ const DATABASE = createMockDatabase({
   tables: [TABLE],
 });
 
-const QUERY = createQuery({
+const METADATA = createMockMetadata({ databases: [DATABASE] });
+const PROVIDER = createMetadataProvider({
+  metadata: METADATA,
   databaseId: DATABASE.id,
-  metadata: createMockMetadata({ databases: [DATABASE] }),
-  query: {
-    database: DATABASE.id,
-    type: "query",
-    query: {
-      "source-table": TABLE.id,
+});
+
+const QUERY = Lib.createTestQuery(PROVIDER, {
+  stages: [
+    {
+      source: { type: "table", id: TABLE.id },
     },
-  },
+  ],
 });
 
 function getColumn(name: string) {

--- a/frontend/src/metabase/query_builder/components/expressions/Editor/HelpText/HelpText.stories.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/Editor/HelpText/HelpText.stories.tsx
@@ -2,7 +2,11 @@ import type { StoryFn } from "@storybook/react";
 
 import { createMockMetadata } from "__support__/metadata";
 import { ReduxProvider } from "__support__/storybook";
-import { createQuery } from "metabase-lib/test-helpers";
+import * as Lib from "metabase-lib";
+import {
+  DEFAULT_TEST_QUERY,
+  createMetadataProvider,
+} from "metabase-lib/test-helpers";
 import { createMockDatabase } from "metabase-types/api/mocks";
 
 import { HelpText } from "./HelpText";
@@ -15,9 +19,11 @@ export default {
 const Template: StoryFn<typeof HelpText> = () => {
   const database = createMockDatabase();
   const metadata = createMockMetadata({ databases: [database] });
-  const query = createQuery({
+  const provider = createMetadataProvider({
     databaseId: database.id,
+    metadata,
   });
+  const query = Lib.createTestQuery(provider, DEFAULT_TEST_QUERY);
 
   return (
     <ReduxProvider>

--- a/frontend/src/metabase/query_builder/components/expressions/Editor/HelpText/tests/setup.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/Editor/HelpText/tests/setup.tsx
@@ -4,8 +4,11 @@ import { mockSettings } from "__support__/settings";
 import { renderWithProviders } from "__support__/ui";
 import { checkNotNull } from "metabase/lib/types";
 import { getHelpText } from "metabase/querying/expressions";
-import type * as Lib from "metabase-lib";
-import { createQuery } from "metabase-lib/test-helpers";
+import * as Lib from "metabase-lib";
+import {
+  DEFAULT_TEST_QUERY,
+  createMetadataProvider,
+} from "metabase-lib/test-helpers";
 import type { TokenFeatures } from "metabase-types/api";
 import { createMockTokenFeatures } from "metabase-types/api/mocks";
 import {
@@ -42,10 +45,12 @@ export async function setup({
   });
 
   const metadata = createMockMetadata({ databases: [createSampleDatabase()] });
-  const database = checkNotNull(metadata.database(SAMPLE_DB_ID));
-  const query = createQuery({
-    databaseId: database.id,
+  const provider = createMetadataProvider({
+    databaseId: SAMPLE_DB_ID,
+    metadata,
   });
+  const database = checkNotNull(metadata.database(SAMPLE_DB_ID));
+  const query = Lib.createTestQuery(provider, DEFAULT_TEST_QUERY);
 
   const props: HelpTextProps = {
     enclosingFunction: {

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget/ExpressionWidget.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget/ExpressionWidget.unit.spec.tsx
@@ -2,7 +2,7 @@ import userEvent from "@testing-library/user-event";
 
 import { renderWithProviders, screen, waitFor } from "__support__/ui";
 import * as Lib from "metabase-lib";
-import { createQuery } from "metabase-lib/test-helpers";
+import { DEFAULT_TEST_QUERY, SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
 
 import type { ExpressionWidgetProps } from "./ExpressionWidget";
 import { ExpressionWidget } from "./ExpressionWidget";
@@ -164,7 +164,7 @@ describe("ExpressionWidget", () => {
 });
 
 async function setup(additionalProps?: Partial<ExpressionWidgetProps>) {
-  const query = createQuery();
+  const query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY);
   const stageIndex = 0;
   const availableColumns = Lib.expressionableColumns(query, stageIndex);
   const onChangeClause = jest.fn();

--- a/frontend/src/metabase/query_builder/components/expressions/ExtractColumn/util.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/components/expressions/ExtractColumn/util.unit.spec.ts
@@ -1,6 +1,6 @@
 import { createMockMetadata } from "__support__/metadata";
-import type * as Lib from "metabase-lib";
-import { createQuery } from "metabase-lib/test-helpers";
+import * as Lib from "metabase-lib";
+import { createMetadataProvider } from "metabase-lib/test-helpers";
 import {
   createMockDatabase,
   createMockField,
@@ -25,16 +25,18 @@ const DATABASE = createMockDatabase({
   tables: [TABLE],
 });
 
-const QUERY = createQuery({
+const METADATA = createMockMetadata({ databases: [DATABASE] });
+const PROVIDER = createMetadataProvider({
   databaseId: DATABASE.id,
-  metadata: createMockMetadata({ databases: [DATABASE] }),
-  query: {
-    database: DATABASE.id,
-    type: "query",
-    query: {
-      "source-table": TABLE.id,
+  metadata: METADATA,
+});
+
+const QUERY = Lib.createTestQuery(PROVIDER, {
+  stages: [
+    {
+      source: { type: "table", id: TABLE.id },
     },
-  },
+  ],
 });
 
 describe("getName", () => {

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/FilterHeaderButton.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/FilterHeaderButton.unit.spec.tsx
@@ -1,17 +1,45 @@
 import { renderWithProviders, screen } from "__support__/ui";
 import * as Lib from "metabase-lib";
-import { SAMPLE_METADATA, createQuery } from "metabase-lib/test-helpers";
+import {
+  DEFAULT_TEST_QUERY,
+  SAMPLE_METADATA,
+  SAMPLE_PROVIDER,
+} from "metabase-lib/test-helpers";
 import Question from "metabase-lib/v1/Question";
+import { ORDERS_ID } from "metabase-types/api/mocks/presets";
 
 import { FilterHeaderButton } from "./FilterHeaderButton";
 
+const queryWithFilters = Lib.createTestQuery(SAMPLE_PROVIDER, {
+  stages: [
+    {
+      source: { type: "table", id: ORDERS_ID },
+      filters: [
+        {
+          type: "operator",
+          operator: ">",
+          args: [
+            { type: "literal", value: 1 },
+            { type: "literal", value: 2 },
+          ],
+        },
+      ],
+    },
+  ],
+});
+
 const QUESTION_WITH_FILTERS = Question.create({
   metadata: SAMPLE_METADATA,
-}).setQuery(Lib.filter(createQuery(), 0, Lib.expressionClause(">", [1, 2])));
+}).setQuery(queryWithFilters);
+
+const queryWithoutFilters = Lib.createTestQuery(
+  SAMPLE_PROVIDER,
+  DEFAULT_TEST_QUERY,
+);
 
 const QUESTION_WITHOUT_FILTERS = Question.create({
   metadata: SAMPLE_METADATA,
-}).setQuery(createQuery());
+}).setQuery(queryWithoutFilters);
 
 type SetupOpts = {
   question?: Question;

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/tests/common.unit.spec.tsx
@@ -4,11 +4,7 @@ import { testDataset } from "__support__/testDataset";
 import { screen, within } from "__support__/ui";
 import * as Urls from "metabase/lib/urls";
 import * as Lib from "metabase-lib";
-import {
-  DEFAULT_TEST_QUERY,
-  SAMPLE_PROVIDER,
-  getJoinQueryHelpers,
-} from "metabase-lib/test-helpers";
+import { SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
 import type { BaseEntityId } from "metabase-types/api";
 import {
   createMockCard,
@@ -16,7 +12,7 @@ import {
   createMockModerationReview,
   createMockUserInfo,
 } from "metabase-types/api/mocks";
-import { PRODUCTS_ID } from "metabase-types/api/mocks/presets";
+import { ORDERS_ID, PRODUCTS_ID } from "metabase-types/api/mocks/presets";
 
 import { setup } from "./setup";
 
@@ -282,26 +278,28 @@ describe("QuestionInfoSidebar", () => {
 });
 
 function getJoinedQuery() {
-  const query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY);
-
-  const {
-    table,
-    defaultStrategy,
-    defaultOperator,
-    findLHSColumn,
-    findRHSColumn,
-  } = getJoinQueryHelpers(query, 0, PRODUCTS_ID);
-  const ordersProductId = findLHSColumn("ORDERS", "PRODUCT_ID");
-  const productsId = findRHSColumn("PRODUCTS", "ID");
-  const stageIndex = -1;
-  const condition = Lib.joinConditionClause(
-    defaultOperator,
-    ordersProductId,
-    productsId,
-  );
-  return Lib.join(
-    query,
-    stageIndex,
-    Lib.joinClause(table, [condition], defaultStrategy),
-  );
+  return Lib.createTestQuery(SAMPLE_PROVIDER, {
+    stages: [
+      {
+        source: { type: "table", id: ORDERS_ID },
+        joins: [
+          {
+            source: { type: "table", id: PRODUCTS_ID },
+            strategy: "left-join",
+            conditions: [
+              {
+                operator: "=",
+                left: {
+                  type: "column",
+                  sourceName: "ORDERS",
+                  name: "PRODUCT_ID",
+                },
+                right: { type: "column", sourceName: "PRODUCTS", name: "ID" },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  });
 }

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/tests/common.unit.spec.tsx
@@ -4,7 +4,11 @@ import { testDataset } from "__support__/testDataset";
 import { screen, within } from "__support__/ui";
 import * as Urls from "metabase/lib/urls";
 import * as Lib from "metabase-lib";
-import { createQuery, getJoinQueryHelpers } from "metabase-lib/test-helpers";
+import {
+  DEFAULT_TEST_QUERY,
+  SAMPLE_PROVIDER,
+  getJoinQueryHelpers,
+} from "metabase-lib/test-helpers";
 import type { BaseEntityId } from "metabase-types/api";
 import {
   createMockCard,
@@ -278,7 +282,8 @@ describe("QuestionInfoSidebar", () => {
 });
 
 function getJoinedQuery() {
-  const query = createQuery();
+  const query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY);
+
   const {
     table,
     defaultStrategy,

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.unit.spec.tsx
@@ -33,11 +33,13 @@ function createSummarizedQuery() {
         breakouts: [
           {
             type: "column",
+            sourceName: "ORDERS",
             name: "CREATED_AT",
             unit: "month",
           },
           {
             type: "column",
+            sourceName: "PRODUCTS",
             name: "CATEGORY",
           },
         ],
@@ -55,11 +57,13 @@ function createQueryWithBreakoutsForSameColumn() {
         breakouts: [
           {
             type: "column",
+            sourceName: "ORDERS",
             name: "CREATED_AT",
             unit: "year",
           },
           {
             type: "column",
+            sourceName: "ORDERS",
             name: "CREATED_AT",
             unit: "quarter",
           },

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.unit.spec.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 
 import { renderWithProviders, screen, waitFor, within } from "__support__/ui";
 import * as Lib from "metabase-lib";
-import { SAMPLE_PROVIDER, createQuery } from "metabase-lib/test-helpers";
+import { DEFAULT_TEST_QUERY, SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
 import { createMockCard } from "metabase-types/api/mocks";
 import { ORDERS_ID } from "metabase-types/api/mocks/presets";
 import {
@@ -70,7 +70,10 @@ function createQueryWithBreakoutsForSameColumn() {
 }
 
 async function setup({
-  query: initialQuery = createQuery(),
+  query: initialQuery = Lib.createTestQuery(
+    SAMPLE_PROVIDER,
+    DEFAULT_TEST_QUERY,
+  ),
   withDefaultAggregation = true,
 }: SetupOpts = {}) {
   const onQueryChange = jest.fn();
@@ -197,7 +200,7 @@ describe("SummarizeSidebar", () => {
   });
 
   it("should list breakoutable columns", async () => {
-    const query = createQuery();
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY);
     const columns = Lib.breakoutableColumns(query, -1);
     await setup({ query });
 

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.unit.spec.tsx
@@ -3,12 +3,7 @@ import { useState } from "react";
 
 import { renderWithProviders, screen, waitFor, within } from "__support__/ui";
 import * as Lib from "metabase-lib";
-import {
-  SAMPLE_DATABASE,
-  SAMPLE_PROVIDER,
-  createQuery,
-  createTestQuery,
-} from "metabase-lib/test-helpers";
+import { SAMPLE_PROVIDER, createQuery } from "metabase-lib/test-helpers";
 import { createMockCard } from "metabase-types/api/mocks";
 import { ORDERS_ID } from "metabase-types/api/mocks/presets";
 import {
@@ -24,8 +19,7 @@ type SetupOpts = {
 };
 
 function createSummarizedQuery() {
-  return createTestQuery(SAMPLE_PROVIDER, {
-    databaseId: SAMPLE_DATABASE.id,
+  return Lib.createTestQuery(SAMPLE_PROVIDER, {
     stages: [
       {
         source: { type: "table", id: ORDERS_ID },
@@ -38,10 +32,12 @@ function createSummarizedQuery() {
         ],
         breakouts: [
           {
+            type: "column",
             name: "CREATED_AT",
             unit: "month",
           },
           {
+            type: "column",
             name: "CATEGORY",
           },
         ],
@@ -51,18 +47,19 @@ function createSummarizedQuery() {
 }
 
 function createQueryWithBreakoutsForSameColumn() {
-  return createTestQuery(SAMPLE_PROVIDER, {
-    databaseId: SAMPLE_DATABASE.id,
+  return Lib.createTestQuery(SAMPLE_PROVIDER, {
     stages: [
       {
         source: { type: "table", id: ORDERS_ID },
         aggregations: [{ type: "operator", operator: "count", args: [] }],
         breakouts: [
           {
+            type: "column",
             name: "CREATED_AT",
             unit: "year",
           },
           {
+            type: "column",
             name: "CREATED_AT",
             unit: "quarter",
           },
@@ -162,8 +159,7 @@ describe("SummarizeSidebar", () => {
 
     it("should allow to remove last not default aggregation (metabase#48033)", async () => {
       await setup({
-        query: createTestQuery(SAMPLE_PROVIDER, {
-          databaseId: SAMPLE_DATABASE.id,
+        query: Lib.createTestQuery(SAMPLE_PROVIDER, {
           stages: [
             {
               source: { type: "table", id: ORDERS_ID },

--- a/frontend/src/metabase/querying/expressions/suggestions/aggregations.unit.spec.ts
+++ b/frontend/src/metabase/querying/expressions/suggestions/aggregations.unit.spec.ts
@@ -1,5 +1,9 @@
 import { createMockMetadata } from "__support__/metadata";
-import { createQuery } from "metabase-lib/test-helpers";
+import * as Lib from "metabase-lib";
+import {
+  DEFAULT_TEST_QUERY,
+  createMetadataProvider,
+} from "metabase-lib/test-helpers";
 import type { DatabaseFeature } from "metabase-types/api";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
 
@@ -20,7 +24,8 @@ describe("suggestAggregations", () => {
         }),
       ],
     });
-    const query = createQuery({ metadata });
+    const provider = createMetadataProvider({ metadata });
+    const query = Lib.createTestQuery(provider, DEFAULT_TEST_QUERY);
     const source = suggestAggregations({
       expressionMode,
       query,

--- a/frontend/src/metabase/querying/expressions/suggestions/fields.unit.spec.ts
+++ b/frontend/src/metabase/querying/expressions/suggestions/fields.unit.spec.ts
@@ -1,21 +1,19 @@
 import { createMockMetadata } from "__support__/metadata";
 import * as Lib from "metabase-lib";
-import { SAMPLE_DATABASE, createQuery } from "metabase-lib/test-helpers";
-import type { DatasetQuery, Join } from "metabase-types/api";
+import {
+  DEFAULT_TEST_QUERY,
+  SAMPLE_PROVIDER,
+  createMetadataProvider,
+} from "metabase-lib/test-helpers";
 import {
   createMockDatabase,
   createMockField,
   createMockTable,
 } from "metabase-types/api/mocks";
-import {
-  ORDERS,
-  ORDERS_ID,
-  REVIEWS,
-  REVIEWS_ID,
-} from "metabase-types/api/mocks/presets";
+import { ORDERS_ID, REVIEWS_ID } from "metabase-types/api/mocks/presets";
 
 import { columnsForExpressionMode } from "../mode";
-import { queryWithAggregation, sharedMetadata } from "../test/shared";
+import { queryWithAggregation, sharedProvider } from "../test/shared";
 
 import { complete } from "./__support__";
 import { suggestFields } from "./fields";
@@ -52,17 +50,16 @@ describe("suggestFields", () => {
       tables: [TABLE],
     });
 
-    const query = createQuery({
+    const metadata = createMockMetadata({ databases: [DATABASE] });
+    const provider = createMetadataProvider({
       databaseId: DATABASE.id,
-      metadata: createMockMetadata({ databases: [DATABASE] }),
-      query: {
-        database: DATABASE.id,
-        type: "query",
-        query: {
-          "source-table": TABLE.id,
-        },
-      },
+      metadata,
     });
+
+    const query = Lib.createTestQuery(provider, {
+      stages: [{ source: { type: "table", id: TABLE.id } }],
+    });
+
     const stageIndex = 0;
     const expressionIndex = 0;
     const source = suggestFields({
@@ -182,7 +179,7 @@ describe("suggestFields", () => {
   });
 
   it("should suggest foreign fields", () => {
-    const query = createQuery();
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY);
     const stageIndex = -1;
     const source = suggestFields({
       query,
@@ -317,28 +314,33 @@ describe("suggestFields", () => {
   });
 
   it("should suggest joined fields", async () => {
-    const JOIN_CLAUSE: Join = {
-      alias: "Foo",
-      ident: "pbHOWTxjodLToOUnFJe_k",
-      "source-table": REVIEWS_ID,
-      condition: [
-        "=",
-        ["field", REVIEWS.PRODUCT_ID, null],
-        ["field", ORDERS.PRODUCT_ID, null],
+    const query = Lib.createTestQuery(sharedProvider, {
+      stages: [
+        {
+          source: { type: "table", id: ORDERS_ID },
+          joins: [
+            {
+              source: { type: "table", id: REVIEWS_ID },
+              strategy: "left-join",
+              conditions: [
+                {
+                  operator: "=",
+                  left: {
+                    type: "column",
+                    sourceName: "REVIEWS",
+                    name: "PRODUCT_ID",
+                  },
+                  right: {
+                    type: "column",
+                    sourceName: "ORDERS",
+                    name: "PRODUCT_ID",
+                  },
+                },
+              ],
+            },
+          ],
+        },
       ],
-    };
-    const queryWithJoins: DatasetQuery = {
-      database: SAMPLE_DATABASE.id,
-      type: "query",
-      query: {
-        "source-table": ORDERS_ID,
-        joins: [JOIN_CLAUSE],
-      },
-    };
-
-    const query = createQuery({
-      metadata: sharedMetadata,
-      query: queryWithJoins,
     });
     const stageIndex = -1;
     const source = suggestFields({
@@ -380,19 +382,25 @@ describe("suggestFields", () => {
   });
 
   it("should suggest nested query fields", () => {
-    const datasetQuery: DatasetQuery = {
-      database: SAMPLE_DATABASE.id,
-      type: "query",
-      query: {
-        "source-table": ORDERS_ID,
-        aggregation: [["count"]],
-        breakout: [["field", ORDERS.TOTAL, null]],
-      },
-    };
-
-    const queryWithAggregation = createQuery({
-      metadata: sharedMetadata,
-      query: datasetQuery,
+    const queryWithAggregation = Lib.createTestQuery(SAMPLE_PROVIDER, {
+      stages: [
+        {
+          source: { type: "table", id: ORDERS_ID },
+          aggregations: [
+            {
+              type: "operator",
+              operator: "count",
+            },
+          ],
+          breakouts: [
+            {
+              type: "column",
+              sourceName: "ORDERS",
+              name: "TOTAL",
+            },
+          ],
+        },
+      ],
     });
 
     const query = Lib.appendStage(queryWithAggregation);

--- a/frontend/src/metabase/querying/expressions/suggestions/fields.unit.spec.ts
+++ b/frontend/src/metabase/querying/expressions/suggestions/fields.unit.spec.ts
@@ -327,12 +327,12 @@ describe("suggestFields", () => {
                   operator: "=",
                   left: {
                     type: "column",
-                    sourceName: "REVIEWS",
+                    sourceName: "ORDERS",
                     name: "PRODUCT_ID",
                   },
                   right: {
                     type: "column",
-                    sourceName: "ORDERS",
+                    sourceName: "REVIEWS",
                     name: "PRODUCT_ID",
                   },
                 },
@@ -353,31 +353,35 @@ describe("suggestFields", () => {
       }),
     });
 
-    complete(source, "Foo|");
-
-    const result = await complete(source, "Foo|");
+    const result = await complete(source, "Body|");
 
     expect(result).toEqual({
       from: 0,
-      to: 3,
+      to: 4,
       options: expect.any(Array),
     });
 
     expect(result?.options[0]).toEqual({
-      displayLabel: "Foo → Body",
-      label: "[Foo → Body]",
+      displayLabel: "Reviews - Product → Body",
+      label: "[Reviews - Product → Body]",
       type: "field",
       icon: "string",
       column: expect.any(Object),
-      matches: [[0, 2]],
+      matches: [
+        [12, 13],
+        [20, 23],
+      ],
     });
     expect(result?.options[1]).toEqual({
-      displayLabel: "Foo → ID",
-      label: "[Foo → ID]",
+      displayLabel: "Product ID",
+      label: "[Product ID]",
       type: "field",
-      icon: "label",
+      icon: "connections",
       column: expect.any(Object),
-      matches: [[0, 2]],
+      matches: [
+        [2, 3],
+        [9, 9],
+      ],
     });
   });
 

--- a/frontend/src/metabase/querying/expressions/suggestions/functions.unit.spec.ts
+++ b/frontend/src/metabase/querying/expressions/suggestions/functions.unit.spec.ts
@@ -1,5 +1,9 @@
 import { createMockMetadata } from "__support__/metadata";
-import { createQuery } from "metabase-lib/test-helpers";
+import * as Lib from "metabase-lib";
+import {
+  DEFAULT_TEST_QUERY,
+  createMetadataProvider,
+} from "metabase-lib/test-helpers";
 import type { DatabaseFeature } from "metabase-types/api";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
 
@@ -20,7 +24,8 @@ describe("suggestFunctions", () => {
         }),
       ],
     });
-    const query = createQuery({ metadata });
+    const provider = createMetadataProvider({ metadata });
+    const query = Lib.createTestQuery(provider, DEFAULT_TEST_QUERY);
     const source = suggestFunctions({
       expressionMode,
       query,

--- a/frontend/src/metabase/querying/expressions/suggestions/metrics.unit.spec.ts
+++ b/frontend/src/metabase/querying/expressions/suggestions/metrics.unit.spec.ts
@@ -1,5 +1,9 @@
 import { createMockMetadata } from "__support__/metadata";
-import { SAMPLE_DATABASE, createQuery } from "metabase-lib/test-helpers";
+import * as Lib from "metabase-lib";
+import {
+  SAMPLE_DATABASE,
+  createMetadataProvider,
+} from "metabase-lib/test-helpers";
 import {
   createMockCard,
   createMockField,
@@ -79,15 +83,17 @@ describe("suggestMetrics", () => {
       questions: [METRIC_FOO],
     });
 
-    const query = createQuery({
+    const provider = createMetadataProvider({
       metadata,
-      query: {
-        database: DATABASE.id,
-        type: "query",
-        query: {
-          "source-table": TABLE.id,
+      databaseId: DATABASE.id,
+    });
+
+    const query = Lib.createTestQuery(provider, {
+      stages: [
+        {
+          source: { type: "table", id: TABLE.id },
         },
-      },
+      ],
     });
 
     const source = suggestMetrics({

--- a/frontend/src/metabase/querying/expressions/suggestions/segments.unit.spec.ts
+++ b/frontend/src/metabase/querying/expressions/suggestions/segments.unit.spec.ts
@@ -1,5 +1,9 @@
 import { createMockMetadata } from "__support__/metadata";
-import { SAMPLE_DATABASE, createQuery } from "metabase-lib/test-helpers";
+import * as Lib from "metabase-lib";
+import {
+  SAMPLE_DATABASE,
+  createMetadataProvider,
+} from "metabase-lib/test-helpers";
 import { createMockSegment, createMockTable } from "metabase-types/api/mocks";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
 
@@ -41,15 +45,20 @@ describe("suggestSegments", () => {
       segments: [SEGMENT_FOO, SEGMENT_BAR],
     });
 
-    const query = createQuery({
+    const provider = createMetadataProvider({
       metadata,
-      query: {
-        database: DATABASE.id,
-        type: "query",
-        query: {
-          "source-table": TABLE.id,
+      databaseId: DATABASE.id,
+    });
+
+    const query = Lib.createTestQuery(provider, {
+      stages: [
+        {
+          source: {
+            type: "table",
+            id: TABLE.id,
+          },
         },
-      },
+      ],
     });
 
     const source = suggestSegments({

--- a/frontend/src/metabase/querying/expressions/test/shared.ts
+++ b/frontend/src/metabase/querying/expressions/test/shared.ts
@@ -2,9 +2,8 @@ import { createMockMetadata } from "__support__/metadata";
 import { getNextId } from "__support__/utils";
 import * as Lib from "metabase-lib";
 import {
-  type ExpressionClauseOpts,
-  createQuery,
-  createQueryWithClauses,
+  createMetadataProvider,
+  createTestQuery,
 } from "metabase-lib/test-helpers";
 import {
   COMMON_DATABASE_FEATURES,
@@ -110,78 +109,199 @@ metadata = createMockMetadata({
   ],
 });
 
-const exprs: ExpressionClauseOpts[] = [
+export const query = createTestQuery(
+  createMetadataProvider({ databaseId: SAMPLE_DB_ID, metadata }),
   {
-    name: "foo",
-    operator: "+",
-    args: [1, 2],
-  },
-  {
-    name: "bool",
-    operator: "=",
-    args: [1, 1],
-  },
-  {
-    name: "name with [brackets]",
-    operator: "+",
-    args: [1, 2],
-  },
-  {
-    name: "name with \\ slash",
-    operator: "+",
-    args: [1, 2],
-  },
-  {
-    name: "stringly",
-    operator: "concat",
-    args: ["foo", "bar"],
-  },
-  {
-    name: "bar",
-    operator: "+",
-    args: [1, 2],
-  },
-  {
-    name: "BAR",
-    operator: "+",
-    args: [1, 2],
-  },
-];
-
-export const query = createQueryWithClauses({
-  query: createQuery({
-    metadata,
-    query: createMockStructuredDatasetQuery({
-      database: SAMPLE_DB_ID,
-      query: createMockStructuredQuery({
-        "source-table": ORDERS_ID,
+    databaseId: SAMPLE_DB_ID,
+    stages: [
+      {
+        source: { type: "table", id: ORDERS_ID },
         fields: [],
-      }),
-    }),
-  }),
-  expressions: exprs,
-});
-
-export const queryWithAggregation = createQueryWithClauses({
-  query: createQuery({
-    metadata,
-    query: createMockStructuredDatasetQuery({
-      database: SAMPLE_DB_ID,
-      query: createMockStructuredQuery({
-        "source-table": ORDERS_ID,
-        fields: [],
-        aggregation: [
-          [
-            "aggregation-options",
-            ["sum", ["field", ORDERS.TOTAL, null]],
-            { name: "Bar Aggregation", "display-name": "Bar Aggregation" },
-          ],
+        expressions: [
+          {
+            name: "foo",
+            value: {
+              type: "operator",
+              operator: "+",
+              args: [
+                { type: "literal", value: 1 },
+                { type: "literal", value: 2 },
+              ],
+            },
+          },
+          {
+            name: "bool",
+            value: {
+              type: "operator",
+              operator: "=",
+              args: [
+                { type: "literal", value: 1 },
+                { type: "literal", value: 1 },
+              ],
+            },
+          },
+          {
+            name: "name with [brackets]",
+            value: {
+              type: "operator",
+              operator: "+",
+              args: [
+                { type: "literal", value: 1 },
+                { type: "literal", value: 2 },
+              ],
+            },
+          },
+          {
+            name: "name with \\ slash",
+            value: {
+              type: "operator",
+              operator: "+",
+              args: [
+                { type: "literal", value: 1 },
+                { type: "literal", value: 2 },
+              ],
+            },
+          },
+          {
+            name: "stringly",
+            value: {
+              type: "operator",
+              operator: "concat",
+              args: [
+                { type: "literal", value: "foo" },
+                { type: "literal", value: "bar" },
+              ],
+            },
+          },
+          {
+            name: "bar",
+            value: {
+              type: "operator",
+              operator: "+",
+              args: [
+                { type: "literal", value: 1 },
+                { type: "literal", value: 2 },
+              ],
+            },
+          },
+          {
+            name: "BAR",
+            value: {
+              type: "operator",
+              operator: "+",
+              args: [
+                { type: "literal", value: 1 },
+                { type: "literal", value: 2 },
+              ],
+            },
+          },
         ],
-      }),
-    }),
-  }),
-  expressions: exprs,
-});
+      },
+    ],
+  },
+);
+
+export const queryWithAggregation = createTestQuery(
+  createMetadataProvider({ databaseId: SAMPLE_DB_ID, metadata }),
+  {
+    databaseId: SAMPLE_DB_ID,
+    stages: [
+      {
+        source: { type: "table", id: ORDERS_ID },
+        fields: [],
+        aggregations: [
+          {
+            name: "Bar Aggregation",
+            value: {
+              type: "operator",
+              operator: "sum",
+              args: [{ type: "column", name: "TOTAL" }],
+            },
+          },
+        ],
+        expressions: [
+          {
+            name: "foo",
+            value: {
+              type: "operator",
+              operator: "+",
+              args: [
+                { type: "literal", value: 1 },
+                { type: "literal", value: 2 },
+              ],
+            },
+          },
+          {
+            name: "bool",
+            value: {
+              type: "operator",
+              operator: "=",
+              args: [
+                { type: "literal", value: 1 },
+                { type: "literal", value: 1 },
+              ],
+            },
+          },
+          {
+            name: "name with [brackets]",
+            value: {
+              type: "operator",
+              operator: "+",
+              args: [
+                { type: "literal", value: 1 },
+                { type: "literal", value: 2 },
+              ],
+            },
+          },
+          {
+            name: "name with \\ slash",
+            value: {
+              type: "operator",
+              operator: "+",
+              args: [
+                { type: "literal", value: 1 },
+                { type: "literal", value: 2 },
+              ],
+            },
+          },
+          {
+            name: "stringly",
+            value: {
+              type: "operator",
+              operator: "concat",
+              args: [
+                { type: "literal", value: "foo" },
+                { type: "literal", value: "bar" },
+              ],
+            },
+          },
+          {
+            name: "bar",
+            value: {
+              type: "operator",
+              operator: "+",
+              args: [
+                { type: "literal", value: 1 },
+                { type: "literal", value: 2 },
+              ],
+            },
+          },
+          {
+            name: "BAR",
+            value: {
+              type: "operator",
+              operator: "+",
+              args: [
+                { type: "literal", value: 1 },
+                { type: "literal", value: 2 },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  },
+);
 
 export const stageIndex = -1;
 

--- a/frontend/src/metabase/querying/expressions/test/shared.ts
+++ b/frontend/src/metabase/querying/expressions/test/shared.ts
@@ -1,10 +1,7 @@
 import { createMockMetadata } from "__support__/metadata";
 import { getNextId } from "__support__/utils";
 import * as Lib from "metabase-lib";
-import {
-  createMetadataProvider,
-  createTestQuery,
-} from "metabase-lib/test-helpers";
+import { createMetadataProvider } from "metabase-lib/test-helpers";
 import {
   COMMON_DATABASE_FEATURES,
   createMockCard,
@@ -109,10 +106,9 @@ metadata = createMockMetadata({
   ],
 });
 
-export const query = createTestQuery(
+export const query = Lib.createTestQuery(
   createMetadataProvider({ databaseId: SAMPLE_DB_ID, metadata }),
   {
-    databaseId: SAMPLE_DB_ID,
     stages: [
       {
         source: { type: "table", id: ORDERS_ID },
@@ -201,10 +197,9 @@ export const query = createTestQuery(
   },
 );
 
-export const queryWithAggregation = createTestQuery(
+export const queryWithAggregation = Lib.createTestQuery(
   createMetadataProvider({ databaseId: SAMPLE_DB_ID, metadata }),
   {
-    databaseId: SAMPLE_DB_ID,
     stages: [
       {
         source: { type: "table", id: ORDERS_ID },

--- a/frontend/src/metabase/querying/expressions/test/shared.ts
+++ b/frontend/src/metabase/querying/expressions/test/shared.ts
@@ -420,3 +420,7 @@ export const { fields, expressions, segments, metrics, measures } =
   findDimensions(query);
 
 export const sharedMetadata = metadata;
+export const sharedProvider = createMetadataProvider({
+  databaseId: database.id,
+  metadata,
+});

--- a/frontend/src/metabase/querying/fields/components/FieldPanel/FieldPanel.unit.spec.tsx
+++ b/frontend/src/metabase/querying/fields/components/FieldPanel/FieldPanel.unit.spec.tsx
@@ -166,7 +166,7 @@ describe("QueryColumnPicker", () => {
                   {
                     type: "column",
                     name: "PRICE",
-                    sourceName: "Product",
+                    sourceName: "PRODUCTS",
                   },
                 ],
               },
@@ -198,7 +198,7 @@ describe("QueryColumnPicker", () => {
               {
                 type: "column",
                 name: "PRICE",
-                sourceName: "Product",
+                sourceName: "PRODUCTS",
               },
             ],
           },
@@ -228,7 +228,7 @@ describe("QueryColumnPicker", () => {
               {
                 type: "column",
                 name: "PRICE",
-                sourceName: "Product",
+                sourceName: "PRODUCTS",
               },
             ],
           },
@@ -241,7 +241,6 @@ describe("QueryColumnPicker", () => {
                   {
                     type: "column",
                     name: "PRICE",
-                    sourceName: "Summaries",
                   },
                   { type: "literal", value: 1 },
                 ],
@@ -275,12 +274,12 @@ describe("QueryColumnPicker", () => {
               {
                 type: "column",
                 name: "PRICE",
-                sourceName: "Product",
+                sourceName: "PRODUCTS",
               },
               {
                 type: "column",
                 name: "CREATED_AT",
-                sourceName: "Product",
+                sourceName: "PRODUCTS",
               },
             ],
           },
@@ -293,7 +292,6 @@ describe("QueryColumnPicker", () => {
                   {
                     type: "column",
                     name: "PRICE",
-                    sourceName: "Summaries",
                   },
                   { type: "literal", value: 1 },
                 ],
@@ -416,7 +414,7 @@ describe("QueryColumnPicker", () => {
               {
                 type: "column",
                 name: "PRICE",
-                sourceName: "Product",
+                sourceName: "PRODUCTS",
               },
             ],
           },
@@ -442,7 +440,6 @@ describe("QueryColumnPicker", () => {
                   {
                     type: "column",
                     name: "PRICE",
-                    sourceName: "Summaries",
                   },
                   { type: "literal", value: 1 },
                 ],

--- a/frontend/src/metabase/querying/fields/components/FieldPanel/FieldPanel.unit.spec.tsx
+++ b/frontend/src/metabase/querying/fields/components/FieldPanel/FieldPanel.unit.spec.tsx
@@ -7,7 +7,6 @@ import {
   SAMPLE_DATABASE,
   SAMPLE_PROVIDER,
   createQuery,
-  createTestQuery,
 } from "metabase-lib/test-helpers";
 import { ORDERS_ID, PRODUCTS_ID } from "metabase-types/api/mocks/presets";
 
@@ -148,8 +147,7 @@ describe("QueryColumnPicker", () => {
 
   it("should not allow to remove fields for aggregated queries", async () => {
     setup({
-      query: createTestQuery(SAMPLE_PROVIDER, {
-        databaseId: SAMPLE_DATABASE.id,
+      query: Lib.createTestQuery(SAMPLE_PROVIDER, {
         stages: [
           {
             source: {
@@ -165,7 +163,7 @@ describe("QueryColumnPicker", () => {
                   {
                     type: "column",
                     name: "PRICE",
-                    groupName: "Product",
+                    sourceName: "Product",
                   },
                 ],
               },
@@ -186,8 +184,7 @@ describe("QueryColumnPicker", () => {
 
   it("should not allow to remove fields for breakout queries", async () => {
     setup({
-      query: createTestQuery(SAMPLE_PROVIDER, {
-        databaseId: SAMPLE_DATABASE.id,
+      query: Lib.createTestQuery(SAMPLE_PROVIDER, {
         stages: [
           {
             source: {
@@ -196,8 +193,9 @@ describe("QueryColumnPicker", () => {
             },
             breakouts: [
               {
+                type: "column",
                 name: "PRICE",
-                groupName: "Product",
+                sourceName: "Product",
               },
             ],
           },
@@ -216,8 +214,7 @@ describe("QueryColumnPicker", () => {
 
   it("should not allow to remove the only field from multi-stage queries", () => {
     setup({
-      query: createTestQuery(SAMPLE_PROVIDER, {
-        databaseId: SAMPLE_DATABASE.id,
+      query: Lib.createTestQuery(SAMPLE_PROVIDER, {
         stages: [
           {
             source: {
@@ -226,8 +223,9 @@ describe("QueryColumnPicker", () => {
             },
             breakouts: [
               {
+                type: "column",
                 name: "PRICE",
-                groupName: "Product",
+                sourceName: "Product",
               },
             ],
           },
@@ -240,7 +238,7 @@ describe("QueryColumnPicker", () => {
                   {
                     type: "column",
                     name: "PRICE",
-                    groupName: "Summaries",
+                    sourceName: "Summaries",
                   },
                   { type: "literal", value: 1 },
                 ],
@@ -263,8 +261,7 @@ describe("QueryColumnPicker", () => {
 
   it("should allow to remove some but not all fields from multi-stage queries", async () => {
     setup({
-      query: createTestQuery(SAMPLE_PROVIDER, {
-        databaseId: SAMPLE_DATABASE.id,
+      query: Lib.createTestQuery(SAMPLE_PROVIDER, {
         stages: [
           {
             source: {
@@ -273,12 +270,14 @@ describe("QueryColumnPicker", () => {
             },
             breakouts: [
               {
+                type: "column",
                 name: "PRICE",
-                groupName: "Product",
+                sourceName: "Product",
               },
               {
+                type: "column",
                 name: "CREATED_AT",
-                groupName: "Product",
+                sourceName: "Product",
               },
             ],
           },
@@ -291,7 +290,7 @@ describe("QueryColumnPicker", () => {
                   {
                     type: "column",
                     name: "PRICE",
-                    groupName: "Summaries",
+                    sourceName: "Summaries",
                   },
                   { type: "literal", value: 1 },
                 ],
@@ -389,8 +388,7 @@ describe("QueryColumnPicker", () => {
 
   it("should not allow to remove columns when there are expressions and only one removable column in multi-stage queries", () => {
     setup({
-      query: createTestQuery(SAMPLE_PROVIDER, {
-        databaseId: SAMPLE_DATABASE.id,
+      query: Lib.createTestQuery(SAMPLE_PROVIDER, {
         stages: [
           {
             source: {
@@ -399,8 +397,9 @@ describe("QueryColumnPicker", () => {
             },
             breakouts: [
               {
+                type: "column",
                 name: "PRICE",
-                groupName: "Product",
+                sourceName: "Product",
               },
             ],
           },
@@ -426,7 +425,7 @@ describe("QueryColumnPicker", () => {
                   {
                     type: "column",
                     name: "PRICE",
-                    groupName: "Summaries",
+                    sourceName: "Summaries",
                   },
                   { type: "literal", value: 1 },
                 ],

--- a/frontend/src/metabase/querying/filters/components/FilterPanel/utils.unit.spec.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterPanel/utils.unit.spec.ts
@@ -1,5 +1,5 @@
 import * as Lib from "metabase-lib";
-import { createQuery } from "metabase-lib/test-helpers";
+import { DEFAULT_TEST_QUERY, SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
 
 import { getFilterItems } from "./utils";
 
@@ -13,7 +13,7 @@ function createMultiStageFilteredQuery() {
   const stageIndexes = Array.from({ length: STAGE_COUNT }, (_, i) => i);
   return stageIndexes.reduce(
     (query) => Lib.appendStage(createFilteredQuery(query)),
-    createQuery(),
+    Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY),
   );
 }
 

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.unit.spec.tsx
@@ -3,9 +3,9 @@ import userEvent from "@testing-library/user-event";
 import { renderWithProviders, screen } from "__support__/ui";
 import { checkNotNull } from "metabase/lib/types";
 import * as Lib from "metabase-lib";
-import { DEFAULT_TEST_QUERY, SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
 
 import {
+  createQuery,
   createQueryWithBooleanFilter,
   findBooleanColumn,
   storeInitialState,
@@ -21,7 +21,7 @@ type SetupOpts = {
 };
 
 function setup({
-  query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY),
+  query = createQuery(),
   column = findBooleanColumn(query),
   filter,
   withAddButton = false,

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.unit.spec.tsx
@@ -3,9 +3,9 @@ import userEvent from "@testing-library/user-event";
 import { renderWithProviders, screen } from "__support__/ui";
 import { checkNotNull } from "metabase/lib/types";
 import * as Lib from "metabase-lib";
+import { DEFAULT_TEST_QUERY, SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
 
 import {
-  createQuery,
   createQueryWithBooleanFilter,
   findBooleanColumn,
   storeInitialState,
@@ -21,7 +21,7 @@ type SetupOpts = {
 };
 
 function setup({
-  query = createQuery(),
+  query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY),
   column = findBooleanColumn(query),
   filter,
   withAddButton = false,

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/DefaultFilterPicker/DefaultFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/DefaultFilterPicker/DefaultFilterPicker.unit.spec.tsx
@@ -2,9 +2,9 @@ import userEvent from "@testing-library/user-event";
 
 import { renderWithProviders, screen } from "__support__/ui";
 import * as Lib from "metabase-lib";
-import { DEFAULT_TEST_QUERY, SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
 
 import {
+  createQuery,
   createQueryWithDefaultFilter,
   findUnknownColumn,
   storeInitialState,
@@ -21,7 +21,7 @@ type SetupOpts = {
 };
 
 function setup({
-  query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY),
+  query = createQuery(),
   stageIndex = -1,
   column = findUnknownColumn(query),
   filter,

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/DefaultFilterPicker/DefaultFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/DefaultFilterPicker/DefaultFilterPicker.unit.spec.tsx
@@ -2,9 +2,9 @@ import userEvent from "@testing-library/user-event";
 
 import { renderWithProviders, screen } from "__support__/ui";
 import * as Lib from "metabase-lib";
+import { DEFAULT_TEST_QUERY, SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
 
 import {
-  createQuery,
   createQueryWithDefaultFilter,
   findUnknownColumn,
   storeInitialState,
@@ -21,7 +21,7 @@ type SetupOpts = {
 };
 
 function setup({
-  query = createQuery(),
+  query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY),
   stageIndex = -1,
   column = findUnknownColumn(query),
   filter,

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.unit.spec.tsx
@@ -1,7 +1,7 @@
 import { setupFieldsValuesEndpoints } from "__support__/server-mocks";
 import { fireEvent, renderWithProviders, screen } from "__support__/ui";
-import type * as Lib from "metabase-lib";
-import { createQuery } from "metabase-lib/test-helpers";
+import * as Lib from "metabase-lib";
+import { DEFAULT_TEST_QUERY, SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
 import { SAMPLE_DB_FIELD_VALUES } from "metabase-types/api/mocks/presets";
 
 import { FilterColumnPicker } from "./FilterColumnPicker";
@@ -27,7 +27,7 @@ function setup({ query, stageIndexes }: SetupOpts) {
 
 describe("FilterColumnPicker", () => {
   test("The info icon should exist on each column", () => {
-    const query = createQuery();
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY);
     const stageIndexes = [0];
     setup({ query, stageIndexes });
     expect(screen.getAllByLabelText("More info").length).toBeGreaterThanOrEqual(
@@ -36,7 +36,7 @@ describe("FilterColumnPicker", () => {
   });
 
   test("Searching by displayName should works (#39622)", () => {
-    const query = createQuery();
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY);
     const stageIndexes = [0];
     setup({ query, stageIndexes });
 

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterValuePicker/FilterValuePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterValuePicker/FilterValuePicker.unit.spec.tsx
@@ -15,9 +15,10 @@ import {
 } from "__support__/ui";
 import * as Lib from "metabase-lib";
 import {
+  DEFAULT_TEST_QUERY,
   SAMPLE_METADATA,
   columnFinder,
-  createQuery,
+  createMetadataProvider,
 } from "metabase-lib/test-helpers";
 import type {
   FieldId,
@@ -1194,7 +1195,8 @@ describe("NumberFilterValuePicker", () => {
 });
 
 function createQueryWithMetadata(metadata = SAMPLE_METADATA) {
-  const query = createQuery({ metadata });
+  const provider = createMetadataProvider({ metadata });
+  const query = Lib.createTestQuery(provider, DEFAULT_TEST_QUERY);
   const stageIndex = 0;
   const availableColumns = Lib.filterableColumns(query, stageIndex);
   const findColumn = columnFinder(query, availableColumns);

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/MultiStageFilterPicker/MultiStageFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/MultiStageFilterPicker/MultiStageFilterPicker.unit.spec.tsx
@@ -2,7 +2,12 @@ import userEvent from "@testing-library/user-event";
 
 import { renderWithProviders, screen } from "__support__/ui";
 import * as Lib from "metabase-lib";
-import { createQueryWithClauses } from "metabase-lib/test-helpers";
+import {
+  SAMPLE_DATABASE,
+  SAMPLE_PROVIDER,
+  createTestQuery,
+} from "metabase-lib/test-helpers";
+import { ORDERS_ID } from "metabase-types/api/mocks/presets";
 
 import { MultiStageFilterPicker } from "./MultiStageFilterPicker";
 
@@ -34,9 +39,15 @@ function setup({ query, canAppendStage = true }: SetupOpts) {
 describe("MultiStageFilterPicker", () => {
   it("should drop empty stages if there is no filter in a post-aggregation stage (metabase#57573)", async () => {
     const { getNewQuery } = setup({
-      query: createQueryWithClauses({
-        aggregations: [{ operatorName: "count" }],
-        breakouts: [{ tableName: "PRODUCTS", columnName: "CATEGORY" }],
+      query: createTestQuery(SAMPLE_PROVIDER, {
+        databaseId: SAMPLE_DATABASE.id,
+        stages: [
+          {
+            source: { type: "table", id: ORDERS_ID },
+            aggregations: [{ type: "operator", operator: "count", args: [] }],
+            breakouts: [{ name: "CATEGORY" }],
+          },
+        ],
       }),
     });
     expect(screen.getByText("Summaries")).toBeInTheDocument();
@@ -52,9 +63,15 @@ describe("MultiStageFilterPicker", () => {
 
   it("should not drop the post-aggregation stage if there is a new filter", async () => {
     const { getNewQuery } = setup({
-      query: createQueryWithClauses({
-        aggregations: [{ operatorName: "count" }],
-        breakouts: [{ tableName: "PRODUCTS", columnName: "CATEGORY" }],
+      query: createTestQuery(SAMPLE_PROVIDER, {
+        databaseId: SAMPLE_DATABASE.id,
+        stages: [
+          {
+            source: { type: "table", id: ORDERS_ID },
+            aggregations: [{ type: "operator", operator: "count", args: [] }],
+            breakouts: [{ name: "CATEGORY" }],
+          },
+        ],
       }),
     });
     expect(screen.getByText("Summaries")).toBeInTheDocument();

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/MultiStageFilterPicker/MultiStageFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/MultiStageFilterPicker/MultiStageFilterPicker.unit.spec.tsx
@@ -2,7 +2,7 @@ import userEvent from "@testing-library/user-event";
 
 import { renderWithProviders, screen } from "__support__/ui";
 import * as Lib from "metabase-lib";
-import { SAMPLE_DATABASE, SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
+import { SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
 import { ORDERS_ID } from "metabase-types/api/mocks/presets";
 
 import { MultiStageFilterPicker } from "./MultiStageFilterPicker";

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/MultiStageFilterPicker/MultiStageFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/MultiStageFilterPicker/MultiStageFilterPicker.unit.spec.tsx
@@ -2,11 +2,7 @@ import userEvent from "@testing-library/user-event";
 
 import { renderWithProviders, screen } from "__support__/ui";
 import * as Lib from "metabase-lib";
-import {
-  SAMPLE_DATABASE,
-  SAMPLE_PROVIDER,
-  createTestQuery,
-} from "metabase-lib/test-helpers";
+import { SAMPLE_DATABASE, SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
 import { ORDERS_ID } from "metabase-types/api/mocks/presets";
 
 import { MultiStageFilterPicker } from "./MultiStageFilterPicker";
@@ -39,13 +35,12 @@ function setup({ query, canAppendStage = true }: SetupOpts) {
 describe("MultiStageFilterPicker", () => {
   it("should drop empty stages if there is no filter in a post-aggregation stage (metabase#57573)", async () => {
     const { getNewQuery } = setup({
-      query: createTestQuery(SAMPLE_PROVIDER, {
-        databaseId: SAMPLE_DATABASE.id,
+      query: Lib.createTestQuery(SAMPLE_PROVIDER, {
         stages: [
           {
             source: { type: "table", id: ORDERS_ID },
             aggregations: [{ type: "operator", operator: "count", args: [] }],
-            breakouts: [{ name: "CATEGORY" }],
+            breakouts: [{ type: "column", name: "CATEGORY" }],
           },
         ],
       }),
@@ -63,13 +58,12 @@ describe("MultiStageFilterPicker", () => {
 
   it("should not drop the post-aggregation stage if there is a new filter", async () => {
     const { getNewQuery } = setup({
-      query: createTestQuery(SAMPLE_PROVIDER, {
-        databaseId: SAMPLE_DATABASE.id,
+      query: Lib.createTestQuery(SAMPLE_PROVIDER, {
         stages: [
           {
             source: { type: "table", id: ORDERS_ID },
             aggregations: [{ type: "operator", operator: "count", args: [] }],
-            breakouts: [{ name: "CATEGORY" }],
+            breakouts: [{ type: "column", name: "CATEGORY" }],
           },
         ],
       }),

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.unit.spec.tsx
@@ -4,9 +4,12 @@ import dayjs from "dayjs";
 import { renderWithProviders, screen, within } from "__support__/ui";
 import { checkNotNull } from "metabase/lib/types";
 import * as Lib from "metabase-lib";
-import { DEFAULT_TEST_QUERY, SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
 
-import { createQueryWithTimeFilter, findTimeColumn } from "../test-utils";
+import {
+  createQuery,
+  createQueryWithTimeFilter,
+  findTimeColumn,
+} from "../test-utils";
 
 import { TimeFilterPicker } from "./TimeFilterPicker";
 
@@ -37,7 +40,7 @@ type SetupOpts = {
 };
 
 function setup({
-  query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY),
+  query = createQuery(),
   column = findTimeColumn(query),
   filter,
   withAddButton = false,

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.unit.spec.tsx
@@ -4,12 +4,9 @@ import dayjs from "dayjs";
 import { renderWithProviders, screen, within } from "__support__/ui";
 import { checkNotNull } from "metabase/lib/types";
 import * as Lib from "metabase-lib";
+import { DEFAULT_TEST_QUERY, SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
 
-import {
-  createQuery,
-  createQueryWithTimeFilter,
-  findTimeColumn,
-} from "../test-utils";
+import { createQueryWithTimeFilter, findTimeColumn } from "../test-utils";
 
 import { TimeFilterPicker } from "./TimeFilterPicker";
 
@@ -40,7 +37,7 @@ type SetupOpts = {
 };
 
 function setup({
-  query = createQuery(),
+  query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY),
   column = findTimeColumn(query),
   filter,
   withAddButton = false,

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/test-utils.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/test-utils.ts
@@ -6,8 +6,9 @@ import { checkNotNull } from "metabase/lib/types";
 import { getMetadata } from "metabase/selectors/metadata";
 import * as Lib from "metabase-lib";
 import {
-  createQuery as _createQuery,
+  DEFAULT_TEST_QUERY,
   columnFinder,
+  createMetadataProvider,
 } from "metabase-lib/test-helpers";
 import { TYPE } from "metabase-lib/v1/types/constants";
 import { createMockField, createMockSegment } from "metabase-types/api/mocks";
@@ -124,9 +125,10 @@ export const storeInitialState = createMockState({
 });
 
 export const metadata = getMetadata(storeInitialState);
+const provider = createMetadataProvider({ metadata });
 
 export function createQuery() {
-  return _createQuery({ metadata });
+  return Lib.createTestQuery(provider, DEFAULT_TEST_QUERY);
 }
 
 export function createFilteredQuery(

--- a/frontend/src/metabase/querying/filters/components/TimeseriesChrome/TimeseriesChrome.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/TimeseriesChrome/TimeseriesChrome.unit.spec.tsx
@@ -3,12 +3,15 @@ import userEvent from "@testing-library/user-event";
 import { renderWithProviders, screen } from "__support__/ui";
 import * as Lib from "metabase-lib";
 import {
+  SAMPLE_DATABASE,
   SAMPLE_METADATA,
+  SAMPLE_PROVIDER,
   createQuery,
-  createQueryWithClauses,
+  createTestQuery,
 } from "metabase-lib/test-helpers";
 import Question from "metabase-lib/v1/Question";
 import { createMockCard } from "metabase-types/api/mocks";
+import { ORDERS_ID } from "metabase-types/api/mocks/presets";
 
 import { TimeseriesChrome } from "./TimeseriesChrome";
 
@@ -45,20 +48,32 @@ describe("TimeseriesChrome", () => {
   });
 
   it("should not render the chrome if there are no breakouts on a temporal column", () => {
-    const query = createQueryWithClauses({
-      breakouts: [{ tableName: "PRODUCTS", columnName: "CATEGORY" }],
+    const query = createTestQuery(SAMPLE_PROVIDER, {
+      databaseId: SAMPLE_DATABASE.id,
+      stages: [
+        {
+          source: {
+            type: "table",
+            id: ORDERS_ID,
+          },
+          breakouts: [{ name: "CATEGORY" }],
+        },
+      ],
     });
     setup({ query });
     expect(screen.queryByText("View")).not.toBeInTheDocument();
   });
 
   it("should allow to change the temporal unit for a breakout", async () => {
-    const query = createQueryWithClauses({
-      breakouts: [
+    const query = createTestQuery(SAMPLE_PROVIDER, {
+      databaseId: SAMPLE_DATABASE.id,
+      stages: [
         {
-          tableName: "PRODUCTS",
-          columnName: "CREATED_AT",
-          temporalBucketName: "Month",
+          source: {
+            type: "table",
+            id: ORDERS_ID,
+          },
+          breakouts: [{ name: "CREATED_AT", unit: "month" }],
         },
       ],
     });
@@ -73,17 +88,18 @@ describe("TimeseriesChrome", () => {
   });
 
   it("should allow to change the temporal unit for a breakout when there are multiple breakouts of the same column", async () => {
-    const query = createQueryWithClauses({
-      breakouts: [
+    const query = createTestQuery(SAMPLE_PROVIDER, {
+      databaseId: SAMPLE_DATABASE.id,
+      stages: [
         {
-          tableName: "PRODUCTS",
-          columnName: "CREATED_AT",
-          temporalBucketName: "Month",
-        },
-        {
-          tableName: "PRODUCTS",
-          columnName: "CREATED_AT",
-          temporalBucketName: "Year",
+          source: {
+            type: "table",
+            id: ORDERS_ID,
+          },
+          breakouts: [
+            { name: "CREATED_AT", unit: "month" },
+            { name: "CREATED_AT", unit: "year" },
+          ],
         },
       ],
     });

--- a/frontend/src/metabase/querying/filters/components/TimeseriesChrome/TimeseriesChrome.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/TimeseriesChrome/TimeseriesChrome.unit.spec.tsx
@@ -71,7 +71,14 @@ describe("TimeseriesChrome", () => {
             type: "table",
             id: ORDERS_ID,
           },
-          breakouts: [{ type: "column", name: "CREATED_AT", unit: "month" }],
+          breakouts: [
+            {
+              type: "column",
+              sourceName: "ORDERS",
+              name: "CREATED_AT",
+              unit: "month",
+            },
+          ],
         },
       ],
     });
@@ -94,8 +101,18 @@ describe("TimeseriesChrome", () => {
             id: ORDERS_ID,
           },
           breakouts: [
-            { type: "column", name: "CREATED_AT", unit: "month" },
-            { type: "column", name: "CREATED_AT", unit: "year" },
+            {
+              type: "column",
+              sourceName: "ORDERS",
+              name: "CREATED_AT",
+              unit: "month",
+            },
+            {
+              type: "column",
+              sourceName: "ORDERS",
+              name: "CREATED_AT",
+              unit: "year",
+            },
           ],
         },
       ],

--- a/frontend/src/metabase/querying/filters/components/TimeseriesChrome/TimeseriesChrome.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/TimeseriesChrome/TimeseriesChrome.unit.spec.tsx
@@ -7,7 +7,6 @@ import {
   SAMPLE_METADATA,
   SAMPLE_PROVIDER,
   createQuery,
-  createTestQuery,
 } from "metabase-lib/test-helpers";
 import Question from "metabase-lib/v1/Question";
 import { createMockCard } from "metabase-types/api/mocks";
@@ -48,15 +47,14 @@ describe("TimeseriesChrome", () => {
   });
 
   it("should not render the chrome if there are no breakouts on a temporal column", () => {
-    const query = createTestQuery(SAMPLE_PROVIDER, {
-      databaseId: SAMPLE_DATABASE.id,
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
       stages: [
         {
           source: {
             type: "table",
             id: ORDERS_ID,
           },
-          breakouts: [{ name: "CATEGORY" }],
+          breakouts: [{ type: "column", name: "CATEGORY" }],
         },
       ],
     });
@@ -65,15 +63,14 @@ describe("TimeseriesChrome", () => {
   });
 
   it("should allow to change the temporal unit for a breakout", async () => {
-    const query = createTestQuery(SAMPLE_PROVIDER, {
-      databaseId: SAMPLE_DATABASE.id,
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
       stages: [
         {
           source: {
             type: "table",
             id: ORDERS_ID,
           },
-          breakouts: [{ name: "CREATED_AT", unit: "month" }],
+          breakouts: [{ type: "column", name: "CREATED_AT", unit: "month" }],
         },
       ],
     });
@@ -88,8 +85,7 @@ describe("TimeseriesChrome", () => {
   });
 
   it("should allow to change the temporal unit for a breakout when there are multiple breakouts of the same column", async () => {
-    const query = createTestQuery(SAMPLE_PROVIDER, {
-      databaseId: SAMPLE_DATABASE.id,
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
       stages: [
         {
           source: {
@@ -97,8 +93,8 @@ describe("TimeseriesChrome", () => {
             id: ORDERS_ID,
           },
           breakouts: [
-            { name: "CREATED_AT", unit: "month" },
-            { name: "CREATED_AT", unit: "year" },
+            { type: "column", name: "CREATED_AT", unit: "month" },
+            { type: "column", name: "CREATED_AT", unit: "year" },
           ],
         },
       ],

--- a/frontend/src/metabase/querying/filters/components/TimeseriesChrome/TimeseriesChrome.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/TimeseriesChrome/TimeseriesChrome.unit.spec.tsx
@@ -3,10 +3,9 @@ import userEvent from "@testing-library/user-event";
 import { renderWithProviders, screen } from "__support__/ui";
 import * as Lib from "metabase-lib";
 import {
-  SAMPLE_DATABASE,
+  DEFAULT_TEST_QUERY,
   SAMPLE_METADATA,
   SAMPLE_PROVIDER,
-  createQuery,
 } from "metabase-lib/test-helpers";
 import Question from "metabase-lib/v1/Question";
 import { createMockCard } from "metabase-types/api/mocks";
@@ -18,7 +17,9 @@ interface SetupOpts {
   query?: Lib.Query;
 }
 
-function setup({ query = createQuery() }: SetupOpts = {}) {
+function setup({
+  query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY),
+}: SetupOpts = {}) {
   const question = new Question(createMockCard(), SAMPLE_METADATA).setQuery(
     query,
   );

--- a/frontend/src/metabase/querying/filters/components/TimeseriesChrome/TimeseriesFilterPicker/TimeseriesFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/TimeseriesChrome/TimeseriesFilterPicker/TimeseriesFilterPicker.unit.spec.tsx
@@ -2,7 +2,11 @@ import _userEvent from "@testing-library/user-event";
 
 import { renderWithProviders, screen } from "__support__/ui";
 import * as Lib from "metabase-lib";
-import { columnFinder, createQuery } from "metabase-lib/test-helpers";
+import {
+  DEFAULT_TEST_QUERY,
+  SAMPLE_PROVIDER,
+  columnFinder,
+} from "metabase-lib/test-helpers";
 
 import { TimeseriesFilterPicker } from "./TimeseriesFilterPicker";
 
@@ -22,7 +26,7 @@ function createDateFilter(query: Lib.Query) {
 }
 
 function createQueryWithFilter(
-  initialQuery: Lib.Query = createQuery(),
+  initialQuery = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY),
   clause = createDateFilter(initialQuery),
 ) {
   const query = Lib.filter(initialQuery, 0, clause);
@@ -42,7 +46,7 @@ const userEvent = _userEvent.setup({
 });
 
 function setup({
-  query = createQuery(),
+  query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY),
   column = findDateColumn(query),
   filter,
 }: SetupOpts = {}) {

--- a/frontend/src/metabase/querying/filters/hooks/use-boolean-filter/use-boolean-filter.unit.spec.ts
+++ b/frontend/src/metabase/querying/filters/hooks/use-boolean-filter/use-boolean-filter.unit.spec.ts
@@ -3,7 +3,11 @@ import { act, renderHook } from "@testing-library/react";
 import { createMockMetadata } from "__support__/metadata";
 import type { BooleanFilterValue } from "metabase/querying/common/types";
 import * as Lib from "metabase-lib";
-import { columnFinder, createQuery } from "metabase-lib/test-helpers";
+import {
+  DEFAULT_TEST_QUERY,
+  columnFinder,
+  createMetadataProvider,
+} from "metabase-lib/test-helpers";
 import { createMockField } from "metabase-types/api/mocks";
 import {
   ORDERS_ID,
@@ -47,8 +51,10 @@ const METADATA = createMockMetadata({
   ],
 });
 
+const PROVIDER = createMetadataProvider({ metadata: METADATA });
+
 describe("useBooleanOptionFilter", () => {
-  const defaultQuery = createQuery({ metadata: METADATA });
+  const defaultQuery = Lib.createTestQuery(PROVIDER, DEFAULT_TEST_QUERY);
   const stageIndex = 0;
   const availableColumns = Lib.filterableColumns(defaultQuery, stageIndex);
   const column = columnFinder(defaultQuery, availableColumns)(

--- a/frontend/src/metabase/querying/filters/hooks/use-coordinate-filter/use-coordinate-filter.unit.spec.ts
+++ b/frontend/src/metabase/querying/filters/hooks/use-coordinate-filter/use-coordinate-filter.unit.spec.ts
@@ -2,7 +2,7 @@ import { act, renderHook } from "@testing-library/react";
 
 import { checkNotNull } from "metabase/lib/types";
 import * as Lib from "metabase-lib";
-import { columnFinder, createQuery } from "metabase-lib/test-helpers";
+import { SAMPLE_PROVIDER, columnFinder } from "metabase-lib/test-helpers";
 import { PEOPLE_ID } from "metabase-types/api/mocks/presets";
 
 import type { NumberOrEmptyValue } from "./types";
@@ -33,7 +33,16 @@ interface ValidateFilterCase {
 }
 
 describe("useCoordinateFilter", () => {
-  const defaultQuery = Lib.withDifferentTable(createQuery(), PEOPLE_ID);
+  const defaultQuery = Lib.createTestQuery(SAMPLE_PROVIDER, {
+    stages: [
+      {
+        source: {
+          type: "table",
+          id: PEOPLE_ID,
+        },
+      },
+    ],
+  });
   const stageIndex = 0;
   const availableColumns = Lib.filterableColumns(defaultQuery, stageIndex);
   const latitudeColumn = columnFinder(defaultQuery, availableColumns)(

--- a/frontend/src/metabase/querying/filters/hooks/use-date-filter/use-date-filter.unit.spec.ts
+++ b/frontend/src/metabase/querying/filters/hooks/use-date-filter/use-date-filter.unit.spec.ts
@@ -3,17 +3,16 @@ import { renderHook } from "@testing-library/react";
 import type { DatePickerValue } from "metabase/querying/common/types";
 import * as Lib from "metabase-lib";
 import {
-  SAMPLE_DATABASE,
+  DEFAULT_TEST_QUERY,
   SAMPLE_PROVIDER,
   columnFinder,
-  createQuery,
 } from "metabase-lib/test-helpers";
 import { ORDERS_ID } from "metabase-types/api/mocks/presets";
 
 import { useDateFilter } from "./use-date-filter";
 
 describe("useDateFilter", () => {
-  const defaultQuery = createQuery();
+  const defaultQuery = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY);
   const stageIndex = 0;
   const availableColumns = Lib.filterableColumns(defaultQuery, stageIndex);
   const defaultColumn = columnFinder(defaultQuery, availableColumns)(

--- a/frontend/src/metabase/querying/filters/hooks/use-date-filter/use-date-filter.unit.spec.ts
+++ b/frontend/src/metabase/querying/filters/hooks/use-date-filter/use-date-filter.unit.spec.ts
@@ -7,7 +7,6 @@ import {
   SAMPLE_PROVIDER,
   columnFinder,
   createQuery,
-  createTestQuery,
 } from "metabase-lib/test-helpers";
 import { ORDERS_ID } from "metabase-types/api/mocks/presets";
 
@@ -78,8 +77,7 @@ describe("useDateFilter", () => {
   });
 
   it("should return available units for a custom column", () => {
-    const query = createTestQuery(SAMPLE_PROVIDER, {
-      databaseId: SAMPLE_DATABASE.id,
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
       stages: [
         {
           source: { type: "table", id: ORDERS_ID },

--- a/frontend/src/metabase/querying/filters/hooks/use-date-filter/use-date-filter.unit.spec.ts
+++ b/frontend/src/metabase/querying/filters/hooks/use-date-filter/use-date-filter.unit.spec.ts
@@ -3,10 +3,13 @@ import { renderHook } from "@testing-library/react";
 import type { DatePickerValue } from "metabase/querying/common/types";
 import * as Lib from "metabase-lib";
 import {
+  SAMPLE_DATABASE,
+  SAMPLE_PROVIDER,
   columnFinder,
   createQuery,
-  createQueryWithClauses,
+  createTestQuery,
 } from "metabase-lib/test-helpers";
+import { ORDERS_ID } from "metabase-types/api/mocks/presets";
 
 import { useDateFilter } from "./use-date-filter";
 
@@ -75,20 +78,30 @@ describe("useDateFilter", () => {
   });
 
   it("should return available units for a custom column", () => {
-    const query = createQueryWithClauses({
-      query: defaultQuery,
-      expressions: [
+    const query = createTestQuery(SAMPLE_PROVIDER, {
+      databaseId: SAMPLE_DATABASE.id,
+      stages: [
         {
-          name: "CustomDate",
-          operator: "=",
-          args: [defaultColumn],
+          source: { type: "table", id: ORDERS_ID },
+          expressions: [
+            {
+              name: "CustomDate",
+              value: {
+                type: "operator",
+                operator: "=",
+                args: [
+                  { type: "column", name: "CREATED_AT", sourceName: "ORDERS" },
+                ],
+              },
+            },
+          ],
         },
       ],
     });
     const column = columnFinder(
       query,
       Lib.filterableColumns(query, stageIndex),
-    )("ORDERS", "CustomDate");
+    )(null, "CustomDate");
 
     const { result } = renderHook(() =>
       useDateFilter({

--- a/frontend/src/metabase/querying/filters/hooks/use-default-filter/use-default-filter.unit.spec.ts
+++ b/frontend/src/metabase/querying/filters/hooks/use-default-filter/use-default-filter.unit.spec.ts
@@ -3,7 +3,11 @@ import { act, renderHook } from "@testing-library/react";
 import { createMockMetadata } from "__support__/metadata";
 import { checkNotNull } from "metabase/lib/types";
 import * as Lib from "metabase-lib";
-import { columnFinder, createQuery } from "metabase-lib/test-helpers";
+import {
+  DEFAULT_TEST_QUERY,
+  columnFinder,
+  createMetadataProvider,
+} from "metabase-lib/test-helpers";
 import { createMockField } from "metabase-types/api/mocks";
 import {
   ORDERS_ID,
@@ -47,8 +51,10 @@ const METADATA = createMockMetadata({
   ],
 });
 
+const PROVIDER = createMetadataProvider({ metadata: METADATA });
+
 describe("useDefaultFilter", () => {
-  const defaultQuery = createQuery({ metadata: METADATA });
+  const defaultQuery = Lib.createTestQuery(PROVIDER, DEFAULT_TEST_QUERY);
   const stageIndex = 0;
   const availableColumns = Lib.filterableColumns(defaultQuery, stageIndex);
   const column = columnFinder(defaultQuery, availableColumns)(

--- a/frontend/src/metabase/querying/filters/hooks/use-number-filter/use-number-filter.unit.spec.ts
+++ b/frontend/src/metabase/querying/filters/hooks/use-number-filter/use-number-filter.unit.spec.ts
@@ -3,7 +3,11 @@ import { act, renderHook } from "@testing-library/react";
 import { createMockMetadata } from "__support__/metadata";
 import { checkNotNull } from "metabase/lib/types";
 import * as Lib from "metabase-lib";
-import { columnFinder, createQuery } from "metabase-lib/test-helpers";
+import {
+  DEFAULT_TEST_QUERY,
+  columnFinder,
+  createMetadataProvider,
+} from "metabase-lib/test-helpers";
 import {
   createOrdersIdField,
   createOrdersProductIdField,
@@ -67,8 +71,10 @@ const METADATA = createMockMetadata({
   ],
 });
 
+const PROVIDER = createMetadataProvider({ metadata: METADATA });
+
 describe("useNumberFilter", () => {
-  const defaultQuery = createQuery({ metadata: METADATA });
+  const defaultQuery = Lib.createTestQuery(PROVIDER, DEFAULT_TEST_QUERY);
   const stageIndex = 0;
   const availableColumns = Lib.filterableColumns(defaultQuery, stageIndex);
   const findColumn = columnFinder(defaultQuery, availableColumns);

--- a/frontend/src/metabase/querying/filters/hooks/use-string-filter/use-string-filter.unit.spec.ts
+++ b/frontend/src/metabase/querying/filters/hooks/use-string-filter/use-string-filter.unit.spec.ts
@@ -3,7 +3,11 @@ import { act, renderHook } from "@testing-library/react";
 import { createMockMetadata } from "__support__/metadata";
 import { checkNotNull } from "metabase/lib/types";
 import * as Lib from "metabase-lib";
-import { columnFinder, createQuery } from "metabase-lib/test-helpers";
+import {
+  DEFAULT_TEST_QUERY,
+  columnFinder,
+  createMetadataProvider,
+} from "metabase-lib/test-helpers";
 import {
   createOrdersIdField,
   createOrdersProductIdField,
@@ -78,8 +82,10 @@ const METADATA = createMockMetadata({
   ],
 });
 
+const PROVIDER = createMetadataProvider({ metadata: METADATA });
+
 describe("useStringFilter", () => {
-  const defaultQuery = createQuery({ metadata: METADATA });
+  const defaultQuery = Lib.createTestQuery(PROVIDER, DEFAULT_TEST_QUERY);
   const stageIndex = 0;
   const availableColumns = Lib.filterableColumns(defaultQuery, stageIndex);
   const findColumn = columnFinder(defaultQuery, availableColumns);

--- a/frontend/src/metabase/querying/filters/hooks/use-time-filter/use-time-filter.unit.spec.ts
+++ b/frontend/src/metabase/querying/filters/hooks/use-time-filter/use-time-filter.unit.spec.ts
@@ -3,7 +3,11 @@ import { act, renderHook } from "@testing-library/react";
 import { createMockMetadata } from "__support__/metadata";
 import { checkNotNull } from "metabase/lib/types";
 import * as Lib from "metabase-lib";
-import { columnFinder, createQuery } from "metabase-lib/test-helpers";
+import {
+  DEFAULT_TEST_QUERY,
+  columnFinder,
+  createMetadataProvider,
+} from "metabase-lib/test-helpers";
 import { createMockField } from "metabase-types/api/mocks";
 import {
   ORDERS_ID,
@@ -63,8 +67,10 @@ const METADATA = createMockMetadata({
   ],
 });
 
+const PROVIDER = createMetadataProvider({ metadata: METADATA });
+
 describe("useTimeFilter", () => {
-  const defaultQuery = createQuery({ metadata: METADATA });
+  const defaultQuery = Lib.createTestQuery(PROVIDER, DEFAULT_TEST_QUERY);
   const stageIndex = 0;
   const availableColumns = Lib.filterableColumns(defaultQuery, stageIndex);
   const column = columnFinder(defaultQuery, availableColumns)(

--- a/frontend/src/metabase/querying/filters/utils/dates.unit.spec.ts
+++ b/frontend/src/metabase/querying/filters/utils/dates.unit.spec.ts
@@ -1,7 +1,11 @@
 import { setLocalization } from "metabase/lib/i18n";
 import type { DateFilterValue } from "metabase/querying/common/types";
 import * as Lib from "metabase-lib";
-import { columnFinder, createQuery } from "metabase-lib/test-helpers";
+import {
+  DEFAULT_TEST_QUERY,
+  SAMPLE_PROVIDER,
+  columnFinder,
+} from "metabase-lib/test-helpers";
 import type { DateFormattingSettings } from "metabase-types/api";
 
 import {
@@ -16,7 +20,7 @@ type DateFilterClauseCase = {
 };
 
 describe("getDateFilterClause", () => {
-  const query = createQuery();
+  const query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY);
   const stageIndex = 0;
   const columns = Lib.filterableColumns(query, stageIndex);
   const findColumn = columnFinder(query, columns);

--- a/frontend/src/metabase/querying/notebook/components/AggregateStep/AggregateStep.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/AggregateStep/AggregateStep.unit.spec.tsx
@@ -7,8 +7,13 @@ import {
   screen,
 } from "__support__/ui";
 import * as Lib from "metabase-lib";
-import { createQueryWithClauses } from "metabase-lib/test-helpers";
+import {
+  SAMPLE_DATABASE,
+  SAMPLE_PROVIDER,
+  createTestQuery,
+} from "metabase-lib/test-helpers";
 import { createMockCard } from "metabase-types/api/mocks";
+import { ORDERS_ID } from "metabase-types/api/mocks/presets";
 import {
   createMockQueryBuilderState,
   createMockState,
@@ -20,9 +25,22 @@ import type { NotebookStep } from "../../types";
 import { AggregateStep } from "./AggregateStep";
 
 function createAggregatedQuery() {
-  return createQueryWithClauses({
-    aggregations: [
-      { operatorName: "avg", tableName: "ORDERS", columnName: "QUANTITY" },
+  return createTestQuery(SAMPLE_PROVIDER, {
+    databaseId: SAMPLE_DATABASE.id,
+    stages: [
+      {
+        source: {
+          type: "table",
+          id: ORDERS_ID,
+        },
+        aggregations: [
+          {
+            type: "operator",
+            operator: "avg",
+            args: [{ type: "column", groupName: "Orders", name: "QUANTITY" }],
+          },
+        ],
+      },
     ],
   });
 }
@@ -85,12 +103,26 @@ describe("AggregateStep", () => {
   it("should use foreign key name for foreign table columns", () => {
     setup({
       step: createMockNotebookStep({
-        query: createQueryWithClauses({
-          aggregations: [
+        query: createTestQuery(SAMPLE_PROVIDER, {
+          databaseId: SAMPLE_DATABASE.id,
+          stages: [
             {
-              operatorName: "avg",
-              tableName: "PRODUCTS",
-              columnName: "RATING",
+              source: {
+                type: "table",
+                id: ORDERS_ID,
+              },
+              aggregations: [
+                {
+                  type: "operator",
+                  operator: "avg",
+                  args: [
+                    {
+                      type: "column",
+                      name: "RATING",
+                    },
+                  ],
+                },
+              ],
             },
           ],
         }),
@@ -180,8 +212,17 @@ describe("AggregateStep", () => {
     // TODO: unskip this once we enable "Compare to the past" again
     // eslint-disable-next-line jest/no-disabled-tests
     it.skip("should not allow to use temporal comparisons for metrics", async () => {
-      const query = createQueryWithClauses({
-        aggregations: [{ operatorName: "count" }],
+      const query = createTestQuery(SAMPLE_PROVIDER, {
+        databaseId: SAMPLE_DATABASE.id,
+        stages: [
+          {
+            source: {
+              type: "table",
+              id: ORDERS_ID,
+            },
+            aggregations: [{ type: "operator", operator: "count", args: [] }],
+          },
+        ],
       });
       const question = DEFAULT_QUESTION.setType("metric").setQuery(query);
       const step = createMockNotebookStep({ question, query });
@@ -195,8 +236,17 @@ describe("AggregateStep", () => {
     // TODO: unskip this once we enable "Compare to the past" again
     // eslint-disable-next-line jest/no-disabled-tests
     it.skip("should allow to use temporal comparisons for non-metrics", async () => {
-      const query = createQueryWithClauses({
-        aggregations: [{ operatorName: "count" }],
+      const query = createTestQuery(SAMPLE_PROVIDER, {
+        databaseId: SAMPLE_DATABASE.id,
+        stages: [
+          {
+            source: {
+              type: "table",
+              id: ORDERS_ID,
+            },
+            aggregations: [{ type: "operator", operator: "count", args: [] }],
+          },
+        ],
       });
       const question = DEFAULT_QUESTION.setType("question").setQuery(query);
       const step = createMockNotebookStep({ question, query });

--- a/frontend/src/metabase/querying/notebook/components/AggregateStep/AggregateStep.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/AggregateStep/AggregateStep.unit.spec.tsx
@@ -7,11 +7,7 @@ import {
   screen,
 } from "__support__/ui";
 import * as Lib from "metabase-lib";
-import {
-  SAMPLE_DATABASE,
-  SAMPLE_PROVIDER,
-  createTestQuery,
-} from "metabase-lib/test-helpers";
+import { SAMPLE_DATABASE, SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
 import { createMockCard } from "metabase-types/api/mocks";
 import { ORDERS_ID } from "metabase-types/api/mocks/presets";
 import {
@@ -25,8 +21,7 @@ import type { NotebookStep } from "../../types";
 import { AggregateStep } from "./AggregateStep";
 
 function createAggregatedQuery() {
-  return createTestQuery(SAMPLE_PROVIDER, {
-    databaseId: SAMPLE_DATABASE.id,
+  return Lib.createTestQuery(SAMPLE_PROVIDER, {
     stages: [
       {
         source: {
@@ -37,7 +32,7 @@ function createAggregatedQuery() {
           {
             type: "operator",
             operator: "avg",
-            args: [{ type: "column", groupName: "Orders", name: "QUANTITY" }],
+            args: [{ type: "column", sourceName: "Orders", name: "QUANTITY" }],
           },
         ],
       },
@@ -103,8 +98,7 @@ describe("AggregateStep", () => {
   it("should use foreign key name for foreign table columns", () => {
     setup({
       step: createMockNotebookStep({
-        query: createTestQuery(SAMPLE_PROVIDER, {
-          databaseId: SAMPLE_DATABASE.id,
+        query: Lib.createTestQuery(SAMPLE_PROVIDER, {
           stages: [
             {
               source: {
@@ -212,8 +206,7 @@ describe("AggregateStep", () => {
     // TODO: unskip this once we enable "Compare to the past" again
     // eslint-disable-next-line jest/no-disabled-tests
     it.skip("should not allow to use temporal comparisons for metrics", async () => {
-      const query = createTestQuery(SAMPLE_PROVIDER, {
-        databaseId: SAMPLE_DATABASE.id,
+      const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
         stages: [
           {
             source: {
@@ -236,8 +229,7 @@ describe("AggregateStep", () => {
     // TODO: unskip this once we enable "Compare to the past" again
     // eslint-disable-next-line jest/no-disabled-tests
     it.skip("should allow to use temporal comparisons for non-metrics", async () => {
-      const query = createTestQuery(SAMPLE_PROVIDER, {
-        databaseId: SAMPLE_DATABASE.id,
+      const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
         stages: [
           {
             source: {

--- a/frontend/src/metabase/querying/notebook/components/AggregateStep/AggregateStep.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/AggregateStep/AggregateStep.unit.spec.tsx
@@ -32,7 +32,7 @@ function createAggregatedQuery() {
           {
             type: "operator",
             operator: "avg",
-            args: [{ type: "column", sourceName: "Orders", name: "QUANTITY" }],
+            args: [{ type: "column", sourceName: "ORDERS", name: "QUANTITY" }],
           },
         ],
       },

--- a/frontend/src/metabase/querying/notebook/components/AggregateStep/AggregateStep.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/AggregateStep/AggregateStep.unit.spec.tsx
@@ -7,7 +7,7 @@ import {
   screen,
 } from "__support__/ui";
 import * as Lib from "metabase-lib";
-import { SAMPLE_DATABASE, SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
+import { SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
 import { createMockCard } from "metabase-types/api/mocks";
 import { ORDERS_ID } from "metabase-types/api/mocks/presets";
 import {

--- a/frontend/src/metabase/querying/notebook/components/BreakoutStep/BreakoutStep.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/BreakoutStep/BreakoutStep.unit.spec.tsx
@@ -10,8 +10,9 @@ import {
   within,
 } from "__support__/ui";
 import * as Lib from "metabase-lib";
-import { SAMPLE_DATABASE, SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
+import { SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
 import Question from "metabase-lib/v1/Question";
+import type { TemporalUnit } from "metabase-types/api";
 import { createMockCard } from "metabase-types/api/mocks";
 import {
   ORDERS_ID,
@@ -24,7 +25,6 @@ import { DEFAULT_QUESTION, createMockNotebookStep } from "../../test-utils";
 import type { NotebookStep } from "../../types";
 
 import { BreakoutStep } from "./BreakoutStep";
-import { TemporalUnit } from "metabase-types/api";
 
 function createQueryWithBreakout() {
   return Lib.createTestQuery(SAMPLE_PROVIDER, {

--- a/frontend/src/metabase/querying/notebook/components/BreakoutStep/BreakoutStep.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/BreakoutStep/BreakoutStep.unit.spec.tsx
@@ -10,11 +10,7 @@ import {
   within,
 } from "__support__/ui";
 import * as Lib from "metabase-lib";
-import {
-  SAMPLE_DATABASE,
-  SAMPLE_PROVIDER,
-  createTestQuery,
-} from "metabase-lib/test-helpers";
+import { SAMPLE_DATABASE, SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
 import Question from "metabase-lib/v1/Question";
 import { createMockCard } from "metabase-types/api/mocks";
 import {
@@ -28,17 +24,17 @@ import { DEFAULT_QUESTION, createMockNotebookStep } from "../../test-utils";
 import type { NotebookStep } from "../../types";
 
 import { BreakoutStep } from "./BreakoutStep";
+import { TemporalUnit } from "metabase-types/api";
 
 function createQueryWithBreakout() {
-  return createTestQuery(SAMPLE_PROVIDER, {
-    databaseId: SAMPLE_DATABASE.id,
+  return Lib.createTestQuery(SAMPLE_PROVIDER, {
     stages: [
       {
         source: {
           type: "table",
           id: ORDERS_ID,
         },
-        breakouts: [{ name: "TAX" }],
+        breakouts: [{ type: "column", name: "TAX" }],
       },
     ],
   });
@@ -47,23 +43,7 @@ function createQueryWithBreakout() {
 function createQueryWithBreakoutAndBinningCount(
   binningCount: number | undefined,
 ) {
-  return createTestQuery(SAMPLE_PROVIDER, {
-    databaseId: SAMPLE_DATABASE.id,
-    stages: [
-      {
-        source: {
-          type: "table",
-          id: ORDERS_ID,
-        },
-        breakouts: [{ name: "TAX", binningCount }],
-      },
-    ],
-  });
-}
-
-function createQueryWithMultipleBreakoutsAndBinningStrategy() {
-  return createTestQuery(SAMPLE_PROVIDER, {
-    databaseId: SAMPLE_DATABASE.id,
+  return Lib.createTestQuery(SAMPLE_PROVIDER, {
     stages: [
       {
         source: {
@@ -71,8 +51,28 @@ function createQueryWithMultipleBreakoutsAndBinningStrategy() {
           id: ORDERS_ID,
         },
         breakouts: [
-          { name: "TAX", binningCount: 10 },
-          { name: "TAX", binningCount: 50 },
+          {
+            type: "column",
+            name: "TAX",
+            bins: binningCount,
+          },
+        ],
+      },
+    ],
+  });
+}
+
+function createQueryWithMultipleBreakoutsAndBinningStrategy() {
+  return Lib.createTestQuery(SAMPLE_PROVIDER, {
+    stages: [
+      {
+        source: {
+          type: "table",
+          id: ORDERS_ID,
+        },
+        breakouts: [
+          { type: "column", name: "TAX", bins: 10 },
+          { type: "column", name: "TAX", bins: 50 },
         ],
       },
     ],
@@ -80,25 +80,9 @@ function createQueryWithMultipleBreakoutsAndBinningStrategy() {
 }
 
 function createQueryWithBreakoutAndTemporalBucket(
-  temporalBucketName: string | undefined,
+  temporalBucketName: TemporalUnit | undefined,
 ) {
-  return createTestQuery(SAMPLE_PROVIDER, {
-    databaseId: SAMPLE_DATABASE.id,
-    stages: [
-      {
-        source: {
-          type: "table",
-          id: ORDERS_ID,
-        },
-        breakouts: [{ name: "CREATED_AT", unit: temporalBucketName }],
-      },
-    ],
-  });
-}
-
-function createQueryWithMultipleBreakoutsAndTemporalBucket() {
-  return createTestQuery(SAMPLE_PROVIDER, {
-    databaseId: SAMPLE_DATABASE.id,
+  return Lib.createTestQuery(SAMPLE_PROVIDER, {
     stages: [
       {
         source: {
@@ -106,8 +90,24 @@ function createQueryWithMultipleBreakoutsAndTemporalBucket() {
           id: ORDERS_ID,
         },
         breakouts: [
-          { name: "CREATED_AT", unit: "year" },
-          { name: "CREATED_AT", unit: "month" },
+          { type: "column", name: "CREATED_AT", unit: temporalBucketName },
+        ],
+      },
+    ],
+  });
+}
+
+function createQueryWithMultipleBreakoutsAndTemporalBucket() {
+  return Lib.createTestQuery(SAMPLE_PROVIDER, {
+    stages: [
+      {
+        source: {
+          type: "table",
+          id: ORDERS_ID,
+        },
+        breakouts: [
+          { type: "column", name: "CREATED_AT", unit: "year" },
+          { type: "column", name: "CREATED_AT", unit: "month" },
         ],
       },
     ],
@@ -571,15 +571,14 @@ describe("BreakoutStep", () => {
     });
 
     it("should not allow to add more than 1 breakout", async () => {
-      const query = createTestQuery(SAMPLE_PROVIDER, {
-        databaseId: SAMPLE_DATABASE.id,
+      const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
         stages: [
           {
             source: {
               type: "table",
               id: ORDERS_ID,
             },
-            breakouts: [{ name: "CREATED_AT" }],
+            breakouts: [{ type: "column", name: "CREATED_AT" }],
           },
         ],
       });

--- a/frontend/src/metabase/querying/notebook/components/BreakoutStep/BreakoutStep.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/BreakoutStep/BreakoutStep.unit.spec.tsx
@@ -34,7 +34,13 @@ function createQueryWithBreakout() {
           type: "table",
           id: ORDERS_ID,
         },
-        breakouts: [{ type: "column", name: "TAX" }],
+        breakouts: [
+          {
+            type: "column",
+            sourceName: "ORDERS",
+            name: "TAX",
+          },
+        ],
       },
     ],
   });
@@ -53,6 +59,7 @@ function createQueryWithBreakoutAndBinningCount(
         breakouts: [
           {
             type: "column",
+            sourceName: "ORDERS",
             name: "TAX",
             bins: binningCount,
           },
@@ -71,8 +78,8 @@ function createQueryWithMultipleBreakoutsAndBinningStrategy() {
           id: ORDERS_ID,
         },
         breakouts: [
-          { type: "column", name: "TAX", bins: 10 },
-          { type: "column", name: "TAX", bins: 50 },
+          { type: "column", sourceName: "ORDERS", name: "TAX", bins: 10 },
+          { type: "column", sourceName: "ORDERS", name: "TAX", bins: 50 },
         ],
       },
     ],
@@ -90,7 +97,12 @@ function createQueryWithBreakoutAndTemporalBucket(
           id: ORDERS_ID,
         },
         breakouts: [
-          { type: "column", name: "CREATED_AT", unit: temporalBucketName },
+          {
+            type: "column",
+            sourceName: "ORDERS",
+            name: "CREATED_AT",
+            unit: temporalBucketName,
+          },
         ],
       },
     ],
@@ -106,8 +118,18 @@ function createQueryWithMultipleBreakoutsAndTemporalBucket() {
           id: ORDERS_ID,
         },
         breakouts: [
-          { type: "column", name: "CREATED_AT", unit: "year" },
-          { type: "column", name: "CREATED_AT", unit: "month" },
+          {
+            type: "column",
+            sourceName: "ORDERS",
+            name: "CREATED_AT",
+            unit: "year",
+          },
+          {
+            type: "column",
+            sourceName: "ORDERS",
+            name: "CREATED_AT",
+            unit: "month",
+          },
         ],
       },
     ],
@@ -578,7 +600,9 @@ describe("BreakoutStep", () => {
               type: "table",
               id: ORDERS_ID,
             },
-            breakouts: [{ type: "column", name: "CREATED_AT" }],
+            breakouts: [
+              { type: "column", sourceName: "ORDERS", name: "CREATED_AT" },
+            ],
           },
         ],
       });

--- a/frontend/src/metabase/querying/notebook/components/DataStep/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/DataStep/tests/common.unit.spec.tsx
@@ -10,7 +10,6 @@ import {
   DEFAULT_TEST_QUERY,
   SAMPLE_PROVIDER,
   columnFinder,
-  findAggregationOperator,
 } from "metabase-lib/test-helpers";
 import Question from "metabase-lib/v1/Question";
 import type { CardType } from "metabase-types/api";
@@ -24,6 +23,21 @@ import {
 import { DEFAULT_QUESTION, createMockNotebookStep } from "../../../test-utils";
 
 import { type SetupOpts, setup as baseSetup } from "./setup";
+
+const findAggregationOperator = (
+  query: Lib.Query,
+  operatorShortName: string,
+) => {
+  const operators = Lib.availableAggregationOperators(query, 0);
+  const operator = operators.find(
+    (operator) =>
+      Lib.displayInfo(query, 0, operator).shortName === operatorShortName,
+  );
+  if (!operator) {
+    throw new Error(`Could not find aggregation operator ${operatorShortName}`);
+  }
+  return operator;
+};
 
 const createQueryWithFields = (columnNames: string[]) => {
   return Lib.createTestQuery(SAMPLE_PROVIDER, {

--- a/frontend/src/metabase/querying/notebook/components/DataStep/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/DataStep/tests/common.unit.spec.tsx
@@ -7,13 +7,15 @@ import { checkNotNull } from "metabase/lib/types";
 import type { IconName } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import {
+  DEFAULT_TEST_QUERY,
+  SAMPLE_PROVIDER,
   columnFinder,
-  createQuery,
   findAggregationOperator,
 } from "metabase-lib/test-helpers";
 import Question from "metabase-lib/v1/Question";
 import type { CardType } from "metabase-types/api";
 import {
+  ORDERS_ID,
   SAMPLE_DB_ID,
   createSampleDatabase,
   createSavedStructuredCard,
@@ -24,21 +26,29 @@ import { DEFAULT_QUESTION, createMockNotebookStep } from "../../../test-utils";
 import { type SetupOpts, setup as baseSetup } from "./setup";
 
 const createQueryWithFields = (columnNames: string[]) => {
-  const query = createQuery();
-  const findColumn = columnFinder(query, Lib.fieldableColumns(query, 0));
-  const columns = columnNames.map((name) => findColumn("ORDERS", name));
-  return Lib.withFields(query, 0, columns);
+  return Lib.createTestQuery(SAMPLE_PROVIDER, {
+    stages: [
+      {
+        source: { type: "table", id: ORDERS_ID },
+        fields: columnNames.map((name) => ({
+          type: "column",
+          sourceName: "ORDERS",
+          name,
+        })),
+      },
+    ],
+  });
 };
 
 const createQueryWithAggregation = () => {
-  const query = createQuery();
+  const query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY);
   const count = findAggregationOperator(query, "count");
   const aggregation = Lib.aggregationClause(count);
   return Lib.aggregate(query, 0, aggregation);
 };
 
 const createQueryWithBreakout = () => {
-  const query = createQuery();
+  const query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY);
   const columns = Lib.breakoutableColumns(query, 0);
   const findColumn = columnFinder(query, columns);
   const column = findColumn("ORDERS", "TAX");

--- a/frontend/src/metabase/querying/notebook/components/ExpressionStep/ExpressionStep.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/ExpressionStep/ExpressionStep.unit.spec.tsx
@@ -2,7 +2,13 @@ import userEvent from "@testing-library/user-event";
 
 import { renderWithProviders, screen, within } from "__support__/ui";
 import * as Lib from "metabase-lib";
-import { createQuery, createQueryWithClauses } from "metabase-lib/test-helpers";
+import {
+  SAMPLE_DATABASE,
+  SAMPLE_PROVIDER,
+  createQuery,
+  createTestQuery,
+} from "metabase-lib/test-helpers";
+import { ORDERS_ID } from "metabase-types/api/mocks/presets";
 
 import { createMockNotebookStep } from "../../test-utils";
 
@@ -66,8 +72,29 @@ describe("Notebook Editor > Expression Step", () => {
   });
 
   it("should handle updating existing expression", async () => {
-    const query = createQueryWithClauses({
-      expressions: [{ name: "old name", operator: "+", args: [1, 1] }],
+    const query = createTestQuery(SAMPLE_PROVIDER, {
+      databaseId: SAMPLE_DATABASE.id,
+      stages: [
+        {
+          source: {
+            type: "table",
+            id: ORDERS_ID,
+          },
+          expressions: [
+            {
+              name: "old name",
+              value: {
+                type: "operator",
+                operator: "+",
+                args: [
+                  { type: "literal", value: 1 },
+                  { type: "literal", value: 1 },
+                ],
+              },
+            },
+          ],
+        },
+      ],
     });
     const { getRecentQuery } = setup({ query });
 
@@ -86,8 +113,29 @@ describe("Notebook Editor > Expression Step", () => {
   });
 
   it("should handle removing existing expression", async () => {
-    const query = createQueryWithClauses({
-      expressions: [{ name: "expression name", operator: "+", args: [1, 1] }],
+    const query = createTestQuery(SAMPLE_PROVIDER, {
+      databaseId: SAMPLE_DATABASE.id,
+      stages: [
+        {
+          source: {
+            type: "table",
+            id: ORDERS_ID,
+          },
+          expressions: [
+            {
+              name: "expression name",
+              value: {
+                type: "operator",
+                operator: "+",
+                args: [
+                  { type: "literal", value: 1 },
+                  { type: "literal", value: 1 },
+                ],
+              },
+            },
+          ],
+        },
+      ],
     });
     const { getRecentQuery } = setup({ query });
 

--- a/frontend/src/metabase/querying/notebook/components/ExpressionStep/ExpressionStep.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/ExpressionStep/ExpressionStep.unit.spec.tsx
@@ -6,7 +6,6 @@ import {
   SAMPLE_DATABASE,
   SAMPLE_PROVIDER,
   createQuery,
-  createTestQuery,
 } from "metabase-lib/test-helpers";
 import { ORDERS_ID } from "metabase-types/api/mocks/presets";
 
@@ -72,8 +71,7 @@ describe("Notebook Editor > Expression Step", () => {
   });
 
   it("should handle updating existing expression", async () => {
-    const query = createTestQuery(SAMPLE_PROVIDER, {
-      databaseId: SAMPLE_DATABASE.id,
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
       stages: [
         {
           source: {
@@ -113,8 +111,7 @@ describe("Notebook Editor > Expression Step", () => {
   });
 
   it("should handle removing existing expression", async () => {
-    const query = createTestQuery(SAMPLE_PROVIDER, {
-      databaseId: SAMPLE_DATABASE.id,
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
       stages: [
         {
           source: {

--- a/frontend/src/metabase/querying/notebook/components/ExpressionStep/ExpressionStep.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/ExpressionStep/ExpressionStep.unit.spec.tsx
@@ -2,11 +2,7 @@ import userEvent from "@testing-library/user-event";
 
 import { renderWithProviders, screen, within } from "__support__/ui";
 import * as Lib from "metabase-lib";
-import {
-  SAMPLE_DATABASE,
-  SAMPLE_PROVIDER,
-  createQuery,
-} from "metabase-lib/test-helpers";
+import { DEFAULT_TEST_QUERY, SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
 import { ORDERS_ID } from "metabase-types/api/mocks/presets";
 
 import { createMockNotebookStep } from "../../test-utils";
@@ -17,7 +13,9 @@ interface SetupOpts {
   query?: Lib.Query;
 }
 
-function setup({ query = createQuery() }: SetupOpts = {}) {
+function setup({
+  query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY),
+}: SetupOpts = {}) {
   const updateQuery = jest.fn();
 
   const step = createMockNotebookStep({

--- a/frontend/src/metabase/querying/notebook/components/FilterStep/FilterStep.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/FilterStep/FilterStep.unit.spec.tsx
@@ -1,18 +1,28 @@
 import { renderWithProviders, screen } from "__support__/ui";
 import * as Lib from "metabase-lib";
-import { columnFinder, createQuery } from "metabase-lib/test-helpers";
+import { SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
+import { ORDERS_ID } from "metabase-types/api/mocks/presets";
 
 import { createMockNotebookStep } from "../../test-utils";
 
 import { FilterStep } from "./FilterStep";
 
 function createQueryWithFilter() {
-  const initialQuery = createQuery();
-  const columns = Lib.filterableColumns(initialQuery, 0);
-  const findColumn = columnFinder(initialQuery, columns);
-  const totalColumn = findColumn("ORDERS", "TOTAL");
-  const clause = Lib.expressionClause(">", [totalColumn, 20], null);
-  const query = Lib.filter(initialQuery, 0, clause);
+  const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
+    stages: [
+      {
+        source: { type: "table", id: ORDERS_ID },
+        filters: [
+          {
+            type: "operator",
+            operator: ">",
+            args: [{ type: "column", sourceName: "ORDERS", name: "TOTAL" }],
+          },
+        ],
+      },
+    ],
+  });
+
   const [filter] = Lib.filters(query, 0);
   return { query, filter };
 }

--- a/frontend/src/metabase/querying/notebook/components/FilterStep/FilterStep.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/FilterStep/FilterStep.unit.spec.tsx
@@ -16,7 +16,10 @@ function createQueryWithFilter() {
           {
             type: "operator",
             operator: ">",
-            args: [{ type: "column", sourceName: "ORDERS", name: "TOTAL" }],
+            args: [
+              { type: "column", sourceName: "ORDERS", name: "TOTAL" },
+              { type: "literal", value: 20 },
+            ],
           },
         ],
       },

--- a/frontend/src/metabase/querying/notebook/components/LimitStep/LimitStep.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/LimitStep/LimitStep.unit.spec.tsx
@@ -1,12 +1,16 @@
 import { fireEvent, render, screen } from "__support__/ui";
 import * as Lib from "metabase-lib";
+import { SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
+import { ORDERS_ID } from "metabase-types/api/mocks/presets";
 
-import { DEFAULT_QUERY, createMockNotebookStep } from "../../test-utils";
+import { createMockNotebookStep } from "../../test-utils";
 
 import { LimitStep } from "./LimitStep";
 
 const DEFAULT_LIMIT = 10;
-const QUERY_WITH_LIMIT = Lib.limit(DEFAULT_QUERY, 0, DEFAULT_LIMIT);
+const QUERY_WITH_LIMIT = Lib.createTestQuery(SAMPLE_PROVIDER, {
+  stages: [{ source: { type: "table", id: ORDERS_ID }, limit: DEFAULT_LIMIT }],
+});
 
 function setup(step = createMockNotebookStep()) {
   const updateQuery = jest.fn();

--- a/frontend/src/metabase/querying/notebook/components/Notebook/Notebook.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/Notebook/Notebook.unit.spec.tsx
@@ -29,8 +29,10 @@ import {
 import type { DataPickerValue } from "metabase/common/components/Pickers/DataPicker";
 import { checkNotNull } from "metabase/lib/types";
 import {
+  SAMPLE_DATABASE,
   SAMPLE_METADATA,
-  createQueryWithClauses,
+  SAMPLE_PROVIDER,
+  createTestQuery,
 } from "metabase-lib/test-helpers";
 import Question from "metabase-lib/v1/Question";
 import type { CardType, RecentItem } from "metabase-types/api";
@@ -41,7 +43,10 @@ import {
   createMockRecentCollectionItem,
   createMockRecentTableItem,
 } from "metabase-types/api/mocks";
-import { createSampleDatabase } from "metabase-types/api/mocks/presets";
+import {
+  ORDERS_ID,
+  createSampleDatabase,
+} from "metabase-types/api/mocks/presets";
 
 import { Notebook, type NotebookProps } from "./Notebook";
 
@@ -191,8 +196,14 @@ function setup({
 }
 
 function createSummarizedQuestion(type: CardType) {
-  const query = createQueryWithClauses({
-    aggregations: [{ operatorName: "count" }],
+  const query = createTestQuery(SAMPLE_PROVIDER, {
+    databaseId: SAMPLE_DATABASE.id,
+    stages: [
+      {
+        source: { type: "table", id: ORDERS_ID },
+        aggregations: [{ type: "operator", operator: "count", args: [] }],
+      },
+    ],
   });
   return new Question(createMockCard({ type }), SAMPLE_METADATA).setQuery(
     query,

--- a/frontend/src/metabase/querying/notebook/components/Notebook/Notebook.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/Notebook/Notebook.unit.spec.tsx
@@ -1,5 +1,4 @@
 import userEvent from "@testing-library/user-event";
-import * as Lib from "metabase-lib";
 
 import {
   setupCollectionByIdEndpoint,
@@ -29,11 +28,8 @@ import {
 } from "metabase/browse/models/test-utils";
 import type { DataPickerValue } from "metabase/common/components/Pickers/DataPicker";
 import { checkNotNull } from "metabase/lib/types";
-import {
-  SAMPLE_DATABASE,
-  SAMPLE_METADATA,
-  SAMPLE_PROVIDER,
-} from "metabase-lib/test-helpers";
+import * as Lib from "metabase-lib";
+import { SAMPLE_METADATA, SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
 import Question from "metabase-lib/v1/Question";
 import type { CardType, RecentItem } from "metabase-types/api";
 import {

--- a/frontend/src/metabase/querying/notebook/components/Notebook/Notebook.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/Notebook/Notebook.unit.spec.tsx
@@ -1,4 +1,5 @@
 import userEvent from "@testing-library/user-event";
+import * as Lib from "metabase-lib";
 
 import {
   setupCollectionByIdEndpoint,
@@ -32,7 +33,6 @@ import {
   SAMPLE_DATABASE,
   SAMPLE_METADATA,
   SAMPLE_PROVIDER,
-  createTestQuery,
 } from "metabase-lib/test-helpers";
 import Question from "metabase-lib/v1/Question";
 import type { CardType, RecentItem } from "metabase-types/api";
@@ -196,8 +196,7 @@ function setup({
 }
 
 function createSummarizedQuestion(type: CardType) {
-  const query = createTestQuery(SAMPLE_PROVIDER, {
-    databaseId: SAMPLE_DATABASE.id,
+  const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
     stages: [
       {
         source: { type: "table", id: ORDERS_ID },

--- a/frontend/src/metabase/querying/notebook/components/NotebookStepList/NotebookStepList.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookStepList/NotebookStepList.unit.spec.tsx
@@ -4,10 +4,18 @@ import { createMockMetadata } from "__support__/metadata";
 import { createMockEntitiesState } from "__support__/store";
 import { renderWithProviders, screen } from "__support__/ui";
 import type * as Lib from "metabase-lib";
-import { createQuery, createQueryWithClauses } from "metabase-lib/test-helpers";
+import {
+  SAMPLE_DATABASE,
+  SAMPLE_PROVIDER,
+  createQuery,
+  createTestQuery,
+} from "metabase-lib/test-helpers";
 import Question from "metabase-lib/v1/Question";
 import { createMockCard } from "metabase-types/api/mocks";
-import { createSampleDatabase } from "metabase-types/api/mocks/presets";
+import {
+  ORDERS_ID,
+  createSampleDatabase,
+} from "metabase-types/api/mocks/presets";
 import {
   createMockQueryBuilderState,
   createMockState,
@@ -54,8 +62,14 @@ function setup(opts: SetupOpts = {}, query: Lib.Query = createQuery()) {
 
 describe("NotebookStepList", () => {
   it("renders a list of actions for Summarize step with no breakouts", () => {
-    const query = createQueryWithClauses({
-      aggregations: [{ operatorName: "count" }],
+    const query = createTestQuery(SAMPLE_PROVIDER, {
+      databaseId: SAMPLE_DATABASE.id,
+      stages: [
+        {
+          source: { type: "table", id: ORDERS_ID },
+          aggregations: [{ type: "operator", operator: "count", args: [] }],
+        },
+      ],
     });
     setup({}, query);
 

--- a/frontend/src/metabase/querying/notebook/components/NotebookStepList/NotebookStepList.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookStepList/NotebookStepList.unit.spec.tsx
@@ -3,12 +3,11 @@ import type { ComponentProps } from "react";
 import { createMockMetadata } from "__support__/metadata";
 import { createMockEntitiesState } from "__support__/store";
 import { renderWithProviders, screen } from "__support__/ui";
-import type * as Lib from "metabase-lib";
+import * as Lib from "metabase-lib";
 import {
   SAMPLE_DATABASE,
   SAMPLE_PROVIDER,
   createQuery,
-  createTestQuery,
 } from "metabase-lib/test-helpers";
 import Question from "metabase-lib/v1/Question";
 import { createMockCard } from "metabase-types/api/mocks";
@@ -62,8 +61,7 @@ function setup(opts: SetupOpts = {}, query: Lib.Query = createQuery()) {
 
 describe("NotebookStepList", () => {
   it("renders a list of actions for Summarize step with no breakouts", () => {
-    const query = createTestQuery(SAMPLE_PROVIDER, {
-      databaseId: SAMPLE_DATABASE.id,
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
       stages: [
         {
           source: { type: "table", id: ORDERS_ID },

--- a/frontend/src/metabase/querying/notebook/components/NotebookStepList/NotebookStepList.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookStepList/NotebookStepList.unit.spec.tsx
@@ -4,11 +4,7 @@ import { createMockMetadata } from "__support__/metadata";
 import { createMockEntitiesState } from "__support__/store";
 import { renderWithProviders, screen } from "__support__/ui";
 import * as Lib from "metabase-lib";
-import {
-  SAMPLE_DATABASE,
-  SAMPLE_PROVIDER,
-  createQuery,
-} from "metabase-lib/test-helpers";
+import { DEFAULT_TEST_QUERY, SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
 import Question from "metabase-lib/v1/Question";
 import { createMockCard } from "metabase-types/api/mocks";
 import {
@@ -30,7 +26,10 @@ const metadata = createMockMetadata({
 
 type SetupOpts = Partial<ComponentProps<typeof NotebookStepList>>;
 
-function setup(opts: SetupOpts = {}, query: Lib.Query = createQuery()) {
+function setup(
+  opts: SetupOpts = {},
+  query: Lib.Query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY),
+) {
   const database = createSampleDatabase();
   const reportTimezone = "UTC";
   const question = new Question(createMockCard(), metadata).setQuery(query);

--- a/frontend/src/metabase/querying/notebook/components/SortStep/SortStep.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/SortStep/SortStep.unit.spec.tsx
@@ -7,17 +7,33 @@ import {
   screen,
 } from "__support__/ui";
 import * as Lib from "metabase-lib";
-import { createQuery } from "metabase-lib/test-helpers";
+import { SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
+import { ORDERS_ID } from "metabase-types/api/mocks/presets";
 
 import { createMockNotebookStep } from "../../test-utils";
 
 import { SortStep } from "./SortStep";
 
 function createQueryWithOrderBy(direction: Lib.OrderByDirection = "asc") {
-  const initialQuery = createQuery();
-  const [column] = Lib.orderableColumns(initialQuery, 0);
-  const query = Lib.orderBy(initialQuery, 0, column, direction);
-  return { query, columnInfo: Lib.displayInfo(query, 0, column) };
+  const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
+    stages: [
+      {
+        source: { type: "table", id: ORDERS_ID },
+        orderBys: [
+          {
+            type: "column",
+            sourceName: "ORDERS",
+            name: "CREATED_AT",
+            direction,
+          },
+        ],
+      },
+    ],
+  });
+  const [orderBy] = Lib.orderBys(query, 0);
+  const columnInfo = Lib.displayInfo(query, 0, orderBy);
+
+  return { query, columnInfo };
 }
 
 function setup(step = createMockNotebookStep()) {

--- a/frontend/src/metabase/querying/notebook/utils/steps.unit.spec.ts
+++ b/frontend/src/metabase/querying/notebook/utils/steps.unit.spec.ts
@@ -1,7 +1,11 @@
 import { createMockMetadata } from "__support__/metadata";
 import { checkNotNull } from "metabase/lib/types";
 import * as Lib from "metabase-lib";
-import { createQueryWithClauses } from "metabase-lib/test-helpers";
+import {
+  SAMPLE_DATABASE,
+  SAMPLE_PROVIDER,
+  createTestQuery,
+} from "metabase-lib/test-helpers";
 import Question from "metabase-lib/v1/Question";
 import type { StructuredQuery as StructuredQueryObject } from "metabase-types/api";
 import {
@@ -287,8 +291,14 @@ describe("filtered and summarized query with post-aggregation filter", () => {
 
 describe("aggregated query without breakout", () => {
   it("provides 'join data' and 'custom column' actions", () => {
-    const query = createQueryWithClauses({
-      aggregations: [{ operatorName: "count" }],
+    const query = createTestQuery(SAMPLE_PROVIDER, {
+      databaseId: SAMPLE_DATABASE.id,
+      stages: [
+        {
+          source: { type: "table", id: ORDERS_ID },
+          aggregations: [{ type: "operator", operator: "count", args: [] }],
+        },
+      ],
     });
 
     const question = Question.create({

--- a/frontend/src/metabase/querying/notebook/utils/steps.unit.spec.ts
+++ b/frontend/src/metabase/querying/notebook/utils/steps.unit.spec.ts
@@ -1,11 +1,7 @@
 import { createMockMetadata } from "__support__/metadata";
 import { checkNotNull } from "metabase/lib/types";
 import * as Lib from "metabase-lib";
-import {
-  SAMPLE_DATABASE,
-  SAMPLE_PROVIDER,
-  createTestQuery,
-} from "metabase-lib/test-helpers";
+import { SAMPLE_DATABASE, SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
 import Question from "metabase-lib/v1/Question";
 import type { StructuredQuery as StructuredQueryObject } from "metabase-types/api";
 import {
@@ -291,8 +287,7 @@ describe("filtered and summarized query with post-aggregation filter", () => {
 
 describe("aggregated query without breakout", () => {
   it("provides 'join data' and 'custom column' actions", () => {
-    const query = createTestQuery(SAMPLE_PROVIDER, {
-      databaseId: SAMPLE_DATABASE.id,
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
       stages: [
         {
           source: { type: "table", id: ORDERS_ID },

--- a/frontend/src/metabase/querying/notebook/utils/steps.unit.spec.ts
+++ b/frontend/src/metabase/querying/notebook/utils/steps.unit.spec.ts
@@ -1,7 +1,7 @@
 import { createMockMetadata } from "__support__/metadata";
 import { checkNotNull } from "metabase/lib/types";
 import * as Lib from "metabase-lib";
-import { SAMPLE_DATABASE, SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
+import { SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
 import Question from "metabase-lib/v1/Question";
 import type { StructuredQuery as StructuredQueryObject } from "metabase-types/api";
 import {

--- a/frontend/src/metabase/querying/parameters/utils/query.unit.spec.ts
+++ b/frontend/src/metabase/querying/parameters/utils/query.unit.spec.ts
@@ -2,9 +2,11 @@ import { createMockMetadata } from "__support__/metadata";
 import { isNotNull } from "metabase/lib/types";
 import * as Lib from "metabase-lib";
 import {
+  SAMPLE_DATABASE,
+  SAMPLE_PROVIDER,
   columnFinder,
   createQuery,
-  createQueryWithClauses,
+  createTestQuery,
 } from "metabase-lib/test-helpers";
 import type {
   ParameterTarget,
@@ -368,12 +370,18 @@ describe("applyParameter", () => {
   });
 
   describe("temporal unit parameters", () => {
-    const query = createQueryWithClauses({
-      breakouts: [
+    const query = createTestQuery(SAMPLE_PROVIDER, {
+      databaseId: SAMPLE_DATABASE.id,
+      stages: [
         {
-          tableName: "ORDERS",
-          columnName: "CREATED_AT",
-          temporalBucketName: "Month",
+          source: { type: "table", id: ORDERS_ID },
+          breakouts: [
+            {
+              name: "CREATED_AT",
+              groupName: "Orders",
+              unit: "month",
+            },
+          ],
         },
       ],
     });

--- a/frontend/src/metabase/querying/parameters/utils/query.unit.spec.ts
+++ b/frontend/src/metabase/querying/parameters/utils/query.unit.spec.ts
@@ -2,10 +2,10 @@ import { createMockMetadata } from "__support__/metadata";
 import { isNotNull } from "metabase/lib/types";
 import * as Lib from "metabase-lib";
 import {
-  SAMPLE_DATABASE,
+  DEFAULT_TEST_QUERY,
   SAMPLE_PROVIDER,
   columnFinder,
-  createQuery,
+  createMetadataProvider,
 } from "metabase-lib/test-helpers";
 import type {
   ParameterTarget,
@@ -59,9 +59,11 @@ const METADATA = createMockMetadata({
   ],
 });
 
+const PROVIDER = createMetadataProvider({ metadata: METADATA });
+
 describe("applyParameter", () => {
   describe("filter parameters", () => {
-    const query = createQuery({ metadata: METADATA });
+    const query = Lib.createTestQuery(PROVIDER, DEFAULT_TEST_QUERY);
     const stageIndex = 0;
     const columns = Lib.filterableColumns(query, stageIndex);
     const findColumn = columnFinder(query, columns);
@@ -348,7 +350,9 @@ describe("applyParameter", () => {
     );
 
     it("should ignore parameters with stage index out of range (metabase#55678)", () => {
-      const query = Lib.appendStage(createQuery());
+      const query = Lib.appendStage(
+        Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY),
+      );
       const stageIndex = 1;
       const column = Lib.filterableColumns(query, stageIndex)[0];
       const columnRef = Lib.legacyRef(query, stageIndex, column);
@@ -377,7 +381,7 @@ describe("applyParameter", () => {
             {
               type: "column",
               name: "CREATED_AT",
-              sourceName: "Orders",
+              sourceName: "ORDERS",
               unit: "month",
             },
           ],

--- a/frontend/src/metabase/querying/parameters/utils/query.unit.spec.ts
+++ b/frontend/src/metabase/querying/parameters/utils/query.unit.spec.ts
@@ -6,7 +6,6 @@ import {
   SAMPLE_PROVIDER,
   columnFinder,
   createQuery,
-  createTestQuery,
 } from "metabase-lib/test-helpers";
 import type {
   ParameterTarget,
@@ -370,15 +369,15 @@ describe("applyParameter", () => {
   });
 
   describe("temporal unit parameters", () => {
-    const query = createTestQuery(SAMPLE_PROVIDER, {
-      databaseId: SAMPLE_DATABASE.id,
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
       stages: [
         {
           source: { type: "table", id: ORDERS_ID },
           breakouts: [
             {
+              type: "column",
               name: "CREATED_AT",
-              groupName: "Orders",
+              sourceName: "Orders",
               unit: "month",
             },
           ],

--- a/frontend/src/metabase/querying/viz-settings/utils/sync-viz-settings.unit.spec.tsx
+++ b/frontend/src/metabase/querying/viz-settings/utils/sync-viz-settings.unit.spec.tsx
@@ -1,9 +1,11 @@
 import * as Lib from "metabase-lib";
 import {
+  SAMPLE_DATABASE,
   SAMPLE_METADATA,
+  SAMPLE_PROVIDER,
   columnFinder,
   createQuery,
-  createQueryWithClauses,
+  createTestQuery,
 } from "metabase-lib/test-helpers";
 import type { Series } from "metabase-types/api";
 import {
@@ -13,7 +15,7 @@ import {
   createMockTableColumnOrderSetting,
   createMockVisualizationSettings,
 } from "metabase-types/api/mocks";
-import { SAMPLE_DB_ID } from "metabase-types/api/mocks/presets";
+import { ORDERS_ID, SAMPLE_DB_ID } from "metabase-types/api/mocks/presets";
 
 import {
   type ColumnInfo,
@@ -477,18 +479,44 @@ describe("syncVizSettingsWithQuery", () => {
 
   describe("graph.metrics", () => {
     it("should handle adding new columns", () => {
-      const oldQuery = createQueryWithClauses({
-        aggregations: [
-          { operatorName: "sum", tableName: "ORDERS", columnName: "TOTAL" },
+      const oldQuery = createTestQuery(SAMPLE_PROVIDER, {
+        databaseId: SAMPLE_DATABASE.id,
+        stages: [
+          {
+            source: { type: "table", id: ORDERS_ID },
+            aggregations: [
+              {
+                type: "operator",
+                operator: "sum",
+                args: [{ type: "column", name: "TOTAL", groupName: "Orders" }],
+              },
+            ],
+            breakouts: [{ name: "CREATED_AT", groupName: "Orders" }],
+          },
         ],
-        breakouts: [{ tableName: "ORDERS", columnName: "CREATED_AT" }],
       });
-      const newQuery = createQueryWithClauses({
-        aggregations: [
-          { operatorName: "sum", tableName: "ORDERS", columnName: "TOTAL" },
-          { operatorName: "sum", tableName: "ORDERS", columnName: "SUBTOTAL" },
+      const newQuery = createTestQuery(SAMPLE_PROVIDER, {
+        databaseId: SAMPLE_DATABASE.id,
+        stages: [
+          {
+            source: { type: "table", id: ORDERS_ID },
+            aggregations: [
+              {
+                type: "operator",
+                operator: "sum",
+                args: [{ type: "column", name: "TOTAL", groupName: "Orders" }],
+              },
+              {
+                type: "operator",
+                operator: "sum",
+                args: [
+                  { type: "column", name: "SUBTOTAL", groupName: "Orders" },
+                ],
+              },
+            ],
+            breakouts: [{ name: "CREATED_AT", groupName: "Orders" }],
+          },
         ],
-        breakouts: [{ tableName: "ORDERS", columnName: "CREATED_AT" }],
       });
       const oldSettings = createMockVisualizationSettings({
         "graph.metrics": ["sum"],

--- a/frontend/src/metabase/querying/viz-settings/utils/sync-viz-settings.unit.spec.tsx
+++ b/frontend/src/metabase/querying/viz-settings/utils/sync-viz-settings.unit.spec.tsx
@@ -1,11 +1,5 @@
 import * as Lib from "metabase-lib";
-import {
-  SAMPLE_DATABASE,
-  SAMPLE_METADATA,
-  SAMPLE_PROVIDER,
-  columnFinder,
-  createQuery,
-} from "metabase-lib/test-helpers";
+import { SAMPLE_METADATA, SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
 import type { Series } from "metabase-types/api";
 import {
   createMockCard,
@@ -435,19 +429,31 @@ describe("syncVizSettings", () => {
 describe("syncVizSettingsWithQuery", () => {
   describe("table.columns", () => {
     it("should handle adding new columns with column.name changes", () => {
-      const baseQuery = createQuery();
-      const stageIndex = -1;
-      const availableColumns = Lib.visibleColumns(baseQuery, stageIndex);
-      const findColumn = columnFinder(baseQuery, availableColumns);
-      const oldQuery = Lib.withFields(baseQuery, stageIndex, [
-        findColumn("ORDERS", "ID"),
-        findColumn("PEOPLE", "ID"),
-      ]);
-      const newQuery = Lib.withFields(baseQuery, stageIndex, [
-        findColumn("ORDERS", "ID"),
-        findColumn("PRODUCTS", "ID"),
-        findColumn("PEOPLE", "ID"),
-      ]);
+      const oldQuery = Lib.createTestQuery(SAMPLE_PROVIDER, {
+        stages: [
+          {
+            source: { type: "table", id: ORDERS_ID },
+            fields: [
+              { type: "column", name: "ID", sourceName: "ORDERS" },
+              { type: "column", name: "ID", sourceName: "PEOPLE" },
+            ],
+          },
+        ],
+      });
+
+      const newQuery = Lib.createTestQuery(SAMPLE_PROVIDER, {
+        stages: [
+          {
+            source: { type: "table", id: ORDERS_ID },
+            fields: [
+              { type: "column", name: "ID", sourceName: "ORDERS" },
+              { type: "column", name: "ID", sourceName: "PRODUCTS" },
+              { type: "column", name: "ID", sourceName: "PEOPLE" },
+            ],
+          },
+        ],
+      });
+
       const oldSettings = createMockVisualizationSettings({
         "table.columns": [
           createMockTableColumnOrderSetting({
@@ -486,11 +492,11 @@ describe("syncVizSettingsWithQuery", () => {
               {
                 type: "operator",
                 operator: "sum",
-                args: [{ type: "column", name: "TOTAL", sourceName: "Orders" }],
+                args: [{ type: "column", name: "TOTAL", sourceName: "ORDERS" }],
               },
             ],
             breakouts: [
-              { type: "column", name: "CREATED_AT", sourceName: "Orders" },
+              { type: "column", name: "CREATED_AT", sourceName: "ORDERS" },
             ],
           },
         ],
@@ -503,18 +509,18 @@ describe("syncVizSettingsWithQuery", () => {
               {
                 type: "operator",
                 operator: "sum",
-                args: [{ type: "column", name: "TOTAL", sourceName: "Orders" }],
+                args: [{ type: "column", name: "TOTAL", sourceName: "ORDERS" }],
               },
               {
                 type: "operator",
                 operator: "sum",
                 args: [
-                  { type: "column", name: "SUBTOTAL", sourceName: "Orders" },
+                  { type: "column", name: "SUBTOTAL", sourceName: "ORDERS" },
                 ],
               },
             ],
             breakouts: [
-              { type: "column", name: "CREATED_AT", sourceName: "Orders" },
+              { type: "column", name: "CREATED_AT", sourceName: "ORDERS" },
             ],
           },
         ],

--- a/frontend/src/metabase/querying/viz-settings/utils/sync-viz-settings.unit.spec.tsx
+++ b/frontend/src/metabase/querying/viz-settings/utils/sync-viz-settings.unit.spec.tsx
@@ -5,7 +5,6 @@ import {
   SAMPLE_PROVIDER,
   columnFinder,
   createQuery,
-  createTestQuery,
 } from "metabase-lib/test-helpers";
 import type { Series } from "metabase-types/api";
 import {
@@ -479,8 +478,7 @@ describe("syncVizSettingsWithQuery", () => {
 
   describe("graph.metrics", () => {
     it("should handle adding new columns", () => {
-      const oldQuery = createTestQuery(SAMPLE_PROVIDER, {
-        databaseId: SAMPLE_DATABASE.id,
+      const oldQuery = Lib.createTestQuery(SAMPLE_PROVIDER, {
         stages: [
           {
             source: { type: "table", id: ORDERS_ID },
@@ -488,15 +486,16 @@ describe("syncVizSettingsWithQuery", () => {
               {
                 type: "operator",
                 operator: "sum",
-                args: [{ type: "column", name: "TOTAL", groupName: "Orders" }],
+                args: [{ type: "column", name: "TOTAL", sourceName: "Orders" }],
               },
             ],
-            breakouts: [{ name: "CREATED_AT", groupName: "Orders" }],
+            breakouts: [
+              { type: "column", name: "CREATED_AT", sourceName: "Orders" },
+            ],
           },
         ],
       });
-      const newQuery = createTestQuery(SAMPLE_PROVIDER, {
-        databaseId: SAMPLE_DATABASE.id,
+      const newQuery = Lib.createTestQuery(SAMPLE_PROVIDER, {
         stages: [
           {
             source: { type: "table", id: ORDERS_ID },
@@ -504,17 +503,19 @@ describe("syncVizSettingsWithQuery", () => {
               {
                 type: "operator",
                 operator: "sum",
-                args: [{ type: "column", name: "TOTAL", groupName: "Orders" }],
+                args: [{ type: "column", name: "TOTAL", sourceName: "Orders" }],
               },
               {
                 type: "operator",
                 operator: "sum",
                 args: [
-                  { type: "column", name: "SUBTOTAL", groupName: "Orders" },
+                  { type: "column", name: "SUBTOTAL", sourceName: "Orders" },
                 ],
               },
             ],
-            breakouts: [{ name: "CREATED_AT", groupName: "Orders" }],
+            breakouts: [
+              { type: "column", name: "CREATED_AT", sourceName: "Orders" },
+            ],
           },
         ],
       });

--- a/src/metabase/lib/query/test_spec.cljc
+++ b/src/metabase/lib/query/test_spec.cljc
@@ -59,7 +59,9 @@
     (case (count columns)
       0 (throw (ex-info "No column found" {:columns available-columns, :column-spec column-spec}))
       1 (first columns)
-      (throw (ex-info "Multiple columns found" {:columns columns, :column-spec column-spec})))))
+      (if (:index column-spec)
+        (get columns (:index column-spec))
+        (throw (ex-info "Multiple columns found" {:columns columns, :column-spec column-spec}))))))
 
 (mu/defn- append-fields :- ::lib.schema/query
   [query        :- ::lib.schema/query

--- a/src/metabase/lib/query/test_spec.cljc
+++ b/src/metabase/lib/query/test_spec.cljc
@@ -97,11 +97,15 @@
 
 (mu/defn- matches-binning? :- :boolean
   [strategy       :- ::lib.schema.binning/strategy
-   value          :- [:or ::lib.schema.binning/num-bins ::lib.schema.binning/bin-width]
+   value          :- [:or ::lib.schema.binning/num-bins ::lib.schema.binning/bin-width ::lib.schema.test-spec/test-auto-bin-spec]
    {:keys [mbql]} :- ::lib.schema.binning/binning-option]
-  (and
-   (= strategy (:strategy mbql))
-   (== value (strategy mbql))))
+  (or
+   (and
+    (= :default (:strategy mbql))
+    (= value :auto))
+   (and
+    (= strategy (:strategy mbql))
+    (== value (strategy mbql)))))
 
 (mu/defn- find-binning-strategy :- ::lib.schema.binning/binning-option
   [query        :- ::lib.schema/query

--- a/src/metabase/lib/schema/test_spec.cljc
+++ b/src/metabase/lib/schema/test_spec.cljc
@@ -32,7 +32,8 @@
    [:type [:= {:decode/normalize lib.schema.common/normalize-keyword} :column]]
    [:name string?]
    [:source-name {:optional true} [:maybe string?]]
-   [:display-name {:optional true} [:maybe string?]]])
+   [:display-name {:optional true} [:maybe string?]]
+   [:index {:optional true} [:maybe pos-int?]]])
 
 (mr/def ::test-temporal-bucket-spec
   [:map

--- a/src/metabase/lib/schema/test_spec.cljc
+++ b/src/metabase/lib/schema/test_spec.cljc
@@ -38,13 +38,16 @@
   [:map
    [:unit {:optional true} [:maybe ::lib.schema.temporal-bucketing/unit]]])
 
+(mr/def ::test-auto-bin-spec
+  [:= {:decode/normalize lib.schema.common/normalize-keyword} :auto])
+
 (mr/def ::test-bin-count-bucket-spec
   [:map
-   [:bins {:optional true} [:maybe ::lib.schema.binning/num-bins]]])
+   [:bins {:optional true} [:maybe [:or ::lib.schema.binning/num-bins ::test-auto-bin-spec]]]])
 
 (mr/def ::test-bin-width-bucket-spec
   [:map
-   [:bin-width {:optional true} [:maybe ::lib.schema.binning/bin-width]]])
+   [:bin-width {:optional true} [:maybe [:or ::lib.schema.binning/bin-width ::test-auto-bin-spec]]]])
 
 (mr/def ::test-column-with-binning-spec
   [:merge


### PR DESCRIPTION
Closes QUE-2995

- Removes deprecated test helpers.
- Updates `createTestQuery` to allow picking a column by index as a last-resort disambiguation mechanism when columns really cannot be disambiguated through other means