### PR TITLE
Introduce Copilot code review instructions

### DIFF
--- a/.claude/skills/typescript-review/SKILL.md
+++ b/.claude/skills/typescript-review/SKILL.md
@@ -12,8 +12,9 @@ allowed-tools: Read, Grep, Bash, Glob
 
 Review pull requests with a focus on:
 
+- Readability and maintainability
+- Appropriate test coverage
 - Compliance with project coding standards and conventions
 - Code quality and best practices
-- Clear and correct JSDoc comments
 - Type safety and proper TypeScript usage
 - React best practices (when applicable)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,15 @@ For detailed coding standards and conventions, see `CLAUDE.md` and the skills in
 
 ## Code Review Standards
 
-When reviewing code, focus on:
+Review focus areas: Security → Performance → Testing → Documentation (in priority order)
+
+When reviewing code, use these emoji prefixes to categorize feedback:
+- 🔒 Security concerns
+- ⚡ Performance opportunities
+- 🧹 Cleanup needs
+- 📚 Documentation gaps
+- 🚨 Blocking issues
+- 💭 Clarification questions
 
 ### Security Critical Issues
 
@@ -36,6 +44,12 @@ When reviewing code, focus on:
 - Explain the "why" behind recommendations
 - Ask clarifying questions when code intent is unclear
 
-Always prioritize security vulnerabilities and performance issues that could impact users.
+### Review Format
+
+- Condense feedback into as few comments as possible
+- Prefer a single summary comment over dozens of inline comments
+- Only use inline comments for critical issues that require immediate attention
+- For non-critical issues, link to the specific line from the summary instead
+- Delete all stale comments and summaries on each new push or CI run
 
 Language-specific rules are in `.github/instructions/*.instructions.md`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,20 +1,15 @@
 # Metabase Developer Assistant Instructions
 
-## Code Review Guidelines
+For detailed coding standards and conventions, see `CLAUDE.md` and the skills in `.claude/skills/`.
 
-When performing a code review, do not post comments congratulating someone for following conventions or saying things "look good". Only flag actual issues worth mentioning.
+## Code Review Standards
 
-When performing a code review on Clojure or ClojureScript code (.clj, .cljs, .cljc files), apply the guidelines in:
+When performing a code review:
 
-- `.claude/skills/_shared/clojure-style-guide.md`
-- `.claude/skills/clojure-review/SKILL.md`
+- Only flag actual issues worth mentioning
+- Do not post comments congratulating someone for following conventions
+- Do not post "looks good" comments on correct code
+- Be specific and actionable in feedback
+- Explain the "why" behind recommendations
 
-When performing a code review on TypeScript or JavaScript code (.ts, .tsx, .js, .jsx files), apply the guidelines in:
-
-- `.claude/skills/typescript-review/SKILL.md`
-- `frontend/CLAUDE.md`
-
-When performing a code review on documentation (.md files in docs/), apply the guidelines in:
-
-- `.claude/skills/_shared/metabase-style-guide.md`
-- `.claude/skills/docs-review/SKILL.md`
+Language-specific rules are in `.github/instructions/*.instructions.md`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,12 +4,38 @@ For detailed coding standards and conventions, see `CLAUDE.md` and the skills in
 
 ## Code Review Standards
 
-When performing a code review:
+When reviewing code, focus on:
+
+### Security Critical Issues
+
+- Check for hardcoded secrets, API keys, or credentials
+- Look for SQL injection and XSS vulnerabilities
+- Verify proper input validation and sanitization
+- Review authentication and authorization logic
+- Ensure enterprise features use the plugin system (no enterprise code in OSS)
+
+### Performance Red Flags
+
+- Identify N+1 database query problems
+- Spot inefficient loops and algorithmic issues
+- Check for memory leaks and resource cleanup
+- Review caching opportunities for expensive operations
+
+### Code Quality Essentials
+
+- Functions should be focused and appropriately sized
+- Use clear, descriptive naming conventions
+- Ensure proper error handling throughout
+- Remove dead code and unused imports
+
+### Review Style
 
 - Only flag actual issues worth mentioning
-- Do not post comments congratulating someone for following conventions
-- Do not post "looks good" comments on correct code
+- Do not post "looks good" comments or congratulate following conventions
 - Be specific and actionable in feedback
 - Explain the "why" behind recommendations
+- Ask clarifying questions when code intent is unclear
+
+Always prioritize security vulnerabilities and performance issues that could impact users.
 
 Language-specific rules are in `.github/instructions/*.instructions.md`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,52 +1,20 @@
 # Metabase Developer Assistant Instructions
 
-## Frontend Development
+## Code Review Guidelines
 
-### Repository Structure
+When performing a code review, do not post comments congratulating someone for following conventions or saying things "look good". Only flag actual issues worth mentioning.
 
