### PR TITLE
Fix flaky view-and-curate-content.cy.spec.ts

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/view-and-curate-content.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/view-and-curate-content.cy.spec.ts
@@ -231,7 +231,7 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
           cy.findByText("Our analytics").click();
         });
 
-        cy.findByText("New collection").click();
+        cy.button("New collection").should("be.enabled").click();
 
         H.modal()
           .contains("header", "Create a new collection", { timeout: 10_000 })


### PR DESCRIPTION
closes EMB-1320

### Description

The button could be disabled, and we need to wait for it to be enabled before clicking it. I found out that in the failed cases, there are some APIs being fired after the button is clicked.

### How to verify

[Stress test PR](https://github.com/metabase/metabase/actions/runs/22069318061/job/63770050998): 20/20 ✅
[Stress test master](https://github.com/metabase/metabase/actions/runs/22068790518/job/63767592789) 1/20 ❌


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
