### PR TITLE
GDGT-1781: Split element chain to fix flaky test

### DIFF
--- a/e2e/test/scenarios/data-studio/workspaces.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/workspaces.cy.spec.ts
@@ -1582,8 +1582,10 @@ describe("scenarios > data studio > workspaces", () => {
 
       Workspaces.getMainlandTransforms()
         .findByText("SQL transform")
-        .should("be.visible")
-        .click();
+        .as("sqlTransform")
+        .should("be.visible");
+
+      cy.get("@sqlTransform").click();
 
       Workspaces.getWorkspaceContent().within(() => {
         H.NativeEditor.type(" LIMIT 2");


### PR DESCRIPTION
Closes [GDGT-1781: Flaky Test e2e-tests transform -> workspace > scenarios > data studio > workspaces transform -> workspace > should check out transform into a new workspace from the transform page](https://linear.app/metabase/issue/GDGT-1781/flaky-test-e2e-tests-transform-workspace-scenarios-data-studio)

Stress test runs: https://github.com/metabase/metabase/actions/runs/21954608624/job/63414794777

I'm not sure what is this error, but it doesn't seem directly related to the test?
> should check out transform into a new workspace from the transform page: burning 8 of 20
> missing environment variables { PR_NUMBER: undefined, HASH: undefined }


### Description

Not sure why exactly that flaked, but Cypress warning stated it's best to unchain the method calls.


- [x] Tests have been added/updated to cover changes in this PR

