### PR TITLE
fix: allow uploads when schema is unrestricted

### DIFF
--- a/src/metabase/upload/impl.clj
+++ b/src/metabase/upload/impl.clj
@@ -464,7 +464,7 @@
 (defn- can-create-upload-error
   "Returns an ExceptionInfo object if the user cannot upload to the given database and schema. Returns nil otherwise."
   [db schema-name]
-  #p (or (cond
+  (or (cond
         (not (:uploads_enabled db))
         (ex-info (tru "Uploads are not enabled.")
                  {:status-code 422})
@@ -474,11 +474,11 @@
                  {:status-code 422})
         (not
          (and
-          #p (= :unrestricted (perms/full-schema-permission-for-user api/*current-user-id*
+          (= :unrestricted (perms/full-schema-permission-for-user api/*current-user-id*
                                                                   :perms/view-data
                                                                   (u/the-id db)
                                                                   schema-name))
-          #p (contains? #{:query-builder :query-builder-and-native}
+          (contains? #{:query-builder :query-builder-and-native}
                      (perms/full-schema-permission-for-user api/*current-user-id*
                                                             :perms/create-queries
                                                             (u/the-id db)

--- a/src/metabase/upload/impl.clj
+++ b/src/metabase/upload/impl.clj
@@ -474,11 +474,10 @@
                  {:status-code 422})
         (not
          (and
-          (= :unrestricted (perms/full-db-permission-for-user api/*current-user-id*
-                                                              :perms/view-data
-                                                              (u/the-id db)))
-          ;; previously this required `unrestricted` data access, i.e. not `no-self-service`, which corresponds to *both*
-          ;; (at least) `:query-builder` plus unrestricted view-data
+          (= :unrestricted (perms/full-schema-permission-for-user api/*current-user-id*
+                                                                  :perms/view-data
+                                                                  (u/the-id db)
+                                                                  schema-name))
           (contains? #{:query-builder :query-builder-and-native}
                      (perms/full-schema-permission-for-user api/*current-user-id*
                                                             :perms/create-queries

--- a/src/metabase/upload/impl.clj
+++ b/src/metabase/upload/impl.clj
@@ -464,7 +464,7 @@
 (defn- can-create-upload-error
   "Returns an ExceptionInfo object if the user cannot upload to the given database and schema. Returns nil otherwise."
   [db schema-name]
-  (or (cond
+  #p (or (cond
         (not (:uploads_enabled db))
         (ex-info (tru "Uploads are not enabled.")
                  {:status-code 422})
@@ -474,11 +474,11 @@
                  {:status-code 422})
         (not
          (and
-          (= :unrestricted (perms/full-schema-permission-for-user api/*current-user-id*
+          #p (= :unrestricted (perms/full-schema-permission-for-user api/*current-user-id*
                                                                   :perms/view-data
                                                                   (u/the-id db)
                                                                   schema-name))
-          (contains? #{:query-builder :query-builder-and-native}
+          #p (contains? #{:query-builder :query-builder-and-native}
                      (perms/full-schema-permission-for-user api/*current-user-id*
                                                             :perms/create-queries
                                                             (u/the-id db)

--- a/test/metabase/upload/impl_test.clj
+++ b/test/metabase/upload/impl_test.clj
@@ -20,6 +20,7 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.models.interface :as mi]
+   [metabase.permissions.core :as perms]
    [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.query-processor :as qp]
@@ -2603,3 +2604,28 @@
       ;; This test ensure drivers always meet any transitive expectations users might have.
       (let [allow-list (driver/allowed-promotions driver/*driver*)]
         (is (= allow-list (or (mt/transitive allow-list) {})))))))
+
+(deftest can-create-upload-with-blocked-table-in-different-schema-test
+  (testing "A user with unrestricted access to the upload schema can upload even if blocked on a table in a different schema"
+    (mt/with-no-data-perms-for-all-users!
+      (mt/with-temp [:model/Database         {db-id :id}             {:engine "h2"}
+                     :model/Table            {upload-table :id}      {:db_id db-id :schema "upload_schema" :name "UploadTable"}
+                     :model/Table            {blocked-table :id}     {:db_id db-id :schema "other_schema"  :name "BlockedTable"}
+                     :model/PermissionsGroup pg                      {}]
+        (perms/add-user-to-group! (mt/user->id :rasta) pg)
+        (t2/delete! :model/DataPermissions :db_id db-id)
+        ;; Set database-level defaults to blocked
+        (data-perms/set-database-permission! pg db-id :perms/view-data :blocked)
+        (data-perms/set-database-permission! pg db-id :perms/create-queries :no)
+        ;; Grant unrestricted access to the upload schema table
+        (data-perms/set-table-permission! pg upload-table :perms/view-data :unrestricted)
+        (data-perms/set-table-permission! pg upload-table :perms/create-queries :query-builder)
+        ;; Block access to the table in the other schema
+        (data-perms/set-table-permission! pg blocked-table :perms/view-data :blocked)
+        (data-perms/set-table-permission! pg blocked-table :perms/create-queries :no)
+        (let [db (assoc (t2/select-one :model/Database db-id) :uploads_enabled true)]
+          (mt/with-current-user (mt/user->id :rasta)
+            (testing "can upload to the upload schema"
+              (is (true? (upload/can-create-upload? db "upload_schema"))))
+            (testing "cannot upload to the blocked schema"
+              (is (false? (upload/can-create-upload? db "other_schema"))))))))))

--- a/test/metabase/upload/impl_test.clj
+++ b/test/metabase/upload/impl_test.clj
@@ -2608,7 +2608,7 @@
 (deftest can-create-upload-with-blocked-table-in-different-schema-test
   (testing "A user with unrestricted access to the upload schema can upload even if blocked on a table in a different schema"
     (mt/with-no-data-perms-for-all-users!
-      (mt/with-temp [:model/Database         {db-id :id}             {:engine "h2"}
+      (mt/with-temp [:model/Database         {db-id :id}             {:engine "h2"  :uploads_enabled true}
                      :model/Table            {upload-table :id}      {:db_id db-id :schema "upload_schema" :name "UploadTable"}
                      :model/Table            {blocked-table :id}     {:db_id db-id :schema "other_schema"  :name "BlockedTable"}
                      :model/PermissionsGroup pg                      {}]
@@ -2623,7 +2623,7 @@
         ;; Block access to the table in the other schema
         (data-perms/set-table-permission! pg blocked-table :perms/view-data :blocked)
         (data-perms/set-table-permission! pg blocked-table :perms/create-queries :no)
-        (let [db (assoc (t2/select-one :model/Database db-id) :uploads_enabled true)]
+        (let [db (t2/select-one :model/Database db-id)]
           (mt/with-current-user (mt/user->id :rasta)
             (testing "can upload to the upload schema"
               (is (true? (upload/can-create-upload? db "upload_schema"))))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #68136
### Description

Updates the permissions required to upload to just be checked against the target schema rather than the entire database. This allows a user with unrestricted access to a given schema to upload to it even if they are blocked in another schema. 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR