### PR TITLE
Add row and column level security step for onboarding

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/CreateTenantsOnboardingStep/CreateTenantsOnboardingStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/CreateTenantsOnboardingStep/CreateTenantsOnboardingStep.tsx
@@ -143,7 +143,7 @@ export const CreateTenantsOnboardingStep = ({
                 onChange={(value) =>
                   updateTenantCard(index, "tenantIdentifier", value)
                 }
-                placeholder="tenant_id"
+                placeholder="1"
               />
 
               <TenantFormField

--- a/frontend/src/metabase/api/group-table-access-policy.ts
+++ b/frontend/src/metabase/api/group-table-access-policy.ts
@@ -1,0 +1,23 @@
+import type { GroupTableAccessPolicy } from "metabase-types/api";
+
+import { Api } from "./api";
+import { listTag } from "./tags";
+
+export const groupTableAccessPolicyApi = Api.injectEndpoints({
+  endpoints: (builder) => ({
+    listGroupTableAccessPolicies: builder.query<
+      GroupTableAccessPolicy[],
+      { group_id?: number; table_id?: number } | void
+    >({
+      query: (params) => ({
+        method: "GET",
+        url: "/api/mt/gtap",
+        params,
+      }),
+      providesTags: () => [listTag("group-table-access-policy")],
+    }),
+  }),
+});
+
+export const { useListGroupTableAccessPoliciesQuery } =
+  groupTableAccessPolicyApi;

--- a/frontend/src/metabase/api/index.ts
+++ b/frontend/src/metabase/api/index.ts
@@ -31,6 +31,7 @@ export * from "./permission";
 export * from "./persist";
 export * from "./premium-features";
 export * from "./revision";
+export * from "./group-table-access-policy";
 export * from "./search";
 export * from "./segment";
 export * from "./session";

--- a/frontend/src/metabase/api/settings.ts
+++ b/frontend/src/metabase/api/settings.ts
@@ -56,6 +56,9 @@ export const settingsApi = Api.injectEndpoints({
           tag("session-properties"),
           ...(key === "uploads-settings" ? [listTag("database")] : []),
           ...(key === "llm-anthropic-api-key" ? [listTag("llm-models")] : []),
+
+          // Enabling tenants creates the "all-external-users" permission group
+          ...(key === "use-tenants" ? [listTag("permissions-group")] : []),
         ]);
       },
     }),

--- a/frontend/src/metabase/api/tags/constants.ts
+++ b/frontend/src/metabase/api/tags/constants.ts
@@ -35,6 +35,7 @@ export const TAG_TYPES = [
   "persisted-info",
   "persisted-model",
   "revision",
+  "group-table-access-policy",
   "schema",
   "segment",
   "session-properties",

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/MiniPicker.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/MiniPicker.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo } from "react";
 
 import { PLUGIN_LIBRARY } from "metabase/plugins";
+import type { MenuDropdownProps } from "metabase/ui";
 import { Box, Menu } from "metabase/ui";
 
 import type { DataPickerValue } from "../../../DataPicker";
