### PR TITLE
ease how we generate nano-ids

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -543,7 +543,7 @@
            view-log}}
 
   driver
-  {:team "Drivers"
+  {:team "Querying"
    :api  #{metabase.driver
            metabase.driver.common
            metabase.driver.common.parameters
@@ -588,7 +588,7 @@
            warehouses}}
 
   driver-api
-  {:team "Drivers"
+  {:team "Querying"
    :api  #{metabase.driver-api.core}
    :uses #{actions
            api
@@ -1320,7 +1320,7 @@
            warehouses}}
 
   secrets
-  {:team "Drivers"
+  {:team "Querying"
    :api  #{metabase.secrets.core}
    :uses #{api driver models premium-features util}}
 
@@ -2141,7 +2141,7 @@
            util}}
 
   enterprise/impersonation
-  {:team "Drivers"
+  {:team "Querying"
    :api  #{metabase-enterprise.impersonation.api}
    :uses #{api
            audit-app

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -1297,7 +1297,8 @@
 
   If an argument is provided, it's taken to be an identity-hash string and used to seed the RNG,
   producing the same value every time. This is only supported on the JVM!"
-  ([] (encore/nanoid))
+  ([]
+   (encore/nanoid false 21))
   ([seed-str]
    #?(:clj  (let [seed (Long/parseLong seed-str 16)
                   rnd  (Random. seed)


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/68130

nano-ids are not needed to be secure, they just need to be distinct. They hide no secrets but assign identity.

In https://github.com/metabase/metabase/pull/66413 we replaced our usage of https://github.com/zelark/nano-id with encore. These are almost the same except that encore uses `secure?` to be true by default. In practice this is:

```clojure
(if secure?
  (com.taoensso.encore.Ids/genNanoId (.get com.taoensso.encore.Ids/SRNG_STRONG) len)
  (com.taoensso.encore.Ids/genNanoId                                            len))
```

And that `com.taoensso.encore.Ids/SRNG_STRONG` is

```java
public static final ThreadLocal<SecureRandom> SRNG        = ThreadLocal.withInitial(SecureRandom::new);
public static final ThreadLocal<SecureRandom> SRNG_STRONG = ThreadLocal.withInitial(() -> {
        try { return SecureRandom.getInstanceStrong(); }
        catch (java.security.NoSuchAlgorithmException e) {
            throw new RuntimeException("Failed to initialize strong SecureRandom", e);
        }});
```

the implmentation in the old library was

```clojure
(defonce *secure-random (delay (SecureRandom.)))
```

So passing `false` for the encore version of the nanoid restores the previous behavior.

CALLOUT:
One thing to call out is that this did slightly change how we generate nano-ids based on a seed. We used this behavior to backfill nano-ids. That let us try to ensure that the same thing in multiple systems would have the same nano-id, thus identifying them across systems.

We are now generating different nanoids for the same inputs.

```clojure
❯ java -cp $JARS/1.45.4.jar clojure.main
Clojure 1.11.1
user=> (doto 'metabase.util require in-ns)
metabase.util
metabase.util=> (generate-nano-id "cafebabe")
"VlXdQMzunVywNw_SArkKX"
metabase.util=>
```
This is a consistent nanoid all the way up to 57:
```clojure
❯ java -cp $JARS/1.57.10.jar clojure.main
Clojure 1.12.2
user=> (doto 'metabase.util require in-ns)
metabase.util
metabase.util=> (generate-nano-id "cafebabe")
"VlXdQMzunVywNw_SArkKX"
metabase.util=>
```

And now is different in 58:

```clojure
❯ java -cp $JARS/1.58.3.jar clojure.main
Clojure 1.12.3
user=> (doto 'metabase.util require in-ns)
metabase.util
metabase.util=> (generate-nano-id "cafebabe")
"xNzFsobWPxaYpY0ucTMmz"
```

This is not a problem because we backfilled these nanoids in ~41 or so and no longer allow anyone to save a model without one. But is worth a callout that 58 changed this.