### PR TITLE
record group membership removals in activity log

### DIFF
--- a/dev/src/dev/search_perf.clj
+++ b/dev/src/dev/search_perf.clj
@@ -23,6 +23,7 @@
    [dev.add-load :as add-load]
    [metabase.api.common :as api]
    [metabase.permissions.core :as perms]
+   [metabase.permissions.models.permissions-group-membership :as perms-group-membership]
    [metabase.permissions.util :as perms-util]
    [metabase.request.core :as request]
    [metabase.search.config :as search.config]
@@ -274,8 +275,8 @@
     ;; Delete group memberships first (foreign key constraints)
     (when (seq user-ids)
       (println (format "Deleting memberships for %d users..." (count user-ids)))
-      ;; Use raw table name to bypass before-delete guard (bulk dev cleanup, not a real user action)
-      (t2/delete! (t2/table-name :model/PermissionsGroupMembership) :user_id [:in user-ids] :group_id [:<> 1]))
+      (perms-group-membership/with-allow-direct-deletion
+        (t2/delete! :model/PermissionsGroupMembership :user_id [:in user-ids] :group_id [:<> 1])))
     ;; Delete users
     (when (seq user-ids)
       (println (format "Deleting %d users..." (count user-ids)))

--- a/dev/src/dev/search_perf.clj
+++ b/dev/src/dev/search_perf.clj
@@ -274,7 +274,8 @@
     ;; Delete group memberships first (foreign key constraints)
     (when (seq user-ids)
       (println (format "Deleting memberships for %d users..." (count user-ids)))
-      (t2/delete! :model/PermissionsGroupMembership :user_id [:in user-ids] :group_id [:<> 1]))
+      ;; Use raw table name to bypass before-delete guard (bulk dev cleanup, not a real user action)
+      (t2/delete! (t2/table-name :model/PermissionsGroupMembership) :user_id [:in user-ids] :group_id [:<> 1]))
     ;; Delete users
     (when (seq user-ids)
       (println (format "Deleting %d users..." (count user-ids)))

--- a/enterprise/backend/src/metabase_enterprise/scim/v2/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/scim/v2/api.clj
@@ -448,7 +448,7 @@
     (when-let [memberships (not-empty (map
                                        (fn [user-id] {:group group-id :user user-id})
                                        user-ids))]
-      (t2/delete! :model/PermissionsGroupMembership :group_id group-id)
+      (perms/remove-all-users-from-group! group-id)
       (perms/add-users-to-groups! memberships))))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/group_manager_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/group_manager_test.clj
