### PR TITLE
Show timezones for scanning / sync schedule

### DIFF
--- a/frontend/src/metabase/common/components/SchedulePicker/SchedulePicker.tsx
+++ b/frontend/src/metabase/common/components/SchedulePicker/SchedulePicker.tsx
@@ -18,6 +18,7 @@ import {
   type BoxProps,
   SegmentedControl,
   type SelectOption,
+  Tooltip,
 } from "metabase/ui";
 import type {
   ScheduleDayType,
@@ -285,6 +286,7 @@ export class SchedulePicker extends Component<SchedulePickerProps> {
             }))}
             fullWidth
           />
+          {timezone && <TimezoneLabel timezone={timezone} />}
         </PickerSpacedRow>
         {textBeforeSendTime && (
           <ScheduleDescriptionContainer>
@@ -343,4 +345,16 @@ export class SchedulePicker extends Component<SchedulePickerProps> {
 function MetabaseTimeZone() {
   const applicationName = useSelector(getApplicationName);
   return <>{t`your ${applicationName} timezone`}</>;
+}
+
+function TimezoneLabel({ timezone }: { timezone: string }) {
+  const applicationName = useSelector(getApplicationName);
+  const tooltipText = t`Your ${applicationName} timezone`;
+  return (
+    <Tooltip label={tooltipText}>
+      <Box role="note" aria-label={tooltipText} tabIndex={0}>
+        {timezone}
+      </Box>
+    </Tooltip>
+  );
 }

--- a/frontend/src/metabase/common/components/SchedulePicker/SchedulePicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/SchedulePicker/SchedulePicker.unit.spec.tsx
@@ -1,6 +1,9 @@
 import userEvent from "@testing-library/user-event";
 
+import { mockSettings } from "__support__/settings";
 import { renderWithProviders, screen, within } from "__support__/ui";
+import { createMockSettings } from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks";
 
 import type { SchedulePickerProps } from "./SchedulePicker";
 import { SchedulePicker } from "./SchedulePicker";
@@ -413,6 +416,71 @@ describe("SchedulePicker", () => {
           value: "monthly",
         },
       );
+    });
+  });
+
+  describe("timezone display", () => {
+    const setupWithTimezone = ({
+      timezone,
+      scheduleType = "daily",
+    }: {
+      timezone?: string;
+      scheduleType?: "hourly" | "daily" | "weekly" | "monthly";
+    }) => {
+      const onScheduleChange = jest.fn();
+
+      const storeInitialState = createMockState({
+        settings: mockSettings(
+          createMockSettings({
+            "application-name": "Metabase",
+          }),
+        ),
+      });
+
+      renderWithProviders(
+        <SchedulePicker
+          schedule={{
+            schedule_type: scheduleType,
+            schedule_hour: 8,
+            schedule_day: "mon",
+            schedule_frame: "first",
+            schedule_minute: 0,
+          }}
+          scheduleOptions={["hourly", "daily", "weekly", "monthly"]}
+          timezone={timezone}
+          onScheduleChange={onScheduleChange}
+        />,
+        { storeInitialState },
+      );
+    };
+
+    it("shows timezone next to the time picker for daily schedules", () => {
+      setupWithTimezone({ timezone: "EST", scheduleType: "daily" });
+      expect(screen.getByText("EST")).toBeInTheDocument();
+      expect(screen.getByRole("note")).toHaveAttribute(
+        "aria-label",
+        "Your Metabase timezone",
+      );
+    });
+
+    it("shows timezone next to the time picker for weekly schedules", () => {
+      setupWithTimezone({ timezone: "PST", scheduleType: "weekly" });
+      expect(screen.getByText("PST")).toBeInTheDocument();
+    });
+
+    it("shows timezone next to the time picker for monthly schedules", () => {
+      setupWithTimezone({ timezone: "UTC", scheduleType: "monthly" });
+      expect(screen.getByText("UTC")).toBeInTheDocument();
+    });
+
+    it("does not show timezone for hourly schedules", () => {
+      setupWithTimezone({ timezone: "EST", scheduleType: "hourly" });
+      expect(screen.queryByRole("note")).not.toBeInTheDocument();
+    });
+
+    it("does not show timezone when timezone prop is not provided", () => {
+      setupWithTimezone({ scheduleType: "daily" });
+      expect(screen.queryByRole("note")).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/metabase/databases/components/DatabaseCacheScheduleField/DatabaseCacheScheduleField.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseCacheScheduleField/DatabaseCacheScheduleField.tsx
@@ -6,6 +6,8 @@ import { t } from "ttag";
 
 import { SchedulePicker } from "metabase/common/components/SchedulePicker/SchedulePicker";
 import { FormField } from "metabase/forms";
+import { useSelector } from "metabase/lib/redux";
+import { getSetting } from "metabase/selectors/settings";
 import { Box, rem } from "metabase/ui";
 import type {
   DatabaseData,
@@ -38,6 +40,9 @@ export const DatabaseCacheScheduleField = ({
 }: DatabaseCacheScheduleFieldProps): JSX.Element => {
   const { values, setFieldValue } = useFormikContext<DatabaseData>();
   const [{ value }, , { setValue }] = useField(name);
+  const timezone = useSelector((state) =>
+    getSetting(state, "report-timezone-short"),
+  );
 
   const handleScheduleChange = useCallback(
     (value: ScheduleSettings) => {
@@ -93,6 +98,7 @@ export const DatabaseCacheScheduleField = ({
         <SchedulePicker
           schedule={value ?? DEFAULT_SCHEDULE}
           scheduleOptions={SCHEDULE_OPTIONS}
+          timezone={timezone}
           onScheduleChange={handleScheduleChange}
         />
       )}

--- a/frontend/src/metabase/databases/components/DatabaseSyncScheduleField/DatabaseSyncScheduleField.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseSyncScheduleField/DatabaseSyncScheduleField.tsx
@@ -5,6 +5,8 @@ import { t } from "ttag";
 
 import { SchedulePicker } from "metabase/common/components/SchedulePicker/SchedulePicker";
 import { FormField } from "metabase/forms";
+import { useSelector } from "metabase/lib/redux";
+import { getSetting } from "metabase/selectors/settings";
 import type { ScheduleSettings, ScheduleType } from "metabase-types/api";
 
 const DEFAULT_SCHEDULE: ScheduleSettings = {
@@ -28,6 +30,9 @@ const DatabaseSyncScheduleField = ({
   description,
 }: DatabaseSyncScheduleFieldProps): JSX.Element => {
   const [{ value }, , { setValue }] = useField(name);
+  const timezone = useSelector((state) =>
+    getSetting(state, "report-timezone-short"),
+  );
 
   const handleScheduleChange = useCallback(
     (value: ScheduleSettings) => {
@@ -43,6 +48,7 @@ const DatabaseSyncScheduleField = ({
         scheduleOptions={SCHEDULE_OPTIONS}
         textBeforeInterval={t`Sync`}
         minutesOnHourPicker
+        timezone={timezone}
         onScheduleChange={handleScheduleChange}
       />
     </FormField>


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #51959
  - Display the timezone abbreviation (e.g., "EST", "UTC") next to the time picker in database sync and scan schedule configuration, so admins know what timezone the scheduled times refer to
  - Uses the same report-timezone-short setting and tooltip pattern already used by the cache invalidation schedule on /admin/performance/databases/