### PR TITLE
[MBQL lib] Don't export a dynamic var; add `with-card-clean-hook` macro

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -734,7 +734,6 @@
   lib
   {:team "Querying"
    :api  #{metabase.lib.binning
-           metabase.lib.convert  ; Only so [[metabase.queries.models.card]] can set dynamic vars.
            metabase.lib.core
            metabase.lib.equality
            metabase.lib.field

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -530,3 +530,14 @@
   all-template-tags-id->field-ids
   any-native-stage?
   any-native-stage-not-introduced-by-sandbox?])
+
+#?(:clj
+   (defmacro with-card-clean-hook
+     "Arranges for `hook-fn` to be called during `lib.convert`'s query cleaning process, and executes the `body`
+     as with [[do]].
+
+     The `hook-fn` will be called whenever [[lib.convert/clean]] makes material changes to the query, with
+     `(hook-fn pre-cleaning-query post-cleaning-query)`."
+     [hook-fn & body]
+     `(binding [lib.convert/*card-clean-hook* ~hook-fn]
+        ~@body)))

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -17,7 +17,6 @@
    [metabase.dashboards.autoplace :as autoplace]
    [metabase.events.core :as events]
    [metabase.lib-be.core :as lib-be]
-   [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.lib.normalize :as lib.normalize]
@@ -738,8 +737,8 @@
              (pr-str (dissoc post-cleaning-query :lib/metadata))
              (:legacy_query untransformed-card)))
 
-;; Dynamically binds [[lib.convert/*card-clean-hook*]] to a function that logs the impact of cleaning,
-;; during `transform-out`, so that we can log whenever a card gets converted and [[lib.convert/clean]] makes material
+;; Uses [[lib/with-card-clean-hook]] to bind a callback which logs the impact of the cleaning process during
+;; `transform-out`, so that we can log whenever a card gets converted and [[lib.convert/clean]] makes material
 ;; changes, which likely indicates a bug.
 (methodical/defmethod t2.pipeline/results-transform [:toucan.result-type/instances :model/Card]
   [query-type model]
@@ -751,7 +750,7 @@
           ([acc]
            (rf' acc))
           ([acc card]
-           (binding [lib.convert/*card-clean-hook* (partial mbql5-conversion-clean-callback card)]
+           (lib/with-card-clean-hook (partial mbql5-conversion-clean-callback card)
              (rf' acc card))))))))
 
 (t2/define-after-select :model/Card


### PR DESCRIPTION
Fixes QUE2-354.

### Description

`lib/with-card-clean-hook` can be used to bind a callback function to
any material changes made by the `lib.convert/clean` process, which
generally indicates errors.

### How to verify

Tests and linters passing; no visible changes.

### Checklist

- ~~Tests have been added/updated to cover changes in this PR~~
