### PR TITLE
Gdgt 1817 add snowplow product events fe

### DIFF
--- a/e2e/test/scenarios/data-studio/transforms/transforms-inspect.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms/transforms-inspect.cy.spec.ts
@@ -17,6 +17,13 @@ describe("scenarios > data-studio > transforms > inspect", () => {
 
     cy.intercept("GET", "/api/transform/*/inspect").as("inspectorDiscovery");
     cy.intercept("GET", "/api/transform/*/inspect/*").as("inspectorLens");
+
+    H.resetSnowplow();
+    H.enableTracking();
+  });
+
+  afterEach(() => {
+    H.expectNoBadSnowplowEvents();
   });
 
   describe("pre-run state", () => {
@@ -133,6 +140,11 @@ describe("scenarios > data-studio > transforms > inspect", () => {
               });
           });
       });
+
+      H.expectUnstructuredSnowplowEvent({
+        event: "transform_inspect_lens_loaded",
+        event_detail: "generic-summary",
+      });
     });
   });
 
@@ -216,6 +228,10 @@ describe("scenarios > data-studio > transforms > inspect", () => {
           "be.visible",
         );
       });
+
+      H.expectUnstructuredSnowplowEvent({
+        event: "transform_inspect_alert_clicked",
+      });
     });
   });
 
@@ -239,6 +255,11 @@ describe("scenarios > data-studio > transforms > inspect", () => {
         name: /Unmatched rows in Animals - Name/,
       }).click();
 
+      H.expectUnstructuredSnowplowEvent({
+        event: "transform_inspect_drill_lens_clicked",
+        triggered_from: "join_analysis",
+      });
+
       cy.findByRole("tab", { name: /Unmatched rows/ }).click();
       cy.findByRole("heading", { name: /Unmatched Row Samples/ }).should(
         "be.visible",
@@ -255,6 +276,11 @@ describe("scenarios > data-studio > transforms > inspect", () => {
           cy.findByTestId("table-footer").should("have.text", "3 rows");
         });
 
+      H.expectUnstructuredSnowplowEvent({
+        event: "transform_inspect_lens_loaded",
+        event_detail: "unmatched-rows",
+      });
+
       cy.findByRole("tab", { name: tabName }).within(() => {
         cy.findByRole("button", { name: /Close tab/i }).click();
       });
@@ -262,6 +288,10 @@ describe("scenarios > data-studio > transforms > inspect", () => {
       cy.findByRole("link", {
         name: tabName,
       }).should("not.exist");
+
+      H.expectUnstructuredSnowplowEvent({
+        event: "transform_inspect_drill_lens_closed",
+      });
     });
   });
 

--- a/frontend/src/metabase-types/analytics/event.ts
+++ b/frontend/src/metabase-types/analytics/event.ts
@@ -308,6 +308,38 @@ export type TransformRunTagsUpdated = ValidateEvent<{
   target_id: number;
 }>;
 
+export type TransformInspectLensLoadedEvent = ValidateEvent<{
+  event: "transform_inspect_lens_loaded";
+  target_id: TransformId;
+  event_detail: string;
+  duration_ms: number;
+}>;
+
+export type TransformInspectDrillLensClickedEvent = ValidateEvent<{
+  event: "transform_inspect_drill_lens_clicked";
+  target_id: TransformId;
+  event_detail: string;
+  triggered_from: "card_drills" | "join_analysis";
+}>;
+
+export type TransformInspectAlertClickedEvent = ValidateEvent<{
+  event: "transform_inspect_alert_clicked";
+  target_id: TransformId;
+  event_detail: string;
+}>;
+
+export type TransformInspectDrillLensClosedEvent = ValidateEvent<{
+  event: "transform_inspect_drill_lens_closed";
+  target_id: TransformId;
+  event_detail: string;
+}>;
+
+export type TransformInspectEvent =
+  | TransformInspectLensLoadedEvent
+  | TransformInspectDrillLensClickedEvent
+  | TransformInspectAlertClickedEvent
+  | TransformInspectDrillLensClosedEvent;
+
 export type DocumentCreatedEvent = ValidateEvent<{
   event: "document_created";
   target_id: number;
@@ -681,6 +713,7 @@ export type SimpleEvent =
   | TransformCreatedEvent
   | TransformCreateEvent
   | TransformRunTagsUpdated
+  | TransformInspectEvent
   | DocumentAddCardEvent
   | DocumentAddSmartLinkEvent
   | DocumentAddSupportingTextEvent

--- a/frontend/src/metabase-types/api/collection.ts
+++ b/frontend/src/metabase-types/api/collection.ts
@@ -16,6 +16,8 @@ import type { SortingOptions } from "./sorting";
 import type { TableId } from "./table";
 import type { UserId, UserInfo } from "./user";
 
+export type { CardId };
+
 export type CollectionNamespace =
   | null
   | "snippets"

--- a/frontend/src/metabase/transforms/analytics.ts
+++ b/frontend/src/metabase/transforms/analytics.ts
@@ -62,3 +62,82 @@ export function trackTransformRunTagsUpdated({
     result,
   });
 }
