### PR TITLE
Gdgt 1812 better handle missing sources in lens inspector

### DIFF
--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/GenericSummarySections/GenericSummarySection.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/GenericSummarySections/GenericSummarySection.tsx
@@ -65,7 +65,7 @@ export const GenericSummarySection = ({
             original.card.metadata.table_id,
             [...sources, target].filter((t) => t !== undefined),
           ),
-        cell: (props) => <Text>{String(props.getValue())}</Text>,
+        cell: (props) => <Text>{String(props.getValue() ?? "")}</Text>,
       },
       {
         id: "row_count",

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/GenericSummarySections/GenericSummarySection.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/GenericSummarySections/GenericSummarySection.tsx
@@ -65,7 +65,7 @@ export const GenericSummarySection = ({
             original.card.metadata.table_id,
             [...sources, target].filter((t) => t !== undefined),
           ),
-        cell: (props) => <Text>{String(props.getValue() ?? "")}</Text>,
+        cell: (props) => <Text>{String(props.getValue() ?? "-")}</Text>,
       },
       {
         id: "row_count",

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/GenericSummarySections/components/FieldInfoSection/FieldInfoSection.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/GenericSummarySections/components/FieldInfoSection/FieldInfoSection.tsx
@@ -3,10 +3,11 @@ import { useCallback, useMemo } from "react";
 import { t } from "ttag";
 
 import {
+  Alert,
   Card,
+  Icon,
   SimpleGrid,
   Stack,
-  Text,
   Title,
   TreeTable,
   type TreeTableColumnDef,
@@ -59,13 +60,20 @@ export const FieldInfoSection = ({
     <SimpleGrid cols={2} spacing="lg" data-testid="generic-summary-fields">
       <Stack gap="md">
         <Title order={4}>{t`Input fields`}</Title>
-        <Card p={0} shadow="none" withBorder>
-          <TreeTable
-            instance={sourceInstance}
-            onRowClick={handleRowClick}
-            styles={treeTableStyles}
-          />
-        </Card>
+        {sources.length > 0 ? (
+          <Card p={0} shadow="none" withBorder>
+            <TreeTable
+              instance={sourceInstance}
+              onRowClick={handleRowClick}
+              styles={treeTableStyles}
+            />
+          </Card>
+        ) : (
+          <Alert
+            color="warning"
+            icon={<Icon name="warning" />}
+          >{t`Missing input data`}</Alert>
+        )}
       </Stack>
 
       <Stack gap="md">
@@ -79,7 +87,10 @@ export const FieldInfoSection = ({
             />
           </Card>
         ) : (
-          <Text c="text-tertiary">{t`No output table`}</Text>
+          <Alert
+            color="warning"
+            icon={<Icon name="warning" />}
+          >{t`No output table`}</Alert>
         )}
       </Stack>
     </SimpleGrid>

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/GenericSummarySections/components/FieldInfoSection/FieldInfoSection.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/GenericSummarySections/components/FieldInfoSection/FieldInfoSection.unit.spec.tsx
@@ -1,0 +1,25 @@
+import { renderWithProviders, screen } from "__support__/ui";
+
+import { FieldInfoSection } from "./FieldInfoSection";
+
+function setup() {
+  renderWithProviders(
+    <FieldInfoSection
+      sources={[]}
+      target={{
+        table_id: 1,
+        table_name: "Output table",
+        column_count: 0,
+        fields: [],
+      }}
+    />,
+  );
+}
+
+describe("FieldInfoSection", () => {
+  it("shows warning when sources are empty", () => {
+    setup();
+
+    expect(screen.getByText("Missing input data")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-1812/better-handle-missing-sources-in-lens-inspector

### Description

- Display a warning if sources are missing. 
- Prevent `undefined` string from being rendered as table name in the column summary.

### Demo

<img width="1409" height="1092" alt="image" src="https://github.com/user-attachments/assets/0ea8b24d-ef22-43af-ab65-1c0374e87bd0" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
