### PR TITLE
fix: Snyk workflow using wrong working directory for release/yarn.lock

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -60,10 +60,12 @@ jobs:
         # The sed commands fix this inconsistency. They continue on error to let
         # Snyk report parsing issues directly rather than failing on the workaround.
       - name: Generate yarn.lock
+        if: matrix.project.file == 'yarn.lock'
         run: |
           bun install --yarn
           sed -i -E 's/< ([0-9]+)\.0\.0"/< \1"/g; s/< ([0-9]+)\.0"/< \1"/g' yarn.lock || true
       - name: Generate release/yarn.lock
+        if: matrix.project.file == 'release/yarn.lock'
         run: |
           bun install --yarn
           sed -i -E 's/< ([0-9]+)\.0\.0"/< \1"/g; s/< ([0-9]+)\.0"/< \1"/g' yarn.lock || true

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -54,16 +54,20 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-        # snyk doesn't support bun yet so we generate yarn.lock and scan that
-      - name: Generate yarn.lock for Snyk compatibility
+        # Snyk doesn't support bun.lock yet, so we generate yarn.lock and scan that.
+        # Bun has a bug where it normalizes "< 3.0.0" to "< 3" in alias entries
+        # but not in dependency specs, causing Snyk to fail matching dependencies.
+        # The sed commands fix this inconsistency. They continue on error to let
+        # Snyk report parsing issues directly rather than failing on the workaround.
+      - name: Generate yarn.lock
         run: |
           bun install --yarn
-          cd release && bun install --yarn
-          # Fix bun's yarn.lock version range normalization inconsistency
-          # Bun normalizes "< 3.0.0" to "< 3" in alias entries but not in dependency specs
-          # This causes Snyk to fail matching dependencies to their resolutions
-          sed -i -E 's/< ([0-9]+)\.0\.0"/< \1"/g; s/< ([0-9]+)\.0"/< \1"/g' yarn.lock
-          sed -i -E 's/< ([0-9]+)\.0\.0"/< \1"/g; s/< ([0-9]+)\.0"/< \1"/g' release/yarn.lock
+          sed -i -E 's/< ([0-9]+)\.0\.0"/< \1"/g; s/< ([0-9]+)\.0"/< \1"/g' yarn.lock || true
+      - name: Generate release/yarn.lock
+        run: |
+          bun install --yarn
+          sed -i -E 's/< ([0-9]+)\.0\.0"/< \1"/g; s/< ([0-9]+)\.0"/< \1"/g' yarn.lock || true
+        working-directory: release
       - uses: snyk/actions/setup@0.4.0
       - name: Run snyk test
         env:


### PR DESCRIPTION
The previous fix ran `cd release && bun install --yarn` which changed the working directory for subsequent commands. The sed command then tried to access `release/yarn.lock` from within the `release/` directory, resulting in "sed: can't read release/yarn.lock: No such file or directory".

Split into separate steps with explicit working-directory for clarity. The sed commands now continue on error to let Snyk report parsing issues directly rather than failing on the workaround.

### Test

The test run was successful: https://github.com/metabase/metabase/actions/runs/21923094983/job/63308381502