### PR TITLE
Don't attempt to add revisions for viewing docs

### DIFF
--- a/src/metabase/documents/view_log.clj
+++ b/src/metabase/documents/view_log.clj
@@ -26,7 +26,9 @@
                                             (fn [xs] (apply t/max (map :timestamp xs))))]
     (try
       (cluster-lock/with-cluster-lock document-statistics-lock
-        (t2/update! :model/Document :id [:in (keys document-id->timestamp)]
+        ;; use `t2/table-name` to avoid triggering `after-update` hooks and creating a revision
+        (t2/update! (t2/table-name :model/Document)
+                    :id [:in (keys document-id->timestamp)]
                     {:last_viewed_at (into [:case]
                                            (mapcat (fn [[id timestamp]]
                                                      [[:= :id id] [:greatest [:coalesce :last_viewed_at (t/offset-date-time 0)] timestamp]])


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #69293
Luckily a bug saved us from *actually* creating revisions here (the `before-update` hook doesn't get an actual instance in this case). But ... we shouldn't be attempting it.

Fixes [GIT-9167: viewing a document adds a revision (which errored)](https://linear.app/metabase/issue/GIT-9167/viewing-a-document-adds-a-revision-which-errored)