### PR TITLE
More metrics for parsing modules

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1439,7 +1439,8 @@
   {:team "DevEx"
    :api #{metabase.sql-tools.core
           metabase.sql-tools.init}
-   :uses #{driver
+   :uses #{analytics
+           driver
            lib
            settings
            sql-parsing

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -503,7 +503,29 @@
                         :labels [:status]})
    ;; SQL parsing metrics
    (prometheus/counter :metabase-sql-parsing/timeouts
-                       {:description "Number of Python/GraalVM SQL parsing execution timeouts."})])
+                       {:description "Number of Python/GraalVM SQL parsing execution timeouts."})
+   (prometheus/counter :metabase-sql-parsing/context-acquisitions
+                       {:description "Number of Python contexts acquired from the pool."})
+   (prometheus/counter :metabase-sql-parsing/context-creations
+                       {:description "Number of new Python contexts created."})
+   (prometheus/counter :metabase-sql-parsing/context-disposals-expired
+                       {:description "Number of Python contexts disposed due to TTL expiry."})
+   (prometheus/counter :metabase-sql-parsing/context-disposals-poisoned
+                       {:description "Number of Python contexts disposed due to poisoning (timeout/hang)."})
+   ;; SQL tools operation metrics
+   (prometheus/counter :metabase-sql-tools/operations-total
+                       {:description "Total number of sql-tools operations started."
+                        :labels [:parser :operation]})
+   (prometheus/counter :metabase-sql-tools/operations-completed
+                       {:description "Number of sql-tools operations completed successfully."
+                        :labels [:parser :operation]})
+   (prometheus/counter :metabase-sql-tools/operations-failed
+                       {:description "Number of sql-tools operations that threw an exception."
+                        :labels [:parser :operation]})
+   (prometheus/histogram :metabase-sql-tools/operation-duration-ms
+                         {:description "Duration in milliseconds of sql-tools operations."
+                          :labels [:parser :operation]
+                          :buckets [1 5 10 25 50 100 250 500 1000 2500 5000 10000 30000]})])
 
 (defn- quartz-collectors
   []

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -502,7 +502,7 @@
                        {:description "Total number of token checks. Includes a status label."
                         :labels [:status]})
    ;; SQL parsing metrics
-   (prometheus/counter :metabase-sql-parsing/timeouts
+   (prometheus/counter :metabase-sql-parsing/context-timeouts
                        {:description "Number of Python/GraalVM SQL parsing execution timeouts."})
    (prometheus/counter :metabase-sql-parsing/context-acquisitions
                        {:description "Number of Python contexts acquired from the pool."})
@@ -510,8 +510,6 @@
                        {:description "Number of new Python contexts created."})
    (prometheus/counter :metabase-sql-parsing/context-disposals-expired
                        {:description "Number of Python contexts disposed due to TTL expiry."})
-   (prometheus/counter :metabase-sql-parsing/context-disposals-poisoned
-                       {:description "Number of Python contexts disposed due to poisoning (timeout/hang)."})
    ;; SQL tools operation metrics
    (prometheus/counter :metabase-sql-tools/operations-total
                        {:description "Total number of sql-tools operations started."

--- a/src/metabase/sql_parsing/pool.clj
+++ b/src/metabase/sql_parsing/pool.clj
@@ -191,7 +191,6 @@
     (if @poisoned?
       (do
         (log/warn "Disposing poisoned Python context (likely hung GraalVM)")
-        (analytics/inc! :metabase-sql-parsing/context-disposals-poisoned)
         (.dispose pool :python tuple))
       (.release pool :python tuple))))
 

--- a/src/metabase/sql_parsing/pool.clj
+++ b/src/metabase/sql_parsing/pool.clj
@@ -6,6 +6,7 @@
    [clojure.java.io :as io]
    [clojure.java.shell :as shell]
    [clojure.string :as str]
+   [metabase.analytics.core :as analytics]
    [metabase.sql-parsing.common :as common]
    [metabase.util.files :as u.files]
    [metabase.util.log :as log]
@@ -190,6 +191,7 @@
     (if @poisoned?
       (do
         (log/warn "Disposing poisoned Python context (likely hung GraalVM)")
+        (analytics/inc! :metabase-sql-parsing/context-disposals-poisoned)
         (.dispose pool :python tuple))
       (.release pool :python tuple))))
 
