### PR TITLE
Improve remote sync errors with missing objects

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
@@ -129,6 +129,13 @@
     (str/includes? (ex-message e) "Missing commit")
     "Repository cache is stale: the remote repository may have been force-pushed. Please retry the operation."
 
+    (= (:error (ex-data e)) :metabase-enterprise.serialization.v2.load/not-found)
+    (let [{:keys [model id]} (ex-data e)]
+      (format "Import failed: %s '%s' does not exist on this instance. Make sure all referenced databases and other dependencies are set up before importing." model id))
+
+    (some-> e ex-cause ex-message (str/includes? "database not found"))
+    (format "Import failed: A referenced database does not exist on this instance. %s" (ex-message (ex-cause e)))
+
     :else
     (format "Failed to reload from git repository: %s" (ex-message e))))
 

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
@@ -133,7 +133,14 @@
       (if-not ingested
         (do
           (when-not (serdes/load-find-local path)
-            (throw (ex-info "Failed to read file" {:path (serdes/log-path-str path)})))
+            (let [missing (last path)
+                  model (:model missing)
+                  id    (:id missing)]
+              (throw (ex-info (format "%s '%s' was not found" model id)
+                              {:path  (serdes/log-path-str path)
+                               :model model
+                               :id    id
+                               :error ::not-found}))))
           (log/debug "Local" {:path (serdes/log-path-str path)})
           ctx)
         (let [_                  (log/info "Loading" (cond-> {:path (serdes/log-path-str path)}

--- a/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
@@ -318,7 +318,7 @@
                                             {:file ba}))
                 log (slurp (io/input-stream res))]
             (testing "Error message indicates missing collection"
-              (is (re-find #"Failed to read file \{:path \"Collection DoesNotExist\"}" log)))
+              (is (re-find #"Collection 'DoesNotExist' was not found" log)))
 
             (testing "Snowplow failure event was sent"
               (is (=? {"success"       false
@@ -328,7 +328,7 @@
                        "duration_ms"   int?
                        "count"         0
                        "error_count"   0
-                       "error_message" "Failed to read file {:path \"Collection DoesNotExist\"}"}
+                       "error_message" #"Collection 'DoesNotExist' was not found"}
                       (-> (snowplow-test/pop-event-data-and-user-id!) last :data))))))))))
 
 (deftest import-continue-on-error-test
@@ -351,7 +351,7 @@
             (testing "Log shows loaded entities and error"
               (is (= #{"Dashboard" "Card" "Collection" "TransformJob" "TransformTag" "PythonLibrary"}
                      (log-types (str/split-lines log))))
-              (is (re-find #"Failed to read file \{:path \"Collection DoesNotExist\"}" log)))
+              (is (re-find #"Collection 'DoesNotExist' was not found" log)))
 
             (testing "Snowplow event shows partial success with error count"
               (is (=? {"success"     true

--- a/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
@@ -328,7 +328,7 @@
                        "duration_ms"   int?
                        "count"         0
                        "error_count"   0
-                       "error_message" #"Collection 'DoesNotExist' was not found"}
+                       "error_message" #"Collection 'DoesNotExist' was not found.*"}
                       (-> (snowplow-test/pop-event-data-and-user-id!) last :data))))))))))
 
 (deftest import-continue-on-error-test

--- a/enterprise/backend/test/metabase_enterprise/serialization/cmd_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/cmd_test.clj
@@ -106,5 +106,5 @@
                              "count"         0
                              "success"       false
                              ;; t2/with-transactions re-wraps errors with data about toucan connections
-                             "error_message" "Failed to read file {:path \"Collection DoesNotExist\"}"}
+                             "error_message" #"Collection 'DoesNotExist' was not found"}
                             (-> (snowplow-test/pop-event-data-and-user-id!) first :data)))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/cmd_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/cmd_test.clj
@@ -106,5 +106,5 @@
                              "count"         0
                              "success"       false
                              ;; t2/with-transactions re-wraps errors with data about toucan connections
-                             "error_message" #"Collection 'DoesNotExist' was not found"}
+                             "error_message" #"Collection 'DoesNotExist' was not found.*"}
                             (-> (snowplow-test/pop-event-data-and-user-id!) first :data)))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -1603,9 +1603,9 @@
               (let [report (serdes.load/load-metabase! (ingestion-in-memory changed) {:continue-on-error true})]
                 (is (= 1 (count (:errors report))))
                 (is (= 3 (count (:seen report)))))
-              (is (= [["Failed to read file {:path \"Collection does-not-exist\"}"]]
-                     (logs-extract #"Skipping deserialization error: (.*)"
-                                   (messages)))))))))))
+              (let [log-msgs (logs-extract #"Skipping deserialization error: (.*)" (messages))]
+                (is (= 1 (count log-msgs)))
+                (is (str/includes? (ffirst log-msgs) "Collection 'does-not-exist' was not found"))))))))))
 
 (deftest with-dbs-works-as-expected-test
   (ts/with-dbs [source-db dest-db]

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -1166,7 +1166,7 @@
                                                  :table_id      ["bad-db" nil "CUSTOMERS"]
                                                  :visualization_settings {}}])]
             (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                                  #"Failed to read file"
+                                  #"was not found"
                                   (serdes.load/load-metabase! ingestion)))))))))
 
 (deftest card-with-snippet-test


### PR DESCRIPTION
### Description

Improves the error message when remote sync tries to load an object which references another, but the referenced object does not exist

Fixes #68705

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
