### PR TITLE
Add tenant creation and tenant summary step for tenants onboarding

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/api/tenants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/tenants.ts
@@ -15,7 +15,11 @@ export const tenantsApi = EnterpriseApi.injectEndpoints({
         url: "/api/ee/tenant",
         body,
       }),
-      invalidatesTags: (_, error) => invalidateTags(error, [listTag("tenant")]),
+      invalidatesTags: (_, error) =>
+        invalidateTags(error, [
+          listTag("tenant"),
+          listTag("embedding-hub-checklist"),
+        ]),
     }),
     getTenant: builder.query<Tenant, Tenant["id"]>({
       query: (id) => ({

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/CreateTenantsOnboardingStep/CreateTenantsOnboardingStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/CreateTenantsOnboardingStep/CreateTenantsOnboardingStep.tsx
@@ -1,0 +1,213 @@
+/* eslint-disable metabase/no-literal-metabase-strings -- This string only shows for admins */
+
+import { useCallback, useState } from "react";
+import { t } from "ttag";
+
+import { getErrorMessage } from "metabase/api/utils";
+import { useToast } from "metabase/common/hooks";
+import { slugify } from "metabase/lib/formatting";
+import type { CreatedTenantData } from "metabase/plugins/oss/tenants";
+import {
+  Button,
+  Flex,
+  Group,
+  Icon,
+  Paper,
+  Stack,
+  Text,
+  TextInput,
+} from "metabase/ui";
+
+import { useCreateTenantMutation } from "../../../api/tenants";
+
+const createEmptyTenant = (index: number): CreatedTenantData => ({
+  name: `Tenant ${index}`,
+  tenantIdentifier: "",
+  slug: `tenant-${index}`,
+});
+
+export const CreateTenantsOnboardingStep = ({
+  onTenantsCreated,
+}: {
+  onTenantsCreated?: (tenants: CreatedTenantData[]) => void;
+}) => {
+  const [sendToast] = useToast();
+
+  const [createTenant, { isLoading }] = useCreateTenantMutation();
+
+  const [tenants, setTenants] = useState<CreatedTenantData[]>([
+    createEmptyTenant(1),
+  ]);
+
+  const addTenantCard = useCallback(() => {
+    setTenants((prev) => [...prev, createEmptyTenant(prev.length + 1)]);
+  }, []);
+
+  const updateTenantCard = useCallback(
+    (index: number, field: keyof CreatedTenantData, value: string) => {
+      setTenants((prev) =>
+        prev.map((tenant, i) => {
+          if (i !== index) {
+            return tenant;
+          }
+
+          const updated = { ...tenant, [field]: value };
+
+          // re-generate slug when name changes
+          if (field === "name") {
+            updated.slug = slugify(value).replaceAll("_", "-");
+          }
+
+          return updated;
+        }),
+      );
+    },
+    [],
+  );
+
+  const removeTenantCard = useCallback((index: number) => {
+    setTenants((prev) => prev.filter((_, i) => i !== index));
+  }, []);
+
+  const handleCreateTenants = useCallback(async () => {
+    try {
+      // Create all tenants sequentially
+      for (const tenant of tenants) {
+        await createTenant({
+          name: tenant.name,
+          slug: tenant.slug,
+        }).unwrap();
+      }
+
+      sendToast({
+        icon: "check",
+        toastColor: "success",
+        message: t`Tenants created successfully`,
+      });
+
+      // Pass the created tenants to the parent
+      onTenantsCreated?.(tenants);
+    } catch (error) {
+      sendToast({
+        icon: "warning",
+        toastColor: "error",
+        message: getErrorMessage(error, t`Failed to create tenants`),
+      });
+    }
+  }, [tenants, createTenant, sendToast, onTenantsCreated]);
+
+  const isValid = tenants.every(
+    (tenant) =>
+      tenant.name.trim() &&
+      tenant.tenantIdentifier.trim() &&
+      tenant.slug.trim(),
+  );
+
+  return (
+    <Stack gap="md">
+      <Text c="text-secondary" size="sm" lh="lg">
+        {t`Use tenants to isolate external organizations on the same Metabase instance. Tenant users will see rows in the tables you selected where the value in the columns you chose in the previous step equals the value you enter in this screen for the tenant_identifier attribute.`}
+      </Text>
+
+      <Stack gap="md">
+        {tenants.map((tenant, index) => (
+          <Paper key={index} withBorder p="md" radius="md">
+            <Stack gap="md">
+              <Group justify="space-between" align="flex-start">
+                <TextInput
+                  value={tenant.name}
+                  onChange={(e) =>
+                    updateTenantCard(index, "name", e.target.value)
+                  }
+                  placeholder={t`Tenant name`}
+                  size="md"
+                  flex={1}
+                />
+                {tenants.length > 1 && (
+                  <Button
+                    variant="subtle"
+                    color="text-secondary"
+                    p={0}
+                    onClick={() => removeTenantCard(index)}
+                    aria-label={t`Remove tenant`}
+                  >
+                    <Icon name="close" size={16} />
+                  </Button>
+                )}
+              </Group>
+
+              <TenantFormField
+                label="tenant_identifier"
+                description={t`Users will only see rows where this matches the value in the column you selected.`}
+                value={tenant.tenantIdentifier}
+                onChange={(value) =>
+                  updateTenantCard(index, "tenantIdentifier", value)
+                }
+                placeholder="tenant_id"
+              />
+
+              <TenantFormField
+                label={t`Tenant slug`}
+                description={t`Can't be changed later. Used to reference tenants via API and SSO.`}
+                value={tenant.slug}
+                onChange={(value) => updateTenantCard(index, "slug", value)}
+                placeholder="tenant-slug"
+              />
+            </Stack>
+          </Paper>
+        ))}
+      </Stack>
+
+      <Flex justify="space-between" align="center">
+        <Button
+          variant="subtle"
+          leftSection={<Icon name="add" size={16} />}
+          onClick={addTenantCard}
+          p={0}
+          fw="bold"
+        >
+          {t`New tenant`}
+        </Button>
+
+        <Button
+          variant="filled"
+          onClick={handleCreateTenants}
+          loading={isLoading}
+          disabled={!isValid}
+        >
+          {t`Next`}
+        </Button>
+      </Flex>
+    </Stack>
+  );
+};
+
+const TenantFormField = ({
+  label,
+  description,
+  value,
+  onChange,
+  placeholder,
+}: {
+  label: string;
+  description: string;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder: string;
+}) => (
+  <Stack gap="xs">
+    <Text fw="bold" size="sm">
+      {label}
+    </Text>
+
+    <Text c="text-secondary" size="xs" mb="sm">
+      {description}
+    </Text>
+
+    <TextInput
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={placeholder}
+    />
+  </Stack>
+);

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/CreateTenantsOnboardingStep/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/CreateTenantsOnboardingStep/index.ts
@@ -1,0 +1,1 @@
+export { CreateTenantsOnboardingStep } from "./CreateTenantsOnboardingStep";

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantsSummaryOnboardingStep/TenantSummaryCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantsSummaryOnboardingStep/TenantSummaryCard.tsx
@@ -1,0 +1,62 @@
+import { t } from "ttag";
+
+import { Grid, Paper, Stack, Text, Title } from "metabase/ui";
+
+export const TenantSummaryCard = ({
+  name,
+  slug,
+  tenantIdentifier,
+}: {
+  name: string;
+  slug: string;
+  tenantIdentifier: string | null;
+}) => {
+  return (
+    <Paper withBorder p="lg" radius="md">
+      <Stack gap="md">
+        <Title order={4} c="text-primary">
+          {name}
+        </Title>
+
+        <Grid>
+          <Grid.Col span={4}>
+            <Stack gap={4}>
+              <Text size="xs" c="text-secondary">
+                {t`tenant_identifier`}
+              </Text>
+
+              <Text size="sm" fw="bold" c="text-primary">
+                {tenantIdentifier ?? "-"}
+              </Text>
+            </Stack>
+          </Grid.Col>
+
+          <Grid.Col span={4}>
+            <Stack gap={4}>
+              <Text size="xs" c="text-secondary">
+                {t`Tenant slug`}
+              </Text>
+
+              <Text size="sm" fw="bold" c="text-primary">
+                {slug}
+              </Text>
+            </Stack>
+          </Grid.Col>
+
+          <Grid.Col span={4}>
+            <Stack gap={4}>
+              <Text size="xs" c="text-secondary">
+                {t`Data permissions`}
+              </Text>
+
+              <Text size="sm" c="text-primary">
+                {/* TODO(EMB-1268): Add data permissions info when available */}
+                {t`Configured via data segregation`}
+              </Text>
+            </Stack>
+          </Grid.Col>
+        </Grid>
+      </Stack>
+    </Paper>
+  );
+};

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantsSummaryOnboardingStep/TenantsSummaryOnboardingStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantsSummaryOnboardingStep/TenantsSummaryOnboardingStep.tsx
@@ -1,0 +1,109 @@
+import { useMemo } from "react";
+import { push } from "react-router-redux";
+import { t } from "ttag";
+
+import { RelatedSettingCard } from "metabase/admin/components/RelatedSettingsSection";
+import { useDispatch } from "metabase/lib/redux";
+import type { CreatedTenantData } from "metabase/plugins/oss/tenants";
+import { Button, Flex, SimpleGrid, Stack, Text, Title } from "metabase/ui";
+
+import { useListTenantsQuery } from "../../../api/tenants";
+
+import { TenantSummaryCard } from "./TenantSummaryCard";
+
+/**
+ * If the user has reloaded the page, we fetch the
+ * latest tenants to show as a fallback.
+ */
+const MAX_FETCHED_TENANTS_TO_SHOW = 3;
+
+export const TenantsSummaryOnboardingStep = ({
+  tenants,
+}: {
+  tenants: CreatedTenantData[];
+}) => {
+  const dispatch = useDispatch();
+
+  const { data: tenantsData } = useListTenantsQuery(
+    { status: "active" },
+    { skip: tenants.length > 0 },
+  );
+
+  const onDone = () => dispatch(push("/admin/embedding/setup-guide"));
+
+  const tenantsToShow = useMemo(() => {
+    // If we have tenants from the flow, use them
+    if (tenants.length > 0) {
+      return tenants;
+    }
+
+    // Fallback to the last N tenants (most recently created are likely at the end)
+    const lastTenants =
+      tenantsData?.data?.slice(-MAX_FETCHED_TENANTS_TO_SHOW) ?? [];
+
+    return lastTenants.map((tenant) => ({
+      name: tenant.name,
+      slug: tenant.slug,
+      tenantIdentifier: tenant.attributes?.tenant_identifier ?? "",
+    }));
+  }, [tenants, tenantsData]);
+
+  return (
+    <Stack gap="lg">
+      <Title order={3} c="text-primary">
+        {t`You created the following tenants`}
+      </Title>
+
+      <Stack gap="md">
+        {tenantsToShow.map((tenant) => (
+          <TenantSummaryCard
+            key={tenant.slug}
+            name={tenant.name}
+            tenantIdentifier={tenant.tenantIdentifier || null}
+            slug={tenant.slug}
+          />
+        ))}
+      </Stack>
+
+      <Text c="text-secondary" lh="lg">
+        {t`If you need to change these settings, you can go back to the previous steps, or configure more details in the following pages.`}
+      </Text>
+
+      <RelatedSettingsSection />
+
+      <Flex justify="flex-end">
+        <Button variant="filled" onClick={onDone}>
+          {t`Done`}
+        </Button>
+      </Flex>
+    </Stack>
+  );
+};
+
+const RelatedSettingsSection = () => (
+  <SimpleGrid cols={2} spacing="md">
+    <RelatedSettingCard
+      name={t`Tenants`}
+      icon="globe"
+      to="/admin/people/tenants"
+    />
+
+    <RelatedSettingCard
+      name={t`People`}
+      icon="person"
+      to="/admin/people/tenants/people"
+    />
+
+    <RelatedSettingCard
+      name={t`Authentication`}
+      icon="lock"
+      to="/admin/settings/authentication"
+    />
+
+    <RelatedSettingCard
+      name={t`Permissions`}
+      icon="group"
+      to="/admin/permissions"
+    />
+  </SimpleGrid>
+);

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantsSummaryOnboardingStep/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantsSummaryOnboardingStep/index.ts
@@ -1,0 +1,1 @@
+export { TenantsSummaryOnboardingStep } from "./TenantsSummaryOnboardingStep";

--- a/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
@@ -33,6 +33,7 @@ import { hasPremiumFeature } from "metabase-enterprise/settings";
 import { EditUserStrategyModal } from "./EditUserStrategyModal";
 import { EditUserStrategySettingsButton } from "./EditUserStrategySettingsButton";
 import { CanAccessTenantSpecificRoute } from "./components/CanAccessTenantSpecificRoute";
+import { CreateTenantsOnboardingStep } from "./components/CreateTenantsOnboardingStep";
 import { ExternalGroupDetailApp } from "./components/ExternalGroupDetailApp/ExternalGroupDetailApp";
 import { ExternalGroupsListingApp } from "./components/ExternalGroupsListingApp/ExternalGroupsListingApp";
 import { ExternalPeopleListingApp } from "./components/ExternalPeopleListingApp/ExternalPeopleListingApp";
@@ -48,6 +49,7 @@ import { TenantSpecificCollectionPermissionsPage } from "./components/TenantSpec
 import { TenantSpecificCollectionsItemList } from "./components/TenantSpecificCollectionsItemList";
 import { TenantUsersList } from "./components/TenantUsersList";
 import { TenantUsersPersonalCollectionList } from "./components/TenantUsersPersonalCollectionList";
+import { TenantsSummaryOnboardingStep } from "./components/TenantsSummaryOnboardingStep";
 import { EditTenantModal } from "./containers/EditTenantModal";
 import { NewTenantModal } from "./containers/NewTenantModal";
 import { TenantActivationModal } from "./containers/TenantActivationModal";
@@ -99,6 +101,8 @@ export function initializePlugin() {
     );
 
     PLUGIN_TENANTS.EditUserStrategyModal = EditUserStrategyModal;
+    PLUGIN_TENANTS.CreateTenantsOnboardingStep = CreateTenantsOnboardingStep;
+    PLUGIN_TENANTS.TenantsSummaryOnboardingStep = TenantsSummaryOnboardingStep;
 
     PLUGIN_TENANTS.userStrategyRoute = (
       <ModalRoute path="user-strategy" modal={EditUserStrategyModal} noWrap />

--- a/frontend/src/metabase/admin/components/RelatedSettingsSection/RelatedSettingsSection.tsx
+++ b/frontend/src/metabase/admin/components/RelatedSettingsSection/RelatedSettingsSection.tsx
@@ -39,7 +39,7 @@ export function RelatedSettingsSection({
   );
 }
 
-const RelatedSettingCard = ({
+export const RelatedSettingCard = ({
   icon,
   name,
   to,

--- a/frontend/src/metabase/admin/components/RelatedSettingsSection/index.ts
+++ b/frontend/src/metabase/admin/components/RelatedSettingsSection/index.ts
@@ -1,4 +1,7 @@
-export { RelatedSettingsSection } from "./RelatedSettingsSection";
+export {
+  RelatedSettingsSection,
+  RelatedSettingCard,
+} from "./RelatedSettingsSection";
 
 export {
   getModularEmbeddingRelatedSettingItems,

--- a/frontend/src/metabase/common/components/OnboardingStepper/OnboardingStepper.tsx
+++ b/frontend/src/metabase/common/components/OnboardingStepper/OnboardingStepper.tsx
@@ -13,6 +13,7 @@ import { OnboardingStepperStep } from "./OnboardingStepperStep";
 import { useAutoAdvanceStep } from "./hooks/use-auto-advance-step";
 import { useScrollStepIntoView } from "./hooks/use-scroll-step-into-view";
 import type { OnboardingStepperHandle, OnboardingStepperProps } from "./types";
+import { getNextIncompleteStepFrom } from "./utils/get-next-incomplete-step-from";
 
 export type {
   OnboardingStepperHandle,
@@ -77,17 +78,32 @@ const OnboardingStepperRoot = forwardRef<
     [onChange, scrollStepIntoView],
   );
 
-  const goToNextIncompleteStep = useCallback(() => {
-    const nextIncomplete = stepIds.find((id) => !completedSteps[id]) ?? null;
+  useAutoAdvanceStep({
+    stepIds,
+    completedSteps,
+    lockedSteps,
+    activeStep,
+    setActiveStep,
+  });
 
-    setActiveStep(nextIncomplete);
-  }, [completedSteps, setActiveStep, stepIds]);
+  const goToNextIncompleteStep = useCallback(() => {
+    if (activeStep === null) {
+      return;
+    }
+
+    const nextIncompleteStepId = getNextIncompleteStepFrom({
+      stepIds,
+      completedSteps,
+      lockedSteps,
+      fromIndex: stepIds.indexOf(activeStep) + 1,
+    });
+
+    setActiveStep(nextIncompleteStepId);
+  }, [activeStep, stepIds, completedSteps, lockedSteps, setActiveStep]);
 
   useImperativeHandle(ref, () => ({ goToNextIncompleteStep }), [
     goToNextIncompleteStep,
   ]);
-
-  useAutoAdvanceStep({ stepIds, completedSteps, activeStep, setActiveStep });
 
   return (
     <StepperContext.Provider

--- a/frontend/src/metabase/common/components/OnboardingStepper/utils/get-next-incomplete-step-from.ts
+++ b/frontend/src/metabase/common/components/OnboardingStepper/utils/get-next-incomplete-step-from.ts
@@ -1,0 +1,20 @@
+/**
+ * Finds the next incomplete and unlocked step,
+ * starting from a given index.
+ */
+export const getNextIncompleteStepFrom = ({
+  fromIndex = 0,
+
+  stepIds,
+  completedSteps,
+  lockedSteps = {},
+}: {
+  fromIndex?: number;
+
+  stepIds: string[];
+  completedSteps: Record<string, boolean>;
+  lockedSteps?: Record<string, boolean>;
+}): string | null =>
+  stepIds
+    .slice(fromIndex)
+    .find((id) => !completedSteps[id] && !lockedSteps?.[id]) ?? null;

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/SetupPermissionsAndTenantsPage.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/SetupPermissionsAndTenantsPage.tsx
@@ -14,6 +14,10 @@ import { getErrorMessage } from "metabase/api/utils";
 import { OnboardingStepper } from "metabase/common/components/OnboardingStepper";
 import type { OnboardingStepperHandle } from "metabase/common/components/OnboardingStepper/types";
 import { useToast } from "metabase/common/hooks";
+import {
+  type CreatedTenantData,
+  PLUGIN_TENANTS,
+} from "metabase/plugins/oss/tenants";
 import { Button, Group, Icon, Stack, Text, Title } from "metabase/ui";
 
 import {
@@ -46,6 +50,9 @@ export const SetupPermissionsAndTenantsPage = () => {
     useState<DataSegregationStrategy | null>(null);
 
   const [isStrategyConfirmed, setIsStrategyConfirmed] = useState(false);
+
+  // Track the tenants created in this onboarding flow
+  const [createdTenants, setCreatedTenants] = useState<CreatedTenantData[]>([]);
 
   const hasSharedCollections =
     sharedTenantCollections && sharedTenantCollections.length > 0;
@@ -208,15 +215,19 @@ export const SetupPermissionsAndTenantsPage = () => {
           stepId="create-tenants"
           title={t`Create tenants`}
         >
-          <Text c="text-secondary" size="sm" lh="lg">
-            {t`Set up tenants to isolate data between different customers.`}
-          </Text>
+          <PLUGIN_TENANTS.CreateTenantsOnboardingStep
+            onTenantsCreated={setCreatedTenants}
+          />
         </OnboardingStepper.Step>
 
-        <OnboardingStepper.Step stepId="summary" title={t`Summary`}>
-          <Text c="text-secondary" size="sm" lh="lg">
-            {t`Review your configuration and complete the setup.`}
-          </Text>
+        <OnboardingStepper.Step
+          stepId="summary"
+          title={t`Summary`}
+          hideTitleOnActive
+        >
+          <PLUGIN_TENANTS.TenantsSummaryOnboardingStep
+            tenants={createdTenants}
+          />
         </OnboardingStepper.Step>
       </OnboardingStepper>
     </Stack>

--- a/frontend/src/metabase/plugins/oss/tenants.ts
+++ b/frontend/src/metabase/plugins/oss/tenants.ts
@@ -16,6 +16,12 @@ import type {
 
 import { PluginPlaceholder } from "../components/PluginPlaceholder";
 
+export type CreatedTenantData = {
+  name: string;
+  slug: string;
+  tenantIdentifier: string;
+};
+
 export type TenantCollectionPathItem = {
   id: CollectionId;
   namespace?: CollectionNamespace;
@@ -30,6 +36,12 @@ const getDefaultPluginTenants = () => ({
   isEnabled: false,
   userStrategyRoute: null as React.ReactElement | null,
   tenantsRoutes: null as React.ReactElement | null,
+  CreateTenantsOnboardingStep: PluginPlaceholder as React.ComponentType<{
+    onTenantsCreated?: (tenants: CreatedTenantData[]) => void;
+  }>,
+  TenantsSummaryOnboardingStep: PluginPlaceholder as React.ComponentType<{
+    tenants: CreatedTenantData[];
+  }>,
   EditUserStrategySettingsButton: PluginPlaceholder,
   FormTenantWidget: (_props: any) => null as React.ReactElement | null,
   TenantDisplayName: (_props: any) => null as React.ReactElement | null,
@@ -92,6 +104,12 @@ export const PLUGIN_TENANTS: {
     sharedTenantCollections: Collection[] | undefined;
   };
   tenantsRoutes: React.ReactElement | null;
+  CreateTenantsOnboardingStep: React.ComponentType<{
+    onTenantsCreated?: (tenants: CreatedTenantData[]) => void;
+  }>;
+  TenantsSummaryOnboardingStep: React.ComponentType<{
+    tenants: CreatedTenantData[];
+  }>;
   EditUserStrategySettingsButton: (props: {
     page: "people" | "tenants";
   }) => React.ReactElement | null;


### PR DESCRIPTION
Closes EMB-1269
Closes EMB-1270

### Description

Adds the tenant creation and tenants summary step that lets you create new tenants and also preview the created tenants.

### How to verify

- Setup sandboxing so that Step 3 passes. Go to "Permissions" and set one of the permissions to "Granular > Row and column security" and set a random user attribute. We haven't implemented step 3 yet, only its checks.

<img width="1456" height="750" alt="CleanShot 2569-02-12 at 03 41 02@2x" src="https://github.com/user-attachments/assets/627d1947-2ed7-48d6-87ee-485afaf0b9ed" />

- Go to `/admin/embedding/setup-guide/permissions` route on EE.
- You should see "Configure data permissions and enable tenants"
- Click on "Enable multi-tenant user strategy" card header if it's not already checked
- Click on "Enable tenants and create shared collection" if it's not already checked
- Click on "Create tenants"
- The "Next" button shouldn't appear until you filled the three form fields
- "New Tenant" should add a new card
- Clicking "Next" should create those tenants
- You should see the three tenants in "You created the following tenants" header
- Data permission should say "Configured via data segregation" -- this is temporarily a mock.

## Caveat

We should actually auto-populate the tenant_id. Will be done in the next PRs.

### Demo

<img width="1904" height="1576" alt="CleanShot 2569-02-12 at 03 40 02@2x" src="https://github.com/user-attachments/assets/fba16f9f-a6e1-4a15-b56f-8ac8d12e1388" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR - E2E + Unit