@@ -257,6 +259,7 @@
      (Pool. (reify IPool$Generator
               (generate [_ _]
                 ;; Generate a tuple of the context and the expiry timestamp.
+                (analytics/inc! :metabase-sql-parsing/context-creations)
                 [(context-generator)
                  (+ (System/nanoTime) (.toNanos TimeUnit/MINUTES ttl-minutes))])
               (destroy [_ _ [^Context ctx _expiry]]
@@ -302,9 +305,11 @@
   (loop []
     (let [[context expiry-ts :as tuple] (.acquire pool :python)]
       (if (>= (System/nanoTime) expiry-ts)
-        (do (.dispose pool :python tuple)
+        (do (analytics/inc! :metabase-sql-parsing/context-disposals-expired)
+            (.dispose pool :python tuple)
             (recur))
-        (->PooledContext context pool tuple (atom false))))))
+        (do (analytics/inc! :metabase-sql-parsing/context-acquisitions)
+            (->PooledContext context pool tuple (atom false)))))))
 
 (defn python-context
   "Acquire a python context from the pool. Must be closed. Use in a `with-open` context."

--- a/src/metabase/sql_tools/core.clj
+++ b/src/metabase/sql_tools/core.clj
@@ -8,6 +8,7 @@
    metabase.sql-tools.init to avoid circular dependencies."
   (:require
    [metabase.sql-tools.interface :as interface]
+   [metabase.sql-tools.metrics :as metrics]
    [metabase.sql-tools.settings :as sql-tools.settings]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
@@ -76,13 +77,17 @@
   "Return appdb columns for the `native-query`."
   [driver :- :keyword
    native-query]
-  (interface/returned-columns-impl (sql-tools.settings/current-parser-backend) driver native-query))
+  (let [parser (sql-tools.settings/current-parser-backend)]
+    (metrics/with-operation-timing [parser "returned-columns"]
+      (interface/returned-columns-impl parser driver native-query))))
 
 (mu/defn referenced-tables :- [:set :map]
   "Return tables referenced by the `native-query`"
   [driver :- :keyword
    native-query]
-  (interface/referenced-tables-impl (sql-tools.settings/current-parser-backend) driver native-query))
+  (let [parser (sql-tools.settings/current-parser-backend)]
+    (metrics/with-operation-timing [parser "referenced-tables"]
+      (interface/referenced-tables-impl parser driver native-query))))
 
 (mu/defn referenced-fields :- [:set :map]
   "Return appdb fields referenced (used) by the `native-query`.
@@ -91,7 +96,9 @@
   Returns a set of :metadata/column maps."
   [driver :- :keyword
    native-query]
-  (interface/referenced-fields-impl (sql-tools.settings/current-parser-backend) driver native-query))
+  (let [parser (sql-tools.settings/current-parser-backend)]
+    (metrics/with-operation-timing [parser "referenced-fields"]
+      (interface/referenced-fields-impl parser driver native-query))))
 
 (mu/defn field-references :- :metabase.sql-tools.macaw.references/field-references
   "Return field references for SQL string.
@@ -102,13 +109,17 @@
   - :errors - set of validation errors"
   [driver :- :keyword
    sql-string :- :string]
-  (interface/field-references-impl (sql-tools.settings/current-parser-backend) driver sql-string))
+  (let [parser (sql-tools.settings/current-parser-backend)]
+    (metrics/with-operation-timing [parser "field-references"]
+      (interface/field-references-impl parser driver sql-string))))
 
 (mu/defn validate-query :- [:set :map]
   "Validate native query. Returns a set of validation errors (empty set if valid)."
   [driver :- :keyword
    native-query]
-  (interface/validate-query-impl (sql-tools.settings/current-parser-backend) driver native-query))
+  (let [parser (sql-tools.settings/current-parser-backend)]
+    (metrics/with-operation-timing [parser "validate-query"]
+      (interface/validate-query-impl parser driver native-query))))
 
 (mu/defn replace-names :- :string
   "Replace schema, table, and column names in a SQL query.
@@ -133,13 +144,17 @@
     sql-string :- :string
     replacements :- ::replacements
     opts :- ::replace-names-opts]
