### PR TITLE
Gdgt 1725 allow running transform from empty screen

### DIFF
--- a/frontend/src/metabase/transforms/hooks/use-transform-with-polling.ts
+++ b/frontend/src/metabase/transforms/hooks/use-transform-with-polling.ts
@@ -1,0 +1,35 @@
+import { useState } from "react";
+
+import { skipToken, useGetTransformQuery } from "metabase/api";
+import type { Transform } from "metabase-types/api";
+
+import { POLLING_INTERVAL } from "../constants";
+import {
+  isTransformCanceling,
+  isTransformRunning,
+  isTransformSyncing,
+} from "../utils";
+
+const isPollingNeeded = (transform?: Transform) =>
+  transform != null &&
+  (isTransformRunning(transform) ||
+    isTransformCanceling(transform) ||
+    isTransformSyncing(transform));
+
+export const useTransformWithPolling = (transformId: number | undefined) => {
+  const [isPolling, setIsPolling] = useState(false);
+
+  const {
+    data: transform,
+    isLoading,
+    error,
+  } = useGetTransformQuery(transformId ?? skipToken, {
+    pollingInterval: isPolling ? POLLING_INTERVAL : undefined,
+  });
+
+  if (isPolling !== isPollingNeeded(transform)) {
+    setIsPolling(isPollingNeeded(transform));
+  }
+
+  return { transform, isLoading, error };
+};

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/TransformInspectPage.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/TransformInspectPage.tsx
@@ -1,21 +1,16 @@
 import type { Location } from "history";
-import { Link } from "react-router";
 import { t } from "ttag";
 
-import {
-  skipToken,
-  useGetInspectorDiscoveryQuery,
-  useGetTransformQuery,
-} from "metabase/api";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { PageContainer } from "metabase/data-studio/common/components/PageContainer";
 import * as Urls from "metabase/lib/urls";
-import { Button, Center, Stack, Text } from "metabase/ui";
+import { useTransformWithPolling } from "metabase/transforms/hooks/use-transform-with-polling";
+import { Alert, Center, Icon, Text } from "metabase/ui";
 
 import { TransformHeader } from "../../components/TransformHeader";
+import { RunSection } from "../TransformRunPage/RunSection";
 
