### PR TITLE
Name the default join strategy

### DIFF
--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -688,14 +688,14 @@
   (merge
    {:lib/type :option/join.strategy
     :strategy raw-strategy}
-   (when (= raw-strategy :left-join)
+   (when (= raw-strategy lib.schema.join/default-strategy)
      {:default true})))
 
 (mu/defn raw-join-strategy :- ::lib.schema.join/strategy
   "Get the raw keyword strategy (type) of a given join, e.g. `:left-join` or `:right-join`. This is either the value
-  of the optional `:strategy` key or the default, `:left-join`, if `:strategy` is not specified."
+  of the optional `:strategy` key or [[lib.schema.join/default-strategy]] if `:strategy` is not specified."
   [a-join :- ::lib.join.util/partial-join]
-  (get a-join :strategy :left-join))
+  (get a-join :strategy lib.schema.join/default-strategy))
 
 (mu/defn join-strategy :- ::lib.schema.join/strategy.option
   "Get the strategy (type) of a given join, as a `:option/join.strategy` map. If `:strategy` is unspecified, returns
@@ -735,7 +735,7 @@
        (u/assoc-default :fields :all)))
 
   ([joinable conditions]
-   (join-clause joinable conditions :left-join))
+   (join-clause joinable conditions lib.schema.join/default-strategy))
 
   ([joinable conditions strategy]
    (-> (join-clause joinable)

--- a/src/metabase/lib/schema/join.cljc
+++ b/src/metabase/lib/schema/join.cljc
@@ -59,14 +59,18 @@
   "Operators that should be listed as options in join conditions."
   (into [:enum] condition-operators))
 
+(def default-strategy
+  "The default join strategy when `:strategy` is not specified."
+  :left-join)
+
 (mr/def ::strategy
   "Valid values for the optional `:strategy` key in a join. Note that these are only valid if the current Database
   supports that specific join type; these match 1:1 with the Database `:features`, e.g. a Database that supports left
   joins will support the `:left-join` feature.
 
-  When `:strategy` is not specified, `:left-join` is the default strategy."
+  When `:strategy` is not specified, [[default-strategy]] is used."
   [:enum
-   {:decode/normalize common/normalize-keyword, :default :left-join}
+   {:decode/normalize common/normalize-keyword, :default default-strategy}
    :left-join
    :right-join
    :inner-join

--- a/src/metabase/query_processor/middleware/resolve_joins.clj
+++ b/src/metabase/query_processor/middleware/resolve_joins.clj
@@ -15,10 +15,7 @@
 
 (mu/defn- merge-defaults :- ::lib.schema.join/join
   [join]
-  ;;; TODO (Cam 9/16/25) -- if we made `:strategy` a required key with a `:default` value in
-  ;;; `:metabase.lib.schema.join/join` then Lib normalization could handle this for us and we wouldn't need QP
-  ;;; middleware to do it. Seems like the better way to deal with defaults. (QUE-2469)
-  (merge {:strategy :left-join}
+  (merge {:strategy lib.schema.join/default-strategy}
          (when (str/starts-with? (:alias join) lib/legacy-default-join-alias)
            {:qp/keep-default-join-alias true})
          join))


### PR DESCRIPTION
Closes QUE2-285

### Description

The original idea was making the :strategy key required and leaving the setting of the value to the normalization, but I decided not to go down that road. Here's why: there are multiple places on the path of constructing a join where we can specify the join strategy but don't have to. These steps are not going through normalization and introducing normalization would be inefficient and feel strange. Also, it would need to be done at several points, so it doesn't seem a gain in the end. Because of this, all this PR does is naming the default strategy, so that changing it should be possible at a single point. (Doing this would be a bad idea, so this PR is meant to be a documentation improvement.)