### PR TITLE
Create a multi-select database selector component

### DIFF
--- a/frontend/src/metabase/common/components/DatabaseMultiSelect/DatabaseMultiSelect.module.css
+++ b/frontend/src/metabase/common/components/DatabaseMultiSelect/DatabaseMultiSelect.module.css
@@ -1,0 +1,35 @@
+.pill {
+  padding: 0.25rem 1rem;
+}
+
+.input:focus-within {
+  border-color: var(--mb-color-brand);
+}
+
+.option {
+  padding: 0.4rem 0.5rem;
+}
+
+.pillContent {
+  color: var(--mb-color-text-primary);
+}
+
+.optionContent {
+  flex: 1;
+}
+
+.optionIcon {
+  color: var(--mb-color-text-primary);
+  flex-shrink: 0;
+}
+
+.optionIconDisabled {
+  color: var(--mb-color-text-tertiary);
+  flex-shrink: 0;
+}
+
+.disabledInfoIcon {
+  color: var(--mb-color-text-secondary);
+  flex-shrink: 0;
+  margin-left: auto;
+}

--- a/frontend/src/metabase/common/components/DatabaseMultiSelect/DatabaseMultiSelect.stories.tsx
+++ b/frontend/src/metabase/common/components/DatabaseMultiSelect/DatabaseMultiSelect.stories.tsx
@@ -1,0 +1,164 @@
+import type { Store } from "@reduxjs/toolkit";
+import type { StoryFn } from "@storybook/react";
+import { HttpResponse, http } from "msw";
+import { useState } from "react";
+import _ from "underscore";
+
+import { getStore } from "__support__/entities-store";
+import { mockSettings } from "__support__/settings";
+import { createMockEntitiesState } from "__support__/store";
+import { Api } from "metabase/api";
+import { MetabaseReduxProvider } from "metabase/lib/redux";
+import { commonReducers } from "metabase/reducers-common";
+import { Stack, Text } from "metabase/ui";
+import type { Database, DatabaseId } from "metabase-types/api";
+import { createMockDatabase } from "metabase-types/api/mocks";
+import type { State } from "metabase-types/store";
+import { createMockState } from "metabase-types/store/mocks";
+
+import {
+  DatabaseMultiSelect,
+  type DatabaseMultiSelectProps,
+} from "./DatabaseMultiSelect";
+
+const mockDatabases: Database[] = [
+  createMockDatabase({ id: 1, name: "Database 1" }),
+  createMockDatabase({ id: 2, name: "Database 2" }),
+  createMockDatabase({ id: 3, name: "Database 3" }),
+];
+
+const storeInitialState = createMockState({
+  settings: mockSettings(),
+  entities: createMockEntitiesState({}),
+});
+
+const publicReducerNames = Object.keys(commonReducers);
+const initialState = _.pick(storeInitialState, ...publicReducerNames) as State;
+
+const storeMiddleware = [Api.middleware];
+
+const store = getStore(
+  commonReducers,
+  initialState,
+  storeMiddleware,
+) as unknown as Store<State>;
+
+const ReduxDecorator = (Story: StoryFn) => {
+  return (
+    <MetabaseReduxProvider store={store}>
+      <Story />
+    </MetabaseReduxProvider>
+  );
+};
+
+const DatabaseMultiSelectWrapper = (
+  props: Omit<DatabaseMultiSelectProps, "value" | "onChange"> & {
+    initialValue?: DatabaseId[];
+  },
+) => {
+  const [value, setValue] = useState<DatabaseId[]>(props.initialValue ?? []);
+
+  return (
+    <Stack>
+      <DatabaseMultiSelect {...props} value={value} onChange={setValue} />
+      <Text size="sm" c="text-secondary">
+        Selected IDs: {value.length > 0 ? value.join(", ") : "none"}
+      </Text>
+    </Stack>
+  );
+};
+
+const msw = {
+  handlers: [
+    http.get("/api/database", () => HttpResponse.json({ data: mockDatabases })),
+  ],
+};
+
+const mswEmpty = {
+  handlers: [http.get("/api/database", () => HttpResponse.json({ data: [] }))],
+};
+
+export default {
+  title: "Common/DatabaseMultiSelect",
+  component: DatabaseMultiSelect,
+  decorators: [ReduxDecorator],
+  parameters: {
+    msw,
+  },
+};
+
+export const Default = {
+  render: () => <DatabaseMultiSelectWrapper placeholder="Pick a database" />,
+};
+
+export const WithInitialSelection = {
+  name: "With initial selection",
+  render: () => (
+    <DatabaseMultiSelectWrapper
+      placeholder="Pick a database"
+      initialValue={[1]}
+    />
+  ),
+};
+
+export const MultipleSelected = {
+  name: "Multiple selected",
+  render: () => (
+    <DatabaseMultiSelectWrapper
+      placeholder="Pick a database"
+      initialValue={[1, 2]}
+    />
+  ),
+};
+
+export const Disabled = {
+  render: () => (
+    <DatabaseMultiSelectWrapper
+      placeholder="Pick a database"
+      initialValue={[1]}
+      disabled
+    />
+  ),
+};
+
+export const WithLabel = {
+  name: "With label",
+  render: () => (
+    <DatabaseMultiSelectWrapper
+      placeholder="Pick a database"
+      label="Select databases"
+    />
+  ),
+};
+
+export const WithDescription = {
+  name: "With description",
+  render: () => (
+    <DatabaseMultiSelectWrapper
+      placeholder="Pick a database"
+      label="Select databases"
+      description="Choose one or more databases to include"
+    />
+  ),
+};
+
+export const EmptyDatabases = {
+  name: "Empty databases",
+  parameters: {
+    msw: mswEmpty,
+  },
+  render: () => (
+    <DatabaseMultiSelectWrapper placeholder="No databases available" />
+  ),
+};
+
+export const WithDisabledOptions = {
+  name: "With disabled options",
+  render: () => (
+    <DatabaseMultiSelectWrapper
+      placeholder="Pick a database"
+      isOptionDisabled={(db) => db.id === 2}
+      disabledOptionTooltip="Connection impersonation is not supported for this database"
+    />
+  ),
+};

