### PR TITLE
hit the airports database

### DIFF
--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -298,25 +298,26 @@
   ;; This test calls driver/describe-database which queries Snowflake directly.
   ;; Requires real sync (not fake-sync) so tables actually exist in Snowflake.
   (mt/test-driver :snowflake
-    (tx/with-driver-supports-feature! [:snowflake :test/use-fake-sync false]
-      (testing "describe-database"
-        (let [expected-tables #{{:name "continent",    :schema "PUBLIC", :description nil}
-                                {:name "municipality", :schema "PUBLIC", :description nil}
-                                {:name "region",       :schema "PUBLIC", :description nil}
-                                {:name "country",      :schema "PUBLIC", :description nil}
-                                {:name "airport",      :schema "PUBLIC", :description nil}}]
-          (testing "should work with normal details"
-            (is (= expected-tables
-                   (:tables (driver/describe-database :snowflake (mt/db))))))
-          (testing "should accept either `:db` or `:dbname` in the details, working around a bug with the original impl"
-            (is (= expected-tables
-                   (:tables (driver/describe-database :snowflake (update (mt/db) :details set/rename-keys {:db :dbname}))))))
-          (testing "should throw an Exception if details have neither `:db` nor `:dbname`"
-            (is (thrown? Exception
-                         (driver/describe-database :snowflake (update (mt/db) :details set/rename-keys {:db :xyz})))))
-          (testing "should use the NAME FROM DETAILS instead of the DB DISPLAY NAME to fetch metadata (#8864)"
-            (is (= expected-tables
-                   (:tables (driver/describe-database :snowflake (assoc (mt/db) :name "ABC")))))))))))
+    (mt/dataset airports
+      (tx/with-driver-supports-feature! [:snowflake :test/use-fake-sync false]
+        (testing "describe-database"
+          (let [expected-tables #{{:name "continent",    :schema "PUBLIC", :description nil}
+                                  {:name "municipality", :schema "PUBLIC", :description nil}
+                                  {:name "region",       :schema "PUBLIC", :description nil}
+                                  {:name "country",      :schema "PUBLIC", :description nil}
+                                  {:name "airport",      :schema "PUBLIC", :description nil}}]
+            (testing "should work with normal details"
+              (is (= expected-tables
+                     (:tables (driver/describe-database :snowflake (mt/db))))))
+            (testing "should accept either `:db` or `:dbname` in the details, working around a bug with the original impl"
+              (is (= expected-tables
+                     (:tables (driver/describe-database :snowflake (update (mt/db) :details set/rename-keys {:db :dbname}))))))
+            (testing "should throw an Exception if details have neither `:db` nor `:dbname`"
+              (is (thrown? Exception
+                           (driver/describe-database :snowflake (update (mt/db) :details set/rename-keys {:db :xyz})))))
+            (testing "should use the NAME FROM DETAILS instead of the DB DISPLAY NAME to fetch metadata (#8864)"
+              (is (= expected-tables
+                     (:tables (driver/describe-database :snowflake (assoc (mt/db) :name "ABC"))))))))))))
 
 (deftest describe-database-default-schema-test
   (testing "describe-database should include Tables from all schemas even if the DB has a default schema (#38135)"


### PR DESCRIPTION
was swapped to this in https://github.com/metabase/metabase/pull/68844, backported in https://github.com/metabase/metabase/pull/68949. But the faster snowflake tests in
https://github.com/metabase/metabase/pull/68760 got the merge conflict wrong and dropped the table.

running locally works:
```shell
source ~/projects/go/mb-test-env/test.env
DRIVERS=snowflake clj -X:dev:drivers:drivers-dev:test :only metabase.driver.snowflake-test/describe-database-test
Running 1 tests
...
LONG TEST in metabase.driver.snowflake-test/describe-database-test
Test took 27.704 seconds seconds to run

1/1   100% [==================================================]  ETA: 00:00

Ran 1 tests in 27.724 seconds
4 assertions, 0 failures, 0 errors.
{:test 1, :pass 4, :fail 0, :error 0, :type :summary, :duration 27723.639959, :single-threaded 1}
Ran 0 tests in parallel, 1 single-threaded.
Finding and running tests took 35.3 s.
All tests passed.
```
