### PR TITLE
Update FE Claude.md scripts instructions

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -50,5 +50,6 @@ All user-facing strings MUST be localized using the ttag library. Localized stri
 
 ### Scripts
 
-- Use `yarn type-check-pure` to run project-wide type checking.
-- Use `yarn lint-eslint-pure` to run project-wide linting.
+- Use `bun run type-check-pure` to run project-wide type checking.
+- Use `bun run lint-eslint-pure` to run project-wide linting.
+- Use `bun run test-unit` to run Jest tests.


### PR DESCRIPTION
Resolves DEV-1529

These Claude instructions are no longer valid because we migrated to `bun`.

Additionally, I've added an explanation how to run fe unit (Jest) tests because Claude was constantly invoking jest using npx for me locally. This sometimes leads to failures if there's no cljs build. Invoking an established `bun run test-unit` takes care of that.