--- a/frontend/src/metabase/common/components/DatabaseMultiSelect/DatabaseMultiSelect.tsx
+++ b/frontend/src/metabase/common/components/DatabaseMultiSelect/DatabaseMultiSelect.tsx
@@ -1,0 +1,123 @@
+import { useMemo } from "react";
+import { t } from "ttag";
+
+import { useListDatabasesQuery } from "metabase/api";
+import {
+  type ComboboxItem,
+  Flex,
+  Icon,
+  MultiAutocomplete,
+  Text,
+  Tooltip,
+} from "metabase/ui";
+import type { Database, DatabaseId } from "metabase-types/api";
+
+import S from "./DatabaseMultiSelect.module.css";
+
+export interface DatabaseMultiSelectProps {
+  value: DatabaseId[];
+  onChange: (value: DatabaseId[]) => void;
+  placeholder?: string;
+  label?: string;
+  description?: string;
+  disabled?: boolean;
+  "data-testid"?: string;
+
+  /** Callback to determine if a database option should be disabled */
+  isOptionDisabled?: (database: Database) => boolean;
+
+  /** Tooltip text to show for disabled options */
+  disabledOptionTooltip?: string;
+}
+
+export const DatabaseMultiSelect = ({
+  value,
+  onChange,
+  placeholder = t`Pick a database`,
+  label,
+  description,
+  disabled,
+  "data-testid": dataTestId,
+  isOptionDisabled,
+  disabledOptionTooltip,
+}: DatabaseMultiSelectProps) => {
+  const { data: databasesResponse } = useListDatabasesQuery();
+
+  const databases = useMemo(
+    () => databasesResponse?.data ?? [],
+    [databasesResponse?.data],
+  );
+
+  const databaseIds = useMemo(() => value.map(String), [value]);
+
+  const options = useMemo(() => {
+    return databases.map((db) => ({
+      value: String(db.id),
+      label: db.name,
+      disabled: isOptionDisabled?.(db) ?? false,
+    }));
+  }, [databases, isOptionDisabled]);
+
+  const handleChange = (databaseIds: string[]) =>
+    onChange(databaseIds.map(Number));
+
+  const renderValue = ({ value }: { value: string }) => {
+    const database = databases.find((db) => db.id.toString() === value);
+
+    if (!database) {
+      return value;
+    }
+
+    return (
+      <Flex align="center" gap="sm" className={S.pillContent}>
+        <Icon name="database" size={16} />
+
+        <Text fw="bold" size="md">
+          {database.name}
+        </Text>
+      </Flex>
+    );
+  };
+
+  const renderOption = ({ option }: { option: ComboboxItem }) => {
+    const isDisabled = option.disabled;
+
+    return (
+      <Flex align="center" gap="sm" className={S.optionContent}>
+        <Icon
+          name="database"
+          size={16}
+          className={isDisabled ? S.optionIconDisabled : S.optionIcon}
+        />
+
+        <Text size="md" c={isDisabled ? "text-tertiary" : undefined}>
+          {option.label}
+        </Text>
+
+        {isDisabled && disabledOptionTooltip && (
+          <Tooltip label={disabledOptionTooltip} position="top">
+            <Icon name="info" size={16} className={S.disabledInfoIcon} />
+          </Tooltip>
+        )}
+      </Flex>
+    );
+  };
+
+  return (
+    <MultiAutocomplete
+      value={databaseIds}
+      data={options}
+      placeholder={placeholder}
+      label={label}
+      description={description}
+      nothingFoundMessage={t`No databases found`}
+      classNames={{ pill: S.pill, input: S.input }}
+      comboboxProps={{ disabled, classNames: { option: S.option } }}
+      data-testid={dataTestId}
+      rightSection={null}
+      renderValue={renderValue}
+      renderOption={renderOption}
+      onChange={handleChange}
+    />
+  );
+};

