### PR TITLE
update check milestone github action

### DIFF
--- a/.github/workflows/check-milestone.yml
+++ b/.github/workflows/check-milestone.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Major version number  (e.g. 52, 78, 109)'
+        description: "Major version number  (e.g. 52, 78, 109)"
         type: number
         required: true
 
@@ -26,11 +26,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          sparse-checkout: release
+          # .github folder is needed for the prepare-release-scripts action in master
+          sparse-checkout: |
+            release
+            .github
           fetch-depth: ${{ env.isNewReleaseBranch == 'false' && 3 || 0 }} # we need the full history to get all the commit messages
           ref: master # we want the logic from master, even though we're triggering on a release branch
-      - name: Prepare build scripts
-        run: cd ${{ github.workspace }}/release && yarn && yarn build
+      - name: Prepare release scripts
+        uses: ./.github/actions/prepare-release-scripts # this action sets up bun, which is used in master, but not on versions prior to 59
       - uses: actions/github-script@v7
         if: ${{ env.isNewReleaseBranch == 'false' }}
         name: Set milestone for single commit


### PR DESCRIPTION
### Description
The check milestone is broken in release branches because of the migration from yarn to bun as a package manager. This should pull down the updated step to prepare the release scripts
