### PR TITLE
Support postMessage for toggling Metabot side panel in full-app embedding

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/metabot/tests/ui.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/tests/ui.unit.spec.tsx
@@ -6,7 +6,10 @@ import { assocIn } from "icepick";
 import { act, screen, waitFor, within } from "__support__/ui";
 import { logout } from "metabase/auth/actions";
 import * as domModule from "metabase/lib/dom";
-import { METABOT_ERR_MSG } from "metabase-enterprise/metabot/constants";
+import {
+  FIXED_METABOT_IDS,
+  METABOT_ERR_MSG,
+} from "metabase-enterprise/metabot/constants";
 import { useMetabotAgent } from "metabase-enterprise/metabot/hooks";
 import { getMetabotInitialState } from "metabase-enterprise/metabot/state/reducer-utils";
 
@@ -305,13 +308,13 @@ describe("metabot > ui", () => {
   describe("postMessage toggleMetabot (embedding)", () => {
     let isWithinIframeSpy: jest.SpyInstance;
 
-    // beforeEach(() => {
-    //   // When isWithinIframe is true, the app uses EMBEDDED metabot id (2) for prompt-suggestions
-    //   fetchMock.get(
-    //     `path:/api/ee/metabot-v3/metabot/${FIXED_METABOT_IDS.EMBEDDED}/prompt-suggestions`,
-    //     { prompts: [], offset: 0, limit: 3, total: 3 },
-    //   );
-    // });
+    beforeEach(() => {
+      // When isWithinIframe is true, the app uses EMBEDDED metabot id (2) for prompt-suggestions
+      fetchMock.get(
+        `path:/api/ee/metabot-v3/metabot/${FIXED_METABOT_IDS.EMBEDDED}/prompt-suggestions`,
+        { prompts: [], offset: 0, limit: 3, total: 3 },
+      );
+    });
 
     afterEach(() => {
       isWithinIframeSpy?.mockRestore();


### PR DESCRIPTION
### Description

When using full-app embedding, the only way to display the Metabot panel is to use the `Ctrl+E` or `Cmd+E` keyboard shortcut. This is a problem because the shortcut conflicts with e.g. focusing the search bar in Edge or Firefox in Windows, or other extensions/custom shortcuts that customers might be using.

Customers can potentially bind any shortcut to `Ctrl+E`, so avoiding conflicts is impossible. Instead of allowing configurable keyboard shortcuts, we add a new `postMessage` message handler so that embedding applications can toggle the Metabot panel. This way, they can add their on keybindings, or add external buttons or arbitrary behavior to let them control the Metabot panel programmatically.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Embed Metabase using full-app embedding
2. From the embedding application, run the `postMessage` command as follows, assuming Metabase is running under `https://dev.metabase.localhost`:

```js
// toggle Metabot visibility
document.getElementsByTagName('iframe')[0].contentWindow.postMessage({ metabase: {type: 'toggleMetabot' }}, 'https://dev.metabase.localhost')

// force Metabot open
document.getElementsByTagName('iframe')[0].contentWindow.postMessage({ metabase: {type: 'toggleMetabot', open: true }}, 'https://dev.metabase.localhost')

// force Metabot closed
document.getElementsByTagName('iframe')[0].contentWindow.postMessage({ metabase: {type: 'toggleMetabot', open: false }}, 'https://dev.metabase.localhost')
```

### Demo

https://github.com/user-attachments/assets/6763cdf9-dd3f-450e-a414-65f9cb234c36

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] ~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~
