### PR TITLE
fix: Snyk scan failing after bun migration

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -59,6 +59,11 @@ jobs:
         run: |
           bun install --yarn
           cd release && bun install --yarn
+          # Fix bun's yarn.lock version range normalization inconsistency
+          # Bun normalizes "< 3.0.0" to "< 3" in alias entries but not in dependency specs
+          # This causes Snyk to fail matching dependencies to their resolutions
+          sed -i -E 's/< ([0-9]+)\.0\.0"/< \1"/g; s/< ([0-9]+)\.0"/< \1"/g' yarn.lock
+          sed -i -E 's/< ([0-9]+)\.0\.0"/< \1"/g; s/< ([0-9]+)\.0"/< \1"/g' release/yarn.lock
       - uses: snyk/actions/setup@0.4.0
       - name: Run snyk test
         env:


### PR DESCRIPTION
Root Cause:
Bun's `bun install --yarn` command has a bug where it normalizes version ranges inconsistently in the generated yarn.lock:

- Alias entries normalize ranges: "safer-buffer@>= 2.1.2 < 3" (converts "< 3.0.0" to "< 3")
- Dependency specs keep original: safer-buffer ">= 2.1.2 < 3.0.0" (preserves the ".0.0")

Snyk performs exact string matching when resolving dependencies to their lock file entries. When it sees `safer-buffer@>= 2.1.2 < 3.0.0` as a dependency, it looks for that exact string in the alias list, but only finds `safer-buffer@>= 2.1.2 < 3`, causing the error:

  "Dependency safer-buffer@>= 2.1.2 < 3.0.0 was not found in yarn.lock"

Solution:
Add a post-processing sed command that normalizes version ranges in the dependency specifications to match the aliases. This transforms:
- "< 3.0.0" → "< 3"
- "< 3.0" → "< 3"

This ensures Snyk can match dependencies to their resolutions.