### PR TITLE
Don't allow pausing JWT if it's on via env var

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/analytics/stats.clj
+++ b/enterprise/backend/src/metabase_enterprise/analytics/stats.clj
@@ -15,7 +15,7 @@
   []
   [{:name      :sso-jwt
     :available (premium-features/enable-sso-jwt?)
-    :enabled   (ee-sso-settings/jwt-enabled)}
+    :enabled   (ee-sso-settings/jwt-enabled-and-configured)}
    {:name      :sso-saml
     :available (premium-features/enable-sso-saml?)
     :enabled   (ee-sso-settings/saml-enabled)}

--- a/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
@@ -38,7 +38,7 @@
        (t2/exists? :model/Sandbox)))
 
 (defn- has-configured-sso? []
-  (or (and (premium-features/has-feature? :sso-jwt) (sso-settings/jwt-enabled) (sso-settings/jwt-configured))
+  (or (and (premium-features/has-feature? :sso-jwt) (sso-settings/jwt-enabled-and-configured))
       (and (premium-features/has-feature? :sso-saml) (sso-settings/saml-enabled) (sso-settings/saml-configured))))
 
 (defn- has-user-created-models? []

--- a/enterprise/backend/src/metabase_enterprise/sso/api/interface.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/interface.clj
@@ -23,14 +23,16 @@
   [req]
   (let [enabled-count (count (filter identity
                                      [(sso-settings/saml-enabled)
-                                      (sso-settings/jwt-enabled)]))]
+                                      (sso-settings/jwt-enabled-and-configured)
+                                      (sso-settings/slack-connect-enabled)]))]
     (cond
       ;; Multiple SSO methods enabled - use preferred_method or selection logic
       (> enabled-count 1) (select-sso-backend req)
 
       ;; Single SSO method enabled
       (sso-settings/saml-enabled) :saml
-      (sso-settings/jwt-enabled)  :jwt
+      (sso-settings/jwt-enabled-and-configured)  :jwt
+      (sso-settings/slack-connect-enabled)  :slack-connect
 
       ;; No SSO method enabled
       :else nil)))

