### PR TITLE
Return WS api key when it's created

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/workspaces/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/api.clj
@@ -879,7 +879,9 @@
           ;; Merge only :database and :schema from existing target to preserve them when not explicitly provided.
           ;; Other fields are NOT merged, allowing them to be removed by omitting from the request.
           merged-body (cond-> body
-                        (:target body) (update :target #(merge (select-keys (:target existing) [:database :schema]) %)))
+                        (:target body)
+                        (let [base (select-keys (:target existing) [:database :schema])]
+                          (update :target (partial merge base))))
           source-or-target-changed? (or (:source body) (:target body))]
       (t2/update! :model/WorkspaceTransform {:workspace_id ws-id :ref_id tx-id} merged-body)
       ;; If source or target changed, increment versions for re-analysis

--- a/enterprise/backend/src/metabase_enterprise/workspaces/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/api.clj
@@ -878,10 +878,9 @@
     (let [existing (api/check-404 (t2/select-one :model/WorkspaceTransform :workspace_id ws-id :ref_id tx-id))
           ;; Merge only :database and :schema from existing target to preserve them when not explicitly provided.
           ;; Other fields are NOT merged, allowing them to be removed by omitting from the request.
+          base (select-keys (:target existing) [:database :schema])
           merged-body (cond-> body
-                        (:target body)
-                        (let [base (select-keys (:target existing) [:database :schema])]
-                          (update :target (partial merge base))))
+                        (:target body) (update :target #(merge base %)))
           source-or-target-changed? (or (:source body) (:target body))]
       (t2/update! :model/WorkspaceTransform {:workspace_id ws-id :ref_id tx-id} merged-body)
       ;; If source or target changed, increment versions for re-analysis

--- a/enterprise/backend/src/metabase_enterprise/workspaces/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/common.clj
@@ -9,7 +9,6 @@
    [metabase.transforms.interface :as transforms.i]
    [metabase.util.log :as log]
    [metabase.util.quick-task :as quick-task]
-   [metabase.util.secret :as u.secret]
    [toucan2.core :as t2]))
 
 (defn- extract-suffix-number
@@ -72,7 +71,7 @@
     (t2/update! :model/Workspace (:id ws) {:collection_id (:id coll)})
     ;; Return the workspace with the unmasked API key attached.
     ;; This is the only time the key is available - after this it's hashed and unrecoverable.
-    (assoc ws :api_key (u.secret/expose (:unmasked_key api-key)))))
+    (assoc ws :api_key (:unmasked_key api-key))))
 
 (defn- unique-constraint-violation?
   "Check if an exception is due to a unique constraint violation."


### PR DESCRIPTION
Lets us provide this API key to agents.

Also preserves `target.database` and `target.schema` when receiving sparse updates over API.