### PR TITLE
Update Jest snapshot headers for Jest v30 compatibility

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/__snapshots__/process-stream.unit.spec.ts.snap
+++ b/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/__snapshots__/process-stream.unit.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`processChatResponse should be able to process a valid stream 1`] = `
 {

--- a/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/__snapshots__/requests.unit.spec.ts.snap
+++ b/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/__snapshots__/requests.unit.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ai requests aiStreamingQuery should return full result of a successful request 1`] = `
 {


### PR DESCRIPTION
Jest v30 validates that snapshot files have the current documentation URL. Updated the header from the old shortened URL to the new official URL.

## Local test run

```
  Test Suites: 2 passed, 2 total
  Tests:       17 passed, 17 total
  Snapshots:   3 passed, 3 total
```