-   (interface/replace-names-impl (sql-tools.settings/current-parser-backend) driver sql-string replacements opts)))
+   (let [parser (sql-tools.settings/current-parser-backend)]
+     (metrics/with-operation-timing [parser "replace-names"]
+       (interface/replace-names-impl parser driver sql-string replacements opts)))))
 
 (mu/defn referenced-tables-raw :- [:sequential ::table-spec]
   "Given a driver and sql string, returns a sequence of {:schema <name> :table <name>} maps."
   [driver :- :keyword
    sql-str :- :string]
-  (interface/referenced-tables-raw-impl (sql-tools.settings/current-parser-backend) driver sql-str))
+  (let [parser (sql-tools.settings/current-parser-backend)]
+    (metrics/with-operation-timing [parser "referenced-tables-raw"]
+      (interface/referenced-tables-raw-impl parser driver sql-str))))
 
 (mu/defn simple-query? :- ::simple-query-result
   "Check if SQL string is a simple SELECT (no LIMIT, OFFSET, or CTEs).
@@ -149,7 +164,9 @@
   - `:is_simple` - boolean indicating if query is simple
   - `:reason` - string explaining why query is not simple (when false)"
   [sql-string :- :string]
-  (interface/simple-query?-impl (sql-tools.settings/current-parser-backend) sql-string))
+  (let [parser (sql-tools.settings/current-parser-backend)]
+    (metrics/with-operation-timing [parser "simple-query?"]
+      (interface/simple-query?-impl parser sql-string))))
 
 (mu/defn add-into-clause :- :string
   "Add an INTO clause to a SELECT statement.
@@ -162,4 +179,6 @@
   [driver :- :keyword
    sql :- :string
    table-name :- :string]
-  (interface/add-into-clause-impl (sql-tools.settings/current-parser-backend) driver sql table-name))
+  (let [parser (sql-tools.settings/current-parser-backend)]
+    (metrics/with-operation-timing [parser "add-into-clause"]
+      (interface/add-into-clause-impl parser driver sql table-name))))

--- a/src/metabase/sql_tools/init.clj
+++ b/src/metabase/sql_tools/init.clj
@@ -2,5 +2,6 @@
   (:require
    ;; metabase.sql-tools.<parser> is required to ensure method's registration
    [metabase.sql-tools.macaw.core]
+   [metabase.sql-tools.metrics]
    [metabase.sql-tools.settings]
    [metabase.sql-tools.sqlglot.core]))

