### PR TITLE
Fix ci-test-config driver quarantine name translation

### DIFF
--- a/mage/src/mage/modules.clj
+++ b/mage/src/mage/modules.clj
@@ -305,7 +305,8 @@
 (defn- quarantined-drivers []
   (-> (read-ci-test-config)
       (get-in [:ignored :drivers] [])
-      (->> (map keyword))
+      (->> (mapcat #(or (get driver-directory->drivers %)
+                        [(keyword %)])))
       (set)))
 
 (defn- parse-bool

--- a/mage/test/mage/modules_test.clj
+++ b/mage/test/mage/modules_test.clj
@@ -52,6 +52,24 @@
       (is (false? (:should-run result)))
       (is (= "driver is quarantined" (:reason result))))))
 
+(deftest quarantine-config-names-are-translated
+  (testing "Config names from ci-test-config.json are translated to internal driver keywords via driver-directory->drivers"
+    (testing "directory names are translated to internal keywords"
+      ;; bigquery-cloud-sdk -> :bigquery (via driver-directory->drivers mapping)
+      (let [result (mage.modules/driver-decision :bigquery
+                                                 (make-ctx {:is-master-or-release true})
+                                                 false
+                                                 #{:bigquery} ; as if translated from "bigquery-cloud-sdk"
+                                                 #{})]
+        (is (false? (:should-run result)))
+        (is (= "driver is quarantined" (:reason result)))))
+    (testing "the driver-directory->drivers mapping contains expected translations"
+      ;; Verify the mapping exists and has expected entries
+      (is (= [:bigquery] (get @#'mage.modules/driver-directory->drivers "bigquery-cloud-sdk"))
+          "bigquery-cloud-sdk should map to [:bigquery]")
+      (is (= [:mongo :mongo-ssl :mongo-sharded-cluster] (get @#'mage.modules/driver-directory->drivers "mongo"))
+          "mongo should map to multiple test jobs"))))
+
 ;;; =============================================================================
 ;;; Priority 1: Global skip
 ;;; =============================================================================

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -887,3 +887,4 @@
   (let [schema (some-> table namespace)
         rand   (subs (str (random-uuid)) 0 8)]
     (keyword schema (str transform-temp-table-prefix "_" rand))))
+;; Temporary change to trigger CI - delete this comment

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -887,4 +887,3 @@
   (let [schema (some-> table namespace)
         rand   (subs (str (random-uuid)) 0 8)]
     (keyword schema (str transform-temp-table-prefix "_" rand))))
-;; Temporary change to trigger CI - delete this comment


### PR DESCRIPTION
Resolves DEV-1553

The ci-test-config.json uses driver directory names (e.g., "bigquery-cloud-sdk") but the mage code uses internal driver keywords (e.g., :bigquery). This mismatch meant quarantined drivers like bigquery were not being recognized.

Now uses the existing driver-directory->drivers mapping to translate config names to internal keywords, with fallback to direct keyword conversion for names that match (like "databricks").

- [x] Tests have been added/updated to cover changes in this PR

- [x] [Mage tests are passing](https://github.com/metabase/metabase/actions/runs/21982742414/job/63509184993?pr=69615) :heavy_check_mark: 

## Temporary CI run

Shows that the big query is now properly skipped
<img width="291" height="639" alt="image" src="https://github.com/user-attachments/assets/2b21114b-f636-452b-a4f5-7220d2dc08b9" />

