### PR TITLE
Convert `lib/encoding` to TypeScript

### DIFF
--- a/frontend/src/metabase/lib/encoding.ts
+++ b/frontend/src/metabase/lib/encoding.ts
@@ -1,22 +1,22 @@
 // escaping before base64 encoding is necessary for non-ASCII characters
 // https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/btoa
-export function utf8_to_b64(str) {
+export function utf8_to_b64(str: string) {
   return window.btoa(unescape(encodeURIComponent(str)));
 }
 
-export function b64_to_utf8(b64) {
+function b64_to_utf8(b64: string) {
   return decodeURIComponent(escape(window.atob(b64)));
 }
 
 // for "URL safe" base64, replace "+" with "-" and "/" with "_" as per RFC 4648
-export function utf8_to_b64url(str) {
+export function utf8_to_b64url(str: string) {
   return utf8_to_b64(str).replace(/\+/g, "-").replace(/\//g, "_");
 }
 
-export function b64url_to_utf8(b64url) {
+export function b64url_to_utf8(b64url: string) {
   return b64_to_utf8(b64url.replace(/-/g, "+").replace(/_/g, "/"));
 }
 
-export function b64hash_to_utf8(b64hash) {
+export function b64hash_to_utf8(b64hash: string) {
   return b64url_to_utf8(b64hash.replace(/^#/, ""));
 }

--- a/frontend/src/metabase/lib/encoding.ts
+++ b/frontend/src/metabase/lib/encoding.ts
@@ -4,7 +4,7 @@ export function utf8_to_b64(str: string) {
   return window.btoa(unescape(encodeURIComponent(str)));
 }
 
-function b64_to_utf8(b64: string) {
+export function b64_to_utf8(b64: string) {
   return decodeURIComponent(escape(window.atob(b64)));
 }
 


### PR DESCRIPTION
Converts `frontend/src/metabase/lib/encoding.js` to TypeScript
Closes DEV-1490