### PR TITLE
Add JWT authentication onboarding for embedding hub

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
@@ -82,7 +82,6 @@
      "configure-row-column-security"     (has-configured-sandboxes?)
      "create-test-embed"                 (embedding.settings/embedding-hub-test-embed-snippet-created)
      "embed-production"                  (embedding.settings/embedding-hub-production-embed-snippet-created)
-     "secure-embeds"                     (has-configured-sso?)
      "data-permissions-and-enable-tenants" (and enable-tenants?
                                                 create-tenants?
                                                 setup-data-segregation-strategy?)
@@ -90,7 +89,11 @@
      ;; for the "configure data permissions and enable tenants" sub-checklist page
      "enable-tenants"                    enable-tenants?
      "create-tenants"                    create-tenants?
-     "setup-data-segregation-strategy"   setup-data-segregation-strategy?}))
+     "setup-data-segregation-strategy"   setup-data-segregation-strategy?
+
+     ;; for the "configure SSO" sub-checklist page
+     "sso-configured"                     (has-configured-sso?)
+     "sso-auth-manual-tested"            (embedding.settings/embedding-hub-sso-auth-manual-tested)}))
 
 (def ^:private EmbeddingHubChecklist
   "Schema for the embedding hub checklist response."
@@ -101,11 +104,12 @@
    ["configure-row-column-security"        :boolean]
    ["create-test-embed"                    :boolean]
    ["embed-production"                     :boolean]
-   ["secure-embeds"                        :boolean]
+   ["sso-configured"                        :boolean]
    ["data-permissions-and-enable-tenants"  :boolean]
    ["enable-tenants"                       :boolean]
    ["create-tenants"                       :boolean]
-   ["setup-data-segregation-strategy"      :boolean]])
+   ["setup-data-segregation-strategy"      :boolean]
+   ["sso-auth-manual-tested"               :boolean]])
 
 (api.macros/defendpoint :get "/checklist" :- EmbeddingHubChecklist
   "Get the embedding hub checklist status, indicating which setup steps have been completed."

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -393,6 +393,7 @@ export const createMockSettings = (
   "setup-license-active-at-setup": false,
   "embedding-hub-test-embed-snippet-created": false,
   "embedding-hub-production-embed-snippet-created": false,
+  "embedding-hub-sso-auth-manual-tested": false,
   "notebook-native-preview-sidebar-width": null,
   "query-analysis-enabled": false,
   "check-for-updates": true,

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -490,6 +490,7 @@ interface AdminSettings {
   "setup-license-active-at-setup": boolean;
   "embedding-hub-test-embed-snippet-created": boolean;
   "embedding-hub-production-embed-snippet-created": boolean;
+  "embedding-hub-sso-auth-manual-tested": boolean;
   "store-url": string;
   gsheets: Partial<GdrivePayload>;
   "license-token-missing-banner-dismissal-timestamp"?: Array<string>;
@@ -734,6 +735,7 @@ export interface EnterpriseSettings extends Settings {
   "database-replication-connections"?: DatabaseReplicationConnections | null;
   "embedding-hub-test-embed-snippet-created": boolean;
   "embedding-hub-production-embed-snippet-created": boolean;
+  "embedding-hub-sso-auth-manual-tested": boolean;
   "python-runner-url"?: string | null;
   "python-runner-api-token"?: string | null;
   "python-storage-s-3-endpoint"?: string | null;

--- a/frontend/src/metabase/admin/routes.jsx
+++ b/frontend/src/metabase/admin/routes.jsx
@@ -38,6 +38,7 @@ import {
 import {
   EmbeddingHubAdminSettingsPage,
   SetupPermissionsAndTenantsPage,
+  SetupSsoPage,
 } from "metabase/embedding/embedding-hub";
 import { ModalRoute } from "metabase/hoc/ModalRoute";
 import { getAdminRoutes as getMetabotAdminRoutes } from "metabase/metabot/components/MetabotAdmin/MetabotAdminPage";
@@ -182,10 +183,17 @@ export const getRoutes = (store, CanAccessSettings, IsAdmin) => {
 
             <Route path="setup-guide" title={t`Setup guide`}>
               <IndexRoute component={EmbeddingHubAdminSettingsPage} />
+
               <Route
                 path="permissions"
                 title={t`Configure data permissions and enable tenants`}
                 component={SetupPermissionsAndTenantsPage}
+              />
+
+              <Route
+                path="sso"
+                title={t`Configure SSO`}
+                component={SetupSsoPage}
               />
             </Route>
 

--- a/frontend/src/metabase/api/embedding-hub.ts
+++ b/frontend/src/metabase/api/embedding-hub.ts
@@ -9,11 +9,12 @@ type CheckListApiStep =
   | "configure-row-column-security"
   | "create-test-embed"
   | "embed-production"
-  | "secure-embeds"
+  | "sso-configured"
   | "enable-tenants"
   | "create-tenants"
   | "setup-data-segregation-strategy"
-  | "data-permissions-and-enable-tenants";
+  | "data-permissions-and-enable-tenants"
+  | "sso-auth-manual-tested";
 export type EmbeddingHubChecklist = Record<CheckListApiStep, boolean>;
 
 export const embeddingHubApi = Api.injectEndpoints({

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.tsx
@@ -33,7 +33,7 @@ export const EmbeddingHub = () => {
 
   const lockedSteps: Partial<Record<EmbeddingHubStepId, boolean>> = useMemo(
     () => ({
-      "embed-production": !completedSteps?.["secure-embeds"],
+      "embed-production": !completedSteps?.["sso-configured"],
     }),
     [completedSteps],
   );

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.unit.spec.tsx
@@ -138,7 +138,7 @@ describe("EmbeddingHub", () => {
 
     expect(configureSsoLink).toHaveAttribute(
       "href",
-      "https://www.metabase.com/docs/latest/embedding/embedded-analytics-js.html?utm_source=product&utm_medium=docs&utm_campaign=embedding_hub&utm_content=secure-embeds&source_plan=oss#set-up-sso",
+      "https://www.metabase.com/docs/latest/embedding/embedded-analytics-js.html?utm_source=product&utm_medium=docs&utm_campaign=embedding_hub&utm_content=sso-configured&source_plan=oss#set-up-sso",
     );
   });
 
@@ -151,7 +151,7 @@ describe("EmbeddingHub", () => {
         "create-models": false,
         "configure-row-column-security": false,
         "embed-production": false,
-        "secure-embeds": false,
+        "sso-configured": false,
         "data-permissions-and-enable-tenants": false,
       },
     });

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupSsoPage/AddEndpointStep.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupSsoPage/AddEndpointStep.tsx
@@ -1,0 +1,51 @@
+/* eslint-disable metabase/no-unconditional-metabase-links-render */
+
+import { jt, t } from "ttag";
+
+import { CopyButton } from "metabase/common/components/CopyButton";
+import { useDocsUrl, useSetting } from "metabase/common/hooks";
+import { Anchor, Button, Group, Stack, Text, TextInput } from "metabase/ui";
+
+import S from "./SetupSsoPage.module.css";
+
+export const AddEndpointStep = ({ onDone }: { onDone: () => void }) => {
+  const jwtSharedSecret = useSetting("jwt-shared-secret");
+
+  // TODO(EMB-1337): replace this with standalone JWT backend docs page.
+  const { url: jwtDocsUrl } = useDocsUrl("embedding/authentication");
+
+  const jwtDocsIframeUrl = `${jwtDocsUrl}?hide_nav=true&no_gdpr=true`;
+
+  return (
+    <Stack gap="lg">
+      <TextInput
+        label={t`JWT Signing Key`}
+        description={t`This secret is used to sign JWT tokens. Replace YOUR_SECRET_HERE in the below snippet with this value.`}
+        value={jwtSharedSecret ?? ""}
+        readOnly
+        rightSection={<CopyButton value={jwtSharedSecret ?? ""} />}
+        rightSectionWidth={40}
+      />
+
+      <iframe
+        src={jwtDocsIframeUrl}
+        title={t`JWT Authentication Documentation`}
+        className={S.docsIframe}
+      />
+
+      <Text size="sm" c="text-secondary">
+        {jt`You can view more examples in the ${(
+          <Anchor key="docs-link" href={jwtDocsUrl} target="_blank">
+            {t`docs`}
+          </Anchor>
+        )}.`}
+      </Text>
+
+      <Group justify="flex-end">
+        <Button variant="filled" onClick={onDone}>
+          {t`Next`}
+        </Button>
+      </Group>
+    </Stack>
+  );
+};

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupSsoPage/SetupJwtStep.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupSsoPage/SetupJwtStep.tsx
@@ -1,0 +1,75 @@
+/* eslint-disable metabase/no-literal-metabase-strings */
+import { useCallback, useEffect, useState } from "react";
+import { t } from "ttag";
+
+import { useUpdateSettingsMutation } from "metabase/api";
+import { useSetting, useToast } from "metabase/common/hooks";
+import { UtilApi } from "metabase/services";
+import { Button, Group, Stack, Text, TextInput } from "metabase/ui";
+
+export const SetupJwtStep = ({ onSuccess }: { onSuccess: () => void }) => {
+  const [sendToast] = useToast();
+  const [updateSettings, { isLoading }] = useUpdateSettingsMutation();
+
+  const existingJwtIdentityProviderUri = useSetting(
+    "jwt-identity-provider-uri",
+  );
+
+  const [jwtIdentityProviderUri, setJwtIdentityProviderUri] = useState("");
+
+  // Initialize with existing IdP URL if available
+  useEffect(() => {
+    if (existingJwtIdentityProviderUri) {
+      setJwtIdentityProviderUri(existingJwtIdentityProviderUri);
+    }
+  }, [existingJwtIdentityProviderUri]);
+
+  const handleEnableJwt = useCallback(async () => {
+    try {
+      const { token } = await UtilApi.random_token();
+
+      await updateSettings({
+        "jwt-identity-provider-uri": jwtIdentityProviderUri.trim(),
+        "jwt-shared-secret": token,
+        "jwt-enabled": true,
+        "jwt-group-sync": true,
+      }).unwrap();
+
+      onSuccess();
+    } catch (error) {
+      sendToast({
+        icon: "warning",
+        toastColor: "error",
+        message: t`Failed to enable JWT authentication`,
+      });
+    }
+  }, [jwtIdentityProviderUri, updateSettings, sendToast, onSuccess]);
+
+  return (
+    <Stack gap="lg">
+      <Text size="md" c="text-secondary" lh="lg">
+        {t`You can connect Metabase to your identity provider using JSON Web Tokens (JWT) to authenticate people. Enabling JWT authentication will also create a signing key and enable group sync.`}
+      </Text>
+
+      <TextInput
+        label={t`JWT Identity Provider URI`}
+        description={t`This is where Metabase will redirect login requests`}
+        placeholder="https://jwt.yourdomain.org"
+        value={jwtIdentityProviderUri}
+        onChange={(e) => setJwtIdentityProviderUri(e.target.value)}
+        required
+      />
+
+      <Group justify="flex-end">
+        <Button
+          variant="filled"
+          onClick={handleEnableJwt}
+          loading={isLoading}
+          disabled={!jwtIdentityProviderUri.trim()}
+        >
+          {t`Enable JWT authentication and continue`}
+        </Button>
+      </Group>
+    </Stack>
+  );
+};

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupSsoPage/SetupSsoPage.module.css
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupSsoPage/SetupSsoPage.module.css
@@ -1,0 +1,14 @@
+.backLink {
+  text-decoration: none;
+}
+
+.backLink:hover {
+  text-decoration: underline;
+}
+
+.docsIframe {
+  width: 100%;
+  height: 50rem;
+  border: 1px solid var(--mb-color-border);
+  border-radius: 0.5rem;
+}

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupSsoPage/SetupSsoPage.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupSsoPage/SetupSsoPage.tsx
@@ -1,0 +1,83 @@
+import { useMemo, useRef, useState } from "react";
+import { Link } from "react-router";
+import { t } from "ttag";
+
+import { useGetEmbeddingHubChecklistQuery } from "metabase/api/embedding-hub";
+import { OnboardingStepper } from "metabase/common/components/OnboardingStepper";
+import type { OnboardingStepperHandle } from "metabase/common/components/OnboardingStepper/types";
+import { Group, Icon, Stack, Text, Title } from "metabase/ui";
+
+import { AddEndpointStep } from "./AddEndpointStep";
+import { SetupJwtStep } from "./SetupJwtStep";
+import S from "./SetupSsoPage.module.css";
+import { TestJwtStep } from "./TestJwtStep";
+
+const SETUP_GUIDE_PATH = "/admin/embedding/setup-guide";
+
+export const SetupSsoPage = () => {
+  const stepperRef = useRef<OnboardingStepperHandle>(null);
+
+  const { data: checklist } = useGetEmbeddingHubChecklistQuery();
+
+  // UI-only confirmation state for step 2
+  const [isAddEndpointConfirmed, setIsAddEndpointConfirmed] = useState(false);
+
+  const handleAddEndpointDone = () => {
+    setIsAddEndpointConfirmed(true);
+    stepperRef.current?.goToNextStep();
+  };
+
+  const completedSteps = useMemo(() => {
+    const isSsoAuthManualTested =
+      checklist?.["sso-auth-manual-tested"] ?? false;
+
+    return {
+      "setup-jwt": checklist?.["sso-configured"] ?? false,
+      "add-endpoint": isAddEndpointConfirmed || isSsoAuthManualTested,
+      "test-jwt": isSsoAuthManualTested,
+    };
+  }, [checklist, isAddEndpointConfirmed]);
+
+  return (
+    <Stack mx="auto" gap="sm" maw={680}>
+      <Link to={SETUP_GUIDE_PATH} className={S.backLink}>
+        <Group gap="xs">
+          <Icon name="chevronleft" size={12} />
+          <Text size="sm" c="text-secondary">{t`Back to the setup guide`}</Text>
+        </Group>
+      </Link>
+
+      <Title order={1} c="text-primary" mb="xl">
+        {t`Configure SSO`}
+      </Title>
+
+      <OnboardingStepper
+        ref={stepperRef}
+        completedSteps={completedSteps}
+        lockedSteps={{}}
+      >
+        <OnboardingStepper.Step
+          stepId="setup-jwt"
+          title={t`Set up JWT authentication`}
+        >
+          <SetupJwtStep onSuccess={() => stepperRef.current?.goToNextStep()} />
+        </OnboardingStepper.Step>
+
+        <OnboardingStepper.Step
+          stepId="add-endpoint"
+          title={t`Add a new endpoint to your app`}
+        >
+          <AddEndpointStep onDone={handleAddEndpointDone} />
+        </OnboardingStepper.Step>
+
+        <OnboardingStepper.Step
+          stepId="test-jwt"
+          title={t`Test that JWT authentication is working correctly`}
+          hideTitleOnActive
+        >
+          <TestJwtStep />
+        </OnboardingStepper.Step>
+      </OnboardingStepper>
+    </Stack>
+  );
+};

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupSsoPage/TestJwtStep.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupSsoPage/TestJwtStep.tsx
@@ -1,0 +1,131 @@
+/* eslint-disable metabase/no-literal-metabase-strings */
+
+import { useState } from "react";
+import { Link } from "react-router";
+import { t } from "ttag";
+
+import { useUpdateSettingsMutation } from "metabase/api";
+import { useToast } from "metabase/common/hooks";
+import { useHelpUrl } from "metabase/embedding/embedding-hub/hooks";
+import { Button, Group, Stack, Text, Title } from "metabase/ui";
+
+const SETUP_GUIDE_PATH = "/admin/embedding/setup-guide";
+
+export const TestJwtStep = () => {
+  const [sendToast] = useToast();
+  const [updateSettings] = useUpdateSettingsMutation();
+
+  const [showTroubleshooting, setShowTroubleshooting] = useState(false);
+
+  const onDone = async () => {
+    try {
+      await updateSettings({
+        "embedding-hub-sso-auth-manual-tested": true,
+      }).unwrap();
+    } catch (error) {
+      sendToast({
+        icon: "warning",
+        toastColor: "error",
+        message: t`Failed to save SSO test status`,
+      });
+    }
+  };
+
+  if (showTroubleshooting) {
+    return <SsoTroubleshootingView onDone={onDone} />;
+  }
+
+  return (
+    <Stack gap="lg">
+      <Title order={3}>{t`Try logging in with SSO. Did it work?`}</Title>
+
+      <Text size="md" c="text-secondary" lh="lg">
+        {t`To check if JWT authentication was configured successfully, open Metabase in a different browser or in a private tab and try logging in to your account using single sign-on (SSO). Is login working correctly?`}
+      </Text>
+
+      <Group justify="flex-end">
+        <Button variant="outline" onClick={() => setShowTroubleshooting(true)}>
+          {t`No, I couldn't log in`}
+        </Button>
+
+        <Button
+          component={Link}
+          to={SETUP_GUIDE_PATH}
+          variant="filled"
+          onClick={onDone}
+        >
+          {t`Log in works, I'm done`}
+        </Button>
+      </Group>
+    </Stack>
+  );
+};
+
+const SsoTroubleshootingView = ({ onDone }: { onDone: () => void }) => {
+  const helpUrl = useHelpUrl();
+
+  return (
+    <Stack gap="lg">
+      <Title order={3}>{t`Troubleshooting`}</Title>
+
+      <Text size="md" c="text-secondary" lh="lg">
+        {t`Try the steps below before testing JWT authentication again. If nothing works, consider contacting support.`}
+      </Text>
+
+      <Stack gap="md">
+        <div>
+          <Text fw={700} mb="xs">{t`404 error after SSO sign-in`}</Text>
+
+          <Text size="md" c="text-secondary" lh="lg">
+            {t`If after clicking on "Sign in with SSO", the browser returns a 404 error, make sure the value of the JWT SSO URI in admin settings / auth / JWT is pointing to your endpoint and your endpoint is up and running and available.`}
+          </Text>
+        </div>
+
+        <div>
+          <Text
+            fw={700}
+            mb="xs"
+          >{t`JWT decryption error: "Message seems corrupt"`}</Text>
+
+          <Text size="md" c="text-secondary" lh="lg">
+            {t`If after being redirected from your app to Metabase, you see "Message seems corrupt or manipulated" there was an issue decrypting signed JWT. Ensure METABASE_JWT_SHARED_SECRET has the right value.`}
+          </Text>
+        </div>
+
+        <div>
+          <Text fw={700} mb="xs">{t`Tenant ID mismatch error`}</Text>
+
+          <Text size="md" c="text-secondary" lh="lg">
+            {t`If after being redirected from your app to Metabase, you see an error message "Tenant ID mismatch with existing user", your application is trying to sign in a the user with the wrong tenant slug. Review @tenant claim in the JWT and ensure it matches the tenant this tenant user belongs to.`}
+          </Text>
+        </div>
+
+        <div>
+          <Text
+            fw={700}
+            mb="xs"
+          >{t`User provisioning disabled for JWT SSO`}</Text>
+
+          <Text size="md" c="text-secondary" lh="lg">
+            {t`If after being redirected from your app to Metabase, you see an error message "Sorry, but you'll need a $SITENAME account to view this page, contact your administrator. User provisioning is turned off for JWT SSO in admin settings/authentication. Either turn this feature on to have users be provisioned if they don't exist yet, or ensure users exist before signing them in via JWT SSO.`}
+          </Text>
+        </div>
+      </Stack>
+
+      <Group justify="flex-end">
+        <Button component="a" href={helpUrl} target="_blank" variant="outline">
+          {t`Contact customer support`}
+        </Button>
+
+        <Button
+          component={Link}
+          to={SETUP_GUIDE_PATH}
+          variant="filled"
+          onClick={onDone}
+        >
+          {t`Log in works, I'm done`}
+        </Button>
+      </Group>
+    </Stack>
+  );
+};

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupSsoPage/index.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupSsoPage/index.ts
@@ -1,0 +1,1 @@
+export { SetupSsoPage } from "./SetupSsoPage";

--- a/frontend/src/metabase/embedding/embedding-hub/components/index.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/components/index.ts
@@ -2,3 +2,4 @@ export { EmbeddingHub } from "./EmbeddingHub";
 export { EmbeddingHubAdminSettingsPage } from "./EmbeddingHubAdminSettingsPage";
 export { EmbeddingHubHomePage } from "./EmbeddingHubHomePage";
 export { SetupPermissionsAndTenantsPage } from "./SetupPermissionsAndTenantsPage";
+export { SetupSsoPage } from "./SetupSsoPage";

--- a/frontend/src/metabase/embedding/embedding-hub/hooks/index.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/hooks/index.ts
@@ -1,2 +1,3 @@
 export { useCompletedEmbeddingHubSteps } from "./use-completed-embedding-hub-steps";
 export { useGetEmbeddingHubSteps } from "./use-get-embedding-hub-steps";
+export { useHelpUrl } from "./use-help-url";

--- a/frontend/src/metabase/embedding/embedding-hub/hooks/use-completed-embedding-hub-steps.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/hooks/use-completed-embedding-hub-steps.ts
@@ -24,7 +24,7 @@ export const useCompletedEmbeddingHubSteps = (): {
         "add-data": false,
         "create-dashboard": false,
         "configure-row-column-security": false,
-        "secure-embeds": false,
+        "sso-configured": false,
         "embed-production": false,
         "create-models": false,
         "data-permissions-and-enable-tenants": false,
@@ -33,10 +33,20 @@ export const useCompletedEmbeddingHubSteps = (): {
         "create-tenants": false,
         "enable-tenants": false,
         "setup-data-segregation-strategy": false,
+
+        // "configure SSO" sub-checklist
+        "sso-auth-manual-tested": false,
       };
     }
 
-    return embeddingHubChecklist;
+    // For the main embedding hub, the SSO step is only complete if both
+    // SSO is configured AND the user has manually acknowledged it works
+    return {
+      ...embeddingHubChecklist,
+      "sso-configured":
+        embeddingHubChecklist["sso-configured"] &&
+        embeddingHubChecklist["sso-auth-manual-tested"],
+    };
   }, [embeddingHubChecklist, isLoading]);
 
   return { data, isLoading };

--- a/frontend/src/metabase/embedding/embedding-hub/hooks/use-get-embedding-hub-steps.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/hooks/use-get-embedding-hub-steps.ts
@@ -95,17 +95,16 @@ export const useGetEmbeddingHubSteps = (): EmbeddingHubStep[] => {
       ],
     };
 
-    const SECURE_EMBEDS: EmbeddingHubStep = {
-      id: "secure-embeds",
+    const SSO_CONFIGURED: EmbeddingHubStep = {
+      id: "sso-configured",
       title: t`Set up authentication`,
       actions: [
         {
           title: t`Configure SSO`,
-          description: t`Configure JWT or SAML authentication to ensure only authorized users can access your embeds.`,
-          docsPath: "embedding/embedded-analytics-js",
-          anchor: "set-up-sso",
+          description: t`Configure JWT authentication to ensure only authorized users can access your embeds.`,
+          to: "/admin/embedding/setup-guide/sso",
           variant: "outline",
-          stepId: "secure-embeds",
+          stepId: "sso-configured",
         },
       ],
     };
@@ -137,7 +136,7 @@ export const useGetEmbeddingHubSteps = (): EmbeddingHubStep[] => {
       ...(isTenantsFeatureAvailable
         ? [DATA_PERMISSIONS_AND_ENABLE_TENANTS]
         : []),
-      SECURE_EMBEDS,
+      SSO_CONFIGURED,
       EMBED_PRODUCTION,
     ];
   }, [openEmbedModal]);

--- a/frontend/src/metabase/embedding/embedding-hub/hooks/use-help-url.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/hooks/use-help-url.ts
@@ -1,0 +1,12 @@
+import { useSetting } from "metabase/common/hooks";
+import { useSelector } from "metabase/lib/redux";
+import { getIsPaidPlan } from "metabase/selectors/settings";
+
+export const useHelpUrl = () => {
+  const isPaidPlan = useSelector(getIsPaidPlan);
+  const { tag } = useSetting("version");
+
+  const path = isPaidPlan ? "help-premium" : "help";
+
+  return `https://www.metabase.com/${path}?utm_source=in-product&utm_medium=menu&utm_campaign=help&instance_version=${tag}`;
+};

--- a/frontend/src/metabase/embedding/embedding-hub/types/embedding-checklist.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/types/embedding-checklist.ts
@@ -5,7 +5,7 @@ export type EmbeddingHubStepId =
   | "add-data"
   | "create-dashboard"
   | "configure-row-column-security"
-  | "secure-embeds"
+  | "sso-configured"
   | "embed-production"
   | "create-models"
   | "data-permissions-and-enable-tenants";

--- a/src/metabase/embedding/settings.clj
+++ b/src/metabase/embedding/settings.clj
@@ -311,3 +311,12 @@
   :visibility :admin
   :can-read-from-env? false
   :doc false)
+
+(defsetting embedding-hub-sso-auth-manual-tested
+  (deferred-tru "Indicates if the user has manually confirmed that SSO authentication is working correctly")
+  :type       :boolean
+  :default    false
+  :export?    true
+  :visibility :admin
+  :can-read-from-env? false
+  :doc false)


### PR DESCRIPTION
Closes EMB-1272

### Description

Adds the JWT authentication onboarding flow for the embedding hub as a sub-checklist / sub-flow.

### How to verify

- Go to the Embedding Hub in "Admin > Embedding > Setup guide"
- Click on the "Configure SSO" step
- Proceed through the three steps. You should get a check at each step.
- JWT should be enabled and configured.
- JWT secret key should be defined and shown.

### Demo

<img width="1948" height="1218" alt="CleanShot 2569-02-18 at 05 18 43@2x" src="https://github.com/user-attachments/assets/3c970bd5-77b4-4255-a17e-1c2319636ce3" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
