### PR TITLE
Add loading state to pull changes

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/GitSyncControls/GitSyncControls.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/GitSyncControls/GitSyncControls.tsx
@@ -44,19 +44,17 @@ export const GitSyncControls = () => {
 
   const { isDirty, refetch: refetchDirty } = useRemoteSyncDirtyState();
 
-  const { data: hasRemoteChangesData, isLoading: isFetchingRemoteChanges } =
-    useGetHasRemoteChangesQuery(undefined, {
-      refetchOnMountOrArgChange: 10, // only refetch if the cache is more than 10 seconds stale
-      skip: !combobox.dropdownOpened,
-    });
+  const {
+    currentData: hasRemoteChangesData,
+    isFetching: isFetchingRemoteChanges,
+  } = useGetHasRemoteChangesQuery(undefined, {
+    refetchOnMountOrArgChange: 10, // only refetch if the cache is more than 10 seconds stale
+    skip: !combobox.dropdownOpened,
+  });
   const { has_changes: hasRemoteChanges } = hasRemoteChangesData || {};
 
   const isSwitchingBranch = !!nextBranch;
-  const isLoading =
-    isSyncTaskRunning ||
-    isSwitchingBranch ||
-    isImporting ||
-    isFetchingRemoteChanges;
+  const isLoading = isSyncTaskRunning || isSwitchingBranch || isImporting;
 
   const changeBranch = useCallback(
     async (branch: string | null, isNewBranch?: boolean) => {
@@ -203,6 +201,7 @@ export const GitSyncControls = () => {
         {dropdownView === "options" ? (
           <GitSyncOptionsDropdown
             isPullDisabled={!hasRemoteChanges}
+            isLoadingPull={isFetchingRemoteChanges}
             isPushDisabled={!isDirty || isLoading}
             onPullClick={handlePullClick}
             onPushClick={handlePushClick}

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/GitSyncControls/GitSyncOptionsDropdown.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/GitSyncControls/GitSyncOptionsDropdown.tsx
@@ -1,9 +1,10 @@
 import { t } from "ttag";
 
-import { Combobox, Group, Icon, Text, Tooltip } from "metabase/ui";
+import { Combobox, Group, Icon, Loader, Text, Tooltip } from "metabase/ui";
 
 export interface GitSyncOptionsDropdownProps {
   isPullDisabled: boolean;
+  isLoadingPull: boolean;
   isPushDisabled: boolean;
   onPullClick: VoidFunction;
   onPushClick: VoidFunction;
@@ -12,6 +13,7 @@ export interface GitSyncOptionsDropdownProps {
 
 export const GitSyncOptionsDropdown = ({
   isPullDisabled,
+  isLoadingPull,
   isPushDisabled,
   onPullClick,
   onPushClick,
@@ -40,13 +42,17 @@ export const GitSyncOptionsDropdown = ({
           label={isPullDisabled ? t`No changes to pull` : t`Pull from remote`}
         >
           <Combobox.Option
-            disabled={isPullDisabled}
+            disabled={isPullDisabled || isLoadingPull}
             onClick={onPullClick}
             py="sm"
             value="pull"
           >
             <Group gap="md" wrap="nowrap">
-              <Icon name="arrow_down" size={12} />
+              {isLoadingPull ? (
+                <Loader size={12} data-testid="pull-changes-loader" />
+              ) : (
+                <Icon name="arrow_down" size={12} />
+              )}
               <Text>{t`Pull changes`}</Text>
             </Group>
           </Combobox.Option>

--- a/frontend/test/__support__/server-mocks/remote-sync.ts
+++ b/frontend/test/__support__/server-mocks/remote-sync.ts
@@ -93,12 +93,14 @@ export const setupRemoteSyncEndpoints = ({
   dirty = [],
   changedCollections = {},
   hasRemoteChanges = false,
+  hasRemoteChangesDelay = 0,
   settingsResponse = { success: true },
 }: {
   branches?: string[];
   dirty?: RemoteSyncEntity[];
   changedCollections?: Record<number, boolean>;
   hasRemoteChanges?: boolean;
+  hasRemoteChangesDelay?: number;
   settingsResponse?: Partial<RemoteSyncSettingsResponse>;
 } = {}) => {
   setupRemoteSyncBranchesEndpoint(branches);
@@ -107,7 +109,13 @@ export const setupRemoteSyncEndpoints = ({
   setupRemoteSyncImportEndpoint();
   setupRemoteSyncSettingsEndpoint(settingsResponse);
   fetchMock.post("path:/api/ee/remote-sync/create-branch", {});
-  fetchMock.get("path:/api/ee/remote-sync/has-remote-changes", {
-    has_changes: hasRemoteChanges,
-  });
+  fetchMock.get(
+    "path:/api/ee/remote-sync/has-remote-changes",
+    {
+      has_changes: hasRemoteChanges,
+    },
+    {
+      delay: hasRemoteChangesDelay,
+    },
+  );
 };


### PR DESCRIPTION
### Description
Adds a loading state for the pull action in the `<GitSyncControls />` component, allowing us to open the dropdown before that check is finished. Also changes the RTK Query to only provide data from the current request, as before it would give you stale data if it existed while re-fetching. 

### How to verify
1. Set up remote sync
2. Open the home page, and throttle your network connection
3. Open the branch switcher. You should see a loading icon while we are fetching whether you can pull

### Demo
<img width="312" height="176" alt="image" src="https://github.com/user-attachments/assets/37704afa-951b-473d-a16b-3225162f0828" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
