### PR TITLE
fix: transforms collections set setting on import

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/remote_sync/spec.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/spec.clj
@@ -455,7 +455,7 @@
 (def transform-models
   "Models that indicate transforms content in a snapshot.
    Derived from specs with `:enabled? :remote-sync-transforms`."
-  (disj (models-for-setting :remote-sync-transforms) :model/TransformTag))
+  (models-for-setting :remote-sync-transforms))
 
 (defn models-in-import
   "Returns set of model-type strings present in the import.

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/spec.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/spec.clj
@@ -509,7 +509,7 @@
    Excludes built-in TransformTags and the built-in PythonLibrary from the count since they are
    system-created and not user data. Namespace collections are not checked here because they are
    organizational containers, not user data that would be lost on import."
-  [_setting-kw specs-for-feature]
+  [specs-for-feature]
   (some (fn [[_ spec]]
           (let [model-key (:model-key spec)
                 model-type (:model-type spec)
@@ -540,7 +540,7 @@
                 :when (or (some feature-model-types models-present)
                           (and feature-namespace
                                (contains? import-namespace-collections (name feature-namespace))))
-                :when (has-unsynced-entities-for-feature? setting-kw specs-for-feature)
+                :when (has-unsynced-entities-for-feature? specs-for-feature)
                 :let [category (setting->category setting-kw)]]
             {:type     (keyword (str (u/lower-case-en category) "-conflict"))
              :category category

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
@@ -1115,8 +1115,8 @@ serdes/meta:
                 (is (false? (remote-sync.settings/remote-sync-transforms))
                     "remote-sync-transforms should remain disabled when no transforms in remote")))))))))
 
-(deftest import!-does-not-disable-transforms-setting-when-already-enabled-test
-  (testing "import! does not modify remote-sync-transforms setting when it's already enabled"
+(deftest import!-disables-transforms-setting-when-no-transforms-in-branch-test
+  (testing "import! disables remote-sync-transforms setting when importing a branch without transforms"
     (mt/with-model-cleanup [:model/RemoteSyncTask]
       (let [task-id (t2/insert-returning-pk! :model/RemoteSyncTask {:sync_task_type "import" :initiated_by (mt/user->id :rasta)})]
         (mt/with-temporary-setting-values [remote-sync-transforms true]
@@ -1128,8 +1128,8 @@ serdes/meta:
                   "remote-sync-transforms should be initially enabled")
               (let [result (impl/import! (source.p/snapshot mock-source) task-id)]
                 (is (= :success (:status result)))
-                (is (true? (remote-sync.settings/remote-sync-transforms))
-                    "remote-sync-transforms should remain enabled even when no transforms in remote")))))))))
+                (is (false? (remote-sync.settings/remote-sync-transforms))
+                    "remote-sync-transforms should be disabled when no transforms in remote")))))))))
 
 (deftest import!-includes-all-optional-paths-regardless-of-settings-test
   (testing "import! always includes all optional paths (transforms, python-libraries, snippets)"

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/test_helpers.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/test_helpers.clj
@@ -297,25 +297,29 @@ width: fixed
     (t2/insert! :model/PythonLibrary builtin-python-library)))
 
 (defn clean-optional-feature-models
-  "Test fixture that cleans Transform, TransformTag, and PythonLibrary tables to prevent
-  conflict detection during first-import tests. Preserves built-in TransformTags and
-  recreates the built-in common.py PythonLibrary after cleanup."
+  "Test fixture that cleans Transform, TransformTag, PythonLibrary, and namespace collection
+  tables to prevent conflict detection during first-import tests. Preserves built-in TransformTags
+  and recreates the built-in common.py PythonLibrary after cleanup."
   [f]
   (let [old-transforms (t2/select :model/Transform)
         old-tags (t2/select :model/TransformTag :built_in_type nil)
-        old-libs (t2/select :model/PythonLibrary)]
+        old-libs (t2/select :model/PythonLibrary)
+        old-ns-colls (t2/select :model/Collection :namespace [:in ["transforms" "snippets"]])]
     (try
       (t2/delete! :model/TransformTag :built_in_type nil)
       (t2/delete! :model/Transform)
       (t2/delete! :model/PythonLibrary)
+      (t2/delete! :model/Collection :namespace [:in ["transforms" "snippets"]])
       (f)
       (finally
         (t2/delete! :model/TransformTag :built_in_type nil)
         (t2/delete! :model/Transform)
         (t2/delete! :model/PythonLibrary)
+        (t2/delete! :model/Collection :namespace [:in ["transforms" "snippets"]])
         (when (seq old-transforms) (t2/insert! :model/Transform old-transforms))
         (when (seq old-tags) (t2/insert! :model/TransformTag old-tags))
         (when (seq old-libs) (t2/insert! :model/PythonLibrary old-libs))
+        (when (seq old-ns-colls) (t2/insert! :model/Collection old-ns-colls))
         (ensure-builtin-python-library!)))))
 
 (def clean-remote-sync-state

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/test_helpers.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/test_helpers.clj
@@ -10,8 +10,9 @@
 
 (defn generate-collection-yaml
   "Generate YAML content for a collection with the given `entity-id` and `name`.
-  Optionally accepts `:parent-id` for nested collections."
-  [entity-id name & {:keys [parent-id]}]
+  Optionally accepts `:parent-id` for nested collections and `:namespace` for
+  namespace collections (e.g., \"transforms\" or \"snippets\")."
+  [entity-id name & {:keys [parent-id namespace]}]
   (format "name: %s
 description: null
 entity_id: %s
@@ -21,7 +22,7 @@ archived: false
 type: null
 parent_id: %s
 personal_owner_id: null
-namespace: null
+namespace: %s
 authority_level: null
 serdes/meta:
 - id: %s
@@ -32,7 +33,7 @@ archived_directly: null
 is_sample: false
 "
           name entity-id (str/replace (u/lower-case-en name) #"\s+" "_")
-          (or parent-id "null") entity-id (str/replace (u/lower-case-en name) #"\s+" "_")))
+          (or parent-id "null") (or namespace "null") entity-id (str/replace (u/lower-case-en name) #"\s+" "_")))
 
 (defn generate-v57-collection-yaml
   "Generate YAML content for a collection in v57 format. In v57, remote-synced collections


### PR DESCRIPTION
### Description

Fixes two issues with the transforms setting after imports:

* Disables the setting when we import a target that does not have any transforms
* Enables the setting when we import a target that only has transform namespaced collections. 

Also fixes an issue where the premium token cache unique key constraint violation would fail and rollback test transactions on postgresql. 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
