### PR TITLE
BOT-985 Add create-alert metabot tool for slackbot

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2200,6 +2200,7 @@
               lib-be
               models
               native-query-snippets
+              notification
               permissions
               premium-features
               pulse

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
@@ -518,14 +518,19 @@
 
 (mr/def ::create-alert-arguments
   [:and
-   [:map
-    [:card_id :int]
-    [:channel_type [:enum {:encode/tool-api-request keyword} "email" "slack"]]
-    [:send_condition [:enum {:encode/tool-api-request keyword} "has_result" "goal_above" "goal_below"]]
-    [:send_once {:optional true, :default false} :boolean]
-    [:email {:optional true} :string]
-    [:slack_channel {:optional true} :string]
-    [:schedule ::subscription-schedule]]
+   [:merge
+    [:map
+     [:card_id :int]
+     [:send_condition [:enum {:encode/tool-api-request keyword} "has_result" "goal_above" "goal_below"]]
+     [:send_once {:optional true, :default false} :boolean]
+     [:schedule ::subscription-schedule]]
+    [:multi {:dispatch :channel_type}
+     ["email" [:map
+               [:channel_type [:= {:encode/tool-api-request keyword} "email"]]
+               [:email :string]]]
+     ["slack" [:map
+               [:channel_type [:= {:encode/tool-api-request keyword} "slack"]]
+               [:slack_channel :string]]]]]
    [:map {:encode/tool-api-request #(update-keys % metabot-v3.u/safe->kebab-case-en)}]])
 
 (deftool "/create-alert"

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
@@ -7,6 +7,8 @@
    [metabase-enterprise.metabot-v3.reactions]
    [metabase-enterprise.metabot-v3.settings :as metabot-v3.settings]
    [metabase-enterprise.metabot-v3.table-utils :as table-utils]
+   [metabase-enterprise.metabot-v3.tools.create-alert
+    :as metabot-v3.tools.create-alert]
    [metabase-enterprise.metabot-v3.tools.create-dashboard-subscription
     :as metabot-v3.tools.create-dashboard-subscription]
    [metabase-enterprise.metabot-v3.tools.deftool :refer [deftool]]
@@ -513,6 +515,25 @@
    :result-schema [:map [:error  {:optional true} :string
                          :output {:optional true} :string]]
    :handler       metabot-v3.tools.create-dashboard-subscription/create-dashboard-subscription})
+
+(mr/def ::create-alert-arguments
+  [:and
+   [:map
+    [:card_id :int]
+    [:channel_type [:enum {:encode/tool-api-request keyword} "email" "slack"]]
+    [:send_condition [:enum {:encode/tool-api-request keyword} "has_result" "goal_above" "goal_below"]]
+    [:send_once {:optional true, :default false} :boolean]
+    [:email {:optional true} :string]
+    [:slack_channel {:optional true} :string]
+    [:schedule ::subscription-schedule]]
+   [:map {:encode/tool-api-request #(update-keys % metabot-v3.u/safe->kebab-case-en)}]])
+
+(deftool "/create-alert"
+  "Create an alert for a saved question."
+  {:args-schema   ::create-alert-arguments
+   :result-schema [:map [:error  {:optional true} :string
+                         :output {:optional true} :string]]
+   :handler       metabot-v3.tools.create-alert/create-alert})
 
 ;;; ---------------------------------------------------- Analytics ----------------------------------------------------
 

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
@@ -518,19 +518,12 @@
 
 (mr/def ::create-alert-arguments
   [:and
-   [:merge
-    [:map
-     [:card_id :int]
-     [:send_condition [:enum {:encode/tool-api-request keyword} "has_result" "goal_above" "goal_below"]]
-     [:send_once {:optional true, :default false} :boolean]
-     [:schedule ::subscription-schedule]]
-    [:multi {:dispatch :channel_type}
-     ["email" [:map
-               [:channel_type [:= {:encode/tool-api-request keyword} "email"]]
-               [:email :string]]]
-     ["slack" [:map
-               [:channel_type [:= {:encode/tool-api-request keyword} "slack"]]
-               [:slack_channel :string]]]]]
+   [:map
+    [:card_id :int]
+    [:send_condition [:enum {:encode/tool-api-request keyword} "has_result" "goal_above" "goal_below"]]
+    [:send_once {:optional true, :default false} :boolean]
+    [:schedule ::subscription-schedule]
+    [:slack_channel :string]]
    [:map {:encode/tool-api-request #(update-keys % metabot-v3.u/safe->kebab-case-en)}]])
 
 (deftool "/create-alert"

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/create_alert.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/create_alert.clj
@@ -1,5 +1,6 @@
 (ns metabase-enterprise.metabot-v3.tools.create-alert
   (:require
+   [clojure.set :as set]
    [metabase-enterprise.metabot-v3.tools.util :as metabot-v3.tools.u]
    [metabase.api.common :as api]
    [metabase.channel.settings :as channel.settings]
@@ -86,4 +87,8 @@
     {:error "slack_channel is required when channel_type is slack"}
 
     :else
-    (create-alert* args)))
+    (try
+      (create-alert* args)
+      (catch Exception e
+        (-> (metabot-v3.tools.u/handle-agent-error e)
+            (set/rename-keys {:output :error}))))))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/create_alert.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/create_alert.clj
@@ -58,7 +58,7 @@
 
 (defn create-alert
   "Create an alert (notification when a saved question returns results)."
-  [{:keys [card-id channel-type send-condition send-once slack-channel]
+  [{:keys [card-id channel-type send-condition send-once email slack-channel]
     :as   args}]
   (cond
     (not (int? card-id))
@@ -79,7 +79,7 @@
     (and (= channel-type :slack) (not (channel.settings/slack-configured?)))
     {:error "slack is not configured. Ask an admin to set up slack notifications in Metabase settings."}
 
-    (and (= channel-type :email) (empty? (:email args)))
+    (and (= channel-type :email) (empty? email))
     {:error "email is required when channel_type is email"}
 
     (and (= channel-type :slack) (empty? slack-channel))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/create_alert.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/create_alert.clj
@@ -1,0 +1,91 @@
+(ns metabase-enterprise.metabot-v3.tools.create-alert
+  (:require
+   [metabase-enterprise.metabot-v3.tools.util :as metabot-v3.tools.u]
+   [metabase.api.common :as api]
+   [metabase.channel.settings :as channel.settings]
+   [metabase.notification.models :as notification.models]
+   [metabase.permissions.core :as perms]
+   [metabase.util.cron :as u.cron]
+   [toucan2.core :as t2]))
+
+(defn- schedule->cron
+  "Convert the tool schedule format to a Quartz cron string.
+  The schedule comes in as e.g. {:frequency :daily :hour 9} and needs to be
+  converted to a Quartz cron string like \"0 0 9 * * ? *\"."
+  [schedule]
+  (u.cron/schedule-map->cron-string (metabot-v3.tools.u/schedule->schedule-map schedule)))
+
+(defn- create-alert*
+  "Private helper for create-alert (call that instead)."
+  [{:keys [card-id channel-type email slack-channel schedule send-condition send-once]
+    :or   {send-once false}}]
+  (let [card              (some-> (t2/select-one :model/Card card-id) api/read-check)
+        recipient-id      (when (= channel-type :email)
+                            (t2/select-one-fn :id :model/User :email email))
+        channel-name      (when (= channel-type :slack)
+                            (some->> slack-channel
+                                     channel.settings/find-cached-slack-channel-or-username
+                                     :display-name))
+        handler+recipient (case channel-type
+                            :email {:channel_type :channel/email
+                                    :recipients   [{:type    :notification-recipient/user
+                                                    :user_id recipient-id}]}
+                            :slack {:channel_type :channel/slack
+                                    :recipients   [{:type    :notification-recipient/raw-value
+                                                    :details {:value channel-name}}]})]
+    (cond
+      (nil? card)
+      {:error "no saved question with this card_id found"}
+
+      (and (= channel-type :email) (nil? recipient-id))
+      {:error "no user with this email found"}
+
+      (and (= channel-type :slack) (nil? channel-name))
+      {:error "no slack channel found with this name"}
+
+      :else
+      (do
+        (notification.models/create-notification!
+         {:payload_type :notification/card
+          :active       true
+          :creator_id   api/*current-user-id*
+          :payload      {:card_id        card-id
+                         :send_condition send-condition
+                         :send_once      send-once}}
+         [{:type          :notification-subscription/cron
+           :cron_schedule (schedule->cron schedule)}]
+         [handler+recipient])
+        {:output "success"}))))
+
+(defn create-alert
+  "Create an alert (notification when a saved question returns results)."
+  [{:keys [card-id channel-type send-condition send-once slack-channel]
+    :as   args}]
+  (perms/check-has-application-permission :subscription false)
+  (cond
+    (not (int? card-id))
+    {:error "invalid card_id"}
+
+    (and (some? send-once) (not (boolean? send-once)))
+    {:error "send_once must be a boolean"}
+
+    (not (#{:email :slack} channel-type))
+    {:error (str "unsupported channel_type: " (some-> channel-type name))}
+
+    (not (#{:has_result :goal_above :goal_below} send-condition))
+    {:error (str "unsupported send_condition: " (some-> send-condition name))}
+
+    (and (= channel-type :email) (not (channel.settings/email-configured?)))
+    {:error "email is not configured. Ask an admin to set up email in Metabase settings."}
+
+    (and (= channel-type :slack) (not (channel.settings/slack-configured?)))
+    {:error "slack is not configured. Ask an admin to set up slack notifications in Metabase settings."}
+
+    (and (= channel-type :email) (empty? (:email args)))
+    {:error "email is required when channel_type is email"}
+
+    (and (= channel-type :slack) (empty? slack-channel))
+    {:error "slack_channel is required when channel_type is slack"}
+
+    :else
+    (create-alert* args)))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/create_dashboard_subscription.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/create_dashboard_subscription.clj
@@ -1,18 +1,11 @@
 (ns metabase-enterprise.metabot-v3.tools.create-dashboard-subscription
   (:require
+   [clojure.set :as set]
    [metabase-enterprise.metabot-v3.tools.util :as metabot-v3.tools.u]
    [metabase.api.common :as api]
    [metabase.channel.settings :as channel.settings]
    [metabase.pulse.api :as pulse.api]
    [toucan2.core :as t2]))
-
-(defn- make-email-channel
-  "Build a pulse channel for email delivery."
-  [schedule recipient-id]
-  (merge {:channel_type :email
-          :enabled      true
-          :recipients   [{:id recipient-id}]}
-         (metabot-v3.tools.u/schedule->schedule-map schedule)))
 
 (defn- make-slack-channel
   "Build a pulse channel for Slack delivery."

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
@@ -148,6 +148,20 @@
                      :status-code 400
                      :field-id field-id}))))
 
+(defn schedule->schedule-map
+  "Convert a tool schedule map to the schedule-map format used by cron and pulse channels.
+  E.g. {:frequency :daily :hour 9} => {:schedule_type \"daily\" :schedule_hour 9 ...}"
+  [{:keys [frequency hour day-of-week day-of-month]}]
+  {:schedule_type  (name frequency)
+   :schedule_hour  hour
+   :schedule_day   (or (some-> day-of-week name (subs 0 3) u/lower-case-en)
+                       (some->> day-of-month
+                                name
+                                u/lower-case-en
+                                (re-find #"^(?:first|last)-(mon|tue|wed|thu|fri|sat|sun)")
+                                second))
+   :schedule_frame (some->> day-of-month name (re-find #"^(?:first|mid|last)"))})
+
 (defn get-database
   "Get the `fields` of the database with ID `id`."
   [id & fields]

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/create_alert_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/create_alert_test.clj
@@ -1,0 +1,124 @@
+(ns metabase-enterprise.metabot-v3.tools.create-alert-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.metabot-v3.tools.create-alert
+    :as metabot-v3.tools.create-alert]
+   [metabase.channel.settings :as channel.settings]
+   [metabase.permissions.models.permissions-group :as perms-group]
+   [metabase.test :as mt]))
+
+(defn- alert-data [card-id email]
+  {:card-id        card-id
+   :send-condition :has_result
+   :channel-type   :email
+   :email          email
+   :schedule       {:frequency :daily
+                    :hour      9}})
+
+(def ^:private fake-channels
+  {:channels [{:display-name "#data-team" :name "data-team" :id "C123"}]})
+
+(deftest create-email-alert-test
+  (mt/with-model-cleanup [:model/Notification]
+    (mt/with-temp [:model/User {:keys [email] user-id :id} {:email "alert-test@example.com"}
+                   :model/Card {card-id :id} {}]
+      (let [invoke-tool #(mt/with-current-user user-id
+                           (metabot-v3.tools.create-alert/create-alert %))
+            base-data   (alert-data card-id email)]
+        (with-redefs [channel.settings/email-configured? (constantly true)]
+          (testing "Email alert can be created"
+            (is (= {:output "success"}
+                   (invoke-tool base-data))))
+          (testing "Alert with goal_above send-condition can be created"
+            (is (= {:output "success"}
+                   (invoke-tool (assoc base-data :send-condition :goal_above)))))
+          (testing "Alert with goal_below send-condition can be created"
+            (is (= {:output "success"}
+                   (invoke-tool (assoc base-data :send-condition :goal_below)))))
+          (testing "Alert with send-once can be created"
+            (is (= {:output "success"}
+                   (invoke-tool (assoc base-data :send-once true))))))))))
+
+(deftest create-slack-alert-test
+  (mt/with-model-cleanup [:model/Notification]
+    (mt/with-temp [:model/Card {card-id :id} {}]
+      (let [invoke-tool #(mt/with-current-user (mt/user->id :rasta)
+                           (metabot-v3.tools.create-alert/create-alert %))]
+        (with-redefs [channel.settings/slack-configured? (constantly true)
+                      channel.settings/slack-cached-channels-and-usernames (constantly fake-channels)]
+          (testing "Slack alert can be created"
+            (is (= {:output "success"}
+                   (invoke-tool {:card-id        card-id
+                                 :send-condition :has_result
+                                 :channel-type   :slack
+                                 :slack-channel  "data-team"
+                                 :schedule       {:frequency :daily
+                                                  :hour      9}})))))))))
+
+(deftest create-alert-validation-test
+  (mt/with-temp [:model/User {:keys [email] user-id :id} {:email "alert-test@example.com"}
+                 :model/Card {card-id :id} {}]
+    (let [invoke-tool #(mt/with-current-user user-id
+                         (metabot-v3.tools.create-alert/create-alert %))
+          base-data   (alert-data card-id email)]
+      (with-redefs [channel.settings/email-configured? (constantly true)
+                    channel.settings/slack-configured? (constantly true)
+                    channel.settings/slack-cached-channels-and-usernames (constantly fake-channels)]
+        (testing "Return an error message if the card-id is invalid"
+          (is (= {:error "invalid card_id"}
+                 (invoke-tool (update base-data :card-id str)))))
+        (testing "Return an error message if the card cannot be found"
+          (is (= {:error "no saved question with this card_id found"}
+                 (invoke-tool (update base-data :card-id + 100)))))
+        (testing "Return an error message if the user cannot be found"
+          (is (= {:error "no user with this email found"}
+                 (invoke-tool (update base-data :email str "nosuchuser@example.com")))))
+        (testing "Email alert requires email"
+          (is (= {:error "email is required when channel_type is email"}
+                 (invoke-tool (dissoc base-data :email)))))
+        (testing "Slack alert requires slack-channel"
+          (is (= {:error "slack_channel is required when channel_type is slack"}
+                 (invoke-tool {:card-id        card-id
+                               :send-condition :has_result
+                               :channel-type   :slack
+                               :schedule       {:frequency :daily
+                                                :hour      9}}))))
+        (testing "Invalid channel-type returns an error"
+          (is (= {:error "unsupported channel_type: sms"}
+                 (invoke-tool (assoc base-data :channel-type :sms)))))
+        (testing "Invalid send-condition returns an error"
+          (is (= {:error "unsupported send_condition: always"}
+                 (invoke-tool (assoc base-data :send-condition :always)))))
+        (testing "Invalid send-once returns an error"
+          (is (= {:error "send_once must be a boolean"}
+                 (invoke-tool (assoc base-data :send-once "true")))))))))
+
+(deftest create-alert-channel-not-configured-test
+  (mt/with-temp [:model/User {:keys [email] user-id :id} {:email "alert-test@example.com"}
+                 :model/Card {card-id :id} {}]
+    (let [invoke-tool #(mt/with-current-user user-id
+                         (metabot-v3.tools.create-alert/create-alert %))
+          base-data   (alert-data card-id email)]
+      (testing "Email alert fails when email is not configured"
+        (with-redefs [channel.settings/email-configured? (constantly false)]
+          (is (= {:error "email is not configured. Ask an admin to set up email in Metabase settings."}
+                 (invoke-tool base-data)))))
+      (testing "Slack alert fails when Slack is not configured"
+        (with-redefs [channel.settings/slack-configured? (constantly false)]
+          (is (= {:error "slack is not configured. Ask an admin to set up slack notifications in Metabase settings."}
+                 (invoke-tool {:card-id        card-id
+                               :send-condition :has_result
+                               :channel-type   :slack
+                               :slack-channel  "data-team"
+                               :schedule       {:frequency :daily
+                                                :hour      9}})))))
+      (testing "Slack alert fails when channel does not exist"
+        (with-redefs [channel.settings/slack-configured? (constantly true)
+                      channel.settings/slack-cached-channels-and-usernames (constantly {:channels []})]
+          (is (= {:error "no slack channel found with this name"}
+                 (invoke-tool {:card-id        card-id
+                               :send-condition :has_result
+                               :channel-type   :slack
+                               :slack-channel  "no-such-channel"
+                               :schedule       {:frequency :daily
+                                                :hour      9}}))))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/create_alert_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/create_alert_test.clj
@@ -4,29 +4,27 @@
    [metabase-enterprise.metabot-v3.tools.create-alert
     :as metabot-v3.tools.create-alert]
    [metabase.channel.settings :as channel.settings]
-   [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.test :as mt]))
 
-(defn- alert-data [card-id email]
+(defn- alert-data [card-id]
   {:card-id        card-id
    :send-condition :has_result
-   :channel-type   :email
-   :email          email
+   :slack-channel  "data-team"
    :schedule       {:frequency :daily
                     :hour      9}})
 
 (def ^:private fake-channels
   {:channels [{:display-name "#data-team" :name "data-team" :id "C123"}]})
 
-(deftest create-email-alert-test
+(deftest create-alert-test
   (mt/with-model-cleanup [:model/Notification]
-    (mt/with-temp [:model/User {:keys [email] user-id :id} {:email "alert-test@example.com"}
-                   :model/Card {card-id :id} {}]
-      (let [invoke-tool #(mt/with-current-user user-id
+    (mt/with-temp [:model/Card {card-id :id} {}]
+      (let [invoke-tool #(mt/with-current-user (mt/user->id :rasta)
                            (metabot-v3.tools.create-alert/create-alert %))
-            base-data   (alert-data card-id email)]
-        (with-redefs [channel.settings/email-configured? (constantly true)]
-          (testing "Email alert can be created"
+            base-data   (alert-data card-id)]
+        (with-redefs [channel.settings/slack-configured? (constantly true)
+                      channel.settings/slack-cached-channels-and-usernames (constantly fake-channels)]
+          (testing "Slack alert can be created"
             (is (= {:output "success"}
                    (invoke-tool base-data))))
           (testing "Alert with goal_above send-condition can be created"
@@ -39,30 +37,12 @@
             (is (= {:output "success"}
                    (invoke-tool (assoc base-data :send-once true))))))))))
 
-(deftest create-slack-alert-test
-  (mt/with-model-cleanup [:model/Notification]
-    (mt/with-temp [:model/Card {card-id :id} {}]
-      (let [invoke-tool #(mt/with-current-user (mt/user->id :rasta)
-                           (metabot-v3.tools.create-alert/create-alert %))]
-        (with-redefs [channel.settings/slack-configured? (constantly true)
-                      channel.settings/slack-cached-channels-and-usernames (constantly fake-channels)]
-          (testing "Slack alert can be created"
-            (is (= {:output "success"}
-                   (invoke-tool {:card-id        card-id
-                                 :send-condition :has_result
-                                 :channel-type   :slack
-                                 :slack-channel  "data-team"
-                                 :schedule       {:frequency :daily
-                                                  :hour      9}})))))))))
-
 (deftest create-alert-validation-test
-  (mt/with-temp [:model/User {:keys [email] user-id :id} {:email "alert-test@example.com"}
-                 :model/Card {card-id :id} {}]
-    (let [invoke-tool #(mt/with-current-user user-id
+  (mt/with-temp [:model/Card {card-id :id} {}]
+    (let [invoke-tool #(mt/with-current-user (mt/user->id :rasta)
                          (metabot-v3.tools.create-alert/create-alert %))
-          base-data   (alert-data card-id email)]
-      (with-redefs [channel.settings/email-configured? (constantly true)
-                    channel.settings/slack-configured? (constantly true)
+          base-data   (alert-data card-id)]
+      (with-redefs [channel.settings/slack-configured? (constantly true)
                     channel.settings/slack-cached-channels-and-usernames (constantly fake-channels)]
         (testing "Return an error message if the card-id is invalid"
           (is (= {:error "invalid card_id"}
@@ -70,22 +50,9 @@
         (testing "Return an error message if the card cannot be found"
           (is (= {:error "no saved question with this card_id found"}
                  (invoke-tool (update base-data :card-id + 100)))))
-        (testing "Return an error message if the user cannot be found"
-          (is (= {:error "no user with this email found"}
-                 (invoke-tool (update base-data :email str "nosuchuser@example.com")))))
-        (testing "Email alert requires email"
-          (is (= {:error "email is required when channel_type is email"}
-                 (invoke-tool (dissoc base-data :email)))))
         (testing "Slack alert requires slack-channel"
-          (is (= {:error "slack_channel is required when channel_type is slack"}
-                 (invoke-tool {:card-id        card-id
-                               :send-condition :has_result
-                               :channel-type   :slack
-                               :schedule       {:frequency :daily
-                                                :hour      9}}))))
-        (testing "Invalid channel-type returns an error"
-          (is (= {:error "unsupported channel_type: sms"}
-                 (invoke-tool (assoc base-data :channel-type :sms)))))
+          (is (= {:error "slack_channel is required"}
+                 (invoke-tool (dissoc base-data :slack-channel)))))
         (testing "Invalid send-condition returns an error"
           (is (= {:error "unsupported send_condition: always"}
                  (invoke-tool (assoc base-data :send-condition :always)))))
@@ -94,31 +61,16 @@
                  (invoke-tool (assoc base-data :send-once "true")))))))))
 
 (deftest create-alert-channel-not-configured-test
-  (mt/with-temp [:model/User {:keys [email] user-id :id} {:email "alert-test@example.com"}
-                 :model/Card {card-id :id} {}]
-    (let [invoke-tool #(mt/with-current-user user-id
+  (mt/with-temp [:model/Card {card-id :id} {}]
+    (let [invoke-tool #(mt/with-current-user (mt/user->id :rasta)
                          (metabot-v3.tools.create-alert/create-alert %))
-          base-data   (alert-data card-id email)]
-      (testing "Email alert fails when email is not configured"
-        (with-redefs [channel.settings/email-configured? (constantly false)]
-          (is (= {:error "email is not configured. Ask an admin to set up email in Metabase settings."}
-                 (invoke-tool base-data)))))
+          base-data   (alert-data card-id)]
       (testing "Slack alert fails when Slack is not configured"
         (with-redefs [channel.settings/slack-configured? (constantly false)]
           (is (= {:error "slack is not configured. Ask an admin to set up slack notifications in Metabase settings."}
-                 (invoke-tool {:card-id        card-id
-                               :send-condition :has_result
-                               :channel-type   :slack
-                               :slack-channel  "data-team"
-                               :schedule       {:frequency :daily
-                                                :hour      9}})))))
+                 (invoke-tool base-data)))))
       (testing "Slack alert fails when channel does not exist"
         (with-redefs [channel.settings/slack-configured? (constantly true)
                       channel.settings/slack-cached-channels-and-usernames (constantly {:channels []})]
           (is (= {:error "no slack channel found with this name"}
-                 (invoke-tool {:card-id        card-id
-                               :send-condition :has_result
-                               :channel-type   :slack
-                               :slack-channel  "no-such-channel"
-                               :schedule       {:frequency :daily
-                                                :hour      9}}))))))))
+                 (invoke-tool (assoc base-data :slack-channel "no-such-channel")))))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/util_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/util_test.clj
@@ -10,6 +10,66 @@
    [metabase.permissions.models.permissions :as perms]
    [metabase.test :as mt]))
 
+(deftest ^:parallel schedule->schedule-map-test
+  (testing "hourly schedule"
+    (is (= {:schedule_type  "hourly"
+            :schedule_hour  nil
+            :schedule_day   nil
+            :schedule_frame nil}
+           (metabot-v3.tools.util/schedule->schedule-map
+            {:frequency :hourly}))))
+  (testing "daily schedule"
+    (is (= {:schedule_type  "daily"
+            :schedule_hour  9
+            :schedule_day   nil
+            :schedule_frame nil}
+           (metabot-v3.tools.util/schedule->schedule-map
+            {:frequency :daily
+             :hour      9}))))
+  (testing "weekly schedule"
+    (is (= {:schedule_type  "weekly"
+            :schedule_hour  8
+            :schedule_day   "mon"
+            :schedule_frame nil}
+           (metabot-v3.tools.util/schedule->schedule-map
+            {:frequency   :weekly
+             :hour        8
+             :day-of-week :monday}))))
+  (testing "weekly schedule truncates day name to 3 chars"
+    (is (= "wed"
+           (:schedule_day
+            (metabot-v3.tools.util/schedule->schedule-map
+             {:frequency   :weekly
+              :hour        10
+              :day-of-week :wednesday})))))
+  (testing "monthly schedule with first-mon"
+    (is (= {:schedule_type  "monthly"
+            :schedule_hour  6
+            :schedule_day   "mon"
+            :schedule_frame "first"}
+           (metabot-v3.tools.util/schedule->schedule-map
+            {:frequency    :monthly
+             :hour         6
+             :day-of-month :first-mon}))))
+  (testing "monthly schedule with last-fri"
+    (is (= {:schedule_type  "monthly"
+            :schedule_hour  17
+            :schedule_day   "fri"
+            :schedule_frame "last"}
+           (metabot-v3.tools.util/schedule->schedule-map
+            {:frequency    :monthly
+             :hour         17
+             :day-of-month :last-fri}))))
+  (testing "monthly schedule with mid"
+    (is (= {:schedule_type  "monthly"
+            :schedule_hour  12
+            :schedule_day   nil
+            :schedule_frame "mid"}
+           (metabot-v3.tools.util/schedule->schedule-map
+            {:frequency    :monthly
+             :hour         12
+             :day-of-month :mid})))))
+
 (deftest metabot-scope-query-test
   (testing "metabot-scope-query with collection hierarchy"
     (mt/dataset test-data

--- a/src/metabase/notification/api.clj
+++ b/src/metabase/notification/api.clj
@@ -9,6 +9,7 @@
 
 (p/import-vars
  [metabase.notification.api.notification
+  create-notification!
   list-notifications
   get-notification
   unsubscribe-user!])


### PR DESCRIPTION
Closes [BOT-985: Slackbot should be able to create an alert](https://linear.app/metabase/issue/BOT-985/slackbot-should-be-able-to-create-an-alert)

ai-service PR: https://github.com/metabase/ai-service/pull/612

### Description

Allow the user to create alerts from slack, similar to the existing [create-dashboard-subscription](https://github.com/metabase/metabase/pull/69371) tool.

* Add create-alert tool with support for creating alerts that are sent to a slack channel
* Add notification.api/create-notification! and call it from metabot_v3.tools/create-alert
   This ensures that create-alert does the same perms checks and send the same verification email and notifications as the main api endpoint.

### Demo

<img width="1145" height="663" alt="Screenshot 2026-02-13 at 5 07 06 PM" src="https://github.com/user-attachments/assets/d43638ed-79b8-41da-8f2d-7fecec0ea0dd" />
<img width="580" height="263" alt="Screenshot 2026-02-13 at 5 07 19 PM" src="https://github.com/user-attachments/assets/f310435a-9390-40f6-833f-52c3227f8429" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
