### PR TITLE
fix: error message for unauthenticated requests is generic

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/metabot/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/constants.ts
@@ -27,6 +27,9 @@ export const METABOT_ERR_MSG = {
   get default() {
     return t`Sorry, I ran into an error. Could you please try that again?`;
   },
+  get unauthenticated() {
+    return t`Metabot could not authenticate your request. Please contact your administrator.`;
+  },
   get agentOffline() {
     return t`Metabot is currently offline. Please try again later.`;
   },

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/actions.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/actions.ts
@@ -93,6 +93,17 @@ const handleResponseError = (error: unknown): PromptErrorOutcome => {
       shouldRetry: false,
     }))
     .with(
+      { message: P.string.startsWith("Response status: 401") },
+      { status: 401 },
+      () => ({
+        errorMessage: {
+          type: "alert" as const,
+          message: METABOT_ERR_MSG.unauthenticated,
+        },
+        shouldRetry: true,
+      }),
+    )
+    .with(
       { message: P.string.startsWith("Response status: 5") },
       { status: 500 },
       () => ({

--- a/enterprise/frontend/src/metabase-enterprise/metabot/tests/errors.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/tests/errors.unit.spec.tsx
@@ -41,6 +41,19 @@ describe("metabot > errors", () => {
     expect(await input()).toHaveTextContent("Who is your favorite?");
   });
 
+  it("should show a better error message for unauthenticated requests", async () => {
+    setup();
+    fetchMock.post(`path:/api/ee/metabot-v3/agent-streaming`, 401);
+
+    await enterChatMessage("Who is your favorite?");
+
+    await assertConversation([
+      ["user", "Who is your favorite?"],
+      ["agent", METABOT_ERR_MSG.unauthenticated],
+    ]);
+    expect(await input()).toHaveTextContent("Who is your favorite?");
+  });
+
   it("should handle show error if data error part is in response", async () => {
     setup();
     mockAgentEndpoint({ textChunks: erroredResponse });


### PR DESCRIPTION
Closes [BOT-209: FE Show better error message for unauthenticated requests](https://linear.app/metabase/issue/BOT-209/fe-show-better-error-message-for-unauthenticated-requests)

### Description

Return a better error message.

### How to verify

1. Force ai the endpoint to return 403 

### Demo

<img width="500" height="964" alt="image" src="https://github.com/user-attachments/assets/47de6036-85dc-498b-b92b-dc6569aa0d48" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
