### PR TITLE
Remove unused HTTP action code paths

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -1124,43 +1124,6 @@
                   (is (= #{[{:model "Card" :id card-eid-1}]}
                          (set (serdes/dependencies ser)))))))))))))
 
-(deftest http-action-test
-  (mt/with-empty-h2-app-db!
-    (ts/with-temp-dpc [:model/User     {ann-id :id} {:first_name "Ann"
-                                                     :last_name  "Wilson"
-                                                     :email      "ann@heart.band"}
-                       :model/Database {db-id :id :as db} {:name "My Database"}]
-      (mt/with-db db
-        (mt/with-actions [{card-id-1  :id
-                           card-eid-1 :entity_id}
-                          {:name          "Source question"
-                           :database_id   db-id
-                           :type          :model
-                           :query_type    :native
-                           :dataset_query (mt/native-query {:query "select 1"})
-                           :creator_id    ann-id}
-
-                          {:keys [action-id]}
-                          {:name       "My Action"
-                           :type       :http
-                           :template   {:method "GET", :url "https://camsaul.com"}
-                           :creator_id ann-id
-                           :model_id   card-id-1}]
-          (let [action (action/select-action :id action-id)]
-            (testing "action"
-              (let [ser (ts/extract-one "Action" action-id)]
-                (is (=? {:serdes/meta [{:model "Action" :id (:entity_id action) :label "my_action"}]
-                         :creator_id  "ann@heart.band"
-                         :type        "http"
-                         :created_at  string?
-                         :model_id    card-eid-1
-                         :http        [{:template {}}]}
-                        ser))
-                (is (not (contains? ser :id)))
-                (testing "depends on the Model"
-                  (is (= #{[{:model "Card" :id card-eid-1}]}
-                         (set (serdes/dependencies ser)))))))))))))
-
 (deftest query-action-test
   (mt/with-empty-h2-app-db!
     (ts/with-temp-dpc [:model/User     {ann-id :id} {:first_name "Ann"

--- a/src/metabase/actions_rest/api.clj
+++ b/src/metabase/actions_rest/api.clj
@@ -83,7 +83,7 @@
     :as action} :- ::actions.schema/action.for-insert]
   (when (= action-type :http)
     (throw (ex-info (tru "HTTP actions are not supported.")
-                    {:type        action-type
+                    {:type        :http
                      :status-code 400})))
   (when (and (nil? database_id)
              (= action-type :query))
@@ -122,7 +122,7 @@
    action :- ::actions.schema/action.for-update]
   (when (= (:type action) :http)
     (throw (ex-info (tru "HTTP actions are not supported.")
-                    {:type        (:type action)
+                    {:type        :http
                      :status-code 400})))
   (actions/check-actions-enabled! id)
   (let [existing-action (api/write-check :model/Action id)]
@@ -213,7 +213,7 @@
   (let [{:keys [type] :as action} (api/check-404 (actions/select-action :id id :archived false))]
     (when (= type :http)
       (throw (ex-info (tru "HTTP actions are not supported.")
-                      {:type        type
+                      {:type        :http
                        :status-code 400})))
     (analytics/track-event! :snowplow/action
                             {:event     :action-executed

--- a/test/metabase/actions/models_test.clj
+++ b/test/metabase/actions/models_test.clj
@@ -119,16 +119,6 @@
                        (->> (action/select-action :id action-id)
                             :parameters (map :id) set)))))))))))
 
