### PR TITLE
Fix case sensitiviy issues with workspace query execution

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/workspaces/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/impl.clj
@@ -10,7 +10,6 @@
    [metabase-enterprise.workspaces.util :as ws.u]
    [metabase.api.common :as api]
    [metabase.driver.sql :as driver.sql]
-   [metabase.driver.sql.util :as sql.util]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [toucan2.core :as t2]))
@@ -147,18 +146,6 @@
     table-id         (assoc table-id replacement)
     in-default-schema? (assoc [db-id nil table] replacement)))
 
-(defn- quote-name [driver s] (when s (sql.util/quote-name driver :table s)))
-
-(defn- quote-default-schema
-  "Return the quoted default schema for a database.
-   Pre-quotes the name because it will be spliced into SQL for unqualified references
-   (e.g. `orders` → `\"public\".\"orders\"` or `test-data`.`orders`).
-   These names don't appear in the original SQL, so macaw won't quote them for us."
-  [{:keys [engine details]}]
-  (quote-name engine (or (driver.sql/default-schema engine)
-                         ;; For MySQL and similar, use database name from connection details
-                         ((some-fn :dbname :db) details))))
-
 (defn- build-remapping
   "Build table remapping from the analyzed input and output tables.
 
@@ -202,7 +189,6 @@
                                        (or (driver.sql/default-schema engine)
                                            ((some-fn :dbname :db) details)))
                                      databases)
-        db-id->quoted    (u/index-by :id quote-default-schema databases)
         fallback-map     (merge
                           (table-ids-fallbacks :global_schema :global_table :global_table_id all-outputs)
                           (table-ids-fallbacks :isolated_schema :isolated_table :isolated_table_id all-outputs))
