### PR TITLE
updating upsell CTA links

### DIFF
--- a/frontend/src/metabase/admin/upsells/constants.ts
+++ b/frontend/src/metabase/admin/upsells/constants.ts
@@ -1,1 +1,2 @@
 export const UPGRADE_URL = "https://www.metabase.com/upgrade";
+export const DATA_STUDIO_UPGRADE_URL = `${UPGRADE_URL}/data-studio`;

--- a/frontend/src/metabase/data-studio/upsells/pages/BaseUpsellPage.tsx
+++ b/frontend/src/metabase/data-studio/upsells/pages/BaseUpsellPage.tsx
@@ -8,7 +8,7 @@ import {
   trackUpsellClicked,
   trackUpsellViewed,
 } from "metabase/admin/upsells/components/analytics";
-import { UPGRADE_URL } from "metabase/admin/upsells/constants";
+import { DATA_STUDIO_UPGRADE_URL } from "metabase/admin/upsells/constants";
 import { useCheckTrialAvailableQuery } from "metabase/api/cloud-proxy";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { DataStudioBreadcrumbs } from "metabase/data-studio/common/components/DataStudioBreadcrumbs";
@@ -52,7 +52,7 @@ export function BaseUpsellPage({
   image,
 }: BaseUpsellPageProps) {
   const { onClick: upgradeOnClick, url: upgradeUrl } = useUpgradeAction({
-    url: UPGRADE_URL,
+    url: DATA_STUDIO_UPGRADE_URL,
     campaign,
     location,
   });

--- a/frontend/src/metabase/data-studio/upsells/pages/RemoteSyncUpsellPage.tsx
+++ b/frontend/src/metabase/data-studio/upsells/pages/RemoteSyncUpsellPage.tsx
@@ -4,7 +4,7 @@ import { useUpgradeAction } from "metabase/admin/upsells/components/UpgradeModal
 import { UpsellCta } from "metabase/admin/upsells/components/UpsellCta";
 import { UpsellGem } from "metabase/admin/upsells/components/UpsellGem";
 import { trackUpsellClicked } from "metabase/admin/upsells/components/analytics";
-import { UPGRADE_URL } from "metabase/admin/upsells/constants";
+import { DATA_STUDIO_UPGRADE_URL } from "metabase/admin/upsells/constants";
 import { useCheckTrialAvailableQuery } from "metabase/api/cloud-proxy";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { DataStudioBreadcrumbs } from "metabase/data-studio/common/components/DataStudioBreadcrumbs";
@@ -35,7 +35,7 @@ const LOCATION = "data-studio-remote-sync";
 
 export function RemoteSyncUpsellPage() {
   const { onClick: upgradeOnClick, url: upgradeUrl } = useUpgradeAction({
-    url: UPGRADE_URL,
+    url: DATA_STUDIO_UPGRADE_URL,
     campaign: CAMPAIGN,
     location: LOCATION,
   });


### PR DESCRIPTION
### Description
Updates the CTAs in the data studio upsell pages to point to specialized campaign pages

### How to verify
1. Start up metabase in OSS
2. go to the data studio. The library, dependency and remote sync pages should have CTAs that point to `https://www.metabase.com/upgrade/data-studio`

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
