### PR TITLE
visualizer trend lines and bug fixes

### DIFF
--- a/e2e/test/scenarios/dashboard/visualizer/cartesian.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/cartesian.cy.spec.ts
@@ -334,6 +334,23 @@ describe("scenarios > dashboard > visualizer > cartesian", () => {
     });
   });
 
+  it("should support trend lines (metabase #61197)", () => {
+    createDashboardWithVisualizerDashcards();
+    H.editDashboard();
+
+    H.showDashcardVisualizerModalSettings(0);
+
+    H.modal().within(() => {
+      cy.findByText("Trend line").click();
+      H.trendLine().should("have.length", 2);
+      cy.findByText("Save").click();
+    });
+
+    H.getDashboardCard(0).within(() => {
+      H.trendLine().should("have.length", 2);
+    });
+  });
+
   describe("timeseries breakout", () => {
     it("should automatically use new columns whenever possible", () => {
       const Q1_NAME = ORDERS_COUNT_BY_CREATED_AT.name;

--- a/e2e/test/scenarios/dashboard/visualizer/drillthrough.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/drillthrough.cy.spec.ts
@@ -69,8 +69,8 @@ describe("scenarios > dashboard > visualizer > drillthrough", () => {
   it("should work", () => {
     createDashboardWithVisualizerDashcards();
 
-    const ORDERS_SERIES_COLOR = "#88BF4D";
-    const PRODUCTS_SERIES_COLOR = "#A989C5";
+    const ORDERS_SERIES_COLOR = "#509EE3";
+    const PRODUCTS_SERIES_COLOR = "#88BF4D";
 
     // 1. Cartesian chart, timeseries breakout
     const SEP_2022_POINT_INDEX = 5;

--- a/e2e/test/scenarios/visualizations-charts/trendline.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/trendline.cy.spec.js
@@ -47,6 +47,36 @@ describe("scenarios > question > trendline", () => {
     cy.get("rect");
   });
 
+  it("should handle per-series trend line settings", () => {
+    setup({
+      name: "Per-series trend line settings",
+      query: {
+        "source-table": ORDERS_ID,
+        aggregation: [
+          ["avg", ["field", ORDERS.SUBTOTAL, null]],
+          ["sum", ["field", ORDERS.TOTAL, null]],
+        ],
+        breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "year" }]],
+      },
+      display: "line",
+    });
+    H.openVizSettingsSidebar();
+    H.leftSidebar().within(() => {
+      cy.findByText("Display").click();
+      cy.findByText("Trend line").click();
+    });
+    H.trendLine().should("have.length", 2);
+
+    H.leftSidebar().within(() => {
+      cy.findByText("Data").click();
+      cy.findByTestId("settings-avg").click();
+    });
+    H.popover().within(() => {
+      cy.findByText("Show trend line for this series").click();
+    });
+    H.trendLine().should("have.length", 1);
+  });
+
   it("should display trend line for stack-100% chart (metabase#25614)", () => {
     setup({
       name: "25614",

--- a/frontend/src/metabase/static-viz/index.js
+++ b/frontend/src/metabase/static-viz/index.js
@@ -87,6 +87,7 @@ function getVisualizerRawSeries(rawSeries, dashcardSettings) {
         visualization_settings: settings,
       },
       data: mergedData,
+      columnValuesMapping,
     },
   ];
 }

--- a/frontend/src/metabase/static-viz/index.js
+++ b/frontend/src/metabase/static-viz/index.js
@@ -112,7 +112,7 @@ export function RenderChart(rawSeries, dashcardSettings, options) {
       rawSeries.map((series) => {
         const source = createDataSource(
           "card",
-          series.card.entity_id,
+          series.card.id,
           series.card.name,
         );
         return [source.id, source.name];

--- a/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesSingle.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesSingle.unit.spec.tsx
@@ -7,6 +7,7 @@ import {
 } from "__support__/ui";
 import { QuestionChartSettings } from "metabase/visualizations/components/ChartSettings";
 import registerVisualizations from "metabase/visualizations/register";
+import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
 import type { Series } from "metabase-types/api";
 
 registerVisualizations();
@@ -67,6 +68,85 @@ function getSeries(): Series {
             field_ref: ["aggregation", 0],
             effective_type: "type/BigInteger",
             base_type: "type/BigInteger",
+          },
+        ],
+      },
+    },
+  ] as any;
+}
+
+function getTrendlineSeries(settings: ComputedVisualizationSettings): Series {
+  return [
+    {
+      card: {
+        dataset_query: {},
+        display: "line",
+        parameters: [],
+        visualization_settings: { ...settings },
+        type: "question",
+      },
+      data: {
+        rows: [
+          ["2022-04-01T00:00:00+02:00", 1],
+          ["2022-05-01T00:00:00+02:00", 2],
+        ],
+        cols: [
+          {
+            unit: "month",
+            name: "CREATED_AT",
+            field_ref: [
+              "field",
+              63,
+              {
+                "base-type": "type/DateTime",
+                "temporal-unit": "month",
+              },
+            ],
+            effective_type: "type/DateTime",
+            base_type: "type/DateTime",
+          },
+          {
+            name: "count",
+            field_ref: ["aggregation", 0],
+            effective_type: "type/BigInteger",
+            base_type: "type/BigInteger",
+          },
+        ],
+      },
+    },
+    {
+      card: {
+        dataset_query: {},
+        display: "line",
+        parameters: [],
+        visualization_settings: {},
+        type: "question",
+      },
+      data: {
+        rows: [
+          ["2022-04-01T00:00:00+02:00", 3],
+          ["2022-05-01T00:00:00+02:00", 4],
+        ],
+        cols: [
+          {
+            unit: "month",
+            name: "CREATED_AT",
+            field_ref: [
+              "field",
+              63,
+              {
+                "base-type": "type/DateTime",
+                "temporal-unit": "month",
+              },
+            ],
+            effective_type: "type/DateTime",
+            base_type: "type/DateTime",
+          },
+          {
+            name: "sum",
+            field_ref: ["aggregation", 1],
+            effective_type: "type/Float",
+            base_type: "type/Float",
           },
         ],
       },
@@ -139,5 +219,58 @@ describe("ChartNestedSettingSeriesSingle", () => {
         screen.getByTestId("chart-settings-widget-series_settings"),
       ).getByTestId("chart-settings-widget-show_series_values"),
     ).not.toHaveAttribute("hidden");
+  });
+
+  it("should render the `Show trend line for this series` switch when graph.show_trendline is true", async () => {
+    setup({ series: getTrendlineSeries({ "graph.show_trendline": true }) });
+
+    const expandButtons = screen.getAllByRole("img", { name: /ellipsis/i });
+    fireEvent.click(expandButtons[1]);
+
+    await waitFor(() => {
+      screen.getByTestId("chart-settings-widget-series_settings");
+    });
+
+    expect(
+      within(
+        screen.getByTestId("chart-settings-widget-series_settings"),
+      ).getByTestId("chart-settings-widget-show_series_trendline"),
+    ).not.toHaveAttribute("hidden");
+  });
+
+  it("should not render the `Show trend line for this series` switch when graph.show_trendline is falsy", async () => {
+    setup({ series: getTrendlineSeries({}) });
+
+    const expandButtons = screen.getAllByRole("img", { name: /ellipsis/i });
+    fireEvent.click(expandButtons[1]);
+
+    await waitFor(() => {
+      screen.getByTestId("chart-settings-widget-series_settings");
+    });
+
+    expect(
+      within(
+        screen.getByTestId("chart-settings-widget-series_settings"),
+      ).getByTestId("chart-settings-widget-show_series_trendline"),
+    ).toHaveAttribute("hidden");
+  });
+
+  it("should not render the `Show trend line for this series` switch for a single series", async () => {
+    setup({
+      series: getTrendlineSeries({ "graph.show_trendline": true }).slice(0, 1),
+    });
+
+    const expandButtons = screen.getAllByRole("img", { name: /ellipsis/i });
+    fireEvent.click(expandButtons[1]);
+
+    await waitFor(() => {
+      screen.getByTestId("chart-settings-widget-series_settings");
+    });
+
+    expect(
+      within(
+        screen.getByTestId("chart-settings-widget-series_settings"),
+      ).getByTestId("chart-settings-widget-show_series_trendline"),
+    ).toHaveAttribute("hidden");
   });
 });

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/trend-line.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/trend-line.ts
@@ -37,9 +37,16 @@ const getTrendKeyForSeries = (dataKey: DataKey) => `${dataKey}_trend`;
 const getSeriesModelsWithTrends = (
   rawSeries: RawSeries,
   seriesModels: SeriesModel[],
+  settings: ComputedVisualizationSettings,
 ): [SeriesModel, TrendFn][] => {
   return seriesModels
     .map((seriesModel) => {
+      if (
+        settings.series(seriesModel.legacySeriesSettingsObjectKey)
+          .show_series_trendline === false
+      ) {
+        return null;
+      }
       // Breakout series do not support trend lines because the data grouping happens on the client
       if ("breakoutColumn" in seriesModel) {
         return null;
@@ -135,6 +142,7 @@ export const getTrendLines = (
   const seriesModelsWithTrends = getSeriesModelsWithTrends(
     rawSeries,
     visibleSeriesModels,
+    settings,
   );
 
   if (seriesModelsWithTrends.length === 0) {

--- a/frontend/src/metabase/visualizations/lib/settings/series.js
+++ b/frontend/src/metabase/visualizations/lib/settings/series.js
@@ -13,6 +13,7 @@ import {
   getSeriesDefaultLineSize,
   getSeriesDefaultLineStyle,
   getSeriesDefaultLinearInterpolate,
+  getSeriesDefaultShowSeriesTrendline,
   getSeriesDefaultShowSeriesValues,
 } from "metabase/visualizations/shared/settings/series";
 
@@ -181,6 +182,17 @@ export function seriesSetting({ readDependencies = [], def } = {}) {
         ],
       },
       readDependencies: ["display"],
+    },
+    show_series_trendline: {
+      title: t`Show trend line for this series`,
+      widget: "toggle",
+      inline: true,
+      getHidden: (single, seriesSettings, { settings, series }) =>
+        series.length <= 1 || // no need to show series-level control if there's only one series
+        !settings["graph.show_trendline"], // don't show it unless this chart has a global setting
+      getDefault: (single, seriesSettings, { settings }) =>
+        getSeriesDefaultShowSeriesTrendline(settings),
+      readDependencies: ["graph.show_trendline"],
     },
     show_series_values: {
       title: t`Show values for this series`,

--- a/frontend/src/metabase/visualizations/shared/settings/series.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/series.ts
@@ -82,6 +82,10 @@ export const getSeriesDefaultLineMissing = (
   settings: ComputedVisualizationSettings,
 ) => settings["line.missing"] ?? "interpolate";
 
+export const getSeriesDefaultShowSeriesTrendline = (
+  settings: ComputedVisualizationSettings,
+) => settings["graph.show_trendline"];
+
 export const getSeriesDefaultShowSeriesValues = (
   settings: ComputedVisualizationSettings,
 ) => settings["graph.show_values"];

--- a/frontend/src/metabase/visualizer/selectors.ts
+++ b/frontend/src/metabase/visualizer/selectors.ts
@@ -151,8 +151,9 @@ const getVisualizerFlatRawSeries = createSelector(
     getVisualizerRawSettings,
     getVisualizerDatasetData,
     getCards,
+    getVisualizerColumnValuesMapping,
   ],
-  (display, settings, data, cards): RawSeries => {
+  (display, settings, data, cards, columnValuesMapping): RawSeries => {
     if (!display) {
       return [];
     }
@@ -168,6 +169,8 @@ const getVisualizerFlatRawSeries = createSelector(
         } as Card,
 
         data,
+
+        columnValuesMapping,
 
         // Certain visualizations memoize settings computation based on series keys
         // This guarantees a visualization always rerenders on changes
@@ -203,10 +206,7 @@ export const getVisualizerRawSeries = createSelector(
         )
       : flatSeries;
 
-    return series.map((s) => ({
-      ...s,
-      columnValuesMapping,
-    }));
+    return series;
   },
 );
 

--- a/frontend/src/metabase/visualizer/utils/merge-data.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/merge-data.unit.spec.ts
@@ -1,0 +1,121 @@
+import { NumberColumn, StringColumn } from "__support__/visualizations";
+import { createMockColumn, createMockDataset } from "metabase-types/api/mocks";
+
+import { mergeVisualizerData } from "./merge-data";
+
+describe("mergeVisualizerData", () => {
+  it("should combine datasets into a single series", () => {
+    const result = mergeVisualizerData({
+      columns: [
+        createMockColumn(StringColumn({ name: "COLUMN_1" })),
+        createMockColumn(NumberColumn({ name: "COLUMN_2" })),
+        createMockColumn(NumberColumn({ name: "COLUMN_3" })),
+        createMockColumn(StringColumn({ name: "COLUMN_4" })),
+      ],
+      columnValuesMapping: {
+        COLUMN_1: [
+          {
+            sourceId: "card:1",
+            originalName: "CREATED_AT",
+            name: "COLUMN_1",
+          },
+        ],
+        COLUMN_2: [
+          {
+            sourceId: "card:1",
+            originalName: "count",
+            name: "COLUMN_2",
+          },
+        ],
+        COLUMN_3: [
+          {
+            sourceId: "card:2",
+            originalName: "count",
+            name: "COLUMN_3",
+          },
+        ],
+        COLUMN_4: [
+          {
+            sourceId: "card:2",
+            originalName: "CREATED_AT",
+            name: "COLUMN_4",
+          },
+        ],
+      },
+      datasets: {
+        "card:1": createMockDataset({
+          data: {
+            cols: [
+              createMockColumn(StringColumn({ name: "CREATED_AT" })),
+              createMockColumn(NumberColumn({ name: "count" })),
+            ],
+            rows: [
+              ["2025-01-01", 1],
+              ["2025-01-02", 2],
+              ["2025-01-03", 3],
+            ],
+            insights: [
+              {
+                col: "count",
+                unit: "month",
+                offset: 0,
+                slope: 1,
+                "last-change": 0,
+                "last-value": 0,
+                "previous-value": 0,
+              },
+            ],
+          },
+        }),
+        "card:2": createMockDataset({
+          data: {
+            cols: [
+              createMockColumn(NumberColumn({ name: "count" })),
+              createMockColumn(StringColumn({ name: "CREATED_AT" })),
+            ],
+            rows: [
+              [4, "2025-01-01"],
+              [5, "2025-01-02"],
+            ],
+            insights: [
+              {
+                col: "count",
+                unit: "month",
+                offset: 0,
+                slope: 2,
+                "last-change": 0,
+                "last-value": 0,
+                "previous-value": 0,
+              },
+            ],
+          },
+        }),
+      },
+      dataSources: [
+        {
+          id: "card:1",
+          sourceId: 1,
+          type: "card",
+          name: "Chart 1",
+        },
+        {
+          id: "card:2",
+          sourceId: 2,
+          type: "card",
+          name: "Chart 2",
+        },
+      ],
+    });
+
+    expect(result.rows).toEqual([
+      ["2025-01-01", 1, 4, "2025-01-01"],
+      ["2025-01-02", 2, 5, "2025-01-02"],
+      ["2025-01-03", 3, undefined, undefined],
+    ]);
+
+    expect(result.insights.map((insight) => insight.col)).toEqual([
+      "COLUMN_2",
+      "COLUMN_3",
+    ]);
+  });
+});

--- a/frontend/src/metabase/visualizer/utils/split-series.ts
+++ b/frontend/src/metabase/visualizer/utils/split-series.ts
@@ -73,9 +73,12 @@ export function splitVisualizerSeries(
         return null;
       }
 
-      const rows = series[0].data.rows.map((row) =>
-        row.filter((_, i) => columnNames.includes(data.cols[i].name)),
-      );
+      const rows = series[0].data.rows
+        .map((row) =>
+          row.filter((_, i) => columnNames.includes(data.cols[i].name)),
+        )
+        // if the entire row is undefined, it was introduced when joining in mergeVisualizerData
+        .filter((row) => row.some((val) => val !== undefined));
 
       const metrics = allMetrics?.filter((columnName) =>
         columnNames.includes(columnName),
@@ -103,8 +106,12 @@ export function splitVisualizerSeries(
         data: {
           cols,
           rows,
+          insights: series[0].data.insights?.filter((insight) =>
+            columnNames.includes(insight.col),
+          ),
           results_metadata: { columns: resultMetadataCols },
         },
+        columnValuesMapping,
         started_at: new Date().toISOString(),
       };
     })

--- a/frontend/src/metabase/visualizer/utils/split-series.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/split-series.unit.spec.ts
@@ -1,0 +1,124 @@
+import registerVisualizations from "metabase/visualizations/register";
+import type { RowValues } from "metabase-types/api/dataset";
+import {
+  createMockCard,
+  createMockColumn,
+  createMockDatasetData,
+} from "metabase-types/api/mocks";
+
+import { splitVisualizerSeries } from "./split-series";
+
+registerVisualizations();
+
+describe("splitVisualizerSeries", () => {
+  it("should split a single series into multiple series", () => {
+    const series = splitVisualizerSeries(
+      [
+        {
+          card: createMockCard({
+            display: "line",
+            visualization_settings: {
+              "graph.metrics": ["COLUMN_2", "COLUMN_3"],
+              "graph.dimensions": ["COLUMN_1", "COLUMN_4"],
+            },
+          }),
+          data: createMockDatasetData({
+            cols: [
+              createMockColumn({ name: "COLUMN_1" }),
+              createMockColumn({ name: "COLUMN_2" }),
+              createMockColumn({ name: "COLUMN_3" }),
+              createMockColumn({ name: "COLUMN_4" }),
+            ],
+            // todo make this more type safe
+            // mergeVisualizerData can return undefined, which isn't a value RowValue
+            // but it's the only way we can determine which rows to filter out when splitting
+            rows: [
+              ["2025-01-01", 1, 4, "2025-01-01"],
+              ["2025-01-02", 2, 5, "2025-01-02"],
+              ["2025-01-03", 3, undefined, undefined],
+            ] as RowValues[],
+            insights: [
+              {
+                col: "COLUMN_2",
+                unit: "month",
+                offset: 0,
+                slope: 1,
+                "last-change": 0,
+                "last-value": 0,
+                "previous-value": 0,
+              },
+              {
+                col: "COLUMN_3",
+                unit: "month",
+                offset: 0,
+                slope: 2,
+                "last-change": 0,
+                "last-value": 0,
+                "previous-value": 0,
+              },
+            ],
+          }),
+        },
+      ],
+      {
+        COLUMN_1: [
+          {
+            sourceId: "card:1",
+            originalName: "CREATED_AT",
+            name: "COLUMN_1",
+          },
+        ],
+        COLUMN_2: [
+          {
+            sourceId: "card:1",
+            originalName: "count",
+            name: "COLUMN_2",
+          },
+        ],
+        COLUMN_3: [
+          {
+            sourceId: "card:2",
+            originalName: "count",
+            name: "COLUMN_3",
+          },
+        ],
+        COLUMN_4: [
+          {
+            sourceId: "card:2",
+            originalName: "CREATED_AT",
+            name: "COLUMN_4",
+          },
+        ],
+      },
+      {},
+    );
+    expect(series).toHaveLength(2);
+    const series1 = series[0];
+    const series2 = series[1];
+    expect(series1.data.cols.map((col) => col.name)).toEqual([
+      "COLUMN_1",
+      "COLUMN_2",
+    ]);
+    expect(series2.data.cols.map((col) => col.name)).toEqual([
+      "COLUMN_3",
+      "COLUMN_4",
+    ]);
+    expect(series1.data.rows).toEqual([
+      ["2025-01-01", 1],
+      ["2025-01-02", 2],
+      ["2025-01-03", 3],
+    ]);
+    expect(series2.data.rows).toEqual([
+      [4, "2025-01-01"],
+      [5, "2025-01-02"],
+    ]);
+    expect(series1.data.insights?.map((insight) => insight.col)).toEqual([
+      "COLUMN_2",
+    ]);
+    expect(series2.data.insights?.map((insight) => insight.col)).toEqual([
+      "COLUMN_3",
+    ]);
+    expect(series1.columnValuesMapping).toBeDefined();
+    expect(series2.columnValuesMapping).toBeDefined();
+  });
+});


### PR DESCRIPTION
Closes #61197
Closes #65304
Closes #64453

### Description

This PR makes a few visualizer fixes:

- Adds trend line support to visualizer by handling `insights` in `mergeVisualizerData` and `splitVisualizerSeries`
  - Also adds a per-series trend line setting as requested by the customer
- While #60115 fixed default colors in the visualizer in some cases, it didn't fix static viz or the case where data from two separate cards is combined in the visualizer. This is fixed by changing the handling of `columnValuesMapping`
- Static viz didn't respect per-series level settings for combined visualizer cards. This is fixed by passing `id` rather than `entity_id` into `createDataSource`, enabling `splitVisualizerSeries` to get the correct series name, which is used in `legacySeriesSettingObjectKey` to look up per-series level settings
  - While looking at other issues, I realized this fixes #64453
- #65304 is fixed by filtering out rows where every value is undefined in `splitVisualizerSeries`
  - This probably deserved its own PR, but would have required the newly added unit test in `split-series.unit.spec.ts` to be wrong in this PR

### How to verify

1. Create two questions: Count of Orders grouped by Created At and Count of Accounts grouped by Created At
2. Create a dashboard and combine the questions in a card using visualizer
3. Save your changes. Verify that the colors match between visualizer and the dashboard (the colors are broken on master).
4. Open visualizer again and add trend lines (this setting is not available on master).
5. Turn off the trend line for Count of Orders and send the dashboard as an email subscription. Verify that the email only includes a trend line for Count of Accounts (per-series settings are broken on master. Since you can't use trend lines on master, you can test this with the "Show values on data points setting).

For #65304 and #64453, follow the steps in the issue.

### Demo

[Loom](https://www.loom.com/share/f0c796b499544858b5921adcdd98c594)

After #65304 fix:
<img width="512" height="399" alt="image" src="https://github.com/user-attachments/assets/a307dcec-489e-4d0a-b602-f003fb6b19cd" />

After #64453 fix:
<img width="571" height="455" alt="image" src="https://github.com/user-attachments/assets/bc6e9852-0bce-457b-b5d2-1524d2a91dc6" />

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
