### PR TITLE
feat: improve mention menu in metabot

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChatEditor/MetabotChatEditor.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChatEditor/MetabotChatEditor.tsx
@@ -36,6 +36,7 @@ export const MetabotChatEditor = forwardRef<
           ref={ref}
           disabled={isResponding}
           data-testid="metabot-chat-input"
+          isCompact
         />
       </Box>
       <UnstyledButton

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChatEditor/MetabotChatEditor.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChatEditor/MetabotChatEditor.tsx
@@ -36,7 +36,6 @@ export const MetabotChatEditor = forwardRef<
           ref={ref}
           disabled={isResponding}
           data-testid="metabot-chat-input"
-          isCompact
         />
       </Box>
       <UnstyledButton

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChatEditor/MetabotChatEditor.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChatEditor/MetabotChatEditor.unit.spec.tsx
@@ -1,17 +1,24 @@
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
 
 import { setupEnterprisePlugins } from "__support__/enterprise";
 import {
   setupCardEndpoints,
-  setupDatabaseEndpoints,
+  setupCollectionByIdEndpoint,
+  setupDatabasesEndpoints,
 } from "__support__/server-mocks";
 import { setupSearchEndpoints } from "__support__/server-mocks/search";
 import { mockSettings } from "__support__/settings";
 import { renderWithProviders } from "__support__/ui";
+import { ROOT_COLLECTION } from "metabase/entities/collections";
 import type { SuggestionModel } from "metabase/rich_text_editing/tiptap/extensions/shared/types";
-import { createMockCard, createMockUser } from "metabase-types/api/mocks";
-import { createSampleDatabase } from "metabase-types/api/mocks/presets";
+import {
+  createMockCard,
+  createMockCollection,
+  createMockDatabase,
+  createMockUser,
+} from "metabase-types/api/mocks";
 import { createMockSearchResult } from "metabase-types/api/mocks/search";
 import { createMockState } from "metabase-types/store/mocks";
 
@@ -33,9 +40,25 @@ const defaultProps = {
   },
 };
 
