### PR TITLE
Fix Circular Dependency in useGetPlan

### DIFF
--- a/frontend/src/metabase/admin/upsells/UpsellHosting.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellHosting.tsx
@@ -1,6 +1,7 @@
 import { jt, t } from "ttag";
 
-import { isProPlan, useGetPlan } from "metabase/common/utils/plan";
+import { useSetting } from "metabase/common/hooks";
+import { getPlan, isProPlan } from "metabase/common/utils/plan";
 import { useSelector } from "metabase/lib/redux";
 import { getIsHosted } from "metabase/setup/selectors";
 
@@ -8,7 +9,9 @@ import { UpsellBanner } from "./components";
 
 export const UpsellHostingBanner = ({ location }: { location: string }) => {
   const isHosted = useSelector(getIsHosted);
-  const plan = useGetPlan();
+  const features = useSetting("token-features");
+
+  const plan = getPlan(features);
   const isPro = isProPlan(plan);
 
   if (isHosted || isPro) {

--- a/frontend/src/metabase/common/utils/plan.ts
+++ b/frontend/src/metabase/common/utils/plan.ts
@@ -1,8 +1,6 @@
 import type { TokenFeatures } from "metabase-types/api";
 import { tokenFeatures } from "metabase-types/api";
 
-import { useSetting } from "../hooks";
-
 export type ProPlan = "pro-cloud" | "pro-cloud-with-dwh" | "pro-self-hosted";
 
 export type Plan = "oss" | "starter" | "starter-with-dwh" | ProPlan;
@@ -38,8 +36,3 @@ export const getPlan = (features?: TokenFeatures | null): Plan => {
 const ssoFeatures = ["sso_google", "sso_jwt", "sso_ldap", "sso_saml"] as const;
 export const hasAnySsoFeature = (features?: TokenFeatures | null): boolean =>
   features != null && ssoFeatures.some((ssoFeature) => features[ssoFeature]);
-
-export const useGetPlan = (): Plan => {
-  const features = useSetting("token-features");
-  return getPlan(features);
-};


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/DEV-1559

### Description

see https://metaboat.slack.com/archives/C5XHN8GLW/p1771021305724849 for lots of details

But the `useGetPlan` created a circular dependency that is failing tests 😱 

```
The dependency cycle:
  settings.ts
    → imports getPlan from plan.ts
      → plan.ts now imports useSetting from ../hooks
        → hooks barrel imports entity-framework
          → ... → questions.js → metadata.ts
            → imports getSettings from settings.ts (BOOM!)
```
