### PR TITLE
Convert `common/hooks/use-scroll-on-mount` to TypeScript

### DIFF
--- a/frontend/src/metabase/common/components/tree/TreeNodeList.tsx
+++ b/frontend/src/metabase/common/components/tree/TreeNodeList.tsx
@@ -31,7 +31,7 @@ function BaseTreeNodeList<TData = unknown>({
   role,
   ...boxProps
 }: TreeNodeListProps<TData>) {
-  const selectedRef = useScrollOnMount();
+  const selectedRef = useScrollOnMount<HTMLLIElement>();
 
   return (
     <Box component="ul" role={role} {...boxProps}>

--- a/frontend/src/metabase/common/hooks/use-scroll-on-mount.ts
+++ b/frontend/src/metabase/common/hooks/use-scroll-on-mount.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from "react";
 
 export const useScrollOnMount = () => {
-  const ref = useRef(null);
+  const ref = useRef<HTMLElement>(null);
 
   useEffect(() => {
     if (ref.current) {

--- a/frontend/src/metabase/common/hooks/use-scroll-on-mount.ts
+++ b/frontend/src/metabase/common/hooks/use-scroll-on-mount.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from "react";
 
-export const useScrollOnMount = () => {
-  const ref = useRef<HTMLElement>(null);
+export const useScrollOnMount = <T extends HTMLElement = HTMLElement>() => {
+  const ref = useRef<T>(null);
 
   useEffect(() => {
     if (ref.current) {

--- a/frontend/src/metabase/timelines/questions/components/EventCard/EventCard.tsx
+++ b/frontend/src/metabase/timelines/questions/components/EventCard/EventCard.tsx
@@ -48,7 +48,7 @@ const EventCard = ({
   onShowTimelineEvents,
   onHideTimelineEvents,
 }: EventCardProps): JSX.Element => {
-  const selectedRef = useScrollOnMount();
+  const selectedRef = useScrollOnMount<HTMLDivElement>();
   const menuItems = getMenuItems(event, timeline, onEdit, onMove, onArchive);
   const dateMessage = getDateMessage(event);
   const creatorMessage = getCreatorMessage(event);


### PR DESCRIPTION
Converts `frontend/src/metabase/common/hooks/use-scroll-on-mount.js` to TypeScript

Closes DEV-1518