### PR TITLE
More replacements

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/replacement/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/replacement/api.clj
@@ -5,31 +5,13 @@
    [metabase-enterprise.replacement.source-swap :as replacement.source-swap]
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
-   [metabase.lib-be.core :as lib-be]
-   [metabase.lib.metadata :as lib.metadata]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.malli.schema :as ms]
-   [toucan2.core :as t2]))
+   [metabase.util.malli.schema :as ms]))
 
 (set! *warn-on-reflection* true)
 
 (def ^:private entity-type-enum
   [:enum :card :table])
-
-(defn- fetch-source
-  "Fetch source metadata and its database ID. Cards are available from any metadata provider,
-  so we use the source entity's provider. Tables are database-scoped, so we look up the db_id
-  first."
-  [entity-type entity-id]
-  (case entity-type
-    :card  (let [mp   (lib-be/application-database-metadata-provider
-                       (t2/select-one-fn :database_id :model/Card :id entity-id))
-                 card (lib.metadata/card mp entity-id)]
-             {:mp mp :source card :database-id (:database-id card)})
-    :table (let [db-id (t2/select-one-fn :db_id :model/Table :id entity-id)
-                 mp    (lib-be/application-database-metadata-provider db-id)
-                 table (lib.metadata/table mp entity-id)]
-             {:mp mp :source table :database-id (:db-id table)})))
 
 (mr/def ::column
   [:map
@@ -77,9 +59,9 @@
        [:source_entity_type entity-type-enum]
        [:target_entity_id   ms/PositiveInt]
        [:target_entity_type entity-type-enum]]]
-  (let [{source-mp :mp old-source :source source-db :database-id} (fetch-source source_entity_type source_entity_id)
-        {new-source :source target-db :database-id}               (fetch-source target_entity_type target_entity_id)
-        errors (replacement.source/check-replace-source source-mp old-source new-source source-db target-db)]
+  (let [errors (replacement.source/check-replace-source
+                [source_entity_type source_entity_id]
+                [target_entity_type target_entity_id])]
     (if (empty? errors)
       {:success true}
       {:success false :errors errors})))
@@ -94,9 +76,9 @@
        [:source_entity_type entity-type-enum]
        [:target_entity_id   ms/PositiveInt]
        [:target_entity_type entity-type-enum]]]
-  (let [{source-mp :mp old-source :source source-db :database-id} (fetch-source source_entity_type source_entity_id)
-        {new-source :source target-db :database-id}               (fetch-source target_entity_type target_entity_id)
-        errors (replacement.source/check-replace-source source-mp old-source new-source source-db target-db)]
+  (let [errors (replacement.source/check-replace-source
+                [source_entity_type source_entity_id]
+                [target_entity_type target_entity_id])]
     (when (seq errors)
       (throw (ex-info "Sources are not replaceable" {:status-code 400
                                                      :errors errors}))))

--- a/enterprise/backend/test/metabase_enterprise/replacement/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/replacement/api_test.clj
@@ -8,6 +8,20 @@
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 
+(defn- wait-for-result-metadata
+  "Poll until `result_metadata` is populated on the card, up to `timeout-ms` (default 5000)."
+  ([card-id] (wait-for-result-metadata card-id 5000))
+  ([card-id timeout-ms]
+   (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
+     (loop []
+       (let [metadata (t2/select-one-fn :result_metadata :model/Card :id card-id)]
+         (if (seq metadata)
+           metadata
+           (if (< (System/currentTimeMillis) deadline)
+             (do (Thread/sleep 200)
+                 (recur))
+             (throw (ex-info "Timed out waiting for result_metadata" {:card-id card-id})))))))))
+
 (defn- card-with-query
   "Create a card map for the given table keyword."
   [card-name table-kw]
@@ -18,6 +32,18 @@
      :query_type             :query
      :type                   :question
      :dataset_query          (lib/query mp (lib.metadata/table mp (mt/id table-kw)))
+     :visualization_settings {}}))
+
+(defn- native-card-with-query
+  "Create a native card map for the given table keyword."
+  [card-name table-kw]
+  (let [mp (mt/metadata-provider)]
+    {:name                   card-name
+     :database_id            (mt/id)
+     :display                :table
+     :query_type             :native
+     :type                   :question
+     :dataset_query          (lib/native-query mp (str "SELECT * FROM " (name table-kw) " LIMIT 1"))
      :visualization_settings {}}))
 
 (defn- card-sourced-from
@@ -113,6 +139,191 @@
               (let [updated-query (t2/select-one-fn :dataset_query :model/Card :id (:id child))
                     source-card   (get-in updated-query [:stages 0 :source-card])]
                 (is (= (:id new-source) source-card))))))))))