-```
-frontend/src/
-├── metabase/           # Main application components and pages
-├── metabase-lib/       # Query building and data modeling utilities
-├── metabase-types/     # TypeScript type definitions
-└── metabase/ui/        # Design system components
+When performing a code review on Clojure or ClojureScript code (.clj, .cljs, .cljc files), apply the guidelines in:
 
-e2e/                    # Cypress end-to-end tests
-frontend/test/          # Jest unit tests
-```
+- `.claude/skills/_shared/clojure-style-guide.md`
+- `.claude/skills/clojure-review/SKILL.md`
 
-### Technology Stack
+When performing a code review on TypeScript or JavaScript code (.ts, .tsx, .js, .jsx files), apply the guidelines in:
 
-- **Framework**: React 18 with TypeScript
-- **State**: Redux Toolkit
-- **Styling**: CSS Modules (preferred) > Emotion styled-components
-- **UI**: `metabase/ui` components built with Mantine v8
-- **Build**: Rspack (primary), Webpack (legacy)
-- **Testing**: Jest + React Testing Library, Cypress
+- `.claude/skills/typescript-review/SKILL.md`
+- `frontend/CLAUDE.md`
 
-### Coding Standards
+When performing a code review on documentation (.md files in docs/), apply the guidelines in:
 
-#### Component Preferences
-
-- Prefer `metabase/ui`components over `metabase/common/components`
-- Use `.tsx` for components, `.ts` for utilities
-
-#### Styling
-
-ALWAYS prefer Mantine style props,then CSS modules. DO NOT suggest styled components, they are deprecated.
-
-#### TypeScript Migration
-
-When heavily editing `.js`/`.jsx` files, create a separate PR to convert to TypeScript first, then implement changes.
-
-#### Enterprise Features
-
-Enterprise functionality MUST use the plugin system. It is very important to not expose enterprise code in the OSS version.
-
-#### Testing Requirements
-
-All PRs should include tests. Prefer Unit tests over E2E tests.
-
-#### Localization
-
-All user-facing strings MUST be localized using the ttag library. Localized strings should be complete phrases, do not concatenate a few separately localized strings. You should add context to strings where the meaning of the string might not be obvious in isolation: e.g. "Home" might have different words in some languages depending on whether you're talking about a dwelling or the landing page for a website.
+- `.claude/skills/_shared/metabase-style-guide.md`
+- `.claude/skills/docs-review/SKILL.md`

--- a/.github/instructions/clojure.instructions.md
+++ b/.github/instructions/clojure.instructions.md
@@ -1,0 +1,9 @@
+---
+applyTo: "**/*.{clj,cljs,cljc}"
+---
+
+# Clojure/ClojureScript Code Review
+
+When reviewing Clojure or ClojureScript code, apply the guidelines in these files:
+- `.claude/skills/_shared/clojure-style-guide.md`
+- `.claude/skills/clojure-review/SKILL.md`

--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -1,0 +1,9 @@
+---
+applyTo: "docs/**/*.md"
+---
+
+# Documentation Review
+
+When reviewing documentation, apply the guidelines in these files:
+- `.claude/skills/_shared/metabase-style-guide.md`
+- `.claude/skills/docs-review/SKILL.md`

--- a/.github/instructions/typescript.instructions.md
+++ b/.github/instructions/typescript.instructions.md
@@ -1,0 +1,9 @@
+---
+applyTo: "**/*.{ts,tsx,js,jsx}"
+---
+
+# TypeScript/JavaScript Code Review
+
+When reviewing TypeScript or JavaScript code, apply the guidelines in these files:
+- `.claude/skills/typescript-review/SKILL.md`
+- `frontend/CLAUDE.md`

--- a/.github/instructions/typescript.instructions.md
+++ b/.github/instructions/typescript.instructions.md
@@ -5,5 +5,7 @@ applyTo: "**/*.{ts,tsx,js,jsx}"
 # TypeScript/JavaScript Code Review
 
 When reviewing TypeScript or JavaScript code, apply the guidelines in these files:
+
 - `.claude/skills/typescript-review/SKILL.md`
+- `docs/developers-guide/frontend.md`
 - `frontend/CLAUDE.md`


### PR DESCRIPTION
Resolves DEV-1533

The [example section](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/request-a-code-review/use-code-review#example) suggests that it is possible to reference the existing files in copilot instructions. Let's try that first rather than duplicating Claude's instructions here.

Test-run code review sessions based on this PR:
- [docs](https://github.com/metabase/metabase/agents/pull/69857?session_id=bff8a68e-59ff-4b7a-be19-cd981fb34109)
- [clj](https://github.com/metabase/metabase/agents/pull/69858?session_id=0a282b88-45b3-4a59-9c1d-b97d87031301)
- [Ts](https://github.com/metabase/metabase/agents/pull/69861?session_id=f9c4c284-663c-48a2-89d2-aaba20b2336f)