@@ -26,7 +27,7 @@ export type MiniPickerProps = {
   onBrowseAll?: () => void;
   shouldHide?: (item: MiniPickerItem | unknown) => boolean;
   shouldShowLibrary?: boolean;
-};
+} & Pick<MenuDropdownProps, "mt" | "ml">;
 
 export function MiniPicker({
   searchQuery,
@@ -39,6 +40,8 @@ export function MiniPicker({
   trapFocus = false,
   shouldHide,
   shouldShowLibrary = true,
+  mt,
+  ml,
 }: MiniPickerProps) {
   const { data: libraryCollection } = PLUGIN_LIBRARY.useGetLibraryCollection();
 
@@ -98,13 +101,7 @@ export function MiniPicker({
           <Box />
         </Menu.Target>
 
-        <Menu.Dropdown
-          mt="xl"
-          ml="-1rem"
-          px={0}
-          py="sm"
-          data-testid="mini-picker"
-        >
+        <Menu.Dropdown mt={mt} ml={ml} px={0} py="sm" data-testid="mini-picker">
           {isLoadingPath ? <MiniPickerListLoader /> : <MiniPickerPane />}
         </Menu.Dropdown>
       </Menu>

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/EnableTenantsStepContent.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/EnableTenantsStepContent.tsx
@@ -1,0 +1,93 @@
+/* eslint-disable metabase/no-literal-metabase-strings -- This string only shows for admins */
+
+import { useCallback } from "react";
+import { t } from "ttag";
+
+import {
+  useCreateCollectionMutation,
+  useListCollectionsTreeQuery,
+  useUpdateSettingMutation,
+} from "metabase/api";
+import { getErrorMessage } from "metabase/api/utils";
+import { useToast } from "metabase/common/hooks";
+import { Button, Group, Stack, Text } from "metabase/ui";
+
+import S from "./SetupPermissionsAndTenantsPage.module.css";
+
+interface EnableTenantsStepContentProps {
+  isTenantsEnabled: boolean;
+}
+
+export const EnableTenantsStepContent = ({
+  isTenantsEnabled,
+}: EnableTenantsStepContentProps) => {
+  const [sendToast] = useToast();
+
+  const { data: sharedTenantCollections } = useListCollectionsTreeQuery({
+    namespace: "shared-tenant-collection",
+  });
+
+  const [updateSetting, { isLoading: isUpdatingSetting }] =
+    useUpdateSettingMutation();
+
+  const [createCollection, { isLoading: isCreatingCollection }] =
+    useCreateCollectionMutation();
+
+  const hasSharedCollections =
+    sharedTenantCollections && sharedTenantCollections.length > 0;
+
+  const isEnablingTenants = isUpdatingSetting || isCreatingCollection;
+
+  const enableTenantsAndCreateSharedCollection = useCallback(async () => {
+    try {
+      await updateSetting({ key: "use-tenants", value: true }).unwrap();
+
+      // Only create a shared collection if none exist yet
+      if (!hasSharedCollections) {
+        await createCollection({
+          name: t`Shared collection`,
+          parent_id: null,
+          namespace: "shared-tenant-collection",
+        }).unwrap();
+      }
+    } catch (error) {
+      sendToast({
+        icon: "warning",
+        toastColor: "error",
+        message: getErrorMessage(
+          error,
+          t`Failed to enable tenants and create shared collection`,
+        ),
+      });
+    }
+  }, [updateSetting, hasSharedCollections, createCollection, sendToast]);
+
+  return (
+    <Stack gap="lg">
+      <img
+        src="app/assets/img/embedding-onboarding/multi-tenant-user-strategy.svg"
+        alt=""
+        className={S.illustration}
+      />
+
+      <Text size="md" c="text-secondary" lh="lg">
+        {t`A tenant is a set of attributes assigned to a user to isolate them from other tenants. For example, in a SaaS app with embedded Metabase dashboards, you can assign each customer to a tenant.`}
+      </Text>
+
+      <Text size="md" c="text-secondary" lh="lg">
+        {t`The main benefit of tenants is that you can reuse the same dashboards and permissions across all tenants, instead of recreating them for each customer, while ensuring each tenant only sees its own data. A shared collection will be created to hold dashboards and charts that are shared between all tenants.`}
+      </Text>
+
+      <Group justify="flex-end">
+        <Button
+          variant="filled"
+          onClick={enableTenantsAndCreateSharedCollection}
+          loading={isEnablingTenants}
+          disabled={isTenantsEnabled && hasSharedCollections}
+        >
+          {t`Enable tenants and create shared collection`}
+        </Button>
+      </Group>
+    </Stack>
+  );
+};

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/RlsDataSelector/RlsDataSelector.module.css
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/RlsDataSelector/RlsDataSelector.module.css
@@ -1,0 +1,39 @@
+[data-can-remove="true"]:hover .RemoveButton {
+  opacity: 1;
+}
+
+.RemoveButton {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: var(--mantine-radius-xs);
+  color: var(--mb-color-text-secondary);
+  opacity: 0;
+  transition:
+    opacity 0.15s ease,
+    background 0.15s ease;
+}
+
+.RemoveButton:hover {
+  background: var(--mb-color-background-hover);
+  color: var(--mb-color-text-primary);
+}
+
+.PickerTrigger {
+  border: 1px solid var(--mb-color-border);
+  transition: border-color 0.15s ease;
+  cursor: pointer;
+}
+
+.PickerTrigger:hover {
+  border-color: var(--mb-color-brand);
+}
+
+.AddTableButton {
+  color: var(--mb-color-brand);
+}

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/RlsDataSelector/RlsDataSelector.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/RlsDataSelector/RlsDataSelector.tsx
@@ -1,0 +1,123 @@
+import { useCallback, useState } from "react";
+import { t } from "ttag";
+
+import { getErrorMessage } from "metabase/api/utils";
+import { useToast } from "metabase/common/hooks";
+import { Button, Flex, Icon, Stack, Text, UnstyledButton } from "metabase/ui";
+import type { FieldId, TableId } from "metabase-types/api";
+
+import { useUpsertGroupTableAccessPolicies } from "../hooks/use-upsert-group-table-access-policies";
+
+import S from "./RlsDataSelector.module.css";
+import { TableColumnCard } from "./TableColumnCard";
+
+export interface TableColumnSelection {
+  tableId: TableId | null;
+  columnId: FieldId | null;
+}
+
+export const RlsDataSelector = ({ onSuccess }: { onSuccess: () => void }) => {
+  const [sendToast] = useToast();
+
+  const [selections, setSelections] = useState<TableColumnSelection[]>([
+    { tableId: null, columnId: null },
+  ]);
+
+  const { handleUpsertPolicies, isCreatingPolicy, isLoadingPolicies } =
+    useUpsertGroupTableAccessPolicies({
+      tableColumnSelections: selections,
+    });
+
+  const handleSubmit = useCallback(async () => {
+    try {
+      await handleUpsertPolicies();
+
+      onSuccess();
+    } catch (error) {
+      sendToast({
+        icon: "warning",
+        toastColor: "error",
+        message: getErrorMessage(
+          error,
+          t`Failed to configure row-level security`,
+        ),
+      });
+    }
+  }, [handleUpsertPolicies, onSuccess, sendToast]);
+
+  const addTable = useCallback(() => {
+    setSelections((prev) => [...prev, { tableId: null, columnId: null }]);
+  }, []);
+
+  const removeTable = useCallback((nextIndex: number) => {
+    setSelections((prev) =>
+      prev.filter((_, prevIndex) => prevIndex !== nextIndex),
+    );
+  }, []);
+
+  const updateTable = useCallback(
+    (index: number, selection: TableColumnSelection) => {
+      setSelections((prev) => {
+        const newSelections = [...prev];
+        newSelections[index] = selection;
+
+        return newSelections;
+      });
+    },
+    [],
+  );
+
+  const canRemove = selections.length > 1;
+
+  const isAllTableAndColumnChosen = selections.every(
+    (selection) => selection.tableId !== null && selection.columnId !== null,
+  );
+
+  return (
+    <Stack gap="md">
+      <Text size="md" c="text-secondary" lh="lg">
+        {t`Select one or more tables to be made visible to tenant users, and the column to filter by. Only rows where the value in the selected column matches the tenant_identifier attribute will be visible to tenant users. You will create tenants and configure this attribute in the next step.`}
+      </Text>
+
+      <Text size="md" c="text-secondary" lh="lg">
+        {t`Tenant users will be able to create queries on these tables with the query builder. All other tables will be blocked.`}
+      </Text>
+
+      <Stack gap="md">
+        {selections.map((selection, index) => {
+          // Get all selected table ids, except the current card's selection
+          const selectedTableIds = selections
+            .filter((_, filterIndex) => filterIndex !== index)
+            .map((selection) => selection.tableId)
+            .filter((tableId) => tableId !== null);
+
+          return (
+            <TableColumnCard
+              key={index}
+              selection={selection}
+              onChange={(nextSelection) => updateTable(index, nextSelection)}
+              onRemove={canRemove ? () => removeTable(index) : undefined}
+              selectedTableIds={selectedTableIds}
+            />
+          );
+        })}
+      </Stack>
+
+      <Flex justify="space-between" align="center">
+        <UnstyledButton onClick={addTable} className={S.AddTableButton}>
+          <Flex align="center" gap="xs">
+            <Icon name="add" size={16} />
+            <Text fw="bold" size="md">{t`Add table`}</Text>
+          </Flex>
+        </UnstyledButton>
+
+        <Button
+          variant="filled"
+          disabled={!isAllTableAndColumnChosen || isLoadingPolicies}
+          onClick={handleSubmit}
+          loading={isCreatingPolicy}
+        >{t`Next`}</Button>
+      </Flex>
+    </Stack>
+  );
+};

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/RlsDataSelector/TableColumnCard.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/RlsDataSelector/TableColumnCard.tsx
@@ -1,0 +1,198 @@
+import { useDisclosure } from "@mantine/hooks";
+import { useCallback } from "react";
+import { t } from "ttag";
+
+import { useGetTableQueryMetadataQuery } from "metabase/api";
+import type { OmniPickerItem } from "metabase/common/components/Pickers";
+import { DataPickerModal } from "metabase/common/components/Pickers/DataPicker";
+import { MiniPicker } from "metabase/common/components/Pickers/MiniPicker";
+import type {
+  MiniPickerItem,
+  MiniPickerPickableItem,
+} from "metabase/common/components/Pickers/MiniPicker/types";
+import {
+  Box,
+  Flex,
+  Icon,
+  Paper,
+  Select,
+  Stack,
+  Text,
+  UnstyledButton,
+} from "metabase/ui";
+import type { TableId } from "metabase-types/api";
+
+import type { TableColumnSelection } from "./RlsDataSelector";
+import S from "./RlsDataSelector.module.css";
+
+interface TableColumnCardProps {
+  selection: TableColumnSelection;
+  onChange: (selection: TableColumnSelection) => void;
+  onRemove?: () => void;
+
+  /** Table IDs that are already selected in other cards and should be hidden */
+  selectedTableIds?: TableId[];
+}
+
+export const TableColumnCard = ({
+  selection,
+  onChange,
+  onRemove,
+  selectedTableIds = [],
+}: TableColumnCardProps) => {
+  const [isPickerOpen, { close: closePicker, open: openPicker }] =
+    useDisclosure(false);
+  const [isBrowsing, { open: openBrowse, close: closeBrowse }] =
+    useDisclosure(false);
+
+  const { data: tableMetadata, isLoading: isLoadingTable } =
+    useGetTableQueryMetadataQuery(
+      { id: selection.tableId! },
+      { skip: !selection.tableId },
+    );
+
+  const handleTableSelect = useCallback(
+    (item: MiniPickerPickableItem) => {
+      if (item.model === "table") {
+        onChange({ tableId: item.id, columnId: null });
+        closePicker();
+      }
+    },
+    [onChange, closePicker],
+  );
+
+  const handleModalSelect = useCallback(
+    (tableId: TableId) => {
+      onChange({ tableId, columnId: null });
+      closeBrowse();
+    },
+    [onChange, closeBrowse],
+  );
+
+  const handleBrowseAll = useCallback(() => {
+    closePicker();
+    openBrowse();
+  }, [closePicker, openBrowse]);
+
+  const handleColumnSelect = useCallback(
+    (columnId: string | null) => {
+      onChange({
+        ...selection,
+        columnId: columnId ? Number(columnId) : null,
+      });
+    },
+    [selection, onChange],
+  );
+
+  const columnOptions =
+    tableMetadata?.fields?.map((field) => ({
+      value: String(field.id),
+      label: field.display_name,
+    })) ?? [];
+
+  const selectedTableName = tableMetadata?.display_name;
+
+  const pickerValue = selection.tableId
+    ? { model: "table" as const, id: selection.tableId }
+    : undefined;
+
+  // Hide tables that are already selected in other cards
+  const shouldHidePickerItem = useCallback(
+    (pickerItem: MiniPickerItem | OmniPickerItem) =>
+      pickerItem.model === "table" && selectedTableIds.includes(pickerItem.id),
+    [selectedTableIds],
+  );
+
+  return (
+    <Paper withBorder radius="md" pos="relative" data-can-remove={!!onRemove}>
+      {onRemove && (
+        <UnstyledButton
+          className={S.RemoveButton}
+          onClick={onRemove}
+          aria-label={t`Remove table`}
+        >
+          <Icon name="close" size={16} />
+        </UnstyledButton>
+      )}
+
+      <Stack gap="lg" p="lg">
+        <Box>
+          <Text fw="bold" size="md" mb={4}>
+            {t`Table`}
+          </Text>
+          <Text size="sm" c="text-secondary" mb="sm">
+            {t`Will be visible to all tenant users`}
+          </Text>
+
+          <Flex
+            component="button"
+            type="button"
+            className={S.PickerTrigger}
+            onClick={openPicker}
+            align="center"
+            justify="space-between"
+            w="100%"
+            px="0.75rem"
+            py="sm"
+            bg="background-primary"
+            bdrs="xs"
+          >
+            <Text
+              c={selectedTableName ? "text-primary" : "text-tertiary"}
+              size="md"
+            >
+              {selectedTableName ?? t`Pick a table`}
+            </Text>
+
+            <Icon name="chevrondown" size={16} />
+          </Flex>
+
+          <MiniPicker
+            value={pickerValue}
+            opened={isPickerOpen && !isBrowsing}
+            onClose={closePicker}
+            models={["table"]}
+            onBrowseAll={handleBrowseAll}
+            onChange={handleTableSelect}
+            shouldShowLibrary={false}
+            shouldHide={(item) => shouldHidePickerItem(item as MiniPickerItem)}
+          />
+
+          {isBrowsing && (
+            <DataPickerModal
+              title={t`Pick a table`}
+              models={["table"]}
+              onChange={handleModalSelect}
+              onClose={closeBrowse}
+              shouldDisableItem={shouldHidePickerItem}
+              options={{
+                hasLibrary: false,
+                hasRootCollection: false,
+                hasPersonalCollections: false,
+              }}
+            />
+          )}
+        </Box>
+
+        <Box>
+          <Text fw="bold" size="md" mb={4}>
+            {t`Column to filter by`}
+          </Text>
+
+          <Text size="sm" c="text-secondary" mb="sm">
+            {t`Tenant users will only see rows where this equals the tenant_identifier attribute.`}
+          </Text>
+
+          <Select
+            placeholder={t`Pick a column`}
+            data={columnOptions}
+            value={selection.columnId ? String(selection.columnId) : null}
+            onChange={handleColumnSelect}
+            disabled={!selection.tableId || isLoadingTable}
+            comboboxProps={{ position: "bottom" }}
+          />
+        </Box>
+      </Stack>
+    </Paper>
+  );
+};

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/RlsDataSelector/index.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/RlsDataSelector/index.ts
@@ -1,0 +1,1 @@
+export { RlsDataSelector, type TableColumnSelection } from "./RlsDataSelector";

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/hooks/use-update-all-tenant-users-group-permissions.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/hooks/use-update-all-tenant-users-group-permissions.ts
@@ -1,0 +1,107 @@
+import { useCallback, useMemo } from "react";
+
+import { Api, useListPermissionsGroupsQuery } from "metabase/api";
+import { listTag } from "metabase/api/tags";
+import { useDispatch } from "metabase/lib/redux";
+import { PLUGIN_TENANTS } from "metabase/plugins";
+import { PermissionsApi } from "metabase/services";
+
+import {
+  type UpdateTenantDataAccessOptions,
+  buildPermissionsGraph,
+  buildSandboxPolicies,
+} from "../utils/permission-utils";
+
+interface UseUpdateAllTenantUsersGroupPermissionsResult {
+  /**
+   * Updates data access for the tenant users group in a single API call.
+   * Supports both connection impersonation and row-level security (sandboxing).
+   */
+  updateDataAccess: (options: UpdateTenantDataAccessOptions) => Promise<void>;
+
+  tenantUsersGroupId?: number;
+
+  /** Whether the tenant users group data is still loading */
+  isLoading: boolean;
+
+  /** Whether the hook is ready to update permissions */
+  isReady: boolean;
+}
+
+/**
+ * Hook for updating data access for the "All tenant users" group:
+ *
+ * - Row-level security (table-level)
+ * - Connection impersonation (database-level)
+ */
+export function useUpdateAllTenantUsersGroupPermissions(): UseUpdateAllTenantUsersGroupPermissionsResult {
+  const dispatch = useDispatch();
+
+  const { data: permissionGroups, isLoading } = useListPermissionsGroupsQuery(
+    {},
+  );
+
+  const allTenantUsersGroupId = useMemo(
+    () => permissionGroups?.find(PLUGIN_TENANTS.isExternalUsersGroup)?.id,
+    [permissionGroups],
+  );
+
+  const updateDataAccess = useCallback(
+    async (options: UpdateTenantDataAccessOptions) => {
+      if (allTenantUsersGroupId === undefined) {
+        return;
+      }
+
+      const { impersonatedDatabaseIds = [], sandboxedTables = [] } = options;
+
+      // at least one impersonations or sandboxes are needed to setup
+      if (
+        impersonatedDatabaseIds.length === 0 &&
+        sandboxedTables.length === 0
+      ) {
+        return;
+      }
+
+      // get the revision number of the graph
+      const graph = await PermissionsApi.graphForGroup({
+        groupId: allTenantUsersGroupId,
+      });
+
+      const groups = buildPermissionsGraph(allTenantUsersGroupId, options);
+      const sandboxes = buildSandboxPolicies(
+        allTenantUsersGroupId,
+        sandboxedTables,
+      );
+
+      const impersonations = impersonatedDatabaseIds.map((databaseId) => ({
+        db_id: databaseId,
+        group_id: allTenantUsersGroupId,
+        attribute: "database_role",
+      }));
+
+      await PermissionsApi.updateGraph({
+        groups,
+        revision: graph?.revision,
+        ...(sandboxes.length > 0 && { sandboxes }),
+        ...(impersonations.length > 0 && { impersonations }),
+      });
+
+      // invalidate the onboarding checklist and group table access policies
+      // so subsequent updates can find the newly created sandbox IDs
+      dispatch(
+        Api.util.invalidateTags([
+          listTag("embedding-hub-checklist"),
+          listTag("group-table-access-policy"),
+        ]),
+      );
+    },
+    [allTenantUsersGroupId, dispatch],
+  );
+
+  return {
+    updateDataAccess,
+    tenantUsersGroupId: allTenantUsersGroupId,
+    isLoading,
+    isReady: allTenantUsersGroupId !== undefined,
+  };
+}

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/hooks/use-upsert-group-table-access-policies.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/hooks/use-upsert-group-table-access-policies.ts
@@ -1,0 +1,96 @@
+import { useCallback, useState } from "react";
+import { t } from "ttag";
+
+import { tableApi, useListGroupTableAccessPoliciesQuery } from "metabase/api";
+import { useDispatch } from "metabase/lib/redux";
+
+import type { TableColumnSelection } from "../RlsDataSelector";
+
+import { useUpdateAllTenantUsersGroupPermissions } from "./use-update-all-tenant-users-group-permissions";
+
+interface UseUpsertGroupTableAccessPoliciesProps {
+  tableColumnSelections: TableColumnSelection[];
+}
+
+/**
+ * Creates group table access policies (sandboxes)
+ * for the given table and column selections.
+ */
+export const useUpsertGroupTableAccessPolicies = ({
+  tableColumnSelections,
+}: UseUpsertGroupTableAccessPoliciesProps) => {
+  const dispatch = useDispatch();
+
+  const [isCreatingPolicy, setIsCreatingPolicy] = useState(false);
+
+  const { updateDataAccess, tenantUsersGroupId, isReady } =
+    useUpdateAllTenantUsersGroupPermissions();
+
+  const { data: existingPolicies, isLoading: isLoadingPolicies } =
+    useListGroupTableAccessPoliciesQuery(
+      tenantUsersGroupId ? { group_id: tenantUsersGroupId } : undefined,
+      { skip: !tenantUsersGroupId },
+    );
+
+  const handleUpsertPolicies = useCallback(async () => {
+    if (!tenantUsersGroupId) {
+      throw new Error(
+        t`Could not find the tenant users group. Please enable tenants first.`,
+      );
+    }
+
+    try {
+      setIsCreatingPolicy(true);
+
+      const nextPolicies = await Promise.all(
+        tableColumnSelections.map(async (selection) => {
+          if (selection.tableId === null || selection.columnId === null) {
+            return null;
+          }
+
+          const { data: table } = await dispatch(
+            tableApi.endpoints.getTable.initiate({ id: selection.tableId }),
+          );
+
+          if (!table) {
+            return null;
+          }
+
+          const existingPolicy = existingPolicies?.find(
+            (policy) => policy.table_id === selection.tableId,
+          );
+
+          return {
+            tableId: table.id,
+            databaseId: table.db_id,
+            schemaName: table.schema ?? "",
+            filterFieldId: selection.columnId,
+
+            // If existing policy is found, this updates
+            // the policy rather than creating a new one.
+            ...(existingPolicy && { id: existingPolicy.id }),
+          };
+        }),
+      );
+
+      const sandboxedTables = nextPolicies.filter((entry) => entry != null);
+      await updateDataAccess({ sandboxedTables });
+    } finally {
+      setIsCreatingPolicy(false);
+    }
+  }, [
+    dispatch,
+    tenantUsersGroupId,
+    tableColumnSelections,
+    existingPolicies,
+    updateDataAccess,
+  ]);
+
+  return {
+    handleUpsertPolicies,
+    isCreatingPolicy,
+    isLoadingPolicies,
+    isReady,
+    existingPolicies,
+  };
+};

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/utils/permission-utils.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/utils/permission-utils.ts
@@ -1,0 +1,101 @@
+import type {
+  DatabaseId,
+  FieldId,
+  GroupId,
+  GroupTableAccessPolicy,
+  TableId,
+} from "metabase-types/api";
+
+export interface UpdateTenantDataAccessOptions {
+  /** Database IDs to enable connection impersonation for */
+  impersonatedDatabaseIds?: DatabaseId[];
+
+  /** Tables to enable sandboxing (row-level security) for */
+  sandboxedTables?: SandboxedTableConfig[];
+}
+
+/** Input type for creating/updating sandbox policies via the API */
+type SandboxPolicyInput = Partial<Pick<GroupTableAccessPolicy, "id">> &
+  Omit<GroupTableAccessPolicy, "id" | "permission_id">;
+
+type SandboxedTableConfig = {
+  /**
+   * Existing sandbox ID.
+   * If provided, updates the existing sandbox.
+   **/
+  id?: number;
+
+  tableId: TableId;
+  databaseId: DatabaseId;
+  schemaName: string;
+
+  /** The field to use for tenant filtering */
+  filterFieldId: FieldId;
+};
+
+type DatabasePermissionGraph = Record<
+  string,
+  string | Record<string, Record<TableId, string>>
+>;
+
+/**
+ * Builds the permission graph structure for the API call.
+ */
+export function buildPermissionsGraph(
+  groupId: GroupId,
+  options: UpdateTenantDataAccessOptions,
+): Record<GroupId, Record<DatabaseId, DatabasePermissionGraph>> {
+  const { impersonatedDatabaseIds = [], sandboxedTables = [] } = options;
+
+  const groupGraph: Record<DatabaseId, DatabasePermissionGraph> = {};
+
+  // Add database-level impersonation permissions
+  for (const databaseId of impersonatedDatabaseIds) {
+    groupGraph[databaseId] = { "view-data": "impersonated" };
+  }
+
+  // Add table-level sandbox permissions
+  for (const table of sandboxedTables) {
+    const { databaseId, schemaName, tableId } = table;
+    const schema = schemaName ?? "";
+
+    if (!groupGraph[databaseId]) {
+      groupGraph[databaseId] = {};
+    }
+
+    const dbPerms = groupGraph[databaseId];
+    if (!dbPerms["view-data"] || typeof dbPerms["view-data"] === "string") {
+      dbPerms["view-data"] = {};
+    }
+
+    const viewData = dbPerms["view-data"] as Record<
+      string,
+      Record<TableId, string>
+    >;
+
+    if (!viewData[schema]) {
+      viewData[schema] = {};
+    }
+
+    viewData[schema][tableId as TableId] = "sandboxed";
+  }
+
+  return { [groupId]: groupGraph };
+}
+
+/**
+ * Builds the sandbox policies array for the API call.
+ */
+export const buildSandboxPolicies = (
+  groupId: GroupId,
+  sandboxedTables: SandboxedTableConfig[] = [],
+): SandboxPolicyInput[] =>
+  sandboxedTables.map((table) => ({
+    ...(table.id != null && { id: table.id }),
+    table_id: Number(table.tableId),
+    group_id: groupId,
+    card_id: null,
+    attribute_remappings: {
+      tenant_identifier: ["dimension", ["field", table.filterFieldId, null]],
+    },
+  }));

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/utils/permission-utils.unit.spec.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/utils/permission-utils.unit.spec.ts
@@ -1,0 +1,44 @@
+import { buildPermissionsGraph } from "./permission-utils";
+
+describe("buildPermissionsGraph", () => {
+  const groupId = 10;
+
+  it("sets view-data to 'impersonated' for database impersonation", () => {
+    const result = buildPermissionsGraph(groupId, {
+      impersonatedDatabaseIds: [1, 2],
+    });
+
+    expect(result).toEqual({
+      [groupId]: {
+        1: { "view-data": "impersonated" },
+        2: { "view-data": "impersonated" },
+      },
+    });
+  });
+
+  it("sets view-data to 'sandboxed' for table sandboxing, grouped by schema", () => {
+    const result = buildPermissionsGraph(groupId, {
+      sandboxedTables: [
+        { tableId: 100, databaseId: 1, schemaName: "public", filterFieldId: 5 },
+        { tableId: 101, databaseId: 1, schemaName: "public", filterFieldId: 6 },
+        {
+          tableId: 200,
+          databaseId: 1,
+          schemaName: "private",
+          filterFieldId: 7,
+        },
+      ],
+    });
+
+    expect(result).toEqual({
+      [groupId]: {
+        1: {
+          "view-data": {
+            public: { 100: "sandboxed", 101: "sandboxed" },
+            private: { 200: "sandboxed" },
+          },
+        },
+      },
+    });
+  });
+});

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
@@ -238,6 +238,8 @@ function ModernDataPicker({
         }}
         shouldHide={shouldHide}
         shouldShowLibrary={shouldShowLibrary}
+        mt="xl"
+        ml="-1rem"
       />
       {isOpened && isBrowsing && (
         <DataPickerModal

--- a/frontend/src/metabase/ui/components/overlays/Menu/index.ts
+++ b/frontend/src/metabase/ui/components/overlays/Menu/index.ts
@@ -1,3 +1,8 @@
-export type { MenuProps, MenuItemProps } from "@mantine/core";
+export type {
+  MenuProps,
+  MenuItemProps,
+  MenuDropdownProps,
+} from "@mantine/core";
+
 export { Menu } from "./Menu";
 export { menuOverrides } from "./Menu.config";


### PR DESCRIPTION
Closes EMB-1268

### Description

Adds the new "Row and column level security" onboarding step, along with the MiniPicker integration and upserting the sandboxing policies. It also refactors the code a bit to be tidier.

### How to verify

- Go to Embedding Hub
- Click on "Configure data permissions and enable tenants"
- Complete "Enable multi-tenant user strategy"
- Chose "Row and column level security" strategy

<img width="1190" height="914" alt="CleanShot 2569-02-13 at 22 26 20@2x" src="https://github.com/user-attachments/assets/36ef3ceb-a421-4b33-b0ef-c9ecac87eb3b" />

- Try to add table and column to filter by
- Click "Next"
- **Check the permissions tab > "All tenant users" group!** It should create the sandboxing configuration in your permission graph.

Keep an eye out for "Granular" on the groups level, then "Row and column security" on the tables level:

<img width="1066" height="576" alt="CleanShot 2569-02-14 at 02 34 38@2x" src="https://github.com/user-attachments/assets/095bfbdb-3af9-441e-aa7b-040c9571dc9d" />

### Demo

<img width="1174" height="1464" alt="CleanShot 2569-02-13 at 22 25 27@2x" src="https://github.com/user-attachments/assets/8f913145-0d65-4fa4-b987-879490fb7d5c" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR - E2E + Unit