### PR TITLE
fix: 404 on lens not found

### DIFF
--- a/src/metabase/transforms_inspector/lens/core.clj
+++ b/src/metabase/transforms_inspector/lens/core.clj
@@ -169,5 +169,6 @@
        (-> (make-lens lens-type ctx params)
            (update :drill_lens_triggers #(filter-applicable-drill-triggers ctx %)))
        (throw (ex-info "Lens data not available"
-                       {:lens_id   lens-id
-                        :lens_type lens-type}))))))
+                       {:lens_id     lens-id
+                        :lens_type   lens-type
+                        :status-code 404}))))))

--- a/test/metabase/transforms_inspector/e2e_test.clj
+++ b/test/metabase/transforms_inspector/e2e_test.clj
@@ -31,12 +31,12 @@
    Returns a map of card-id -> result map."
   [lens-id lens]
   (into {}
-        (pmap (fn [card]
-                (let [row    (execute-card card)
-                      result (inspector/compute-card-result
-                              (keyword lens-id) card row)]
-                  [(:id card) result]))
-              (:cards lens))))
+        (map (fn [card]
+               (let [row    (execute-card card)
+                     result (inspector/compute-card-result
+                             (keyword lens-id) card row)]
+                 [(:id card) result]))
+             (:cards lens))))
 
 (defn- make-transform
   "Create a transform map for testing."

--- a/test/metabase/transforms_rest/api/transform_test.clj
+++ b/test/metabase/transforms_rest/api/transform_test.clj
@@ -1672,6 +1672,18 @@
               (is (= #{native-id mbql-id}
                      (search-transform-ids search-term))))))))))
 
+;;; -------------------------------------------------- Inspector API --------------------------------------------------
+
+(deftest inspect-lens-not-found-test
+  (mt/with-premium-features #{}
+    (testing "GET /api/transform/:id/inspect/:lens-id returns 404 for a nonexistent lens"
+      (mt/with-temp [:model/Transform {transform-id :id} {}]
+        (mt/with-data-analyst-role! (mt/user->id :lucky)
+          (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
+            (is (= "Lens data not available"
+                   (:message (mt/user-http-request :lucky :get 404
+                                                   (format "transform/%d/inspect/no-such-lens" transform-id)))))))))))
+
 ;;; -------------------------------------------------- Inspector Query API --------------------------------------------------
 
 (deftest inspect-query-execute-test


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-1830/return-404-when-lens-is-not-found-not-500