### PR TITLE
Migrate dashboard subscriptions to notification system

### DIFF
--- a/frontend/src/metabase-types/api/notification-channels.ts
+++ b/frontend/src/metabase-types/api/notification-channels.ts
@@ -100,5 +100,9 @@ export type Channel = {
   channel_id?: number;
 } & Pick<
   ScheduleSettings,
-  "schedule_day" | "schedule_type" | "schedule_hour" | "schedule_frame"
+  | "schedule_day"
+  | "schedule_type"
+  | "schedule_hour"
+  | "schedule_frame"
+  | "schedule_minute"
 >;

--- a/frontend/src/metabase-types/api/notification.ts
+++ b/frontend/src/metabase-types/api/notification.ts
@@ -43,6 +43,7 @@ type NotificationDashboardPayload = {
     dashboard_id: DashboardId;
     parameters?: Record<string, unknown>[] | null;
     skip_if_empty?: boolean;
+    disable_links?: boolean;
     dashboard_subscription_dashcards?: DashboardSubscriptionDashcard[] | null;
 
     id?: number;

--- a/frontend/src/metabase-types/api/notification.ts
+++ b/frontend/src/metabase-types/api/notification.ts
@@ -1,4 +1,5 @@
 import type { Card, CardId } from "./card";
+import type { DashboardId } from "./dashboard";
 import type { Channel } from "./notification-channels";
 import type { PaginationRequest } from "./pagination";
 import type { ScheduleDisplayType } from "./settings";
@@ -27,7 +28,33 @@ type NotificationCardPayload = {
   payload_id?: number;
 };
 
-type NotificationPayload = NotificationCardPayload; // will be populated with more variants later on
+export type DashboardSubscriptionDashcard = {
+  card_id: CardId | null;
+  dashboard_card_id?: number;
+  include_csv?: boolean;
+  include_xls?: boolean;
+  format_rows?: boolean;
+  pivot_results?: boolean;
+};
+
+type NotificationDashboardPayload = {
+  payload_type: "notification/dashboard";
+  payload: {
+    dashboard_id: DashboardId;
+    parameters?: Record<string, unknown>[] | null;
+    skip_if_empty?: boolean;
+    dashboard_subscription_dashcards?: DashboardSubscriptionDashcard[] | null;
+
+    id?: number;
+    created_at?: string;
+    updated_at?: string;
+  };
+  payload_id?: number;
+};
+
+type NotificationPayload =
+  | NotificationCardPayload
+  | NotificationDashboardPayload;
 
 //#endregion
 
@@ -124,6 +151,8 @@ export interface ListNotificationsRequest extends PaginationRequest {
   recipient_id?: UserId;
   creator_or_recipient_id?: UserId;
   card_id?: CardId;
+  dashboard_id?: DashboardId;
+  payload_type?: "notification/card" | "notification/dashboard";
   permission_group_id?: number;
 }
 
@@ -132,7 +161,15 @@ export type CreateAlertNotificationRequest = NotificationCardPayload & {
   subscriptions: NotificationCronSubscription[];
 };
 
-export type CreateNotificationRequest = CreateAlertNotificationRequest; // will be populated with more variants later on
+export type CreateDashboardNotificationRequest =
+  NotificationDashboardPayload & {
+    handlers: NotificationHandler[];
+    subscriptions: NotificationCronSubscription[];
+  };
+
+export type CreateNotificationRequest =
+  | CreateAlertNotificationRequest
+  | CreateDashboardNotificationRequest;
 
 export type UpdateAlertNotificationRequest = NotificationCardPayload & {
   id: NotificationId;
@@ -141,7 +178,17 @@ export type UpdateAlertNotificationRequest = NotificationCardPayload & {
   subscriptions: NotificationCronSubscription[];
 };
 
-export type UpdateNotificationRequest = UpdateAlertNotificationRequest; // will be populated with more variants later on
+export type UpdateDashboardNotificationRequest =
+  NotificationDashboardPayload & {
+    id: NotificationId;
+    active: boolean;
+    handlers: NotificationHandler[];
+    subscriptions: NotificationCronSubscription[];
+  };
+
+export type UpdateNotificationRequest =
+  | UpdateAlertNotificationRequest
+  | UpdateDashboardNotificationRequest;
 
 export type Notification = NotificationPayload & {
   id: NotificationId;

--- a/frontend/src/metabase/notifications/AddEditSidebar/AddEditEmailSidebar.tsx
+++ b/frontend/src/metabase/notifications/AddEditSidebar/AddEditEmailSidebar.tsx
@@ -23,28 +23,39 @@ import type { UiParameter } from "metabase-lib/v1/parameters/types";
 import type {
   Channel,
   ChannelApiResponse,
-  ChannelSpec,
   Dashboard,
   ScheduleSettings,
+  ScheduleType,
   User,
 } from "metabase-types/api";
 import type { DraftDashboardSubscription } from "metabase-types/store";
 
+import S from "./AddEditSidebar.module.css";
 import { CaveatMessage } from "./CaveatMessage";
 import DefaultParametersSection from "./DefaultParametersSection";
 import { DeleteSubscriptionAction } from "./DeleteSubscriptionAction";
 import { CHANNEL_NOUN_PLURAL } from "./constants";
 import Heading from "./Heading";
 
+const SUBSCRIPTION_SCHEDULE_OPTIONS: ScheduleType[] = [
+  "every_n_minutes",
+  "hourly",
+  "daily",
+  "weekly",
+  "monthly",
+  "cron",
+];
+
 interface AddEditEmailSidebarProps {
   pulse: DraftDashboardSubscription;
   formInput: ChannelApiResponse;
   channel: Channel;
-  channelSpec: ChannelSpec;
   users: User[];
   parameters: UiParameter[];
   hiddenParameters?: string;
   dashboard: Dashboard;
+  cronString?: string;
+  isCustomSchedule?: boolean;
   handleSave: () => void;
   onCancel: () => void;
   onChannelPropertyChange: (property: string, value: unknown) => void;
@@ -63,11 +74,12 @@ export const AddEditEmailSidebar = ({
   pulse,
   formInput,
   channel,
-  channelSpec,
   users,
   parameters,
   hiddenParameters,
   dashboard,
+  cronString: cronStringProp,
+  isCustomSchedule,
 
   // form callbacks
   handleSave,
@@ -110,7 +122,7 @@ export const AddEditEmailSidebar = ({
         className={cx(CS.my2, CS.px4, CS.fullHeight, CS.flex, CS.flexColumn)}
       >
         {isEmbeddingSdk() ? null : (
-          <div>
+          <div className={CS.pb2}>
             <div className={cx(CS.textBold, CS.mb1)}>{t`To:`}</div>
             <RecipientPicker
               autoFocus={false}
@@ -128,17 +140,25 @@ export const AddEditEmailSidebar = ({
           </div>
         )}
         <Schedule
-          cronString={scheduleSettingsToCron(
-            _.pick(
-              channel,
-              "schedule_day",
-              "schedule_frame",
-              "schedule_hour",
-              "schedule_type",
-            ),
-          )}
-          scheduleOptions={channelSpec.schedules}
+          cronString={
+            cronStringProp ??
+            scheduleSettingsToCron(
+              _.pick(
+                channel,
+                "schedule_day",
+                "schedule_frame",
+                "schedule_hour",
+                "schedule_type",
+                "schedule_minute",
+              ),
+            )
+          }
+          scheduleOptions={SUBSCRIPTION_SCHEDULE_OPTIONS}
           verb={t`Sent`}
+          minutesOnHourPicker
+          labelAlignment="left"
+          className={S.schedule}
+          isCustomSchedule={isCustomSchedule}
           onScheduleChange={(nextCronString, nextSchedule) =>
             onChannelScheduleChange(nextCronString, nextSchedule)
           }

--- a/frontend/src/metabase/notifications/AddEditSidebar/AddEditEmailSidebar.tsx
+++ b/frontend/src/metabase/notifications/AddEditSidebar/AddEditEmailSidebar.tsx
@@ -4,11 +4,9 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import { getCurrentUser } from "metabase/admin/datamodel/selectors";
+import { scheduleSettingsToCron } from "metabase/admin/performance/utils";
 import { DataPermissionValue } from "metabase/admin/permissions/types";
-import {
-  type ScheduleChangeProp,
-  SchedulePicker,
-} from "metabase/common/components/SchedulePicker";
+import { Schedule } from "metabase/common/components/Schedule";
 import { SendTestPulse } from "metabase/common/components/SendTestPulse";
 import { Toggle } from "metabase/common/components/Toggle";
 import CS from "metabase/css/core/index.css";
@@ -36,6 +34,7 @@ import { CaveatMessage } from "./CaveatMessage";
 import DefaultParametersSection from "./DefaultParametersSection";
 import { DeleteSubscriptionAction } from "./DeleteSubscriptionAction";
 import { CHANNEL_NOUN_PLURAL } from "./constants";
+import Heading from "./Heading";
 
 interface AddEditEmailSidebarProps {
   pulse: DraftDashboardSubscription;
@@ -50,8 +49,8 @@ interface AddEditEmailSidebarProps {
   onCancel: () => void;
   onChannelPropertyChange: (property: string, value: unknown) => void;
   onChannelScheduleChange: (
+    cronString: string,
     schedule: ScheduleSettings,
-    changedProp: ScheduleChangeProp,
   ) => void;
   testPulse: (pulse: DraftDashboardSubscription) => Promise<unknown>;
   toggleSkipIfEmpty: () => void;
@@ -128,22 +127,20 @@ export const AddEditEmailSidebar = ({
             />
           </div>
         )}
-        <SchedulePicker
-          schedule={_.pick(
-            channel,
-            "schedule_day",
-            "schedule_frame",
-            "schedule_hour",
-            "schedule_type",
+        <Schedule
+          cronString={scheduleSettingsToCron(
+            _.pick(
+              channel,
+              "schedule_day",
+              "schedule_frame",
+              "schedule_hour",
+              "schedule_type",
+            ),
           )}
           scheduleOptions={channelSpec.schedules}
-          textBeforeInterval={t`Sent`}
-          textBeforeSendTime={t`${
-            (channelSpec?.type && CHANNEL_NOUN_PLURAL[channelSpec.type]) ??
-            t`Messages`
-          } will be sent at`}
-          onScheduleChange={(newSchedule, changedProp) =>
-            onChannelScheduleChange(newSchedule, changedProp)
+          verb={t`Sent`}
+          onScheduleChange={(nextCronString, nextSchedule) =>
+            onChannelScheduleChange(nextCronString, nextSchedule)
           }
         />
         <div className={cx(CS.py2)}>

--- a/frontend/src/metabase/notifications/AddEditSidebar/AddEditSidebar.module.css
+++ b/frontend/src/metabase/notifications/AddEditSidebar/AddEditSidebar.module.css
@@ -1,0 +1,7 @@
+.schedule {
+  --schedule-grid-gap: 1.5rem;
+  --schedule-row-gap: 1rem;
+  --schedule-first-column-font-weight: bold;
+
+  grid-template-columns: minmax(2.5rem, min-content) auto;
+}

--- a/frontend/src/metabase/notifications/AddEditSidebar/AddEditSlackSidebar.tsx
+++ b/frontend/src/metabase/notifications/AddEditSidebar/AddEditSlackSidebar.tsx
@@ -2,10 +2,8 @@ import cx from "classnames";
 import { t } from "ttag";
 import _ from "underscore";
 
-import {
-  type ScheduleChangeProp,
-  SchedulePicker,
-} from "metabase/common/components/SchedulePicker";
+import { scheduleSettingsToCron } from "metabase/admin/performance/utils";
+import { Schedule } from "metabase/common/components/Schedule";
 import { SendTestPulse } from "metabase/common/components/SendTestPulse";
 import { Toggle } from "metabase/common/components/Toggle";
 import CS from "metabase/css/core/index.css";
@@ -29,6 +27,7 @@ import { CaveatMessage } from "./CaveatMessage";
 import DefaultParametersSection from "./DefaultParametersSection";
 import { DeleteSubscriptionAction } from "./DeleteSubscriptionAction";
 import { CHANNEL_NOUN_PLURAL } from "./constants";
+import Heading from "./Heading";
 
 interface AddEditSlackSidebarProps {
   pulse: DraftDashboardSubscription;
@@ -42,8 +41,8 @@ interface AddEditSlackSidebarProps {
   onCancel: () => void;
   onChannelPropertyChange: (property: string, value: unknown) => void;
   onChannelScheduleChange: (
+    cronString: string,
     schedule: ScheduleSettings,
-    changedProp: ScheduleChangeProp,
   ) => void;
   testPulse: (pulse: DraftDashboardSubscription) => Promise<unknown>;
   toggleSkipIfEmpty: () => void;
@@ -95,22 +94,20 @@ export const AddEditSlackSidebar = ({
             onChannelPropertyChange={onChannelPropertyChange}
           />
         )}
-        <SchedulePicker
-          schedule={_.pick(
-            channel,
-            "schedule_day",
-            "schedule_frame",
-            "schedule_hour",
-            "schedule_type",
+        <Schedule
+          cronString={scheduleSettingsToCron(
+            _.pick(
+              channel,
+              "schedule_day",
+              "schedule_frame",
+              "schedule_hour",
+              "schedule_type",
+            ),
           )}
           scheduleOptions={channelSpec.schedules}
-          textBeforeInterval={t`Send`}
-          textBeforeSendTime={t`${
-            (channelSpec?.type && CHANNEL_NOUN_PLURAL[channelSpec.type]) ??
-            t`Messages`
-          } will be sent at`}
-          onScheduleChange={(newSchedule, changedProp) =>
-            onChannelScheduleChange(newSchedule, changedProp)
+          verb={t`Send`}
+          onScheduleChange={(nextCronString, nextSchedule) =>
+            onChannelScheduleChange(nextCronString, nextSchedule)
           }
         />
         <div className={cx(CS.pt2, CS.pb1)}>

--- a/frontend/src/metabase/notifications/AddEditSidebar/AddEditSlackSidebar.tsx
+++ b/frontend/src/metabase/notifications/AddEditSidebar/AddEditSlackSidebar.tsx
@@ -20,14 +20,25 @@ import type {
   ChannelSpecs,
   Dashboard,
   ScheduleSettings,
+  ScheduleType,
 } from "metabase-types/api";
 import type { DraftDashboardSubscription } from "metabase-types/store";
 
+import S from "./AddEditSidebar.module.css";
 import { CaveatMessage } from "./CaveatMessage";
 import DefaultParametersSection from "./DefaultParametersSection";
 import { DeleteSubscriptionAction } from "./DeleteSubscriptionAction";
 import { CHANNEL_NOUN_PLURAL } from "./constants";
 import Heading from "./Heading";
+
+const SUBSCRIPTION_SCHEDULE_OPTIONS: ScheduleType[] = [
+  "every_n_minutes",
+  "hourly",
+  "daily",
+  "weekly",
+  "monthly",
+  "cron",
+];
 
 interface AddEditSlackSidebarProps {
   pulse: DraftDashboardSubscription;
@@ -37,6 +48,8 @@ interface AddEditSlackSidebarProps {
   parameters: UiParameter[];
   hiddenParameters?: string;
   dashboard: Dashboard;
+  cronString?: string;
+  isCustomSchedule?: boolean;
   handleSave: () => void;
   onCancel: () => void;
   onChannelPropertyChange: (property: string, value: unknown) => void;
@@ -58,6 +71,8 @@ export const AddEditSlackSidebar = ({
   parameters,
   hiddenParameters,
   dashboard,
+  cronString: cronStringProp,
+  isCustomSchedule,
   // form callbacks
   handleSave,
   onCancel,
@@ -95,17 +110,25 @@ export const AddEditSlackSidebar = ({
           />
         )}
         <Schedule
-          cronString={scheduleSettingsToCron(
-            _.pick(
-              channel,
-              "schedule_day",
-              "schedule_frame",
-              "schedule_hour",
-              "schedule_type",
-            ),
-          )}
-          scheduleOptions={channelSpec.schedules}
+          cronString={
+            cronStringProp ??
+            scheduleSettingsToCron(
+              _.pick(
+                channel,
+                "schedule_day",
+                "schedule_frame",
+                "schedule_hour",
+                "schedule_type",
+                "schedule_minute",
+              ),
+            )
+          }
+          scheduleOptions={SUBSCRIPTION_SCHEDULE_OPTIONS}
           verb={t`Send`}
+          minutesOnHourPicker
+          labelAlignment="left"
+          className={S.schedule}
+          isCustomSchedule={isCustomSchedule}
           onScheduleChange={(nextCronString, nextSchedule) =>
             onChannelScheduleChange(nextCronString, nextSchedule)
           }

--- a/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/DashboardSubscriptionsSidebar.tsx
+++ b/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/DashboardSubscriptionsSidebar.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import _ from "underscore";
 
+import { cronToScheduleSettings } from "metabase/admin/performance/utils";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
-import type { ScheduleChangeProp } from "metabase/common/components/SchedulePicker";
 import { Sidebar } from "metabase/dashboard/components/Sidebar";
 import { useDashboardContext } from "metabase/dashboard/context";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
@@ -316,17 +316,12 @@ function DashboardSubscriptionsSidebarInner({
     [setPulse],
   );
 
-  // changedProp contains the schedule property that user just changed
-  // newSchedule may contain also other changed properties as some property changes reset other properties
   const onChannelScheduleChange = useCallback(
-    (
-      index: number,
-      newSchedule: ScheduleSettings,
-      _changedProp: ScheduleChangeProp,
-    ) => {
+    (index: number, cronString: string, schedule: ScheduleSettings) => {
       const p = pulseRef.current;
       const channels = [...p.channels];
-      channels[index] = { ...channels[index], ...newSchedule };
+      const scheduleSettings = cronToScheduleSettings(cronString) ?? schedule;
+      channels[index] = { ...channels[index], ...scheduleSettings };
       setPulse({ ...p, channels });
     },
     [setPulse],
@@ -557,8 +552,8 @@ interface AddEditEmailSidebarWithHooksProps {
   ) => void;
   onChannelScheduleChange: (
     index: number,
+    cronString: string,
     schedule: ScheduleSettings,
-    changedProp: ScheduleChangeProp,
   ) => void;
   testPulse: (pulse: DraftDashboardSubscription) => Promise<unknown>;
   toggleSkipIfEmpty: () => void;

--- a/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/common.unit.spec.ts
+++ b/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/common.unit.spec.ts
@@ -118,19 +118,6 @@ describe("DashboardSubscriptionsSidebar", () => {
         },
       ] satisfies (Partial<DashboardSubscription> & { id: number })[];
 
-      // Dynamically modify `pulses` so that we get the new updated list of pulses after archiving
-      fetchMock.put({
-        url: "express:/api/pulse/:id",
-        response: ({ expressParams = {} }) => {
-          const pulseId = parseInt(expressParams?.id);
-          pulses.splice(
-            pulses.findIndex((pulse) => pulse.id === pulseId),
-            1,
-          );
-          return {};
-        },
-      });
-
       const setSharing = jest.fn();
 
       setup({
@@ -281,10 +268,14 @@ describe("DashboardSubscriptionsSidebar", () => {
 
       await userEvent.click(await screen.findByText("Send email now"));
 
-      const lastCall = fetchMock.callHistory.lastCall("path:/api/pulse/test");
+      const lastCall = fetchMock.callHistory.lastCall(
+        "path:/api/notification/send",
+      );
       const payload = await lastCall?.request?.json();
-      expect(payload.cards).toHaveLength(1);
-      expect(payload.cards[0].id).toEqual(dashcard.id);
+      expect(payload.payload.dashboard_subscription_dashcards).toHaveLength(1);
+      expect(
+        payload.payload.dashboard_subscription_dashcards[0].card_id,
+      ).toEqual(dashcard.card_id);
     });
   });
 });

--- a/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/common.unit.spec.ts
+++ b/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/common.unit.spec.ts
@@ -347,7 +347,7 @@ describe("DashboardSubscriptionsSidebar", () => {
       setup({ pulses });
 
       expect(await screen.findByText("Subscriptions")).toBeInTheDocument();
-      expect(await screen.findByText("Emailed daily")).toBeInTheDocument();
+      expect(await screen.findByText(/Emailed daily/)).toBeInTheDocument();
       expect(await screen.findByText("Test User")).toBeInTheDocument();
     });
 
@@ -377,8 +377,8 @@ describe("DashboardSubscriptionsSidebar", () => {
       setup({ pulses, isAdmin: true });
 
       // Open the subscription
-      expect(await screen.findByText("Emailed weekly")).toBeInTheDocument();
-      await userEvent.click(await screen.findByText("Emailed weekly"));
+      expect(await screen.findByText(/Emailed Monday/)).toBeInTheDocument();
+      await userEvent.click(await screen.findByText(/Emailed Monday/));
 
       // Delete it
       await userEvent.click(

--- a/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/setup.tsx
+++ b/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/setup.tsx
@@ -8,6 +8,7 @@ import { mockSettings } from "__support__/settings";
 import type { Screen } from "__support__/ui";
 import { renderWithProviders } from "__support__/ui";
 import { getNextId } from "__support__/utils";
+import { scheduleSettingsToCron } from "metabase/admin/performance/utils";
 import { isEmbeddingSdk as mockIsEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { MockDashboardContext } from "metabase/public/containers/PublicOrEmbeddedDashboard/mock-context";
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
@@ -25,6 +26,7 @@ import {
   createMockTokenFeatures,
   createMockUser,
 } from "metabase-types/api/mocks";
+import type { Notification } from "metabase-types/api/notification";
 import {
   createMockDashboardState,
   createMockState,
@@ -81,6 +83,78 @@ function createDashboardState(
   });
 }
 
+/** Convert pulse-shaped test data to a notification mock object */
+function pulseToMockNotification(
+  pulse: Partial<DashboardSubscription> & { id: number },
+  dashboardId: number,
+  creator: ReturnType<typeof createMockUser>,
+): Notification {
+  const channel = pulse.channels?.[0];
+  const cronSchedule = channel
+    ? scheduleSettingsToCron({
+        schedule_day: channel.schedule_day,
+        schedule_frame: channel.schedule_frame,
+        schedule_hour: channel.schedule_hour,
+        schedule_type: channel.schedule_type,
+      })
+    : "0 0 * * * ? *";
+
+  return {
+    id: pulse.id,
+    active: !pulse.archived,
+    payload_type: "notification/dashboard",
+    payload: {
+      dashboard_id: pulse.dashboard_id ?? dashboardId,
+      parameters: (pulse.parameters as Record<string, unknown>[]) ?? null,
+      skip_if_empty: pulse.skip_if_empty ?? false,
+      dashboard_subscription_dashcards: null,
+    },
+    handlers: (pulse.channels ?? []).map((ch) => {
+      if (ch.channel_type === "email") {
+        return {
+          channel_type: "channel/email" as const,
+          active: ch.enabled !== false,
+          recipients: (ch.recipients ?? []).map((u) => ({
+            type: "notification-recipient/user" as const,
+            user_id: u.id,
+            details: null,
+            user: u,
+          })),
+        };
+      }
+      if (ch.channel_type === "slack") {
+        return {
+          channel_type: "channel/slack" as const,
+          active: ch.enabled !== false,
+          recipients: ch.details?.channel
+            ? [
+                {
+                  type: "notification-recipient/raw-value" as const,
+                  details: { value: String(ch.details.channel) },
+                },
+              ]
+            : [],
+        };
+      }
+      return {
+        channel_type: `channel/${ch.channel_type}` as any,
+        active: ch.enabled !== false,
+        recipients: [],
+      };
+    }),
+    subscriptions: [
+      {
+        type: "notification-subscription/cron" as const,
+        event_name: null,
+        cron_schedule: cronSchedule,
+        ui_display_type: null,
+      },
+    ],
+    creator_id: creator.id,
+    creator,
+  } as Notification;
+}
+
 type SetupOpts = {
   email?: boolean;
   slack?: boolean;
@@ -117,6 +191,17 @@ export function setup({
     dashcards,
     parameters,
   });
+
+  const currentUserMock = createMockUser({
+    first_name: currentUser?.firstName,
+    last_name: currentUser?.lastName,
+    is_superuser: isAdmin,
+  });
+
+  // Convert pulse-shaped test data to notification format for the API mock
+  const notifications: Notification[] = pulses.map((p) =>
+    pulseToMockNotification(p, dashboard.id, currentUserMock),
+  );
 
   const channelData: {
     channels: {
@@ -163,23 +248,43 @@ export function setup({
     users: [user],
   });
 
+  // Mock notification API
   fetchMock.get({
-    url: `path:/api/pulse`,
-    query: { dashboard_id: dashboard.id },
-    response: () => pulses,
+    url: `path:/api/notification`,
+    response: () => notifications,
     // Delay is crucial to reproduce (EMB-1060), otherwise, the state updates too fast which isn't realistic
     delay: pulseListDelay,
   });
 
-  // Mock POST that updates the GET response
-  fetchMock.post("path:/api/pulse", ({ options }) => {
+  // Mock POST that creates a notification and updates the GET response
+  fetchMock.post("path:/api/notification", ({ options }) => {
     const body = JSON.parse(options.body as string);
-    const newPulse = { ...body, id: getNextId() } as DashboardSubscription;
-    pulses.push(newPulse);
-    return newPulse;
+    const newNotification = {
+      ...body,
+      id: getNextId(),
+      active: true,
+      creator_id: currentUserMock.id,
+      creator: currentUserMock,
+    } as Notification;
+    notifications.push(newNotification);
+    return newNotification;
   });
 
-  fetchMock.post("path:/api/pulse/test", 200);
+  // Mock PUT for archive/update — removes from notifications array so refetch returns updated list
+  fetchMock.put({
+    url: "express:/api/notification/:id",
+    response: (callLog: any) => {
+      const notificationId = parseInt(callLog.expressParams?.id);
+      const idx = notifications.findIndex((n: any) => n.id === notificationId);
+      if (idx !== -1) {
+        const [removed] = notifications.splice(idx, 1);
+        return { ...removed, active: false };
+      }
+      return {};
+    },
+  });
+
+  fetchMock.post("path:/api/notification/send", 200);
 
   const features = createMockTokenFeatures(tokenFeatures);
   const storeSettings = mockSettings({ "token-features": features });
@@ -197,11 +302,7 @@ export function setup({
     {
       storeInitialState: createMockState({
         settings: storeSettings,
-        currentUser: createMockUser({
-          first_name: currentUser?.firstName,
-          last_name: currentUser?.lastName,
-          is_superuser: isAdmin,
-        }),
+        currentUser: currentUserMock,
         dashboard: createDashboardState(dashboard, dashcards),
       }),
     },
@@ -211,7 +312,7 @@ export function setup({
 export const hasAdvancedFilterOptionsHidden = (screen: Screen) => {
   expect(
     screen.queryByText(
-      /If a dashboard filter has a default value, it’ll be applied when your subscription is sent./i,
+      /If a dashboard filter has a default value, it'll be applied when your subscription is sent./i,
     ),
   ).not.toBeInTheDocument();
 

--- a/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/setup.tsx
+++ b/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/setup.tsx
@@ -259,8 +259,19 @@ export function setup({
   // Mock POST that creates a notification and updates the GET response
   fetchMock.post("path:/api/notification", ({ options }) => {
     const body = JSON.parse(options.body as string);
+    // Hydrate user objects on recipients (the real backend does this)
+    const handlers = (body.handlers ?? []).map((handler: any) => ({
+      ...handler,
+      recipients: (handler.recipients ?? []).map((r: any) => {
+        if (r.type === "notification-recipient/user") {
+          return { ...r, user: currentUserMock };
+        }
+        return r;
+      }),
+    }));
     const newNotification = {
       ...body,
+      handlers,
       id: getNextId(),
       active: true,
       creator_id: currentUserMock.id,

--- a/resources/migrations/059_update_migrations.yaml
+++ b/resources/migrations/059_update_migrations.yaml
@@ -3574,6 +3574,95 @@ databaseChangeLog:
             path: instance_analytics_views/query_log/v2/h2-query_log.sql
             relativeToChangelogFile: true
 
+  - changeSet:
+      id: v59.2026-02-08T10:00:00
+      author: jseidner
+      comment: Create the notification_dashboard table
+      changes:
+        - createTable:
+            tableName: notification_dashboard
+            remarks: Dashboard related notifications (subscriptions)
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: dashboard_id
+                  type: int
+                  remarks: The dashboard that this subscription is connected to
+                  constraints:
+                    nullable: false
+                    referencedTableName: report_dashboard
+                    referencedColumnNames: id
+                    foreignKeyName: fk_notification_dashboard_dashboard_id
+                    deleteCascade: true
+              - column:
+                  name: parameters
+                  type: ${text.type}
+                  remarks: JSON serialized dashboard filter parameters for this subscription
+                  constraints:
+                    nullable: true
+              - column:
+                  name: skip_if_empty
+                  type: ${boolean.type}
+                  remarks: Whether to skip sending the notification if all cards return empty results
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              - column:
+                  name: disable_links
+                  type: ${boolean.type}
+                  remarks: Whether to disable links in notification emails
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              - column:
+                  name: dashboard_subscription_dashcards
+                  type: ${text.type}
+                  remarks: JSON serialized per-card export options (include_csv, include_xls, format_rows, pivot_results)
+                  constraints:
+                    nullable: true
+              - column:
+                  name: created_at
+                  type: ${timestamp_type}
+                  remarks: The timestamp of when the record was created
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: ${timestamp_type}
+                  remarks: The timestamp of when the record was updated
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: v59.2026-02-08T10:00:01
+      author: jseidner
+      comment: Add an index for notification_dashboard.dashboard_id
+      rollback: # will be removed with the column
+      changes:
+        - createIndex:
+            indexName: idx_notification_dashboard_dashboard_id
+            tableName: notification_dashboard
+            columns:
+              - column:
+                  name: dashboard_id
+
+  - changeSet:
+      id: v59.2026-02-08T10:00:02
+      author: jseidner
+      comment: Migrate dashboard subscriptions from pulse to notification
+      validCheckSum: ANY
+      changes:
+        - customChange:
+            class: "metabase.app_db.custom_migrations.MigrateDashboardSubscriptionsToNotification"
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/app_db/custom_migrations.clj
+++ b/src/metabase/app_db/custom_migrations.clj
@@ -25,6 +25,7 @@
    [medley.core :as m]
    [metabase.app-db.connection :as mdb.connection]
    [metabase.app-db.custom-migrations.metrics-v2 :as metrics-v2]
+   [metabase.app-db.custom-migrations.pulse-subscription-to-notification :as pulse-subscription-to-notification]
    [metabase.app-db.custom-migrations.pulse-to-notification :as pulse-to-notification]
    [metabase.app-db.custom-migrations.reserve-at-symbol-user-attributes :as reserve-at-symbol-user-attributes]
    [metabase.app-db.custom-migrations.util :as custom-migrations.util]
@@ -1854,3 +1855,11 @@
 
 (define-migration MoveExistingAtSymbolUserAttributes
   (reserve-at-symbol-user-attributes/migrate!))
+
+;; Migrate dashboard subscriptions to notifications
+;; on migrate up:
+;; - migrate dashboard subscriptions from pulse table to notification table
+;; - And then on startup new send notification triggers are created by running
+;; [[metabase.notification.task.send/init-send-notification-triggers!]]
+(define-migration MigrateDashboardSubscriptionsToNotification
+  (pulse-subscription-to-notification/migrate-subscriptions!))

--- a/src/metabase/app_db/custom_migrations/pulse_subscription_to_notification.clj
+++ b/src/metabase/app_db/custom_migrations/pulse_subscription_to_notification.clj
@@ -1,0 +1,176 @@
+(ns metabase.app-db.custom-migrations.pulse-subscription-to-notification
+  (:require
+   [clojure.string :as str]
+   [clojurewerkz.quartzite.scheduler :as qs]
+   [clojurewerkz.quartzite.triggers :as triggers]
+   [metabase.app-db.custom-migrations.util :as custom-migrations.util]
+   [metabase.util.json :as json]
+   [toucan2.core :as t2]))
+
+;; ------------------------------------------------------------------------------------------------
+;; Cron string conversion (copied from pulse_to_notification.clj to avoid depending on app code)
+;; ------------------------------------------------------------------------------------------------
+
+(defn- cron-string
+  "Build a cron string from key-value pair parts."
+  [{:keys [seconds minutes hours day-of-month month day-of-week year]}]
+  (str/join " " [(or seconds      "0")
+                 (or minutes      "0")
+                 (or hours        "*")
+                 (or day-of-month "*")
+                 (or month        "*")
+                 (or day-of-week  "?")
+                 (or year         "*")]))
+
+(def ^:private day-of-week->cron
+  {"sun"  1
+   "mon"  2
+   "tue"  3
+   "wed"  4
+   "thu"  5
+   "fri"  6
+   "sat"  7})
+
+(defn- frame->cron [frame day-of-week]
+  (if day-of-week
+    ;; specific days of week like Mon or Fri
+    (assoc {:day-of-month "?"}
+           :day-of-week (case frame
+                          "first" (str (day-of-week->cron day-of-week) "#1")
+                          "last"  (str (day-of-week->cron day-of-week) "L")))
+    ;; specific CALENDAR DAYS like 1st or 15th
+    (assoc {:day-of-week "?"}
+           :day-of-month (case frame
+                           "first" "1"
+                           "mid"   "15"
+                           "last"  "L"))))
+
+(defn- schedule-map->cron-string
+  "Convert the frontend schedule map into a cron string."
+  [{day-of-week :schedule_day, hour :schedule_hour, minute :schedule_minute,
+    frame :schedule_frame,  schedule-type :schedule_type}]
+  (cron-string (case (keyword schedule-type)
+                 :hourly  {:minutes minute}
+                 :daily   {:hours (or hour 0)}
+                 :weekly  {:hours       hour
+                           :day-of-week  (day-of-week->cron day-of-week)
+                           :day-of-month "?"}
+                 :monthly (assoc (frame->cron frame day-of-week)
+                                 :hours hour))))
+
+;; ------------------------------------------------------------------------------------------------
+;; Migration logic
+;; ------------------------------------------------------------------------------------------------
+
+(defn- hydrate-recipients
+  [pcs]
+  (when (seq pcs)
+    (let [pc-id->recipients (group-by :pulse_channel_id
+                                      (t2/select :pulse_channel_recipient :pulse_channel_id [:in (map :id pcs)]))]
+      (map (fn [pc]
+             (assoc pc :recipients (get pc-id->recipients (:id pc))))
+           pcs))))
+
+(defn- send-pulse-trigger-key
+  [pulse-id schedule-map]
+  (triggers/key (format "metabase.task.send-pulse.trigger.%d.%s"
+                        pulse-id (-> schedule-map
+                                     schedule-map->cron-string
+                                     (str/replace " " "_")))))
+
+(defn- create-notification!
+  "Create a new notification with `subscriptions`.
+  Return the created notification."
+  [notification subscriptions handlers+recipients]
+  (let [notification-dashboard-id (t2/insert-returning-pk! :notification_dashboard (:payload notification))
+        instance                  (t2/insert-returning-instance! :notification (-> notification
+                                                                                   (dissoc :payload)
+                                                                                   (assoc :payload_id notification-dashboard-id)))
+        notification-id           (:id instance)]
+    (when (seq subscriptions)
+      (t2/insert! :notification_subscription (map #(assoc % :notification_id notification-id) subscriptions)))
+    (doseq [handler handlers+recipients]
+      (let [recipients (:recipients handler)
+            handler    (-> handler
+                           (dissoc :recipients)
+                           (assoc :notification_id notification-id))
+            handler-id (t2/insert-returning-pk! :notification_handler handler)]
+        (when (seq recipients)
+          (t2/insert! :notification_recipient (map #(assoc % :notification_handler_id handler-id) recipients)))))
+    instance))
+
+(defn- pulse-cards->dashcards
+  "Convert pulse_card records to dashboard_subscription_dashcards JSON."
+  [pulse-cards]
+  (json/encode
+   (mapv (fn [pc]
+           {:card_id       (:card_id pc)
+            :include_csv   (boolean (:include_csv pc))
+            :include_xls   (boolean (:include_xls pc))
+            :format_rows   (boolean (if (some? (:format_rows pc)) (:format_rows pc) true))
+            :pivot_results (boolean (:pivot_results pc))})
+         pulse-cards)))
+
+(defn- subscription->notification!
+  "Create a new notification from a dashboard subscription pulse.
+  Return the created notifications."
+  [scheduler pulse]
+  (let [pulse-id    (:id pulse)
+        pcs         (hydrate-recipients (t2/select :pulse_channel :pulse_id pulse-id :enabled true))
+        pulse-cards (t2/select :pulse_card :pulse_id pulse-id {:order-by [[:position :asc]]})]
+    ;; Group pulse_channels by schedule and create a notification for each group
+    (doall
+     (for [pcs (vals (group-by (juxt :schedule_type :schedule_hour :schedule_day :schedule_frame) pcs))]
+       (let [notification  {:payload_type "notification/dashboard"
+                            :payload      {:dashboard_id                     (:dashboard_id pulse)
+                                           :parameters                       (or (:parameters pulse) "[]")
+                                           :skip_if_empty                    (boolean (:skip_if_empty pulse))
+                                           :disable_links                    (boolean (:disable_links pulse))
+                                           :dashboard_subscription_dashcards (pulse-cards->dashcards pulse-cards)
+                                           :created_at                       (:created_at pulse)
+                                           :updated_at                       (:updated_at pulse)}
+                            :active       (not (:archived pulse))
+                            :creator_id   (:creator_id pulse)
+                            :created_at   (:created_at pulse)
+                            :updated_at   (:updated_at pulse)}
+             pc            (first pcs)
+             subscriptions [{:type          "notification-subscription/cron"
+                             :cron_schedule (schedule-map->cron-string pc)
+                             :created_at    (:created_at pc)}]
+             handlers      (map (fn [pc]
+                                  (merge
+                                   {:active (:enabled pc)}
+                                   (case (:channel_type pc)
+                                     "email"
+                                     {:channel_type "channel/email"
+                                      :template_id  nil
+                                      :recipients   (concat
+                                                     (map (fn [recipient]
+                                                            {:type    "notification-recipient/user"
+                                                             :user_id (:user_id recipient)})
+                                                          (:recipients pc))
+                                                     (map (fn [email]
+                                                            {:type    "notification-recipient/raw-value"
+                                                             :details (json/encode {:value email})})
+                                                          (some-> pc :details json/decode (get "emails"))))}
+                                     "slack"
+                                     {:channel_type "channel/slack"
+                                      :template_id  nil
+                                      :recipients   [{:type    "notification-recipient/raw-value"
+                                                      :details (json/encode {:value (-> pc :details json/decode (get "channel"))})}]}
+                                     "http"
+                                     {:channel_type "channel/http"
+                                      :channel_id   (:channel_id pc)})))
+                                pcs)]
+         (qs/delete-trigger scheduler (send-pulse-trigger-key pulse-id pc))
+         (create-notification! notification subscriptions handlers))))))
+
+(defn migrate-subscriptions!
+  "Migrate dashboard subscriptions from `pulse` to `notification`."
+  []
+  #_{:clj-kondo/ignore [:unresolved-symbol]}
+  (custom-migrations.util/with-temp-schedule! [scheduler]
+    (run! #(subscription->notification! scheduler %)
+          (t2/reducible-query {:select [:*]
+                               :from   [:pulse]
+                               :where  [:and [:not= :dashboard_id nil] [:not :archived]]}))))

--- a/src/metabase/notification/api/notification.clj
+++ b/src/metabase/notification/api/notification.clj
@@ -57,9 +57,13 @@
   [notification]
   (= :notification/card (:payload_type notification)))
 
+(defn- dashboard-notification?
+  [notification]
+  (= :notification/dashboard (:payload_type notification)))
+
 (defn list-notifications
   "List notifications. See `GET /` for parameters."
-  [{:keys [creator_id creator_or_recipient_id recipient_id card_id payload_type include_inactive legacy-active legacy-user-id]}]
+  [{:keys [creator_id creator_or_recipient_id recipient_id card_id dashboard_id payload_type include_inactive legacy-active legacy-user-id]}]
   (->> (t2/reducible-select :model/Notification
                             (cond-> {:select-distinct [:notification.*]}
                               creator_id
@@ -87,6 +91,14 @@
                                     [:= :notification_card.id :notification.payload_id]
                                     [:= :notification.payload_type "notification/card"]])
                                   (sql.helpers/where [:= :notification_card.card_id card_id]))
+
+                              dashboard_id
+                              (-> (sql.helpers/left-join
+                                   :notification_dashboard
+                                   [:and
+                                    [:= :notification_dashboard.id :notification.payload_id]
+                                    [:= :notification.payload_type "notification/dashboard"]])
+                                  (sql.helpers/where [:= :notification_dashboard.dashboard_id dashboard_id]))
 
                               (and (nil? legacy-active) (not (true? include_inactive)))
                               (sql.helpers/where [:= :notification.active true])
@@ -125,20 +137,23 @@
   - `creator_id`: if provided returns only notifications created by this user
   - `recipient_id`: if provided returns only notification that has recipient_id as a recipient
   - `creator_or_recipient_id`: if provided returns only notification that has user_id as creator or recipient
-  - `card_id`: if provided returns only notification that has card_id as payload"
+  - `card_id`: if provided returns only notification that has card_id as payload
+  - `dashboard_id`: if provided returns only notification that has dashboard_id as payload"
   [_route-params
-   {:keys [creator_id creator_or_recipient_id recipient_id card_id include_inactive payload_type]} :-
+   {:keys [creator_id creator_or_recipient_id recipient_id card_id dashboard_id include_inactive payload_type]} :-
    [:map
     [:creator_id              {:optional true} ms/PositiveInt]
     [:recipient_id            {:optional true} ms/PositiveInt]
     [:creator_or_recipient_id {:optional true} ms/PositiveInt]
     [:card_id                 {:optional true} ms/PositiveInt]
+    [:dashboard_id            {:optional true} ms/PositiveInt]
     [:include_inactive        {:optional true} ms/BooleanValue]
     [:payload_type            {:optional true} [:maybe (into [:enum] models.notification/notification-types)]]]]
   (list-notifications {:creator_id              creator_id
                        :recipient_id            recipient_id
                        :creator_or_recipient_id creator_or_recipient_id
                        :card_id                 card_id
+                       :dashboard_id            dashboard_id
                        :include_inactive        include_inactive
                        :payload_type            payload_type}))
 
@@ -198,9 +213,11 @@
     notification))
 
 (defn- notify-notification-updates!
-  "Send notification emails based on changes between updated and existing notification"
+  "Send notification emails based on changes between updated and existing notification.
+  Currently only sends emails for card notifications."
   [updated-notification existing-notification]
-  (when (channel.settings/email-configured?)
+  (when (and (card-notification? existing-notification)
+             (channel.settings/email-configured?))
     (let [was-active?  (:active existing-notification)
           is-active?   (:active updated-notification)
           current-user @api/*current-user*
@@ -237,8 +254,7 @@
   (let [existing-notification (get-notification id)]
     (api/update-check existing-notification body)
     (models.notification/update-notification! existing-notification body)
-    (when (card-notification? existing-notification)
-      (notify-notification-updates! body existing-notification))
+    (notify-notification-updates! body existing-notification)
     (u/prog1 (get-notification id)
       (events/publish-event! :event/notification-update {:object          <>
                                                          :previous-object existing-notification

--- a/src/metabase/notification/api/notification.clj
+++ b/src/metabase/notification/api/notification.clj
@@ -57,10 +57,6 @@
   [notification]
   (= :notification/card (:payload_type notification)))
 
-(defn- dashboard-notification?
-  [notification]
-  (= :notification/dashboard (:payload_type notification)))
-
 (defn list-notifications
   "List notifications. See `GET /` for parameters."
   [{:keys [creator_id creator_or_recipient_id recipient_id card_id dashboard_id payload_type include_inactive legacy-active legacy-user-id]}]

--- a/src/metabase/notification/models.clj
+++ b/src/metabase/notification/models.clj
@@ -641,6 +641,13 @@
                                                :ref-in-parent :template_id
                                                :compare-cols  [:channel_type :name :details]}}}})
 
+(models.u.spec-update/define-spec notification-testing-update-spec
+  "Spec for updating a testing notification (no payload model)."
+  {:model        :model/Notification
+   :compare-cols [:active]
+   :extra-cols   [:payload_type :internal_id :payload_id]
+   :nested-specs common-notification-nested-specs})
+
 (models.u.spec-update/define-spec notification-card-update-spec
   "Spec for updating a card notification (alert)."
   {:model        :model/Notification
@@ -666,7 +673,8 @@
   [notification]
   (case (:payload_type notification)
     :notification/card      notification-card-update-spec
-    :notification/dashboard notification-dashboard-update-spec))
+    :notification/dashboard notification-dashboard-update-spec
+    :notification/testing   notification-testing-update-spec))
 
 (defn update-notification!
   "Update an existing notification with `new-notification`."

--- a/src/metabase/notification/payload/core.clj
+++ b/src/metabase/notification/payload/core.clj
@@ -51,10 +51,7 @@
     [:notification/dashboard
      [:map
       [:creator_id ms/PositiveInt]
-      ;; new path: hydrated NotificationDashboard record
-      [:payload                  {:optional true} ::models.notification/NotificationDashboard]
-      ;; legacy path: inline dashboard_subscription from pulse/send.clj
-      [:dashboard_subscription   {:optional true} [:maybe :map]]]]]
+      [:payload    {:optional true} ::models.notification/NotificationDashboard]]]]
     ;; for testing only
     [:notification/testing :map]]])
 

--- a/src/metabase/notification/payload/core.clj
+++ b/src/metabase/notification/payload/core.clj
@@ -51,18 +51,10 @@
     [:notification/dashboard
      [:map
       [:creator_id ms/PositiveInt]
-      ;; replacement of pulse
-      [:dashboard_subscription #_{:optional true}
-       [:map
-        [:dashboard_id ms/PositiveInt]
-        [:parameters {:optional true} [:maybe [:sequential :map]]]
-        [:dashboard_subscription_dashcards {:optional true}
-         [:sequential [:map
-                       [:card_id                        [:maybe ms/PositiveInt]]
-                       [:include_csv   {:optional true} [:maybe ms/BooleanValue]]
-                       [:include_xls   {:optional true} [:maybe ms/BooleanValue]]
-                       [:format_rows   {:optional true} [:maybe ms/BooleanValue]]
-                       [:pivot_results {:optional true} [:maybe ms/BooleanValue]]]]]]]]]
+      ;; new path: hydrated NotificationDashboard record
+      [:payload                  {:optional true} ::models.notification/NotificationDashboard]
+      ;; legacy path: inline dashboard_subscription from pulse/send.clj
+      [:dashboard_subscription   {:optional true} [:maybe :map]]]]]
     ;; for testing only
     [:notification/testing :map]]])
 

--- a/src/metabase/notification/payload/core.clj
+++ b/src/metabase/notification/payload/core.clj
@@ -51,7 +51,7 @@
     [:notification/dashboard
      [:map
       [:creator_id ms/PositiveInt]
-      [:payload    {:optional true} ::models.notification/NotificationDashboard]]]]
+      [:payload    {:optional true} ::models.notification/NotificationDashboard]]]
     ;; for testing only
     [:notification/testing :map]]])
 

--- a/src/metabase/notification/payload/impl/dashboard.clj
+++ b/src/metabase/notification/payload/impl/dashboard.clj
@@ -26,23 +26,26 @@
    (the-parameters dashboard-subscription-params dashboard-params)))
 
 (mu/defmethod notification.payload/payload :notification/dashboard
-  [{:keys [creator_id dashboard_subscription] :as _notification-info} :- ::notification.payload/Notification]
-  (log/with-context {:dashboard_id (:dashboard_id dashboard_subscription)}
-    (let [dashboard-id (:dashboard_id dashboard_subscription)
-          dashboard    (t2/hydrate (t2/select-one :model/Dashboard dashboard-id) :tabs)
-          parameters   (parameters (:parameters dashboard_subscription) (:parameters dashboard))]
-      {:dashboard_parts        (cond->> (notification.execute/execute-dashboard dashboard-id creator_id parameters)
-                                 (:skip_if_empty dashboard_subscription)
-                                 (remove (fn [{part-type :type :as part}]
-                                           (and
-                                            (= part-type :card)
-                                            (zero? (get-in part [:result :row_count] 0))))))
-       :dashboard              dashboard
-       :style                  {:color_text_dark   channel.render/color-text-dark
-                                :color_text_light  channel.render/color-text-light
-                                :color_text_medium channel.render/color-text-medium}
-       :parameters             parameters
-       :dashboard_subscription dashboard_subscription})))
+  [{:keys [creator_id payload dashboard_subscription] :as _notification-info} :- ::notification.payload/Notification]
+  ;; `payload` comes from the hydrated NotificationDashboard record (new path).
+  ;; `dashboard_subscription` is used for backwards compatibility with the legacy pulse send path.
+  (let [sub          (or payload dashboard_subscription)
+        dashboard-id (:dashboard_id sub)]
+    (log/with-context {:dashboard_id dashboard-id}
+      (let [dashboard  (t2/hydrate (t2/select-one :model/Dashboard dashboard-id) :tabs)
+            parameters (parameters (:parameters sub) (:parameters dashboard))]
+        {:dashboard_parts        (cond->> (notification.execute/execute-dashboard dashboard-id creator_id parameters)
+                                   (:skip_if_empty sub)
+                                   (remove (fn [{part-type :type :as part}]
+                                             (and
+                                              (= part-type :card)
+                                              (zero? (get-in part [:result :row_count] 0))))))
+         :dashboard              dashboard
+         :style                  {:color_text_dark   channel.render/color-text-dark
+                                  :color_text_light  channel.render/color-text-light
+                                  :color_text_medium channel.render/color-text-medium}
+         :parameters             parameters
+         :dashboard_subscription sub}))))
 
 (mu/defmethod notification.payload/skip-reason :notification/dashboard
   [{:keys [payload] :as _noti-payload}]
@@ -71,4 +74,5 @@
                            {:id      id
                             :user-id creator_id
                             :object  {:recipients (handlers->audit-recipients handlers)
-                                      :filters    (-> notification-info :dashboard_subscription :parameters)}})))
+                                      :filters    (or (-> notification-info :payload :parameters)
+                                                      (-> notification-info :dashboard_subscription :parameters))}})))

--- a/src/metabase/notification/send.clj
+++ b/src/metabase/notification/send.clj
@@ -98,11 +98,10 @@
 (defn- hydrate-notification
   [notification-info]
   (case (:payload_type notification-info)
-    (:notification/system-event :notification/testing :notification/card)
+    (:notification/system-event :notification/testing :notification/card :notification/dashboard)
     (cond-> notification-info
       (t2/instance? notification-info)
       models.notification/hydrate-notification)
-    ;; :notification/dashboard is still on pulse, so we expect it to self-contained. see [[metabase.pulse.send]]
     notification-info))
 
 (defmulti do-after-notification-sent

--- a/src/metabase/pulse/send.clj
+++ b/src/metabase/pulse/send.clj
@@ -64,7 +64,7 @@
     {:id                     (:id pulse)
      :payload_type           :notification/dashboard
      :creator_id             (:creator_id pulse)
-     :dashboard_subscription {:id                               (:id pulse)
+     :payload                {:id                               (:id pulse)
                               :dashboard_id                     (:id dashboard)
                               :parameters                       (:parameters pulse)
                               :skip_if_empty                    (:skip_if_empty pulse)

--- a/src/metabase/pulse/task/send_pulses.clj
+++ b/src/metabase/pulse/task/send_pulses.clj
@@ -23,7 +23,7 @@
    [toucan2.core :as t2])
   (:import
    (java.util TimeZone)
-   (org.quartz CronTrigger DisallowConcurrentExecution JobExecutionContext TriggerKey)))
+   (org.quartz CronTrigger JobExecutionContext TriggerKey)))
 
 (set! *warn-on-reflection* true)
 
@@ -174,31 +174,6 @@
 
 (declare update-send-pulse-trigger-if-needed!)
 
-(defn- active-dashsub-pcs
-  []
-  (t2/select :model/PulseChannel
-             {:select    [:pc.*]
-              :from      [[:pulse_channel :pc]]
-              :left-join [[:pulse :p] [:= :pc.pulse_id :p.id]
-                          [:report_dashboard :d] [:= :p.dashboard_id :d.id]]
-              :where     [:and
-                          [:= :pc.enabled true]
-                          ;; only do this for dashboard subscriptions, alert has been
-                          ;; migrated to notifications
-                          [:not= :p.dashboard_id nil]
-                          [:= :d.archived false]]}))
-
-(defn init-dashboard-subscription-triggers!
-  "Update send pulse triggers for all active pulses.
-  Called once when Metabase starts up to create triggers for all existing PulseChannels"
-  []
-  (assert (task/scheduler) "Scheduler must be started before initializing SendPulse triggers")
-  (let [trigger-slot->pc-ids (as-> (active-dashsub-pcs) results
-                               (group-by #(select-keys % [:pulse_id :schedule_type :schedule_day :schedule_hour :schedule_frame]) results)
-                               (update-vals results #(map :id %)))]
-    (doseq [[{:keys [pulse_id] :as schedule-map} pc-ids] trigger-slot->pc-ids]
-      (update-send-pulse-trigger-if-needed! pulse_id schedule-map :add-pc-ids (set pc-ids)))))
-
 ;;; --------------------------------------------- Helpers -------------------------------------------
 
 ;; called by PulseChannel hooks
@@ -249,37 +224,15 @@
         (task/delete-trigger! trigger-key)
         (task/add-trigger! (send-pulse-trigger pulse-id schedule-map new-pc-ids (send-trigger-timezone)))))))
 
-(task/defjob
-  ^{:doc
-    "Find all notification subscriptions with cron schedules and create a trigger for each.
-    Run once on startup.
-
-    Context: Prior to 50, the SendPulse job has a single trigger that sends all pulses, but in #42316
-    We've changed it to one trigger per PulseChannel. We need this job so that users migrate from < 50
-    have all the triggers initiated properly.
-    The fact that it runs on every startup is because we have no way to have it run only once.
-    Ideally this should be a migration."
-    DisallowConcurrentExecution true}
-  InitSendPulseTriggers
-  [_context]
-  (log/info "Initializing SendPulse triggers for dashboard subscriptions")
-  (init-dashboard-subscription-triggers!))
-
 ;;; -------------------------------------------------- Task init ------------------------------------------------
 
+;; NOTE: Dashboard subscriptions have been migrated to the notification system.
+;; The SendPulse job is kept for backward compatibility with any remaining pulse triggers
+;; but no new triggers are created on startup (InitSendPulseTriggers was removed).
 (defmethod task/init! ::SendPulses [_]
   (let [send-pulse-job (jobs/build
                         (jobs/with-identity send-pulse-job-key)
                         (jobs/with-description "Send Pulse")
                         (jobs/of-type SendPulse)
-                        (jobs/store-durably))
-        init-job       (jobs/build
-                        (jobs/of-type InitSendPulseTriggers)
-                        (jobs/with-identity (jobs/key "metabase.task.send-pulses.init-send-pulse-triggers.job"))
-                        (jobs/store-durably))
-        init-trigger   (triggers/build
-                        ;; run once on startup
-                        (triggers/with-identity (triggers/key "metabase.task.send-pulses.init-send-pulse-triggers.trigger"))
-                        (triggers/start-now))]
-    (task/add-job! send-pulse-job)
-    (task/schedule-task! init-job init-trigger)))
+                        (jobs/store-durably))]
+    (task/add-job! send-pulse-job)))

--- a/test/metabase/app_db/custom_migrations/pulse_subscription_to_notification_test.clj
+++ b/test/metabase/app_db/custom_migrations/pulse_subscription_to_notification_test.clj
@@ -1,0 +1,221 @@
+(ns metabase.app-db.custom-migrations.pulse-subscription-to-notification-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.app-db.custom-migrations.pulse-subscription-to-notification :as pulse-subscription-to-notification]
+   [metabase.notification.models :as models.notification]
+   [metabase.pulse.models.pulse-channel-test :as pulse-channel-test]
+   [metabase.pulse.task.send-pulses :as task.send-pulses]
+   [metabase.task.core :as task]
+   [metabase.test :as mt]
+   [metabase.util.json :as json]
+   [toucan2.core :as t2]))
+
+(defn- sort-handlers
+  [notification]
+  (update notification :handlers #(sort-by :channel_type %)))
+
+(defmacro with-test-setup!
+  [& body]
+  `(mt/with-model-cleanup [:model/Pulse :model/Notification]
+     (mt/with-temp-scheduler!
+       (task/init! ::task.send-pulses/SendPulses)
+       ~@body)))
+
+(defn migrate-subscription!
+  [scheduler pulse-id]
+  (->> (#'pulse-subscription-to-notification/subscription->notification! scheduler (t2/select-one :pulse pulse-id))
+       (map :id)
+       (map (partial t2/select-one :model/Notification))
+       (map models.notification/hydrate-notification)
+       (map sort-handlers)))
+
+(def schedule-daily-6-am
+  {:schedule_type "daily"
+   :schedule_hour 6})
+
+(def timestamp-now
+  {:created_at :%now
+   :updated_at :%now})
+
+(def cron-daily-6-am
+  "0 0 6 * * ? *")
+
+(defn- add-timestamp
+  [x]
+  (if (sequential? x)
+    (map #(merge timestamp-now %) x)
+    (merge timestamp-now x)))
+
+(defn- create-pulse!
+  [pulse pulse-cards pcs+recipients]
+  (let [pulse-id (t2/insert-returning-pk! :pulse (add-timestamp pulse))]
+    (t2/insert! :pulse_card (map-indexed #(assoc %2 :pulse_id pulse-id :position %1) pulse-cards))
+    (doseq [pcr pcs+recipients]
+      (let [pc-id (t2/insert-returning-pk! :model/PulseChannel (-> pcr (assoc :pulse_id pulse-id) (dissoc :recipients) add-timestamp))]
+        (when (seq (:recipients pcr))
+          (t2/insert! :pulse_channel_recipient (map #(assoc % :pulse_channel_id pc-id) (:recipients pcr))))))
+    pulse-id))
+
+(defn create-subscription!
+  [subscription-props dashboard-id pulse-cards pcs+recipients]
+  (create-pulse! (merge {:dashboard_id  dashboard-id
+                         :skip_if_empty false
+                         :name          (mt/random-name)
+                         :parameters    "[]"
+                         :creator_id    (mt/user->id :crowberto)}
+                        subscription-props)
+                 pulse-cards
+                 (map #(merge schedule-daily-6-am {:details "{}"} %) pcs+recipients)))
+
+(deftest migrate-basic-subscription-test
+  (testing "basic dashboard subscription migration with email recipients"
+    (with-test-setup!
+      (mt/with-temp [:model/Dashboard {dashboard-id :id} {}
+                     :model/Card      {card-id :id}      {}]
+        (let [sub-id       (create-subscription!
+                            {} dashboard-id
+                            [{:card_id card-id}]
+                            [{:channel_type "email"
+                              :recipients   [{:user_id (mt/user->id :rasta)}]}])
+              pulse        (t2/select-one :model/Pulse sub-id)
+              triggers     (pulse-channel-test/send-pulse-triggers sub-id)
+              notification (first (migrate-subscription! (task/scheduler) sub-id))]
+          (testing "sanity check that there is a trigger for the subscription to begin with"
+            (is (= 1 (count triggers)))
+            (testing "after the migration it got deleted"
+              (is (zero? (count (pulse-channel-test/send-pulse-triggers sub-id))))))
+          (is (=? {:payload_type   :notification/dashboard
+                   :active         true
+                   :creator_id     (mt/user->id :crowberto)
+                   :subscriptions  [{:type          :notification-subscription/cron
+                                     :cron_schedule cron-daily-6-am}]
+                   :handlers       [{:channel_type :channel/email
+                                     :recipients   [{:type    :notification-recipient/user
+                                                     :user_id (mt/user->id :rasta)}]}]
+                   :created_at     (:created_at pulse)
+                   :updated_at     (:updated_at pulse)}
+                  notification)))))))
+
+(deftest migrate-subscription-payload-fields-test
+  (testing "dashboard subscription payload fields are correctly migrated"
+    (with-test-setup!
+      (mt/with-temp [:model/Dashboard {dashboard-id :id} {}
+                     :model/Card      {card-id :id}      {}]
+        (let [parameters   (json/encode [{:id "abc" :type "category" :value ["foo"]}])
+              sub-id       (create-subscription!
+                            {:skip_if_empty true
+                             :disable_links true
+                             :parameters    parameters}
+                            dashboard-id
+                            [{:card_id card-id}]
+                            [{:channel_type "email"
+                              :recipients   [{:user_id (mt/user->id :rasta)}]}])
+              notification (first (migrate-subscription! (task/scheduler) sub-id))]
+          (is (=? {:payload_type :notification/dashboard
+                   :payload      {:dashboard_id                     dashboard-id
+                                  :skip_if_empty                    true
+                                  :disable_links                    true
+                                  :parameters                       [{:id "abc" :type "category" :value ["foo"]}]
+                                  :dashboard_subscription_dashcards [{:card_id     card-id
+                                                                      :include_csv false
+                                                                      :include_xls false
+                                                                      :format_rows true
+                                                                      :pivot_results false}]}}
+                  notification)))))))
+
+(deftest migrate-subscription-dashcards-test
+  (testing "pulse_cards with export options are correctly converted to dashboard_subscription_dashcards"
+    (with-test-setup!
+      (mt/with-temp [:model/Dashboard {dashboard-id :id} {}
+                     :model/Card      {card-id-1 :id}    {}
+                     :model/Card      {card-id-2 :id}    {}]
+        (let [sub-id       (create-subscription!
+                            {} dashboard-id
+                            [{:card_id      card-id-1
+                              :include_csv  true
+                              :include_xls  false
+                              :format_rows  false
+                              :pivot_results true}
+                             {:card_id      card-id-2
+                              :include_csv  false
+                              :include_xls  true
+                              :format_rows  true
+                              :pivot_results false}]
+                            [{:channel_type "email"
+                              :recipients   [{:user_id (mt/user->id :rasta)}]}])
+              notification (first (migrate-subscription! (task/scheduler) sub-id))]
+          (is (=? {:payload {:dashboard_subscription_dashcards
+                             [{:card_id       card-id-1
+                               :include_csv   true
+                               :include_xls   false
+                               :format_rows   false
+                               :pivot_results true}
+                              {:card_id       card-id-2
+                               :include_csv   false
+                               :include_xls   true
+                               :format_rows   true
+                               :pivot_results false}]}}
+                  notification)))))))
+
+(deftest migrate-subscription-multiple-channels-test
+  (testing "migrate subscription with multiple channels: 1 email, 1 slack, 1 http, 1 disabled email"
+    (with-test-setup!
+      (mt/with-temp [:model/Dashboard {dashboard-id :id} {}
+                     :model/Card      {card-id :id}      {}
+                     :model/Channel   {channel-id :id}   {:type "channel/http"}]
+        (let [sub-id       (create-subscription!
+                            {} dashboard-id
+                            [{:card_id card-id}]
+                            [{:channel_type "email"
+                              :enabled      true
+                              :details      (json/encode {:emails ["ngoc@metabase.com"]})
+                              :recipients   [{:user_id (mt/user->id :rasta)}]}
+                             {:channel_type "slack"
+                              :enabled      true
+                              :details      (json/encode {:channel "#test-channel"})}
+                             {:channel_type "http"
+                              :enabled      true
+                              :channel_id   channel-id}
+                             {:channel_type "email"
+                              :enabled      false
+                              :recipients   [{:user_id (mt/user->id :crowberto)}]}])
+              notification (first (migrate-subscription! (task/scheduler) sub-id))]
+          (testing "are correctly migrated, the disabled channel is not migrated"
+            (is (=? {:payload_type   :notification/dashboard
+                     :active         true
+                     :creator_id     (mt/user->id :crowberto)
+                     :subscriptions  [{:type          :notification-subscription/cron
+                                       :cron_schedule cron-daily-6-am}]
+                     :handlers       [{:channel_type :channel/email
+                                       :recipients   [{:type    :notification-recipient/user
+                                                       :user_id (mt/user->id :rasta)}
+                                                      {:type    :notification-recipient/raw-value
+                                                       :details {:value "ngoc@metabase.com"}}]}
+                                      {:channel_type :channel/http
+                                       :channel_id   channel-id}
+                                      {:channel_type :channel/slack
+                                       :recipients   [{:type    :notification-recipient/raw-value
+                                                       :details {:value "#test-channel"}}]}]}
+                    notification))))))))
+
+(deftest migrate-subscription-http-channel-test
+  (testing "migrate subscription with http channel"
+    (with-test-setup!
+      (mt/with-temp [:model/Dashboard {dashboard-id :id} {}
+                     :model/Card      {card-id :id}      {}
+                     :model/Channel   {channel-id :id}   {}]
+        (let [sub-id       (create-subscription!
+                            {} dashboard-id
+                            [{:card_id card-id}]
+                            [{:channel_type "http"
+                              :channel_id   channel-id}])
+              notification (first (migrate-subscription! (task/scheduler) sub-id))]
+          (is (=? {:payload_type   :notification/dashboard
+                   :payload        {:dashboard_id dashboard-id}
+                   :active         true
+                   :creator_id     (mt/user->id :crowberto)
+                   :subscriptions  [{:type          :notification-subscription/cron
+                                     :cron_schedule cron-daily-6-am}]
+                   :handlers       [{:channel_type :channel/http
+                                     :channel_id   channel-id}]}
+                  notification)))))))

--- a/test/metabase/notification/api/notification_test.clj
+++ b/test/metabase/notification/api/notification_test.clj
@@ -1165,3 +1165,101 @@
                (testing "success if recipients matches allowed domains"
                  (mt/user-http-request :crowberto :post 204 "notification/send"
                                        (assoc notification :handlers success-handlers)))))))))))
+
+;;; ------------------------------------------------ Dashboard Notification Tests -----------------------------------------------
+
+(deftest create-dashboard-notification-test
+  (testing "POST /api/notification with dashboard payload"
+    (mt/with-model-cleanup [:model/Notification]
+      (mt/with-temp [:model/Dashboard {dashboard-id :id} {}]
+        (let [notification {:payload_type  "notification/dashboard"
+                            :creator_id    (mt/user->id :crowberto)
+                            :payload       {:dashboard_id  dashboard-id
+                                            :skip_if_empty true
+                                            :parameters    []}
+                            :subscriptions [{:type          "notification-subscription/cron"
+                                             :cron_schedule "0 0 6 * * ? *"}]
+                            :handlers      [{:channel_type "channel/email"
+                                             :recipients   [{:type    "notification-recipient/user"
+                                                             :user_id (mt/user->id :crowberto)}]}]}]
+          (is (=? (assoc notification :id (mt/malli=? int?))
+                  (mt/user-http-request :crowberto :post 200 "notification" notification))))))))
+
+(deftest list-notifications-dashboard-filter-test
+  (testing "GET /api/notification with dashboard_id filter"
+    (mt/with-model-cleanup [:model/Notification]
+      (notification.tu/with-dashboard-notification [{dashboard-noti :id} {:notification {:creator_id (mt/user->id :rasta)}
+                                                                          :handlers     [{:channel_type "channel/email"
+                                                                                          :recipients   [{:type    :notification-recipient/user
+                                                                                                          :user_id (mt/user->id :lucky)}]}]}]
+        (let [dashboard-id (-> (t2/select-one :model/Notification dashboard-noti)
+                               models.notification/hydrate-notification
+                               :payload
+                               :dashboard_id)]
+          (letfn [(get-notification-ids [user & params]
+                    (->> (apply mt/user-http-request user :get 200 "notification" params)
+                         (map :id)
+                         (filter #{dashboard-noti})
+                         set))]
+
+            (testing "admin can filter by dashboard_id"
+              (is (= #{dashboard-noti}
+                     (get-notification-ids :crowberto :dashboard_id dashboard-id))))
+
+            (testing "creator can filter by dashboard_id"
+              (is (= #{dashboard-noti}
+                     (get-notification-ids :rasta :dashboard_id dashboard-id))))
+
+            (testing "recipient can filter by dashboard_id"
+              (is (= #{dashboard-noti}
+                     (get-notification-ids :lucky :dashboard_id dashboard-id))))
+
+            (testing "non-existent dashboard_id returns empty"
+              (is (= #{}
+                     (get-notification-ids :crowberto :dashboard_id Integer/MAX_VALUE))))))))))
+
+(deftest update-dashboard-notification-test
+  (testing "PUT /api/notification/:id for dashboard notification"
+    (notification.tu/with-dashboard-notification
+      [notification {:notification-dashboard {:skip_if_empty false}
+                     :subscriptions          [{:type          :notification-subscription/cron
+                                               :cron_schedule "0 0 6 * * ? *"}]
+                     :handlers               [{:channel_type :channel/email
+                                               :recipients   [{:type    :notification-recipient/user
+                                                               :user_id (mt/user->id :crowberto)}]}]}]
+      (let [notification-id (:id notification)]
+        (testing "can update subscription schedule"
+          (let [updated (mt/user-http-request :crowberto :put 200
+                                              (format "notification/%d" notification-id)
+                                              (assoc-in notification [:subscriptions 0 :cron_schedule] "0 0 8 * * ? *"))]
+            (is (=? [{:type          "notification-subscription/cron"
+                      :cron_schedule "0 0 8 * * ? *"}]
+                    (:subscriptions updated)))))
+
+        (testing "can update dashboard payload fields"
+          (let [updated (mt/user-http-request :crowberto :put 200
+                                              (format "notification/%d" notification-id)
+                                              (assoc-in notification [:payload :skip_if_empty] true))]
+            (is (true? (get-in updated [:payload :skip_if_empty])))))))))
+
+(deftest get-dashboard-notification-permissions-test
+  (mt/with-temp
+    [:model/User {third-user-id :id} {:is_superuser false}]
+    (notification.tu/with-dashboard-notification
+      [notification {:notification {:creator_id (mt/user->id :rasta)}
+                     :handlers     [{:channel_type "channel/email"
+                                     :recipients   [{:type    :notification-recipient/user
+                                                     :user_id (mt/user->id :lucky)}]}]}]
+      (let [get-notification (fn [user-or-id expected-status]
+                               (mt/user-http-request user-or-id :get expected-status (format "notification/%d" (:id notification))))]
+        (testing "admin can view"
+          (get-notification :crowberto 200))
+
+        (testing "creator can view"
+          (get-notification :rasta 200))
+
+        (testing "recipient can view"
+          (get-notification :lucky 200))
+
+        (testing "other than that no one can view"
+          (get-notification third-user-id 403))))))

--- a/test/metabase/notification/payload/impl/dashboard_test.clj
+++ b/test/metabase/notification/payload/impl/dashboard_test.clj
@@ -1,12 +1,19 @@
 (ns metabase.notification.payload.impl.dashboard-test
   (:require
+   [clojure.java.io :as io]
+   [clojure.string :as str]
    [clojure.test :refer :all]
+   [medley.core :as m]
+   [metabase.channel.core :as channel]
    [metabase.notification.core :as notification]
    [metabase.notification.payload.core :as notification.payload]
    [metabase.notification.payload.execute :as notification.payload.execute]
    [metabase.notification.send :as notification.send]
    [metabase.notification.test-util :as notification.tu]
-   [metabase.test :as mt]))
+   [metabase.permissions.core :as perms]
+   [metabase.test :as mt]
+   [ring.util.codec :as codec]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -17,6 +24,10 @@
       (thunk))))
 
 (def ^:private dashboard-name "Test Dashboard Subscription")
+
+;; ------------------------------------------------------------------------------------------------;;
+;;                                     Basic send tests                                            ;;
+;; ------------------------------------------------------------------------------------------------;;
 
 (deftest basic-dashboard-notification-test
   (testing "dashboard notification sends email and slack messages with correct content"
@@ -55,6 +66,103 @@
                 (let [msg (notification.tu/slack-message->boolean message)]
                   (testing "slack message is sent to the correct channel"
                     (is (= "#general" (:channel msg))))))})))))))
+
+(deftest basic-line-graph-dashboard-test
+  (testing "dashboard notification with a line graph card includes static visualization"
+    (notification.tu/with-notification-testing-setup!
+      (notification.tu/with-dashboard-notification
+        [notification {:dashboard {:name dashboard-name}
+                       :handlers  [@notification.tu/default-email-handler
+                                   notification.tu/default-slack-handler]}]
+        (let [dashboard-id (-> notification :payload :dashboard_id)]
+          (mt/with-temp [:model/Card          {card-id :id} {:dataset_query (mt/mbql-query orders {:aggregation [["count"]]
+                                                                                                   :breakout    [!day.created_at]})
+                                                             :display       :line}
+                         :model/DashboardCard _              {:dashboard_id dashboard-id
+                                                              :card_id      card-id}]
+            (notification.tu/test-send-notification!
+             notification
+             {:channel/email
+              (fn [[email]]
+                (let [summary (mt/summarize-multipart-single-email
+                               email
+                               (re-pattern dashboard-name))]
+                  (testing "email subject is the dashboard name"
+                    (is (= dashboard-name (:subject summary))))
+                  (testing "email has png attachment (static viz)"
+                    (is (some #(= "image/png" (:content-type %)) (:message email))))))
+
+              :channel/slack
+              (fn [[message]]
+                (testing "slack message is sent to the correct channel"
+                  (is (= "#general" (:channel (notification.tu/slack-message->boolean message))))))})))))))
+
+;; ------------------------------------------------------------------------------------------------;;
+;;                                   Multiple recipients                                           ;;
+;; ------------------------------------------------------------------------------------------------;;
+
+(deftest multiple-email-recipients-test
+  (testing "dashboard notification is sent to multiple recipients (users + raw emails)"
+    (notification.tu/with-dashboard-notification
+      [notification {:handlers [{:channel_type :channel/email
+                                 :recipients   [{:type    :notification-recipient/user
+                                                 :user_id (mt/user->id :crowberto)}
+                                                {:type    :notification-recipient/user
+                                                 :user_id (mt/user->id :rasta)}
+                                                {:type    :notification-recipient/raw-value
+                                                 :details {:value "external@metabase.com"}}]}]}]
+      (let [dashboard-id (-> notification :payload :dashboard_id)]
+        (mt/with-temp [:model/Card          {card-id :id} {:dataset_query (mt/native-query {:query "SELECT 1 as data"})}
+                       :model/DashboardCard _              {:dashboard_id dashboard-id
+                                                            :card_id      card-id}]
+          (notification.tu/test-send-notification!
+           notification
+           {:channel/email
+            (fn [emails]
+              (is (= #{#{"external@metabase.com"} #{"crowberto@metabase.com" "rasta@metabase.com"}}
+                     (->> emails
+                          (map (comp set :recipients))
+                          set))))}))))))
+
+(deftest non-user-email-test
+  (testing "dashboard notification to non-user email shows Unsubscribe instead of Manage"
+    (notification.tu/with-dashboard-notification
+      [notification {:handlers [{:channel_type :channel/email
+                                 :recipients   [{:type    :notification-recipient/raw-value
+                                                 :details {:value "external@metabase.com"}}]}]}]
+      (let [dashboard-id (-> notification :payload :dashboard_id)]
+        (mt/with-temp [:model/Card          {card-id :id} {:dataset_query (mt/native-query {:query "SELECT 1 as data"})}
+                       :model/DashboardCard _              {:dashboard_id dashboard-id
+                                                            :card_id      card-id}]
+          (notification.tu/test-send-notification!
+           notification
+           {:channel/email
+            (fn [[email]]
+              (testing "email is sent correctly"
+                (let [summary (mt/summarize-multipart-single-email
+                               email
+                               (re-pattern dashboard-name)
+                               #"Manage your subscriptions"
+                               #"Unsubscribe")]
+                  (testing "non-user email does NOT see Manage link"
+                    (is (false? (get (first (:message summary)) "Manage your subscriptions"))))
+                  (testing "non-user email sees Unsubscribe link"
+                    (is (true? (get (first (:message summary)) "Unsubscribe"))))))
+
+              (testing "the unsubscribe url is correct"
+                ;; Dashboard template uses {{management_url}} (double braces) which HTML-escapes
+                ;; & → &amp; and = → &#x3D;
+                (let [html    (-> email :message first :content)
+                      raw-url (re-find #"https://[^/]+/unsubscribe[^\"\s<>]*" html)
+                      url     (-> raw-url (str/replace "&amp;" "&") (str/replace "&#x3D;" "="))
+                      params  (codec/form-decode (second (str/split url #"\?")))]
+                  (is (int? (parse-long (get params "pulse-id"))))
+                  (is (= "external@metabase.com" (get params "email")))
+                  (is (string? (get params "hash"))))))}))))))
+
+;; ------------------------------------------------------------------------------------------------;;
+;;                                     Skip-if-empty tests                                         ;;
+;; ------------------------------------------------------------------------------------------------;;
 
 (deftest skip-if-empty-with-results-test
   (testing "dashboard with results is NOT skipped when skip_if_empty is true"
@@ -119,6 +227,38 @@
             (fn [emails]
               (is (= 1 (count emails))))}))))))
 
+;; ------------------------------------------------------------------------------------------------;;
+;;                               Rows-to-disk and cleanup tests                                    ;;
+;; ------------------------------------------------------------------------------------------------;;
+
+(deftest dashboard-rows-saved-to-disk-all-channels-test
+  (testing "whether the rows of a card saved to disk or in memory, all channels should work"
+    (doseq [limit [1 10]]
+      (with-redefs [notification.payload.execute/cells-to-disk-threshold 5]
+        (testing (if (> limit @#'notification.payload.execute/cells-to-disk-threshold)
+                   "card has rows saved to disk"
+                   "card has rows saved in memory")
+          (notification.tu/with-notification-testing-setup!
+            (notification.tu/with-dashboard-notification
+              [notification {:dashboard {:name dashboard-name}
+                             :handlers  [@notification.tu/default-email-handler
+                                         notification.tu/default-slack-handler]}]
+              (let [dashboard-id (-> notification :payload :dashboard_id)]
+                (mt/with-temp [:model/Card          {card-id :id} {:dataset_query (mt/mbql-query orders {:limit limit})}
+                               :model/DashboardCard _              {:dashboard_id dashboard-id
+                                                                    :card_id      card-id}]
+                  (notification.tu/test-send-notification!
+                   notification
+                   {:channel/email
+                    (fn [[email]]
+                      (let [summary (mt/summarize-multipart-single-email
+                                     email
+                                     (re-pattern dashboard-name))]
+                        (is (= dashboard-name (:subject summary)))))
+                    :channel/slack
+                    (fn [[message]]
+                      (is (= "#general" (:channel (notification.tu/slack-message->boolean message)))))}))))))))))
+
 (deftest dashboard-rows-saved-to-disk-cleanup-test
   (testing "temp files created for dashboard card results are cleaned up after send"
     (let [rows-atom       (atom nil)
@@ -144,6 +284,282 @@
                   (is (not (.exists ^java.io.File
                             (.file ^metabase.notification.payload.temp_storage.StreamingTempFileStorage
                              @rows-atom)))))))))))))
+
+;; ------------------------------------------------------------------------------------------------;;
+;;                                    Constraint/limit tests                                       ;;
+;; ------------------------------------------------------------------------------------------------;;
+
+(defn- email->attachment-line-count
+  [email]
+  (let [attachment (m/find-first #(= "text/csv" (:content-type %)) (:message email))]
+    (when attachment
+      (with-open [rdr (io/reader (:content attachment))]
+        (count (line-seq rdr))))))
+
+(deftest dashboard-attachment-limit-test
+  (testing "respect attachment limit env if set"
+    (mt/with-temporary-setting-values [attachment-row-limit 10]
+      (notification.tu/with-dashboard-notification
+        [notification {:handlers [@notification.tu/default-email-handler]}]
+        (let [dashboard-id (-> notification :payload :dashboard_id)
+              nd-id        (-> notification :payload :id)]
+          (mt/with-temp [:model/Card          {card-id :id} {:dataset_query (mt/mbql-query orders)}
+                         :model/DashboardCard _              {:dashboard_id dashboard-id
+                                                              :card_id      card-id}]
+            ;; Update dashcards config with actual card_id so assoc-attachment-booleans can match
+            (t2/update! :model/NotificationDashboard nd-id
+                        {:dashboard_subscription_dashcards [{:card_id card-id :include_csv true}]})
+            ;; dissoc :payload to force re-hydration from DB (t2/hydrate skips already-hydrated keys)
+            (notification.tu/test-send-notification!
+             (dissoc notification :payload)
+             {:channel/email
+              (fn [[email]]
+                ;; 10 data rows + 1 header row = 11 lines
+                (is (= 11 (email->attachment-line-count email))))})))))))
+
+;; ------------------------------------------------------------------------------------------------;;
+;;                                     Permission tests                                            ;;
+;; ------------------------------------------------------------------------------------------------;;
+
+(deftest permission-test
+  (testing "dashboard subscription respects collection permissions of the creator"
+    (mt/with-temp [:model/Collection coll {}]
+      (letfn [(payload! [user-kw]
+                (notification.tu/with-dashboard-notification
+                  [notification {:dashboard    {:collection_id (:id coll)}
+                                 :notification {:creator_id (mt/user->id user-kw)}}]
+                  (let [dashboard-id (-> notification :payload :dashboard_id)]
+                    (mt/with-temp [:model/Card          {card-id :id} {:collection_id (:id coll)
+                                                                       :dataset_query (mt/native-query {:query "SELECT 1 as data"})}
+                                   :model/DashboardCard _              {:dashboard_id dashboard-id
+                                                                        :card_id      card-id}]
+                      (perms/revoke-collection-permissions! (perms/all-users-group) coll)
+                      (get-in (notification/notification-payload notification)
+                              [:payload :dashboard_parts])))))]
+        (testing "rasta has no permissions and gets empty dashboard parts (card query fails silently)"
+          ;; Dashboard card queries that fail return nil (caught by try/catch in execute-dashboard-subscription-card)
+          (is (empty? (payload! :rasta))))
+        (testing "crowberto can see the card and gets results"
+          (is (seq (payload! :crowberto))))))))
+
+;; ------------------------------------------------------------------------------------------------;;
+;;                                  Partial failure tests                                          ;;
+;; ------------------------------------------------------------------------------------------------;;
+
+(deftest partial-channel-failure-will-deliver-all-that-success-test
+  (testing "if one channel fails, the other channels should still receive the message"
+    (notification.tu/with-send-notification-sync
+      (notification.tu/with-dashboard-notification
+        [notification {:handlers [@notification.tu/default-email-handler
+                                  notification.tu/default-slack-handler]}]
+        (let [dashboard-id      (-> notification :payload :dashboard_id)
+              original-render   (var-get #'channel/render-notification)]
+          (mt/with-temp [:model/Card          {card-id :id} {:dataset_query (mt/native-query {:query "SELECT 1 as data"})}
+                         :model/DashboardCard _              {:dashboard_id dashboard-id
+                                                              :card_id      card-id}]
+            (with-redefs [channel/render-notification (fn [& args]
+                                                        (if (= :channel/slack (first args))
+                                                          (throw (ex-info "Slack failed" {}))
+                                                          (apply original-render args)))]
+              ;; slack failed but email should still be sent
+              (notification.tu/test-send-notification!
+               notification
+               {:channel/email
+                (fn [emails]
+                  (is (pos-int? (count emails))))
+                :channel/slack
+                (fn [messages]
+                  (is (nil? messages)))}))))))))
+
+;; ------------------------------------------------------------------------------------------------;;
+;;                               Archived / invalid card tests                                     ;;
+;; ------------------------------------------------------------------------------------------------;;
+
+(deftest archived-card-on-dashboard-test
+  (testing "archived cards on a dashboard are silently skipped during subscription send"
+    (notification.tu/with-dashboard-notification
+      [notification {:notification-dashboard {:skip_if_empty true}
+                     :handlers              [@notification.tu/default-email-handler]}]
+      (let [dashboard-id (-> notification :payload :dashboard_id)]
+        (mt/with-temp [:model/Card          {card-id :id} {:dataset_query (mt/native-query {:query "SELECT 1 as data"})
+                                                           :archived      true}
+                       :model/DashboardCard _              {:dashboard_id dashboard-id
+                                                            :card_id      card-id}]
+          (testing "with skip_if_empty=true, archived card is treated as empty → skipped"
+            (notification.tu/test-send-notification!
+             notification
+             {:channel/email
+              (fn [emails]
+                (is (empty? emails)))})))))))
+
+(deftest archived-card-with-skip-false-test
+  (testing "archived cards on a dashboard are skipped but dashboard still sends when skip_if_empty is false"
+    (notification.tu/with-dashboard-notification
+      [notification {:notification-dashboard {:skip_if_empty false}
+                     :handlers              [@notification.tu/default-email-handler]}]
+      (let [dashboard-id (-> notification :payload :dashboard_id)]
+        (mt/with-temp [:model/Card          {archived-id :id} {:dataset_query (mt/native-query {:query "SELECT 1 as data"})
+                                                               :archived      true}
+                       :model/DashboardCard _                  {:dashboard_id dashboard-id
+                                                                :card_id      archived-id}
+                       :model/Card          {live-id :id}      {:dataset_query (mt/native-query {:query "SELECT 'alive' as msg"})}
+                       :model/DashboardCard _                  {:dashboard_id dashboard-id
+                                                                :card_id      live-id}]
+          (notification.tu/test-send-notification!
+           notification
+           {:channel/email
+            (fn [emails]
+              (is (= 1 (count emails))))}))))))
+
+(deftest card-query-failure-on-dashboard-test
+  (testing "a card with a failing query does not crash the entire dashboard subscription"
+    (notification.tu/with-dashboard-notification
+      [notification {:handlers [@notification.tu/default-email-handler]}]
+      (let [dashboard-id (-> notification :payload :dashboard_id)]
+        (mt/with-temp [:model/Card          {bad-id :id}  {:dataset_query (mt/native-query {:query "SELECT 1/0"})}
+                       :model/DashboardCard _              {:dashboard_id dashboard-id
+                                                            :card_id      bad-id}
+                       :model/Card          {good-id :id} {:dataset_query (mt/native-query {:query "SELECT 'ok' as msg"})}
+                       :model/DashboardCard _              {:dashboard_id dashboard-id
+                                                            :card_id      good-id}]
+          (testing "dashboard still sends — failing card is silently dropped, good card is included"
+            (notification.tu/test-send-notification!
+             notification
+             {:channel/email
+              (fn [emails]
+                (is (= 1 (count emails))))})))))))
+
+;; ------------------------------------------------------------------------------------------------;;
+;;                              Empty dashboard / edge case tests                                  ;;
+;; ------------------------------------------------------------------------------------------------;;
+
+(deftest empty-dashboard-no-dashcards-test
+  (testing "dashboard with no cards still sends (empty content) when skip_if_empty is false"
+    (notification.tu/with-dashboard-notification
+      [notification {:notification-dashboard {:skip_if_empty false}
+                     :handlers              [@notification.tu/default-email-handler]}]
+      (notification.tu/test-send-notification!
+       notification
+       {:channel/email
+        (fn [emails]
+          (is (= 1 (count emails))))})))
+
+  (testing "dashboard with no cards is skipped when skip_if_empty is true"
+    (notification.tu/with-dashboard-notification
+      [notification {:notification-dashboard {:skip_if_empty true}
+                     :handlers              [@notification.tu/default-email-handler]}]
+      (notification.tu/test-send-notification!
+       notification
+       {:channel/email
+        (fn [emails]
+          (is (empty? emails)))}))))
+
+;; ------------------------------------------------------------------------------------------------;;
+;;                                    Multi-tab tests                                              ;;
+;; ------------------------------------------------------------------------------------------------;;
+
+(deftest multi-tab-dashboard-test
+  (testing "dashboard with multiple tabs renders tab titles in the notification"
+    (notification.tu/with-notification-testing-setup!
+      (notification.tu/with-dashboard-notification
+        [notification {:dashboard {:name dashboard-name}
+                       :handlers  [@notification.tu/default-email-handler]}]
+        (let [dashboard-id (-> notification :payload :dashboard_id)]
+          (mt/with-temp [:model/DashboardTab  {tab1-id :id} {:dashboard_id dashboard-id :name "Tab One" :position 0}
+                         :model/DashboardTab  {tab2-id :id} {:dashboard_id dashboard-id :name "Tab Two" :position 1}
+                         :model/Card          {card1-id :id} {:dataset_query (mt/native-query {:query "SELECT 'tab1' as msg"})}
+                         :model/Card          {card2-id :id} {:dataset_query (mt/native-query {:query "SELECT 'tab2' as msg"})}
+                         :model/DashboardCard _               {:dashboard_id dashboard-id
+                                                               :card_id      card1-id
+                                                               :dashboard_tab_id tab1-id}
+                         :model/DashboardCard _               {:dashboard_id dashboard-id
+                                                               :card_id      card2-id
+                                                               :dashboard_tab_id tab2-id}]
+            (notification.tu/test-send-notification!
+             notification
+             {:channel/email
+              (fn [[email]]
+                (let [summary (mt/summarize-multipart-single-email
+                               email
+                               (re-pattern dashboard-name)
+                               #"Tab One"
+                               #"Tab Two")]
+                  (testing "email contains tab titles"
+                    (is (true? (get (first (:message summary)) "Tab One")))
+                    (is (true? (get (first (:message summary)) "Tab Two"))))))})))))))
+
+(deftest single-tab-dashboard-test
+  (testing "dashboard with a single tab does NOT render the tab title"
+    (notification.tu/with-notification-testing-setup!
+      (notification.tu/with-dashboard-notification
+        [notification {:dashboard {:name dashboard-name}
+                       :handlers  [@notification.tu/default-email-handler]}]
+        (let [dashboard-id (-> notification :payload :dashboard_id)]
+          (mt/with-temp [:model/DashboardTab  {tab-id :id}  {:dashboard_id dashboard-id :name "Only Tab" :position 0}
+                         :model/Card          {card-id :id} {:dataset_query (mt/native-query {:query "SELECT 'data' as msg"})}
+                         :model/DashboardCard _              {:dashboard_id dashboard-id
+                                                              :card_id      card-id
+                                                              :dashboard_tab_id tab-id}]
+            (notification.tu/test-send-notification!
+             notification
+             {:channel/email
+              (fn [[email]]
+                (let [summary (mt/summarize-multipart-single-email
+                               email
+                               (re-pattern dashboard-name)
+                               #"Only Tab")]
+                  (testing "email does NOT contain the single tab title"
+                    (is (false? (get (first (:message summary)) "Only Tab"))))))})))))))
+
+;; ------------------------------------------------------------------------------------------------;;
+;;                                 card.hide_empty tests                                           ;;
+;; ------------------------------------------------------------------------------------------------;;
+
+(deftest card-hide-empty-visualization-setting-test
+  (testing "card with card.hide_empty=true is excluded from dashboard when empty"
+    (notification.tu/with-notification-testing-setup!
+      (notification.tu/with-dashboard-notification
+        [notification {:dashboard {:name dashboard-name}
+                       :handlers  [@notification.tu/default-email-handler]}]
+        (let [dashboard-id (-> notification :payload :dashboard_id)]
+          (mt/with-temp [:model/Card          {hidden-id :id}  {:dataset_query (mt/native-query {:query "SELECT NULL"})}
+                         :model/DashboardCard _                {:dashboard_id          dashboard-id
+                                                                :card_id               hidden-id
+                                                                :visualization_settings {:card.hide_empty true}}
+                         :model/Card          {visible-id :id} {:dataset_query (mt/native-query {:query "SELECT 'visible' as msg"})}
+                         :model/DashboardCard _                {:dashboard_id dashboard-id
+                                                                :card_id      visible-id}]
+            (notification.tu/test-send-notification!
+             notification
+             {:channel/email
+              (fn [[email]]
+                (let [summary (mt/summarize-multipart-single-email
+                               email
+                               (re-pattern dashboard-name)
+                               #"visible")]
+                  (testing "email still sends (non-hidden card has results)"
+                    (is (= dashboard-name (:subject summary))))
+                  (testing "email contains the visible card"
+                    (is (true? (get (first (:message summary)) "visible"))))))}))))))
+
+  (testing "card with card.hide_empty=false is NOT excluded even when empty"
+    (notification.tu/with-dashboard-notification
+      [notification {:handlers [@notification.tu/default-email-handler]}]
+      (let [dashboard-id (-> notification :payload :dashboard_id)]
+        (mt/with-temp [:model/Card          {card-id :id} {:dataset_query (mt/native-query {:query "SELECT NULL"})}
+                       :model/DashboardCard _              {:dashboard_id          dashboard-id
+                                                            :card_id               card-id
+                                                            :visualization_settings {:card.hide_empty false}}]
+          (notification.tu/test-send-notification!
+           notification
+           {:channel/email
+            (fn [emails]
+              (testing "email still sends even though card result is empty"
+                (is (= 1 (count emails)))))}))))))
+
+;; ------------------------------------------------------------------------------------------------;;
+;;                                     Audit event tests                                           ;;
+;; ------------------------------------------------------------------------------------------------;;
 
 (deftest audit-subscription-send-event-test
   (testing "When we send a dashboard subscription, the event is logged"

--- a/test/metabase/notification/payload/impl/dashboard_test.clj
+++ b/test/metabase/notification/payload/impl/dashboard_test.clj
@@ -1,0 +1,170 @@
+(ns metabase.notification.payload.impl.dashboard-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.notification.core :as notification]
+   [metabase.notification.payload.core :as notification.payload]
+   [metabase.notification.payload.execute :as notification.payload.execute]
+   [metabase.notification.send :as notification.send]
+   [metabase.notification.test-util :as notification.tu]
+   [metabase.test :as mt]))
+
+(set! *warn-on-reflection* true)
+
+(use-fixtures
+  :each
+  (fn [thunk]
+    (binding [notification.send/*default-options* {:notification/sync? true}]
+      (thunk))))
+
+(def ^:private dashboard-name "Test Dashboard Subscription")
+
+(deftest basic-dashboard-notification-test
+  (testing "dashboard notification sends email and slack messages with correct content"
+    (notification.tu/with-notification-testing-setup!
+      (notification.tu/with-dashboard-notification
+        [notification {:dashboard {:name dashboard-name}
+                       :handlers  [@notification.tu/default-email-handler
+                                   notification.tu/default-slack-handler]}]
+        (let [dashboard-id (-> notification :payload :dashboard_id)]
+          (mt/with-temp [:model/Card          {card-id :id} {:name          "Test Card"
+                                                             :dataset_query (mt/native-query {:query "SELECT 'hello world' as msg"})}
+                         :model/DashboardCard _              {:dashboard_id dashboard-id
+                                                              :card_id      card-id}]
+            (notification.tu/test-send-notification!
+             notification
+             {:channel/email
+              (fn [[email]]
+                (let [summary (mt/summarize-multipart-single-email
+                               email
+                               (re-pattern dashboard-name)
+                               #"Manage your subscriptions"
+                               #"hello world")]
+                  (testing "email subject is the dashboard name"
+                    (is (= dashboard-name (:subject summary))))
+                  (testing "email is sent to the correct recipient"
+                    (is (= #{"rasta@metabase.com"} (:recipients summary))))
+                  (testing "email body contains dashboard name"
+                    (is (true? (get (first (:message summary)) dashboard-name))))
+                  (testing "email body contains management link"
+                    (is (true? (get (first (:message summary)) "Manage your subscriptions"))))
+                  (testing "email body contains card content"
+                    (is (true? (get (first (:message summary)) "hello world"))))))
+
+              :channel/slack
+              (fn [[message]]
+                (let [msg (notification.tu/slack-message->boolean message)]
+                  (testing "slack message is sent to the correct channel"
+                    (is (= "#general" (:channel msg))))))})))))))
+
+(deftest skip-if-empty-with-results-test
+  (testing "dashboard with results is NOT skipped when skip_if_empty is true"
+    (notification.tu/with-dashboard-notification
+      [notification {:notification-dashboard {:skip_if_empty true}
+                     :handlers              [@notification.tu/default-email-handler]}]
+      (let [dashboard-id (-> notification :payload :dashboard_id)]
+        (mt/with-temp [:model/Card          {card-id :id} {:dataset_query (mt/native-query {:query "SELECT 1 as data"})}
+                       :model/DashboardCard _              {:dashboard_id dashboard-id
+                                                            :card_id      card-id}]
+          (notification.tu/test-send-notification!
+           notification
+           {:channel/email
+            (fn [emails]
+              (is (= 1 (count emails))))}))))))
+
+(deftest skip-if-empty-no-results-test
+  (testing "dashboard with empty results IS skipped when skip_if_empty is true"
+    (notification.tu/with-dashboard-notification
+      [notification {:notification-dashboard {:skip_if_empty true}
+                     :handlers              [@notification.tu/default-email-handler]}]
+      (let [dashboard-id (-> notification :payload :dashboard_id)]
+        (mt/with-temp [:model/Card          {card-id :id} {:dataset_query (mt/native-query {:query "SELECT NULL"})}
+                       :model/DashboardCard _              {:dashboard_id dashboard-id
+                                                            :card_id      card-id}]
+          (notification.tu/test-send-notification!
+           notification
+           {:channel/email
+            (fn [emails]
+              (is (empty? emails)))}))))))
+
+(deftest no-skip-when-flag-is-false-test
+  (testing "dashboard with empty results is NOT skipped when skip_if_empty is false"
+    (notification.tu/with-dashboard-notification
+      [notification {:notification-dashboard {:skip_if_empty false}
+                     :handlers              [@notification.tu/default-email-handler]}]
+      (let [dashboard-id (-> notification :payload :dashboard_id)]
+        (mt/with-temp [:model/Card          {card-id :id} {:dataset_query (mt/native-query {:query "SELECT NULL"})}
+                       :model/DashboardCard _              {:dashboard_id dashboard-id
+                                                            :card_id      card-id}]
+          (notification.tu/test-send-notification!
+           notification
+           {:channel/email
+            (fn [emails]
+              (is (= 1 (count emails))))}))))))
+
+(deftest skip-if-empty-mixed-results-test
+  (testing "dashboard with mix of empty and non-empty cards is NOT skipped when skip_if_empty is true"
+    (notification.tu/with-dashboard-notification
+      [notification {:notification-dashboard {:skip_if_empty true}
+                     :handlers              [@notification.tu/default-email-handler]}]
+      (let [dashboard-id (-> notification :payload :dashboard_id)]
+        (mt/with-temp [:model/Card          {empty-card-id :id} {:dataset_query (mt/native-query {:query "SELECT NULL"})}
+                       :model/DashboardCard _                   {:dashboard_id dashboard-id
+                                                                 :card_id      empty-card-id}
+                       :model/Card          {full-card-id :id}  {:dataset_query (mt/native-query {:query "SELECT 1 as data"})}
+                       :model/DashboardCard _                   {:dashboard_id dashboard-id
+                                                                 :card_id      full-card-id}]
+          (notification.tu/test-send-notification!
+           notification
+           {:channel/email
+            (fn [emails]
+              (is (= 1 (count emails))))}))))))
+
+(deftest dashboard-rows-saved-to-disk-cleanup-test
+  (testing "temp files created for dashboard card results are cleaned up after send"
+    (let [rows-atom       (atom nil)
+          orig-execute-fn @#'notification.payload.execute/execute-dashboard-subscription-card]
+      (with-redefs [notification.payload.execute/cells-to-disk-threshold           1
+                    notification.payload.execute/execute-dashboard-subscription-card
+                    (fn [& args]
+                      (let [result (apply orig-execute-fn args)]
+                        (when result
+                          (reset! rows-atom (-> result :result :data :rows)))
+                        result))]
+        (notification.tu/with-notification-testing-setup!
+          (notification.tu/with-dashboard-notification
+            [notification {:handlers [@notification.tu/default-email-handler]}]
+            (let [dashboard-id (-> notification :payload :dashboard_id)]
+              (mt/with-temp [:model/Card          {card-id :id} {:dataset_query (mt/mbql-query orders {:limit 2})}
+                             :model/DashboardCard _              {:dashboard_id dashboard-id
+                                                                  :card_id      card-id}]
+                (notification/send-notification! notification)
+                (testing "sanity check that the rows were saved to disk"
+                  (is (notification.payload/cleanable? @rows-atom)))
+                (testing "the files are cleaned up after send"
+                  (is (not (.exists ^java.io.File
+                            (.file ^metabase.notification.payload.temp_storage.StreamingTempFileStorage
+                             @rows-atom)))))))))))))
+
+(deftest audit-subscription-send-event-test
+  (testing "When we send a dashboard subscription, the event is logged"
+    (mt/when-ee-evailable
+     (mt/with-premium-features #{:audit-app}
+       (notification.tu/with-dashboard-notification
+         [notification {:handlers [{:channel_type :channel/email
+                                    :recipients   [{:type    :notification-recipient/user
+                                                    :user_id (mt/user->id :rasta)}
+                                                   {:type    :notification-recipient/raw-value
+                                                    :details {:value "external@example.com"}}]}]}]
+         (let [dashboard-id (-> notification :payload :dashboard_id)]
+           (mt/with-temp [:model/Card          {card-id :id} {:dataset_query (mt/native-query {:query "SELECT 1 as data"})}
+                          :model/DashboardCard _              {:dashboard_id dashboard-id
+                                                               :card_id      card-id}]
+             (notification/send-notification! notification :notification/sync? true)
+             (is (=? {:topic    :subscription-send
+                      :user_id  (mt/user->id :crowberto)
+                      :model    "Pulse"
+                      :model_id (:id notification)
+                      :details  {:recipients [{:id (mt/user->id :rasta)}
+                                              "external@example.com"]
+                                 :filters    nil}}
+                     (mt/latest-audit-log-entry :subscription-send (:id notification)))))))))))

--- a/test/metabase/notification/test_util.clj
+++ b/test/metabase/notification/test_util.clj
@@ -105,6 +105,7 @@
   [& body]
   `(mt/with-model-cleanup [:model/Notification
                            :model/NotificationCard
+                           :model/NotificationDashboard
                            :model/NotificationHandler
                            :model/NotificationSubscription
                            :model/NotificationRecipient]
@@ -171,6 +172,31 @@
                      :handlers          []}]"
   [[bindings props] & body]
   `(do-with-card-notification ~props (fn [~bindings] ~@body)))
+
+(defn do-with-dashboard-notification
+  [{:keys [dashboard notification-dashboard notification subscriptions handlers]} thunk]
+  (mt/with-temp
+    [:model/Dashboard {dashboard-id :id} (merge {:name "Dashboard notification test"} dashboard)]
+    (do-with-temp-notification
+     {:notification  (merge {:payload      (assoc notification-dashboard
+                                                  :dashboard_id dashboard-id)
+                             :payload_type :notification/dashboard
+                             :creator_id   (mt/user->id :crowberto)}
+                            notification)
+      :subscriptions subscriptions
+      :handlers      handlers}
+     thunk)))
+
+(defmacro with-dashboard-notification
+  "Macro that sets up a dashboard notification for testing.
+    (with-dashboard-notification
+      [notification {:dashboard              {:name \"My Dashboard\"}
+                     :notification           {:creator_id 1}
+                     :notification-dashboard {:skip_if_empty true}
+                     :subscriptions          []
+                     :handlers               []}]"
+  [[bindings props] & body]
+  `(do-with-dashboard-notification ~props (fn [~bindings] ~@body)))
 
 (defn do-with-system-event-notification!
   [{:keys [event notification subscriptions handlers]} thunk]


### PR DESCRIPTION
## Summary

Fixes #3846

Migrates dashboard subscriptions from the legacy pulse system to the notification system, unifying them with alerts (migrated in v54). This enables cron-based scheduling for subscriptions — the #1 most requested feature (151 upvotes, 9+ years old).

### What changed

**Database & Migration**
- New `notification_dashboard` table (parallel to `notification_card` for alerts) storing dashboard_id, parameters, skip_if_empty, and per-card export options
- Data migration converts existing pulse-based subscriptions to notification records, including schedule-to-cron conversion and Quartz trigger cleanup

**Backend**
- Full model support for `NotificationDashboard` with CRUD, hydration, permissions, and spec-update
- `GET /api/notification?dashboard_id=X` endpoint for listing subscriptions per dashboard
- Updated payload impl to read from `notification_dashboard`
- Removed dashboard subscription handling from legacy `send_pulses` task

**Frontend**
- Rewrote `DashboardSubscriptionsSidebar` to use the notification API instead of pulse API
- Replaced legacy `SchedulePicker` with the modern `Schedule` component (supports cron expressions)
- Added adapter layer to maintain backward compatibility with existing UI patterns
- Updated TypeScript types for dashboard notification payloads

### Tests
- 21 comprehensive dashboard notification payload tests (email + Slack rendering, skip-if-empty, multi-tab, permissions, attachments, audit events, etc.)
- Data migration tests covering schedule conversion, recipient mapping, archived pulse handling
- API endpoint tests for dashboard notification CRUD
- Updated frontend unit tests for notification-based sidebar

## Test plan

- [ ] Verify existing dashboard subscriptions are migrated correctly after running migrations
- [ ] Create a new email subscription from the dashboard sidebar
- [ ] Create a new Slack subscription from the dashboard sidebar
- [ ] Edit schedule, recipients, and filter parameters on an existing subscription
- [ ] Delete a subscription and verify it's removed
- [ ] Test skip-if-empty behavior
- [ ] Verify subscription sends at the scheduled time
- [ ] Test with multi-tab dashboards
- [ ] Verify CSV/XLS attachment options work correctly
- [ ] Run full backend test suite for notification namespace