+
+(deftest replace-source-card-to-table-test
+  (testing "POST /api/ee/replacement/replace-source — card -> table swap"
+    (mt/dataset test-data
+      (mt/with-premium-features #{:dependencies}
+        (mt/with-temp [:model/User user {:email "replacement-card-table@test.com"}]
+          (mt/with-model-cleanup [:model/Card :model/Dependency]
+            (let [old-source (card/create-card! (card-with-query "Old source" :products) user)
+                  child      (card/create-card! (card-sourced-from "Child card" old-source) user)]
+              (mt/user-http-request :crowberto :post 204 "ee/replacement/replace-source"
+                                    {:source_entity_id   (:id old-source)
+                                     :source_entity_type :card
+                                     :target_entity_id   (mt/id :products)
+                                     :target_entity_type :table})
+              (let [updated-query (t2/select-one-fn :dataset_query :model/Card :id (:id child))
+                    source-table  (get-in updated-query [:stages 0 :source-table])]
+                (is (= (mt/id :products) source-table))
+                (is (nil? (get-in updated-query [:stages 0 :source-card])))))))))))
+
+(deftest replace-source-card-to-native-card-test
+  (testing "POST /api/ee/replacement/replace-source — MBQL card -> native card swap (same table, no FKs)"
+    (mt/dataset test-data
+      (mt/with-premium-features #{:dependencies}
+        (mt/with-temp [:model/User user {:email "replacement-card-native@test.com"}]
+          (mt/with-model-cleanup [:model/Card :model/Dependency]
+            ;; Use a table without FKs or hidden columns so native card is compatible
+            (let [old-source  (card/create-card! (card-with-query "Old source" :products) user)
+                  native-card (card/create-card! (native-card-with-query "Native source" :products) user)
+                  _           (wait-for-result-metadata (:id native-card))
+                  child       (card/create-card! (card-sourced-from "Child card" old-source) user)]
+              (mt/user-http-request :crowberto :post 204 "ee/replacement/replace-source"
+                                    {:source_entity_id   (:id old-source)
+                                     :source_entity_type :card
+                                     :target_entity_id   (:id native-card)
+                                     :target_entity_type :card})
+              (let [updated-query (t2/select-one-fn :dataset_query :model/Card :id (:id child))
+                    source-card   (get-in updated-query [:stages 0 :source-card])]
+                (is (= (:id native-card) source-card))))))))))
+
+(deftest replace-source-native-card-to-card-test
+  (testing "POST /api/ee/replacement/replace-source — native card -> MBQL card swap (same table, no FKs)"
+    (mt/dataset test-data
+      (mt/with-premium-features #{:dependencies}
+        (mt/with-temp [:model/User user {:email "replacement-native-card@test.com"}]
+          (mt/with-model-cleanup [:model/Card :model/Dependency]
+            (let [native-card (card/create-card! (native-card-with-query "Native source" :products) user)
+                  _           (wait-for-result-metadata (:id native-card))
+                  new-source  (card/create-card! (card-with-query "New source" :products) user)
+                  child       (card/create-card! (card-sourced-from "Child card" native-card) user)]
+              (mt/user-http-request :crowberto :post 204 "ee/replacement/replace-source"
+                                    {:source_entity_id   (:id native-card)
+                                     :source_entity_type :card
+                                     :target_entity_id   (:id new-source)
+                                     :target_entity_type :card})
+              (let [updated-query (t2/select-one-fn :dataset_query :model/Card :id (:id child))
+                    source-card   (get-in updated-query [:stages 0 :source-card])]
+                (is (= (:id new-source) source-card))))))))))
+
+(deftest replace-source-native-card-to-native-card-test
+  (testing "POST /api/ee/replacement/replace-source — native card -> native card swap (same table, no FKs)"
+    (mt/dataset test-data
+      (mt/with-premium-features #{:dependencies}
+        (mt/with-temp [:model/User user {:email "replacement-native-native@test.com"}]
+          (mt/with-model-cleanup [:model/Card :model/Dependency]
+            (let [old-native (card/create-card! (native-card-with-query "Old native" :products) user)
+                  _          (wait-for-result-metadata (:id old-native))
+                  new-native (card/create-card! (native-card-with-query "New native" :products) user)
+                  _          (wait-for-result-metadata (:id new-native))
+                  child      (card/create-card! (card-sourced-from "Child card" old-native) user)]
+              (mt/user-http-request :crowberto :post 204 "ee/replacement/replace-source"
+                                    {:source_entity_id   (:id old-native)
+                                     :source_entity_type :card
+                                     :target_entity_id   (:id new-native)
+                                     :target_entity_type :card})
+              (let [updated-query (t2/select-one-fn :dataset_query :model/Card :id (:id child))
+                    source-card   (get-in updated-query [:stages 0 :source-card])]
+                (is (= (:id new-native) source-card))))))))))
+
+(deftest replace-source-native-card-to-table-test
+  (testing "POST /api/ee/replacement/replace-source — native card -> table swap (same table, no FKs)"
+    (mt/dataset test-data
+      (mt/with-premium-features #{:dependencies}
+        (mt/with-temp [:model/User user {:email "replacement-native-table@test.com"}]
+          (mt/with-model-cleanup [:model/Card :model/Dependency]
+            (let [native-card (card/create-card! (native-card-with-query "Native source" :products) user)
+                  _           (wait-for-result-metadata (:id native-card))
+                  child       (card/create-card! (card-sourced-from "Child card" native-card) user)]
+              (mt/user-http-request :crowberto :post 204 "ee/replacement/replace-source"
+                                    {:source_entity_id   (:id native-card)
+                                     :source_entity_type :card
+                                     :target_entity_id   (mt/id :products)
+                                     :target_entity_type :table})
+              (let [updated-query (t2/select-one-fn :dataset_query :model/Card :id (:id child))
+                    source-table  (get-in updated-query [:stages 0 :source-table])]
+                (is (= (mt/id :products) source-table))
+                (is (nil? (get-in updated-query [:stages 0 :source-card])))))))))))
+
+(deftest replace-source-table-to-card-test
+  (testing "POST /api/ee/replacement/replace-source — table -> card swap"
+    (mt/dataset test-data
+      (mt/with-premium-features #{:dependencies}
+        (mt/with-temp [:model/User user {:email "replacement-table-card@test.com"}]
+          (mt/with-model-cleanup [:model/Card :model/Dependency]
+            (let [new-source (card/create-card! (card-with-query "New source" :products) user)
+                  ;; Child card built directly on the products table
+                  child      (card/create-card! (card-with-query "Child card" :products) user)]
+              (mt/user-http-request :crowberto :post 204 "ee/replacement/replace-source"
+                                    {:source_entity_id   (mt/id :products)
+                                     :source_entity_type :table
+                                     :target_entity_id   (:id new-source)
+                                     :target_entity_type :card})
+              (let [updated-query (t2/select-one-fn :dataset_query :model/Card :id (:id child))
+                    source-card   (get-in updated-query [:stages 0 :source-card])]
+                (is (= (:id new-source) source-card))
+                (is (nil? (get-in updated-query [:stages 0 :source-table])))))))))))
+
+(deftest replace-source-table-to-table-test
+  (testing "POST /api/ee/replacement/replace-source — table -> table swap (same schema)"
+    (mt/dataset test-data
+      (mt/with-premium-features #{:dependencies}
+        (mt/with-temp [:model/User user {:email "replacement-table-table@test.com"}
+                       ;; Create a second table with the same schema by using a card on products
+                       ;; We can't easily create a real second table, so we test table -> table
+                       ;; by swapping products for itself (verifies the mechanics work)
+                       ]
+          (mt/with-model-cleanup [:model/Card :model/Dependency]
+            (let [child (card/create-card! (card-with-query "Child card" :products) user)]
+              (mt/user-http-request :crowberto :post 204 "ee/replacement/replace-source"
+                                    {:source_entity_id   (mt/id :products)
+                                     :source_entity_type :table
+                                     :target_entity_id   (mt/id :products)
+                                     :target_entity_type :table})
+              (let [updated-query (t2/select-one-fn :dataset_query :model/Card :id (:id child))
+                    source-table  (get-in updated-query [:stages 0 :source-table])]
+                (is (= (mt/id :products) source-table))))))))))
+
+(deftest replace-source-table-to-native-card-test
+  (testing "POST /api/ee/replacement/replace-source — table -> native card swap (same table, no FKs)"
+    (mt/dataset test-data
+      (mt/with-premium-features #{:dependencies}
+        (mt/with-temp [:model/User user {:email "replacement-table-native@test.com"}]
+          (mt/with-model-cleanup [:model/Card :model/Dependency]
+            (let [native-card (card/create-card! (native-card-with-query "Native target" :products) user)
+                  _           (wait-for-result-metadata (:id native-card))
+                  child       (card/create-card! (card-with-query "Child card" :products) user)]
+              (mt/user-http-request :crowberto :post 204 "ee/replacement/replace-source"
+                                    {:source_entity_id   (mt/id :products)
+                                     :source_entity_type :table
+                                     :target_entity_id   (:id native-card)
+                                     :target_entity_type :card})
+              (let [updated-query (t2/select-one-fn :dataset_query :model/Card :id (:id child))
+                    source-card   (get-in updated-query [:stages 0 :source-card])]
+                (is (= (:id native-card) source-card))
+                (is (nil? (get-in updated-query [:stages 0 :source-table])))))))))))
+
+(deftest replace-source-incompatible-returns-400-test
+  (testing "POST /api/ee/replacement/replace-source — incompatible sources return 400"
+    (mt/dataset test-data
+      (mt/with-premium-features #{:dependencies}
+        (mt/with-temp [:model/User user {:email "replacement-incompat@test.com"}]
+          (mt/with-model-cleanup [:model/Card :model/Dependency]
+            (let [old-source (card/create-card! (card-with-query "Products card" :products) user)
+                  new-source (card/create-card! (card-with-query "Orders card" :orders) user)]
+              (mt/user-http-request :crowberto :post 400 "ee/replacement/replace-source"
+                                    {:source_entity_id   (:id old-source)
+                                     :source_entity_type :card
+                                     :target_entity_id   (:id new-source)
+                                     :target_entity_type :card}))))))))
+
+(deftest replace-source-database-mismatch-returns-400-test
+  (testing "POST /api/ee/replacement/replace-source — database mismatch returns 400"
+    (mt/dataset test-data
+      (mt/with-premium-features #{:dependencies}
+        (mt/with-temp [:model/Card card-a (card-with-query "Card A" :products)]
+          (with-redefs [replacement.api/fetch-source
+                        (fn [_entity-type entity-id]
+                          (if (= entity-id (:id card-a))
+                            {:mp nil :source nil :database-id 1}
+                            {:mp nil :source nil :database-id 999}))]
+            (mt/with-temp [:model/Card card-b (card-with-query "Card B" :products)]
+              (mt/user-http-request :crowberto :post 400 "ee/replacement/replace-source"
+                                    {:source_entity_id   (:id card-a)
+                                     :source_entity_type :card
+                                     :target_entity_id   (:id card-b)
+                                     :target_entity_type :card}))))))))
 
 (deftest replace-source-requires-premium-feature-test
   (testing "POST /api/ee/replacement/replace-source — requires :dependencies premium feature"

--- a/enterprise/backend/test/metabase_enterprise/replacement/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/replacement/api_test.clj
@@ -1,40 +1,10 @@
 (ns metabase-enterprise.replacement.api-test
   (:require
    [clojure.test :refer :all]
-   [metabase-enterprise.replacement.api :as replacement.api]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.queries.models.card :as card]
-   [metabase.test :as mt]
-   [toucan2.core :as t2]))
-
-(defn- wait-for-result-metadata
-  "Poll until `result_metadata` is populated on the card, up to `timeout-ms` (default 5000)."
-  ([card-id] (wait-for-result-metadata card-id 5000))
-  ([card-id timeout-ms]
-   (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
-     (loop []
-       (let [metadata (t2/select-one-fn :result_metadata :model/Card :id card-id)]
-         (if (seq metadata)
-           metadata
-           (if (< (System/currentTimeMillis) deadline)
-             (do (Thread/sleep 200)
-                 (recur))
-             (throw (ex-info "Timed out waiting for result_metadata" {:card-id card-id})))))))))
-
-(defmacro with-restored-card-queries
-  "Snapshots every card's `dataset_query` before `body` and restores them
-  afterwards, so that swap-source side-effects on pre-existing cards don't
-  leak between tests."
-  [& body]
-  `(let [snapshot# (into {} (t2/select-fn->fn :id :dataset_query :model/Card))]
-     (try
-       ~@body
-       (finally
-         (doseq [[id# old-query#] snapshot#
-                 :let [current# (t2/select-one-fn :dataset_query :model/Card :id id#)]
-                 :when (and (some? old-query#) (not= old-query# current#))]
-           (t2/update! :model/Card id# {:dataset_query old-query#}))))))
+   [metabase.test :as mt]))
 
 (defn- card-with-query
   "Create a card map for the given table keyword."
@@ -46,18 +16,6 @@
      :query_type             :query
      :type                   :question
      :dataset_query          (lib/query mp (lib.metadata/table mp (mt/id table-kw)))
-     :visualization_settings {}}))
-
-(defn- native-card-with-query
-  "Create a native card map for the given table keyword."
-  [card-name table-kw]
-  (let [mp (mt/metadata-provider)]
-    {:name                   card-name
-     :database_id            (mt/id)
-     :display                :table
-     :query_type             :native
-     :type                   :question
-     :dataset_query          (lib/native-query mp (str "SELECT * FROM " (name table-kw) " LIMIT 1"))
      :visualization_settings {}}))
 
 (defn- card-sourced-from
@@ -107,21 +65,23 @@
   (testing "POST /api/ee/replacement/check-replace-source — database mismatch short-circuits"
     (mt/dataset test-data
       (mt/with-premium-features #{:dependencies}
-        (mt/with-temp [:model/Card card-a (card-with-query "Card A" :products)]
-          (with-redefs [replacement.api/fetch-source
-                        (fn [entity-type entity-id]
-                          ;; Return different database-id values to trigger the mismatch
-                          (if (= entity-id (:id card-a))
-                            {:mp nil :source nil :database-id 1}
-                            {:mp nil :source nil :database-id 999}))]
-            (mt/with-temp [:model/Card card-b (card-with-query "Card B" :products)]
-              (let [response (mt/user-http-request :crowberto :post 200 "ee/replacement/check-replace-source"
-                                                   {:source_entity_id   (:id card-a)
-                                                    :source_entity_type :card
-                                                    :target_entity_id   (:id card-b)
-                                                    :target_entity_type :card})]
-                (is (false? (:success response)))
-                (is (some #(= "database-mismatch" (:type %)) (:errors response)))))))))))
+        (mt/with-temp [:model/Database other-db {:engine  :h2
+                                                 :details (:details (mt/db))}
+                       :model/Card card-a (card-with-query "Card A" :products)
+                       :model/Card card-b {:name                   "Card B"
+                                           :database_id            (:id other-db)
+                                           :type                   :question
+                                           :dataset_query          {:database (:id other-db)
+                                                                    :type     :native
+                                                                    :native   {:query "SELECT 1"}}
+                                           :visualization_settings {}}]
+          (let [response (mt/user-http-request :crowberto :post 200 "ee/replacement/check-replace-source"
+                                               {:source_entity_id   (:id card-a)
+                                                :source_entity_type :card
+                                                :target_entity_id   (:id card-b)
+                                                :target_entity_type :card})]
+            (is (false? (:success response)))
+            (is (some #(= "database-mismatch" (:type %)) (:errors response)))))))))
 
 (deftest check-replace-source-requires-premium-feature-test
   (testing "POST /api/ee/replacement/check-replace-source — requires :dependencies premium feature"
@@ -134,178 +94,20 @@
 
 ;;; ------------------------------------------------ replace-source ------------------------------------------------
 
-(deftest replace-source-swaps-card-references-test
-  (testing "POST /api/ee/replacement/replace-source — swaps child card references"
+(deftest replace-source-returns-204-test
+  (testing "POST /api/ee/replacement/replace-source — returns 204 on success"
     (mt/dataset test-data
       (mt/with-premium-features #{:dependencies}
         (mt/with-temp [:model/User user {:email "replacement-test@test.com"}]
           (mt/with-model-cleanup [:model/Card :model/Dependency]
-            ;; Use create-card! so that dependency events fire and seed the Dependency table
             (let [old-source (card/create-card! (card-with-query "Old source" :products) user)
                   new-source (card/create-card! (card-with-query "New source" :products) user)
-                  child      (card/create-card! (card-sourced-from "Child card" old-source) user)]
+                  _child     (card/create-card! (card-sourced-from "Child card" old-source) user)]
               (mt/user-http-request :crowberto :post 204 "ee/replacement/replace-source"
                                     {:source_entity_id   (:id old-source)
                                      :source_entity_type :card
                                      :target_entity_id   (:id new-source)
-                                     :target_entity_type :card})
-              ;; The child card's query should now reference new-source
-              (let [updated-query (t2/select-one-fn :dataset_query :model/Card :id (:id child))
-                    source-card   (get-in updated-query [:stages 0 :source-card])]
-                (is (= (:id new-source) source-card))))))))))
-
-(deftest replace-source-card-to-table-test
-  (testing "POST /api/ee/replacement/replace-source — card -> table swap"
-    (mt/dataset test-data
-      (mt/with-premium-features #{:dependencies}
-        (mt/with-temp [:model/User user {:email "replacement-card-table@test.com"}]
-          (mt/with-model-cleanup [:model/Card :model/Dependency]
-            (let [old-source (card/create-card! (card-with-query "Old source" :products) user)
-                  child      (card/create-card! (card-sourced-from "Child card" old-source) user)]
-              (mt/user-http-request :crowberto :post 204 "ee/replacement/replace-source"
-                                    {:source_entity_id   (:id old-source)
-                                     :source_entity_type :card
-                                     :target_entity_id   (mt/id :products)
-                                     :target_entity_type :table})
-              (let [updated-query (t2/select-one-fn :dataset_query :model/Card :id (:id child))
-                    source-table  (get-in updated-query [:stages 0 :source-table])]
-                (is (= (mt/id :products) source-table))
-                (is (nil? (get-in updated-query [:stages 0 :source-card])))))))))))
-
-(deftest replace-source-card-to-native-card-test
-  (testing "POST /api/ee/replacement/replace-source — MBQL card -> native card swap (same table, no FKs)"
-    (mt/dataset test-data
-      (mt/with-premium-features #{:dependencies}
-        (mt/with-temp [:model/User user {:email "replacement-card-native@test.com"}]
-          (mt/with-model-cleanup [:model/Card :model/Dependency]
-            ;; Use a table without FKs or hidden columns so native card is compatible
-            (let [old-source  (card/create-card! (card-with-query "Old source" :products) user)
-                  native-card (card/create-card! (native-card-with-query "Native source" :products) user)
-                  _           (wait-for-result-metadata (:id native-card))
-                  child       (card/create-card! (card-sourced-from "Child card" old-source) user)]
-              (mt/user-http-request :crowberto :post 204 "ee/replacement/replace-source"
-                                    {:source_entity_id   (:id old-source)
-                                     :source_entity_type :card
-                                     :target_entity_id   (:id native-card)
-                                     :target_entity_type :card})
-              (let [updated-query (t2/select-one-fn :dataset_query :model/Card :id (:id child))
-                    source-card   (get-in updated-query [:stages 0 :source-card])]
-                (is (= (:id native-card) source-card))))))))))
-
-(deftest replace-source-native-card-to-card-test
-  (testing "POST /api/ee/replacement/replace-source — native card -> MBQL card swap (same table, no FKs)"
-    (mt/dataset test-data
-      (mt/with-premium-features #{:dependencies}
-        (mt/with-temp [:model/User user {:email "replacement-native-card@test.com"}]
-          (mt/with-model-cleanup [:model/Card :model/Dependency]
-            (let [native-card (card/create-card! (native-card-with-query "Native source" :products) user)
-                  _           (wait-for-result-metadata (:id native-card))
-                  new-source  (card/create-card! (card-with-query "New source" :products) user)
-                  child       (card/create-card! (card-sourced-from "Child card" native-card) user)]
-              (mt/user-http-request :crowberto :post 204 "ee/replacement/replace-source"
-                                    {:source_entity_id   (:id native-card)
-                                     :source_entity_type :card
-                                     :target_entity_id   (:id new-source)
-                                     :target_entity_type :card})
-              (let [updated-query (t2/select-one-fn :dataset_query :model/Card :id (:id child))
-                    source-card   (get-in updated-query [:stages 0 :source-card])]
-                (is (= (:id new-source) source-card))))))))))
-
-(deftest replace-source-native-card-to-native-card-test
-  (testing "POST /api/ee/replacement/replace-source — native card -> native card swap (same table, no FKs)"
-    (mt/dataset test-data
-      (mt/with-premium-features #{:dependencies}
-        (mt/with-temp [:model/User user {:email "replacement-native-native@test.com"}]
-          (mt/with-model-cleanup [:model/Card :model/Dependency]
-            (let [old-native (card/create-card! (native-card-with-query "Old native" :products) user)
-                  _          (wait-for-result-metadata (:id old-native))
-                  new-native (card/create-card! (native-card-with-query "New native" :products) user)
-                  _          (wait-for-result-metadata (:id new-native))
-                  child      (card/create-card! (card-sourced-from "Child card" old-native) user)]
-              (mt/user-http-request :crowberto :post 204 "ee/replacement/replace-source"
-                                    {:source_entity_id   (:id old-native)
-                                     :source_entity_type :card
-                                     :target_entity_id   (:id new-native)
-                                     :target_entity_type :card})
-              (let [updated-query (t2/select-one-fn :dataset_query :model/Card :id (:id child))
-                    source-card   (get-in updated-query [:stages 0 :source-card])]
-                (is (= (:id new-native) source-card))))))))))
-
-(deftest replace-source-native-card-to-table-test
-  (testing "POST /api/ee/replacement/replace-source — native card -> table swap (same table, no FKs)"
-    (mt/dataset test-data
-      (mt/with-premium-features #{:dependencies}
-        (mt/with-temp [:model/User user {:email "replacement-native-table@test.com"}]
-          (mt/with-model-cleanup [:model/Card :model/Dependency]
-            (let [native-card (card/create-card! (native-card-with-query "Native source" :products) user)
-                  _           (wait-for-result-metadata (:id native-card))
-                  child       (card/create-card! (card-sourced-from "Child card" native-card) user)]
-              (mt/user-http-request :crowberto :post 204 "ee/replacement/replace-source"
-                                    {:source_entity_id   (:id native-card)
-                                     :source_entity_type :card
-                                     :target_entity_id   (mt/id :products)
-                                     :target_entity_type :table})
-              (let [updated-query (t2/select-one-fn :dataset_query :model/Card :id (:id child))
-                    source-table  (get-in updated-query [:stages 0 :source-table])]
-                (is (= (mt/id :products) source-table))
-                (is (nil? (get-in updated-query [:stages 0 :source-card])))))))))))
-
-(deftest replace-source-table-to-card-test
-  (testing "POST /api/ee/replacement/replace-source — table -> card swap"
-    (mt/dataset test-data
-      (mt/with-premium-features #{:dependencies}
-        (mt/with-temp [:model/User user {:email "replacement-table-card@test.com"}]
-          (mt/with-model-cleanup [:model/Card :model/Dependency]
-            (with-restored-card-queries
-              (let [new-source (card/create-card! (card-with-query "New source" :products) user)
-                    ;; Child card built directly on the products table
-                    child      (card/create-card! (card-with-query "Child card" :products) user)]
-                (mt/user-http-request :crowberto :post 204 "ee/replacement/replace-source"
-                                      {:source_entity_id   (mt/id :products)
-                                       :source_entity_type :table
-                                       :target_entity_id   (:id new-source)
-                                       :target_entity_type :card})
-                (let [updated-query (t2/select-one-fn :dataset_query :model/Card :id (:id child))
-                      source-card   (get-in updated-query [:stages 0 :source-card])]
-                  (is (= (:id new-source) source-card))
-                  (is (nil? (get-in updated-query [:stages 0 :source-table]))))))))))))
-
-(deftest replace-source-table-to-table-test
-  (testing "POST /api/ee/replacement/replace-source — table -> table swap (same schema)"
-    (mt/dataset test-data
-      (mt/with-premium-features #{:dependencies}
-        (mt/with-temp [:model/User user {:email "replacement-table-table@test.com"}]
-          (mt/with-model-cleanup [:model/Card :model/Dependency]
-            (with-restored-card-queries
-              (let [child (card/create-card! (card-with-query "Child card" :products) user)]
-                (mt/user-http-request :crowberto :post 204 "ee/replacement/replace-source"
-                                      {:source_entity_id   (mt/id :products)
-                                       :source_entity_type :table
-                                       :target_entity_id   (mt/id :products)
-                                       :target_entity_type :table})
-                (let [updated-query (t2/select-one-fn :dataset_query :model/Card :id (:id child))
-                      source-table  (get-in updated-query [:stages 0 :source-table])]
-                  (is (= (mt/id :products) source-table)))))))))))
-
-(deftest replace-source-table-to-native-card-test
-  (testing "POST /api/ee/replacement/replace-source — table -> native card swap (same table, no FKs)"
-    (mt/dataset test-data
-      (mt/with-premium-features #{:dependencies}
-        (mt/with-temp [:model/User user {:email "replacement-table-native@test.com"}]
-          (mt/with-model-cleanup [:model/Card :model/Dependency]
-            (with-restored-card-queries
-              (let [native-card (card/create-card! (native-card-with-query "Native target" :products) user)
-                    _           (wait-for-result-metadata (:id native-card))
-                    child       (card/create-card! (card-with-query "Child card" :products) user)]
-                (mt/user-http-request :crowberto :post 204 "ee/replacement/replace-source"
-                                      {:source_entity_id   (mt/id :products)
-                                       :source_entity_type :table
-                                       :target_entity_id   (:id native-card)
-                                       :target_entity_type :card})
-                (let [updated-query (t2/select-one-fn :dataset_query :model/Card :id (:id child))
-                      source-card   (get-in updated-query [:stages 0 :source-card])]
-                  (is (= (:id native-card) source-card))
-                  (is (nil? (get-in updated-query [:stages 0 :source-table]))))))))))))
+                                     :target_entity_type :card}))))))))
 
 (deftest replace-source-incompatible-returns-400-test
   (testing "POST /api/ee/replacement/replace-source — incompatible sources return 400"
@@ -325,18 +127,21 @@
   (testing "POST /api/ee/replacement/replace-source — database mismatch returns 400"
     (mt/dataset test-data
       (mt/with-premium-features #{:dependencies}
-        (mt/with-temp [:model/Card card-a (card-with-query "Card A" :products)]
-          (with-redefs [replacement.api/fetch-source
-                        (fn [_entity-type entity-id]
-                          (if (= entity-id (:id card-a))
-                            {:mp nil :source nil :database-id 1}
-                            {:mp nil :source nil :database-id 999}))]
-            (mt/with-temp [:model/Card card-b (card-with-query "Card B" :products)]
-              (mt/user-http-request :crowberto :post 400 "ee/replacement/replace-source"
-                                    {:source_entity_id   (:id card-a)
-                                     :source_entity_type :card
-                                     :target_entity_id   (:id card-b)
-                                     :target_entity_type :card}))))))))
+        (mt/with-temp [:model/Database other-db {:engine  :h2
+                                                 :details (:details (mt/db))}
+                       :model/Card card-a (card-with-query "Card A" :products)
+                       :model/Card card-b {:name                   "Card B"
+                                           :database_id            (:id other-db)
+                                           :type                   :question
+                                           :dataset_query          {:database (:id other-db)
+                                                                    :type     :native
+                                                                    :native   {:query "SELECT 1"}}
+                                           :visualization_settings {}}]
+          (mt/user-http-request :crowberto :post 400 "ee/replacement/replace-source"
+                                {:source_entity_id   (:id card-a)
+                                 :source_entity_type :card
+                                 :target_entity_id   (:id card-b)
+                                 :target_entity_type :card}))))))
 
 (deftest replace-source-requires-premium-feature-test
   (testing "POST /api/ee/replacement/replace-source — requires :dependencies premium feature"

--- a/enterprise/backend/test/metabase_enterprise/replacement/source_swap_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/replacement/source_swap_test.clj
@@ -7,11 +7,79 @@
    [metabase.events.core :as events]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.queries.models.card :as card]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 
 (comment
   metabase-enterprise.dependencies.events/keep-me)
+
+(defn- wait-for-result-metadata
+  "Poll until `result_metadata` is populated on the card, up to `timeout-ms` (default 5000)."
+  ([card-id] (wait-for-result-metadata card-id 5000))
+  ([card-id timeout-ms]
+   (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
+     (loop []
+       (let [metadata (t2/select-one-fn :result_metadata :model/Card :id card-id)]
+         (if (seq metadata)
+           metadata
+           (if (< (System/currentTimeMillis) deadline)
+             (do (Thread/sleep 200)
+                 (recur))
+             (throw (ex-info "Timed out waiting for result_metadata" {:card-id card-id})))))))))
+
+(defn- card-with-query
+  "Create a card map for the given table keyword."
+  [card-name table-kw]
+  (let [mp (mt/metadata-provider)]
+    {:name                   card-name
+     :database_id            (mt/id)
+     :display                :table
+     :query_type             :query
+     :type                   :question
+     :dataset_query          (lib/query mp (lib.metadata/table mp (mt/id table-kw)))
+     :visualization_settings {}}))
+
+(defn- native-card-with-query
+  "Create a native card map for the given table keyword."
+  [card-name table-kw]
+  (let [mp (mt/metadata-provider)]
+    {:name                   card-name
+     :database_id            (mt/id)
+     :display                :table
+     :query_type             :native
+     :type                   :question
+     :dataset_query          (lib/native-query mp (str "SELECT * FROM " (name table-kw) " LIMIT 1"))
+     :visualization_settings {}}))
+
+(defn- card-sourced-from
+  "Create a card map whose query sources `inner-card`."
+  [card-name inner-card]
+  (let [mp        (mt/metadata-provider)
+        card-meta (lib.metadata/card mp (:id inner-card))]
+    {:name                   card-name
+     :database_id            (mt/id)
+     :display                :table
+     :query_type             :query
+     :type                   :question
+     :dataset_query          (lib/query mp card-meta)
+     :visualization_settings {}}))
+
+(defmacro ^:private with-restored-card-queries
+  "Snapshots every card's `dataset_query` before `body` and restores them
+  afterwards, so that swap-source side-effects on pre-existing cards don't
+  leak between tests."
+  [& body]
+  `(let [snapshot# (into {} (t2/select-fn->fn :id :dataset_query :model/Card))]
+     (try
+       ~@body
+       (finally
+         (doseq [[id# old-query#] snapshot#
+                 :let [current# (t2/select-one-fn :dataset_query :model/Card :id id#)]
+                 :when (and (some? old-query#) (not= old-query# current#))]
+           (t2/update! :model/Card id# {:dataset_query old-query#}))))))
+
+;;; ------------------------------------------------ swap-native-card-source! ------------------------------------------------
 
 (deftest swap-native-card-source!-updates-query-test
   (testing "Card referencing the old card gets its query text and template tags updated"
@@ -72,3 +140,133 @@
                   "After swap: dependency on new source should exist")
               (is (not (contains? deps {:to_entity_type :card :to_entity_id old-source-id}))
                   "After swap: dependency on old source should be gone"))))))))
+
+;;; ------------------------------------------------ swap-source: card -> X ------------------------------------------------
+
+(deftest swap-source-card-to-card-test
+  (testing "swap-source card -> card: child card's source-card is updated"
+    (mt/dataset test-data
+      (mt/with-premium-features #{:dependencies}
+        (mt/with-temp [:model/User user {:email "swap-card-card@test.com"}]
+          (mt/with-model-cleanup [:model/Card :model/Dependency]
+            (let [old-source (card/create-card! (card-with-query "Old source" :products) user)
+                  new-source (card/create-card! (card-with-query "New source" :products) user)
+                  child      (card/create-card! (card-sourced-from "Child card" old-source) user)]
+              (source-swap/swap-source [:card (:id old-source)] [:card (:id new-source)])
+              (let [updated-query (t2/select-one-fn :dataset_query :model/Card :id (:id child))]
+                (is (= (:id new-source) (get-in updated-query [:stages 0 :source-card])))))))))))
+
+(deftest swap-source-card-to-table-test
+  (testing "swap-source card -> table: child card's source changes to source-table"
+    (mt/dataset test-data
+      (mt/with-premium-features #{:dependencies}
+        (mt/with-temp [:model/User user {:email "swap-card-table@test.com"}]
+          (mt/with-model-cleanup [:model/Card :model/Dependency]
+            (let [old-source (card/create-card! (card-with-query "Old source" :products) user)
+                  child      (card/create-card! (card-sourced-from "Child card" old-source) user)]
+              (source-swap/swap-source [:card (:id old-source)] [:table (mt/id :products)])
+              (let [updated-query (t2/select-one-fn :dataset_query :model/Card :id (:id child))]
+                (is (= (mt/id :products) (get-in updated-query [:stages 0 :source-table])))
+                (is (nil? (get-in updated-query [:stages 0 :source-card])))))))))))
+
+(deftest swap-source-card-to-native-card-test
+  (testing "swap-source card -> native card: child card's source-card is updated"
+    (mt/dataset test-data
+      (mt/with-premium-features #{:dependencies}
+        (mt/with-temp [:model/User user {:email "swap-card-native@test.com"}]
+          (mt/with-model-cleanup [:model/Card :model/Dependency]
+            (let [old-source  (card/create-card! (card-with-query "Old source" :products) user)
+                  native-card (card/create-card! (native-card-with-query "Native target" :products) user)
+                  _           (wait-for-result-metadata (:id native-card))
+                  child       (card/create-card! (card-sourced-from "Child card" old-source) user)]
+              (source-swap/swap-source [:card (:id old-source)] [:card (:id native-card)])
+              (let [updated-query (t2/select-one-fn :dataset_query :model/Card :id (:id child))]
+                (is (= (:id native-card) (get-in updated-query [:stages 0 :source-card])))))))))))
+
+;;; ------------------------------------------------ swap-source: native card -> X ------------------------------------------------
+
+(deftest swap-source-native-card-to-card-test
+  (testing "swap-source native card -> card: child card's source-card is updated"
+    (mt/dataset test-data
+      (mt/with-premium-features #{:dependencies}
+        (mt/with-temp [:model/User user {:email "swap-native-card@test.com"}]
+          (mt/with-model-cleanup [:model/Card :model/Dependency]
+            (let [native-card (card/create-card! (native-card-with-query "Native source" :products) user)
+                  _           (wait-for-result-metadata (:id native-card))
+                  new-source  (card/create-card! (card-with-query "New source" :products) user)
+                  child       (card/create-card! (card-sourced-from "Child card" native-card) user)]
+              (source-swap/swap-source [:card (:id native-card)] [:card (:id new-source)])
+              (let [updated-query (t2/select-one-fn :dataset_query :model/Card :id (:id child))]
+                (is (= (:id new-source) (get-in updated-query [:stages 0 :source-card])))))))))))
+
+(deftest swap-source-native-card-to-native-card-test
+  (testing "swap-source native card -> native card: child card's source-card is updated"
+    (mt/dataset test-data
+      (mt/with-premium-features #{:dependencies}
+        (mt/with-temp [:model/User user {:email "swap-native-native@test.com"}]
+          (mt/with-model-cleanup [:model/Card :model/Dependency]
+            (let [old-native (card/create-card! (native-card-with-query "Old native" :products) user)
+                  _          (wait-for-result-metadata (:id old-native))
+                  new-native (card/create-card! (native-card-with-query "New native" :products) user)
+                  _          (wait-for-result-metadata (:id new-native))
+                  child      (card/create-card! (card-sourced-from "Child card" old-native) user)]
+              (source-swap/swap-source [:card (:id old-native)] [:card (:id new-native)])
+              (let [updated-query (t2/select-one-fn :dataset_query :model/Card :id (:id child))]
+                (is (= (:id new-native) (get-in updated-query [:stages 0 :source-card])))))))))))
+
+(deftest swap-source-native-card-to-table-test
+  (testing "swap-source native card -> table: child card's source changes to source-table"
+    (mt/dataset test-data
+      (mt/with-premium-features #{:dependencies}
+        (mt/with-temp [:model/User user {:email "swap-native-table@test.com"}]
+          (mt/with-model-cleanup [:model/Card :model/Dependency]
+            (let [native-card (card/create-card! (native-card-with-query "Native source" :products) user)
+                  _           (wait-for-result-metadata (:id native-card))
+                  child       (card/create-card! (card-sourced-from "Child card" native-card) user)]
+              (source-swap/swap-source [:card (:id native-card)] [:table (mt/id :products)])
+              (let [updated-query (t2/select-one-fn :dataset_query :model/Card :id (:id child))]
+                (is (= (mt/id :products) (get-in updated-query [:stages 0 :source-table])))
+                (is (nil? (get-in updated-query [:stages 0 :source-card])))))))))))
+
+;;; ------------------------------------------------ swap-source: table -> X ------------------------------------------------
+
+(deftest swap-source-table-to-card-test
+  (testing "swap-source table -> card: child card's source changes to source-card"
+    (mt/dataset test-data
+      (mt/with-premium-features #{:dependencies}
+        (mt/with-temp [:model/User user {:email "swap-table-card@test.com"}]
+          (mt/with-model-cleanup [:model/Card :model/Dependency]
+            (with-restored-card-queries
+              (let [new-source (card/create-card! (card-with-query "New source" :products) user)
+                    child      (card/create-card! (card-with-query "Child card" :products) user)]
+                (source-swap/swap-source [:table (mt/id :products)] [:card (:id new-source)])
+                (let [updated-query (t2/select-one-fn :dataset_query :model/Card :id (:id child))]
+                  (is (= (:id new-source) (get-in updated-query [:stages 0 :source-card])))
+                  (is (nil? (get-in updated-query [:stages 0 :source-table]))))))))))))
+
+(deftest swap-source-table-to-table-test
+  (testing "swap-source table -> table: child card's source-table is updated"
+    (mt/dataset test-data
+      (mt/with-premium-features #{:dependencies}
+        (mt/with-temp [:model/User user {:email "swap-table-table@test.com"}]
+          (mt/with-model-cleanup [:model/Card :model/Dependency]
+            (with-restored-card-queries
+              (let [child (card/create-card! (card-with-query "Child card" :products) user)]
+                (source-swap/swap-source [:table (mt/id :products)] [:table (mt/id :products)])
+                (let [updated-query (t2/select-one-fn :dataset_query :model/Card :id (:id child))]
+                  (is (= (mt/id :products) (get-in updated-query [:stages 0 :source-table]))))))))))))
+
+(deftest swap-source-table-to-native-card-test
+  (testing "swap-source table -> native card: child card's source changes to source-card"
+    (mt/dataset test-data
+      (mt/with-premium-features #{:dependencies}
+        (mt/with-temp [:model/User user {:email "swap-table-native@test.com"}]
+          (mt/with-model-cleanup [:model/Card :model/Dependency]
+            (with-restored-card-queries
+              (let [native-card (card/create-card! (native-card-with-query "Native target" :products) user)
+                    _           (wait-for-result-metadata (:id native-card))
+                    child       (card/create-card! (card-with-query "Child card" :products) user)]
+                (source-swap/swap-source [:table (mt/id :products)] [:card (:id native-card)])
+                (let [updated-query (t2/select-one-fn :dataset_query :model/Card :id (:id child))]
+                  (is (= (:id native-card) (get-in updated-query [:stages 0 :source-card])))
+                  (is (nil? (get-in updated-query [:stages 0 :source-table]))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/replacement/source_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/replacement/source_test.clj
@@ -31,7 +31,7 @@
             tables (lib.metadata/tables mp)]
         (doseq [table tables]
           (testing (str "table: " (:name table))
-            (is (empty? (replacement.source/check-replace-source mp table table)))))))))
+            (is (empty? (replacement.source/check-replace-source mp table table (mt/id) (mt/id))))))))))
 
 (deftest card-swappable-with-underlying-table-test
   (testing "A card built on a table is swappable with that table in both directions"
@@ -48,9 +48,9 @@
               (let [card-meta (lib.metadata/card mp (:id card))]
                 (testing (str "table: " (:name table))
                   (testing "card -> table"
-                    (is (empty? (replacement.source/check-replace-source mp card-meta table))))
+                    (is (empty? (replacement.source/check-replace-source mp card-meta table (mt/id) (mt/id)))))
                   (testing "table -> card"
-                    (is (empty? (replacement.source/check-replace-source mp table card-meta)))))))))))))
+                    (is (empty? (replacement.source/check-replace-source mp table card-meta (mt/id) (mt/id))))))))))))))
 
 (deftest two-cards-on-same-table-swappable-test
   (testing "Two cards built on the same table are swappable in both directions"
@@ -72,9 +72,9 @@
                   meta-b (lib.metadata/card mp (:id card-b))]
               (testing (str "table: " (:name table))
                 (testing "card-a -> card-b"
-                  (is (empty? (replacement.source/check-replace-source mp meta-a meta-b))))
+                  (is (empty? (replacement.source/check-replace-source mp meta-a meta-b (mt/id) (mt/id)))))
                 (testing "card-b -> card-a"
-                  (is (empty? (replacement.source/check-replace-source mp meta-b meta-a))))))))))))
+                  (is (empty? (replacement.source/check-replace-source mp meta-b meta-a (mt/id) (mt/id)))))))))))))
 
 (deftest card-with-expression-reports-extra-column-test
   (testing "A card with an added expression column reports :column-mismatch with :extra_columns"
@@ -89,7 +89,7 @@
                                          :database_id   (mt/id)
                                          :type          :question}]
           (let [card-meta (lib.metadata/card mp (:id card))
-                errors    (replacement.source/check-replace-source mp table card-meta)]
+                errors    (replacement.source/check-replace-source mp table card-meta (mt/id) (mt/id))]
             (testing "table -> card with expression: extra column reported"
               (is (some #(= :column-mismatch (:type %)) errors))
               (is (some (fn [err]
@@ -97,7 +97,7 @@
                                (some #(= "double_price" (:name %)) (:extra_columns err))))
                         errors)))
             (testing "card with expression -> table: missing column reported"
-              (let [reverse-errors (replacement.source/check-replace-source mp card-meta table)]
+              (let [reverse-errors (replacement.source/check-replace-source mp card-meta table (mt/id) (mt/id))]
                 (is (some #(= :column-mismatch (:type %)) reverse-errors))
                 (is (some (fn [err]
                             (and (= :column-mismatch (:type err))
@@ -118,7 +118,7 @@
                                          :type          :question}]
           (let [card-meta     (lib.metadata/card mp (:id card))
                 dropped-names (set (map #(or (:lib/desired-column-alias %) (:name %)) (drop 2 cols)))
-                errors        (replacement.source/check-replace-source mp table card-meta)]
+                errors        (replacement.source/check-replace-source mp table card-meta (mt/id) (mt/id))]
             (testing "table -> card with fewer fields: extra columns reported (card is missing them)"
               (is (some #(= :column-mismatch (:type %)) errors))
               (is (some (fn [err]
@@ -126,7 +126,7 @@
                                (every? #(contains? dropped-names (:name %)) (:missing_columns err))))
                         errors)))
             (testing "card with fewer fields -> table: extra columns reported"
-              (let [reverse-errors (replacement.source/check-replace-source mp card-meta table)]
+              (let [reverse-errors (replacement.source/check-replace-source mp card-meta table (mt/id) (mt/id))]
                 (is (some #(= :column-mismatch (:type %)) reverse-errors))
                 (is (some (fn [err]
                             (and (= :column-mismatch (:type err))
@@ -173,10 +173,10 @@
                 (testing (str "table: " (:name table))
                   (testing "table -> native card: fk-mismatch reported"
                     (is (some #(= :fk-mismatch (:type %))
-                              (replacement.source/check-replace-source mp table card-meta))))
+                              (replacement.source/check-replace-source mp table card-meta (mt/id) (mt/id)))))
                   (testing "native card -> table: fk-mismatch reported"
                     (is (some #(= :fk-mismatch (:type %))
-                              (replacement.source/check-replace-source mp card-meta table)))))))))))))
+                              (replacement.source/check-replace-source mp card-meta table (mt/id) (mt/id))))))))))))))
 
 (deftest native-card-swappable-with-table-test
   ;; We only test tables without FK columns because native query result_metadata
@@ -203,6 +203,6 @@
                     card-meta (lib.metadata/card mp (:id card))]
                 (testing (str "table: " (:name table))
                   (testing "table -> native card"
-                    (is (empty? (replacement.source/check-replace-source mp table card-meta))))
+                    (is (empty? (replacement.source/check-replace-source mp table card-meta (mt/id) (mt/id)))))
                   (testing "native card -> table"
-                    (is (empty? (replacement.source/check-replace-source mp card-meta table)))))))))))))
+                    (is (empty? (replacement.source/check-replace-source mp card-meta table (mt/id) (mt/id))))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/replacement/source_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/replacement/source_test.clj
@@ -31,7 +31,7 @@
             tables (lib.metadata/tables mp)]
         (doseq [table tables]
           (testing (str "table: " (:name table))
-            (is (empty? (replacement.source/check-replace-source mp table table (mt/id) (mt/id))))))))))
+            (is (empty? (replacement.source/check-replace-source [:table (:id table)] [:table (:id table)])))))))))
 
 (deftest card-swappable-with-underlying-table-test
   (testing "A card built on a table is swappable with that table in both directions"
@@ -45,12 +45,11 @@
             (mt/with-temp [:model/Card card {:dataset_query query
                                              :database_id   (mt/id)
                                              :type          :question}]
-              (let [card-meta (lib.metadata/card mp (:id card))]
-                (testing (str "table: " (:name table))
-                  (testing "card -> table"
-                    (is (empty? (replacement.source/check-replace-source mp card-meta table (mt/id) (mt/id)))))
-                  (testing "table -> card"
-                    (is (empty? (replacement.source/check-replace-source mp table card-meta (mt/id) (mt/id))))))))))))))
+              (testing (str "table: " (:name table))
+                (testing "card -> table"
+                  (is (empty? (replacement.source/check-replace-source [:card (:id card)] [:table (:id table)]))))
+                (testing "table -> card"
+                  (is (empty? (replacement.source/check-replace-source [:table (:id table)] [:card (:id card)]))))))))))))
 
 (deftest two-cards-on-same-table-swappable-test
   (testing "Two cards built on the same table are swappable in both directions"
@@ -68,13 +67,11 @@
                                                               legacy-replacement? lib.convert/->legacy-MBQL)
                                              :database_id   (mt/id)
                                              :type          :question}]
