### PR TITLE
fix: double new lines are not pasted correctly into metabot prompt input

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/AIMarkdown/AIMarkdown.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/AIMarkdown/AIMarkdown.tsx
@@ -17,6 +17,9 @@ type AIMarkdownProps = MarkdownProps & {
   onInternalLinkClick?: (link: string) => void;
 };
 
+const splitMessageLinesAsParagraphs = (message: string) =>
+  message.replaceAll(/\r?\n|\r/g, "\n\n");
+
 const getComponents = ({
   onInternalLinkClick,
 }: Pick<AIMarkdownProps, "onInternalLinkClick">) => ({
@@ -60,10 +63,15 @@ const getComponents = ({
 });
 
 export const AIMarkdown = memo(
-  ({ className, onInternalLinkClick, ...props }: AIMarkdownProps) => {
+  ({ className, onInternalLinkClick, children, ...props }: AIMarkdownProps) => {
     const components = useMemo(
       () => getComponents({ onInternalLinkClick }),
       [onInternalLinkClick],
+    );
+
+    const normalizedChildren = useMemo(
+      () => splitMessageLinesAsParagraphs(children),
+      [children],
     );
 
     return (
@@ -71,7 +79,9 @@ export const AIMarkdown = memo(
         className={cx(S.aiMarkdown, className)}
         components={components}
         {...props}
-      />
+      >
+        {normalizedChildren}
+      </Markdown>
     );
   },
 );

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChatMessage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChatMessage.tsx
@@ -62,6 +62,9 @@ interface UserMessageProps extends Omit<BaseMessageProps, "message"> {
   onCopy: () => void;
 }
 
+const splitLinesAsParagraphs = (message: string) =>
+  message.replaceAll(/\r?\n|\r/g, "\n\n");
+
 export const UserMessage = ({
   message,
   className,
@@ -72,7 +75,7 @@ export const UserMessage = ({
   <MessageContainer chatRole={message.role} {...props}>
     {message.type === "text" && (
       <AIMarkdown className={cx(Styles.message, Styles.messageUser)}>
-        {message.message}
+        {splitLinesAsParagraphs(message.message)}
       </AIMarkdown>
     )}
 

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChatMessage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChatMessage.tsx
@@ -62,9 +62,6 @@ interface UserMessageProps extends Omit<BaseMessageProps, "message"> {
   onCopy: () => void;
 }
 
-const splitLinesAsParagraphs = (message: string) =>
-  message.replaceAll(/\r?\n|\r/g, "\n\n");
-
 export const UserMessage = ({
   message,
   className,
@@ -75,7 +72,7 @@ export const UserMessage = ({
   <MessageContainer chatRole={message.role} {...props}>
     {message.type === "text" && (
       <AIMarkdown className={cx(Styles.message, Styles.messageUser)}>
-        {splitLinesAsParagraphs(message.message)}
+        {message.message}
       </AIMarkdown>
     )}
 

--- a/enterprise/frontend/src/metabase-enterprise/metabot/tests/ui.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/tests/ui.unit.spec.tsx
@@ -7,6 +7,7 @@ import { logout } from "metabase/auth/actions";
 import * as domModule from "metabase/lib/dom";
 import { METABOT_ERR_MSG } from "metabase-enterprise/metabot/constants";
 import { useMetabotAgent } from "metabase-enterprise/metabot/hooks";
+import { metabotActions } from "metabase-enterprise/metabot/state";
 import { getMetabotInitialState } from "metabase-enterprise/metabot/state/reducer-utils";
 
 import { Metabot } from "../components/Metabot";
@@ -142,6 +143,56 @@ describe("metabot > ui", () => {
       level: 1,
       name: `You, but don't tell anyone.`,
     });
+  });
+
+  it("should render single newlines in user input as separate paragraphs", async () => {
+    const { store } = setup();
+
+    store.dispatch(
+      metabotActions.addUserMessage({
+        agentId: "omnibot",
+        id: "user-1",
+        type: "text",
+        message: "first line\nsecond line",
+      }),
+    );
+
+    const messages = await screen.findAllByTestId("metabot-chat-message");
+    const userMessage = messages[0];
+    const firstParagraph = within(userMessage).getByText("first line", {
+      selector: "p",
+    });
+    const secondParagraph = within(userMessage).getByText("second line", {
+      selector: "p",
+    });
+
+    expect(firstParagraph).toBeInTheDocument();
+    expect(secondParagraph).toBeInTheDocument();
+  });
+
+  it("should preserve double newlines from user input", async () => {
+    const { store } = setup();
+
+    store.dispatch(
+      metabotActions.addUserMessage({
+        agentId: "omnibot",
+        id: "user-2",
+        type: "text",
+        message: "first line\n\nsecond line",
+      }),
+    );
+
+    const messages = await screen.findAllByTestId("metabot-chat-message");
+    const userMessage = messages[0];
+    const firstParagraph = within(userMessage).getByText("first line", {
+      selector: "p",
+    });
+    const secondParagraph = within(userMessage).getByText("second line", {
+      selector: "p",
+    });
+
+    expect(firstParagraph).toBeInTheDocument();
+    expect(secondParagraph).toBeInTheDocument();
   });
 
   it("should present the user an option to retry a response", async () => {

--- a/frontend/src/metabase/metabot/components/MetabotPromptInput/MetabotPromptInput.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotPromptInput/MetabotPromptInput.tsx
@@ -3,6 +3,7 @@ import HardBreak from "@tiptap/extension-hard-break";
 import Paragraph from "@tiptap/extension-paragraph";
 import { Placeholder } from "@tiptap/extension-placeholder";
 import Text from "@tiptap/extension-text";
+import { Fragment, Node, Slice } from "@tiptap/pm/model";
 import { TextSelection } from "@tiptap/pm/state";
 import type { EditorView } from "@tiptap/pm/view";
 import { EditorContent, useEditor } from "@tiptap/react";
@@ -159,6 +160,21 @@ export const MetabotPromptInput = forwardRef<
         },
         clipboardTextSerializer: (content) => {
           return serializeTiptapToMetabotMessage(content.toJSON());
+        },
+        clipboardTextParser: (text, context) => {
+          const blocks = text.split(/(?:\r\n?|\n)/);
+
+          const nodes = blocks.map((line) => {
+            return Node.fromJSON(context.doc.type.schema, {
+              type: "paragraph",
+              ...(line.length > 0
+                ? { content: [{ type: "text", text: line }] }
+                : {}),
+            });
+          });
+
+          const fragment = Fragment.fromArray(nodes);
+          return Slice.maxOpen(fragment);
         },
       },
     });

--- a/frontend/src/metabase/metabot/components/MetabotPromptInput/MetabotPromptInput.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotPromptInput/MetabotPromptInput.tsx
@@ -3,7 +3,6 @@ import HardBreak from "@tiptap/extension-hard-break";
 import Paragraph from "@tiptap/extension-paragraph";
 import { Placeholder } from "@tiptap/extension-placeholder";
 import Text from "@tiptap/extension-text";
-import { Fragment, Node, Slice } from "@tiptap/pm/model";
 import { TextSelection } from "@tiptap/pm/state";
 import type { EditorView } from "@tiptap/pm/view";
 import { EditorContent, useEditor } from "@tiptap/react";
@@ -26,6 +25,7 @@ import { getSetting } from "metabase/selectors/settings";
 
 import S from "./MetabotPromptInput.module.css";
 import {
+  parseClipboardTextAsParagraphs,
   parseMetabotMessageToTiptapDoc,
   serializeTiptapToMetabotMessage,
 } from "./utils";
@@ -161,21 +161,7 @@ export const MetabotPromptInput = forwardRef<
         clipboardTextSerializer: (content) => {
           return serializeTiptapToMetabotMessage(content.toJSON());
         },
-        clipboardTextParser: (text, context) => {
-          const blocks = text.split(/(?:\r\n?|\n)/);
-
-          const nodes = blocks.map((line) => {
-            return Node.fromJSON(context.doc.type.schema, {
-              type: "paragraph",
-              ...(line.length > 0
-                ? { content: [{ type: "text", text: line }] }
-                : {}),
-            });
-          });
-
-          const fragment = Fragment.fromArray(nodes);
-          return Slice.maxOpen(fragment);
-        },
+        clipboardTextParser: parseClipboardTextAsParagraphs,
       },
     });
 

--- a/frontend/src/metabase/metabot/components/MetabotPromptInput/utils.ts
+++ b/frontend/src/metabase/metabot/components/MetabotPromptInput/utils.ts
@@ -1,4 +1,10 @@
 import type { JSONContent } from "@tiptap/core";
+import {
+  Fragment,
+  Node,
+  type Node as ProseMirrorNode,
+  Slice,
+} from "@tiptap/pm/model";
 import { match } from "ts-pattern";
 
 import {
@@ -52,6 +58,23 @@ function serializeNode(node: JSONContent): string {
 export function serializeTiptapToMetabotMessage(content: JSONContent): string {
   return serializeNodes(content?.content || []).trim();
 }
+
+export const parseClipboardTextAsParagraphs = (
+  text: string,
+  context: { doc: ProseMirrorNode },
+): Slice => {
+  const blocks = text.split(/(?:\r\n?|\n)/);
+
+  const nodes = blocks.map((line) => {
+    return Node.fromJSON(context.doc.type.schema, {
+      type: "paragraph",
+      ...(line.length > 0 ? { content: [{ type: "text", text: line }] } : {}),
+    });
+  });
+
+  const fragment = Fragment.fromArray(nodes);
+  return Slice.maxOpen(fragment);
+};
 
 const MENTION_REGEX = new RegExp(METABSE_PROTOCOL_MD_LINK, "g");
 


### PR DESCRIPTION
Closes [BOT-438: Text with carriage returns copy & paste support in chat](https://linear.app/metabase/issue/BOT-438/text-with-carriage-returns-copy-and-paste-support-in-chat)

### Description

There are two issues
1. Prosemirror parses double newline into one paragraph. Added a `clipboardTextParser` the retains those double newlines as empty paragraphs
2. User message renderer was not turning single newlines into paragraphs

### How to verify

1. Paste this into metabot prompt input:

```
I need to build a complete user engagement analytics system from scratch. Here's what I want to accomplish:

I want to understand user behavior patterns across our Metabase platform. Create a series of transforms that work together to give me:

1. A clean staging layer that combines login sessions with activity data
2. Daily user engagement scores based on content interactions
3. User classification tiers (casual, regular, power users) with historical tracking
4. Department-level adoption metrics that roll up individual user behaviors

The end goal is to have executive dashboards showing adoption trends by team, identify power users who could be trainers, and spot departments that need more analytics support. I want this to be a proper data warehouse approach with clear staging, intermediate, and mart layers.

1
2
3
4
```

### Demo

Before:
<img width="480" height="938" alt="image" src="https://github.com/user-attachments/assets/2dbf3030-8e3d-4062-b9e0-d0032dcddb04" />

After:
<img width="479" height="936" alt="image" src="https://github.com/user-attachments/assets/a5c8b63f-3841-4354-ba4c-693c52563a22" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
