### PR TITLE
Ad-hoc querying for slackbot

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot.clj
@@ -333,8 +333,7 @@
         (perms/query-creation-capabilities api/*current-user-id*)]
     (cond-> []
       can-create-queries        (conj "permission:save_questions")
-      can-create-native-queries (conj "permission:write_sql_queries")
-      api/*is-superuser?*       (conj "permission:write_transforms"))))
+      can-create-native-queries (conj "permission:write_sql_queries"))))
 
 (defn- make-ai-request
   "Make an AI request and return both text and data parts.

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot.clj
@@ -807,9 +807,8 @@
   ;; 4. execute this form to copy the manifest to clipboard, paste the result in the manifest page
   (do
     (require '[clojure.java.shell :refer [sh]])
-    (sh "pbcopy" :in (json/encode (slackbot-manifest (system/site-url)) {:pretty true})))
+    (sh "pbcopy" :in (json/encode (slackbot-manifest (system/site-url)) {:pretty true}))))
   ;; 5. there will be a notification at the top of the manifest page to verify your new site url, click verify
-  )
 
 ;; ----------------- DEV -----------------------
 

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot.clj
@@ -8,6 +8,7 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [malli.core :as mc]
+   [metabase-enterprise.metabot-v3.api.slackbot.query :as slackbot.query]
    [metabase-enterprise.metabot-v3.client :as metabot-v3.client]
    [metabase-enterprise.metabot-v3.config :as metabot-v3.config]
    [metabase-enterprise.metabot-v3.context :as metabot-v3.context]
@@ -610,14 +611,27 @@
          {:keys [text data-parts]} (make-ai-request (str (random-uuid)) prompt thread extra-history)]
      (delete-message client thinking-message)
      (post-message client (merge message-ctx {:text text}))
-     (let [vizs (filter #(= (:type %) "static_viz") data-parts)]
-       (doseq [viz vizs]
-         (when-let [card-id (get-in viz [:value :entity_id])]
-           (let [png-bytes (generate-card-png card-id)
-                 filename (str "chart-" card-id ".png")]
-             (post-image client png-bytes filename
-                         (:channel message-ctx)
-                         (:thread_ts message-ctx)))))))))
+     (let [vizs      (filter #(#{"static_viz" "adhoc_viz"} (:type %)) data-parts)
+           channel   (:channel message-ctx)
+           thread-ts (:thread_ts message-ctx)]
+       (doseq [{:keys [type value]} vizs]
+         (try
+           (case type
+             "static_viz"
+             (when-let [card-id (:entity_id value)]
+               (let [png-bytes (generate-card-png card-id)
+                     filename  (str "chart-" card-id ".png")]
+                 (post-image client png-bytes filename channel thread-ts)))
+
+             "adhoc_viz"
+             (let [{:keys [query display]} value
+                   png-bytes (slackbot.query/generate-adhoc-png
+                              query
+                              :display (or (some-> display keyword) :table))
+                   filename  (str "adhoc-" (System/currentTimeMillis) ".png")]
+               (post-image client png-bytes filename channel thread-ts)))
+           (catch Exception e
+             (log/errorf e "Failed to generate visualization for %s" type))))))))
 
 (defn- send-auth-link
   "Respond to an incoming slack message with a request to authorize"

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/query.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/query.clj
@@ -19,13 +19,13 @@
 
 (defn generate-adhoc-png
   "Execute an ad-hoc query and render results to PNG."
-  [query & {:keys [display width]
-            :or   {display :table width 1280}}]
+  [query & {:keys [display]
+            :or   {display :table}}]
   (let [results    (execute-adhoc-query query)
         adhoc-card {:display                display
                     :visualization_settings {}}]
     (channel.render/render-adhoc-card-to-png
      adhoc-card
      results
-     width
+     1280
      {:channel.render/padding-x 32})))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/query.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/query.clj
@@ -1,0 +1,30 @@
+(ns metabase-enterprise.metabot-v3.api.slackbot.query
+  "Ad-hoc query execution and visualization for slackbot."
+  (:require
+   [metabase.api.common :as api]
+   [metabase.channel.render.core :as channel.render]
+   [metabase.query-processor :as qp]))
+
+(set! *warn-on-reflection* true)
+
+(defn execute-adhoc-query
+  "Execute an ad-hoc MBQL query and return results."
+  [query]
+  (qp/process-query
+   (-> query
+       (update-in [:middleware :js-int-to-string?] (fnil identity true))
+       qp/userland-query-with-default-constraints
+       (update :info merge {:executed-by api/*current-user-id*
+                            :context     :slackbot}))))
+
+(defn generate-adhoc-png
+  "Execute an ad-hoc query and render results to PNG."
+  [query & {:keys [display width]
+            :or   {display :table width 1280}}]
+  (let [results    (execute-adhoc-query query)
+        adhoc-card {:display display}]
+    (channel.render/render-adhoc-card-to-png
+     adhoc-card
+     results
+     width
+     {:channel.render/padding-x 32})))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/query.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/query.clj
@@ -22,7 +22,8 @@
   [query & {:keys [display width]
             :or   {display :table width 1280}}]
   (let [results    (execute-adhoc-query query)
-        adhoc-card {:display display}]
+        adhoc-card {:display                display
+                    :visualization_settings {}}]
     (channel.render/render-adhoc-card-to-png
      adhoc-card
      results

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/settings.clj
@@ -1,6 +1,6 @@
 (ns metabase-enterprise.metabot-v3.settings
   (:require
-   [metabase.premium-features.defenterprise :refer [defenterprise]]
+   [metabase.premium-features.core :refer [defenterprise]]
    [metabase.settings.core :as setting :refer [defsetting]]
    [metabase.util.i18n :refer [deferred-tru]]))
 

--- a/enterprise/backend/src/metabase_enterprise/sso/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/settings.clj
@@ -416,7 +416,10 @@ using, this usually looks like `https://your-org-name.example.com` or `https://e
   :default false
   :feature :sso-slack
   :audit   :getter
-  :getter  slack-connect-configured)
+  :getter  (fn []
+             (if (slack-connect-configured)
+               (setting/get-value-of-type :boolean :slack-connect-enabled)
+               false)))
 
 (slack-connect-enabled)
 

--- a/enterprise/backend/src/metabase_enterprise/sso/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/settings.clj
@@ -421,8 +421,6 @@ using, this usually looks like `https://your-org-name.example.com` or `https://e
                (setting/get-value-of-type :boolean :slack-connect-enabled)
                false)))
 
-(slack-connect-enabled)
-
 (defsetting other-sso-enabled?
   "Are we using an SSO integration other than LDAP or Google Auth? These integrations use the `/auth/sso` endpoint for
   authorization rather than the normal login form or Google Auth button."

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot/query_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot/query_test.clj
@@ -1,0 +1,90 @@
+(ns metabase-enterprise.metabot-v3.api.slackbot.query-test
+  "Integration tests for ad-hoc query execution and visualization."
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.metabot-v3.api.slackbot.query :as slackbot.query]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.test :as mt])
+  (:import
+   (java.awt.image BufferedImage)
+   (java.io ByteArrayInputStream)
+   (javax.imageio ImageIO)))
+
+(set! *warn-on-reflection* true)
+
+(defn- bytes->image
+  "Parse PNG bytes into a BufferedImage. Returns nil if bytes are not a valid image."
+  ^BufferedImage [^bytes b]
+  (with-open [input-stream (ByteArrayInputStream. b)]
+    (ImageIO/read input-stream)))
+
+(deftest execute-adhoc-query-test
+  (testing "execute-adhoc-query runs a query and returns results"
+    (mt/with-current-user (mt/user->id :rasta)
+      (let [mp      (mt/metadata-provider)
+            query   (-> (lib/query mp (lib.metadata/table mp (mt/id :venues)))
+                        (lib/limit 5))
+            results (slackbot.query/execute-adhoc-query query)]
+        (testing "returns query results with expected structure"
+          (is (map? results))
+          (is (contains? results :data))
+          (is (contains? (:data results) :rows))
+          (is (contains? (:data results) :cols)))
+        (testing "returns correct number of rows"
+          (is (= 5 (count (get-in results [:data :rows])))))))))
+
+(deftest execute-adhoc-query-aggregation-test
+  (testing "execute-adhoc-query handles aggregation queries"
+    (mt/with-current-user (mt/user->id :rasta)
+      (let [mp      (mt/metadata-provider)
+            query   (-> (lib/query mp (lib.metadata/table mp (mt/id :venues)))
+                        (lib/aggregate (lib/count))
+                        (lib/breakout (lib.metadata/field mp (mt/id :venues :category_id))))
+            results (slackbot.query/execute-adhoc-query query)]
+        (testing "returns aggregated results"
+          (is (seq (get-in results [:data :rows]))))
+        (testing "has correct columns for aggregation"
+          (let [col-names (map :name (get-in results [:data :cols]))]
+            (is (some #(re-find #"(?i)category" %) col-names))
+            (is (some #(re-find #"(?i)count" %) col-names))))))))
+
+(deftest generate-adhoc-png-table-test
+  (testing "generate-adhoc-png renders table visualization as PNG"
+    (mt/with-current-user (mt/user->id :rasta)
+      (let [mp    (mt/metadata-provider)
+            query (-> (lib/query mp (lib.metadata/table mp (mt/id :venues)))
+                      (lib/limit 10))
+            png   (slackbot.query/generate-adhoc-png query :display :table)
+            image (bytes->image png)]
+        (testing "returns parseable PNG"
+          (is (some? image)))
+        (testing "image has reasonable dimensions"
+          (is (< 100 (.getWidth image))))))))
+
+(deftest generate-adhoc-png-bar-chart-test
+  (testing "generate-adhoc-png renders bar chart visualization as PNG"
+    (mt/with-current-user (mt/user->id :rasta)
+      (let [mp    (mt/metadata-provider)
+            query (-> (lib/query mp (lib.metadata/table mp (mt/id :venues)))
+                      (lib/aggregate (lib/count))
+                      (lib/breakout (lib.metadata/field mp (mt/id :venues :category_id))))
+            png   (slackbot.query/generate-adhoc-png query :display :bar)
+            image (bytes->image png)]
+        (testing "returns parseable PNG"
+          (is (some? image)))))))
+
+(deftest generate-adhoc-png-line-chart-test
+  (testing "generate-adhoc-png renders line chart visualization as PNG"
+    (mt/dataset test-data
+      (mt/with-current-user (mt/user->id :rasta)
+        (let [mp         (mt/metadata-provider)
+              created-at (lib.metadata/field mp (mt/id :orders :created_at))
+              query      (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+                             (lib/aggregate (lib/count))
+                             (lib/breakout (lib/with-temporal-bucket created-at :month))
+                             (lib/limit 12))
+              png        (slackbot.query/generate-adhoc-png query :display :line)
+              image      (bytes->image png)]
+          (testing "returns parseable PNG"
+            (is (some? image))))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api_test.clj
@@ -168,16 +168,17 @@
             (mt/user-http-request :rasta :post 400 "ee/metabot-v3/feedback" {:foo "bar"})))))))
 
 (deftest endpoints-require-authentication-test
-  (testing "Metabot v3 endpoints require authentication"
-    (testing "/agent-streaming"
-      (is (= "Unauthenticated"
-             (mt/client :post 401 "ee/metabot-v3/agent-streaming"
-                        {:message "Test"
-                         :context {}
-                         :conversation_id (str (random-uuid))
-                         :history []
-                         :state {}}))))
-    (testing "/feedback"
-      (is (= "Unauthenticated"
-             (mt/client :post 401 "ee/metabot-v3/feedback"
-                        {:feedback {}}))))))
+  (mt/with-premium-features #{:metabot-v3}
+    (testing "Metabot v3 endpoints require authentication"
+      (testing "/agent-streaming"
+        (is (= "Unauthenticated"
+               (mt/client :post 401 "ee/metabot-v3/agent-streaming"
+                          {:message "Test"
+                           :context {}
+                           :conversation_id (str (random-uuid))
+                           :history []
+                           :state {}}))))
+      (testing "/feedback"
+        (is (= "Unauthenticated"
+               (mt/client :post 401 "ee/metabot-v3/feedback"
+                          {:feedback {}})))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/middleware/auth_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/middleware/auth_test.clj
@@ -1,0 +1,74 @@
+(ns metabase-enterprise.metabot-v3.middleware.auth-test
+  "EE-specific tests for auth middleware, particularly Slack signature verification."
+  (:require
+   [buddy.core.codecs :as codecs]
+   [buddy.core.mac :as mac]
+   [clojure.test :refer :all]
+   [metabase-enterprise.metabot-v3.settings :as metabot.settings]
+   [metabase.server.middleware.auth :as mw.auth]
+   [metabase.test :as mt]
+   [ring.mock.request :as ring.mock]))
+
+(set! *warn-on-reflection* true)
+
+;;; ------------------------------------------ TEST verify-slack-request middleware ------------------------------------------
+
+(def ^:private test-signing-secret "test-slack-signing-secret-12345")
+
+(defn- compute-slack-signature
+  "Compute a valid Slack signature for testing"
+  [body timestamp signing-secret]
+  (let [message   (str "v0:" timestamp ":" body)
+        signature (-> (mac/hash message {:key signing-secret :alg :hmac+sha256})
+                      codecs/bytes->hex)]
+    (str "v0=" signature)))
+
+(defn- wrapped-slack-handler
+  "Invoke verify-slack-request middleware and return the modified request"
+  [request]
+  ((mw.auth/verify-slack-request
+    (fn [request respond _] (respond request)))
+   request
+   identity
+   (fn [e] (throw e))))
+
+(defn- slack-request
+  "Create a mock request with Slack signature headers and a body"
+  ^java.util.Map [^String body ^String timestamp ^String signature]
+  (-> (ring.mock/request :post "/anyurl")
+      (ring.mock/header "x-slack-signature" signature)
+      (ring.mock/header "x-slack-request-timestamp" timestamp)
+      (assoc :body (java.io.ByteArrayInputStream. (.getBytes body "UTF-8")))))
+
+(deftest verify-slack-request-test
+  (mt/with-premium-features #{:metabot-v3}
+    (testing "Valid signature w/ signing secret configured"
+      (mt/with-temporary-setting-values [metabot.settings/metabot-slack-signing-secret test-signing-secret]
+        (let [body      "test-body"
+              timestamp "1234567890"
+              signature (compute-slack-signature body timestamp test-signing-secret)
+              result    (wrapped-slack-handler (slack-request body timestamp signature))]
+          (is (true? (:slack/validated? result))))))
+
+    (testing "Invalid signature"
+      (mt/with-temporary-setting-values [metabot.settings/metabot-slack-signing-secret test-signing-secret]
+        (let [body      "test-body"
+              timestamp "1234567890"
+              signature "v0=invalid-signature"
+              result    (wrapped-slack-handler (slack-request body timestamp signature))]
+          (is (false? (:slack/validated? result))))))
+
+    (testing "No signature header present - request passes through unchanged"
+      (let [body    "test-body"
+            request (-> (ring.mock/request :post "/anyurl")
+                        (assoc :body (java.io.ByteArrayInputStream. (.getBytes ^String body "UTF-8"))))
+            result  (wrapped-slack-handler request)]
+        (is (not (contains? result :slack/validated?)))))
+
+    (testing "No signing secret configured"
+      (mt/with-temporary-setting-values [metabot.settings/metabot-slack-signing-secret nil]
+        (let [body      "test-body"
+              timestamp "1234567890"
+              signature "v0=some-signature"
+              result    (wrapped-slack-handler (slack-request body timestamp signature))]
+          (is (nil? (:slack/validated? result))))))))

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/slack_connect_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/slack_connect_test.clj
@@ -65,81 +65,82 @@
 ;;; -------------------------------------------------- Prerequisites Tests --------------------------------------------------
 
 (deftest sso-prereqs-test
-  (sso.test-setup/do-with-other-sso-types-disabled!
-   (fn []
-     (mt/with-additional-premium-features #{:sso-slack}
-       (testing "SSO requests fail if Slack Connect hasn't been configured or enabled"
-         (mt/with-temporary-setting-values
-           [slack-connect-enabled false
-            slack-connect-client-id nil
-            slack-connect-client-secret nil]
-           (is
-            (partial=
-             {:cause "SSO has not been enabled and/or configured",
-              :data {:status "error-sso-disabled", :status-code 400},
-              :message "SSO has not been enabled and/or configured",
-              :status "error-sso-disabled"}
-             (mt/client :get 400 "/auth/sso"
-                        {:request-options {:redirect-strategy :none}}
-                        :preferred_method "slack-connect"))))
+  (with-test-encryption!
+    (sso.test-setup/do-with-other-sso-types-disabled!
+     (fn []
+       (mt/with-additional-premium-features #{:sso-slack}
+         (testing "SSO requests fail if Slack Connect hasn't been configured or enabled"
+           (mt/with-temporary-setting-values
+             [slack-connect-enabled false
+              slack-connect-client-id nil
+              slack-connect-client-secret nil]
+             (is
+              (partial=
+               {:cause "SSO has not been enabled and/or configured",
+                :data {:status "error-sso-disabled", :status-code 400},
+                :message "SSO has not been enabled and/or configured",
+                :status "error-sso-disabled"}
+               (mt/client :get 400 "/auth/sso"
+                          {:request-options {:redirect-strategy :none}}
+                          :preferred_method "slack-connect"))))
 
-         (testing "SSO requests fail if they don't have a valid premium-features token"
-           (sso.test-setup/call-with-default-slack-config!
-            (fn []
-              (mt/with-premium-features #{}
-                (is
-                 (partial=
-                  {:cause "SSO has not been enabled and/or configured",
-                   :data {:status "error-sso-disabled", :status-code 400},
-                   :message "SSO has not been enabled and/or configured",
-                   :status "error-sso-disabled"}
-                  (mt/client :get 400 "/auth/sso"
-                             {:request-options {:redirect-strategy :none}}
-                             :preferred_method "slack-connect"))))))))
+           (testing "SSO requests fail if they don't have a valid premium-features token"
+             (sso.test-setup/call-with-default-slack-config!
+              (fn []
+                (mt/with-premium-features #{}
+                  (is
+                   (partial=
+                    {:cause "SSO has not been enabled and/or configured",
+                     :data {:status "error-sso-disabled", :status-code 400},
+                     :message "SSO has not been enabled and/or configured",
+                     :status "error-sso-disabled"}
+                    (mt/client :get 400 "/auth/sso"
+                               {:request-options {:redirect-strategy :none}}
+                               :preferred_method "slack-connect"))))))))
 
-       (testing "SSO requests fail if Slack Connect is enabled but hasn't been configured"
-         (mt/with-temporary-setting-values
-           [slack-connect-enabled true
-            slack-connect-client-id nil]
-           (is
-            (partial=
-             {:cause "SSO has not been enabled and/or configured",
-              :data {:status "error-sso-disabled", :status-code 400},
-              :message "SSO has not been enabled and/or configured",
-              :status "error-sso-disabled"}
-             (mt/client :get 400 "/auth/sso"
-                        {:request-options {:redirect-strategy :none}}
-                        :preferred_method "slack-connect")))))
+         (testing "SSO requests fail if Slack Connect is enabled but hasn't been configured"
+           (mt/with-temporary-setting-values
+             [slack-connect-enabled true
+              slack-connect-client-id nil]
+             (is
+              (partial=
+               {:cause "SSO has not been enabled and/or configured",
+                :data {:status "error-sso-disabled", :status-code 400},
+                :message "SSO has not been enabled and/or configured",
+                :status "error-sso-disabled"}
+               (mt/client :get 400 "/auth/sso"
+                          {:request-options {:redirect-strategy :none}}
+                          :preferred_method "slack-connect")))))
 
-       (testing "SSO requests fail if Slack Connect is configured but hasn't been enabled"
-         (mt/with-temporary-setting-values
-           [slack-connect-enabled false
-            slack-connect-client-id "test-slack-client-id"
-            slack-connect-client-secret "test-slack-client-secret"]
-           (is
-            (partial=
-             {:cause "SSO has not been enabled and/or configured",
-              :data {:status "error-sso-disabled", :status-code 400},
-              :message "SSO has not been enabled and/or configured",
-              :status "error-sso-disabled"}
-             (mt/client :get 400 "/auth/sso"
-                        {:request-options {:redirect-strategy :none}}
-                        :preferred_method "slack-connect")))))
+         (testing "SSO requests fail if Slack Connect is configured but hasn't been enabled"
+           (mt/with-temporary-setting-values
+             [slack-connect-enabled false
+              slack-connect-client-id "test-slack-client-id"
+              slack-connect-client-secret "test-slack-client-secret"]
+             (is
+              (partial=
+               {:cause "SSO has not been enabled and/or configured",
+                :data {:status "error-sso-disabled", :status-code 400},
+                :message "SSO has not been enabled and/or configured",
+                :status "error-sso-disabled"}
+               (mt/client :get 400 "/auth/sso"
+                          {:request-options {:redirect-strategy :none}}
+                          :preferred_method "slack-connect")))))
 
-       (testing "The client secret must also be included for SSO to be configured"
-         (mt/with-temporary-setting-values
-           [slack-connect-enabled true
-            slack-connect-client-id "test-slack-client-id"
-            slack-connect-client-secret nil]
-           (is
-            (partial=
-             {:cause "SSO has not been enabled and/or configured",
-              :data {:status "error-sso-disabled", :status-code 400},
-              :message "SSO has not been enabled and/or configured",
-              :status "error-sso-disabled"}
-             (mt/client :get 400 "/auth/sso"
-                        {:request-options {:redirect-strategy :none}}
-                        :preferred_method "slack-connect")))))))))
+         (testing "The client secret must also be included for SSO to be configured"
+           (mt/with-temporary-setting-values
+             [slack-connect-enabled true
+              slack-connect-client-id "test-slack-client-id"
+              slack-connect-client-secret nil]
+             (is
+              (partial=
+               {:cause "SSO has not been enabled and/or configured",
+                :data {:status "error-sso-disabled", :status-code 400},
+                :message "SSO has not been enabled and/or configured",
+                :status "error-sso-disabled"}
+               (mt/client :get 400 "/auth/sso"
+                          {:request-options {:redirect-strategy :none}}
+                          :preferred_method "slack-connect"))))))))))
 
 ;;; -------------------------------------------------- Redirect Tests --------------------------------------------------
 

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -119,6 +119,7 @@ export const createMockTokenFeatures = (
   sso_jwt: false,
   sso_ldap: false,
   sso_saml: false,
+  sso_slack: false,
   session_timeout_config: false,
   whitelabel: false,
   dashboard_subscription_filters: false,

--- a/src/metabase/channel/render/body.clj
+++ b/src/metabase/channel/render/body.clj
@@ -193,7 +193,7 @@
 (mr/def ::RenderedPartCard
   "Schema used for functions that operate on pulse card contents and their attachments"
   [:map
-   [:attachments                  [:maybe [:map-of :string (ms/InstanceOfClass URL)]]]
+   [:attachments {:optional true} [:maybe [:map-of :string (ms/InstanceOfClass URL)]]]
    [:content                      [:sequential :any]]
    [:render/text {:optional true} [:maybe :string]]])
 

--- a/src/metabase/channel/render/card.clj
+++ b/src/metabase/channel/render/card.clj
@@ -39,7 +39,8 @@
 
 (defn- card-href
   [card]
-  (h (urls/card-url (u/the-id card))))
+  (when-let [card-id (u/id card)]
+    (h (urls/card-url card-id))))
 
 (mu/defn- make-title-if-needed :- [:maybe ::body/RenderedPartCard]
   [render-type card dashcard options :- [:maybe ::options]]

--- a/src/metabase/lib/schema/info.cljc
+++ b/src/metabase/lib/schema/info.cljc
@@ -36,7 +36,8 @@
    :embedded-csv-download
    :embedded-xlsx-download
    :embedded-json-download
-   :table-grid])
+   :table-grid
+   :slackbot])
 
 (mr/def ::hash
   #?(:clj bytes?

--- a/src/metabase/permissions/core.clj
+++ b/src/metabase/permissions/core.clj
@@ -107,6 +107,7 @@
   collection-readwrite-path
   collection-path?]
  [metabase.permissions.user
+  query-creation-capabilities
   user-permissions-set
   user->tenant-collection-and-descendant-ids
   has-any-transforms-permission?

--- a/src/metabase/permissions/user.clj
+++ b/src/metabase/permissions/user.clj
@@ -3,8 +3,10 @@
    [metabase.app-db.core :as app-db]
    [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.permissions.path :as permissions.path]
+   [metabase.permissions.published-tables :as published-tables]
    [metabase.premium-features.core :refer [defenterprise]]
-   [metabase.util :as u]))
+   [metabase.util :as u]
+   [toucan2.core :as t2]))
 
 (defenterprise user->tenant-collection-and-descendant-ids
   "OSS version of user->tenant-collection-and-descendant-ids. Returns an empty vector since tenants are an EE feature."
@@ -54,3 +56,20 @@
                                             :where  [:= :pgm.user_id user-id]})))))]
     ;; Append permissions as a vector for more efficient iteration in checks that go over each permission linearly.
     (with-meta s {:as-vec (vec s)})))
+
+(defn query-creation-capabilities
+  "Returns a map with `:can-create-queries` and `:can-create-native-queries` for the given user,
+   based on their create-queries permissions across all databases."
+  [user-id]
+  (let [db-ids             (t2/select-pks-set :model/Database)
+        _                  (data-perms/prime-db-cache db-ids)
+        create-query-perms (into #{}
+                                 (map #(data-perms/most-permissive-database-permission-for-user
+                                        user-id :perms/create-queries %))
+                                 db-ids)]
+    {:can-create-queries        (boolean
+                                 (or (some #(data-perms/at-least-as-permissive?
+                                             :perms/create-queries % :query-builder)
+                                           create-query-perms)
+                                     (published-tables/user-has-any-published-table-permission?)))
+     :can-create-native-queries (contains? create-query-perms :query-builder-and-native)}))

--- a/src/metabase/premium_features/token_check.clj
+++ b/src/metabase/premium_features/token_check.clj
@@ -566,21 +566,13 @@
   []
   (boolean (seq (*token-features*))))
 
-#_(defn has-feature?
-    "Does this instance's premium token have `feature`?
-
-    (has-feature? :sandboxes)          ; -> true
-    (has-feature? :toucan-management)  ; -> false"
-    [feature]
-    (contains? (*token-features*) (name feature)))
-
 (defn has-feature?
   "Does this instance's premium token have `feature`?
 
     (has-feature? :sandboxes)          ; -> true
     (has-feature? :toucan-management)  ; -> false"
   [feature]
-  (or (= "sso-slack" (name feature)) (contains? (*token-features*) (name feature))))
+  (contains? (*token-features*) (name feature)))
 
 (defn ee-feature-error
   "Returns an error that can be used to throw when an enterprise feature check fails."

--- a/src/metabase/premium_features/token_check.clj
+++ b/src/metabase/premium_features/token_check.clj
@@ -186,8 +186,7 @@
                      :throw-exceptions false
                      ;; socket is data transfer, connection is handshake and create connection timeout
                      :socket-timeout     5000     ;; in milliseconds
-                     :connection-timeout 2000     ;; in milliseconds
-                     })))
+                     :connection-timeout 2000})))     ;; in milliseconds
 
 (defn- fetch-token-and-parse-body
   [token base-url site-uuid]
@@ -566,6 +565,14 @@
   "True if we have a valid premium features token with ANY features."
   []
   (boolean (seq (*token-features*))))
+
+#_(defn has-feature?
+    "Does this instance's premium token have `feature`?
+
+    (has-feature? :sandboxes)          ; -> true
+    (has-feature? :toucan-management)  ; -> false"
+    [feature]
+    (contains? (*token-features*) (name feature)))
 
 (defn has-feature?
   "Does this instance's premium token have `feature`?

--- a/src/metabase/system/settings.clj
+++ b/src/metabase/system/settings.clj
@@ -131,6 +131,7 @@
   "Whether encryption is enabled for this Metabase instance via MB_ENCRYPTION_SECRET_KEY."
   :visibility :admin
   :type       :boolean
+  :export?    false
   :setter     :none
   :getter     encryption/default-encryption-enabled?
   :doc        false)

--- a/test/metabase/server/middleware/auth_test.clj
+++ b/test/metabase/server/middleware/auth_test.clj
@@ -1,16 +1,12 @@
 (ns metabase.server.middleware.auth-test
   (:require
-   [buddy.core.codecs :as codecs]
-   [buddy.core.mac :as mac]
    [clojure.test :refer :all]
    [java-time.api :as t]
-   [metabase-enterprise.metabot-v3.settings :as metabot.settings]
    [metabase.api.response :as api.response]
    [metabase.api.routes.common :as api.routes.common]
    [metabase.server.middleware.auth :as mw.auth]
    [metabase.server.middleware.session :as mw.session]
    [metabase.session.core :as session]
-   [metabase.test :as mt]
    [metabase.test.data.users :as test.users]
    [metabase.test.fixtures :as fixtures]
    [ring.mock.request :as ring.mock]
@@ -111,65 +107,3 @@
            (:static-metabase-api-key
             (wrapped-api-key-handler
              (ring.mock/header (ring.mock/request :get "/anyurl") @#'mw.auth/static-metabase-api-key-header "foobar")))))))
-
-;;; ------------------------------------------ TEST verify-slack-request middleware ------------------------------------------
-
-(def ^:private test-signing-secret "test-slack-signing-secret-12345")
-
-(defn- compute-slack-signature
-  "Compute a valid Slack signature for testing"
-  [body timestamp signing-secret]
-  (let [message (str "v0:" timestamp ":" body)
-        signature (-> (mac/hash message {:key signing-secret :alg :hmac+sha256})
-                      codecs/bytes->hex)]
-    (str "v0=" signature)))
-
-(defn- wrapped-slack-handler
-  "Invoke verify-slack-request middleware and return the modified request"
-  [request]
-  ((mw.auth/verify-slack-request
-    (fn [request respond _] (respond request)))
-   request
-   identity
-   (fn [e] (throw e))))
-
-(defn- slack-request
-  "Create a mock request with Slack signature headers and a body"
-  ^java.util.Map [^String body ^String timestamp ^String signature]
-  (-> (ring.mock/request :post "/anyurl")
-      (ring.mock/header "x-slack-signature" signature)
-      (ring.mock/header "x-slack-request-timestamp" timestamp)
-      (assoc :body (java.io.ByteArrayInputStream. (.getBytes body "UTF-8")))))
-
-(deftest verify-slack-request-test
-  (mt/with-premium-features #{:metabot-v3}
-    (testing "Valid signature w/ signing secret configured"
-      (mt/with-temporary-setting-values [metabot.settings/metabot-slack-signing-secret test-signing-secret]
-        (let [body "test-body"
-              timestamp "1234567890"
-              signature (compute-slack-signature body timestamp test-signing-secret)
-              result (wrapped-slack-handler (slack-request body timestamp signature))]
-          (is (true? (:slack/validated? result))))))
-
-    (testing "Invalid signature"
-      (mt/with-temporary-setting-values [metabot.settings/metabot-slack-signing-secret test-signing-secret]
-        (let [body "test-body"
-              timestamp "1234567890"
-              signature "v0=invalid-signature"
-              result (wrapped-slack-handler (slack-request body timestamp signature))]
-          (is (false? (:slack/validated? result))))))
-
-    (testing "No signature header present - request passes through unchanged"
-      (let [body "test-body"
-            request (-> (ring.mock/request :post "/anyurl")
-                        (assoc :body (java.io.ByteArrayInputStream. (.getBytes ^String body "UTF-8"))))
-            result (wrapped-slack-handler request)]
-        (is (not (contains? result :slack/validated?)))))
-
-    (testing "No signing secret configured"
-      (mt/with-temporary-setting-values [metabot.settings/metabot-slack-signing-secret nil]
-        (let [body "test-body"
-              timestamp "1234567890"
-              signature "v0=some-signature"
-              result (wrapped-slack-handler (slack-request body timestamp signature))]
-          (is (nil? (:slack/validated? result))))))))


### PR DESCRIPTION
* Adds support for an adhoc_viz data part type that automatically executes the provided query and generates a static viz image with default viz settings
* Sends some capabilities in our slackbot AI service calls so that the querying tool gets enabled. I've ported some permission checking logic from the FE in the `compute-capabilities` function. Also had to pull out `query-creation-capabilities` into a helper function in `metabase.permissions.user`
* Fixed `slack-connect-enabled setting` to properly respect the stored enabled value (was only checking if credentials were configured), and fixed test failures in `sso-prereqs-test` and `endpoints-require-authentication-test` by adding proper premium feature and encryption mocks