### PR TITLE
[MBQL lib] Move leaky column logic from models.interface into lib

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -733,8 +733,7 @@
 
   lib
   {:team "Querying"
-   :api  #{metabase.lib.binning
-           metabase.lib.core
+   :api  #{metabase.lib.core
            metabase.lib.equality
            metabase.lib.field
            metabase.lib.init
@@ -768,7 +767,6 @@
            metabase.lib.schema.test-spec
            metabase.lib.schema.util
            metabase.lib.schema.validate
-           metabase.lib.temporal-bucket
            metabase.lib.types.isa
            metabase.lib.util
            metabase.lib.util.match

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -37,6 +37,7 @@
    [metabase.lib.metadata.column]
    [metabase.lib.metadata.composed-provider :as lib.metadata.composed-provider]
    [metabase.lib.metadata.protocols]
+   [metabase.lib.metadata.result-metadata]
    [metabase.lib.metric :as lib.metric]
    [metabase.lib.native :as lib.native]
    [metabase.lib.normalize :as lib.normalize]
@@ -97,6 +98,7 @@
          metabase.lib.metadata.column/keep-me
          lib.metadata.composed-provider/keep-me
          metabase.lib.metadata.protocols/keep-me
+         metabase.lib.metadata.result-metadata/keep-me
          lib.metric/keep-me
          lib.native/keep-me
          lib.normalize/keep-me
@@ -374,6 +376,8 @@
   cached-metadata-provider-with-cache?
   metadata-provider?
   metadata-providerable?]
+ [metabase.lib.metadata.result-metadata
+  normalize-result-metadata-column]
  [lib.native
   add-parameters-for-template-tags
   engine

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -16,11 +16,7 @@
    [medley.core :as m]
    ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.legacy-mbql.normalize :as mbql.normalize]
    ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.legacy-mbql.schema :as mbql.s]
-   [metabase.lib.binning :as lib.binning]
    [metabase.lib.core :as lib]
-   [metabase.lib.normalize :as lib.normalize]
-   [metabase.lib.schema.metadata :as lib.schema.metadata]
-   [metabase.lib.temporal-bucket :as lib.temporal-bucket]
    [metabase.models.dispatch :as models.dispatch]
    [metabase.models.json-migration :as jm]
    [metabase.models.resolution]
@@ -218,23 +214,12 @@
    :out (comp (catch-normalization-exceptions #_{:clj-kondo/ignore [:deprecated-var]} mbql.normalize/normalize-field-ref)
               json-out-with-keywordization)})
 
-(defn- normalize-result-metadata-column [col]
-  (if (:lib/type col)
-    (lib.normalize/normalize ::lib.schema.metadata/column col)
-    ;; legacy usages -- do not use these going forward
-    #_{:clj-kondo/ignore [:deprecated-var]}
-    (-> col
-        (->> (lib/normalize :metabase.query-processor.schema/result-metadata.column))
-        ;; This is necessary, because in the wild, there may be cards created prior to this change.
-        lib.temporal-bucket/ensure-temporal-unit-in-display-name
-        lib.binning/ensure-binning-in-display-name)))
-
 (defn- result-metadata-out
   "Transform the Card result metadata as it comes out of the DB. Convert columns to keywords where appropriate."
   [metadata]
   ;; TODO -- can we make this whole thing a lazy seq?
   (when-let [metadata (not-empty (json-out-with-keywordization metadata))]
-    (not-empty (mapv normalize-result-metadata-column metadata))))
+    (not-empty (mapv lib/normalize-result-metadata-column metadata))))
 
 (def transform-result-metadata
   "Transform for card.result_metadata like columns."


### PR DESCRIPTION
Fixes QUE2-353.

### Description

`mi/normalize-result-metadata-column` called some internals to modernize
a possibly-lib, possibly-legacy column from `:result_metadata` on a
card. Pull that logic into Lib as a new exported function.

Describe the overall approach and the problem being solved.

### How to verify

No visible changes. Tests and linters only.

### Checklist

- ~~Tests have been added/updated to cover changes in this PR~~
