### PR TITLE
Fix the release discrepancies in v55

### DIFF
--- a/.github/workflows/check-milestone.yml
+++ b/.github/workflows/check-milestone.yml
@@ -26,11 +26,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          sparse-checkout: release
+          sparse-checkout: |
+            release
+            .github
           fetch-depth: ${{ env.isNewReleaseBranch == 'false' && 3 || 0 }} # we need the full history to get all the commit messages
           ref: master # we want the logic from master, even though we're triggering on a release branch
-      - name: Prepare build scripts
-        run: cd ${{ github.workspace }}/release && yarn && yarn build
+      - name: Prepare release scripts
+        uses: ./.github/actions/prepare-release-scripts # this action sets up bun, which is used in master, but not on versions prior to 59
       - uses: actions/github-script@v7
         if: ${{ env.isNewReleaseBranch == 'false' }}
         name: Set milestone for single commit

--- a/.github/workflows/release-log.yml
+++ b/.github/workflows/release-log.yml
@@ -40,10 +40,10 @@ jobs:
         with:
           ref: master # this only works on master
           fetch-depth: 0 # we want all branches and tags
-      - name: Install Dependencies
-        run: yarn --cwd release --frozen-lockfile && npm i -g tsx
-      - name: Build release scripts
-        run: yarn --cwd release build
+      - name: Prepare release scripts
+        uses: ./.github/actions/prepare-release-scripts # this action sets up bun, which is used in master, but not on versions prior to 59
+      - name: Install tsx
+        run: npm i -g tsx
       - name: Get version number
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
This PR addresses the discrepancy where we check out the code from `master` (which uses `bun`) but workflows still reference `yarn`.

The logic is the same as in #69547 and #69559