### PR TITLE
Transforms with parameters

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1184,6 +1184,7 @@
            metabase.query-processor.middleware.add-remaps
            metabase.query-processor.middleware.annotate
            metabase.query-processor.middleware.cache-backend.db
+           metabase.query-processor.middleware.catch-exceptions
            metabase.query-processor.middleware.constraints
            metabase.query-processor.middleware.limit
            metabase.query-processor.middleware.permissions

--- a/src/metabase/transforms/api/transform.clj
+++ b/src/metabase/transforms/api/transform.clj
@@ -182,7 +182,6 @@
 (defn- validate-transform-query!
   [transform]
   (let [message (transforms.util/validate-transform-query transform)]
-    (prn "validate returned" message)
     (api/check (nil? message)
                [400 message])))
 

--- a/src/metabase/transforms/api/transform.clj
+++ b/src/metabase/transforms/api/transform.clj
@@ -181,11 +181,10 @@
 
 (defn- validate-transform-query!
   [transform]
-  (let [error (transforms.util/validate-transform-query transform)]
-    (when (some? error)
-      (throw (ex-info (:error error)
-                      (assoc error
-                             :status-code 400))))))
+  (when-let [error (transforms.util/validate-transform-query transform)]
+    (throw (ex-info (:error error)
+                    (assoc error
+                           :status-code 400)))))
 
 (defn get-transforms
   "Get a list of transforms."

--- a/src/metabase/transforms/api/transform.clj
+++ b/src/metabase/transforms/api/transform.clj
@@ -181,9 +181,11 @@
 
 (defn- validate-transform-query!
   [transform]
-  (let [message (transforms.util/validate-transform-query transform)]
-    (api/check (nil? message)
-               [400 message])))
+  (let [error (transforms.util/validate-transform-query transform)]
+    (when (some? error)
+      (throw (ex-info (:error error)
+                      (assoc error
+                             :status-code 400))))))
 
 (defn get-transforms
   "Get a list of transforms."

--- a/src/metabase/transforms/util.clj
+++ b/src/metabase/transforms/util.clj
@@ -22,6 +22,7 @@
    [metabase.query-processor.middleware.add-remaps :as remap]
    [metabase.query-processor.parameters.dates :as params.dates]
    [metabase.query-processor.pipeline :as qp.pipeline]
+   [metabase.query-processor.preprocess :as qp.preprocess]
    [metabase.sync.core :as sync]
    [metabase.transforms.canceling :as canceling]
    [metabase.transforms.feature-gating :as transforms.gating]
@@ -398,6 +399,16 @@
                            (first (sql.qp/format-honeysql driver honeysql-query))))]
         (update outer-query :query wrap-query))
       outer-query)))
+
+(defn validate-transform-query
+  "Verifies that a query transform's query can actually be run as is.  Returns nil on success and an error message on failure."
+  [{:keys [source]}]
+  (case (keyword (:type source))
+    (try
+      (qp.preprocess/preprocess (:query source))
+      nil
+      (catch Exception e
+        (.getMessage e)))))
 
 (defn compile-source
   "Compile the source query of a transform to SQL, applying incremental filtering if required."

--- a/src/metabase/transforms/util.clj
+++ b/src/metabase/transforms/util.clj
@@ -405,6 +405,7 @@
   "Verifies that a query transform's query can actually be run as is.  Returns nil on success and an error map on failure."
   [{:keys [source]}]
   (case (keyword (:type source))
+    :query
     (try
       (qp.preprocess/preprocess (:query source))
       nil

--- a/src/metabase/transforms/util.clj
+++ b/src/metabase/transforms/util.clj
@@ -401,7 +401,7 @@
         (update outer-query :query wrap-query))
       outer-query)))
 
