### PR TITLE
Gdgt 1754 handle slow loading lens indicator

### DIFF
--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/InspectorContent.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/InspectorContent.tsx
@@ -23,8 +23,15 @@ export const InspectorContent = ({
     error: discoveryError,
   } = useGetInspectorDiscoveryQuery(transform.id);
 
-  const { tabs, activeTabKey, currentLens, addDrillLens, closeTab, switchTab } =
-    useLensNavigation(discovery?.available_lenses ?? [], location);
+  const {
+    tabs,
+    activeTabKey,
+    currentLens,
+    addDrillLens,
+    closeTab,
+    switchTab,
+    handleAllCardsLoaded,
+  } = useLensNavigation(discovery?.available_lenses ?? [], location);
 
   if (isLoadingDiscovery || discoveryError || !discovery) {
     return (
@@ -53,6 +60,7 @@ export const InspectorContent = ({
         currentLens={currentLens}
         discovery={discovery}
         onDrill={addDrillLens}
+        onAllCardsLoaded={handleAllCardsLoaded}
       />
     </LensNavigator>
   );

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensContent/LensContent.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensContent/LensContent.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useMemo } from "react";
 import { match } from "ts-pattern";
 import _ from "underscore";
 
@@ -9,7 +9,7 @@ import type { TriggeredDrillLens } from "metabase-lib/transforms-inspector";
 import type { InspectorDiscoveryResponse, Transform } from "metabase-types/api";
 
 import { useCardLoadingTracker, useTriggerEvaluation } from "../../hooks";
-import type { CardStats, Lens, LensQueryParams } from "../../types";
+import type { Lens, LensQueryParams } from "../../types";
 import { isDrillLens } from "../../utils";
 import {
   DefaultLensSections,
@@ -33,7 +33,7 @@ export const LensContent = ({
   currentLens,
   discovery,
   onDrill,
-  onAllCardsLoaded
+  onAllCardsLoaded,
 }: LensContentProps) => {
   const queryParams = useMemo<LensQueryParams>(() => {
     if (isDrillLens(currentLens)) {
@@ -61,16 +61,6 @@ export const LensContent = ({
     onAllCardsLoaded,
   );
 
-  const onStatsReady = useCallback(
-    (cardId: string, stats: CardStats | null) => {
-      markCardLoaded(cardId);
-      pushNewStats(cardId, stats);
-    },
-    [markCardLoaded, pushNewStats],
-  );
-
-
-
   const cardsBySection = useMemo(
     () => _.groupBy(lens?.cards ?? [], (c) => c.section_id ?? "default"),
     [lens],
@@ -95,8 +85,9 @@ export const LensContent = ({
       alertsByCardId={alertsByCardId}
       drillLensesByCardId={drillLensesByCardId}
       collectedCardStats={collectedCardStats}
-      onStatsReady={onStatsReady}
+      onStatsReady={pushNewStats}
       onCardStartedLoading={markCardStartedLoading}
+      onCardLoaded={markCardLoaded}
       onDrill={onDrill}
     >
       <Stack gap="xl">

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensContent/LensContentContext.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensContent/LensContentContext.tsx
@@ -22,6 +22,7 @@ type LensContentContextValue = {
   drillLensesByCardId: Record<string, TriggeredDrillLens[]>;
   collectedCardStats: Record<string, CardStats>;
   onStatsReady: (cardId: string, stats: CardStats | null) => void;
+  onCardStartedLoading: (lensId: string, cardId: string) => void;
   onDrill: (lens: TriggeredDrillLens) => void;
 };
 
@@ -47,6 +48,7 @@ export const LensContentProvider = ({
   drillLensesByCardId,
   collectedCardStats,
   onStatsReady,
+  onCardStartedLoading,
   onDrill,
   children,
 }: PropsWithChildren<LensContentContextValue>) => {
@@ -59,6 +61,7 @@ export const LensContentProvider = ({
       drillLensesByCardId,
       collectedCardStats,
       onStatsReady,
+      onCardStartedLoading,
       onDrill,
     }),
     [
@@ -69,6 +72,7 @@ export const LensContentProvider = ({
       drillLensesByCardId,
       collectedCardStats,
       onStatsReady,
+      onCardStartedLoading,
       onDrill,
     ],
   );

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensContent/LensContentContext.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensContent/LensContentContext.tsx
@@ -23,6 +23,7 @@ type LensContentContextValue = {
   collectedCardStats: Record<string, CardStats>;
   onStatsReady: (cardId: string, stats: CardStats | null) => void;
   onCardStartedLoading: (lensId: string, cardId: string) => void;
+  onCardLoaded: (lensId: string, cardId: string) => void;
   onDrill: (lens: TriggeredDrillLens) => void;
 };
 
@@ -49,6 +50,7 @@ export const LensContentProvider = ({
   collectedCardStats,
   onStatsReady,
   onCardStartedLoading,
+  onCardLoaded,
   onDrill,
   children,
 }: PropsWithChildren<LensContentContextValue>) => {
@@ -62,6 +64,7 @@ export const LensContentProvider = ({
       collectedCardStats,
       onStatsReady,
       onCardStartedLoading,
+      onCardLoaded,
       onDrill,
     }),
     [
@@ -73,6 +76,7 @@ export const LensContentProvider = ({
       collectedCardStats,
       onStatsReady,
       onCardStartedLoading,
+      onCardLoaded,
       onDrill,
     ],
   );

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensNavigator/LensNavigator.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensNavigator/LensNavigator.tsx
@@ -53,6 +53,7 @@ export const LensNavigator = ({
                 {tab.title}
               </Text>
               {!isDrillLens(tab.lens) &&
+                !tab.isFullyLoaded &&
                 match(tab.lens.complexity?.level)
                   .with("slow", "very-slow", (level) => (
                     <Tooltip

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensNavigator/types.ts
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensNavigator/types.ts
@@ -5,4 +5,5 @@ export type LensTab = {
   title: string;
   isStatic?: boolean;
   lens: Lens;
+  isFullyLoaded?: boolean;
 };

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensNavigator/useLensNavigation.ts
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensNavigator/useLensNavigation.ts
@@ -18,6 +18,7 @@ type UseLensNavigationResult = {
   addDrillLens: (lens: TriggeredDrillLens) => void;
   closeTab: (tabId: string) => void;
   switchTab: (tabId: string) => void;
+  handleAllCardsLoaded: (lensId: string) => void;
 };
 
 export const useLensNavigation = (
@@ -25,12 +26,13 @@ export const useLensNavigation = (
   location: Location,
 ): UseLensNavigationResult => {
   const activeTabKey = location.query.tab?.toString() ?? null;
+  const [staticTabs, setStaticTabs] = useState<LensTab[]>([]);
 
   const dispatch = useDispatch();
-  const staticTabs = useMemo(
-    () => availableLenses.map(createTab),
-    [availableLenses],
-  );
+
+  useEffect(() => {
+    setStaticTabs(() => availableLenses.map(createTab));
+  }, [availableLenses]);
 
   const [dynamicTabs, setDynamicTabs] = useState<LensTab[]>([]);
 
@@ -93,6 +95,19 @@ export const useLensNavigation = (
     [tabs, activeTabKey, navigate],
   );
 
+  const handleAllCardsLoaded = useCallback((lensId: string) => {
+    setDynamicTabs((prev) =>
+      prev.map((tab) =>
+        tab.key === lensId ? { ...tab, isFullyLoaded: true } : tab,
+      ),
+    );
+    setStaticTabs((prev) =>
+      prev.map((tab) =>
+        tab.key === lensId ? { ...tab, isFullyLoaded: true } : tab,
+      ),
+    );
+  }, []);
+
   const switchTab = useCallback(
     (tabKey: string) => navigate(tabKey, false),
     [navigate],
@@ -105,5 +120,6 @@ export const useLensNavigation = (
     addDrillLens,
     closeTab,
     switchTab,
+    handleAllCardsLoaded,
   };
 };

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/hooks/index.ts
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/hooks/index.ts
@@ -1,2 +1,3 @@
+export { useCardLoadingTracker } from "./useCardLoadingTracker";
 export { useTriggerEvaluation } from "./useTriggerEvaluation";
 export { useLensCardLoader } from "./useLensCardLoader";

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/hooks/useCardLoadingTracker.ts
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/hooks/useCardLoadingTracker.ts
@@ -56,25 +56,18 @@ export const useCardLoadingTracker = (
     [],
   );
 
-  const markCardLoaded = useCallback(
-    (cardId: string) => {
-      if (!lens) {
-        return;
+  const markCardLoaded = useCallback((lensId: string, cardId: string) => {
+    setLoadedCardsByLensId((prev) => {
+      const loadedCards = prev[lensId] ?? new Set<string>();
+      if (loadedCards.has(cardId)) {
+        return prev;
       }
-      const lensId = lens.id;
-      setLoadedCardsByLensId((prev) => {
-        const loadedCards = prev[lensId] ?? new Set<string>();
-        if (loadedCards.has(cardId)) {
-          return prev;
-        }
-        return {
-          ...prev,
-          [lensId]: new Set(loadedCards).add(cardId),
-        };
-      });
-    },
-    [lens],
-  );
+      return {
+        ...prev,
+        [lensId]: new Set(loadedCards).add(cardId),
+      };
+    });
+  }, []);
 
   return {
     markCardLoaded,

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/hooks/useCardLoadingTracker.ts
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/hooks/useCardLoadingTracker.ts
@@ -1,0 +1,83 @@
+import { useCallback, useEffect, useState } from "react";
+
+import type { InspectorLens } from "metabase-types/api";
+
+export const useCardLoadingTracker = (
+  lens: InspectorLens | undefined,
+  onAllCardsLoaded: (lensId: string) => void,
+) => {
+  const [lenses, setLenses] = useState<Record<string, InspectorLens>>({});
+  const [loadingCardsByLensId, setLoadingCardsByLensId] = useState<
+    Record<string, Set<string>>
+  >({});
+  const [loadedCardsByLensId, setLoadedCardsByLensId] = useState<
+    Record<string, Set<string>>
+  >({});
+
+  useEffect(() => {
+    if (!lens) {
+      return;
+    }
+    setLenses((prev) => ({ ...prev, [lens.id]: lens }));
+  }, [lens]);
+
+  useEffect(() => {
+    Object.entries(lenses).forEach(([lensId]) => {
+      const loadedCards = loadedCardsByLensId[lensId];
+      const loadingCards = loadingCardsByLensId[lensId];
+
+      if (!loadedCards || !loadingCards) {
+        return;
+      }
+
+      const allStartedCardsHaveLoaded = [...loadingCards].every((cardId) =>
+        loadedCards.has(cardId),
+      );
+
+      if (loadedCards.size > 0 && allStartedCardsHaveLoaded) {
+        onAllCardsLoaded(lensId);
+      }
+    });
+  }, [lenses, loadedCardsByLensId, loadingCardsByLensId, onAllCardsLoaded]);
+
+  const markCardStartedLoading = useCallback(
+    (lensId: string, cardId: string) => {
+      setLoadingCardsByLensId((prev) => {
+        const loadingCards = prev[lensId] ?? new Set<string>();
+        if (loadingCards.has(cardId)) {
+          return prev;
+        }
+        return {
+          ...prev,
+          [lensId]: new Set(loadingCards).add(cardId),
+        };
+      });
+    },
+    [],
+  );
+
+  const markCardLoaded = useCallback(
+    (cardId: string) => {
+      if (!lens) {
+        return;
+      }
+      const lensId = lens.id;
+      setLoadedCardsByLensId((prev) => {
+        const loadedCards = prev[lensId] ?? new Set<string>();
+        if (loadedCards.has(cardId)) {
+          return prev;
+        }
+        return {
+          ...prev,
+          [lensId]: new Set(loadedCards).add(cardId),
+        };
+      });
+    },
+    [lens],
+  );
+
+  return {
+    markCardLoaded,
+    markCardStartedLoading,
+  };
+};

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/hooks/useLensCardLoader.ts
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/hooks/useLensCardLoader.ts
@@ -14,8 +14,14 @@ type UseLensCardLoaderOptions = {
 };
 
 export const useLensCardLoader = ({ card }: UseLensCardLoaderOptions) => {
-  const { lens, transform, onStatsReady, queryParams, onCardStartedLoading } =
-    useLensContentContext();
+  const {
+    lens,
+    transform,
+    onStatsReady,
+    queryParams,
+    onCardStartedLoading,
+    onCardLoaded,
+  } = useLensContentContext();
   const { data, isLoading } = useRunInspectorQueryQuery({
     transformId: transform.id,
     lensId: lens.id,
@@ -40,7 +46,8 @@ export const useLensCardLoader = ({ card }: UseLensCardLoaderOptions) => {
     const stats = computeCardStats(lens.id, card, data?.data?.rows);
     setStats(stats);
     onStatsReady(card.id, stats);
-  }, [card, lens, data, isLoading, onStatsReady]);
+    onCardLoaded(lens.id, card.id);
+  }, [card, lens, data, isLoading, onStatsReady, onCardLoaded]);
 
   return { data, isLoading, stats };
 };

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/hooks/useLensCardLoader.ts
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/hooks/useLensCardLoader.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { useRunInspectorQueryQuery } from "metabase/api";
 import {
@@ -14,7 +14,7 @@ type UseLensCardLoaderOptions = {
 };
 
 export const useLensCardLoader = ({ card }: UseLensCardLoaderOptions) => {
-  const { lens, transform, onStatsReady, queryParams } =
+  const { lens, transform, onStatsReady, queryParams, onCardStartedLoading } =
     useLensContentContext();
   const { data, isLoading } = useRunInspectorQueryQuery({
     transformId: transform.id,
@@ -23,6 +23,15 @@ export const useLensCardLoader = ({ card }: UseLensCardLoaderOptions) => {
     lensParams: queryParams,
   });
   const [stats, setStats] = useState<CardStats | null>();
+
+  const hasReportedStartedLoading = useRef(false);
+
+  useEffect(() => {
+    if (onCardStartedLoading && !hasReportedStartedLoading.current) {
+      hasReportedStartedLoading.current = true;
+      onCardStartedLoading(lens.id, card.id);
+    }
+  }, [lens, card.id, onCardStartedLoading]);
 
   useEffect(() => {
     if (isLoading) {

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/hooks/useTriggerEvaluation.ts
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/hooks/useTriggerEvaluation.ts
@@ -37,10 +37,9 @@ export const useTriggerEvaluation = (
 
   const pushNewStats = useCallback(
     (cardId: string, stats: CardStats | null) => {
-      if (!stats) {
-        return;
+      if (stats) {
+        setCardsStats((prev) => ({ ...prev, [cardId]: stats }));
       }
-      setCardsStats((prev) => ({ ...prev, [cardId]: stats }));
     },
     [],
   );


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-1754/handle-slow-loading-lens-indicator

### Description

- Create a hook that track what cards for lens have loaded. 
- Hook then calls a new callback form `useLensNavigation` (`handleAllCardsLoaded`) that tabs as fully loaded


### Demo

https://github.com/user-attachments/assets/ad3d7d82-7251-48e4-8756-0f7838d10376
