### PR TITLE
fix chatty postgres logs

### DIFF
--- a/src/metabase/app_db/connection_pool_setup.clj
+++ b/src/metabase/app_db/connection_pool_setup.clj
@@ -47,7 +47,8 @@
   (when (postgres-connection? connection)
     (try
       (with-open [stmt (.createStatement connection)]
-        (.execute stmt "ROLLBACK")
+        (when-not (.getAutoCommit connection)
+          (.execute stmt "ROLLBACK"))
         (.execute stmt "DISCARD ALL;"))
       (catch Exception e
         (log/warn e "Failed to DISCARD ALL on connection check-in; connection will be destroyed")


### PR DESCRIPTION
Postgres `WARN`s when you `ROLLBACK` outside of a transaction. So let's just conditionally `ROLLBACK` when we're in a transaction, aka `cxn.getAutoCommit` returns false.