### PR TITLE
Fix the release-log workflow

### DIFF
--- a/.github/workflows/release-log.yml
+++ b/.github/workflows/release-log.yml
@@ -38,15 +38,10 @@ jobs:
         with:
           ref: master # this only works on master
           fetch-depth: 0 # we want all branches and tags
-      - name: Install bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3.7"
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install Dependencies
-        run: bun install --cwd release --frozen-lockfile && npm i -g tsx
-      - name: Build release scripts
-        run: bun run --cwd release build
+      - name: Prepare release scripts
+        uses: ./.github/actions/prepare-release-scripts
+      - name: Install tsx
+        run: npm i -g tsx
       - name: Get version number
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
Resolves DEV-1544

## Summary

Simplifies the release-log workflow by using the shared prepare-release-scripts action instead of manually setting up bun and building release scripts.

### Key insight

When a workflow uses workflow_dispatch, workflow_call, or even push triggers, local composite actions (uses: ./.github/actions/*) resolve from the checked-out code, not from the branch that triggered the workflow.

Since release-log.yml always checks out master (ref: master), any composite actions used after checkout will come from master - which has bun properly configured.

### Best practice

For release-related workflows, prefer using composite actions over manually invoking package manager commands. This ensures:

1. Consistent tooling setup across workflows
2. Automatic compatibility with the checked-out code's package manager
3. Single source of truth for build/setup steps

### Changes

- Replaced manual bun setup + dependency install + build steps with prepare-release-scripts action
- Kept separate npm i -g tsx step (not included in the action, needed for running TypeScript files)
