### PR TITLE
Convert `caching/utils` to TypeScript

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/caching/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/caching/utils.ts
@@ -1,4 +1,6 @@
-export function hasQuestionCacheSection(question) {
+import type Question from "metabase-lib/v1/Question";
+
+export function hasQuestionCacheSection(question: Question) {
   const type = question.type();
 
   return (


### PR DESCRIPTION
Closes DEV-1522

- Converts `enterprise/frontend/src/metabase-enterprise/caching/utils.js` to TypeScript