### PR TITLE
Prefer SQL DML for insert-from-source! to fix bigquery metadata consistency

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/transforms_python/transforms_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_python/transforms_api_test.clj
@@ -158,8 +158,7 @@
                 (transforms.tu/test-run transform-id)
                 (transforms.tu/wait-for-table table-name 10000)
                 (is (true? (driver/table-exists? driver/*driver* (mt/db) target)))
-                (is (= [["Alice" 25] ["Bob" 30]]
-                       (transforms.tu/table-rows table-name)))))))))))
+                (is (= [["Alice" 25] ["Bob" 30]] (sort-by first (transforms.tu/table-rows table-name))))))))))))
 
 (defn- subsequence?
   "Returns true if sequence ys is a subsequence of xs:

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -53,8 +53,6 @@
     Field$Mode
     FieldValue
     FieldValueList
-    InsertAllRequest
-    InsertAllRequest$RowToInsert
     JobInfo
     QueryJobConfiguration
     Schema
@@ -1006,30 +1004,23 @@
     v))
 
 (defmethod driver/insert-from-source! [:bigquery-cloud-sdk :rows]
-  [_driver db-id {table-name :name :keys [columns]} {:keys [data]}]
-  (let [col-names (map :name columns)
-        database  (t2/select-one :model/Database db-id)
-        details   (driver.conn/effective-details database)
-
-        client     (database-details->client details)
-        project-id (get-project-id details)
-
-        dataset-id (namespace table-name)
-        table-name (name table-name)
-
-        table-id (.getTableId (get-table client project-id dataset-id table-name))
-
-        prepared-rows (map #(into {} (map vector col-names %)) data)]
-    (doseq [chunk (partition-all (or driver/*insert-chunk-rows* 1000) prepared-rows)]
-      (let [insert-request-builder (InsertAllRequest/newBuilder table-id)]
-        (doseq [^java.util.Map row chunk]
-          (.addRow insert-request-builder (InsertAllRequest$RowToInsert/of row)))
-        (let [insert-request (.build insert-request-builder)
-              response       (.insertAll client insert-request)]
-          (when (.hasErrors response)
-            (let [errors (.getInsertErrors response)]
-              (throw (ex-info "BigQuery insert failed"
-                              {:errors (into [] (map str errors))})))))))))
+  [driver db-id {table-name :name :keys [columns]} {:keys [data]}]
+  ;; Uses SQL inserts instead of the Storage API or the legacy .insertAll API.
+  ;; this is because during transforms tables are dropped and re-created, and both these API's do not
+  ;; update their metadata caches frequently enough for timely transform runs (or interactive previews).
+  ;; rather than waiting many minutes, we trade torward consistency by using SQL DML, whose table metadata
+  ;; is consistent and we do not see cached non-existence and things like that causing trouble.
+  (let [database   (t2/select-one :model/Database db-id)
+        col-kws    (mapv (comp keyword name :name) columns)
+        num-cols   (count col-kws)
+        ;; bigquery allows 10k query parameters per request
+        max-rows   (max 1 (quot 10000 num-cols))
+        chunk-size (min (or driver/*insert-chunk-rows* 1000) max-rows)]
+    (doseq [chunk (partition-all chunk-size data)]
+      (let [[sql & params] (sql.qp/format-honeysql driver {:insert-into table-name
+                                                           :columns     col-kws
+                                                           :values      (vec chunk)})]
+        (driver/execute-raw-queries! driver database [[sql params]])))))
 
 (defmethod driver/execute-raw-queries! :bigquery-cloud-sdk
   [driver conn-spec queries]

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/params.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/params.clj
@@ -8,7 +8,9 @@
 
 (set! *warn-on-reflection* true)
 
-(defn- param ^QueryParameterValue [type-name v]
+(defn param
+  "Constructs a QueryParameterValue wrapper that hints a sql type via the type-name (mapping to StandardSQLTypeName)."
+  ^QueryParameterValue [type-name v]
   (.build (doto (QueryParameterValue/newBuilder)
             (.setType (StandardSQLTypeName/valueOf type-name))
             (.setValue (some-> v str)))))
@@ -16,6 +18,8 @@
 (defmulti ^:private ->QueryParameterValue
   {:arglists '(^QueryParameterValue [v])}
   class)
+
+(defmethod ->QueryParameterValue QueryParameterValue [v] v)
 
 (defmethod ->QueryParameterValue :default
   [v]


### PR DESCRIPTION
The legacy .insertAll API (and newer Storage API) do not work well with tables that are created/dropped frequently. This is because their metadata caches can take a long time to up date.

Python transforms use the drop-recreate fallback strategy for bigquery so we observe this inconsistency for every run after the first, even with absurd multi minute timeouts.

The SQL API does not have a problem, so we'll use that. We expect a performance regression but its better to work slowly than not work at all.

Note: BigQuery now has no writeback for 'STRUCT' columns - I could not easily get the existing code to work for them. We can investigate what it might take to bring these back (like parsing STRUCT definitions and emitting literals in the SQL) but I am unsure the value is there early on anyway.