### PR TITLE
BOT-984 Add slack channel support to create-dashboard-subscription tool

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
@@ -503,14 +503,18 @@
   [:and
    [:map
     [:dashboard_id :int]
-    [:email :string]
+    [:channel_type {:optional true, :default "email"}
+     [:enum {:encode/tool-api-request keyword} "email" "slack"]]
+    [:email {:optional true} :string]
+    [:slack_channel {:optional true} :string]
     [:schedule ::subscription-schedule]]
    [:map {:encode/tool-api-request #(update-keys % metabot-v3.u/safe->kebab-case-en)}]])
 
 (deftool "/create-dashboard-subscription"
   "Create a dashboard subscription."
   {:args-schema   ::create-dashboard-subscription-arguments
-   :result-schema [:map [:output :string]]
+   :result-schema [:map [:error  {:optional true} :string
+                         :output {:optional true} :string]]
    :handler       metabot-v3.tools.create-dashboard-subscription/create-dashboard-subscription})
 
 ;;; ---------------------------------------------------- Analytics ----------------------------------------------------

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
@@ -503,15 +503,12 @@
   [:and
    [:map
     [:dashboard_id :int]
-    [:channel_type {:optional true, :default "email"}
-     [:enum {:encode/tool-api-request keyword} "email" "slack"]]
-    [:email {:optional true} :string]
-    [:slack_channel {:optional true} :string]
+    [:slack_channel :string]
     [:schedule ::subscription-schedule]]
    [:map {:encode/tool-api-request #(update-keys % metabot-v3.u/safe->kebab-case-en)}]])
 
 (deftool "/create-dashboard-subscription"
-  "Create a dashboard subscription."
+  "Create a dashboard subscription and send it to a slack channel."
   {:args-schema   ::create-dashboard-subscription-arguments
    :result-schema [:map [:error  {:optional true} :string
                          :output {:optional true} :string]]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/create_dashboard_subscription.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/create_dashboard_subscription.clj
@@ -1,5 +1,7 @@
 (ns metabase-enterprise.metabot-v3.tools.create-dashboard-subscription
   (:require
+   [clojure.set :as set]
+   [metabase-enterprise.metabot-v3.tools.util :as metabot-v3.tools.u]
    [metabase.api.common :as api]
    [metabase.channel.settings :as channel.settings]
    [metabase.permissions.core :as perms]
@@ -78,4 +80,8 @@
     {:error "slack_channel is required"}
 
     :else
-    (create-dashboard-subscription* args)))
+    (try
+      (create-dashboard-subscription* args)
+      (catch Exception e
+        (-> (metabot-v3.tools.u/handle-agent-error e)
+            (set/rename-keys {:output :error}))))))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/create_dashboard_subscription.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/create_dashboard_subscription.clj
@@ -1,55 +1,102 @@
 (ns metabase-enterprise.metabot-v3.tools.create-dashboard-subscription
   (:require
    [metabase.api.common :as api]
+   [metabase.channel.settings :as channel.settings]
    [metabase.permissions.core :as perms]
    ^{:clj-kondo/ignore [:deprecated-namespace]}
    [metabase.pulse.core :as pulse]
    [metabase.util :as u]
    [toucan2.core :as t2]))
 
+(defn- schedule->channel-fields
+  "Convert a schedule map to the pulse channel schedule fields."
+  [{:keys [frequency hour day-of-week day-of-month]}]
+  {:schedule_type  frequency
+   :schedule_hour  hour
+   :schedule_day   (or (some-> day-of-week name (subs 0 3) u/lower-case-en)
+                       (some->> day-of-month
+                                name
+                                u/lower-case-en
+                                (re-find #"^(?:first|last)-(mon|tue|wed|thu|fri|sat|sun)")
+                                second))
+   :schedule_frame (some->> day-of-month name (re-find #"^(?:first|mid|last)"))})
+
+(defn- make-email-channel
+  "Build a pulse channel for email delivery."
+  [schedule recipient-id]
+  (merge {:channel_type :email
+          :enabled      true
+          :recipients   [{:id recipient-id}]}
+         (schedule->channel-fields schedule)))
+
+(defn- make-slack-channel
+  "Build a pulse channel for Slack delivery."
+  [schedule slack-channel]
+  (merge {:channel_type :slack
+          :enabled      true
+          :details      {:channel slack-channel}}
+         (schedule->channel-fields schedule)))
+
+(defn- create-dashboard-subscription*
+  "Private helper for create-dashboard-subscription (call that instead)."
+  [{:keys [dashboard-id channel-type email slack-channel schedule]
+    :or   {channel-type :email}}]
+  (let [dashboard (some-> (t2/select-one :model/Dashboard dashboard-id)
+                          api/read-check
+                          (t2/hydrate [:dashcards :card]))
+        cards (for [{:keys [id card]} (:dashcards dashboard)
+                    :when (-> card :id int?)]
+                (-> card
+                    api/read-check
+                    (select-keys [:id :name :collection_id :description :display :parameter_mappings])
+                    (assoc :dashboard_card_id id :dashboard_id dashboard-id)))
+        recipient-id (when (= channel-type :email)
+                       (t2/select-one-fn :id :model/User :email email))
+        pulse-data (-> dashboard
+                       (select-keys [:collection_id :collection_position :name :parameters])
+                       (assoc :dashboard_id  dashboard-id
+                              :creator_id    api/*current-user-id*
+                              :skip_if_empty false))]
+    (cond
+      (nil? dashboard)
+      {:error "no dashboard with this dashboard_id found"}
+
+      (and (= channel-type :email) (nil? recipient-id))
+      {:error "no user with this email found"}
+
+      (= channel-type :email)
+      (do (pulse/create-pulse! (map pulse/card->ref cards)
+                               [(make-email-channel schedule recipient-id)]
+                               pulse-data)
+          {:output "success"})
+
+      (= channel-type :slack)
+      (do (pulse/create-pulse! (map pulse/card->ref cards)
+                               [(make-slack-channel schedule slack-channel)]
+                               pulse-data)
+          {:output "success"})
+
+      :else
+      {:error (str "unsupported channel_type: " (name channel-type))})))
+
 (defn create-dashboard-subscription
   "Create a dashboard subscription."
-  [{:keys [dashboard-id email schedule]}]
+  [{:keys [dashboard-id channel-type slack-channel _email _schedule]
+    :or   {channel-type :email}
+    :as   args}]
   (perms/check-has-application-permission :subscription false)
-  (if (int? dashboard-id)
-    (let [dashboard (some-> (t2/select-one :model/Dashboard dashboard-id)
-                            api/read-check
-                            (t2/hydrate [:dashcards :card]))
-          cards (for [{:keys [id card]} (:dashcards dashboard)
-                      :when (-> card :id int?)]
-                  (-> card
-                      api/read-check
-                      (select-keys [:id :name :collection_id :description :display :parameter_mappings])
-                      (assoc :dashboard_card_id id :dashboard_id dashboard-id)))
-          recipient-id (t2/select-one-fn :id :model/User :email email)
-          recipient {:id recipient-id}
-          {:keys [frequency hour day-of-week day-of-month]} schedule
-          channel {:channel_type :email
-                   :enabled true
-                   :recipients [recipient]
-                   :schedule_day (or (some-> day-of-week name (subs 0 3) u/lower-case-en)
-                                     (some->> day-of-month
-                                              name
-                                              u/lower-case-en
-                                              (re-find #"^(?:first|last)-(mon|tue|wed|thu|fri|sat|sun)")
-                                              second))
-                   :schedule_frame (some->> day-of-month name (re-find #"^(?:first|mid|last)"))
-                   :schedule_hour hour
-                   :schedule_type frequency}
-          pulse-data (-> dashboard
-                         (select-keys [:collection_id :collection_position :name :parameters])
-                         (assoc :dashboard_id  dashboard-id
-                                :creator_id    api/*current-user-id*
-                                :skip_if_empty false))]
-      {:output
-       (cond
-         (nil? recipient-id)
-         "no user with this email found"
+  (cond
+    (not (int? dashboard-id))
+    {:error "invalid dashboard_id"}
 
-         (nil? dashboard)
-         "no dashboard with this dashboard_id found"
+    (and (= channel-type :email) (not (channel.settings/email-configured?)))
+    {:error "email is not configured. Ask an admin to set up email in Metabase settings."}
 
-         :else
-         (do (pulse/create-pulse! (map pulse/card->ref cards) [channel] pulse-data)
-             "success"))})
-    {:output "invalid dashboard_id"}))
+    (and (= channel-type :slack) (not (channel.settings/slack-configured?)))
+    {:error "slack is not configured. Ask an admin to connect slack in Metabase settings."}
+
+    (and (= channel-type :slack) (empty? slack-channel))
+    {:error "slack_channel is required when channel_type is slack"}
+
+    :else
+    (create-dashboard-subscription* args)))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/create_dashboard_subscription.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/create_dashboard_subscription.clj
@@ -4,9 +4,7 @@
    [metabase-enterprise.metabot-v3.tools.util :as metabot-v3.tools.u]
    [metabase.api.common :as api]
    [metabase.channel.settings :as channel.settings]
-   [metabase.permissions.core :as perms]
-   ^{:clj-kondo/ignore [:deprecated-namespace]}
-   [metabase.pulse.core :as pulse]
+   [metabase.pulse.api :as pulse.api]
    [metabase.util :as u]
    [toucan2.core :as t2]))
 
@@ -60,15 +58,15 @@
       {:error "no slack channel found with this name"}
 
       :else
-      (do (pulse/create-pulse! (map pulse/card->ref cards)
-                               [(make-slack-channel schedule channel-name)]
-                               pulse-data)
+      (do (pulse.api/create-pulse-with-perm-checks!
+           cards
+           [(make-slack-channel schedule channel-name)]
+           pulse-data)
           {:output "success"}))))
 
 (defn create-dashboard-subscription
   "Create a dashboard subscription and send it to a slack channel."
   [{:keys [dashboard-id slack-channel] :as args}]
-  (perms/check-has-application-permission :subscription false)
   (cond
     (not (int? dashboard-id))
     {:error "invalid dashboard_id"}

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
@@ -56,17 +56,17 @@
                       {:output output})]
         (let [response (mt/user-http-request :rasta :post 200 "ee/metabot-tools/create-dashboard-subscription"
                                              {:request-options {:headers {"x-metabase-session" ai-token}}}
-                                             {:arguments       {:dashboard_id 1
-                                                                :email        "user@example.com"
-                                                                :schedule     {:frequency "monthly"
-                                                                               :hour 15
-                                                                               :day_of_month "middle-of-month"}}
+                                             {:arguments       {:dashboard_id    1
+                                                                :slack_channel   "data-team"
+                                                                :schedule        {:frequency "monthly"
+                                                                                  :hour 15
+                                                                                  :day_of_month "middle-of-month"}}
                                               :conversation_id conversation-id})]
-          (is (=? [{:dashboard-id 1
-                    :email        "user@example.com"
-                    :schedule     {:frequency :monthly
-                                   :hour 15
-                                   :day-of-month :middle-of-month}}]
+          (is (=? [{:dashboard-id  1
+                    :slack-channel "data-team"
+                    :schedule      {:frequency :monthly
+                                    :hour 15
+                                    :day-of-month :middle-of-month}}]
                   @tool-requests))
           (is (=? {:output output
                    :conversation_id conversation-id}

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/create_dashboard_subscription_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/create_dashboard_subscription_test.clj
@@ -8,7 +8,7 @@
 
 (deftest create-dashboard-subscription-test
   (mt/with-model-cleanup [:model/Pulse]
-    (mt/with-temp [:model/User          {:keys [email] user-id :id} {:email "email@example.com"}
+    (mt/with-temp [:model/User          {user-id :id} {:email "email@example.com"}
                    :model/Collection    {collection-id :id} {}
                    :model/Dashboard     {dashboard-id :id} {:collection_id collection-id}
                    :model/Card          {card-id-0 :id} {}
@@ -34,60 +34,35 @@
       (let [invoke-tool #(mt/with-current-user user-id
                            (metabot-v3.tools.create-dashboard-subscription/create-dashboard-subscription %))
             base-data {:dashboard-id dashboard-id
-                       :email email
-                       :schedule {:frequency "monthly"
-                                  :day-of-month "last-sunday"
-                                  :hour 7}}
+                       :slack-channel "data-team"
+                       :schedule {:frequency :daily
+                                  :hour 9}}
             fake-channels {:channels [{:display-name "#data-team" :name "data-team" :id "C123"}]}]
-        (with-redefs [channel.settings/email-configured? (constantly true)
-                      channel.settings/slack-configured? (constantly true)
+        (with-redefs [channel.settings/slack-configured? (constantly true)
                       channel.settings/slack-cached-channels-and-usernames (constantly fake-channels)]
-          (testing "Email subscription can be created"
+          (testing "Slack subscription can be created"
             (is (= {:output "success"}
                    (invoke-tool base-data))))
-          (testing "Email subscription can be created with explicit channel-type"
+          (testing "Slack subscription can be created with monthly schedule"
             (is (= {:output "success"}
-                   (invoke-tool (assoc base-data :channel-type :email)))))
-          (testing "Return an error message if the user cannot be found"
-            (is (= {:error "no user with this email found"}
-                   (invoke-tool (update base-data :email str ".hu")))))
+                   (invoke-tool (assoc base-data :schedule {:frequency "monthly"
+                                                            :day-of-month "last-sunday"
+                                                            :hour 7})))))
           (testing "Return an error message if the dashboard-id is invalid"
             (is (= {:error "invalid dashboard_id"}
                    (invoke-tool (update base-data :dashboard-id str)))))
           (testing "Return an error message if the dashboard cannot be found"
             (is (= {:error "no dashboard with this dashboard_id found"}
                    (invoke-tool (update base-data :dashboard-id -)))))
-          (testing "Slack subscription can be created"
-            (is (= {:output "success"}
-                   (invoke-tool {:dashboard-id dashboard-id
-                                 :channel-type :slack
-                                 :slack-channel "data-team"
-                                 :schedule {:frequency :daily
-                                            :hour 9}}))))
           (testing "Slack subscription requires slack-channel"
-            (is (= {:error "slack_channel is required when channel_type is slack"}
-                   (invoke-tool {:dashboard-id dashboard-id
-                                 :channel-type :slack
-                                 :schedule {:frequency :daily
-                                            :hour 9}})))))
-        (testing "Email subscription fails when email is not configured"
-          (with-redefs [channel.settings/email-configured? (constantly false)]
-            (is (= {:error "email is not configured. Ask an admin to set up email in Metabase settings."}
-                   (invoke-tool base-data)))))
+            (is (= {:error "slack_channel is required"}
+                   (invoke-tool (dissoc base-data :slack-channel))))))
         (testing "Slack subscription fails when Slack is not configured"
           (with-redefs [channel.settings/slack-configured? (constantly false)]
             (is (= {:error "slack is not configured. Ask an admin to connect slack in Metabase settings."}
-                   (invoke-tool {:dashboard-id dashboard-id
-                                 :channel-type :slack
-                                 :slack-channel "data-team"
-                                 :schedule {:frequency :daily
-                                            :hour 9}})))))
+                   (invoke-tool base-data)))))
         (testing "Slack subscription fails when channel does not exist"
           (with-redefs [channel.settings/slack-configured? (constantly true)
                         channel.settings/slack-cached-channels-and-usernames (constantly {:channels []})]
             (is (= {:error "no slack channel found with this name"}
-                   (invoke-tool {:dashboard-id dashboard-id
-                                 :channel-type :slack
-                                 :slack-channel "no-such-channel"
-                                 :schedule {:frequency :daily
-                                            :hour 9}})))))))))
+                   (invoke-tool (assoc base-data :slack-channel "no-such-channel"))))))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/create_dashboard_subscription_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/create_dashboard_subscription_test.clj
@@ -37,9 +37,11 @@
                        :email email
                        :schedule {:frequency "monthly"
                                   :day-of-month "last-sunday"
-                                  :hour 7}}]
+                                  :hour 7}}
+            fake-channels {:channels [{:display-name "#data-team" :name "data-team" :id "C123"}]}]
         (with-redefs [channel.settings/email-configured? (constantly true)
-                      channel.settings/slack-configured? (constantly true)]
+                      channel.settings/slack-configured? (constantly true)
+                      channel.settings/slack-cached-channels-and-usernames (constantly fake-channels)]
           (testing "Email subscription can be created"
             (is (= {:output "success"}
                    (invoke-tool base-data))))
@@ -78,5 +80,14 @@
                    (invoke-tool {:dashboard-id dashboard-id
                                  :channel-type :slack
                                  :slack-channel "data-team"
+                                 :schedule {:frequency :daily
+                                            :hour 9}})))))
+        (testing "Slack subscription fails when channel does not exist"
+          (with-redefs [channel.settings/slack-configured? (constantly true)
+                        channel.settings/slack-cached-channels-and-usernames (constantly {:channels []})]
+            (is (= {:error "no slack channel found with this name"}
+                   (invoke-tool {:dashboard-id dashboard-id
+                                 :channel-type :slack
+                                 :slack-channel "no-such-channel"
                                  :schedule {:frequency :daily
                                             :hour 9}})))))))))

--- a/src/metabase/channel/render/png.clj
+++ b/src/metabase/channel/render/png.clj
@@ -123,9 +123,9 @@
 
 (mu/defn render-html-to-png :- bytes?
   "Render the Hiccup HTML `content` of a Pulse to a PNG image, returning a byte array."
-  (^bytes [{:keys [content]} :- ::body/RenderedPartCard
+  (^bytes [rendered-info :- ::body/RenderedPartCard
            width]
-   (render-html-to-png {:content content} width nil))
+   (render-html-to-png rendered-info width nil))
 
   (^bytes [{:keys [content]} :- ::body/RenderedPartCard
            width

--- a/src/metabase/channel/settings.clj
+++ b/src/metabase/channel/settings.clj
@@ -72,6 +72,18 @@
   (when-not (str/blank? channel-name)
     (if (str/starts-with? channel-name "#") (subs channel-name 1) channel-name)))
 
+(defn find-cached-slack-channel-or-username
+  "Look up a Slack channel or username by name or ID in [[slack-cached-channels-and-usernames]].
+
+  Returns the cached entry or `nil` if not found. The input is normalized by stripping a leading `#` before matching."
+  [channel-name]
+  (let [normalized (process-files-channel-name channel-name)]
+    (some (fn [channel]
+            (when (or (= normalized (:name channel))
+                      (= normalized (:id channel)))
+              channel))
+          (:channels (slack-cached-channels-and-usernames)))))
+
 (defsetting slack-files-channel
   (deferred-tru "The name of the channel to which Metabase files should be initially uploaded")
   :deprecated "0.54.0"

--- a/src/metabase/pulse/api.clj
+++ b/src/metabase/pulse/api.clj
@@ -9,10 +9,16 @@
    [metabase.pulse.api.alert]
    ^{:clj-kondo/ignore [:deprecated-namespace]}
    [metabase.pulse.api.pulse]
-   [metabase.pulse.api.unsubscribe]))
+   [metabase.pulse.api.unsubscribe]
+   [potemkin :as p]))
 
 (comment metabase.pulse.api.alert/keep-me
+         metabase.pulse.api.pulse/keep-me
          metabase.pulse.api.unsubscribe/keep-me)
+
+(p/import-vars
+ [metabase.pulse.api.pulse
+  create-pulse-with-perm-checks!])
 
 (def ^{:arglists '([request respond raise])} pulse-routes
   "`/api/pulse` routes. `/api/pulse/unsubscribe/*` does not require authentication, so you can unsubscribe without being

--- a/src/metabase/pulse/core.clj
+++ b/src/metabase/pulse/core.clj
@@ -14,7 +14,6 @@
 (p/import-vars
  [metabase.pulse.models.pulse
   card->ref
-  create-pulse!
   retrieve-alerts-for-cards
   update-pulse!]
  [metabase.pulse.update-alerts

--- a/test/metabase/channel/settings_test.clj
+++ b/test/metabase/channel/settings_test.clj
@@ -81,3 +81,20 @@
       (mt/with-temporary-setting-values [smtp-override-enabled nil
                                          email-smtp-host-override "localhost"]
         (is (= "true" (channel.settings/smtp-override-enabled! true)))))))
+
+(deftest find-cached-slack-channel-or-username-test
+  (let [channels [{:display-name "#general"   :name "general"   :id "C001"}
+                  {:display-name "#data-team" :name "data-team" :id "C002"}
+                  {:display-name "@alice"     :name "alice"     :id "U001"}]]
+    (with-redefs [channel.settings/slack-cached-channels-and-usernames (constantly {:channels channels})]
+      (testing "finds by name"
+        (is (= {:display-name "#general" :name "general" :id "C001"}
+               (channel.settings/find-cached-slack-channel-or-username "general"))))
+      (testing "finds by name with # prefix"
+        (is (= {:display-name "#data-team" :name "data-team" :id "C002"}
+               (channel.settings/find-cached-slack-channel-or-username "#data-team"))))
+      (testing "finds by ID"
+        (is (= {:display-name "@alice" :name "alice" :id "U001"}
+               (channel.settings/find-cached-slack-channel-or-username "U001"))))
+      (testing "returns nil when not found"
+        (is (nil? (channel.settings/find-cached-slack-channel-or-username "no-such-channel")))))))


### PR DESCRIPTION
Closes [BOT-984 Slackbot should be able to create a dashboard subscription](https://linear.app/metabase/issue/BOT-984/slackbot-should-be-able-to-create-a-dashboard-subscription)

ai-service PR: https://github.com/metabase/ai-service/pull/609

### Description

Allow the user to create dashboard subscriptions from slack. There was a pre-existing but no-longer-used tool for this in `create-dashboard-subscription`. This PR dusts it off and modifies it to support targeting slack channels rather than email alerts.

* Add slack channel support to create-dashboard-subscription tool
* Drop support for email subscriptions
* Fix render-html-to-png
* Add find-cached-slack-channel-or-username
* Validate slack-channel in create-dashboard-subscription

### Demo

#### happy path
<img width="1045" height="634" alt="Screenshot 2026-02-13 at 4 29 57 PM" src="https://github.com/user-attachments/assets/2f7b9582-97d0-45ed-a139-f0c04113aaf8" />
<img width="384" height="311" alt="Screenshot 2026-02-13 at 4 30 06 PM" src="https://github.com/user-attachments/assets/314dbe85-ca8a-4a7b-918c-9b2377741110" />

#### invalid slack channel
<img width="825" height="147" alt="Screenshot 2026-02-13 at 4 31 44 PM" src="https://github.com/user-attachments/assets/382f46cf-924a-402d-a1f2-0320c4522e9e" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
