### PR TITLE
Show tenant_identifier autocompletion from column values in RLS

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
@@ -543,7 +543,7 @@ describe("scenarios - embedding hub", () => {
 
           cy.log("fill out the tenant form");
           cy.findByPlaceholderText("Tenant name").clear().type("Acme Corp");
-          cy.findByPlaceholderText("1").type("acme-123");
+          cy.findByPlaceholderText("e.g. 1").type("acme-123");
           cy.findByPlaceholderText("tenant-slug")
             .clear()
             .type("acme-corp-slug");
@@ -560,7 +560,7 @@ describe("scenarios - embedding hub", () => {
             .clear()
             .type("Beta Inc");
 
-          cy.findAllByPlaceholderText("1")
+          cy.findAllByPlaceholderText("e.g. 1")
             .should("have.length", 2)
             .last()
             .type("beta-456");
@@ -614,6 +614,28 @@ describe("scenarios - embedding hub", () => {
           .findByText("Done")
           .should("be.visible");
 
+        cy.log("verify tenant_attributes are saved correctly via API");
+        cy.request("GET", "/api/ee/tenant").should((response) => {
+          const tenants = response.body.data;
+
+          const acmeTenant = tenants.find(
+            (t: { slug: string }) => t.slug === "acme-corp-slug",
+          );
+          const betaTenant = tenants.find(
+            (t: { slug: string }) => t.slug === "beta-inc-slug",
+          );
+
+          expect(acmeTenant).to.exist;
+          expect(acmeTenant.attributes).to.deep.equal({
+            tenant_identifier: "acme-123",
+          });
+
+          expect(betaTenant).to.exist;
+          expect(betaTenant.attributes).to.deep.equal({
+            tenant_identifier: "beta-456",
+          });
+        });
+
         cy.visit("/admin/people/tenants");
 
         cy.log("tenants are shown in the tenants page");
@@ -643,7 +665,7 @@ describe("scenarios - embedding hub", () => {
             .clear()
             .type("Another Tenant");
 
-          cy.findByPlaceholderText("1").type("another-id");
+          cy.findByPlaceholderText("e.g. 1").type("another-id");
 
           cy.findByPlaceholderText("tenant-slug")
             .clear()
@@ -661,6 +683,60 @@ describe("scenarios - embedding hub", () => {
 
         cy.log("we should still be on the create tenants step");
         H.main().findByPlaceholderText("Tenant name").should("be.visible");
+      });
+
+      it("shows autocomplete suggestions for tenant_identifier based on selected field values", () => {
+        H.restore("setup");
+        cy.signInAsAdmin();
+        H.activateToken("bleeding-edge");
+
+        cy.visit("/admin/embedding/setup-guide/permissions");
+
+        cy.log("enable tenants and create shared collection");
+        H.main()
+          .findByRole("button", {
+            name: "Enable tenants and create shared collection",
+          })
+          .click();
+
+        cy.log("wait for tenants to be enabled");
+        H.main()
+          .findByRole("listitem", {
+            name: "Enable multi-tenant user strategy",
+            timeout: 10_000,
+          })
+          .icon("check")
+          .should("exist");
+
+        cy.log("use row and column level security");
+        H.main()
+          .findByRole("radio", { name: /Row and column level security/ })
+          .scrollIntoView()
+          .click();
+
+        H.main()
+          .findByRole("button", { name: "Use row and column level security" })
+          .scrollIntoView()
+          .click();
+
+        cy.log("pick orders table");
+        H.main().findByText("Pick a table").click();
+        H.miniPicker().findByText("Sample Database").click();
+        H.miniPicker().findByText("Orders").click();
+
+        H.main().findByPlaceholderText("Pick a column").click();
+        H.popover().findByText("User ID").click();
+        H.main().findByRole("button", { name: "Next" }).click();
+
+        cy.log("autocomplete dropdown should show matching user id values");
+        H.main().findByPlaceholderText("e.g. 1").type("1");
+
+        H.popover().within(() => {
+          cy.findAllByRole("option").should("have.length.at.least", 8);
+
+          // The ID differs across run, so let's only do one assertion here.
+          cy.findByRole("option", { name: "1" }).should("exist");
+        });
       });
     });
 

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/CreateTenantsOnboardingStep/CreateTenantsOnboardingStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/CreateTenantsOnboardingStep/CreateTenantsOnboardingStep.tsx
@@ -17,8 +17,11 @@ import {
   Text,
   TextInput,
 } from "metabase/ui";
+import type { FieldId } from "metabase-types/api";
 
 import { useCreateTenantMutation } from "../../../api/tenants";
+
+import { TenantIdentifierInput } from "./TenantIdentifierInput";
 
 const createEmptyTenant = (index: number): CreatedTenantData => ({
   name: `Tenant ${index}`,
@@ -28,8 +31,10 @@ const createEmptyTenant = (index: number): CreatedTenantData => ({
 
 export const CreateTenantsOnboardingStep = ({
   onTenantsCreated,
+  selectedFieldIds,
 }: {
   onTenantsCreated?: (tenants: CreatedTenantData[]) => void;
+  selectedFieldIds?: FieldId[];
 }) => {
   const [sendToast] = useToast();
 
@@ -76,6 +81,9 @@ export const CreateTenantsOnboardingStep = ({
         await createTenant({
           name: tenant.name,
           slug: tenant.slug,
+          attributes: {
+            tenant_identifier: tenant.tenantIdentifier,
+          },
         }).unwrap();
       }
 
@@ -136,14 +144,12 @@ export const CreateTenantsOnboardingStep = ({
                 )}
               </Group>
 
-              <TenantFormField
-                label="tenant_identifier"
-                description={t`Users will only see rows where this matches the value in the column you selected.`}
+              <TenantIdentifierInput
                 value={tenant.tenantIdentifier}
                 onChange={(value) =>
                   updateTenantCard(index, "tenantIdentifier", value)
                 }
-                placeholder="1"
+                selectedFieldIds={selectedFieldIds}
               />
 
               <TenantFormField

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/CreateTenantsOnboardingStep/TenantIdentifierInput.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/CreateTenantsOnboardingStep/TenantIdentifierInput.tsx
@@ -1,0 +1,48 @@
+import { c, t } from "ttag";
+
+import { Autocomplete, Stack, Text } from "metabase/ui";
+import type { FieldId } from "metabase-types/api";
+
+import { useFieldDistinctValues } from "./hooks/use-field-distinct-values";
+
+export const TenantIdentifierInput = ({
+  value,
+  onChange,
+  selectedFieldIds,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  selectedFieldIds?: FieldId[];
+}) => {
+  // Fetch value from first field only.
+  // We expect all tables to share the same multi-tenancy column,
+  // and they should share the same tenant_id values.
+  const firstFieldId = selectedFieldIds?.[0];
+
+  const { values: suggestions } = useFieldDistinctValues(firstFieldId);
+
+  const placeholder = suggestions[0]
+    ? c("example tenant identifier value from the database")
+        .t`e.g. ${suggestions[0]}`
+    : c("example tenant identifier value").t`e.g. acme-corp`;
+
+  return (
+    <Stack gap="xs">
+      <Text fw="bold" size="sm">
+        {t`tenant_identifier`}
+      </Text>
+
+      <Text c="text-secondary" size="xs" mb="sm">
+        {t`Users will only see rows where this matches the value in the column you selected.`}
+      </Text>
+
+      <Autocomplete
+        value={value}
+        onChange={onChange}
+        data={suggestions}
+        placeholder={placeholder}
+        aria-label={t`tenant_identifier`}
+      />
+    </Stack>
+  );
+};

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/CreateTenantsOnboardingStep/hooks/use-field-distinct-values.ts
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/CreateTenantsOnboardingStep/hooks/use-field-distinct-values.ts
@@ -1,0 +1,69 @@
+import { useMemo } from "react";
+
+import {
+  skipToken,
+  useGetAdhocQueryQuery,
+  useGetFieldQuery,
+} from "metabase/api";
+import type { FieldId, LocalFieldReference } from "metabase-types/api";
+
+/** How many distinct values to fetch from the field. */
+const DISTINCT_VALUES_LIMIT = 100;
+
+/**
+ * Fetch distinct values for a field by running an ad-hoc query.
+ * This is used for autocompleting multi-tenancy column values.
+ *
+ * We intentionally use an ad-hoc query instead of `useGetFieldValuesQuery`.
+ * The field values API only returns pre-scanned values.
+ * During onboarding the cache is empty and we need fresh values.
+ */
+export function useFieldDistinctValues(fieldId: FieldId | undefined) {
+  const { data: field, isLoading: isFieldLoading } = useGetFieldQuery(
+    fieldId != null
+      ? { id: fieldId, include_editable_data_model: true }
+      : skipToken,
+  );
+
+  const tableId = field?.table_id;
+  const databaseId = field?.table?.db_id;
+
+  const query = useMemo(() => {
+    if (fieldId == null || tableId == null || databaseId == null) {
+      return null;
+    }
+
+    const breakout = [
+      ["field", fieldId, null],
+    ] as const satisfies LocalFieldReference[];
+
+    return {
+      database: databaseId,
+      type: "query" as const,
+      query: {
+        "source-table": tableId,
+        breakout,
+        limit: DISTINCT_VALUES_LIMIT,
+      },
+    };
+  }, [fieldId, tableId, databaseId]);
+
+  const { data: adhocQueryDataset, isLoading: isAdHocQueryLoading } =
+    useGetAdhocQueryQuery(query ?? skipToken, { ignore_error: true });
+
+  // Extract row values from query results
+  const values = useMemo(() => {
+    if (!adhocQueryDataset?.data?.rows) {
+      return [];
+    }
+
+    return adhocQueryDataset.data.rows
+      .map(([rowValue]) => (rowValue != null ? String(rowValue) : null))
+      .filter((rowValue): rowValue is string => rowValue !== null);
+  }, [adhocQueryDataset]);
+
+  return {
+    values,
+    isLoading: isFieldLoading || isAdHocQueryLoading,
+  };
+}

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/CreateTenantsOnboardingStep/hooks/use-field-distinct-values.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/CreateTenantsOnboardingStep/hooks/use-field-distinct-values.unit.spec.tsx
@@ -1,0 +1,98 @@
+import { renderHook } from "@testing-library/react";
+
+import {
+  setupCardDataset,
+  setupFieldEndpoints,
+} from "__support__/server-mocks";
+import { waitFor } from "__support__/ui";
+import { MetabaseReduxProvider } from "metabase/lib/redux";
+import { mainReducers as reducers } from "metabase/reducers-main";
+import { getStore } from "metabase/store";
+import type { FieldId, RowValue } from "metabase-types/api";
+import { createMockField, createMockTable } from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks";
+
+import { useFieldDistinctValues } from "./use-field-distinct-values";
+
+interface SetupOpts {
+  fieldId: FieldId | undefined;
+  rows?: RowValue[][];
+}
+
+function setup({ fieldId, rows }: SetupOpts) {
+  if (fieldId != null) {
+    const field = createMockField({
+      id: fieldId,
+      table_id: 10,
+      table: createMockTable({ id: 10, db_id: 100 }),
+    });
+
+    setupFieldEndpoints(field);
+
+    if (rows) {
+      setupCardDataset({ data: { rows } });
+    }
+  }
+
+  const store = getStore(reducers, undefined, createMockState());
+
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <MetabaseReduxProvider store={store}>{children}</MetabaseReduxProvider>
+    );
+  }
+
+  const { result } = renderHook(() => useFieldDistinctValues(fieldId), {
+    wrapper: Wrapper,
+  });
+
+  return result;
+}
+
+describe("useFieldDistinctValues", () => {
+  it("returns distinct values from ad-hoc query", async () => {
+    const result = setup({
+      fieldId: 1,
+      rows: [["tenant_a"], ["tenant_b"], ["tenant_c"]],
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.values).toEqual(["tenant_a", "tenant_b", "tenant_c"]);
+  });
+
+  it("returns empty values when fieldId is undefined", async () => {
+    const result = setup({ fieldId: undefined });
+
+    expect(result.current.values).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("filters out null values from results", async () => {
+    const result = setup({
+      fieldId: 1,
+      rows: [["tenant_a"], [null], ["tenant_b"], [null]],
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.values).toEqual(["tenant_a", "tenant_b"]);
+  });
+
+  it("converts numeric values to strings", async () => {
+    const result = setup({
+      fieldId: 1,
+      rows: [[1], [2], [3]],
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.values).toEqual(["1", "2", "3"]);
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/tenants/containers/NewTenantModal/NewTenantModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/containers/NewTenantModal/NewTenantModal.tsx
@@ -31,6 +31,7 @@ export const NewTenantModal = ({ onClose, location }: NewUserModalProps) => {
       ...vals,
       name: vals.name ?? "",
       slug: vals.slug ?? "",
+      attributes: vals.attributes ?? {},
     }).unwrap();
     dispatch(addUndo({ message: t`Tenant creation successful` }));
     onClose();

--- a/frontend/src/metabase-types/api/tenants.ts
+++ b/frontend/src/metabase-types/api/tenants.ts
@@ -10,7 +10,9 @@ export type Tenant = {
   tenant_collection_id: number | null;
 };
 
-export type CreateTenantInput = Pick<Tenant, "name" | "slug">;
+export type CreateTenantInput = Pick<Tenant, "name" | "slug"> & {
+  attributes?: Tenant["attributes"];
+};
 
 export type UpdateTenantInput = Pick<Tenant, "id"> &
   Partial<Pick<Tenant, "name" | "is_active">>;

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/RlsDataSelector/RlsDataSelector.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/RlsDataSelector/RlsDataSelector.tsx
@@ -16,7 +16,11 @@ export interface TableColumnSelection {
   columnId: FieldId | null;
 }
 
-export const RlsDataSelector = ({ onSuccess }: { onSuccess: () => void }) => {
+interface RlsDataSelectorProps {
+  onSuccess: (selectedFieldIds: FieldId[]) => void;
+}
+
+export const RlsDataSelector = ({ onSuccess }: RlsDataSelectorProps) => {
   const [sendToast] = useToast();
 
   const [selections, setSelections] = useState<TableColumnSelection[]>([
@@ -26,13 +30,12 @@ export const RlsDataSelector = ({ onSuccess }: { onSuccess: () => void }) => {
   const { handleUpsertPolicies, isCreatingPolicy, isLoadingPolicies } =
     useUpsertGroupTableAccessPolicies({
       tableColumnSelections: selections,
+      onSuccess,
     });
 
   const handleSubmit = useCallback(async () => {
     try {
       await handleUpsertPolicies();
-
-      onSuccess();
     } catch (error) {
       sendToast({
         icon: "warning",
@@ -43,7 +46,7 @@ export const RlsDataSelector = ({ onSuccess }: { onSuccess: () => void }) => {
         ),
       });
     }
-  }, [handleUpsertPolicies, onSuccess, sendToast]);
+  }, [handleUpsertPolicies, sendToast]);
 
   const addTable = useCallback(() => {
     setSelections((prev) => [...prev, { tableId: null, columnId: null }]);

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/SetupPermissionsAndTenantsPage.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/SetupPermissionsAndTenantsPage.tsx
@@ -11,6 +11,7 @@ import {
   PLUGIN_TENANTS,
 } from "metabase/plugins/oss/tenants";
 import { Group, Icon, Stack, Text, Title } from "metabase/ui";
+import type { FieldId } from "metabase-types/api";
 
 import { ConnectionImpersonationStepContent } from "./ConnectionImpersonationStepContent";
 import {
@@ -37,6 +38,9 @@ export const SetupPermissionsAndTenantsPage = () => {
 
   // Track the tenants created in this onboarding flow
   const [createdTenants, setCreatedTenants] = useState<CreatedTenantData[]>([]);
+
+  // Track the selected field IDs from the RLS step (in-session only)
+  const [selectedFieldIds, setSelectedFieldIds] = useState<FieldId[]>([]);
 
   const isTenantsEnabled = checklist?.["enable-tenants"] ?? false;
 
@@ -142,7 +146,9 @@ export const SetupPermissionsAndTenantsPage = () => {
           {match(selectedStrategy)
             .with("row-column-level-security", () => (
               <RlsDataSelector
-                onSuccess={() => {
+                onSuccess={(fieldIds) => {
+                  setSelectedFieldIds(fieldIds);
+
                   // User might had already created tenants before,
                   // so we allow jumping straight to the summary flow.
                   stepperRef.current?.goToNextIncompleteStep();
@@ -164,6 +170,7 @@ export const SetupPermissionsAndTenantsPage = () => {
         >
           <PLUGIN_TENANTS.CreateTenantsOnboardingStep
             onTenantsCreated={setCreatedTenants}
+            selectedFieldIds={selectedFieldIds}
           />
         </OnboardingStepper.Step>
 

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/hooks/use-upsert-group-table-access-policies.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/hooks/use-upsert-group-table-access-policies.ts
@@ -3,6 +3,7 @@ import { t } from "ttag";
 
 import { tableApi, useListGroupTableAccessPoliciesQuery } from "metabase/api";
 import { useDispatch } from "metabase/lib/redux";
+import type { FieldId } from "metabase-types/api";
 
 import type { TableColumnSelection } from "../RlsDataSelector";
 
@@ -10,6 +11,7 @@ import { useUpdateAllTenantUsersGroupPermissions } from "./use-update-all-tenant
 
 interface UseUpsertGroupTableAccessPoliciesProps {
   tableColumnSelections: TableColumnSelection[];
+  onSuccess?: (selectedFieldIds: FieldId[]) => void;
 }
 
 /**
@@ -18,6 +20,7 @@ interface UseUpsertGroupTableAccessPoliciesProps {
  */
 export const useUpsertGroupTableAccessPolicies = ({
   tableColumnSelections,
+  onSuccess,
 }: UseUpsertGroupTableAccessPoliciesProps) => {
   const dispatch = useDispatch();
 
@@ -75,15 +78,28 @@ export const useUpsertGroupTableAccessPolicies = ({
 
       const sandboxedTables = nextPolicies.filter((entry) => entry != null);
       await updateDataAccess({ sandboxedTables });
+
+      // Extract field IDs from policies that were actually created/updated,
+      // excluding entries that were skipped (e.g. table failed to fetch).
+      const selectedFieldIds = Array.from(
+        new Set(
+          sandboxedTables
+            .map((policy) => policy.filterFieldId)
+            .filter((id): id is FieldId => id != null),
+        ),
+      );
+
+      onSuccess?.(selectedFieldIds);
     } finally {
       setIsCreatingPolicy(false);
     }
   }, [
-    dispatch,
     tenantUsersGroupId,
     tableColumnSelections,
-    existingPolicies,
     updateDataAccess,
+    onSuccess,
+    dispatch,
+    existingPolicies,
   ]);
 
   return {

--- a/frontend/src/metabase/plugins/oss/tenants.ts
+++ b/frontend/src/metabase/plugins/oss/tenants.ts
@@ -38,6 +38,7 @@ const getDefaultPluginTenants = () => ({
   tenantsRoutes: null as React.ReactElement | null,
   CreateTenantsOnboardingStep: PluginPlaceholder as React.ComponentType<{
     onTenantsCreated?: (tenants: CreatedTenantData[]) => void;
+    selectedFieldIds?: number[];
   }>,
   TenantsSummaryOnboardingStep: PluginPlaceholder as React.ComponentType<{
     tenants: CreatedTenantData[];
@@ -106,6 +107,7 @@ export const PLUGIN_TENANTS: {
   tenantsRoutes: React.ReactElement | null;
   CreateTenantsOnboardingStep: React.ComponentType<{
     onTenantsCreated?: (tenants: CreatedTenantData[]) => void;
+    selectedFieldIds?: number[];
   }>;
   TenantsSummaryOnboardingStep: React.ComponentType<{
     tenants: CreatedTenantData[];


### PR DESCRIPTION
Closes EMB-1327

### Description

Shows the tenant_identifier auto-completion from the multi-tenancy column's existing values in the database, if RLS is **configured in the same session**. It also correctly assigns the `tenant_identifier` attribute mapping when we actually create new tenants via the onboarding flow.

### How to verify

- Go to Embedding Hub > Data permissions and tenants card
- Select the "Row and column level security"
- Pick columns and tables.
- **Make sure your database actually have row and values in that column!!**
- Go to tenants creation step
- In the tenant_identifier, you should see the column values from your database 💪🏻 
- The created tenant should have **tenant_identifier** assigned to their **tenant attribute**

### Demos

<img width="1354" height="1072" alt="image" src="https://github.com/user-attachments/assets/fd702913-e364-47f1-b002-1a3a9c2deb9e" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR - E2E + Unit