### PR TITLE
Fix race condition in FormattingWidget initialization (#69777)

### DIFF
--- a/frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.tsx
@@ -40,13 +40,19 @@ export function FormattingWidget() {
   const {
     value: initialValue,
     updateSetting,
-    isLoading,
     settingDetails,
   } = useAdminSetting("custom-formatting");
   const [localValue, setLocalValue] = useState<FormattingSettings | undefined>({
     ...DEFAULT_FORMATTING_SETTINGS,
     ...initialValue,
   });
+
+  useEffect(() => {
+    setLocalValue({
+      ...DEFAULT_FORMATTING_SETTINGS,
+      ...initialValue,
+    });
+  }, [initialValue]);
 
   const {
     date_style: dateStyle,
@@ -70,10 +76,6 @@ export function FormattingWidget() {
     ).map(mapNameToLabel);
     return [currencyOptions, currencyStyleOptions];
   }, [currency, currencyStyle]);
-
-  if (isLoading) {
-    return null;
-  }
 
   const dateStyleOptions = getDateStyleOptionsForUnit("default", dateAbreviate);
 


### PR DESCRIPTION

Closes https://github.com/metabase/metabase/issues/69777

### Description

Although there was an early return if isLoading is true, the useState had already run, and set the state to the DEFAULT_FORMATTING_SETTINGS. This would then not get replaced when isLoading became false.

Instead, use the same idiom as SessionTimeoutSetting - install a useEffect hook that depends on the setting value and applies that setting value to the local state.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Run Metabase remotely, somewhere with a little latency from your browser
2. Go to 'Admin settings'
3. Click on 'Localization'
4. Scroll down to 'Currency'
5. Set a non-default currency if you haven't already
6. Repeatedly reload the page, scroll down to 'Currency', and check if your currency is still set
