### PR TITLE
Remove `@peculiar/webcrypto` polyfill from the Jest setup

### DIFF
--- a/frontend/test/jest-setup.js
+++ b/frontend/test/jest-setup.js
@@ -1,6 +1,6 @@
+import { webcrypto } from "crypto";
 import { TextDecoder, TextEncoder } from "util";
 
-import { Crypto, CryptoKey } from "@peculiar/webcrypto";
 import { ReadableStream } from "web-streams-polyfill";
 import "cross-fetch/polyfill";
 import "raf/polyfill";
@@ -41,10 +41,12 @@ class JSDOMTextEncoder extends TextEncoder {
 
 // global TextEncoder and Crypto are not available in jsdom + Jest, see
 // https://stackoverflow.com/questions/70808405/how-to-set-global-textdecoder-in-jest-for-jsdom-if-nodes-util-textdecoder-is-ty
-// (hacky fix)
-delete globalThis.crypto;
-globalThis.crypto = new Crypto();
-globalThis.CryptoKey = CryptoKey;
+// Use Node.js native webcrypto instead of @peculiar/webcrypto polyfill
+Object.defineProperty(globalThis, "crypto", {
+  value: webcrypto,
+  writable: true,
+  configurable: true,
+});
 global.TextEncoder = JSDOMTextEncoder;
 global.TextDecoder = TextDecoder;
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,9 @@ const esmPackages = require("./jest.esm-packages.js");
 
 const baseConfig = {
   moduleNameMapper: {
+    // Force jose to use Node.js runtime instead of browser runtime in jsdom environment.
+    // The browser runtime expects CryptoKey to be globally available, which jsdom doesn't provide.
+    "^jose$": "<rootDir>/node_modules/jose/dist/node/cjs/index.js",
     "^build-configs/(.*)$": "<rootDir>/frontend/build/$1",
     "\\.(css|less)$": "<rootDir>/frontend/test/__mocks__/styleMock.js",
     "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":


### PR DESCRIPTION
Resolves DEV-1527

## Changes Made This Session

### 1. Replaced `@peculiar/webcrypto` with Node.js native `webcrypto`

**File:** `frontend/test/jest-setup.js`

### 2. Fixed `jose` library CryptoKey issue

**Problem:** After replacing `@peculiar/webcrypto`, tests using the `jose` library (JWT operations) failed with:
```
ReferenceError: CryptoKey is not defined
```

**Root Cause:**
- The `jose` library has both browser and Node.js runtimes
- In jsdom environment, Jest resolves to jose's browser runtime (`dist/browser/`)
- The browser runtime expects `CryptoKey` to be a global class (like in browsers)
- jsdom doesn't provide `CryptoKey` as a global
- Node's `globalThis.CryptoKey` is available in pure Node.js, but jsdom replaces `globalThis` with its window object

**Solution:** Added moduleNameMapper in `jest.config.js` to force jose to use its Node.js runtime:

```javascript
moduleNameMapper: {
  "^jose$": "<rootDir>/node_modules/jose/dist/node/cjs/index.js",
  // ...
}
```

**Why this works:** Jose's Node.js runtime uses Node's native `crypto` module directly (via `require('crypto')`) and doesn't rely on global `CryptoKey`.

---

## Investigation Findings

### jsdom 22.1.0 Crypto Support

| Feature | jsdom Native | Node.js 22+ Native |
|---------|--------------|-------------------|
| `crypto.getRandomValues()` | ✅ | ✅ |
| `crypto.randomUUID()` | ✅ | ✅ |
| `crypto.subtle` | ❌ undefined | ✅ |
| `crypto.subtle.digest()` | ❌ | ✅ |

**Conclusion:** jsdom still does not implement `crypto.subtle` ([issue #1612](https://github.com/jsdom/jsdom/issues/1612) from 2016 remains open). A polyfill is still required, but Node's native `webcrypto` can replace the third-party package.

## Why Remove It

- Node.js native support: crypto.webcrypto has been available since Node 15, globalThis.crypto since Node 19, and is fully supported in Node 22 LTS (our current version)
- Reduced dependencies: One less third-party package to maintain and audit
- Better performance: Native implementation vs third-party polyfill