### PR TITLE
Pin bun version in workflows

### DIFF
--- a/.github/actions/prepare-frontend/action.yml
+++ b/.github/actions/prepare-frontend/action.yml
@@ -20,8 +20,8 @@ runs:
     - name: Install bun
       uses: oven-sh/setup-bun@v2
       with:
-        bun-version: latest
-        github-token: ${{ github.token }}
+        bun-version: "1.3.7"
+        token: ${{ github.token }}
 
     - name: Get cache keys
       uses: ./.github/actions/get-cache-keys

--- a/.github/actions/prepare-release-scripts/action.yml
+++ b/.github/actions/prepare-release-scripts/action.yml
@@ -6,8 +6,8 @@ runs:
   steps:
     - uses: oven-sh/setup-bun@v2
       with:
-        bun-version: latest
-        github-token: ${{ github.token }}
+        bun-version: "1.3.7"
+        token: ${{ github.token }}
 
     - name: Build release scripts
       shell: bash

--- a/.github/workflows/release-log.yml
+++ b/.github/workflows/release-log.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Install bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          bun-version: "1.3.7"
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Dependencies
         run: bun install --cwd release --frozen-lockfile && npm i -g tsx
       - name: Build release scripts

--- a/.github/workflows/release-milestone-check.yml
+++ b/.github/workflows/release-milestone-check.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Install bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          bun-version: "1.3.7"
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Prepare build scripts
         run: bun install --cwd release --frozen-lockfile && bun run --cwd release build
       - uses: actions/github-script@v7

--- a/.github/workflows/release-patch.yml
+++ b/.github/workflows/release-patch.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Install bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          bun-version: "1.3.7"
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Prepare build scripts
         run: bun install --cwd release --frozen-lockfile && bun run --cwd release build
       - name: Trigger auto-patch

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -39,8 +39,8 @@ jobs:
       - name: Install bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          bun-version: "1.3.7"
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: prepare dependencies in release directory
         run: bun install --cwd release --frozen-lockfile
       - name: Run frontend type-check
@@ -58,8 +58,8 @@ jobs:
       - name: Install bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          bun-version: "1.3.7"
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: prepare dependencies in release directory
         run: bun install --cwd release --frozen-lockfile
       - name: Run release unit tests
@@ -77,8 +77,8 @@ jobs:
       - name: Install bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          bun-version: "1.3.7"
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: prepare dependencies in release directory
         run: bun install --cwd release --frozen-lockfile
       - name: Build release bundle

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -53,7 +53,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          bun-version: "1.3.7"
+          token: ${{ secrets.GITHUB_TOKEN }}
         # Snyk doesn't support bun.lock yet, so we generate yarn.lock and scan that.
         # Bun has a bug where it normalizes "< 3.0.0" to "< 3" in alias entries
         # but not in dependency specs, causing Snyk to fail matching dependencies.


### PR DESCRIPTION
Ensures we're using a consistent version for bun and stops the action from making api calls (it was causing us to hit api rate limits).

Also fixes action key to use `token`