-(defn validate-transform-query
+(mu/defn validate-transform-query :- [:maybe [:map [:error :string]]]
   "Verifies that a query transform's query can actually be run as is.  Returns nil on success and an error map on failure."
   [{:keys [source]}]
   (case (keyword (:type source))

--- a/src/metabase/transforms/util.clj
+++ b/src/metabase/transforms/util.clj
@@ -20,6 +20,7 @@
    [metabase.query-processor :as qp]
    [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.middleware.add-remaps :as remap]
+   [metabase.query-processor.middleware.catch-exceptions :as qp.catch-exceptions]
    [metabase.query-processor.parameters.dates :as params.dates]
    [metabase.query-processor.pipeline :as qp.pipeline]
    [metabase.query-processor.preprocess :as qp.preprocess]
@@ -401,14 +402,14 @@
       outer-query)))
 
 (defn validate-transform-query
-  "Verifies that a query transform's query can actually be run as is.  Returns nil on success and an error message on failure."
+  "Verifies that a query transform's query can actually be run as is.  Returns nil on success and an error map on failure."
   [{:keys [source]}]
   (case (keyword (:type source))
     (try
       (qp.preprocess/preprocess (:query source))
       nil
       (catch Exception e
-        (.getMessage e)))))
+        (qp.catch-exceptions/exception-response e)))))
 
 (defn compile-source
   "Compile the source query of a transform to SQL, applying incremental filtering if required."

--- a/test/metabase/transforms/api/transform_test.clj
+++ b/test/metabase/transforms/api/transform_test.clj
@@ -131,7 +131,9 @@
                                                                  :schema schema
                                                                  :name   table-name}})
                     transform-id (:id response)]
