### PR TITLE
Dont show hosting upsell to pro self hosted users

### DIFF
--- a/frontend/src/metabase/admin/upsells/UpsellHosting.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellHosting.tsx
@@ -1,44 +1,17 @@
 import { jt, t } from "ttag";
 
-const RocketGlobeIllustrationSrc = "app/assets/img/rocket-globe.svg";
-import { UpsellCard } from "metabase/common/components/UpsellCard";
+import { isProPlan, useGetPlan } from "metabase/common/utils/plan";
 import { useSelector } from "metabase/lib/redux";
 import { getIsHosted } from "metabase/setup/selectors";
 
 import { UpsellBanner } from "./components";
 
-// the default 200px width will break the title into two lines
-const UPSELL_CARD_WIDTH = 202;
-const CLOUD_PAGE = "/admin/settings/cloud";
-
-export const UpsellHosting = ({ location }: { location: string }) => {
-  const isHosted = useSelector(getIsHosted);
-
-  if (isHosted) {
-    return null;
-  }
-
-  return (
-    <UpsellCard
-      title={t`Minimize maintenance`}
-      campaign="hosting"
-      buttonText={t`Learn more`}
-      internalLink={CLOUD_PAGE}
-      illustrationSrc={RocketGlobeIllustrationSrc}
-      location={location}
-      maxWidth={UPSELL_CARD_WIDTH}
-    >
-      {jt`${(
-        <strong key="migrate">{t`Migrate to Metabase Cloud`}</strong>
-      )} for fast, reliable, and secure deployment.`}
-    </UpsellCard>
-  );
-};
-
 export const UpsellHostingBanner = ({ location }: { location: string }) => {
   const isHosted = useSelector(getIsHosted);
+  const plan = useGetPlan();
+  const isPro = isProPlan(plan);
 
-  if (isHosted) {
+  if (isHosted || isPro) {
     return null;
   }
 
@@ -54,29 +27,5 @@ export const UpsellHostingBanner = ({ location }: { location: string }) => {
         <strong key="migrate">{t`Migrate to Metabase Cloud`}</strong>
       )} for fast, reliable, and secure deployment.`}
     </UpsellBanner>
-  );
-};
-
-export const UpsellHostingUpdates = ({ location }: { location: string }) => {
-  const isHosted = useSelector(getIsHosted);
-
-  if (isHosted) {
-    return null;
-  }
-
-  return (
-    <UpsellCard
-      title={t`Get automatic updates`}
-      campaign="hosting"
-      buttonText={t`Learn more`}
-      internalLink={CLOUD_PAGE}
-      illustrationSrc={RocketGlobeIllustrationSrc}
-      location={location}
-      maxWidth={UPSELL_CARD_WIDTH}
-    >
-      {jt`${(
-        <strong key="migrate">{t`Migrate to Metabase Cloud`}</strong>
-      )} for fast, reliable, and secure deployment.`}
-    </UpsellCard>
   );
 };

--- a/frontend/src/metabase/common/utils/plan.ts
+++ b/frontend/src/metabase/common/utils/plan.ts
@@ -1,6 +1,8 @@
 import type { TokenFeatures } from "metabase-types/api";
 import { tokenFeatures } from "metabase-types/api";
 
+import { useSetting } from "../hooks";
+
 export type ProPlan = "pro-cloud" | "pro-cloud-with-dwh" | "pro-self-hosted";
 
 export type Plan = "oss" | "starter" | "starter-with-dwh" | ProPlan;
@@ -36,3 +38,8 @@ export const getPlan = (features?: TokenFeatures | null): Plan => {
 const ssoFeatures = ["sso_google", "sso_jwt", "sso_ldap", "sso_saml"] as const;
 export const hasAnySsoFeature = (features?: TokenFeatures | null): boolean =>
   features != null && ssoFeatures.some((ssoFeature) => features[ssoFeature]);
+
+export const useGetPlan = (): Plan => {
+  const features = useSetting("token-features");
+  return getPlan(features);
+};


### PR DESCRIPTION
Closes GRO-59

reverts https://github.com/metabase/metabase/pull/14458

### Description

Removes this upsell for pro self hosted instances

<img width="1260" height="666" alt="CleanShot 2026-02-11 at 16 11 37" src="https://github.com/user-attachments/assets/aaffeacf-bf4d-4ffc-ab83-b1645d1b7138" />


### How to verify

1. go to `/admin/settings/updates` with a pro self hosted token
2. dont see any upsells
3. go there with no token
4. see upsells