### PR TITLE
Conditionally resolve the package manager in pre-release

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -30,6 +30,7 @@ jobs:
     outputs:
       run_mode: ${{ fromJson(steps.config.outputs.result).runMode }}
       dev_server: ${{ fromJson(steps.config.outputs.result).metastoreDevServer }}
+      package_manager: ${{ fromJson(steps.config.outputs.result).packageManager }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -50,13 +51,17 @@ jobs:
             // with v55 and later we use enterprise tokens that mirror actual Metabase plans
             const MULTIPLE_TEST_TOKEN_THRESHOLD = 55;
 
+            // Versions before v59 used yarn, v59 and later use bun
+            const BUN_PACKAGE_MANAGER_THRESHOLD = 59;
+
             const version = '${{ inputs.version }}';
             const majorVersion = Number(getMajorVersion(version));
             const oldTestToken = majorVersion < MULTIPLE_TEST_TOKEN_THRESHOLD;
 
             return ({
               runMode: oldTestToken ? 'prod' : 'e2e',
-              metastoreDevServer: oldTestToken ? '' : '${{ vars.METASTORE_DEV_SERVER_URL }}'
+              metastoreDevServer: oldTestToken ? '' : '${{ vars.METASTORE_DEV_SERVER_URL }}',
+              packageManager: majorVersion < BUN_PACKAGE_MANAGER_THRESHOLD ? 'yarn' : 'bun',
             });
 
   release-artifact:
@@ -173,7 +178,7 @@ jobs:
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
       - name: Compile CLJS
-        run: bun run build-pure:cljs
+        run: ${{ needs.test-mode-config.outputs.package_manager }} run build-pure:cljs
       - name: Prepare Cypress environment
         id: cypress-prep
         uses: ./.github/actions/prepare-cypress


### PR DESCRIPTION
Resolves DEV-1542 and unblocks releasing the older (pre-59) releases.

## Summary

Pre-release testing for v58.x releases was failing because the CLJS build step was hardcoded to use bun, but versions before v59 use yarn.

Root cause: The pre-release workflow runs via `workflow_dispatch` from master (which has bun), but it checks out and tests older release branches that only have yarn configured. The Compile CLJS step was hardcoded as `bun run build-pure:cljs`, causing failures on pre-v59 releases.

## Fix

Added version-aware package manager detection:
  - Extended the test-mode-config job to output package_manager based on the release version
  - Versions < 59 → yarn
  - Versions ≥ 59 → bun
  - The CLJS compile step now dynamically uses the correct package manager

This follows the existing pattern used for MULTIPLE_TEST_TOKEN_THRESHOLD and leverages the getMajorVersion helper already available in the release scripts.
