### PR TITLE
Add "New embed" to command palette in OSS

### DIFF
--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -444,19 +444,19 @@ describe("command palette", () => {
       .should("contain", "Search everything");
   });
 
+  it("should show the 'New embed' command palette item", () => {
+    cy.visit("/");
+    cy.findByRole("button", { name: /search/i }).click();
+
+    H.commandPalette().within(() => {
+      H.commandPaletteInput().should("exist").type("new embed");
+      cy.findByText("New embed").should("be.visible");
+    });
+  });
+
   describe("ee", () => {
     beforeEach(() => {
       H.activateToken("bleeding-edge");
-    });
-
-    it("should show the 'New embed' command palette item", () => {
-      cy.visit("/");
-      cy.findByRole("button", { name: /search/i }).click();
-
-      H.commandPalette().within(() => {
-        H.commandPaletteInput().should("exist").type("new embed");
-        cy.findByText("New embed").should("be.visible");
-      });
     });
 
     it("should have a 'New document' item", () => {

--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -167,7 +167,7 @@ describe("command palette", () => {
     cy.wait(100); // pressing page down too fast does nothing
     H.pressPageDown();
     H.commandPalette()
-      .findByRole("option", { name: "New model" })
+      .findByRole("option", { name: "New collection" })
       .should("have.attr", "aria-selected", "true");
 
     H.pressPageDown();
@@ -177,7 +177,7 @@ describe("command palette", () => {
 
     H.pressPageUp();
     H.commandPalette()
-      .findByRole("option", { name: "New model" })
+      .findByRole("option", { name: "New collection" })
       .should("have.attr", "aria-selected", "true");
 
     H.pressPageUp();

--- a/frontend/src/metabase-types/store/modal.ts
+++ b/frontend/src/metabase-types/store/modal.ts
@@ -25,7 +25,5 @@ export type ModalState<TProps = Record<string, unknown>> =
     }
   | {
       id: "static-legacy";
-      props: {
-        initialState: LegacyStaticEmbeddingModalProps;
-      } | null;
+      props: LegacyStaticEmbeddingModalProps | null;
     };

--- a/frontend/src/metabase-types/store/modal.ts
+++ b/frontend/src/metabase-types/store/modal.ts
@@ -1,4 +1,6 @@
 import type { STATIC_LEGACY_EMBEDDING_TYPE } from "metabase/embedding/constants";
+import type { LegacyStaticEmbeddingModalProps } from "metabase/embedding/embedding-iframe-sdk-setup/components/LegacyStaticEmbeddingModal";
+import type { SdkIframeEmbedSetupModalInitialState } from "metabase/plugins/oss/embedding-iframe-sdk-setup";
 
 export type ModalName =
   | null
@@ -10,7 +12,20 @@ export type ModalName =
   | "upgrade"
   | typeof STATIC_LEGACY_EMBEDDING_TYPE;
 
-export type ModalState<TProps = Record<string, unknown>> = {
-  id: ModalName | null;
-  props: TProps | null;
-};
+export type ModalState<TProps = Record<string, unknown>> =
+  | {
+      id: ModalName;
+      props: TProps | null;
+    }
+  | {
+      id: "embed";
+      props: {
+        initialState: SdkIframeEmbedSetupModalInitialState;
+      } | null;
+    }
+  | {
+      id: "static-legacy";
+      props: {
+        initialState: LegacyStaticEmbeddingModalProps;
+      } | null;
+    };

--- a/frontend/src/metabase-types/store/modal.ts
+++ b/frontend/src/metabase-types/store/modal.ts
@@ -14,7 +14,7 @@ export type ModalName =
 
 export type ModalState<TProps = Record<string, unknown>> =
   | {
-      id: ModalName;
+      id: Exclude<ModalName, "embed" | "static-legacy">;
       props: TProps | null;
     }
   | {

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/NewEmbedButton/NewEmbedButton.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/NewEmbedButton/NewEmbedButton.tsx
@@ -1,7 +1,6 @@
 import { t } from "ttag";
 
 import { useDispatch } from "metabase/lib/redux";
-import type { SdkIframeEmbedSetupModalProps } from "metabase/plugins";
 import { setOpenModalWithProps } from "metabase/redux/ui";
 import { Button } from "metabase/ui";
 
@@ -13,15 +12,17 @@ export const NewEmbedButton = () => {
       variant="brand"
       size="sm"
       onClick={() => {
-        const modalProps: Pick<SdkIframeEmbedSetupModalProps, "initialState"> =
-          {
-            initialState: {
-              isGuest: true,
-              useExistingUserSession: true,
+        dispatch(
+          setOpenModalWithProps({
+            id: "embed",
+            props: {
+              initialState: {
+                isGuest: true,
+                useExistingUserSession: true,
+              },
             },
-          };
-
-        dispatch(setOpenModalWithProps({ id: "embed", props: modalProps }));
+          }),
+        );
       }}
     >
       {t`New embed`}

--- a/frontend/src/metabase/embedding/embedding-hub/hooks/use-get-embedding-hub-steps.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/hooks/use-get-embedding-hub-steps.ts
@@ -4,7 +4,7 @@ import { t } from "ttag";
 import { useDispatch } from "metabase/lib/redux";
 import {
   PLUGIN_TENANTS,
-  type SdkIframeEmbedSetupModalProps,
+  type SdkIframeEmbedSetupModalInitialState,
 } from "metabase/plugins";
 import { setOpenModalWithProps } from "metabase/redux/ui";
 
@@ -14,7 +14,7 @@ export const useGetEmbeddingHubSteps = (): EmbeddingHubStep[] => {
   const dispatch = useDispatch();
 
   const openEmbedModal = useCallback(
-    (props: Pick<SdkIframeEmbedSetupModalProps, "initialState">) => {
+    (props: { initialState: SdkIframeEmbedSetupModalInitialState }) => {
       dispatch(
         setOpenModalWithProps({
           id: "embed",

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/LegacyStaticEmbeddingAlert.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/LegacyStaticEmbeddingAlert.tsx
@@ -1,7 +1,6 @@
 import { c, t } from "ttag";
 
 import { STATIC_LEGACY_EMBEDDING_TYPE } from "metabase/embedding/constants";
-import type { LegacyStaticEmbeddingModalProps } from "metabase/embedding/embedding-iframe-sdk-setup/components/LegacyStaticEmbeddingModal";
 import { useSdkIframeEmbedSetupContext } from "metabase/embedding/embedding-iframe-sdk-setup/context";
 import { getResourceTypeFromExperience } from "metabase/embedding/embedding-iframe-sdk-setup/utils/get-resource-type-from-experience";
 import { useDispatch } from "metabase/lib/redux";
@@ -58,22 +57,20 @@ export const LegacyStaticEmbeddingAlert = () => {
             onClick={() => {
               onClose();
 
-              const modalProps: LegacyStaticEmbeddingModalProps = {
-                experience,
-                dashboardId: settings.dashboardId,
-                questionId: settings.questionId,
-                parentInitialState: {
-                  resourceId: resource.id,
-                  resourceType,
-                  isGuest: isGuestEmbed,
-                  useExistingUserSession,
-                },
-              };
-
               dispatch(
                 setOpenModalWithProps({
                   id: STATIC_LEGACY_EMBEDDING_TYPE,
-                  props: modalProps,
+                  props: {
+                    experience,
+                    dashboardId: settings.dashboardId,
+                    questionId: settings.questionId,
+                    parentInitialState: {
+                      resourceId: resource.id,
+                      resourceType,
+                      isGuest: isGuestEmbed,
+                      useExistingUserSession,
+                    },
+                  },
                 }),
               );
             }}

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/LegacyStaticEmbeddingModal.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/LegacyStaticEmbeddingModal.tsx
@@ -13,7 +13,7 @@ export type LegacyStaticEmbeddingModalProps = {
   experience: SdkIframeEmbedSetupExperience;
   dashboardId?: DashboardId | null;
   questionId?: string | number | null;
-  parentInitialState: SdkIframeEmbedSetupModalInitialState | undefined;
+  parentInitialState: SdkIframeEmbedSetupModalInitialState;
 };
 
 export type InternalProps = LegacyStaticEmbeddingModalProps & {

--- a/frontend/src/metabase/embedding/hooks/use-open-embed-js-wizard.ts
+++ b/frontend/src/metabase/embedding/hooks/use-open-embed-js-wizard.ts
@@ -1,13 +1,13 @@
 import { useCallback } from "react";
 
 import { useDispatch } from "metabase/lib/redux";
-import type { SdkIframeEmbedSetupModalProps } from "metabase/plugins";
+import type { SdkIframeEmbedSetupModalInitialState } from "metabase/plugins";
 import { setOpenModalWithProps } from "metabase/redux/ui";
 
 export const useOpenEmbedJsWizard = ({
   initialState,
 }: {
-  initialState: SdkIframeEmbedSetupModalProps["initialState"];
+  initialState: SdkIframeEmbedSetupModalInitialState;
 }) => {
   const dispatch = useDispatch();
 

--- a/frontend/src/metabase/embedding/hooks/use-open-embed-js-wizard.ts
+++ b/frontend/src/metabase/embedding/hooks/use-open-embed-js-wizard.ts
@@ -13,16 +13,14 @@ export const useOpenEmbedJsWizard = ({
 
   return useCallback(
     ({ onBeforeOpen }: { onBeforeOpen?: () => void }) => {
-      const modalProps: Pick<SdkIframeEmbedSetupModalProps, "initialState"> = {
-        initialState,
-      };
-
       onBeforeOpen?.();
 
       dispatch(
         setOpenModalWithProps({
           id: "embed",
-          props: modalProps,
+          props: {
+            initialState,
+          },
         }),
       );
     },

--- a/frontend/src/metabase/palette/components/test/PaletteResults/PaletteResults-oss.unit.spec.tsx
+++ b/frontend/src/metabase/palette/components/test/PaletteResults/PaletteResults-oss.unit.spec.tsx
@@ -13,20 +13,21 @@ const setup = (props: CommonSetupProps = {}) => {
 };
 
 describe("PaletteResults", () => {
-  it("should not show actions when there is no search query", () => {
+  it("should not show actions when there is no search query", async () => {
     setup();
+    expect(await screen.findByText("Recents")).toBeInTheDocument();
+    expect(screen.queryByText("New question")).not.toBeInTheDocument();
+    expect(screen.queryByText("New SQL query")).not.toBeInTheDocument();
     expect(screen.queryByText("New dashboard")).not.toBeInTheDocument();
-    expect(screen.queryByText("New collection")).not.toBeInTheDocument();
-    expect(screen.queryByText("New model")).not.toBeInTheDocument();
 
     expect(screen.queryByText("Results")).not.toBeInTheDocument();
   });
 
   it("should show actions when there is a search query", async () => {
     setup({ query: "new" });
+    expect(await screen.findByText("New question")).toBeInTheDocument();
+    expect(await screen.findByText("New SQL query")).toBeInTheDocument();
     expect(await screen.findByText("New dashboard")).toBeInTheDocument();
-    expect(await screen.findByText("New collection")).toBeInTheDocument();
-    expect(await screen.findByText("New model")).toBeInTheDocument();
 
     expect(screen.getByText("Results")).toBeInTheDocument();
   });

--- a/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
@@ -242,7 +242,8 @@ export const useCommandPaletteBasicActions = ({
         id: "navigate-embed-js",
         section: "basic",
         icon: "embed",
-        keywords: "embed flow, new embed, embed js",
+        keywords:
+          "embed flow, new embed, embed js, modular embedding, guest embed",
         perform: () =>
           openNewModalWithProps("embed", {
             initialState: {

--- a/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
@@ -13,7 +13,6 @@ import {
 import { Collections } from "metabase/entities/collections/collections";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
-import type { SdkIframeEmbedSetupModalProps } from "metabase/plugins";
 import { openDiagnostics } from "metabase/redux/app";
 import {
   closeModal,
@@ -247,9 +246,7 @@ export const useCommandPaletteBasicActions = ({
         icon: "embed",
         keywords: "embed flow, new embed, embed js",
         perform: () =>
-          openNewModalWithProps<
-            Pick<SdkIframeEmbedSetupModalProps, "initialState">
-          >("embed", {
+          openNewModalWithProps("embed", {
             initialState: {
               isGuest: true,
               useExistingUserSession: true,

--- a/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
@@ -33,6 +33,26 @@ import {
   useRegisterShortcut,
 } from "./useRegisterShortcut";
 
+export const BASIC_ACTION_ORDER = [
+  "create-new-question",
+  "create-new-native-query",
+  "create-new-dashboard",
+  "create-new-document",
+  "create-new-collection",
+  "create-new-model",
+  "create-new-metric",
+  "download-diagnostics",
+  "navigate-admin-settings",
+  "navigate-embed-js",
+  "navigate-personal-collection",
+  "navigate-user-settings",
+  "navigate-trash",
+  "navigate-home",
+  "navigate-browse-model",
+  "navigate-browse-database",
+  "navigate-browse-metric",
+];
+
 export const useCommandPaletteBasicActions = ({
   isLoggedIn,
   ...props
@@ -197,36 +217,6 @@ export const useCommandPaletteBasicActions = ({
       },
     });
 
-    const browseActions: RegisterShortcutProps[] = [
-      {
-        id: "navigate-browse-model",
-        name: t`Browse models`,
-        section: "basic",
-        icon: "model",
-        perform: () => {
-          dispatch(push("/browse/models"));
-        },
-      },
-      {
-        id: "navigate-browse-database",
-        name: t`Browse databases`,
-        section: "basic",
-        icon: "database",
-        perform: () => {
-          dispatch(push("/browse/databases"));
-        },
-      },
-      {
-        id: "navigate-browse-metric",
-        name: t`Browse metrics`,
-        section: "basic",
-        icon: "metric",
-        perform: () => {
-          dispatch(push("/browse/metrics"));
-        },
-      },
-    ];
-
     if (isAdmin) {
       actions.push({
         id: "navigate-admin-settings",
@@ -275,6 +265,36 @@ export const useCommandPaletteBasicActions = ({
         perform: () => dispatch(push("/")),
       },
     );
+
+    const browseActions: RegisterShortcutProps[] = [
+      {
+        id: "navigate-browse-model",
+        name: t`Browse models`,
+        section: "basic",
+        icon: "model",
+        perform: () => {
+          dispatch(push("/browse/models"));
+        },
+      },
+      {
+        id: "navigate-browse-database",
+        name: t`Browse databases`,
+        section: "basic",
+        icon: "database",
+        perform: () => {
+          dispatch(push("/browse/databases"));
+        },
+      },
+      {
+        id: "navigate-browse-metric",
+        name: t`Browse metrics`,
+        section: "basic",
+        icon: "metric",
+        perform: () => {
+          dispatch(push("/browse/metrics"));
+        },
+      },
+    ];
 
     return [...actions, ...browseActions];
   }, [

--- a/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
@@ -7,7 +7,6 @@ import { t } from "ttag";
 
 import {
   useDatabaseListQuery,
-  useHasTokenFeature,
   useSearchListQuery,
 } from "metabase/common/hooks";
 import { Collections } from "metabase/entities/collections/collections";
@@ -59,7 +58,6 @@ export const useCommandPaletteBasicActions = ({
   const hasDatabaseWithActionsEnabled =
     getHasDatabaseWithActionsEnabled(databases);
   const hasModels = models.length > 0;
-  const hasEmbedJsFeature = useHasTokenFeature("embedding_simple");
 
   const openNewModal = useCallback(
     (modalId: ModalName) => {
@@ -239,7 +237,7 @@ export const useCommandPaletteBasicActions = ({
       });
     }
 
-    if (isAdmin && hasEmbedJsFeature) {
+    if (isAdmin) {
       actions.push({
         id: "navigate-embed-js",
         section: "basic",
@@ -287,7 +285,6 @@ export const useCommandPaletteBasicActions = ({
     openNewModalWithProps,
     isAdmin,
     personalCollectionId,
-    hasEmbedJsFeature,
   ]);
 
   useRegisterShortcut(initialActions, [initialActions]);

--- a/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
@@ -67,12 +67,9 @@ export const useCommandPaletteBasicActions = ({
     [dispatch],
   );
   const openNewModalWithProps = useCallback(
-    <TProps extends Record<string, unknown>>(
-      modalId: ModalName,
-      props?: TProps,
-    ) => {
+    (payload: Parameters<typeof setOpenModalWithProps>[0]) => {
       dispatch(closeModal());
-      dispatch(setOpenModalWithProps({ id: modalId, props }));
+      dispatch(setOpenModalWithProps(payload));
     },
     [dispatch],
   );
@@ -245,10 +242,13 @@ export const useCommandPaletteBasicActions = ({
         keywords:
           "embed flow, new embed, embed js, modular embedding, guest embed",
         perform: () =>
-          openNewModalWithProps("embed", {
-            initialState: {
-              isGuest: true,
-              useExistingUserSession: true,
+          openNewModalWithProps({
+            id: "embed",
+            props: {
+              initialState: {
+                isGuest: true,
+                useExistingUserSession: true,
+              },
             },
           }),
       });

--- a/frontend/src/metabase/palette/utils.ts
+++ b/frontend/src/metabase/palette/utils.ts
@@ -7,7 +7,15 @@ import type { ColorName } from "metabase/lib/colors/types";
 import type { IconName } from "metabase/ui";
 import type { RecentItem } from "metabase-types/api";
 
+import { BASIC_ACTION_ORDER } from "./hooks/useCommandPaletteBasicActions";
 import type { PaletteActionImpl } from "./types";
+
+const BASIC_ACTION_ORDER_BY_NAME = BASIC_ACTION_ORDER.reduce<
+  Record<string, number>
+>((acc, actionName, index) => {
+  acc[actionName] = index;
+  return acc;
+}, {});
 
 export const processResults = (
   results: (string | PaletteActionImpl)[],
@@ -18,7 +26,11 @@ export const processResults = (
     "section",
   );
 
-  const actions = processSection(t`Actions`, groupedResults["basic"]);
+  const actions = processSection(
+    t`Actions`,
+    groupedResults["basic"],
+    BASIC_ACTION_ORDER_BY_NAME,
+  );
   const search = processSection(t`Results`, groupedResults["search"]);
   const recent = processSection(t`Recents`, groupedResults["recent"]);
   const admin = processSection(t`Admin`, groupedResults["admin"]);
@@ -28,14 +40,31 @@ export const processResults = (
     return [...recent];
   }
 
-  return [...recent, ...actions.slice(0, 6), ...admin, ...search, ...docs];
+  return [
+    ...recent,
+    // Get the first 5 actions, the first index is the section title
+    ...actions.slice(0, 6),
+    ...admin,
+    ...search,
+    ...docs,
+  ];
 };
 
 export const processSection = (
   sectionName: string,
   items?: PaletteActionImpl[],
+  sortOrder?: Record<string, number>,
 ) => {
   if (items && items.length > 0) {
+    if (sortOrder) {
+      const sortedItems = [...items].sort((a, b) => {
+        const aOrder = sortOrder[a.id] ?? Number.MAX_SAFE_INTEGER;
+        const bOrder = sortOrder[b.id] ?? Number.MAX_SAFE_INTEGER;
+        return aOrder - bOrder;
+      });
+
+      return [sectionName, ...sortedItems];
+    }
     return [sectionName, ...items];
   } else {
     return [];

--- a/frontend/src/metabase/palette/utils.unit.spec.ts
+++ b/frontend/src/metabase/palette/utils.unit.spec.ts
@@ -9,17 +9,19 @@ import {
 } from "./utils";
 
 interface mockAction {
+  id?: string;
   name: string;
   section?: string;
   disabled?: boolean;
 }
 
 const createMockAction = ({
+  id,
   name,
   section = "basic",
   disabled,
 }: mockAction): PaletteActionImpl =>
-  ({ name, section, disabled }) as PaletteActionImpl;
+  ({ id, name, section, disabled }) as PaletteActionImpl;
 
 describe("command palette utils", () => {
   describe("processSection", () => {
@@ -121,6 +123,58 @@ describe("command palette utils", () => {
     it("should not show actions if there is no search query", () => {
       const result = processResults(testActions, "");
       expect(result).toHaveLength(0);
+    });
+
+    it("should sort basic actions according to their order of registration", () => {
+      // Random order of basic actions
+      const actionIds = [
+        "navigate-embed-js",
+        "create-new-question",
+        "navigate-trash",
+        "create-new-metric",
+        "navigate-home",
+        "create-new-native-query",
+        "navigate-browse-database",
+        "create-new-dashboard",
+        "navigate-user-settings",
+        "create-new-collection",
+        "navigate-browse-model",
+        "download-diagnostics",
+        "create-new-document",
+        "navigate-admin-settings",
+        "navigate-personal-collection",
+        "create-new-model",
+        "navigate-browse-metric",
+      ];
+
+      const actionsList = actionIds.map((id) =>
+        createMockAction({ id, name: id }),
+      );
+
+      const result = processResults(actionsList, "xyz");
+      expect(result).toEqual([
+        "Actions",
+        createMockAction({
+          id: "create-new-question",
+          name: "create-new-question",
+        }),
+        createMockAction({
+          id: "create-new-native-query",
+          name: "create-new-native-query",
+        }),
+        createMockAction({
+          id: "create-new-dashboard",
+          name: "create-new-dashboard",
+        }),
+        createMockAction({
+          id: "create-new-document",
+          name: "create-new-document",
+        }),
+        createMockAction({
+          id: "create-new-collection",
+          name: "create-new-collection",
+        }),
+      ]);
     });
   });
 

--- a/frontend/src/metabase/redux/ui.ts
+++ b/frontend/src/metabase/redux/ui.ts
@@ -36,10 +36,10 @@ function validateSerializableProps(props: unknown): void {
   );
 }
 
-const DEFAULT_MODAL_STATE: ModalState = {
+const DEFAULT_MODAL_STATE = {
   id: null,
   props: null,
-};
+} as ModalState;
 
 const modalSlice = createSlice({
   name: "modal",

--- a/frontend/src/metabase/redux/ui.ts
+++ b/frontend/src/metabase/redux/ui.ts
@@ -5,10 +5,17 @@ import { isSerializable } from "metabase/lib/objects";
 import type { ModalState } from "metabase-types/store/modal";
 
 type SetOpenModalPayload = ModalState["id"];
-type SetOpenModalWithPropsPayload<T = ModalState["props"]> = {
-  id: ModalState["id"];
-  props?: T;
-};
+/**
+ * This makes all `props` property optional while maintaining discriminated union types.
+ *
+ * This is necessary because `props` can never be undefined in the store, but can be
+ * omitted in the actions.
+ */
+type SetOpenModalWithPropsPayload = ModalState extends infer U
+  ? U extends { id: infer ID; props: infer P }
+    ? { id: ID; props?: P }
+    : never
+  : never;
 
 /**
  * Validates that modal props are serializable.
@@ -60,11 +67,5 @@ const modalSlice = createSlice({
 
 export const modal = modalSlice.reducer;
 
-export const { setOpenModal, closeModal } = modalSlice.actions;
-
-export const setOpenModalWithProps = <T = ModalState["props"]>(
-  payload: SetOpenModalWithPropsPayload<T>,
-): ReturnType<typeof modalSlice.actions.setOpenModalWithProps> =>
-  modalSlice.actions.setOpenModalWithProps(
-    payload as SetOpenModalWithPropsPayload,
-  );
+export const { setOpenModal, closeModal, setOpenModalWithProps } =
+  modalSlice.actions;


### PR DESCRIPTION
closes EMB-849

### Description

Add a way to launch guest embed wizard on OSS

### How to verify

On OSS, type <kbd>CMD</kbd> + <kbd>K</kbd> and then search with any of these keywords


https://github.com/metabase/metabase/blob/e45c1cef7255987ac14168bb6bd7faaa98f9a177/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx#L245-L246

### Demo
<img width="757" height="445" alt="image" src="https://github.com/user-attachments/assets/0d0e74a1-cdaa-4a13-ac0f-23d65e5b60c4" />


<img width="2470" height="1315" alt="image" src="https://github.com/user-attachments/assets/8957aefb-9a03-4e90-acc7-3aa040b7b48f" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