+
+export function trackTransformInspectLensLoaded({
+  transformId,
+  lensId,
+  durationMs,
+}: {
+  transformId: TransformId;
+  lensId: string;
+  durationMs: number;
+}) {
+  trackSimpleEvent({
+    event: "transform_inspect_lens_loaded",
+    target_id: transformId,
+    event_detail: lensId,
+    duration_ms: durationMs,
+  });
+}
+
+export function trackTransformInspectDrillLensClicked({
+  transformId,
+  lensId,
+  triggeredFrom,
+}: {
+  transformId: TransformId;
+  lensId: string;
+  triggeredFrom: "card_drills" | "join_analysis";
+}) {
+  trackSimpleEvent({
+    event: "transform_inspect_drill_lens_clicked",
+    target_id: transformId,
+    event_detail: lensId,
+    triggered_from: triggeredFrom,
+  });
+}
+
+export function trackTransformInspectAlertClicked({
+  transformId,
+  cardId,
+}: {
+  transformId: TransformId;
+  cardId: string;
+}) {
+  trackSimpleEvent({
+    event: "transform_inspect_alert_clicked",
+    target_id: transformId,
+    event_detail: cardId,
+  });
+}
+
+export function trackTransformInspectDrillLensClosed({
+  transformId,
+  lensId,
+}: {
+  transformId: TransformId;
+  lensId: string;
+}) {
+  trackSimpleEvent({
+    event: "transform_inspect_drill_lens_closed",
+    target_id: transformId,
+    event_detail: lensId,
+  });
+}
+
+export function trackDependencyDiagnosticsEntitySelected({
+  triggeredFrom,
+  entityId,
+  entityType,
+}: {
+  entityId: number;
+  entityType: string;
+  triggeredFrom: "broken" | "unreferenced";
+}) {
+  trackSimpleEvent({
+    event: "dependency_diagnostics_entity_selected",
+    triggered_from: triggeredFrom,
+    target_id: entityId,
+    event_detail: entityType,
+  });
+}

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/CardDrills.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/CardDrills.tsx
@@ -1,5 +1,6 @@
 import { t } from "ttag";
 
+import { trackTransformInspectDrillLensClicked } from "metabase/transforms/analytics";
 import { Flex } from "metabase/ui";
 import type { TriggeredDrillLens } from "metabase-lib/transforms-inspector";
 
