### PR TITLE
Fix containerize-uberjar workflow failing on pull requests

### DIFF
--- a/.github/workflows/containerize-uberjar.yml
+++ b/.github/workflows/containerize-uberjar.yml
@@ -56,12 +56,12 @@ jobs:
     secrets: inherit
     with:
       edition: ${{ matrix.edition }}
-      commit: ${{ github.event.inputs.commit || github.sha }}
+      commit: ${{ github.event.inputs.commit || github.event.pull_request.head.sha || github.sha }}
       repo: ${{ fromJson(needs.get-container-info.outputs[matrix.edition]).repo }}
       tag: ${{ fromJson(needs.get-container-info.outputs[matrix.edition]).tag }}
       release: "false"
       build-args: |
-        GIT_COMMIT_SHA=${{ github.event.inputs.commit || github.sha }}
+        GIT_COMMIT_SHA=${{ github.event.inputs.commit || github.event.pull_request.head.sha || github.sha }}
 
   run-trivy:
     needs: [get-container-info, containerize]
@@ -74,7 +74,7 @@ jobs:
       - name: Check out the code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.commit || github.sha }}
+          ref: ${{ github.event.inputs.commit || github.event.pull_request.head.sha || github.sha }}
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.29.0
         env:


### PR DESCRIPTION
Resolves DEV-1484

The workflow was using `github.sha` (the merge commit SHA) when fetching artifacts, but the uberjar workflow uploads artifacts using the PR head commit SHA (`github.event.pull_request.head.sha`). This mismatch caused the containerize workflow to fail with "artifact not found" errors.

Added `github.event.pull_request.head.sha` to the fallback chain in three places: the artifact fetch commit, the GIT_COMMIT_SHA build arg, and the Trivy scanner checkout ref.