--- a/src/metabase/sql_tools/metrics.clj
+++ b/src/metabase/sql_tools/metrics.clj
@@ -1,0 +1,79 @@
+(ns metabase.sql-tools.metrics
+  "Prometheus metrics instrumentation for sql-tools operations.
+
+   Provides recording functions and a `with-operation-timing` macro that wraps
+   sql-tools public API calls with counters and histograms, labeled by parser
+   backend and operation name."
+  (:require
+   [metabase.analytics.core :as analytics]
+   [metabase.util :as u]))
+
+(set! *warn-on-reflection* true)
+
+;;; -------------------------------------------------- Known labels --------------------------------------------------
+
+(def ^:private parsers ["macaw" "sqlglot"])
+
+(def ^:private operations
+  ["returned-columns"
+   "referenced-tables"
+   "referenced-fields"
+   "field-references"
+   "validate-query"
+   "replace-names"
+   "referenced-tables-raw"
+   "simple-query?"
+   "add-into-clause"])
+
+(def ^:private operation-labels
+  (vec (for [parser    parsers
+             operation operations]
+         {:parser parser :operation operation})))
+
+(defmethod analytics/known-labels :metabase-sql-tools/operations-total [_] operation-labels)
+(defmethod analytics/known-labels :metabase-sql-tools/operations-completed [_] operation-labels)
+(defmethod analytics/known-labels :metabase-sql-tools/operations-failed [_] operation-labels)
+
+;;; -------------------------------------------------- Recording fns --------------------------------------------------
+
+(defn record-operation-start!
+  "Record the start of an sql-tools operation."
+  [parser operation]
+  (analytics/inc! :metabase-sql-tools/operations-total
+                   {:parser (name parser) :operation operation}))
+
+(defn record-operation-completion!
+  "Record the successful completion of an sql-tools operation."
+  [parser operation duration-ms]
+  (let [labels {:parser (name parser) :operation operation}]
+    (analytics/inc! :metabase-sql-tools/operations-completed labels)
+    (analytics/observe! :metabase-sql-tools/operation-duration-ms labels duration-ms)))
+
+(defn record-operation-failure!
+  "Record the failure of an sql-tools operation."
+  [parser operation duration-ms]
+  (let [labels {:parser (name parser) :operation operation}]
+    (analytics/inc! :metabase-sql-tools/operations-failed labels)
+    (analytics/observe! :metabase-sql-tools/operation-duration-ms labels duration-ms)))
+
+;;; -------------------------------------------------- Timing macro --------------------------------------------------
+
+(defmacro with-operation-timing
+  "Execute body while timing an sql-tools operation. Automatically records
+   start, completion or failure metrics labeled by parser and operation.
+
+   Usage:
+   (with-operation-timing [parser \"returned-columns\"]
+     (interface/returned-columns-impl parser driver native-query))"
+  [[parser operation] & body]
+  `(let [parser#    ~parser
+         operation# ~operation
+         start#     (u/start-timer)]
+     (record-operation-start! parser# operation#)
+     (try
+       (let [result# (do ~@body)]
+         (record-operation-completion! parser# operation# (long (u/since-ms start#)))
+         result#)
+       (catch Throwable t#
+         (record-operation-failure! parser# operation# (long (u/since-ms start#)))
+         (throw t#)))))

--- a/test/metabase/sql_tools/metrics_test.clj
+++ b/test/metabase/sql_tools/metrics_test.clj
@@ -1,0 +1,83 @@
+(ns metabase.sql-tools.metrics-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.analytics.prometheus :as prometheus]
+   [metabase.analytics.prometheus-test :as prometheus-test]
+   [metabase.sql-tools.metrics :as metrics]
+   [metabase.test :as mt]))
+
+(set! *warn-on-reflection* true)
+
+(deftest with-operation-timing-success-test
+  (testing "with-operation-timing increments counters on success"
+    (mt/with-prometheus-system! [_ system]
+      (metrics/with-operation-timing [:macaw "returned-columns"]
+        :ok)
+      (is (prometheus-test/approx= 1 (mt/metric-value system :metabase-sql-tools/operations-total
+                                                       {:parser "macaw" :operation "returned-columns"})))
+      (is (prometheus-test/approx= 1 (mt/metric-value system :metabase-sql-tools/operations-completed
+                                                       {:parser "macaw" :operation "returned-columns"})))
+      (is (prometheus-test/approx= 0 (mt/metric-value system :metabase-sql-tools/operations-failed
+                                                       {:parser "macaw" :operation "returned-columns"}))))))
+
+(deftest with-operation-timing-failure-test
+  (testing "with-operation-timing increments failure counter on exception"
+    (mt/with-prometheus-system! [_ system]
+      (is (thrown? Exception
+                   (metrics/with-operation-timing [:sqlglot "validate-query"]
+                     (throw (Exception. "boom")))))
+      (is (prometheus-test/approx= 1 (mt/metric-value system :metabase-sql-tools/operations-total
+                                                       {:parser "sqlglot" :operation "validate-query"})))
+      (is (prometheus-test/approx= 0 (mt/metric-value system :metabase-sql-tools/operations-completed
+                                                       {:parser "sqlglot" :operation "validate-query"})))
+      (is (prometheus-test/approx= 1 (mt/metric-value system :metabase-sql-tools/operations-failed
+                                                       {:parser "sqlglot" :operation "validate-query"}))))))
+
+(deftest with-operation-timing-returns-value-test
+  (testing "with-operation-timing returns the body's value"
+    (mt/with-prometheus-system! [_ _system]
+      (is (= :result
+             (metrics/with-operation-timing [:macaw "simple-query?"]
+               :result))))))
+
+(deftest with-operation-timing-duration-test
+  (testing "with-operation-timing records duration in histogram"
+    (mt/with-prometheus-system! [_ system]
+      (metrics/with-operation-timing [:macaw "replace-names"]
+        (Thread/sleep 10))
+      (let [histogram-val (mt/metric-value system :metabase-sql-tools/operation-duration-ms
+                                           {:parser "macaw" :operation "replace-names"})]
+        (is (pos? (:sum histogram-val)))))))
+
+(deftest record-functions-test
+  (testing "record-operation-start! increments operations-total"
+    (mt/with-prometheus-system! [_ system]
+      (metrics/record-operation-start! :macaw "field-references")
+      (is (prometheus-test/approx= 1 (mt/metric-value system :metabase-sql-tools/operations-total
+                                                       {:parser "macaw" :operation "field-references"})))))
+  (testing "record-operation-completion! increments completed and observes duration"
+    (mt/with-prometheus-system! [_ system]
+      (metrics/record-operation-completion! :sqlglot "referenced-tables" 42)
+      (is (prometheus-test/approx= 1 (mt/metric-value system :metabase-sql-tools/operations-completed
+                                                       {:parser "sqlglot" :operation "referenced-tables"})))
+      (is (prometheus-test/approx= 42 (:sum (mt/metric-value system :metabase-sql-tools/operation-duration-ms
+                                                              {:parser "sqlglot" :operation "referenced-tables"}))))))
+  (testing "record-operation-failure! increments failed and observes duration"
+    (mt/with-prometheus-system! [_ system]
+      (metrics/record-operation-failure! :macaw "add-into-clause" 100)
+      (is (prometheus-test/approx= 1 (mt/metric-value system :metabase-sql-tools/operations-failed
+                                                       {:parser "macaw" :operation "add-into-clause"})))
+      (is (prometheus-test/approx= 100 (:sum (mt/metric-value system :metabase-sql-tools/operation-duration-ms
+                                                               {:parser "macaw" :operation "add-into-clause"})))))))
+
+(deftest pool-metrics-registered-test
+  (testing "Pool metrics are registered in prometheus"
+    (mt/with-prometheus-system! [_ system]
+      (prometheus/inc! :metabase-sql-parsing/context-acquisitions)
+      (is (prometheus-test/approx= 1 (mt/metric-value system :metabase-sql-parsing/context-acquisitions)))
+      (prometheus/inc! :metabase-sql-parsing/context-creations)
+      (is (prometheus-test/approx= 1 (mt/metric-value system :metabase-sql-parsing/context-creations)))
+      (prometheus/inc! :metabase-sql-parsing/context-disposals-expired)
+      (is (prometheus-test/approx= 1 (mt/metric-value system :metabase-sql-parsing/context-disposals-expired)))
+      (prometheus/inc! :metabase-sql-parsing/context-disposals-poisoned)
+      (is (prometheus-test/approx= 1 (mt/metric-value system :metabase-sql-parsing/context-disposals-poisoned))))))

--- a/test/metabase/sql_tools/metrics_test.clj
+++ b/test/metabase/sql_tools/metrics_test.clj
@@ -73,11 +73,11 @@
 (deftest pool-metrics-registered-test
   (testing "Pool metrics are registered in prometheus"
     (mt/with-prometheus-system! [_ system]
+      (prometheus/inc! :metabase-sql-parsing/context-timeouts)
+      (is (prometheus-test/approx= 1 (mt/metric-value system :metabase-sql-parsing/context-timeouts)))
       (prometheus/inc! :metabase-sql-parsing/context-acquisitions)
       (is (prometheus-test/approx= 1 (mt/metric-value system :metabase-sql-parsing/context-acquisitions)))
       (prometheus/inc! :metabase-sql-parsing/context-creations)
       (is (prometheus-test/approx= 1 (mt/metric-value system :metabase-sql-parsing/context-creations)))
       (prometheus/inc! :metabase-sql-parsing/context-disposals-expired)
-      (is (prometheus-test/approx= 1 (mt/metric-value system :metabase-sql-parsing/context-disposals-expired)))
-      (prometheus/inc! :metabase-sql-parsing/context-disposals-poisoned)
-      (is (prometheus-test/approx= 1 (mt/metric-value system :metabase-sql-parsing/context-disposals-poisoned))))))
+      (is (prometheus-test/approx= 1 (mt/metric-value system :metabase-sql-parsing/context-disposals-expired))))))


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/BOT-991/more-metrics-for-parsing-modules

Adding more metrics that could be interesting for us when Sqlglot parsing is merged.

Targeting `sqlglot-sql-parsing`. When that is merged the target will be changed to master.