--- a/frontend/src/metabase/common/components/DatabaseMultiSelect/DatabaseMultiSelect.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/DatabaseMultiSelect/DatabaseMultiSelect.unit.spec.tsx
@@ -1,0 +1,136 @@
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+
+import { setupDatabasesEndpoints } from "__support__/server-mocks";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import type { Database } from "metabase-types/api";
+import { createMockDatabase } from "metabase-types/api/mocks";
+
+import { DatabaseMultiSelect } from "./DatabaseMultiSelect";
+
+const mockDatabases: Database[] = [
+  createMockDatabase({ id: 1, name: "Database 1" }),
+  createMockDatabase({ id: 2, name: "Database 2" }),
+  createMockDatabase({ id: 3, name: "Database 3" }),
+];
+
+const TestDatabaseMultiSelect = ({
+  initialValue = [],
+  isOptionDisabled,
+  disabledOptionTooltip,
+}: {
+  initialValue?: number[];
+  isOptionDisabled?: (database: Database) => boolean;
+  disabledOptionTooltip?: string;
+}) => {
+  const [value, setValue] = useState(initialValue);
+
+  return (
+    <DatabaseMultiSelect
+      value={value}
+      onChange={setValue}
+      placeholder="Pick a database"
+      isOptionDisabled={isOptionDisabled}
+      disabledOptionTooltip={disabledOptionTooltip}
+    />
+  );
+};
+
+interface SetupOpts {
+  initialValue?: number[];
+  databases?: Database[];
+  isOptionDisabled?: (database: Database) => boolean;
+  disabledOptionTooltip?: string;
+}
+
+function setup({
+  initialValue = [],
+  databases = mockDatabases,
+  isOptionDisabled,
+  disabledOptionTooltip,
+}: SetupOpts = {}) {
+  setupDatabasesEndpoints(databases);
+
+  renderWithProviders(
+    <TestDatabaseMultiSelect
+      initialValue={initialValue}
+      isOptionDisabled={isOptionDisabled}
+      disabledOptionTooltip={disabledOptionTooltip}
+    />,
+  );
+}
+
+describe("DatabaseMultiSelect", () => {
+  it("should show database options in the dropdown", async () => {
+    setup();
+
+    expect(
+      await screen.findByPlaceholderText("Pick a database"),
+    ).toBeInTheDocument();
+
+    await userEvent.click(
+      await screen.findByPlaceholderText("Pick a database"),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("option", { name: /Database 1/ }),
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole("option", { name: /Database 2/ }),
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole("option", { name: /Database 3/ }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("should allow selecting a database", async () => {
+    setup();
+
+    await userEvent.click(
+      await screen.findByPlaceholderText("Pick a database"),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Database 1")).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByText("Database 1"));
+
+    // after selecting, the pill should appear in the input area
+    await waitFor(() => {
+      expect(screen.getByText("Database 1")).toBeInTheDocument();
+    });
+  });
+
+  it("should show pre-selected databases as pills", async () => {
+    setup({ initialValue: [1, 2] });
+
+    // pills show database names (wait for data to load)
+    expect(await screen.findByText("Database 1")).toBeInTheDocument();
+    expect(screen.getByText("Database 2")).toBeInTheDocument();
+
+    // each pill has a remove button
+    expect(screen.getAllByLabelText("Remove")).toHaveLength(2);
+  });
+
+  it("should prevent selecting disabled options", async () => {
+    setup({
+      isOptionDisabled: (db) => db.id === 1,
+      disabledOptionTooltip: "Not supported",
+    });
+
+    await userEvent.click(
+      await screen.findByPlaceholderText("Pick a database"),
+    );
+
+    const option = await screen.findByRole("option", { name: /Database 1/ });
+    await userEvent.click(option);
+
+    // clicking a disabled option should not select it - no pills should appear
+    expect(screen.queryByLabelText("Remove")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/common/components/DatabaseMultiSelect/index.ts
+++ b/frontend/src/metabase/common/components/DatabaseMultiSelect/index.ts
@@ -1,0 +1,1 @@
+export * from "./DatabaseMultiSelect";

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
@@ -14,6 +14,7 @@ import {
   getParsedComboboxData,
   isOptionsGroup,
 } from "@mantine/core";
+import cx from "classnames";
 import type { ReactNode } from "react";
 import { useMemo } from "react";
 import { t } from "ttag";
@@ -41,6 +42,10 @@ export type MultiAutocompleteProps = BoxProps &
     autoFocus?: boolean;
     rightSection?: ReactNode;
     nothingFoundMessage?: ReactNode;
+    classNames?: {
+      pill?: string;
+      input?: string;
+    };
     "aria-label"?: string;
     "data-testid"?: string;
     parseValue?: (rawValue: string) => string | null;
@@ -69,6 +74,7 @@ export function MultiAutocomplete({
   autoFocus,
   rightSection,
   nothingFoundMessage,
+  classNames,
   maxDropdownHeight,
   dropdownOpened,
   defaultDropdownOpened,
@@ -175,11 +181,12 @@ export function MultiAutocomplete({
         <Combobox.DropdownTarget>
           <PillsInput
             {...styleProps}
+            classNames={{ input: classNames?.input }}
             label={label}
             description={description}
             error={error}
             required={required}
-            rightSection={rightSection ?? infoIcon}
+            rightSection={rightSection === undefined ? infoIcon : rightSection}
             withAsterisk={withAsterisk}
             labelProps={labelProps}
             descriptionProps={descriptionProps}
@@ -194,7 +201,7 @@ export function MultiAutocomplete({
                 value !== null ? (
                   <Pill
                     key={valueIndex}
-                    className={S.pill}
+                    className={cx(S.pill, classNames?.pill)}
                     removeButtonProps={{ "aria-label": t`Remove` }}
                     withRemoveButton
                     onClick={(event) => handlePillClick(event, valueIndex)}


### PR DESCRIPTION
Closes EMB-1274

### Description

Adds a [multi-select component](https://www.figma.com/design/5ZpoBYjn70prjvqDXVfT5e/Embedding-Hub?node-id=16800-30112&m=dev) that lets you pick multiple databases at once. Uses `MultiAutocomplete` under the hood.

### How to verify

Try out the storybook at http://localhost:6006/?path=/story/common-databasemultiselect--default.

### Demo

<img width="920" height="368" alt="CleanShot 2569-02-14 at 00 25 15@2x" src="https://github.com/user-attachments/assets/4c661739-fbd9-4a81-b2ba-b37a34479e43" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR - Unit

