### PR TITLE
Audit DB should exclude databasechangeloglock

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit_app/audit.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/audit.clj
@@ -98,8 +98,9 @@
   (let [table-ids-to-update (t2/query {:select [:table.id]
                                        :from [[(t2/table-name :model/Table) :table]]
                                        :where [:and [:= :table.db_id audit-db-id]
-                                               ;; Exclude DATABASECHANGELOG and QRTZ_* tables, they are not metabase managed
+                                               ;; Exclude DATABASECHANGELOG, DATABASECHANGELOGLOCK, and QRTZ_* tables, they are not metabase managed
                                                [:not= :table.name [:inline "DATABASECHANGELOG"]]
+                                               [:not= :table.name [:inline "DATABASECHANGELOGLOCK"]] ;; new instances do not get this file, but existing instances may have it
                                                [:not [:like :table.name [:inline "QRTZ_%"]]]
                                                [:not [:exists {:select [1]
                                                                :from [[(t2/table-name :model/Table) :self_table]]


### PR DESCRIPTION
### Description

We no longer use or create databasechangeloglock, but existing instances may still have it and it is not a metabase-managed table so it should be excluded like databasechangelog is. 

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
