### PR TITLE
Convert `visualizations/lib/numeric` to TypeScript

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/axis.ts
@@ -767,7 +767,7 @@ function getNumericXAxisModel(
     axisTransforms.toEChartsAxisValue(rawExtent[1]) ?? 0,
   ];
 
-  const xValues = dataset.map((datum) => datum[X_AXIS_DATA_KEY]);
+  const xValues = dataset.map((datum) => datum[X_AXIS_DATA_KEY]) as number[];
   const interval =
     column.binning_info?.bin_width ?? computeNumericDataInterval(xValues);
 
@@ -863,7 +863,7 @@ export function getXAxisModel(
   const histogramInterval = isHistogram
     ? (column.binning_info?.bin_width ??
       computeNumericDataInterval(
-        dataset.map((datum) => datum[X_AXIS_DATA_KEY]),
+        dataset.map((datum) => datum[X_AXIS_DATA_KEY]) as number[],
       ))
     : undefined;
 

--- a/frontend/src/metabase/visualizations/lib/numeric.ts
+++ b/frontend/src/metabase/visualizations/lib/numeric.ts
@@ -1,6 +1,10 @@
 import { isNumeric } from "metabase-lib/v1/types/utils/isa";
+import type { DatasetColumn, RowValues } from "metabase-types/api";
 
-export function dimensionIsNumeric({ cols, rows }, i = 0) {
+export function dimensionIsNumeric(
+  { cols, rows }: { cols: DatasetColumn[]; rows: RowValues[] },
+  i = 0,
+) {
   if (isNumeric(cols[i])) {
     return true;
   }
@@ -13,7 +17,7 @@ export function dimensionIsNumeric({ cols, rows }, i = 0) {
   return hasNumbersOrNullsOnly && hasAtLeastOneNumber;
 }
 
-export const isMultipleOf = (value, base) => {
+export const isMultipleOf = (value: number, base: number) => {
   // Ideally we could use Number.EPSILON as constant diffThreshold here.
   // However, we sometimes see very small errors that are bigger than EPSILON.
   // For example, when called 1.23456789 and 1e-8 we see a diff of ~1e-16.
@@ -24,7 +28,7 @@ export const isMultipleOf = (value, base) => {
 // We seem to run into float bugs if we get any more precise than this.
 const SMALLEST_PRECISION_EXP = -13;
 
-export function precision(a) {
+export function precision(a: number) {
   if (!isFinite(a)) {
     return 0;
   }
@@ -42,7 +46,7 @@ export function precision(a) {
   return Math.pow(10, e);
 }
 
-export function decimalCount(a) {
+export function decimalCount(a: number) {
   if (!isFinite(a)) {
     return 0;
   }
@@ -55,7 +59,7 @@ export function decimalCount(a) {
   return p;
 }
 
-export function computeNumericDataInterval(xValues) {
+export function computeNumericDataInterval(xValues: number[]) {
   let bestPrecision = Infinity;
   for (const value of xValues) {
     const p = precision(value) || 1;
@@ -66,7 +70,7 @@ export function computeNumericDataInterval(xValues) {
   return bestPrecision;
 }
 
-export function computeChange(comparisonVal, currVal) {
+export function computeChange(comparisonVal: number, currVal: number) {
   if (comparisonVal === 0) {
     return currVal === 0 ? 0 : currVal > 0 ? Infinity : -Infinity;
   }

--- a/frontend/src/metabase/visualizations/lib/numeric.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/lib/numeric.unit.spec.ts
@@ -47,14 +47,14 @@ describe("visualization.lib.numeric", () => {
   });
 
   describe("computeNumericDataInterval", () => {
-    const CASES = [
+    const CASES: [number[], number][] = [
       [[0], 1],
       [[1], 1],
       [[0, 1], 1],
       [[0.1, 1], 0.1],
       [[0.1, 10], 0.1],
       [[10, 1], 1],
-      [[0, null, 1], 1],
+      [[0, null as unknown as number, 1], 1],
     ];
     for (const c of CASES) {
       it("precision of " + c[0] + " should be " + c[1], () => {
@@ -64,18 +64,20 @@ describe("visualization.lib.numeric", () => {
   });
 
   describe("isMultipleOf", () => {
-    [
-      [1, 0.1, true],
-      [1, 1, true],
-      [10, 1, true],
-      [1, 10, false],
-      [3, 1, true],
-      [0.3, 0.1, true],
-      [0.25, 0.1, false],
-      [0.000000001, 0.0000000001, true],
-      [0.0000000001, 0.000000001, false],
-      [100, 1e-14, true],
-    ].map(([value, base, expected]) =>
+    (
+      [
+        [1, 0.1, true],
+        [1, 1, true],
+        [10, 1, true],
+        [1, 10, false],
+        [3, 1, true],
+        [0.3, 0.1, true],
+        [0.25, 0.1, false],
+        [0.000000001, 0.0000000001, true],
+        [0.0000000001, 0.000000001, false],
+        [100, 1e-14, true],
+      ] as [number, number, boolean][]
+    ).map(([value, base, expected]) =>
       it(`${value} ${expected ? "is" : "is not"} a multiple of ${base}`, () =>
         expect(isMultipleOf(value, base)).toBe(expected)),
     );

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
@@ -271,7 +271,7 @@ const computeDiffWithPreviousPeriod = (
     return null;
   }
 
-  const change = computeChange(previousValue, currentValue);
+  const change = computeChange(previousValue as number, currentValue as number);
 
   return formatChangeWithSign(change);
 };

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.ts
@@ -139,7 +139,7 @@ function buildComparisonObject({
     }) || {};
 
   const percentChange = !isEmpty(comparisonValue)
-    ? computeChange(comparisonValue, value)
+    ? computeChange(comparisonValue as number, value as number)
     : undefined;
 
   const {


### PR DESCRIPTION
## Summary
- Converts `frontend/src/metabase/visualizations/lib/numeric.js` to TypeScript

## Test plan
- [ ] `yarn type-check-pure` passes
- [ ] Existing tests still pass

Closes DEV-1512

🤖 Generated with [Claude Code](https://claude.com/claude-code)