### PR TITLE
Fix downloading currency values in narrowSymbol format (#69779)

### DIFF
--- a/src/metabase/query_processor/streaming/common.clj
+++ b/src/metabase/query_processor/streaming/common.clj
@@ -103,6 +103,12 @@
         ;; Fall back to using code if symbol isn't supported on the Metabase frontend
         currency-code)
 
+      "narrowSymbol"
+      (if (currency/supports-symbol? currency-code)
+        (get-in currency/currency [(keyword currency-code) :symbol_native])
+        ;; Fall back to using code if symbol_native isn't supported on the Metabase frontend
+        currency-code)
+
       "code"
       currency-code
 

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -77,6 +77,11 @@
         (str "[$" currency-identifier "]" base-string)
         (str "[$" currency-identifier "] " base-string))
 
+      "narrowSymbol"
+      (if (currency/supports-symbol? currency-code)
+        (str "[$" currency-identifier "]" base-string)
+        (str "[$" currency-identifier "] " base-string))
+
       "code"
       (str "[$" currency-identifier "] " base-string)
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/69779

### Description

In 8f037b00, @kamilmielnik implemented support for the "Local symbol" currency format, which was a huge improvement for localization support. However, the corresponding case was not implemented in the download streaming code, which now produces a Clojure error.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Go to Localization in admin settings and configure a non-US-Dollar currency, and change the format to "Local symbol ($)"
2. Go to a query with currency columns
3. Download in CSV format
4. Confirm that the data is visible instead of an error