-(deftest hydrate-http-action-test
-  (mt/test-drivers (mt/normal-drivers-with-feature :actions/custom)
-    (mt/with-actions-test-data-and-actions-enabled
-      (mt/with-actions [{:keys [action-id] :as _context} {:type :http}]
-        (is (partial= {:id action-id
-                       :name "Echo Example"
-                       :parameters [{:id "id" :type :number}
-                                    {:id "fail" :type :text}]}
-                      (action/select-action :id action-id)))))))
-
 (deftest hydrate-creator-test
   (mt/test-drivers (mt/normal-drivers-with-feature :actions/custom)
     (mt/with-actions-test-data-and-actions-enabled

--- a/test/metabase/actions_rest/api_test.clj
+++ b/test/metabase/actions_rest/api_test.clj
@@ -240,10 +240,7 @@
 
                                        (= (:type initial-action) "query")
                                        (assoc :dataset_query
-                                              (lib/native-query (mt/metadata-provider) "update users set name = 'bar' where id = {{x}}"))
-
-                                       (= (:type initial-action) "http")
-                                       (-> (assoc :response_handle ".body.result"  :description nil))))
+                                              (lib/native-query (mt/metadata-provider) "update users set name = 'bar' where id = {{x}}"))))
                     expected-fn    (fn [m]
                                      (-> m
                                          (cond-> (= (:type initial-action) "implicit")

--- a/test/metabase/actions_rest/api_test.clj
+++ b/test/metabase/actions_rest/api_test.clj
@@ -651,7 +651,6 @@
                         {create-action-id :action-id} {:type :implicit :kind "row/create"}
                         {update-action-id :action-id} {:type :implicit :kind "row/update"}
                         {delete-action-id :action-id} {:type :implicit :kind "row/delete"}
-                        {http-action-id :action-id}   {:type :http}
                         {query-action-id :action-id}  {:type :query}]
         (testing "403 if user does not have permission to view the action"
           (is (= "You don't have permissions to do that."
@@ -661,10 +660,7 @@
           (is (= "Not found."
                  (mt/user-http-request :rasta :get 404 (format "action/%d/execute" Integer/MAX_VALUE) :parameters (json/encode {:id 1})))))
 
-        (testing "returns empty map for actions that are not implicit"
-          (is (= {}
-                 (mt/user-http-request :crowberto :get 200 (format "action/%d/execute" http-action-id) :parameters (json/encode {:id 1}))))
-
+        (testing "returns empty map for query actions (not implicit)"
           (is (= {}
                  (mt/user-http-request :crowberto :get 200 (format "action/%d/execute" query-action-id) :parameters (json/encode {:id 1})))))
 

--- a/test/metabase/actions_rest/api_test.clj
+++ b/test/metabase/actions_rest/api_test.clj
@@ -62,16 +62,7 @@
 
 (defn- all-actions-default
   [card-id]
-  [{:name            "Get example"
-    :description     "A dummy HTTP action"
-    :type            "http"
-    :model_id        card-id
-    :template        {:method "GET"
-                      :url    "https://example.com/{{x}}"}
-    :parameters      [{:id "x" :type "text"}]
-    :response_handle ".body"
-    :error_handle    ".status >= 400"}
-   {:name          "Query example"
+  [{:name          "Query example"
     :description   "A simple update query action"
     :type          "query"
     :model_id      card-id
@@ -91,17 +82,7 @@
     (mt/with-non-admin-groups-no-root-collection-perms
       (mt/with-actions-test-data-tables #{"users"}
         (mt/with-actions [{card-id :id} {:type :model :dataset_query (mt/mbql-query users)}
-                          action-1 {:name              "Get example"
-                                    :type              :http
-                                    :model_id          card-id
-                                    :template          {:method "GET"
-                                                        :url "https://example.com/{{x}}"}
-                                    :parameters        [{:id "x" :type "text"}]
-                                    :public_uuid       (str (random-uuid))
-                                    :made_public_by_id (mt/user->id :crowberto)
-                                    :response_handle   ".body"
-                                    :error_handle      ".status >= 400"}
-                          action-2 {:name                   "Query example"
+                          action-1 {:name                   "Query example"
                                     :type                   :query
                                     :model_id               card-id
                                     :dataset_query          (update (mt/native-query {:query "update venues set name = 'foo' where id = {{x}}"})
@@ -109,7 +90,7 @@
                                     :database_id            (mt/id)
                                     :parameters             [{:id "x" :type "number"}]
                                     :visualization_settings {:position "top"}}
-                          action-3 {:name       "Implicit example"
+                          action-2 {:name       "Implicit example"
                                     :type       :implicit
                                     :model_id   card-id
                                     :kind       "row/create"
@@ -124,7 +105,7 @@
                                     :visualization_settings {:position "top"}
                                     :archived               true}]
           (let [response (mt/user-http-request :crowberto :get 200 (str "action?model-id=" card-id))]
-            (is (= (map :action-id [action-1 action-2 action-3])
+            (is (= (map :action-id [action-1 action-2])
                    (map :id response)))
             (doseq [action response
                     :when (= (:type action) "query")]
@@ -138,7 +119,7 @@
           (testing "Can list all actions"
             (let [response (mt/user-http-request :crowberto :get 200 "action")
                   action-ids (into #{} (map :id) response)]
-              (is (set/subset? (into #{} (map :action-id) [action-1 action-2 action-3])
+              (is (set/subset? (into #{} (map :action-id) [action-1 action-2])
                                action-ids))
               (doseq [action response
                       :when (= (:type action) "query")]
@@ -149,7 +130,7 @@
                 (is (not (contains? action-ids (:id archived)))))
               (testing "Does not return actions on models without permissions"
                 (let [rasta-list (mt/user-http-request :rasta :get 200 "action")]
-                  (is (empty? (set/intersection (into #{} (map :action-id) [action-1 action-2 action-3])
+                  (is (empty? (set/intersection (into #{} (map :action-id) [action-1 action-2])
                                                 (into #{} (map :id) rasta-list)))))))))))))
 
 (deftest get-action-test
@@ -388,16 +369,16 @@
 
 (deftest action-parameters-test
   (mt/with-actions-enabled
-    (mt/with-temp [:model/Card {card-id :id} {:type :model}]
+    (mt/with-temp [:model/Card {card-id :id} {:type          :model
+                                              :dataset_query (mt/mbql-query venues)}]
       (mt/with-model-cleanup [:model/Action]
-        (let [initial-action {:name "Get example"
-                              :type "http"
-                              :model_id card-id
-                              :template {:method "GET"
-                                         :url "https://example.com/{{x}}"
-                                         :parameters [{:id "x" :type "text"}]}
-                              :response_handle ".body"
-                              :error_handle ".status >= 400"}
+        (let [initial-action {:name          "Query example"
+                              :type          "query"
+                              :model_id      card-id
+                              :database_id   (mt/id)
+                              :dataset_query (update (mt/native-query {:query "update venues set name = 'foo' where id = {{x}}"})
+                                                     :type name)
+                              :parameters    [{:id "x" :type "number"}]}
               created-action (mt/user-http-request :crowberto :post 200 "action" initial-action)
               action-id      (u/the-id created-action)
               action-path    (str "action/" action-id)]
@@ -410,30 +391,10 @@
             (testing "Required fields"
               (is (=? {:errors {:name "string"},
                        :specific-errors {:name ["missing required key, received: nil"]}}
-                      (mt/user-http-request :crowberto :post 400 "action" {:type "http"})))
+                      (mt/user-http-request :crowberto :post 400 "action" {:type "query"})))
               (is (=? {:errors {:model_id "Valid Card ID"}
                        :specific-errors {:model_id ["missing required key, received: nil"]}}
-                      (mt/user-http-request :crowberto :post 400 "action" {:type "http" :name "test"}))))
-            (testing "Handles need to be valid jq"
-              (is (=? {:errors {:response_handle "nullable must be a valid json-query, something like '.item.title'"}
-                       :specific-errors {:response_handle ["must be a valid json-query, something like '.item.title', received: \"body\""]}}
-                      (mt/user-http-request :crowberto :post 400 "action" (assoc initial-action :response_handle "body"))))
-              (is (=? {:errors {:error_handle "nullable must be a valid json-query, something like '.item.title'"}
-                       :specific-errors {:error_handle ["must be a valid json-query, something like '.item.title', received: \"x\""]}}
-                      (mt/user-http-request :crowberto :post 400 "action" (assoc initial-action :error_handle "x"))))))
-          (testing "Validate PUT"
-            (testing "Template needs method and url"
-              (is (=? {:specific-errors
-                       {:template {:method ["missing required key, received: nil"], :url ["missing required key, received: nil"]}},
-                       :errors {:template {:method "enum of GET, POST, PUT, DELETE, PATCH", :url "string with length >= 1"}}}
-                      (mt/user-http-request :crowberto :put 400 action-path {:type "http" :template {}}))))
-            (testing "Handles need to be valid jq"
-              (is (=? {:errors {:response_handle "nullable must be a valid json-query, something like '.item.title'"},
-                       :specific-errors {:response_handle ["must be a valid json-query, something like '.item.title', received: \"body\""]}}
-                      (mt/user-http-request :crowberto :put 400 action-path (assoc initial-action :response_handle "body"))))
-              (is (=? {:errors {:error_handle "nullable must be a valid json-query, something like '.item.title'"},
-                       :specific-errors {:error_handle ["must be a valid json-query, something like '.item.title', received: \"x\""]}}
-                      (mt/user-http-request :crowberto :put 400 action-path (assoc initial-action :error_handle "x")))))))))))
+                      (mt/user-http-request :crowberto :post 400 "action" {:type "query" :name "test"}))))))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                            PUBLIC SHARING ENDPOINTS                                            |


### PR DESCRIPTION
HTTP actions aren't [Basic](https://www.metabase.com/docs/latest/actions/basic) (Create/Update/Delete) or [Custom](https://www.metabase.com/docs/latest/actions/custom) Action types.

## Summary
- Removes dead code related to HTTP action type that is no longer used
- Cleans up unused code paths in the actions API

## Test plan
- Existing tests pass