### PR TITLE
fix: line height of placeholder text in metabot side panel should be 20px

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
@@ -117,7 +117,7 @@ export const MetabotChat = ({
               data-testid="metabot-empty-chat-info"
             >
               <Box component={EmptyDashboardBot} w="6rem" />
-              <Text c="text-tertiary" maw="12rem" ta="center">
+              <Text c="text-tertiary" maw="12rem" ta="center" lh="lg">
                 {config.emptyText ??
                   t`I can help you explore your metrics and models.`}
               </Text>


### PR DESCRIPTION
Closes [BOT-468: Line height of placeholder text in metabot side panel should be 20px instead of 24px](https://linear.app/metabase/issue/BOT-468/line-height-of-placeholder-text-in-metabot-side-panel-should-be-20px)

### Description

Describe the overall approach and the problem being solved.

### How to verify

1. Open metabot panel
2. See the middle section

### Demo

Before:
<img width="426" height="282" alt="image" src="https://github.com/user-attachments/assets/e1678f65-403f-43bb-b7ac-b24916dcc582" />

After:
<img width="336" height="277" alt="image" src="https://github.com/user-attachments/assets/dcba8f0e-2038-4269-9b08-8d55350e52eb" />

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