@@ -6,6 +6,7 @@
    [metabase-enterprise.advanced-permissions.models.permissions.group-manager :as gm]
    [metabase.permissions.core :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
+   [metabase.permissions.models.permissions-group-membership :as perms-group-membership]
    [metabase.test :as mt]
    [metabase.users.models.user :as user]
    [metabase.util :as u]
@@ -309,10 +310,10 @@
                                             {:first_name (mt/random-name)})))
                   (add-user-to-group! [req-user status group-to-add]
                     ;; ensure `user-to-update` is not in `group-to-add`
-                    ;; Use raw table name to bypass before-delete guard (test setup, not a real user action)
-                    (t2/delete! (t2/table-name :model/PermissionsGroupMembership)
-                                :user_id (:id user-to-update)
-                                :group_id (:id group-to-add))
+                    (perms-group-membership/with-allow-direct-deletion
+                      (t2/delete! :model/PermissionsGroupMembership
+                                  :user_id (:id user-to-update)
+                                  :group_id (:id group-to-add)))
                     (let [current-user-group-membership (gm/user-group-memberships user-to-update)
                           new-user-group-membership (conj current-user-group-membership
                                                           {:id               (:id group-to-add)
@@ -321,10 +322,10 @@
                         (mt/user-http-request req-user :put status (format "user/%d" (:id user-to-update))
                                               {:user_group_memberships (map #(dissoc % :is_group_manager) new-user-group-membership)})))
 
-                    ;; Use raw table name to bypass before-delete guard (test setup, not a real user action)
-                    (t2/delete! (t2/table-name :model/PermissionsGroupMembership)
-                                :user_id (:id user-to-update)
-                                :group_id (:id group-to-add))
+                    (binding [perms-group-membership/*allow-direct-deletion* true]
+                      (t2/delete! :model/PermissionsGroupMembership
+                                  :user_id (:id user-to-update)
+                                  :group_id (:id group-to-add)))
                     (let [current-user-group-membership (gm/user-group-memberships user-to-update)
                           new-user-group-membership     (conj current-user-group-membership
                                                               {:id               (:id group-to-add)

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/group_manager_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/group_manager_test.clj
@@ -309,7 +309,8 @@
                                             {:first_name (mt/random-name)})))
                   (add-user-to-group! [req-user status group-to-add]
                     ;; ensure `user-to-update` is not in `group-to-add`
-                    (t2/delete! :model/PermissionsGroupMembership
+                    ;; Use raw table name to bypass before-delete guard (test setup, not a real user action)
+                    (t2/delete! (t2/table-name :model/PermissionsGroupMembership)
                                 :user_id (:id user-to-update)
                                 :group_id (:id group-to-add))
                     (let [current-user-group-membership (gm/user-group-memberships user-to-update)
@@ -320,7 +321,8 @@
                         (mt/user-http-request req-user :put status (format "user/%d" (:id user-to-update))
                                               {:user_group_memberships (map #(dissoc % :is_group_manager) new-user-group-membership)})))
 
-                    (t2/delete! :model/PermissionsGroupMembership
+                    ;; Use raw table name to bypass before-delete guard (test setup, not a real user action)
+                    (t2/delete! (t2/table-name :model/PermissionsGroupMembership)
                                 :user_id (:id user-to-update)
                                 :group_id (:id group-to-add))
                     (let [current-user-group-membership (gm/user-group-memberships user-to-update)

--- a/enterprise/backend/test/metabase_enterprise/data_studio/api/permissions_groups_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_studio/api/permissions_groups_test.clj
@@ -71,7 +71,8 @@
         (let [group-count-before (t2/count :model/PermissionsGroup)
               data-analyst-group-id (t2/select-one-pk :model/PermissionsGroup :magic_group_type perms-group/data-analyst-magic-group-type)]
           ;; Ensure no members in the group
-          (t2/delete! :model/PermissionsGroupMembership :group_id data-analyst-group-id)
+          ;; Use raw table name to bypass before-delete guard (test setup, not a real user action)
+          (t2/delete! (t2/table-name :model/PermissionsGroupMembership) :group_id data-analyst-group-id)
           (perms-group/sync-data-analyst-group-for-oss!)
           (testing "No new groups should be created"
             (is (= group-count-before (t2/count :model/PermissionsGroup))))

--- a/enterprise/backend/test/metabase_enterprise/data_studio/api/permissions_groups_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_studio/api/permissions_groups_test.clj
@@ -4,6 +4,7 @@
    [clojure.test :refer [deftest testing is]]
    [metabase.permissions.core :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
+   [metabase.permissions.models.permissions-group-membership :as perms-group-membership]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 
@@ -71,8 +72,8 @@
         (let [group-count-before (t2/count :model/PermissionsGroup)
               data-analyst-group-id (t2/select-one-pk :model/PermissionsGroup :magic_group_type perms-group/data-analyst-magic-group-type)]
           ;; Ensure no members in the group
-          ;; Use raw table name to bypass before-delete guard (test setup, not a real user action)
-          (t2/delete! (t2/table-name :model/PermissionsGroupMembership) :group_id data-analyst-group-id)
+          (perms-group-membership/with-allow-direct-deletion
+            (t2/delete! :model/PermissionsGroupMembership :group_id data-analyst-group-id))
           (perms-group/sync-data-analyst-group-for-oss!)
           (testing "No new groups should be created"
             (is (= group-count-before (t2/count :model/PermissionsGroup))))

--- a/src/metabase/permissions/core.clj
+++ b/src/metabase/permissions/core.clj
@@ -101,6 +101,8 @@
   fail-to-remove-last-admin-msg
   remove-user-from-group!
   remove-user-from-groups!
+  remove-all-users-from-group!
+  remove-user-from-all-groups!
   throw-if-last-admin!
   without-is-superuser-sync-on-add-to-admin-group]
  [metabase.permissions.path

--- a/src/metabase/permissions/models/permissions_group_membership.clj
+++ b/src/metabase/permissions/models/permissions_group_membership.clj
@@ -79,6 +79,13 @@
   blessed helper functions like `remove-user-from-group!` bind this to `true`."
   false)
 
+(defmacro with-allow-direct-deletion
+  "Execute `form` with `*allow-direct-deletion*` bound to `true`, allowing direct `t2/delete!` calls on
+  PermissionsGroupMembership."
+  [& form]
+  `(binding [*allow-direct-deletion* true]
+     (do ~@form)))
+
 (t2/define-before-delete :model/PermissionsGroupMembership
   [{:keys [group_id user_id]}]
   (when-not *allow-direct-deletion*

--- a/src/metabase/permissions_rest/api.clj
+++ b/src/metabase/permissions_rest/api.clj
@@ -366,7 +366,7 @@
   (perms/check-manager-of-group group-id)
   (api/check-404 (t2/exists? :model/PermissionsGroup :id group-id))
   (api/check-400 (not= group-id (u/the-id (perms/admin-group))))
-  (t2/delete! :model/PermissionsGroupMembership :group_id group-id)
+  (perms/remove-all-users-from-group! group-id)
   api/generic-204-no-content)
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
@@ -380,5 +380,5 @@
   (let [membership (t2/select-one :model/PermissionsGroupMembership :id id)]
     (api/check-404 membership)
     (perms/check-manager-of-group (:group_id membership))
-    (t2/delete! :model/PermissionsGroupMembership :id id)
+    (perms/remove-user-from-group! (:user_id membership) (:group_id membership))
     api/generic-204-no-content))

--- a/src/metabase/users_rest/api.clj
+++ b/src/metabase/users_rest/api.clj
@@ -539,7 +539,7 @@
   [user-id tenant-id]
   (perms/allow-changing-all-users-group-members
     (perms/allow-changing-all-external-users-group-members
-     (t2/delete! :model/PermissionsGroupMembership :user_id user-id)
+     (perms/remove-user-from-all-groups! user-id)
      (when tenant-id
        (perms/add-user-to-group! user-id (perms/all-external-users-group)))
      (when (nil? tenant-id)

--- a/test/metabase/permissions/models/permissions_group_membership_test.clj
+++ b/test/metabase/permissions/models/permissions_group_membership_test.clj
@@ -19,21 +19,21 @@
 (deftest remove-is-superuser-test
   (testing "when you delete a PermissionsGroupMembership for a User in the admin group, it should set their `is_superuser` flag"
     (mt/with-temp [:model/User user {:is_superuser true}]
-      (t2/delete! :model/PermissionsGroupMembership :user_id (u/the-id user), :group_id (u/the-id (perms-group/admin)))
+      (perms/remove-user-from-group! user (perms-group/admin))
       (is (= false
              (t2/select-one-fn :is_superuser :model/User :id (u/the-id user))))))
 
   (testing "it should not let you remove the last admin"
     (mt/with-single-admin-user! [{id :id}]
       (is (thrown? Exception
-                   (t2/delete! :model/PermissionsGroupMembership :user_id id, :group_id (u/the-id (perms-group/admin)))))))
+                   (perms/remove-user-from-group! id (perms-group/admin))))))
 
   (testing "it should not let you remove the last non-archived admin"
     (mt/with-single-admin-user! [{id :id}]
       (mt/with-temp [:model/User _ {:is_active    false
                                     :is_superuser true}]
         (is (thrown? Exception
-                     (t2/delete! :model/PermissionsGroupMembership :user_id id, :group_id (u/the-id (perms-group/admin)))))))))
+                     (perms/remove-user-from-group! id (perms-group/admin))))))))
 
 (deftest permissions-group-membership-audit-add-test
   (testing "PermissionsGroupMembership audit events"
@@ -59,3 +59,45 @@
                 (is (= "PermissionsGroupMembership" (:model audit-entry)))
                 (is (= user-id (get-in audit-entry [:details :user_id])))
                 (is (= group-id (get-in audit-entry [:details :group_id])))))))))))
+
+(deftest delete-membership-api-audit-test
+  (testing "DELETE /api/permissions/membership/:id creates audit log entry"
+    (mt/with-premium-features #{:audit-app}
+      (mt/with-temp [:model/User {user-id :id} {}
+                     :model/PermissionsGroup {group-id :id} {:name "Test Group"}]
+        (perms/add-user-to-group! user-id group-id)
+        (let [membership-id (:id (t2/select-one :model/PermissionsGroupMembership
+                                                :user_id user-id :group_id group-id))
+              before-count  (t2/count :model/AuditLog :topic "group-membership-delete")]
+          (mt/user-http-request :crowberto :delete 204
+                                (format "permissions/membership/%d" membership-id))
+          (is (= (inc before-count)
+                 (t2/count :model/AuditLog :topic "group-membership-delete")))
+          (let [audit-entry (t2/select-one :model/AuditLog :topic "group-membership-delete"
+                                           {:order-by [[:id :desc]]})]
+            (is (= "PermissionsGroupMembership" (:model audit-entry)))
+            (is (= user-id (get-in audit-entry [:details :user_id])))
+            (is (= group-id (get-in audit-entry [:details :group_id])))))))))
+
+(deftest clear-group-membership-api-audit-test
+  (testing "PUT /api/permissions/membership/:group-id/clear creates audit log entries"
+    (mt/with-premium-features #{:audit-app}
+      (mt/with-temp [:model/User {user-1-id :id} {}
+                     :model/User {user-2-id :id} {}
+                     :model/PermissionsGroup {group-id :id} {:name "Test Group"}]
+        (perms/add-user-to-group! user-1-id group-id)
+        (perms/add-user-to-group! user-2-id group-id)
+        (let [before-count (t2/count :model/AuditLog :topic "group-membership-delete")]
+          (mt/user-http-request :crowberto :put 204
+                                (format "permissions/membership/%d/clear" group-id))
+          (is (= (+ 2 before-count)
+                 (t2/count :model/AuditLog :topic "group-membership-delete"))))))))
+
+(deftest direct-delete-guard-test
+  (testing "Direct t2/delete! on :model/PermissionsGroupMembership throws"
+    (mt/with-temp [:model/User {user-id :id} {}
+                   :model/PermissionsGroup {group-id :id} {:name "Test Group"}]
+      (perms/add-user-to-group! user-id group-id)
+      (is (thrown-with-msg? Exception #"Do not use `t2/delete!`"
+                            (t2/delete! :model/PermissionsGroupMembership
+                                        :user_id user-id :group_id group-id))))))

--- a/test/metabase/permissions/models/permissions_group_test.clj
+++ b/test/metabase/permissions/models/permissions_group_test.clj
@@ -100,7 +100,7 @@
   (testing "flipping the is_superuser bit should add/remove user from Admin group as appropriate"
     (testing "removing user from Admin should set is_superuser -> false"
       (mt/with-temp [:model/User {user-id :id} {:is_superuser true}]
-        (t2/delete! :model/PermissionsGroupMembership, :user_id user-id, :group_id (u/the-id (perms-group/admin)))
+        (perms/remove-user-from-group! user-id (perms-group/admin))
         (is (false? (t2/select-one-fn :is_superuser :model/User, :id user-id)))))))
 
 (deftest add-remove-from-admin-group-test-3

--- a/test/metabase/warehouses/models/database_test.clj
+++ b/test/metabase/warehouses/models/database_test.clj
@@ -13,6 +13,7 @@
    [metabase.models.serialization :as serdes]
    [metabase.permissions.core :as perms]
    [metabase.permissions.models.data-permissions :as data-perms]
+   [metabase.permissions.models.permissions-group-membership :as perms-group-membership]
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.request.core :as request]
    [metabase.secrets.core :as secret]
@@ -815,10 +816,10 @@
         (data-perms/set-database-permission! pg1 db3-id :perms/view-data :blocked)
         (data-perms/set-database-permission! pg2 db3-id :perms/view-data :blocked)
         ;; Remove user from groups we added (avoid touching All Users group)
-        ;; Use raw table name to bypass before-delete guard (test cleanup, not a real user action)
-        (t2/delete! (t2/table-name :model/PermissionsGroupMembership)
-                    :user_id (mt/user->id :rasta)
-                    :group_id [:in [(:id pg1) (:id pg2)]])
+        (perms-group-membership/with-allow-direct-deletion
+          (t2/delete! :model/PermissionsGroupMembership
+                      :user_id (mt/user->id :rasta)
+                      :group_id [:in [(:id pg1) (:id pg2)]]))
         (is (empty? (fetch-visible-db-ids [db1-id db2-id db3-id]
                                           {:user-id (mt/user->id :rasta) :is-superuser? false}
                                           default-permission-mapping

--- a/test/metabase/warehouses/models/database_test.clj
+++ b/test/metabase/warehouses/models/database_test.clj
@@ -815,7 +815,8 @@
         (data-perms/set-database-permission! pg1 db3-id :perms/view-data :blocked)
         (data-perms/set-database-permission! pg2 db3-id :perms/view-data :blocked)
         ;; Remove user from groups we added (avoid touching All Users group)
-        (t2/delete! :model/PermissionsGroupMembership
+        ;; Use raw table name to bypass before-delete guard (test cleanup, not a real user action)
+        (t2/delete! (t2/table-name :model/PermissionsGroupMembership)
                     :user_id (mt/user->id :rasta)
                     :group_id [:in [(:id pg1) (:id pg2)]])
         (is (empty? (fetch-visible-db-ids [db1-id db2-id db3-id]


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #66905
Previously the `PUT /api/membership/:group-id/clear` and `DELETE /api/membership/:id` endpoints did not emit group membership deletion events.

In the long run it would be better if `t2` were the interface for PermissionsGroupMembership, so users didn't need to call these "blessed" functions. But for now, let's go along with the existing pattern here, have some blessed functions for doing things, and throw exceptions if someone does a direct `t2/delete!` on a `:model/PermissionsGroupMembership`.

Fixes [UXW-2564: Group membership removal from custom groups is not recorded in activity log](https://linear.app/metabase/issue/UXW-2564/group-membership-removal-from-custom-groups-is-not-recorded-in)