### PR TITLE
Convert `audit_app/lib/cards/queries` to TypeScript

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/audit_app/lib/cards/queries.ts
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/lib/cards/queries.ts
@@ -1,9 +1,9 @@
 export const bad_table = (
-  errorFilter,
-  dbFilter,
-  collectionFilter,
-  sortColumn,
-  sortDirection,
+  errorFilter: string | null,
+  dbFilter: string | null,
+  collectionFilter: string | null,
+  sortColumn: string | null,
+  sortDirection: string | null,
 ) => ({
   card: {
     name: "Failing Questions",


### PR DESCRIPTION
Closes DEV-1521
- Converts `enterprise/frontend/src/metabase-enterprise/audit_app/lib/cards/queries.js` to TypeScript