### PR TITLE
Fix more measure unit tests

### DIFF
--- a/frontend/src/metabase-types/api/measure.ts
+++ b/frontend/src/metabase-types/api/measure.ts
@@ -1,4 +1,4 @@
-import type { DatasetQuery } from "./query";
+import type { DatasetQuery, OpaqueDatasetQuery } from "./query";
 import type { Table, TableId } from "./table";
 import type { UserInfo } from "./user";
 
@@ -11,7 +11,7 @@ export interface Measure {
   table_id: TableId;
   table?: Table;
   archived: boolean;
-  definition: DatasetQuery;
+  definition: OpaqueDatasetQuery;
   definition_description?: string;
   revision_message?: string;
   created_at: string;

--- a/frontend/src/metabase-types/api/mocks/measure.ts
+++ b/frontend/src/metabase-types/api/mocks/measure.ts
@@ -1,6 +1,6 @@
+import * as Lib from "metabase-lib";
+import { SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
 import type { Measure } from "metabase-types/api";
-
-import { createMockStructuredDatasetQuery } from "./query";
 
 export const createMockMeasure = (opts?: Partial<Measure>): Measure => ({
   id: 1,
@@ -8,7 +8,18 @@ export const createMockMeasure = (opts?: Partial<Measure>): Measure => ({
   description: "A measure",
   table_id: 1,
   archived: false,
-  definition: createMockStructuredDatasetQuery(),
+  definition: Lib.toJsQuery(
+    Lib.createTestQuery(SAMPLE_PROVIDER, {
+      stages: [
+        {
+          source: {
+            type: "table",
+            id: 1,
+          },
+        },
+      ],
+    }),
+  ),
   definition_description: "",
   created_at: "2021-01-01T00:00:00Z",
   updated_at: "2021-01-01T00:00:00Z",

--- a/frontend/src/metabase-types/api/mocks/measure.ts
+++ b/frontend/src/metabase-types/api/mocks/measure.ts
@@ -1,6 +1,4 @@
-import * as Lib from "metabase-lib";
-import { SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
-import type { Measure } from "metabase-types/api";
+import type { Measure, OpaqueDatasetQuery } from "metabase-types/api";
 
 export const createMockMeasure = (opts?: Partial<Measure>): Measure => ({
   id: 1,
@@ -8,18 +6,12 @@ export const createMockMeasure = (opts?: Partial<Measure>): Measure => ({
   description: "A measure",
   table_id: 1,
   archived: false,
-  definition: Lib.toJsQuery(
-    Lib.createTestQuery(SAMPLE_PROVIDER, {
-      stages: [
-        {
-          source: {
-            type: "table",
-            id: 1,
-          },
-        },
-      ],
-    }),
-  ),
+  // HACK: we cannot create a valid OpaqueDatasetQuery here since that would
+  // lead to cyclic imports in metabase-types/api/mocks.
+  //
+  // Most unit tests don't rely on the definition of the measure and the ones that do
+  // can override the definition with a valid OpaqueDatasetQuery.
+  definition: {} as unknown as OpaqueDatasetQuery,
   definition_description: "",
   created_at: "2021-01-01T00:00:00Z",
   updated_at: "2021-01-01T00:00:00Z",

--- a/frontend/src/metabase/querying/expressions/test/shared.ts
+++ b/frontend/src/metabase/querying/expressions/test/shared.ts
@@ -27,69 +27,85 @@ import {
   createSampleDatabase,
 } from "metabase-types/api/mocks/presets";
 
-const metadata = createMockMetadata({
-  databases: [
-    createSampleDatabase({
-      features: [
-        ...COMMON_DATABASE_FEATURES,
-        "expressions/date",
-        "expressions/integer",
-        "expressions/date",
-      ],
-      tables: [
-        createPeopleTable(),
-        createProductsTable(),
-        createReviewsTable(),
-        createOrdersTable({
-          segments: [
-            createMockSegment({
-              id: getNextId(),
-              name: "Expensive Things",
-              table_id: ORDERS_ID,
-              definition: createMockStructuredDatasetQuery({
-                database: 1,
-                query: {
-                  "source-table": ORDERS_ID,
-                  filter: [">", ["field", ORDERS.TOTAL, null], 30],
-                },
-              }),
-            }),
-          ],
-          metrics: [
-            createMockCard({
-              id: getNextId(),
-              name: "Foo Metric",
-              type: "metric",
-              table_id: ORDERS_ID,
-              dataset_query: createMockStructuredDatasetQuery({
-                database: SAMPLE_DB_ID,
-                query: createMockStructuredQuery({
-                  "source-table": ORDERS_ID,
-                  aggregation: [["sum", ["field", ORDERS.TOTAL, {}]]],
-                }),
-              }),
-            }),
-          ],
-          measures: [
-            createMockMeasure({
-              id: getNextId(),
-              name: "Bar Measure",
-              table_id: ORDERS_ID,
-              definition: {
-                "lib/type": "mbql/query",
-                database: SAMPLE_DB_ID,
-                stages: [
-                  {
-                    "lib/type": "mbql.stage/mbql",
-                    "source-table": ORDERS_ID,
-                    aggregation: [["sum", {}, ["field", {}, ORDERS.TOTAL]]],
-                  },
-                ],
-              } as any,
-            }),
-          ],
+const database = createSampleDatabase({
+  features: [
+    ...COMMON_DATABASE_FEATURES,
+    "expressions/date",
+    "expressions/integer",
+    "expressions/date",
+  ],
+  tables: [
+    createPeopleTable(),
+    createProductsTable(),
+    createReviewsTable(),
+    createOrdersTable({
+      segments: [
+        createMockSegment({
+          id: getNextId(),
+          name: "Expensive Things",
+          table_id: ORDERS_ID,
+          definition: createMockStructuredDatasetQuery({
+            database: 1,
+            query: {
+              "source-table": ORDERS_ID,
+              filter: [">", ["field", ORDERS.TOTAL, null], 30],
+            },
+          }),
         }),
       ],
+      metrics: [
+        createMockCard({
+          id: getNextId(),
+          name: "Foo Metric",
+          type: "metric",
+          table_id: ORDERS_ID,
+          dataset_query: createMockStructuredDatasetQuery({
+            database: SAMPLE_DB_ID,
+            query: createMockStructuredQuery({
+              "source-table": ORDERS_ID,
+              aggregation: [["sum", ["field", ORDERS.TOTAL, {}]]],
+            }),
+          }),
+        }),
+      ],
+    }),
+  ],
+});
+
+let metadata = createMockMetadata({
+  databases: [database],
+});
+
+metadata = createMockMetadata({
+  databases: [database],
+
+  measures: [
+    createMockMeasure({
+      id: getNextId(),
+      name: "Bar Measure",
+      table_id: ORDERS_ID,
+      definition: Lib.toJsQuery(
+        Lib.createTestQuery(Lib.metadataProvider(SAMPLE_DB_ID, metadata), {
+          stages: [
+            {
+              source: { type: "table", id: ORDERS_ID },
+              aggregations: [
+                {
+                  type: "operator",
+                  operator: "sum",
+                  args: [
+                    {
+                      type: "column",
+                      name: "TOTAL",
+                      sourceName: "ORDERS",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        }),
+      ),
     }),
   ],
 });


### PR DESCRIPTION
Fixes unit tests by using `OpaqueDatasetQuery` when defining measures.

Also amends types to enforce this globally.