-            (let [meta-a (lib.metadata/card mp (:id card-a))
-                  meta-b (lib.metadata/card mp (:id card-b))]
-              (testing (str "table: " (:name table))
-                (testing "card-a -> card-b"
-                  (is (empty? (replacement.source/check-replace-source mp meta-a meta-b (mt/id) (mt/id)))))
-                (testing "card-b -> card-a"
-                  (is (empty? (replacement.source/check-replace-source mp meta-b meta-a (mt/id) (mt/id)))))))))))))
+            (testing (str "table: " (:name table))
+              (testing "card-a -> card-b"
+                (is (empty? (replacement.source/check-replace-source [:card (:id card-a)] [:card (:id card-b)]))))
+              (testing "card-b -> card-a"
+                (is (empty? (replacement.source/check-replace-source [:card (:id card-b)] [:card (:id card-a)])))))))))))
 
 (deftest card-with-expression-reports-extra-column-test
   (testing "A card with an added expression column reports :column-mismatch with :extra_columns"
@@ -88,8 +85,7 @@
         (mt/with-temp [:model/Card card {:dataset_query query
                                          :database_id   (mt/id)
                                          :type          :question}]
-          (let [card-meta (lib.metadata/card mp (:id card))
-                errors    (replacement.source/check-replace-source mp table card-meta (mt/id) (mt/id))]
+          (let [errors (replacement.source/check-replace-source [:table (:id table)] [:card (:id card)])]
             (testing "table -> card with expression: extra column reported"
               (is (some #(= :column-mismatch (:type %)) errors))
               (is (some (fn [err]
@@ -97,7 +93,7 @@
                                (some #(= "double_price" (:name %)) (:extra_columns err))))
                         errors)))
             (testing "card with expression -> table: missing column reported"
-              (let [reverse-errors (replacement.source/check-replace-source mp card-meta table (mt/id) (mt/id))]
+              (let [reverse-errors (replacement.source/check-replace-source [:card (:id card)] [:table (:id table)])]
                 (is (some #(= :column-mismatch (:type %)) reverse-errors))
                 (is (some (fn [err]
                             (and (= :column-mismatch (:type err))
@@ -116,9 +112,8 @@
         (mt/with-temp [:model/Card card {:dataset_query query
                                          :database_id   (mt/id)
                                          :type          :question}]
-          (let [card-meta     (lib.metadata/card mp (:id card))
-                dropped-names (set (map #(or (:lib/desired-column-alias %) (:name %)) (drop 2 cols)))
-                errors        (replacement.source/check-replace-source mp table card-meta (mt/id) (mt/id))]
+          (let [dropped-names (set (map #(or (:lib/desired-column-alias %) (:name %)) (drop 2 cols)))
+                errors        (replacement.source/check-replace-source [:table (:id table)] [:card (:id card)])]
             (testing "table -> card with fewer fields: extra columns reported (card is missing them)"
               (is (some #(= :column-mismatch (:type %)) errors))
               (is (some (fn [err]
@@ -126,7 +121,7 @@
                                (every? #(contains? dropped-names (:name %)) (:missing_columns err))))
                         errors)))
             (testing "card with fewer fields -> table: extra columns reported"
-              (let [reverse-errors (replacement.source/check-replace-source mp card-meta table (mt/id) (mt/id))]
+              (let [reverse-errors (replacement.source/check-replace-source [:card (:id card)] [:table (:id table)])]
                 (is (some #(= :column-mismatch (:type %)) reverse-errors))
                 (is (some (fn [err]
                             (and (= :column-mismatch (:type err))
@@ -163,20 +158,19 @@
                            (not (table-has-hidden-columns? mp table)))]
           (let [native-query (lib/native-query mp (str "SELECT * FROM " (:name table) " LIMIT 1"))]
             (mt/with-model-cleanup [:model/Card]
-              (let [card      (card/create-card! {:name                   (str "Native FK " (:name table))
-                                                  :display                :table
-                                                  :visualization_settings {}
-                                                  :dataset_query          native-query}
-                                                 {:id (mt/user->id :rasta)})
-                    _         (wait-for-result-metadata (:id card))
-                    card-meta (lib.metadata/card mp (:id card))]
+              (let [card (card/create-card! {:name                   (str "Native FK " (:name table))
+                                             :display                :table
+                                             :visualization_settings {}
+                                             :dataset_query          native-query}
+                                            {:id (mt/user->id :rasta)})
+                    _    (wait-for-result-metadata (:id card))]
                 (testing (str "table: " (:name table))
                   (testing "table -> native card: fk-mismatch reported"
                     (is (some #(= :fk-mismatch (:type %))
-                              (replacement.source/check-replace-source mp table card-meta (mt/id) (mt/id)))))
+                              (replacement.source/check-replace-source [:table (:id table)] [:card (:id card)]))))
                   (testing "native card -> table: fk-mismatch reported"
                     (is (some #(= :fk-mismatch (:type %))
-                              (replacement.source/check-replace-source mp card-meta table (mt/id) (mt/id))))))))))))))
+                              (replacement.source/check-replace-source [:card (:id card)] [:table (:id table)])))))))))))))
 
 (deftest native-card-swappable-with-table-test
   ;; We only test tables without FK columns because native query result_metadata
@@ -194,15 +188,14 @@
                            (not (table-has-hidden-columns? mp table)))]
           (let [native-query (lib/native-query mp (str "SELECT * FROM " (:name table) " LIMIT 1"))]
             (mt/with-model-cleanup [:model/Card]
-              (let [card      (card/create-card! {:name                   (str "Native " (:name table))
-                                                  :display                :table
-                                                  :visualization_settings {}
-                                                  :dataset_query          native-query}
-                                                 {:id (mt/user->id :rasta)})
-                    _         (wait-for-result-metadata (:id card))
-                    card-meta (lib.metadata/card mp (:id card))]
+              (let [card (card/create-card! {:name                   (str "Native " (:name table))
+                                             :display                :table
+                                             :visualization_settings {}
+                                             :dataset_query          native-query}
+                                            {:id (mt/user->id :rasta)})
+                    _    (wait-for-result-metadata (:id card))]
                 (testing (str "table: " (:name table))
                   (testing "table -> native card"
-                    (is (empty? (replacement.source/check-replace-source mp table card-meta (mt/id) (mt/id)))))
+                    (is (empty? (replacement.source/check-replace-source [:table (:id table)] [:card (:id card)]))))
                   (testing "native card -> table"
-                    (is (empty? (replacement.source/check-replace-source mp card-meta table (mt/id) (mt/id))))))))))))))
+                    (is (empty? (replacement.source/check-replace-source [:card (:id card)] [:table (:id table)])))))))))))))


### PR DESCRIPTION
Closes QUE-3094

 source.clj — Core compatibility checking                                                                                                                                                                                                      
                                                                                                                                                                                                                                                
  - check-replace-source signature changed to matchswap-source
  - Database mismatch check added inside check-replace-source

  api.clj — API endpoints

  - fetch-source moved to source.clj
  - /replace-source now validates before swapping — calls check-replace-source and throws 400 if errors found (was a TODO before)

  source_swap.clj — Swap execution

  - Table sources now supported
  - nil dataset_query guard

  source_swap_test.clj — New file (198 lines)

  - Tests for swap-source calling the function directly (not through the API)
  - 9 swap-source tests covering all combinations: card→card, card→table, card→native, native→card, native→native, native→table, table→card, table→table, table→native
  - 3 swap-native-card-source! tests for the native query text/template-tag rewriting
  - Helpers: wait-for-result-metadata, card-with-query, native-card-with-query, card-sourced-from, with-restored-card-queries (cleanup macro for table-source tests)

  api_test.clj — API-level tests

  - Added 4 tests for /replace-source: 204 success, 400 incompatible, 400 database mismatch, 402 premium feature required
  - Database mismatch tests rewritten — use a real temp :model/Database instead of with-redefs on fetch-source