### PR TITLE
docs - fix typo in transforms-enabled setting description

### DIFF
--- a/src/metabase/transforms/settings.clj
+++ b/src/metabase/transforms/settings.clj
@@ -17,7 +17,7 @@
   :audit      :getter)
 
 (setting/defsetting transforms-enabled
-  (deferred-tru "Enable transforms for instances that have not explicetly purchased the transform add-on")
+  (deferred-tru "Enable transforms for instances that have not explicitly purchased the transform add-on.")
   :type       :boolean
   :visibility :authenticated
   :default    false


### PR DESCRIPTION
Like it says on the tin.