### PR TITLE
Un-publishing remote-sync'ed library tables should remove them from the git repo

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/remote_sync/spec.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/spec.clj
@@ -225,7 +225,6 @@
     :identity       :hybrid  ; entity_id but needs table context for path
     :path-keys      [:database :schema :table]
     :parent-model   :model/Table
-    :parent-fk      :table_id
     :events         {:prefix :event/segment
                      :types  [:create :update :delete]}
     :eligibility    {:type :parent-table}
@@ -249,7 +248,6 @@
     :identity       :hybrid  ; entity_id but needs table context for path
     :path-keys      [:database :schema :table]
     :parent-model   :model/Table
-    :parent-fk      :table_id
     :events         {:prefix :event/measure
                      :types  [:create :update :delete]}
     :eligibility    {:type :parent-table}
@@ -357,7 +355,8 @@
   [parent-model-key]
   (into []
         (comp (map val)
-              (filter #(= (:parent-model %) parent-model-key)))
+              (filter #(and (= (:parent-model %) parent-model-key)
+                            (:parent-fk %))))
         remote-sync-specs))
 
 (defn specs-by-identity-type

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/spec_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/spec_test.clj
@@ -79,9 +79,10 @@
               "removal :scope-key should be a keyword when present"))))))
 
 (deftest parent-fk-specs-are-valid-test
-  (testing "Every spec with :parent-model has a :parent-fk keyword"
+  (testing "Every spec with :parent-model and :parent-fk has a keyword :parent-fk"
     (doseq [[model-key spec] spec/remote-sync-specs
-            :when (:parent-model spec)]
+            :when (and (:parent-model spec)
+                       (:parent-fk spec))]
       (testing (str "Spec for " model-key)
         (is (keyword? (:parent-fk spec))
             ":parent-fk should be a keyword")
@@ -91,8 +92,8 @@
 
   (testing "children-specs derives the correct children for Table"
     (let [children (spec/children-specs :model/Table)]
-      (is (= 3 (count children)))
-      (is (= #{:model/Field :model/Segment :model/Measure}
+      (is (= 1 (count children)))
+      (is (= #{:model/Field}
              (into #{} (map :model-key) children)))))
 
   (testing "children-specs returns empty for models with no children"


### PR DESCRIPTION
### Description

Adds publish/unpublish events to the table remote-sync/spec

Also has dependent fields follow it's publish/unpublish events. Any metrics or segments that use an unpublished table remain in the library, just referencing an unpublished table now.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
