### PR TITLE
Fix job-run-with-tranform-run-failure-test

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/transforms/jobs_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/jobs_test.clj
@@ -303,7 +303,7 @@
                                  ;; depends on faulty transform
                                  :model/Transform t2 {:name "transform2"
                                                       :source {:type :query
-                                                               :query (lib/native-query mp (str/replace sql "transforms_products" (:name target1)))}
+                                                               :query (lib/native-query mp (str/replace sql (:name table) (:name target1)))}
                                                       :creator_id (mt/user->id :crowberto)
                                                       :target target2}
                                  :model/TransformTransformTag _tag2 {:transform_id (:id t2)


### PR DESCRIPTION
This test was fixed in #66015, commit dbe8b1f36d2 , probably just as a cleanup. We don't want to backport this whole thing but the test fix is nice.

Fixes [UXW-2861: \[Broken Test\] \[be-tests-redshift-ee\] metabase-enterprise.transforms.jobs-test job-run-with-tranform-run-failure-test](https://linear.app/metabase/issue/UXW-2861/broken-test-be-tests-redshift-ee-metabase-enterprisetransformsjobs)