### PR TITLE
Convert `admin/datamodel/selectors` to TypeScript

### DIFF
--- a/frontend/src/metabase-types/store/admin.ts
+++ b/frontend/src/metabase-types/store/admin.ts
@@ -2,6 +2,7 @@ import type {
   CollectionPermissions,
   DatabaseId,
   GroupsPermissions,
+  Revision,
 } from "metabase-types/api";
 
 export type AdminPathKey =
@@ -50,6 +51,13 @@ export interface AdminState {
   databases: {
     deletionError: null | unknown;
     deletes: DatabaseId[];
+  };
+  people: {
+    temporaryPasswords: Record<number, string | null>;
+  };
+  datamodel: {
+    previewSummary: string | null;
+    revisions: Revision[] | null;
   };
 }
 

--- a/frontend/src/metabase-types/store/mocks/admin.ts
+++ b/frontend/src/metabase-types/store/mocks/admin.ts
@@ -9,6 +9,13 @@ export const createMockAdminState = (
     deletionError: null,
     deletes: [],
   },
+  people: {
+    temporaryPasswords: {},
+  },
+  datamodel: {
+    previewSummary: null,
+    revisions: null,
+  },
   ...opts,
 });
 

--- a/frontend/src/metabase/admin/datamodel/selectors.js
+++ b/frontend/src/metabase/admin/datamodel/selectors.js
@@ -1,4 +1,0 @@
-export const getPreviewSummary = (state) =>
-  state.admin.datamodel.previewSummary;
-export const getRevisions = (state) => state.admin.datamodel.revisions;
-export const getCurrentUser = (state) => state.currentUser;

--- a/frontend/src/metabase/admin/datamodel/selectors.ts
+++ b/frontend/src/metabase/admin/datamodel/selectors.ts
@@ -1,0 +1,6 @@
+import type { State } from "metabase-types/store";
+
+export const getPreviewSummary = (state: State) =>
+  state.admin.datamodel.previewSummary;
+export const getRevisions = (state: State) => state.admin.datamodel.revisions;
+export const getCurrentUser = (state: State) => state.currentUser;

--- a/frontend/src/metabase/admin/datamodel/selectors.ts
+++ b/frontend/src/metabase/admin/datamodel/selectors.ts
@@ -3,5 +3,4 @@ import type { State } from "metabase-types/store";
 export const getPreviewSummary = (state: State) =>
   state.admin.datamodel.previewSummary;
 export const getRevisions = (state: State) => state.admin.datamodel.revisions;
-// Non-null assertion: getCurrentUser is only used in authenticated contexts
-export const getCurrentUser = (state: State) => state.currentUser!;
+export const getCurrentUser = (state: State) => state.currentUser;

--- a/frontend/src/metabase/admin/datamodel/selectors.ts
+++ b/frontend/src/metabase/admin/datamodel/selectors.ts
@@ -3,4 +3,5 @@ import type { State } from "metabase-types/store";
 export const getPreviewSummary = (state: State) =>
   state.admin.datamodel.previewSummary;
 export const getRevisions = (state: State) => state.admin.datamodel.revisions;
-export const getCurrentUser = (state: State) => state.currentUser;
+// Non-null assertion: getCurrentUser is only used in authenticated contexts
+export const getCurrentUser = (state: State) => state.currentUser!;


### PR DESCRIPTION
## Summary
- Converts `frontend/src/metabase/admin/datamodel/selectors.js` to TypeScript
- Updates `AdminState` types accordingly

Closes DEV-1508