-import { LensContent } from "./components";
-import { LensNavigator, useLensNavigation } from "./components/LensNavigator";
+import { InspectorContent } from "./components/InspectorContent";
 
 type TransformInspectPageProps = {
   params: { transformId: string };
@@ -28,25 +23,9 @@ export const TransformInspectPage = ({
 }: TransformInspectPageProps) => {
   const transformId = Urls.extractEntityId(params.transformId);
 
-  const {
-    data: transform,
-    isLoading: isLoadingTransform,
-    error: transformError,
-  } = useGetTransformQuery(transformId ?? skipToken);
+  const { transform, isLoading, error } = useTransformWithPolling(transformId);
 
-  const {
-    data: discovery,
-    isLoading: isLoadingDiscovery,
-    error: discoveryError,
-  } = useGetInspectorDiscoveryQuery(transformId ?? skipToken);
-
-  const { tabs, activeTabKey, currentLens, addDrillLens, closeTab, switchTab } =
-    useLensNavigation(discovery?.available_lenses ?? [], location);
-
-  const isLoading = isLoadingTransform || isLoadingDiscovery;
-  const error = transformError ?? discoveryError;
-
-  if (isLoading || error || transform == null) {
+  if (isLoading || error || !transform) {
     return (
       <Center h="100%">
         <LoadingAndErrorWrapper loading={isLoading} error={error} />
@@ -54,44 +33,24 @@ export const TransformInspectPage = ({
     );
   }
 
-  if (!discovery || discovery.status === "not-run") {
-    return (
-      <PageContainer data-testid="transform-inspect-content">
-        <TransformHeader transform={transform} />
-        <Center h="100%" style={{ flex: 1 }}>
-          <Stack align="center" gap="md">
-            <Text c="text-secondary">
-              {t`To inspect the transform you need to run it first.`}
-            </Text>
-            <Button component={Link} to={Urls.transformRun(transform.id)}>
-              {t`Go to Run`}
-            </Button>
-          </Stack>
-        </Center>
-      </PageContainer>
-    );
-  }
-
-  if (!currentLens) {
-    return null;
-  }
+  const renderContent = () => {
+    if (transform.last_run?.status !== "succeeded") {
+      return (
+        <>
+          <Alert color="brand" icon={<Icon name="info" />}>
+            <Text>{t`To inspect the transform you need to run it first.`}</Text>
+          </Alert>
+          <RunSection transform={transform} noTitle={true} />
+        </>
+      );
+    }
+    return <InspectorContent transform={transform} location={location} />;
+  };
 
   return (
     <PageContainer data-testid="transform-inspect-content">
       <TransformHeader transform={transform} />
-      <LensNavigator
-        tabs={tabs}
-        activeTabKey={activeTabKey}
-        onSwitchTab={switchTab}
-        onCloseTab={closeTab}
-      >
-        <LensContent
-          transformId={transform.id}
-          currentLens={currentLens}
-          discovery={discovery}
-          onDrill={addDrillLens}
-        />
-      </LensNavigator>
+      {renderContent()}
     </PageContainer>
   );
 };

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/TransformInspectPage.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/TransformInspectPage.tsx
@@ -33,24 +33,19 @@ export const TransformInspectPage = ({
     );
   }
 
-  const renderContent = () => {
-    if (transform.last_run?.status !== "succeeded") {
-      return (
+  return (
+    <PageContainer data-testid="transform-inspect-content">
+      <TransformHeader transform={transform} />
+      {transform.last_run?.status !== "succeeded" ? (
         <>
           <Alert color="brand" icon={<Icon name="info" />}>
             <Text>{t`To inspect the transform you need to run it first.`}</Text>
           </Alert>
           <RunSection transform={transform} noTitle={true} />
         </>
-      );
-    }
-    return <InspectorContent transform={transform} location={location} />;
-  };
-
-  return (
-    <PageContainer data-testid="transform-inspect-content">
-      <TransformHeader transform={transform} />
-      {renderContent()}
+      ) : (
+        <InspectorContent transform={transform} location={location} />
+      )}
     </PageContainer>
   );
 };

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/InspectorContent.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/InspectorContent.tsx
@@ -1,0 +1,59 @@
+import type { Location } from "history";
+
+import { useGetInspectorDiscoveryQuery } from "metabase/api";
+import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
+import { Center } from "metabase/ui";
+import type { Transform } from "metabase-types/api";
+
+import { LensContent } from "./LensContent/LensContent";
+import { LensNavigator, useLensNavigation } from "./LensNavigator";
+
+type InspectorContentProps = {
+  transform: Transform;
+  location: Location;
+};
+
+export const InspectorContent = ({
+  transform,
+  location,
+}: InspectorContentProps) => {
+  const {
+    data: discovery,
+    isLoading: isLoadingDiscovery,
+    error: discoveryError,
+  } = useGetInspectorDiscoveryQuery(transform.id);
+
+  const { tabs, activeTabKey, currentLens, addDrillLens, closeTab, switchTab } =
+    useLensNavigation(discovery?.available_lenses ?? [], location);
+
+  if (isLoadingDiscovery || discoveryError || !discovery) {
+    return (
+      <Center h="100%" style={{ flex: 1 }}>
+        <LoadingAndErrorWrapper
+          loading={isLoadingDiscovery}
+          error={discoveryError}
+        />
+      </Center>
+    );
+  }
+
+  if (!currentLens) {
+    return null;
+  }
+
+  return (
+    <LensNavigator
+      tabs={tabs}
+      activeTabKey={activeTabKey}
+      onSwitchTab={switchTab}
+      onCloseTab={closeTab}
+    >
+      <LensContent
+        transformId={transform.id}
+        currentLens={currentLens}
+        discovery={discovery}
+        onDrill={addDrillLens}
+      />
+    </LensNavigator>
+  );
+};

--- a/frontend/src/metabase/transforms/pages/TransformRunPage/RunSection/RunSection.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformRunPage/RunSection/RunSection.tsx
@@ -14,7 +14,7 @@ import { useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { useMetadataToasts } from "metabase/metadata/hooks";
 import { PLUGIN_REMOTE_SYNC } from "metabase/plugins";
-import { Anchor, Box, Divider, Group, Stack } from "metabase/ui";
+import { Anchor, Box, Card, Divider, Group, Stack } from "metabase/ui";
 import type { Transform, TransformTagId } from "metabase-types/api";
 
 import { trackTransformTriggerManualRun } from "../../../analytics";
@@ -28,18 +28,16 @@ import { LogOutput } from "./LogOutput";
 type RunSectionProps = {
   transform: Transform;
   readOnly?: boolean;
+  noTitle?: boolean;
 };
 
-export function RunSection({ transform, readOnly }: RunSectionProps) {
+export function RunSection({ transform, readOnly, noTitle }: RunSectionProps) {
   const isRemoteSyncReadOnly = useSelector(
     PLUGIN_REMOTE_SYNC.getIsRemoteSyncReadOnly,
   );
 
-  return (
-    <TitleSection
-      label={t`Run this transform`}
-      description={t`This transform will be run whenever the jobs it belongs are scheduled.`}
-    >
+  const renderContent = () => (
+    <>
       <Stack>
         <Group p="lg" justify="space-between">
           <RunStatusSection transform={transform} />
@@ -58,6 +56,23 @@ export function RunSection({ transform, readOnly }: RunSectionProps) {
           readOnly={readOnly || isRemoteSyncReadOnly}
         />
       </Group>
+    </>
+  );
+
+  if (noTitle) {
+    return (
+      <Card p={0} shadow="none" withBorder>
+        {renderContent()}
+      </Card>
+    );
+  }
+
+  return (
+    <TitleSection
+      label={t`Run this transform`}
+      description={t`This transform will be run whenever the jobs it belongs are scheduled.`}
+    >
+      {renderContent()}
     </TitleSection>
   );
 }

--- a/frontend/src/metabase/transforms/pages/TransformRunPage/RunSection/RunSection.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformRunPage/RunSection/RunSection.tsx
@@ -36,7 +36,7 @@ export function RunSection({ transform, readOnly, noTitle }: RunSectionProps) {
     PLUGIN_REMOTE_SYNC.getIsRemoteSyncReadOnly,
   );
 
-  const renderContent = () => (
+  const content = (
     <>
       <Stack>
         <Group p="lg" justify="space-between">
@@ -62,7 +62,7 @@ export function RunSection({ transform, readOnly, noTitle }: RunSectionProps) {
   if (noTitle) {
     return (
       <Card p={0} shadow="none" withBorder>
-        {renderContent()}
+        {content}
       </Card>
     );
   }
@@ -72,7 +72,7 @@ export function RunSection({ transform, readOnly, noTitle }: RunSectionProps) {
       label={t`Run this transform`}
       description={t`This transform will be run whenever the jobs it belongs are scheduled.`}
     >
-      {renderContent()}
+      {content}
     </TitleSection>
   );
 }

--- a/frontend/src/metabase/transforms/pages/TransformSettingsPage/TransformSettingsPage.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformSettingsPage/TransformSettingsPage.tsx
@@ -1,20 +1,11 @@
-import { useState } from "react";
-
-import { skipToken, useGetTransformQuery } from "metabase/api";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { PageContainer } from "metabase/data-studio/common/components/PageContainer";
 import * as Urls from "metabase/lib/urls";
 import { useTransformPermissions } from "metabase/transforms/hooks/use-transform-permissions";
 import { Center } from "metabase/ui";
-import type { Transform } from "metabase-types/api";
 
 import { TransformHeader } from "../../components/TransformHeader";
-import { POLLING_INTERVAL } from "../../constants";
-import {
-  isTransformCanceling,
-  isTransformRunning,
-  isTransformSyncing,
-} from "../../utils";
+import { useTransformWithPolling } from "../../hooks/use-transform-with-polling";
 
 import { TransformSettingsSection } from "./TransformSettingsSection";
 
@@ -27,23 +18,16 @@ type TransformTargetPageProps = {
 };
 
 export const TransformSettingsPage = ({ params }: TransformTargetPageProps) => {
-  const [isPolling, setIsPolling] = useState(false);
   const transformId = Urls.extractEntityId(params.transformId);
   const {
-    data: transform,
+    transform,
     isLoading: isLoadingTransform,
     error: transformError,
-  } = useGetTransformQuery(transformId ?? skipToken, {
-    pollingInterval: isPolling ? POLLING_INTERVAL : undefined,
-  });
+  } = useTransformWithPolling(transformId);
   const { readOnly, isLoadingDatabases, databasesError } =
     useTransformPermissions({ transform });
   const isLoading = isLoadingTransform || isLoadingDatabases;
   const error = transformError || databasesError;
-
-  if (isPolling !== isPollingNeeded(transform)) {
-    setIsPolling(isPollingNeeded(transform));
-  }
 
   if (isLoading || error || transform == null) {
     return (
@@ -60,12 +44,3 @@ export const TransformSettingsPage = ({ params }: TransformTargetPageProps) => {
     </PageContainer>
   );
 };
-
-function isPollingNeeded(transform?: Transform) {
-  return (
-    transform != null &&
-    (isTransformRunning(transform) ||
-      isTransformCanceling(transform) ||
-      isTransformSyncing(transform))
-  );
-}


### PR DESCRIPTION
Closes [GDGT-1725: Allow running transform from empty screen](https://linear.app/metabase/issue/GDGT-1725/allow-running-transform-from-empty-screen)

### Description
Now we allow users to run the transform in Inspect tab in order to enable the inspection.

### Demo

https://github.com/user-attachments/assets/ecf72338-ed11-42c1-868f-ffeeaa54aa29