-const setup = (props = {}) => {
+const setup = (
+  props = {},
+  {
+    searchItems = [],
+  }: { searchItems?: ReturnType<typeof createMockSearchResult>[] } = {},
+) => {
   setupEnterprisePlugins();
   setupCardEndpoints(createMockCard({ id: 123, name: "Test Model" }));
+  setupDatabasesEndpoints(
+    [createMockDatabase({ id: 1, name: "DB 1" })],
+    {},
+    {
+      "can-query": true,
+    },
+  );
+  setupCollectionByIdEndpoint({
+    collections: [createMockCollection(ROOT_COLLECTION)],
+  });
+  setupSearchEndpoints(searchItems);
   const settings = mockSettings({ "site-url": "http://localhost:3000" });
 
   return renderWithProviders(
@@ -52,7 +75,7 @@ const setup = (props = {}) => {
 const getEditor = () =>
   // eslint-disable-next-line testing-library/no-node-access
   document.querySelector('[contenteditable="true"]')! as HTMLElement;
-const getPopup = () => screen.findByTestId("mention-suggestions-popup");
+const getPopup = () => screen.findByTestId("mini-picker");
 
 describe("MetabotChatEditor", () => {
   it("should convert text value to formatted tiptap", async () => {
@@ -88,72 +111,99 @@ describe("MetabotChatEditor", () => {
     expect(await getPopup()).toBeInTheDocument();
   });
 
-  it("should show available models when @ is typed", async () => {
+  it("should show browse all when @ is typed", async () => {
     setup();
 
     await userEvent.type(getEditor(), "@");
 
     const popup = await getPopup();
     expect(popup).toBeInTheDocument();
-    expect(await screen.findByText("Table")).toBeInTheDocument();
-    expect(await screen.findByText("Database")).toBeInTheDocument();
-    expect(await screen.findByText("Collection")).toBeInTheDocument();
+    expect(await screen.findByText("Browse all")).toBeInTheDocument();
   });
 
-  it("should filter available models when @d is typed", async () => {
-    setup();
+  it("should query search endpoint when typing mention query", async () => {
+    setup(
+      {},
+      {
+        searchItems: [
+          createMockSearchResult({
+            id: 1234,
+            name: "Sample card",
+            model: "card",
+          }),
+        ],
+      },
+    );
 
-    await userEvent.type(getEditor(), "@d");
-
-    const popup = await getPopup();
-    expect(popup).toBeInTheDocument();
-    expect(await screen.findByText("Database")).toBeInTheDocument();
-    expect(screen.queryByText("Table")).not.toBeInTheDocument();
-  });
-
-  it("should only search selected @mention model when selected", async () => {
-    const db = createSampleDatabase();
-    setupDatabaseEndpoints(db);
-    setupSearchEndpoints([
-      createMockSearchResult({
-        id: db.id,
-        name: db.name,
-        model: "database",
-      }),
-    ]);
-    setup();
-
-    await userEvent.type(getEditor(), "@d{Enter}Sample");
-    expect(getEditor()).toHaveTextContent("@Sample");
-
-    expect(await screen.findByText("Sample Database")).toBeInTheDocument();
-
-    await userEvent.keyboard("{Enter}");
-
-    expect(getEditor()).toHaveTextContent("Sample Database");
+    await userEvent.type(getEditor(), "@sample");
+    await waitFor(() => {
+      const searchCall = fetchMock.callHistory.lastCall("path:/api/search");
+      expect(searchCall?.request).toBeDefined();
+      const url = new URL(searchCall!.request!.url);
+      expect(url.searchParams.get("q")).toBe("sample");
+    });
   });
 
   it("should search all models if @mention input doesn't match any search model name", async () => {
-    setupSearchEndpoints([
-      createMockSearchResult({ id: 1, name: "Test Card", model: "card" }),
-      createMockSearchResult({
-        id: 2,
-        name: "Test Dashboard",
-        model: "dashboard",
-      }),
-      createMockSearchResult({
-        id: 3,
-        name: "Test Collection",
-        model: "collection",
-      }),
-    ]);
-    setup();
+    setup(
+      {},
+      {
+        searchItems: [
+          createMockSearchResult({ id: 1, name: "Test Card", model: "card" }),
+          createMockSearchResult({
+            id: 2,
+            name: "Test Dashboard",
+            model: "dashboard",
+          }),
+          createMockSearchResult({
+            id: 3,
+            name: "Test Collection",
+            model: "collection",
+          }),
+        ],
+      },
+    );
 
     await userEvent.type(getEditor(), "@test");
 
-    expect(await screen.findByText("Test Card")).toBeInTheDocument();
-    expect(await screen.findByText("Test Dashboard")).toBeInTheDocument();
-    expect(await screen.findByText("Test Collection")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        fetchMock.callHistory.calls("path:/api/search").length,
+      ).toBeGreaterThan(0),
+    );
+    const searchCall = fetchMock.callHistory.lastCall("path:/api/search");
+    expect(searchCall?.request).toBeDefined();
+    const url = new URL(searchCall!.request!.url);
+    const models = url.searchParams.getAll("models");
+
+    expect(models).toContain("table");
+    expect(models).toContain("card");
+    expect(models).toContain("dashboard");
+    expect(models).toContain("collection");
+    expect(models).not.toContain("database");
+  });
+
+  it("requests search with allowed models for @mentions", async () => {
+    setup(
+      {},
+      {
+        searchItems: [
+          createMockSearchResult({ id: 1, name: "Test card", model: "card" }),
+        ],
+      },
+    );
+
+    await userEvent.type(getEditor(), "@test");
+
+    const lastSearchCall = fetchMock.callHistory.lastCall("path:/api/search");
+    expect(lastSearchCall?.request).toBeDefined();
+    const requestUrl = new URL(lastSearchCall!.request!.url);
+    const models = requestUrl.searchParams.getAll("models");
+
+    expect(models).toContain("table");
+    expect(models).toContain("card");
+    expect(models).toContain("dashboard");
+    expect(models).not.toContain("database");
   });
 
   it("should handle paste events with metabase protocol links", async () => {

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-sql-suggestion.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-sql-suggestion.tsx
@@ -94,7 +94,7 @@ export function useMetabotSQLSuggestion({
   }, [dispatch, bufferId]);
 
   const suggestionModels: SuggestionModel[] = useMemo(
-    () => ["dataset", "card", "table"],
+    () => ["dataset", "table"],
     [],
   );
 

--- a/frontend/src/metabase/common/components/Pickers/EntityPicker/components/EntityPickerModal.tsx
+++ b/frontend/src/metabase/common/components/Pickers/EntityPicker/components/EntityPickerModal.tsx
@@ -60,6 +60,7 @@ export type EntityPickerModalProps = {
 
 export function EntityPickerModal({
   title = t`Choose an item`,
+  searchQuery: initialSearchQuery,
   options,
   onClose,
   onChange,
@@ -67,7 +68,9 @@ export function EntityPickerModal({
 }: EntityPickerModalProps) {
   const [modalContentMinWidth, setModalContentMinWidth] = useState(920);
   const modalContentRef = useRef<HTMLDivElement | null>(null);
-  const [searchQuery, setSearchQuery] = useState<string>("");
+  const [searchQuery, setSearchQuery] = useState<string>(
+    initialSearchQuery || "",
+  );
   const [
     isNewCollectionDialogOpen,
     { open: openNewCollectionDialog, close: closeNewCollectionDialog },

--- a/frontend/src/metabase/common/components/Pickers/EntityPicker/components/test/EntityPickerModal.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/Pickers/EntityPicker/components/test/EntityPickerModal.unit.spec.tsx
@@ -432,6 +432,14 @@ describe("EntityPickerModal", () => {
       await expectActiveItem('Search results for "My"');
     });
 
+    it("should prefill the search input when searchQuery is provided", async () => {
+      await setup({ searchQuery: "My prefilled query" });
+
+      expect(await screen.findByPlaceholderText("Search…")).toHaveValue(
+        "My prefilled query",
+      );
+    });
+
     it("should return to previous location when clearing the search input", async () => {
       await setup();
       await userEvent.click(await screen.findByText("Our analytics"));

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/MiniPicker.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/MiniPicker.tsx
@@ -31,6 +31,7 @@ export type MiniPickerProps = {
   menuDropdownProps?: MenuDropdownProps;
   closeOnClickOutside?: boolean;
   menuDropdownRef?: Ref<HTMLDivElement>;
+  isCompact?: boolean;
 };
 
 export function MiniPicker({
@@ -47,6 +48,7 @@ export function MiniPicker({
   children = <Box />,
   menuDropdownProps,
   closeOnClickOutside = true,
+  isCompact,
   menuDropdownRef,
 }: MiniPickerProps) {
   const { data: libraryCollection } = PLUGIN_LIBRARY.useGetLibraryCollection();
@@ -92,6 +94,7 @@ export function MiniPicker({
         canBrowse: !!onBrowseAll,
         libraryCollection,
         shouldShowLibrary,
+        isCompact,
       }}
     >
       <Menu

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/MiniPicker.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/MiniPicker.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useMemo } from "react";
+import { type Ref, useCallback, useEffect, useMemo } from "react";
 
 import { PLUGIN_LIBRARY } from "metabase/plugins";
+import type { MenuDropdownProps } from "metabase/ui";
 import { Box, Menu } from "metabase/ui";
 
 import type { DataPickerValue } from "../../../DataPicker";
@@ -26,6 +27,10 @@ export type MiniPickerProps = {
   onBrowseAll?: () => void;
   shouldHide?: (item: MiniPickerItem | unknown) => boolean;
   shouldShowLibrary?: boolean;
+  children?: React.ReactNode;
+  menuDropdownProps?: MenuDropdownProps;
+  closeOnClickOutside?: boolean;
+  menuDropdownRef?: Ref<HTMLDivElement>;
 };
 
 export function MiniPicker({
@@ -39,6 +44,10 @@ export function MiniPicker({
   trapFocus = false,
   shouldHide,
   shouldShowLibrary = true,
+  children = <Box />,
+  menuDropdownProps,
+  closeOnClickOutside = true,
+  menuDropdownRef,
 }: MiniPickerProps) {
   const { data: libraryCollection } = PLUGIN_LIBRARY.useGetLibraryCollection();
 
@@ -90,20 +99,19 @@ export function MiniPicker({
         onChange={onClose}
         closeOnItemClick={false}
         clickOutsideEvents={["mousedown", "touchstart"]}
+        closeOnClickOutside={closeOnClickOutside}
         position="bottom-start"
         // menuItemTabIndex={-1}
         trapFocus={false}
       >
-        <Menu.Target>
-          <Box />
-        </Menu.Target>
+        <Menu.Target>{children}</Menu.Target>
 
         <Menu.Dropdown
-          mt="xl"
-          ml="-1rem"
           px={0}
           py="sm"
           data-testid="mini-picker"
+          {...menuDropdownProps}
+          ref={menuDropdownRef}
         >
           {isLoadingPath ? <MiniPickerListLoader /> : <MiniPickerPane />}
         </Menu.Dropdown>

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/MiniPicker.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/MiniPicker.tsx
@@ -31,7 +31,7 @@ export type MiniPickerProps = {
   menuDropdownProps?: MenuDropdownProps;
   closeOnClickOutside?: boolean;
   menuDropdownRef?: Ref<HTMLDivElement>;
-  isCompact?: boolean;
+  className?: string;
 };
 
 export function MiniPicker({
@@ -48,8 +48,8 @@ export function MiniPicker({
   children = <Box />,
   menuDropdownProps,
   closeOnClickOutside = true,
-  isCompact,
   menuDropdownRef,
+  className,
 }: MiniPickerProps) {
   const { data: libraryCollection } = PLUGIN_LIBRARY.useGetLibraryCollection();
 
@@ -94,7 +94,6 @@ export function MiniPicker({
         canBrowse: !!onBrowseAll,
         libraryCollection,
         shouldShowLibrary,
-        isCompact,
       }}
     >
       <Menu
@@ -116,7 +115,11 @@ export function MiniPicker({
           {...menuDropdownProps}
           ref={menuDropdownRef}
         >
-          {isLoadingPath ? <MiniPickerListLoader /> : <MiniPickerPane />}
+          {isLoadingPath ? (
+            <MiniPickerListLoader />
+          ) : (
+            <MiniPickerPane className={className} />
+          )}
         </Menu.Dropdown>
       </Menu>
     </MiniPickerContext.Provider>

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItem.module.css
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItem.module.css
@@ -1,0 +1,17 @@
+.section {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.rightSection[data-position="right"] {
+  min-width: 0;
+  overflow: hidden;
+  flex-basis: 40%;
+  justify-content: start;
+}
+
+.leftSection {
+  min-width: 0;
+  overflow: hidden;
+  flex-basis: 60%;
+}

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItem.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItem.tsx
@@ -2,6 +2,7 @@ import { Ellipsified } from "metabase/common/components/Ellipsified";
 import { getIcon } from "metabase/lib/icon";
 import { Box, Icon, Menu, type MenuItemProps } from "metabase/ui";
 
+import { useMiniPickerContext } from "../context";
 import type {
   MiniPickerCollectionItem,
   MiniPickerItem as MiniPickerItemType,
@@ -21,6 +22,7 @@ export const MiniPickerItem = ({
   onClick?: () => void;
   isFolder?: boolean;
 } & MenuItemProps) => {
+  const { isCompact } = useMiniPickerContext();
   return (
     <Box px="sm" py="2px">
       <Menu.Item
@@ -31,7 +33,19 @@ export const MiniPickerItem = ({
         onClick={onClick}
         {...menuItemProps}
       >
-        <Ellipsified maw={isFolder ? "13rem" : "16rem"}>{name}</Ellipsified>
+        <Ellipsified
+          maw={
+            isFolder
+              ? isCompact
+                ? "9rem"
+                : "13rem"
+              : isCompact
+                ? "12rem"
+                : "16rem"
+          }
+        >
+          {name}
+        </Ellipsified>
       </Menu.Item>
     </Box>
   );

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItem.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItem.tsx
@@ -2,11 +2,12 @@ import { Ellipsified } from "metabase/common/components/Ellipsified";
 import { getIcon } from "metabase/lib/icon";
 import { Box, Icon, Menu, type MenuItemProps } from "metabase/ui";
 
-import { useMiniPickerContext } from "../context";
 import type {
   MiniPickerCollectionItem,
   MiniPickerItem as MiniPickerItemType,
 } from "../types";
+
+import styles from "./MiniPickerItem.module.css";
 
 export const MiniPickerItem = ({
   model,
@@ -22,7 +23,6 @@ export const MiniPickerItem = ({
   onClick?: () => void;
   isFolder?: boolean;
 } & MenuItemProps) => {
-  const { isCompact } = useMiniPickerContext();
   return (
     <Box px="sm" py="2px">
       <Menu.Item
@@ -31,21 +31,13 @@ export const MiniPickerItem = ({
         }
         rightSection={isFolder ? <Icon name="chevronright" /> : undefined}
         onClick={onClick}
+        classNames={{
+          itemLabel: styles.section,
+          itemSection: styles.section,
+        }}
         {...menuItemProps}
       >
-        <Ellipsified
-          maw={
-            isFolder
-              ? isCompact
-                ? "9rem"
-                : "13rem"
-              : isCompact
-                ? "12rem"
-                : "16rem"
-          }
-        >
-          {name}
-        </Ellipsified>
+        <Ellipsified>{name}</Ellipsified>
       </Menu.Item>
     </Box>
   );

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
@@ -401,6 +401,7 @@ const ItemList = ({ children }: { children: React.ReactNode[] }) => {
 };
 
 const LocationInfo = ({ item }: { item: MiniPickerPickableItem }) => {
+  const { isCompact } = useMiniPickerContext();
   const isTable = isTableInDb(item);
 
   const itemText = isTable
@@ -422,7 +423,9 @@ const LocationInfo = ({ item }: { item: MiniPickerPickableItem }) => {
     <Flex gap="xs" align="center">
       {iconProps && <Icon {...iconProps} size={12} />}
       <Text size="sm" c="text-secondary">
-        <Ellipsified maw="18rem">{itemText}</Ellipsified>
+        <Ellipsified maw={isCompact ? "12rem" : "18rem"}>
+          {itemText}
+        </Ellipsified>
       </Text>
     </Flex>
   );

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
@@ -38,6 +38,7 @@ import type {
 } from "../types";
 
 import { MiniPickerItem } from "./MiniPickerItem";
+import styles from "./MiniPickerItem.module.css";
 
 export function MiniPickerItemList() {
   const { path, searchQuery } = useMiniPickerContext();
@@ -364,6 +365,10 @@ function SearchItemList({ query }: { query: string }) {
                 onChange(item);
               }}
               rightSection={<LocationInfo item={item} />}
+              classNames={{
+                itemLabel: styles.leftSection,
+                itemSection: styles.rightSection,
+              }}
             />
           );
         })}
@@ -401,7 +406,6 @@ const ItemList = ({ children }: { children: React.ReactNode[] }) => {
 };
 
 const LocationInfo = ({ item }: { item: MiniPickerPickableItem }) => {
-  const { isCompact } = useMiniPickerContext();
   const isTable = isTableInDb(item);
 
   const itemText = isTable
@@ -420,12 +424,10 @@ const LocationInfo = ({ item }: { item: MiniPickerPickableItem }) => {
       });
 
   return (
-    <Flex gap="xs" align="center">
-      {iconProps && <Icon {...iconProps} size={12} />}
-      <Text size="sm" c="text-secondary">
-        <Ellipsified maw={isCompact ? "12rem" : "18rem"}>
-          {itemText}
-        </Ellipsified>
+    <Flex gap="xs" align="center" ml="auto" style={{ overflow: "hidden" }}>
+      {iconProps && <Icon {...iconProps} size={12} miw={12} />}
+      <Text size="sm" c="text-secondary" miw="0">
+        <Ellipsified>{itemText}</Ellipsified>
       </Text>
     </Flex>
   );

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerPane.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerPane.tsx
@@ -7,12 +7,16 @@ import { MiniPickerHeader } from "./MiniPickerHeader";
 import { MiniPickerItemList } from "./MiniPickerItemList";
 
 export function MiniPickerPane() {
-  const { path, searchQuery } = useMiniPickerContext();
+  const { path, searchQuery, isCompact } = useMiniPickerContext();
 
   const isRoot = path.length === 0;
 
   return (
-    <Stack mah="30rem" w={searchQuery ? "40rem" : "20rem"} gap={0}>
+    <Stack
+      mah="30rem"
+      w={searchQuery ? (isCompact ? "29.125rem" : "40rem") : "20rem"}
+      gap={0}
+    >
       {!isRoot && !searchQuery && <MiniPickerHeader />}
       <MiniPickerItemList />
       {(isRoot || searchQuery) && <MiniPickerFooter />}

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerPane.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerPane.tsx
@@ -14,7 +14,7 @@ export function MiniPickerPane() {
   return (
     <Stack
       mah="30rem"
-      w={searchQuery ? (isCompact ? "29.125rem" : "40rem") : "20rem"}
+      w={isCompact ? "29.125rem" : searchQuery ? "40rem" : "20rem"}
       gap={0}
     >
       {!isRoot && !searchQuery && <MiniPickerHeader />}

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerPane.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerPane.tsx
@@ -6,16 +6,17 @@ import { MiniPickerFooter } from "./MiniPickerFooter";
 import { MiniPickerHeader } from "./MiniPickerHeader";
 import { MiniPickerItemList } from "./MiniPickerItemList";
 
-export function MiniPickerPane() {
-  const { path, searchQuery, isCompact } = useMiniPickerContext();
+export function MiniPickerPane({ className }: { className?: string }) {
+  const { path, searchQuery } = useMiniPickerContext();
 
   const isRoot = path.length === 0;
 
   return (
     <Stack
       mah="30rem"
-      w={isCompact ? "29.125rem" : searchQuery ? "40rem" : "20rem"}
+      w={searchQuery ? "40rem" : "20rem"}
       gap={0}
+      className={className}
     >
       {!isRoot && !searchQuery && <MiniPickerHeader />}
       <MiniPickerItemList />

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/context.ts
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/context.ts
@@ -25,6 +25,7 @@ export interface MiniPickerContextValue {
   onBrowseAll?: () => void;
   libraryCollection?: MiniPickerCollectionItem;
   shouldShowLibrary?: boolean;
+  isCompact?: boolean;
 }
 
 export const MiniPickerContext = createContext<

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/context.ts
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/context.ts
@@ -25,7 +25,6 @@ export interface MiniPickerContextValue {
   onBrowseAll?: () => void;
   libraryCollection?: MiniPickerCollectionItem;
   shouldShowLibrary?: boolean;
-  isCompact?: boolean;
 }
 
 export const MiniPickerContext = createContext<

--- a/frontend/src/metabase/metabot/components/MetabotInlineSQLPrompt/MetabotInlineSQLPrompt.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotInlineSQLPrompt/MetabotInlineSQLPrompt.tsx
@@ -114,7 +114,7 @@ export const MetabotInlineSQLPrompt = ({
           onStop={handleClose}
           suggestionConfig={{
             suggestionModels,
-            searchOptions: databaseId ? { table_db_id: databaseId } : undefined,
+            onlyDatabaseId: databaseId ?? undefined,
           }}
         />
       </Box>

--- a/frontend/src/metabase/metabot/components/MetabotPromptInput/MetabotPromptInput.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotPromptInput/MetabotPromptInput.tsx
@@ -12,16 +12,16 @@ import { t } from "ttag";
 
 import { useSelector } from "metabase/lib/redux";
 import type { MetabotPromptInputRef } from "metabase/metabot";
-import { createMentionSuggestion } from "metabase/rich_text_editing/tiptap/extensions/Mention/MentionSuggestion";
 import {
   MetabotMentionExtension,
   MetabotMentionPluginKey,
 } from "metabase/rich_text_editing/tiptap/extensions/MetabotMention/MetabotMentionExtension";
+import { createMetabotMentionSuggestionNew } from "metabase/rich_text_editing/tiptap/extensions/MetabotMention/MetabotSuggestionNew";
 import { SmartLink } from "metabase/rich_text_editing/tiptap/extensions/SmartLink/SmartLinkNode";
 import type { SuggestionModel } from "metabase/rich_text_editing/tiptap/extensions/shared/types";
-import type { EntitySearchOptions } from "metabase/rich_text_editing/tiptap/extensions/shared/useEntitySearch";
-import { createSuggestionRenderer } from "metabase/rich_text_editing/tiptap/extensions/suggestionRenderer";
+import { createBareSuggestionRenderer } from "metabase/rich_text_editing/tiptap/extensions/suggestionRenderer";
 import { getSetting } from "metabase/selectors/settings";
+import type { DatabaseId } from "metabase-types/api";
 
 import S from "./MetabotPromptInput.module.css";
 import {
@@ -40,7 +40,7 @@ export interface MetabotPromptInputProps {
   onStop: () => void;
   suggestionConfig: {
     suggestionModels: SuggestionModel[];
-    searchOptions?: EntitySearchOptions;
+    onlyDatabaseId?: DatabaseId;
   };
 }
 export const MetabotPromptInput = forwardRef<
@@ -76,12 +76,10 @@ export const MetabotPromptInput = forwardRef<
       }),
       MetabotMentionExtension.configure({
         suggestion: {
-          render: createSuggestionRenderer(
-            createMentionSuggestion({
+          render: createBareSuggestionRenderer(
+            createMetabotMentionSuggestionNew({
               searchModels: suggestionConfig.suggestionModels,
-              searchOptions: suggestionConfig.searchOptions,
-              canFilterSearchModels: true,
-              canBrowseAll: false,
+              onlyDatabaseId: suggestionConfig.onlyDatabaseId,
             }),
           ),
         },
@@ -132,13 +130,15 @@ export const MetabotPromptInput = forwardRef<
           },
         },
         handleKeyDown: (view, event) => {
-          if (event.key === "Enter") {
+          if (event.key === "Escape" || event.key === "Enter") {
             // Defer enter handling to mention UI if open
             const mentionState = MetabotMentionPluginKey.getState(view.state);
             if (mentionState?.active) {
               return false; // Let the suggestion system handle it
             }
+          }
 
+          if (event.key === "Enter") {
             // Check for any modifier keys (shift, ctrl, meta, alt)
             const isModifiedKeyPress =
               event.shiftKey || event.ctrlKey || event.metaKey || event.altKey;

--- a/frontend/src/metabase/metabot/components/MetabotPromptInput/MetabotPromptInput.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotPromptInput/MetabotPromptInput.tsx
@@ -42,6 +42,7 @@ export interface MetabotPromptInputProps {
     suggestionModels: SuggestionModel[];
     onlyDatabaseId?: DatabaseId;
   };
+  isCompact?: boolean;
 }
 export const MetabotPromptInput = forwardRef<
   MetabotPromptInputRef | null,
@@ -57,6 +58,7 @@ export const MetabotPromptInput = forwardRef<
       onChange,
       onSubmit,
       onStop,
+      isCompact,
       ...props
     },
     ref,
@@ -80,6 +82,7 @@ export const MetabotPromptInput = forwardRef<
             createMetabotMentionSuggestionNew({
               searchModels: suggestionConfig.suggestionModels,
               onlyDatabaseId: suggestionConfig.onlyDatabaseId,
+              isCompact,
             }),
           ),
         },

--- a/frontend/src/metabase/metabot/components/MetabotPromptInput/MetabotPromptInput.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotPromptInput/MetabotPromptInput.tsx
@@ -42,7 +42,6 @@ export interface MetabotPromptInputProps {
     suggestionModels: SuggestionModel[];
     onlyDatabaseId?: DatabaseId;
   };
-  isCompact?: boolean;
 }
 export const MetabotPromptInput = forwardRef<
   MetabotPromptInputRef | null,
@@ -58,7 +57,6 @@ export const MetabotPromptInput = forwardRef<
       onChange,
       onSubmit,
       onStop,
-      isCompact,
       ...props
     },
     ref,
@@ -82,7 +80,6 @@ export const MetabotPromptInput = forwardRef<
             createMetabotMentionSuggestionNew({
               searchModels: suggestionConfig.suggestionModels,
               onlyDatabaseId: suggestionConfig.onlyDatabaseId,
-              isCompact,
             }),
           ),
         },

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
@@ -238,6 +238,10 @@ function ModernDataPicker({
         }}
         shouldHide={shouldHide}
         shouldShowLibrary={shouldShowLibrary}
+        menuDropdownProps={{
+          mt: "xl",
+          ml: "-1rem",
+        }}
       />
       {isOpened && isBrowsing && (
         <DataPickerModal

--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/MetabotMention/MetabotMentionExtension.tsx
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/MetabotMention/MetabotMentionExtension.tsx
@@ -12,7 +12,7 @@ export interface MentionOptions {
   suggestion: Partial<SuggestionOptions>;
 }
 
-interface MentionProps {
+export interface MentionProps {
   type?: string;
   id?: number | string;
   model?: string;

--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/MetabotMention/MetabotSuggestion.module.css
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/MetabotMention/MetabotSuggestion.module.css
@@ -1,0 +1,3 @@
+.miniPicker {
+  max-width: 29.125rem;
+}

--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/MetabotMention/MetabotSuggestion.tsx
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/MetabotMention/MetabotSuggestion.tsx
@@ -162,4 +162,5 @@ const MetabotMentionSuggestionComponent = forwardRef<
   );
 });
 
+// @deprecated only supports databases, use `MetabotMentionSuggestionNew` instead
 export const MetabotMentionSuggestion = MetabotMentionSuggestionComponent;

--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/MetabotMention/MetabotSuggestionNew.tsx
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/MetabotMention/MetabotSuggestionNew.tsx
@@ -35,6 +35,7 @@ interface MetabotMentionSuggestionPropsBase {
   searchModels?: SuggestionModel[];
   searchOptions?: EntitySearchOptions;
   onlyDatabaseId?: DatabaseId;
+  isCompact?: boolean;
 }
 export type MetabotMentionSuggestionProps = MetabotMentionSuggestionPropsBase &
   BareSuggestionRendererProps<unknown, MentionProps>;
@@ -53,6 +54,7 @@ const MetabotMentionSuggestionComponent = forwardRef<
     onlyDatabaseId,
     decorationNode,
     onClose,
+    isCompact,
   },
   ref,
 ) {
@@ -145,6 +147,7 @@ const MetabotMentionSuggestionComponent = forwardRef<
         menuDropdownProps={{
           onFocus,
         }}
+        isCompact={isCompact}
       >
         <ExternalMenuTarget element={decorationNode} />
       </MiniPicker>

--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/MetabotMention/MetabotSuggestionNew.tsx
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/MetabotMention/MetabotSuggestionNew.tsx
@@ -1,0 +1,324 @@
+import { useClickOutside } from "@mantine/hooks";
+import {
+  forwardRef,
+  useCallback,
+  useImperativeHandle,
+  useMemo,
+  useState,
+} from "react";
+import { match } from "ts-pattern";
+import { t } from "ttag";
+
+import {
+  EntityPickerModal,
+  MiniPicker,
+  type OmniPickerItem,
+} from "metabase/common/components/Pickers";
+import { shouldDisableItemNotInDb } from "metabase/common/components/Pickers/DataPicker";
+import type {
+  MiniPickerItem,
+  MiniPickerPickableItem,
+} from "metabase/common/components/Pickers/MiniPicker/types";
+import type { DatabaseId } from "metabase-types/api";
+
+import { ExternalMenuTarget } from "../shared/ExternalMenuTarget";
+import type { SuggestionModel } from "../shared/types";
+import type { EntitySearchOptions } from "../shared/useEntitySearch";
+import type {
+  BareSuggestionRendererProps,
+  BareSuggestionRendererRef,
+} from "../suggestionRenderer";
+
+import type { MentionProps } from "./MetabotMentionExtension";
+
+interface MetabotMentionSuggestionPropsBase {
+  searchModels?: SuggestionModel[];
+  searchOptions?: EntitySearchOptions;
+  onlyDatabaseId?: DatabaseId;
+}
+export type MetabotMentionSuggestionProps = MetabotMentionSuggestionPropsBase &
+  BareSuggestionRendererProps<unknown, MentionProps>;
+
+const MetabotMentionSuggestionComponent = forwardRef<
+  BareSuggestionRendererRef,
+  MetabotMentionSuggestionProps
+>(function MentionSuggestionComponent(
+  {
+    items: _items,
+    command,
+    editor,
+    range: _range,
+    query,
+    searchModels,
+    onlyDatabaseId,
+    decorationNode,
+    onClose,
+  },
+  ref,
+) {
+  const [isBrowsing, setIsBrowsing] = useState(false);
+
+  const onSelectEntity = useCallback(
+    (item: OmniPickerItem) => {
+      command({
+        id: item.id,
+        model: item.model,
+        label: item.name,
+      });
+    },
+    [command],
+  );
+
+  const closeOnClickOutside = !isBrowsing;
+  const [menuDropdownDom, setMenuDropdownDom] = useState<HTMLDivElement | null>(
+    null,
+  );
+  const menuDropdownRef = useCallback((node: HTMLDivElement | null) => {
+    setMenuDropdownDom(node);
+  }, []);
+
+  const { onKeyDown, onFocus } = useFakeKeyboardHandler(menuDropdownDom);
+
+  useImperativeHandle(ref, () => ({
+    onKeyDown: ({ event }: { event: KeyboardEvent }) => {
+      if (onKeyDown(event)) {
+        return true;
+      }
+
+      if (event.key === "Escape") {
+        onClose();
+        return true;
+      }
+      return false;
+    },
+  }));
+
+  const searchModelsReal = searchModels?.filter(
+    (model) =>
+      model !== "database" &&
+      model !== "action" &&
+      model !== "segment" &&
+      model !== "user",
+  );
+
+  const shouldHide = useMemo(() => {
+    const shouldDisableBasedOnDb = shouldDisableItemNotInDb(onlyDatabaseId);
+
+    return (item: MiniPickerItem | unknown): item is MiniPickerPickableItem => {
+      // @ts-expect-error - will fix when we align types with minipicker: UXW-2735
+      const dbId = item?.db_id ?? item?.database_id ?? item?.dbId ?? undefined;
+
+      return Boolean(
+        // @ts-expect-error - Will be fixed once we align types with minipicker: UXW-2735
+        shouldDisableBasedOnDb({ ...item, database_id: dbId }),
+      );
+    };
+  }, [onlyDatabaseId]);
+
+  // Because `Menu.Target` is set to just the mention decoration node,
+  // we need to have a custom "outside" definition to not close when clicking inside the editor.
+  useClickOutside(
+    () => {
+      if (closeOnClickOutside) {
+        onClose();
+      }
+    },
+    ["mousedown", "touchstart"],
+    [editor.view.dom, menuDropdownDom],
+  );
+
+  return (
+    <>
+      <MiniPicker
+        opened
+        searchQuery={query}
+        shouldShowLibrary
+        models={searchModelsReal ?? []}
+        closeOnClickOutside={false}
+        onChange={onSelectEntity}
+        onClose={onClose}
+        shouldHide={shouldHide}
+        onBrowseAll={() => {
+          setIsBrowsing(true);
+        }}
+        menuDropdownRef={menuDropdownRef}
+        menuDropdownProps={{
+          onFocus,
+        }}
+      >
+        <ExternalMenuTarget element={decorationNode} />
+      </MiniPicker>
+      {isBrowsing && (
+        <EntityPickerModal
+          title={t`Mention an item`}
+          value={
+            onlyDatabaseId
+              ? {
+                  model: "database",
+                  id: onlyDatabaseId,
+                }
+              : undefined
+          }
+          models={searchModelsReal ?? []}
+          options={{
+            hasDatabases: true,
+            hasRootCollection: true,
+            hasPersonalCollections: true,
+            hasSearch: true,
+            hasRecents: true,
+            hasLibrary: true,
+            hasConfirmButtons: false,
+            canCreateCollections: false,
+            canCreateDashboards: false,
+          }}
+          onChange={(item) => {
+            onSelectEntity(item);
+            onClose();
+          }}
+          onClose={() => {
+            setIsBrowsing(false);
+          }}
+          isDisabledItem={shouldDisableItemNotInDb(onlyDatabaseId)}
+          searchParams={
+            onlyDatabaseId !== undefined
+              ? {
+                  table_db_id: onlyDatabaseId,
+                }
+              : undefined
+          }
+          searchQuery={query}
+        />
+      )}
+    </>
+  );
+});
+
+// In case of mentions, we want to have the editor focused while allowing navigation
+// inside the menu. We can't have two elements focused at the same time, so we fake
+// selections inside the menu.
+function useFakeKeyboardHandler(menuDropdownDom: Element | null) {
+  const getAllMenuItems = useCallback(() => {
+    if (!menuDropdownDom) {
+      throw Error("Menu element is not mounted.");
+    }
+
+    const items = Array.from(
+      menuDropdownDom.querySelectorAll('[role="menuitem"]'),
+    );
+
+    const selectedIndex = items.findIndex(
+      (item) => item.getAttribute("aria-selected") === "true",
+    );
+
+    if (selectedIndex === -1) {
+      return {
+        selectedItem: null,
+        selectedIndex: null,
+        items,
+      };
+    }
+
+    return {
+      selectedItem: items[selectedIndex],
+      selectedIndex: selectedIndex,
+      items,
+    };
+  }, [menuDropdownDom]);
+
+  const onKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (!menuDropdownDom) {
+        return false;
+      }
+
+      return match(event.key)
+        .returnType<boolean>()
+        .with("Home", "End", (key) => {
+          const { items, selectedItem } = getAllMenuItems();
+
+          if (selectedItem !== null) {
+            selectedItem.setAttribute("aria-selected", "false");
+          }
+
+          const nextIndex = key === "Home" ? 0 : items.length - 1;
+          const nextItem = items[nextIndex];
+          if (nextItem) {
+            nextItem.setAttribute("aria-selected", "true");
+            nextItem.scrollIntoView({ block: "nearest" });
+          }
+          return true;
+        })
+        .with("ArrowUp", "ArrowDown", (key) => {
+          const { items, selectedIndex, selectedItem } = getAllMenuItems();
+
+          if (selectedItem === null) {
+            items.at(0)?.setAttribute("aria-selected", "true");
+            return true;
+          }
+
+          let nextIndex =
+            key === "ArrowUp" ? selectedIndex - 1 : selectedIndex + 1;
+
+          if (nextIndex > items.length - 1) {
+            nextIndex = 0;
+          }
+          if (nextIndex < 0) {
+            nextIndex = items.length - 1;
+          }
+
+          const nextItem = items.at(nextIndex);
+          if (nextItem) {
+            selectedItem.removeAttribute("aria-selected");
+            nextItem.setAttribute("aria-selected", "true");
+            nextItem.scrollIntoView({ block: "nearest" });
+          }
+          return true;
+        })
+        .with("Enter", () => {
+          const { selectedItem } = getAllMenuItems();
+          if (selectedItem === null) {
+            return false;
+          }
+
+          if (selectedItem instanceof HTMLElement) {
+            selectedItem.click();
+          }
+          return true;
+        })
+        .otherwise(() => false);
+    },
+    [getAllMenuItems, menuDropdownDom],
+  );
+
+  // If the user explicitly focused in the menu, we want to switch to the default handlers instead of fake ones.
+  const onFocus = useCallback(() => {
+    if (!menuDropdownDom) {
+      return;
+    }
+
+    const { selectedItem } = getAllMenuItems();
+    if (selectedItem === null) {
+      return;
+    }
+    selectedItem.removeAttribute("aria-selected");
+  }, [getAllMenuItems, menuDropdownDom]);
+
+  return {
+    onKeyDown,
+    onFocus,
+  };
+}
+
+export const MetabotMentionSuggestionNew = MetabotMentionSuggestionComponent;
+
+export const createMetabotMentionSuggestionNew = (
+  outerProps: MetabotMentionSuggestionPropsBase,
+) => {
+  return forwardRef<BareSuggestionRendererRef, MetabotMentionSuggestionProps>(
+    function MentionSuggestionWrapper(props, ref) {
+      return (
+        <MetabotMentionSuggestionNew {...props} ref={ref} {...outerProps} />
+      );
+    },
+  );
+};

--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/MetabotMention/MetabotSuggestionNew.tsx
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/MetabotMention/MetabotSuggestionNew.tsx
@@ -30,12 +30,12 @@ import type {
 } from "../suggestionRenderer";
 
 import type { MentionProps } from "./MetabotMentionExtension";
+import styles from "./MetabotSuggestion.module.css";
 
 interface MetabotMentionSuggestionPropsBase {
   searchModels?: SuggestionModel[];
   searchOptions?: EntitySearchOptions;
   onlyDatabaseId?: DatabaseId;
-  isCompact?: boolean;
 }
 export type MetabotMentionSuggestionProps = MetabotMentionSuggestionPropsBase &
   BareSuggestionRendererProps<unknown, MentionProps>;
@@ -54,7 +54,6 @@ const MetabotMentionSuggestionComponent = forwardRef<
     onlyDatabaseId,
     decorationNode,
     onClose,
-    isCompact,
   },
   ref,
 ) {
@@ -147,7 +146,7 @@ const MetabotMentionSuggestionComponent = forwardRef<
         menuDropdownProps={{
           onFocus,
         }}
-        isCompact={isCompact}
+        className={styles.miniPicker}
       >
         <ExternalMenuTarget element={decorationNode} />
       </MiniPicker>

--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/MetabotMention/MetabotSuggestionNew.unit.spec.tsx
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/MetabotMention/MetabotSuggestionNew.unit.spec.tsx
@@ -1,0 +1,150 @@
+import userEvent from "@testing-library/user-event";
+import type { Editor } from "@tiptap/core";
+import { createRef } from "react";
+import { act } from "react-dom/test-utils";
+
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import type { EntityPickerModalProps } from "metabase/common/components/Pickers";
+import type { OmniPickerItem } from "metabase/common/components/Pickers/EntityPicker/types";
+import type { MiniPickerProps } from "metabase/common/components/Pickers/MiniPicker/components/MiniPicker/MiniPicker";
+import type { MiniPickerPickableItem } from "metabase/common/components/Pickers/MiniPicker/types";
+import type { BareSuggestionRendererRef } from "metabase/rich_text_editing/tiptap/extensions/suggestionRenderer";
+
+import type { MetabotMentionSuggestionProps } from "./MetabotSuggestionNew";
+import { MetabotMentionSuggestionNew } from "./MetabotSuggestionNew";
+
+jest.mock("metabase/common/components/Pickers", () => {
+  return {
+    MiniPicker: (props: MiniPickerProps) => {
+      const miniItem: MiniPickerPickableItem = {
+        id: 1,
+        model: "card",
+        name: "Mini card",
+      };
+
+      return (
+        <div data-testid="mini-picker">
+          <button onClick={() => props.onChange(miniItem)}>mini-select</button>
+          <button onClick={() => props.onBrowseAll?.()}>browse-all</button>
+          {props.children}
+        </div>
+      );
+    },
+    EntityPickerModal: (props: EntityPickerModalProps) => {
+      const modalItem: OmniPickerItem = {
+        id: 2,
+        model: "dashboard",
+        name: "Modal dashboard",
+      };
+
+      return (
+        <div data-testid="entity-picker-modal">
+          <button onClick={() => props.onChange(modalItem)}>
+            modal-select
+          </button>
+          <button onClick={props.onClose}>modal-close</button>
+        </div>
+      );
+    },
+  };
+});
+
+const setup = (props: Partial<MetabotMentionSuggestionProps> = {}) => {
+  const command = jest.fn();
+  const onClose = jest.fn();
+  const ref = createRef<BareSuggestionRendererRef>();
+  const focusMock = jest.fn();
+  const editor = {
+    commands: {
+      focus: focusMock,
+    },
+    view: {
+      dom: document.createElement("div"),
+    },
+  } as unknown as Editor;
+
+  const defaultProps: MetabotMentionSuggestionProps = {
+    items: [],
+    command,
+    editor,
+    range: { from: 1, to: 1 },
+    query: "ord",
+    text: "@ord",
+    onClose,
+    decorationNode: null,
+    clientRect: null,
+    ...props,
+  };
+
+  renderWithProviders(
+    <MetabotMentionSuggestionNew {...defaultProps} ref={ref} />,
+  );
+
+  return { command, onClose, editor, ref, focusMock };
+};
+
+describe("MetabotMentionSuggestionNew", () => {
+  it("selecting mini picker item calls command with mention payload", async () => {
+    const { command } = setup();
+
+    await userEvent.click(screen.getByRole("button", { name: "mini-select" }));
+
+    expect(command).toHaveBeenCalledWith({
+      id: 1,
+      model: "card",
+      label: "Mini card",
+    });
+  });
+
+  it("selecting browse-all modal item calls command and closes suggestion", async () => {
+    const { command, onClose } = setup();
+
+    await userEvent.click(screen.getByRole("button", { name: "browse-all" }));
+    expect(
+      await screen.findByTestId("entity-picker-modal"),
+    ).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "modal-select" }));
+
+    expect(command).toHaveBeenCalledWith({
+      id: 2,
+      model: "dashboard",
+      label: "Modal dashboard",
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("closing browse-all modal hides EntityPickerModal but not the mini picker", async () => {
+    setup();
+
+    await userEvent.click(screen.getByRole("button", { name: "browse-all" }));
+    expect(
+      await screen.findByTestId("entity-picker-modal"),
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "modal-close" }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("entity-picker-modal"),
+      ).not.toBeInTheDocument();
+    });
+
+    expect(
+      await screen.findByRole("button", { name: "mini-select" }),
+    ).toBeInTheDocument();
+  });
+
+  it("pressing Escape closes suggestion when focus is on field", () => {
+    const { onClose, ref } = setup();
+    let handled: boolean | undefined;
+
+    act(() => {
+      handled = ref.current?.onKeyDown({
+        event: new KeyboardEvent("keydown", { key: "Escape" }),
+      });
+    });
+
+    expect(handled).toBe(true);
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/shared/ExternalMenuTarget.tsx
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/shared/ExternalMenuTarget.tsx
@@ -1,0 +1,20 @@
+import { forwardRef, useImperativeHandle } from "react";
+
+type ExternalMenuTargetProps = {
+  element: Element | null;
+};
+
+/**
+ * Mantine's Menu.Target expects a React element it can attach a ref to.
+ * For TipTap suggestions we often already have a real DOM node (`decorationNode`).
+ *
+ * This component bridges those worlds by forwarding the ref to an existing DOM element.
+ */
+export const ExternalMenuTarget = forwardRef<
+  Element | null,
+  ExternalMenuTargetProps
+>(function ExternalMenuTarget({ element }, ref) {
+  useImperativeHandle(ref, () => element, [element]);
+
+  return null;
+});

--- a/frontend/src/metabase/ui/components/overlays/Menu/Menu.module.css
+++ b/frontend/src/metabase/ui/components/overlays/Menu/Menu.module.css
@@ -21,7 +21,8 @@
     background-color: var(--mb-color-background-hover);
   }
 
-  &:focus {
+  &:focus,
+  &[aria-selected="true"] {
     outline: none;
     background-color: var(--mb-color-background-hover);
     border: none;

--- a/frontend/src/metabase/ui/components/overlays/Menu/MenuDropdown/MenuDropdown.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Menu/MenuDropdown/MenuDropdown.tsx
@@ -1,22 +1,25 @@
 import type { MenuDropdownProps } from "@mantine/core";
 import { Menu } from "@mantine/core";
-import type { ReactNode } from "react";
-import { useEffect } from "react";
+import type { ReactNode, Ref } from "react";
+import { forwardRef, useEffect } from "react";
 
 import { useSequencedContentCloseHandler } from "metabase/common/hooks/use-sequenced-content-close-handler";
 import { PreventEagerPortal } from "metabase/ui";
 
 // hack to prevent parent TippyPopover from closing when selecting a Menu.Item
 // remove when TippyPopover is no longer used
-export function MenuDropdown({ children, ...props }: MenuDropdownProps) {
+export const MenuDropdown = forwardRef(function MenuDropdown(
+  { children, ...props }: MenuDropdownProps,
+  ref: Ref<HTMLDivElement>,
+) {
   return (
     <PreventEagerPortal {...props}>
-      <Menu.Dropdown {...props} data-element-id="mantine-popover">
+      <Menu.Dropdown {...props} data-element-id="mantine-popover" ref={ref}>
         <MenuDropdownContent>{children}</MenuDropdownContent>
       </Menu.Dropdown>
     </PreventEagerPortal>
   );
-}
+});
 
 interface MenuDropdownContentProps {
   children?: ReactNode;

--- a/frontend/src/metabase/ui/index.ts
+++ b/frontend/src/metabase/ui/index.ts
@@ -1,5 +1,6 @@
 export { rem, useCombobox, useMantineTheme, useMatches } from "@mantine/core";
 export type {
+  MenuDropdownProps,
   ComboboxStore,
   FloatingPosition,
   MantineSize,


### PR DESCRIPTION
Closes [BOT-996: Improve @-mention entity suggestions and table browsing](https://linear.app/metabase/issue/BOT-996/improve-mention-entity-suggestions-and-table-browsing)

### Description

Mentions in metabot were using a custom component for picking entities. Changed to use `MiniPicker` instead.

### How to verify

1. Open Metabot tab
2. Type `@`
3. See the new picker in action

### Demo

https://github.com/user-attachments/assets/f53cb84b-9a9a-4025-9eb9-2f0e6987d802



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
