### PR TITLE
GDGT-1776 Query Builder transform fails at join stage

### DIFF
--- a/e2e/test/scenarios/data-studio/transforms/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms/reproductions.cy.spec.ts
@@ -1,3 +1,5 @@
+import { createMockSearchResult } from "metabase-types/api/mocks";
+
 const { H } = cy;
 
 describe("issue #68378", () => {
@@ -25,6 +27,54 @@ describe("issue #68378", () => {
     H.popover().findByText("empty_schema").should("be.visible").click();
 
     H.modal().button("Save").click();
+  });
+});
+
+describe("issue GDGT-1776", () => {
+  beforeEach(() => {
+    H.restore("postgres-writable");
+    H.resetTestTable({ type: "postgres", table: "empty_schema" });
+    cy.signInAsAdmin();
+    H.activateToken("bleeding-edge");
+
+    const ITEMS_COUNT = 1000;
+
+    cy.intercept("GET", "/api/collection/root/items*", {
+      statusCode: 200,
+      body: {
+        data: Array.from({ length: ITEMS_COUNT }).map((_value, index) => {
+          return createMockSearchResult({
+            id: index + 1,
+            model: "table",
+          });
+        }),
+        limit: null,
+        models: [
+          "card",
+          "collection",
+          "dashboard",
+          "dataset",
+          "document",
+          "metric",
+          "pulse",
+          "table",
+          "timeline",
+        ],
+        offset: null,
+        total: ITEMS_COUNT,
+      },
+    }).as("getUsers");
+  });
+
+  it("should not crash the app when processing lots of hidden items in the MiniPicker (GDGT-1776)", () => {
+    visitTransformListPage();
+    cy.button("Create a transform").click();
+    H.popover().findByText("Query builder").click();
+    H.popover().findByText("Our analytics").click();
+
+    cy.findByTestId("loading-indicator").should("not.exist");
+    H.main().findByText("Something’s gone wrong").should("not.exist");
+    cy.button("Cancel").should("be.visible");
   });
 });
 

--- a/e2e/test/scenarios/data-studio/transforms/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms/reproductions.cy.spec.ts
@@ -63,7 +63,7 @@ describe("issue GDGT-1776", () => {
         offset: null,
         total: ITEMS_COUNT,
       },
-    }).as("getUsers");
+    });
   });
 
   it("should not crash the app when processing lots of hidden items in the MiniPicker (GDGT-1776)", () => {

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItem.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItem.tsx
@@ -24,7 +24,7 @@ export const MiniPickerItem = ({
   isHidden?: boolean;
 } & MenuItemProps) => {
   if (isHidden) {
-    return null;
+    return <Box />;
   }
   return (
     <Box px="sm" py="2px">

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItem.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItem.tsx
@@ -12,7 +12,6 @@ export const MiniPickerItem = ({
   name,
   onClick,
   isFolder,
-  isHidden,
   display,
   ...menuItemProps
 }: {
@@ -21,11 +20,7 @@ export const MiniPickerItem = ({
   display?: MiniPickerCollectionItem["display"];
   onClick?: () => void;
   isFolder?: boolean;
-  isHidden?: boolean;
 } & MenuItemProps) => {
-  if (isHidden) {
-    return <Box />;
-  }
   return (
     <Box px="sm" py="2px">
       <Menu.Item

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
@@ -162,6 +162,8 @@ function DatabaseItemList({
         : skipToken,
     );
 
+  const dbId = parent.model === "database" ? parent.id : parent.dbId!;
+
   const schemas = allSchemas?.filter((schema) => {
     return !isHidden({
       model: "schema",
@@ -177,8 +179,6 @@ function DatabaseItemList({
       : schemas?.length === 1
         ? schemas[0] // if there's one schema, go straight to tables
         : null;
-
-  const dbId = parent.model === "database" ? parent.id : parent.dbId!;
 
   const { data: tablesData, isLoading: isLoadingTables } =
     useListDatabaseSchemaTablesQuery(

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
@@ -22,6 +22,7 @@ import { useSelector } from "metabase/lib/redux";
 import { PLUGIN_LIBRARY } from "metabase/plugins";
 import { Box, Flex, Icon, Repeat, Skeleton, Stack, Text } from "metabase/ui";
 import type {
+  CollectionItem,
   SchemaName,
   SearchModel,
   SearchRequest,
@@ -260,7 +261,8 @@ function CollectionItemList({ parent }: { parent: MiniPickerCollectionItem }) {
     include_can_run_adhoc_query: true,
   });
 
-  const items = data?.data?.filter(canCollectionCardBeUsed);
+  const allItems = data?.data?.filter(canCollectionCardBeUsed) ?? [];
+  const items = allItems.filter((item) => !isHidden(item)) as CollectionItem[];
 
   if (isLoading || isFetching) {
     return <MiniPickerListLoader />;


### PR DESCRIPTION
Closes [GDGT-1776](https://linear.app/metabase/issue/GDGT-1776/query-builder-transform-fails-at-join-stage)

### Description

`MiniPickerItem` component had an `isHidden` prop, which when `true` would render `null`.
When `@tanstack/react-virtual` tried to render a lot (>= ~1000) of such hidden items, it'd enter a never-ending update loop and eventually crash the app with `React “Maximum update depth exceeded”` error (it kept trying to measure the elements but their height would always be `0`).

The solution is to never try to render elements that are supposed to be hidden.
This PR removes `isHidden` prop from `MiniPickerItem` and filters out hidden items before rendering.

e2e test is added as the issue cannot be reproduced with unit tests.

### How to verify

1. Publish 1000 tables
2. Go to Data studio > Transforms
3. Create a new Query builder transform
4. Pick data source
5. Add a join - when asked for data source, open "Data" collection

App should not crash.
