### PR TITLE
GDGT-1823 make guarantee that LensContent is always stores one lens data

### DIFF
--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/InspectorContent.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/InspectorContent.tsx
@@ -5,6 +5,8 @@ import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErr
 import { Center } from "metabase/ui";
 import type { Transform } from "metabase-types/api";
 
+import { getLensKey } from "../utils";
+
 import { LensContent } from "./LensContent/LensContent";
 import { LensNavigator, useLensNavigation } from "./LensNavigator";
 
@@ -56,6 +58,7 @@ export const InspectorContent = ({
       onCloseTab={closeTab}
     >
       <LensContent
+        key={getLensKey(currentLens)}
         transform={transform}
         currentLens={currentLens}
         discovery={discovery}

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/hooks/useCardLoadingTracker.ts
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/hooks/useCardLoadingTracker.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import type { InspectorLens } from "metabase-types/api";
 
@@ -9,12 +9,6 @@ export const useCardLoadingTracker = (
   onAllCardsLoaded: (lensId: string) => void,
 ) => {
   const [cardsStates, setCardsStates] = useState<Record<string, CardState>>({});
-
-  const prevLensIdRef = useRef(lens?.id);
-  if (prevLensIdRef.current !== lens?.id) {
-    prevLensIdRef.current = lens?.id;
-    setCardsStates({});
-  }
 
   useEffect(() => {
     if (!lens) {

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/hooks/useTriggerEvaluation.ts
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/hooks/useTriggerEvaluation.ts
@@ -1,4 +1,3 @@
-import { useDebouncedValue } from "@mantine/hooks";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import _ from "underscore";
 
@@ -25,15 +24,12 @@ type TriggerEvaluationState = {
 
 export const useTriggerEvaluation = (
   lens: InspectorLens | undefined,
-  debounceMs = 100,
 ): TriggerEvaluationResult => {
   const [cardsStats, setCardsStats] = useState<Record<string, CardStats>>({});
   const [state, setState] = useState<TriggerEvaluationState>({
     alerts: [],
     drillLenses: [],
   });
-
-  const [debouncedCardsStats] = useDebouncedValue(cardsStats, debounceMs);
 
   const pushNewStats = useCallback(
     (cardId: string, stats: CardStats | null) => {
@@ -48,12 +44,12 @@ export const useTriggerEvaluation = (
     if (!lens) {
       return;
     }
-    const result = evaluateTriggers(lens, debouncedCardsStats);
+    const result = evaluateTriggers(lens, cardsStats);
     setState({
       alerts: result.alerts,
       drillLenses: result.drill_lenses,
     });
-  }, [lens, debouncedCardsStats]);
+  }, [lens, cardsStats]);
 
   const alertsByCardId = useMemo(
     () => _.groupBy(state.alerts, ({ condition }) => condition.card_id),


### PR DESCRIPTION
Closes [GDGT-1823: Isolate card state by lens to prevent collisions](https://linear.app/metabase/issue/GDGT-1823/isolate-card-state-by-lens-to-prevent-collisions)

### Description
There is a problem that `LensContent` is mounted once so the hooks inside it are also "mounted" once - so their state is persistent. But each lens should have it's own card stats (for the triggers evaluation) and card loading states (to track that all cards are loaded). In order to keep these hooks (`useTriggerEvaluation` and `useCardLoadingTracker`) simple, without adding extra complexity to store the state for all lenses I decided to just remount `LensContent` when the current lens changes. 

This works well, as all underlying requests are cached by RTK Query. However, `useTriggerEvaluation` tries to debounce calculations which causes the alerts and drill lenses to blink if we switch tabs back and forth. I removed this debounced logic as we expect that cljc `evaluateTriggers` function works fast. It also adds much nicer UX - the alerts and drill lenses now appear once they are ready, without extra delay.