### PR TITLE
Run-stale-ancestors option for workspace transform execution

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/workspaces/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/api.clj
@@ -937,10 +937,11 @@
         run-ancestors?     (flag-enabled? run_stale_ancestors)
         ancestors-result   (when run-ancestors?
                              (ws.impl/run-stale-ancestors! workspace graph tx-id))
-        ancestors-failed?  (seq (:failed ancestors-result))
-        transform-result   (if ancestors-failed?
+        failed-ancestors   (:failed ancestors-result)
+        transform-result   (if (seq failed-ancestors)
                              {:status  :failed
-                              :message "Ancestor transform failed"
+                              :message (str "Ancestor transform failed: "
+                                            (str/join ", " failed-ancestors))
                               :table   (select-keys (:target transform) [:schema :name])}
                              (ws.impl/run-transform! workspace graph transform))]
     (cond-> transform-result
@@ -968,10 +969,11 @@
         run-ancestors?     (flag-enabled? run_stale_ancestors)
         ancestors-result   (when run-ancestors?
                              (ws.impl/run-stale-ancestors! workspace graph tx-id))
-        ancestors-failed?  (seq (:failed ancestors-result))
-        dry-run-result     (if ancestors-failed?
+        failed-ancestors   (:failed ancestors-result)
+        dry-run-result     (if (seq failed-ancestors)
                              {:status  :failed
-                              :message "Ancestor transform failed"}
+                              :message (str "Ancestor transform failed: "
+                                            (str/join ", " failed-ancestors))}
                              (ws.impl/dry-run-transform workspace graph transform))]
     (cond-> dry-run-result
       run-ancestors? (assoc :ancestors ancestors-result))))

--- a/enterprise/backend/src/metabase_enterprise/workspaces/types.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/types.clj
@@ -7,6 +7,10 @@
 
 (mr/def ::ref-id [:string {:min 1 :api/regex #".+"}])
 
+(mr/def ::flag
+  "Boolean flag that accepts true, false, or 1 (for query param compatibility)."
+  [:or [:= 1] :boolean])
+
 (def entity-types
   "The kinds of entities we can store within a Workspace."
   [{:name  "Transform"
@@ -22,6 +26,13 @@
 (mr/def ::entity-map
   [:map-of ::entity-grouping [:sequential ms/PositiveInt]])
 
+(mr/def ::ancestors-result
+  "Result of running stale ancestor transforms."
+  [:map
+   [:succeeded [:sequential :string]]
+   [:failed [:sequential :string]]
+   [:not_run [:sequential :string]]])
+
 (mr/def ::execution-result
   [:map
    [:status [:enum :succeeded :failed]]
@@ -30,7 +41,8 @@
    [:message {:optional true} [:maybe :string]]
    [:table [:map
             [:name :string]
-            [:schema {:optional true} [:maybe :string]]]]])
+            [:schema {:optional true} [:maybe :string]]]]
+   [:ancestors {:optional true} ::ancestors-result]])
 
 (mr/def ::dry-run-result
   "Result of a transform dry-run (preview without persisting).
@@ -43,7 +55,8 @@
      [:rows {:optional true} [:sequential :any]]
      [:cols {:optional true} [:sequential :map]]
      [:results_metadata {:optional true} [:map
-                                          [:columns {:optional true} [:sequential :map]]]]]]])
+                                          [:columns {:optional true} [:sequential :map]]]]]]
+   [:ancestors {:optional true} ::ancestors-result]])
 
 ;;; ---------------------------------------- Graph/Problem Types ----------------------------------------
 

--- a/enterprise/backend/src/metabase_enterprise/workspaces/types.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/types.clj
@@ -29,9 +29,9 @@
 (mr/def ::ancestors-result
   "Result of running stale ancestor transforms."
   [:map
-   [:succeeded [:sequential :string]]
-   [:failed [:sequential :string]]
-   [:not_run [:sequential :string]]])
+   [:succeeded [:sequential ::ref-id]]
+   [:failed [:sequential ::ref-id]]
+   [:not_run [:sequential ::ref-id]]])
 
 (mr/def ::execution-result
   [:map

--- a/enterprise/backend/test/metabase_enterprise/workspaces/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/api_test.clj
@@ -1299,6 +1299,9 @@
                      :message string?}
                     (mt/user-http-request :crowberto :post 200 (ws-url (:id ws1) "transform" ref-id "dry-run"))))))))))
 
