### PR TITLE
Gdgt 1737 use card metadata instead of parsing card ids

### DIFF
--- a/frontend/src/metabase-types/api/mocks/transform.ts
+++ b/frontend/src/metabase-types/api/mocks/transform.ts
@@ -193,6 +193,10 @@ export function createMockInspectorCard(
     title: "Card",
     display: "scalar",
     dataset_query: createMockNativeDatasetQuery(),
+    metadata: {
+      card_type: "table_count",
+      dedup_key: ["table-1"],
+    },
     ...opts,
   };
 }

--- a/frontend/src/metabase-types/api/transform.ts
+++ b/frontend/src/metabase-types/api/transform.ts
@@ -477,6 +477,18 @@ export type InspectorSection = {
 
 export type InspectorCardDisplayType = CardDisplayType | "hidden";
 
+type InspectorCardMetadata = {
+  card_type: "join_step" | "table_count" | "base_count";
+  dedup_key: Array<string | number>;
+  table_id?: number;
+  join_step?: number;
+  join_alias?: string;
+  join_strategy?: JoinStrategy;
+  group_id?: string;
+  group_role?: "input" | "output";
+  group_order?: number;
+};
+
 export type InspectorCard = {
   id: string;
   section_id?: string;
@@ -486,7 +498,7 @@ export type InspectorCard = {
   interestingness?: number;
   summary?: boolean;
   visualization_settings?: Record<string, unknown>;
-  metadata?: Record<string, unknown>;
+  metadata: InspectorCardMetadata;
 };
 
 export type InspectorSummaryHighlight = {

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/DefaultLensSections/components/ComparisonLayout/utils.ts
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/DefaultLensSections/components/ComparisonLayout/utils.ts
@@ -111,7 +111,7 @@ function isNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value);
 }
 
-function getGroupOrder(card: { metadata?: { group_order?: unknown } }) {
+function getGroupOrder(card: InspectorCard) {
   const order = card.metadata?.group_order;
   if (isNumber(order)) {
     return order;

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/GenericSummarySections/GenericSummarySection.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/GenericSummarySections/GenericSummarySection.tsx
@@ -61,7 +61,10 @@ export const GenericSummarySection = ({
         id: "table_name",
         header: t`Table`,
         accessorFn: (original) =>
-          original.card.title.replace(/ Row Count$/, ""),
+          getTableName(
+            original.card.metadata.table_id,
+            [...sources, target].filter((t) => t !== undefined),
+          ),
         cell: (props) => <Text>{String(props.getValue())}</Text>,
       },
       {
@@ -79,7 +82,7 @@ export const GenericSummarySection = ({
         ),
       },
     ],
-    [],
+    [sources, target],
   );
 
   const inputInstance = useTreeTableInstance({
@@ -126,3 +129,14 @@ export const GenericSummarySection = ({
     </Stack>
   );
 };
+
+function getTableName(
+  tableId: number | undefined,
+  tables: Array<TransformInspectSource | TransformInspectTarget>,
+): string | undefined {
+  if (!tableId) {
+    return undefined;
+  }
+  const table = tables.find((table) => table.table_id === tableId);
+  return table?.table_name;
+}

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/JoinAnalysisSections/JoinAnalysisSection.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/JoinAnalysisSections/JoinAnalysisSection.tsx
@@ -33,8 +33,10 @@ export const JoinAnalysisSection = ({ cards }: JoinAnalysisSectionProps) => {
 
   const { joinStepCards, tableCountCards } = useMemo(
     () => ({
-      joinStepCards: cards.filter((c) => c.id.startsWith("join-step-")),
-      tableCountCards: cards.filter((c) => /^table-.*-count$/.test(c.id)),
+      joinStepCards: cards.filter((c) => c.metadata.card_type === "join_step"),
+      tableCountCards: cards.filter(
+        (c) => c.metadata.card_type === "table_count",
+      ),
     }),
     [cards],
   );
@@ -53,8 +55,8 @@ export const JoinAnalysisSection = ({ cards }: JoinAnalysisSectionProps) => {
         id: card.id,
         card,
         tableCard,
-        joinAlias: card.metadata?.join_alias?.toString() ?? t`Unknown`,
-        joinStrategy: card.metadata?.join_strategy?.toString() ?? "left-join",
+        joinAlias: card.metadata.join_alias?.toString() ?? t`Unknown`,
+        joinStrategy: card.metadata.join_strategy?.toString() ?? "left-join",
         alerts,
         severity: alerts.length > 0 ? getMaxSeverity(alerts) : null,
         drillLenses: drillLensesByCardId[card.id] ?? [],


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-1737/use-card-metadata-instead-of-parsing-card-ids

### Description

- Used available metadata in `JoinAnalysisSection` to get  `tableCountCards` and `joinStepCards`
- Improved in a similar way how table names in Data Summary section are accessed.

### Demo

<img width="1618" height="616" alt="30771" src="https://github.com/user-attachments/assets/9767740c-f99d-4f60-9ab9-76c0489ec89d" />
