### PR TITLE
Fix navigate_to not doing anything in full-app embedding

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/actions.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/actions.ts
@@ -8,8 +8,8 @@ import { push } from "react-router-redux";
 import { P, match } from "ts-pattern";
 import _ from "underscore";
 
+import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { addUndo } from "metabase/redux/undo";
-import { getIsEmbedding } from "metabase/selectors/embed";
 import { getIsWorkspace } from "metabase/selectors/routing";
 import { getUser } from "metabase/selectors/user";
 import {
@@ -313,7 +313,6 @@ export const sendAgentRequest = createAsyncThunk<
     payload,
     { dispatch, getState, signal, rejectWithValue, fulfillWithValue },
   ) => {
-    const isEmbedding = getIsEmbedding(getState());
     const isWorkspace = getIsWorkspace(getState());
     const { agentId, ...request } = payload;
 
@@ -352,7 +351,7 @@ export const sendAgentRequest = createAsyncThunk<
               .with({ type: "navigate_to" }, (part) => {
                 dispatch(setNavigateToPath(part.value));
 
-                if (!isEmbedding && !isWorkspace) {
+                if (!isEmbeddingSdk() && !isWorkspace) {
                   dispatch(push(part.value) as UnknownAction);
                 }
               })


### PR DESCRIPTION
### Description

When using full-app embedding, going to New > AI Exploration and entering a prompt that returns a `navigate_to` command does nothing.

Example: using the sample database, go to New > AI Exploration and enter `customer list`. This generates this request:

```json
{
  "type": "text",
  "context": {
    "user_is_viewing": [],
    "current_time_with_timezone": "2026-02-16T17:47:36-03:00",
    "capabilities": [
      "frontend:navigate_user_v1",
      "permission:save_questions",
      "permission:write_sql_queries",
      "permission:write_transforms"
    ]
  },
  "message": "customer list",
  "conversation_id": "981317f3-c582-7167-fee6-785dbc03720d",
  "state": {},
  "history": [],
  "profile_id": "nlq"
}
```

Using the default ai-service profile, this generates a response like this:

<details><summary>Response</summary>

```
0:"I'll"
0:" help you fin"
0:"d customer"
0:" data"
0:"."
0:" Let me search for customer"
0:"-"
0:"related data"
0:" sources"
0:"."
9:{"toolCallId":"toolu_01V8nM456QGH9RsuAnSYeSnx","toolName":"search","args":"{\"semantic_queries\": [\"customer information and profiles\",\"customer list and details\"], \"keyword_queries\": [\"customer\",\"people\",\"user\",\"account\"], \"entity_types\": [\"table\",\"model\"]}"}
a:{"toolCallId":"toolu_01V8nM456QGH9RsuAnSYeSnx","result":"\n<result>\nHere are the search results:\n<search-results>\n<metabase-model id=\"1\" name=\"Orders + People\" is_verified=\"False\" database_id=\"1\" database_engine=\"unknown\" fully_qualified_name=\"{#1}-orders-people\">\n\n### Description\nSample orders joined with products\n\n\n\n\n\n\n\nBefore using any field in comparisons, filters, or conditions, you should check their metadata and sample values first, using the uri `metabase://model/{model.id}/fields/{field_id}`.\nThis will help avoid errors due to unexpected data types or formats.\n</model>\n\n<table id=\"349\", name=\"my_customers\" database_id=\"3\" database_engine=\"unknown\" fully_qualified_name=\"public.my_customers\">\n\n### Description\nNone\n\n\n\n\n\n\n\nBefore using any field in comparisons, filters, or conditions, you should check their metadata and sample values first, using the uri `metabase://table/{table.id}/fields/{field_id}`.\nThis will help avoid errors due to unexpected data types or formats.\n</table>\n\n<table id=\"1\", name=\"PEOPLE\" database_id=\"1\" database_engine=\"unknown\" fully_qualified_name=\"PUBLIC.PEOPLE\">\n\n### Description\nInformation on the user accounts registered with Sample Company.\n\n\n\n\n\n\n\nBefore using any field in comparisons, filters, or conditions, you should check their metadata and sample values first, using the uri `metabase://table/{table.id}/fields/{field_id}`.\nThis will help avoid errors due to unexpected data types or formats.\n</table>\n\n<table id=\"2\", name=\"ORDERS\" database_id=\"1\" database_engine=\"unknown\" fully_qualified_name=\"PUBLIC.ORDERS\">\n\n### Description\nConfirmed Sample Company orders for a product, from a user.\n\n\n\n\n\n\n\nBefore using any field in comparisons, filters, or conditions, you should check their metadata and sample values first, using the uri `metabase://table/{table.id}/fields/{field_id}`.\nThis will help avoid errors due to unexpected data types or formats.\n</table>\n\n<table id=\"129\", name=\"user_key_value\" database_id=\"2\" database_engine=\"unknown\" fully_qualified_name=\"public.user_key_value\">\n\n### Description\nA simple key value store for each user.\n\n\n\n\n\n\n\nBefore using any field in comparisons, filters, or conditions, you should check their metadata and sample values first, using the uri `metabase://table/{table.id}/fields/{field_id}`.\nThis will help avoid errors due to unexpected data types or formats.\n</table>\n\n<table id=\"82\", name=\"user_parameter_value\" database_id=\"2\" database_engine=\"unknown\" fully_qualified_name=\"public.user_parameter_value\">\n\n### Description\nTable holding last set value of a parameter per user\n\n\n\n\n\n\n\nBefore using any field in comparisons, filters, or conditions, you should check their metadata and sample values first, using the uri `metabase://table/{table.id}/fields/{field_id}`.\nThis will help avoid errors due to unexpected data types or formats.\n</table>\n\n<table id=\"145\", name=\"metabase_field_user_settings\" database_id=\"2\" database_engine=\"unknown\" fully_qualified_name=\"public.metabase_field_user_settings\">\n\n### Description\nMirror table of metabase_field to keep track of user-set values (only settable fields are mirrored)\n\n\n\n\n\n\n\nBefore using any field in comparisons, filters, or conditions, you should check their metadata and sample values first, using the uri `metabase://table/{table.id}/fields/{field_id}`.\nThis will help avoid errors due to unexpected data types or formats.\n</table>\n\n<table id=\"43\", name=\"v_users\" database_id=\"2\" database_engine=\"unknown\" fully_qualified_name=\"public.v_users\">\n\n### Description\nNone\n\n\n\n\n\n\n\nBefore using any field in comparisons, filters, or conditions, you should check their metadata and sample values first, using the uri `metabase://table/{table.id}/fields/{field_id}`.\nThis will help avoid errors due to unexpected data types or formats.\n</table>\n\n<table id=\"46\", name=\"core_user\" database_id=\"2\" database_engine=\"unknown\" fully_qualified_name=\"public.core_user\">\n\n### Description\nNone\n\n\n\n\n\n\n\nBefore using any field in comparisons, filters, or conditions, you should check their metadata and sample values first, using the uri `metabase://table/{table.id}/fields/{field_id}`.\nThis will help avoid errors due to unexpected data types or formats.\n</table>\n\n<table id=\"455\", name=\"my_customers\" database_id=\"4\" database_engine=\"unknown\" fully_qualified_name=\"public.my_customers\">\n\n### Description\nNone\n\n\n\n\n\n\n\nBefore using any field in comparisons, filters, or conditions, you should check their metadata and sample values first, using the uri `metabase://table/{table.id}/fields/{field_id}`.\nThis will help avoid errors due to unexpected data types or formats.\n</table>\n\n<table id=\"347\", name=\"users\" database_id=\"3\" database_engine=\"unknown\" fully_qualified_name=\"public.users\">\n\n### Description\nNone\n\n\n\n\n\n\n\nBefore using any field in comparisons, filters, or conditions, you should check their metadata and sample values first, using the uri `metabase://table/{table.id}/fields/{field_id}`.\nThis will help avoid errors due to unexpected data types or formats.\n</table>\n\n<table id=\"387\", name=\"people\" database_id=\"3\" database_engine=\"unknown\" fully_qualified_name=\"public.people\">\n\n### Description\nNone\n\n\n\n\n\n\n\nBefore using any field in comparisons, filters, or conditions, you should check their metadata and sample values first, using the uri `metabase://table/{table.id}/fields/{field_id}`.\nThis will help avoid errors due to unexpected data types or formats.\n</table>\n\n<table id=\"58\", name=\"tenant\" database_id=\"2\" database_engine=\"unknown\" fully_qualified_name=\"public.tenant\">\n\n### Description\nTenants (collections of external users). A user can be in exactly zero or one tenants.\n\n\n\n\n\n\n\nBefore using any field in comparisons, filters, or conditions, you should check their metadata and sample values first, using the uri `metabase://table/{table.id}/fields/{field_id}`.\nThis will help avoid errors due to unexpected data types or formats.\n</table>\n\n<table id=\"137\", name=\"recent_views\" database_id=\"2\" database_engine=\"unknown\" fully_qualified_name=\"public.recent_views\">\n\n### Description\nUsed to store recently viewed objects for each user\n\n\n\n\n\n\n\nBefore using any field in comparisons, filters, or conditions, you should check their metadata and sample values first, using the uri `metabase://table/{table.id}/fields/{field_id}`.\nThis will help avoid errors due to unexpected data types or formats.\n</table>\n\n<table id=\"47\", name=\"channel_template\" database_id=\"2\" database_engine=\"unknown\" fully_qualified_name=\"public.channel_template\">\n\n### Description\ncustom template for the channel\n\n\n\n\n\n\n\nBefore using any field in comparisons, filters, or conditions, you should check their metadata and sample values first, using the uri `metabase://table/{table.id}/fields/{field_id}`.\nThis will help avoid errors due to unexpected data types or formats.\n</table>\n\n<table id=\"123\", name=\"table_privileges\" database_id=\"2\" database_engine=\"unknown\" fully_qualified_name=\"public.table_privileges\">\n\n### Description\nTable for user and role privileges by table\n\n\n\n\n\n\n\nBefore using any field in comparisons, filters, or conditions, you should check their metadata and sample values first, using the uri `metabase://table/{table.id}/fields/{field_id}`.\nThis will help avoid errors due to unexpected data types or formats.\n</table>\n\n<table id=\"48\", name=\"python_library\" database_id=\"2\" database_engine=\"unknown\" fully_qualified_name=\"public.python_library\">\n\n### Description\nStore Python library code for user modules in transforms\n\n\n\n\n\n\n\nBefore using any field in comparisons, filters, or conditions, you should check their metadata and sample values first, using the uri `metabase://table/{table.id}/fields/{field_id}`.\nThis will help avoid errors due to unexpected data types or formats.\n</table>\n\n<table id=\"149\", name=\"db_router\" database_id=\"2\" database_engine=\"unknown\" fully_qualified_name=\"public.db_router\">\n\n### Description\nConfiguration for Database Routers. Currently just holds which user attribute each\nconfigured router database should use to choose a mirror database to route to.\n\n\n\n\n\n\n\nBefore using any field in comparisons, filters, or conditions, you should check their metadata and sample values first, using the uri `metabase://table/{table.id}/fields/{field_id}`.\nThis will help avoid errors due to unexpected data types or formats.\n</table>\n\n<table id=\"62\", name=\"document_bookmark\" database_id=\"2\" database_engine=\"unknown\" fully_qualified_name=\"public.document_bookmark\">\n\n### Description\nStore user bookmarks for documents\n\n\n\n\n\n\n\nBefore using any field in comparisons, filters, or conditions, you should check their metadata and sample values first, using the uri `metabase://table/{table.id}/fields/{field_id}`.\nThis will help avoid errors due to unexpected data types or formats.\n</table>\n\n<table id=\"6\", name=\"ACCOUNTS\" database_id=\"1\" database_engine=\"unknown\" fully_qualified_name=\"PUBLIC.ACCOUNTS\">\n\n### Description\nInformation on customer accounts registered with Piespace. Each account represents a new organization signing up for on-demand pies.\n\n\n\n\n\n\n\nBefore using any field in comparisons, filters, or conditions, you should check their metadata and sample values first, using the uri `metabase://table/{table.id}/fields/{field_id}`.\nThis will help avoid errors due to unexpected data types or formats.\n</table></search-results>\n</result>\n<instructions>\nSearch results ranked by relevance (highest first).\n\nWhen using results:\n- Prioritize verified dashboards, questions, and metrics over raw data exploration when they match the user's request\n- Check available fields or metadata of promising results before recommending them to ensure they contain needed data\n- **Be proactive with clear matches**: When the top result(s) have names or descriptions that clearly match the user's request, use them to achieve the users goal first, then list alternatives at the end. Don't ask for confirmation when there's an obvious best choice.\n- **Collection metadata**: Results may include collection information (name, description, authority level) that can help you determine whether the result is relevant to the user's query. Use this context to assess relevance.\n- **Present options for ambiguous results**: When search returns multiple plausible options without a clear best match, present them and ask the user to choose\n- Reference results using the metabase protocol link format: [display name](metabase://type/id)\n\nExamples: [Customer Metrics](metabase://metric/42), [Sales Dashboard](metabase://dashboard/158)\n\n</instructions>"}
0:"Great"
0:"! I found several"
0:" customer"
0:"-"
0:"related data"
0:" sources. Base"
0:"d on your"
0:" recent"
0:" views"
0:" an"
0:"d the"
0:" search results, the"
0:" most relevant option"
0:" is"
0:" the "
0:"[PEOPLE](/question#eyJkYXRhc2V0X3F1ZXJ5IjogeyJkYXRhYmFzZSI6IDEsICJ0eXBlIjogInF1ZXJ5IiwgInF1ZXJ5IjogeyJzb3VyY2UtdGFibGUiOiAxfX0sICJkaXNwbGF5SXNMb2NrZWQiOiB0cnVlLCAidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6IHt9fQ==) table,"
0:" which contains"
0:" \""
0:"Information"
0:" on the"
0:" user"
0:" accounts"
0:" registered with Sample"
0:" Company"
0:".\""
0:"\n\nLet me get"
0:" the"
0:" details of"
0:" this table so"
0:" I can show"
0:" you the"
0:" customer"
0:" list"
0:":"
9:{"toolCallId":"toolu_01L9PRRS9vuj94f2C26tEUpq","toolName":"read_resource","args":"{\"uris\": [\"metabase://table/1/fields\"]}"}
a:{"toolCallId":"toolu_01L9PRRS9vuj94f2C26tEUpq","result":"<resources>\n<resource uri=\"metabase://table/1/fields\">\n<table id=\"1\", name=\"PEOPLE\" database_id=\"1\" database_engine=\"h2\" fully_qualified_name=\"PUBLIC.PEOPLE\">\n\n### Description\nInformation on the user accounts registered with Sample Company.\n\n### Fields\n\nThe following fields are available in this table.\n\n\n<field id=\"t1-0\" name=\"\"ID\"\" display_name=\"ID\" type=\"number\" database_type=\"bigint\">## Description\nA unique identifier given to each user.\n</field>\n<field id=\"t1-1\" name=\"\"ADDRESS\"\" display_name=\"Address\" type=\"string\" database_type=\"character_varying\">## Description\nThe street address of the account\u2019s billing address\n</field>\n<field id=\"t1-2\" name=\"\"EMAIL\"\" display_name=\"Email\" type=\"string\" database_type=\"character_varying\">## Description\nThe contact email for the account.\n</field>\n<field id=\"t1-3\" name=\"\"PASSWORD\"\" display_name=\"Password\" type=\"string\" database_type=\"character_varying\">## Description\nThis is the salted password of the user. It should not be visible\n</field>\n<field id=\"t1-4\" name=\"\"NAME\"\" display_name=\"Name\" type=\"string\" database_type=\"character_varying\">## Description\nThe name of the user who owns an account\n</field>\n<field id=\"t1-5\" name=\"\"CITY\"\" display_name=\"City\" type=\"string\" database_type=\"character_varying\">## Description\nThe city of the account\u2019s billing address\n</field>\n<field id=\"t1-6\" name=\"\"LONGITUDE\"\" display_name=\"Longitude\" type=\"number\" database_type=\"double_precision\">## Description\nThis is the longitude of the user on sign-up. It might be updated in the future to the last seen location.\n</field>\n<field id=\"t1-7\" name=\"\"STATE\"\" display_name=\"State\" type=\"string\" database_type=\"character\">## Description\nThe state or province of the account\u2019s billing address\n</field>\n<field id=\"t1-8\" name=\"\"SOURCE\"\" display_name=\"Source\" type=\"string\" database_type=\"character_varying\">## Description\nThe channel through which we acquired this user. Valid values include: Affiliate, Facebook, Google, Organic and Twitter\n</field>\n<field id=\"t1-9\" name=\"\"BIRTH_DATE\"\" display_name=\"Birth Date\" type=\"date\" database_type=\"date\">## Description\nThe date of birth of the user\n</field>\n<field id=\"t1-10\" name=\"\"ZIP\"\" display_name=\"Zip\" type=\"string\" database_type=\"character\">## Description\nThe postal code of the account\u2019s billing address\n</field>\n<field id=\"t1-11\" name=\"\"LATITUDE\"\" display_name=\"Latitude\" type=\"number\" database_type=\"double_precision\">## Description\nThis is the latitude of the user on sign-up. It might be updated in the future to the last seen location.\n</field>\n<field id=\"t1-12\" name=\"\"CREATED_AT\"\" display_name=\"Created At\" type=\"datetime\" database_type=\"timestamp\">## Description\nThe date the user record was created. Also referred to as the user\u2019s \"join date\"\n</field>\n\n\n\n\n\n\nBefore using any field in comparisons, filters, or conditions, you should check their metadata and sample values first, using the uri `metabase://table/{table.id}/fields/{field_id}`.\nThis will help avoid errors due to unexpected data types or formats.\n</table>\n</resource>\n</resources>"}
0:"Perfect"
0:"! Now let"
0:" me create"
0:" a customer"
0:" list"
0:" for"
0:" you"
0:" showing"
0:" all"
0:" the key"
0:" customer"
0:" information:"
9:{"toolCallId":"toolu_01KLLsTzMHigcoTe1kSG2Tb8","toolName":"construct_notebook_query","args":"{\"reasoning\": \"The user wants a customer list. The PEOPLE table contains customer/user information with fields like ID, Name, Email, Address, City, State, and other contact details. I'll create a raw data query to display all customer records with the most relevant fields: ID, Name, Email, City, State, and Created At (join date). This will give a comprehensive customer list view.\", \"query\": {\"query_type\":\"raw\",\"source\":{\"table_id\":1},\"fields\":[{\"field_id\":\"t1-0\"},{\"field_id\":\"t1-4\"},{\"field_id\":\"t1-2\"},{\"field_id\":\"t1-1\"},{\"field_id\":\"t1-5\"},{\"field_id\":\"t1-7\"},{\"field_id\":\"t1-12\"}],\"filters\":[],\"order_by\":[{\"field\":{\"field_id\":\"t1-12\"},\"direction\":\"desc\"}],\"limit\":null}, \"visualization\": {\"chart_type\":\"table\"}}"}
2:{"type":"navigate_to","version":1,"value":"/question#eyJkYXRhc2V0X3F1ZXJ5IjogeyJsaWIvdHlwZSI6ICJtYnFsL3F1ZXJ5IiwgInN0YWdlcyI6IFt7ImxpYi90eXBlIjogIm1icWwuc3RhZ2UvbWJxbCIsICJzb3VyY2UtdGFibGUiOiAxLCAiZmllbGRzIjogW1siZmllbGQiLCB7ImxpYi91dWlkIjogIjAwMjU2MjdhLWYxZTMtNGZmMS04YjMzLTU4M2NmMDAwYjFjYiIsICJlZmZlY3RpdmUtdHlwZSI6ICJ0eXBlL0JpZ0ludGVnZXIiLCAiYmFzZS10eXBlIjogInR5cGUvQmlnSW50ZWdlciJ9LCA0XSwgWyJmaWVsZCIsIHsibGliL3V1aWQiOiAiM2ZiZDJlNTEtZmI0Ni00MGYyLWJjMzctYzM1MWEyNmU3YTNjIiwgImVmZmVjdGl2ZS10eXBlIjogInR5cGUvVGV4dCIsICJiYXNlLXR5cGUiOiAidHlwZS9UZXh0In0sIDQ4XSwgWyJmaWVsZCIsIHsibGliL3V1aWQiOiAiMDBhZTRhY2QtNmMxZC00MjQ2LWJhNmUtODg4OTA1ZjFjZGNhIiwgImVmZmVjdGl2ZS10eXBlIjogInR5cGUvVGV4dCIsICJiYXNlLXR5cGUiOiAidHlwZS9UZXh0In0sIDddLCBbImZpZWxkIiwgeyJsaWIvdXVpZCI6ICIyMjBjNTMzZC01NzllLTRiZGItOTA2Ni1mODlhMGZlODE4ZGMiLCAiZWZmZWN0aXZlLXR5cGUiOiAidHlwZS9UZXh0IiwgImJhc2UtdHlwZSI6ICJ0eXBlL1RleHQifSwgNTFdLCBbImZpZWxkIiwgeyJsaWIvdXVpZCI6ICI4ZTBmZmY4MC05NDQ4LTQzNWMtYjczYy00MjcyODIyM2RkMTciLCAiZWZmZWN0aXZlLXR5cGUiOiAidHlwZS9UZXh0IiwgImJhc2UtdHlwZSI6ICJ0eXBlL1RleHQifSwgNTNdLCBbImZpZWxkIiwgeyJsaWIvdXVpZCI6ICIzYTkwNDI1My0yYThlLTRhY2UtYTE1Ni0yZjc0YzhlOTM1MzgiLCAiZWZmZWN0aXZlLXR5cGUiOiAidHlwZS9UZXh0IiwgImJhc2UtdHlwZSI6ICJ0eXBlL1RleHQifSwgMV0sIFsiZmllbGQiLCB7ImxpYi91dWlkIjogIjc1OWZkZTk0LTY2OGItNGMyMy1hN2U4LTQ0NTc0M2JkMDU5MiIsICJlZmZlY3RpdmUtdHlwZSI6ICJ0eXBlL0RhdGVUaW1lIiwgImJhc2UtdHlwZSI6ICJ0eXBlL0RhdGVUaW1lIn0sIDUwXV0sICJvcmRlci1ieSI6IFtbImRlc2MiLCB7ImxpYi91dWlkIjogImNiYjIxMTgzLTFlYmQtNDM4Ni1iZTJmLTkwMjMzZjJkYTc4NiJ9LCBbImZpZWxkIiwgeyJsaWIvdXVpZCI6ICIwNjIwOGY3Yy03ZjZmLTQ0ZTEtYjU0Yy0yMGMzMjEyZjFjODAiLCAiZWZmZWN0aXZlLXR5cGUiOiAidHlwZS9EYXRlVGltZSIsICJiYXNlLXR5cGUiOiAidHlwZS9EYXRlVGltZSJ9LCA1MF1dXX1dLCAiZGF0YWJhc2UiOiAxfSwgImRpc3BsYXkiOiAidGFibGUiLCAiZGlzcGxheUlzTG9ja2VkIjogdHJ1ZSwgInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOiB7fX0="}
a:{"toolCallId":"toolu_01KLLsTzMHigcoTe1kSG2Tb8","result":"\n<result>\n\n<chart id=\"74c3cc02-40f4-4667-a596-af7d628c072b\">\nThe chart is powered by the following queries:\n\n<query type=\"notebook\" id=\"FFnq_p7DEjQ_rjpBGSdtY\" database_id=\"1\">\n{\"lib/type\": \"mbql/query\", \"stages\": [{\"lib/type\": \"mbql.stage/mbql\", \"source-table\": 1, \"fields\": [[\"field\", {\"lib/uuid\": \"0025627a-f1e3-4ff1-8b33-583cf000b1cb\", \"effective-type\": \"type/BigInteger\", \"base-type\": \"type/BigInteger\"}, 4], [\"field\", {\"lib/uuid\": \"3fbd2e51-fb46-40f2-bc37-c351a26e7a3c\", \"effective-type\": \"type/Text\", \"base-type\": \"type/Text\"}, 48], [\"field\", {\"lib/uuid\": \"00ae4acd-6c1d-4246-ba6e-888905f1cdca\", \"effective-type\": \"type/Text\", \"base-type\": \"type/Text\"}, 7], [\"field\", {\"lib/uuid\": \"220c533d-579e-4bdb-9066-f89a0fe818dc\", \"effective-type\": \"type/Text\", \"base-type\": \"type/Text\"}, 51], [\"field\", {\"lib/uuid\": \"8e0fff80-9448-435c-b73c-42728223dd17\", \"effective-type\": \"type/Text\", \"base-type\": \"type/Text\"}, 53], [\"field\", {\"lib/uuid\": \"3a904253-2a8e-4ace-a156-2f74c8e93538\", \"effective-type\": \"type/Text\", \"base-type\": \"type/Text\"}, 1], [\"field\", {\"lib/uuid\": \"759fde94-668b-4c23-a7e8-445743bd0592\", \"effective-type\": \"type/DateTime\", \"base-type\": \"type/DateTime\"}, 50]], \"order-by\": [[\"desc\", {\"lib/uuid\": \"cbb21183-1ebd-4386-be2f-90233f2da786\"}, [\"field\", {\"lib/uuid\": \"06208f7c-7f6f-44e1-b54c-20c3212f1c80\", \"effective-type\": \"type/DateTime\", \"base-type\": \"type/DateTime\"}, 50]]]}], \"database\": 1}\n\n<query_results>\n### Result Columns\n| Field Name | Display Name | Type | Description |\n| ---------- | ------------ | ---- | ----------- |\n| ID | ID | number | A unique identifier given to each user. |\n| NAME | Name | string | The name of the user who owns an account |\n| EMAIL | Email | string | The contact email for the account. |\n| ADDRESS | Address | string | The street address of the account\u2019s billing address |\n| CITY | City | string | The city of the account\u2019s billing address |\n| STATE | State | string | The state or province of the account\u2019s billing address |\n| CREATED_AT | Created At | datetime | The date the user record was created. Also referred to as the user\u2019s \"join date\" |\n\n</query_results>\n</query>\n<visualization>{\"chart_type\":\"table\"}</visualization>\n</chart>\n    \n</result>\n<instructions>\nYour query and chart have been created successfully.\n\nNext steps to present the chart to the user:\n- Always provide a direct link using: `[Chart](metabase://chart/74c3cc02-40f4-4667-a596-af7d628c072b)` where Chart is a meaningful link text\n- If creating multiple charts, present all chart links\n\n</instructions>"}
0:"Perfect! Here"
0:"'s your"
0:" "
0:"[Customer List](/question#eyJkYXRhc2V0X3F1ZXJ5IjogeyJsaWIvdHlwZSI6ICJtYnFsL3F1ZXJ5IiwgInN0YWdlcyI6IFt7ImxpYi90eXBlIjogIm1icWwuc3RhZ2UvbWJxbCIsICJzb3VyY2UtdGFibGUiOiAxLCAiZmllbGRzIjogW1siZmllbGQiLCB7ImxpYi91dWlkIjogIjAwMjU2MjdhLWYxZTMtNGZmMS04YjMzLTU4M2NmMDAwYjFjYiIsICJlZmZlY3RpdmUtdHlwZSI6ICJ0eXBlL0JpZ0ludGVnZXIiLCAiYmFzZS10eXBlIjogInR5cGUvQmlnSW50ZWdlciJ9LCA0XSwgWyJmaWVsZCIsIHsibGliL3V1aWQiOiAiM2ZiZDJlNTEtZmI0Ni00MGYyLWJjMzctYzM1MWEyNmU3YTNjIiwgImVmZmVjdGl2ZS10eXBlIjogInR5cGUvVGV4dCIsICJiYXNlLXR5cGUiOiAidHlwZS9UZXh0In0sIDQ4XSwgWyJmaWVsZCIsIHsibGliL3V1aWQiOiAiMDBhZTRhY2QtNmMxZC00MjQ2LWJhNmUtODg4OTA1ZjFjZGNhIiwgImVmZmVjdGl2ZS10eXBlIjogInR5cGUvVGV4dCIsICJiYXNlLXR5cGUiOiAidHlwZS9UZXh0In0sIDddLCBbImZpZWxkIiwgeyJsaWIvdXVpZCI6ICIyMjBjNTMzZC01NzllLTRiZGItOTA2Ni1mODlhMGZlODE4ZGMiLCAiZWZmZWN0aXZlLXR5cGUiOiAidHlwZS9UZXh0IiwgImJhc2UtdHlwZSI6ICJ0eXBlL1RleHQifSwgNTFdLCBbImZpZWxkIiwgeyJsaWIvdXVpZCI6ICI4ZTBmZmY4MC05NDQ4LTQzNWMtYjczYy00MjcyODIyM2RkMTciLCAiZWZmZWN0aXZlLXR5cGUiOiAidHlwZS9UZXh0IiwgImJhc2UtdHlwZSI6ICJ0eXBlL1RleHQifSwgNTNdLCBbImZpZWxkIiwgeyJsaWIvdXVpZCI6ICIzYTkwNDI1My0yYThlLTRhY2UtYTE1Ni0yZjc0YzhlOTM1MzgiLCAiZWZmZWN0aXZlLXR5cGUiOiAidHlwZS9UZXh0IiwgImJhc2UtdHlwZSI6ICJ0eXBlL1RleHQifSwgMV0sIFsiZmllbGQiLCB7ImxpYi91dWlkIjogIjc1OWZkZTk0LTY2OGItNGMyMy1hN2U4LTQ0NTc0M2JkMDU5MiIsICJlZmZlY3RpdmUtdHlwZSI6ICJ0eXBlL0RhdGVUaW1lIiwgImJhc2UtdHlwZSI6ICJ0eXBlL0RhdGVUaW1lIn0sIDUwXV0sICJvcmRlci1ieSI6IFtbImRlc2MiLCB7ImxpYi91dWlkIjogImNiYjIxMTgzLTFlYmQtNDM4Ni1iZTJmLTkwMjMzZjJkYTc4NiJ9LCBbImZpZWxkIiwgeyJsaWIvdXVpZCI6ICIwNjIwOGY3Yy03ZjZmLTQ0ZTEtYjU0Yy0yMGMzMjEyZjFjODAiLCAiZWZmZWN0aXZlLXR5cGUiOiAidHlwZS9EYXRlVGltZSIsICJiYXNlLXR5cGUiOiAidHlwZS9EYXRlVGltZSJ9LCA1MF1dXX1dLCAiZGF0YWJhc2UiOiAxfSwgImRpc3BsYXkiOiAidGFibGUiLCAiZGlzcGxheUlzTG9ja2VkIjogdHJ1ZSwgInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOiB7fX0=) showing"
0:" all customers"
0:" from"
0:" the"
0:" PEOPLE"
0:" table"
0:"."
0:"\n\nThe table"
0:" displays:\n- **ID**"
0:" -"
0:" Unique customer"
0:" identifier\n- **Name"
0:"** - Customer name"
0:"\n- **Email** - Contact"
0:" email\n- **Address** -"
0:" Billing address\n- **City** -"
0:" City"
0:"\n- **State** - State/Province"
0:"\n- **Created At** - Join"
0:" date ("
0:"sorte"
0:"d most"
0:" recent first)\n\nYou"
0:" can click on the"
0:" chart link to"
0:" view the full"
0:" customer"
0:" list"
0:","
0:" search"
0:","
0:" filter, or export the"
0:" data as needed."
2:{"type":"state","version":1,"value":{"queries":{"FFnq_p7DEjQ_rjpBGSdtY":{"lib/type":"mbql/query","stages":[{"lib/type":"mbql.stage/mbql","source-table":1,"fields":[["field",{"lib/uuid":"0025627a-f1e3-4ff1-8b33-583cf000b1cb","effective-type":"type/BigInteger","base-type":"type/BigInteger"},4],["field",{"lib/uuid":"3fbd2e51-fb46-40f2-bc37-c351a26e7a3c","effective-type":"type/Text","base-type":"type/Text"},48],["field",{"lib/uuid":"00ae4acd-6c1d-4246-ba6e-888905f1cdca","effective-type":"type/Text","base-type":"type/Text"},7],["field",{"lib/uuid":"220c533d-579e-4bdb-9066-f89a0fe818dc","effective-type":"type/Text","base-type":"type/Text"},51],["field",{"lib/uuid":"8e0fff80-9448-435c-b73c-42728223dd17","effective-type":"type/Text","base-type":"type/Text"},53],["field",{"lib/uuid":"3a904253-2a8e-4ace-a156-2f74c8e93538","effective-type":"type/Text","base-type":"type/Text"},1],["field",{"lib/uuid":"759fde94-668b-4c23-a7e8-445743bd0592","effective-type":"type/DateTime","base-type":"type/DateTime"},50]],"order-by":[["desc",{"lib/uuid":"cbb21183-1ebd-4386-be2f-90233f2da786"},["field",{"lib/uuid":"06208f7c-7f6f-44e1-b54c-20c3212f1c80","effective-type":"type/DateTime","base-type":"type/DateTime"},50]]]}],"database":1}},"charts":{"74c3cc02-40f4-4667-a596-af7d628c072b":{"chart_id":"74c3cc02-40f4-4667-a596-af7d628c072b","queries":[{"query_id":"FFnq_p7DEjQ_rjpBGSdtY","query":{"lib/type":"mbql/query","stages":[{"lib/type":"mbql.stage/mbql","source-table":1,"fields":[["field",{"lib/uuid":"0025627a-f1e3-4ff1-8b33-583cf000b1cb","effective-type":"type/BigInteger","base-type":"type/BigInteger"},4],["field",{"lib/uuid":"3fbd2e51-fb46-40f2-bc37-c351a26e7a3c","effective-type":"type/Text","base-type":"type/Text"},48],["field",{"lib/uuid":"00ae4acd-6c1d-4246-ba6e-888905f1cdca","effective-type":"type/Text","base-type":"type/Text"},7],["field",{"lib/uuid":"220c533d-579e-4bdb-9066-f89a0fe818dc","effective-type":"type/Text","base-type":"type/Text"},51],["field",{"lib/uuid":"8e0fff80-9448-435c-b73c-42728223dd17","effective-type":"type/Text","base-type":"type/Text"},53],["field",{"lib/uuid":"3a904253-2a8e-4ace-a156-2f74c8e93538","effective-type":"type/Text","base-type":"type/Text"},1],["field",{"lib/uuid":"759fde94-668b-4c23-a7e8-445743bd0592","effective-type":"type/DateTime","base-type":"type/DateTime"},50]],"order-by":[["desc",{"lib/uuid":"cbb21183-1ebd-4386-be2f-90233f2da786"},["field",{"lib/uuid":"06208f7c-7f6f-44e1-b54c-20c3212f1c80","effective-type":"type/DateTime","base-type":"type/DateTime"},50]]]}],"database":1},"result":{"result_columns":[{"field_id":"qFFnq_p7DEjQ_rjpBGSdtY-0","name":"ID","display_name":"ID","type":"number","database_type":"bigint","semantic_type":"pk","description":"A unique identifier given to each user.","field_values":null},{"field_id":"qFFnq_p7DEjQ_rjpBGSdtY-1","name":"NAME","display_name":"Name","type":"string","database_type":"character_varying","semantic_type":"name","description":"The name of the user who owns an account","field_values":null},{"field_id":"qFFnq_p7DEjQ_rjpBGSdtY-2","name":"EMAIL","display_name":"Email","type":"string","database_type":"character_varying","semantic_type":"email","description":"The contact email for the account.","field_values":null},{"field_id":"qFFnq_p7DEjQ_rjpBGSdtY-3","name":"ADDRESS","display_name":"Address","type":"string","database_type":"character_varying","semantic_type":null,"description":"The street address of the account\u2019s billing address","field_values":null},{"field_id":"qFFnq_p7DEjQ_rjpBGSdtY-4","name":"CITY","display_name":"City","type":"string","database_type":"character_varying","semantic_type":"city","description":"The city of the account\u2019s billing address","field_values":null},{"field_id":"qFFnq_p7DEjQ_rjpBGSdtY-5","name":"STATE","display_name":"State","type":"string","database_type":"character","semantic_type":"state","description":"The state or province of the account\u2019s billing address","field_values":null},{"field_id":"qFFnq_p7DEjQ_rjpBGSdtY-6","name":"CREATED_AT","display_name":"Created At","type":"datetime","database_type":"timestamp","semantic_type":"creation_timestamp","description":"The date the user record was created. Also referred to as the user\u2019s \"join date\"","field_values":null}],"rows":[]}}],"visualization_settings":{"chart_type":"table"},"image_base_64":null,"timeline_events":null}},"todos":[],"transforms":{},"link_registry":{"/question#eyJkYXRhc2V0X3F1ZXJ5IjogeyJkYXRhYmFzZSI6IDEsICJ0eXBlIjogInF1ZXJ5IiwgInF1ZXJ5IjogeyJzb3VyY2UtdGFibGUiOiAxfX0sICJkaXNwbGF5SXNMb2NrZWQiOiB0cnVlLCAidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6IHt9fQ==":"metabase://table/1","/question#eyJkYXRhc2V0X3F1ZXJ5IjogeyJsaWIvdHlwZSI6ICJtYnFsL3F1ZXJ5IiwgInN0YWdlcyI6IFt7ImxpYi90eXBlIjogIm1icWwuc3RhZ2UvbWJxbCIsICJzb3VyY2UtdGFibGUiOiAxLCAiZmllbGRzIjogW1siZmllbGQiLCB7ImxpYi91dWlkIjogIjAwMjU2MjdhLWYxZTMtNGZmMS04YjMzLTU4M2NmMDAwYjFjYiIsICJlZmZlY3RpdmUtdHlwZSI6ICJ0eXBlL0JpZ0ludGVnZXIiLCAiYmFzZS10eXBlIjogInR5cGUvQmlnSW50ZWdlciJ9LCA0XSwgWyJmaWVsZCIsIHsibGliL3V1aWQiOiAiM2ZiZDJlNTEtZmI0Ni00MGYyLWJjMzctYzM1MWEyNmU3YTNjIiwgImVmZmVjdGl2ZS10eXBlIjogInR5cGUvVGV4dCIsICJiYXNlLXR5cGUiOiAidHlwZS9UZXh0In0sIDQ4XSwgWyJmaWVsZCIsIHsibGliL3V1aWQiOiAiMDBhZTRhY2QtNmMxZC00MjQ2LWJhNmUtODg4OTA1ZjFjZGNhIiwgImVmZmVjdGl2ZS10eXBlIjogInR5cGUvVGV4dCIsICJiYXNlLXR5cGUiOiAidHlwZS9UZXh0In0sIDddLCBbImZpZWxkIiwgeyJsaWIvdXVpZCI6ICIyMjBjNTMzZC01NzllLTRiZGItOTA2Ni1mODlhMGZlODE4ZGMiLCAiZWZmZWN0aXZlLXR5cGUiOiAidHlwZS9UZXh0IiwgImJhc2UtdHlwZSI6ICJ0eXBlL1RleHQifSwgNTFdLCBbImZpZWxkIiwgeyJsaWIvdXVpZCI6ICI4ZTBmZmY4MC05NDQ4LTQzNWMtYjczYy00MjcyODIyM2RkMTciLCAiZWZmZWN0aXZlLXR5cGUiOiAidHlwZS9UZXh0IiwgImJhc2UtdHlwZSI6ICJ0eXBlL1RleHQifSwgNTNdLCBbImZpZWxkIiwgeyJsaWIvdXVpZCI6ICIzYTkwNDI1My0yYThlLTRhY2UtYTE1Ni0yZjc0YzhlOTM1MzgiLCAiZWZmZWN0aXZlLXR5cGUiOiAidHlwZS9UZXh0IiwgImJhc2UtdHlwZSI6ICJ0eXBlL1RleHQifSwgMV0sIFsiZmllbGQiLCB7ImxpYi91dWlkIjogIjc1OWZkZTk0LTY2OGItNGMyMy1hN2U4LTQ0NTc0M2JkMDU5MiIsICJlZmZlY3RpdmUtdHlwZSI6ICJ0eXBlL0RhdGVUaW1lIiwgImJhc2UtdHlwZSI6ICJ0eXBlL0RhdGVUaW1lIn0sIDUwXV0sICJvcmRlci1ieSI6IFtbImRlc2MiLCB7ImxpYi91dWlkIjogImNiYjIxMTgzLTFlYmQtNDM4Ni1iZTJmLTkwMjMzZjJkYTc4NiJ9LCBbImZpZWxkIiwgeyJsaWIvdXVpZCI6ICIwNjIwOGY3Yy03ZjZmLTQ0ZTEtYjU0Yy0yMGMzMjEyZjFjODAiLCAiZWZmZWN0aXZlLXR5cGUiOiAidHlwZS9EYXRlVGltZSIsICJiYXNlLXR5cGUiOiAidHlwZS9EYXRlVGltZSJ9LCA1MF1dXX1dLCAiZGF0YWJhc2UiOiAxfSwgImRpc3BsYXkiOiAidGFibGUiLCAiZGlzcGxheUlzTG9ja2VkIjogdHJ1ZSwgInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOiB7fX0=":"metabase://chart/74c3cc02-40f4-4667-a596-af7d628c072b"}}}
d:{"finishReason":"stop","usage":{"openrouter/anthropic/claude-haiku-4.5":{"prompt":45777,"completion":636,"costs":0.048957},"promptTokens":45777,"completionTokens":636}}

```
</details> 

### How to verify

1. On latest master, go to New > AI Exploration and enter `customer list`
2. Nothing happens
3. Apply this patch, try again
4. Observe that this works

### Demo

https://github.com/user-attachments/assets/8f1cbf06-2e79-4896-a7ec-e585fbf30732

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
- [ ] ~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~
