### PR TITLE
[MBQL lib] "Befriend" `legacy-mbql` module, drop some exported namespaces

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -736,8 +736,6 @@
            metabase.lib.core
            metabase.lib.equality
            metabase.lib.field
-           metabase.lib.filter.desugar.jvm ; only so [[metabase.legacy-mbql.jvm-util]] can use defined regexes
-           metabase.lib.hierarchy
            metabase.lib.init
            metabase.lib.metadata
            metabase.lib.metadata.cached-provider
@@ -751,12 +749,9 @@
            metabase.lib.schema
            metabase.lib.schema.actions
            metabase.lib.schema.aggregation
-           metabase.lib.schema.binning
            metabase.lib.schema.common
-           metabase.lib.schema.constraints
            metabase.lib.schema.expression
            metabase.lib.schema.expression.temporal
-           metabase.lib.schema.expression.window
            metabase.lib.schema.id
            metabase.lib.schema.info
            metabase.lib.schema.join
@@ -765,10 +760,8 @@
            metabase.lib.schema.measure
            metabase.lib.schema.metadata
            metabase.lib.schema.metadata.fingerprint
-           metabase.lib.schema.middleware-options
            metabase.lib.schema.parameter
            metabase.lib.schema.ref
-           metabase.lib.schema.settings
            metabase.lib.schema.template-tag
            metabase.lib.schema.temporal-bucketing
            metabase.lib.schema.test-spec
@@ -784,7 +777,7 @@
            legacy-mbql
            types
            util}
-   :friends #{query-processor}}
+   :friends #{query-processor legacy-mbql}}
 
   lib-be
   {:team "Querying"


### PR DESCRIPTION
Fixes QUE2-349.

### Description

This removes several namespaces from the export list for `lib` which were only used by `legacy-mbql`.

- `metabase.lib.filter.desugar.jvm`
- `metabase.lib.hierarchy`
- `metabase.lib.schema.binning`
- `metabase.lib.schema.middleware-options`
- `metabase.lib.schema.settings`

### How to verify

No visible change. Kondo linters failed when I removed these modules, and passed when I befriended

### Checklist

- ~~Tests have been added/updated to cover changes in this PR~~
  - I tested that the Kondo linters caught this issue, and were fixed by befriending legacy-mbql.