@@ -229,13 +215,14 @@
         ;; When the table already has an explicit schema, Macaw will preserve it as-is.
         input-map        (reduce
                           (fn [m {:keys [db_id schema table table_id]}]
-                            (let [quoted-schema (db-id->quoted db_id)]
+                            (let [default-schema (db-id->default db_id)]
                               ;; Only add a mapping for unqualified references (nil schema).
                               ;; When the table already has an explicit schema, Macaw preserves it.
+                              ;; Use unquoted schema here; remap-sql-source handles quoting for SQL.
                               (cond-> m
-                                (and (nil? schema) (some? quoted-schema))
+                                (and (nil? schema) (some? default-schema))
                                 (assoc [db_id nil table] {:db-id  db_id
-                                                          :schema quoted-schema
+                                                          :schema default-schema
                                                           :table  table
                                                           :id     table_id}))))
                           {}

--- a/enterprise/backend/src/metabase_enterprise/workspaces/query_processor/middleware.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/query_processor/middleware.clj
@@ -31,18 +31,11 @@
           ;; Drivers like Snowflake uppercase unquoted identifiers; without quoting, a lowercase
           ;; isolation schema like `mb__isolation_xxx` would become `MB__ISOLATION_XXX` and not match.
           ;; The same applies to table names containing lowercase characters.
-          drv       driver/*driver*
-          quote-id  (fn [s] (if s (sql.u/quote-name drv :table s) s))
-          remapping (update remapping :tables
-                            (fn [tables]
-                              (into {}
-                                    (map (fn [[src tgt]]
-                                           [src (-> tgt
-                                                    (update :schema quote-id)
-                                                    (update :table quote-id))]))
-                                    tables)))]
+          quote-id  (fn [s] (if s (sql.u/quote-name driver/*driver* :table s) s))
+          ;; tables has the form {:schema,:table} => {:schema,:table}, and we want to quote the target schema + table.
+          remapping (update remapping :tables update-vals #(update-vals % quote-id))]
       (u/update-in-if-exists query [:stages 0 :native]
-                             (fn [sql] (sql-tools/replace-names drv
+                             (fn [sql] (sql-tools/replace-names driver/*driver*
                                                                 sql
                                                                 remapping
                                                                 {:allow-unused? true}))))))

--- a/enterprise/backend/src/metabase_enterprise/workspaces/query_processor/middleware.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/query_processor/middleware.clj
@@ -5,6 +5,7 @@
   code), this middleware rewrites table names in the native SQL using [[sql-tools/replace-names]]."
   (:require
    [metabase.driver :as driver]
+   [metabase.driver.sql.util :as sql.u]
    [metabase.lib.schema :as lib.schema]
    [metabase.premium-features.core :refer [defenterprise]]
    [metabase.sql-tools.core :as sql-tools]
@@ -26,8 +27,22 @@
                     {:query query, :remapping remapping}))
 
     :else
-    (u/update-in-if-exists query [:stages 0 :native]
-                           (fn [sql] (sql-tools/replace-names driver/*driver*
-                                                              sql
-                                                              remapping
-                                                              {:allow-unused? true})))))
+    (let [;; Quote replacement identifiers so the SQL parser preserves their case.
+          ;; Drivers like Snowflake uppercase unquoted identifiers; without quoting, a lowercase
+          ;; isolation schema like `mb__isolation_xxx` would become `MB__ISOLATION_XXX` and not match.
+          ;; The same applies to table names containing lowercase characters.
+          drv       driver/*driver*
+          quote-id  (fn [s] (if s (sql.u/quote-name drv :table s) s))
+          remapping (update remapping :tables
+                            (fn [tables]
+                              (into {}
+                                    (map (fn [[src tgt]]
+                                           [src (-> tgt
+                                                    (update :schema quote-id)
+                                                    (update :table quote-id))]))
+                                    tables)))]
+      (u/update-in-if-exists query [:stages 0 :native]
+                             (fn [sql] (sql-tools/replace-names drv
+                                                                sql
+                                                                remapping
+                                                                {:allow-unused? true}))))))

--- a/enterprise/backend/src/metabase_enterprise/workspaces/query_processor/middleware.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/query_processor/middleware.clj
@@ -27,12 +27,12 @@
                     {:query query, :remapping remapping}))
 
     :else
-    (let [;; Quote replacement identifiers so the SQL parser preserves their case.
-          ;; Drivers like Snowflake uppercase unquoted identifiers; without quoting, a lowercase
-          ;; isolation schema like `mb__isolation_xxx` would become `MB__ISOLATION_XXX` and not match.
-          ;; The same applies to table names containing lowercase characters.
-          quote-id  (fn [s] (if s (sql.u/quote-name driver/*driver* :table s) s))
-          ;; tables has the form {:schema,:table} => {:schema,:table}, and we want to quote the target schema + table.
+    ;; Replacement identifiers must be quoted to preserve case — e.g., Snowflake uppercases
+    ;; unquoted identifiers, so `mb__isolation_xxx` would become `MB__ISOLATION_XXX`.
+    ;; TODO (2026-03-07): We pre-quote here with HoneySQL, but sql-tools/replace-names strips
+    ;; and re-quotes using its own dialect convention. Consider adding a :force-quote? flag to
+    ;; replace-names so it can handle quoting internally without this round-trip.
+    (let [quote-id  (fn [s] (if s (sql.u/quote-name driver/*driver* :table s) s))
           remapping (update remapping :tables update-vals #(update-vals % quote-id))]
       (u/update-in-if-exists query [:stages 0 :native]
                              (fn [sql] (sql-tools/replace-names driver/*driver*

--- a/enterprise/backend/test/metabase_enterprise/workspaces/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/api_test.clj
@@ -1629,48 +1629,34 @@
                                      (ws-url (:id ws) "/query")
                                      {:sql "SELECT 1"})))))))
 
-#_(deftest ^:synchronized adhoc-query-remapping-test
-    (testing "POST /api/ee/workspace/:id/query remaps table references to isolated tables"
-      (ws.tu/with-workspaces! [ws {:name "Adhoc Query Remapping Test"}]
-        (let [target-schema (driver.sql/default-schema driver/*driver*)
-              target-table  (str "adhoc_remap_" (str/replace (str (random-uuid)) "-" "_"))
-              transform-def {:name   "Remapping Test Transform"
-                             :source {:type  "query"
-                                      :query (mt/native-query
-                                              {:query "SELECT 1 as id, 'remapped' as status"})}
-                             :target {:type     "table"
-                                      :database (mt/id)
-                                      :schema   target-schema
-                                      :name     target-table}}
-            ;; Add transform to workspace
-              ref-id        (:ref_id (mt/user-http-request :crowberto :post 200
-                                                           (ws-url (:id ws) "/transform")
-                                                           transform-def))
-              ws            (ws.tu/ws-done! (:id ws))]
-          ;; Run the transform to populate the isolated table
-          #_{:clj-kondo/ignore [:redundant-let]}
-          (let [run-result (mt/user-http-request :crowberto :post 200
-                                                 (ws-url (:id ws) "/transform/" ref-id "/run"))]
-            (is (= "succeeded" (:status run-result)) "Transform should run successfully"))
+(deftest ^:synchronized adhoc-query-remapping-test
+  (testing "POST /api/ee/workspace/:id/query remaps table references to isolated tables"
+    (ws.tu/with-workspaces! [ws {:name "Adhoc Query Remapping Test"}]
+      (let [default-schema (driver.sql/default-schema driver/*driver*)
+            target-schema  (or default-schema (sql.normalize/normalize-name driver/*driver* "public"))
+            target-table   (str "adhoc_remap_" (str/replace (str (random-uuid)) "-" "_"))
+            tx-def         {:name   "Remapping Test Transform"
+                            :source {:type  "query"
+                                     :query (mt/native-query
+                                             {:query "SELECT 1 as id, 'remapped' as status"})}
+                            :target {:type     "table"
+                                     :database (mt/id)
+                                     :schema   target-schema
+                                     :name     target-table}}
+            ref-id         (:ref_id (mt/user-http-request :crowberto :post 200 (ws-url (:id ws) "/transform") tx-def))
+            ws             (ws.tu/ws-ready! ws)
+            run-result     (mt/user-http-request :crowberto :post 200 (ws-url (:id ws) "/transform/" ref-id "/run"))]
+        (is (= "succeeded" (:status run-result)) "Transform should have run successfully")
+        (let [run-qry (fn [query-sql]
+                        (mt/user-http-request :crowberto :post 200 (ws-url (:id ws) "/query") {:sql query-sql}))
+              expected {:status "succeeded"
+                        :data   {:rows [[1 "remapped"]]
+                                 :cols [{:name #"(?i)id"} {:name #"(?i)status"}]}}]
           (testing "ad-hoc query can SELECT from transform output using schema-qualified table name"
-            (let [query-sql (str "SELECT * FROM " target-schema "." target-table)
-                  result    (mt/user-http-request :crowberto :post 200
-                                                  (ws-url (:id ws) "/query")
-                                                  {:sql query-sql})]
-              (is (=? {:status "succeeded"
-                       :data   {:rows [[1 "remapped"]]
-                                :cols [{:name #"(?i)id"} {:name #"(?i)status"}]}}
-                      result))))
-
-          (testing "ad-hoc query can SELECT from transform output using unqualified table name"
-            (let [query-sql (str "SELECT * FROM " target-table)
-                  result    (mt/user-http-request :crowberto :post 200
-                                                  (ws-url (:id ws) "/query")
-                                                  {:sql query-sql})]
-              (is (=? {:status "succeeded"
-                       :data   {:rows [[1 "remapped"]]
-                                :cols [{:name #"(?i)id"} {:name #"(?i)status"}]}}
-                      result))))))))
+            (is (=? expected (run-qry (str "SELECT * FROM " target-schema "." target-table)))))
+          (when default-schema
+            (testing "ad-hoc query can SELECT from transform output using unqualified table name"
+              (is (=? expected (run-qry (str "SELECT * FROM " target-table)))))))))))
 
 (deftest ^:synchronized adhoc-query-uses-isolated-credentials-test
   (testing "POST /api/ee/workspace/:id/query executes with workspace isolated credentials"

--- a/enterprise/backend/test/metabase_enterprise/workspaces/execute_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/execute_test.clj
@@ -12,6 +12,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.test-metadata :as meta]
    [metabase.query-processor.compile :as qp.compile]
+   [metabase.sql-tools.core :as sql-tools]
    [metabase.test :as mt]
    [metabase.transforms.test-util :as transforms.tu]
    [toucan2.core :as t2])
@@ -280,10 +281,26 @@
                  :schema "public" :table "orders" :table_id 123}]
                (:source-tables (remap-python-source table-mapping source))))))))
 
+(defn- sql-tools-quote
+  "Quote an identifier using the same pipeline as the workspace middleware.
+   Pre-quotes with sql.u/quote-name (triggering was_quoted in the sql-tools backend),
+   then feeds through sql-tools/replace-names to get the final dialect-specific quoting
+   (e.g., brackets for SQL Server, backticks for MySQL, double quotes for ANSI)."
+  [s]
+  (let [pre-quoted (sql.u/quote-name driver/*driver* :table s)
+        result     (sql-tools/replace-names
+                    driver/*driver*
+                    "SELECT * FROM __placeholder__"
+                    {:tables {{:table "__placeholder__"} pre-quoted}}
+                    {:allow-unused? true})]
+    (second (re-find #"(?i)SELECT \* FROM (.+)" result))))
+
 (deftest workspace-sql-remapping-test
   (let [db-id (mt/id)
         ;; The middleware quotes replacement identifiers to preserve case for drivers like Snowflake.
-        q     (fn [s] (sql.u/quote-name driver/*driver* :table s))]
+        ;; The final quoting style depends on the sql-tools backend dialect (not HoneySQL),
+        ;; so we derive it from the same pipeline the middleware uses.
+        q     sql-tools-quote]
     (doseq [[label table-mapping input-sql expected-sql]
             [["remaps qualified table reference to isolated table"
               {[db-id "public" "orders"] {:db-id db-id :schema "ws_isolated_123" :table "public__orders" :id 456}}

--- a/enterprise/backend/test/metabase_enterprise/workspaces/execute_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/execute_test.clj
@@ -7,6 +7,8 @@
    [metabase-enterprise.workspaces.impl :as ws.impl]
    [metabase-enterprise.workspaces.query-processor.middleware :as ws.qp.middleware]
    [metabase-enterprise.workspaces.test-util :as ws.tu]
+   [metabase.driver :as driver]
+   [metabase.driver.sql.util :as sql.u]
    [metabase.lib.core :as lib]
    [metabase.lib.test-metadata :as meta]
    [metabase.query-processor.compile :as qp.compile]
@@ -279,22 +281,24 @@
                (:source-tables (remap-python-source table-mapping source))))))))
 
 (deftest workspace-sql-remapping-test
-  (let [db-id (mt/id)]
+  (let [db-id (mt/id)
+        ;; The middleware quotes replacement identifiers to preserve case for drivers like Snowflake.
+        q     (fn [s] (sql.u/quote-name driver/*driver* :table s))]
     (doseq [[label table-mapping input-sql expected-sql]
             [["remaps qualified table reference to isolated table"
               {[db-id "public" "orders"] {:db-id db-id :schema "ws_isolated_123" :table "public__orders" :id 456}}
               "SELECT * FROM public.orders"
-              "SELECT * FROM ws_isolated_123.public__orders"]
+              (str "SELECT * FROM " (q "ws_isolated_123") "." (q "public__orders"))]
 
              ["remaps unqualified table reference using nil-schema mapping"
               {[db-id nil "orders"] {:db-id db-id :schema "ws_isolated_123" :table "public__orders" :id 456}}
               "SELECT * FROM orders"
-              "SELECT * FROM ws_isolated_123.public__orders"]
+              (str "SELECT * FROM " (q "ws_isolated_123") "." (q "public__orders"))]
 
              ["qualifies unqualified input table reference (no isolation, just adds schema)"
               {[db-id nil "orders"] {:db-id db-id :schema "public" :table "orders" :id 123}}
               "SELECT * FROM orders"
-              "SELECT * FROM public.orders"]
+              (str "SELECT * FROM " (q "public") "." (q "orders"))]
 
              ["leaves unmapped tables unchanged"
               {[db-id nil "other_table"] {:db-id db-id :schema "public" :table "other_table" :id 789}}
@@ -307,7 +311,9 @@
               {[db-id nil "orders"]   {:db-id db-id :schema "public" :table "orders" :id 123}
                [db-id nil "products"] {:db-id db-id :schema "public" :table "products" :id 124}}
               "SELECT * FROM orders JOIN products ON orders.product_id = products.id"
-              "SELECT * FROM public.orders JOIN public.products ON orders.product_id = products.id"]
+              (str "SELECT * FROM " (q "public") "." (q "orders")
+                   " JOIN " (q "public") "." (q "products")
+                   " ON orders.product_id = products.id")]
 
              ["ignores numeric keys in table-mapping"
               {123 {:db-id db-id :schema "ws_isolated_123" :table "public__orders" :id 456}}

--- a/enterprise/backend/test/metabase_enterprise/workspaces/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/test_util.clj
@@ -179,6 +179,14 @@
                  :timeout-ms (if config/is-dev? 10000 60000)})
         (throw (ex-info "Timeout waiting for workspace to finish initializing" {:workspace-id ws-id})))))
 
+(defn ws-ready!
+  "Like [[ws-done!]], but throws if the workspace does not reach :ready status."
+  [ws-or-id]
+  (u/prog1 (ws-done! ws-or-id)
+    (when (not= :ready (:db_status <>))
+      (throw (ex-info "Workspace failed to become ready"
+                      {:db_status (:db_status <>) :workspace-id (:id <>)})))))
+
 (defn analyze-workspace!
   "Trigger the reconstruction and persistence of the workspace graph."
   [id]
@@ -403,11 +411,7 @@
   "Create a simple workspace and wait for it to finish initializing database resources.
    Throws if workspace does not become ready."
   [name]
-  (let [ws (initialize-ws! name)]
-    (if (= :ready (:db_status ws))
-      ws
-      (throw (ex-info "Workspace failed to become ready"
-                      {:name name :db_status (:db_status ws) :workspace-id (:id ws)})))))
+  (ws-ready! (initialize-ws! name)))
 
 (defn do-with-workspaces!
   "Function that sets up workspaces for testing and cleans up afterwards.

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -1041,7 +1041,7 @@
 (defmethod driver/destroy-workspace-isolation! :snowflake
   [_driver database workspace]
   (let [details     (driver.conn/effective-details database)
-        schema-name (driver.u/workspace-isolation-namespace-name workspace)
+        schema-name (or (:schema workspace) (driver.u/workspace-isolation-namespace-name workspace))
         db-name     (:db details)
         role-name   (isolation-role-name workspace)
         username    (driver.u/workspace-isolation-user-name workspace)

--- a/test/metabase/warehouses_rest/api_test.clj
+++ b/test/metabase/warehouses_rest/api_test.clj
@@ -2545,11 +2545,12 @@
         (t2/update! :model/Database (mt/id) {:workspace_permissions_status nil})
         (let [response (mt/user-http-request :crowberto :post 200
                                              (format "database/%d/permission/workspace/check" (mt/id)))]
-          (is (= "ok" (:status response)))
+          (is (= "ok" (:status response)) (str "response: " (pr-str response)))
           (is (some? (:checked_at response)))
           ;; Verify it was cached
           (let [db (t2/select-one :model/Database (mt/id))]
-            (is (= "ok" (:status (:workspace_permissions_status db)))))))
+            (is (= "ok" (:status (:workspace_permissions_status db)))
+                (str "cached: " (pr-str (:workspace_permissions_status db)))))))
 
       (testing "cached=false forces permission check"
         ;; Set a stale cache value


### PR DESCRIPTION
See https://metaboat.slack.com/archives/C5XHN8GLW/p1770725770601969

This re-enables the `adhoc-query-remapping-test` scenario.

- Qualified references: if there is no default schema, use "public" as a fallback name
- Unqualified references: skip this test if there is no default schema for the database