### PR TITLE
Gdgt 1774 incremental update field not displaying in transforms

### DIFF
--- a/e2e/support/helpers/e2e-data-studio-helpers.ts
+++ b/e2e/support/helpers/e2e-data-studio-helpers.ts
@@ -1,7 +1,13 @@
-import type { MeasureId, SegmentId, TableId } from "metabase-types/api";
+import type {
+  MeasureId,
+  SegmentId,
+  TableId,
+  TransformId,
+} from "metabase-types/api";
 
 import { codeMirrorHelpers } from "./e2e-codemirror-helpers";
 import { popover } from "./e2e-ui-elements-helpers";
+
 const { H } = cy;
 
 const libraryPage = () => cy.findByTestId("library-page");
@@ -52,6 +58,8 @@ export const DataStudio = {
       cy.visit("/data-studio/transforms");
       DataStudio.Transforms.list().should("be.visible");
     },
+    visitSettingsTab: (transformId: TransformId) =>
+      cy.visit(`/data-studio/transforms/${transformId}/settings`),
     pythonResults: () => cy.findByTestId("python-results"),
     enableTransformPage: () => cy.findByTestId("enable-transform-page"),
   },

--- a/frontend/src/metabase/transforms/components/IncrementalTransform/IncrementalTransformSettings.tsx
+++ b/frontend/src/metabase/transforms/components/IncrementalTransform/IncrementalTransformSettings.tsx
@@ -27,7 +27,7 @@ import type * as Lib from "metabase-lib";
 import type { TransformSource } from "metabase-types/api";
 
 import {
-  KeysetColumnSelect,
+  MBQLKeysetColumnSelect,
   PythonKeysetColumnSelect,
 } from "./KeysetColumnSelect";
 import { NativeQueryColumnSelect } from "./NativeQueryColumnSelect";
@@ -230,13 +230,14 @@ function SourceStrategyFields({
       {values.sourceStrategy === "checkpoint" && (
         <>
           {type === "query" && query && (
-            <KeysetColumnSelect
+            <MBQLKeysetColumnSelect
               name="checkpointFilterUniqueKey"
               label={t`Field to check for new values`}
               placeholder={t`Pick a field`}
               description={t`Pick the field that we should scan to determine which records are new or changed`}
               descriptionProps={{ lh: "1rem" }}
               query={query}
+              source={source}
               disabled={readOnly}
             />
           )}

--- a/frontend/src/metabase/transforms/components/IncrementalTransform/KeysetColumnSelect/KeysetColumnSelect.tsx
+++ b/frontend/src/metabase/transforms/components/IncrementalTransform/KeysetColumnSelect/KeysetColumnSelect.tsx
@@ -1,10 +1,11 @@
 import { useMemo } from "react";
 
 import { FormSelect } from "metabase/forms";
-import type {
-  DataAttributes,
-  InputDescriptionProps,
-  SelectOption,
+import {
+  type DataAttributes,
+  type InputDescriptionProps,
+  Loader,
+  type SelectOption,
 } from "metabase/ui";
 import * as Lib from "metabase-lib";
 
@@ -16,6 +17,7 @@ type KeysetColumnSelectProps = {
   descriptionProps?: InputDescriptionProps & DataAttributes;
   query: Lib.Query | null;
   disabled?: boolean;
+  isLoading?: boolean;
 };
 
 export function KeysetColumnSelect({
@@ -26,6 +28,7 @@ export function KeysetColumnSelect({
   descriptionProps,
   query,
   disabled,
+  isLoading,
 }: KeysetColumnSelectProps) {
   const columnOptions = useMemo((): Array<SelectOption> => {
     if (!query) {
@@ -90,6 +93,7 @@ export function KeysetColumnSelect({
       searchable
       disabled={disabled || columnOptions.length === 0}
       descriptionProps={descriptionProps}
+      rightSection={isLoading ? <Loader size="xs" /> : undefined}
     />
   );
 }

--- a/frontend/src/metabase/transforms/components/IncrementalTransform/KeysetColumnSelect/MBQLKeysetColumnSelect.tsx
+++ b/frontend/src/metabase/transforms/components/IncrementalTransform/KeysetColumnSelect/MBQLKeysetColumnSelect.tsx
@@ -1,0 +1,47 @@
+import { skipToken, useGetAdhocQueryMetadataQuery } from "metabase/api";
+import type { DataAttributes, InputDescriptionProps } from "metabase/ui";
+import type * as Lib from "metabase-lib";
+import type { TransformSource } from "metabase-types/api";
+
+import { KeysetColumnSelect } from "./KeysetColumnSelect";
+
+type MBQLKeysetColumnSelectProps = {
+  source: TransformSource;
+  name: string;
+  label: string;
+  placeholder: string;
+  description: React.ReactNode;
+  descriptionProps?: InputDescriptionProps & DataAttributes;
+  query: Lib.Query;
+  disabled?: boolean;
+};
+
+export const MBQLKeysetColumnSelect = ({
+  source,
+  name,
+  label,
+  placeholder,
+  description,
+  descriptionProps,
+  query,
+  disabled,
+}: MBQLKeysetColumnSelectProps) => {
+  /**
+   * we need this metadata in order to get incremental fields to select
+   */
+  const { isLoading } = useGetAdhocQueryMetadataQuery(
+    source.type === "query" ? source.query : skipToken,
+  );
+  return (
+    <KeysetColumnSelect
+      name={name}
+      label={label}
+      placeholder={placeholder}
+      description={description}
+      query={query}
+      descriptionProps={descriptionProps}
+      disabled={disabled}
+      isLoading={isLoading}
+    />
+  );
+};

--- a/frontend/src/metabase/transforms/components/IncrementalTransform/KeysetColumnSelect/PythonKeysetColumnSelect.tsx
+++ b/frontend/src/metabase/transforms/components/IncrementalTransform/KeysetColumnSelect/PythonKeysetColumnSelect.tsx
@@ -71,7 +71,8 @@ export function PythonKeysetColumnSelect({
       description={description}
       descriptionProps={descriptionProps}
       query={query}
-      disabled={disabled || isLoading || !!error}
+      disabled={disabled || !!error}
+      isLoading={isLoading}
     />
   );
 }

--- a/frontend/src/metabase/transforms/components/IncrementalTransform/KeysetColumnSelect/index.ts
+++ b/frontend/src/metabase/transforms/components/IncrementalTransform/KeysetColumnSelect/index.ts
@@ -1,2 +1,3 @@
 export { KeysetColumnSelect } from "./KeysetColumnSelect";
+export { MBQLKeysetColumnSelect } from "./MBQLKeysetColumnSelect";
 export { PythonKeysetColumnSelect } from "./PythonKeysetColumnSelect";


### PR DESCRIPTION
Closes [GDGT-1774: Incremental update field not displaying in transforms](https://linear.app/metabase/issue/GDGT-1774/incremental-update-field-not-displaying-in-transforms)

### Description
The field list wasn't loaded because nothing triggered the metadata request in case we visit Settings tab first. In the default case the user visit Definition tab first which triggers the metadata fetching deep inside `QueryEditor`.

### How to verify

1. Create a MBQL transform with incremental feature enabled
2. Visit settings tab and see that the list of fields is loaded and select is not disabled
3. Refresh the page and see that the list of fields still allows you to select a field

### Demo

https://github.com/user-attachments/assets/ab12988f-f73d-4054-a92b-3141f5487914



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
