### PR TITLE
Fixes isSticky class not being properly applied to dashboard parameters

### DIFF
--- a/frontend/src/metabase/dashboard/hooks/use-is-parameter-panel-sticky.ts
+++ b/frontend/src/metabase/dashboard/hooks/use-is-parameter-panel-sticky.ts
@@ -24,7 +24,6 @@ export function useIsParameterPanelSticky({
     sentinel.style.width = "100%";
     sentinel.style.position = "absolute";
     sentinel.style.top = "0";
-    sentinel.setAttribute("data-testid", "sticky-sentinel");
     sentinel.style.visibility = "hidden";
 
     if (parameterPanelRef.current) {

--- a/frontend/src/metabase/dashboard/hooks/use-is-parameter-panel-sticky.ts
+++ b/frontend/src/metabase/dashboard/hooks/use-is-parameter-panel-sticky.ts
@@ -24,12 +24,14 @@ export function useIsParameterPanelSticky({
     sentinel.style.width = "100%";
     sentinel.style.position = "absolute";
     sentinel.style.top = "0";
+    sentinel.setAttribute("data-testid", "sticky-sentinel");
     sentinel.style.visibility = "hidden";
 
-    // Insert sentinel before the parent of our sticky element
-    const parent = parameterPanelRef.current.parentElement;
-    if (parent) {
-      parent.insertBefore(sentinel, parameterPanelRef.current);
+    if (parameterPanelRef.current) {
+      parameterPanelRef.current.insertBefore(
+        sentinel,
+        parameterPanelRef.current.firstChild,
+      );
     }
 
     const settings: IntersectionObserverInit = {

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
@@ -253,7 +253,7 @@ export const EmbedFrame = ({
         {/* show floating header buttons if there is no title */}
         {headerButtons && !titled ? headerButtons : null}
 
-        <span ref={parameterPanelRef} />
+        <span ref={parameterPanelRef} style={{ position: "relative" }} />
         {hasVisibleParameters && (
           <FullWidthContainer
             className={cx(EmbedFrameS.ParameterPanel, {


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #66742
Closes [EMB-1125: IsSticky CSS applied to Parameter/Filter Panel upon scroll, not when panel sticks](https://linear.app/metabase/issue/EMB-1125/issticky-css-applied-to-parameterfilter-panel-upon-scroll-not-when)

### Description

The IsSticky class wasn't properly applied to the dashboard parameters panel, in embeds, because of the wrong position of the sentinel we use to detect scrolling.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Open the old static embedding on a dashboard
2. Make sure it has parameters
3. Scroll
4. The element with a testID `dashboard-parameters-widget-container`
 should  not have a CSS class `IsSticky` (and no bottom border) until it's actually sticky

### Demo

Before

https://github.com/user-attachments/assets/e7b22cd3-261b-436b-b0d8-2cfcf526a154


After

https://github.com/user-attachments/assets/b9a6503c-5413-4f00-b3fb-a2acd5373cdd


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