+;; Note: API-level tests for run_stale_ancestors would require real executable transforms.
+;; The core logic is tested in impl_test.clj (run-stale-ancestors-* tests).
+
 (defn- random-target [db-id]
   {:type     "table"
    :database db-id

--- a/enterprise/backend/test/metabase_enterprise/workspaces/impl_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/impl_test.clj
@@ -494,7 +494,12 @@
                                                        :x5 [:t0] :x6 [:x5]
                                                        :x7 [:x2 :x4 :x6]}
                                          :properties  {:x1 {:definition_changed true}
-                                                       :x4 {:definition_changed true}}}}]
+                                                       :x2 {:definition_changed false}
+                                                       :x3 {:definition_changed false}
+                                                       :x4 {:definition_changed true}
+                                                       :x5 {:definition_changed false}
+                                                       :x6 {:definition_changed false}
+                                                       :x7 {:definition_changed false}}}}]
       (let [t1-ref (workspace-map :x1)
             t2-ref (workspace-map :x2)
             t4-ref (workspace-map :x4)
@@ -517,7 +522,8 @@
     (ws.tu/with-resources! [{:keys [workspace-id workspace-map]}
                             {:workspace {:definitions {:x1 [:t0] :x2 [:x1] :x3 [:x2]}
                                          :properties  {:x1 {:definition_changed true}
-                                                       :x2 {:definition_changed true}}}}]
+                                                       :x2 {:definition_changed true}
+                                                       :x3 {:definition_changed false}}}}]
       (let [t1-ref    (workspace-map :x1)
             t2-ref    (workspace-map :x2)
             t3-ref    (workspace-map :x3)
@@ -539,7 +545,8 @@
     (ws.tu/with-resources! [{:keys [workspace-id workspace-map]}
                             {:workspace {:definitions {:x1 [:t0] :x2 [:x1] :x3 [:x2]}
                                          :properties  {:x1 {:definition_changed true}
-                                                       :x2 {:definition_changed true}}}}]
+                                                       :x2 {:definition_changed true}
+                                                       :x3 {:definition_changed false}}}}]
       (let [t1-ref (workspace-map :x1)
             t2-ref (workspace-map :x2)
             t3-ref (workspace-map :x3)]
@@ -559,7 +566,9 @@
 (deftest run-stale-ancestors-no-stale-ancestors-test
   (testing "run-stale-ancestors! returns empty results when no ancestors are stale"
     (ws.tu/with-resources! [{:keys [workspace-id workspace-map]}
-                            {:workspace {:definitions {:x1 [:t0] :x2 [:x1]}}}]
+                            {:workspace {:definitions {:x1 [:t0] :x2 [:x1]}
+                                         :properties  {:x1 {:definition_changed false}
+                                                       :x2 {:definition_changed false}}}}]
       (let [t2-ref (workspace-map :x2)]
         (ws.tu/with-mocked-execution
           (let [workspace (t2/select-one :model/Workspace workspace-id)

--- a/enterprise/backend/test/metabase_enterprise/workspaces/impl_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/impl_test.clj
@@ -425,16 +425,15 @@
           ;; t1 -> t2 -> t3
           graph {:entities     [t1 t2 t3]
                  :dependencies {t2 [t1]
-                                t3 [t2]}}
-          ws-tx? #(= :workspace-transform (:node-type %))]
+                                t3 [t2]}}]
       (testing "t1 has t2 and t3 as descendants"
         (is (= #{"t2" "t3"}
-               (set (ws.impl/downstream-ids graph "t1" ws-tx?)))))
+               (set (ws.impl/downstream-ids graph :workspace-transform "t1")))))
       (testing "t2 has only t3 as descendant"
         (is (= #{"t3"}
-               (set (ws.impl/downstream-ids graph "t2" ws-tx?)))))
+               (set (ws.impl/downstream-ids graph :workspace-transform "t2")))))
       (testing "t3 has no descendants"
-        (is (empty? (ws.impl/downstream-ids graph "t3" ws-tx?)))))))
+        (is (empty? (ws.impl/downstream-ids graph :workspace-transform "t3")))))))
 
 (deftest downstream-ids-diamond-test
   (testing "Diamond graph: computes all downstream paths"
@@ -450,14 +449,13 @@
           graph {:entities     [t1 t2 t3 t4]
                  :dependencies {t2 [t1]
                                 t3 [t1]
-                                t4 [t2 t3]}}
-          ws-tx? #(= :workspace-transform (:node-type %))]
+                                t4 [t2 t3]}}]
       (testing "t1 has all transforms as descendants"
         (is (= #{"t2" "t3" "t4"}
-               (set (ws.impl/downstream-ids graph "t1" ws-tx?)))))
+               (set (ws.impl/downstream-ids graph :workspace-transform "t1")))))
       (testing "t2 has only t4 as descendant"
         (is (= #{"t4"}
-               (set (ws.impl/downstream-ids graph "t2" ws-tx?))))))))
+               (set (ws.impl/downstream-ids graph :workspace-transform "t2"))))))))
 
 (deftest downstream-ids-with-external-transforms-test
   (testing "External transforms are traversed but not included when filtered"
@@ -467,14 +465,13 @@
           ;; t1 -> ext -> t2
           graph {:entities     [t1 ext t2]
                  :dependencies {ext [t1]
-                                t2  [ext]}}
-          ws-tx? #(= :workspace-transform (:node-type %))]
+                                t2  [ext]}}]
       (testing "t1 can reach through external transform to t2"
         (is (= #{"t2"}
-               (set (ws.impl/downstream-ids graph "t1" ws-tx?)))))
+               (set (ws.impl/downstream-ids graph :workspace-transform "t1")))))
       (testing "downstream-nodes returns all node types including external"
-        (is (= #{{:node-type :workspace-transform :id "t2"}
-                 {:node-type :external-transform :id 100}}
+        (is (= #{{:node-type :workspace-transform, :id "t2"}
+                 {:node-type :external-transform, :id 100}}
                (ws.impl/downstream-nodes graph "t1")))))))
 
 (deftest downstream-nodes-empty-graph-test


### PR DESCRIPTION
Closes [BOT-947](https://linear.app/metabase/issue/BOT-947/option-on-run-and-dry-run-to-automatically-run-missing-or-stale)

This makes things more ergonomic for agents to execute what they want.