### PR TITLE
Fix broken measure unit tests

### DIFF
--- a/frontend/src/metabase/querying/expressions/suggestions/measures.unit.spec.ts
+++ b/frontend/src/metabase/querying/expressions/suggestions/measures.unit.spec.ts
@@ -70,23 +70,25 @@ describe("suggestMeasures", () => {
     const MEASURE_BAR = createMockMeasure({
       name: "BAR",
       table_id: TABLE_ID,
-      definition: Lib.createTestQuery(metadataProvider, {
-        stages: [
-          {
-            source: {
-              type: "table",
-              id: TABLE_ID,
-            },
-            aggregations: [
-              {
-                type: "operator",
-                operator: "sum",
-                args: [{ type: "column", name: "sum", displayName: "Sum" }],
+      definition: Lib.toJsQuery(
+        Lib.createTestQuery(metadataProvider, {
+          stages: [
+            {
+              source: {
+                type: "table",
+                id: TABLE_ID,
               },
-            ],
-          },
-        ],
-      }),
+              aggregations: [
+                {
+                  type: "operator",
+                  operator: "sum",
+                  args: [{ type: "column", name: "sum", displayName: "Sum" }],
+                },
+              ],
+            },
+          ],
+        }),
+      ),
     });
 
     // Recreate metadata with measure in place

--- a/frontend/src/metabase/querying/expressions/suggestions/measures.unit.spec.ts
+++ b/frontend/src/metabase/querying/expressions/suggestions/measures.unit.spec.ts
@@ -1,9 +1,9 @@
 import { createMockMetadata } from "__support__/metadata";
-import { SAMPLE_DATABASE, createQuery } from "metabase-lib/test-helpers";
+import * as Lib from "metabase-lib";
+import { SAMPLE_DATABASE } from "metabase-lib/test-helpers";
 import {
   createMockField,
   createMockMeasure,
-  createMockStructuredDatasetQuery,
   createMockTable,
 } from "metabase-types/api/mocks";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
@@ -15,18 +15,6 @@ describe("suggestMeasures", () => {
   function setup({ expressionMode = "expression" }: Partial<Options>) {
     const DATABASE_ID = SAMPLE_DATABASE.id;
     const TABLE_ID = 1;
-
-    const MEASURE_BAR = createMockMeasure({
-      name: "BAR",
-      table_id: TABLE_ID,
-      definition: createMockStructuredDatasetQuery({
-        database: DATABASE_ID,
-        query: {
-          "source-table": TABLE_ID,
-          aggregation: [["sum", ["field", 11, {}]]],
-        },
-      }),
-    });
 
     const TABLE = createMockTable({
       db_id: DATABASE_ID,
@@ -41,6 +29,7 @@ describe("suggestMeasures", () => {
         createMockField({
           id: 11,
           table_id: TABLE_ID,
+          name: "sum",
           display_name: "Sum",
           base_type: "type/Float",
         }),
@@ -63,7 +52,6 @@ describe("suggestMeasures", () => {
           base_type: "type/DateTime",
         }),
       ],
-      measures: [MEASURE_BAR],
     });
 
     const DATABASE = createSampleDatabase({
@@ -77,15 +65,46 @@ describe("suggestMeasures", () => {
       tables: [TABLE],
     });
 
-    const query = createQuery({
-      metadata,
-      query: {
-        database: DATABASE.id,
-        type: "query",
-        query: {
-          "source-table": TABLE.id,
+    const metadataProvider = Lib.metadataProvider(DATABASE_ID, metadata);
+
+    const MEASURE_BAR = createMockMeasure({
+      name: "BAR",
+      table_id: TABLE_ID,
+      definition: Lib.createTestQuery(metadataProvider, {
+        stages: [
+          {
+            source: {
+              type: "table",
+              id: TABLE_ID,
+            },
+            aggregations: [
+              {
+                type: "operator",
+                operator: "sum",
+                args: [{ type: "column", name: "sum", displayName: "Sum" }],
+              },
+            ],
+          },
+        ],
+      }),
+    });
+
+    // Recreate metadata with measure in place
+    const metadataProviderWithMeasure = Lib.metadataProvider(
+      DATABASE_ID,
+      createMockMetadata({
+        databases: [DATABASE],
+        tables: [TABLE],
+        measures: [MEASURE_BAR],
+      }),
+    );
+
+    const query = Lib.createTestQuery(metadataProviderWithMeasure, {
+      stages: [
+        {
+          source: { type: "table", id: TABLE.id },
         },
-      },
+      ],
     });
 
     const source = suggestMeasures({

--- a/frontend/test/__support__/store.ts
+++ b/frontend/test/__support__/store.ts
@@ -22,6 +22,7 @@ import type {
   Dashboard,
   Database,
   Field,
+  Measure,
   NativeQuerySnippet,
   SavedQuestionDatabase,
   Schema,
@@ -42,6 +43,7 @@ export interface EntitiesStateOpts {
   tables?: Table[];
   fields?: Field[];
   segments?: Segment[];
+  measures?: Measure[];
   snippets?: NativeQuerySnippet[];
   users?: User[];
   questions?: Card[];


### PR DESCRIPTION
Closes QUE-3068

In this unit test we are passing legacy MBQL as a measure definition, whereas `lib.measure` expects the definition to be a MBQL query.

This PR fixes that.

