### PR TITLE
Fix flaky embedding sdk backward compatibility test

### DIFF
--- a/e2e/support/helpers/e2e-native-editor-helpers.ts
+++ b/e2e/support/helpers/e2e-native-editor-helpers.ts
@@ -12,7 +12,7 @@ export function selectNativeEditorDataSource(name: string) {
 
 function clickOnRun() {
   cy.findByTestId("native-query-editor-container").within(() =>
-    cy.findByTestId("run-button").should("be.enabled").click(),
+    cy.findByTestId("run-button").click(),
   );
 }
 

--- a/e2e/support/helpers/e2e-native-editor-helpers.ts
+++ b/e2e/support/helpers/e2e-native-editor-helpers.ts
@@ -12,7 +12,7 @@ export function selectNativeEditorDataSource(name: string) {
 
 function clickOnRun() {
   cy.findByTestId("native-query-editor-container").within(() =>
-    cy.findByTestId("run-button").click(),
+    cy.findByTestId("run-button").should("be.enabled").click(),
   );
 }
 

--- a/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
@@ -95,6 +95,9 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
 
       cy.wait("@schema");
 
+      // Wait for the Sample database to auto-select
+      cy.findByText("Sample Database").should("be.visible");
+
       H.NativeEditor.type("SELECT * from ORDERS LIMIT 10");
 
       H.NativeEditor.clickOnRun();


### PR DESCRIPTION
Closes [EMB-1314: Fix flaky embedding SDK backward compatibility test](https://linear.app/metabase/issue/EMB-1314/fix-flaky-embedding-sdk-backward-compatibility-test)

### Description

Sometimes in CI the QueryEditor doesn't wait for a database to be selected, for some reason. This PR makes the e2e test sturdier.

Stress test (100 burns): https://github.com/metabase/metabase/actions/runs/21914364198
Stress test master: https://github.com/metabase/metabase/actions/runs/21936682821