-                (is (nil? transform-id))))))))))
+                (is (nil? transform-id))
+                (is (= "You'll need to pick a value for 'ID' before this query can run."
+                       (:message response)))))))))))
 
 (deftest create-transform-with-owner-test
   (mt/with-premium-features #{}

--- a/test/metabase/transforms/api/transform_test.clj
+++ b/test/metabase/transforms/api/transform_test.clj
@@ -99,17 +99,18 @@
         (mt/with-data-analyst-role! (mt/user->id :lucky)
           (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
             (with-transform-cleanup! [table-name "gadget_products"]
-              (let [query        (lib/native-query (mt/metadata-provider) "select * from foo [[where {{id}} = id]]")
-                    schema       (get-test-schema)
-                    response     (mt/user-http-request :lucky :post 200 "transform"
-                                                       {:name   "Gadget Products"
-                                                        :source {:type  "query"
-                                                                 :query query}
-                                                        :target {:type   "table"
-                                                                 :schema schema
-                                                                 :name   table-name}})
-                    transform-id (:id response)]
-                (is (some? transform-id))))))))))
+              (testing "Can create a transform with a param"
+                (let [query        (lib/native-query (mt/metadata-provider) "select * from foo [[where {{id}} = id]]")
+                      schema       (get-test-schema)
+                      response     (mt/user-http-request :lucky :post 200 "transform"
+                                                         {:name   "Gadget Products"
+                                                          :source {:type  "query"
+                                                                   :query query}
+                                                          :target {:type   "table"
+                                                                   :schema schema
+                                                                   :name   table-name}})
+                      transform-id (:id response)]
+                  (is (some? transform-id)))))))))))
 
 (deftest create-transform-with-required-param-test
   (mt/with-premium-features #{}
@@ -118,22 +119,48 @@
         (mt/with-data-analyst-role! (mt/user->id :lucky)
           (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
             (with-transform-cleanup! [table-name "gadget_products"]
-              (let [base-query   (lib/native-query (mt/metadata-provider) "select * from foo where {{id}} = id")
-                    tag          (get (lib/template-tags base-query) "id")
-                    query        (lib/with-template-tags base-query
-                                   {"id" (assoc tag :required true)})
-                    schema       (get-test-schema)
-                    response     (mt/user-http-request :lucky :post 400 "transform"
-                                                       {:name   "Gadget Products"
-                                                        :source {:type  "query"
-                                                                 :query query}
-                                                        :target {:type   "table"
-                                                                 :schema schema
-                                                                 :name   table-name}})
-                    transform-id (:id response)]
-                (is (nil? transform-id))
-                (is (= "You'll need to pick a value for 'ID' before this query can run."
-                       (:message response)))))))))))
+              (testing "Cannot create a transform with a required param"
+                (let [base-query   (lib/native-query (mt/metadata-provider) "select * from foo where {{id}} = id")
+                      tag          (get (lib/template-tags base-query) "id")
+                      query        (lib/with-template-tags base-query
+                                     {"id" (assoc tag :required true)})
+                      schema       (get-test-schema)
+                      response     (mt/user-http-request :lucky :post 400 "transform"
+                                                         {:name   "Gadget Products"
+                                                          :source {:type  "query"
+                                                                   :query query}
+                                                          :target {:type   "table"
+                                                                   :schema schema
+                                                                   :name   table-name}})
+                      transform-id (:id response)]
+                  (is (nil? transform-id))
+                  (is (= "You'll need to pick a value for 'ID' before this query can run."
+                         (:message response))))))))))))
+
+(deftest create-transform-with-unofficial-required-param-test
+  (mt/with-premium-features #{}
+    (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
+      (mt/dataset transforms-dataset/transforms-test
+        (mt/with-data-analyst-role! (mt/user->id :lucky)
+          (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
+            (with-transform-cleanup! [table-name "gadget_products"]
+              (testing "Cannot create a transform with a param that is necessary but not marked as required"
+                (let [base-query   (lib/native-query (mt/metadata-provider) "select * from foo where {{id}} = id")
+                      tag          (get (lib/template-tags base-query) "id")
+                      query        (lib/with-template-tags base-query
+                                     {"id" (assoc tag :required true)})
+                      schema       (get-test-schema)
+                      response     (mt/user-http-request :lucky :post 400 "transform"
+                                                         {:name   "Gadget Products"
+                                                          :source {:type  "query"
+                                                                   :query query}
+                                                          :target {:type   "table"
+                                                                   :schema schema
+                                                                   :name   table-name}})
+                      transform-id (:id response)]
+                  (is (nil? transform-id))
+                  (is (= "Cannot run the query: missing required parameters: #{\"id\"}"
+                         (:message response))))))))))))
 
 (deftest create-transform-with-owner-test
   (mt/with-premium-features #{}

--- a/test/metabase/transforms/api/transform_test.clj
+++ b/test/metabase/transforms/api/transform_test.clj
@@ -145,10 +145,7 @@
           (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
             (with-transform-cleanup! [table-name "gadget_products"]
               (testing "Cannot create a transform with a param that is necessary but not marked as required"
-                (let [base-query   (lib/native-query (mt/metadata-provider) "select * from foo where {{id}} = id")
-                      tag          (get (lib/template-tags base-query) "id")
-                      query        (lib/with-template-tags base-query
-                                     {"id" (assoc tag :required true)})
+                (let [query   (lib/native-query (mt/metadata-provider) "select * from foo where {{id}} = id")
                       schema       (get-test-schema)
                       response     (mt/user-http-request :lucky :post 400 "transform"
                                                          {:name   "Gadget Products"

--- a/test/metabase/transforms/api/transform_test.clj
+++ b/test/metabase/transforms/api/transform_test.clj
@@ -270,7 +270,7 @@
                                                      {:source {:type "query"
                                                                :query new-query}})]
               (is (= "You'll need to pick a value for 'ID' before this query can run."
-                     (:error response))))))))))
+                     (:message response))))))))))
 
 (deftest update-transform-query-with-unofficial-required-param-test
   (mt/with-premium-features #{}
@@ -294,7 +294,7 @@
                                                      {:source {:type "query"
                                                                :query new-query}})]
               (is (= "Cannot run the query: missing required parameters: #{\"id\"}"
-                     (:error response))))))))))
+                     (:message response))))))))))
 
 (deftest transform-type-detection-test
   (mt/with-premium-features #{}


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/QUE-3111/backend-validates-transform-parameters

### Description

We want to support transforms with template tags, as long as those tags aren't required or have default values.  However, if we do that, the backend should actually verify that we do in fact have values for all relevant template tags.  This pr adds basic validation logic to transform creation and update routes -- essentially, we just run qp.preprocess/preprocess and see if we get an error.

### How to verify

Edit getValidationResult in frontend/src/metabase/transforms/utils.ts to not check hasInvalidTags and then try to save a transform with template tags.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
