### PR TITLE
Default viz behavior fixes

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
@@ -481,7 +481,9 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
     });
 
     // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Pivot tables can only be used with aggregated queries.");
+    cy.findByText(
+      "Pivot tables are only supported for questions built in the query builder.",
+    );
   });
 
   describe("custom columns (metabase#14604)", () => {

--- a/frontend/src/metabase/visualizations/lib/settings/visualization.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/settings/visualization.unit.spec.js
@@ -1,6 +1,10 @@
 import icepick from "icepick";
 
-import { DateTimeColumn, NumberColumn } from "__support__/visualizations";
+import {
+  DateTimeColumn,
+  NumberColumn,
+  StringColumn,
+} from "__support__/visualizations";
 import {
   getComputedSettingsForSeries,
   getStoredSettingsForSeries,
@@ -256,6 +260,56 @@ describe("visualization_settings", () => {
           originalName: "1",
         },
       ]);
+    });
+  });
+
+  describe("pie.metric and pie.dimension", () => {
+    it("should pick defaults when there are multiple metric columns", () => {
+      const series = [
+        {
+          card: { display: "pie", visualization_settings: {} },
+          data: {
+            cols: [
+              StringColumn({ name: "category" }),
+              NumberColumn({ name: "sum" }),
+              NumberColumn({ name: "count" }),
+            ],
+            rows: [
+              ["a", 10, 1],
+              ["b", 20, 2],
+            ],
+          },
+        },
+      ];
+      const settings = getComputedSettingsForSeries(series);
+      expect(settings["pie.dimension"]).toEqual(["category"]);
+      expect(settings["pie.metric"]).toBe("sum");
+    });
+  });
+
+  describe("map.metric and map.dimension", () => {
+    it("should pick defaults when there are multiple metric columns", () => {
+      const series = [
+        {
+          card: {
+            display: "map",
+            visualization_settings: { "map.type": "region" },
+          },
+          data: {
+            cols: [
+              StringColumn({
+                name: "state",
+                semantic_type: "type/State",
+              }),
+              NumberColumn({ name: "count" }),
+              NumberColumn({ name: "sum" }),
+            ],
+            rows: [["CA", 100, 100]],
+          },
+        },
+      ];
+      const settings = getComputedSettingsForSeries(series);
+      expect(settings["map.metric"]).toBe("count");
     });
   });
 });

--- a/frontend/src/metabase/visualizations/shared/settings/pie.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/pie.ts
@@ -37,11 +37,7 @@ export function getPieDimensions(settings: ComputedVisualizationSettings) {
 }
 
 export function getDefaultPieColumns(rawSeries: RawSeries) {
-  const { dimensions, metrics } = getDefaultDimensionsAndMetrics(
-    rawSeries,
-    3,
-    1,
-  );
+  const { dimensions, metrics } = getDefaultDimensionsAndMetrics(rawSeries, 3);
   return {
     dimension: dimensions,
     metric: metrics[0],

--- a/frontend/src/metabase/visualizations/visualizations/Map/Map.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Map/Map.jsx
@@ -21,6 +21,7 @@ import {
 import {
   hasLatitudeAndLongitudeColumns,
   isCountry,
+  isDimension,
   isLatitude,
   isLongitude,
   isMetric,
@@ -216,11 +217,27 @@ export class Map extends Component {
       get title() {
         return t`Metric field`;
       },
+      getDefault: ([
+        {
+          data: { cols },
+        },
+      ]) => cols.find(isMetric)?.name,
       getHidden: (series, vizSettings) => vizSettings["map.type"] !== "region",
     }),
     ...dimensionSetting("map.dimension", {
       get title() {
         return t`Region field`;
+      },
+      getDefault: ([
+        {
+          data: { cols },
+        },
+      ]) => {
+        const geoDimension = cols.find((col) => isCountry(col) || isState(col));
+        if (geoDimension) {
+          return geoDimension.name;
+        }
+        return cols.find(isDimension)?.name;
       },
       getHidden: (series, vizSettings) => vizSettings["map.type"] !== "region",
     }),

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/utils.ts
@@ -228,6 +228,11 @@ export function checkRenderable(
   settings: VisualizationSettings,
   query?: NativeQuery | null,
 ) {
+  if (data.cols.some((col) => col.source === "native")) {
+    throw new Error(
+      t`Pivot tables are only supported for questions built in the query builder.`,
+    );
+  }
   if (data.cols.length < 2 || !data.cols.every(isColumnValid)) {
     throw new Error(t`Pivot tables can only be used with aggregated queries.`);
   }


### PR DESCRIPTION
Closes [UXW-3068](https://linear.app/metabase/issue/UXW-3068/default-visualization-setting-follow-ups)

### Description

As a follow up to #69289, where we improve the chart types we recommend, we want to ensure that any charts that are recommended will render a chart with their default settings:

- Pie and Map charts should render if there are multiple metrics
- Pivot tables should show a more explanatory error message when the user tries to use them with a native query
  - While we don't recommend pivot tables in this case, it falls under the theme of less confusing default behavior

### How to verify

1.  Create a query Count of orders and Sum of total grouped by Created at. Switch the visualization to Pie. Verify we now render the pie chart.
2.  Create a query Count of accounts and Sum of seats grouped by Country. Switch the visualization to Map. Verify we now render the map.
3. Try to create a pivot table from a native query

### Demo

[Loom](https://www.loom.com/share/a793c572b2f345e4a2bc18c3be3df3f8)

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