@@ -11,7 +12,7 @@ type CardDrillsProps = {
 };
 
 export const CardDrills = ({ drillLenses }: CardDrillsProps) => {
-  const { onDrill } = useLensContentContext();
+  const { onDrill, transform } = useLensContentContext();
 
   if (drillLenses.length === 0) {
     return null;
@@ -24,7 +25,14 @@ export const CardDrills = ({ drillLenses }: CardDrillsProps) => {
         return (
           <DrillButton
             key={drillLens.lens_id}
-            onClick={() => onDrill(drillLens)}
+            onClick={() => {
+              trackTransformInspectDrillLensClicked({
+                transformId: transform.id,
+                lensId: drillLens.lens_id,
+                triggeredFrom: "card_drills",
+              });
+              onDrill(drillLens);
+            }}
           >
             {t`Inspect`} {title}
           </DrillButton>

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/InspectorContent.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/InspectorContent.tsx
@@ -1,7 +1,9 @@
 import type { Location } from "history";
+import { useCallback } from "react";
 
 import { useGetInspectorDiscoveryQuery } from "metabase/api";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
+import { trackTransformInspectDrillLensClosed } from "metabase/transforms/analytics";
 import { Center } from "metabase/ui";
 import type { Transform } from "metabase-types/api";
 
@@ -35,6 +37,17 @@ export const InspectorContent = ({
     markLensAsLoaded,
   } = useLensNavigation(discovery?.available_lenses ?? [], location);
 
+  const handleCloseTab = useCallback(
+    (tabKey: string) => {
+      trackTransformInspectDrillLensClosed({
+        transformId: transform.id,
+        lensId: tabKey,
+      });
+      closeTab(tabKey);
+    },
+    [transform.id, closeTab],
+  );
+
   if (isLoadingDiscovery || discoveryError || !discovery) {
     return (
       <Center h="100%" style={{ flex: 1 }}>
@@ -55,7 +68,7 @@ export const InspectorContent = ({
       tabs={tabs}
       activeTabKey={activeTabKey}
       onSwitchTab={switchTab}
-      onCloseTab={closeTab}
+      onCloseTab={handleCloseTab}
     >
       <LensContent
         key={getLensKey(currentLens)}

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensContent/LensContent.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensContent/LensContent.tsx
@@ -42,10 +42,9 @@ export const LensContent = ({
     return { lensId: currentLens.id, lensParams: undefined };
   }, [currentLens]);
 
-  const handleAllCardsLoaded = useLensLoadedTracking(
+  const trackLensLoaded = useLensLoadedTracking(
     transform.id,
     queryParams.lensId,
-    onAllCardsLoaded,
   );
 
   const {
@@ -68,7 +67,12 @@ export const LensContent = ({
 
   const { markCardLoaded, markCardStartedLoading } = useCardLoadingTracker(
     lens,
-    handleAllCardsLoaded,
+    () => {
+      if (lens) {
+        onAllCardsLoaded(lens.id);
+        trackLensLoaded();
+      }
+    },
   );
 
   const cardsBySection = useMemo(

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensContent/LensContent.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensContent/LensContent.tsx
@@ -18,6 +18,7 @@ import {
 } from "../LensSections";
 
 import { LensContentProvider } from "./LensContentContext";
+import { useLensLoadedTracking } from "./useLensLoadedTracking";
 
 type LensContentProps = {
   transform: Transform;
@@ -41,6 +42,12 @@ export const LensContent = ({
     return { lensId: currentLens.id, lensParams: undefined };
   }, [currentLens]);
 
+  const handleAllCardsLoaded = useLensLoadedTracking(
+    transform.id,
+    queryParams.lensId,
+    onAllCardsLoaded,
+  );
+
   const {
     data: lens,
     isLoading,
@@ -61,7 +68,7 @@ export const LensContent = ({
 
   const { markCardLoaded, markCardStartedLoading } = useCardLoadingTracker(
     lens,
-    onAllCardsLoaded,
+    handleAllCardsLoaded,
   );
 
   const cardsBySection = useMemo(

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensContent/useLensLoadedTracking.ts
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensContent/useLensLoadedTracking.ts
@@ -8,8 +8,13 @@ export const useLensLoadedTracking = (
   lensId: string,
 ) => {
   const lensStartTimeRef = useRef<number>(Date.now());
+  const hasCalledRef = useRef(false);
 
   const handleAllCardsLoaded = useCallback(() => {
+    if (hasCalledRef.current) {
+      return;
+    }
+    hasCalledRef.current = true;
     trackTransformInspectLensLoaded({
       transformId,
       lensId,

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensContent/useLensLoadedTracking.ts
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensContent/useLensLoadedTracking.ts
@@ -1,0 +1,36 @@
+import { useCallback, useRef } from "react";
+
+import { trackTransformInspectLensLoaded } from "metabase/transforms/analytics";
+import type { TransformId } from "metabase-types/api";
+
+export const useLensLoadedTracking = (
+  transformId: TransformId,
+  lensId: string,
+  onAllCardsLoaded: (lensId: string) => void,
+) => {
+  const lensStartTimeRef = useRef<number>(Date.now());
+  const prevLensIdRef = useRef<string>(lensId);
+  const trackedLensIdRef = useRef<string | null>(null);
+  if (prevLensIdRef.current !== lensId) {
+    prevLensIdRef.current = lensId;
+    lensStartTimeRef.current = Date.now();
+    trackedLensIdRef.current = null;
+  }
+
+  const handleAllCardsLoaded = useCallback(
+    (loadedLensId: string) => {
+      if (trackedLensIdRef.current !== loadedLensId) {
+        trackedLensIdRef.current = loadedLensId;
+        trackTransformInspectLensLoaded({
+          transformId,
+          lensId: loadedLensId,
+          durationMs: Date.now() - lensStartTimeRef.current,
+        });
+      }
+      onAllCardsLoaded(loadedLensId);
+    },
+    [transformId, onAllCardsLoaded],
+  );
+
+  return handleAllCardsLoaded;
+};

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensContent/useLensLoadedTracking.ts
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensContent/useLensLoadedTracking.ts
@@ -6,31 +6,16 @@ import type { TransformId } from "metabase-types/api";
 export const useLensLoadedTracking = (
   transformId: TransformId,
   lensId: string,
-  onAllCardsLoaded: (lensId: string) => void,
 ) => {
   const lensStartTimeRef = useRef<number>(Date.now());
-  const prevLensIdRef = useRef<string>(lensId);
-  const trackedLensIdRef = useRef<string | null>(null);
-  if (prevLensIdRef.current !== lensId) {
-    prevLensIdRef.current = lensId;
-    lensStartTimeRef.current = Date.now();
-    trackedLensIdRef.current = null;
-  }
 
-  const handleAllCardsLoaded = useCallback(
-    (loadedLensId: string) => {
-      if (trackedLensIdRef.current !== loadedLensId) {
-        trackedLensIdRef.current = loadedLensId;
-        trackTransformInspectLensLoaded({
-          transformId,
-          lensId: loadedLensId,
-          durationMs: Date.now() - lensStartTimeRef.current,
-        });
-      }
-      onAllCardsLoaded(loadedLensId);
-    },
-    [transformId, onAllCardsLoaded],
-  );
+  const handleAllCardsLoaded = useCallback(() => {
+    trackTransformInspectLensLoaded({
+      transformId,
+      lensId,
+      durationMs: Date.now() - lensStartTimeRef.current,
+    });
+  }, [transformId, lensId]);
 
   return handleAllCardsLoaded;
 };

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/JoinAnalysisSections/JoinAnalysisSection.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/JoinAnalysisSections/JoinAnalysisSection.tsx
@@ -28,8 +28,13 @@ type JoinAnalysisSectionProps = {
 };
 
 export const JoinAnalysisSection = ({ cards }: JoinAnalysisSectionProps) => {
-  const { alertsByCardId, drillLensesByCardId, collectedCardStats, onDrill } =
-    useLensContentContext();
+  const {
+    alertsByCardId,
+    drillLensesByCardId,
+    collectedCardStats,
+    onDrill,
+    transform,
+  } = useLensContentContext();
 
   const { joinStepCards, tableCountCards } = useMemo(
     () => ({
@@ -86,6 +91,7 @@ export const JoinAnalysisSection = ({ cards }: JoinAnalysisSectionProps) => {
             <JoinHeaderCell
               card={row.original.card}
               severity={row.original.severity}
+              transformId={transform.id}
               onToggleAlerts={() => row.toggleExpanded()}
             />
           ),
@@ -143,12 +149,13 @@ export const JoinAnalysisSection = ({ cards }: JoinAnalysisSectionProps) => {
           cell: ({ row }) => (
             <DrillLensesCell
               drillLenses={row.original.drillLenses}
+              transformId={transform.id}
               onDrill={onDrill}
             />
           ),
         },
       ]),
-    [hasDrills, onDrill],
+    [hasDrills, onDrill, transform.id],
   );
 
   const instance = useTreeTableInstance({

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/JoinAnalysisSections/components/DrillLensesCell.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/JoinAnalysisSections/components/DrillLensesCell.tsx
@@ -1,18 +1,22 @@
 import { t } from "ttag";
 
+import { trackTransformInspectDrillLensClicked } from "metabase/transforms/analytics";
 import { Flex } from "metabase/ui";
 import type { TriggeredDrillLens } from "metabase-lib/transforms-inspector";
+import type { TransformId } from "metabase-types/api";
 
 import { getLensKey } from "../../../../utils";
 import { DrillButton } from "../../../DrillButton";
 
 type DrillLensesCellProps = {
   drillLenses: TriggeredDrillLens[];
+  transformId: TransformId;
   onDrill: (lens: TriggeredDrillLens) => void;
 };
 
 export const DrillLensesCell = ({
   drillLenses,
+  transformId,
   onDrill,
 }: DrillLensesCellProps) => {
   if (drillLenses.length === 0) {
@@ -24,7 +28,14 @@ export const DrillLensesCell = ({
       {drillLenses.map((drillLens) => (
         <DrillButton
           key={getLensKey(drillLens)}
-          onClick={() => onDrill(drillLens)}
+          onClick={() => {
+            trackTransformInspectDrillLensClicked({
+              transformId,
+              lensId: drillLens.lens_id,
+              triggeredFrom: "join_analysis",
+            });
+            onDrill(drillLens);
+          }}
         >
           {t`Inspect`} {drillLens.reason ?? drillLens.lens_id}
         </DrillButton>

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/JoinAnalysisSections/components/JoinHeaderCell.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/JoinAnalysisSections/components/JoinHeaderCell.tsx
@@ -1,20 +1,23 @@
 import { match } from "ts-pattern";
 
+import { trackTransformInspectAlertClicked } from "metabase/transforms/analytics";
 import { ActionIcon, Icon } from "metabase/ui";
 import type { TriggeredAlert } from "metabase-lib/transforms-inspector";
-import type { InspectorCard } from "metabase-types/api";
+import type { InspectorCard, TransformId } from "metabase-types/api";
 
 import { useLensCardLoader } from "../../../../hooks";
 
 type JoinHeaderCellProps = {
   card: InspectorCard;
   severity: TriggeredAlert["severity"] | null;
+  transformId: TransformId;
   onToggleAlerts?: () => void;
 };
 
 export const JoinHeaderCell = ({
   card,
   severity,
+  transformId,
   onToggleAlerts,
 }: JoinHeaderCellProps) => {
   useLensCardLoader({ card });
@@ -32,6 +35,7 @@ export const JoinHeaderCell = ({
       size="lg"
       onClick={(e) => {
         e.stopPropagation();
+        trackTransformInspectAlertClicked({ transformId, cardId: card.id });
         onToggleAlerts?.();
       }}
     >

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/hooks/useCardLoadingTracker.ts
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/hooks/useCardLoadingTracker.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import type { InspectorLens } from "metabase-types/api";
 
@@ -9,7 +9,6 @@ export const useCardLoadingTracker = (
   onAllCardsLoaded: (lensId: string) => void,
 ) => {
   const [cardsStates, setCardsStates] = useState<Record<string, CardState>>({});
-  const hasCalledOnAllCardsLoaded = useRef(false);
 
   useEffect(() => {
     if (!lens) {
@@ -17,13 +16,8 @@ export const useCardLoadingTracker = (
     }
     const states = Object.values(cardsStates);
     const isSomethingLoading = states.includes("loading");
-    if (
-      states.length > 0 &&
-      !isSomethingLoading &&
-      !hasCalledOnAllCardsLoaded.current
-    ) {
+    if (states.length > 0 && !isSomethingLoading) {
       onAllCardsLoaded(lens.id);
-      hasCalledOnAllCardsLoaded.current = true;
     }
   }, [lens, cardsStates, onAllCardsLoaded]);
 

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/hooks/useCardLoadingTracker.ts
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/hooks/useCardLoadingTracker.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { InspectorLens } from "metabase-types/api";
 
@@ -9,6 +9,7 @@ export const useCardLoadingTracker = (
   onAllCardsLoaded: (lensId: string) => void,
 ) => {
   const [cardsStates, setCardsStates] = useState<Record<string, CardState>>({});
+  const hasCalledOnAllCardsLoaded = useRef(false);
 
   useEffect(() => {
     if (!lens) {
@@ -16,8 +17,13 @@ export const useCardLoadingTracker = (
     }
     const states = Object.values(cardsStates);
     const isSomethingLoading = states.includes("loading");
-    if (states.length > 0 && !isSomethingLoading) {
+    if (
+      states.length > 0 &&
+      !isSomethingLoading &&
+      !hasCalledOnAllCardsLoaded.current
+    ) {
       onAllCardsLoaded(lens.id);
+      hasCalledOnAllCardsLoaded.current = true;
     }
   }, [lens, cardsStates, onAllCardsLoaded]);
 


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-1817/add-snowplow-product-events-fe

### Description

4 basic events were added to track product usage

```
export type TransformInspectEvent =
  | TransformInspectLensLoadedEvent
  | TransformInspectDrillLensClickedEvent
  | TransformInspectAlertClickedEvent
  | TransformInspectDrillLensClosedEvent;
```

### How to verify

Click around the app with Snowplow extension and/or Snowplow instance running. Verify those  ☝️  4 events are triggered.


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
