### PR TITLE
Accept string target :type in transform test helper

### DIFF
--- a/test/metabase/transforms/test_util.clj
+++ b/test/metabase/transforms/test_util.clj
@@ -31,7 +31,10 @@
               api/*current-user-id* (mt/user->id :crowberto)]
       ;; Drop the actual table/view from the database
       (try
-        (driver/drop-transform-target! driver (mt/db) target)
+        (driver/drop-transform-target! driver (mt/db) (update target :type (fn [target-type]
+                                                                             (if (string? target-type)
+                                                                               (keyword target-type)
+                                                                               target-type))))
         (catch Exception e
           (log/warnf e "Failed to drop transform target table %s.%s for driver %s"
                      (:schema target) (:name target) driver)))


### PR DESCRIPTION
It makes sense to use strings in http tests because that is what the http-client will accept as json.

If a string target :type is supplied, we convert it to a keyword to ensure we can dispatch to the intended method.
