### PR TITLE
[Metabot] Slackbot channel support

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot.clj
@@ -630,6 +630,12 @@
   [event]
   (mr/validate SlackAppMentionEvent event))
 
+(defn- edited-message?
+  "Check if event is an edited message (message_changed subtype or has :edited key)."
+  [event]
+  (or (= (:subtype event) "message_changed")
+      (some? (:edited event))))
+
 (def ^:private ack-msg
   "Acknowledgement payload"
   {:status  200
@@ -816,6 +822,9 @@
   (let [client {:token (metabot.settings/metabot-slack-bot-token)}
         event (:event payload)]
     (cond
+      (edited-message? event)
+      nil ; ignore edited messages
+
       (app-mention? event)
       (future
         (try

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
@@ -874,4 +874,3 @@
     (is (false? (#'slackbot/csv-file? {:filetype "xlsx"})))
     (is (false? (#'slackbot/csv-file? {:filetype nil})))
     (is (false? (#'slackbot/csv-file? {})))))
-

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
@@ -192,6 +192,33 @@
                 :ephemeral-calls          ephemeral-calls
                 :fake-png-bytes           fake-png-bytes}))))
 
+(deftest edited-message-ignored-test
+  (testing "POST /events ignores edited messages"
+    (with-slackbot-setup
+      (doseq [[desc event-mod] [["with :edited key" {:edited {:user "U123" :ts "123"}}]
+                                ["with message_changed subtype" {:subtype "message_changed"}]]]
+        (testing desc
+          (let [event-body {:type "event_callback"
+                            :event (merge {:type "message"
+                                           :text "Edited message"
+                                           :user "U123"
+                                           :channel "C123"
+                                           :ts "1234567890.000001"
+                                           :event_ts "1234567890.000001"
+                                           :channel_type "im"}
+                                          event-mod)}]
+            (with-slackbot-mocks
+              {:ai-text "Should not be called"}
+              (fn [{:keys [post-calls ephemeral-calls]}]
+                (let [response (mt/client :post 200 "ee/metabot-v3/slack/events"
+                                          (slack-request-options event-body)
+                                          event-body)]
+                  (is (= "ok" response))
+                  ;; Brief wait to ensure no async processing starts
+                  (Thread/sleep 200)
+                  (is (= 0 (count @post-calls)))
+                  (is (= 0 (count @ephemeral-calls))))))))))))
+
 (deftest user-message-triggers-response-test
   (testing "POST /events with user message triggers AI response via Slack"
     (with-slackbot-setup
@@ -218,6 +245,31 @@
               (is (= mock-ai-text (:text (second @post-calls))))
               (is (= 1 (count @delete-calls)))
               (is (= "_Thinking..._" (get-in (first @delete-calls) [:message :text]))))))))))
+
+(deftest app-mention-triggers-response-test
+  (testing "POST /events with app_mention triggers AI response"
+    (with-slackbot-setup
+      (let [mock-ai-text "Here is your answer"
+            event-body {:type "event_callback"
+                        :event {:type "app_mention"
+                                :text "<@UBOT123> Hello!"
+                                :user "U123"
+                                :channel "C123"
+                                :ts "1234567890.000001"
+                                :event_ts "1234567890.000001"}}]
+        (with-slackbot-mocks
+          {:ai-text mock-ai-text}
+          (fn [{:keys [post-calls delete-calls]}]
+            (let [response (mt/client :post 200 "ee/metabot-v3/slack/events"
+                                      (slack-request-options event-body)
+                                      event-body)]
+              (is (= "ok" response))
+              (u/poll {:thunk #(>= (count @post-calls) 2)
+                       :done? true?
+                       :timeout-ms 5000})
+              (is (= "_Thinking..._" (:text (first @post-calls))))
+              (is (= mock-ai-text (:text (second @post-calls))))
+              (is (= 1 (count @delete-calls))))))))))
 
 (deftest user-message-with-visualizations-test
   (testing "POST /events with visualizations uploads multiple images to Slack"
@@ -303,6 +355,31 @@
                           :channel "C123"
                           :text #"(?i).*connect.*slack.*metabase.*"}]
                         @ephemeral-calls))))))))))
+
+(deftest app-mention-unlinked-user-test
+  (testing "POST /events with app_mention from unlinked user sends auth message"
+    (with-slackbot-setup
+      (let [event-body {:type "event_callback"
+                        :event {:type "app_mention"
+                                :text "<@UBOT123> Hello!"
+                                :user "U-UNKNOWN"
+                                :channel "C123"
+                                :ts "1234567890.000001"
+                                :event_ts "1234567890.000001"}}]
+        (with-slackbot-mocks
+          {:ai-text "Should not be called"
+           :user-id ::no-user}
+          (fn [{:keys [post-calls ephemeral-calls]}]
+            (let [response (mt/client :post 200 "ee/metabot-v3/slack/events"
+                                      (slack-request-options event-body)
+                                      event-body)]
+              (is (= "ok" response))
+              (u/poll {:thunk #(= 1 (count @ephemeral-calls))
+                       :done? true?
+                       :timeout-ms 5000})
+              (is (= 0 (count @post-calls)))
+              (is (=? [{:user "U-UNKNOWN" :channel "C123"}]
+                      @ephemeral-calls)))))))))
 
 ;; -------------------------------- Setup Complete Tests --------------------------------
 
@@ -797,3 +874,5 @@
     (is (false? (#'slackbot/csv-file? {:filetype "xlsx"})))
     (is (false? (#'slackbot/csv-file? {:filetype nil})))
     (is (false? (#'slackbot/csv-file? {})))))
+
+

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
@@ -875,4 +875,3 @@
     (is (false? (#'slackbot/csv-file? {:filetype nil})))
     (is (false? (#'slackbot/csv-file? {})))))
 
-

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
@@ -157,6 +157,7 @@
                                    :else user-id)]
     (mt/with-dynamic-fn-redefs
       [slackbot/slack-id->user-id (constantly mock-user-id)
+       slackbot/get-bot-user-id (constantly "UBOT123")
        slackbot/fetch-thread (constantly {:ok true, :messages []})
        slackbot/post-message (fn [_ msg]
                                (swap! post-calls conj msg)


### PR DESCRIPTION
Closes [BOT-966: Agent should only reply when mentioned in a channel](https://linear.app/metabase/issue/BOT-966/agent-should-only-reply-when-mentioned-in-a-channel)
Closes [BOT-518: Build history from multi-user threads from channels](https://linear.app/metabase/issue/BOT-518/build-history-from-multi-user-threads-from-channels)

### Description

Adds support for having conversations with metabot in channels via app mentions (e.g. `@Metabot do xyz`). Metabot should now only reply when directly mentioned from within a thread in a channel.

I've also added a change to keep metabot from replying again after a message is edited.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR