### PR TITLE
Fix docs link on incremental transforms section

### DIFF
--- a/frontend/src/metabase/transforms/components/IncrementalTransform/IncrementalTransformSettings.tsx
+++ b/frontend/src/metabase/transforms/components/IncrementalTransform/IncrementalTransformSettings.tsx
@@ -2,11 +2,11 @@ import { useFormikContext } from "formik";
 import { match } from "ts-pattern";
 import { t } from "ttag";
 
+import { useDocsUrl } from "metabase/common/hooks";
 import { FormSelect } from "metabase/forms";
 import { useSelector } from "metabase/lib/redux";
 import { PLUGIN_REMOTE_SYNC } from "metabase/plugins";
 import { getMetadata } from "metabase/selectors/metadata";
-import { getShowMetabaseLinks } from "metabase/selectors/whitelabel";
 import { TitleSection } from "metabase/transforms/components/TitleSection";
 import {
   SOURCE_STRATEGY_OPTIONS,
@@ -50,7 +50,6 @@ export const IncrementalTransformSettings = ({
 }: IncrementalTransformSettingsProps) => {
   const metadata = useSelector(getMetadata);
   const libQuery = getLibQuery(source, metadata);
-  const showMetabaseLinks = useSelector(getShowMetabaseLinks);
   const isRemoteSyncReadOnly = useSelector(
     PLUGIN_REMOTE_SYNC.getIsRemoteSyncReadOnly,
   );
@@ -68,6 +67,11 @@ export const IncrementalTransformSettings = ({
     .with({ isMbqlQuery: true }, () => "query" as const)
     .with({ isPythonTransform: true }, () => "python" as const)
     .otherwise(() => "native" as const);
+  const { url: incrementalTransformsDocsUrl, showMetabaseLinks } = useDocsUrl(
+    isPythonTransform
+      ? "data-studio/transforms/python-transforms#incremental-python-transforms"
+      : "data-studio/transforms/query-transforms#incremental-query-transforms",
+  );
 
   const renderIncrementalSwitch = () => {
     const switchContent = (
@@ -111,7 +115,7 @@ export const IncrementalTransformSettings = ({
         {description}
         {showMetabaseLinks && (
           <Anchor
-            href="https://www.metabase.com/docs/latest/"
+            href={incrementalTransformsDocsUrl}
             target="_blank"
             td="underline"
             c="inherit"


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-3089/fix-incremental-transforms-docs-link

### How to verify

When saving a new transform, in the "Save your transform" modal > "Incremental Transforms" section, make sure the "Learn more" link matches the ones described in the task.

Related convo: https://metaboat.slack.com/archives/C09HKPWRG4B/p1771008686406639?thread_ts=1770984458.620269&cid=C09HKPWRG4B

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
