### PR TITLE
Fix missing availableHeight on model native editor

### DIFF
--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -2100,3 +2100,20 @@ describe("issue 67680", () => {
     });
   });
 });
+
+describe("issue 69722", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+    cy.visit("/model/new");
+    cy.findByRole("link", { name: /native query/ }).click();
+  });
+
+  it("should not be possible to overflow the native query editor (metabase#69722)", () => {
+    H.NativeEditor.type("{enter}".repeat(20));
+
+    cy.findByTestId("native-query-editor-container")
+      .findByTestId("run-button")
+      .should("be.visible");
+  });
+});

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditorInner.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditorInner.tsx
@@ -732,7 +732,7 @@ const DatasetEditorInnerView = (props: DatasetEditorInnerProps) => {
                 {...props}
                 isActive={isEditingQuery}
                 height={editorHeight}
-                viewHeight={height}
+                availableHeight={height}
                 onResizeStop={handleResize}
               />
             )}

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetQueryEditor.jsx
@@ -25,6 +25,7 @@ const SMOOTH_RESIZE_STYLE = { transition: "height 0.25s" };
 const propTypes = {
   question: PropTypes.object.isRequired,
   isActive: PropTypes.bool.isRequired, // if QB mode is set to "query"
+  availableHeight: PropTypes.number.isRequired,
   height: PropTypes.number.isRequired,
   onSetDatabaseId: PropTypes.func,
 };


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/69722

Fixes missing availableHeight prop on model native editor which caused resizing behavior to be a bit wonky.

Fixes [this comment](https://github.com/metabase/metabase/issues/68563#issuecomment-3898094958)