### PR TITLE
metabot/slackbot - Adjust CSV upload support

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot.clj
@@ -335,7 +335,6 @@
   "Convert a Slack thread to an ai-service history object.
    Strips bot mentions from user messages when bot-user-id is provided."
   [thread bot-user-id]
-  (def tsp-thread thread)
   (->> (:messages thread)
        (filter :text)
        (mapv (fn [msg]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot.clj
@@ -289,7 +289,7 @@
     (cond-> []
       (seq successes)
       (conj {:role :assistant
-             :content (format "The user uploaded CSV files that are now available as models in Metabase: %s. You can help them query this data."
+             :content (format "The following message included 1 or more attached CSV files which are now available as models in Metabase: %s. You can help them query this data."
                               (str/join ", " (map #(format "%s (model ID: %d)"
                                                            (:filename %)
                                                            (:model-id %))
@@ -297,7 +297,7 @@
 
       (seq failures)
       (conj {:role :assistant
-             :content (format "Some file uploads failed: %s. Explain these errors to the user."
+             :content (format "The following message included 1 or more attached CSV files. Some file uploads failed: %s. Explain these errors to the user."
                               (str/join ", " (map #(format "%s: %s"
                                                            (:filename %)
                                                            (:error %))
@@ -305,7 +305,7 @@
 
       (seq skipped)
       (conj {:role :assistant
-             :content (format "The user tried to upload non-CSV files which are not supported: %s. Let them know only CSV files can be uploaded."
+             :content (format "The following message included 1 or more non-CSV files which are not supported: %s. Let them know only CSV files can be uploaded."
                               (str/join ", " skipped))}))))
 
 (defn- handle-file-uploads
@@ -335,6 +335,7 @@
   "Convert a Slack thread to an ai-service history object.
    Strips bot mentions from user messages when bot-user-id is provided."
   [thread bot-user-id]
+  (def tsp-thread thread)
   (->> (:messages thread)
        (filter :text)
        (mapv (fn [msg]
@@ -675,7 +676,9 @@
     event         :- SlackRespondableEvent
     extra-history :- [:maybe [:sequential :map]]]
    (let [prompt (:text event)
-         thread (fetch-thread client event)
+         thread (-> (fetch-thread client event)
+                    ;; Exclude the current message from history since it will be sent as the new message
+                    (update :messages #(remove (fn [m] (= (:ts m) (:ts event))) %)))
          bot-user-id (get-bot-user-id client)
          message-ctx (event->reply-context event)
          thinking-message (post-message client (merge message-ctx {:text "_Thinking..._"}))
@@ -805,6 +808,16 @@
       (send-metabot-response client event)))
   nil)
 
+(defn- app-mention-with-files?
+  "Check if event is an app_mention that has file attachments.
+   When a user @mentions the bot with a file in a channel, Slack sends two events:
+   1. message.channels with subtype: file_share (handled by process-message-file-share)
+   2. app_mention (this duplicate needs to be skipped)
+   We skip app_mention events with files to avoid duplicate processing."
+  [event]
+  (and (app-mention? event)
+       (seq (:files event))))
+
 (mu/defn- handle-event-callback :- SlackEventsResponse
   "Respond to an event_callback request"
   [payload :- SlackEventCallbackEvent]
@@ -813,6 +826,11 @@
     (cond
       (edited-message? event)
       nil ; ignore edited messages
+
+      ;; Skip app_mention events with files - these will be handled by the file_share event
+      (app-mention-with-files? event)
+      (log/debugf "[slackbot] Skipping app_mention with files (will be handled by file_share): ts=%s"
+                  (:ts event))
 
       (app-mention? event)
       (future
@@ -877,7 +895,7 @@
   ;; Updating an existing slack app
   ;; 1. create a tunnel via `ngrok http 3000`
   ;; 2. update your site url to the provided tunnel url
-  (system/site-url! "https://barcelona-shift-midwest-latex.trycloudflare.com")
+  (system/site-url! "https://3ee6-104-174-230-42.ngrok-free.app")
   ;; 3. visit the app manifest slack settings page for your slack app (https://app.slack.com/app-settings/.../..../app-manifest)
   ;; 4. execute this form to copy the manifest to clipboard, paste the result in the manifest page
   (do


### PR DESCRIPTION
Changes include:
- Fixes bug where user prompt / message was being duplicated in AI service requests since it is already present from `fetch-thread`
- Fixes bug where an @ mention event with a file share triggers duplicate event handling by metabot since we receive both events and then handle both