### PR TITLE
feat: add @ mention to metabot placeholders

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
@@ -190,7 +190,7 @@ export const MetabotChat = ({
             value={metabot.prompt}
             autoFocus
             isResponding={metabot.isDoingScience}
-            placeholder={t`Tell me to do something, ask a question, @ to mention items`}
+            placeholder={t`How can I help? Type @ to mention items.`}
             onChange={metabot.setPrompt}
             onSubmit={handleEditorSubmit}
             onStop={metabot.cancelRequest}

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
@@ -190,7 +190,7 @@ export const MetabotChat = ({
             value={metabot.prompt}
             autoFocus
             isResponding={metabot.isDoingScience}
-            placeholder={t`Tell me to do something, or ask a question`}
+            placeholder={t`Tell me to do something, ask a question, @mention items`}
             onChange={metabot.setPrompt}
             onSubmit={handleEditorSubmit}
             onStop={metabot.cancelRequest}

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
@@ -190,7 +190,7 @@ export const MetabotChat = ({
             value={metabot.prompt}
             autoFocus
             isResponding={metabot.isDoingScience}
-            placeholder={t`Tell me to do something, ask a question, @mention items`}
+            placeholder={t`Tell me to do something, ask a question, @ to mention items`}
             onChange={metabot.setPrompt}
             onSubmit={handleEditorSubmit}
             onStop={metabot.cancelRequest}

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotQueryBuilder/MetabotQueryBuilder.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotQueryBuilder/MetabotQueryBuilder.tsx
@@ -186,7 +186,7 @@ export const MetabotQueryBuilder = () => {
                 value={prompt}
                 autoFocus
                 disabled={isDoingScience}
-                placeholder={t`Ask about your data`}
+                placeholder={t`Ask about your data. Type "@" to mention an item.`}
                 onChange={setPrompt}
                 onSubmit={handleEditorSubmit}
                 onStop={cancelRequest}

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotQueryBuilder/MetabotQueryBuilder.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotQueryBuilder/MetabotQueryBuilder.tsx
@@ -186,7 +186,7 @@ export const MetabotQueryBuilder = () => {
                 value={prompt}
                 autoFocus
                 disabled={isDoingScience}
-                placeholder={t`Ask about your data. Type "@" to mention an item.`}
+                placeholder={t`Ask about your data, and type @ to mention an item`}
                 onChange={setPrompt}
                 onSubmit={handleEditorSubmit}
                 onStop={cancelRequest}

--- a/frontend/src/metabase/metabot/components/MetabotInlineSQLPrompt/MetabotInlineSQLPrompt.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotInlineSQLPrompt/MetabotInlineSQLPrompt.tsx
@@ -105,8 +105,8 @@ export const MetabotInlineSQLPrompt = ({
           value={value}
           placeholder={
             isTableBarEnabled
-              ? t`Then, ask for what you'd like to see.`
-              : t`Describe what SQL you want...`
+              ? t`Then, ask for what you'd like to see. Type @ to mention an item.`
+              : t`Describe what SQL you want, type @ to mention an item.`
           }
           autoFocus={!isTableBarEnabled}
           disabled={isLoading}

--- a/frontend/src/metabase/metabot/components/MetabotPromptInput/MetabotPromptInput.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotPromptInput/MetabotPromptInput.tsx
@@ -49,7 +49,7 @@ export const MetabotPromptInput = forwardRef<
   (
     {
       value,
-      placeholder = t`Tell me to do something, or ask a question`,
+      placeholder = t`Tell me to do something, ask a question, @mention items`,
       autoFocus,
       disabled,
       suggestionConfig,

--- a/frontend/src/metabase/metabot/components/MetabotPromptInput/MetabotPromptInput.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotPromptInput/MetabotPromptInput.tsx
@@ -49,7 +49,7 @@ export const MetabotPromptInput = forwardRef<
   (
     {
       value,
-      placeholder = t`Tell me to do something, ask a question, @mention items`,
+      placeholder = t`Tell me to do something, ask a question, @ to mention items`,
       autoFocus,
       disabled,
       suggestionConfig,

--- a/frontend/src/metabase/metabot/components/MetabotPromptInput/MetabotPromptInput.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotPromptInput/MetabotPromptInput.tsx
@@ -49,7 +49,7 @@ export const MetabotPromptInput = forwardRef<
   (
     {
       value,
-      placeholder = t`Tell me to do something, ask a question, @ to mention items`,
+      placeholder = t`How can I help? Type @ to mention items.`,
       autoFocus,
       disabled,
       suggestionConfig,


### PR DESCRIPTION
Closes [BOT-779: Add @ mention hint to Metabot input placeholder](https://linear.app/metabase/issue/BOT-779/add-mention-hint-to-metabot-input-placeholder)

### Description

Changed the placeholders in some places.

### How to verify

1. Open metabot
2. See the new placeholder

### Demo

<img width="473" height="239" alt="image" src="https://github.com/user-attachments/assets/f5dab361-4d03-4208-b7db-e32684657378" />

<img width="951" height="248" alt="image" src="https://github.com/user-attachments/assets/d8655bac-5443-4264-a41b-eba8704596a7" />

<img width="1039" height="239" alt="image" src="https://github.com/user-attachments/assets/696aa76b-a549-4940-9bd9-df0deb7cab7b" />


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
