### PR TITLE
Fix `determine-driver-skips` failing on a release branch

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -72,7 +72,7 @@ jobs:
           # All decision logic is in mage - it analyzes module dependencies,
           # branch context, labels, and file changes to decide what runs.
           MAGE_ARGS=(
-            --git-ref="${{ github.event.pull_request.base.ref || 'master' }}"
+            --git-ref="${{ github.event.pull_request.base.ref || github.ref_name }}"
             --is-master-or-release="${{ github.ref_name == 'master' || startsWith(github.ref_name, 'release-') }}"
             --pr-labels="${{ join(github.event.pull_request.labels.*.name, ',') }}"
             --skip="${{ inputs.skip }}"


### PR DESCRIPTION
Resolves DEV-1524

## Summary

Fix determine-driver-skips CI failure on release branches by using the current branch name as the git-ref fallback instead of hardcoded 'master'.

### Problem

On release branches (not PRs), the workflow passed --git-ref="master" to mage -driver-decisions, but master isn't fetched in CI shallow clones, causing:

```
fatal: ambiguous argument 'master': unknown revision or path not in the working tree.
```

### Fix

Changed the fallback from 'master' to `github.ref_name` which gives us the current branch name ([reference](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context))


## Why this didn't fail on `release-x.58.x`?

The driver decision logic was refactored in f290bbbbe0b ("Skip cloud driver tests when possible + consolidate test skipping logic (#67568)").

On release-x.58.x, the workflow had a bash-level short-circuit:
```bash
if [[ "${IS_MASTER_OR_RELEASE}" == "true" ]]; the
  echo "skip=false" >> $GITHUB_OUTPUT
  # Never calls mage on master/release branches
else
    ./bin/mage can-skip-driver-tests ...
fi
```

On release-x.59.x, the consolidated logic calls mage -driver-decisions unconditionally and passes --is-master-or-release as a flag. The mage code then runs git diff before checking that flag, which fails when the ref doesn't exist.
