### PR TITLE
Convert `visualizations/lib/trends` to TypeScript

### DIFF
--- a/frontend/src/metabase-types/api/index.ts
+++ b/frontend/src/metabase-types/api/index.ts
@@ -23,6 +23,7 @@ export * from "./entity-id";
 export * from "./field";
 export * from "./geojson";
 export * from "./group";
+export * from "./insight";
 export * from "./llm";
 export * from "./logger";
 export * from "./measure";

--- a/frontend/src/metabase/visualizations/lib/trends.ts
+++ b/frontend/src/metabase/visualizations/lib/trends.ts
@@ -1,5 +1,7 @@
+import type { Insight, InsightExpressionOperand } from "metabase-types/api";
+
 // mappings of allowed operators
-const EXPRESSION_OPERATORS = new Map([
+const EXPRESSION_OPERATORS = new Map<string, (...args: number[]) => number>([
   ["+", (...args) => args.reduce((x, y) => x + y)],
   ["-", (...args) => args.reduce((x, y) => x - y)],
   ["*", (...args) => args.reduce((x, y) => x * y)],
@@ -11,11 +13,11 @@ const EXPRESSION_OPERATORS = new Map([
 // list of allowed expressions
 const EXPRESSION_IDENTIFIERS = new Set(["x"]);
 
-function computeExpression(node, x) {
+function computeExpression(node: InsightExpressionOperand, x: number): number {
   if (Array.isArray(node)) {
     const [operator, ...args] = node;
     if (EXPRESSION_OPERATORS.has(operator)) {
-      const operatorFn = EXPRESSION_OPERATORS.get(operator);
+      const operatorFn = EXPRESSION_OPERATORS.get(operator)!;
       const argValues = args.map((arg) => computeExpression(arg, x));
       return operatorFn(...argValues);
     }
@@ -27,9 +29,9 @@ function computeExpression(node, x) {
   throw new Error(`Invalid expression: ${node}`);
 }
 
-export const getTrendLineFunction = (insight) => {
+export const getTrendLineFunction = (insight: Insight) => {
   if (insight["best-fit"]) {
-    return (x) => computeExpression(insight["best-fit"], x);
+    return (x: number) => computeExpression(insight["best-fit"]!, x);
   }
-  return (x) => x * insight.slope + insight.offset;
+  return (x: number) => x * insight.slope + insight.offset;
 };


### PR DESCRIPTION
## Summary
- Converts `frontend/src/metabase/visualizations/lib/trends.js` to TypeScript

## Test plan
- [ ] `yarn type-check-pure` passes
- [ ] Existing tests still pass

Closes DEV-1513

🤖 Generated with [Claude Code](https://claude.com/claude-code)