### PR TITLE
Convert `moderation/selectors` to TypeScript

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/moderation/selectors.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/selectors.js
@@ -1,5 +1,0 @@
-import { getUserIsAdmin } from "metabase/selectors/user";
-
-export const getIsModerator = (state, props) => {
-  return getUserIsAdmin(state, props);
-};

--- a/enterprise/frontend/src/metabase-enterprise/moderation/selectors.ts
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/selectors.ts
@@ -1,0 +1,6 @@
+import { getUserIsAdmin } from "metabase/selectors/user";
+import type { State } from "metabase-types/store";
+
+export const getIsModerator = (state: State) => {
+  return getUserIsAdmin(state);
+};


### PR DESCRIPTION
Closes DEV-1523

- Converts `enterprise/frontend/src/metabase-enterprise/moderation/selectors.js` to TypeScript