### PR TITLE
support `targetCollection` in `CreateDashboardModal`

### DIFF
--- a/frontend/src/embedding-sdk-bundle/components/public/CreateDashboardModal/CreateDashboardModal.schema.ts
+++ b/frontend/src/embedding-sdk-bundle/components/public/CreateDashboardModal/CreateDashboardModal.schema.ts
@@ -6,6 +6,7 @@ import type { CreateDashboardModalProps } from "./CreateDashboardModal";
 
 const propsSchema: Yup.SchemaOf<CreateDashboardModalProps> = Yup.object({
   initialCollectionId: Yup.mixed().optional(),
+  targetCollection: Yup.mixed().optional(),
   isOpen: Yup.mixed().optional(),
   onClose: Yup.mixed().optional(),
   onCreate: Yup.object().required(),

--- a/frontend/src/embedding-sdk-bundle/components/public/CreateDashboardModal/CreateDashboardModal.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/CreateDashboardModal/CreateDashboardModal.tsx
@@ -24,6 +24,11 @@ export interface CreateDashboardModalProps {
   initialCollectionId?: SdkCollectionId;
 
   /**
+   * The collection to save the dashboard to. This will hide the collection picker from the save modal.
+   */
+  targetCollection?: SdkCollectionId;
+
+  /**
    * Whether the modal is open or not.
    */
   isOpen?: boolean;
@@ -41,6 +46,7 @@ export interface CreateDashboardModalProps {
 
 const CreateDashboardModalInner = ({
   initialCollectionId = "personal",
+  targetCollection,
   isOpen = true,
   onCreate,
   onClose,
@@ -69,6 +75,7 @@ const CreateDashboardModalInner = ({
       onCreate={onCreate}
       onClose={() => onClose?.()}
       collectionId={collectionId}
+      targetCollection={targetCollection}
     />
   );
 };

--- a/frontend/src/embedding-sdk-bundle/components/public/CreateDashboardModal/CreateDashboardModal.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/CreateDashboardModal/CreateDashboardModal.tsx
@@ -61,6 +61,12 @@ const CreateDashboardModalInner = ({
     getCollectionIdSlugFromReference(state, initialCollectionId),
   );
 
+  const resolvedTargetCollection = useSelector((state) =>
+    targetCollection
+      ? getCollectionIdValueFromReference(state, targetCollection)
+      : undefined,
+  );
+
   const { isLoading: isCollectionQueryLoading } = useCollectionQuery({
     id: collectionIdSlug,
   });
@@ -75,7 +81,7 @@ const CreateDashboardModalInner = ({
       onCreate={onCreate}
       onClose={() => onClose?.()}
       collectionId={collectionId}
-      targetCollection={targetCollection}
+      targetCollection={resolvedTargetCollection}
     />
   );
 };

--- a/frontend/src/embedding-sdk-bundle/components/public/CreateDashboardModal/CreateDashboardModal.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/CreateDashboardModal/CreateDashboardModal.unit.spec.tsx
@@ -126,7 +126,7 @@ describe("CreateDashboardModal", () => {
     expect(onCreate).toHaveBeenLastCalledWith(mockResponseDashboard);
   });
 
-  it('should support "isOpen" prop', async () => {
+  it("should support `isOpen` prop", async () => {
     const { rerender } = setup({
       props: {
         isOpen: false,
@@ -142,7 +142,7 @@ describe("CreateDashboardModal", () => {
     });
   });
 
-  it('should set the starting collection to the user\'s personal collection when not passing "initialCollectionId"', async () => {
+  it("should set the starting collection to the user's personal collection when not passing `initialCollectionId`", async () => {
     setup();
 
     await waitFor(() => {
@@ -154,7 +154,7 @@ describe("CreateDashboardModal", () => {
     );
   });
 
-  it('should set the starting collection from "initialCollectionId" prop', async () => {
+  it("should set the starting collection from `initialCollectionId` prop", async () => {
     const anotherCollection = createMockCollection({
       id: getNextId(),
       name: "Another collection",
@@ -177,7 +177,7 @@ describe("CreateDashboardModal", () => {
     );
   });
 
-  it('should hide the collection picker when passing "targetCollection"', async () => {
+  it("should hide the collection picker when passing `targetCollection`", async () => {
     const anotherCollection = createMockCollection({
       id: getNextId(),
       name: "Another collection",
@@ -226,7 +226,7 @@ describe("CreateDashboardModal", () => {
     });
   });
 
-  it('should resolve special collection name like "root" when passing "targetCollection"', async () => {
+  it("should resolve special collection name like `root` when passing `targetCollection`", async () => {
     const expectedDashboard = {
       name: "My awesome dashboard title",
     } satisfies Partial<Dashboard>;

--- a/frontend/src/embedding-sdk-bundle/components/public/CreateDashboardModal/CreateDashboardModal.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/CreateDashboardModal/CreateDashboardModal.unit.spec.tsx
@@ -11,6 +11,7 @@ import { renderWithSDKProviders } from "embedding-sdk-bundle/test/__support__/ui
 import { createMockSdkConfig } from "embedding-sdk-bundle/test/mocks/config";
 import { useLocale } from "metabase/common/hooks/use-locale";
 import { ROOT_COLLECTION as ROOT } from "metabase/entities/collections";
+import type { Collection, Dashboard } from "metabase-types/api";
 import {
   createMockCollection,
   createMockDashboard,
@@ -140,20 +141,106 @@ describe("CreateDashboardModal", () => {
       expect(screen.getByText("New dashboard")).toBeInTheDocument();
     });
   });
+
+  it('should set the starting collection to the user\'s personal collection when not passing "initialCollectionId"', async () => {
+    setup();
+
+    await waitFor(() => {
+      expect(screen.getByText("New dashboard")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("collection-picker-button")).toHaveTextContent(
+      PERSONAL_COLLECTION.name,
+    );
+  });
+
+  it('should set the starting collection from "initialCollectionId" prop', async () => {
+    const anotherCollection = createMockCollection({
+      id: getNextId(),
+      name: "Another collection",
+      can_write: true,
+    });
+
+    setup({
+      props: {
+        initialCollectionId: anotherCollection.id,
+      },
+      collections: [...COLLECTIONS, anotherCollection],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("New dashboard")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("collection-picker-button")).toHaveTextContent(
+      anotherCollection.name,
+    );
+  });
+
+  it('should hide the collection picker when passing "targetCollection"', async () => {
+    const anotherCollection = createMockCollection({
+      id: getNextId(),
+      name: "Another collection",
+      can_write: true,
+    });
+
+    const expectedDashboard = {
+      name: "My awesome dashboard title",
+    } satisfies Partial<Dashboard>;
+    setupDashboardCreateEndpoint(expectedDashboard);
+
+    setup({
+      props: {
+        // Should prioritize `targetCollection` over `initialCollectionId`
+        initialCollectionId: PERSONAL_COLLECTION.id,
+        targetCollection: anotherCollection.id,
+      },
+      collections: [...COLLECTIONS, anotherCollection],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("New dashboard")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByTestId("collection-picker-button"),
+    ).not.toBeInTheDocument();
+
+    await userEvent.type(
+      screen.getByPlaceholderText("What is the name of your dashboard?"),
+      expectedDashboard.name,
+    );
+
+    await userEvent.click(screen.getByText("Create"));
+
+    // api called with typed form input
+    const createDashboardCall = fetchMock.callHistory.lastCall(
+      `path:/api/dashboard`,
+      {
+        method: "POST",
+      },
+    );
+    expect(await createDashboardCall?.request?.json()).toMatchObject({
+      name: expectedDashboard.name,
+      collection_id: anotherCollection.id,
+    });
+  });
 });
 
-function setup(
-  {
-    isLocaleLoading,
-    props,
-  }: {
-    isLocaleLoading?: boolean;
-    props?: Partial<CreateDashboardModalProps>;
-  } = { isLocaleLoading: false, props: {} },
-) {
+interface SetupOpts {
+  isLocaleLoading?: boolean;
+  props?: Partial<CreateDashboardModalProps>;
+  collections?: Collection[];
+}
+
+function setup({
+  isLocaleLoading = false,
+  props = {},
+  collections = COLLECTIONS,
+}: SetupOpts = {}) {
   useLocaleMock.mockReturnValue({ isLocaleLoading });
 
-  setupCollectionByIdEndpoint({ collections: COLLECTIONS });
+  setupCollectionByIdEndpoint({ collections });
 
   // Mock the "personal" collection endpoint since the component now passes string IDs directly
   fetchMock.get("path:/api/collection/personal", PERSONAL_COLLECTION);

--- a/frontend/src/embedding-sdk-bundle/components/public/CreateDashboardModal/CreateDashboardModal.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/CreateDashboardModal/CreateDashboardModal.unit.spec.tsx
@@ -225,6 +225,46 @@ describe("CreateDashboardModal", () => {
       collection_id: anotherCollection.id,
     });
   });
+
+  it('should resolve special collection name like "root" when passing "targetCollection"', async () => {
+    const expectedDashboard = {
+      name: "My awesome dashboard title",
+    } satisfies Partial<Dashboard>;
+    setupDashboardCreateEndpoint(expectedDashboard);
+
+    setup({
+      props: {
+        targetCollection: "root",
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("New dashboard")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByTestId("collection-picker-button"),
+    ).not.toBeInTheDocument();
+
+    await userEvent.type(
+      screen.getByPlaceholderText("What is the name of your dashboard?"),
+      expectedDashboard.name,
+    );
+
+    await userEvent.click(screen.getByText("Create"));
+
+    // api called with typed form input
+    const createDashboardCall = fetchMock.callHistory.lastCall(
+      `path:/api/dashboard`,
+      {
+        method: "POST",
+      },
+    );
+    expect(await createDashboardCall?.request?.json()).toMatchObject({
+      name: expectedDashboard.name,
+      collection_id: null,
+    });
+  });
 });
 
 interface SetupOpts {

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardForm.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardForm.tsx
@@ -56,7 +56,7 @@ export interface CreateDashboardProperties {
 
 export interface CreateDashboardFormOwnProps {
   collectionId?: CollectionId | null; // can be used by `getInitialCollectionId`
-  targetCollection?: SdkCollectionId;
+  targetCollection?: SdkCollectionId | null;
   onCreate?: (dashboard: Dashboard) => void;
   onCancel?: () => void;
 }
@@ -71,14 +71,20 @@ export function CreateDashboardForm({
     Collections.selectors.getInitialCollectionId(state, { collectionId }),
   );
 
+  // ID: `null` = Our analytics
+  const hasTargetCollection = targetCollection !== undefined;
+
   const [handleCreateDashboard] = useCreateDashboardMutation();
-  const computedInitialValues = useMemo(
-    () => ({
+  const computedInitialValues = useMemo(() => {
+    // Redeclare to avoid putting it in the hook dependencies
+    const hasTargetCollection = targetCollection !== undefined;
+    return {
       ...DASHBOARD_SCHEMA.getDefault(),
-      collection_id: targetCollection ?? initialCollectionId,
-    }),
-    [initialCollectionId, targetCollection],
-  );
+      collection_id: hasTargetCollection
+        ? targetCollection
+        : initialCollectionId,
+    };
+  }, [initialCollectionId, targetCollection]);
 
   const handleCreate = useCallback(
     async (values: CreateDashboardProperties) => {
@@ -118,7 +124,7 @@ export function CreateDashboardForm({
             maxRows={5}
             my="md"
           />
-          {!targetCollection && (
+          {!hasTargetCollection && (
             <FormCollectionPicker
               name="collection_id"
               title={t`Which collection should this go in?`}

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardForm.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardForm.tsx
@@ -5,7 +5,6 @@ import * as Yup from "yup";
 import { useCreateDashboardMutation } from "metabase/api";
 import FormCollectionPicker from "metabase/collections/containers/FormCollectionPicker/FormCollectionPicker";
 import { FormFooter } from "metabase/common/components/FormFooter";
-import type { FilterItemsInPersonalCollection } from "metabase/common/components/Pickers";
 import { Collections } from "metabase/entities/collections";
 import {
   Form,
@@ -58,15 +57,11 @@ export interface CreateDashboardFormOwnProps {
   collectionId?: CollectionId | null; // can be used by `getInitialCollectionId`
   onCreate?: (dashboard: Dashboard) => void;
   onCancel?: () => void;
-  initialValues?: CreateDashboardProperties | null;
-  filterPersonalCollections?: FilterItemsInPersonalCollection;
 }
 
 export function CreateDashboardForm({
   onCreate,
   onCancel,
-  initialValues,
-  filterPersonalCollections,
   collectionId,
 }: CreateDashboardFormOwnProps) {
   const initialCollectionId = useSelector((state) =>
@@ -78,9 +73,8 @@ export function CreateDashboardForm({
     () => ({
       ...DASHBOARD_SCHEMA.getDefault(),
       collection_id: initialCollectionId,
-      ...initialValues,
     }),
-    [initialCollectionId, initialValues],
+    [initialCollectionId],
   );
 
   const handleCreate = useCallback(
@@ -124,7 +118,6 @@ export function CreateDashboardForm({
           <FormCollectionPicker
             name="collection_id"
             title={t`Which collection should this go in?`}
-            filterPersonalCollections={filterPersonalCollections}
             entityType="dashboard"
           />
           <FormFooter>

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardForm.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardForm.tsx
@@ -71,20 +71,18 @@ export function CreateDashboardForm({
     Collections.selectors.getInitialCollectionId(state, { collectionId }),
   );
 
-  // ID: `null` = Our analytics
+  // When passing `"root"` it will be resolved to `null`
   const hasTargetCollection = targetCollection !== undefined;
 
   const [handleCreateDashboard] = useCreateDashboardMutation();
   const computedInitialValues = useMemo(() => {
-    // Redeclare to avoid putting it in the hook dependencies
-    const hasTargetCollection = targetCollection !== undefined;
     return {
       ...DASHBOARD_SCHEMA.getDefault(),
       collection_id: hasTargetCollection
         ? targetCollection
         : initialCollectionId,
     };
-  }, [initialCollectionId, targetCollection]);
+  }, [hasTargetCollection, initialCollectionId, targetCollection]);
 
   const handleCreate = useCallback(
     async (values: CreateDashboardProperties) => {

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardForm.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardForm.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from "react";
 import { t } from "ttag";
 import * as Yup from "yup";
 
+import type { SdkCollectionId } from "embedding-sdk-bundle/types";
 import { useCreateDashboardMutation } from "metabase/api";
 import FormCollectionPicker from "metabase/collections/containers/FormCollectionPicker/FormCollectionPicker";
 import { FormFooter } from "metabase/common/components/FormFooter";
@@ -55,14 +56,16 @@ export interface CreateDashboardProperties {
 
 export interface CreateDashboardFormOwnProps {
   collectionId?: CollectionId | null; // can be used by `getInitialCollectionId`
+  targetCollection?: SdkCollectionId;
   onCreate?: (dashboard: Dashboard) => void;
   onCancel?: () => void;
 }
 
 export function CreateDashboardForm({
+  collectionId,
+  targetCollection,
   onCreate,
   onCancel,
-  collectionId,
 }: CreateDashboardFormOwnProps) {
   const initialCollectionId = useSelector((state) =>
     Collections.selectors.getInitialCollectionId(state, { collectionId }),
@@ -72,9 +75,9 @@ export function CreateDashboardForm({
   const computedInitialValues = useMemo(
     () => ({
       ...DASHBOARD_SCHEMA.getDefault(),
-      collection_id: initialCollectionId,
+      collection_id: targetCollection ?? initialCollectionId,
     }),
-    [initialCollectionId],
+    [initialCollectionId, targetCollection],
   );
 
   const handleCreate = useCallback(
@@ -115,11 +118,13 @@ export function CreateDashboardForm({
             maxRows={5}
             my="md"
           />
-          <FormCollectionPicker
-            name="collection_id"
-            title={t`Which collection should this go in?`}
-            entityType="dashboard"
-          />
+          {!targetCollection && (
+            <FormCollectionPicker
+              name="collection_id"
+              title={t`Which collection should this go in?`}
+              entityType="dashboard"
+            />
+          )}
           <FormFooter>
             <FormErrorMessage inline />
             {!!onCancel && (

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardModal.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardModal.tsx
@@ -19,10 +19,8 @@ export interface CreateDashboardModalProps
 export const CreateDashboardModal = ({
   onCreate,
   onClose,
-  initialValues,
-  filterPersonalCollections,
   collectionId,
-  ...modalProps
+  opened,
 }: CreateDashboardModalProps & Omit<ModalProps, "onClose">) => {
   const dispatch = useDispatch();
   const handleCreate = useCallback(
@@ -46,13 +44,11 @@ export const CreateDashboardModal = ({
       data-testid="new-dashboard-modal"
       size="lg"
       closeOnEscape={false}
-      {...modalProps}
+      opened={opened}
     >
       <CreateDashboardForm
         onCreate={handleCreate}
         onCancel={onClose}
-        initialValues={initialValues}
-        filterPersonalCollections={filterPersonalCollections}
         collectionId={collectionId}
       />
     </Modal>

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardModal.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardModal.tsx
@@ -14,7 +14,7 @@ import { CreateDashboardForm } from "./CreateDashboardForm";
 export interface CreateDashboardModalProps {
   opened: boolean;
   collectionId?: CollectionId | null; // can be used by `getInitialCollectionId`
-  targetCollection?: SdkCollectionId;
+  targetCollection?: SdkCollectionId | null;
   onCreate?: (dashboard: Dashboard) => void;
   onClose: () => void;
 }

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardModal.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardModal.tsx
@@ -2,25 +2,29 @@ import { useCallback } from "react";
 import { push } from "react-router-redux";
 import { t } from "ttag";
 
+import type { SdkCollectionId } from "embedding-sdk-bundle/types";
 import { useEscapeToCloseModal } from "metabase/common/hooks/use-escape-to-close-modal";
 import { useDispatch } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { Modal, type ModalProps } from "metabase/ui";
-import type { Dashboard } from "metabase-types/api";
+import type { CollectionId, Dashboard } from "metabase-types/api";
 
-import type { CreateDashboardFormOwnProps } from "./CreateDashboardForm";
 import { CreateDashboardForm } from "./CreateDashboardForm";
 
-export interface CreateDashboardModalProps
-  extends Omit<CreateDashboardFormOwnProps, "onCancel"> {
+export interface CreateDashboardModalProps {
+  opened: boolean;
+  collectionId?: CollectionId | null; // can be used by `getInitialCollectionId`
+  targetCollection?: SdkCollectionId;
+  onCreate?: (dashboard: Dashboard) => void;
   onClose: () => void;
 }
 
 export const CreateDashboardModal = ({
+  opened,
+  collectionId,
+  targetCollection,
   onCreate,
   onClose,
-  collectionId,
-  opened,
 }: CreateDashboardModalProps & Omit<ModalProps, "onClose">) => {
   const dispatch = useDispatch();
   const handleCreate = useCallback(
@@ -50,6 +54,7 @@ export const CreateDashboardModal = ({
         onCreate={handleCreate}
         onCancel={onClose}
         collectionId={collectionId}
+        targetCollection={targetCollection}
       />
     </Modal>
   );


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #62607
closes EMB-797

### Description

Support `targetCollection` in `CreateDashboardModal`. When setting this property, the collection picker will also be hidden. This is the same behavior as questions. When providing both `initialCollectionId` and `targetCollection`, only `targetCollection` will be used.

### How to verify

Pass `targetCollection` to `CreateDashboardModal` in the SDK. You shouldn't see the collection picker any more. Clicking save should use the provided collection ID in the request, this doesn't validate if users has any access to the collection though. So, the request would fail if you provide the ID that the logged-in users have no access to, or non-existing collection.


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
