### PR TITLE
Dashboard category filter not correctly populated when using multiple datasources in one graph

### DIFF
--- a/src/metabase/parameters/params.clj
+++ b/src/metabase/parameters/params.clj
@@ -21,7 +21,6 @@
    [metabase.lib.schema.parameter :as lib.schema.parameter]
    [metabase.lib.schema.template-tag :as lib.schema.template-tag]
    [metabase.parameters.schema :as parameters.schema]
-   [metabase.queries.schema :as queries.schema]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
@@ -284,7 +283,9 @@
                                  (cons (:card dashcard) (:series dashcard)))
                    (:card dashcard))
                (:card dashcard))]
-    (queries.schema/normalize-card card)))
+    (cond-> card
+      (string? (:type card))          (update :type keyword)
+      (seq (:dataset_query card))     (update :dataset_query lib-be/normalize-query))))
 
 (mu/defn dashcards->param-id->field-ids* :- [:map-of ::lib.schema.parameter/id [:set ::lib.schema.id/field]]
   "Return map of parameter ids to mapped field ids."


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/68998

### Description

This fixes issue that dashboard filter doesn't return all category values when attached to a card that has multiple datasets.

### How to verify

Follow steps from https://github.com/metabase/metabase/issues/68998

### Demo

Before:

https://github.com/user-attachments/assets/925b6e15-683d-43d3-af6e-23f0a4dd8bca



After:


https://github.com/user-attachments/assets/0ee1b21b-fba3-46da-8dba-0897bfaa22cc



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
