### PR TITLE
Ensure race free waiting for overlapping transforms

### DIFF
--- a/src/metabase/transforms/jobs.clj
+++ b/src/metabase/transforms/jobs.clj
@@ -71,19 +71,31 @@
         {:order (map transforms-by-id complete)
          :deps global-ordering}))))
 
+(defn- block-until-not-already-running [transform-id]
+  (when-let [active-run (transform-run/running-run-for-transform-id transform-id)]
+    (log/warn "Transform" (pr-str transform-id) "already running, waiting for run" (:id active-run))
+    (while (transform-run/running-run-for-transform-id transform-id)
+      (Thread/sleep 2000))))
+
 (defn- run-transform! [run-id run-method user-id {transform-id :id :as transform}]
   (if-not (transforms.util/check-feature-enabled transform)
     (log/warnf "Skip running transform %d due to lacking premium features" transform-id)
     (do
-      (when (transform-run/running-run-for-transform-id transform-id)
-        (log/warn "Transform" (pr-str transform-id) "already running, waiting")
+      (block-until-not-already-running transform-id)
+      (let [try-exec
+            (fn []
+              (try
+                (log/info "Executing job transform" (pr-str transform-id))
+                (transforms.execute/execute! transform {:run-method run-method
+                                                        :user-id user-id})
+                (catch Exception e
+                  (if (= :already-running (:error (ex-data e)))
+                    :already-running
+                    (throw e)))))]
         (loop []
-          (Thread/sleep 2000)
-          (when (transform-run/running-run-for-transform-id transform-id)
+          (when (= :already-running (try-exec))
+            (block-until-not-already-running transform-id)
             (recur))))
-      (log/info "Executing job transform" (pr-str transform-id))
-      (transforms.execute/execute! transform {:run-method run-method
-                                              :user-id user-id})
       (transforms.job-run/add-run-activity! run-id))))
 
 (defn run-transforms!

--- a/src/metabase/transforms/query_impl.clj
+++ b/src/metabase/transforms/query_impl.clj
@@ -72,7 +72,6 @@
            run-user-id (if (and (= run-method :manual) user-id)
                          user-id
                          (or owner_user_id creator_id))]
-
        (when-not (every? (fn [feature] (driver.u/supports? (:engine database) feature database)) features)
          (throw (ex-info "The database does not support the requested transform target type."
                          {:driver driver, :database database, :features features})))
@@ -90,7 +89,9 @@
           :transform transform
           :db database)))
      (catch Throwable t
-       (log/error t "Error executing transform")
+       (if (= :already-running (:error (ex-data t)))
+         (log/warnf "Transform %d is already running" id)
+         (log/error t "Error executing transform"))
        (when start-promise
          ;; if the start-promise has been delivered, this is a no-op,
          ;; but we assume nobody would catch the exception anyway


### PR DESCRIPTION
Previously transforms could contend for the `is_active` slot. A common outcome (observed with two overlapping schedules) was that one transform would crash (due to the duplicate key violation).

This commit ensures a collision will fallback to waiting to try again rather than crashing (and alerting the user).