### PR TITLE
Convert `visualizations/lib/errors` to TypeScript

### DIFF
--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
@@ -166,7 +166,7 @@ type VisualizationOwnProps = {
   tc?: ContentTranslationFunction;
   zoomedRowIndex?: number;
   onOpenChartSettings?: (data: {
-    initialChartSettings: { section: string };
+    initialChartSettings?: { section: string };
     showSidebarTitle?: boolean;
   }) => void;
   onChangeCardAndRun?: ((opts: OnChangeCardAndRunOpts) => void) | null;

--- a/frontend/src/metabase/visualizations/lib/errors.ts
+++ b/frontend/src/metabase/visualizations/lib/errors.ts
@@ -1,7 +1,7 @@
 import { msgid, ngettext, t } from "ttag";
 
 export class MinColumnsError extends Error {
-  constructor(minColumns, actualColumns) {
+  constructor(minColumns: number, actualColumns: number) {
     super(
       t`Doh! The data from your query doesn't fit the chosen display choice. This visualization requires at least ${actualColumns} ${ngettext(
         msgid`column`,
@@ -13,7 +13,7 @@ export class MinColumnsError extends Error {
 }
 
 export class MinRowsError extends Error {
-  constructor(minRows, actualRows) {
+  constructor(minRows: number, actualRows: number) {
     super(
       t`No dice. We have ${actualRows} data ${ngettext(
         msgid`point`,
@@ -38,10 +38,14 @@ export class LatitudeLongitudeError extends Error {
  * to determine whether or not to display the empty visuzalization state.
  */
 export class ChartSettingsError extends Error {
-  initial;
-  buttonText;
+  initial: { section: string } | undefined;
+  buttonText: string;
 
-  constructor(message, initial, buttonText) {
+  constructor(
+    message: string,
+    initial?: { section: string },
+    buttonText?: string,
+  ) {
     super(message || t`Please configure this chart in the chart settings`);
     this.initial = initial;
     this.buttonText = buttonText || t`Edit Settings`;


### PR DESCRIPTION
## Summary
- Converts `frontend/src/metabase/visualizations/lib/errors.js` to TypeScript

## Test plan
- [ ] `yarn type-check-pure` passes
- [ ] Existing tests still pass

Closes DEV-1511

🤖 Generated with [Claude Code](https://claude.com/claude-code)