### PR TITLE
Remove superfluous `jest-localstorage-mock`

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -328,7 +328,6 @@
         "jest-canvas-mock": "^2.5.2",
         "jest-environment-jsdom": "^29.7.0",
         "jest-junit": "^16.0.0",
-        "jest-localstorage-mock": "^2.4.22",
         "jest-watch-typeahead": "^2.2.1",
         "jose": "^5.6.3",
         "json-to-pretty-yaml": "^1.2.2",
@@ -3466,8 +3465,6 @@
     "jest-junit": ["jest-junit@16.0.0", "", { "dependencies": { "mkdirp": "^1.0.4", "strip-ansi": "^6.0.1", "uuid": "^8.3.2", "xml": "^1.0.1" } }, "sha512-A94mmw6NfJab4Fg/BlvVOUXzXgF0XIH6EmTgJ5NDPp4xoKq0Kr7sErb+4Xs9nZvu58pJojz5RFGpqnZYJTrRfQ=="],
 
     "jest-leak-detector": ["jest-leak-detector@29.7.0", "", { "dependencies": { "jest-get-type": "^29.6.3", "pretty-format": "^29.7.0" } }, "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw=="],
-
-    "jest-localstorage-mock": ["jest-localstorage-mock@2.4.22", "", {}, "sha512-60PWSDFQOS5v7JzSmYLM3dPLg0JLl+2Vc4lIEz/rj2yrXJzegsFLn7anwc5IL0WzJbBa/Las064CHbFg491/DQ=="],
 
     "jest-matcher-utils": ["jest-matcher-utils@29.3.1", "", { "dependencies": { "chalk": "^4.0.0", "jest-diff": "^29.3.1", "jest-get-type": "^29.2.0", "pretty-format": "^29.3.1" } }, "sha512-fkRMZUAScup3txIKfMe3AIZZmPEjWEdsPJFK3AIy5qRohWqQFg1qrmKfYXR9qEkNc7OdAu2N4KPHibEmy4HPeQ=="],
 

--- a/frontend/test/jest-setup.js
+++ b/frontend/test/jest-setup.js
@@ -4,7 +4,6 @@ import { Crypto, CryptoKey } from "@peculiar/webcrypto";
 import { ReadableStream } from "web-streams-polyfill";
 import "cross-fetch/polyfill";
 import "raf/polyfill";
-import "jest-localstorage-mock";
 import "jest-canvas-mock";
 import "metabase/lib/dayjs";
 import "__support__/mocks";

--- a/package.json
+++ b/package.json
@@ -333,7 +333,6 @@
     "jest-canvas-mock": "^2.5.2",
     "jest-environment-jsdom": "^29.7.0",
     "jest-junit": "^16.0.0",
-    "jest-localstorage-mock": "^2.4.22",
     "jest-watch-typeahead": "^2.2.1",
     "jose": "^5.6.3",
     "json-to-pretty-yaml": "^1.2.2",


### PR DESCRIPTION
  Since jsdom 16+, localStorage is provided natively, so the mock was mostly redundant. The performance gains are:
  ```
  ┌─────────────────────┬──────────────────────┐
  │       Factor        │        Impact        │
  ├─────────────────────┼──────────────────────┤
  │ Import/require time │ ~1-2ms per test file │
  ├─────────────────────┼──────────────────────┤
  │ Module resolution   │ Negligible           │
  ├─────────────────────┼──────────────────────┤
  │ Memory              │ Negligible           │
  └─────────────────────┴──────────────────────┘
```
Real benefit: Reduced dependency surface area and simpler setup - not speed.