--- a/enterprise/backend/src/metabase_enterprise/sso/api/interface.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/interface.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.sso.api.interface
   (:require
-   [metabase-enterprise.sso.settings :as sso-settings]
+   [metabase-enterprise.sso.settings :as ee-sso-settings]
+   [metabase.sso.settings :as sso-settings]
    [metabase.util.i18n :refer [tru]]))
 
 (defn- select-sso-backend
@@ -22,16 +23,16 @@
   preferred_method parameter if provided."
   [req]
   (let [enabled-count (count (filter identity
-                                     [(sso-settings/saml-enabled)
-                                      (sso-settings/jwt-enabled-and-configured)
+                                     [(ee-sso-settings/saml-enabled)
+                                      (ee-sso-settings/jwt-enabled-and-configured)
                                       (sso-settings/slack-connect-enabled)]))]
     (cond
       ;; Multiple SSO methods enabled - use preferred_method or selection logic
       (> enabled-count 1) (select-sso-backend req)
 
       ;; Single SSO method enabled
-      (sso-settings/saml-enabled) :saml
-      (sso-settings/jwt-enabled-and-configured)  :jwt
+      (ee-sso-settings/saml-enabled) :saml
+      (ee-sso-settings/jwt-enabled-and-configured)  :jwt
       (sso-settings/slack-connect-enabled)  :slack-connect
 
       ;; No SSO method enabled

--- a/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
@@ -124,7 +124,7 @@
    _query-params
    {:keys [jwt]} :- [:map [:jwt ms/NonBlankString]]
    request]
-  (when-not (sso-settings/jwt-enabled)
+  (when-not (sso-settings/jwt-enabled-and-configured)
     (throw (ex-info "JWT authentication is not enabled"
                     {:status-code 400})))
   {:session_token (jwt/jwt->session jwt request)})

--- a/enterprise/backend/src/metabase_enterprise/sso/providers/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/providers/jwt.clj
@@ -80,7 +80,7 @@
 (methodical/defmethod auth-identity/authenticate :provider/jwt
   [_provider {:keys [token] :as _request}]
   (cond
-    (not (sso-settings/jwt-enabled))
+    (not (sso-settings/jwt-enabled-and-configured))
     {:success? false
      :error :jwt-not-enabled
      :message (str (tru "JWT authentication is not enabled"))}

--- a/enterprise/backend/src/metabase_enterprise/sso/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/settings.clj
@@ -7,6 +7,7 @@
    [metabase-enterprise.scim.core :as scim]
    [metabase.appearance.core :as appearance]
    [metabase.settings.core :as setting :refer [define-multi-setting-impl defsetting]]
+   [metabase.sso.settings :as sso-settings]
    [metabase.system.core :as system]
    [metabase.util.i18n :refer [deferred-tru tru]]
    [metabase.util.log :as log]
@@ -432,4 +433,4 @@ using, this usually looks like `https://your-org-name.example.com` or `https://e
   (SAML/JWT) or `/auth/sso/slack-connect` (Slack Connect) for authorization rather than the normal login form or Google Auth button."
   :visibility :public
   :setter     :none
-  :getter     (fn [] (or (saml-enabled) (jwt-enabled-and-configured) (slack-connect-enabled))))
+  :getter     (fn [] (or (saml-enabled) (jwt-enabled-and-configured) (sso-settings/slack-connect-enabled))))

--- a/enterprise/backend/src/metabase_enterprise/sso/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/settings.clj
@@ -301,17 +301,22 @@ using, this usually looks like `https://your-org-name.example.com` or `https://e
                        (boolean (jwt-identity-provider-uri)))))
 
 (defsetting jwt-enabled
-  (deferred-tru "Is JWT authentication configured and enabled?")
+  (deferred-tru "Is JWT authentication enabled?")
   :type    :boolean
   :default false
   :feature :sso-jwt
   :audit   :getter
-  :getter  (fn []
-             (if (jwt-configured)
-               (setting/get-value-of-type :boolean :jwt-enabled)
-               false))
   :doc "When set to true, will enable JWT authentication with the options configured in the MB_JWT_* variables.
         This is for JWT SSO authentication, and has nothing to do with Static embedding, which is MB_EMBEDDING_SECRET_KEY.")
+
+(defsetting jwt-enabled-and-configured
+  (deferred-tru "Is JWT authentication configured and enabled?")
+  :type             :boolean
+  :default          false
+  :feature          :sso-jwt
+  :audit            :getter
+  :getter           (fn [] (and (jwt-configured) (jwt-enabled)))
+  :can-set-via-env? false)
 
 (defsetting sdk-encryption-validation-key
   (deferred-tru "Used for encrypting and checking whether SDK requests are signed")
@@ -426,4 +431,4 @@ using, this usually looks like `https://your-org-name.example.com` or `https://e
   (SAML/JWT) or `/auth/sso/slack-connect` (Slack Connect) for authorization rather than the normal login form or Google Auth button."
   :visibility :public
   :setter     :none
-  :getter     (fn [] (or (saml-enabled) (jwt-enabled))))
+  :getter     (fn [] (or (saml-enabled) (jwt-enabled-and-configured) (slack-connect-enabled))))

--- a/enterprise/backend/src/metabase_enterprise/sso/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/settings.clj
@@ -316,6 +316,7 @@ using, this usually looks like `https://your-org-name.example.com` or `https://e
   :feature          :sso-jwt
   :audit            :getter
   :getter           (fn [] (and (jwt-configured) (jwt-enabled)))
+  :export?          false
   :can-set-via-env? false)
 
 (defsetting sdk-encryption-validation-key

--- a/enterprise/backend/test/metabase_enterprise/sso/settings_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/settings_test.clj
@@ -207,6 +207,24 @@
            #"Setting jwt-enabled is not enabled because feature :sso-jwt is not available"
            (sso-settings/jwt-enabled! true))))))
 
+(deftest jwt-enabled-without-configuration-test
+  (testing "jwt-enabled returns true even when JWT is not configured"
+    (mt/with-premium-features #{:sso-jwt}
+      (tu/with-temporary-setting-values [jwt-enabled             true
+                                         jwt-identity-provider-uri nil
+                                         jwt-shared-secret         nil]
+        (is (true? (sso-settings/jwt-enabled)))
+        (is (false? (sso-settings/jwt-configured)))
+        (is (false? (sso-settings/jwt-enabled-and-configured))))))
+  (testing "jwt-enabled-and-configured returns true only when both enabled and configured"
+    (mt/with-premium-features #{:sso-jwt}
+      (tu/with-temporary-setting-values [jwt-enabled               true
+                                         jwt-identity-provider-uri "example.com"
+                                         jwt-shared-secret         "0123456789012345678901234567890123456789012345678901234567890123"]
+        (is (true? (sso-settings/jwt-enabled)))
+        (is (true? (sso-settings/jwt-configured)))
+        (is (true? (sso-settings/jwt-enabled-and-configured)))))))
+
 (deftest can-turn-off-password-login-with-jwt-enabled
   (mt/with-premium-features #{:sso-jwt}
     (tu/with-temporary-setting-values [jwt-enabled               true

--- a/enterprise/frontend/src/metabase-enterprise/auth/containers/JwtAuthCard/JwtAuthCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/auth/containers/JwtAuthCard/JwtAuthCard.tsx
@@ -16,7 +16,10 @@ export function JwtAuthCard() {
     settingDetails,
     isLoading,
   } = useAdminSetting("jwt-configured");
-  const { value: isEnabled } = useAdminSetting("jwt-enabled");
+  const { value: isEnabled, settingDetails: jwtEnabledDetails } =
+    useAdminSetting("jwt-enabled");
+
+  const isEnabledViaEnv = !!jwtEnabledDetails?.is_env_setting;
 
   const handleDeactivate = () => {
     return updateSettings(
@@ -41,12 +44,15 @@ export function JwtAuthCard() {
       description={t`Allows users to login via a JWT Identity Provider.`}
       isEnabled={!!isEnabled}
       isConfigured={!!isConfigured}
-      onDeactivate={handleDeactivate}
-      onChange={(newValue) =>
-        updateSetting({
-          key: "jwt-enabled",
-          value: newValue,
-        })
+      onDeactivate={isEnabledViaEnv ? undefined : handleDeactivate}
+      onChange={
+        isEnabledViaEnv
+          ? undefined
+          : (newValue) =>
+              updateSetting({
+                key: "jwt-enabled",
+                value: newValue,
+              })
       }
       setting={settingDetails}
     />

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -283,6 +283,7 @@ export const createMockSettings = (
   "google-auth-enabled": false,
   "is-hosted?": false,
   "jwt-enabled": false,
+  "jwt-enabled-and-configured": false,
   "jwt-configured": false,
   "jwt-user-provisioning-enabled?": false,
   "jwt-identity-provider-uri": null,

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -728,6 +728,7 @@ export interface EnterpriseSettings extends Settings {
   "send-new-sso-user-admin-email?"?: boolean;
   "jwt-configured"?: boolean;
   "jwt-enabled"?: boolean;
+  "jwt-enabled-and-configured"?: boolean;
   "jwt-user-provisioning-enabled?": boolean;
   "jwt-identity-provider-uri": string | null;
   "jwt-shared-secret": string | null;

--- a/frontend/src/metabase/admin/settings/auth/components/AuthCard/AuthCard.tsx
+++ b/frontend/src/metabase/admin/settings/auth/components/AuthCard/AuthCard.tsx
@@ -27,8 +27,8 @@ export interface AuthCardProps {
   description: string;
   isEnabled: boolean;
   isConfigured: boolean;
-  onChange: (value: boolean) => void;
-  onDeactivate: () => void;
+  onChange?: (value: boolean) => void;
+  onDeactivate?: () => void;
 }
 
 export const AuthCard = ({
@@ -55,7 +55,7 @@ export const AuthCard = ({
   }, []);
 
   const handleDeactivate = useCallback(async () => {
-    await onDeactivate();
+    await onDeactivate?.();
     handleClose();
   }, [onDeactivate, handleClose]);
 
@@ -77,7 +77,7 @@ export const AuthCard = ({
       isConfigured={isConfigured && !isEnvSetting}
       footer={footer}
     >
-      {isConfigured && !isEnvSetting && (
+      {isConfigured && !isEnvSetting && onChange && (
         <AuthCardMenu
           isEnabled={isEnabled}
           onChange={onChange}

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/test-setup.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/test-setup.tsx
@@ -53,6 +53,7 @@ export const setup = (options?: {
     "enable-embedding-simple": options?.simpleEmbeddingEnabled ?? false,
     "jwt-enabled": options?.jwtReady ?? false,
     "jwt-configured": options?.jwtReady ?? false,
+    "jwt-enabled-and-configured": options?.jwtReady ?? false,
   });
 
   setupRecentViewsAndSelectionsEndpoints([], ["selections", "views"]);

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-is-sso-enabled-and-configured.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-is-sso-enabled-and-configured.ts
@@ -1,12 +1,9 @@
 import { useSetting } from "metabase/common/hooks";
 
 export const useIsSsoEnabledAndConfigured = () => {
-  const isJwtEnabled = useSetting("jwt-enabled");
+  const isJwtEnabledAndConfigured = useSetting("jwt-enabled-and-configured");
   const isSamlEnabled = useSetting("saml-enabled");
-  const isJwtConfigured = useSetting("jwt-configured");
   const isSamlConfigured = useSetting("saml-configured");
 
-  return (
-    (isJwtEnabled && isJwtConfigured) || (isSamlEnabled && isSamlConfigured)
-  );
+  return isJwtEnabledAndConfigured || (isSamlEnabled && isSamlConfigured);
 };


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #66533
This separate the `jwt-enabled` setting into two parts:

- `jwt-enabled`, which is settable via an env var, and means "do I want JWT to run or not"?

- `jwt-enabled-and-configured`, which is not settable at all, and simply computes `(and (jwt-enabled) (jwt-configured))`. This one means "JWT is running".

This way, if you set MB_JWT_ENABLED via the env, we don't give you the option to pause or disable JWT anymore. If it's configured, it's on.

In some ways `MB_JWT_ENABLED` feels useless here, when set alone - it's not really doing anything other than blocking the user from pausing JWT. But I think in context it makes sense: you want to be able to configure JWT solely via the env, but if you do that partially, it makes sense that we just don't let you change the env-configured bits.
